### PR TITLE
bench: calibrate SQLite public result reads

### DIFF
--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -46,6 +46,11 @@ name = "exact_file_read_benchmark"
 path = "tests/exact_file_read_benchmark.rs"
 required-features = ["rocksdb", "slatedb"]
 
+[[test]]
+name = "tracked_state_crud_public_result"
+path = "tests/tracked_state_crud_public_result.rs"
+required-features = ["storage-benches"]
+
 [[bench]]
 name = "storage_v2"
 path = "benches/storage_v2.rs"

--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -44,7 +44,7 @@ fn tracked_state_crud_benches(c: &mut Criterion) {
 /// operation. Criterion's CodSpeed-compatible harness intentionally delegates
 /// timing to the runner, while this opt-in mode is useful for local profiling
 /// and before/after investigation. Each sample starts from an independently
-/// seeded RocksDB fixture, matching the benchmark's measurement boundary.
+/// seeded fixture, matching the benchmark's measurement boundary.
 fn profile_operation(runtime: &tokio::runtime::Runtime, rows: &[WorkloadRow]) {
     let operation = match std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_OP").as_deref() {
         Ok("insert_all") => TransactionBenchOp::InsertAll,
@@ -87,17 +87,19 @@ fn profile_operation(runtime: &tokio::runtime::Runtime, rows: &[WorkloadRow]) {
             profile_kv_layout_operation(runtime, rows, operation, sample_count);
         }
         Ok("raw_sqlite") => {
+            let output = raw_sqlite_profile_output(operation);
             if let Some(repeats) = hot_repeats {
-                profile_hot_raw_sqlite_operations(rows, operation, repeats);
+                profile_hot_raw_sqlite_operations(rows, operation, repeats, output);
             } else {
-                profile_raw_sqlite_operation(rows, operation, sample_count);
+                profile_raw_sqlite_operation(rows, operation, sample_count, output);
             }
         }
         Ok("sql_session") => {
+            let profile = profile_sql_session_storage();
             if let Some(repeats) = hot_repeats {
-                profile_hot_sql_session_operations(runtime, rows, operation, repeats);
+                profile_hot_sql_session_operations(runtime, rows, operation, repeats, profile);
             } else {
-                profile_sql_session_operation(runtime, rows, operation, sample_count);
+                profile_sql_session_operation(runtime, rows, operation, sample_count, profile);
             }
         }
         Ok("transaction") | Err(_) => {
@@ -109,6 +111,52 @@ fn profile_operation(runtime: &tokio::runtime::Runtime, rows: &[WorkloadRow]) {
         }
         Ok(other) => panic!(
             "unknown LIX_TRACKED_STATE_CRUD_PROFILE_LAYER '{other}'; expected transaction, sql_session, kv_layout, or raw_sqlite"
+        ),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum RawSqliteProfileOutput {
+    Borrowed,
+    PublicResult,
+}
+
+impl RawSqliteProfileOutput {
+    const fn layer(self) -> &'static str {
+        match self {
+            Self::Borrowed => "raw_sqlite",
+            Self::PublicResult => "raw_sqlite/public_result",
+        }
+    }
+}
+
+fn raw_sqlite_profile_output(operation: TransactionBenchOp) -> RawSqliteProfileOutput {
+    match std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_OUTPUT").as_deref() {
+        Ok("public_result") => {
+            assert!(
+                matches!(
+                    operation,
+                    TransactionBenchOp::ReadAll
+                        | TransactionBenchOp::ReadOneByPk
+                        | TransactionBenchOp::ReadManyByPk
+                ),
+                "LIX_TRACKED_STATE_CRUD_PROFILE_OUTPUT=public_result only supports read_all, read_one, or read_many"
+            );
+            RawSqliteProfileOutput::PublicResult
+        }
+        Ok("borrowed") | Err(_) => RawSqliteProfileOutput::Borrowed,
+        Ok(other) => panic!(
+            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_OUTPUT '{other}'; expected borrowed or public_result"
+        ),
+    }
+}
+
+fn profile_sql_session_storage() -> StorageProfile {
+    match std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_STORAGE").as_deref() {
+        Ok("sqlite") => StorageProfile::SQLite,
+        Ok("rocksdb") | Err(_) => StorageProfile::RocksDB,
+        Ok(other) => panic!(
+            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_STORAGE '{other}'; expected rocksdb or sqlite"
         ),
     }
 }
@@ -149,11 +197,12 @@ fn profile_hot_sql_session_operations(
     rows: &[WorkloadRow],
     operation: TransactionBenchOp,
     repeats: usize,
+    profile: StorageProfile,
 ) {
     operation.assert_supports_hot_repeats();
     let repeats_u32 =
         u32::try_from(repeats).expect("LIX_TRACKED_STATE_CRUD_PROFILE_HOT_REPEATS must fit in u32");
-    let fixture = runtime.block_on(sql_session::seeded_fixture(StorageProfile::RocksDB, rows));
+    let fixture = runtime.block_on(sql_session::seeded_fixture(profile, rows));
     let start = Instant::now();
     let mut row_count = 0;
     for _ in 0..repeats {
@@ -161,7 +210,8 @@ fn profile_hot_sql_session_operations(
     }
     let elapsed = start.elapsed();
     println!(
-        "tracked_state_crud hot profile: sql_session/lix_rocksdb/{}/{} repeats: total={elapsed:?} per_operation={:?}",
+        "tracked_state_crud hot profile: sql_session/{}/{}/{} repeats: total={elapsed:?} per_operation={:?}",
+        profile.name(),
         profile_operation_name(operation),
         repeats,
         elapsed / repeats_u32,
@@ -173,6 +223,7 @@ fn profile_hot_raw_sqlite_operations(
     rows: &[WorkloadRow],
     operation: TransactionBenchOp,
     repeats: usize,
+    output: RawSqliteProfileOutput,
 ) {
     operation.assert_supports_hot_repeats();
     let repeats_u32 =
@@ -181,11 +232,12 @@ fn profile_hot_raw_sqlite_operations(
     let start = Instant::now();
     let mut row_count = 0;
     for _ in 0..repeats {
-        row_count += run_raw_sqlite_operation(operation, &mut fixture);
+        row_count += run_raw_sqlite_operation(operation, &mut fixture, output);
     }
     let elapsed = start.elapsed();
     println!(
-        "tracked_state_crud hot profile: raw_sqlite/{}/{} repeats: total={elapsed:?} per_operation={:?}",
+        "tracked_state_crud hot profile: {}/{}/{} repeats: total={elapsed:?} per_operation={:?}",
+        output.layer(),
         profile_operation_name(operation),
         repeats,
         elapsed / repeats_u32,
@@ -261,6 +313,7 @@ fn profile_raw_sqlite_operation(
     rows: &[WorkloadRow],
     operation: TransactionBenchOp,
     sample_count: usize,
+    output: RawSqliteProfileOutput,
 ) {
     let mut samples = Vec::with_capacity(sample_count);
     for _ in 0..sample_count {
@@ -270,11 +323,11 @@ fn profile_raw_sqlite_operation(
             raw_sqlite::empty_fixture(rows)
         };
         let start = Instant::now();
-        let result = run_raw_sqlite_operation(operation, &mut fixture);
+        let result = run_raw_sqlite_operation(operation, &mut fixture, output);
         samples.push(start.elapsed());
         black_box(result);
     }
-    print_profile_samples("raw_sqlite", operation, samples);
+    print_profile_samples(output.layer(), operation, samples);
 }
 
 fn profile_sql_session_operation(
@@ -282,20 +335,25 @@ fn profile_sql_session_operation(
     rows: &[WorkloadRow],
     operation: TransactionBenchOp,
     sample_count: usize,
+    profile: StorageProfile,
 ) {
     let mut samples = Vec::with_capacity(sample_count);
     for _ in 0..sample_count {
         let fixture = if operation.needs_seed() {
-            runtime.block_on(sql_session::seeded_fixture(StorageProfile::RocksDB, rows))
+            runtime.block_on(sql_session::seeded_fixture(profile, rows))
         } else {
-            runtime.block_on(sql_session::empty_fixture(StorageProfile::RocksDB, rows))
+            runtime.block_on(sql_session::empty_fixture(profile, rows))
         };
         let start = Instant::now();
         let result = runtime.block_on(run_sql_session_operation(operation, &fixture));
         samples.push(start.elapsed());
         black_box(result);
     }
-    print_profile_samples("sql_session/lix_rocksdb", operation, samples);
+    print_profile_samples(
+        &format!("sql_session/{}", profile.name()),
+        operation,
+        samples,
+    );
 }
 
 async fn run_sql_session_operation(
@@ -317,16 +375,26 @@ async fn run_sql_session_operation(
 fn run_raw_sqlite_operation(
     operation: TransactionBenchOp,
     fixture: &mut raw_sqlite::RawSqliteFixture,
+    output: RawSqliteProfileOutput,
 ) -> usize {
-    match operation {
-        TransactionBenchOp::InsertAll => fixture.insert_all(),
-        TransactionBenchOp::ReadAll => fixture.read_all(),
-        TransactionBenchOp::ReadOneByPk => fixture.read_one_by_pk(),
-        TransactionBenchOp::ReadManyByPk => fixture.read_many_by_pk(READ_MANY_PK_COUNT),
-        TransactionBenchOp::UpdateAll => fixture.update_all(),
-        TransactionBenchOp::UpdateOneByPk => fixture.update_one_by_pk(),
-        TransactionBenchOp::DeleteAll => fixture.delete_all(),
-        TransactionBenchOp::DeleteOneByPk => fixture.delete_one_by_pk(),
+    match (operation, output) {
+        (TransactionBenchOp::ReadAll, RawSqliteProfileOutput::PublicResult) => {
+            black_box(fixture.read_all_public_result()).len()
+        }
+        (TransactionBenchOp::ReadOneByPk, RawSqliteProfileOutput::PublicResult) => {
+            black_box(fixture.read_one_by_pk_public_result()).len()
+        }
+        (TransactionBenchOp::ReadManyByPk, RawSqliteProfileOutput::PublicResult) => {
+            black_box(fixture.read_many_by_pk_public_result(READ_MANY_PK_COUNT)).len()
+        }
+        (TransactionBenchOp::InsertAll, _) => fixture.insert_all(),
+        (TransactionBenchOp::ReadAll, _) => fixture.read_all(),
+        (TransactionBenchOp::ReadOneByPk, _) => fixture.read_one_by_pk(),
+        (TransactionBenchOp::ReadManyByPk, _) => fixture.read_many_by_pk(READ_MANY_PK_COUNT),
+        (TransactionBenchOp::UpdateAll, _) => fixture.update_all(),
+        (TransactionBenchOp::UpdateOneByPk, _) => fixture.update_one_by_pk(),
+        (TransactionBenchOp::DeleteAll, _) => fixture.delete_all(),
+        (TransactionBenchOp::DeleteOneByPk, _) => fixture.delete_one_by_pk(),
     }
 }
 
@@ -374,6 +442,19 @@ fn bench_raw_sqlite(c: &mut Criterion, rows: &[WorkloadRow], label: &str) {
             BatchSize::LargeInput,
         );
     });
+    // Lix SQL-session `read_all_rows` already returns an owned public
+    // ExecuteResult. This companion control separates that common result
+    // materialization from the deliberately borrowed raw SQLite lower bound.
+    group.bench_function(
+        format!("read_all_public_result_rows/{}", row_label(rows.len())),
+        |b| {
+            b.iter_batched_ref(
+                || raw_sqlite::seeded_fixture(&rows),
+                |fixture| black_box(fixture.read_all_public_result()),
+                BatchSize::LargeInput,
+            );
+        },
+    );
     group.bench_function(format!("read_one_by_pk/{}", row_label(rows.len())), |b| {
         b.iter_batched_ref(
             || raw_sqlite::seeded_fixture(&rows),
@@ -381,6 +462,16 @@ fn bench_raw_sqlite(c: &mut Criterion, rows: &[WorkloadRow], label: &str) {
             BatchSize::LargeInput,
         );
     });
+    group.bench_function(
+        format!("read_one_by_pk_public_result/{}", row_label(rows.len())),
+        |b| {
+            b.iter_batched_ref(
+                || raw_sqlite::seeded_fixture(&rows),
+                |fixture| black_box(fixture.read_one_by_pk_public_result()),
+                BatchSize::LargeInput,
+            );
+        },
+    );
     group.bench_function(format!("read_many_by_pk/{READ_MANY_PK_COUNT}"), |b| {
         b.iter_batched_ref(
             || raw_sqlite::seeded_fixture(&rows),
@@ -388,6 +479,16 @@ fn bench_raw_sqlite(c: &mut Criterion, rows: &[WorkloadRow], label: &str) {
             BatchSize::LargeInput,
         );
     });
+    group.bench_function(
+        format!("read_many_by_pk_public_result/{READ_MANY_PK_COUNT}"),
+        |b| {
+            b.iter_batched_ref(
+                || raw_sqlite::seeded_fixture(&rows),
+                |fixture| black_box(fixture.read_many_by_pk_public_result(READ_MANY_PK_COUNT)),
+                BatchSize::LargeInput,
+            );
+        },
+    );
     group.bench_function(format!("update_all_rows/{}", row_label(rows.len())), |b| {
         b.iter_batched_ref(
             || raw_sqlite::seeded_fixture(&rows),

--- a/packages/engine-benchmarks/benches/tracked_state_crud/raw_sqlite.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/raw_sqlite.rs
@@ -1,7 +1,8 @@
-use rusqlite::{Connection, params, params_from_iter};
+use rusqlite::{Connection, Rows, params, params_from_iter};
 use tempfile::TempDir;
 
 use crate::workload::WorkloadRow;
+use lix_engine::{ExecuteResult, Value};
 
 pub(crate) struct RawSqliteFixture {
     connection: Connection,
@@ -94,6 +95,24 @@ impl RawSqliteFixture {
         count
     }
 
+    /// Reads through standalone SQLite, then constructs the same public
+    /// `ExecuteResult` value shape that the Lix SQL session returns.
+    ///
+    /// Keep this separate from [`Self::read_all`]. The latter intentionally
+    /// borrows SQLite text values, which is the storage-engine lower bound;
+    /// this control attributes the unavoidable owned `Value`/JSON-DOM result
+    /// construction independently from the Lix SQL and storage layers.
+    pub(crate) fn read_all_public_result(&self) -> ExecuteResult {
+        let mut statement = self
+            .connection
+            .prepare_cached("SELECT path, value FROM json_pointer ORDER BY path")
+            .expect("prepare raw sqlite public-result read all");
+        let query = statement
+            .query([])
+            .expect("query all raw sqlite public-result rows");
+        Self::public_result_from_query(query, self.rows.len())
+    }
+
     pub(crate) fn read_one_by_pk(&self) -> usize {
         let row = &self.rows[self.rows.len() / 2];
         let mut statement = self
@@ -124,6 +143,18 @@ impl RawSqliteFixture {
                 .is_none()
         );
         1
+    }
+
+    pub(crate) fn read_one_by_pk_public_result(&self) -> ExecuteResult {
+        let row = &self.rows[self.rows.len() / 2];
+        let mut statement = self
+            .connection
+            .prepare_cached("SELECT path, value FROM json_pointer WHERE path = ?1")
+            .expect("prepare raw sqlite public-result point read");
+        let query = statement
+            .query(params![row.path])
+            .expect("query raw sqlite public-result point row");
+        Self::public_result_from_query(query, 1)
     }
 
     pub(crate) fn read_many_by_pk(&self, count: usize) -> usize {
@@ -157,6 +188,24 @@ impl RawSqliteFixture {
         }
         assert_eq!(found, count);
         found
+    }
+
+    pub(crate) fn read_many_by_pk_public_result(&self, count: usize) -> ExecuteResult {
+        let count = count.min(self.rows.len());
+        assert_eq!(
+            count, self.read_many_by_pk_count,
+            "read-many benchmark must use the fixture's setup-excluded query shape"
+        );
+        let mut statement = self
+            .connection
+            .prepare_cached(&self.read_many_by_pk_sql)
+            .expect("prepare raw sqlite public-result multi-point read");
+        let query = statement
+            .query(params_from_iter(
+                self.rows[..count].iter().map(|row| row.path.as_str()),
+            ))
+            .expect("query raw sqlite public-result multi-point rows");
+        Self::public_result_from_query(query, count)
     }
 
     pub(crate) fn update_all(&mut self) -> usize {
@@ -215,6 +264,35 @@ impl RawSqliteFixture {
             .expect("delete one raw sqlite row");
         assert_eq!(affected, 1);
         affected
+    }
+
+    fn public_result_from_query(mut query: Rows<'_>, expected_rows: usize) -> ExecuteResult {
+        let mut rows = Vec::with_capacity(expected_rows);
+        while let Some(row) = query
+            .next()
+            .expect("read next raw sqlite public-result row")
+        {
+            // `String` ownership and the JSON parse intentionally mirror
+            // `query_result_from_batches` -> `string_scalar_to_lix_value`.
+            let path = row
+                .get::<_, String>(0)
+                .expect("read raw sqlite public-result path");
+            let value_json = row
+                .get::<_, String>(1)
+                .expect("read raw sqlite public-result value");
+            let value =
+                serde_json::from_str(&value_json).expect("raw sqlite fixture JSON must be valid");
+            // Entity projection represents JSON `null` as an Arrow null, so
+            // the public Lix result is `Value::Null` rather than
+            // `Value::Json(JsonValue::Null)`.
+            let value = match value {
+                serde_json::Value::Null => Value::Null,
+                value => Value::Json(value),
+            };
+            rows.push(vec![Value::Text(path), value]);
+        }
+        assert_eq!(rows.len(), expected_rows);
+        ExecuteResult::from_rows(vec!["path".to_string(), "value".to_string()], rows)
     }
 }
 

--- a/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
@@ -64,6 +64,15 @@ impl SqlFixture {
         }
     }
 
+    #[cfg(test)]
+    #[allow(dead_code)]
+    pub(crate) async fn read_all_result(&self) -> ExecuteResult {
+        match self {
+            Self::SQLite(fixture) => fixture.read_all_result().await,
+            Self::RocksDB(fixture) => fixture.read_all_result().await,
+        }
+    }
+
     pub(crate) async fn read_many_by_pk(&self) -> usize {
         match self {
             Self::SQLite(fixture) => fixture.read_many_by_pk().await,
@@ -71,10 +80,28 @@ impl SqlFixture {
         }
     }
 
+    #[cfg(test)]
+    #[allow(dead_code)]
+    pub(crate) async fn read_many_by_pk_result(&self) -> ExecuteResult {
+        match self {
+            Self::SQLite(fixture) => fixture.read_many_by_pk_result().await,
+            Self::RocksDB(fixture) => fixture.read_many_by_pk_result().await,
+        }
+    }
+
     pub(crate) async fn read_one_by_pk(&self) -> usize {
         match self {
             Self::SQLite(fixture) => fixture.read_one_by_pk().await,
             Self::RocksDB(fixture) => fixture.read_one_by_pk().await,
+        }
+    }
+
+    #[cfg(test)]
+    #[allow(dead_code)]
+    pub(crate) async fn read_one_by_pk_result(&self) -> ExecuteResult {
+        match self {
+            Self::SQLite(fixture) => fixture.read_one_by_pk_result().await,
+            Self::RocksDB(fixture) => fixture.read_one_by_pk_result().await,
         }
     }
 
@@ -123,21 +150,33 @@ where
     }
 
     async fn read_all(&self) -> usize {
-        let result = execute(&self.session, &self.select_all_sql).await;
+        let result = std::hint::black_box(self.read_all_result().await);
         assert_eq!(result.len(), self.row_count);
         result.len()
     }
 
+    async fn read_all_result(&self) -> ExecuteResult {
+        execute(&self.session, &self.select_all_sql).await
+    }
+
     async fn read_many_by_pk(&self) -> usize {
-        let result = execute(&self.session, &self.select_many_by_pk_sql).await;
+        let result = std::hint::black_box(self.read_many_by_pk_result().await);
         assert_eq!(result.len(), READ_MANY_PK_COUNT.min(self.row_count));
         result.len()
     }
 
+    async fn read_many_by_pk_result(&self) -> ExecuteResult {
+        execute(&self.session, &self.select_many_by_pk_sql).await
+    }
+
     async fn read_one_by_pk(&self) -> usize {
-        let result = execute(&self.session, &self.select_one_by_pk_sql).await;
+        let result = std::hint::black_box(self.read_one_by_pk_result().await);
         assert_eq!(result.len(), 1);
         result.len()
+    }
+
+    async fn read_one_by_pk_result(&self) -> ExecuteResult {
+        execute(&self.session, &self.select_one_by_pk_sql).await
     }
 
     #[expect(clippy::cast_possible_truncation)]

--- a/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
+++ b/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
@@ -1,0 +1,56 @@
+// This parity test includes the benchmark-only fixture modules directly.
+// Most of their CRUD helpers are intentionally unused by this one focused
+// assertion.
+#![allow(dead_code)]
+
+const READ_MANY_PK_COUNT: usize = 10;
+
+#[path = "../benches/tracked_state_crud/raw_sqlite.rs"]
+mod raw_sqlite;
+#[path = "../benches/tracked_state_crud/sql_session.rs"]
+mod sql_session;
+#[path = "../benches/tracked_state_crud/storage.rs"]
+mod storage;
+#[path = "../benches/tracked_state_crud/workload.rs"]
+mod workload;
+
+use storage::StorageProfile;
+use workload::WorkloadRow;
+
+#[tokio::test]
+async fn standalone_sqlite_public_results_match_lix_sql_results() {
+    let rows = [
+        WorkloadRow {
+            path: "/alpha".to_string(),
+            value_json: r#"{"enabled":true}"#.to_string(),
+            updated_value_json: r#"{"enabled":false}"#.to_string(),
+        },
+        WorkloadRow {
+            path: "/beta".to_string(),
+            value_json: r"[1,2,3]".to_string(),
+            updated_value_json: r"[4,5,6]".to_string(),
+        },
+        WorkloadRow {
+            path: "/null".to_string(),
+            value_json: "null".to_string(),
+            updated_value_json: r#"{"updated":true}"#.to_string(),
+        },
+        WorkloadRow {
+            path: "/text".to_string(),
+            value_json: r#""hello""#.to_string(),
+            updated_value_json: r#""updated""#.to_string(),
+        },
+    ];
+    let raw = raw_sqlite::seeded_fixture(&rows);
+    let lix = sql_session::seeded_fixture(StorageProfile::SQLite, &rows).await;
+
+    assert_eq!(raw.read_all_public_result(), lix.read_all_result().await);
+    assert_eq!(
+        raw.read_one_by_pk_public_result(),
+        lix.read_one_by_pk_result().await
+    );
+    assert_eq!(
+        raw.read_many_by_pk_public_result(READ_MANY_PK_COUNT),
+        lix.read_many_by_pk_result().await
+    );
+}


### PR DESCRIPTION
## What changed

Adds two controls to the tracked CRUD benchmark:

- a standalone SQLite path that constructs the same public `ExecuteResult` shape returned by Lix SQL (owned `String` values plus parsed JSON), alongside the existing borrowed/raw SQLite lower bound;
- a Lix SQL run backed by Lix's SQLite storage, selectable only for profiling.

It also keeps the complete `ExecuteResult` live in the Lix benchmark and adds an integration test covering equivalent public results for read-all, read-one, read-many, and JSON `null`.

## Why

The old standalone SQLite number borrowed text directly from SQLite and only counted rows. That is the right storage lower bound, but Lix's unchanged public API returns owned, typed values. The new control separates that unavoidable result construction from Lix's remaining execution, storage, and materialization cost.

No production code or public API changes are included.

## Representative hot-profile results

10k tracked rows; warm fixture; setup excluded; pinned CPU core. These are calibration profiles, not a replacement for the full statistical benchmark suite.

| Operation | Raw standalone SQLite, borrowed | Raw standalone SQLite, Lix public result shape | Lix SQL + RocksDB | Lix SQL + Lix SQLite |
| --- | ---: | ---: | ---: | ---: |
| read all | 1.173 ms | 6.009 ms | 22.886 ms | 28.978 ms |
| read one | 2.637 µs | 2.887 µs | 23.382 µs | 37.233 µs |
| read many (10 keys) | 7.750 µs | 33.397 µs | 140.510 µs | 162.190 µs |

The raw-public control queries standalone SQLite, then deliberately constructs Lix's existing public value/result shape. It remains a standalone SQLite control; it does not use Lix storage.

This makes the current gaps explicit:

- The original 19.5× read-all figure is the raw storage lower bound. After equivalent public-result construction, RocksDB is 3.81× for read-all.
- RocksDB remains 8.10× for read-one and 4.21× for ten-key read-many against that equivalent control.
- The Lix SQLite-storage control is slower than RocksDB in these profiles, so the broad-read bottleneck is shared execution/materialization rather than RocksDB alone.

That is why the next optimization work should focus on the tracked-head execution/materialization architecture, while preserving normal SQL's transparent tracked-plus-cache semantics.

## Validation

```sh
cargo fmt --check
CARGO_TARGET_DIR=/root/projects/lix-mixed-point-read/target \
  cargo clippy -p lix_engine_benchmarks --bench tracked_state_crud --features storage-benches -- -D warnings
CARGO_TARGET_DIR=/root/projects/lix-mixed-point-read/target \
  cargo clippy -p lix_engine_benchmarks --test tracked_state_crud_public_result --features storage-benches -- -D warnings
CARGO_TARGET_DIR=/root/projects/lix-mixed-point-read/target \
  cargo test -p lix_engine_benchmarks --test tracked_state_crud_public_result --features storage-benches
CARGO_TARGET_DIR=/root/projects/lix-mixed-point-read/target \
  cargo bench -p lix_engine_benchmarks --bench tracked_state_crud --features storage-benches --no-run
```