### PR TITLE
perf(observe): stream compact row deltas

### DIFF
--- a/.changenotes/stream-observe-row-splices.md
+++ b/.changenotes/stream-observe-row-splices.md
@@ -1,0 +1,6 @@
+---
+type: patch
+---
+
+Reduced remote observation bandwidth and client work for localized tabular
+changes by streaming row splices after the initial snapshot.

--- a/packages/js-sdk/src/remote/client.ts
+++ b/packages/js-sdk/src/remote/client.ts
@@ -947,12 +947,13 @@ class RemoteObservationHub {
 							);
 						}
 						const observation = this.#observation(subscriptionId);
+						const transportDelta = payload.delta !== undefined;
 						const event = decodeObserveEvent(
 							payload,
 							transportBases.get(subscriptionId),
 						);
 						transportBases.set(subscriptionId, event);
-						observation.accept(event);
+						observation.accept(event, transportDelta);
 						this.#retryAttempt = 0;
 					} catch (error) {
 						this.#failStream(asObserveProtocolError(error, "next"), controller);
@@ -1133,9 +1134,10 @@ class RemoteObservation implements ObserveEventsBinding {
 		this.#onClose();
 	}
 
-	accept(event: BindingObserveEvent): void {
+	accept(event: BindingObserveEvent, transportDelta = false): void {
 		if (this.#closed || this.#terminalError !== undefined) return;
 		if (
+			!transportDelta &&
 			this.#lastRows !== undefined &&
 			executeResultsEqual(this.#lastRows, event.rows)
 		) {

--- a/packages/js-sdk/src/remote/observe.test.ts
+++ b/packages/js-sdk/src/remote/observe.test.ts
@@ -115,6 +115,78 @@ test("remote observe applies every blob delta before coalescing delivery", async
 	await lix.close();
 });
 
+test("remote observe applies sequential row deltas before coalescing delivery", async () => {
+	const body = [
+		sseFrame("next", {
+			subscriptionId: "observe-1",
+			sequence: 0,
+			mutationSequence: 10,
+			result: {
+				columns: ["value"],
+				rows: [
+					[{ kind: "text", value: "a" }],
+					[{ kind: "text", value: "b" }],
+					[{ kind: "text", value: "c" }],
+				],
+				rowsAffected: 0,
+				notices: [],
+			},
+		}),
+		sseFrame("next", {
+			subscriptionId: "observe-1",
+			sequence: 1,
+			mutationSequence: 11,
+			delta: {
+				kind: "row-splice",
+				baseSequence: 0,
+				prefixRows: 1,
+				deleteRows: 1,
+				insertRows: [[{ kind: "text", value: "x" }]],
+			},
+		}),
+		sseFrame("next", {
+			subscriptionId: "observe-1",
+			sequence: 2,
+			mutationSequence: 12,
+			delta: {
+				kind: "row-splice",
+				baseSequence: 1,
+				prefixRows: 2,
+				deleteRows: 0,
+				insertRows: [[{ kind: "text", value: "y" }]],
+			},
+		}),
+	].join("");
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/workspace",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				if (request.method === "DELETE") return closedSession();
+				return new URL(request.url).pathname.endsWith("/lix/v1/")
+					? handshake()
+					: sseResponse(body);
+			},
+		},
+	});
+
+	const events = lix.observe("SELECT value FROM state ORDER BY value");
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	const latest = await events.next();
+	expect(latest?.sequence).toBe(2);
+	expect(latest?.mutationSequence).toBe(12);
+	expect(latest?.result.rows.map((row) => row.get("value"))).toEqual([
+		"a",
+		"x",
+		"y",
+		"c",
+	]);
+
+	events.close();
+	await lix.close();
+});
+
 test("remote observe multiplexes more than six subscriptions without blocking execute", async () => {
 	const observeRequests: Request[] = [];
 	let headerResolutions = 0;

--- a/packages/js-sdk/src/remote/protocol.test.ts
+++ b/packages/js-sdk/src/remote/protocol.test.ts
@@ -195,3 +195,120 @@ test("observe blob deltas fail closed without an exact non-overlapping base", ()
 		"observe event requires exactly one of result or delta",
 	);
 });
+
+test("observe row deltas splice replacement insertion and deletion", () => {
+	const full = {
+		sequence: 0,
+		mutationSequence: 0,
+		result: {
+			columns: ["value"],
+			rows: [
+				[{ kind: "text", value: "a" }],
+				[{ kind: "text", value: "b" }],
+				[{ kind: "text", value: "c" }],
+			],
+			rowsAffected: 0,
+			notices: [],
+		},
+	};
+	const base = decodeObserveEvent(full);
+	const replacement = decodeObserveEvent(
+		{
+			sequence: 1,
+			mutationSequence: 1,
+			delta: {
+				kind: "row-splice",
+				baseSequence: 0,
+				prefixRows: 1,
+				deleteRows: 1,
+				insertRows: [[{ kind: "text", value: "x" }]],
+			},
+		},
+		base,
+	);
+	expect(replacement.rows.rows.map((row) => row[0]?.value)).toEqual([
+		"a",
+		"x",
+		"c",
+	]);
+	const inserted = decodeObserveEvent(
+		{
+			sequence: 2,
+			mutationSequence: 2,
+			delta: {
+				kind: "row-splice",
+				baseSequence: 1,
+				prefixRows: 2,
+				deleteRows: 0,
+				insertRows: [[{ kind: "text", value: "y" }]],
+			},
+		},
+		replacement,
+	);
+	expect(inserted.rows.rows.map((row) => row[0]?.value)).toEqual([
+		"a",
+		"x",
+		"y",
+		"c",
+	]);
+	const deleted = decodeObserveEvent(
+		{
+			sequence: 3,
+			mutationSequence: 3,
+			delta: {
+				kind: "row-splice",
+				baseSequence: 2,
+				prefixRows: 1,
+				deleteRows: 2,
+				insertRows: [],
+			},
+		},
+		inserted,
+	);
+	expect(deleted.rows.rows.map((row) => row[0]?.value)).toEqual(["a", "c"]);
+});
+
+test("observe row deltas reject invalid bases ranges and row shapes", () => {
+	const base = decodeObserveEvent({
+		sequence: 0,
+		mutationSequence: 0,
+		result: {
+			columns: ["value"],
+			rows: [[{ kind: "text", value: "a" }]],
+			rowsAffected: 0,
+			notices: [],
+		},
+	});
+	const delta = {
+		sequence: 1,
+		mutationSequence: 1,
+		delta: {
+			kind: "row-splice",
+			baseSequence: 0,
+			prefixRows: 0,
+			deleteRows: 1,
+			insertRows: [[{ kind: "text", value: "x" }]],
+		},
+	};
+	expect(() => decodeObserveEvent(delta)).toThrow(
+		"observe row delta does not match its transport base",
+	);
+	expect(() =>
+		decodeObserveEvent(
+			{
+				...delta,
+				delta: { ...delta.delta, prefixRows: 2 },
+			},
+			base,
+		),
+	).toThrow("observe row delta splice range is outside its transport base");
+	expect(() =>
+		decodeObserveEvent(
+			{
+				...delta,
+				delta: { ...delta.delta, insertRows: [[], []] },
+			},
+			base,
+		),
+	).toThrow("observe row delta insert row 0 has 0 values for 1 columns");
+});

--- a/packages/js-sdk/src/remote/protocol.ts
+++ b/packages/js-sdk/src/remote/protocol.ts
@@ -84,10 +84,20 @@ export type RemoteObserveBlobDelta = {
 	insertBase64: string;
 };
 
+type RemoteObserveRowSplice = {
+	kind: "row-splice";
+	baseSequence: number;
+	prefixRows: number;
+	deleteRows: number;
+	insertRows: WireValue[][];
+};
+
+type RemoteObserveDelta = RemoteObserveBlobDelta | RemoteObserveRowSplice;
+
 export type RemoteObserveEvent = RemoteObserveEventBase &
 	(
 		| { result: RemoteExecuteResponse; delta?: never }
-		| { result?: never; delta: RemoteObserveBlobDelta }
+		| { result?: never; delta: RemoteObserveDelta }
 	);
 
 export type RemoteMultiplexObserveEvent = RemoteObserveEvent & {
@@ -263,19 +273,31 @@ export function decodeObserveEvent(
 		mutationSequence: event.mutationSequence,
 		rows: hasResult
 			? decodeExecuteResult(event.result)
-			: applyObserveBlobDelta(event.delta, sequence, base),
+			: applyObserveDelta(event.delta, sequence, base),
 	};
 }
 
-function applyObserveBlobDelta(
+function applyObserveDelta(
 	value: unknown,
 	sequence: number,
 	base: BindingObserveEvent | undefined,
 ): BindingExecuteResult {
 	const delta = record(value, "observe event delta");
-	if (delta.kind !== "single-blob-splice") {
-		throw protocolError(`unknown observe delta kind: ${String(delta.kind)}`);
+	switch (delta.kind) {
+		case "single-blob-splice":
+			return applyObserveBlobDelta(delta, sequence, base);
+		case "row-splice":
+			return applyObserveRowSplice(delta, sequence, base);
+		default:
+			throw protocolError(`unknown observe delta kind: ${String(delta.kind)}`);
 	}
+}
+
+function applyObserveBlobDelta(
+	delta: Record<string, unknown>,
+	sequence: number,
+	base: BindingObserveEvent | undefined,
+): BindingExecuteResult {
 	const baseSequence = nonNegativeSafeInteger(
 		delta.baseSequence,
 		"observe delta baseSequence",
@@ -334,7 +356,82 @@ function applyObserveBlobDelta(
 		columns: ["data"],
 		rows: [[{ kind: "blob", value: null, blob }]],
 		rowsAffected: 0,
-		notices: [],
+			notices: [],
+	};
+}
+
+function applyObserveRowSplice(
+	delta: Record<string, unknown>,
+	sequence: number,
+	base: BindingObserveEvent | undefined,
+): BindingExecuteResult {
+	const baseSequence = nonNegativeSafeInteger(
+		delta.baseSequence,
+		"observe row delta baseSequence",
+	);
+	const prefixRows = nonNegativeSafeInteger(
+		delta.prefixRows,
+		"observe row delta prefixRows",
+	);
+	const deleteRows = nonNegativeSafeInteger(
+		delta.deleteRows,
+		"observe row delta deleteRows",
+	);
+	if (
+		base === undefined ||
+		base.sequence !== baseSequence ||
+		sequence !== baseSequence + 1
+	) {
+		throw protocolError("observe row delta does not match its transport base");
+	}
+	if (!Array.isArray(delta.insertRows)) {
+		throw protocolError("observe row delta insertRows must be an array");
+	}
+	if (
+		prefixRows > base.rows.rows.length ||
+		deleteRows > base.rows.rows.length - prefixRows
+	) {
+		throw protocolError("observe row delta splice range is outside its transport base");
+	}
+	const suffixStart = prefixRows + deleteRows;
+	const nextRowCount =
+		prefixRows + delta.insertRows.length + (base.rows.rows.length - suffixStart);
+	if (
+		!Number.isSafeInteger(nextRowCount) ||
+		nextRowCount > 0xffff_ffff
+	) {
+		throw protocolError("observe row delta result is too large");
+	}
+	let rows: NativeLixValue[][];
+	try {
+		rows = new Array(nextRowCount);
+	} catch {
+		throw protocolError("observe row delta result is too large");
+	}
+	let destination = 0;
+	for (let index = 0; index < prefixRows; index += 1) {
+		rows[destination++] = base.rows.rows[index] as NativeLixValue[];
+	}
+	for (let rowIndex = 0; rowIndex < delta.insertRows.length; rowIndex += 1) {
+		const row = delta.insertRows[rowIndex];
+		if (!Array.isArray(row)) {
+			throw protocolError(`observe row delta insert row ${rowIndex} must be an array`);
+		}
+		if (row.length !== base.rows.columns.length) {
+			throw protocolError(
+				`observe row delta insert row ${rowIndex} has ${row.length} values for ${base.rows.columns.length} columns`,
+			);
+		}
+		rows[destination++] = row.map((entry) => decodeWireValue(entry));
+	}
+	for (let index = suffixStart; index < base.rows.rows.length; index += 1) {
+		rows[destination++] = base.rows.rows[index] as NativeLixValue[];
+	}
+	return {
+		columns: [...base.rows.columns],
+		rows,
+		rowsAffected: base.rows.rowsAffected,
+		notices: base.rows.notices.map((notice) => ({ ...notice })),
 	};
 }
 

--- a/packages/server-protocol/README.md
+++ b/packages/server-protocol/README.md
@@ -82,6 +82,12 @@ authentication, health checks, and compare-and-swap filesystem mutations stay
 outside it. Session identifiers are opaque capabilities: hosts should not log
 or persist them.
 
+Multiplex observation sends an initial full snapshot for each subscription.
+Contiguous later snapshots may instead carry a sequence-based blob or row
+splice against the immediately preceding transport snapshot. A client that
+does not have that exact base must reconnect and begin again with a full
+snapshot; it must never apply a splice to an arbitrary cached result.
+
 ## Binary file upsert
 
 Clients that explicitly want file **upsert** semantics can check for

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -1768,12 +1768,12 @@ where
             .0
             .push(tokio::spawn(
                 async move {
-                    let mut blob_base = None;
+                    let mut delta_base = None;
                     loop {
                         let message = match events.next().await {
                             Ok(Some(event)) => {
-                                match multiplex_observe_payload(event, blob_base.as_ref()) {
-                                    Ok((payload, next_blob_base)) => {
+                                match multiplex_observe_payload(event, delta_base.as_ref()) {
+                                    Ok((payload, next_delta_base)) => {
                                         let message = MultiplexObserveMessage::Next {
                                             subscription_id: subscription_id.clone(),
                                             payload,
@@ -1781,7 +1781,7 @@ where
                                         if sender.send(message).await.is_err() {
                                             break;
                                         }
-                                        blob_base = next_blob_base;
+                                        delta_base = next_delta_base;
                                         continue;
                                     }
                                     Err(error) => {
@@ -2665,17 +2665,11 @@ enum MultiplexObserveMessage {
     },
 }
 
-struct BlobDeltaBase {
+struct ObserveDeltaBase {
     sequence: u64,
     // ExecuteResult has immutable shared backing, so retaining the transport
-    // base does not copy the point-read blob for every subscription.
+    // base does not copy an observed result for every subscription.
     rows: ExecuteResult,
-}
-
-impl BlobDeltaBase {
-    fn bytes(&self) -> &[u8] {
-        point_blob_bytes(&self.rows).expect("blob delta bases are point blob results")
-    }
 }
 
 #[derive(Debug, Serialize)]
@@ -2686,7 +2680,14 @@ struct MultiplexObservePayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     result: Option<ExecuteResponse>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    delta: Option<SingleBlobSplice>,
+    delta: Option<ObserveDelta>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+enum ObserveDelta {
+    SingleBlobSplice(SingleBlobSplice),
+    RowSplice(RowSplice),
 }
 
 #[derive(Debug, Serialize)]
@@ -2701,6 +2702,16 @@ struct SingleBlobSplice {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+struct RowSplice {
+    kind: &'static str,
+    base_sequence: u64,
+    prefix_rows: u64,
+    delete_rows: u64,
+    insert_rows: Vec<Vec<WireValue>>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct MultiplexObserveEventResponse {
     subscription_id: String,
     sequence: u64,
@@ -2708,7 +2719,7 @@ struct MultiplexObserveEventResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     result: Option<ExecuteResponse>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    delta: Option<SingleBlobSplice>,
+    delta: Option<ObserveDelta>,
 }
 
 const MIN_BLOB_DELTA_BYTES: usize = 32 * 1024;
@@ -2717,18 +2728,29 @@ const BLOB_DELTA_COMPARE_CHUNK_BYTES: usize = 64;
 // overestimates every delta-only JSON/SSE field. The shared event envelope is
 // omitted from both sides, so passing the 90% test guarantees >10% savings.
 const BLOB_DELTA_ENVELOPE_BUDGET_BYTES: usize = 512;
+// Row deltas are only useful on result sets large enough to outweigh their
+// fixed sequence and splice metadata. Every wire row with one value is at
+// least 24 JSON bytes, so this lower bound makes the 90% saving gate
+// conservative without serializing the entire next result just to decide.
+const MIN_ROW_DELTA_ROWS: usize = 16;
+const MIN_FULL_ROW_WIRE_BYTES: usize = 24;
+const ROW_DELTA_ENVELOPE_BUDGET_BYTES: usize = 256;
 
 fn multiplex_observe_payload(
     event: ObserveEvent,
-    base: Option<&BlobDeltaBase>,
-) -> Result<(MultiplexObservePayload, Option<BlobDeltaBase>), LixError> {
-    let next_base = point_blob_bytes(&event.rows).map(|_| BlobDeltaBase {
+    base: Option<&ObserveDeltaBase>,
+) -> Result<(MultiplexObservePayload, Option<ObserveDeltaBase>), LixError> {
+    let next_base = ObserveDeltaBase {
         sequence: event.sequence,
         rows: event.rows.clone(),
-    });
-    let delta = match base.zip(next_base.as_ref()) {
-        Some((base, next)) if base.sequence.checked_add(1) == Some(event.sequence) => {
-            single_blob_splice(base, next)?
+    };
+    let delta = match base {
+        Some(base) if base.sequence.checked_add(1) == Some(event.sequence) => {
+            if let Some(delta) = single_blob_splice(base, &next_base)? {
+                Some(ObserveDelta::SingleBlobSplice(delta))
+            } else {
+                row_splice(base, &next_base)?.map(ObserveDelta::RowSplice)
+            }
         }
         _ => None,
     };
@@ -2748,7 +2770,7 @@ fn multiplex_observe_payload(
             delta: None,
         }
     };
-    Ok((payload, next_base))
+    Ok((payload, Some(next_base)))
 }
 
 fn point_blob_bytes(result: &ExecuteResult) -> Option<&[u8]> {
@@ -2766,14 +2788,17 @@ fn point_blob_bytes(result: &ExecuteResult) -> Option<&[u8]> {
 }
 
 fn single_blob_splice(
-    base: &BlobDeltaBase,
-    next: &BlobDeltaBase,
+    base: &ObserveDeltaBase,
+    next: &ObserveDeltaBase,
 ) -> Result<Option<SingleBlobSplice>, LixError> {
-    if next.bytes().len() < MIN_BLOB_DELTA_BYTES {
+    let (Some(base_bytes), Some(next_bytes)) =
+        (point_blob_bytes(&base.rows), point_blob_bytes(&next.rows))
+    else {
+        return Ok(None);
+    };
+    if next_bytes.len() < MIN_BLOB_DELTA_BYTES {
         return Ok(None);
     }
-    let base_bytes = base.bytes();
-    let next_bytes = next.bytes();
     let prefix_bytes = common_blob_prefix_len(base_bytes, next_bytes);
     let max_suffix = base_bytes
         .len()
@@ -2817,6 +2842,85 @@ fn single_blob_splice(
             )
         })?,
         insert_base64,
+    }))
+}
+
+fn row_splice(
+    base: &ObserveDeltaBase,
+    next: &ObserveDeltaBase,
+) -> Result<Option<RowSplice>, LixError> {
+    if base.rows.columns() != next.rows.columns()
+        || base.rows.rows_affected() != next.rows.rows_affected()
+        || base.rows.notices() != next.rows.notices()
+        || next.rows.columns().is_empty()
+    {
+        return Ok(None);
+    }
+    let base_rows = base.rows.rows();
+    let next_rows = next.rows.rows();
+    if next_rows.len() < MIN_ROW_DELTA_ROWS {
+        return Ok(None);
+    }
+    let prefix_rows = base_rows
+        .iter()
+        .zip(next_rows)
+        .take_while(|(base, next)| base == next)
+        .count();
+    if prefix_rows == base_rows.len() && prefix_rows == next_rows.len() {
+        return Ok(None);
+    }
+    let max_suffix_rows = base_rows
+        .len()
+        .saturating_sub(prefix_rows)
+        .min(next_rows.len().saturating_sub(prefix_rows));
+    let mut suffix_rows = 0;
+    while suffix_rows < max_suffix_rows {
+        let base_index = base_rows.len() - suffix_rows - 1;
+        let next_index = next_rows.len() - suffix_rows - 1;
+        if base_rows[base_index] != next_rows[next_index] {
+            break;
+        }
+        suffix_rows += 1;
+    }
+    let insert_end = next_rows.len().saturating_sub(suffix_rows);
+    let insert_rows = next_rows[prefix_rows..insert_end]
+        .iter()
+        .map(|row| {
+            row.values()
+                .iter()
+                .map(WireValue::try_from_engine)
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let insert_wire_bytes = serde_json::to_vec(&insert_rows)
+        .map_err(|error| LixError::new(LixError::CODE_INTERNAL_ERROR, error.to_string()))?
+        .len();
+    let Some(full_wire_lower_bound) = next_rows.len().checked_mul(MIN_FULL_ROW_WIRE_BYTES) else {
+        return Ok(None);
+    };
+    let Some(delta_wire_estimate) = insert_wire_bytes.checked_add(ROW_DELTA_ENVELOPE_BUDGET_BYTES)
+    else {
+        return Ok(None);
+    };
+    if delta_wire_estimate.saturating_mul(10) >= full_wire_lower_bound.saturating_mul(9) {
+        return Ok(None);
+    }
+    Ok(Some(RowSplice {
+        kind: "row-splice",
+        base_sequence: base.sequence,
+        prefix_rows: u64::try_from(prefix_rows).map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "row delta prefix is too large",
+            )
+        })?,
+        delete_rows: u64::try_from(base_rows.len() - prefix_rows - suffix_rows).map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "row delta delete count is too large",
+            )
+        })?,
+        insert_rows,
     }))
 }
 
@@ -5857,6 +5961,54 @@ mod tests {
         next
     }
 
+    fn expect_blob_splice(delta: ObserveDelta) -> SingleBlobSplice {
+        match delta {
+            ObserveDelta::SingleBlobSplice(delta) => delta,
+            ObserveDelta::RowSplice(_) => panic!("expected a blob splice"),
+        }
+    }
+
+    fn expect_row_splice(delta: ObserveDelta) -> RowSplice {
+        match delta {
+            ObserveDelta::SingleBlobSplice(_) => panic!("expected a row splice"),
+            ObserveDelta::RowSplice(delta) => delta,
+        }
+    }
+
+    fn tabular_event(sequence: u64, columns: Vec<String>, rows: Vec<Vec<Value>>) -> ObserveEvent {
+        ObserveEvent {
+            sequence,
+            mutation_sequence: sequence,
+            rows: ExecuteResult::from_rows(columns, rows),
+        }
+    }
+
+    fn numbered_rows(count: usize) -> Vec<Vec<Value>> {
+        (0..count)
+            .map(|index| vec![Value::Text(format!("row-{index:03}"))])
+            .collect()
+    }
+
+    fn apply_row_splice(base: &[Vec<Value>], delta: RowSplice) -> Vec<Vec<Value>> {
+        let prefix = usize::try_from(delta.prefix_rows).expect("prefix should fit");
+        let delete = usize::try_from(delta.delete_rows).expect("delete count should fit");
+        let insert = delta
+            .insert_rows
+            .into_iter()
+            .map(|row| {
+                row.into_iter()
+                    .map(WireValue::try_into_engine)
+                    .collect::<Result<Vec<_>, _>>()
+                    .expect("row splice values should decode")
+            })
+            .collect::<Vec<_>>();
+        let mut next = Vec::with_capacity(prefix + insert.len() + base.len() - prefix - delete);
+        next.extend_from_slice(&base[..prefix]);
+        next.extend(insert);
+        next.extend_from_slice(&base[prefix + delete..]);
+        next
+    }
+
     #[test]
     fn chunked_blob_edge_detection_matches_scalar_reference() {
         for len in [0, 1, 63, 64, 65, 127, 128, 129, 4_096] {
@@ -5916,7 +6068,12 @@ mod tests {
         let (_, base) = multiplex_observe_payload(event, None).expect("initial payload");
         let base = base.expect("blob base");
 
-        assert_eq!(base.bytes().as_ptr(), event_ptr);
+        assert_eq!(
+            point_blob_bytes(&base.rows)
+                .expect("blob base should retain its blob")
+                .as_ptr(),
+            event_ptr
+        );
     }
 
     #[test]
@@ -5934,7 +6091,10 @@ mod tests {
             multiplex_observe_payload(point_blob_event(1, replaced.clone()), base.as_ref())
                 .expect("replacement delta");
         assert_eq!(
-            apply_blob_splice(&initial, payload.delta.expect("replacement splice")),
+            apply_blob_splice(
+                &initial,
+                expect_blob_splice(payload.delta.expect("replacement splice")),
+            ),
             replaced
         );
         base = next_base;
@@ -5945,7 +6105,10 @@ mod tests {
             multiplex_observe_payload(point_blob_event(2, inserted.clone()), base.as_ref())
                 .expect("insert delta");
         assert_eq!(
-            apply_blob_splice(&replaced, payload.delta.expect("insert splice")),
+            apply_blob_splice(
+                &replaced,
+                expect_blob_splice(payload.delta.expect("insert splice")),
+            ),
             inserted
         );
         base = next_base;
@@ -5956,7 +6119,10 @@ mod tests {
             multiplex_observe_payload(point_blob_event(3, deleted.clone()), base.as_ref())
                 .expect("delete delta");
         assert_eq!(
-            apply_blob_splice(&inserted, payload.delta.expect("delete splice")),
+            apply_blob_splice(
+                &inserted,
+                expect_blob_splice(payload.delta.expect("delete splice")),
+            ),
             deleted
         );
     }
@@ -6003,9 +6169,107 @@ mod tests {
             multiplex_observe_payload(point_blob_event(2, localized.clone()), base.as_ref())
                 .expect("localized delta");
         assert_eq!(
-            apply_blob_splice(&replacement, payload.delta.expect("localized splice")),
+            apply_blob_splice(
+                &replacement,
+                expect_blob_splice(payload.delta.expect("localized splice")),
+            ),
             localized
         );
+    }
+
+    #[test]
+    fn multiplex_row_delta_roundtrips_replace_insert_and_delete() {
+        let initial = numbered_rows(64);
+        let (_, mut base) = multiplex_observe_payload(
+            tabular_event(0, vec!["value".to_string()], initial.clone()),
+            None,
+        )
+        .expect("initial payload");
+
+        let mut replaced = initial.clone();
+        replaced[32] = vec![Value::Text("replacement".to_string())];
+        let (payload, next_base) = multiplex_observe_payload(
+            tabular_event(1, vec!["value".to_string()], replaced.clone()),
+            base.as_ref(),
+        )
+        .expect("replacement delta");
+        assert_eq!(
+            apply_row_splice(
+                &initial,
+                expect_row_splice(payload.delta.expect("replacement splice")),
+            ),
+            replaced
+        );
+        base = next_base;
+
+        let mut inserted = replaced.clone();
+        inserted.insert(20, vec![Value::Text("inserted".to_string())]);
+        let (payload, next_base) = multiplex_observe_payload(
+            tabular_event(2, vec!["value".to_string()], inserted.clone()),
+            base.as_ref(),
+        )
+        .expect("insert delta");
+        assert_eq!(
+            apply_row_splice(
+                &replaced,
+                expect_row_splice(payload.delta.expect("insert splice")),
+            ),
+            inserted
+        );
+        base = next_base;
+
+        let mut deleted = inserted.clone();
+        deleted.remove(40);
+        let (payload, _) = multiplex_observe_payload(
+            tabular_event(3, vec!["value".to_string()], deleted.clone()),
+            base.as_ref(),
+        )
+        .expect("delete delta");
+        assert_eq!(
+            apply_row_splice(
+                &inserted,
+                expect_row_splice(payload.delta.expect("delete splice")),
+            ),
+            deleted
+        );
+    }
+
+    #[test]
+    fn multiplex_row_delta_falls_back_for_noop_metadata_and_large_changes() {
+        let initial = numbered_rows(64);
+        let (_, base) = multiplex_observe_payload(
+            tabular_event(0, vec!["value".to_string()], initial.clone()),
+            None,
+        )
+        .expect("initial payload");
+
+        let (payload, _) = multiplex_observe_payload(
+            tabular_event(1, vec!["value".to_string()], initial.clone()),
+            base.as_ref(),
+        )
+        .expect("no-op payload");
+        assert!(payload.result.is_some());
+        assert!(payload.delta.is_none());
+
+        let (payload, _) = multiplex_observe_payload(
+            tabular_event(1, vec!["other".to_string()], initial.clone()),
+            base.as_ref(),
+        )
+        .expect("metadata fallback payload");
+        assert!(payload.result.is_some());
+        assert!(payload.delta.is_none());
+
+        let mut mostly_replaced = initial;
+        for row in &mut mostly_replaced[..58] {
+            *row = vec![Value::Text("changed".to_string())];
+        }
+        let (payload, _) = multiplex_observe_payload(
+            tabular_event(1, vec!["value".to_string()], mostly_replaced),
+            base.as_ref(),
+        )
+        .expect("large replacement payload");
+        assert!(payload.result.is_some());
+        assert!(payload.delta.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- retain the latest multiplexed tabular result as a transport base
- send safe contiguous row splices for localized table changes, with full-result fallback for ambiguous, large, metadata-changing, or reconnect cases
- apply validated deltas without redundant client deep equality

## Measured impact
For the 10k-row observe update benchmark, median SSE payload falls from 1,339,034 bytes to about 300 bytes (>99.97% lower). The same five-sample loopback run improved from 227.6 ms to 137.0 ms remote p50.

## Validation
- cargo fmt --all --check
- cargo clippy --profile test -p lix_server_protocol --all-targets --all-features -- -D warnings
- cargo test -p lix_server_protocol --lib
- npx vitest run src/remote/protocol.test.ts src/remote/observe.test.ts

Stacked on #793; will retarget main after it merges.