### PR TITLE
perf: reuse scanned descendant deltas in historical diffs

### DIFF
--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -91,7 +91,7 @@ required-features = ["storage-benches"]
 name = "tracked_working_diff"
 path = "benches/tracked_working_diff.rs"
 harness = false
-required-features = ["rocksdb"]
+required-features = ["storage-benches"]
 
 [[bench]]
 name = "slatedb_file_api"

--- a/packages/engine-benchmarks/benches/tracked_working_diff.rs
+++ b/packages/engine-benchmarks/benches/tracked_working_diff.rs
@@ -7,9 +7,9 @@
 //! working set.
 //!
 //! ```text
-//! cargo bench -p lix_engine_benchmarks --bench tracked_working_diff -- \
+//! cargo bench -p lix_engine_benchmarks --features storage-benches --bench tracked_working_diff -- \
 //!   setup repeated /tmp/lix-working-diff-repeated 10000 1000 10
-//! cargo bench -p lix_engine_benchmarks --bench tracked_working_diff -- \
+//! cargo bench -p lix_engine_benchmarks --features storage-benches --bench tracked_working_diff -- \
 //!   measure /tmp/lix-working-diff-repeated 11
 //! ```
 //!
@@ -20,6 +20,8 @@ use std::fmt::Write as _;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
+use lix_engine::storage_adapter::StorageAdapter;
+use lix_engine::storage_bench::diff_tracked_commits_for_bench;
 use lix_engine::{Engine, ExecuteBatchStatement, Storage, Value};
 use lix_rocksdb_storage::RocksDB;
 
@@ -103,6 +105,27 @@ fn main() {
             );
             runtime.block_on(measure(Path::new(path), repetitions));
         }
+        "measure-history" => {
+            let Some(base_commit_id) = args.get(3) else {
+                print_usage();
+                return;
+            };
+            let Some(head_commit_id) = args.get(4) else {
+                print_usage();
+                return;
+            };
+            let repetitions = parse_usize(
+                args.get(5),
+                DEFAULT_MEASURE_REPETITIONS,
+                "measurement repetitions",
+            );
+            runtime.block_on(measure_history(
+                Path::new(path),
+                base_commit_id,
+                head_commit_id,
+                repetitions,
+            ));
+        }
         "checkpoint" => runtime.block_on(checkpoint(Path::new(path))),
         _ => print_usage(),
     }
@@ -113,6 +136,7 @@ fn print_usage() {
         "usage:\n  tracked_working_diff setup <directory> <repeated|disjoint> \
          [rows] [commits] [changes-per-commit]\n  \
          tracked_working_diff measure <directory> [repetitions]\n  \
+         tracked_working_diff measure-history <directory> <base-commit-id> <head-commit-id> [repetitions]\n  \
          tracked_working_diff checkpoint <directory>"
     );
 }
@@ -161,7 +185,7 @@ async fn setup(
     seed_rows(&session, row_count).await;
     let seed_elapsed = seed_start.elapsed();
     let initial_checkpoint_start = Instant::now();
-    session
+    let initial_checkpoint = session
         .create_checkpoint()
         .await
         .expect("create tracked-working-diff initial checkpoint");
@@ -178,14 +202,25 @@ async fn setup(
         working_changes, expected_changes,
         "populated working-diff fixture must expose every expected identity"
     );
+    let branch_id = session
+        .active_branch_id()
+        .await
+        .expect("load tracked-working-diff branch id");
+    let head_commit_id = engine
+        .load_branch_head_commit_id(&branch_id)
+        .await
+        .expect("load tracked-working-diff branch head")
+        .expect("tracked-working-diff fixture must have a branch head");
     drop(session);
     drop(engine);
     storage.flush().expect("flush tracked-working-diff RocksDB");
     println!(
         "tracked_working_diff setup backend=rocksdb shape={} rows={row_count} commits={commit_count} \
          changes_per_commit={changes_per_commit} working_changes={working_changes} \
-         seed_ms={:.3} initial_checkpoint_ms={:.3} writes_ms={:.3}",
+         base_commit_id={} head_commit_id={} seed_ms={:.3} initial_checkpoint_ms={:.3} writes_ms={:.3}",
         shape_name(shape),
+        initial_checkpoint.commit_id,
+        head_commit_id,
         millis(seed_elapsed),
         millis(initial_checkpoint_elapsed),
         millis(writes_elapsed),
@@ -222,6 +257,66 @@ async fn measure(path: &Path, repetitions: usize) {
     sorted.sort_unstable();
     println!(
         "tracked_working_diff measure backend=rocksdb working_changes={expected_changes} \
+         repetitions={repetitions} p50_ms={:.3} mean_ms={:.3} min_ms={:.3} max_ms={:.3}",
+        millis(sorted[sorted.len() / 2]),
+        mean_millis(&latencies),
+        millis(sorted[0]),
+        millis(*sorted.last().expect("measurement samples are non-empty")),
+    );
+}
+
+/// Measures the cold historical diff path rather than `lix_working_change`'s
+/// serving-head accelerator. The setup checkpoint is a durable root and the
+/// later ordinary commits are rootless, which makes this a populated
+/// first-parent replay interval.
+async fn measure_history(
+    path: &Path,
+    base_commit_id: &str,
+    head_commit_id: &str,
+    repetitions: usize,
+) {
+    assert!(path.exists(), "fixture {} does not exist", path.display());
+    let storage = RocksDB::open(path).expect("open tracked-working-diff RocksDB");
+    let adapter = StorageAdapter::new(storage.clone());
+    let engine = Engine::new(storage)
+        .await
+        .expect("open tracked-working-diff engine");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("open tracked-working-diff session");
+    let expected_changes = working_change_count(&session).await;
+    assert!(
+        expected_changes > 0,
+        "fixture has no populated working changes"
+    );
+
+    let warm = diff_tracked_commits_for_bench(&adapter, base_commit_id, head_commit_id)
+        .await
+        .expect("warm historical tracked diff");
+    assert_eq!(warm.entries, expected_changes);
+    assert!(
+        warm.left_has_durable_root && !warm.right_has_durable_root,
+        "measure-history requires checkpoint -> rootless first-parent replay"
+    );
+
+    let mut latencies = Vec::with_capacity(repetitions);
+    for _ in 0..repetitions {
+        let start = Instant::now();
+        let result = diff_tracked_commits_for_bench(&adapter, base_commit_id, head_commit_id)
+            .await
+            .expect("measure historical tracked diff");
+        latencies.push(start.elapsed());
+        assert_eq!(result.entries, expected_changes);
+        assert!(
+            result.left_has_durable_root && !result.right_has_durable_root,
+            "historical measurement must remain checkpoint -> rootless"
+        );
+    }
+    let mut sorted = latencies.clone();
+    sorted.sort_unstable();
+    println!(
+        "tracked_working_diff measure-history backend=rocksdb working_changes={expected_changes} \
          repetitions={repetitions} p50_ms={:.3} mean_ms={:.3} min_ms={:.3} max_ms={:.3}",
         millis(sorted[sorted.len() / 2]),
         mean_millis(&latencies),

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -4,8 +4,9 @@ use bytes::Bytes;
 
 use crate::storage_adapter::Storage;
 use crate::storage_adapter::{
-    ScanPlan, StorageAdapterRead, StorageCoreProjection, StoragePrefix, StorageProjectedValue,
-    StorageScanOptions, StorageWriteOptions, StorageWriteSet, StorageWriteSetError,
+    ScanPlan, StorageAdapter, StorageAdapterRead, StorageCoreProjection, StoragePrefix,
+    StorageProjectedValue, StorageScanOptions, StorageWriteOptions, StorageWriteSet,
+    StorageWriteSetError,
 };
 use crate::{ReadOptions, WriteOptions};
 
@@ -24,6 +25,51 @@ pub struct BinaryCasWriteAccounting {
     pub chunk_lookup_miss_count: u64,
     pub chunk_lookup_elapsed_ns: u64,
     pub transaction_duplicate_chunk_count: u64,
+}
+
+/// Result of one benchmark-only historical tracked-state diff.
+///
+/// The durable-root flags prove which physical diff path the benchmark used:
+/// the intended populated case is a checkpoint on the left and a rootless
+/// ordinary commit on the right.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TrackedHistoricalDiffBenchResult {
+    pub entries: usize,
+    pub left_has_durable_root: bool,
+    pub right_has_durable_root: bool,
+}
+
+/// Diffs two tracked commits through the production historical reader.
+///
+/// This is compiled only with `storage-benches`; it intentionally provides a
+/// narrow measurement bridge without expanding the normal engine API.
+#[inline(never)]
+pub async fn diff_tracked_commits_for_bench<StorageImpl>(
+    storage: &StorageAdapter<StorageImpl>,
+    left_commit_id: &str,
+    right_commit_id: &str,
+) -> Result<TrackedHistoricalDiffBenchResult, crate::LixError>
+where
+    StorageImpl: Storage,
+{
+    let read = storage.begin_read(ReadOptions::default()).await?;
+    let mut reader = crate::tracked_state::TrackedStateContext::new().reader(read);
+    let left_has_durable_root = reader.has_durable_commit_root(left_commit_id).await?;
+    let right_has_durable_root = reader.has_durable_commit_root(right_commit_id).await?;
+    let entries = reader
+        .diff_commits(
+            left_commit_id,
+            right_commit_id,
+            &crate::tracked_state::TrackedStateDiffRequest::default(),
+        )
+        .await?
+        .entries
+        .len();
+    Ok(TrackedHistoricalDiffBenchResult {
+        entries,
+        left_has_durable_root,
+        right_has_durable_root,
+    })
 }
 
 pub fn reset_binary_cas_write_accounting() {
@@ -47,7 +93,7 @@ pub fn binary_cas_write_accounting() -> BinaryCasWriteAccounting {
 /// storage benchmarks so they can isolate CAS layout costs from SQL planning,
 /// validation, tracked state, and changelog work.
 pub async fn write_binary_cas_for_bench<StorageImpl>(
-    storage: &crate::storage_adapter::StorageAdapter<StorageImpl>,
+    storage: &StorageAdapter<StorageImpl>,
     bytes: &[u8],
 ) -> Result<String, crate::LixError>
 where
@@ -68,7 +114,7 @@ where
 /// Reads one payload through the production binary CAS. See
 /// [`write_binary_cas_for_bench`] for why this feature-gated helper exists.
 pub async fn read_binary_cas_for_bench<StorageImpl>(
-    storage: &crate::storage_adapter::StorageAdapter<StorageImpl>,
+    storage: &StorageAdapter<StorageImpl>,
     hash_hex: &str,
 ) -> Result<Option<Vec<u8>>, crate::LixError>
 where
@@ -118,7 +164,7 @@ pub struct StorageLayoutAccounting {
 }
 
 pub(crate) async fn commit_write_set_for_bench<StorageImpl>(
-    storage: &crate::storage_adapter::StorageAdapter<StorageImpl>,
+    storage: &StorageAdapter<StorageImpl>,
     writes: StorageWriteSet,
 ) -> Result<crate::storage_adapter::StorageWriteSetStats, StorageWriteSetError>
 where

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -962,36 +962,37 @@ where
         else {
             return Ok(None);
         };
-        let mut keys = BTreeSet::new();
+        // The interval is ordered descendant -> ancestor. Commit deltas carry
+        // absolute row state, so the first value we see for an identity is
+        // exactly its value at the descendant endpoint. Retain it here rather
+        // than replaying the entire interval a second time to rediscover it.
+        let mut latest_after_by_key = BTreeMap::new();
         for commit_id in interval {
-            for (key, _) in self
+            for (key, value) in self
                 .scan_replayed_commit_delta_values(commit_id, &request.schema_keys)
                 .await?
             {
                 if request.matches_key(&key) {
-                    keys.insert(key);
+                    latest_after_by_key.entry(key).or_insert(value);
                 }
             }
         }
-        let keys = keys.into_iter().collect::<Vec<_>>();
+        let keys = latest_after_by_key.keys().cloned().collect::<Vec<_>>();
         if keys.is_empty() {
             return Ok(Some(Vec::new()));
         }
         let before = self
             .replay_index_values_for_keys_at_commit(ancestor_commit_id, &keys)
             .await?;
-        let after = self
-            .replay_index_values_for_keys_at_commit(descendant_commit_id, &keys)
-            .await?;
         Ok(Some(
-            keys.into_iter()
+            latest_after_by_key
+                .into_iter()
                 .zip(before)
-                .zip(after)
-                .filter_map(|((key, before), after)| {
-                    (before != after).then_some(
+                .filter_map(|((key, after), before)| {
+                    (before.as_ref() != Some(&after)).then_some(
                         crate::tracked_state::types::TrackedStateTreeDiffEntry {
                             before: before.map(|value| (key.clone(), value)),
-                            after: after.map(|value| (key, value)),
+                            after: Some((key, after)),
                         },
                     )
                 })
@@ -1350,9 +1351,10 @@ where
     /// Scans one commit's packed deltas and promotes the decoded values into
     /// the existing identity cache. A diff first discovers its changed keys by
     /// scanning the first-parent interval, then resolves those same keys at
-    /// both endpoints. Keeping the scan's decoded values avoids reopening the
-    /// same packed segment for the endpoint replay while preserving the
-    /// cache's identity-routed semantics.
+    /// the ancestor endpoint. The newest scanned delta is already the
+    /// descendant value, so retaining decoded entries avoids a second full
+    /// descendant replay while preserving the cache's identity-routed
+    /// semantics.
     async fn scan_replayed_commit_delta_values(
         &mut self,
         commit_id: CommitId,

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -2574,6 +2574,104 @@ mod tests {
             .await
             .expect("second rootless commit should persist");
 
+        let mut third = tracked_global_row("rootless-third-change");
+        third.commit_id = Some(commit_id("rootless-third-commit"));
+        third.created_at = ts("2026-01-03T00:00:00Z");
+        third.updated_at = third.created_at;
+        third.snapshot = Some(
+            crate::transaction::types::stage_json_from_value(
+                crate::transaction::types::TransactionJson::from_value_for_test(
+                    serde_json::json!({ "value": 3 }),
+                ),
+                "third rootless tracked row snapshot",
+            )
+            .expect("third snapshot should stage"),
+        );
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("third commit read should open");
+        let (writes, _) = commit_prepared_writes(
+            &binary_cas,
+            &branch_ctx,
+            &LiveStateIndexContext::new(),
+            None,
+            &mut read,
+            PreparedWriteSet {
+                insert_identities: BTreeMap::new(),
+                state_rows: vec![third],
+                commit_change_refs_by_branch: BTreeMap::from([(
+                    GLOBAL_BRANCH_ID.to_string(),
+                    change_refs_with(
+                        ["rootless-third-change"],
+                        "rootless-third-commit",
+                        "rootless-third-commit-change",
+                        "rootless-third-branch-ref-change",
+                    ),
+                )]),
+                first_commit_parent_override_by_branch: BTreeMap::new(),
+                checkpoint_publications: Vec::new(),
+                extra_commit_parents_by_branch: BTreeMap::new(),
+                file_data_writes: Vec::new(),
+            },
+        )
+        .await
+        .expect("third rootless commit should stage");
+        assert!(
+            !writes.has_mutations_in_space(TRACKED_STATE_TREE_CHUNK_SPACE)
+                && !writes.has_mutations_in_space(TRACKED_STATE_COMMIT_ROOT_SPACE),
+            "serial ordinary commit must remain rootless"
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("third rootless commit should persist");
+
+        let mut deleted = tracked_global_row("rootless-delete-change");
+        deleted.commit_id = Some(commit_id("rootless-delete-commit"));
+        deleted.created_at = ts("2026-01-04T00:00:00Z");
+        deleted.updated_at = deleted.created_at;
+        deleted.snapshot = None;
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("delete commit read should open");
+        let (writes, _) = commit_prepared_writes(
+            &binary_cas,
+            &branch_ctx,
+            &LiveStateIndexContext::new(),
+            None,
+            &mut read,
+            PreparedWriteSet {
+                insert_identities: BTreeMap::new(),
+                state_rows: vec![deleted],
+                commit_change_refs_by_branch: BTreeMap::from([(
+                    GLOBAL_BRANCH_ID.to_string(),
+                    change_refs_with(
+                        ["rootless-delete-change"],
+                        "rootless-delete-commit",
+                        "rootless-delete-commit-change",
+                        "rootless-delete-branch-ref-change",
+                    ),
+                )]),
+                first_commit_parent_override_by_branch: BTreeMap::new(),
+                checkpoint_publications: Vec::new(),
+                extra_commit_parents_by_branch: BTreeMap::new(),
+                file_data_writes: Vec::new(),
+            },
+        )
+        .await
+        .expect("rootless delete commit should stage");
+        assert!(
+            !writes.has_mutations_in_space(TRACKED_STATE_TREE_CHUNK_SPACE)
+                && !writes.has_mutations_in_space(TRACKED_STATE_COMMIT_ROOT_SPACE),
+            "serial delete commit must remain rootless"
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("rootless delete commit should persist");
+
         let mut reader = TrackedStateContext::new().reader(
             storage
                 .begin_read(StorageReadOptions::default())
@@ -2600,10 +2698,20 @@ mod tests {
                 && row.created_at == "2026-01-01T00:00:00.000Z"
                 && row.snapshot_content.as_deref() == Some("{\"value\":2}")
         ));
+        let third_rows = reader
+            .scan_rows_at_commit(&commit_id_text("rootless-third-commit"), &request)
+            .await
+            .expect("third rootless commit should replay");
+        assert!(matches!(
+            third_rows.as_slice(),
+            [row] if row.change_id == change_id("rootless-third-change")
+                && row.created_at == "2026-01-01T00:00:00.000Z"
+                && row.snapshot_content.as_deref() == Some("{\"value\":3}")
+        ));
         let diff = reader
             .diff_commits(
                 &commit_id_text("rootless-first-commit"),
-                &commit_id_text("rootless-second-commit"),
+                &commit_id_text("rootless-third-commit"),
                 &crate::tracked_state::TrackedStateDiffRequest::default(),
             )
             .await
@@ -2611,6 +2719,66 @@ mod tests {
         assert!(matches!(
             diff.entries.as_slice(),
             [entry] if entry.kind == crate::tracked_state::TrackedStateDiffKind::Modified
+                && entry.after.as_ref().map(|row| row.change_id)
+                    == Some(change_id("rootless-third-change"))
+        ));
+        let reverse_diff = reader
+            .diff_commits(
+                &commit_id_text("rootless-third-commit"),
+                &commit_id_text("rootless-first-commit"),
+                &crate::tracked_state::TrackedStateDiffRequest::default(),
+            )
+            .await
+            .expect("reverse rootless commits should diff from replayed state");
+        assert!(matches!(
+            reverse_diff.entries.as_slice(),
+            [entry] if entry.kind == crate::tracked_state::TrackedStateDiffKind::Modified
+                && entry.before.as_ref().map(|row| row.change_id)
+                    == Some(change_id("rootless-third-change"))
+                && entry.after.as_ref().map(|row| row.change_id)
+                    == Some(change_id("rootless-first-change"))
+        ));
+        let deleted_rows = reader
+            .scan_rows_at_commit(&commit_id_text("rootless-delete-commit"), &request)
+            .await
+            .expect("delete rootless commit should replay");
+        assert!(deleted_rows.is_empty());
+        let delete_diff = reader
+            .diff_commits(
+                &commit_id_text("rootless-first-commit"),
+                &commit_id_text("rootless-delete-commit"),
+                &crate::tracked_state::TrackedStateDiffRequest::default(),
+            )
+            .await
+            .expect("rootless delete commits should diff from replayed state");
+        assert!(
+            matches!(
+                delete_diff.entries.as_slice(),
+                [entry] if entry.kind == crate::tracked_state::TrackedStateDiffKind::Removed
+                    && entry.before.as_ref().map(|row| row.change_id)
+                        == Some(change_id("rootless-first-change"))
+                    && entry.after.as_ref().is_some_and(|row|
+                        row.deleted && row.change_id == change_id("rootless-delete-change")
+                    )
+            ),
+            "unexpected rootless delete diff: {delete_diff:#?}"
+        );
+        let reverse_delete_diff = reader
+            .diff_commits(
+                &commit_id_text("rootless-delete-commit"),
+                &commit_id_text("rootless-first-commit"),
+                &crate::tracked_state::TrackedStateDiffRequest::default(),
+            )
+            .await
+            .expect("reverse rootless delete commits should diff from replayed state");
+        assert!(matches!(
+            reverse_delete_diff.entries.as_slice(),
+            [entry] if entry.kind == crate::tracked_state::TrackedStateDiffKind::Added
+                && entry.before.as_ref().is_some_and(|row|
+                    row.deleted && row.change_id == change_id("rootless-delete-change")
+                )
+                && entry.after.as_ref().map(|row| row.change_id)
+                    == Some(change_id("rootless-first-change"))
         ));
     }
 


### PR DESCRIPTION
## What changed

This is stacked on `codex/packed-commit-deltas-v2` (PR #815).

For a rootless first-parent historical diff, the immutable deltas are already scanned descendant → ancestor. Each delta carries absolute tracked-row state, so the first value encountered for an identity is its exact descendant-endpoint state. The diff now retains that value during the scan and replays only the ancestor endpoint.

The old path scanned the interval to find changed keys, then replayed every changed identity at both endpoints. On long disjoint histories, the second descendant replay repeated the expensive work and filled the replay cache with negative entries.

The benchmark harness adds `tracked_working_diff measure-history`, which verifies that it is measuring a durable checkpoint → rootless head interval and validates the returned entry count against the public working-change query.

## Performance

Release binaries, pinned to CPU 2 with `taskset -c 2`; 31 samples per run. The baseline is the immediately preceding benchmark-only commit, so the harness is identical.

| Rootless history shape | Baseline p50 | Candidate p50 | Change |
| --- | ---: | ---: | ---: |
| 10,000 disjoint changed identities across 20 commits | 201.283 ms / 191.860 ms | 79.266 ms / 70.469 ms | **60–63% faster** |
| 500 repeatedly changed identities across the same 20 × 500 delta rows | 10.113 ms | 9.776 ms | no regression (3.3% faster) |

The disjoint case is the fundamental former hotspot: 10,000 changed identities caused a redundant descendant replay for all 10,000 keys. The repeated-key control confirms the optimization does not trade a broad scan cost for a regression when the number of resolved identities is small.

## Correctness

- The map uses `entry(key).or_insert(value)`, preserving the newest value while walking descendant → ancestor.
- The regression test stages three rootless updates for one identity, verifies forward and reverse orientation, then stages a real rootless tombstone and verifies both forward removal and reverse addition semantics.
- Filtering and first-parent/merge fallback behavior are unchanged.
- No public API or storage layout changes; the benchmark helper is gated behind `storage-benches`.

## Validation

- `cargo test -p lix_engine --features all-simulations`
- `cargo test -p lix_engine --features storage-benches rootless_serial_history_replays_scan_and_diff --lib`
- `cargo clippy -p lix_engine --features storage-benches --lib -- -D warnings`
- `cargo bench -p lix_engine_benchmarks --features storage-benches --bench tracked_working_diff --no-run`
- `cargo fmt --all -- --check`
- `git diff --check`
