### PR TITLE
perf: persist compiled Wasmtime components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2086,6 +2086,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2245,7 +2266,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "toml",
+ "toml 0.8.23",
  "uncased",
  "version_check",
 ]
@@ -3180,6 +3201,15 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "librocksdb-sys"
@@ -4444,6 +4474,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "regalloc2"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4695,6 +4736,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -5184,9 +5234,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -5199,6 +5264,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5206,10 +5280,19 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -5217,6 +5300,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -5698,6 +5787,7 @@ dependencies = [
  "target-lexicon",
  "wasmparser 0.248.0",
  "wasmtime-environ",
+ "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
@@ -5740,6 +5830,26 @@ dependencies = [
  "wasmprinter",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
+]
+
+[[package]]
+name = "wasmtime-internal-cache"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef87f84d976e2f98a541eaf5837df0424e2039837fc20bd6cd4b4b5a322939c0"
+dependencies = [
+ "base64 0.22.1",
+ "directories-next",
+ "log",
+ "postcard",
+ "rustix",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "toml 0.9.12+spec-1.1.0",
+ "wasmtime-environ",
+ "windows-sys 0.61.2",
+ "zstd",
 ]
 
 [[package]]
@@ -6325,6 +6435,12 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "winx"

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "1"
 tempfile = { version = "3", optional = true }
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", optional = true }
-wasmtime = { version = "45", default-features = false, features = ["component-model", "cranelift", "runtime", "std"], optional = true }
+wasmtime = { version = "45", default-features = false, features = ["cache", "component-model", "cranelift", "runtime", "std"], optional = true }
 wasmtime-wasi = { version = "45", default-features = false, features = ["p2"], optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/packages/rs-sdk/src/default_wasm_runtime.rs
+++ b/packages/rs-sdk/src/default_wasm_runtime.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
+use std::env;
+use std::ffi::OsString;
 use std::fmt;
 use std::num::NonZeroUsize;
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread::JoinHandle;
@@ -11,7 +14,9 @@ use lix_engine::LixError;
 use lix_engine::wasm::{WasmLimits, WasmRuntime};
 use lru::LruCache;
 use wasmtime::component::{Component, Linker};
-use wasmtime::{Config, Engine, ResourceLimiter, Store, StoreLimits, StoreLimitsBuilder};
+use wasmtime::{
+    Cache, CacheConfig, Config, Engine, ResourceLimiter, Store, StoreLimits, StoreLimitsBuilder,
+};
 use wasmtime_wasi::{
     ResourceTable, WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView, p2::add_to_linker_sync,
 };
@@ -24,6 +29,7 @@ const MAX_PLUGIN_INSTANCES: usize = 64;
 const MAX_PLUGIN_MEMORIES: usize = 1;
 const MAX_PLUGIN_TABLES: usize = 8;
 const MAX_PLUGIN_TABLE_ELEMENTS: usize = 1_000_000;
+const LIX_WASMTIME_CACHE_DIR_ENV: &str = "LIX_WASMTIME_CACHE_DIR";
 
 pub(crate) fn runtime() -> Result<Arc<dyn WasmRuntime>, LixError> {
     Ok(Arc::new(WasmtimePluginRuntime::new()?))
@@ -34,7 +40,53 @@ fn create_engine(consume_fuel: bool, epoch_interruption: bool) -> wasmtime::Resu
     config.wasm_component_model(true);
     config.consume_fuel(consume_fuel);
     config.epoch_interruption(epoch_interruption);
+    configure_component_cache(&mut config)?;
     Engine::new(&config)
+}
+
+/// Enables Wasmtime's host-local AOT cache for sandboxed plugin components.
+///
+/// This cache is deliberately outside the workspace and its storage adapter:
+/// native compiled artifacts are tied to the host architecture, Wasmtime
+/// version, and engine settings. Wasmtime keys and validates those artifacts
+/// itself, while the optional override makes isolated deployments and tests
+/// deterministic.
+fn configure_component_cache(config: &mut Config) -> wasmtime::Result<()> {
+    let mut cache_config = CacheConfig::new();
+    let directory = lix_wasmtime_cache_dir()?;
+    let explicitly_configured = directory.is_some();
+    if let Some(directory) = directory {
+        cache_config.with_directory(directory);
+    }
+    match Cache::new(cache_config) {
+        Ok(cache) => {
+            config.cache(Some(cache));
+        }
+        // The stock cache location is an opportunistic latency optimization.
+        // A read-only or home-less deployment must retain the pre-cache
+        // behavior rather than fail to initialize every sandboxed plugin.
+        Err(_) if !explicitly_configured => {}
+        Err(error) => return Err(error),
+    }
+    Ok(())
+}
+
+fn lix_wasmtime_cache_dir() -> wasmtime::Result<Option<PathBuf>> {
+    lix_wasmtime_cache_dir_from(env::var_os(LIX_WASMTIME_CACHE_DIR_ENV))
+}
+
+fn lix_wasmtime_cache_dir_from(directory: Option<OsString>) -> wasmtime::Result<Option<PathBuf>> {
+    let Some(directory) = directory else {
+        return Ok(None);
+    };
+    let directory = PathBuf::from(directory);
+    if !directory.is_absolute() {
+        return Err(wasmtime::Error::msg(format!(
+            "{LIX_WASMTIME_CACHE_DIR_ENV} must be an absolute path, got '{}'",
+            directory.display()
+        )));
+    }
+    Ok(Some(directory))
 }
 
 struct WasmtimePluginRuntime {
@@ -502,6 +554,7 @@ fn wasm_runtime_error(context: impl Into<String>, error: impl fmt::Display) -> L
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
     use std::sync::Barrier;
     use std::sync::atomic::AtomicUsize;
 
@@ -518,6 +571,56 @@ mod tests {
         let first = WasmtimePluginRuntime::new().expect("first runtime should initialize");
         let second = WasmtimePluginRuntime::new().expect("second runtime should initialize");
         assert!(Arc::ptr_eq(&first.shared, &second.shared));
+    }
+
+    #[test]
+    fn wasmtime_component_cache_persists_between_engines() {
+        let directory = tempfile::tempdir().expect("cache directory should initialize");
+        let component_bytes = wasm_encoder::Component::new().finish();
+
+        let first_cache = test_component_cache(directory.path());
+        let first_engine = test_engine_with_component_cache(first_cache.clone());
+        Component::new(&first_engine, &component_bytes)
+            .expect("first engine should compile the component");
+        assert!(
+            first_cache.cache_misses() > 0,
+            "the first engine must populate the persistent cache"
+        );
+
+        // A separate Cache and Engine model a fresh Lix process. The in-process
+        // component LRU cannot satisfy this compile, so a hit proves the
+        // host-local Wasmtime cache is active.
+        let second_cache = test_component_cache(directory.path());
+        let second_engine = test_engine_with_component_cache(second_cache.clone());
+        Component::new(&second_engine, &component_bytes)
+            .expect("second engine should load the cached component");
+        assert!(
+            second_cache.cache_hits() > 0,
+            "the second engine must reuse the persistent component cache"
+        );
+    }
+
+    #[test]
+    fn wasmtime_cache_override_requires_an_absolute_path() {
+        assert_eq!(
+            lix_wasmtime_cache_dir_from(None).expect("an absent override should be valid"),
+            None
+        );
+
+        let absolute = env::temp_dir().join("lix-wasmtime-cache");
+        assert_eq!(
+            lix_wasmtime_cache_dir_from(Some(absolute.clone().into_os_string()))
+                .expect("an absolute override should be valid"),
+            Some(absolute)
+        );
+
+        let error = lix_wasmtime_cache_dir_from(Some(OsString::from("relative-cache")))
+            .expect_err("a relative override must be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("LIX_WASMTIME_CACHE_DIR must be an absolute path")
+        );
     }
 
     #[test]
@@ -886,6 +989,19 @@ mod tests {
         let engine = create_engine(false, false).expect("test engine should initialize");
         Component::new(&engine, wasm_encoder::Component::new().finish())
             .expect("empty component should compile")
+    }
+
+    fn test_component_cache(directory: &Path) -> Cache {
+        let mut config = CacheConfig::new();
+        config.with_directory(directory);
+        Cache::new(config).expect("test cache should initialize")
+    }
+
+    fn test_engine_with_component_cache(cache: Cache) -> Engine {
+        let mut config = Config::new();
+        config.wasm_component_model(true);
+        config.cache(Some(cache));
+        Engine::new(&config).expect("test engine should initialize")
     }
 
     fn component_with_initial_memory(pages: u64) -> Vec<u8> {


### PR DESCRIPTION
## What changed

Enables Wasmtime's persistent host-local component cache for the sandboxed v2 plugin runtime. The existing in-process LRU remains in place; a second Lix process can now reuse compiled native component code. `LIX_WASMTIME_CACHE_DIR` optionally selects an absolute cache directory for isolated deployments and tests.

The cache is deliberately outside Lix storage because compiled code is specific to the host architecture, Wasmtime version, and engine configuration. If the default user cache directory is unavailable, runtime initialization retains the prior uncached behavior; an explicitly invalid override is rejected.

## Why

Every new process previously recompiled the same Wasm component before the first plugin mutation. This removes that repeated compilation work without changing the plugin API, WIT boundary, sandbox, or persisted workspace data.

## Measured impact

- Markdown, 3.50 MiB / 7,253-paragraph RocksDB fixture: component compile `1.59 s -> 20.8 ms` on a new process (98.7%); initial import `5.09 s -> 3.51 s` (31.2%).
- JSON, real 10 MiB RocksDB fixture: component compile `852 ms -> 11.1 ms` (98.7%); end-to-end first mutation `5.13 s -> 4.27 s` (16.8%).
- JSON hot full-byte write stayed within normal variance; the final validation run measured p50 13.140 ms.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --profile test -p lix_sdk --lib --all-features -- -D warnings`
- `cargo test --release -p lix_sdk --lib default_wasm_runtime -- --nocapture --test-threads=1`
- `cargo test --release -p lix_sdk_tests --test e2e v2_json_ten_mib_ordinary_sql_byte_edit_benchmark -- --ignored --exact --nocapture --test-threads=1`
- `cargo test --release -p lix_sdk_tests --test markdown_git_benchmark markdown_git_semantic_entities_benchmark -- --ignored --exact --nocapture --test-threads=1`
- `cargo test --release -p lix_sdk_tests --test e2e v2_excalidraw_roundtrips_and_renders_local_element_edits -- --exact --nocapture --test-threads=1`
