### PR TITLE
fix(protocol): reject non-finite query results

### DIFF
--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -2133,9 +2133,9 @@ fn scalar_value_to_lix_value(value: ScalarValue, field: Option<&Field>) -> Resul
             Err(_) => Ok(Value::Text(value.to_string())),
         },
         ScalarValue::UInt64(None) => Ok(Value::Null),
-        ScalarValue::Float32(Some(value)) => Ok(Value::Real(f64::from(value))),
+        ScalarValue::Float32(Some(value)) => finite_query_float(f64::from(value)),
         ScalarValue::Float32(None) => Ok(Value::Null),
-        ScalarValue::Float64(Some(value)) => Ok(Value::Real(value)),
+        ScalarValue::Float64(Some(value)) => finite_query_float(value),
         ScalarValue::Float64(None) => Ok(Value::Null),
         ScalarValue::Utf8(Some(value))
         | ScalarValue::Utf8View(Some(value))
@@ -2149,6 +2149,16 @@ fn scalar_value_to_lix_value(value: ScalarValue, field: Option<&Field>) -> Resul
         ScalarValue::Binary(None) | ScalarValue::LargeBinary(None) => Ok(Value::Null),
         other => Ok(Value::Text(other.to_string())),
     }
+}
+
+fn finite_query_float(value: f64) -> Result<Value, LixError> {
+    if !value.is_finite() {
+        return Err(LixError::new(
+            LixError::CODE_TYPE_MISMATCH,
+            "SQL query produced a non-finite number",
+        ));
+    }
+    Ok(Value::Real(value))
 }
 
 fn string_scalar_to_lix_value(value: String, field: Option<&Field>) -> Result<Value, LixError> {

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -5150,6 +5150,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_batch_rejects_non_finite_results_before_committing() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let response = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute-batch",
+            Some(&session_id),
+            Some(json!({
+                "statements": [
+                    {
+                        "sql": "INSERT INTO lix_key_value (key, value) VALUES ('nonfinite-batch', 'written')",
+                        "params": []
+                    },
+                    { "sql": "SELECT 0e0 / 0e0 AS value", "params": [] }
+                ]
+            })),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(error_code(response).await, LixError::CODE_TYPE_MISMATCH);
+
+        let persisted = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT key FROM lix_key_value WHERE key = 'nonfinite-batch'"
+            })),
+        )
+        .await;
+        assert_eq!(persisted.status(), StatusCode::OK);
+        assert_eq!(response_json(persisted).await["rows"], json!([]));
+    }
+
+    #[tokio::test]
     async fn execute_reconstructs_cached_blob_splices_and_caches_each_result() {
         let app = app().await;
         let (session_id, _) = new_session(&app.router).await;


### PR DESCRIPTION
## Confirmed failure

An atomic remote batch could persist a write and still return an error:

```sql
INSERT INTO lix_key_value (key, value) VALUES ('proof-nonfinite', 'durable');
SELECT 0e0 / 0e0 AS value;
```

The transaction collected `NaN` as a `Value::Real`, committed the batch, and only then did the protocol reject that value while converting the response to the JSON wire format. A caller could retry after the error and duplicate the durable mutation.

## Fix

Reject non-finite `Float32` and `Float64` query results during DataFusion result materialization. This happens inside the transaction closure, so the error aborts the batch before `commit()`; the existing wire-level validation remains defensive.

## Regression coverage

Adds an HTTP protocol regression that submits the write + `NaN` batch, asserts `LIX_TYPE_MISMATCH`, and verifies the inserted key is absent afterward.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- Targeted `cargo test -p lix_server_protocol execute_batch_rejects_non_finite_results_before_committing -- --exact --nocapture` was started but stopped safely before completion because the shared workspace fell to 5.3 GB free; no test failure was observed. Vendor CI will execute the full Rust suite.