### PR TITLE
refactor(remote): remove splice capability shim

### DIFF
--- a/.changenotes/remove-splice-capability-shim.md
+++ b/.changenotes/remove-splice-capability-shim.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Removed the legacy `requestBlobSplice` capability negotiation. Remote protocol v1 clients now use SHA-256 blob splices directly.

--- a/packages/js-sdk/src/remote/client.test.ts
+++ b/packages/js-sdk/src/remote/client.test.ts
@@ -519,7 +519,7 @@ test("remote execute keeps small and low-saving blob updates full", async () => 
 	expect(bodies[2]).not.toHaveProperty("cacheBlobs");
 });
 
-test("remote execute keeps large writes full without the splice capability", async () => {
+test("remote protocol v1 uses blob splices without capability negotiation", async () => {
 	const bodies: Array<Record<string, unknown>> = [];
 	const lix = await openLix({
 		server: {
@@ -552,12 +552,14 @@ test("remote execute keeps large writes full without the splice capability", asy
 	await lix.close();
 
 	expect(bodies).toHaveLength(2);
-	for (const body of bodies) {
-		expect((body.params as Array<Record<string, unknown>>)[0]?.kind).toBe(
-			"blob",
-		);
-		expect(body).not.toHaveProperty("cacheBlobs");
-	}
+	expect((bodies[0]?.params as Array<Record<string, unknown>>)[0]?.kind).toBe(
+		"blob",
+	);
+	expect(bodies[0]?.cacheBlobs).toBe(true);
+	expect((bodies[1]?.params as Array<Record<string, unknown>>)[0]?.kind).toBe(
+		"blob-splice",
+	);
+	expect(bodies[1]?.cacheBlobs).toBe(true);
 });
 
 test("remote executeBatch uses blob splices for stable statement slots", async () => {
@@ -1174,7 +1176,6 @@ function handshakeResponse() {
 		protocolVersion: 1,
 		activeBranchId: "main-id",
 		sessionId: "session-1",
-		capabilities: { requestBlobSplice: true },
 	});
 }
 

--- a/packages/js-sdk/src/remote/client.ts
+++ b/packages/js-sdk/src/remote/client.ts
@@ -82,7 +82,6 @@ class RemoteLixBinding implements LixBinding {
 	readonly #requestBlobBases = new Map<string, RequestBlobBase>();
 	#sessionId: string | undefined;
 	#activeBranchId: string | undefined;
-	#supportsRequestBlobSplice = false;
 	#requestBlobBaseBytes = 0;
 	#acceptingOperations = true;
 	#operationQueue: Promise<void> = Promise.resolve();
@@ -137,7 +136,6 @@ class RemoteLixBinding implements LixBinding {
 		);
 		this.#sessionId = handshake.sessionId;
 		this.#activeBranchId = handshake.activeBranchId;
-		this.#supportsRequestBlobSplice = handshake.requestBlobSplice;
 	}
 
 	async execute(
@@ -262,7 +260,6 @@ class RemoteLixBinding implements LixBinding {
 					throw protocolError("remote handshake changed sessionId");
 				}
 				this.#activeBranchId = handshake.activeBranchId;
-				this.#supportsRequestBlobSplice = handshake.requestBlobSplice;
 			}
 			return this.#activeBranchId;
 		});
@@ -493,7 +490,6 @@ class RemoteLixBinding implements LixBinding {
 		const prepared = await Promise.all(
 			params.map(async (param, index): Promise<PreparedRequestParam> => {
 				if (
-					!this.#supportsRequestBlobSplice ||
 					param.kind !== "blob" ||
 					param.blob.byteLength < REQUEST_BLOB_DELTA_MIN_BYTES ||
 					param.blob.byteLength > REQUEST_BLOB_BASE_MAX_BYTES

--- a/packages/js-sdk/src/remote/protocol.test.ts
+++ b/packages/js-sdk/src/remote/protocol.test.ts
@@ -6,26 +6,6 @@ import {
 	encodeWireValue,
 } from "./protocol.js";
 
-test.each([
-	[undefined, false],
-	[{}, false],
-	[{ requestBlobSplice: false }, false],
-	[{ requestBlobSplice: "true" }, false],
-	[{ requestBlobSplice: true }, true],
-])(
-	"remote handshake negotiates only the exact blob splice capability: %j",
-	(capabilities, expected) => {
-		expect(
-			decodeHandshake({
-				protocolVersion: 1,
-				activeBranchId: "main-id",
-				sessionId: "session-1",
-				...(capabilities === undefined ? {} : { capabilities }),
-			}).requestBlobSplice,
-		).toBe(expected);
-	},
-);
-
 test("remote blobs use native typed-array base64 when available", () => {
 	const prototype = Uint8Array.prototype as Uint8Array & {
 		toBase64?: () => string;

--- a/packages/js-sdk/src/remote/protocol.ts
+++ b/packages/js-sdk/src/remote/protocol.ts
@@ -31,7 +31,6 @@ export type RemoteHandshake = {
 	protocolVersion: number;
 	activeBranchId: string;
 	sessionId: string;
-	requestBlobSplice: boolean;
 };
 
 export type RemoteHandshakeRequest = {
@@ -233,9 +232,6 @@ export function decodeHandshake(value: unknown): RemoteHandshake {
 		protocolVersion: REMOTE_PROTOCOL_VERSION,
 		activeBranchId: handshake.activeBranchId,
 		sessionId: handshake.sessionId,
-		requestBlobSplice:
-			isRecord(handshake.capabilities) &&
-			handshake.capabilities.requestBlobSplice === true,
 	};
 }
 

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -1387,7 +1387,6 @@ where
             active_branch_id,
             session_id: lease.session_id.clone(),
             capabilities: ProtocolCapabilities {
-                request_blob_splice: true,
                 binary_file_upsert: true,
                 binary_file_upsert_batch: true,
                 binary_file_read: true,
@@ -2555,7 +2554,6 @@ struct HandshakeResponse {
 // change the flat handshake response without reducing protocol complexity.
 #[allow(clippy::struct_excessive_bools)]
 struct ProtocolCapabilities {
-    request_blob_splice: bool,
     binary_file_upsert: bool,
     binary_file_upsert_batch: bool,
     binary_file_read: bool,
@@ -5113,7 +5111,7 @@ mod tests {
         let app = app().await;
         let (session_id, first) = new_session(&app.router).await;
         assert_eq!(first["protocolVersion"], PROTOCOL_VERSION);
-        assert_eq!(first["capabilities"]["requestBlobSplice"], true);
+        assert!(first["capabilities"].get("requestBlobSplice").is_none());
         assert_eq!(first["capabilities"]["binaryFileUpsert"], true);
         assert_eq!(first["capabilities"]["binaryFileUpsertBatch"], true);
         assert_eq!(first["capabilities"]["binaryFileRead"], true);


### PR DESCRIPTION
## Summary
- keep remote protocol v1 and SHA-256 splice provenance unchanged
- remove optional requestBlobSplice capability negotiation from the handshake and client
- make v1 clients use blob splices directly while preserving exact cache-miss recovery

## Compatibility
This is an intentional clean cut. Older v1 servers that do not implement blob splices are not supported by the updated client.

## Validation
- cargo test -p lix_server_protocol (79 passed, 3 ignored)
- cargo clippy -p lix_server_protocol --all-targets --no-deps -- -D warnings
- npm run typecheck
- npx vitest run src/remote (50 passed)
- subagent review: APPROVE