### PR TITLE
fix(remote): stop retrying terminal observations

### DIFF
--- a/packages/js-sdk/src/remote/client.ts
+++ b/packages/js-sdk/src/remote/client.ts
@@ -973,8 +973,14 @@ class RemoteObservationHub {
 							);
 						}
 						const error = errorFromResponseBody(payload);
-						if (payload.subscriptionId !== undefined) {
-							const observation = this.#observation(payload.subscriptionId);
+						const subscriptionId = payload.subscriptionId;
+						if (subscriptionId !== undefined) {
+							if (typeof subscriptionId !== "string") {
+								throw protocolError(
+									"remote observe event requires subscriptionId",
+								);
+							}
+							const observation = this.#observation(subscriptionId);
 							if (payload.retryable === true) {
 								observation.recover(error);
 								reconnect = true;
@@ -982,6 +988,7 @@ class RemoteObservationHub {
 								return;
 							}
 							observation.fail(error);
+							this.#observations.delete(subscriptionId);
 							continue;
 						}
 						if (payload.retryable === true) {

--- a/packages/js-sdk/src/remote/observe.test.ts
+++ b/packages/js-sdk/src/remote/observe.test.ts
@@ -327,42 +327,49 @@ test("remote observe can continue after a semantic SSE error", async () => {
 });
 
 test("remote observe treats unmarked semantic errors as terminal", async () => {
-	let observeRequests = 0;
-	const lix = await openLix({
-		server: {
-			mode: "remote",
-			url: "https://lixray.test/@acme/workspace",
-			fetch: async (input, init) => {
-				const request = new Request(input, init);
-				if (new URL(request.url).pathname.endsWith("/lix/v1/")) {
-					return handshake();
-				}
-				if (request.method === "DELETE") return closedSession();
-				observeRequests += 1;
-				return sseResponse(
-					sseFrame("error", {
-						subscriptionId: "observe-1",
-						error: {
-							code: "LIX_INVALID_SQL",
-							message: "invalid observed query",
-						},
-					}),
-				);
+	vi.useFakeTimers();
+	try {
+		let observeRequests = 0;
+		const lix = await openLix({
+			server: {
+				mode: "remote",
+				url: "https://lixray.test/@acme/workspace",
+				fetch: async (input, init) => {
+					const request = new Request(input, init);
+					if (new URL(request.url).pathname.endsWith("/lix/v1/")) {
+						return handshake();
+					}
+					if (request.method === "DELETE") return closedSession();
+					observeRequests += 1;
+					return sseResponse(
+						sseFrame("error", {
+							subscriptionId: "observe-1",
+							error: {
+								code: "LIX_INVALID_SQL",
+								message: "invalid observed query",
+							},
+						}),
+					);
+				},
 			},
-		},
-	});
+		});
 
-	const events = lix.observe("INVALID");
-	await expect(events.next()).rejects.toMatchObject({
-		code: "LIX_INVALID_SQL",
-	});
-	await expect(events.next()).rejects.toMatchObject({
-		code: "LIX_INVALID_SQL",
-	});
-	expect(observeRequests).toBe(1);
+		const events = lix.observe("INVALID");
+		await expect(events.next()).rejects.toMatchObject({
+			code: "LIX_INVALID_SQL",
+		});
+		await expect(events.next()).rejects.toMatchObject({
+			code: "LIX_INVALID_SQL",
+		});
+		expect(observeRequests).toBe(1);
+		await vi.advanceTimersByTimeAsync(100);
+		expect(observeRequests).toBe(1);
 
-	events.close();
-	await lix.close();
+		events.close();
+		await lix.close();
+	} finally {
+		vi.useRealTimers();
+	}
 });
 
 test("a successful branch switch restarts observations on the pinned session", async () => {


### PR DESCRIPTION
## Confirmed failure

A non-retryable per-subscription SSE error called `observation.fail()` but left that subscription in the multiplex reconnect set. When the SSE response ended, the hub scheduled another observe POST every reconnect interval, duplicating a request that had already reached a terminal error.

## Fix

Record the terminal error, then remove only that failed subscription from the reconnect set. Other active subscriptions remain registered and retain their normal recovery behavior.

## Regression coverage

Added a fake-timer assertion that a terminal `LIX_INVALID_SQL` observation error does not issue a second observe POST after 100 ms.

## Validation

- `pnpm exec vitest run src/remote/client.test.ts src/remote/observe.test.ts src/remote/protocol.test.ts src/remote/sse.test.ts` (51 passed)
- `pnpm run typecheck`
- `git diff --check`

No formatter or linter is configured for this package.