### PR TITLE
perf: return broad tracked reads without Arrow

### DIFF
--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -401,7 +401,7 @@ mod tests {
         StorageProjectedValue, StorageScanOptions, StorageSpace, StorageSpaceId, StorageValue,
     };
 
-    async fn register_json_pointer_schema(session: &SessionContext<Memory>) {
+    async fn register_json_pointer_schema_in_scope(session: &SessionContext<Memory>, global: bool) {
         let schema = json!({
             "x-lix-key": "json_pointer",
             "x-lix-primary-key": ["/path"],
@@ -418,14 +418,25 @@ mod tests {
         assert_eq!(
             session
                 .execute(
-                    "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
-                    &[crate::Value::Text(schema.to_string())],
+                    "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), $2, false)",
+                    &[
+                        crate::Value::Text(schema.to_string()),
+                        crate::Value::Boolean(global),
+                    ],
                 )
                 .await
                 .expect("register json_pointer schema")
                 .rows_affected(),
             1
         );
+    }
+
+    async fn register_json_pointer_schema(session: &SessionContext<Memory>) {
+        register_json_pointer_schema_in_scope(session, false).await;
+    }
+
+    async fn register_global_json_pointer_schema(session: &SessionContext<Memory>) {
+        register_json_pointer_schema_in_scope(session, true).await;
     }
 
     #[tokio::test]
@@ -684,6 +695,210 @@ mod tests {
                 .get::<serde_json::Value>("value")
                 .expect("tracked row value"),
             json!({"n": 2})
+        );
+    }
+
+    #[tokio::test]
+    async fn tracked_entity_public_fast_path_preserves_canonical_primary_key_order() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let engine = Engine::new(storage)
+            .await
+            .expect("initialized engine should open");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("workspace session should open");
+        register_json_pointer_schema(&session).await;
+
+        // These values exercise the order-preserving tracked-head codec's
+        // edge cases: empty strings, embedded NULs, control bytes, and UTF-8.
+        // The no-LIMIT single-PK query below is the native public-result
+        // shape; the two-key ORDER BY forces the ordinary SQL executor and is
+        // the semantic control.
+        let paths = ["", "\0", "a", "a\0", "a\u{1}", "z", "é"];
+        for (index, path) in paths.iter().enumerate() {
+            assert_eq!(
+                session
+                    .execute(
+                        "INSERT INTO json_pointer (path, value) VALUES ($1, lix_json($2))",
+                        &[
+                            crate::Value::Text((*path).to_string()),
+                            crate::Value::Text(json!({"index": index}).to_string()),
+                        ],
+                    )
+                    .await
+                    .expect("write ordered tracked row")
+                    .rows_affected(),
+                1
+            );
+        }
+
+        let native_shape = session
+            .execute("SELECT path, value FROM json_pointer ORDER BY path", &[])
+            .await
+            .expect("native public tracked read should execute");
+        let generic_control = session
+            .execute(
+                "SELECT path, value FROM json_pointer ORDER BY path, path",
+                &[],
+            )
+            .await
+            .expect("generic ordering control should execute");
+        let native_values = native_shape
+            .rows()
+            .iter()
+            .map(|row| row.values().to_vec())
+            .collect::<Vec<_>>();
+        let generic_values = generic_control
+            .rows()
+            .iter()
+            .map(|row| row.values().to_vec())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            native_values, generic_values,
+            "the direct result must retain the normal SQL order and values"
+        );
+        assert_eq!(
+            native_shape
+                .rows()
+                .iter()
+                .map(|row| row.get::<String>("path").expect("tracked row path"))
+                .collect::<Vec<_>>(),
+            paths,
+            "the raw tracked-head scan is ordered by the visible string PK"
+        );
+    }
+
+    #[tokio::test]
+    async fn tracked_entity_public_fast_path_falls_back_for_staged_transaction_rows() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let engine = Engine::new(storage)
+            .await
+            .expect("initialized engine should open");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("workspace session should open");
+        register_json_pointer_schema(&session).await;
+        session
+            .execute(
+                "INSERT INTO json_pointer (path, value) VALUES ('/committed', lix_json('{\"source\":\"tracked\"}'))",
+                &[],
+            )
+            .await
+            .expect("write committed tracked row");
+
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("transaction should open");
+        transaction
+            .execute(
+                "INSERT INTO json_pointer (path, value) VALUES ('/staged', lix_json('{\"source\":\"staged\"}'))",
+                &[],
+            )
+            .await
+            .expect("stage tracked row");
+        let rows = transaction
+            .execute("SELECT path, value FROM json_pointer ORDER BY path", &[])
+            .await
+            .expect("transaction read must retain its staged overlay");
+        assert_eq!(
+            rows.rows()
+                .iter()
+                .map(|row| row.get::<String>("path").expect("row path"))
+                .collect::<Vec<_>>(),
+            ["/committed", "/staged"],
+            "transaction contexts have no raw snapshot capability and must use the generic overlay"
+        );
+        transaction
+            .rollback()
+            .await
+            .expect("transaction rollback should succeed");
+    }
+
+    #[tokio::test]
+    async fn tracked_entity_public_fast_path_falls_back_for_untracked_entity_rows() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let engine = Engine::new(storage)
+            .await
+            .expect("initialized engine should open");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("workspace session should open");
+        register_json_pointer_schema(&session).await;
+        session
+            .execute(
+                "INSERT INTO json_pointer (path, value, lixcol_untracked) \
+                 VALUES ('/untracked', lix_json('{\"source\":\"untracked\"}'), true)",
+                &[],
+            )
+            .await
+            .expect("write untracked entity row");
+
+        let rows = session
+            .execute("SELECT path, value FROM json_pointer ORDER BY path", &[])
+            .await
+            .expect("mixed tracked/untracked read should execute");
+        assert_eq!(
+            rows.rows()
+                .iter()
+                .map(|row| row.get::<String>("path").expect("untracked path"))
+                .collect::<Vec<_>>(),
+            ["/untracked"],
+            "normal SQL must retain the merged tracked/untracked visibility path"
+        );
+    }
+
+    #[tokio::test]
+    async fn tracked_entity_public_fast_path_falls_back_for_global_tracked_rows() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let engine = Engine::new(storage)
+            .await
+            .expect("initialized engine should open");
+        let global_session = engine
+            .open_session(GLOBAL_BRANCH_ID)
+            .await
+            .expect("global session should open");
+        register_global_json_pointer_schema(&global_session).await;
+        global_session
+            .execute(
+                "INSERT INTO json_pointer (path, value, lixcol_global, lixcol_untracked) \
+                 VALUES ('/global', lix_json('{\"source\":\"global\"}'), true, false)",
+                &[],
+            )
+            .await
+            .expect("write global tracked entity row");
+
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("workspace session should open");
+        register_json_pointer_schema(&session).await;
+        let rows = session
+            .execute("SELECT path, value FROM json_pointer ORDER BY path", &[])
+            .await
+            .expect("global-overlaid tracked read should execute");
+        assert_eq!(
+            rows.rows()
+                .iter()
+                .map(|row| row.get::<String>("path").expect("global path"))
+                .collect::<Vec<_>>(),
+            ["/global"],
+            "a global tracked overlay must retain the general visibility resolver"
         );
     }
 

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -1529,7 +1529,11 @@ async fn scan_entries(
 
 /// Broad entity projection consumes only snapshot payloads. Scan the fixed
 /// schema prefix and retain member bytes without allocating logical row
-/// identities or intermediate JSON strings.
+/// identities or intermediate JSON strings. `schema_group_prefix` uses the
+/// order-preserving entity-PK codec, so entries are returned in ascending
+/// logical primary-key order. Every live member is retained; file-backed
+/// siblings for one primary key are adjacent but intentionally have no extra
+/// tie ordering contract.
 async fn scan_entity_snapshots(
     store: &(impl StorageAdapterRead + ?Sized),
     branch_id: &str,

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -640,8 +640,8 @@ where
         Arc::new(self.live_state.reader(self.read_store.clone())) as Arc<dyn LiveStateReader>
     }
 
-    fn entity_batch_reader(&self) -> Option<Arc<dyn crate::sql2::EntityBatchReader>> {
-        Some(Arc::new(crate::sql2::TrackedEntityBatchReader::new(
+    fn entity_snapshot_reader(&self) -> Option<Arc<dyn crate::sql2::EntitySnapshotReader>> {
+        Some(Arc::new(crate::sql2::TrackedEntitySnapshotReader::new(
             Arc::clone(&self.live_state),
             self.read_store.clone(),
         )))

--- a/packages/engine/src/sql2/context.rs
+++ b/packages/engine/src/sql2/context.rs
@@ -64,11 +64,11 @@ pub(crate) trait SqlExecutionContext: Sync {
 
     fn active_branch_id(&self) -> &str;
     fn live_state(&self) -> Arc<dyn LiveStateReader>;
-    /// Supplies the committed tracked-head entity serving capability when the
+    /// Supplies the committed tracked-head entity snapshot capability when the
     /// read context can prove it is scoped to one immutable storage snapshot.
     /// Generic and transaction contexts intentionally retain the default
     /// materialized-row path.
-    fn entity_batch_reader(&self) -> Option<Arc<dyn super::EntityBatchReader>> {
+    fn entity_snapshot_reader(&self) -> Option<Arc<dyn super::EntitySnapshotReader>> {
         None
     }
     fn filesystem_path_index(&self) -> Arc<dyn FilesystemPathIndexReader> {

--- a/packages/engine/src/sql2/entity_batch.rs
+++ b/packages/engine/src/sql2/entity_batch.rs
@@ -1,100 +1,75 @@
-//! Direct tracked-head serving for broad SQL entity scans.
+//! Direct tracked-head snapshot serving for broad SQL entity scans.
 //!
 //! The generic live-state reader intentionally exposes fully materialized
-//! engine rows. SQL entity projection has a narrower need: it can decode the
-//! durable tracked snapshot bytes straight into Arrow. Keeping that capability
-//! here prevents Arrow types from leaking into the engine's general read
-//! contract and leaves every unsupported shape on the established row path.
+//! engine rows. The committed tracked-head has a narrower, private capability:
+//! it can serve durable snapshot bytes directly. Arrow providers and native
+//! public-result reads consume those same bytes, keeping visibility proof in
+//! one place and leaving every unsupported shape on the established row path.
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::common::{DataFusionError, Result};
+use bytes::Bytes;
 
+use crate::LixError;
 use crate::live_state::{LiveStateContext, LiveStateRowFilter, LiveStateScanRequest};
-use crate::sql2::catalog::EntitySurfaceSpec;
-use crate::sql2::entity_projection::{
-    EntityProjectionDecoder, entity_projection_error_to_datafusion_error,
-};
-use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::storage_adapter::StorageAdapterRead;
-
-/// One entity scan that may be served directly from durable tracked-head
-/// bytes. It owns every planning input because providers outlive the SQL
-/// planner that constructed them.
-#[derive(Clone)]
-pub(crate) struct EntityBatchRequest {
-    pub(crate) spec: Arc<EntitySurfaceSpec>,
-    pub(crate) schema: datafusion::arrow::datatypes::SchemaRef,
-    pub(crate) live_request: LiveStateScanRequest,
-}
 
 /// Optional private capability supplied only by committed read sessions.
 ///
 /// Returning `None` is the normal conservative answer: generic contexts,
 /// transaction overlays, untracked state, exact reads, and unsupported
-/// SQL shapes all retain the existing materialized-row implementation.
+/// SQL shapes all retain the existing materialized-row implementation. A
+/// successful result has one entry per live tracked member, ordered by the
+/// logical entity primary key ascending. File-backed members sharing a
+/// primary key remain separate adjacent entries; a caller that relies on a
+/// stronger tie order must retain the general SQL path.
 #[async_trait]
-pub(crate) trait EntityBatchReader: Send + Sync {
-    async fn scan_entity_batch(&self, request: EntityBatchRequest) -> Result<Option<RecordBatch>>;
+pub(crate) trait EntitySnapshotReader: Send + Sync {
+    async fn scan_entity_snapshots(
+        &self,
+        request: LiveStateScanRequest,
+    ) -> Result<Option<Vec<Option<Bytes>>>, LixError>;
 }
 
-pub(crate) struct TrackedEntityBatchReader<S> {
+pub(crate) struct TrackedEntitySnapshotReader<S> {
     live_state: Arc<LiveStateContext>,
     store: S,
 }
 
-impl<S> TrackedEntityBatchReader<S> {
+impl<S> TrackedEntitySnapshotReader<S> {
     pub(crate) fn new(live_state: Arc<LiveStateContext>, store: S) -> Self {
         Self { live_state, store }
     }
 }
 
 #[async_trait]
-impl<S> EntityBatchReader for TrackedEntityBatchReader<S>
+impl<S> EntitySnapshotReader for TrackedEntitySnapshotReader<S>
 where
     S: StorageAdapterRead + Clone + Send + Sync + 'static,
 {
-    async fn scan_entity_batch(&self, request: EntityBatchRequest) -> Result<Option<RecordBatch>> {
-        if !matches!(request.live_request.filter.rows, LiveStateRowFilter::All)
-            || request.schema.fields().is_empty()
-            || request.live_request.filter.include_tombstones
-            || !request.live_request.filter.entity_pks.is_empty()
-            || !request.live_request.filter.file_ids.is_empty()
-            || !request.live_request.filter.constraints.is_empty()
-            || request
-                .schema
-                .fields()
-                .iter()
-                .any(|field| field.name().starts_with("lixcol_"))
-        {
+    async fn scan_entity_snapshots(
+        &self,
+        request: LiveStateScanRequest,
+    ) -> Result<Option<Vec<Option<Bytes>>>, LixError> {
+        if !direct_entity_snapshot_request(&request) {
             return Ok(None);
         }
-
-        let Some(rows) = self
-            .live_state
+        self.live_state
             .reader(self.store.clone())
-            .scan_direct_entity_snapshots(&request.live_request)
+            .scan_direct_entity_snapshots(&request)
             .await
-            .map_err(lix_error_to_datafusion_error)?
-        else {
-            return Ok(None);
-        };
-        let decoder = EntityProjectionDecoder::new(
-            &request.spec,
-            request
-                .schema
-                .fields()
-                .iter()
-                .map(|field| field.name().as_str()),
-        )
-        .map_err(entity_projection_error_to_datafusion_error)?;
-        let columns = decoder
-            .decode_arrow_columns(rows.iter().map(Option::as_deref))
-            .map_err(entity_projection_error_to_datafusion_error)?;
-        RecordBatch::try_new(request.schema, columns)
-            .map(Some)
-            .map_err(DataFusionError::from)
     }
+}
+
+/// The raw snapshot plane is deliberately narrower than the general
+/// live-state reader. It has no identity/filter evaluator, so only a broad
+/// no-tombstone request can use it. Both Arrow and public-result consumers add
+/// their own output-shape checks above this shared serving boundary.
+fn direct_entity_snapshot_request(request: &LiveStateScanRequest) -> bool {
+    matches!(request.filter.rows, LiveStateRowFilter::All)
+        && !request.filter.include_tombstones
+        && request.filter.entity_pks.is_empty()
+        && request.filter.file_ids.is_empty()
+        && request.filter.constraints.is_empty()
 }

--- a/packages/engine/src/sql2/entity_projection.rs
+++ b/packages/engine/src/sql2/entity_projection.rs
@@ -16,10 +16,10 @@ use serde::de::{DeserializeSeed, IgnoredAny, MapAccess, SeqAccess, Visitor};
 use serde_json::Value as JsonValue;
 use serde_json::value::RawValue;
 
-use crate::LixError;
 use crate::sql2::catalog::{EntityColumnType, EntitySurfaceSpec};
-use crate::sql2::error::lix_error_to_datafusion_error;
+use crate::sql2::error::{datafusion_error_to_lix_error, lix_error_to_datafusion_error};
 use crate::sql2::value_contract::{json_bigint_value, json_double_value};
+use crate::{LixError, Value};
 
 /// A projection decoder for the general entity provider.
 pub(crate) struct EntityProjectionDecoder {
@@ -38,6 +38,16 @@ pub(crate) fn entity_projection_error_to_datafusion_error(error: LixError) -> Da
     } else {
         lix_error_to_datafusion_error(error)
     }
+}
+
+/// Applies the same public SQL error classification as the Arrow provider.
+///
+/// The native public-result route shares this decoder but deliberately skips
+/// Arrow and DataFusion result conversion. Keep decoder failures on the
+/// established public error surface rather than leaking a different internal
+/// error shape solely because this route avoided those allocations.
+pub(crate) fn entity_projection_error_to_lix_error(error: LixError) -> LixError {
+    datafusion_error_to_lix_error(entity_projection_error_to_datafusion_error(error))
 }
 
 #[derive(Clone)]
@@ -103,6 +113,25 @@ impl EntityProjectionDecoder {
             .into_iter()
             .map(EntityProjectionColumn::into_array)
             .collect())
+    }
+
+    /// Decodes a batch directly into the public row values in constructor
+    /// field order. This shares the raw JSON visitor with Arrow projection so
+    /// a strict native public read does not build Arrow arrays only to turn
+    /// them back into owned `Value`s.
+    pub(crate) fn decode_value_rows<'a>(
+        &self,
+        snapshots: impl IntoIterator<Item = Option<&'a [u8]>>,
+    ) -> Result<Vec<Vec<Value>>, LixError> {
+        let snapshots = snapshots.into_iter();
+        let (capacity, _) = snapshots.size_hint();
+        let mut sink = ValueProjectionSink {
+            rows: Vec::with_capacity(capacity),
+        };
+        for snapshot in snapshots {
+            self.decode_into(snapshot, &mut sink)?;
+        }
+        Ok(sink.rows)
     }
 
     fn decode_into<S>(&self, snapshot: Option<&[u8]>, sink: &mut S) -> Result<(), LixError>
@@ -301,6 +330,31 @@ impl EntityProjectionSink for ArrowProjectionSink {
     }
 }
 
+struct ValueProjectionSink {
+    rows: Vec<Vec<Value>>,
+}
+
+impl EntityProjectionSink for ValueProjectionSink {
+    fn begin_row(&mut self, field_count: usize) {
+        self.rows.push(vec![Value::Null; field_count]);
+    }
+
+    fn project_raw(
+        &mut self,
+        decoder: &EntityProjectionDecoder,
+        indices: &[usize],
+        raw: &RawValue,
+    ) -> Result<(), LixError> {
+        for index in indices {
+            let value = public_value_from_raw(raw, &decoder.fields[*index], &decoder.schema_key)?;
+            self.rows
+                .last_mut()
+                .expect("projection sink must start the row first")[*index] = value;
+        }
+        Ok(())
+    }
+}
+
 fn parse_json_value(raw: &RawValue) -> Result<JsonValue, LixError> {
     serde_json::from_str(raw.get()).map_err(snapshot_decode_error)
 }
@@ -339,6 +393,51 @@ fn raw_json_text(raw: &RawValue) -> Option<String> {
         return None;
     }
     Some(json.to_string())
+}
+
+fn public_value_from_raw(
+    raw: &RawValue,
+    field: &EntityProjectionField,
+    schema_key: &str,
+) -> Result<Value, LixError> {
+    match field.column_type {
+        EntityColumnType::String => Ok(raw_string_text(raw)?.map_or(Value::Null, Value::Text)),
+        EntityColumnType::Json => {
+            if raw.get().trim() == "null" {
+                return Ok(Value::Null);
+            }
+            serde_json::from_str(raw.get())
+                .map(Value::Json)
+                .map_err(|error| {
+                    LixError::new(
+                        "LIX_ERROR_INVALID_JSON",
+                        format!(
+                            "column '{}' is marked as JSON but contains invalid JSON: {error}",
+                            field.name
+                        ),
+                    )
+                })
+        }
+        EntityColumnType::Integer => {
+            let value = parse_json_value(raw)?;
+            json_bigint_value(Some(&value), schema_key, &field.name)
+                .map(|value| value.map_or(Value::Null, Value::Integer))
+        }
+        EntityColumnType::Number => {
+            let value = parse_json_value(raw)?;
+            let Some(value) = json_double_value(Some(&value), schema_key, &field.name)? else {
+                return Ok(Value::Null);
+            };
+            if !value.is_finite() {
+                return Err(LixError::new(
+                    LixError::CODE_TYPE_MISMATCH,
+                    "SQL query produced a non-finite number",
+                ));
+            }
+            Ok(Value::Real(value))
+        }
+        EntityColumnType::Boolean => Ok(raw_bool(raw).map_or(Value::Null, Value::Boolean)),
+    }
 }
 
 fn snapshot_decode_error(error: serde_json::Error) -> LixError {
@@ -434,13 +533,19 @@ impl EntityProjectionColumn {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use datafusion::arrow::array::{Array, BooleanArray, Float64Array, Int64Array, StringArray};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::arrow::record_batch::RecordBatch;
     use serde_json::json;
 
     use super::EntityProjectionDecoder;
-    use crate::LixError;
     use crate::sql2::catalog::derive_entity_surface_spec_from_schema;
+    use crate::sql2::exec::datafusion::query_result_from_batches;
+    use crate::sql2::result_metadata::mark_json_field;
     use crate::transaction::types::TransactionJson;
+    use crate::{LixError, Value};
 
     fn spec() -> crate::sql2::catalog::EntitySurfaceSpec {
         derive_entity_surface_spec_from_schema(&json!({
@@ -540,6 +645,146 @@ mod tests {
     }
 
     #[test]
+    fn decodes_selected_fields_to_public_values_without_arrow_round_trip() {
+        let spec = spec();
+        let decoder = EntityProjectionDecoder::new(
+            &spec,
+            [
+                "text",
+                "json",
+                "integer",
+                "number",
+                "boolean",
+                "coerce_bool",
+                "coerce_object",
+                "null_text",
+                "missing",
+                "text",
+            ],
+        )
+        .expect("decoder should build");
+        let snapshot = TransactionJson::from_value(
+            json!({
+                "text": "line\nquote: \"",
+                "json": {"z": [true, null], "a": "value"},
+                "integer": 7.0,
+                "number": 4.5,
+                "boolean": true,
+                "coerce_bool": false,
+                "coerce_object": {"z": 2, "a": 1},
+                "null_text": null,
+                "ignored": {"nested": [1, 2, 3]}
+            }),
+            "canonical tracked public projection test",
+        )
+        .expect("transaction JSON should normalize");
+
+        let rows = decoder
+            .decode_value_rows([Some(snapshot.normalized().as_bytes()), None, Some(br"[]")])
+            .expect("snapshots should decode");
+        assert_eq!(
+            rows[0],
+            vec![
+                Value::Text("line\nquote: \"".to_string()),
+                Value::Json(json!({"a": "value", "z": [true, null]})),
+                Value::Integer(7),
+                Value::Real(4.5),
+                Value::Boolean(true),
+                Value::Text("false".to_string()),
+                Value::Text(r#"{"a":1,"z":2}"#.to_string()),
+                Value::Null,
+                Value::Null,
+                Value::Text("line\nquote: \"".to_string()),
+            ]
+        );
+        assert_eq!(rows[1], vec![Value::Null; 10]);
+        assert_eq!(rows[2], vec![Value::Null; 10]);
+    }
+
+    #[test]
+    fn public_value_projection_matches_the_existing_arrow_result_contract() {
+        let spec = spec();
+        let decoder = EntityProjectionDecoder::new(
+            &spec,
+            [
+                "text",
+                "json",
+                "integer",
+                "number",
+                "boolean",
+                "coerce_bool",
+                "coerce_object",
+                "null_text",
+                "missing",
+                "text",
+            ],
+        )
+        .expect("decoder should build");
+        // Raw snapshots are allowed to contain duplicate JSON member names.
+        // The visitor must retain the final member in both result paths.
+        let duplicate_source_snapshot: &[u8] = br#"{
+            "text":"old",
+            "text":"line\nquote: \"",
+            "json":{"old":true},
+            "json":{"z":[true,null],"a":"value"},
+            "integer":7.0,
+            "number":4.5,
+            "boolean":true,
+            "coerce_bool":false,
+            "coerce_object":{"z":2,"a":1},
+            "null_text":null
+        }"#;
+        let snapshots = [
+            Some(duplicate_source_snapshot),
+            None,
+            Some(br"[]".as_slice()),
+        ];
+
+        let direct_rows = decoder
+            .decode_value_rows(snapshots)
+            .expect("native public values should decode");
+        let arrays = decoder
+            .decode_arrow_columns(snapshots)
+            .expect("Arrow values should decode");
+        let fields = vec![
+            Field::new("text", DataType::Utf8, true),
+            mark_json_field(Field::new("json", DataType::Utf8, true)),
+            Field::new("integer", DataType::Int64, true),
+            Field::new("number", DataType::Float64, true),
+            Field::new("boolean", DataType::Boolean, true),
+            Field::new("coerce_bool", DataType::Utf8, true),
+            Field::new("coerce_object", DataType::Utf8, true),
+            Field::new("null_text", DataType::Utf8, true),
+            Field::new("missing", DataType::Utf8, true),
+            Field::new("text", DataType::Utf8, true),
+        ];
+        let batch = RecordBatch::try_new(Arc::new(Schema::new(fields.clone())), arrays)
+            .expect("decoded arrays should form a batch");
+        let arrow_rows = query_result_from_batches(&fields, &[batch])
+            .expect("Arrow result values should decode")
+            .rows;
+
+        assert_eq!(direct_rows, arrow_rows);
+        assert_eq!(
+            direct_rows[0],
+            vec![
+                Value::Text("line\nquote: \"".to_string()),
+                Value::Json(json!({"a": "value", "z": [true, null]})),
+                Value::Integer(7),
+                Value::Real(4.5),
+                Value::Boolean(true),
+                Value::Text("false".to_string()),
+                Value::Text(r#"{"a":1,"z":2}"#.to_string()),
+                Value::Null,
+                Value::Null,
+                Value::Text("line\nquote: \"".to_string()),
+            ]
+        );
+        assert_eq!(direct_rows[1], vec![Value::Null; 10]);
+        assert_eq!(direct_rows[2], vec![Value::Null; 10]);
+    }
+
+    #[test]
     fn reports_the_existing_typed_number_contract_error() {
         let spec = spec();
         let decoder = EntityProjectionDecoder::new(&spec, ["integer", "number"])
@@ -552,6 +797,13 @@ mod tests {
         let error = decoder
             .decode_arrow_columns([Some(snapshot.normalized().as_bytes())])
             .expect_err("string must not become a BIGINT");
+        assert_eq!(error.code, LixError::CODE_TYPE_MISMATCH);
+        assert!(error.message.contains("projection_test"));
+        assert!(error.message.contains("integer"));
+
+        let error = decoder
+            .decode_value_rows([Some(snapshot.normalized().as_bytes())])
+            .expect_err("string must not become a public BIGINT");
         assert_eq!(error.code, LixError::CODE_TYPE_MISMATCH);
         assert!(error.message.contains("projection_test"));
         assert!(error.message.contains("integer"));

--- a/packages/engine/src/sql2/exec/bound_public_read.rs
+++ b/packages/engine/src/sql2/exec/bound_public_read.rs
@@ -1,4 +1,4 @@
-//! Strict native reads for the common public entity primary-key shape.
+//! Strict native reads for common public entity shapes.
 //!
 //! Lix keeps the full SQL surface in DataFusion.  This module intentionally
 //! recognizes only a small shape which has a direct, row-oriented execution
@@ -19,6 +19,9 @@ use crate::entity_pk::EntityPk;
 use crate::live_state::{LiveStateFilter, LiveStateProjection, LiveStateScanRequest};
 use crate::sql2::SqlExecutionContext;
 use crate::sql2::catalog::{EntityColumnType, PublicSurfaceKind};
+use crate::sql2::entity_projection::{
+    EntityProjectionDecoder, entity_projection_error_to_lix_error,
+};
 use crate::{LixError, SqlQueryResult, Value};
 
 /// Attempts the one public entity read shape that can be evaluated directly
@@ -33,7 +36,10 @@ pub(crate) async fn try_execute_bound_public_read<C>(
 where
     C: SqlExecutionContext + ?Sized,
 {
-    let Some(shape) = strict_entity_primary_key_read(statement, params) else {
+    let Some(shape) = strict_entity_primary_key_read(statement, params)
+        .map(StrictEntityRead::PrimaryKey)
+        .or_else(|| strict_entity_broad_read(statement, params).map(StrictEntityRead::Broad))
+    else {
         return Ok(None);
     };
 
@@ -43,7 +49,7 @@ where
     crate::sql2::bind_read_statement(sql, statement)?;
 
     let catalog = ctx.public_catalog().await?;
-    let Some(surface) = catalog.surface(&shape.table_name) else {
+    let Some(surface) = catalog.surface(shape.table_name()) else {
         return Ok(None);
     };
     let PublicSurfaceKind::EntityBase { schema_key } = &surface.kind else {
@@ -55,53 +61,101 @@ where
     let Some(primary_key_column) = single_top_level_string_primary_key(spec) else {
         return Ok(None);
     };
-    if primary_key_column != shape.primary_key_column
-        || shape.projection.iter().any(|column| {
-            !matches!(
-                spec.visible_column(column).map(|column| column.column_type),
-                Some(EntityColumnType::String | EntityColumnType::Json)
-            )
-        })
-    {
-        return Ok(None);
+    match shape {
+        StrictEntityRead::PrimaryKey(shape) => {
+            if primary_key_column != shape.primary_key_column
+                || shape.projection.iter().any(|column| {
+                    !matches!(
+                        spec.visible_column(column).map(|column| column.column_type),
+                        Some(EntityColumnType::String | EntityColumnType::Json)
+                    )
+                })
+            {
+                return Ok(None);
+            }
+
+            let entity_pks = shape
+                .primary_key_values
+                .into_iter()
+                .map(EntityPk::single)
+                .collect::<Vec<_>>();
+            let mut rows = ctx
+                .live_state()
+                .scan_rows(&LiveStateScanRequest {
+                    filter: LiveStateFilter {
+                        schema_keys: vec![schema_key.clone()],
+                        entity_pks,
+                        branch_ids: vec![ctx.active_branch_id().to_string()],
+                        include_tombstones: false,
+                        ..LiveStateFilter::default()
+                    },
+                    projection: LiveStateProjection {
+                        columns: vec!["snapshot_content".to_string()],
+                    },
+                    limit: None,
+                })
+                .await?;
+
+            // The accepted ORDER BY is the complete one-column primary key.
+            // Retain multiple file-backed identities for one logical primary
+            // key; `file_id` is a first-class row identity and must not be
+            // collapsed by this route.
+            rows.sort_by(|left, right| left.entity_pk.cmp(&right.entity_pk));
+            let result_rows = rows
+                .iter()
+                .map(|row| {
+                    materialize_row(spec, &shape.projection, row.snapshot_content.as_deref())
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            Ok(Some(SqlQueryResult {
+                columns: shape.projection,
+                rows: result_rows,
+                notices: Vec::new(),
+            }))
+        }
+        StrictEntityRead::Broad(shape) => {
+            if primary_key_column != shape.primary_key_column
+                || shape
+                    .projection
+                    .iter()
+                    .any(|column| spec.visible_column(column).is_none())
+            {
+                return Ok(None);
+            }
+            let Some(reader) = ctx.entity_snapshot_reader() else {
+                return Ok(None);
+            };
+            let Some(snapshots) = reader
+                .scan_entity_snapshots(LiveStateScanRequest {
+                    filter: LiveStateFilter {
+                        schema_keys: vec![schema_key.clone()],
+                        branch_ids: vec![ctx.active_branch_id().to_string()],
+                        include_tombstones: false,
+                        ..LiveStateFilter::default()
+                    },
+                    projection: LiveStateProjection {
+                        columns: vec!["snapshot_content".to_string()],
+                    },
+                    limit: None,
+                })
+                .await?
+            else {
+                return Ok(None);
+            };
+            let decoder =
+                EntityProjectionDecoder::new(spec, shape.projection.iter().map(String::as_str))
+                    .map_err(entity_projection_error_to_lix_error)?;
+            let rows = decoder
+                .decode_value_rows(snapshots.iter().map(Option::as_deref))
+                .map_err(entity_projection_error_to_lix_error)?;
+            Ok(Some(SqlQueryResult {
+                columns: shape.projection,
+                rows,
+                notices: Vec::new(),
+            }))
+        }
     }
-
-    let entity_pks = shape
-        .primary_key_values
-        .into_iter()
-        .map(EntityPk::single)
-        .collect::<Vec<_>>();
-    let mut rows = ctx
-        .live_state()
-        .scan_rows(&LiveStateScanRequest {
-            filter: LiveStateFilter {
-                schema_keys: vec![schema_key.clone()],
-                entity_pks,
-                branch_ids: vec![ctx.active_branch_id().to_string()],
-                include_tombstones: false,
-                ..LiveStateFilter::default()
-            },
-            projection: LiveStateProjection {
-                columns: vec!["snapshot_content".to_string()],
-            },
-            limit: None,
-        })
-        .await?;
-
-    // The accepted ORDER BY is the complete one-column primary key. Retain
-    // multiple file-backed identities for one logical primary key; `file_id`
-    // is a first-class row identity and must not be collapsed by this route.
-    rows.sort_by(|left, right| left.entity_pk.cmp(&right.entity_pk));
-    let result_rows = rows
-        .iter()
-        .map(|row| materialize_row(spec, &shape.projection, row.snapshot_content.as_deref()))
-        .collect::<Result<Vec<_>, _>>()?;
-
-    Ok(Some(SqlQueryResult {
-        columns: shape.projection,
-        rows: result_rows,
-        notices: Vec::new(),
-    }))
 }
 
 fn single_top_level_string_primary_key(
@@ -190,6 +244,27 @@ struct StrictEntityPrimaryKeyRead {
     primary_key_values: Vec<String>,
 }
 
+enum StrictEntityRead {
+    PrimaryKey(StrictEntityPrimaryKeyRead),
+    Broad(StrictEntityBroadRead),
+}
+
+impl StrictEntityRead {
+    fn table_name(&self) -> &str {
+        match self {
+            Self::PrimaryKey(shape) => &shape.table_name,
+            Self::Broad(shape) => &shape.table_name,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct StrictEntityBroadRead {
+    table_name: String,
+    projection: Vec<String>,
+    primary_key_column: String,
+}
+
 /// Recognizes a single, active entity table with an `IN`/`=` primary-key
 /// predicate and canonical ascending primary-key order. It intentionally does
 /// not inspect catalog metadata: catalog mismatches are handled by the caller
@@ -217,6 +292,29 @@ fn strict_entity_primary_key_read(
         projection,
         primary_key_column,
         primary_key_values,
+    })
+}
+
+/// Recognizes the canonical broad tracked entity read. The packed head index
+/// already stores one schema in primary-key order, so this shape can return
+/// final public rows without routing an otherwise no-op sort through
+/// DataFusion. Any clause that needs general SQL semantics remains a normal
+/// DataFusion query.
+fn strict_entity_broad_read(
+    statement: &DataFusionStatement,
+    params: &[Value],
+) -> Option<StrictEntityBroadRead> {
+    if !params.is_empty() {
+        return None;
+    }
+    let (query, select, table_name) = strict_single_table_select(statement)?;
+    if query.limit_clause.is_some() || query.fetch.is_some() || select.selection.is_some() {
+        return None;
+    }
+    Some(StrictEntityBroadRead {
+        table_name,
+        projection: strict_projection(&select.projection)?,
+        primary_key_column: canonical_ascending_order_column(query)?,
     })
 }
 
@@ -307,17 +405,18 @@ fn strict_single_table_select(
 fn strict_projection(
     projection: &[datafusion::sql::sqlparser::ast::SelectItem],
 ) -> Option<Vec<String>> {
-    projection
-        .iter()
-        .map(|item| match item {
-            datafusion::sql::sqlparser::ast::SelectItem::UnnamedExpr(Expr::Identifier(column))
-                if column.quote_style.is_none() =>
-            {
-                Some(column.value.to_ascii_lowercase())
-            }
-            _ => None,
-        })
-        .collect()
+    let columns =
+        projection
+            .iter()
+            .map(|item| match item {
+                datafusion::sql::sqlparser::ast::SelectItem::UnnamedExpr(Expr::Identifier(
+                    column,
+                )) if column.quote_style.is_none() => Some(column.value.to_ascii_lowercase()),
+                _ => None,
+            })
+            .collect::<Option<Vec<_>>>()?;
+    let unique_count = columns.iter().collect::<BTreeSet<_>>().len();
+    (unique_count == columns.len()).then_some(columns)
 }
 
 fn strict_primary_key_values(expression: &Expr, params: &[Value]) -> Option<(String, Vec<String>)> {
@@ -375,22 +474,26 @@ fn strict_text_value(
 }
 
 fn canonical_primary_key_order(query: &Query, primary_key_column: &str) -> bool {
+    canonical_ascending_order_column(query).as_deref() == Some(primary_key_column)
+}
+
+fn canonical_ascending_order_column(query: &Query) -> Option<String> {
     let Some(order_by) = &query.order_by else {
-        return false;
+        return None;
     };
     if order_by.interpolate.is_some() {
-        return false;
+        return None;
     }
     let OrderByKind::Expressions(expressions) = &order_by.kind else {
-        return false;
+        return None;
     };
     let [order] = expressions.as_slice() else {
-        return false;
+        return None;
     };
-    order.with_fill.is_none()
+    (order.with_fill.is_none()
         && order.options.asc != Some(false)
-        && order.options.nulls_first.is_none()
-        && strict_identifier(&order.expr).as_deref() == Some(primary_key_column)
+        && order.options.nulls_first.is_none())
+    .then(|| strict_identifier(&order.expr))?
 }
 
 fn strict_identifier(expression: &Expr) -> Option<String> {
@@ -441,6 +544,19 @@ mod tests {
     }
 
     #[test]
+    fn recognizes_benchmark_broad_read() {
+        let shape = strict_entity_broad_read(
+            &parse("SELECT path, value FROM json_pointer ORDER BY path"),
+            &[],
+        )
+        .expect("benchmark query should use the broad direct route");
+
+        assert_eq!(shape.table_name, "json_pointer");
+        assert_eq!(shape.projection, ["path", "value"]);
+        assert_eq!(shape.primary_key_column, "path");
+    }
+
+    #[test]
     fn rejects_noncanonical_or_ambiguous_sql() {
         for sql in [
             "SELECT path, value FROM json_pointer WHERE path IN ('/a')",
@@ -454,5 +570,31 @@ mod tests {
                 "{sql} must fall back"
             );
         }
+    }
+
+    #[test]
+    fn broad_read_rejects_any_clause_that_needs_general_sql() {
+        for sql in [
+            "SELECT path, value FROM json_pointer",
+            "SELECT path, value FROM json_pointer ORDER BY path DESC",
+            "SELECT path, value FROM json_pointer WHERE true ORDER BY path",
+            "SELECT path, value FROM json_pointer ORDER BY path LIMIT 1",
+            "SELECT path, value FROM json_pointer AS p ORDER BY path",
+            "SELECT * FROM json_pointer ORDER BY path",
+            "SELECT path, path FROM json_pointer ORDER BY path",
+        ] {
+            assert!(
+                strict_entity_broad_read(&parse(sql), &[]).is_none(),
+                "{sql} must fall back"
+            );
+        }
+        assert!(
+            strict_entity_broad_read(
+                &parse("SELECT path, value FROM json_pointer ORDER BY path"),
+                &[Value::Text("unused".to_string())],
+            )
+            .is_none(),
+            "an unused parameter must retain normal SQL validation"
+        );
     }
 }

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -41,7 +41,7 @@ pub(crate) use context::{
     SqlHistoryQuerySource, SqlWriteContext, SqlWriteExecutionContext, WriteAccess,
     WriteContextBranchRefReader, WriteContextLiveStateReader,
 };
-pub(crate) use entity_batch::{EntityBatchReader, EntityBatchRequest, TrackedEntityBatchReader};
+pub(crate) use entity_batch::{EntitySnapshotReader, TrackedEntitySnapshotReader};
 pub(crate) use exec::{SessionReadSqlResult, SqlWriteResult};
 #[allow(unused_imports)]
 pub(crate) use exec::{

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -35,7 +35,7 @@ use crate::sql2::value_contract::{json_bigint_value, json_double_value};
 use crate::{GLOBAL_BRANCH_ID, LixError, parse_row_metadata_value};
 
 use crate::sql2::{
-    EntityBatchReader, EntityBatchRequest, SqlHistoryQuerySource, SqlWriteContext, WriteAccess,
+    EntitySnapshotReader, SqlHistoryQuerySource, SqlWriteContext, WriteAccess,
     WriteContextLiveStateReader,
 };
 use crate::transaction::types::{
@@ -60,7 +60,7 @@ pub(crate) async fn register_entity_providers<S>(
     ctx: &SessionContext,
     active_branch_id: &str,
     live_state: Arc<dyn LiveStateReader>,
-    entity_batch_reader: Option<Arc<dyn EntityBatchReader>>,
+    entity_snapshot_reader: Option<Arc<dyn EntitySnapshotReader>>,
     branch_ref: Arc<dyn BranchRefReader>,
     commit_graph: Option<Arc<tokio::sync::Mutex<Box<dyn CommitGraphReader>>>>,
     query_source: Option<SqlHistoryQuerySource<S>>,
@@ -86,7 +86,7 @@ where
                         Arc::clone(&live_state),
                         Arc::clone(&branch_ref),
                         active_branch_id.to_string(),
-                        entity_batch_reader.clone(),
+                        entity_snapshot_reader.clone(),
                     )),
                     WriteAccess::read_only(),
                 )?;
@@ -100,7 +100,7 @@ where
                         spec,
                         Arc::clone(&live_state),
                         Arc::clone(&branch_ref),
-                        entity_batch_reader.clone(),
+                        entity_snapshot_reader.clone(),
                     )),
                     WriteAccess::read_only(),
                 )?;
@@ -198,7 +198,7 @@ struct EntitySpec {
     surface_name: String,
     spec: Arc<EntitySurfaceSpec>,
     live_state: Arc<dyn LiveStateReader>,
-    entity_batch_reader: Option<Arc<dyn EntityBatchReader>>,
+    entity_snapshot_reader: Option<Arc<dyn EntitySnapshotReader>>,
     branch_ref: Arc<dyn BranchRefReader>,
     schema: SchemaRef,
     branch_binding: BranchBinding,
@@ -210,14 +210,14 @@ impl EntitySpec {
         live_state: Arc<dyn LiveStateReader>,
         branch_ref: Arc<dyn BranchRefReader>,
         active_branch_id: String,
-        entity_batch_reader: Option<Arc<dyn EntityBatchReader>>,
+        entity_snapshot_reader: Option<Arc<dyn EntitySnapshotReader>>,
     ) -> Self {
         Self {
             surface_name: spec.schema_key.clone(),
             schema: entity_surface_schema(&spec, EntitySurfaceShape::Active),
             spec,
             live_state,
-            entity_batch_reader,
+            entity_snapshot_reader,
             branch_ref,
             branch_binding: BranchBinding::active(active_branch_id),
         }
@@ -237,14 +237,14 @@ impl EntitySpec {
         spec: Arc<EntitySurfaceSpec>,
         live_state: Arc<dyn LiveStateReader>,
         branch_ref: Arc<dyn BranchRefReader>,
-        entity_batch_reader: Option<Arc<dyn EntityBatchReader>>,
+        entity_snapshot_reader: Option<Arc<dyn EntitySnapshotReader>>,
     ) -> Self {
         Self {
             surface_name: format!("{}_by_branch", spec.schema_key),
             schema: entity_surface_schema(&spec, EntitySurfaceShape::ByBranch),
             spec,
             live_state,
-            entity_batch_reader,
+            entity_snapshot_reader,
             branch_ref,
             branch_binding: BranchBinding::explicit(),
         }
@@ -333,8 +333,8 @@ impl TableSpec for EntitySpec {
         let (schema, request, row_filters) =
             self.plan_scan_parts(projection, filters, limit).await?;
         let batch_projection = EntityBatchProjection::for_request(&request);
-        let direct_entity_batch = direct_entity_batch_eligible(&schema, &request, &row_filters)
-            .then(|| self.entity_batch_reader.clone())
+        let direct_entity_snapshot = direct_entity_batch_eligible(&schema, &request, &row_filters)
+            .then(|| self.entity_snapshot_reader.clone())
             .flatten();
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
@@ -347,7 +347,7 @@ impl TableSpec for EntitySpec {
                     request,
                     row_filters,
                     batch_projection,
-                    direct_entity_batch,
+                    direct_entity_snapshot,
                 ),
                 |(
                     spec,
@@ -356,18 +356,24 @@ impl TableSpec for EntitySpec {
                     request,
                     row_filters,
                     batch_projection,
-                    direct_entity_batch,
+                    direct_entity_snapshot,
                 )| async move {
-                    if let Some(direct_entity_batch) = direct_entity_batch
-                        && let Some(batch) = direct_entity_batch
-                            .scan_entity_batch(EntityBatchRequest {
-                                spec: Arc::clone(&spec),
-                                schema: Arc::clone(&schema),
-                                live_request: request.clone(),
-                            })
-                            .await?
+                    if let Some(direct_entity_snapshot) = direct_entity_snapshot
+                        && let Some(rows) = direct_entity_snapshot
+                            .scan_entity_snapshots(request.clone())
+                            .await
+                            .map_err(lix_error_to_datafusion_error)?
                     {
-                        return Ok(batch);
+                        let decoder = EntityProjectionDecoder::new(
+                            &spec,
+                            schema.fields().iter().map(|field| field.name().as_str()),
+                        )
+                        .map_err(entity_projection_error_to_datafusion_error)?;
+                        let columns = decoder
+                            .decode_arrow_columns(rows.iter().map(Option::as_deref))
+                            .map_err(entity_projection_error_to_datafusion_error)?;
+                        return RecordBatch::try_new(schema, columns)
+                            .map_err(DataFusionError::from);
                     }
                     let mut rows = live_state
                         .scan_rows(&request)

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -518,7 +518,7 @@ where
         session,
         ctx.active_branch_id(),
         ctx.live_state(),
-        ctx.entity_batch_reader(),
+        ctx.entity_snapshot_reader(),
         Arc::clone(&branch_ref),
         needs_entity_history.then(|| Arc::new(tokio::sync::Mutex::new(ctx.commit_graph()))),
         if needs_entity_history {


### PR DESCRIPTION
## What changed

The parent PR (#817) exposes canonical tracked snapshots directly from the v10 serving-head layout. This child uses the same snapshots for the strict, normal public read shape:

```sql
SELECT <visible columns>
FROM <active entity>
ORDER BY <the single string primary key>
```

It returns the public `ExecuteResult` directly instead of materializing Arrow batches, running DataFusion's sort, converting every scalar back to owned values, and reparsing JSON. All non-canonical SQL continues through the existing general executor.

This is backend-neutral at the engine boundary; the benchmarked normal path is Lix with RocksDB.

## Why

Profiles of the parent fast path showed the remaining broad-read cost was dominated by Arrow/DataFusion/public-result conversion and sorting rather than RocksDB reads. The direct result path removes that whole conversion pipeline without changing the public API or the v10 storage layout.

## Before / after

Setup is excluded. The workload is 10,000 tracked `json_pointer` rows and repeatedly executes:

```sql
SELECT path, value FROM json_pointer ORDER BY path
```

CPU was pinned to one core; each result is the median of 9 independent hot runs with 100 operations/run.

| Implementation | Median ms/op | Change |
| --- | ---: | ---: |
| Lix + RocksDB, parent Arrow route (#817) | 23.791 | baseline |
| Lix + RocksDB, this direct public-result route | 17.103 | **-28.1%** |
| Standalone SQLite, equivalent public-result construction | 6.848 | Lix is **2.50×** |

Raw Lix samples (ms/op): 17.440, 16.912, 16.818, 15.016, 17.103, 17.544, 15.089, 17.234, 18.185.

## Correctness

- Shares the parent route's logical-PK ordering proof.
- Strictly falls back for writes, expressions, aliases, joins, filters, limits, transactions with staged rows, tracked global overlays, untracked rows, non-v10 repositories, and ambiguous/multi-key shapes.
- Differential tests compare the direct JSON/projection result with the existing Arrow public-result conversion, including nulls, malformed/type-error behavior, duplicate source JSON keys, and selected types.

## Validation

- `cargo clippy --profile test -p lix_engine --all-targets --all-features -- -D warnings`
- `cargo test -p lix_engine --lib sql2::exec::bound_public_read::tests -- --nocapture`
- `cargo test -p lix_engine --lib entity_projection -- --nocapture`
- `cargo test -p lix_engine --lib engine::tests::tracked_entity_public_fast_path -- --nocapture`
- `cargo test -p lix_engine --lib tracked_entity_fast_path -- --nocapture`
- `cargo test -p lix_engine --lib direct_entity -- --nocapture`
- `cargo test -p lix_engine --lib legacy_v9_protocol_opens_and_uses_generic_entity_reads -- --nocapture`

Stacked on #817, which targets `main`.