### PR TITLE
perf(plugin): reuse renderer splice chunks

### DIFF
--- a/.changenotes/accelerate-semantic-plugin-merges.md
+++ b/.changenotes/accelerate-semantic-plugin-merges.md
@@ -1,0 +1,8 @@
+---
+type: patch
+---
+
+Improved semantic plugin write and merge performance for large files.
+
+Lix now reuses unchanged binary storage chunks for common fixed-width semantic
+edits, reducing the work needed to persist plugin-rendered changes.

--- a/packages/engine/src/plugin/incremental.rs
+++ b/packages/engine/src/plugin/incremental.rs
@@ -1062,11 +1062,28 @@ pub(crate) struct ResolvedOutputSplice {
     pub(crate) insert: Vec<u8>,
 }
 
+/// One fixed-width renderer splice which the host has applied against the
+/// accepted actor bytes.
+///
+/// This is deliberately not guest authority. It is created only after the
+/// complete renderer output has passed host range/order validation and has
+/// been reconstructed from the immutable base. Transaction code may pair it
+/// with an independently loaded durable blob hash as a private CAS hint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ValidatedSameLengthOutputSplice {
+    pub(crate) offset: usize,
+    pub(crate) length: usize,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct ValidatedEntityTransition {
     pub(crate) document: WasmDocumentHandle,
     pub(crate) bytes: Blob,
     pub(crate) bytes_sha256: Option<FileBytesSha256>,
+    /// Present only for one non-empty fixed-width edit that the host applied
+    /// to the complete accepted base. It carries no inserted guest bytes and
+    /// is not persisted.
+    pub(crate) same_length_output_splice: Option<ValidatedSameLengthOutputSplice>,
     #[cfg(test)]
     pub(crate) edits: Vec<ResolvedOutputSplice>,
     pub(crate) counters: WasmTransitionCounters,
@@ -1237,21 +1254,24 @@ async fn drain_entity_transition_edits_inner(
         }
     }
 
-    let bytes = if let (Some(expected), Some(expected_delta)) = (&expected, expected_delta) {
-        validate_resolved_output_against_known_delta(base, expected, expected_delta, &edits)?;
-        expected.clone()
-    } else {
-        let bytes: Blob = apply_resolved_output_splices(base, &edits)?.into();
-        if expected
-            .as_ref()
-            .is_some_and(|expected| expected.as_ref() != bytes.as_ref())
-        {
-            return Err(invalid_guest(
-                "v2 renderer edits do not reproduce the independently expected bytes",
-            ));
-        }
-        bytes
-    };
+    let (bytes, same_length_output_splice) =
+        if let (Some(expected), Some(expected_delta)) = (&expected, expected_delta) {
+            validate_resolved_output_against_known_delta(base, expected, expected_delta, &edits)?;
+            (expected.clone(), None)
+        } else {
+            let (rendered_bytes, same_length_output_splice) =
+                apply_resolved_output_splices(base, &edits)?;
+            let bytes: Blob = rendered_bytes.into();
+            if expected
+                .as_ref()
+                .is_some_and(|expected| expected.as_ref() != bytes.as_ref())
+            {
+                return Err(invalid_guest(
+                    "v2 renderer edits do not reproduce the independently expected bytes",
+                ));
+            }
+            (bytes, same_length_output_splice)
+        };
     // Cold-open validation benefits from caching the accepted protocol
     // digest. A normal semantic render does not: defer that O(file) SHA-256
     // until a later request actually presents transport splice provenance.
@@ -1261,10 +1281,33 @@ async fn drain_entity_transition_edits_inner(
         document: transition.document,
         bytes,
         bytes_sha256,
+        same_length_output_splice,
         #[cfg(test)]
         edits,
         counters: merge_counter_snapshots(local_counters, runtime_counters),
     })
+}
+
+/// Extracts a private CAS hint after the surrounding output application has
+/// completed its range/order validation. A guest cannot manufacture this fact
+/// by merely emitting splice metadata: malformed, overlapping,
+/// out-of-bounds, empty, length-changing, and multi-splice outputs all yield
+/// no hint.
+fn same_length_output_splice_after_host_validation(
+    base_len: usize,
+    output_len: usize,
+    edits: &[ResolvedOutputSplice],
+) -> Option<ValidatedSameLengthOutputSplice> {
+    let [edit] = edits else {
+        return None;
+    };
+    let offset = usize::try_from(edit.offset).ok()?;
+    let length = usize::try_from(edit.delete_len).ok()?;
+    let end = offset.checked_add(length)?;
+    if length == 0 || length != edit.insert.len() || end > base_len || output_len != base_len {
+        return None;
+    }
+    Some(ValidatedSameLengthOutputSplice { offset, length })
 }
 
 async fn cleanup_rejected_transition(
@@ -1651,7 +1694,7 @@ impl OutputDrainBudget {
 fn apply_resolved_output_splices(
     base: &[u8],
     edits: &[ResolvedOutputSplice],
-) -> Result<Vec<u8>, LixError> {
+) -> Result<(Vec<u8>, Option<ValidatedSameLengthOutputSplice>), LixError> {
     let mut capacity = base.len();
     let mut previous_start = None;
     let mut previous_end = 0usize;
@@ -1691,7 +1734,9 @@ fn apply_resolved_output_splices(
         cursor = end;
     }
     bytes.extend_from_slice(&base[cursor..]);
-    Ok(bytes)
+    let same_length_output_splice =
+        same_length_output_splice_after_host_validation(base.len(), bytes.len(), edits);
+    Ok((bytes, same_length_output_splice))
 }
 
 fn merge_counter_snapshots(
@@ -2466,6 +2511,111 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn edit_drain_marks_one_host_validated_same_length_splice() {
+        let mut actor = FakeActor {
+            edit_pages: [WasmEditPage {
+                edits: vec![WasmOutputSplice {
+                    offset: 2,
+                    delete_len: 2,
+                    insert: WasmGuestBytes::Inline(b"XY".to_vec()),
+                }],
+                outputs: None,
+            }]
+            .into(),
+            ..FakeActor::default()
+        };
+        let drained = drain_entity_transition_edits(
+            &mut actor,
+            WasmEntityTransition {
+                transition: WasmTransitionHandle(1),
+                document: WasmDocumentHandle(2),
+                edits: WasmEditCursorHandle(3),
+            },
+            b"abcdef",
+            None,
+            None,
+            WasmTransitionLimits::default(),
+        )
+        .await
+        .expect("one valid fixed-width renderer edit should drain");
+
+        assert_eq!(drained.bytes.as_ref(), b"abXYef");
+        assert_eq!(
+            drained.same_length_output_splice,
+            Some(ValidatedSameLengthOutputSplice {
+                offset: 2,
+                length: 2,
+            })
+        );
+        assert!(actor.finished);
+    }
+
+    #[test]
+    fn only_one_nonempty_fixed_width_output_splice_is_cas_eligible() {
+        let fixed_width = ResolvedOutputSplice {
+            offset: 2,
+            delete_len: 2,
+            insert: b"XY".to_vec(),
+        };
+        assert_eq!(
+            same_length_output_splice_after_host_validation(
+                b"abcdef".len(),
+                b"abXYef".len(),
+                std::slice::from_ref(&fixed_width),
+            ),
+            Some(ValidatedSameLengthOutputSplice {
+                offset: 2,
+                length: 2,
+            })
+        );
+
+        let length_changing = ResolvedOutputSplice {
+            offset: 2,
+            delete_len: 1,
+            insert: b"XY".to_vec(),
+        };
+        assert_eq!(
+            same_length_output_splice_after_host_validation(
+                b"abcdef".len(),
+                b"abXYdef".len(),
+                std::slice::from_ref(&length_changing),
+            ),
+            None
+        );
+        assert_eq!(
+            same_length_output_splice_after_host_validation(
+                b"abcdef".len(),
+                b"aXcdYf".len(),
+                &[
+                    ResolvedOutputSplice {
+                        offset: 1,
+                        delete_len: 1,
+                        insert: b"X".to_vec(),
+                    },
+                    ResolvedOutputSplice {
+                        offset: 4,
+                        delete_len: 1,
+                        insert: b"Y".to_vec(),
+                    },
+                ],
+            ),
+            None,
+        );
+        assert_eq!(
+            same_length_output_splice_after_host_validation(
+                b"abcdef".len(),
+                b"abcdef".len(),
+                &[ResolvedOutputSplice {
+                    offset: 6,
+                    delete_len: 1,
+                    insert: b"X".to_vec(),
+                }],
+            ),
+            None,
+        );
+    }
+
+    #[tokio::test]
     async fn edit_drain_reuses_exact_expected_blob_after_local_delta_proof() {
         let mut actor = FakeActor {
             edit_pages: [WasmEditPage {
@@ -2501,6 +2651,10 @@ mod tests {
         .unwrap();
         assert_eq!(drained.bytes.as_ptr(), expected.as_ptr());
         assert_eq!(drained.bytes.len(), expected.len());
+        assert_eq!(
+            drained.same_length_output_splice, None,
+            "known-delta validation reuses independently supplied bytes and never grants CAS splice provenance"
+        );
         assert!(actor.finished);
     }
 }

--- a/packages/engine/src/plugin/mod.rs
+++ b/packages/engine/src/plugin/mod.rs
@@ -27,10 +27,10 @@ pub(crate) use id_namespace::{
     validate_namespace_reservation,
 };
 pub(crate) use incremental::{
-    ArcByteSource, V2SchemaAllowlist, VecEntityChangeSource, VecEntitySource,
-    build_file_update_splices, drain_entity_transition_edits, drain_file_transition_changes,
-    host_entity_change_with_lazy_snapshot, host_entity_with_lazy_snapshot,
-    transport_splice_preserves_utf8,
+    ArcByteSource, V2SchemaAllowlist, ValidatedSameLengthOutputSplice, VecEntityChangeSource,
+    VecEntitySource, build_file_update_splices, drain_entity_transition_edits,
+    drain_file_transition_changes, host_entity_change_with_lazy_snapshot,
+    host_entity_with_lazy_snapshot, transport_splice_preserves_utf8,
 };
 pub(crate) use install::{PluginArchiveInstallPlan, plugin_install_plan_from_archive_path};
 pub(crate) use manifest::{

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -50,11 +50,12 @@ use crate::plugin::{
     PluginActorCache, PluginActorColdInstall, PluginActorColdOpen, PluginActorKey,
     PluginActorLease, PluginActorStore, PluginArchiveInstallPlan, PluginContentType,
     PluginDetectedChange, PluginFileOwner, PluginObservation, PluginRegistry, PluginRegistryEntry,
-    PluginRegistryEntryInput, PluginRuntimeHost, V2SchemaAllowlist, VecEntityChangeSource,
-    VecEntitySource, build_file_update_splices, drain_entity_transition_edits,
-    drain_file_transition_changes, host_entity_change_with_lazy_snapshot,
-    host_entity_with_lazy_snapshot, inferred_media_type_for_path, is_plugin_storage_path,
-    is_reservation_key, local_mutation_identity, plugin_install_plan_from_archive_path,
+    PluginRegistryEntryInput, PluginRuntimeHost, V2SchemaAllowlist,
+    ValidatedSameLengthOutputSplice, VecEntityChangeSource, VecEntitySource,
+    build_file_update_splices, drain_entity_transition_edits, drain_file_transition_changes,
+    host_entity_change_with_lazy_snapshot, host_entity_with_lazy_snapshot,
+    inferred_media_type_for_path, is_plugin_storage_path, is_reservation_key,
+    local_mutation_identity, plugin_install_plan_from_archive_path,
     plugin_key_from_archive_file_id, plugin_state_live_state_projection,
     require_existing_id_authorities, reservation_tombstone_row, reserve_namespace_row,
     transport_splice_preserves_utf8, validate_host_allocated_changes,
@@ -3155,32 +3156,32 @@ where
                 "lix.perf.plugin_semantic_render"
             ))
             .await;
-            let (publication, rendered_bytes, counters) = match transition {
-                Ok(transition) => transition,
-                Err((error, publication)) => {
-                    if was_chained {
-                        self.pending_plugin_actor_publications.push(publication);
-                    } else {
-                        publication.discard().await;
+            let (publication, rendered_bytes, same_length_output_splice, counters) =
+                match transition {
+                    Ok(transition) => transition,
+                    Err((error, publication)) => {
+                        if was_chained {
+                            self.pending_plugin_actor_publications.push(publication);
+                        } else {
+                            publication.discard().await;
+                        }
+                        discard_plugin_actor_publications(std::mem::take(
+                            &mut reconciliation.actor_publications,
+                        ))
+                        .await;
+                        return Err(error);
                     }
-                    discard_plugin_actor_publications(std::mem::take(
-                        &mut reconciliation.actor_publications,
-                    ))
-                    .await;
-                    return Err(error);
-                }
-            };
+                };
             self.plugin_host.record_v2_transition_counters(counters);
-            let rendered_file = TransactionFileData::new(
+            let rendered_file = semantic_rendered_file_data(
                 file_key.file_id.clone(),
-                Some(group.path),
-                Some(group.filename),
+                group.path,
+                group.filename,
                 file_key.branch_id.clone(),
-                false,
-                false,
+                &visible_materialization,
                 rendered_bytes,
-            )
-            .with_had_blob_ref(true);
+                same_length_output_splice,
+            );
             file_data.push(rendered_file);
             reconciliation
                 .materialized_file_keys
@@ -4699,6 +4700,44 @@ impl PendingPluginActorPublication {
     }
 }
 
+/// Builds the file write for an accepted semantic renderer transition.
+///
+/// The visible materialization was loaded from the same durable blob-ref row
+/// whose semantic root fenced the actor call. `same_length_output_splice` is
+/// host-validated renderer metadata, never a guest assertion. Pairing the two
+/// lets the private CAS writer reuse only chunks from that exact base blob;
+/// unavailable, malformed, or mismatched state still follows canonical full
+/// staging.
+fn semantic_rendered_file_data(
+    file_id: String,
+    path: String,
+    filename: String,
+    branch_id: String,
+    visible_materialization: &VisibleV2Materialization,
+    rendered_bytes: crate::Blob,
+    same_length_output_splice: Option<ValidatedSameLengthOutputSplice>,
+) -> TransactionFileData {
+    let mut rendered_file = TransactionFileData::new(
+        file_id,
+        Some(path),
+        Some(filename),
+        branch_id,
+        false,
+        false,
+        rendered_bytes,
+    )
+    .with_had_blob_ref(true)
+    .with_base_blob_hash(Some(visible_materialization.blob_hash));
+    if let Some(splice) = same_length_output_splice {
+        rendered_file.set_verified_same_length_blob_splice(
+            visible_materialization.blob_hash,
+            splice.offset,
+            splice.length,
+        );
+    }
+    rendered_file
+}
+
 async fn render_v2_semantic_changes_with_lease(
     mut lease: PluginActorLease,
     successor_key: PluginActorKey,
@@ -4712,6 +4751,7 @@ async fn render_v2_semantic_changes_with_lease(
     (
         PendingPluginActorPublication,
         crate::Blob,
+        Option<ValidatedSameLengthOutputSplice>,
         crate::wasm::WasmTransitionCounters,
     ),
     (LixError, PendingPluginActorPublication),
@@ -4794,6 +4834,7 @@ async fn render_v2_semantic_changes_with_lease(
         return Err((error, publication(lease)));
     }
     let rendered_bytes = rendered.bytes.clone();
+    let same_length_output_splice = rendered.same_length_output_splice;
     let mut counters = rendered.counters;
     counters.private_document_cache_hits = 1;
     counters.durable_semantic_changes = change_count;
@@ -4809,7 +4850,12 @@ async fn render_v2_semantic_changes_with_lease(
     {
         return Err((error, publication(lease)));
     }
-    Ok((publication(lease), rendered_bytes, counters))
+    Ok((
+        publication(lease),
+        rendered_bytes,
+        same_length_output_splice,
+        counters,
+    ))
 }
 
 async fn discard_plugin_actor_publications(publications: Vec<PendingPluginActorPublication>) {
@@ -5680,6 +5726,56 @@ mod tests {
         let error = decode_visible_v2_materialization(&row("other-file"), "file-a")
             .expect_err("mismatched blob-ref identity must not authorize a cached actor base");
         assert_eq!(error.code, LixError::CODE_INVALID_PLUGIN);
+    }
+
+    #[test]
+    fn semantic_renderer_splice_provenance_is_bound_to_its_visible_blob() {
+        let base_blob_hash = BlobHash::from_content(b"abcdef");
+        let materialization = VisibleV2Materialization {
+            semantic_root: "semantic-root".to_string(),
+            blob_hash: base_blob_hash,
+        };
+        let rendered = semantic_rendered_file_data(
+            "file-a".to_string(),
+            "/document.md".to_string(),
+            "document.md".to_string(),
+            "main".to_string(),
+            &materialization,
+            b"abXYef".as_slice().into(),
+            Some(ValidatedSameLengthOutputSplice {
+                offset: 2,
+                length: 2,
+            }),
+        );
+
+        assert_eq!(rendered.base_blob_hash(), Some(base_blob_hash));
+        assert_eq!(
+            rendered.same_length_blob_splice(),
+            Some(crate::binary_cas::BlobSameLengthSplice::new(
+                base_blob_hash,
+                2,
+                2,
+            ))
+        );
+
+        let malformed = semantic_rendered_file_data(
+            "file-a".to_string(),
+            "/document.md".to_string(),
+            "document.md".to_string(),
+            "main".to_string(),
+            &materialization,
+            b"abXYef".as_slice().into(),
+            Some(ValidatedSameLengthOutputSplice {
+                offset: 6,
+                length: 1,
+            }),
+        );
+        assert_eq!(malformed.base_blob_hash(), Some(base_blob_hash));
+        assert_eq!(
+            malformed.same_length_blob_splice(),
+            None,
+            "transaction-side bounds checks must force malformed metadata through the ordinary CAS path"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Reuses existing binary-CAS chunks for a single host-validated, fixed-width semantic renderer splice. The hint is bound to the exact visible materialization blob and revalidated before staging; every other renderer output follows the existing canonical path.

No WIT, SQL, or public API change.

## Benchmarks

Real RocksDB E2E, 7 samples:

- Markdown 3.5 MiB direct semantic edit: 7.393 → 5.749 ms (22.2% faster)
- Markdown 3.5 MiB unrelated semantic merge: 6.444 → 4.287 ms (33.5% faster)
- JSON 10 MiB unrelated semantic merge control: 18.010 → 18.040 ms (+0.17%, neutral; expected for a length-changing splice)

## Validation

- `cargo test -p lix_engine --features all-simulations` (758 tests + 3 doctests)
- Focused release fixed-width test, 5/5
- Rebuilt source-provenance Markdown and JSON RocksDB E2Es