### PR TITLE
fix(storage): report ambiguous SlateDB commits

### DIFF
--- a/packages/engine/src/common/error.rs
+++ b/packages/engine/src/common/error.rs
@@ -91,6 +91,11 @@ impl LixError {
     /// longer serve requests.
     pub const CODE_STORAGE_CLOSED: &'static str = "LIX_STORAGE_CLOSED";
 
+    /// A storage commit may have been applied, but its caller did not receive
+    /// a definitive result.
+    pub const CODE_STORAGE_COMMIT_OUTCOME_UNKNOWN: &'static str =
+        "LIX_STORAGE_COMMIT_OUTCOME_UNKNOWN";
+
     /// Optimistic transaction publication lost a race with a newer commit.
     pub const CODE_TRANSACTION_CONFLICT: &'static str = "LIX_TRANSACTION_CONFLICT";
 
@@ -340,6 +345,17 @@ impl From<crate::storage_adapter::StorageError> for LixError {
                 "retryable": false,
                 "outcome": "unknown",
             })),
+            crate::storage_adapter::StorageError::CommitOutcomeUnknown(message) => Self::new(
+                Self::CODE_STORAGE_COMMIT_OUTCOME_UNKNOWN,
+                format!("the storage commit outcome is unknown: {message}"),
+            )
+            .with_hint(
+                "Do not automatically retry this request; a mutation may still have completed.",
+            )
+            .with_details(json!({
+                "retryable": false,
+                "outcome": "unknown",
+            })),
             error => Self::new(Self::CODE_STORAGE_ERROR, error.to_string()),
         }
     }
@@ -417,6 +433,26 @@ mod tests {
                 "retryable": false,
                 "outcome": "unknown",
             }))
+        );
+    }
+
+    #[test]
+    fn unknown_commit_outcome_is_not_retryable() {
+        let error = LixError::from(crate::storage::StorageError::CommitOutcomeUnknown(
+            "storage reply was lost after commit".to_string(),
+        ));
+
+        assert_eq!(error.code, LixError::CODE_STORAGE_COMMIT_OUTCOME_UNKNOWN);
+        assert_eq!(
+            error.details,
+            Some(serde_json::json!({
+                "retryable": false,
+                "outcome": "unknown",
+            }))
+        );
+        assert_eq!(
+            error.hint(),
+            Some("Do not automatically retry this request; a mutation may still have completed.")
         );
     }
 

--- a/packages/engine/src/storage/error.rs
+++ b/packages/engine/src/storage/error.rs
@@ -17,6 +17,9 @@ pub enum StorageError {
     Fenced,
     /// The storage instance has stopped and cannot be reused.
     Closed(String),
+    /// A commit may have been applied, but the caller did not receive a
+    /// definitive result.
+    CommitOutcomeUnknown(String),
     Corruption(String),
     Io(String),
 }
@@ -96,6 +99,9 @@ impl fmt::Display for StorageError {
             Self::Durability => f.write_str("durability failure"),
             Self::Fenced => f.write_str("storage writer was fenced by a newer client"),
             Self::Closed(message) => write!(f, "storage instance is closed: {message}"),
+            Self::CommitOutcomeUnknown(message) => {
+                write!(f, "storage commit outcome is unknown: {message}")
+            }
             Self::Corruption(message) => write!(f, "storage corruption: {message}"),
             Self::Io(message) => write!(f, "io error: {message}"),
         }

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -2450,6 +2450,7 @@ fn status_for_lix_error(error: &LixError) -> StatusCode {
         LixError::CODE_CLOSED | LixError::CODE_STORAGE_FENCED | LixError::CODE_STORAGE_CLOSED => {
             StatusCode::CONFLICT
         }
+        LixError::CODE_STORAGE_COMMIT_OUTCOME_UNKNOWN => StatusCode::SERVICE_UNAVAILABLE,
         LixError::CODE_PLUGIN_OBSERVATION_STALE => StatusCode::GONE,
         LixError::CODE_INTERNAL_ERROR => StatusCode::INTERNAL_SERVER_ERROR,
         _ => StatusCode::BAD_REQUEST,
@@ -2913,9 +2914,9 @@ mod tests {
     use flate2::{Compression, read::GzDecoder, write::GzEncoder};
     use http_body_util::BodyExt as _;
     use lix_sdk::{
-        Blob, Memory, MemoryRead, MemoryWrite, OpenLixOptions, ReadOptions,
-        RequestBlobSpliceProvenance, StorageError, TracingTelemetrySink, WriteOptions, open_lix,
-        open_lix_with_telemetry,
+        Blob, CommitResult, Key, KeyRange, Memory, MemoryRead, MemoryWrite, OpenLixOptions,
+        PutBatch, ReadOptions, RequestBlobSpliceProvenance, SpaceId, StorageError, StorageWrite,
+        TracingTelemetrySink, WriteOptions, open_lix, open_lix_with_telemetry,
     };
     use serde_json::{Value as JsonValue, json};
     use std::{
@@ -2939,6 +2940,18 @@ mod tests {
             assert_eq!(response.status(), StatusCode::CONFLICT);
             assert!(is_terminal_storage_response(&response));
         }
+    }
+
+    #[test]
+    fn unknown_commit_outcome_is_non_retryable_but_does_not_retire_the_runtime() {
+        let response = ApiError::from(LixError::new(
+            LixError::CODE_STORAGE_COMMIT_OUTCOME_UNKNOWN,
+            "the storage commit outcome is unknown",
+        ))
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert!(!is_terminal_storage_response(&response));
     }
 
     #[derive(Clone, Debug)]
@@ -3200,6 +3213,91 @@ mod tests {
                 return Err(StorageError::Fenced);
             }
             self.inner.begin_write(options).await
+        }
+    }
+
+    #[derive(Clone)]
+    struct PostCommitUnknownStorage {
+        inner: Memory,
+        fail_next_commit: Arc<AtomicBool>,
+    }
+
+    impl PostCommitUnknownStorage {
+        fn new() -> Self {
+            Self {
+                inner: Memory::new(),
+                fail_next_commit: Arc::new(AtomicBool::new(false)),
+            }
+        }
+
+        fn fail_next_commit(&self) {
+            self.fail_next_commit.store(true, Ordering::Release);
+        }
+    }
+
+    struct PostCommitUnknownWrite {
+        inner: MemoryWrite,
+        fail_after_commit: bool,
+    }
+
+    impl Storage for PostCommitUnknownStorage {
+        type Read<'a>
+            = MemoryRead
+        where
+            Self: 'a;
+        type Write<'a>
+            = PostCommitUnknownWrite
+        where
+            Self: 'a;
+
+        async fn begin_read(&self, options: ReadOptions) -> Result<Self::Read<'_>, StorageError> {
+            self.inner.begin_read(options).await
+        }
+
+        async fn begin_write(
+            &self,
+            options: WriteOptions,
+        ) -> Result<Self::Write<'_>, StorageError> {
+            Ok(PostCommitUnknownWrite {
+                inner: self.inner.begin_write(options).await?,
+                fail_after_commit: self.fail_next_commit.swap(false, Ordering::AcqRel),
+            })
+        }
+    }
+
+    impl StorageWrite for PostCommitUnknownWrite {
+        async fn put_many(
+            &mut self,
+            space: SpaceId,
+            entries: PutBatch,
+        ) -> Result<(), StorageError> {
+            self.inner.put_many(space, entries).await
+        }
+
+        async fn delete_many(&mut self, space: SpaceId, keys: &[Key]) -> Result<(), StorageError> {
+            self.inner.delete_many(space, keys).await
+        }
+
+        async fn delete_range(
+            &mut self,
+            space: SpaceId,
+            range: KeyRange,
+        ) -> Result<(), StorageError> {
+            self.inner.delete_range(space, range).await
+        }
+
+        async fn commit(self) -> Result<CommitResult, StorageError> {
+            let result = self.inner.commit().await?;
+            if self.fail_after_commit {
+                return Err(StorageError::CommitOutcomeUnknown(
+                    "injected post-commit failure".to_string(),
+                ));
+            }
+            Ok(result)
+        }
+
+        async fn rollback(self) -> Result<(), StorageError> {
+            self.inner.rollback().await
         }
     }
 
@@ -3872,6 +3970,55 @@ mod tests {
         let server = LixProtocolServer::with_options(lix, options).expect("protocol server");
         let router = handler(server.clone());
         TestApp { server, router }
+    }
+
+    #[tokio::test]
+    async fn applied_write_with_unknown_commit_outcome_is_not_safe_to_retry() {
+        let storage = PostCommitUnknownStorage::new();
+        let lix = Arc::new(
+            open_lix(OpenLixOptions::new(storage.clone()))
+                .await
+                .expect("open Lix"),
+        );
+        let server = LixProtocolServer::new(lix);
+        let router = handler(server);
+        let (session_id, _) = new_session(&router).await;
+
+        storage.fail_next_commit();
+        let response = request(
+            &router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "INSERT INTO lix_key_value (key, value) VALUES ('unknown-commit', 'written')"
+            })),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let error = response_json(response).await;
+        assert_eq!(
+            error["error"]["code"],
+            LixError::CODE_STORAGE_COMMIT_OUTCOME_UNKNOWN
+        );
+        assert_eq!(error["error"]["details"]["retryable"], false);
+        assert_eq!(error["error"]["details"]["outcome"], "unknown");
+
+        let persisted = request(
+            &router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT COUNT(*) FROM lix_key_value WHERE key = 'unknown-commit'"
+            })),
+        )
+        .await;
+        assert_eq!(persisted.status(), StatusCode::OK);
+        assert_eq!(
+            response_json(persisted).await["rows"][0][0],
+            json!({ "kind": "int", "value": 1 })
+        );
     }
 
     async fn app_with_tracing_telemetry() -> TestApp {

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -548,6 +548,7 @@ impl StorageWrite for SlateDBWrite {
                     })
                 })
                 .await
+                .map_err(commit_outcome_unknown)
         }
     }
 
@@ -1122,6 +1123,18 @@ fn slatedb_error(error: slatedb::Error) -> StorageError {
     }
 }
 
+/// Errors from an accepted SlateDB write cannot prove the batch was not
+/// applied: SlateDB can fail after its atomic WAL/memtable publication and
+/// before returning the durability watcher. Preserve the known terminal
+/// states, but make every other attempted commit outcome explicit so callers
+/// do not blindly replay it.
+fn commit_outcome_unknown(error: StorageError) -> StorageError {
+    match error {
+        StorageError::Fenced | StorageError::Closed(_) => error,
+        error => StorageError::CommitOutcomeUnknown(error.to_string()),
+    }
+}
+
 fn object_store_error(error: object_store::Error) -> StorageError {
     StorageError::Io(format!("slatedb object store: {error}"))
 }
@@ -1506,7 +1519,7 @@ mod tests {
     }
 
     #[test]
-    fn commit_reports_wal_durability_failure() {
+    fn commit_failure_is_not_advertised_as_a_definite_abort() {
         let store = Arc::new(BlockingStore::new(Arc::new(InMemory::new())));
         let storage = SlateDB::open_object_store_with_options(
             "test-failed-commit",
@@ -1550,8 +1563,8 @@ mod tests {
             .recv_timeout(Duration::from_secs(2))
             .expect("failed commit should finish after its WAL upload");
         assert!(
-            matches!(commit_error, Err(StorageError::Io(message)) if message.contains("injected write failure")),
-            "commit should preserve the SlateDB WAL error"
+            matches!(commit_error, Err(StorageError::CommitOutcomeUnknown(message)) if message.contains("injected write failure")),
+            "an attempted SlateDB commit failure must not claim that the write aborted"
         );
         committer.join().expect("join failed committer");
     }


### PR DESCRIPTION
## Summary

- classify non-terminal errors returned from an attempted SlateDB commit as `LIX_STORAGE_COMMIT_OUTCOME_UNKNOWN`
- expose the result as HTTP 503 with `retryable: false` and `outcome: "unknown"`, without retiring a live runtime
- add adapter and end-to-end regression coverage for an applied write whose caller receives no definitive result

## Confirmed failure

With `await_durable: true`, a successful SlateDB write has crossed the durability boundary. However, SlateDB can still return an error after internal WAL/memtable publication and before the public write call returns. Lix previously reduced that commit-specific outcome to generic `LIX_STORAGE_ERROR` / HTTP 400, which falsely suggested a definite abort and gave callers no guard against replaying a mutation that may already exist.

## Fix and contract

Only errors escaping an actual `SlateDBWrite::commit` are classified. `Fenced` and `Closed` retain their existing terminal/recovery semantics; all other commit-call failures explicitly report an unknown, non-retryable outcome. No SlateDB behavior is changed or strengthened.

This follows the documented SlateDB durability boundary ([WriteOptions::await_durable](https://docs.rs/slatedb/latest/slatedb/config/struct.WriteOptions.html)) and the established practice of treating uncertain commit results as ambiguous rather than blindly retrying ([FoundationDB](https://apple.github.io/foundationdb/developer-guide.html#transactions-with-unknown-results), [CockroachDB](https://www.cockroachlabs.com/docs/v26.2/transactions#error-handling)).

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p lix_engine --lib unknown_commit_outcome_is_not_retryable`
- source review confirms the mutation client does not automatically retry HTTP 503

The full SlateDB and server-protocol Rust test targets were left to CI because the local host filesystem is full while their target directories already consume the available space.

## Remaining risk

A caller that loses a commit response still has an inherently ambiguous result and must reconcile state or use application-level idempotency before trying again. This change makes that ambiguity explicit instead of falsely acknowledging a definite failure.