### PR TITLE
bench: calibrate literal and bound SQL updates

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -94,12 +94,35 @@ fn profile_operation(runtime: &tokio::runtime::Runtime, rows: &[WorkloadRow]) {
                 profile_raw_sqlite_operation(rows, operation, sample_count, output);
             }
         }
+        Ok("raw_sqlite_literal") => {
+            assert!(
+                matches!(operation, TransactionBenchOp::UpdateAll),
+                "raw_sqlite_literal only supports update_all"
+            );
+            if let Some(repeats) = hot_repeats {
+                profile_hot_raw_sqlite_literal_updates(rows, repeats);
+            } else {
+                profile_raw_sqlite_literal_updates(rows, sample_count);
+            }
+        }
         Ok("sql_session") => {
             let profile = profile_sql_session_storage();
             if let Some(repeats) = hot_repeats {
                 profile_hot_sql_session_operations(runtime, rows, operation, repeats, profile);
             } else {
                 profile_sql_session_operation(runtime, rows, operation, sample_count, profile);
+            }
+        }
+        Ok("sql_session_bound") => {
+            assert!(
+                matches!(operation, TransactionBenchOp::UpdateAll),
+                "sql_session_bound only supports update_all"
+            );
+            let profile = profile_sql_session_storage();
+            if let Some(repeats) = hot_repeats {
+                profile_hot_sql_session_bound_updates(runtime, rows, repeats, profile);
+            } else {
+                profile_sql_session_bound_updates(runtime, rows, sample_count, profile);
             }
         }
         Ok("transaction") | Err(_) => {
@@ -110,7 +133,7 @@ fn profile_operation(runtime: &tokio::runtime::Runtime, rows: &[WorkloadRow]) {
             }
         }
         Ok(other) => panic!(
-            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_LAYER '{other}'; expected transaction, sql_session, kv_layout, or raw_sqlite"
+            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_LAYER '{other}'; expected transaction, sql_session, sql_session_bound, kv_layout, raw_sqlite, or raw_sqlite_literal"
         ),
     }
 }
@@ -219,6 +242,29 @@ fn profile_hot_sql_session_operations(
     black_box(row_count);
 }
 
+fn profile_hot_sql_session_bound_updates(
+    runtime: &tokio::runtime::Runtime,
+    rows: &[WorkloadRow],
+    repeats: usize,
+    profile: StorageProfile,
+) {
+    let repeats_u32 =
+        u32::try_from(repeats).expect("LIX_TRACKED_STATE_CRUD_PROFILE_HOT_REPEATS must fit in u32");
+    let fixture = runtime.block_on(sql_session::seeded_fixture(profile, rows));
+    let start = Instant::now();
+    let mut row_count = 0;
+    for _ in 0..repeats {
+        row_count += runtime.block_on(fixture.update_all_bound());
+    }
+    let elapsed = start.elapsed();
+    println!(
+        "tracked_state_crud hot profile: sql_session_bound/{}/update_all/{repeats} repeats: total={elapsed:?} per_operation={:?}",
+        profile.name(),
+        elapsed / repeats_u32,
+    );
+    black_box(row_count);
+}
+
 fn profile_hot_raw_sqlite_operations(
     rows: &[WorkloadRow],
     operation: TransactionBenchOp,
@@ -240,6 +286,23 @@ fn profile_hot_raw_sqlite_operations(
         output.layer(),
         profile_operation_name(operation),
         repeats,
+        elapsed / repeats_u32,
+    );
+    black_box(row_count);
+}
+
+fn profile_hot_raw_sqlite_literal_updates(rows: &[WorkloadRow], repeats: usize) {
+    let repeats_u32 =
+        u32::try_from(repeats).expect("LIX_TRACKED_STATE_CRUD_PROFILE_HOT_REPEATS must fit in u32");
+    let mut fixture = raw_sqlite::seeded_fixture(rows);
+    let start = Instant::now();
+    let mut row_count = 0;
+    for _ in 0..repeats {
+        row_count += fixture.update_all_literal();
+    }
+    let elapsed = start.elapsed();
+    println!(
+        "tracked_state_crud hot profile: raw_sqlite/literal/update_all/{repeats} repeats: total={elapsed:?} per_operation={:?}",
         elapsed / repeats_u32,
     );
     black_box(row_count);
@@ -330,6 +393,18 @@ fn profile_raw_sqlite_operation(
     print_profile_samples(output.layer(), operation, samples);
 }
 
+fn profile_raw_sqlite_literal_updates(rows: &[WorkloadRow], sample_count: usize) {
+    let mut samples = Vec::with_capacity(sample_count);
+    for _ in 0..sample_count {
+        let mut fixture = raw_sqlite::seeded_fixture(rows);
+        let start = Instant::now();
+        let result = fixture.update_all_literal();
+        samples.push(start.elapsed());
+        black_box(result);
+    }
+    print_profile_samples("raw_sqlite/literal", TransactionBenchOp::UpdateAll, samples);
+}
+
 fn profile_sql_session_operation(
     runtime: &tokio::runtime::Runtime,
     rows: &[WorkloadRow],
@@ -352,6 +427,27 @@ fn profile_sql_session_operation(
     print_profile_samples(
         &format!("sql_session/{}", profile.name()),
         operation,
+        samples,
+    );
+}
+
+fn profile_sql_session_bound_updates(
+    runtime: &tokio::runtime::Runtime,
+    rows: &[WorkloadRow],
+    sample_count: usize,
+    profile: StorageProfile,
+) {
+    let mut samples = Vec::with_capacity(sample_count);
+    for _ in 0..sample_count {
+        let fixture = runtime.block_on(sql_session::seeded_fixture(profile, rows));
+        let start = Instant::now();
+        let result = runtime.block_on(fixture.update_all_bound());
+        samples.push(start.elapsed());
+        black_box(result);
+    }
+    print_profile_samples(
+        &format!("sql_session_bound/{}", profile.name()),
+        TransactionBenchOp::UpdateAll,
         samples,
     );
 }

--- a/packages/engine-benchmarks/benches/tracked_state_crud/raw_sqlite.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/raw_sqlite.rs
@@ -1,7 +1,7 @@
 use rusqlite::{Connection, Rows, params, params_from_iter};
 use tempfile::TempDir;
 
-use crate::workload::WorkloadRow;
+use crate::workload::{WorkloadRow, sql_string};
 use lix_engine::{ExecuteResult, Value};
 
 pub(crate) struct RawSqliteFixture {
@@ -9,6 +9,7 @@ pub(crate) struct RawSqliteFixture {
     rows: Vec<WorkloadRow>,
     read_many_by_pk_count: usize,
     read_many_by_pk_sql: String,
+    literal_update_sql: Vec<String>,
     _dir: TempDir,
 }
 
@@ -37,6 +38,7 @@ pub(crate) fn empty_fixture(rows: &[WorkloadRow]) -> RawSqliteFixture {
         rows: rows.to_vec(),
         read_many_by_pk_count,
         read_many_by_pk_sql: select_many_by_pk_sql(read_many_by_pk_count),
+        literal_update_sql: rows.iter().map(literal_update_sql).collect(),
         _dir: dir,
     }
 }
@@ -231,6 +233,28 @@ impl RawSqliteFixture {
         affected
     }
 
+    /// Runs the same prebuilt literal-statement shape as the public Lix SQL
+    /// session fixture. Unlike [`Self::update_all`], this deliberately does
+    /// not reuse a parameterized SQLite statement, so it isolates parser and
+    /// statement-setup cost from Lix's versioned commit work.
+    pub(crate) fn update_all_literal(&mut self) -> usize {
+        let transaction = self
+            .connection
+            .transaction()
+            .expect("begin literal raw sqlite update transaction");
+        let mut affected = 0;
+        for sql in &self.literal_update_sql {
+            affected += transaction
+                .execute(sql, [])
+                .expect("run literal raw sqlite update row");
+        }
+        transaction
+            .commit()
+            .expect("commit literal raw sqlite update transaction");
+        assert_eq!(affected, self.rows.len());
+        affected
+    }
+
     pub(crate) fn update_one_by_pk(&self) -> usize {
         let row = &self.rows[self.rows.len() / 2];
         let affected = self
@@ -303,4 +327,12 @@ fn select_many_by_pk_sql(count: usize) -> String {
         .collect::<Vec<_>>()
         .join(",");
     format!("SELECT path, value FROM json_pointer WHERE path IN ({placeholders}) ORDER BY path")
+}
+
+fn literal_update_sql(row: &WorkloadRow) -> String {
+    format!(
+        "UPDATE json_pointer SET value = '{}' WHERE path = '{}'",
+        sql_string(row.updated_value_json.as_str()),
+        sql_string(row.path.as_str())
+    )
 }

--- a/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
@@ -7,6 +7,7 @@ use crate::workload::{WorkloadRow, sql_string};
 
 const SQL_CHUNK_SIZE: usize = 500;
 const READ_MANY_PK_COUNT: usize = crate::READ_MANY_PK_COUNT;
+const BOUND_UPDATE_ALL_SQL: &str = "UPDATE json_pointer SET value = lix_json($1) WHERE path = $2";
 
 pub(crate) enum SqlFixture {
     SQLite(GenericSqlFixture<SQLite>),
@@ -22,6 +23,7 @@ pub(crate) struct GenericSqlFixture<StorageImpl: Storage> {
     select_one_by_pk_sql: String,
     update_one_by_pk_sql: String,
     update_all_sql_rows: Vec<String>,
+    bound_update_all_params: Vec<Vec<Value>>,
     delete_all_sql: String,
     delete_one_by_pk_sql: String,
     // Keep the storage path alive until after the session/storage is dropped.
@@ -112,6 +114,16 @@ impl SqlFixture {
         }
     }
 
+    /// Executes the tracked bulk-update workload through the public bound
+    /// parameter surface. This is a profiling control for separating repeated
+    /// literal SQL planning from the versioned write path.
+    pub(crate) async fn update_all_bound(&self) -> usize {
+        match self {
+            Self::SQLite(fixture) => fixture.update_all_bound().await,
+            Self::RocksDB(fixture) => fixture.update_all_bound().await,
+        }
+    }
+
     pub(crate) async fn update_one_by_pk(&self) -> usize {
         match self {
             Self::SQLite(fixture) => fixture.update_one_by_pk().await,
@@ -191,6 +203,29 @@ where
     }
 
     #[expect(clippy::cast_possible_truncation)]
+    async fn update_all_bound(&self) -> usize {
+        let mut transaction = self
+            .session
+            .begin_transaction()
+            .await
+            .expect("begin tracked-state CRUD bound transaction");
+        let mut affected = 0;
+        for params in &self.bound_update_all_params {
+            affected += transaction
+                .execute(BOUND_UPDATE_ALL_SQL, params)
+                .await
+                .expect("execute tracked-state CRUD bound transaction SQL")
+                .rows_affected();
+        }
+        transaction
+            .commit()
+            .await
+            .expect("commit tracked-state CRUD bound transaction");
+        assert_eq!(affected as usize, self.row_count);
+        affected as usize
+    }
+
+    #[expect(clippy::cast_possible_truncation)]
     async fn update_one_by_pk(&self) -> usize {
         let affected = execute(&self.session, &self.update_one_by_pk_sql)
             .await
@@ -236,6 +271,15 @@ where
         select_one_by_pk_sql: select_by_pk_sql(&rows[mid..][..1]),
         update_one_by_pk_sql: update_row_sql(&rows[mid]),
         update_all_sql_rows: rows.iter().map(update_row_sql).collect(),
+        bound_update_all_params: rows
+            .iter()
+            .map(|row| {
+                vec![
+                    Value::Text(row.updated_value_json.clone()),
+                    Value::Text(row.path.clone()),
+                ]
+            })
+            .collect(),
         delete_all_sql: "DELETE FROM json_pointer".to_string(),
         delete_one_by_pk_sql: format!(
             "DELETE FROM json_pointer WHERE path = '{}'",

--- a/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
+++ b/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
@@ -41,8 +41,8 @@ async fn standalone_sqlite_public_results_match_lix_sql_results() {
             updated_value_json: r#""updated""#.to_string(),
         },
     ];
-    let raw = raw_sqlite::seeded_fixture(&rows);
-    let lix = sql_session::seeded_fixture(StorageProfile::SQLite, &rows).await;
+    let mut raw = raw_sqlite::seeded_fixture(&rows);
+    let lix = sql_session::seeded_fixture(StorageProfile::RocksDB, &rows).await;
 
     assert_eq!(raw.read_all_public_result(), lix.read_all_result().await);
     assert_eq!(
@@ -53,4 +53,8 @@ async fn standalone_sqlite_public_results_match_lix_sql_results() {
         raw.read_many_by_pk_public_result(READ_MANY_PK_COUNT),
         lix.read_many_by_pk_result().await
     );
+
+    assert_eq!(raw.update_all_literal(), rows.len());
+    assert_eq!(lix.update_all_bound().await, rows.len());
+    assert_eq!(raw.read_all_public_result(), lix.read_all_result().await);
 }


### PR DESCRIPTION
## What changed

Adds profile-only controls for the 10k tracked update workload:

- standalone SQLite executing prebuilt literal updates inside one transaction;
- Lix on RocksDB executing the same updates through the existing bound-parameter API inside one transaction.

The parity test verifies both controls converge to the same public result.

## Measurements (fresh 11-sample median, 10k updates)

| path | median |
| --- | ---: |
| standalone SQLite, prepared statement | 14.895 ms |
| standalone SQLite, distinct literal statements | 28.745 ms |
| Lix SQL + RocksDB, distinct literals | 521.431 ms |
| Lix SQL + RocksDB, bound parameters | 354.928 ms |

Literal SQL setup accounts for roughly 14 ms in standalone SQLite, while Lix's exact-text parse/plan cache miss costs 166.5 ms (32%) on the RocksDB tracked path. This makes an internal literal-template cache a measurable next candidate.

## Validation

- `cargo fmt --check`
- `cargo clippy -p lix_engine_benchmarks --bench tracked_state_crud --features storage-benches -- -D warnings`
- `cargo test -p lix_engine_benchmarks --test tracked_state_crud_public_result --features storage-benches`