### PR TITLE
perf: materialize tracked working diffs from serving head

### DIFF
--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -88,6 +88,12 @@ harness = false
 required-features = ["storage-benches"]
 
 [[bench]]
+name = "tracked_working_diff"
+path = "benches/tracked_working_diff.rs"
+harness = false
+required-features = ["rocksdb"]
+
+[[bench]]
 name = "slatedb_file_api"
 path = "benches/slatedb_file_api.rs"
 harness = false

--- a/packages/engine-benchmarks/benches/tracked_working_diff.rs
+++ b/packages/engine-benchmarks/benches/tracked_working_diff.rs
@@ -1,0 +1,401 @@
+//! Two-phase populated tracked-working-diff benchmark for RocksDB.
+//!
+//! The fixture deliberately remains *between* checkpoints. The old checkpoint
+//! scale harness only measured `lix_working_change` after a checkpoint, when
+//! there is no interval to diff. This harness records the real common shapes:
+//! repeated edits to a small working set and disjoint edits across a large
+//! working set.
+//!
+//! ```text
+//! cargo bench -p lix_engine_benchmarks --bench tracked_working_diff -- \
+//!   setup repeated /tmp/lix-working-diff-repeated 10000 1000 10
+//! cargo bench -p lix_engine_benchmarks --bench tracked_working_diff -- \
+//!   measure /tmp/lix-working-diff-repeated 11
+//! ```
+//!
+//! `setup` refuses to overwrite an existing directory. `measure` is read-only
+//! and can therefore be used for profiles against the same warmed fixture.
+
+use std::fmt::Write as _;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use lix_engine::{Engine, ExecuteBatchStatement, Storage, Value};
+use lix_rocksdb_storage::RocksDB;
+
+const DEFAULT_ROW_COUNT: usize = 10_000;
+const DEFAULT_COMMIT_COUNT: usize = 1_000;
+const DEFAULT_CHANGES_PER_COMMIT: usize = 10;
+const DEFAULT_MEASURE_REPETITIONS: usize = 11;
+const INSERT_BATCH_SIZE: usize = 500;
+const WORKING_DIFF_SQL: &str = "SELECT entity_pk, schema_key, change_kind, before_change_id, after_change_id \
+    FROM lix_working_change ORDER BY schema_key, entity_pk";
+
+#[derive(Clone, Copy)]
+enum Shape {
+    Repeated,
+    Disjoint,
+}
+
+impl Shape {
+    fn parse(value: &str) -> Self {
+        match value {
+            "repeated" => Self::Repeated,
+            "disjoint" => Self::Disjoint,
+            _ => panic!("shape must be 'repeated' or 'disjoint', got '{value}'"),
+        }
+    }
+
+    fn expected_changes(
+        self,
+        row_count: usize,
+        commit_count: usize,
+        changes_per_commit: usize,
+    ) -> usize {
+        match self {
+            Self::Repeated => changes_per_commit,
+            Self::Disjoint => (commit_count * changes_per_commit).min(row_count),
+        }
+    }
+}
+
+fn main() {
+    let args = std::env::args().collect::<Vec<_>>();
+    let Some(mode) = args.get(1).map(String::as_str) else {
+        print_usage();
+        return;
+    };
+    let Some(path) = args.get(2).map(String::as_str) else {
+        print_usage();
+        return;
+    };
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("create tracked-working-diff benchmark runtime");
+
+    match mode {
+        "setup" => {
+            let Some(shape) = args.get(3).map(|value| Shape::parse(value)) else {
+                print_usage();
+                return;
+            };
+            let row_count = parse_usize(args.get(4), DEFAULT_ROW_COUNT, "row count");
+            let commit_count = parse_usize(args.get(5), DEFAULT_COMMIT_COUNT, "commit count");
+            let changes_per_commit = parse_usize(
+                args.get(6),
+                DEFAULT_CHANGES_PER_COMMIT,
+                "changes per commit",
+            );
+            runtime.block_on(setup(
+                Path::new(path),
+                shape,
+                row_count,
+                commit_count,
+                changes_per_commit,
+            ));
+        }
+        "measure" => {
+            let repetitions = parse_usize(
+                args.get(3),
+                DEFAULT_MEASURE_REPETITIONS,
+                "measurement repetitions",
+            );
+            runtime.block_on(measure(Path::new(path), repetitions));
+        }
+        "checkpoint" => runtime.block_on(checkpoint(Path::new(path))),
+        _ => print_usage(),
+    }
+}
+
+fn print_usage() {
+    eprintln!(
+        "usage:\n  tracked_working_diff setup <directory> <repeated|disjoint> \
+         [rows] [commits] [changes-per-commit]\n  \
+         tracked_working_diff measure <directory> [repetitions]\n  \
+         tracked_working_diff checkpoint <directory>"
+    );
+}
+
+fn parse_usize(value: Option<&String>, default: usize, label: &str) -> usize {
+    let value = value.map_or(default, |value| {
+        value
+            .parse::<usize>()
+            .unwrap_or_else(|_| panic!("{label} must be a positive integer"))
+    });
+    assert!(value > 0, "{label} must be a positive integer");
+    value
+}
+
+async fn setup(
+    path: &Path,
+    shape: Shape,
+    row_count: usize,
+    commit_count: usize,
+    changes_per_commit: usize,
+) {
+    assert!(
+        !path.exists(),
+        "refusing to overwrite existing fixture {}",
+        path.display()
+    );
+    assert!(
+        changes_per_commit <= row_count,
+        "changes per commit must not exceed row count"
+    );
+
+    let storage = RocksDB::open(path).expect("open tracked-working-diff RocksDB");
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize tracked-working-diff storage");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("open tracked-working-diff engine");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("open tracked-working-diff session");
+    register_schema(&session).await;
+
+    let seed_start = Instant::now();
+    seed_rows(&session, row_count).await;
+    let seed_elapsed = seed_start.elapsed();
+    let initial_checkpoint_start = Instant::now();
+    session
+        .create_checkpoint()
+        .await
+        .expect("create tracked-working-diff initial checkpoint");
+    let initial_checkpoint_elapsed = initial_checkpoint_start.elapsed();
+
+    let writes_start = Instant::now();
+    for commit_index in 0..commit_count {
+        update_commit(&session, shape, row_count, commit_index, changes_per_commit).await;
+    }
+    let writes_elapsed = writes_start.elapsed();
+    let expected_changes = shape.expected_changes(row_count, commit_count, changes_per_commit);
+    let working_changes = working_change_count(&session).await;
+    assert_eq!(
+        working_changes, expected_changes,
+        "populated working-diff fixture must expose every expected identity"
+    );
+    drop(session);
+    drop(engine);
+    storage.flush().expect("flush tracked-working-diff RocksDB");
+    println!(
+        "tracked_working_diff setup backend=rocksdb shape={} rows={row_count} commits={commit_count} \
+         changes_per_commit={changes_per_commit} working_changes={working_changes} \
+         seed_ms={:.3} initial_checkpoint_ms={:.3} writes_ms={:.3}",
+        shape_name(shape),
+        millis(seed_elapsed),
+        millis(initial_checkpoint_elapsed),
+        millis(writes_elapsed),
+    );
+}
+
+async fn measure(path: &Path, repetitions: usize) {
+    assert!(path.exists(), "fixture {} does not exist", path.display());
+    let storage = RocksDB::open(path).expect("open tracked-working-diff RocksDB");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("open tracked-working-diff engine");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("open tracked-working-diff session");
+
+    let expected_changes = working_change_count(&session).await;
+    assert!(
+        expected_changes > 0,
+        "fixture has no populated working changes"
+    );
+    // Warm SQL/provider construction and the RocksDB block cache outside the
+    // reported samples. Repeated measurements remain read-only.
+    assert_eq!(working_change_count(&session).await, expected_changes);
+    let mut latencies = Vec::with_capacity(repetitions);
+    for _ in 0..repetitions {
+        let start = Instant::now();
+        let count = profile_working_change_query(&session).await;
+        latencies.push(start.elapsed());
+        assert_eq!(count, expected_changes);
+    }
+    let mut sorted = latencies.clone();
+    sorted.sort_unstable();
+    println!(
+        "tracked_working_diff measure backend=rocksdb working_changes={expected_changes} \
+         repetitions={repetitions} p50_ms={:.3} mean_ms={:.3} min_ms={:.3} max_ms={:.3}",
+        millis(sorted[sorted.len() / 2]),
+        mean_millis(&latencies),
+        millis(sorted[0]),
+        millis(*sorted.last().expect("measurement samples are non-empty")),
+    );
+}
+
+async fn checkpoint(path: &Path) {
+    assert!(path.exists(), "fixture {} does not exist", path.display());
+    let storage = RocksDB::open(path).expect("open tracked-working-diff RocksDB");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("open tracked-working-diff engine");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("open tracked-working-diff session");
+    let before = working_change_count(&session).await;
+    assert!(before > 0, "fixture has no populated working changes");
+    let start = Instant::now();
+    session
+        .create_checkpoint()
+        .await
+        .expect("checkpoint populated working-diff fixture");
+    let elapsed = start.elapsed();
+    assert_eq!(working_change_count(&session).await, 0);
+    println!(
+        "tracked_working_diff checkpoint backend=rocksdb working_changes_before={before} \
+         checkpoint_ms={:.3}",
+        millis(elapsed),
+    );
+}
+
+async fn register_schema<StorageImpl>(session: &lix_engine::SessionContext<StorageImpl>)
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let schema = serde_json::json!({
+        "x-lix-key": "working_diff_row",
+        "x-lix-primary-key": ["/id"],
+        "type": "object",
+        "required": ["id", "value"],
+        "properties": {
+            "id": { "type": "string" },
+            "value": { "type": "string" }
+        },
+        "additionalProperties": false
+    });
+    let affected = session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register tracked-working-diff schema")
+        .rows_affected();
+    assert_eq!(affected, 1);
+}
+
+async fn seed_rows<StorageImpl>(session: &lix_engine::SessionContext<StorageImpl>, row_count: usize)
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let mut transaction = session
+        .begin_transaction()
+        .await
+        .expect("begin tracked-working-diff seed transaction");
+    for start in (0..row_count).step_by(INSERT_BATCH_SIZE) {
+        let end = (start + INSERT_BATCH_SIZE).min(row_count);
+        let mut sql = String::from("INSERT INTO working_diff_row (id, value) VALUES ");
+        let mut params = Vec::with_capacity((end - start) * 2);
+        for (offset, row_index) in (start..end).enumerate() {
+            if offset > 0 {
+                sql.push(',');
+            }
+            let parameter = offset * 2;
+            write!(sql, "(${}, ${})", parameter + 1, parameter + 2)
+                .expect("write tracked-working-diff insert parameters");
+            params.push(Value::Text(row_id(row_index)));
+            params.push(Value::Text("baseline".to_string()));
+        }
+        let affected = transaction
+            .execute(&sql, &params)
+            .await
+            .expect("seed tracked-working-diff rows")
+            .rows_affected();
+        let affected = usize::try_from(affected).expect("affected row count fits usize");
+        assert_eq!(affected, end - start);
+    }
+    transaction
+        .commit()
+        .await
+        .expect("commit tracked-working-diff seed transaction");
+}
+
+async fn update_commit<StorageImpl>(
+    session: &lix_engine::SessionContext<StorageImpl>,
+    shape: Shape,
+    row_count: usize,
+    commit_index: usize,
+    changes_per_commit: usize,
+) where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let statements = (0..changes_per_commit)
+        .map(|offset| {
+            let row_index = match shape {
+                Shape::Repeated => offset,
+                Shape::Disjoint => (commit_index * changes_per_commit + offset) % row_count,
+            };
+            ExecuteBatchStatement {
+                sql: "UPDATE working_diff_row SET value = $1 WHERE id = $2".to_string(),
+                params: vec![
+                    Value::Text(format!("commit-{commit_index:05}")),
+                    Value::Text(row_id(row_index)),
+                ],
+            }
+        })
+        .collect::<Vec<_>>();
+    let results = session
+        .execute_batch(&statements)
+        .await
+        .expect("update tracked-working-diff commit");
+    assert!(
+        results.iter().all(|result| result.rows_affected() == 1),
+        "every working-diff update must affect exactly one row"
+    );
+}
+
+#[inline(never)]
+async fn profile_working_change_query<StorageImpl>(
+    session: &lix_engine::SessionContext<StorageImpl>,
+) -> usize
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    session
+        .execute(WORKING_DIFF_SQL, &[])
+        .await
+        .expect("query populated working diff")
+        .len()
+}
+
+async fn working_change_count<StorageImpl>(
+    session: &lix_engine::SessionContext<StorageImpl>,
+) -> usize
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    profile_working_change_query(session).await
+}
+
+fn row_id(row_index: usize) -> String {
+    format!("row-{row_index:05}")
+}
+
+const fn shape_name(shape: Shape) -> &'static str {
+    match shape {
+        Shape::Repeated => "repeated",
+        Shape::Disjoint => "disjoint",
+    }
+}
+
+fn mean_millis(durations: &[Duration]) -> f64 {
+    let sample_count = u32::try_from(durations.len()).expect("benchmark sample count fits u32");
+    durations
+        .iter()
+        .map(|duration| millis(*duration))
+        .sum::<f64>()
+        / f64::from(sample_count)
+}
+
+fn millis(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}

--- a/packages/engine/src/branch/control.rs
+++ b/packages/engine/src/branch/control.rs
@@ -2,7 +2,7 @@
 //!
 //! A branch head is a tiny mutable control-plane record, not a user row.  It
 //! therefore has its own space and exact-byte CAS token.  The current tracked
-//! serving generation lives beside the head so readers can bind a v5 group
+//! serving generation lives beside the head so readers can bind a v6 group
 //! marker to the same atomic publication without consulting `lix_branch_ref`
 //! through the mutable live-state index.
 
@@ -24,10 +24,10 @@ pub(crate) const BRANCH_HEAD_CONTROL_SPACE: StorageSpace =
 
 /// The one mutable publication record for a branch.
 ///
-/// `generation` is the physical v5 tracked-head generation currently serving
+/// `generation` is the physical v6 tracked-head generation currently serving
 /// `head_commit_id`. Serial normal commits retain it; a rewind, merge fence,
 /// or bootstrap gets a fresh generation and takes the historical fallback
-/// until a complete v5 projection is published.
+/// until a complete v6 projection is published.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, musli::Encode, musli::Decode)]
 #[musli(packed)]
 pub(crate) struct BranchHeadControl {

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -4,6 +4,7 @@ use crate::GLOBAL_BRANCH_ID;
 use crate::binary_cas::BinaryCasContext;
 use crate::branch::{BranchContext, BranchRefReader};
 use crate::catalog::{CatalogContext, CatalogFingerprint};
+use crate::changelog::COMMIT_SPACE;
 use crate::commit_graph::CommitGraphContext;
 use crate::entity_pk::EntityPk;
 use crate::init::InitReceipt;
@@ -18,7 +19,10 @@ use crate::plugin::{
 use crate::session::SessionContext;
 use crate::sql2::SqlPlanningCache;
 use crate::storage_adapter::Storage;
-use crate::storage_adapter::{SharedStorageAdapterRead, StorageReadOptions, StorageWriteOptions};
+use crate::storage_adapter::{
+    ScanPlan, SharedStorageAdapterRead, StorageCoreProjection, StoragePrefix, StorageReadOptions,
+    StorageScanOptions, StorageWriteOptions,
+};
 use crate::storage_adapter::{StorageAdapter, StorageWriteSet};
 use crate::telemetry::TelemetrySink;
 use crate::tracked_state::TrackedStateContext;
@@ -319,26 +323,70 @@ where
 {
     let read =
         SharedStorageAdapterRead::new(storage.begin_read(StorageReadOptions::default()).await?);
-    let protocol_read = read.clone();
-    let reader = live_state.reader(read);
-    let initialized = reader
-        .load_row(&LiveStateRowRequest {
-            schema_key: "lix_key_value".to_string(),
-            branch_id: GLOBAL_BRANCH_ID.to_string(),
-            entity_pk: EntityPk::single("lix_id"),
-            file_id: NullableKeyFilter::Null,
-        })
-        .await?
-        .is_some();
-
-    if initialized {
-        return crate::init::assert_repository_protocol(&protocol_read).await;
+    match crate::init::repository_protocol_status(&read).await? {
+        // The protocol check must precede the live-state read: tracked-head
+        // spaces keep their physical IDs across hard layout cuts, so an old
+        // group value could otherwise be decoded before we reject it.
+        crate::init::RepositoryProtocolStatus::Current => {
+            let reader = live_state.reader(read);
+            let initialized = reader
+                .load_row(&LiveStateRowRequest {
+                    schema_key: "lix_key_value".to_string(),
+                    branch_id: GLOBAL_BRANCH_ID.to_string(),
+                    entity_pk: EntityPk::single("lix_id"),
+                    file_id: NullableKeyFilter::Null,
+                })
+                .await?
+                .is_some();
+            if initialized {
+                Ok(())
+            } else {
+                Err(not_initialized_error())
+            }
+        }
+        crate::init::RepositoryProtocolStatus::Unsupported => {
+            Err(crate::init::unsupported_repository_protocol_error())
+        }
+        crate::init::RepositoryProtocolStatus::Missing => {
+            // A raw changelog key is the initialization sentinel. Unlike a
+            // live-state lookup it cannot parse an old tracked-head layout.
+            if repository_has_changelog_commit(&read).await? {
+                Err(crate::init::unsupported_repository_protocol_error())
+            } else {
+                Err(not_initialized_error())
+            }
+        }
     }
+}
 
-    Err(LixError::new(
+async fn repository_has_changelog_commit(
+    read: &(impl crate::storage_adapter::StorageAdapterRead + ?Sized),
+) -> Result<bool, LixError> {
+    Ok(!ScanPlan::prefix(
+        COMMIT_SPACE,
+        StoragePrefix {
+            bytes: bytes::Bytes::new(),
+        },
+    )
+    .collect(
+        read,
+        StorageScanOptions {
+            projection: StorageCoreProjection::KeyOnly,
+            limit_rows: 1,
+            ..StorageScanOptions::default()
+        },
+    )
+    .await?
+    .value
+    .entries
+    .is_empty())
+}
+
+fn not_initialized_error() -> LixError {
+    LixError::new(
         "LIX_ERROR_NOT_INITIALIZED",
         "engine storage is not initialized; call Engine::initialize(...) before Engine::new(...)",
-    ))
+    )
 }
 
 #[cfg(test)]
@@ -347,8 +395,8 @@ mod tests {
 
     use super::*;
     use crate::storage_adapter::{
-        Memory, PointReadPlan, StorageGetOptions, StorageKey, StorageProjectedValue, StorageSpace,
-        StorageSpaceId, StorageValue,
+        Memory, PointReadPlan, ScanPlan, StorageGetOptions, StorageKey, StoragePrefix,
+        StorageProjectedValue, StorageScanOptions, StorageSpace, StorageSpaceId, StorageValue,
     };
 
     #[tokio::test]
@@ -480,6 +528,96 @@ mod tests {
 
         let Err(error) = Engine::new(storage).await else {
             panic!("initialized pre-protocol storage must fail closed");
+        };
+        assert_eq!(error.code, "LIX_ERROR_UNSUPPORTED_STORAGE_FORMAT");
+    }
+
+    #[tokio::test]
+    async fn predecessor_protocol_is_rejected_before_old_head_bytes_are_decoded() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let storage_adapter = StorageAdapter::new(storage.clone());
+        let read = storage_adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read initialized head groups");
+        let groups = ScanPlan::prefix(
+            crate::live_state::TRACKED_HEAD_GROUP_SPACE,
+            StoragePrefix {
+                bytes: Bytes::new(),
+            },
+        )
+        .collect(&read, StorageScanOptions::default())
+        .await
+        .expect("scan initialized head groups")
+        .value
+        .entries;
+        assert!(
+            !groups.is_empty(),
+            "initialized repository must have head groups"
+        );
+
+        let mut writes = storage_adapter.new_write_set();
+        writes.put(
+            crate::init::REPOSITORY_PROTOCOL_SPACE,
+            crate::init::REPOSITORY_PROTOCOL_KEY,
+            &b"tracked-direct-plane.v6"[..],
+        );
+        for group in groups {
+            writes.put(
+                crate::live_state::TRACKED_HEAD_GROUP_SPACE,
+                group.key,
+                StorageValue {
+                    bytes: Bytes::from_static(b"predecessor-head-bytes"),
+                },
+            );
+        }
+        storage_adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("predecessor bytes should commit");
+
+        let Err(error) = Engine::new(storage).await else {
+            panic!("predecessor protocol must fail before head visibility reads");
+        };
+        assert_eq!(error.code, "LIX_ERROR_UNSUPPORTED_STORAGE_FORMAT");
+    }
+
+    #[tokio::test]
+    async fn initialize_refuses_to_overwrite_existing_repository() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("first initialization should succeed");
+
+        let Err(error) = Engine::initialize(storage).await else {
+            panic!("initialization must not overwrite an existing repository");
+        };
+        assert_eq!(error.code, "LIX_ERROR_ALREADY_INITIALIZED");
+    }
+
+    #[tokio::test]
+    async fn initialize_refuses_to_overwrite_a_predecessor_protocol() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("first initialization should succeed");
+        let storage_adapter = StorageAdapter::new(storage.clone());
+        let mut writes = storage_adapter.new_write_set();
+        writes.put(
+            crate::init::REPOSITORY_PROTOCOL_SPACE,
+            crate::init::REPOSITORY_PROTOCOL_KEY,
+            &b"tracked-direct-plane.v6"[..],
+        );
+        storage_adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("write predecessor protocol marker");
+
+        let Err(error) = Engine::initialize(storage).await else {
+            panic!("initialization must not overwrite a predecessor protocol");
         };
         assert_eq!(error.code, "LIX_ERROR_UNSUPPORTED_STORAGE_FORMAT");
     }

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -12,7 +12,7 @@ use bytes::Bytes;
 
 use crate::branch::BranchHeadControlContext;
 use crate::changelog::{ChangelogContext, ChangelogWriter, CommitId, GcPlan, GcRoot};
-use crate::live_state::LiveStateIndexContext;
+use crate::live_state::{LiveStateIndexContext, stage_collect_stale_working_diff_indexes};
 use crate::storage_adapter::{
     PointReadPlan, ScanPlan, StorageAdapterRead, StorageGetOptions, StorageKey, StoragePrefix,
     StorageProjectedValue, StorageScanOptions, StorageSpace, StorageSpaceId, StorageValue,
@@ -420,6 +420,10 @@ where
         crate::tracked_state::stage_delete_commit_root(writes, *commit_id);
         crate::tracked_state::stage_delete_commit_deltas(&store, writes, *commit_id).await?;
     }
+    // Checkpoint publication leaves prior dirty-index generations unreachable
+    // in O(1). Reclaim those auxiliary records only in the asynchronous GC
+    // pass so a foreground checkpoint never pays a history-sized delete cost.
+    stage_collect_stale_working_diff_indexes(&store, writes).await?;
     let tracked_root_stage_us = elapsed_micros(phase_started);
 
     Ok(RepositoryGcPlan {

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -17,6 +17,7 @@ use crate::functions::FunctionProviderHandle;
 use crate::json_store::{JsonStoreContext, JsonWritePlacementRef, NormalizedJsonRef};
 use crate::live_state::{
     LiveStateIndexContext, LiveStateIndexDeltaRef, TrackedHeadContext, TrackedHeadDeltaRef,
+    TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage, stage_tracked_working_diff_epoch,
 };
 use crate::schema::{
     registered_schema_entity_pk, schema_key_from_definition, seed_schema_definitions,
@@ -38,14 +39,25 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 
 /// Repository-wide compatibility gate for physical storage protocols.
 ///
-/// The v6 direct branch-control plane changes the authority for current
-/// branch heads. Those proofs are only sound for repositories initialized
-/// with this protocol, so opening an older store must fail closed rather than
-/// mixing a legacy `lix_branch_ref` row with current visibility rules.
+/// The v8 direct branch-control plane binds checkpoint-relative first-before
+/// summaries and their sparse-index coverage to the serving-head marker.
+/// Those proofs are only sound for repositories initialized with this
+/// protocol, so opening an older store must fail closed rather than mixing an
+/// older group wire format with current visibility and working-diff rules.
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"tracked-direct-plane.v6";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"tracked-direct-plane.v8";
+
+/// Raw status of the repository protocol marker. Engine opening consults this
+/// before it touches any tracked-head space, whose physical IDs deliberately
+/// remain stable across hard layout cuts.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RepositoryProtocolStatus {
+    Current,
+    Missing,
+    Unsupported,
+}
 
 pub(crate) fn stage_repository_protocol(writes: &mut StorageWriteSet) {
     writes.put(
@@ -55,27 +67,31 @@ pub(crate) fn stage_repository_protocol(writes: &mut StorageWriteSet) {
     );
 }
 
-pub(crate) async fn assert_repository_protocol(
+pub(crate) async fn repository_protocol_status(
     read: &(impl StorageAdapterRead + ?Sized),
-) -> Result<(), LixError> {
+) -> Result<RepositoryProtocolStatus, LixError> {
     let values = PointReadPlan::new(
         REPOSITORY_PROTOCOL_SPACE,
         &[StorageKey(Bytes::from_static(REPOSITORY_PROTOCOL_KEY))],
     )
     .materialize(read, StorageGetOptions::default())
     .await?;
-    let supported = matches!(
-        values.value.into_iter().next().flatten(),
+    Ok(match values.value.into_iter().next().flatten() {
         Some(StorageProjectedValue::FullValue(value))
-            if value.as_ref() == REPOSITORY_PROTOCOL_VALUE
-    );
-    if supported {
-        return Ok(());
-    }
-    Err(LixError::new(
+            if value.as_ref() == REPOSITORY_PROTOCOL_VALUE =>
+        {
+            RepositoryProtocolStatus::Current
+        }
+        Some(_) => RepositoryProtocolStatus::Unsupported,
+        None => RepositoryProtocolStatus::Missing,
+    })
+}
+
+pub(crate) fn unsupported_repository_protocol_error() -> LixError {
+    LixError::new(
         "LIX_ERROR_UNSUPPORTED_STORAGE_FORMAT",
         "repository uses an unsupported tracked direct-plane storage protocol; recreate the repository",
-    ))
+    )
 }
 
 /// Pure seed plan for initializing an engine repository.
@@ -282,15 +298,16 @@ pub(crate) async fn initialize<StorageImpl>(
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
-    let functions = FunctionProviderHandle::system();
-    let plan = plan_init_seed(functions)?;
-    let receipt = plan.receipt.clone();
-
     let mut read = SharedStorageAdapterRead::new(
         storage
             .begin_read(crate::storage_adapter::StorageReadOptions::default())
             .await?,
     );
+    assert_empty_repository_for_initialize::<StorageImpl>(&read).await?;
+
+    let functions = FunctionProviderHandle::system();
+    let plan = plan_init_seed(functions)?;
+    let receipt = plan.receipt.clone();
     let mut writes = StorageWriteSet::new();
     let authored_changes = plan
         .changes
@@ -341,7 +358,7 @@ where
             .stage_commit_root(&receipt.initial_commit_id, None, deltas)
             .await?;
 
-        // Seed both visible branches with a complete v5 serving generation.
+        // Seed both visible branches with a complete v6 serving generation.
         // The initial commit is shared, but the branch-scoped marker and
         // groups are intentionally independent so normal reads never need a
         // historical fallback immediately after initialization.
@@ -363,17 +380,30 @@ where
         let tracked_head = TrackedHeadContext::new();
         let absence_guards = std::collections::BTreeSet::default();
         for branch in &plan.branch_controls {
+            let mut working_diff_coverage = WorkingDiffIndexCoverage::default();
             tracked_head
                 .writer(&read, &mut writes)
-                .stage_commit(
+                .stage_commit_with_working_diff(
                     &branch.branch_id,
                     None,
                     plan.commit.id,
                     &head_deltas,
                     &absence_guards,
                     None,
+                    Some(plan.commit.id),
+                    None,
+                    &mut working_diff_coverage,
                 )
                 .await?;
+            stage_tracked_working_diff_epoch(
+                &mut writes,
+                &branch.branch_id,
+                TrackedWorkingDiffEpoch {
+                    checkpoint_commit_id: plan.commit.id,
+                    generation: Some(plan.commit.id),
+                    coverage: working_diff_coverage,
+                },
+            )?;
             stage_branch_head_control(&mut writes, &branch.branch_id, branch.control)?;
         }
 
@@ -406,6 +436,35 @@ where
         )
         .await?;
     Ok(receipt)
+}
+
+/// Initialization is a create operation, never a migration. The direct-head
+/// spaces intentionally retain their physical IDs across protocol cuts, so
+/// writing a new protocol marker over existing bytes would make old values
+/// look like current layout state.
+async fn assert_empty_repository_for_initialize<StorageImpl>(
+    read: &SharedStorageAdapterRead<StorageImpl::Read<'_>>,
+) -> Result<(), LixError>
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    match repository_protocol_status(read).await? {
+        RepositoryProtocolStatus::Current => Err(LixError::new(
+            "LIX_ERROR_ALREADY_INITIALIZED",
+            "engine storage is already initialized; initialization does not migrate or overwrite repositories",
+        )),
+        RepositoryProtocolStatus::Unsupported => Err(unsupported_repository_protocol_error()),
+        RepositoryProtocolStatus::Missing => {
+            if StorageAdapter::<StorageImpl>::load_mutation_revision_from_read(read)
+                .await?
+                .is_some()
+            {
+                Err(unsupported_repository_protocol_error())
+            } else {
+                Ok(())
+            }
+        }
+    }
 }
 
 fn seed_change_to_change_record(change: &InitSeedChange) -> ChangeRecord {

--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -23,7 +23,9 @@ pub(crate) use reader::load_exact_rows_via_scan_for_test;
 #[allow(unused_imports)]
 pub(crate) use tracked_head::{
     TRACKED_HEAD_GROUP_SPACE, TRACKED_HEAD_MARKER_SPACE, TRACKED_HEAD_MEMBER_SPACE,
-    TrackedHeadContext, TrackedHeadDeltaRef,
+    TRACKED_WORKING_DIFF_GROUP_SPACE, TRACKED_WORKING_DIFF_MARKER_SPACE, TrackedHeadContext,
+    TrackedHeadDeltaRef, TrackedWorkingDiff, TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage,
+    stage_collect_stale_working_diff_indexes, stage_tracked_working_diff_epoch,
 };
 #[allow(unused_imports)]
 pub(crate) use types::{

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -4,7 +4,7 @@
 //! generation-keyed serving state for one branch head, letting the normal
 //! live-state path range scan rows and hydrate JSON directly without replaying
 //! changelog history. A marker binds a generation to the branch ref's commit.
-//! Any mismatch is a cache miss and callers take the historical fallback.
+//! Any mismatch is a direct-plane miss and callers take the historical fallback.
 
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
@@ -16,7 +16,7 @@ use bytes::Bytes;
 
 use crate::LixError;
 use crate::NullableKeyFilter;
-use crate::branch::BranchHeadControl;
+use crate::branch::{BranchHeadControl, BranchHeadControlContext};
 use crate::changelog::{ChangeId, ChangeRecordProjection, CommitId};
 use crate::common::LixTimestamp;
 use crate::entity_pk::EntityPk;
@@ -26,23 +26,25 @@ use crate::json_store::{
 use crate::live_state::MaterializedLiveStateRow;
 use crate::storage_adapter::{
     PointReadPlan, ScanPlan, StorageAdapterRead, StorageGetOptions, StorageKey, StoragePrefix,
-    StorageProjectedValue, StorageScanOptions, StorageSpace, StorageSpaceId, StorageValue,
-    StorageWriteSet,
+    StorageProjectedValue, StorageReadEntry, StorageScanOptions, StorageSpace, StorageSpaceId,
+    StorageValue, StorageWriteSet,
 };
 use crate::storage_codec;
 use crate::tracked_state::{
-    MaterializedTrackedStateRow, TrackedStateFilter, TrackedStateKey, TrackedStateScanRequest,
+    MaterializedTrackedStateRow, TrackedStateDiff, TrackedStateDiffEntry, TrackedStateDiffIdentity,
+    TrackedStateDiffKind, TrackedStateDiffRequest, TrackedStateDiffRow, TrackedStateFilter,
+    TrackedStateKey, TrackedStateScanRequest,
 };
 
-// v5 makes the durable tracked head authoritative for normal current reads.
+// v6 makes the durable tracked head authoritative for normal current reads.
 // A physical record owns every file-backed member of one logical entity PK.
 // Public entity reads know `(branch, schema, entity_pk)` but intentionally do
 // not invent a `file_id`; keeping those members together lets that common
 // lookup be a RocksDB point get rather than a prefix scan. Repositories use a
-// protocol gate, so v4 bytes are never interpreted as v5 groups.
-pub(crate) const TRACKED_HEAD_GROUP_NAMESPACE: &str = "live_state.tracked_head_group.v5";
-pub(crate) const TRACKED_HEAD_MEMBER_NAMESPACE: &str = "live_state.tracked_head_member.v5";
-pub(crate) const TRACKED_HEAD_MARKER_NAMESPACE: &str = "live_state.tracked_head_marker.v5";
+// protocol gate, so predecessor bytes are never interpreted as v6 groups.
+pub(crate) const TRACKED_HEAD_GROUP_NAMESPACE: &str = "live_state.tracked_head_group.v6";
+pub(crate) const TRACKED_HEAD_MEMBER_NAMESPACE: &str = "live_state.tracked_head_member.v6";
+pub(crate) const TRACKED_HEAD_MARKER_NAMESPACE: &str = "live_state.tracked_head_marker.v6";
 pub(crate) const TRACKED_HEAD_GROUP_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_0012), TRACKED_HEAD_GROUP_NAMESPACE);
 /// File-id projection for explicit file-backed identities.
@@ -58,6 +60,22 @@ pub(crate) const TRACKED_HEAD_MEMBER_SPACE: StorageSpace =
 pub(crate) const TRACKED_HEAD_MARKER_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_0014), TRACKED_HEAD_MARKER_NAMESPACE);
 
+/// Sparse enumeration index for the first-before summaries co-located in v6
+/// head groups. It contains no row payload: the authoritative current row
+/// and its immutable baseline remain one physical group record.
+pub(crate) const TRACKED_WORKING_DIFF_GROUP_NAMESPACE: &str =
+    "live_state.tracked_working_diff_group.v2";
+pub(crate) const TRACKED_WORKING_DIFF_MARKER_NAMESPACE: &str =
+    "live_state.tracked_working_diff_marker.v2";
+pub(crate) const TRACKED_WORKING_DIFF_GROUP_SPACE: StorageSpace = StorageSpace::new(
+    StorageSpaceId(0x0004_0016),
+    TRACKED_WORKING_DIFF_GROUP_NAMESPACE,
+);
+pub(crate) const TRACKED_WORKING_DIFF_MARKER_SPACE: StorageSpace = StorageSpace::new(
+    StorageSpaceId(0x0004_0018),
+    TRACKED_WORKING_DIFF_MARKER_NAMESPACE,
+);
+
 /// Immutable manifest for the currently readable generation of a branch.
 ///
 /// A new generation is used after a branch ref moves away from the parent of
@@ -68,6 +86,122 @@ pub(crate) const TRACKED_HEAD_MARKER_SPACE: StorageSpace =
 struct TrackedHeadMarker {
     head_commit_id: CommitId,
     generation: CommitId,
+    /// Checkpoint whose first-before baselines live in this generation.
+    /// `None` means the head is still a correct serving projection but cannot
+    /// answer a checkpoint-relative direct diff.
+    #[musli(with = storage_codec::option)]
+    working_diff_checkpoint_commit_id: Option<CommitId>,
+}
+
+/// The current serving generation plus the checkpoint epoch to which its
+/// first-before summaries are bound. This is a read-side observation only;
+/// the private marker remains the durable wire record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TrackedHeadMarkerInfo {
+    pub(crate) generation: CommitId,
+    pub(crate) working_diff_checkpoint_commit_id: Option<CommitId>,
+}
+
+/// The active checkpoint epoch for the sparse working-diff indexes.
+///
+/// `None` is the freshly published checkpoint state: it is known empty until
+/// the first ordinary child bootstraps a complete v6 serving generation.
+/// Once initialized, the generation is immutable for serial normal commits;
+/// the tracked-head marker and branch control publish the moving head.
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+pub(crate) struct TrackedWorkingDiffEpoch {
+    pub(crate) checkpoint_commit_id: CommitId,
+    // Musli's built-in packed Option encoding is terminal-field oriented.
+    // This explicit bool-prefixed representation keeps `coverage` readable
+    // when a freshly published checkpoint has no generation yet.
+    #[musli(with = storage_codec::option)]
+    pub(crate) generation: Option<CommitId>,
+    pub(crate) coverage: WorkingDiffIndexCoverage,
+}
+
+/// A tiny atomic coverage proof for the current checkpoint's group index.
+///
+/// Count catches loss or duplication; the XOR of BLAKE3 key hashes also
+/// catches a same-count replacement without adding another read structure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+pub(crate) struct WorkingDiffIndexCoverage {
+    group_count: u64,
+    group_key_xor: JsonRef,
+}
+
+impl Default for WorkingDiffIndexCoverage {
+    fn default() -> Self {
+        Self {
+            group_count: 0,
+            group_key_xor: JsonRef::from_hash_bytes([0; JSON_REF_BYTES]),
+        }
+    }
+}
+
+impl WorkingDiffIndexCoverage {
+    fn add_encoded_group_key(&mut self, key: &[u8]) -> Option<()> {
+        self.group_count = self.group_count.checked_add(1)?;
+        let hash = blake3::hash(key);
+        let mut group_key_xor = *self.group_key_xor.as_hash_array();
+        for (target, source) in group_key_xor.iter_mut().zip(hash.as_bytes()) {
+            *target ^= source;
+        }
+        self.group_key_xor = JsonRef::from_hash_bytes(group_key_xor);
+        Some(())
+    }
+}
+
+/// A checkpoint-relative direct diff assembled from the current v6 head.
+/// This is internal plumbing for SQL working-change and checkpoint compaction;
+/// the public API remains the existing tracked-state diff representation.
+pub(crate) struct TrackedWorkingDiff {
+    pub(crate) checkpoint_commit_id: CommitId,
+    pub(crate) diff: TrackedStateDiff,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WorkingDiffBaseline {
+    Clean,
+    Absent(CommitId),
+    Present {
+        checkpoint_commit_id: CommitId,
+        version: WorkingDiffVersion,
+    },
+}
+
+impl WorkingDiffBaseline {
+    fn is_for_checkpoint(self, checkpoint_commit_id: Option<CommitId>) -> bool {
+        match (self, checkpoint_commit_id) {
+            (
+                Self::Absent(baseline_checkpoint_id)
+                | Self::Present {
+                    checkpoint_commit_id: baseline_checkpoint_id,
+                    ..
+                },
+                Some(checkpoint_commit_id),
+            ) => baseline_checkpoint_id == checkpoint_commit_id,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct WorkingDiffVersion {
+    change_id: ChangeId,
+    commit_id: CommitId,
+    deleted: bool,
+    created_at: LixTimestamp,
+    updated_at: LixTimestamp,
+    snapshot: WorkingDiffSlotFingerprint,
+    metadata: WorkingDiffSlotFingerprint,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct WorkingDiffSlotFingerprint {
+    kind: u8,
+    hash: [u8; JSON_REF_BYTES],
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, musli::Encode, musli::Decode)]
@@ -81,7 +215,7 @@ struct HeadIdentity {
     file_id: Option<String>,
 }
 
-/// The physical v5 key for all current members of one logical entity PK.
+/// The physical v6 key for all current members of one logical entity PK.
 ///
 /// `file_id` is deliberately not a key part. It remains part of the packed
 /// group value so a tombstone or a file-backed variant affects only its own
@@ -172,6 +306,12 @@ struct BranchRef<'a> {
     branch_id: &'a str,
 }
 
+#[derive(Debug, Clone, musli::Encode, musli::Decode)]
+#[musli(packed)]
+struct BranchRefKey {
+    branch_id: String,
+}
+
 /// Zero-copy normal tracked mutation staged into a head generation.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct TrackedHeadDeltaRef<'a> {
@@ -250,7 +390,7 @@ where
 {
     /// v6 control-plane variant of [`Self::scan_live_rows_if_current`].
     ///
-    /// The direct branch control and the v5 marker are published in one
+    /// The direct branch control and the v6 marker are published in one
     /// storage commit. Requiring both the head and generation to agree makes
     /// a partially rebuilt or stale group projection a clean historical
     /// fallback rather than visible current state.
@@ -269,7 +409,7 @@ where
     }
 
     /// Returns `None` when this branch has no projection for the canonical
-    /// branch ref. That is a cache miss, not empty tracked state.
+    /// branch ref. That is a direct-plane miss, not empty tracked state.
     #[cfg(test)]
     pub(crate) async fn scan_live_rows_if_current(
         &self,
@@ -455,17 +595,83 @@ where
             .map(|marker| marker.generation))
     }
 
-    /// Returns the durable v5 generation only when it is atomically bound to
-    /// the observed v6 branch control.
-    pub(crate) async fn generation_if_control_current(
+    /// Returns the durable serving generation and working-diff epoch binding
+    /// only when both are atomically bound to the observed branch control.
+    pub(crate) async fn marker_info_if_control_current(
         &self,
         branch_id: &str,
         control: BranchHeadControl,
-    ) -> Result<Option<CommitId>, LixError> {
+    ) -> Result<Option<TrackedHeadMarkerInfo>, LixError> {
         Ok(self
             .marker_if_control_current(branch_id, control)
             .await?
-            .map(|marker| marker.generation))
+            .map(|marker| TrackedHeadMarkerInfo {
+                generation: marker.generation,
+                working_diff_checkpoint_commit_id: marker.working_diff_checkpoint_commit_id,
+            }))
+    }
+
+    /// Loads the checkpoint epoch marker without treating it as visibility.
+    /// Commit staging combines it with a coherent v6 branch-control
+    /// observation before deciding whether it can preserve first-before
+    /// summaries.
+    pub(crate) async fn working_diff_epoch(
+        &self,
+        branch_id: &str,
+    ) -> Result<Option<TrackedWorkingDiffEpoch>, LixError> {
+        load_tracked_working_diff_epoch(&self.store, branch_id).await
+    }
+
+    /// Returns an O(ever-dirty groups since checkpoint) tracked diff only when the sparse
+    /// working-diff epoch and the current v6 serving generation agree. Any
+    /// missing, stale, or malformed auxiliary record returns `None`, leaving
+    /// the canonical historical replay path authoritative.
+    pub(crate) async fn working_diff_if_control_current(
+        &self,
+        branch_id: &str,
+        control: BranchHeadControl,
+        request: &TrackedStateDiffRequest,
+    ) -> Result<Option<TrackedWorkingDiff>, LixError> {
+        // The marker is an accelerator, not a source of visibility. A
+        // malformed or unavailable auxiliary marker selects canonical replay
+        // instead of making a valid SQL query fail.
+        let Ok(Some(epoch)) = self.working_diff_epoch(branch_id).await else {
+            return Ok(None);
+        };
+        let Some(generation) = epoch.generation else {
+            return Ok(
+                (epoch.checkpoint_commit_id == control.head_commit_id).then_some(
+                    TrackedWorkingDiff {
+                        checkpoint_commit_id: epoch.checkpoint_commit_id,
+                        diff: TrackedStateDiff::default(),
+                    },
+                ),
+            );
+        };
+        let Ok(Some(marker)) = self.marker_if_control_current(branch_id, control).await else {
+            return Ok(None);
+        };
+        if generation != control.generation
+            || marker.working_diff_checkpoint_commit_id != Some(epoch.checkpoint_commit_id)
+        {
+            return Ok(None);
+        }
+        let Some(entries) = working_diff_entries_from_current_head(
+            &self.store,
+            branch_id,
+            epoch.checkpoint_commit_id,
+            generation,
+            epoch.coverage,
+            &request.filter,
+        )
+        .await?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(TrackedWorkingDiff {
+            checkpoint_commit_id: epoch.checkpoint_commit_id,
+            diff: TrackedStateDiff { entries },
+        }))
     }
 
     #[cfg(test)]
@@ -506,6 +712,7 @@ where
     /// generation from a caller-provided parent snapshot. The latter is used
     /// after branch movement and for old repositories which predate this
     /// serving table.
+    #[cfg(any(test, feature = "storage-benches"))]
     pub(crate) async fn stage_commit(
         &mut self,
         branch_id: &str,
@@ -515,11 +722,41 @@ where
         absence_guards: &BTreeSet<TrackedStateKey>,
         parent_rows: Option<Vec<MaterializedTrackedStateRow>>,
     ) -> Result<CommitId, LixError> {
+        let mut working_diff_coverage = WorkingDiffIndexCoverage::default();
+        self.stage_commit_with_working_diff(
+            branch_id,
+            parent_generation,
+            new_head,
+            deltas,
+            absence_guards,
+            parent_rows,
+            None,
+            None,
+            &mut working_diff_coverage,
+        )
+        .await
+    }
+
+    /// Internal variant used only when an active checkpoint epoch makes the
+    /// v6 group baseline authoritative for `lix_working_change`.
+    pub(crate) async fn stage_commit_with_working_diff(
+        &mut self,
+        branch_id: &str,
+        parent_generation: Option<CommitId>,
+        new_head: CommitId,
+        deltas: &[TrackedHeadDeltaRef<'_>],
+        absence_guards: &BTreeSet<TrackedStateKey>,
+        parent_rows: Option<Vec<MaterializedTrackedStateRow>>,
+        working_diff_marker_checkpoint_commit_id: Option<CommitId>,
+        working_diff_capture_checkpoint_commit_id: Option<CommitId>,
+        working_diff_coverage: &mut WorkingDiffIndexCoverage,
+    ) -> Result<CommitId, LixError> {
         let matches_parent = parent_generation.is_some();
         let generation = parent_generation.unwrap_or(new_head);
         let marker = TrackedHeadMarker {
             head_commit_id: new_head,
             generation,
+            working_diff_checkpoint_commit_id: working_diff_marker_checkpoint_commit_id,
         };
         // Preflight the only fallible publication bytes before staging an
         // incremental generation in the caller's write set. A failed writer
@@ -530,7 +767,7 @@ where
         // Sorting borrowed deltas establishes both the exact-mutation
         // uniqueness check and the group order needed for a streaming merge.
         // The normal matching-generation path must never reconstruct every
-        // v5 member in an owned BTreeMap just to change one member.
+        // v6 member in an owned BTreeMap just to change one member.
         let mut sorted_deltas = deltas.iter().collect::<Vec<_>>();
         sorted_deltas.sort_unstable_by(|left, right| compare_head_deltas(left, right));
         for pair in sorted_deltas.windows(2) {
@@ -563,12 +800,24 @@ where
                     previous.as_deref(),
                     &sorted_deltas[group.deltas.clone()],
                     absence_guards,
+                    working_diff_capture_checkpoint_commit_id,
                 )?);
             }
             for (group, next) in groups.iter().zip(next_groups) {
+                let became_dirty_group = next.became_dirty_group;
                 stage_put_group_bytes(self.writes, &group.identity, next.bytes);
                 for (file_id, value) in next.explicit_member_projections {
                     stage_put_file_member_bytes(self.writes, &group.identity, file_id, &value);
+                }
+                if became_dirty_group {
+                    stage_put_working_diff_group_index(
+                        self.writes,
+                        working_diff_coverage,
+                        working_diff_capture_checkpoint_commit_id.expect(
+                            "a newly dirty group requires an active working-diff checkpoint",
+                        ),
+                        &group.identity,
+                    )?;
                 }
             }
         } else {
@@ -579,6 +828,8 @@ where
                 &sorted_deltas,
                 absence_guards,
                 parent_rows.unwrap_or_default(),
+                working_diff_capture_checkpoint_commit_id,
+                working_diff_coverage,
             )?;
         }
         stage_marker_encoded(self.writes, marker_key, marker_value);
@@ -586,7 +837,7 @@ where
     }
 }
 
-/// One contiguous range of sorted mutations for a physical v5 group.
+/// One contiguous range of sorted mutations for a physical v6 group.
 ///
 /// The range borrows the transaction's deltas, while the group identity is
 /// owned once. This is intentionally not a map of decoded members: matching
@@ -605,6 +856,7 @@ struct HeadGroupMutation {
 struct EncodedHeadGroup<'a> {
     bytes: Vec<u8>,
     explicit_member_projections: Vec<(&'a str, Vec<u8>)>,
+    became_dirty_group: bool,
 }
 
 fn compare_head_deltas(
@@ -658,7 +910,7 @@ fn group_sorted_head_deltas(
     groups
 }
 
-/// Builds a fresh v5 generation after a branch movement.
+/// Builds a fresh v6 generation after a branch movement.
 ///
 /// This path necessarily starts from materialized parent rows, so it retains
 /// the simple owned-map implementation. Ordinary commits keep their parent
@@ -670,8 +922,12 @@ fn stage_bootstrap_groups(
     deltas: &[&TrackedHeadDeltaRef<'_>],
     absence_guards: &BTreeSet<TrackedStateKey>,
     parent_rows: Vec<MaterializedTrackedStateRow>,
+    working_diff_checkpoint_commit_id: Option<CommitId>,
+    working_diff_coverage: &mut WorkingDiffIndexCoverage,
 ) -> Result<(), LixError> {
     let mut groups = BTreeMap::<HeadGroupIdentity, BTreeMap<Option<String>, Vec<u8>>>::new();
+    let mut baselines =
+        BTreeMap::<HeadGroupIdentity, BTreeMap<Option<String>, WorkingDiffBaseline>>::new();
     for row in parent_rows {
         let MaterializedTrackedStateRow {
             entity_pk,
@@ -712,9 +968,9 @@ fn stage_bootstrap_groups(
                 .as_deref()
                 .map_or(JsonSlot::None, JsonSlot::from_json),
         };
-        let members = groups.entry(identity).or_default();
+        let members = groups.entry(identity.clone()).or_default();
         if members
-            .insert(file_id, encode_head_value(&value.as_ref())?)
+            .insert(file_id.clone(), encode_head_value(&value.as_ref())?)
             .is_some()
         {
             return Err(LixError::new(
@@ -722,8 +978,13 @@ fn stage_bootstrap_groups(
                 "tracked-head bootstrap contains duplicate full row identity",
             ));
         }
+        baselines
+            .entry(identity)
+            .or_default()
+            .insert(file_id, WorkingDiffBaseline::Clean);
     }
 
+    let mut dirty_groups = BTreeSet::new();
     for delta in deltas {
         let group = HeadGroupIdentity {
             branch_id: branch_id.to_string(),
@@ -731,19 +992,32 @@ fn stage_bootstrap_groups(
             schema_key: delta.schema_key.to_string(),
             entity_pk: delta.entity_pk.clone(),
         };
-        let members = groups.entry(group).or_default();
-        let created_at = match members.get(&delta.file_id.map(str::to_string)) {
+        let file_id = delta.file_id.map(str::to_string);
+        let members = groups.entry(group.clone()).or_default();
+        let baseline_members = baselines.entry(group.clone()).or_default();
+        let baseline = match members.get(&file_id) {
             Some(existing) => {
                 let existing = decode_head_value(existing)?;
                 reject_guarded_live_member(absence_guards, delta, existing)?;
-                existing.created_at
+                working_diff_baseline_for_existing_value(
+                    existing,
+                    working_diff_checkpoint_commit_id,
+                )
             }
+            None => working_diff_baseline_for_absent_delta(working_diff_checkpoint_commit_id),
+        };
+        let created_at = match members.get(&file_id) {
+            Some(existing) => decode_head_value(existing)?.created_at,
             None => delta.created_at,
         };
         members.insert(
-            delta.file_id.map(str::to_string),
+            file_id.clone(),
             encode_head_value(&delta.value_ref(created_at))?,
         );
+        baseline_members.insert(file_id.clone(), baseline);
+        if working_diff_checkpoint_commit_id.is_some() {
+            dirty_groups.insert(group.clone());
+        }
     }
 
     writes.reserve_space(TRACKED_HEAD_GROUP_SPACE, groups.len(), 0);
@@ -753,17 +1027,30 @@ fn stage_bootstrap_groups(
         .sum();
     writes.reserve_space(TRACKED_HEAD_MEMBER_SPACE, explicit_member_count, 0);
     for (identity, members) in groups {
-        stage_put_group_members(writes, &identity, &members)?;
+        let member_baselines = baselines
+            .get(&identity)
+            .ok_or_else(|| head_group_error("bootstrap group is missing working-diff baselines"))?;
+        stage_put_group_members_with_baselines(writes, &identity, &members, member_baselines)?;
         for (file_id, value) in &members {
             if file_id.is_some() {
                 stage_put_member_bytes(writes, &identity, file_id.as_deref(), value)?;
             }
         }
     }
+    if let Some(checkpoint_commit_id) = working_diff_checkpoint_commit_id {
+        for group in &dirty_groups {
+            stage_put_working_diff_group_index(
+                writes,
+                working_diff_coverage,
+                checkpoint_commit_id,
+                group,
+            )?;
+        }
+    }
     Ok(())
 }
 
-/// Merges one existing v5 group and its sorted mutations without decoding the
+/// Merges one existing v6 group and its sorted mutations without decoding the
 /// whole group into owned member values. Every old member is still parsed and
 /// validated before it is copied, so an unrelated malformed sibling cannot be
 /// silently republished.
@@ -771,6 +1058,7 @@ fn encode_incremental_group<'a>(
     previous: Option<&[u8]>,
     deltas: &[&TrackedHeadDeltaRef<'a>],
     absence_guards: &BTreeSet<TrackedStateKey>,
+    working_diff_checkpoint_commit_id: Option<CommitId>,
 ) -> Result<EncodedHeadGroup<'a>, LixError> {
     debug_assert!(!deltas.is_empty());
     debug_assert!(
@@ -788,6 +1076,8 @@ fn encode_incremental_group<'a>(
     encoded.push(HEAD_GROUP_VALUE_VERSION);
     encoded.extend_from_slice(&[0; 4]);
     let mut member_count = 0usize;
+    let mut previous_has_current_dirty_member = false;
+    let mut became_current_dirty_member = false;
     let mut explicit_member_projections = Vec::new();
     explicit_member_projections
         .try_reserve(
@@ -805,25 +1095,47 @@ fn encode_incremental_group<'a>(
                     &mut encoded,
                     delta,
                     delta.created_at,
+                    working_diff_baseline_for_absent_delta(working_diff_checkpoint_commit_id),
                     &mut explicit_member_projections,
                 )?;
+                became_current_dirty_member |= working_diff_checkpoint_commit_id.is_some();
                 increment_head_group_member_count(&mut member_count)?;
                 break;
             };
             match member.file_id.cmp(&delta.file_id) {
                 Ordering::Less => {
-                    append_head_group_member(&mut encoded, member.file_id, member.value)?;
+                    previous_has_current_dirty_member |= member
+                        .baseline
+                        .is_for_checkpoint(working_diff_checkpoint_commit_id);
+                    append_head_group_member(
+                        &mut encoded,
+                        member.file_id,
+                        member.value,
+                        member.baseline,
+                    )?;
                     increment_head_group_member_count(&mut member_count)?;
                     current = next_head_group_member(&mut cursor)?;
                 }
                 Ordering::Equal => {
                     reject_guarded_live_member(absence_guards, delta, member.head)?;
+                    let (baseline, became_dirty) = working_diff_baseline_for_existing_delta(
+                        member.baseline,
+                        member.head,
+                        working_diff_checkpoint_commit_id,
+                    );
+                    previous_has_current_dirty_member |= member
+                        .baseline
+                        .is_for_checkpoint(working_diff_checkpoint_commit_id);
                     append_delta_head_group_member(
                         &mut encoded,
                         delta,
                         member.head.created_at,
+                        baseline,
                         &mut explicit_member_projections,
                     )?;
+                    if became_dirty {
+                        became_current_dirty_member = true;
+                    }
                     increment_head_group_member_count(&mut member_count)?;
                     current = next_head_group_member(&mut cursor)?;
                     break;
@@ -833,8 +1145,10 @@ fn encode_incremental_group<'a>(
                         &mut encoded,
                         delta,
                         delta.created_at,
+                        working_diff_baseline_for_absent_delta(working_diff_checkpoint_commit_id),
                         &mut explicit_member_projections,
                     )?;
+                    became_current_dirty_member |= working_diff_checkpoint_commit_id.is_some();
                     increment_head_group_member_count(&mut member_count)?;
                     break;
                 }
@@ -842,7 +1156,10 @@ fn encode_incremental_group<'a>(
         }
     }
     while let Some(member) = current {
-        append_head_group_member(&mut encoded, member.file_id, member.value)?;
+        previous_has_current_dirty_member |= member
+            .baseline
+            .is_for_checkpoint(working_diff_checkpoint_commit_id);
+        append_head_group_member(&mut encoded, member.file_id, member.value, member.baseline)?;
         increment_head_group_member_count(&mut member_count)?;
         current = next_head_group_member(&mut cursor)?;
     }
@@ -853,7 +1170,45 @@ fn encode_incremental_group<'a>(
     Ok(EncodedHeadGroup {
         bytes: encoded,
         explicit_member_projections,
+        became_dirty_group: working_diff_checkpoint_commit_id.is_some()
+            && !previous_has_current_dirty_member
+            && became_current_dirty_member,
     })
+}
+
+fn working_diff_baseline_for_absent_delta(
+    checkpoint_commit_id: Option<CommitId>,
+) -> WorkingDiffBaseline {
+    checkpoint_commit_id.map_or(WorkingDiffBaseline::Clean, WorkingDiffBaseline::Absent)
+}
+
+fn working_diff_baseline_for_existing_value(
+    prior_value: HeadValueView<'_>,
+    checkpoint_commit_id: Option<CommitId>,
+) -> WorkingDiffBaseline {
+    checkpoint_commit_id.map_or(WorkingDiffBaseline::Clean, |checkpoint_commit_id| {
+        WorkingDiffBaseline::Present {
+            checkpoint_commit_id,
+            version: prior_value.working_diff_version(),
+        }
+    })
+}
+
+fn working_diff_baseline_for_existing_delta(
+    prior: WorkingDiffBaseline,
+    prior_value: HeadValueView<'_>,
+    checkpoint_commit_id: Option<CommitId>,
+) -> (WorkingDiffBaseline, bool) {
+    match checkpoint_commit_id {
+        Some(checkpoint_commit_id) if !prior.is_for_checkpoint(Some(checkpoint_commit_id)) => (
+            WorkingDiffBaseline::Present {
+                checkpoint_commit_id,
+                version: prior_value.working_diff_version(),
+            },
+            true,
+        ),
+        _ => (prior, false),
+    }
 }
 
 fn increment_head_group_member_count(member_count: &mut usize) -> Result<(), LixError> {
@@ -894,10 +1249,11 @@ fn append_delta_head_group_member<'a>(
     encoded: &mut Vec<u8>,
     delta: &TrackedHeadDeltaRef<'a>,
     created_at: LixTimestamp,
+    baseline: WorkingDiffBaseline,
     explicit_member_projections: &mut Vec<(&'a str, Vec<u8>)>,
 ) -> Result<(), LixError> {
     let value = encode_head_value(&delta.value_ref(created_at))?;
-    append_head_group_member(encoded, delta.file_id, &value)?;
+    append_head_group_member(encoded, delta.file_id, &value, baseline)?;
     // The group is authoritative. An unchanged explicit projection already
     // belongs to this generation, so only rewrite projections whose member
     // changed in this commit.
@@ -938,7 +1294,7 @@ async fn load_marker(
         .transpose()
 }
 
-/// Loads packed v5 groups without materializing their members.
+/// Loads packed v6 groups without materializing their members.
 async fn load_group_bytes<'a>(
     store: &(impl StorageAdapterRead + ?Sized),
     identities: impl IntoIterator<Item = &'a HeadGroupIdentity>,
@@ -961,7 +1317,7 @@ async fn load_group_bytes<'a>(
 }
 
 /// Loads the explicit-file member projection. Its physical access pattern is
-/// intentionally the same single-key point lookup as v4 so file-id queries
+/// intentionally the same single-key point lookup as the prior member layout so file-id queries
 /// do not become proportional to the size of their logical PK group.
 async fn load_member_bytes(
     store: &(impl StorageAdapterRead + ?Sized),
@@ -1084,6 +1440,203 @@ async fn scan_entries(
         }
     }
     Ok(rows)
+}
+
+/// Reads the checkpoint's sparse dirty-group index and resolves before images
+/// from authoritative v6 group values. The index is auxiliary: its complete
+/// key coverage is verified before any result is returned, so a bad record is
+/// a fallback (`None`), never an empty diff.
+async fn working_diff_entries_from_current_head(
+    store: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    checkpoint_commit_id: CommitId,
+    generation: CommitId,
+    expected_coverage: WorkingDiffIndexCoverage,
+    filter: &TrackedStateFilter,
+) -> Result<Option<Vec<TrackedStateDiffEntry>>, LixError> {
+    let (groups, require_current_dirty_member) =
+        match exact_group_identities(branch_id, generation, filter) {
+            Some(groups) => (groups, false),
+            None => {
+                let Some(groups) = scan_working_diff_group_index(
+                    store,
+                    branch_id,
+                    checkpoint_commit_id,
+                    generation,
+                    expected_coverage,
+                    filter,
+                )
+                .await?
+                else {
+                    return Ok(None);
+                };
+                (groups, true)
+            }
+        };
+
+    let values = load_group_bytes(store, &groups).await?;
+    let mut dirty_rows = Vec::new();
+    for (group, value) in groups.into_iter().zip(values) {
+        let Some(value) = value else {
+            return Ok(None);
+        };
+        let Ok(members) = decode_head_group_members(&value) else {
+            return Ok(None);
+        };
+        let mut has_current_dirty_member = false;
+        for member in members {
+            if !member
+                .baseline
+                .is_for_checkpoint(Some(checkpoint_commit_id))
+            {
+                continue;
+            }
+            has_current_dirty_member = true;
+            let identity = HeadRowIdentity {
+                schema_key: group.schema_key.clone(),
+                entity_pk: group.entity_pk.clone(),
+                file_id: member.file_id,
+            };
+            if matches_filter(&identity, filter) {
+                let after = match decode_head_value(&member.value) {
+                    Ok(value) => value.working_diff_version(),
+                    Err(_) => return Ok(None),
+                };
+                dirty_rows.push((identity, member.baseline, after));
+            }
+        }
+        if require_current_dirty_member && !has_current_dirty_member {
+            return Ok(None);
+        }
+    }
+
+    Ok(Some(
+        dirty_rows
+            .into_iter()
+            .filter_map(|(identity, baseline, after)| {
+                classify_working_diff_entry(identity, baseline, after)
+            })
+            .collect(),
+    ))
+}
+
+async fn scan_working_diff_group_index(
+    store: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    checkpoint_commit_id: CommitId,
+    generation: CommitId,
+    expected_coverage: WorkingDiffIndexCoverage,
+    filter: &TrackedStateFilter,
+) -> Result<Option<Vec<HeadGroupIdentity>>, LixError> {
+    let scope = encode_working_diff_scope_prefix(branch_id, checkpoint_commit_id, generation);
+    let plan = ScanPlan::prefix(
+        TRACKED_WORKING_DIFF_GROUP_SPACE,
+        StoragePrefix {
+            bytes: Bytes::from(scope.clone()),
+        },
+    );
+    let mut actual_coverage = WorkingDiffIndexCoverage::default();
+    let mut found = Vec::new();
+    let mut resume_after = None;
+    loop {
+        let page = plan
+            .collect(
+                store,
+                StorageScanOptions {
+                    resume_after: resume_after.clone(),
+                    ..StorageScanOptions::default()
+                },
+            )
+            .await?;
+        resume_after = page.value.entries.last().map(|entry| entry.key.clone());
+        for entry in page.value.entries {
+            if !is_working_diff_index_value(&entry.value)
+                || actual_coverage
+                    .add_encoded_group_key(entry.key.0.as_ref())
+                    .is_none()
+            {
+                return Ok(None);
+            }
+            let Ok(identity) = decode_working_diff_group_key_in_scope(entry.key.0.as_ref(), &scope)
+            else {
+                return Ok(None);
+            };
+            if matches_group_filter(&identity, filter) {
+                found.push(HeadGroupIdentity {
+                    branch_id: branch_id.to_string(),
+                    generation,
+                    schema_key: identity.schema_key,
+                    entity_pk: identity.entity_pk,
+                });
+            }
+        }
+        if !page.value.has_more || resume_after.is_none() {
+            break;
+        }
+    }
+    if actual_coverage != expected_coverage {
+        return Ok(None);
+    }
+    found.sort();
+    found.dedup();
+    Ok(Some(found))
+}
+
+fn is_working_diff_index_value(value: &StorageProjectedValue) -> bool {
+    matches!(value, StorageProjectedValue::FullValue(bytes) if bytes.as_ref() == WORKING_DIFF_INDEX_VALUE)
+}
+
+fn classify_working_diff_entry(
+    identity: HeadRowIdentity,
+    baseline: WorkingDiffBaseline,
+    after_version: WorkingDiffVersion,
+) -> Option<TrackedStateDiffEntry> {
+    let before_version = match baseline {
+        WorkingDiffBaseline::Clean => return None,
+        WorkingDiffBaseline::Absent(_) => None,
+        WorkingDiffBaseline::Present { version, .. } => Some(version),
+    };
+    let before = before_version.map(|version| version.into_diff_row(&identity));
+    let after = after_version.into_diff_row(&identity);
+    let identity = TrackedStateDiffIdentity {
+        schema_key: identity.schema_key,
+        entity_pk: identity.entity_pk,
+        file_id: identity.file_id,
+    };
+    match (
+        before.as_ref().filter(|row| !row.deleted),
+        (!after.deleted).then_some(&after),
+    ) {
+        (None, None) => None,
+        (None, Some(_)) => Some(TrackedStateDiffEntry {
+            identity,
+            kind: TrackedStateDiffKind::Added,
+            before,
+            after: Some(after),
+        }),
+        (Some(_), None) => Some(TrackedStateDiffEntry {
+            identity,
+            kind: TrackedStateDiffKind::Removed,
+            before,
+            after: Some(after),
+        }),
+        (Some(_), Some(_))
+            if before_version.is_some_and(|version| version.payload_eq(after_version)) =>
+        {
+            None
+        }
+        (Some(_), Some(_)) => Some(TrackedStateDiffEntry {
+            identity,
+            kind: TrackedStateDiffKind::Modified,
+            before,
+            after: Some(after),
+        }),
+    }
+}
+
+fn matches_group_filter(identity: &HeadRowIdentity, filter: &TrackedStateFilter) -> bool {
+    (filter.schema_keys.is_empty() || filter.schema_keys.contains(&identity.schema_key))
+        && (filter.entity_pks.is_empty() || filter.entity_pks.contains(&identity.entity_pk))
 }
 
 fn exact_group_identities(
@@ -1305,6 +1858,230 @@ fn stage_marker_encoded(writes: &mut StorageWriteSet, key: Vec<u8>, value: Vec<u
     );
 }
 
+/// Publishes the checkpoint epoch that owns the sparse working-diff indexes.
+/// The surrounding branch-control CAS makes this marker, the v6 head groups,
+/// and the current branch head one atomic visibility boundary.
+pub(crate) fn stage_tracked_working_diff_epoch(
+    writes: &mut StorageWriteSet,
+    branch_id: &str,
+    epoch: TrackedWorkingDiffEpoch,
+) -> Result<(), LixError> {
+    writes.put(
+        TRACKED_WORKING_DIFF_MARKER_SPACE,
+        StorageKey(Bytes::from(marker_key(branch_id)?)),
+        StorageValue {
+            bytes: Bytes::from(storage_codec::encode(
+                "tracked working-diff marker",
+                &epoch,
+            )?),
+        },
+    );
+    Ok(())
+}
+
+async fn load_tracked_working_diff_epoch(
+    store: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+) -> Result<Option<TrackedWorkingDiffEpoch>, LixError> {
+    let result = PointReadPlan::new(
+        TRACKED_WORKING_DIFF_MARKER_SPACE,
+        &[StorageKey(Bytes::from(marker_key(branch_id)?))],
+    )
+    .materialize(store, StorageGetOptions::default())
+    .await?;
+    result
+        .value
+        .into_iter()
+        .next()
+        .flatten()
+        .map(|value| {
+            let StorageProjectedValue::FullValue(bytes) = value else {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked working-diff marker read unexpectedly omitted its value",
+                ));
+            };
+            storage_codec::decode("tracked working-diff marker", &bytes)
+        })
+        .transpose()
+}
+
+/// Reclaims sparse dirty-index records outside every currently published
+/// checkpoint epoch. This deliberately runs only from repository GC: a
+/// checkpoint reset is O(1), while old index prefixes are unreachable as soon
+/// as its marker commits.
+pub(crate) async fn stage_collect_stale_working_diff_indexes<S>(
+    store: &S,
+    writes: &mut StorageWriteSet,
+) -> Result<(), LixError>
+where
+    S: StorageAdapterRead + Clone,
+{
+    let controls = BranchHeadControlContext::new()
+        .reader(store.clone())
+        .scan()
+        .await?
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
+    let active = stage_active_working_diff_scopes(store, writes, &controls).await?;
+    stage_collect_stale_working_diff_space(
+        store,
+        writes,
+        TRACKED_WORKING_DIFF_GROUP_SPACE,
+        |entry| {
+            is_working_diff_index_value(&entry.value)
+                && decode_working_diff_group_key(entry.key.0.as_ref()).is_ok_and(
+                    |(checkpoint_commit_id, identity)| {
+                        active.get(&identity.branch_id).is_some_and(|scope| {
+                            scope.checkpoint_commit_id == checkpoint_commit_id
+                                && scope.generation == identity.generation
+                        })
+                    },
+                )
+        },
+    )
+    .await
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ActiveWorkingDiffScope {
+    checkpoint_commit_id: CommitId,
+    generation: CommitId,
+}
+
+/// Validates and keeps only auxiliary epochs that are presently bound by the
+/// authoritative branch control and tracked-head marker. Broken auxiliary
+/// bytes are reclaimed here rather than turning background GC into a retry
+/// loop; normal readers already select canonical replay for the same cases.
+async fn stage_active_working_diff_scopes<S>(
+    store: &S,
+    writes: &mut StorageWriteSet,
+    controls: &BTreeMap<String, BranchHeadControl>,
+) -> Result<BTreeMap<String, ActiveWorkingDiffScope>, LixError>
+where
+    S: StorageAdapterRead + Clone,
+{
+    let plan = ScanPlan::prefix(
+        TRACKED_WORKING_DIFF_MARKER_SPACE,
+        StoragePrefix {
+            bytes: Bytes::new(),
+        },
+    );
+    let mut active = BTreeMap::new();
+    let mut resume_after = None;
+    loop {
+        let page = plan
+            .collect(
+                store,
+                StorageScanOptions {
+                    resume_after: resume_after.clone(),
+                    ..StorageScanOptions::default()
+                },
+            )
+            .await?;
+        resume_after = page.value.entries.last().map(|entry| entry.key.clone());
+        for entry in page.value.entries {
+            let key: BranchRefKey = match storage_codec::decode(
+                "tracked working-diff marker key",
+                entry.key.0.as_ref(),
+            ) {
+                Ok(key) => key,
+                Err(_) => {
+                    writes.delete(TRACKED_WORKING_DIFF_MARKER_SPACE, entry.key);
+                    continue;
+                }
+            };
+            let StorageProjectedValue::FullValue(bytes) = entry.value else {
+                writes.delete(TRACKED_WORKING_DIFF_MARKER_SPACE, entry.key);
+                continue;
+            };
+            let epoch: TrackedWorkingDiffEpoch =
+                match storage_codec::decode("tracked working-diff marker", &bytes) {
+                    Ok(epoch) => epoch,
+                    Err(_) => {
+                        writes.delete(TRACKED_WORKING_DIFF_MARKER_SPACE, entry.key);
+                        continue;
+                    }
+                };
+            let Some(control) = controls.get(&key.branch_id).copied() else {
+                writes.delete(TRACKED_WORKING_DIFF_MARKER_SPACE, entry.key);
+                continue;
+            };
+            let valid = match epoch.generation {
+                // A checkpoint reset is known empty and deliberately leaves
+                // the prior serving group generation intact until its first
+                // ordinary child captures a new baseline.
+                None => epoch.checkpoint_commit_id == control.head_commit_id,
+                Some(generation) if generation == control.generation => {
+                    matches!(
+                        TrackedHeadContext::new()
+                            .reader(store.clone())
+                            .marker_info_if_control_current(&key.branch_id, control)
+                            .await,
+                        Ok(Some(marker))
+                            if marker.working_diff_checkpoint_commit_id
+                                == Some(epoch.checkpoint_commit_id)
+                    )
+                }
+                Some(_) => false,
+            };
+            if !valid || active.contains_key(&key.branch_id) {
+                writes.delete(TRACKED_WORKING_DIFF_MARKER_SPACE, entry.key);
+                continue;
+            }
+            if let Some(generation) = epoch.generation {
+                active.insert(
+                    key.branch_id,
+                    ActiveWorkingDiffScope {
+                        checkpoint_commit_id: epoch.checkpoint_commit_id,
+                        generation,
+                    },
+                );
+            }
+        }
+        if !page.value.has_more || resume_after.is_none() {
+            break;
+        }
+    }
+    Ok(active)
+}
+
+async fn stage_collect_stale_working_diff_space(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    space: StorageSpace,
+    is_active: impl Fn(&StorageReadEntry) -> bool,
+) -> Result<(), LixError> {
+    let plan = ScanPlan::prefix(
+        space,
+        StoragePrefix {
+            bytes: Bytes::new(),
+        },
+    );
+    let mut resume_after = None;
+    loop {
+        let page = plan
+            .collect(
+                store,
+                StorageScanOptions {
+                    resume_after: resume_after.clone(),
+                    ..StorageScanOptions::default()
+                },
+            )
+            .await?;
+        resume_after = page.value.entries.last().map(|entry| entry.key.clone());
+        for entry in page.value.entries {
+            if !is_active(&entry) {
+                writes.delete(space, entry.key);
+            }
+        }
+        if !page.value.has_more || resume_after.is_none() {
+            break;
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 fn stage_put(
     writes: &mut StorageWriteSet,
@@ -1334,12 +2111,27 @@ fn stage_put_ref(
     Ok(())
 }
 
+#[cfg(test)]
 fn stage_put_group_members(
     writes: &mut StorageWriteSet,
     identity: &HeadGroupIdentity,
     members: &BTreeMap<Option<String>, Vec<u8>>,
 ) -> Result<(), LixError> {
     stage_put_group_bytes(writes, identity, encode_head_group_members(members)?);
+    Ok(())
+}
+
+fn stage_put_group_members_with_baselines(
+    writes: &mut StorageWriteSet,
+    identity: &HeadGroupIdentity,
+    members: &BTreeMap<Option<String>, Vec<u8>>,
+    baselines: &BTreeMap<Option<String>, WorkingDiffBaseline>,
+) -> Result<(), LixError> {
+    stage_put_group_bytes(
+        writes,
+        identity,
+        encode_head_group_members_with_baselines(members, baselines)?,
+    );
     Ok(())
 }
 
@@ -1355,6 +2147,28 @@ fn stage_put_group_bytes(
             bytes: Bytes::from(bytes),
         },
     );
+}
+
+const WORKING_DIFF_INDEX_VALUE: &[u8] = b"\x01";
+
+fn stage_put_working_diff_group_index(
+    writes: &mut StorageWriteSet,
+    coverage: &mut WorkingDiffIndexCoverage,
+    checkpoint_commit_id: CommitId,
+    identity: &HeadGroupIdentity,
+) -> Result<(), LixError> {
+    let key = encode_working_diff_group_key(checkpoint_commit_id, identity);
+    coverage
+        .add_encoded_group_key(&key)
+        .ok_or_else(|| head_group_error("working-diff group index count exceeds u64"))?;
+    writes.put(
+        TRACKED_WORKING_DIFF_GROUP_SPACE,
+        StorageKey(Bytes::from(key)),
+        StorageValue {
+            bytes: Bytes::from_static(WORKING_DIFF_INDEX_VALUE),
+        },
+    );
+    Ok(())
 }
 
 fn stage_put_member_bytes(
@@ -1406,6 +2220,32 @@ fn encode_group_key(identity: &HeadGroupIdentity) -> Vec<u8> {
     out
 }
 
+fn encode_working_diff_scope_prefix(
+    branch_id: &str,
+    checkpoint_commit_id: CommitId,
+    generation: CommitId,
+) -> Vec<u8> {
+    let mut out = Vec::with_capacity(branch_id.len() + 2 + 2 * GENERATION_BYTES);
+    write_key_string(&mut out, branch_id, KEY_PART_FINAL);
+    out.extend_from_slice(checkpoint_commit_id.as_uuid().as_bytes());
+    out.extend_from_slice(generation.as_uuid().as_bytes());
+    out
+}
+
+fn encode_working_diff_group_key(
+    checkpoint_commit_id: CommitId,
+    identity: &HeadGroupIdentity,
+) -> Vec<u8> {
+    let mut out = encode_working_diff_scope_prefix(
+        &identity.branch_id,
+        checkpoint_commit_id,
+        identity.generation,
+    );
+    write_key_string(&mut out, &identity.schema_key, KEY_PART_FINAL);
+    write_entity_pk(&mut out, &identity.entity_pk);
+    out
+}
+
 fn encode_member_key(identity: &HeadIdentity) -> Vec<u8> {
     debug_assert!(identity.file_id.is_some());
     let mut out = encode_scope_prefix(&identity.branch_id, identity.generation);
@@ -1437,6 +2277,33 @@ fn decode_group_key(bytes: &[u8]) -> Result<HeadGroupIdentity, LixError> {
         schema_key,
         entity_pk,
     })
+}
+
+fn decode_working_diff_group_key(bytes: &[u8]) -> Result<(CommitId, HeadGroupIdentity), LixError> {
+    let mut offset = 0usize;
+    let (branch_id, branch_terminator) = read_key_string(bytes, &mut offset, "branch id")?;
+    if branch_terminator != KEY_PART_FINAL {
+        return Err(key_codec_error("branch id has an invalid terminator"));
+    }
+    let checkpoint_commit_id = read_generation(bytes, &mut offset)?;
+    let generation = read_generation(bytes, &mut offset)?;
+    let (schema_key, schema_terminator) = read_key_string(bytes, &mut offset, "schema key")?;
+    if schema_terminator != KEY_PART_FINAL {
+        return Err(key_codec_error("schema key has an invalid terminator"));
+    }
+    let entity_pk = read_entity_pk(bytes, &mut offset)?;
+    if offset != bytes.len() {
+        return Err(key_codec_error("working-diff group key has trailing bytes"));
+    }
+    Ok((
+        checkpoint_commit_id,
+        HeadGroupIdentity {
+            branch_id,
+            generation,
+            schema_key,
+            entity_pk,
+        },
+    ))
 }
 
 fn decode_member_key(bytes: &[u8]) -> Result<HeadIdentity, LixError> {
@@ -1486,6 +2353,31 @@ fn decode_group_key_in_scope(bytes: &[u8], scope: &[u8]) -> Result<HeadRowIdenti
     let entity_pk = read_entity_pk(bytes, &mut offset)?;
     if offset != bytes.len() {
         return Err(key_codec_error("group key has trailing bytes"));
+    }
+    Ok(HeadRowIdentity {
+        schema_key,
+        entity_pk,
+        file_id: None,
+    })
+}
+
+fn decode_working_diff_group_key_in_scope(
+    bytes: &[u8],
+    scope: &[u8],
+) -> Result<HeadRowIdentity, LixError> {
+    if !bytes.starts_with(scope) {
+        return Err(key_codec_error(
+            "does not begin with the scanned working-diff checkpoint-generation scope",
+        ));
+    }
+    let mut offset = scope.len();
+    let (schema_key, schema_terminator) = read_key_string(bytes, &mut offset, "schema key")?;
+    if schema_terminator != KEY_PART_FINAL {
+        return Err(key_codec_error("schema key has an invalid terminator"));
+    }
+    let entity_pk = read_entity_pk(bytes, &mut offset)?;
+    if offset != bytes.len() {
+        return Err(key_codec_error("working-diff group key has trailing bytes"));
     }
     Ok(HeadRowIdentity {
         schema_key,
@@ -1681,7 +2573,7 @@ fn decode_marker_value(value: StorageProjectedValue) -> Result<TrackedHeadMarker
     storage_codec::decode("tracked-head marker", &bytes)
 }
 
-/// v5 packs all file-backed members of one logical entity PK into one
+/// v6 packs all file-backed members of one logical entity PK into one
 /// canonical current-state group. The individual member payload is the proven
 /// fixed-header v3 value below; only the outer framing is new.
 ///
@@ -1699,15 +2591,24 @@ fn decode_marker_value(value: StorageProjectedValue) -> Result<TrackedHeadMarker
 /// Members are strictly sorted by Rust's `Option<String>` ordering. This
 /// makes scans deterministic and, more importantly, rejects silently
 /// duplicated full identities at the storage boundary.
-const HEAD_GROUP_VALUE_VERSION: u8 = 1;
+const HEAD_GROUP_VALUE_VERSION: u8 = 3;
 const HEAD_GROUP_HEADER_BYTES: usize = 5;
+const WORKING_DIFF_BASELINE_CLEAN: u8 = 0;
+const WORKING_DIFF_BASELINE_ABSENT: u8 = 1;
+const WORKING_DIFF_BASELINE_PRESENT: u8 = 2;
+const WORKING_DIFF_SLOT_NONE: u8 = 0;
+const WORKING_DIFF_SLOT_REF: u8 = 1;
+const WORKING_DIFF_SLOT_INLINE: u8 = 2;
+const WORKING_DIFF_VERSION_BYTES: usize =
+    16 + 16 + 1 + 8 + 8 + 1 + JSON_REF_BYTES + 1 + JSON_REF_BYTES;
 
 struct HeadGroupMemberBytes {
     file_id: Option<String>,
     value: Bytes,
+    baseline: WorkingDiffBaseline,
 }
 
-/// A validated, borrowed member from a v5 group value.
+/// A validated, borrowed member from a v6 group value.
 ///
 /// The incremental writer uses this cursor to copy untouched member bytes
 /// directly into the next group while retaining the old fixed-header value
@@ -1717,9 +2618,10 @@ struct HeadGroupMemberView<'a> {
     file_id: Option<&'a str>,
     value: &'a [u8],
     head: HeadValueView<'a>,
+    baseline: WorkingDiffBaseline,
 }
 
-/// Streaming parser for the authoritative v5 group bytes.
+/// Streaming parser for the authoritative v6 group bytes.
 ///
 /// Unlike the reader-side decoder, this does not allocate a `String`,
 /// `Bytes`, or map for every member. It still enforces the complete wire
@@ -1802,12 +2704,14 @@ impl<'a> HeadGroupMembers<'a> {
             .ok_or_else(|| head_group_error("is truncated in member value"))?;
         let head = decode_head_value(value)?;
         self.offset = value_end;
+        let baseline = decode_working_diff_baseline(self.bytes, &mut self.offset)?;
         self.remaining -= 1;
         self.prior_file_id = Some(file_id);
         Ok(Some(HeadGroupMemberView {
             file_id,
             value,
             head,
+            baseline,
         }))
     }
 }
@@ -1816,6 +2720,7 @@ fn append_head_group_member(
     encoded: &mut Vec<u8>,
     file_id: Option<&str>,
     value: &[u8],
+    baseline: WorkingDiffBaseline,
 ) -> Result<(), LixError> {
     let file_id_bytes = match file_id {
         None => 0,
@@ -1831,6 +2736,7 @@ fn append_head_group_member(
         .checked_add(file_id_bytes)
         .and_then(|length| length.checked_add(4))
         .and_then(|length| length.checked_add(value.len()))
+        .and_then(|length| length.checked_add(working_diff_baseline_len(baseline)))
         .ok_or_else(|| head_group_error("group value length overflow"))?;
     encoded
         .len()
@@ -1854,15 +2760,200 @@ fn append_head_group_member(
         u32::try_from(value.len()).map_err(|_| head_group_error("member value exceeds u32"))?;
     encoded.extend_from_slice(&value_len.to_be_bytes());
     encoded.extend_from_slice(value);
+    encode_working_diff_baseline(encoded, baseline);
     Ok(())
 }
 
+fn working_diff_baseline_len(baseline: WorkingDiffBaseline) -> usize {
+    match baseline {
+        WorkingDiffBaseline::Clean => 1,
+        WorkingDiffBaseline::Absent(_) => 1 + UUID_BYTES,
+        WorkingDiffBaseline::Present { .. } => 1 + UUID_BYTES + WORKING_DIFF_VERSION_BYTES,
+    }
+}
+
+fn encode_working_diff_baseline(encoded: &mut Vec<u8>, baseline: WorkingDiffBaseline) {
+    match baseline {
+        WorkingDiffBaseline::Clean => encoded.push(WORKING_DIFF_BASELINE_CLEAN),
+        WorkingDiffBaseline::Absent(checkpoint_commit_id) => {
+            encoded.push(WORKING_DIFF_BASELINE_ABSENT);
+            encoded.extend_from_slice(checkpoint_commit_id.as_uuid().as_bytes());
+        }
+        WorkingDiffBaseline::Present {
+            checkpoint_commit_id,
+            version,
+        } => {
+            encoded.push(WORKING_DIFF_BASELINE_PRESENT);
+            encoded.extend_from_slice(checkpoint_commit_id.as_uuid().as_bytes());
+            encode_working_diff_version(encoded, version);
+        }
+    }
+}
+
+fn encode_working_diff_version(encoded: &mut Vec<u8>, version: WorkingDiffVersion) {
+    encoded.extend_from_slice(version.change_id.as_uuid().as_bytes());
+    encoded.extend_from_slice(version.commit_id.as_uuid().as_bytes());
+    encoded.push(u8::from(version.deleted));
+    encoded.extend_from_slice(&version.created_at.packed().to_be_bytes());
+    encoded.extend_from_slice(&version.updated_at.packed().to_be_bytes());
+    encode_working_diff_slot(encoded, version.snapshot);
+    encode_working_diff_slot(encoded, version.metadata);
+}
+
+fn encode_working_diff_slot(encoded: &mut Vec<u8>, slot: WorkingDiffSlotFingerprint) {
+    encoded.push(slot.kind);
+    encoded.extend_from_slice(&slot.hash);
+}
+
+fn decode_working_diff_baseline(
+    bytes: &[u8],
+    offset: &mut usize,
+) -> Result<WorkingDiffBaseline, LixError> {
+    let tag = *bytes
+        .get(*offset)
+        .ok_or_else(|| head_group_error("is truncated before working-diff baseline"))?;
+    *offset += 1;
+    match tag {
+        WORKING_DIFF_BASELINE_CLEAN => Ok(WorkingDiffBaseline::Clean),
+        WORKING_DIFF_BASELINE_ABSENT => Ok(WorkingDiffBaseline::Absent(CommitId::new(
+            uuid_from_working_diff_bytes(
+                take_working_diff_bytes(bytes, offset, UUID_BYTES)?,
+                "baseline checkpoint id",
+            )?,
+        ))),
+        WORKING_DIFF_BASELINE_PRESENT => {
+            let checkpoint_commit_id = CommitId::new(uuid_from_working_diff_bytes(
+                take_working_diff_bytes(bytes, offset, UUID_BYTES)?,
+                "baseline checkpoint id",
+            )?);
+            let version = decode_working_diff_version(bytes, offset)?;
+            Ok(WorkingDiffBaseline::Present {
+                checkpoint_commit_id,
+                version,
+            })
+        }
+        _ => Err(head_group_error("has an invalid working-diff baseline tag")),
+    }
+}
+
+fn decode_working_diff_version(
+    bytes: &[u8],
+    offset: &mut usize,
+) -> Result<WorkingDiffVersion, LixError> {
+    let payload = take_working_diff_bytes(bytes, offset, WORKING_DIFF_VERSION_BYTES)?;
+    let mut field_offset = 0usize;
+    let change_id = ChangeId::new(uuid_from_working_diff_bytes(
+        take_working_diff_bytes(payload, &mut field_offset, UUID_BYTES)?,
+        "change id",
+    )?);
+    let commit_id = CommitId::new(uuid_from_working_diff_bytes(
+        take_working_diff_bytes(payload, &mut field_offset, UUID_BYTES)?,
+        "commit id",
+    )?);
+    let deleted = match *take_working_diff_bytes(payload, &mut field_offset, 1)?
+        .first()
+        .ok_or_else(|| head_group_error("working-diff deletion flag is missing"))?
+    {
+        0 => false,
+        1 => true,
+        _ => return Err(head_group_error("working-diff deletion flag is invalid")),
+    };
+    let created_at = LixTimestamp::from_packed(read_u64(
+        take_working_diff_bytes(payload, &mut field_offset, 8)?,
+        "working-diff created_at",
+    )?)
+    .map_err(|error| head_group_error(&format!("invalid working-diff created_at: {error}")))?;
+    let updated_at = LixTimestamp::from_packed(read_u64(
+        take_working_diff_bytes(payload, &mut field_offset, 8)?,
+        "working-diff updated_at",
+    )?)
+    .map_err(|error| head_group_error(&format!("invalid working-diff updated_at: {error}")))?;
+    let snapshot = decode_working_diff_slot(payload, &mut field_offset, "snapshot")?;
+    let metadata = decode_working_diff_slot(payload, &mut field_offset, "metadata")?;
+    debug_assert_eq!(field_offset, WORKING_DIFF_VERSION_BYTES);
+    Ok(WorkingDiffVersion {
+        change_id,
+        commit_id,
+        deleted,
+        created_at,
+        updated_at,
+        snapshot,
+        metadata,
+    })
+}
+
+fn decode_working_diff_slot(
+    bytes: &[u8],
+    offset: &mut usize,
+    field: &str,
+) -> Result<WorkingDiffSlotFingerprint, LixError> {
+    let kind = *take_working_diff_bytes(bytes, offset, 1)?
+        .first()
+        .ok_or_else(|| head_group_error(&format!("working-diff {field} kind is missing")))?;
+    if !matches!(
+        kind,
+        WORKING_DIFF_SLOT_NONE | WORKING_DIFF_SLOT_REF | WORKING_DIFF_SLOT_INLINE
+    ) {
+        return Err(head_group_error(&format!(
+            "working-diff {field} slot kind is invalid"
+        )));
+    }
+    let hash: [u8; JSON_REF_BYTES] = take_working_diff_bytes(bytes, offset, JSON_REF_BYTES)?
+        .try_into()
+        .map_err(|_| head_group_error(&format!("working-diff {field} hash is invalid")))?;
+    if kind == WORKING_DIFF_SLOT_NONE && hash != [0; JSON_REF_BYTES] {
+        return Err(head_group_error(&format!(
+            "working-diff {field} none slot must have a zero hash"
+        )));
+    }
+    Ok(WorkingDiffSlotFingerprint { kind, hash })
+}
+
+fn take_working_diff_bytes<'a>(
+    bytes: &'a [u8],
+    offset: &mut usize,
+    length: usize,
+) -> Result<&'a [u8], LixError> {
+    let end = offset
+        .checked_add(length)
+        .ok_or_else(|| head_group_error("working-diff value offset overflow"))?;
+    let value = bytes
+        .get(*offset..end)
+        .ok_or_else(|| head_group_error("is truncated in working-diff value"))?;
+    *offset = end;
+    Ok(value)
+}
+
+fn uuid_from_working_diff_bytes(bytes: &[u8], field: &str) -> Result<uuid::Uuid, LixError> {
+    let bytes: [u8; UUID_BYTES] = bytes
+        .try_into()
+        .map_err(|_| head_group_error(&format!("working-diff {field} has invalid width")))?;
+    Ok(uuid::Uuid::from_bytes(bytes))
+}
+
+#[cfg(test)]
 fn encode_head_group_members(
     members: &BTreeMap<Option<String>, Vec<u8>>,
+) -> Result<Vec<u8>, LixError> {
+    let baselines = members
+        .keys()
+        .cloned()
+        .map(|file_id| (file_id, WorkingDiffBaseline::Clean))
+        .collect::<BTreeMap<_, _>>();
+    encode_head_group_members_with_baselines(members, &baselines)
+}
+
+fn encode_head_group_members_with_baselines(
+    members: &BTreeMap<Option<String>, Vec<u8>>,
+    baselines: &BTreeMap<Option<String>, WorkingDiffBaseline>,
 ) -> Result<Vec<u8>, LixError> {
     let member_count =
         u32::try_from(members.len()).map_err(|_| head_group_error("member count exceeds u32"))?;
     let payload_len = members.iter().try_fold(0usize, |total, (file_id, value)| {
+        let baseline = baselines
+            .get(file_id)
+            .copied()
+            .ok_or_else(|| head_group_error("is missing a working-diff baseline for one member"))?;
         let file_id_len = file_id.as_ref().map_or(0, String::len);
         u32::try_from(file_id_len).map_err(|_| head_group_error("file id exceeds u32"))?;
         let file_id_bytes = if file_id.is_some() {
@@ -1878,6 +2969,7 @@ fn encode_head_group_members(
             .checked_add(file_id_bytes)
             .and_then(|length| length.checked_add(4))
             .and_then(|length| length.checked_add(value.len()))
+            .and_then(|length| length.checked_add(working_diff_baseline_len(baseline)))
             .ok_or_else(|| head_group_error("group value length overflow"))?;
         total
             .checked_add(member_len)
@@ -1890,6 +2982,10 @@ fn encode_head_group_members(
     encoded.push(HEAD_GROUP_VALUE_VERSION);
     encoded.extend_from_slice(&member_count.to_be_bytes());
     for (file_id, value) in members {
+        let baseline = baselines
+            .get(file_id)
+            .copied()
+            .ok_or_else(|| head_group_error("is missing a working-diff baseline for one member"))?;
         match file_id {
             None => encoded.push(FILE_ID_NONE),
             Some(file_id) => {
@@ -1904,6 +3000,7 @@ fn encode_head_group_members(
             u32::try_from(value.len()).map_err(|_| head_group_error("member value exceeds u32"))?;
         encoded.extend_from_slice(&value_len.to_be_bytes());
         encoded.extend_from_slice(value);
+        encode_working_diff_baseline(&mut encoded, baseline);
     }
     debug_assert_eq!(encoded.len(), capacity);
     Ok(encoded)
@@ -1967,10 +3064,12 @@ fn decode_head_group_members(bytes: &[u8]) -> Result<Vec<HeadGroupMemberBytes>, 
             .ok_or_else(|| head_group_error("is truncated in member value"))?;
         decode_head_value(value)?;
         offset = value_end;
+        let baseline = decode_working_diff_baseline(bytes, &mut offset)?;
         prior_file_id = Some(file_id.clone());
         members.push(HeadGroupMemberBytes {
             file_id,
             value: Bytes::copy_from_slice(value),
+            baseline,
         });
     }
     if offset != bytes.len() {
@@ -1996,7 +3095,7 @@ fn read_group_u32(bytes: &[u8], offset: &mut usize, field: &str) -> Result<usize
 fn head_group_error(message: &str) -> LixError {
     LixError::new(
         LixError::CODE_INTERNAL_ERROR,
-        format!("invalid tracked-head v5 group: {message}"),
+        format!("invalid tracked-head v6 group: {message}"),
     )
 }
 
@@ -2051,6 +3150,60 @@ struct HeadValueView<'a> {
     updated_at: LixTimestamp,
     snapshot: HeadSlotView<'a>,
     metadata: HeadSlotView<'a>,
+}
+
+impl HeadValueView<'_> {
+    fn working_diff_version(self) -> WorkingDiffVersion {
+        WorkingDiffVersion {
+            change_id: self.change_id,
+            commit_id: self.commit_id,
+            deleted: self.deleted,
+            created_at: self.created_at,
+            updated_at: self.updated_at,
+            snapshot: working_diff_slot_fingerprint(self.snapshot),
+            metadata: working_diff_slot_fingerprint(self.metadata),
+        }
+    }
+}
+
+impl WorkingDiffVersion {
+    fn payload_eq(self, other: Self) -> bool {
+        // Keep the accelerator's net-change classification identical to the
+        // canonical tracked diff: a shared change record is intrinsically the
+        // same payload, otherwise compare the two stored payload slots.
+        self.change_id == other.change_id
+            || (self.snapshot == other.snapshot && self.metadata == other.metadata)
+    }
+
+    fn into_diff_row(self, identity: &HeadRowIdentity) -> TrackedStateDiffRow {
+        TrackedStateDiffRow {
+            entity_pk: identity.entity_pk.clone(),
+            schema_key: identity.schema_key.clone(),
+            file_id: identity.file_id.clone(),
+            deleted: self.deleted,
+            created_at: self.created_at,
+            updated_at: self.updated_at,
+            change_id: self.change_id,
+            commit_id: self.commit_id,
+        }
+    }
+}
+
+fn working_diff_slot_fingerprint(slot: HeadSlotView<'_>) -> WorkingDiffSlotFingerprint {
+    match slot {
+        HeadSlotView::None => WorkingDiffSlotFingerprint {
+            kind: WORKING_DIFF_SLOT_NONE,
+            hash: [0; JSON_REF_BYTES],
+        },
+        HeadSlotView::Ref(json_ref) => WorkingDiffSlotFingerprint {
+            kind: WORKING_DIFF_SLOT_REF,
+            hash: *json_ref.as_hash_array(),
+        },
+        HeadSlotView::Inline(json) => WorkingDiffSlotFingerprint {
+            kind: WORKING_DIFF_SLOT_INLINE,
+            hash: *JsonRef::for_content(json.as_bytes()).as_hash_array(),
+        },
+    }
 }
 
 fn encode_head_value(value: &HeadValueRef<'_>) -> Result<Vec<u8>, LixError> {
@@ -2439,7 +3592,7 @@ mod tests {
     }
 
     #[test]
-    fn v5_group_codec_roundtrips_sorted_members_and_rejects_corruption() {
+    fn v6_group_codec_roundtrips_sorted_members_and_rejects_corruption() {
         let mut members = BTreeMap::new();
         members.insert(
             None,
@@ -2477,6 +3630,368 @@ mod tests {
         let mut bad_version = encoded;
         bad_version[0] = HEAD_GROUP_VALUE_VERSION + 1;
         assert!(decode_head_group_members(&bad_version).is_err());
+    }
+
+    #[test]
+    fn working_diff_payload_equality_matches_canonical_change_identity_semantics() {
+        let slot = WorkingDiffSlotFingerprint {
+            kind: WORKING_DIFF_SLOT_INLINE,
+            hash: [1; JSON_REF_BYTES],
+        };
+        let other_slot = WorkingDiffSlotFingerprint {
+            kind: WORKING_DIFF_SLOT_INLINE,
+            hash: [2; JSON_REF_BYTES],
+        };
+        let baseline = WorkingDiffVersion {
+            change_id: ChangeId::for_test_label("same-change"),
+            commit_id: CommitId::for_test_label("baseline-commit"),
+            deleted: false,
+            created_at: ts("2026-01-01T00:00:00Z"),
+            updated_at: ts("2026-01-01T00:00:00Z"),
+            snapshot: slot,
+            metadata: slot,
+        };
+        let same_change = WorkingDiffVersion {
+            snapshot: other_slot,
+            metadata: other_slot,
+            ..baseline
+        };
+        let same_payload = WorkingDiffVersion {
+            change_id: ChangeId::for_test_label("different-change"),
+            ..baseline
+        };
+        let different_payload = WorkingDiffVersion {
+            change_id: ChangeId::for_test_label("different-change"),
+            snapshot: other_slot,
+            ..baseline
+        };
+
+        assert!(baseline.payload_eq(same_change));
+        assert!(baseline.payload_eq(same_payload));
+        assert!(!baseline.payload_eq(different_payload));
+    }
+
+    #[tokio::test]
+    async fn working_diff_restarts_after_a_noop_checkpoint_and_verifies_coverage() {
+        let storage = StorageAdapter::new(Memory::new());
+        let branch_id = "branch";
+        let checkpoint = CommitId::for_test_label("checkpoint");
+        let first_head = CommitId::for_test_label("first-head");
+        let no_op_checkpoint = CommitId::for_test_label("no-op-checkpoint");
+        let second_head = CommitId::for_test_label("second-head");
+        let entity_pk = EntityPk::single("row");
+        let control = |head_commit_id| BranchHeadControl {
+            head_commit_id,
+            generation: checkpoint,
+            created_at: ts("2026-01-01T00:00:00Z"),
+            updated_at: ts("2026-01-01T00:00:00Z"),
+            ref_change_id: ChangeId::for_test_label("branch-ref"),
+        };
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open initial write read");
+        let mut writes = StorageWriteSet::new();
+        let mut initial_coverage = WorkingDiffIndexCoverage::default();
+        TrackedHeadContext::new()
+            .writer(&read, &mut writes)
+            .stage_commit_with_working_diff(
+                branch_id,
+                None,
+                checkpoint,
+                &[TrackedHeadDeltaRef {
+                    schema_key: "schema",
+                    file_id: None,
+                    entity_pk: &entity_pk,
+                    change_id: ChangeId::for_test_label("initial-change"),
+                    commit_id: checkpoint,
+                    deleted: false,
+                    created_at: ts("2026-01-01T00:00:00Z"),
+                    updated_at: ts("2026-01-01T00:00:00Z"),
+                    snapshot: JsonSlotRef::Inline("{\"value\":\"one\"}"),
+                    metadata: JsonSlotRef::None,
+                }],
+                &BTreeSet::new(),
+                None,
+                Some(checkpoint),
+                None,
+                &mut initial_coverage,
+            )
+            .await
+            .expect("stage clean checkpoint head");
+        assert_eq!(initial_coverage, WorkingDiffIndexCoverage::default());
+        stage_tracked_working_diff_epoch(
+            &mut writes,
+            branch_id,
+            TrackedWorkingDiffEpoch {
+                checkpoint_commit_id: checkpoint,
+                generation: Some(checkpoint),
+                coverage: initial_coverage,
+            },
+        )
+        .expect("stage initial epoch");
+        stage_branch_head_control(&mut writes, branch_id, control(checkpoint))
+            .expect("stage initial control");
+        drop(read);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit initial head");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open first update read");
+        let mut writes = StorageWriteSet::new();
+        let mut first_coverage = WorkingDiffIndexCoverage::default();
+        TrackedHeadContext::new()
+            .writer(&read, &mut writes)
+            .stage_commit_with_working_diff(
+                branch_id,
+                Some(checkpoint),
+                first_head,
+                &[TrackedHeadDeltaRef {
+                    schema_key: "schema",
+                    file_id: None,
+                    entity_pk: &entity_pk,
+                    change_id: ChangeId::for_test_label("first-change"),
+                    commit_id: first_head,
+                    deleted: false,
+                    created_at: ts("2026-01-01T00:00:00Z"),
+                    updated_at: ts("2026-01-02T00:00:00Z"),
+                    snapshot: JsonSlotRef::Inline("{\"value\":\"two\"}"),
+                    metadata: JsonSlotRef::None,
+                }],
+                &BTreeSet::new(),
+                None,
+                Some(checkpoint),
+                Some(checkpoint),
+                &mut first_coverage,
+            )
+            .await
+            .expect("stage first update");
+        stage_tracked_working_diff_epoch(
+            &mut writes,
+            branch_id,
+            TrackedWorkingDiffEpoch {
+                checkpoint_commit_id: checkpoint,
+                generation: Some(checkpoint),
+                coverage: first_coverage,
+            },
+        )
+        .expect("stage first epoch");
+        stage_branch_head_control(&mut writes, branch_id, control(first_head))
+            .expect("stage first control");
+        drop(read);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit first update");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open first direct read");
+        let first_diff = TrackedHeadContext::new()
+            .reader(read)
+            .working_diff_if_control_current(
+                branch_id,
+                control(first_head),
+                &TrackedStateDiffRequest::default(),
+            )
+            .await
+            .expect("first direct diff should read")
+            .expect("first direct diff should be current");
+        assert_eq!(first_diff.checkpoint_commit_id, checkpoint);
+        assert_eq!(first_diff.diff.entries.len(), 1);
+        assert_eq!(
+            first_diff.diff.entries[0].kind,
+            TrackedStateDiffKind::Modified
+        );
+        assert_eq!(
+            first_diff.diff.entries[0]
+                .before
+                .as_ref()
+                .expect("modified diff has before row")
+                .change_id,
+            ChangeId::for_test_label("initial-change")
+        );
+
+        // A net-zero checkpoint keeps the existing serving generation but
+        // starts a new diff epoch. Old first-before summaries stay harmless:
+        // the next mutation tags its own checkpoint and gets a new index key.
+        let mut writes = StorageWriteSet::new();
+        stage_marker(
+            &mut writes,
+            branch_id,
+            &TrackedHeadMarker {
+                head_commit_id: no_op_checkpoint,
+                generation: checkpoint,
+                working_diff_checkpoint_commit_id: Some(checkpoint),
+            },
+        )
+        .expect("stage no-op checkpoint head marker");
+        stage_tracked_working_diff_epoch(
+            &mut writes,
+            branch_id,
+            TrackedWorkingDiffEpoch {
+                checkpoint_commit_id: no_op_checkpoint,
+                generation: None,
+                coverage: WorkingDiffIndexCoverage::default(),
+            },
+        )
+        .expect("reset no-op checkpoint epoch");
+        stage_branch_head_control(&mut writes, branch_id, control(no_op_checkpoint))
+            .expect("stage no-op checkpoint control");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit no-op checkpoint");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open no-op checkpoint epoch read");
+        assert_eq!(
+            TrackedHeadContext::new()
+                .reader(read)
+                .working_diff_epoch(branch_id)
+                .await
+                .expect("no-op checkpoint epoch should decode"),
+            Some(TrackedWorkingDiffEpoch {
+                checkpoint_commit_id: no_op_checkpoint,
+                generation: None,
+                coverage: WorkingDiffIndexCoverage::default(),
+            })
+        );
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open no-op checkpoint read");
+        let empty_diff = TrackedHeadContext::new()
+            .reader(read)
+            .working_diff_if_control_current(
+                branch_id,
+                control(no_op_checkpoint),
+                &TrackedStateDiffRequest::default(),
+            )
+            .await
+            .expect("no-op checkpoint direct diff should read")
+            .expect("no-op checkpoint direct diff should be known empty");
+        assert!(empty_diff.diff.entries.is_empty());
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open second update read");
+        let mut writes = StorageWriteSet::new();
+        let mut second_coverage = WorkingDiffIndexCoverage::default();
+        TrackedHeadContext::new()
+            .writer(&read, &mut writes)
+            .stage_commit_with_working_diff(
+                branch_id,
+                Some(checkpoint),
+                second_head,
+                &[TrackedHeadDeltaRef {
+                    schema_key: "schema",
+                    file_id: None,
+                    entity_pk: &entity_pk,
+                    change_id: ChangeId::for_test_label("second-change"),
+                    commit_id: second_head,
+                    deleted: false,
+                    created_at: ts("2026-01-01T00:00:00Z"),
+                    updated_at: ts("2026-01-03T00:00:00Z"),
+                    snapshot: JsonSlotRef::Inline("{\"value\":\"three\"}"),
+                    metadata: JsonSlotRef::None,
+                }],
+                &BTreeSet::new(),
+                None,
+                Some(no_op_checkpoint),
+                Some(no_op_checkpoint),
+                &mut second_coverage,
+            )
+            .await
+            .expect("stage second update");
+        stage_tracked_working_diff_epoch(
+            &mut writes,
+            branch_id,
+            TrackedWorkingDiffEpoch {
+                checkpoint_commit_id: no_op_checkpoint,
+                generation: Some(checkpoint),
+                coverage: second_coverage,
+            },
+        )
+        .expect("stage second epoch");
+        stage_branch_head_control(&mut writes, branch_id, control(second_head))
+            .expect("stage second control");
+        drop(read);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit second update");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open second direct read");
+        let second_diff = TrackedHeadContext::new()
+            .reader(read)
+            .working_diff_if_control_current(
+                branch_id,
+                control(second_head),
+                &TrackedStateDiffRequest::default(),
+            )
+            .await
+            .expect("second direct diff should read")
+            .expect("second direct diff should be current");
+        assert_eq!(second_diff.checkpoint_commit_id, no_op_checkpoint);
+        assert_eq!(second_diff.diff.entries.len(), 1);
+        assert_eq!(
+            second_diff.diff.entries[0].kind,
+            TrackedStateDiffKind::Modified
+        );
+        assert_eq!(
+            second_diff.diff.entries[0]
+                .before
+                .as_ref()
+                .expect("modified diff has before row")
+                .change_id,
+            ChangeId::for_test_label("first-change")
+        );
+
+        let mut writes = StorageWriteSet::new();
+        stage_tracked_working_diff_epoch(
+            &mut writes,
+            branch_id,
+            TrackedWorkingDiffEpoch {
+                checkpoint_commit_id: no_op_checkpoint,
+                generation: Some(checkpoint),
+                coverage: WorkingDiffIndexCoverage::default(),
+            },
+        )
+        .expect("stage bad coverage epoch");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit bad coverage epoch");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open bad coverage read");
+        assert!(
+            TrackedHeadContext::new()
+                .reader(read)
+                .working_diff_if_control_current(
+                    branch_id,
+                    control(second_head),
+                    &TrackedStateDiffRequest::default(),
+                )
+                .await
+                .expect("bad coverage should not error")
+                .is_none(),
+            "bad index coverage must select canonical replay"
+        );
     }
 
     #[tokio::test]
@@ -2517,6 +4032,7 @@ mod tests {
             &TrackedHeadMarker {
                 head_commit_id: head,
                 generation,
+                working_diff_checkpoint_commit_id: None,
             },
         )
         .expect("stage v3 marker");
@@ -2820,7 +4336,7 @@ mod tests {
 
         // The v6 control plane only validates the generation marker. Exact
         // file identity and schema-scoped file-id reads must still route to
-        // the v5 member projection even when every backing group is absent.
+        // the v6 member projection even when every backing group is absent.
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
@@ -3024,6 +4540,7 @@ mod tests {
             &TrackedHeadMarker {
                 head_commit_id: head,
                 generation,
+                working_diff_checkpoint_commit_id: None,
             },
         )
         .expect("stage marker");
@@ -3085,6 +4602,7 @@ mod tests {
             &TrackedHeadMarker {
                 head_commit_id: head,
                 generation,
+                working_diff_checkpoint_commit_id: None,
             },
         )
         .expect("stage marker");
@@ -3270,6 +4788,7 @@ mod tests {
             &TrackedHeadMarker {
                 head_commit_id: generation,
                 generation,
+                working_diff_checkpoint_commit_id: None,
             },
         )
         .expect("stage initial marker");
@@ -3483,6 +5002,7 @@ mod tests {
             &TrackedHeadMarker {
                 head_commit_id: generation,
                 generation,
+                working_diff_checkpoint_commit_id: None,
             },
         )
         .expect("stage existing head marker");
@@ -3549,6 +5069,7 @@ mod tests {
             &TrackedHeadMarker {
                 head_commit_id: generation,
                 generation,
+                working_diff_checkpoint_commit_id: None,
             },
         )
         .expect("stage existing tombstone marker");
@@ -3694,5 +5215,266 @@ mod tests {
         );
         assert_eq!(rows[0].created_at, ts("2026-01-01T00:00:00Z"));
         assert_eq!(rows[0].snapshot_content.as_deref(), Some("{\"value\":2}"));
+    }
+
+    #[tokio::test]
+    async fn working_diff_gc_reclaims_malformed_auxiliary_records() {
+        let storage = StorageAdapter::new(Memory::new());
+        let malformed_epoch_key = StorageKey(Bytes::from_static(b"not-a-working-diff-marker"));
+        let malformed_index_key = StorageKey(Bytes::from_static(b"not-a-working-diff-index"));
+        let mut writes = StorageWriteSet::new();
+        writes.put(
+            TRACKED_WORKING_DIFF_MARKER_SPACE,
+            malformed_epoch_key.clone(),
+            StorageValue {
+                bytes: Bytes::from_static(b"not-a-working-diff-epoch"),
+            },
+        );
+        writes.put(
+            TRACKED_WORKING_DIFF_GROUP_SPACE,
+            malformed_index_key.clone(),
+            StorageValue {
+                bytes: Bytes::from_static(WORKING_DIFF_INDEX_VALUE),
+            },
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit malformed auxiliary records");
+
+        let read = crate::storage_adapter::SharedStorageAdapterRead::new(
+            storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("open GC read"),
+        );
+        let mut gc_writes = StorageWriteSet::new();
+        stage_collect_stale_working_diff_indexes(&read, &mut gc_writes)
+            .await
+            .expect("GC must discard malformed auxiliary records");
+        drop(read);
+        storage
+            .commit_write_set(gc_writes, StorageWriteOptions::default())
+            .await
+            .expect("commit GC auxiliary cleanup");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open cleanup verification read");
+        for (space, key) in [
+            (TRACKED_WORKING_DIFF_MARKER_SPACE, malformed_epoch_key),
+            (TRACKED_WORKING_DIFF_GROUP_SPACE, malformed_index_key),
+        ] {
+            let value = PointReadPlan::new(space, &[key])
+                .materialize(&read, StorageGetOptions::default())
+                .await
+                .expect("read cleaned auxiliary key")
+                .value
+                .into_iter()
+                .next()
+                .flatten();
+            assert!(value.is_none(), "malformed auxiliary key must be reclaimed");
+        }
+    }
+
+    #[tokio::test]
+    async fn working_diff_gc_keeps_only_marker_bound_active_scopes() {
+        let storage = StorageAdapter::new(Memory::new());
+        let timestamp = ts("2026-01-01T00:00:00Z");
+        let active_generation = CommitId::for_test_label("active-generation");
+        let active_checkpoint = CommitId::for_test_label("active-checkpoint");
+        let active_group = HeadGroupIdentity {
+            branch_id: "active".to_string(),
+            generation: active_generation,
+            schema_key: "schema".to_string(),
+            entity_pk: EntityPk::single("active-row"),
+        };
+        let stale_generation = CommitId::for_test_label("stale-generation");
+        let stale_checkpoint = CommitId::for_test_label("stale-checkpoint");
+        let stale_group = HeadGroupIdentity {
+            branch_id: "stale".to_string(),
+            generation: stale_generation,
+            schema_key: "schema".to_string(),
+            entity_pk: EntityPk::single("stale-row"),
+        };
+        let orphan_generation = CommitId::for_test_label("orphan-generation");
+        let orphan_checkpoint = CommitId::for_test_label("orphan-checkpoint");
+        let orphan_group = HeadGroupIdentity {
+            branch_id: "deleted".to_string(),
+            generation: orphan_generation,
+            schema_key: "schema".to_string(),
+            entity_pk: EntityPk::single("orphan-row"),
+        };
+
+        let mut writes = StorageWriteSet::new();
+        let active_control = BranchHeadControl {
+            head_commit_id: active_generation,
+            generation: active_generation,
+            created_at: timestamp,
+            updated_at: timestamp,
+            ref_change_id: ChangeId::for_test_label("active-ref"),
+        };
+        stage_marker(
+            &mut writes,
+            "active",
+            &TrackedHeadMarker {
+                head_commit_id: active_generation,
+                generation: active_generation,
+                working_diff_checkpoint_commit_id: Some(active_checkpoint),
+            },
+        )
+        .expect("stage active marker");
+        stage_tracked_working_diff_epoch(
+            &mut writes,
+            "active",
+            TrackedWorkingDiffEpoch {
+                checkpoint_commit_id: active_checkpoint,
+                generation: Some(active_generation),
+                coverage: WorkingDiffIndexCoverage::default(),
+            },
+        )
+        .expect("stage active epoch");
+        stage_branch_head_control(&mut writes, "active", active_control)
+            .expect("stage active control");
+
+        let stale_control = BranchHeadControl {
+            head_commit_id: stale_generation,
+            generation: stale_generation,
+            created_at: timestamp,
+            updated_at: timestamp,
+            ref_change_id: ChangeId::for_test_label("stale-ref"),
+        };
+        stage_marker(
+            &mut writes,
+            "stale",
+            &TrackedHeadMarker {
+                head_commit_id: stale_generation,
+                generation: stale_generation,
+                working_diff_checkpoint_commit_id: Some(CommitId::for_test_label("wrong")),
+            },
+        )
+        .expect("stage stale marker");
+        stage_tracked_working_diff_epoch(
+            &mut writes,
+            "stale",
+            TrackedWorkingDiffEpoch {
+                checkpoint_commit_id: stale_checkpoint,
+                generation: Some(stale_generation),
+                coverage: WorkingDiffIndexCoverage::default(),
+            },
+        )
+        .expect("stage stale epoch");
+        stage_branch_head_control(&mut writes, "stale", stale_control)
+            .expect("stage stale control");
+
+        stage_tracked_working_diff_epoch(
+            &mut writes,
+            "deleted",
+            TrackedWorkingDiffEpoch {
+                checkpoint_commit_id: orphan_checkpoint,
+                generation: Some(orphan_generation),
+                coverage: WorkingDiffIndexCoverage::default(),
+            },
+        )
+        .expect("stage orphan epoch");
+
+        let mut coverage = WorkingDiffIndexCoverage::default();
+        for (checkpoint, group) in [
+            (active_checkpoint, &active_group),
+            (stale_checkpoint, &stale_group),
+            (orphan_checkpoint, &orphan_group),
+        ] {
+            stage_put_working_diff_group_index(&mut writes, &mut coverage, checkpoint, group)
+                .expect("stage working-diff index");
+        }
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit working-diff GC fixture");
+
+        let read = crate::storage_adapter::SharedStorageAdapterRead::new(
+            storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("open working-diff GC read"),
+        );
+        let mut gc_writes = StorageWriteSet::new();
+        stage_collect_stale_working_diff_indexes(&read, &mut gc_writes)
+            .await
+            .expect("stage working-diff GC");
+        drop(read);
+        storage
+            .commit_write_set(gc_writes, StorageWriteOptions::default())
+            .await
+            .expect("commit working-diff GC");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open working-diff GC verification read");
+        let active_epoch = PointReadPlan::new(
+            TRACKED_WORKING_DIFF_MARKER_SPACE,
+            &[StorageKey(Bytes::from(
+                marker_key("active").expect("active marker key"),
+            ))],
+        )
+        .materialize(&read, StorageGetOptions::default())
+        .await
+        .expect("read active epoch")
+        .value
+        .into_iter()
+        .next()
+        .flatten();
+        assert!(active_epoch.is_some(), "active epoch must survive GC");
+
+        for (branch_id, checkpoint, group) in [
+            ("stale", stale_checkpoint, &stale_group),
+            ("deleted", orphan_checkpoint, &orphan_group),
+        ] {
+            let epoch = PointReadPlan::new(
+                TRACKED_WORKING_DIFF_MARKER_SPACE,
+                &[StorageKey(Bytes::from(
+                    marker_key(branch_id).expect("marker key"),
+                ))],
+            )
+            .materialize(&read, StorageGetOptions::default())
+            .await
+            .expect("read stale epoch")
+            .value
+            .into_iter()
+            .next()
+            .flatten();
+            assert!(epoch.is_none(), "inactive epoch must be reclaimed");
+            let index = PointReadPlan::new(
+                TRACKED_WORKING_DIFF_GROUP_SPACE,
+                &[StorageKey(Bytes::from(encode_working_diff_group_key(
+                    checkpoint, group,
+                )))],
+            )
+            .materialize(&read, StorageGetOptions::default())
+            .await
+            .expect("read stale index")
+            .value
+            .into_iter()
+            .next()
+            .flatten();
+            assert!(index.is_none(), "inactive index must be reclaimed");
+        }
+        let active_index = PointReadPlan::new(
+            TRACKED_WORKING_DIFF_GROUP_SPACE,
+            &[StorageKey(Bytes::from(encode_working_diff_group_key(
+                active_checkpoint,
+                &active_group,
+            )))],
+        )
+        .materialize(&read, StorageGetOptions::default())
+        .await
+        .expect("read active index")
+        .value
+        .into_iter()
+        .next()
+        .flatten();
+        assert!(active_index.is_some(), "active index must survive GC");
     }
 }

--- a/packages/engine/src/session/checkpoint.rs
+++ b/packages/engine/src/session/checkpoint.rs
@@ -58,41 +58,58 @@ where
                             )
                             .await?
                     };
-                    let direct_checkpoint = {
-                        let mut tracked = transaction.tracked_state_reader().await;
-                        latest_checkpoint_at_head(&mut tracked, &head_commit_id, &branch_id).await?
-                    };
-                    let previous_checkpoint_commit_id = match direct_checkpoint {
-                        Some(commit_id) => commit_id,
-                        None => {
-                            let mut reader = transaction.commit_graph_reader().await;
-                            checkpoint_history_from_head(&mut reader, &head_commit_id)
+                    let direct_working_diff = transaction
+                        .working_diff_at_head(
+                            &branch_id,
+                            head_commit_id,
+                            &TrackedStateDiffRequest::default(),
+                        )
+                        .await?;
+                    let previous_checkpoint_commit_id = if let Some(direct) = &direct_working_diff {
+                        direct.checkpoint_commit_id
+                    } else {
+                        let direct_checkpoint = {
+                            let mut tracked = transaction.tracked_state_reader().await;
+                            latest_checkpoint_at_head(&mut tracked, &head_commit_id, &branch_id)
                                 .await?
-                                .into_iter()
-                                .next()
-                                .ok_or_else(|| {
-                                    LixError::new(
-                                        LixError::CODE_INTERNAL_ERROR,
-                                        format!(
-                                            "branch '{branch_id}' has no checkpoint baseline in its first-parent history"
-                                        ),
-                                    )
-                                })?
-                                .commit_id
+                        };
+                        match direct_checkpoint {
+                            Some(commit_id) => commit_id,
+                            None => {
+                                let mut reader = transaction.commit_graph_reader().await;
+                                checkpoint_history_from_head(&mut reader, &head_commit_id)
+                                    .await?
+                                    .into_iter()
+                                    .next()
+                                    .ok_or_else(|| {
+                                        LixError::new(
+                                            LixError::CODE_INTERNAL_ERROR,
+                                            format!(
+                                                "branch '{branch_id}' has no checkpoint baseline in its first-parent history"
+                                            ),
+                                        )
+                                    })?
+                                    .commit_id
+                            }
                         }
                     };
                     let interval_has_commits =
                         head_commit_id != previous_checkpoint_commit_id;
                     let selected_changes = {
-                        let mut reader = transaction.tracked_state_reader().await;
-                        reader
-                            .diff_commits(
-                                &previous_checkpoint_commit_id.to_string(),
-                                &head_commit_id.to_string(),
-                                &TrackedStateDiffRequest::default(),
-                            )
-                            .await?
-                            .entries
+                        let entries = if let Some(direct) = direct_working_diff {
+                            direct.diff.entries
+                        } else {
+                            let mut reader = transaction.tracked_state_reader().await;
+                            reader
+                                .diff_commits(
+                                    &previous_checkpoint_commit_id.to_string(),
+                                    &head_commit_id.to_string(),
+                                    &TrackedStateDiffRequest::default(),
+                                )
+                                .await?
+                                .entries
+                        };
+                        entries
                             .into_iter()
                             .filter(|entry| {
                                 entry.identity.schema_key != CHECKPOINT_MARKER_SCHEMA_KEY

--- a/packages/engine/src/sql2/providers/working_change.rs
+++ b/packages/engine/src/sql2/providers/working_change.rs
@@ -8,10 +8,11 @@ use datafusion::execution::context::ExecutionProps;
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
 use tokio::sync::Mutex;
 
-use crate::branch::BranchRefReader;
+use crate::branch::{BranchHeadControlContext, BranchRefReader};
 use crate::checkpoint::{CHECKPOINT_MARKER_SCHEMA_KEY, latest_checkpoint_for_branch};
 use crate::commit_graph::CommitGraphReader;
 use crate::entity_pk::EntityPk;
+use crate::live_state::TrackedHeadContext;
 use crate::sql2::result_metadata::json_field;
 use crate::sql2::{SqlChangelogQuerySource, WriteAccess};
 use crate::storage_adapter::StorageAdapterRead;
@@ -127,35 +128,72 @@ where
                     )
                     .await
                     .map_err(lix_error_to_datafusion_error)?;
-                    let mut graph = commit_graph.lock().await;
-                    let mut tracked = TrackedStateContext::new().reader(store);
+                    let tracked_head = TrackedHeadContext::new();
+                    // Normal tracked reads use the direct head epoch and do
+                    // not need the historical graph or tracked-state reader.
+                    // Keep both fallback-only so the accelerated route does
+                    // not serialize behind an unrelated historical diff.
+                    let mut graph = None;
+                    let mut tracked = None;
                     let mut rows = Vec::new();
                     for head in heads {
                         if limit.is_some_and(|limit| rows.len() >= limit) {
                             break;
                         }
-                        let checkpoint_commit_id = latest_checkpoint_for_branch(
-                            graph.as_mut(),
-                            &mut tracked,
-                            &head.commit_id,
-                            &head.branch_id,
-                        )
-                        .await
-                        .map_err(lix_error_to_datafusion_error)?
-                        .ok_or_else(|| {
-                            DataFusionError::Execution(format!(
-                                "branch '{}' has no checkpoint baseline",
-                                head.branch_id
-                            ))
-                        })?;
-                        let diff = tracked
-                            .diff_commits(
-                                &checkpoint_commit_id.to_string(),
-                                &head.commit_id.to_string(),
-                                &route.diff_request,
+                        let direct_diff = match BranchHeadControlContext::new()
+                            .reader(store.clone())
+                            .load(&head.branch_id)
+                            .await
+                            .map_err(lix_error_to_datafusion_error)?
+                        {
+                            Some(control) if control.head_commit_id == head.commit_id => {
+                                tracked_head
+                                    .reader(store.clone())
+                                    .working_diff_if_control_current(
+                                        &head.branch_id,
+                                        control,
+                                        &route.diff_request,
+                                    )
+                                    .await
+                                    .map_err(lix_error_to_datafusion_error)?
+                            }
+                            _ => None,
+                        };
+                        let diff = if let Some(direct) = direct_diff {
+                            direct.diff
+                        } else {
+                            if graph.is_none() {
+                                graph = Some(commit_graph.lock().await);
+                            }
+                            let graph = graph
+                                .as_mut()
+                                .expect("historical working-change graph should be initialized");
+                            let tracked = tracked.get_or_insert_with(|| {
+                                TrackedStateContext::new().reader(store.clone())
+                            });
+                            let checkpoint_commit_id = latest_checkpoint_for_branch(
+                                graph.as_mut(),
+                                tracked,
+                                &head.commit_id,
+                                &head.branch_id,
                             )
                             .await
-                            .map_err(lix_error_to_datafusion_error)?;
+                            .map_err(lix_error_to_datafusion_error)?
+                            .ok_or_else(|| {
+                                DataFusionError::Execution(format!(
+                                    "branch '{}' has no checkpoint baseline",
+                                    head.branch_id
+                                ))
+                            })?;
+                            tracked
+                                .diff_commits(
+                                    &checkpoint_commit_id.to_string(),
+                                    &head.commit_id.to_string(),
+                                    &route.diff_request,
+                                )
+                                .await
+                                .map_err(lix_error_to_datafusion_error)?
+                        };
                         for entry in diff.entries {
                             if entry.identity.schema_key == CHECKPOINT_MARKER_SCHEMA_KEY {
                                 continue;

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -176,6 +176,8 @@ fn native_storage_spaces() -> &'static [crate::storage_adapter::StorageSpace] {
         crate::live_state::TRACKED_HEAD_GROUP_SPACE,
         crate::live_state::TRACKED_HEAD_MEMBER_SPACE,
         crate::live_state::TRACKED_HEAD_MARKER_SPACE,
+        crate::live_state::TRACKED_WORKING_DIFF_GROUP_SPACE,
+        crate::live_state::TRACKED_WORKING_DIFF_MARKER_SPACE,
         crate::json_store::store::JSON_SPACE,
         crate::tracked_state::TRACKED_STATE_TREE_CHUNK_SPACE,
         crate::tracked_state::TRACKED_STATE_COMMIT_ROOT_SPACE,

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -572,6 +572,7 @@ mod tests {
     use crate::live_state::{
         LIVE_STATE_INDEX_ROW_SPACE, LIVE_STATE_LOCAL_SIDECAR_BRANCH_SPACE,
         TRACKED_HEAD_GROUP_SPACE, TRACKED_HEAD_MARKER_SPACE, TRACKED_HEAD_MEMBER_SPACE,
+        TRACKED_WORKING_DIFF_GROUP_SPACE, TRACKED_WORKING_DIFF_MARKER_SPACE,
     };
     use crate::tracked_state::types::{
         TrackedStateCommitRoot, TrackedStateCommitRootParent, TrackedStateRootId,
@@ -592,6 +593,8 @@ mod tests {
             TRACKED_HEAD_GROUP_SPACE,
             TRACKED_HEAD_MEMBER_SPACE,
             TRACKED_HEAD_MARKER_SPACE,
+            TRACKED_WORKING_DIFF_GROUP_SPACE,
+            TRACKED_WORKING_DIFF_MARKER_SPACE,
             JSON_SPACE,
             TRACKED_STATE_TREE_CHUNK_SPACE,
             TRACKED_STATE_COMMIT_ROOT_SPACE,

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -26,9 +26,10 @@ use crate::functions::FunctionContext;
 use crate::json_store::{JsonStoreContext, JsonWritePlacementRef, NormalizedJsonRef};
 use crate::live_state::{
     LiveStateIndexContext, LiveStateIndexDeltaRef, LiveStateIndexFilter, LiveStateIndexRowRequest,
-    LiveStateIndexScanRequest, TrackedHeadContext, TrackedHeadDeltaRef, branch_empty_precondition,
-    load_local_sidecar_branch_token, local_sidecar_branch_precondition, row_absent_precondition,
-    row_raw_token_precondition, stage_local_sidecar_branch_marker,
+    LiveStateIndexScanRequest, TrackedHeadContext, TrackedHeadDeltaRef, TrackedWorkingDiffEpoch,
+    WorkingDiffIndexCoverage, branch_empty_precondition, load_local_sidecar_branch_token,
+    local_sidecar_branch_precondition, row_absent_precondition, row_raw_token_precondition,
+    stage_local_sidecar_branch_marker, stage_tracked_working_diff_epoch,
 };
 use crate::storage_adapter::{StorageAdapterRead, StoragePrecondition, StorageWriteSet};
 use crate::tracked_state::{
@@ -248,6 +249,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         "lix.perf.materialization.tracked_head"
     ))
     .await?;
+    stage_checkpoint_working_diff_epochs(&mut writes, &prepared_writes.checkpoint_publications)?;
     stage_branch_head_control_publications(
         &mut writes,
         &normal_branch_controls,
@@ -862,7 +864,7 @@ async fn stage_flat_current_rows(
 }
 
 /// A branch ref targets changelog history, not an implementation detail of
-/// its sparse immutable-root checkpoints. Ordinary v4 commits intentionally
+/// its sparse immutable-root checkpoints. Ordinary v6 commits intentionally
 /// have no root, so validate the canonical commit record instead.
 async fn ensure_branch_ref_target_exists(
     read: &(impl StorageAdapterRead + ?Sized),
@@ -1136,7 +1138,6 @@ async fn stage_tracked_head(
     observations: &BTreeMap<String, BranchHeadControlObservation>,
 ) -> Result<BTreeMap<String, BranchHeadControl>, LixError> {
     let tracked_head = TrackedHeadContext::new();
-    let mut writer = tracked_head.writer(read, writes);
     let mut controls = BTreeMap::new();
     for root in tracked_roots_parent_first(tracked_roots)? {
         let staged = staged_commits.get(&root.commit_id).ok_or_else(|| {
@@ -1188,20 +1189,63 @@ async fn stage_tracked_head(
             })
             .collect::<BTreeSet<_>>();
 
-        // The v4 marker is the durable authority for current state. It is
+        // The v6 marker is the durable authority for current state. It is
         // intentionally bound only to the first-parent commit: serial normal
         // commits can append deltas without materializing an immutable root.
-        let parent_generation = match (root.parent_commit_id, parent_control) {
+        let parent_marker = match (root.parent_commit_id, parent_control) {
             (Some(parent_commit_id), Some(control))
                 if control.head_commit_id == parent_commit_id =>
             {
                 tracked_head
                     .reader(read)
-                    .generation_if_control_current(&root.branch_id, control)
+                    .marker_info_if_control_current(&root.branch_id, control)
                     .await?
             }
             _ => None,
         };
+        let parent_generation = parent_marker.map(|marker| marker.generation);
+        // The working-diff epoch is valid only when it names the exact
+        // parent generation being materialized. A just-published checkpoint
+        // has no active diff generation yet; its first ordinary child either
+        // reuses an already materialized serving generation or bootstraps one.
+        let working_diff_epoch = match (root.parent_commit_id, parent_control) {
+            (Some(parent_commit_id), Some(control))
+                if control.head_commit_id == parent_commit_id =>
+            {
+                match tracked_head
+                    .reader(read)
+                    .working_diff_epoch(&root.branch_id)
+                    .await
+                {
+                    Ok(Some(epoch))
+                        if epoch.generation == parent_generation
+                            && parent_generation == Some(control.generation)
+                            && parent_marker.is_some_and(|marker| {
+                                marker.working_diff_checkpoint_commit_id
+                                    == Some(epoch.checkpoint_commit_id)
+                            }) =>
+                    {
+                        Some(epoch)
+                    }
+                    Ok(Some(epoch))
+                        if epoch.generation.is_none()
+                            && epoch.checkpoint_commit_id == parent_commit_id =>
+                    {
+                        Some(epoch)
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        };
+        let working_diff_checkpoint_commit_id = working_diff_epoch
+            .as_ref()
+            .map(|epoch| epoch.checkpoint_commit_id);
+        let mut working_diff_coverage = working_diff_epoch
+            .as_ref()
+            .filter(|epoch| epoch.generation.is_some() && epoch.generation == parent_generation)
+            .map(|epoch| epoch.coverage)
+            .unwrap_or_default();
         let parent_is_current = parent_generation.is_some();
         let parent_rows = if parent_is_current || root.parent_commit_id.is_none() {
             None
@@ -1209,7 +1253,7 @@ async fn stage_tracked_head(
             // A parent staged earlier in this same write set is not visible
             // through `read`; publish no partial generation. Once committed,
             // current reads safely take the changelog-replay fallback until a
-            // following ordinary child bootstraps a complete v4 head.
+            // following ordinary child bootstraps a complete v6 head.
             if tracked_roots
                 .iter()
                 .any(|candidate| candidate.commit_id == parent_commit_id)
@@ -1240,16 +1284,32 @@ async fn stage_tracked_head(
         } else {
             None
         };
-        let generation = writer
-            .stage_commit(
-                &root.branch_id,
-                parent_generation,
-                root.commit_id,
-                &deltas,
-                &absence_guards,
-                parent_rows,
-            )
-            .await?;
+        let generation = {
+            let mut writer = tracked_head.writer(read, writes);
+            writer
+                .stage_commit_with_working_diff(
+                    &root.branch_id,
+                    parent_generation,
+                    root.commit_id,
+                    &deltas,
+                    &absence_guards,
+                    parent_rows,
+                    working_diff_checkpoint_commit_id,
+                    working_diff_checkpoint_commit_id,
+                    &mut working_diff_coverage,
+                )
+                .await?
+        };
+        if let Some(epoch) = working_diff_epoch {
+            let next_epoch = TrackedWorkingDiffEpoch {
+                checkpoint_commit_id: epoch.checkpoint_commit_id,
+                generation: Some(generation),
+                coverage: working_diff_coverage,
+            };
+            if next_epoch != epoch {
+                stage_tracked_working_diff_epoch(writes, &root.branch_id, next_epoch)?;
+            }
+        }
         insert_direct_branch_control(
             &mut controls,
             &root.branch_id,
@@ -1257,6 +1317,39 @@ async fn stage_tracked_head(
         )?;
     }
     Ok(controls)
+}
+
+/// A selected-ref checkpoint has after images but no trustworthy first-before
+/// values. Reset its working-diff epoch to the known-empty state instead; the
+/// first ordinary child bootstraps a fresh v6 head generation and captures
+/// its own preimages.
+fn stage_checkpoint_working_diff_epochs(
+    writes: &mut StorageWriteSet,
+    publications: &[crate::gc::CheckpointPublication],
+) -> Result<(), LixError> {
+    let mut branches = BTreeSet::new();
+    for publication in publications {
+        let recovery = &publication.recovery_ref;
+        if !branches.insert(recovery.branch_id.as_str()) {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "transaction publishes more than one working-diff checkpoint epoch for branch '{}'",
+                    recovery.branch_id
+                ),
+            ));
+        }
+        stage_tracked_working_diff_epoch(
+            writes,
+            &recovery.branch_id,
+            TrackedWorkingDiffEpoch {
+                checkpoint_commit_id: recovery.checkpoint_commit_id,
+                generation: None,
+                coverage: WorkingDiffIndexCoverage::default(),
+            },
+        )?;
+    }
+    Ok(())
 }
 
 fn normal_branch_head_control(
@@ -1292,7 +1385,7 @@ fn insert_direct_branch_control(
 /// Publishes every v6 branch-head control under an exact-byte CAS token.
 ///
 /// Normal tracked commits arrive as `normal_controls`, built from the same
-/// parent/generation decision that wrote the v5 group marker. Explicit branch
+/// parent/generation decision that wrote the v6 group marker. Explicit branch
 /// management still enters the prepared-row pipeline for validation and
 /// changelog compatibility, but its authoritative moving head is lowered
 /// here as well. This deliberately keeps the rare lifecycle lane compatible
@@ -1335,12 +1428,12 @@ async fn stage_branch_head_control_publications(
             .head_commit_id
             .map(|head_commit_id| BranchHeadControl {
                 head_commit_id,
-                // Repointing to the same head must not invalidate a complete v5
+                // Repointing to the same head must not invalidate a complete v6
                 // serving generation merely because public ref metadata changed.
                 generation: existing
                     .filter(|control| control.head_commit_id == head_commit_id)
                     .map_or(head_commit_id, |control| control.generation),
-                // The flat v5 branch-ref projection preserved creation time on
+                // The direct branch-ref projection preserves creation time on
                 // replacement. The control record owns that same public fact.
                 created_at: existing.map_or(target.created_at, |control| control.created_at),
                 updated_at: target.updated_at,
@@ -1439,7 +1532,7 @@ fn explicit_branch_head_targets(
 }
 
 /// Takes one coherent raw point batch for every control this materialization
-/// can publish. The result is threaded through v5 generation selection and
+/// can publish. The result is threaded through v6 generation selection and
 /// final CAS staging, so the control plane adds exactly one control batch to
 /// a commit rather than a head lookup plus a second token lookup.
 async fn observe_branch_head_controls(
@@ -1602,7 +1695,7 @@ async fn stage_tracked_roots(
 /// Immutable roots are a cold-path history structure. Keep them at topology
 /// and checkpoint fences, plus any staged first-parent ancestors necessary to
 /// build that fence in one atomic write set. Ordinary serial commits are
-/// represented only by the changelog and the v4 durable head projection.
+/// represented only by the changelog and the v6 durable head projection.
 fn tracked_root_fence_ids(
     tracked_roots: &[PendingTrackedRoot],
     force_all: bool,
@@ -3148,6 +3241,134 @@ mod tests {
             counts.marker_get_many_calls.load(Ordering::Relaxed),
             1,
             "serial tracked-head staging must reuse the generation it already read"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_working_diff_epoch_is_not_promoted_into_the_next_head() {
+        let storage = StorageAdapter::new(Memory::new());
+        let binary_cas = BinaryCasContext::new();
+        let branch_ctx = BranchContext::new();
+        let first_commit = commit_id("epoch-first-commit");
+
+        let mut first = tracked_branch_row("branch-a", "epoch-first-change");
+        first.commit_id = Some(first_commit);
+        let mut first_read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open first commit read");
+        let (writes, _) = commit_prepared_writes(
+            &binary_cas,
+            &branch_ctx,
+            &LiveStateIndexContext::new(),
+            None,
+            &mut first_read,
+            PreparedWriteSet {
+                insert_identities: BTreeMap::new(),
+                state_rows: vec![first],
+                commit_change_refs_by_branch: BTreeMap::from([(
+                    "branch-a".to_string(),
+                    change_refs_with(
+                        ["epoch-first-change"],
+                        "epoch-first-commit",
+                        "epoch-first-commit-change",
+                        "epoch-first-branch-ref-change",
+                    ),
+                )]),
+                first_commit_parent_override_by_branch: BTreeMap::new(),
+                checkpoint_publications: Vec::new(),
+                extra_commit_parents_by_branch: BTreeMap::new(),
+                file_data_writes: Vec::new(),
+            },
+        )
+        .await
+        .expect("first commit should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("first commit should persist");
+
+        // This deliberately names the right serving generation but a
+        // checkpoint that the marker never bound. It models a stale or
+        // corrupted auxiliary epoch; the next serial commit must not turn it
+        // into authoritative visibility.
+        let mut stale_epoch_writes = StorageWriteSet::new();
+        stage_tracked_working_diff_epoch(
+            &mut stale_epoch_writes,
+            "branch-a",
+            TrackedWorkingDiffEpoch {
+                checkpoint_commit_id: commit_id("wrong-checkpoint"),
+                generation: Some(first_commit),
+                coverage: WorkingDiffIndexCoverage::default(),
+            },
+        )
+        .expect("stage stale epoch");
+        storage
+            .commit_write_set(stale_epoch_writes, StorageWriteOptions::default())
+            .await
+            .expect("persist stale epoch");
+
+        let second_commit = commit_id("epoch-second-commit");
+        let mut second = tracked_branch_row("branch-a", "epoch-second-change");
+        second.commit_id = Some(second_commit);
+        let mut second_read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open second commit read");
+        let (writes, _) = commit_prepared_writes(
+            &binary_cas,
+            &branch_ctx,
+            &LiveStateIndexContext::new(),
+            None,
+            &mut second_read,
+            PreparedWriteSet {
+                insert_identities: BTreeMap::new(),
+                state_rows: vec![second],
+                commit_change_refs_by_branch: BTreeMap::from([(
+                    "branch-a".to_string(),
+                    change_refs_with(
+                        ["epoch-second-change"],
+                        "epoch-second-commit",
+                        "epoch-second-commit-change",
+                        "epoch-second-branch-ref-change",
+                    ),
+                )]),
+                first_commit_parent_override_by_branch: BTreeMap::new(),
+                checkpoint_publications: Vec::new(),
+                extra_commit_parents_by_branch: BTreeMap::new(),
+                file_data_writes: Vec::new(),
+            },
+        )
+        .await
+        .expect("second commit should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("second commit should persist");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open direct-diff verification read");
+        let control = BranchHeadControlContext::new()
+            .reader(&read)
+            .load("branch-a")
+            .await
+            .expect("load branch control")
+            .expect("branch control must exist");
+        assert_eq!(control.head_commit_id, second_commit);
+        assert!(
+            TrackedHeadContext::new()
+                .reader(read)
+                .working_diff_if_control_current(
+                    "branch-a",
+                    control,
+                    &crate::tracked_state::TrackedStateDiffRequest::default(),
+                )
+                .await
+                .expect("stale epoch must select fallback, not error")
+                .is_none(),
+            "a stale epoch must not be rebound by a later serial commit"
         );
     }
 

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -20,7 +20,10 @@ use tracing::Instrument as _;
 
 use crate::GLOBAL_BRANCH_ID;
 use crate::binary_cas::{BinaryCasContext, BlobBytesBatch, BlobDataReader, BlobHash};
-use crate::branch::{BRANCH_REF_SCHEMA_KEY, BranchContext, BranchRefReader, branch_ref_stage_row};
+use crate::branch::{
+    BRANCH_REF_SCHEMA_KEY, BranchContext, BranchHeadControlContext, BranchRefReader,
+    branch_ref_stage_row,
+};
 use crate::catalog::{
     CatalogContext, CatalogFingerprint, CatalogSnapshot, load_catalog_revision,
     stage_catalog_revision,
@@ -43,6 +46,7 @@ use crate::gc::{
 use crate::live_state::{
     LiveStateContext, LiveStateExactBatchRequest, LiveStateExactRowRequest, LiveStateFilter,
     LiveStateProjection, LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow,
+    TrackedHeadContext, TrackedWorkingDiff,
 };
 use crate::live_state::{overlay_load_exact_rows, overlay_scan_rows};
 use crate::plugin::{
@@ -78,7 +82,7 @@ use crate::storage_adapter::{
 use crate::storage_adapter::{
     SharedStorageAdapterRead, StorageAdapter, StorageAdapterRead, StorageAdapterReadScope,
 };
-use crate::tracked_state::{TrackedStateContext, TrackedStateStoreReader};
+use crate::tracked_state::{TrackedStateContext, TrackedStateDiffRequest, TrackedStateStoreReader};
 use crate::transaction::commit;
 use crate::transaction::normalization::{
     NormalizedTransactionWriteRow, REGISTERED_SCHEMA_KEY, normalize_transaction_write_row,
@@ -3678,6 +3682,36 @@ where
             .expect("open transaction read scope");
         self.tracked_state
             .reader(SharedStorageAdapterRead::new(read))
+    }
+
+    /// Attempts the current branch's checkpoint-relative direct diff from one
+    /// transaction-scoped snapshot. A missing or stale accelerator is an
+    /// ordinary `None`; callers retain the historical tracked-state oracle.
+    pub(crate) async fn working_diff_at_head(
+        &self,
+        branch_id: &str,
+        head_commit_id: CommitId,
+        request: &TrackedStateDiffRequest,
+    ) -> Result<Option<TrackedWorkingDiff>, LixError> {
+        let read = SharedStorageAdapterRead::new(
+            self.storage
+                .begin_read(StorageReadOptions::default())
+                .await?,
+        );
+        let Some(control) = BranchHeadControlContext::new()
+            .reader(read.clone())
+            .load(branch_id)
+            .await?
+        else {
+            return Ok(None);
+        };
+        if control.head_commit_id != head_commit_id {
+            return Ok(None);
+        }
+        TrackedHeadContext::new()
+            .reader(read)
+            .working_diff_if_control_current(branch_id, control, request)
+            .await
     }
 
     /// Creates a commit-graph reader scoped to this write transaction.

--- a/packages/engine/tests/integration/sql/checkpoint.rs
+++ b/packages/engine/tests/integration/sql/checkpoint.rs
@@ -225,6 +225,80 @@ simulation_test!(
 );
 
 simulation_test!(
+    working_change_reports_net_tracked_adds_and_removals_after_a_revert,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("workspace session should open"),
+            &engine,
+        );
+
+        for (key, value) in [("working-removed", "old"), ("working-reverted", "old")] {
+            session
+                .execute(
+                    &format!("INSERT INTO lix_key_value (key, value) VALUES ('{key}', '{value}')"),
+                    &[],
+                )
+                .await
+                .expect("tracked baseline insert should succeed");
+        }
+        session
+            .create_checkpoint()
+            .await
+            .expect("baseline checkpoint should succeed");
+
+        for sql in [
+            "UPDATE lix_key_value SET value = 'new' WHERE key = 'working-reverted'",
+            "UPDATE lix_key_value SET value = 'old' WHERE key = 'working-reverted'",
+            "DELETE FROM lix_key_value WHERE key = 'working-removed'",
+            "INSERT INTO lix_key_value (key, value) VALUES ('working-added', 'new')",
+        ] {
+            session
+                .execute(sql, &[])
+                .await
+                .expect("tracked working change should succeed");
+        }
+
+        assert_eq!(
+            select_rows(
+                &session,
+                "SELECT entity_pk, change_kind \
+                 FROM lix_working_change \
+                 WHERE schema_key = 'lix_key_value' \
+                 ORDER BY entity_pk",
+            )
+            .await,
+            vec![
+                vec![
+                    Value::Json(json!(["working-added"])),
+                    Value::Text("added".to_string()),
+                ],
+                vec![
+                    Value::Json(json!(["working-removed"])),
+                    Value::Text("removed".to_string()),
+                ],
+            ],
+            "the direct working-diff path must collapse a payload revert",
+        );
+        assert_eq!(
+            select_rows(
+                &session,
+                "SELECT change_kind \
+                 FROM lix_working_change \
+                 WHERE schema_key = 'lix_key_value' \
+                   AND entity_pk = lix_json('[\"working-removed\"]')",
+            )
+            .await,
+            vec![vec![Value::Text("removed".to_string())]],
+            "an exact PK filter must preserve the same net diff",
+        );
+    }
+);
+
+simulation_test!(
     filesystem_working_change_surfaces_compose_paths_and_directory_moves,
     |sim| async move {
         let engine = sim.boot_engine().await;


### PR DESCRIPTION
## What changed

Moves populated `lix_working_change` off the historical replay path.

- v6 serving-head groups now carry an immutable first-before baseline for the active checkpoint epoch: clean, absent, or present.
- A sparse, group-only working-diff index enumerates ever-dirty groups. The authoritative current row remains in the serving-head group.
- The head marker atomically binds the active checkpoint epoch; a count + BLAKE3-XOR coverage proof prevents a partial index from returning a partial diff.
- Normal `lix_working_change` and checkpoint compaction read that direct plane first. Missing, stale, malformed, or incomplete accelerator state falls back to canonical historical replay.
- No-op checkpoints reset the epoch in O(1); background checkpoint GC reclaims stale/malformed auxiliary records.
- The repository protocol is now `tracked-direct-plane.v8`. This is an intentional storage hard cut: predecessor layouts fail closed and repositories must be recreated.

The public SQL/API does not change. Untracked remains a separate sidecar and is not consulted by this tracked working-diff path. Explicit file-ID reads still use the unchanged member projection, so they remain one member-key point read rather than sibling-group decoding.

## Benchmark

New public-SQL RocksDB harness: 10k baseline rows, checkpoint, then 10-row `execute_batch` transactions. Measurements are CPU-pinned (`taskset -c 0`), warmed, and query `lix_working_change`.

| Populated interval | Historical replay p50 | Direct-head p50 | Change |
| --- | ---: | ---: | ---: |
| 1,000 commits × 10 repeated identities | 10.391 ms | 0.602 ms | 94.2% lower / 17.3× faster |
| 100 commits × 10 disjoint identities | 92.002 ms | 3.745 ms | 95.9% lower / 24.6× faster |

For the full 10k-disjoint-identity fixture, the direct path is 37.900 ms p50; no historical full-scale timing is claimed because the prior generic run was interrupted before completion.

A sampled full-10k profile no longer contains the commit-interval/delta replay route. The remaining direct-path cost is sparse-index scanning, one RocksDB MultiGet of current head groups, group decoding, and SQL/Arrow result materialization (including the benchmark's requested ORDER BY).

This is a Lix-specific versioned-diff operation, so standalone SQLite has no equivalent working-diff baseline. The normal CRUD scorecard remains Lix + RocksDB versus standalone SQLite.

## Correctness and safety

- Added integration coverage for added, removed, and payload-reverted tracked rows plus exact-PK filtering.
- Covers no-op checkpoint restart, stale epoch non-promotion, incomplete coverage fallback, malformed auxiliary GC, marker-bound scope GC, and predecessor-format rejection before tracked-head decoding.
- Explicit file-ID projection and Untracked sidecar compatibility tests remain green.

## Validation

- `cargo fmt --all --check`
- `cargo check -p lix_engine --lib`
- `cargo test -p lix_engine engine::tests --lib`
- `cargo test -p lix_engine tracked_head --lib`
- `cargo test -p lix_engine stale_working_diff_epoch_is_not_promoted_into_the_next_head --lib`
- `cargo test -p lix_engine --test integration sql::checkpoint -- --nocapture`
- all-simulations binaries: 1,302 unit tests and 760 integration tests passed (6 and 2 ignored respectively).