### PR TITLE
perf: decode historical delta segments once

### DIFF
--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -968,9 +968,14 @@ where
         // than replaying the entire interval a second time to rediscover it.
         let mut latest_after_by_key = BTreeMap::new();
         for commit_id in interval {
-            for (key, value) in self
-                .scan_replayed_commit_delta_values(commit_id, &request.schema_keys)
-                .await?
+            // This interval is strictly newer than `ancestor_commit_id`, while
+            // the before-image replay below walks the ancestor and its own
+            // parents. Caching the descendant rows by `(commit, key)` cannot
+            // satisfy that replay, so keep this one-pass diff discovery free
+            // of duplicate key/value ownership.
+            for (key, value) in
+                storage::scan_commit_delta_values(&self.store, commit_id, &request.schema_keys)
+                    .await?
             {
                 if request.matches_key(&key) {
                     latest_after_by_key.entry(key).or_insert(value);

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -356,7 +356,7 @@ pub(crate) async fn load_commit_delta_values(
         .await?;
     for ((segment_index, lookups), value) in lookups_by_segment.into_iter().zip(result.value) {
         let bytes = value
-            .and_then(full_value)
+            .and_then(full_value_bytes)
             .ok_or_else(|| {
                 LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
@@ -394,7 +394,7 @@ pub(crate) async fn scan_commit_delta_values(
         .map(String::as_str)
         .collect::<BTreeSet<_>>();
     if let Some(inline_segment) = manifest.inline_segment() {
-        let leaf = decode_commit_delta_segment(inline_segment, None, commit_id)?;
+        let leaf = decode_commit_delta_leaf(inline_segment, None)?;
         let mut entries = Vec::with_capacity(leaf.len());
         collect_commit_delta_leaf_entries(&leaf, commit_id, &requested_schemas, &mut entries)?;
         return Ok(entries);
@@ -416,7 +416,7 @@ pub(crate) async fn scan_commit_delta_values(
     let mut entries = Vec::new();
     for (segment_index, value) in segment_indices.into_iter().zip(segments.value) {
         let bytes = value
-            .and_then(full_value)
+            .and_then(full_value_bytes)
             .ok_or_else(|| {
                 LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
@@ -425,11 +425,7 @@ pub(crate) async fn scan_commit_delta_values(
                     ),
                 )
             })?;
-        let leaf = decode_commit_delta_segment(
-            &bytes,
-            Some(&manifest.segments[segment_index]),
-            commit_id,
-        )?;
+        let leaf = decode_commit_delta_leaf(&bytes, Some(&manifest.segments[segment_index]))?;
         collect_commit_delta_leaf_entries(&leaf, commit_id, &requested_schemas, &mut entries)?;
     }
     Ok(entries)
@@ -586,10 +582,9 @@ fn encode_commit_delta_segment(entries: &[EncodedLeafEntry]) -> Vec<u8> {
     encoded
 }
 
-fn decode_commit_delta_segment(
+fn decode_commit_delta_leaf(
     bytes: &[u8],
     expected_bounds: Option<&CommitDeltaSegmentBounds>,
-    expected_commit_id: CommitId,
 ) -> Result<DecodedLeafNodeRef, LixError> {
     let Some(leaf_bytes) = bytes.strip_prefix(COMMIT_DELTA_FORMAT_MAGIC) else {
         return Err(LixError::new(
@@ -621,6 +616,28 @@ fn decode_commit_delta_segment(
             "tracked_state commit_delta segment does not match its manifest bounds",
         ));
     }
+    Ok(leaf)
+}
+
+fn decode_commit_delta_segment(
+    bytes: &[u8],
+    expected_bounds: Option<&CommitDeltaSegmentBounds>,
+    expected_commit_id: CommitId,
+) -> Result<DecodedLeafNodeRef, LixError> {
+    let leaf = decode_commit_delta_leaf(bytes, expected_bounds)?;
+    visit_commit_delta_leaf(&leaf, expected_commit_id, |_, _| Ok(()))?;
+    Ok(leaf)
+}
+
+/// Visits each packed delta exactly once while validating the full immutable
+/// segment contract. Scan callers decode the key and retain matching values in
+/// the same pass; point callers use the no-op visitor before their binary
+/// search, preserving eager corruption detection.
+fn visit_commit_delta_leaf(
+    leaf: &DecodedLeafNodeRef,
+    expected_commit_id: CommitId,
+    mut visit: impl FnMut(&[u8], TrackedStateIndexValue) -> Result<(), LixError>,
+) -> Result<(), LixError> {
     let mut previous_key: Option<&[u8]> = None;
     for entry_index in 0..leaf.len() {
         let entry = leaf.entry(entry_index)?.ok_or_else(|| {
@@ -645,9 +662,10 @@ fn decode_commit_delta_segment(
                 ),
             ));
         }
+        visit(entry.key, value)?;
         previous_key = Some(entry.key);
     }
-    Ok(leaf)
+    Ok(())
 }
 
 fn collect_commit_delta_leaf_entries(
@@ -656,30 +674,13 @@ fn collect_commit_delta_leaf_entries(
     requested_schemas: &BTreeSet<&str>,
     entries: &mut Vec<(TrackedStateKey, TrackedStateIndexValue)>,
 ) -> Result<(), LixError> {
-    for entry_index in 0..leaf.len() {
-        let entry = leaf.entry(entry_index)?.ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                "tracked_state packed commit_delta leaf has a missing entry",
-            )
-        })?;
-        let key = decode_key(entry.key)?;
-        if !requested_schemas.is_empty() && !requested_schemas.contains(key.schema_key.as_str()) {
-            continue;
+    visit_commit_delta_leaf(leaf, commit_id, |encoded_key, value| {
+        let key = decode_key(encoded_key)?;
+        if requested_schemas.is_empty() || requested_schemas.contains(key.schema_key.as_str()) {
+            entries.push((key, value));
         }
-        let value = decode_value(entry.value)?;
-        if value.commit_id != commit_id {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "tracked_state packed commit_delta for commit '{commit_id}' contains an entry for commit '{}'",
-                    value.commit_id
-                ),
-            ));
-        }
-        entries.push((key, value));
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 fn find_commit_delta_value(
@@ -900,11 +901,15 @@ fn value(bytes: Vec<u8>) -> StorageValue {
     }
 }
 
-fn full_value(value: StorageProjectedValue) -> Option<Vec<u8>> {
+fn full_value_bytes(value: StorageProjectedValue) -> Option<Bytes> {
     match value {
-        StorageProjectedValue::FullValue(bytes) => Some(bytes.to_vec()),
+        StorageProjectedValue::FullValue(bytes) => Some(bytes),
         StorageProjectedValue::KeyOnly => None,
     }
+}
+
+fn full_value(value: StorageProjectedValue) -> Option<Vec<u8>> {
+    full_value_bytes(value).map(|bytes| bytes.to_vec())
 }
 
 fn encode_commit_root(metadata: &TrackedStateCommitRoot) -> Result<Vec<u8>, LixError> {
@@ -952,17 +957,20 @@ mod tests {
         TRACKED_WORKING_DIFF_MARKER_SPACE,
     };
     use crate::storage_adapter::{Memory, StorageAdapter, StorageReadOptions, StorageWriteOptions};
+    use crate::tracked_state::codec::{EncodedLeafEntry, encode_key_ref, encode_value_ref};
     use crate::tracked_state::types::{
         TrackedStateCommitRoot, TrackedStateCommitRootParent, TrackedStateDeltaRef,
-        TrackedStateIndexValue, TrackedStateKey, TrackedStateRootId,
+        TrackedStateIndexValue, TrackedStateIndexValueRef, TrackedStateKey, TrackedStateKeyRef,
+        TrackedStateRootId,
     };
 
     use super::{
-        TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
-        TRACKED_STATE_COMMIT_ROOT_MAGIC, TRACKED_STATE_COMMIT_ROOT_SPACE,
-        TRACKED_STATE_TREE_CHUNK_SPACE, decode_commit_delta_manifest, decode_commit_root,
-        encode_commit_root, load_commit_delta_values, scan_commit_delta_values,
-        stage_commit_deltas, stage_delete_commit_deltas,
+        CommitDeltaManifest, TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
+        TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, TRACKED_STATE_COMMIT_ROOT_MAGIC,
+        TRACKED_STATE_COMMIT_ROOT_SPACE, TRACKED_STATE_TREE_CHUNK_SPACE, commit_delta_manifest_key,
+        decode_commit_delta_manifest, decode_commit_root, encode_commit_delta_manifest,
+        encode_commit_delta_segment, encode_commit_root, key, load_commit_delta_values,
+        scan_commit_delta_values, stage_commit_deltas, stage_delete_commit_deltas, value,
     };
 
     #[derive(Clone)]
@@ -1160,6 +1168,76 @@ mod tests {
             deletes.stats().staged_deletes,
             1,
             "GC should delete the inline manifest only"
+        );
+    }
+
+    #[tokio::test]
+    async fn schema_scan_validates_unselected_packed_delta_entries() {
+        let storage = StorageAdapter::new(Memory::new());
+        let commit_id = CommitId::for_test_label("packed-delta-expected-commit");
+        let wrong_commit_id = CommitId::for_test_label("packed-delta-wrong-commit");
+        let fixtures = packed_commit_delta_fixtures();
+        let alpha = &fixtures[0];
+        let beta = &fixtures[1];
+        let mut entries = vec![
+            EncodedLeafEntry {
+                key: encode_key_ref(TrackedStateKeyRef {
+                    schema_key: &alpha.schema_key,
+                    file_id: alpha.file_id.as_deref(),
+                    entity_pk: &alpha.entity_pk,
+                }),
+                value: encode_value_ref(TrackedStateIndexValueRef {
+                    change_id: alpha.change_id,
+                    commit_id,
+                    deleted: alpha.deleted,
+                    created_at: alpha.created_at,
+                    updated_at: alpha.updated_at,
+                }),
+            },
+            EncodedLeafEntry {
+                key: encode_key_ref(TrackedStateKeyRef {
+                    schema_key: &beta.schema_key,
+                    file_id: beta.file_id.as_deref(),
+                    entity_pk: &beta.entity_pk,
+                }),
+                value: encode_value_ref(TrackedStateIndexValueRef {
+                    change_id: beta.change_id,
+                    commit_id: wrong_commit_id,
+                    deleted: beta.deleted,
+                    created_at: beta.created_at,
+                    updated_at: beta.updated_at,
+                }),
+            },
+        ];
+        entries.sort_unstable_by(|left, right| left.key.cmp(&right.key));
+
+        let mut writes = storage.new_write_set();
+        writes.put(
+            TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
+            key(commit_delta_manifest_key(commit_id)),
+            value(
+                encode_commit_delta_manifest(&CommitDeltaManifest {
+                    inline_segment: encode_commit_delta_segment(&entries),
+                    segments: Vec::new(),
+                })
+                .expect("inline manifest should encode"),
+            ),
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("corrupt fixture should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let error = scan_commit_delta_values(&read, commit_id, &["alpha".to_string()])
+            .await
+            .expect_err("schema scans must validate entries outside the requested schema");
+        assert!(
+            error.to_string().contains("contains an entry for commit"),
+            "unexpected error: {error}"
         );
     }
 


### PR DESCRIPTION
## What changed

- Makes checkpoint → rootless historical diffs scan packed commit-delta segments directly, rather than cloning every descendant key/value into a replay cache that the diff cannot reuse.
- Decodes and validates each scanned packed entry once. The former scan validated every entry and then decoded every matching entry again.
- Keeps RocksDB's returned segment value as `Bytes` until decoding, avoiding an intermediate `Bytes -> Vec<u8>` copy.
- Adds a corruption test proving a schema-filtered scan still rejects a bad commit ID in an unselected entry of the same packed segment.

## Why

A populated historical diff has to discover changes across its rootless interval, then resolve each before-image from the checkpoint. Descendant replay-cache writes cannot help that before-image lookup. Eliminating them, duplicate decoding, and the segment copy removes work from the actual diff critical path without changing query semantics, storage layout, or the public API.

## Measured impact

Lix + RocksDB, 20 commits × 500 rows:

| Populated diff fixture | Before | After | Change |
| --- | ---: | ---: | ---: |
| checkpoint → rootless, 10k disjoint changes | 71.354 ms | 63.024 ms | **-11.7%** |
| checkpoint → rootless, 500 repeated identities | 13.156 ms | 5.866 ms | **-55.4%** |
| working diff, 10k disjoint changes | 36.754 ms | 36.326 ms | -1.2% |
| working diff, 500 repeated identities | 2.885 ms | 2.298 ms | -20.3% |

Values are medians of per-run p50 measurements (41 diff operations per run; nine after-runs). The change does not enter normal tracked-head CRUD serving. It only changes packed historical-delta replay; direct working diff is measured as a non-regression guard.

## Validation

- `cargo fmt --check`
- `cargo clippy -p lix_engine --features storage-benches --release -- -D warnings`
- `cargo test -p lix_engine schema_scan_validates_unselected_packed_delta_entries --lib`
- `tracked_state::storage::tests` (12 passed)
- `rootless_serial_history_replays_scan_and_diff`
- `explicit_rebuild_repairs_missing_child_root_from_nearest_parent`

Stacked on #820, which is stacked on #818, both ultimately targeting `main`.