### PR TITLE
perf(markdown): skip redundant canonical rendering

### DIFF
--- a/.changenotes/accelerate-markdown-literal-imports.md
+++ b/.changenotes/accelerate-markdown-literal-imports.md
@@ -1,0 +1,8 @@
+---
+type: patch
+---
+
+Improved Markdown import performance for large plain-prose documents.
+
+Lix now avoids redundant canonical rendering work when Markdown source is already
+canonical literal prose, while preserving the existing behavior for rich Markdown.

--- a/packages/rs-sdk-tests/tests/markdown_git_benchmark.rs
+++ b/packages/rs-sdk-tests/tests/markdown_git_benchmark.rs
@@ -19,6 +19,7 @@ const DEFAULT_EDIT_SAMPLES: usize = 20;
 const DEFAULT_MERGE_SAMPLES: usize = 7;
 const DEFAULT_COLD_SAMPLES: usize = 5;
 const DEFAULT_PROFILE_SAMPLES: usize = 200;
+const DEFAULT_SYNTAX_RICH_SAMPLES: usize = 3;
 const PARAGRAPH_BODY_BYTES: usize = 496;
 
 #[derive(Debug)]
@@ -108,6 +109,59 @@ async fn markdown_lix_byte_hotpath_profile() {
         &bytes,
     );
     lix.close().await.expect("close Markdown profile Lix");
+}
+
+/// Guards the fallback side of the canonical literal-prose optimization with
+/// a realistic GFM document. The timer deliberately follows the ordinary
+/// public SQL write path and excludes workspace/plugin installation.
+#[tokio::test]
+#[ignore = "manual syntax-rich Markdown initial-import control"]
+async fn markdown_syntax_rich_initial_import_control() {
+    init_perf_tracing();
+
+    let target_bytes = env_usize("LIX_MARKDOWN_SYNTAX_RICH_BENCH_BYTES", DEFAULT_TARGET_BYTES);
+    let samples = env_usize(
+        "LIX_MARKDOWN_SYNTAX_RICH_BENCH_SAMPLES",
+        DEFAULT_SYNTAX_RICH_SAMPLES,
+    );
+    assert!(samples > 0);
+    let source = syntax_rich_markdown_corpus(target_bytes);
+    assert!(source.len() >= target_bytes.saturating_sub(1_024));
+    let archive = build_markdown_v2_plugin_archive();
+    let mut imports = Vec::with_capacity(samples);
+
+    for _sample in 0..samples {
+        let root = tempfile::tempdir().expect("create syntax-rich Markdown benchmark directory");
+        let lix = open_lix_with_rocksdb(root.path()).await;
+        install_plugin(&lix, "plugin_markdown_incremental_v2", &archive).await;
+
+        let started = Instant::now();
+        write_file(&lix, "/syntax-rich.md", source.clone()).await;
+        imports.push(started.elapsed());
+
+        assert_same_bytes(
+            "syntax-rich Markdown import must preserve exact source bytes",
+            &read_file(&lix, "/syntax-rich.md").await,
+            &source,
+        );
+        let file_id = file_id_at_path(&lix, "/syntax-rich.md").await;
+        assert!(
+            !markdown_nodes_by_kind(&lix, &file_id, "table_cell")
+                .await
+                .is_empty(),
+            "syntax-rich import must materialize semantic table-cell entities"
+        );
+        lix.close()
+            .await
+            .expect("close syntax-rich Markdown benchmark Lix");
+    }
+
+    print_duration_metric("syntax_rich_initial_import", "lix-semantic", &imports);
+    eprintln!(
+        "markdown_syntax_rich_control corpus_bytes={} samples={}",
+        source.len(),
+        samples,
+    );
 }
 
 #[tokio::test]
@@ -732,6 +786,33 @@ fn markdown_corpus(target_bytes: usize) -> Corpus {
         edit_offsets,
         texts,
     }
+}
+
+fn syntax_rich_markdown_corpus(target_bytes: usize) -> Vec<u8> {
+    const RICH_BLOCK_INTERVAL: usize = 64;
+
+    let mut bytes = Vec::with_capacity(target_bytes + 512);
+    for index in 0usize.. {
+        let prose = format!("P{index:06} {}\n\n", paragraph_body(index));
+        if bytes.len() + prose.len() > target_bytes {
+            break;
+        }
+        bytes.extend_from_slice(prose.as_bytes());
+
+        // A single non-literal block makes the entire document take the
+        // canonical-rendering fallback. Keeping these periodic mirrors a
+        // typical prose document and avoids treating an all-table stress case
+        // as the 90%-path control.
+        if index % RICH_BLOCK_INTERVAL == RICH_BLOCK_INTERVAL - 1 {
+            let block = format!(
+                "## Section {index}\n\nParagraph {index} has *emphasis*, **strong**, ~~delete~~, [a link](https://example.com/{index}), and `code`.\n\n- alpha {index}\n- beta {index}\n\n| key | value |\n| --- | :--- |\n| left {index} | right {index} |\n\n```rust\nlet value_{index} = {index};\n```\n\n> quoted paragraph {index}\n\n"
+            );
+            if bytes.len() + block.len() <= target_bytes {
+                bytes.extend_from_slice(block.as_bytes());
+            }
+        }
+    }
+    bytes
 }
 
 fn spread_index(sample: usize, samples: usize, upper: usize) -> usize {

--- a/plugins/markdown-v2/src/core.rs
+++ b/plugins/markdown-v2/src/core.rs
@@ -1,4 +1,7 @@
-use crate::markdown_file::{ParsedMarkdown, parse_file, parse_markdown_source, render_tree};
+use crate::markdown_file::{
+    ParsedMarkdown, parse_file, parse_file_with_literal_fast_path, parse_markdown_source,
+    render_tree,
+};
 use crate::model::{
     InlineNode, NodeKind, NodeSnapshot, NodeTree, Projection, parse_inline_payload,
     replace_column_ids, semantic_payload,
@@ -1906,11 +1909,29 @@ impl Document {
         path: Option<&str>,
         namespace: IdNamespace,
     ) -> Result<(Self, Vec<EntityChange>), PluginError> {
+        Self::open_file_with_literal_fast_path(bytes, path, namespace, true)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn open_file_forced_canonical_fallback(
+        bytes: Vec<u8>,
+        path: Option<&str>,
+        namespace: IdNamespace,
+    ) -> Result<(Self, Vec<EntityChange>), PluginError> {
+        Self::open_file_with_literal_fast_path(bytes, path, namespace, false)
+    }
+
+    fn open_file_with_literal_fast_path(
+        bytes: Vec<u8>,
+        path: Option<&str>,
+        namespace: IdNamespace,
+        allow_literal_fast_path: bool,
+    ) -> Result<(Self, Vec<EntityChange>), PluginError> {
         let file = File {
             filename: path.map(ToOwned::to_owned),
             data: bytes.clone(),
         };
-        let mut parsed = parse_file(&file)?;
+        let mut parsed = parse_file_with_literal_fast_path(&file, allow_literal_fast_path)?;
         retain_noncanonical_source(&mut parsed, &file.data)?;
         let top_level_ranges = parsed.top_level_ranges.clone();
         let detected = detect_changes_for_markdown(&Projection::default(), parsed, namespace)?;

--- a/plugins/markdown-v2/src/markdown_file.rs
+++ b/plugins/markdown-v2/src/markdown_file.rs
@@ -18,6 +18,10 @@ use uuid::Uuid;
 pub(crate) struct ParsedMarkdown {
     pub(crate) root: NodeTree,
     pub(crate) top_level_ranges: Vec<Range<usize>>,
+    /// The source was proven to be canonical literal prose directly from the
+    /// parser AST and source spans. `parse_markdown_source` can then retain
+    /// the original bytes without building and serializing a second AST.
+    pub(crate) canonical_literal_paragraph_layout: bool,
     /// The stable canonical bytes already rendered while parsing. Callers that
     /// need to compare source layout can consume this instead of rendering the
     /// reconstructed tree a second time.
@@ -25,9 +29,16 @@ pub(crate) struct ParsedMarkdown {
 }
 
 pub(crate) fn parse_file(file: &File) -> Result<ParsedMarkdown, PluginError> {
+    parse_file_with_literal_fast_path(file, true)
+}
+
+pub(crate) fn parse_file_with_literal_fast_path(
+    file: &File,
+    allow_literal_fast_path: bool,
+) -> Result<ParsedMarkdown, PluginError> {
     let (buf, encoding) = buffer_with_encoding(&file.data);
     let (decoded, _had_errors) = encoding.decode_without_bom_handling(buf);
-    parse_markdown_source(&decoded)
+    parse_markdown_source_with_literal_fast_path(&decoded, allow_literal_fast_path)
 }
 
 fn buffer_with_encoding(buf: &[u8]) -> (&[u8], &'static Encoding) {
@@ -41,11 +52,25 @@ fn buffer_with_encoding(buf: &[u8]) -> (&[u8], &'static Encoding) {
 }
 
 pub(crate) fn parse_markdown_source(source: &str) -> Result<ParsedMarkdown, PluginError> {
+    parse_markdown_source_with_literal_fast_path(source, true)
+}
+
+fn parse_markdown_source_with_literal_fast_path(
+    source: &str,
+    allow_literal_fast_path: bool,
+) -> Result<ParsedMarkdown, PluginError> {
+    let mut parsed = parse_markdown_source_once(source)?;
+    let source_is_canonical_literal_paragraph_layout = parsed.canonical_literal_paragraph_layout;
+    if allow_literal_fast_path && source_is_canonical_literal_paragraph_layout {
+        parsed.canonical_render = Some(source.as_bytes().to_vec());
+        return Ok(parsed);
+    }
     let mut canonical = source.to_string();
-    let mut parsed = parse_markdown_source_once(&canonical)?;
     for _ in 0..8 {
         let rendered = render_tree(&parsed.root)?;
         if rendered == canonical.as_bytes() {
+            parsed.canonical_literal_paragraph_layout =
+                source_is_canonical_literal_paragraph_layout;
             parsed.canonical_render = Some(rendered);
             return Ok(parsed);
         }
@@ -80,6 +105,8 @@ fn parse_markdown_source_once(source: &str) -> Result<ParsedMarkdown, PluginErro
     }
 
     repair_definition_adjacency(&mut output.document, source);
+    let canonical_literal_paragraph_layout =
+        canonical_literal_paragraph_layout(&output.document, source);
     let top_level_ranges = output
         .document
         .children
@@ -116,8 +143,135 @@ fn parse_markdown_source_once(source: &str) -> Result<ParsedMarkdown, PluginErro
     Ok(ParsedMarkdown {
         root,
         top_level_ranges,
+        canonical_literal_paragraph_layout,
         canonical_render: None,
     })
+}
+
+/// Proves that the parser produced the exact canonical form for a deliberately
+/// narrow, high-frequency Markdown shape: one literal text paragraph per
+/// line, blank-line separated, ending in LF. The predicate runs on parser AST
+/// spans before NodeTree payload JSON is built, so its linear scan is much
+/// cheaper than the canonical serializer/fixpoint work it avoids.
+///
+/// The character filter excludes every ASCII construct whose Markdown
+/// serializer may add an escape. It intentionally accepts ordinary prose,
+/// Unicode, and punctuation that is never escaped in a literal paragraph.
+fn canonical_literal_paragraph_layout(document: &md::Document, source: &str) -> bool {
+    if source.is_empty() || !source.ends_with('\n') || source.as_bytes().contains(&b'\r') {
+        return false;
+    }
+    let Some(body) = source.strip_suffix('\n') else {
+        return false;
+    };
+    if body.is_empty() || document.children.is_empty() {
+        return false;
+    }
+
+    let mut start = 0;
+    for (index, block) in document.children.iter().enumerate() {
+        let last = index + 1 == document.children.len();
+        let end = if last {
+            body.len()
+        } else {
+            let Some(relative) = body[start..].find("\n\n") else {
+                return false;
+            };
+            start + relative
+        };
+        let Some(raw) = source.get(start..end) else {
+            return false;
+        };
+        if !literal_paragraph_source_is_safe(raw) {
+            return false;
+        }
+
+        let md::Block::Paragraph(paragraph) = block else {
+            return false;
+        };
+        let Some(paragraph_span) = paragraph.meta.span else {
+            return false;
+        };
+        if paragraph_span.start != start || paragraph_span.end != end {
+            return false;
+        }
+        let [md::Inline::Text(text)] = paragraph.children.as_slice() else {
+            return false;
+        };
+        let Some(text_span) = text.meta.span else {
+            return false;
+        };
+        if text_span.start != start || text_span.end != end || text.value != raw {
+            return false;
+        }
+
+        if last {
+            return end + 1 == source.len();
+        }
+        start = end + 2;
+    }
+    false
+}
+
+fn literal_paragraph_source_is_safe(raw: &str) -> bool {
+    let Some(first) = raw.chars().next() else {
+        return false;
+    };
+    if matches!(first, ' ' | '\t' | '-' | '+' | '=' | '>')
+        || matches!(raw.chars().last(), Some(' ' | '\t'))
+        || raw.contains('\n')
+        || starts_with_ambiguous_ordered_list_marker(raw)
+    {
+        return false;
+    }
+    let bytes = raw.as_bytes();
+    for (index, &byte) in bytes.iter().enumerate() {
+        if matches!(
+            byte,
+            b'\\'
+                | b'&'
+                | b'`'
+                | b'|'
+                | b'*'
+                | b'_'
+                | b'+'
+                | b'='
+                | b'~'
+                | b'^'
+                | b'['
+                | b']'
+                | b'$'
+                | b'<'
+                | b'>'
+                | b'{'
+                | b'}'
+                | b':'
+                | b'@'
+                | b'#'
+                | b'\0'
+        ) {
+            return false;
+        }
+        if byte == b'.' && index >= 3 && bytes[index - 3..index].eq_ignore_ascii_case(b"www") {
+            return false;
+        }
+    }
+    raw.chars().all(|character| {
+        character == ' ' || (!character.is_control() && !character.is_whitespace())
+    })
+}
+
+fn starts_with_ambiguous_ordered_list_marker(raw: &str) -> bool {
+    let digits = raw.bytes().take_while(u8::is_ascii_digit).count();
+    let Some(marker) = raw.as_bytes().get(digits) else {
+        return false;
+    };
+    if !matches!(*marker, b'.' | b')') {
+        return false;
+    }
+    raw.get(digits + 1..)
+        .and_then(|tail| tail.chars().next())
+        .is_none_or(char::is_whitespace)
 }
 
 fn repair_definition_adjacency(document: &mut md::Document, source: &str) {

--- a/plugins/markdown-v2/src/tests.rs
+++ b/plugins/markdown-v2/src/tests.rs
@@ -1,3 +1,4 @@
+use crate::markdown_file::parse_markdown_source;
 use crate::{
     ChangeEffect, Document, EntityChange, EntityRecord, IdNamespace, InputSplice, NODE_SCHEMA_KEY,
 };
@@ -372,4 +373,70 @@ fn entity_edit_returns_a_minimal_file_splice_and_preserves_old_fork() {
     assert_eq!(edits[0].insert.as_slice(), b"After");
     assert_eq!(after.accepted_bytes(), b"After\n\nUntouched\n");
     assert_eq!(old.accepted_bytes(), source);
+}
+
+#[test]
+fn canonical_literal_prose_fast_path_matches_forced_fallback_bytes_and_entities() {
+    let cases = [
+        "Café, naïve prose — with commas, semicolons; parentheses (like these), and a question?\n\nSecond paragraph has 42% ordinary prose.\n",
+        "Unicode punctuation… “quoted prose” stays literal; so do apostrophes.\n\nA second plain paragraph, too.\n",
+    ];
+
+    for (index, source) in cases.into_iter().enumerate() {
+        let parsed = parse_markdown_source(source).expect("literal prose should parse");
+        assert!(
+            parsed.canonical_literal_paragraph_layout,
+            "{source:?} should meet the strict literal-prose predicate"
+        );
+        assert_eq!(parsed.canonical_render.as_deref(), Some(source.as_bytes()));
+
+        let namespace = IdNamespace::from_halves(12, u64::try_from(index).unwrap());
+        let (fast_document, fast_changes) =
+            Document::open_file(source.as_bytes().to_vec(), Some("prose.md"), namespace)
+                .expect("fast-path document should open");
+        let (fallback_document, fallback_changes) = Document::open_file_forced_canonical_fallback(
+            source.as_bytes().to_vec(),
+            Some("prose.md"),
+            namespace,
+        )
+        .expect("forced-fallback document should open");
+
+        assert_eq!(fast_document.accepted_bytes(), source.as_bytes());
+        assert_eq!(fallback_document.accepted_bytes(), source.as_bytes());
+        assert_eq!(fast_changes, fallback_changes);
+    }
+}
+
+#[test]
+fn literal_prose_fast_path_rejects_markdown_syntax_and_noncanonical_layout() {
+    let cases = [
+        ("heading", "# Heading\n\nPlain prose.\n"),
+        ("inline syntax", "Plain *emphasis* is Markdown syntax.\n"),
+        (
+            "soft line break",
+            "Plain prose\ncontinues on the next line.\n",
+        ),
+        (
+            "extra blank line",
+            "First paragraph.\n\n\nSecond paragraph.\n",
+        ),
+        (
+            "trailing spaces",
+            "First paragraph.  \n\nSecond paragraph.\n",
+        ),
+        ("crlf", "First paragraph.\r\n\r\nSecond paragraph.\r\n"),
+        (
+            "unsafe literal punctuation",
+            "A [literal] bracket needs serializer escaping.\n",
+        ),
+    ];
+
+    for (name, source) in cases {
+        let parsed = parse_markdown_source(source)
+            .unwrap_or_else(|error| panic!("{name} should remain valid Markdown: {error:?}"));
+        assert!(
+            !parsed.canonical_literal_paragraph_layout,
+            "{name} must use the existing canonical-render fallback"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

For a deliberately narrow, parser-proven canonical literal-prose shape, retain the original source as canonical output rather than rebuilding and serializing a second AST through the canonical-render fixpoint. Rich Markdown and noncanonical layout retain the existing path.

No plugin API, WIT, or SQL change.

## Measured result

Source-provenance-controlled real Wasm + RocksDB E2E (exact `c39429f2`, isolated clean host/Wasm builds and Wasmtime caches):

- 3.5 MiB plain-prose initial import p50: **1547.495 → 699.927 ms** (**54.77% lower; 2.21× faster**)
- Hot byte edit p50: 5.776 → 5.828 ms (+0.9%)
- Direct semantic edit p50: 7.230 → 7.271 ms (+0.6%)
- Semantic merge p50: 6.576 → 6.771 ms (+3.0%, small-ms noise)

Fallback control: 3,669,908-byte mixed GFM corpus with headings, inline syntax, lists, tables, fences, and quotes forces the old canonical-render path for the whole file. It remained byte/entity exact and was neutral: 2719.969 → 2787.910 ms in-test p50 (+2.50%).

## Validation

- Full `plugin_markdown_incremental_v2` release suite
- Fast-path vs forced-fallback byte/entity equivalence tests
- Syntax/layout rejection tests
- Rebuilt rebased Wasm component and E2E harness

Note: an all-dense GFM stress fixture hits an existing baseline guest/runtime error above roughly 512 KiB; this PR does not change that path or treat it as a happy-path result.