### PR TITLE
perf(binary-cas): reuse chunks for fixed-width edits

### DIFF
--- a/packages/engine/src/binary_cas/context.rs
+++ b/packages/engine/src/binary_cas/context.rs
@@ -2,7 +2,9 @@ use async_trait::async_trait;
 
 use crate::LixError;
 use crate::binary_cas::BinaryCasChunking;
-use crate::binary_cas::{BlobBytesBatch, BlobHash, BlobPayload, BlobWriteReceipt};
+use crate::binary_cas::{
+    BlobBytesBatch, BlobHash, BlobPayload, BlobSameLengthSplice, BlobWriteReceipt,
+};
 use crate::storage_adapter::{StorageAdapterRead, StorageWriteSet};
 use std::collections::HashSet;
 
@@ -123,5 +125,32 @@ where
             payload.hash(),
         )
         .await
+    }
+
+    /// Stages a normal file payload, opportunistically retaining unchanged
+    /// manifest chunks for one host-verified same-length splice. Any
+    /// ineligible or unavailable base falls through to the canonical full
+    /// rechunking path.
+    pub(crate) async fn stage_file_payload(
+        &mut self,
+        payload: &BlobPayload,
+        same_length_splice: Option<BlobSameLengthSplice>,
+    ) -> Result<(), LixError> {
+        if let Some(splice) = same_length_splice
+            && crate::binary_cas::kv::try_stage_blob_write_reusing_same_length_splice(
+                self.store,
+                self.writes,
+                &mut self.blob_hashes,
+                &mut self.chunk_keys,
+                payload.bytes(),
+                payload.hash(),
+                splice,
+            )
+            .await?
+        {
+            return Ok(());
+        }
+        self.stage_payload(payload).await?;
+        Ok(())
     }
 }

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -12,19 +12,22 @@ use crate::binary_cas::codec::{
 use crate::binary_cas::compression::{decode_zstd_chunk, encode_chunk_payload};
 use crate::binary_cas::{
     BinaryCasChunking, BlobBytesBatch, BlobHash, BlobLayout, BlobMetadata, BlobMetadataBatch,
-    BlobWriteReceipt, InlineBlob,
+    BlobSameLengthSplice, BlobWriteReceipt, InlineBlob,
 };
+#[cfg(test)]
+use crate::storage_adapter::StoragePrefix;
 use crate::storage_adapter::{
     PointReadPlan, ScanPlan, StorageAdapterRead, StorageSpace, StorageWriteSet,
 };
 use crate::storage_adapter::{
-    StorageCoreProjection, StorageGetOptions, StorageKey, StoragePrefix, StorageProjectedValue,
+    StorageCoreProjection, StorageGetOptions, StorageKey, StorageKeyRange, StorageProjectedValue,
     StorageScanOptions, StorageSpaceId, StorageValue,
 };
 use bytes::Bytes;
 use futures_util::{StreamExt, stream};
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
+use std::ops::Bound;
 use web_time::Instant;
 
 // Keep independent manifest scans bounded so large blob batches do not create
@@ -102,6 +105,7 @@ pub(crate) fn stage_manifest(
     );
 }
 
+#[cfg(test)]
 pub(crate) async fn scan_manifest_chunks(
     store: &impl StorageAdapterRead,
     blob_hash: BlobHash,
@@ -121,6 +125,42 @@ pub(crate) async fn scan_manifest_chunks(
         })
     })
     .collect()
+}
+
+/// Loads exactly the manifest rows declared by a chunked blob's metadata.
+///
+/// Blob roots are content-addressed by their complete bytes, while chunk rows
+/// are a mutable physical representation. A later valid writer may select a
+/// different layout for the same content hash. Restricting reads to the
+/// declared ordinal range keeps stale suffix rows harmless; the caller still
+/// rejects missing declared rows by comparing the resulting count.
+async fn load_declared_manifest_chunks(
+    store: &impl StorageAdapterRead,
+    blob_hash: BlobHash,
+    chunk_count: u32,
+) -> Result<Vec<KvBlobManifestChunk>, LixError> {
+    if chunk_count == 0 {
+        return Ok(Vec::new());
+    }
+    let range = StorageKeyRange {
+        lower: Bound::Included(StorageKey(Bytes::from(manifest_chunk_key(blob_hash, 0)))),
+        upper: Bound::Excluded(StorageKey(Bytes::from(manifest_chunk_key(
+            blob_hash,
+            u64::from(chunk_count),
+        )))),
+    };
+    let plan = ScanPlan::range(BINARY_CAS_MANIFEST_CHUNK_SPACE, range);
+    scan_all_values_for_plan(store, &plan)
+        .await?
+        .into_iter()
+        .map(|value| {
+            let (chunk_hash, chunk_size) = decode_binary_cas_manifest_chunk(&value)?;
+            Ok(KvBlobManifestChunk {
+                chunk_hash,
+                chunk_size,
+            })
+        })
+        .collect()
 }
 
 pub(crate) fn stage_manifest_chunk(
@@ -213,6 +253,7 @@ async fn get_one(
         .map(|bytes| bytes.to_vec()))
 }
 
+#[cfg(test)]
 async fn scan_all_values(
     store: &impl StorageAdapterRead,
     space: StorageSpace,
@@ -224,6 +265,13 @@ async fn scan_all_values(
             bytes: Bytes::from(prefix),
         },
     );
+    scan_all_values_for_plan(store, &plan).await
+}
+
+async fn scan_all_values_for_plan(
+    store: &impl StorageAdapterRead,
+    plan: &ScanPlan,
+) -> Result<Vec<Vec<u8>>, LixError> {
     let mut values = Vec::new();
     let mut resume_after = None;
     loop {
@@ -313,7 +361,8 @@ pub(crate) async fn load_bytes_many(
     let mut scans = stream::iter(chunked_blobs.into_iter().enumerate())
         .map(|(order, (blob_hash, chunk_count))| async move {
             let result = async {
-                let manifest_chunks = scan_manifest_chunks(store, blob_hash).await?;
+                let manifest_chunks =
+                    load_declared_manifest_chunks(store, blob_hash, chunk_count).await?;
                 if manifest_chunks.len() != chunk_count as usize {
                     return Err(LixError::new(
                         "LIX_ERROR_UNKNOWN",
@@ -710,6 +759,132 @@ where
     Ok(receipt)
 }
 
+/// Attempts to stage a full replacement by retaining the base manifest's
+/// unchanged chunk references around one host-verified fixed-width splice.
+///
+/// This is deliberately opportunistic. The caller still owns complete
+/// replacement bytes and falls back to [`stage_blob_write_skipping_existing_chunks`]
+/// for every missing, malformed, non-chunked, length-changing, or otherwise
+/// ineligible base. A manifest is an ordered content-addressed chunk list;
+/// readers do not require its boundaries to have been freshly produced by
+/// FastCDC, so keeping valid existing boundaries is format-compatible.
+pub(in crate::binary_cas) async fn try_stage_blob_write_reusing_same_length_splice<S>(
+    store: &S,
+    writes: &mut StorageWriteSet,
+    blob_hashes: &mut HashSet<[u8; 32]>,
+    chunk_keys: &mut HashSet<Vec<u8>>,
+    bytes: &[u8],
+    precomputed_hash: Option<BlobHash>,
+    splice: BlobSameLengthSplice,
+) -> Result<bool, LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    let Some(blob_hash) = precomputed_hash else {
+        return Ok(false);
+    };
+    let Some(splice_end) = splice.end() else {
+        return Ok(false);
+    };
+    if splice.length == 0 || splice_end > bytes.len() {
+        return Ok(false);
+    }
+    if blob_hashes.contains(&blob_hash.into_bytes()) {
+        return Ok(true);
+    }
+
+    let metadata = match load_metadata_many(&store, &[splice.base_blob_hash]).await {
+        Ok(metadata) => metadata.into_vec().pop().flatten(),
+        Err(_) => return Ok(false),
+    };
+    let Some(metadata) = metadata else {
+        return Ok(false);
+    };
+    let BlobLayout::Chunked { chunk_count } = &metadata.layout else {
+        return Ok(false);
+    };
+    let chunk_count = *chunk_count;
+    if metadata.size_bytes != bytes.len() as u64 {
+        return Ok(false);
+    }
+
+    let base_chunks =
+        match load_declared_manifest_chunks(&store, splice.base_blob_hash, chunk_count).await {
+            Ok(chunks) => chunks,
+            Err(_) => return Ok(false),
+        };
+    if base_chunks.len() != chunk_count as usize {
+        return Ok(false);
+    }
+
+    let mut cursor = 0usize;
+    let mut chunks = Vec::with_capacity(base_chunks.len());
+    let mut changed_chunks = Vec::new();
+    for base_chunk in base_chunks {
+        let Ok(chunk_len) = usize::try_from(base_chunk.chunk_size) else {
+            return Ok(false);
+        };
+        if chunk_len == 0 || chunk_len > MAX_BINARY_CAS_CHUNK_BYTES {
+            return Ok(false);
+        }
+        let Some(end) = cursor.checked_add(chunk_len) else {
+            return Ok(false);
+        };
+        if end > bytes.len() {
+            return Ok(false);
+        }
+        let changed = cursor < splice_end && splice.offset < end;
+        let chunk = PreparedChunk {
+            start: cursor,
+            end,
+            hash: if changed {
+                BlobHash::from_content(&bytes[cursor..end])
+            } else {
+                BlobHash::from_bytes(base_chunk.chunk_hash)
+            },
+        };
+        if changed {
+            changed_chunks.push(chunk);
+        }
+        chunks.push((chunk, changed));
+        cursor = end;
+    }
+    if cursor != bytes.len() || changed_chunks.is_empty() {
+        return Ok(false);
+    }
+
+    let mut chunk_hashes_to_stage =
+        missing_chunk_hashes_for_chunks(store, chunk_keys, &changed_chunks).await?;
+    if !blob_hashes.insert(blob_hash.into_bytes()) {
+        return Ok(true);
+    }
+
+    stage_manifest(
+        writes,
+        blob_hash,
+        &BinaryCasManifest::Chunked {
+            size_bytes: bytes.len() as u64,
+            chunk_count,
+        },
+    );
+    for (chunk_index, (chunk, changed)) in chunks.into_iter().enumerate() {
+        let chunk_data = &bytes[chunk.start..chunk.end];
+        if changed && chunk_hashes_to_stage.remove(&chunk.hash) {
+            stage_content_chunk(writes, chunk.hash, chunk_data)?;
+        }
+        stage_manifest_chunk(
+            writes,
+            blob_hash,
+            chunk_index as u64,
+            &KvBlobManifestChunk {
+                chunk_hash: *chunk.hash.as_bytes(),
+                chunk_size: chunk_data.len() as u64,
+            },
+        );
+    }
+    Ok(true)
+}
+
 fn prepare_blob_write(
     chunking: BinaryCasChunking,
     bytes: &[u8],
@@ -892,6 +1067,30 @@ async fn missing_chunk_hashes(
         .collect())
 }
 
+async fn missing_chunk_hashes_for_chunks(
+    store: &(impl StorageAdapterRead + ?Sized),
+    transaction_chunk_keys: &mut HashSet<Vec<u8>>,
+    chunks: &[PreparedChunk],
+) -> Result<HashSet<BlobHash>, LixError> {
+    let mut candidates = Vec::<(BlobHash, StorageKey)>::new();
+    for chunk in chunks {
+        collect_chunk_lookup_candidate(chunk.hash, transaction_chunk_keys, &mut candidates);
+    }
+    if candidates.is_empty() {
+        return Ok(HashSet::new());
+    }
+    let keys = candidates
+        .iter()
+        .map(|(_, key)| key.clone())
+        .collect::<Vec<_>>();
+    let existing = chunk_keys_exist(store, keys).await?;
+    Ok(candidates
+        .into_iter()
+        .zip(existing)
+        .filter_map(|((chunk_hash, _), exists)| (!exists).then_some(chunk_hash))
+        .collect())
+}
+
 fn collect_chunk_lookup_candidate(
     chunk_hash: BlobHash,
     transaction_chunk_keys: &mut HashSet<Vec<u8>>,
@@ -989,6 +1188,7 @@ fn manifest_key(blob_hash: BlobHash) -> Vec<u8> {
     blob_hash.as_bytes().to_vec()
 }
 
+#[cfg(test)]
 fn manifest_chunk_prefix(blob_hash: BlobHash) -> Vec<u8> {
     blob_hash.as_bytes().to_vec()
 }
@@ -1246,6 +1446,23 @@ mod tests {
             .expect("test blob write should stage")
     }
 
+    async fn stage_test_file_payload(
+        storage: &StorageAdapter<Memory>,
+        writes: &mut StorageWriteSet,
+        payload: &BlobPayload,
+        same_length_splice: Option<BlobSameLengthSplice>,
+    ) {
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("test blob read should open");
+        BinaryCasContext::new()
+            .writer_skipping_existing_chunks(&store, writes)
+            .stage_file_payload(payload, same_length_splice)
+            .await
+            .expect("test file payload should stage")
+    }
+
     async fn stage_test_bytes(
         storage: &StorageAdapter<Memory>,
         writes: &mut StorageWriteSet,
@@ -1326,6 +1543,49 @@ mod tests {
                     chunk_size: 6,
                 },
             ]
+        );
+    }
+
+    #[tokio::test]
+    async fn declared_manifest_reads_ignore_stale_suffix_rows() {
+        let storage = StorageAdapter::new(Memory::new());
+        let (blob_hash, expected) = {
+            let mut writes = storage.new_write_set();
+            let fixture = stage_two_chunk_blob(&mut writes, 0);
+            stage_manifest_chunk(
+                &mut writes,
+                fixture.0,
+                2,
+                &KvBlobManifestChunk {
+                    chunk_hash: BlobHash::from_content(b"stale manifest suffix").into_bytes(),
+                    chunk_size: 1,
+                },
+            );
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .expect("manifest fixture should commit");
+            fixture
+        };
+
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        assert_eq!(
+            scan_manifest_chunks(&store, blob_hash)
+                .await
+                .expect("raw manifest rows should scan")
+                .len(),
+            3,
+            "the physical suffix is intentionally present",
+        );
+        assert_eq!(
+            load_bytes_many(&store, &[blob_hash])
+                .await
+                .expect("declared manifest rows should load")
+                .into_vec(),
+            vec![Some(expected)],
         );
     }
 
@@ -1891,6 +2151,156 @@ mod tests {
                 .expect("blob should load")
                 .into_vec(),
             vec![Some(data)]
+        );
+    }
+
+    #[tokio::test]
+    async fn same_length_splice_writer_reuses_unchanged_manifest_chunks_and_roundtrips() {
+        let storage = StorageAdapter::new(Memory::new());
+        let before = definitely_multi_chunk_blob_bytes();
+        let base_blob_hash = BlobHash::from_content(&before);
+
+        {
+            let mut writes = storage.new_write_set();
+            stage_test_bytes(&storage, &mut writes, &before).await;
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .expect("base blob should commit");
+        }
+
+        let base_chunks = {
+            let store = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("base manifest read should open");
+            scan_manifest_chunks(&store, base_blob_hash)
+                .await
+                .expect("base manifest should scan")
+        };
+        assert!(base_chunks.len() > 1, "fixture must be chunked");
+        let changed_chunk_index = base_chunks.len() / 2;
+        let changed_chunk_start = base_chunks
+            .iter()
+            .take(changed_chunk_index)
+            .map(|chunk| usize::try_from(chunk.chunk_size).expect("chunk size should fit"))
+            .sum::<usize>();
+        let changed_chunk_len =
+            usize::try_from(base_chunks[changed_chunk_index].chunk_size).expect("chunk fits");
+        let edit_offset = changed_chunk_start + changed_chunk_len / 2;
+        let mut after = before.clone();
+        after[edit_offset] ^= 0xff;
+        let after_blob_hash = BlobHash::from_content(&after);
+        let after_payload = BlobPayload::from_bytes(after.clone());
+
+        {
+            let mut writes = storage.new_write_set();
+            stage_test_file_payload(
+                &storage,
+                &mut writes,
+                &after_payload,
+                Some(BlobSameLengthSplice::new(base_blob_hash, edit_offset, 1)),
+            )
+            .await;
+            assert_eq!(
+                writes.stats().staged_puts,
+                u64::try_from(base_chunks.len() + 3).expect("write count should fit"),
+                "one changed chunk needs one presence marker and one payload; all other chunks are manifest references",
+            );
+            writes
+                .validate()
+                .expect("reused manifest writes should be canonical");
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .expect("same-length replacement should commit");
+        }
+
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("result read should open");
+        let after_chunks = scan_manifest_chunks(&store, after_blob_hash)
+            .await
+            .expect("replacement manifest should scan");
+        assert_eq!(after_chunks.len(), base_chunks.len());
+        let changed_chunk_count = after_chunks
+            .iter()
+            .zip(&base_chunks)
+            .filter(|(after_chunk, base_chunk)| after_chunk.chunk_hash != base_chunk.chunk_hash)
+            .count();
+        assert_eq!(
+            changed_chunk_count, 1,
+            "only the overlapping chunk may change"
+        );
+        assert_eq!(
+            load_bytes_many(&store, &[after_blob_hash])
+                .await
+                .expect("replacement bytes should load")
+                .into_vec(),
+            vec![Some(after)],
+        );
+    }
+
+    #[tokio::test]
+    async fn same_length_splice_writer_falls_back_when_result_length_changes() {
+        let storage = StorageAdapter::new(Memory::new());
+        let before = definitely_multi_chunk_blob_bytes();
+        let base_blob_hash = BlobHash::from_content(&before);
+
+        {
+            let mut writes = storage.new_write_set();
+            stage_test_bytes(&storage, &mut writes, &before).await;
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .expect("base blob should commit");
+        }
+
+        let edit_offset = before.len() / 2;
+        let mut after = before.clone();
+        after.insert(edit_offset, b'!');
+        let after_blob_hash = BlobHash::from_content(&after);
+        let after_payload = BlobPayload::from_bytes(after.clone());
+        {
+            let mut writes = storage.new_write_set();
+            stage_test_file_payload(
+                &storage,
+                &mut writes,
+                &after_payload,
+                Some(BlobSameLengthSplice::new(base_blob_hash, edit_offset, 1)),
+            )
+            .await;
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .expect("length-changing replacement should fall back and commit");
+        }
+
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("result read should open");
+        let expected_hashes = crate::binary_cas::chunking::fastcdc_chunk_ranges(&after)
+            .into_iter()
+            .map(|(start, end)| BlobHash::from_content(&after[start..end]).into_bytes())
+            .collect::<Vec<_>>();
+        let actual_hashes = scan_manifest_chunks(&store, after_blob_hash)
+            .await
+            .expect("fallback manifest should scan")
+            .into_iter()
+            .map(|chunk| chunk.chunk_hash)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            actual_hashes, expected_hashes,
+            "fallback must retain FastCDC layout"
+        );
+        assert_eq!(
+            load_bytes_many(&store, &[after_blob_hash])
+                .await
+                .expect("fallback bytes should load")
+                .into_vec(),
+            vec![Some(after)],
         );
     }
 

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -808,11 +808,11 @@ where
         return Ok(false);
     }
 
-    let base_chunks =
-        match load_declared_manifest_chunks(&store, splice.base_blob_hash, chunk_count).await {
-            Ok(chunks) => chunks,
-            Err(_) => return Ok(false),
-        };
+    let Ok(base_chunks) =
+        load_declared_manifest_chunks(&store, splice.base_blob_hash, chunk_count).await
+    else {
+        return Ok(false);
+    };
     if base_chunks.len() != chunk_count as usize {
         return Ok(false);
     }
@@ -1460,7 +1460,7 @@ mod tests {
             .writer_skipping_existing_chunks(&store, writes)
             .stage_file_payload(payload, same_length_splice)
             .await
-            .expect("test file payload should stage")
+            .expect("test file payload should stage");
     }
 
     async fn stage_test_bytes(

--- a/packages/engine/src/binary_cas/mod.rs
+++ b/packages/engine/src/binary_cas/mod.rs
@@ -12,5 +12,5 @@ pub(crate) use chunking::BinaryCasChunking;
 pub(crate) use context::{BinaryCasContext, BlobDataReader};
 pub(crate) use types::{
     BlobBytesBatch, BlobHash, BlobLayout, BlobMetadata, BlobMetadataBatch, BlobPayload,
-    BlobWriteReceipt, InlineBlob,
+    BlobSameLengthSplice, BlobWriteReceipt, InlineBlob,
 };

--- a/packages/engine/src/binary_cas/types.rs
+++ b/packages/engine/src/binary_cas/types.rs
@@ -31,6 +31,34 @@ impl BlobHash {
     }
 }
 
+/// A host-verified fixed-width replacement in an already materialized blob.
+///
+/// The ordinary SQL surface still submits complete replacement bytes. The
+/// transaction layer creates this internal hint only after it has verified a
+/// v2 file transition against the exact accepted document. A CAS writer may
+/// then retain the base blob's chunk boundaries and references for every
+/// non-overlapping chunk instead of rechunking the complete replacement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BlobSameLengthSplice {
+    pub(crate) base_blob_hash: BlobHash,
+    pub(crate) offset: usize,
+    pub(crate) length: usize,
+}
+
+impl BlobSameLengthSplice {
+    pub(crate) fn new(base_blob_hash: BlobHash, offset: usize, length: usize) -> Self {
+        Self {
+            base_blob_hash,
+            offset,
+            length,
+        }
+    }
+
+    pub(crate) fn end(self) -> Option<usize> {
+        self.offset.checked_add(self.length)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct BlobPayload {
     bytes: crate::Blob,

--- a/packages/engine/src/plugin/incremental.rs
+++ b/packages/engine/src/plugin/incremental.rs
@@ -256,6 +256,24 @@ pub(crate) struct BuiltInputSplices {
     pub(crate) full_diff_bytes_compared: u64,
 }
 
+impl BuiltInputSplices {
+    /// Returns the one fixed-width base-relative replacement, if this update
+    /// can retain its prior binary-CAS chunk boundaries. This is private host
+    /// staging information; the WIT input remains the ordinary splice vector.
+    pub(crate) fn same_length_replacement(&self) -> Option<(usize, usize)> {
+        let [splice] = self.edits.as_slice() else {
+            return None;
+        };
+        let insert_len = match &splice.insert {
+            WasmInputBytes::Inline(bytes) => bytes.len(),
+            WasmInputBytes::AfterRange(range) => usize::try_from(range.length).ok()?,
+        };
+        let offset = usize::try_from(splice.offset).ok()?;
+        let delete_len = usize::try_from(splice.delete_len).ok()?;
+        (delete_len == insert_len && delete_len != 0).then_some((offset, delete_len))
+    }
+}
+
 /// Builds one coalesced base-relative replacement. Protocol-verified transport
 /// provenance preserves the exact remote splice only when its base digest
 /// names `before`. Without that proof, the fallback compares the full
@@ -1806,6 +1824,7 @@ mod tests {
         assert!(from_transport.used_transport_provenance);
         assert_eq!(from_transport.full_diff_bytes_compared, 0);
         assert_eq!(from_transport.after_sha256, Some(after_sha256));
+        assert_eq!(from_transport.same_length_replacement(), Some((2, 2)));
         assert_eq!(
             from_transport.edits,
             vec![WasmInputSplice {
@@ -1857,6 +1876,17 @@ mod tests {
                 length: 2
             })
         ));
+        assert_eq!(lazy.same_length_replacement(), Some((2, 2)));
+
+        let length_changing = build_file_update_splices(
+            before,
+            before_sha256,
+            b"abXYZef",
+            None,
+            WasmTransitionLimits::default(),
+        )
+        .expect("length-changing splice should still build");
+        assert_eq!(length_changing.same_length_replacement(), None);
     }
 
     #[test]

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -2045,6 +2045,10 @@ pub(crate) async fn execute_fast_lix_file_path_writes(
 
     for write in parsed_writes {
         if let Some(existing) = filesystem.file_entry(&write.parsed.path).cloned() {
+            let base_blob_hash = existing
+                .blob_hash
+                .as_deref()
+                .and_then(|hash| BlobHash::from_hex(hash).ok());
             if conflict != FastLixFilePathWriteConflict::None {
                 validate_fast_lix_file_path_conflict_pair(
                     existing.scope.untracked,
@@ -2092,6 +2096,7 @@ pub(crate) async fn execute_fast_lix_file_path_writes(
                         write.data,
                         context,
                         existing.blob_hash.is_some(),
+                        base_blob_hash,
                         None,
                     )
                     .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
@@ -2125,6 +2130,7 @@ pub(crate) async fn execute_fast_lix_file_path_writes(
                         write.data,
                         context,
                         existing.blob_hash.is_some(),
+                        base_blob_hash,
                         None,
                     )
                     .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
@@ -2264,12 +2270,13 @@ async fn stage_indexed_file_path_writes(
         .iter()
         .filter_map(|entry| entry.as_ref().map(Arc::clone))
         .collect::<Vec<_>>();
-    let blob_backed = load_exact_existing_blob_keys(ctx, &existing).await?;
+    let existing_blobs = load_exact_existing_blob_hashes(ctx, &existing).await?;
     let mut staged = LixFileStagedBatch::default();
 
     for (write, entry) in writes.into_iter().zip(indexed.existing) {
         if let Some(entry) = entry {
-            let has_blob_ref = blob_backed.contains(&entry.key);
+            let has_blob_ref = existing_blobs.contains_key(&entry.key);
+            let base_blob_hash = existing_blobs.get(&entry.key).copied().flatten();
             let mut context = FilesystemRowContext {
                 branch_id: entry.key.branch_id().to_string(),
                 global: entry.key.global(),
@@ -2312,6 +2319,7 @@ async fn stage_indexed_file_path_writes(
                 write.data,
                 context,
                 has_blob_ref,
+                base_blob_hash,
                 None,
             )
             .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
@@ -2359,12 +2367,12 @@ async fn stage_indexed_file_path_writes(
     stage_lix_file_fast_batch(ctx, TransactionWriteMode::Replace, staged).await
 }
 
-async fn load_exact_existing_blob_keys(
+async fn load_exact_existing_blob_hashes(
     ctx: &mut dyn SqlWriteExecutionContext,
     entries: &[Arc<FilesystemPathEntry>],
-) -> Result<BTreeSet<FilesystemDescriptorKey>, LixError> {
+) -> Result<BTreeMap<FilesystemDescriptorKey, Option<BlobHash>>, LixError> {
     if entries.is_empty() {
-        return Ok(BTreeSet::new());
+        return Ok(BTreeMap::new());
     }
     let unique = entries
         .iter()
@@ -2385,18 +2393,29 @@ async fn load_exact_existing_blob_keys(
         include_tombstones: false,
     };
     let rows = ctx.load_exact_live_state_rows(&request).await?;
-    Ok(unique
-        .into_keys()
-        .zip(rows)
-        .filter_map(|(key, row)| {
-            row.filter(|row| {
-                row.branch_id.as_ref() == key.branch_id()
-                    && row.global == key.global()
-                    && row.untracked == key.is_untracked()
-            })
-            .map(|_| key)
-        })
-        .collect())
+    let mut blobs = BTreeMap::new();
+    for ((key, entry), row) in unique.into_iter().zip(rows) {
+        let Some(row) = row else {
+            continue;
+        };
+        if row.branch_id.as_ref() != key.branch_id()
+            || row.global != key.global()
+            || row.untracked != key.is_untracked()
+        {
+            continue;
+        }
+        // This exact row is already the authoritative answer to whether the
+        // file has a blob. A malformed old snapshot must preserve that normal
+        // behavior while simply declining the optional manifest-reuse path.
+        let hash = row
+            .snapshot_content
+            .as_deref()
+            .and_then(|snapshot| serde_json::from_str::<BlobRefSnapshot>(snapshot).ok())
+            .filter(|snapshot| snapshot.id == entry.id())
+            .and_then(|snapshot| BlobHash::from_hex(&snapshot.blob_hash).ok());
+        blobs.insert(key, hash);
+    }
+    Ok(blobs)
 }
 
 pub(crate) async fn execute_fast_lix_file_data_update_by_id(
@@ -2451,8 +2470,11 @@ pub(crate) async fn execute_fast_lix_file_data_update_by_id(
                 .get(&key)
                 .cloned()
                 .expect("prepared lix_file descriptor should have a path");
+            let base_blob_hash = blob_rows
+                .get(&file.blob_ref_key())
+                .and_then(|row| BlobHash::from_hex(&row.blob_hash).ok());
             let has_blob_ref = blob_rows.contains_key(&file.blob_ref_key());
-            (path, file, has_blob_ref)
+            (path, file, has_blob_ref, base_blob_hash)
         })
         .collect::<Vec<_>>();
     if existing.is_empty() {
@@ -2460,7 +2482,7 @@ pub(crate) async fn execute_fast_lix_file_data_update_by_id(
     }
 
     let mut staged = LixFileStagedBatch::default();
-    for (path, existing, has_blob_ref) in existing {
+    for (path, existing, has_blob_ref, base_blob_hash) in existing {
         parse_file_upsert_path(&path, TransactionWriteOperation::Update)
             .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
         let mut context = existing.row_context();
@@ -2475,6 +2497,7 @@ pub(crate) async fn execute_fast_lix_file_data_update_by_id(
             data.clone(),
             context,
             has_blob_ref,
+            base_blob_hash,
             None,
         )
         .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
@@ -2801,6 +2824,7 @@ fn lix_file_existing_update_stage_from_batch(
                 context,
                 has_blob_ref,
                 None,
+                None,
             )?;
         }
 
@@ -3032,6 +3056,7 @@ fn lix_file_path_update_stage_from_batch(
                 context,
                 has_blob_ref,
                 None,
+                None,
             )?;
         } else if plugin_rewrite_file_ids.contains(&id) {
             let data = required_binary_value(batch, row_index, "data")?;
@@ -3045,6 +3070,7 @@ fn lix_file_path_update_stage_from_batch(
                 data,
                 context,
                 has_blob_ref,
+                None,
                 None,
             )?;
         }
@@ -3330,6 +3356,7 @@ fn stage_lix_file_data_update_write(
     data: impl Into<crate::Blob>,
     context: FilesystemRowContext,
     has_blob_ref: bool,
+    base_blob_hash: Option<BlobHash>,
     origin: Option<TransactionWriteOrigin>,
 ) -> Result<()> {
     let file_payload = TransactionFileData::new(
@@ -3341,7 +3368,8 @@ fn stage_lix_file_data_update_write(
         context.untracked,
         data,
     )
-    .with_had_blob_ref(has_blob_ref);
+    .with_had_blob_ref(has_blob_ref)
+    .with_base_blob_hash(base_blob_hash);
     if file_payload.is_empty() {
         if has_blob_ref {
             let mut row = blob_ref_tombstone_row(file_id, context.clone());
@@ -10165,6 +10193,11 @@ mod tests {
         assert_eq!(file_data[0].path.as_deref(), Some("/readme.md"));
         assert_eq!(file_data[0].data(), b"new");
         assert!(file_data[0].had_blob_ref);
+        assert_eq!(
+            file_data[0].base_blob_hash(),
+            Some(BlobHash::from_content(old_data)),
+            "the exact indexed blob hash should be retained for optional CAS reuse",
+        );
         let descriptor = rows
             .iter()
             .find(|row| row.schema_key == super::FILE_DESCRIPTOR_SCHEMA_KEY)

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -96,7 +96,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         let mut blob_writer = binary_cas.writer_skipping_existing_chunks(&*read, &mut writes);
         for write in &prepared_writes.file_data_writes {
             blob_writer
-                .stage_payload(write.payload())
+                .stage_file_payload(write.payload(), write.same_length_blob_splice())
                 .instrument(tracing::debug_span!(
                     target: "lix_perf",
                     "lix.perf.binary_cas_stage_payload"

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -104,6 +104,55 @@ pub(crate) struct TransactionCommitOutcome {
     pub(crate) storage_stats: StorageWriteSetStats,
 }
 
+/// The durable identity and binary base of one plugin materialization.
+///
+/// The semantic root fences actor state, while the blob hash proves the exact
+/// binary base from which a private CAS acceleration may retain chunks.
+#[derive(Debug, Clone)]
+struct VisibleV2Materialization {
+    semantic_root: String,
+    blob_hash: BlobHash,
+}
+
+fn decode_visible_v2_materialization(
+    row: &MaterializedLiveStateRow,
+    file_id: &str,
+) -> Result<VisibleV2Materialization, LixError> {
+    let semantic_root = row.change_id.map(|root| root.to_string()).ok_or_else(|| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("v2 materialization root for file '{file_id}' is missing change_id"),
+        )
+    })?;
+    let snapshot = row.snapshot_content.as_deref().ok_or_else(|| {
+        LixError::new(
+            LixError::CODE_INVALID_PLUGIN,
+            format!(
+                "owned v2 plugin file '{file_id}' materialization is missing its blob reference"
+            ),
+        )
+    })?;
+    let snapshot: PluginUpgradeBlobRefSnapshot =
+        serde_json::from_str(snapshot).map_err(|error| {
+            LixError::new(
+                LixError::CODE_INVALID_PLUGIN,
+                format!("owned v2 plugin file '{file_id}' has an invalid blob reference: {error}"),
+            )
+        })?;
+    if snapshot.id != file_id {
+        return Err(LixError::new(
+            LixError::CODE_INVALID_PLUGIN,
+            format!(
+                "owned v2 plugin file '{file_id}' materialization identity does not match its file scope"
+            ),
+        ));
+    }
+    Ok(VisibleV2Materialization {
+        semantic_root,
+        blob_hash: BlobHash::from_hex(&snapshot.blob_hash)?,
+    })
+}
+
 #[cfg(test)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 struct TransactionPathIndexBuildStats {
@@ -753,10 +802,10 @@ where
         overlay_scan_rows(&base, &staged, request).await
     }
 
-    async fn visible_v2_materialization_root(
+    async fn visible_v2_materialization(
         &mut self,
         key: &PluginFileWriteKey,
-    ) -> Result<Option<String>, LixError> {
+    ) -> Result<Option<VisibleV2Materialization>, LixError> {
         let rows = self
             .scan_visible_live_state(&LiveStateScanRequest {
                 filter: LiveStateFilter {
@@ -782,17 +831,7 @@ where
         }
         rows.into_iter()
             .next()
-            .map(|row| {
-                row.change_id.map(|root| root.to_string()).ok_or_else(|| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        format!(
-                            "v2 materialization root for file '{}' is missing change_id",
-                            key.file_id
-                        ),
-                    )
-                })
-            })
+            .map(|row| decode_visible_v2_materialization(&row, &key.file_id))
             .transpose()
     }
 
@@ -845,53 +884,15 @@ where
                 ),
             ));
         };
-        let semantic_root = blob_row
-            .change_id
-            .map(|root| root.to_string())
-            .ok_or_else(|| {
-                LixError::new(
-                    LixError::CODE_INVALID_PLUGIN,
-                    format!(
-                        "owned v2 plugin file '{}' materialization is missing its semantic root",
-                        actor_key.file_id
-                    ),
-                )
-            })?;
+        let materialization = decode_visible_v2_materialization(blob_row, &actor_key.file_id)?;
+        let semantic_root = materialization.semantic_root;
         let cold_open = cache.prepare_cold_open(actor_key, &semantic_root).await?;
         let mut cold_install: PluginActorColdInstall = match cold_open {
             PluginActorColdOpen::Ready(observation) => return Ok(observation),
             PluginActorColdOpen::Build(cold_install) => cold_install,
         };
         let store_permit = cache.admit_cold_store(&mut cold_install)?;
-        let snapshot = blob_row.snapshot_content.as_deref().ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_INVALID_PLUGIN,
-                format!(
-                    "owned v2 plugin file '{}' materialization is missing its blob reference",
-                    actor_key.file_id
-                ),
-            )
-        })?;
-        let snapshot: PluginUpgradeBlobRefSnapshot =
-            serde_json::from_str(snapshot).map_err(|error| {
-                LixError::new(
-                    LixError::CODE_INVALID_PLUGIN,
-                    format!(
-                        "owned v2 plugin file '{}' has an invalid blob reference: {error}",
-                        actor_key.file_id
-                    ),
-                )
-            })?;
-        if snapshot.id != actor_key.file_id {
-            return Err(LixError::new(
-                LixError::CODE_INVALID_PLUGIN,
-                format!(
-                    "owned v2 plugin file '{}' materialization identity does not match its file scope",
-                    actor_key.file_id
-                ),
-            ));
-        }
-        let hash = BlobHash::from_hex(&snapshot.blob_hash)?;
+        let hash = materialization.blob_hash;
         let base_blob_reader = self.binary_cas.reader(read);
         let materialized_bytes: crate::Blob =
             load_transaction_blob_bytes(&base_blob_reader, &self.staged_writes, &[hash])
@@ -905,7 +906,8 @@ where
                         LixError::CODE_INVALID_PLUGIN,
                         format!(
                             "owned v2 plugin file '{}' references missing materialized blob '{}'",
-                            actor_key.file_id, snapshot.blob_hash
+                            actor_key.file_id,
+                            hash.to_hex()
                         ),
                     )
                 })?
@@ -2533,6 +2535,7 @@ where
                 };
             let materialization_version = self.functions.call_uuid_v7().to_string();
             let submitted_bytes = write.payload().shared_bytes();
+            let mut verified_same_length_blob_splice = None;
 
             let (changes, publication, materialized_bytes) = if same_plugin_owner {
                 let acknowledged_view = self.acknowledged_session_plugin_view(
@@ -2594,8 +2597,8 @@ where
                 // would mistake that valid serialization for an external
                 // stale-cache race.
                 let mut lease = cache.lease_for_transition(&observation).await?;
-                let visible_root = self
-                    .visible_v2_materialization_root(&file_key)
+                let visible_materialization = self
+                    .visible_v2_materialization(&file_key)
                     .await?
                     .ok_or_else(|| {
                         LixError::new(
@@ -2604,8 +2607,9 @@ where
                         )
                         .with_hint("read the exact file bytes again before retrying the edit")
                     })?;
-                lease.require_accepted_semantic_root(&visible_root)?;
-                let observation_is_current = observation.semantic_root() == visible_root;
+                lease.require_accepted_semantic_root(&visible_materialization.semantic_root)?;
+                let observation_is_current =
+                    observation.semantic_root() == visible_materialization.semantic_root;
                 let observed_bytes = lease.observed_bytes();
                 let built_splices = tracing::debug_span!(
                     target: "lix_perf",
@@ -2622,6 +2626,7 @@ where
                 })?;
                 let submitted_bytes_sha256 = built_splices.after_sha256;
                 let host_full_diff_bytes_compared = built_splices.full_diff_bytes_compared;
+                let same_length_blob_splice = built_splices.same_length_replacement();
                 let observed_source = ArcByteSource::new(observed_bytes.clone());
                 let submitted_source = ArcByteSource::new(submitted_bytes.clone());
                 let observed_document = lease.observed_document();
@@ -2700,6 +2705,10 @@ where
                         // validated file successor is therefore already the
                         // exact merge result; rendering the same sparse change
                         // onto the same base would only repeat guest work.
+                        verified_same_length_blob_splice =
+                            same_length_blob_splice.map(|(offset, length)| {
+                                (visible_materialization.blob_hash, offset, length)
+                            });
                         (
                             detection_document,
                             submitted_bytes.clone(),
@@ -2904,6 +2913,10 @@ where
             reconciliation.rows.extend(change_rows);
             if materialized_bytes.as_ref() != write.data() {
                 write.replace_data(materialized_bytes);
+            } else if let Some((visible_base_blob_hash, offset, length)) =
+                verified_same_length_blob_splice
+            {
+                write.set_verified_same_length_blob_splice(visible_base_blob_hash, offset, length);
             }
             reconciliation
                 .materialized_file_keys
@@ -3033,8 +3046,8 @@ where
                 }
                 None => {
                     let cache = self.plugin_host.actor_cache();
-                    let visible_root = self
-                        .visible_v2_materialization_root(&file_key)
+                    let visible_materialization = self
+                        .visible_v2_materialization(&file_key)
                         .await?
                         .ok_or_else(|| {
                             LixError::new(
@@ -3046,7 +3059,7 @@ where
                             )
                         })?;
                     let cold_open = cache
-                        .prepare_cold_open(&actor_key, &visible_root)
+                        .prepare_cold_open(&actor_key, &visible_materialization.semantic_root)
                         .instrument(tracing::debug_span!(
                             target: "lix_perf",
                             "lix.perf.plugin_semantic_actor_lookup"
@@ -3091,8 +3104,8 @@ where
                     )
                 }
             };
-            let visible_root = match self.visible_v2_materialization_root(&file_key).await {
-                Ok(Some(root)) => root,
+            let visible_materialization = match self.visible_v2_materialization(&file_key).await {
+                Ok(Some(materialization)) => materialization,
                 Ok(None) => {
                     let publication = PendingPluginActorPublication::Existing {
                         lease,
@@ -3133,7 +3146,7 @@ where
                 publication_view,
                 descriptor,
                 changes,
-                &visible_root,
+                &visible_materialization.semantic_root,
                 &materialization_version,
                 limits,
             )
@@ -5635,6 +5648,39 @@ mod tests {
     }
 
     const SCHEMA_FIXTURE_COMMIT_ID: &str = "01920000-0000-7000-8000-0000000000f1";
+
+    #[test]
+    fn visible_materialization_requires_a_matching_blob_ref_identity() {
+        let blob_hash = BlobHash::from_content(b"base");
+        let row = |snapshot_id: &str| MaterializedLiveStateRow {
+            entity_pk: EntityPk::single("file-a"),
+            schema_key: BLOB_REF_SCHEMA_KEY.to_string(),
+            file_id: Some("file-a".to_string()),
+            snapshot_content: Some(
+                serde_json::json!({
+                    "id": snapshot_id,
+                    "blob_hash": blob_hash.to_hex(),
+                })
+                .to_string(),
+            ),
+            metadata: None,
+            deleted: false,
+            created_at: LixTimestamp::from_unix_millis_utc_lossy(0),
+            updated_at: LixTimestamp::from_unix_millis_utc_lossy(0),
+            global: false,
+            change_id: Some(ChangeId::default()),
+            commit_id: None,
+            untracked: false,
+            branch_id: "main".into(),
+        };
+
+        let visible = decode_visible_v2_materialization(&row("file-a"), "file-a")
+            .expect("matching materialization should decode");
+        assert_eq!(visible.blob_hash, blob_hash);
+        let error = decode_visible_v2_materialization(&row("other-file"), "file-a")
+            .expect_err("mismatched blob-ref identity must not authorize a cached actor base");
+        assert_eq!(error.code, LixError::CODE_INVALID_PLUGIN);
+    }
 
     #[test]
     fn format_only_equal_snapshots_are_semantic_noops() {

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeSet, fmt, ops::Deref, sync::Arc};
 
 use crate::LixError;
-use crate::binary_cas::{BlobHash, BlobPayload};
+use crate::binary_cas::{BlobHash, BlobPayload, BlobSameLengthSplice};
 use crate::catalog::SchemaPlanId;
 use crate::changelog::{ChangeId, CommitId};
 use crate::common::{LixTimestamp, MutationIdentity, RequestBlobSpliceProvenance};
@@ -187,6 +187,15 @@ pub(crate) struct TransactionFileData {
     /// scanning the filesystem during plugin reconciliation. Inserts and
     /// callers without a prior row leave this false.
     pub(crate) had_blob_ref: bool,
+    /// Content hash of the visible pre-write blob when the SQL lowerer had it
+    /// available without an additional read. This is transient write
+    /// provenance only; it lets a verified v2 same-length edit reuse durable
+    /// CAS chunk references at commit.
+    base_blob_hash: Option<BlobHash>,
+    /// A fixed-width replacement proven by the v2 transition against the
+    /// exact accepted document. The complete output bytes remain authoritative;
+    /// this only permits an internal CAS staging fast path.
+    same_length_blob_splice: Option<BlobSameLengthSplice>,
     /// Validated transport splice that produced `payload`, when the ordinary
     /// SQL blob parameter arrived through the remote splice optimization.
     /// This is transient execution provenance and is never persisted as file
@@ -222,6 +231,8 @@ impl TransactionFileData {
             global,
             untracked,
             had_blob_ref: false,
+            base_blob_hash: None,
+            same_length_blob_splice: None,
             splice_provenance: None,
             mutation_identity: None,
             payload: BlobPayload::from_bytes(data),
@@ -231,6 +242,12 @@ impl TransactionFileData {
 
     pub(crate) fn with_had_blob_ref(mut self, had_blob_ref: bool) -> Self {
         self.had_blob_ref = had_blob_ref;
+        self
+    }
+
+    pub(crate) fn with_base_blob_hash(mut self, base_blob_hash: Option<BlobHash>) -> Self {
+        self.had_blob_ref |= base_blob_hash.is_some();
+        self.base_blob_hash = base_blob_hash;
         self
     }
 
@@ -266,6 +283,34 @@ impl TransactionFileData {
         // Transport provenance describes the replaced request payload. Once a
         // plugin renderer materializes merged bytes, it no longer applies.
         self.splice_provenance = None;
+        self.base_blob_hash = None;
+        self.same_length_blob_splice = None;
+    }
+
+    /// Marks a single fixed-width replacement that was independently verified
+    /// by the v2 file transition. Invalid/unknown base state intentionally
+    /// leaves this unset so CAS staging follows the normal full path.
+    pub(crate) fn set_verified_same_length_blob_splice(
+        &mut self,
+        visible_base_blob_hash: BlobHash,
+        offset: usize,
+        length: usize,
+    ) {
+        let Some(base_blob_hash) = self.base_blob_hash else {
+            return;
+        };
+        if base_blob_hash != visible_base_blob_hash {
+            return;
+        }
+        if length == 0
+            || offset
+                .checked_add(length)
+                .is_none_or(|end| end > self.payload.len())
+        {
+            return;
+        }
+        self.same_length_blob_splice =
+            Some(BlobSameLengthSplice::new(base_blob_hash, offset, length));
     }
 
     pub(crate) fn blob_hash(&self) -> Option<BlobHash> {
@@ -278,6 +323,15 @@ impl TransactionFileData {
 
     pub(crate) fn payload(&self) -> &BlobPayload {
         &self.payload
+    }
+
+    pub(crate) fn same_length_blob_splice(&self) -> Option<BlobSameLengthSplice> {
+        self.same_length_blob_splice
+    }
+
+    #[cfg(test)]
+    pub(crate) fn base_blob_hash(&self) -> Option<BlobHash> {
+        self.base_blob_hash
     }
 
     pub(crate) fn auxiliary_payloads(&self) -> &[BlobPayload] {
@@ -550,5 +604,39 @@ impl StagedCommitChangeRefs {
 
     pub(crate) fn allow_empty(&mut self) {
         self.allow_empty = true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verified_same_length_splice_requires_the_visible_blob_base() {
+        let base = BlobHash::from_content(b"before");
+        let wrong_base = BlobHash::from_content(b"other!");
+        let mut write = TransactionFileData::new(
+            "file".to_string(),
+            None,
+            None,
+            "main".to_string(),
+            false,
+            false,
+            b"after!".to_vec(),
+        )
+        .with_base_blob_hash(Some(base));
+
+        write.set_verified_same_length_blob_splice(wrong_base, 2, 1);
+        assert_eq!(
+            write.same_length_blob_splice(),
+            None,
+            "a same-sized but different visible blob must not donate chunk references"
+        );
+
+        write.set_verified_same_length_blob_splice(base, 2, 1);
+        assert_eq!(
+            write.same_length_blob_splice(),
+            Some(BlobSameLengthSplice::new(base, 2, 1))
+        );
     }
 }


### PR DESCRIPTION
## Summary

Keeps the public SQL and plugin API unchanged while making ordinary fixed-width full-byte writes reuse the existing CAS manifest's unchanged chunks. The hot path is enabled only after binding the SQL-derived base hash to the exact visible v2 materialization row, so a same-sized but stale base cannot authorize reuse.

The CAS reader now also honors the manifest's declared chunk count, avoiding stale physical suffix rows when identical content has been stored with different chunk layouts.

## Why

For a warm v2-owned file, an ordinary `write_file` knows the before/after bytes but previously FastCDC-rechunked and recompressed the complete file. A single fixed-width edit can instead hash and stage only its touched chunks while preserving the untouched durable references. Length-changing and untrusted cases retain the canonical fallback.

## Measured RocksDB E2E impact

Seven-sample release measurements against the immediate main baseline:

- JSON, 10 MiB, ordinary full-byte SQL write with a one-byte fixed-width edit: **14.103 ms → 7.004 ms p50** (**50.3% faster**); p95 **15.414 ms → 8.643 ms**.
- Markdown, 3.5 MiB, public full-byte hot edit: **8.004 ms → 6.727 ms mean** (**16.0% faster**).
- JSON, 10 MiB, unrelated-entity semantic merge: **18.228 ms → 18.419 ms p50**, within measurement noise (no material regression).

The newest base adds SlateDB error reporting only; the final branch is rebased on it and all validation was rerun.

## Validation

- `cargo test -p lix_engine --features all-simulations` (758 passed; 3 doctests passed)
- `cargo test -p lix_rocksdb_storage --quiet`
- `cargo fmt --all -- --check`
- `git diff --check`
- Release RocksDB JSON write/merge benchmark and Markdown hot-edit benchmark, plus Markdown and Excalidraw v2 round-trip/merge E2Es.
