### PR TITLE
refactor: require v10 tracked storage protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Added SQL script planning to the Rust and Workerd SDKs.
 
   Lix now parses single and multi-statement SQL into one atomic statement plan with request-wide parameter ranges.
+- Enforced the current tracked direct-plane storage format.
+
+  Repositories marked with the predecessor v9 layout now fail closed with `LIX_ERROR_UNSUPPORTED_STORAGE_FORMAT`; recreate them or explicitly export and import their data. The public API is unchanged.
 
 ## 0.8.3 - 2026-07-15
 

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -327,8 +327,7 @@ where
         // The protocol check must precede the live-state read: tracked-head
         // spaces keep their physical IDs across hard layout cuts, so an old
         // group value could otherwise be decoded before we reject it.
-        crate::init::RepositoryProtocolStatus::Current
-        | crate::init::RepositoryProtocolStatus::Legacy => {
+        crate::init::RepositoryProtocolStatus::Current => {
             let reader = live_state.reader(read);
             let initialized = reader
                 .load_row(&LiveStateRowRequest {
@@ -573,32 +572,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn legacy_v9_protocol_opens_and_uses_generic_entity_reads() {
+    async fn legacy_v9_protocol_is_rejected() {
         let storage = Memory::new();
         Engine::initialize(storage.clone())
             .await
             .expect("engine should initialize");
-        {
-            let engine = Engine::new(storage.clone())
-                .await
-                .expect("current repository should open");
-            let session = engine
-                .open_workspace_session()
-                .await
-                .expect("workspace session should open");
-            register_json_pointer_schema(&session).await;
-            assert_eq!(
-                session
-                    .execute(
-                        "INSERT INTO json_pointer (path, value) VALUES ('/legacy', lix_json('{\"version\":9}'))",
-                        &[],
-                    )
-                    .await
-                    .expect("write tracked-only legacy probe row")
-                    .rows_affected(),
-                1
-            );
-        }
         let storage_adapter = StorageAdapter::new(storage.clone());
         let mut writes = storage_adapter.new_write_set();
         writes.put(
@@ -611,42 +589,10 @@ mod tests {
             .await
             .expect("legacy protocol marker should commit");
 
-        let read = storage_adapter
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("legacy protocol read should open");
-        assert_eq!(
-            crate::init::repository_protocol_status(&read)
-                .await
-                .expect("legacy protocol should decode"),
-            crate::init::RepositoryProtocolStatus::Legacy
-        );
-
-        let engine = Engine::new(storage)
-            .await
-            .expect("v9 repository should remain readable through the generic path");
-        let session = engine
-            .open_workspace_session()
-            .await
-            .expect("workspace session should open");
-        let rows = session
-            .execute("SELECT path, value FROM json_pointer ORDER BY path", &[])
-            .await
-            .expect("generic entity read should execute");
-        assert_eq!(rows.len(), 1);
-        assert_eq!(
-            rows.rows()[0]
-                .get::<String>("path")
-                .expect("legacy tracked row path"),
-            "/legacy"
-        );
-        assert_eq!(
-            rows.rows()[0]
-                .get::<serde_json::Value>("value")
-                .expect("legacy tracked row value"),
-            json!({"version": 9}),
-            "v9 must preserve a tracked-only entity through the generic path"
-        );
+        let Err(error) = Engine::new(storage).await else {
+            panic!("v9 repository must fail closed");
+        };
+        assert_eq!(error.code, "LIX_ERROR_UNSUPPORTED_STORAGE_FORMAT");
     }
 
     #[tokio::test]

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -48,7 +48,6 @@ pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
 const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"tracked-direct-plane.v10";
-const LEGACY_REPOSITORY_PROTOCOL_VALUE: &[u8] = b"tracked-direct-plane.v9";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately
@@ -58,9 +57,6 @@ pub(crate) enum RepositoryProtocolStatus {
     /// The current layout records every untracked schema mutation, so direct
     /// tracked-head serving may prove that marker absence is safe.
     Current,
-    /// The compatible v9 layout lacks complete untracked-schema markers.
-    /// It remains readable through the generic visibility path only.
-    Legacy,
     Missing,
     Unsupported,
 }
@@ -87,11 +83,6 @@ pub(crate) async fn repository_protocol_status(
             if value.as_ref() == REPOSITORY_PROTOCOL_VALUE =>
         {
             RepositoryProtocolStatus::Current
-        }
-        Some(StorageProjectedValue::FullValue(value))
-            if value.as_ref() == LEGACY_REPOSITORY_PROTOCOL_VALUE =>
-        {
-            RepositoryProtocolStatus::Legacy
         }
         Some(_) => RepositoryProtocolStatus::Unsupported,
         None => RepositoryProtocolStatus::Missing,
@@ -460,7 +451,7 @@ where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
     match repository_protocol_status(read).await? {
-        RepositoryProtocolStatus::Current | RepositoryProtocolStatus::Legacy => Err(LixError::new(
+        RepositoryProtocolStatus::Current => Err(LixError::new(
             "LIX_ERROR_ALREADY_INITIALIZED",
             "engine storage is already initialized; initialization does not migrate or overwrite repositories",
         )),

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -119,14 +119,8 @@ where
         &self,
         request: &LiveStateScanRequest,
     ) -> Result<Option<Vec<Option<Bytes>>>, LixError> {
-        // This capability relies on v10's complete untracked-schema marker.
-        // Keep the proof at its storage-facing boundary so a future caller
-        // cannot accidentally treat a v9 marker absence as tracked-only.
-        if crate::init::repository_protocol_status(&self.store).await?
-            != crate::init::RepositoryProtocolStatus::Current
-        {
-            return Ok(None);
-        }
+        // Engine construction admits only the v10 layout, whose complete
+        // untracked-schema marker makes a missing marker a tracked-only proof.
         if request.filter.untracked == Some(true)
             || request_may_include_commit_derived(request)
             || request


### PR DESCRIPTION
## What changed

- Removes the only accepted predecessor repository marker, `tracked-direct-plane.v9`.
- Opens only repositories marked with the current v10 direct-plane protocol.
- Removes the per-query protocol-marker point read from direct broad tracked entity serving.
- Replaces the legacy-open test with a fail-closed v9 rejection test.

## Why

The repository protocol is a physical-layout fence, not a public API. Keeping v9 open required every direct broad read to re-check a marker solely to decline the fast path. Engine construction now certifies v10 once; any older or unknown marker fails with `LIX_ERROR_UNSUPPORTED_STORAGE_FORMAT` before tracked-head bytes are decoded.

This is intentionally a small cleanup PR, not a claimed double-digit benchmark win. It removes a read and branch from the normal broad tracked path while preserving the existing generic SQL and diff behavior.

## Compatibility

This is an intentional storage-format hard cut. Repositories with a v9 marker must be recreated or explicitly exported and imported. The public API is unchanged.

## Validation

- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/lix-profiling-target cargo test -p lix_engine legacy_v9_protocol_is_rejected --lib`
