### PR TITLE
perf(markdown): reuse canonical parse render

### DIFF
--- a/plugins/markdown-v2/src/core.rs
+++ b/plugins/markdown-v2/src/core.rs
@@ -155,7 +155,11 @@ fn retain_noncanonical_source(
     parsed: &mut ParsedMarkdown,
     source: &[u8],
 ) -> Result<(), PluginError> {
-    let canonical = render_tree(&parsed.root)?;
+    let canonical = parsed.canonical_render.take().ok_or_else(|| {
+        PluginError::Internal(
+            "stable Markdown parse is missing its canonical render for lexical fallback".into(),
+        )
+    })?;
     if canonical == source {
         return Ok(());
     }

--- a/plugins/markdown-v2/src/markdown_file.rs
+++ b/plugins/markdown-v2/src/markdown_file.rs
@@ -18,6 +18,10 @@ use uuid::Uuid;
 pub(crate) struct ParsedMarkdown {
     pub(crate) root: NodeTree,
     pub(crate) top_level_ranges: Vec<Range<usize>>,
+    /// The stable canonical bytes already rendered while parsing. Callers that
+    /// need to compare source layout can consume this instead of rendering the
+    /// reconstructed tree a second time.
+    pub(crate) canonical_render: Option<Vec<u8>>,
 }
 
 pub(crate) fn parse_file(file: &File) -> Result<ParsedMarkdown, PluginError> {
@@ -42,6 +46,7 @@ pub(crate) fn parse_markdown_source(source: &str) -> Result<ParsedMarkdown, Plug
     for _ in 0..8 {
         let rendered = render_tree(&parsed.root)?;
         if rendered == canonical.as_bytes() {
+            parsed.canonical_render = Some(rendered);
             return Ok(parsed);
         }
         canonical = String::from_utf8(rendered).map_err(|error| {
@@ -111,6 +116,7 @@ fn parse_markdown_source_once(source: &str) -> Result<ParsedMarkdown, PluginErro
     Ok(ParsedMarkdown {
         root,
         top_level_ranges,
+        canonical_render: None,
     })
 }
 

--- a/plugins/markdown-v2/src/tests.rs
+++ b/plugins/markdown-v2/src/tests.rs
@@ -1,6 +1,7 @@
 use crate::{
     ChangeEffect, Document, EntityChange, EntityRecord, IdNamespace, InputSplice, NODE_SCHEMA_KEY,
 };
+use base64::Engine as _;
 use serde_json::Value;
 
 fn assert_number_free(value: &Value) {
@@ -23,6 +24,17 @@ fn records(changes: &[EntityChange]) -> Vec<EntityRecord> {
             })
         })
         .collect()
+}
+
+fn document_format(changes: &[EntityChange]) -> Value {
+    let wire = changes
+        .iter()
+        .filter_map(|change| change.snapshot.as_deref())
+        .map(|snapshot| serde_json::from_slice::<Value>(snapshot).expect("valid wire snapshot"))
+        .find(|wire| wire["kind"] == "document")
+        .expect("document snapshot");
+    serde_json::from_str(wire["format_json"].as_str().expect("document format_json"))
+        .expect("valid document format JSON")
 }
 
 fn utf16le(source: &str) -> Vec<u8> {
@@ -121,6 +133,43 @@ fn cold_entity_open_preserves_accepted_noncanonical_source_bytes() {
         assert_eq!(edits[0].delete_len, 0, "{name}");
         assert_eq!(edits[0].insert.as_slice(), source, "{name}");
     }
+}
+
+#[test]
+fn canonical_source_avoids_fallback_and_encoded_source_preserves_it() {
+    let canonical = b"# Heading\n\nBody\n".to_vec();
+    let (_, canonical_changes) = Document::open_file(
+        canonical,
+        Some("canonical.md"),
+        IdNamespace::from_halves(1, 2),
+    )
+    .expect("canonical Markdown should open");
+    assert!(
+        document_format(&canonical_changes)
+            .get("lexical_fallback_base64")
+            .is_none(),
+        "canonical input must not retain an unnecessary raw fallback",
+    );
+
+    let encoded = b"\xef\xbb\xbf# Heading\n\nBody\n".to_vec();
+    let (_, encoded_changes) = Document::open_file(
+        encoded.clone(),
+        Some("encoded.md"),
+        IdNamespace::from_halves(3, 4),
+    )
+    .expect("encoded Markdown should open");
+    let expected_fallback = base64::engine::general_purpose::STANDARD.encode(&encoded);
+    assert_eq!(
+        document_format(&encoded_changes)
+            .get("lexical_fallback_base64")
+            .and_then(Value::as_str),
+        Some(expected_fallback.as_str()),
+        "noncanonical bytes must remain available for exact lexical restoration",
+    );
+    let (restored, edits) = Document::open_entities(records(&encoded_changes), None)
+        .expect("encoded Markdown should restore from semantic entities");
+    assert_eq!(restored.accepted_bytes(), encoded);
+    assert_eq!(edits.len(), 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Reuse the canonical Markdown bytes already produced by the parser's stability pass when deciding whether to retain an exact lexical fallback. This removes a redundant full-tree serialization on every full Markdown open and non-incremental byte transition.

The public plugin API and semantic model are unchanged. Noncanonical input, including BOM-prefixed source, still retains and restores its exact original bytes.

## Measured result

3.50 MiB / 7,253-paragraph Markdown corpus, RocksDB, persistent Wasmtime component cache hit:

- Initial import: 3,520.657 ms -> 2,528.496 ms (**28.18% faster**)
- Fresh component-cache run: 5,105.427 ms -> 4,157.073 ms (**18.58% faster**)
- Byte write, semantic write, unrelated semantic merge, and cold materialized read stayed within normal measurement noise.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p plugin_markdown_incremental_v2`
- Release Markdown direct-edit and unrelated-merge E2E tests
- Paired RocksDB/Git benchmark with a separately built, cache-hit `main` control
