### PR TITLE
perf(merge): reconcile sparse semantic history

### DIFF
--- a/packages/engine/src/commit_graph/walker.rs
+++ b/packages/engine/src/commit_graph/walker.rs
@@ -84,44 +84,34 @@ where
         .map(|reachable| reachable.commit.commit_id)
         .collect::<BTreeSet<_>>();
 
-    let mut best = Vec::new();
-    for reachable in left_reachable {
-        let commit_id = &reachable.commit.commit_id;
-        if !common_ids.contains(commit_id) {
+    // The intersection of two ancestor sets is ancestor-closed: every parent
+    // of a common ancestor is itself a common ancestor. Therefore a common
+    // commit is "best" exactly when it is not a direct parent of another
+    // common commit. Marking those direct parents avoids the previous
+    // per-candidate graph walk, which made merge-base discovery quadratic in
+    // the length of ordinary shared history.
+    let mut superseded = BTreeSet::new();
+    for reachable in &left_reachable {
+        if !common_ids.contains(&reachable.commit.commit_id) {
             continue;
         }
-
-        if has_descendant_in_set(reader, commit_id, &common_ids).await? {
-            continue;
+        for parent_commit_id in &reachable.commit.parent_commit_ids {
+            if common_ids.contains(parent_commit_id) {
+                superseded.insert(*parent_commit_id);
+            }
         }
-
-        best.push(reachable.commit);
     }
+
+    let mut best = left_reachable
+        .into_iter()
+        .filter(|reachable| {
+            common_ids.contains(&reachable.commit.commit_id)
+                && !superseded.contains(&reachable.commit.commit_id)
+        })
+        .map(|reachable| reachable.commit)
+        .collect::<Vec<_>>();
     best.sort_by_key(|left| left.commit_id);
     Ok(best)
-}
-
-async fn has_descendant_in_set<S>(
-    reader: &mut CommitGraphStoreReader<S>,
-    commit_id: &CommitId,
-    candidate_descendant_ids: &BTreeSet<CommitId>,
-) -> Result<bool, LixError>
-where
-    S: StorageAdapterRead,
-{
-    for candidate_descendant_id in candidate_descendant_ids {
-        if candidate_descendant_id == commit_id {
-            continue;
-        }
-        let reachable = walk_reachable_commits(reader, candidate_descendant_id).await?;
-        if reachable
-            .iter()
-            .any(|reachable| reachable.commit.commit_id == *commit_id)
-        {
-            return Ok(true);
-        }
-    }
-    Ok(false)
 }
 
 struct CommitTraversalLoader<'a, S>

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -44,6 +44,8 @@ use crate::live_state::{
     LiveStateExactBatchRequest, LiveStateExactRowRequest, LiveStateFilter, LiveStateProjection,
     LiveStateReader, LiveStateScanRequest, MaterializedLiveStateRow,
 };
+#[cfg(test)]
+use crate::plugin::host_entity_with_lazy_snapshot;
 use crate::plugin::{
     CompiledPluginCatalog, PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY, PluginActorKey, PluginFileOwner,
     PluginRegistry, PluginRegistryEntry, PluginRuntimeHost, is_plugin_storage_path,
@@ -64,8 +66,6 @@ use crate::sql2::write_normalization::{
 };
 use crate::sql2::{SessionFileViewKey, SessionFileViews, SessionPluginFileView};
 use crate::transaction::types::{TransactionJson, TransactionWriteRow};
-#[cfg(test)]
-use crate::plugin::host_entity_with_lazy_snapshot;
 #[cfg(test)]
 use crate::wasm::{WasmHostEntity, WasmTransitionLimits};
 use crate::{

--- a/packages/engine/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/engine/src/tracked_state/commit_root_rebuild.rs
@@ -211,15 +211,6 @@ where
                 ));
             }
         };
-        if record.tracked_state_rootless && record.parent_commit_ids.len() > 1 {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "rootless tracked-state commit '{current_commit_id}' has {} parents",
-                    record.parent_commit_ids.len()
-                ),
-            ));
-        }
         if !record.tracked_state_rootless
             && let Some(root_id) = storage::load_root(store, &current_commit_id.to_string()).await?
         {

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -140,6 +140,7 @@ struct DiffCommitRootValidationCache {
 struct PointReplayCommit {
     parent_commit_id: Option<CommitId>,
     root_id: Option<TrackedStateRootId>,
+    rootless: bool,
 }
 
 impl DiffCommitRootValidationCache {
@@ -901,6 +902,21 @@ where
                 .diff_tree_entries_from_roots(left_commit_id, right_commit_id, request)
                 .await;
         }
+        if let Some(entries) = self
+            .diff_tree_entries_from_first_parent_interval(left_commit_id, right_commit_id, request)
+            .await?
+        {
+            return Ok(entries);
+        }
+        if let Some(mut entries) = self
+            .diff_tree_entries_from_first_parent_interval(right_commit_id, left_commit_id, request)
+            .await?
+        {
+            for entry in &mut entries {
+                std::mem::swap(&mut entry.before, &mut entry.after);
+            }
+            return Ok(entries);
+        }
         let left = self.replay_index_entries_at_commit(left_commit_id).await?;
         let right = if left_commit_id == right_commit_id {
             left.clone()
@@ -926,6 +942,98 @@ where
                 )
             })
             .collect())
+    }
+
+    /// Diffs an ancestor/descendant pair from immutable per-commit deltas.
+    ///
+    /// Merge always compares its merge base with each head. Walking only that
+    /// first-parent interval makes the common branch case proportional to the
+    /// commits and identities changed since the base, rather than every entity
+    /// inherited by both commits.
+    async fn diff_tree_entries_from_first_parent_interval(
+        &mut self,
+        ancestor_commit_id: &str,
+        descendant_commit_id: &str,
+        request: &TrackedStateTreeScanRequest,
+    ) -> Result<Option<Vec<crate::tracked_state::types::TrackedStateTreeDiffEntry>>, LixError> {
+        let Some(interval) = self
+            .first_parent_interval_between(ancestor_commit_id, descendant_commit_id)
+            .await?
+        else {
+            return Ok(None);
+        };
+        let mut keys = BTreeSet::new();
+        for commit_id in interval {
+            for (key, _) in
+                storage::scan_commit_delta_values(&self.store, commit_id, &request.schema_keys)
+                    .await?
+            {
+                if request.matches_key(&key) {
+                    keys.insert(key);
+                }
+            }
+        }
+        let keys = keys.into_iter().collect::<Vec<_>>();
+        if keys.is_empty() {
+            return Ok(Some(Vec::new()));
+        }
+        let before = self
+            .replay_index_values_for_keys_at_commit(ancestor_commit_id, &keys)
+            .await?;
+        let after = self
+            .replay_index_values_for_keys_at_commit(descendant_commit_id, &keys)
+            .await?;
+        Ok(Some(
+            keys.into_iter()
+                .zip(before)
+                .zip(after)
+                .filter_map(|((key, before), after)| {
+                    (before != after).then_some(
+                        crate::tracked_state::types::TrackedStateTreeDiffEntry {
+                            before: before.map(|value| (key.clone(), value)),
+                            after: after.map(|value| (key, value)),
+                        },
+                    )
+                })
+                .collect(),
+        ))
+    }
+
+    async fn first_parent_interval_between(
+        &mut self,
+        ancestor_commit_id: &str,
+        descendant_commit_id: &str,
+    ) -> Result<Option<Vec<CommitId>>, LixError> {
+        let ancestor =
+            CommitId::parse_lix(ancestor_commit_id, "tracked-state diff ancestor commit_id")?;
+        let mut current = CommitId::parse_lix(
+            descendant_commit_id,
+            "tracked-state diff descendant commit_id",
+        )?;
+        let mut interval = Vec::new();
+        let mut seen = HashSet::new();
+        loop {
+            if current == ancestor {
+                return Ok(Some(interval));
+            }
+            if !seen.insert(current) {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "cannot diff tracked_state commits: first-parent cycle includes '{current}'"
+                    ),
+                ));
+            }
+            interval.push(current);
+            let replay_commit = self.load_point_replay_commit(current).await?;
+            if !replay_commit.rootless {
+                return Ok(None);
+            }
+            let Some(parent_commit_id) = replay_commit.parent_commit_id else {
+                return Ok(None);
+            };
+            current = parent_commit_id;
+        }
     }
 
     async fn diff_tree_entries_from_roots(
@@ -1188,15 +1296,6 @@ where
                 }
             }
         };
-        if record.tracked_state_rootless && record.parent_commit_ids.len() > 1 {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "rootless tracked-state commit '{commit_id}' has {} parents",
-                    record.parent_commit_ids.len()
-                ),
-            ));
-        }
         let root_id = if record.tracked_state_rootless {
             None
         } else {
@@ -1207,6 +1306,7 @@ where
         let replay_commit = PointReplayCommit {
             parent_commit_id: record.parent_commit_ids.first().copied(),
             root_id,
+            rootless: record.tracked_state_rootless,
         };
         self.point_replay_commits
             .insert(commit_id, replay_commit.clone());

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -400,9 +400,10 @@ async fn stage_changelog_commits(
             format_version: 1,
             commit_id: commit_row.commit_id,
             parent_commit_ids: commit_row.parent_commit_ids.clone(),
-            tracked_state_rootless: !force_root_fence
-                && commit_row.parent_commit_ids.len() <= 1
-                && commit_row.selected_change_refs.is_empty(),
+            // Every commit carries absolute per-identity deltas against its
+            // first parent. Additional ancestry and selected historical refs
+            // therefore do not require eagerly materializing the full root.
+            tracked_state_rootless: !force_root_fence,
             change_id: commit_row.change_id,
             author_account_ids: Vec::new(),
             created_at: commit_row.created_at,
@@ -1116,9 +1117,8 @@ fn stage_tracked_commit_delta_index(
 }
 
 /// Stages the generation-keyed head projection only for normal prepared
-/// rows. Merge/checkpoint selected references stay on the immutable-root
-/// fallback until their next ordinary child commit bootstraps a generation.
-/// This keeps the hot path direct while never publishing an incomplete head.
+/// rows. Merge selected references use rootless first-parent replay until
+/// their next ordinary child commit bootstraps a generation.
 async fn stage_tracked_head(
     read: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
@@ -1604,27 +1604,7 @@ fn tracked_root_fence_ids(
     if force_all {
         return tracked_roots.iter().map(|root| root.commit_id).collect();
     }
-    let roots_by_id = tracked_roots
-        .iter()
-        .map(|root| (root.commit_id, root))
-        .collect::<BTreeMap<_, _>>();
-    let mut required = tracked_roots
-        .iter()
-        .filter(|root| root.requires_root)
-        .map(|root| root.commit_id)
-        .collect::<BTreeSet<_>>();
-    loop {
-        let ancestors = required
-            .iter()
-            .filter_map(|commit_id| roots_by_id[commit_id].parent_commit_id)
-            .filter(|parent_id| roots_by_id.contains_key(parent_id))
-            .collect::<Vec<_>>();
-        let before = required.len();
-        required.extend(ancestors);
-        if required.len() == before {
-            return required;
-        }
-    }
+    BTreeSet::new()
 }
 
 fn tracked_state_rows_are_strictly_sorted(
@@ -1750,7 +1730,6 @@ struct PendingTrackedRoot {
     /// Metadata for the public synthesized `lix_branch_ref` row.
     ref_change_id: ChangeId,
     ref_updated_at: LixTimestamp,
-    requires_root: bool,
 }
 
 async fn finalize_commit_rows(
@@ -1797,8 +1776,6 @@ async fn finalize_commit_rows(
                 .unwrap_or_default(),
         );
         let parent_commit_id = parent_commit_ids.first().copied();
-        let requires_root = parent_commit_ids.len() > 1 || !selected_change_refs.is_empty();
-
         commit_rows.push(FinalizedCommitRow {
             commit_id,
             parent_commit_ids: parent_commit_ids.clone(),
@@ -1812,7 +1789,6 @@ async fn finalize_commit_rows(
             parent_commit_id,
             ref_change_id: branch_ref_change_id,
             ref_updated_at: timestamp,
-            requires_root,
         });
     }
 
@@ -2552,7 +2528,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn root_fence_materializes_a_rootless_first_parent_chain() {
+    async fn selected_reference_commit_stays_rootless_and_replays_first_parent() {
         let storage = StorageAdapter::new(Memory::new());
         let binary_cas = BinaryCasContext::new();
         let branch_ctx = BranchContext::new();
@@ -2637,11 +2613,11 @@ mod tests {
             },
         )
         .await
-        .expect("fence should rebuild its rootless first-parent chain");
+        .expect("selected-reference commit should stage");
         assert!(
-            writes.has_mutations_in_space(TRACKED_STATE_TREE_CHUNK_SPACE)
-                && writes.has_mutations_in_space(TRACKED_STATE_COMMIT_ROOT_SPACE),
-            "selected-reference fence must materialize history roots"
+            !writes.has_mutations_in_space(TRACKED_STATE_TREE_CHUNK_SPACE)
+                && !writes.has_mutations_in_space(TRACKED_STATE_COMMIT_ROOT_SPACE),
+            "absolute selected-reference deltas must keep the commit rootless"
         );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -2660,7 +2636,7 @@ mod tests {
                 &TrackedStateScanRequest::default(),
             )
             .await
-            .expect("fence root should serve history");
+            .expect("rootless selected-reference commit should replay history");
         assert!(matches!(
             rows.as_slice(),
             [row] if row.change_id == change_id("fence-normal-change")

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -1748,25 +1748,27 @@ where
                 .extend(lifecycle_schema_rows.into_iter().map(|(_, row)| row));
         }
 
-        let registry_rows = overlay_scan_rows(
+        let registry_rows = overlay_load_exact_rows(
             &base,
             &staged,
-            &LiveStateScanRequest {
-                filter: LiveStateFilter {
-                    schema_keys: vec![KEY_VALUE_SCHEMA_KEY.to_string()],
-                    entity_pks: vec![EntityPk::single(PLUGIN_REGISTRY_KEY)],
-                    branch_ids: branch_ids.iter().cloned().collect(),
-                    file_ids: vec![NullableKeyFilter::Null],
-                    untracked: Some(false),
-                    ..Default::default()
-                },
+            &LiveStateExactBatchRequest {
+                rows: branch_ids
+                    .iter()
+                    .map(|branch_id| LiveStateExactRowRequest {
+                        schema_key: KEY_VALUE_SCHEMA_KEY.to_string(),
+                        branch_id: branch_id.clone(),
+                        entity_pk: EntityPk::single(PLUGIN_REGISTRY_KEY),
+                        file_id: None,
+                    })
+                    .collect(),
                 projection: plugin_registry_live_state_projection(),
-                ..Default::default()
+                untracked: Some(false),
+                include_tombstones: false,
             },
         )
         .await?;
         let mut registry_rows_by_branch = BTreeMap::<String, MaterializedLiveStateRow>::new();
-        for row in registry_rows {
+        for row in registry_rows.into_iter().flatten() {
             if registry_rows_by_branch
                 .insert(row.branch_id.to_string(), row)
                 .is_some()
@@ -1891,12 +1893,7 @@ where
             return Ok(reconciliation);
         }
 
-        let owner_branch_ids = active_branch_ids
-            .iter()
-            .cloned()
-            .chain(deleted_file_keys.keys().map(|key| key.branch_id.clone()))
-            .collect::<BTreeSet<_>>();
-        let mut candidate_file_ids = BTreeSet::<String>::new();
+        let mut candidate_file_keys = BTreeSet::<PluginFileWriteKey>::new();
         for write in file_data.iter() {
             if write.global
                 || write.untracked
@@ -1905,10 +1902,10 @@ where
             {
                 continue;
             }
-            candidate_file_ids.insert(write.file_id.clone());
+            candidate_file_keys.insert(PluginFileWriteKey::from(write));
         }
         for key in deleted_file_keys.keys() {
-            candidate_file_ids.insert(key.file_id.clone());
+            candidate_file_keys.insert(key.clone());
         }
         for row in input_rows {
             if row.global
@@ -1918,36 +1915,42 @@ where
             {
                 continue;
             }
-            candidate_file_ids.extend(row.file_id.iter().cloned());
+            candidate_file_keys.insert(PluginFileWriteKey {
+                branch_id: row.branch_id.clone(),
+                global: false,
+                untracked: false,
+                file_id: row
+                    .file_id
+                    .clone()
+                    .expect("candidate semantic row has a file id"),
+            });
         }
-        if candidate_file_ids.is_empty() {
+        if candidate_file_keys.is_empty() {
             return Ok(reconciliation);
         }
 
-        let owner_rows = overlay_scan_rows(
+        let owner_rows = overlay_load_exact_rows(
             &base,
             &staged,
-            &LiveStateScanRequest {
-                filter: LiveStateFilter {
-                    schema_keys: vec![KEY_VALUE_SCHEMA_KEY.to_string()],
-                    entity_pks: vec![EntityPk::single(PLUGIN_OWNER_KEY)],
-                    branch_ids: owner_branch_ids.into_iter().collect(),
-                    file_ids: candidate_file_ids
-                        .iter()
-                        .cloned()
-                        .map(NullableKeyFilter::Value)
-                        .collect(),
-                    untracked: Some(false),
-                    ..Default::default()
-                },
+            &LiveStateExactBatchRequest {
+                rows: candidate_file_keys
+                    .iter()
+                    .map(|key| LiveStateExactRowRequest {
+                        schema_key: KEY_VALUE_SCHEMA_KEY.to_string(),
+                        branch_id: key.branch_id.clone(),
+                        entity_pk: EntityPk::single(PLUGIN_OWNER_KEY),
+                        file_id: Some(key.file_id.clone()),
+                    })
+                    .collect(),
                 projection: plugin_registry_live_state_projection(),
-                ..Default::default()
+                untracked: Some(false),
+                include_tombstones: false,
             },
         )
         .await?;
         let mut owners = BTreeMap::<PluginFileWriteKey, PluginFileOwner>::new();
         let mut owner_change_ids = BTreeMap::<PluginFileWriteKey, String>::new();
-        for row in owner_rows {
+        for row in owner_rows.into_iter().flatten() {
             let branch_id = row.branch_id.to_string();
             let Some(owner) = PluginFileOwner::from_live_state_row(&row, &branch_id)? else {
                 continue;
@@ -2220,11 +2223,15 @@ where
         let mut state_groups = BTreeMap::<PluginStateGroupKey, PluginStateGroup>::new();
         for (key, owner) in &owners {
             let selected = selected_plugins.get(key);
+            let semantic = semantic_groups.get(key).map(|group| &group.plugin);
             // A same-owner v2 write is authorized by an exact document
             // observation and must not hydrate the complete durable graph.
             // Lifecycle removal/reselection still needs the old rows so it
             // can tombstone every schema owned by the previous plugin.
-            if selected.is_some_and(|selected| selected.key() == owner.plugin_key()) {
+            if selected
+                .or(semantic)
+                .is_some_and(|selected| selected.key() == owner.plugin_key())
+            {
                 continue;
             }
             let group_key = PluginStateGroupKey {
@@ -2236,7 +2243,7 @@ where
             group
                 .schema_keys
                 .extend(owner.schema_keys().iter().cloned());
-            if let Some(selected) = selected
+            if let Some(selected) = selected.or(semantic)
                 && selected.key() == owner.plugin_key()
             {
                 group
@@ -2893,7 +2900,13 @@ where
                 plugin_key: group.plugin.key().to_string(),
                 plugin_generation: group.plugin.archive_blob_hash().to_string(),
             };
-            let prepared = self.prepare_transaction_rows(group.rows.clone()).await?;
+            let prepared = self
+                .prepare_transaction_rows(group.rows.clone())
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.plugin_semantic_prepare_rows"
+                ))
+                .await?;
             if prepared.iter().any(|row| {
                 row.branch_id != file_key.branch_id
                     || row.file_id.as_deref() != Some(file_key.file_id.as_str())
@@ -2974,7 +2987,13 @@ where
                                 ),
                             )
                         })?;
-                    let cold_open = cache.prepare_cold_open(&actor_key, &visible_root).await?;
+                    let cold_open = cache
+                        .prepare_cold_open(&actor_key, &visible_root)
+                        .instrument(tracing::debug_span!(
+                            target: "lix_perf",
+                            "lix.perf.plugin_semantic_actor_lookup"
+                        ))
+                        .await?;
                     let observation = match cold_open {
                         PluginActorColdOpen::Ready(observation) => observation,
                         PluginActorColdOpen::Build(cold_install) => {
@@ -2985,6 +3004,10 @@ where
                                 descriptor.clone(),
                                 factory,
                             )
+                            .instrument(tracing::debug_span!(
+                                target: "lix_perf",
+                                "lix.perf.plugin_semantic_actor_cold_open"
+                            ))
                             .await?
                         }
                     };
@@ -2998,7 +3021,13 @@ where
                         ));
                     }
                     (
-                        cache.lease_for_transition(&observation).await?,
+                        cache
+                            .lease_for_transition(&observation)
+                            .instrument(tracing::debug_span!(
+                                target: "lix_perf",
+                                "lix.perf.plugin_semantic_actor_lease"
+                            ))
+                            .await?,
                         actor_key,
                         view,
                     )
@@ -3050,6 +3079,10 @@ where
                 &materialization_version,
                 limits,
             )
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.plugin_semantic_render"
+            ))
             .await;
             let (publication, rendered_bytes, counters) = match transition {
                 Ok(transition) => transition,


### PR DESCRIPTION
Stacked on #779. This consolidates the earlier semantic-reconciliation, sparse-history, and linear-ancestor experiments into one review boundary.

## Outcome

Makes merge work proportional to changes since the merge base while retaining semantic entities and clean unrelated-entity merges.

- reconcile semantic writes directly from sparse changed identities
- diff first-parent ancestor intervals from immutable per-commit delta indexes
- point-load only identities changed since the base
- keep merge commits rootless and replay absolute first-parent deltas
- find the common ancestor in one graph pass
- retain full replay for rooted or damaged histories without a complete rootless interval

No public API changes and no conflict-model API is introduced.

## Current full-stack evidence

3,670,017-byte Markdown fixture:

- Lix unrelated-entity merge: 6.868 ms p50 / 7.283 ms p95
- Git merge: 123.419 ms p50 / 127.648 ms p95
- Lix is 18.0x faster at p50
- Lix cleanly preserves both unrelated same-line table-cell edits; Git reports a conflict

10,485,760-byte JSON fixture:

- unrelated-property merge: 18.514 ms p50 / 19.283 ms p95

## Validation

- engine `all-simulations`
- rootless selected-reference and two-parent merge simulations
- damaged-history fallback regression tests
- release Markdown and JSON merge gates

