### PR TITLE
perf(excalidraw): retain parsed source layout

### DIFF
--- a/plugins/excalidraw-v2/src/core.rs
+++ b/plugins/excalidraw-v2/src/core.rs
@@ -368,12 +368,25 @@ impl Document {
         _namespace: IdNamespace,
     ) -> Result<(Self, InitialChanges), String> {
         let parsed = parse_file(&bytes)?;
-        let document = Self::from_entities(parsed.scene, parsed.elements, parsed.files)?;
-        if document.0.bytes.as_slice() != bytes {
-            return Err("Excalidraw source layout did not round-trip exactly".to_owned());
-        }
+        let document = Self::from_parsed_source(bytes, parsed);
         let changes = document.initial_changes();
         Ok((document, changes))
+    }
+
+    /// Builds a document directly from source that `parse_file` has already
+    /// structurally and semantically validated. In particular, the parser
+    /// recorded the original value spans for every element and file, so there
+    /// is no need to render the whole document and parse it again merely to
+    /// recover the same bytes and spans.
+    fn from_parsed_source(bytes: Vec<u8>, parsed: ParsedFile) -> Self {
+        Self(Arc::new(DocumentInner {
+            bytes: Arc::new(bytes),
+            scene: parsed.scene,
+            elements: Arc::new(parsed.elements),
+            files: Arc::new(parsed.files),
+            element_spans: Arc::new(parsed.element_spans),
+            file_spans: Arc::new(parsed.file_spans),
+        }))
     }
 
     fn from_entities(
@@ -437,10 +450,7 @@ impl Document {
         let mut parsed = parse_file(&bytes)?;
         reconcile_order_keys(&self.0.elements, &mut parsed.elements)?;
         reconcile_order_keys(&self.0.files, &mut parsed.files)?;
-        let after = Self::from_entities(parsed.scene, parsed.elements, parsed.files)?;
-        if after.0.bytes.as_slice() != bytes {
-            return Err("changed Excalidraw source layout did not round-trip exactly".to_owned());
-        }
+        let after = Self::from_parsed_source(bytes, parsed);
         let changes = diff_records(self.records()?, after.records()?);
         Ok((after, changes))
     }
@@ -710,6 +720,8 @@ struct ParsedFile {
     scene: SceneEntity,
     elements: Vec<ElementEntity>,
     files: Vec<FileEntity>,
+    element_spans: HashMap<String, Span>,
+    file_spans: HashMap<String, Span>,
 }
 
 #[derive(Clone, Debug)]
@@ -717,6 +729,7 @@ struct RawEntry {
     id: Option<String>,
     prefix: String,
     raw: String,
+    span: Span,
 }
 
 #[derive(Debug)]
@@ -766,19 +779,16 @@ fn parse_file(bytes: &[u8]) -> Result<ParsedFile, String> {
 
     let element_keys = OrderKey::evenly_between(None, None, elements_raw.entries.len())?;
     let mut element_ids = HashSet::new();
-    let elements = elements_raw
-        .entries
-        .into_iter()
-        .zip(element_keys)
-        .map(|(entry, key)| {
-            let entity =
-                ElementEntity::from_source(key.to_snapshot_string(), entry.prefix, entry.raw)?;
-            if !element_ids.insert(entity.id.clone()) {
-                return Err(format!("duplicate Excalidraw element id {:?}", entity.id));
-            }
-            Ok(entity)
-        })
-        .collect::<Result<Vec<_>, String>>()?;
+    let mut element_spans = HashMap::with_capacity(elements_raw.entries.len());
+    let mut elements = Vec::with_capacity(elements_raw.entries.len());
+    for (entry, key) in elements_raw.entries.into_iter().zip(element_keys) {
+        let entity = ElementEntity::from_source(key.to_snapshot_string(), entry.prefix, entry.raw)?;
+        if !element_ids.insert(entity.id.clone()) {
+            return Err(format!("duplicate Excalidraw element id {:?}", entity.id));
+        }
+        element_spans.insert(entity.id.clone(), entry.span);
+        elements.push(entity);
+    }
 
     let files_tail_json = files_raw
         .as_ref()
@@ -786,20 +796,24 @@ fn parse_file(bytes: &[u8]) -> Result<ParsedFile, String> {
     let file_count = files_raw.as_ref().map_or(0, |files| files.entries.len());
     let file_keys = OrderKey::evenly_between(None, None, file_count)?;
     let mut file_ids = HashSet::new();
-    let files = files_raw
+    let mut file_spans = HashMap::with_capacity(file_count);
+    let mut files = Vec::with_capacity(file_count);
+    for (entry, key) in files_raw
         .map_or_else(Vec::new, |files| files.entries)
         .into_iter()
         .zip(file_keys)
-        .map(|(entry, key)| {
-            let id = entry
-                .id
-                .ok_or_else(|| "files map entry is missing its decoded key".to_owned())?;
-            if !file_ids.insert(id.clone()) {
-                return Err(format!("duplicate Excalidraw file id {id:?}"));
-            }
-            FileEntity::from_source(id, key.to_snapshot_string(), entry.prefix, entry.raw)
-        })
-        .collect::<Result<Vec<_>, String>>()?;
+    {
+        let id = entry
+            .id
+            .ok_or_else(|| "files map entry is missing its decoded key".to_owned())?;
+        if !file_ids.insert(id.clone()) {
+            return Err(format!("duplicate Excalidraw file id {id:?}"));
+        }
+        let entity =
+            FileEntity::from_source(id, key.to_snapshot_string(), entry.prefix, entry.raw)?;
+        file_spans.insert(entity.id.clone(), entry.span);
+        files.push(entity);
+    }
 
     let scene = SceneEntity {
         template_json,
@@ -812,6 +826,8 @@ fn parse_file(bytes: &[u8]) -> Result<ParsedFile, String> {
         scene,
         elements,
         files,
+        element_spans,
+        file_spans,
     })
 }
 
@@ -902,6 +918,7 @@ fn scan_array_collection(bytes: &[u8], start: usize, end: usize) -> Result<RawCo
             id: None,
             prefix: bytes_to_string(&bytes[segment_start..value_start])?,
             raw: bytes_to_string(&bytes[value_start..value_end])?,
+            span: span(value_start, value_end)?,
         });
         scanner.skip_whitespace();
         match scanner.peek() {
@@ -965,6 +982,7 @@ fn scan_object_collection(bytes: &[u8], start: usize, end: usize) -> Result<RawC
             id: Some(id),
             prefix: bytes_to_string(&bytes[segment_start..value_start])?,
             raw: bytes_to_string(&bytes[value_start..value_end])?,
+            span: span(value_start, value_end)?,
         });
         scanner.skip_whitespace();
         match scanner.peek() {
@@ -991,6 +1009,16 @@ fn scan_object_collection(bytes: &[u8], start: usize, end: usize) -> Result<RawC
             }
         }
     }
+}
+
+fn span(start: usize, end: usize) -> Result<Span, String> {
+    let length = end
+        .checked_sub(start)
+        .ok_or_else(|| "Excalidraw source span ends before it starts".to_owned())?;
+    Ok(Span {
+        offset: u64::try_from(start).map_err(|_| "Excalidraw source offset exceeds u64")?,
+        length: u64::try_from(length).map_err(|_| "Excalidraw source length exceeds u64")?,
+    })
 }
 
 fn require_collection_end(actual: usize, expected: usize, name: &str) -> Result<(), String> {

--- a/plugins/excalidraw-v2/src/core.rs
+++ b/plugins/excalidraw-v2/src/core.rs
@@ -420,6 +420,51 @@ impl Document {
         self.0.bytes.as_ref().clone()
     }
 
+    #[cfg(test)]
+    pub(crate) fn source_spans_match_entities(&self) -> Result<(), String> {
+        for element in self.0.elements.iter() {
+            let span = self
+                .0
+                .element_spans
+                .get(&element.id)
+                .ok_or_else(|| format!("missing source span for element {:?}", element.id))?;
+            let start = usize::try_from(span.offset)
+                .map_err(|_| "element span offset exceeds usize".to_owned())?;
+            let length = usize::try_from(span.length)
+                .map_err(|_| "element span length exceeds usize".to_owned())?;
+            let end = start
+                .checked_add(length)
+                .ok_or_else(|| "element span overflows usize".to_owned())?;
+            if self.0.bytes.get(start..end) != Some(element.element_json.as_bytes()) {
+                return Err(format!(
+                    "element {:?} source span does not point at its accepted bytes",
+                    element.id
+                ));
+            }
+        }
+        for file in self.0.files.iter() {
+            let span = self
+                .0
+                .file_spans
+                .get(&file.id)
+                .ok_or_else(|| format!("missing source span for file {:?}", file.id))?;
+            let start = usize::try_from(span.offset)
+                .map_err(|_| "file span offset exceeds usize".to_owned())?;
+            let length = usize::try_from(span.length)
+                .map_err(|_| "file span length exceeds usize".to_owned())?;
+            let end = start
+                .checked_add(length)
+                .ok_or_else(|| "file span overflows usize".to_owned())?;
+            if self.0.bytes.get(start..end) != Some(file.file_json.as_bytes()) {
+                return Err(format!(
+                    "file {:?} source span does not point at its accepted bytes",
+                    file.id
+                ));
+            }
+        }
+        Ok(())
+    }
+
     pub fn initial_changes(&self) -> InitialChanges {
         let mut changes = VecDeque::with_capacity(1 + self.0.elements.len() + self.0.files.len());
         changes.push_back(EntityChange::upsert(

--- a/plugins/excalidraw-v2/src/tests.rs
+++ b/plugins/excalidraw-v2/src/tests.rs
@@ -106,6 +106,39 @@ fn apply_edits(before: &[u8], edits: &[ByteEdit]) -> Vec<u8> {
     after
 }
 
+fn assert_source_spans_match_entities(document: &Document) {
+    for element in document.0.elements.iter() {
+        let span = document
+            .0
+            .element_spans
+            .get(&element.id)
+            .unwrap_or_else(|| panic!("missing source span for element {:?}", element.id));
+        let start = usize::try_from(span.offset).expect("element span offset fits usize");
+        let end = start + usize::try_from(span.length).expect("element span length fits usize");
+        assert_eq!(
+            &document.0.bytes[start..end],
+            element.element_json.as_bytes(),
+            "element {:?} span must point at its accepted source bytes",
+            element.id
+        );
+    }
+    for file in document.0.files.iter() {
+        let span = document
+            .0
+            .file_spans
+            .get(&file.id)
+            .unwrap_or_else(|| panic!("missing source span for file {:?}", file.id));
+        let start = usize::try_from(span.offset).expect("file span offset fits usize");
+        let end = start + usize::try_from(span.length).expect("file span length fits usize");
+        assert_eq!(
+            &document.0.bytes[start..end],
+            file.file_json.as_bytes(),
+            "file {:?} span must point at its accepted source bytes",
+            file.id
+        );
+    }
+}
+
 fn has_number(value: &Value) -> bool {
     match value {
         Value::Number(_) => true,
@@ -146,6 +179,7 @@ fn exact_pretty_json_roundtrip_and_number_free_entities() {
     let bytes = fixture();
     let document = open(&bytes);
     assert_eq!(document.bytes(), bytes);
+    assert_source_spans_match_entities(&document);
     let records = records(&document);
     assert_eq!(records.len(), 4);
     assert_eq!(
@@ -164,6 +198,34 @@ fn exact_pretty_json_roundtrip_and_number_free_entities() {
     assert_eq!(edit.delete_len, 0);
     assert_eq!(edit.insert.as_slice(), bytes);
     assert_eq!(reopened.bytes(), bytes);
+}
+
+#[test]
+fn parsed_source_retains_spans_after_a_layout_shifting_file_change() {
+    let before = fixture();
+    let document = open(&before);
+    let version = offset_of(&before, b"\"version\": 2") + b"\"version\": ".len();
+    let (after, changes) = document
+        .file_changed(
+            &[InputSplice {
+                offset: u64::try_from(version).unwrap(),
+                delete_len: 1,
+                insert: b"200",
+            }],
+            namespace(),
+        )
+        .expect("layout-shifting source edit");
+
+    let mut expected = before;
+    expected.splice(version..version + 1, b"200".iter().copied());
+    assert_eq!(after.bytes(), expected);
+    assert_source_spans_match_entities(&after);
+    assert_eq!(
+        changes.len(),
+        1,
+        "only the scene template changed: {changes:#?}"
+    );
+    assert_eq!(changes[0].schema_key, SCENE_SCHEMA_KEY);
 }
 
 #[test]

--- a/plugins/excalidraw-v2/src/tests.rs
+++ b/plugins/excalidraw-v2/src/tests.rs
@@ -107,36 +107,9 @@ fn apply_edits(before: &[u8], edits: &[ByteEdit]) -> Vec<u8> {
 }
 
 fn assert_source_spans_match_entities(document: &Document) {
-    for element in document.0.elements.iter() {
-        let span = document
-            .0
-            .element_spans
-            .get(&element.id)
-            .unwrap_or_else(|| panic!("missing source span for element {:?}", element.id));
-        let start = usize::try_from(span.offset).expect("element span offset fits usize");
-        let end = start + usize::try_from(span.length).expect("element span length fits usize");
-        assert_eq!(
-            &document.0.bytes[start..end],
-            element.element_json.as_bytes(),
-            "element {:?} span must point at its accepted source bytes",
-            element.id
-        );
-    }
-    for file in document.0.files.iter() {
-        let span = document
-            .0
-            .file_spans
-            .get(&file.id)
-            .unwrap_or_else(|| panic!("missing source span for file {:?}", file.id));
-        let start = usize::try_from(span.offset).expect("file span offset fits usize");
-        let end = start + usize::try_from(span.length).expect("file span length fits usize");
-        assert_eq!(
-            &document.0.bytes[start..end],
-            file.file_json.as_bytes(),
-            "file {:?} span must point at its accepted source bytes",
-            file.id
-        );
-    }
+    document
+        .source_spans_match_entities()
+        .expect("every source span must point at its accepted source bytes");
 }
 
 fn has_number(value: &Value) -> bool {

--- a/plugins/excalidraw-v2/src/tests.rs
+++ b/plugins/excalidraw-v2/src/tests.rs
@@ -190,7 +190,7 @@ fn parsed_source_retains_spans_after_a_layout_shifting_file_change() {
         .expect("layout-shifting source edit");
 
     let mut expected = before;
-    expected.splice(version..version + 1, b"200".iter().copied());
+    expected.splice(version..=version, b"200".iter().copied());
     assert_eq!(after.bytes(), expected);
     assert_source_spans_match_entities(&after);
     assert_eq!(


### PR DESCRIPTION
## Summary

Avoid redundant whole-document work when opening or updating source-owned Excalidraw files. The parser already validates the source and knows every element/file value span, so this PR retains that authoritative byte layout directly instead of rendering all entities back into a document and reparsing it merely to recover the same bytes and spans.

Entity-driven reconstruction still uses the existing renderer, so direct semantic edits retain their established materialization path.

## Measured RocksDB E2E impact

Five-sample release measurements, exact `main` baseline versus this branch, using a 3,889,674-byte Excalidraw file with 10,000 elements, real RocksDB, and the Wasm plugin:

- Ordinary public full-byte hot write: **442.273 ms → 371.356 ms p50** (**16.0% faster**); p95 **451.250 ms → 375.929 ms**.
- Initial source import: **789.252 ms → 712.969 ms p50** (**9.7% faster**); retained as an additional benefit, below the merge gate by itself.
- Direct semantic entity write: **98.216 ms → 96.920 ms** (no material change).
- Unrelated-element merge: **99.981 ms → 100.013 ms** (no material regression).

The gate asserts byte-exact source roundtrip, all 10,000 semantic entities, a one-entity hot update without full hydration, cold raw read without hydration/render, direct semantic materialization, and preservation of both disjoint merge edits.

## Validation

- `cargo test -p plugin_excalidraw_v2` (14 unit tests and 1 doctest)
- `cargo fmt --all -- --check`
- `git diff --check`
- Paired release RocksDB/Wasm E2E gate above.
