### PR TITLE
perf: flatten tracked current state rows

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -141,9 +141,9 @@ fn profile_operation(runtime: &tokio::runtime::Runtime, rows: &[WorkloadRow]) {
             match operation {
                 TransactionBenchOp::UpdateAll => {
                     if let Some(repeats) = hot_repeats {
-                        profile_hot_raw_sqlite_literal_updates(rows, repeats);
+                        profile_hot_raw_sqlite_literal_updates(rows, read_many_pk_count, repeats);
                     } else {
-                        profile_raw_sqlite_literal_updates(rows, sample_count);
+                        profile_raw_sqlite_literal_updates(rows, read_many_pk_count, sample_count);
                     }
                 }
                 TransactionBenchOp::ReadManyByPk => {
@@ -189,9 +189,21 @@ fn profile_operation(runtime: &tokio::runtime::Runtime, rows: &[WorkloadRow]) {
             );
             let profile = profile_sql_session_storage();
             if let Some(repeats) = hot_repeats {
-                profile_hot_sql_session_bound_updates(runtime, rows, repeats, profile);
+                profile_hot_sql_session_bound_updates(
+                    runtime,
+                    rows,
+                    read_many_pk_count,
+                    repeats,
+                    profile,
+                );
             } else {
-                profile_sql_session_bound_updates(runtime, rows, sample_count, profile);
+                profile_sql_session_bound_updates(
+                    runtime,
+                    rows,
+                    read_many_pk_count,
+                    sample_count,
+                    profile,
+                );
             }
         }
         Ok("transaction") | Err(_) => {
@@ -221,7 +233,7 @@ fn profile_operation(runtime: &tokio::runtime::Runtime, rows: &[WorkloadRow]) {
 
 fn profile_read_many_pk_count(operation: TransactionBenchOp, row_count: usize) -> usize {
     let Ok(value) = std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_READ_MANY_PK_COUNT") else {
-        return READ_MANY_PK_COUNT;
+        return READ_MANY_PK_COUNT.min(row_count);
     };
     assert!(
         matches!(operation, TransactionBenchOp::ReadManyByPk),
@@ -354,12 +366,17 @@ fn profile_hot_sql_session_operations(
 fn profile_hot_sql_session_bound_updates(
     runtime: &tokio::runtime::Runtime,
     rows: &[WorkloadRow],
+    read_many_pk_count: usize,
     repeats: usize,
     profile: StorageProfile,
 ) {
     let repeats_u32 =
         u32::try_from(repeats).expect("LIX_TRACKED_STATE_CRUD_PROFILE_HOT_REPEATS must fit in u32");
-    let fixture = runtime.block_on(sql_session::seeded_fixture(profile, rows));
+    let fixture = runtime.block_on(sql_session::seeded_fixture_with_read_many_pk_count(
+        profile,
+        rows,
+        read_many_pk_count,
+    ));
     let start = Instant::now();
     let mut row_count = 0;
     for _ in 0..repeats {
@@ -402,10 +419,14 @@ fn profile_hot_raw_sqlite_operations(
     black_box(row_count);
 }
 
-fn profile_hot_raw_sqlite_literal_updates(rows: &[WorkloadRow], repeats: usize) {
+fn profile_hot_raw_sqlite_literal_updates(
+    rows: &[WorkloadRow],
+    read_many_pk_count: usize,
+    repeats: usize,
+) {
     let repeats_u32 =
         u32::try_from(repeats).expect("LIX_TRACKED_STATE_CRUD_PROFILE_HOT_REPEATS must fit in u32");
-    let mut fixture = raw_sqlite::seeded_fixture(rows);
+    let mut fixture = raw_sqlite::seeded_fixture_with_read_many_pk_count(rows, read_many_pk_count);
     let start = Instant::now();
     let mut row_count = 0;
     for _ in 0..repeats {
@@ -549,10 +570,15 @@ fn profile_raw_sqlite_operation(
     print_profile_samples(output.layer(), operation, read_many_pk_count, samples);
 }
 
-fn profile_raw_sqlite_literal_updates(rows: &[WorkloadRow], sample_count: usize) {
+fn profile_raw_sqlite_literal_updates(
+    rows: &[WorkloadRow],
+    read_many_pk_count: usize,
+    sample_count: usize,
+) {
     let mut samples = Vec::with_capacity(sample_count);
     for _ in 0..sample_count {
-        let mut fixture = raw_sqlite::seeded_fixture(rows);
+        let mut fixture =
+            raw_sqlite::seeded_fixture_with_read_many_pk_count(rows, read_many_pk_count);
         let start = Instant::now();
         let result = fixture.update_all_literal();
         samples.push(start.elapsed());
@@ -561,7 +587,7 @@ fn profile_raw_sqlite_literal_updates(rows: &[WorkloadRow], sample_count: usize)
     print_profile_samples(
         "raw_sqlite/literal",
         TransactionBenchOp::UpdateAll,
-        READ_MANY_PK_COUNT,
+        read_many_pk_count,
         samples,
     );
 }
@@ -626,12 +652,17 @@ fn profile_sql_session_operation(
 fn profile_sql_session_bound_updates(
     runtime: &tokio::runtime::Runtime,
     rows: &[WorkloadRow],
+    read_many_pk_count: usize,
     sample_count: usize,
     profile: StorageProfile,
 ) {
     let mut samples = Vec::with_capacity(sample_count);
     for _ in 0..sample_count {
-        let fixture = runtime.block_on(sql_session::seeded_fixture(profile, rows));
+        let fixture = runtime.block_on(sql_session::seeded_fixture_with_read_many_pk_count(
+            profile,
+            rows,
+            read_many_pk_count,
+        ));
         let start = Instant::now();
         let result = runtime.block_on(fixture.update_all_bound());
         samples.push(start.elapsed());
@@ -640,7 +671,7 @@ fn profile_sql_session_bound_updates(
     print_profile_samples(
         &format!("sql_session_bound/{}", profile.name()),
         TransactionBenchOp::UpdateAll,
-        READ_MANY_PK_COUNT,
+        read_many_pk_count,
         samples,
     );
 }

--- a/packages/engine/src/branch/control.rs
+++ b/packages/engine/src/branch/control.rs
@@ -3,7 +3,7 @@
 //! A branch head is a tiny mutable control-plane record, not a user row.  It
 //! therefore has its own space and exact-byte CAS token.  The current tracked
 //! serving generation lives beside the head, so readers can bind packed
-//! tracked-head groups to the same atomic publication without consulting
+//! hot rows to the same atomic publication without consulting
 //! `lix_branch_ref` through the mutable live-state index.
 
 use bytes::Bytes;
@@ -18,29 +18,25 @@ use crate::storage_adapter::{
 };
 use crate::storage_codec;
 
-pub(crate) const BRANCH_HEAD_CONTROL_NAMESPACE: &str = "branch.head_control.v6";
+pub(crate) const BRANCH_HEAD_CONTROL_NAMESPACE: &str = "branch.head_control.v7";
 pub(crate) const BRANCH_HEAD_CONTROL_SPACE: StorageSpace =
-    StorageSpace::new(StorageSpaceId(0x0004_0015), BRANCH_HEAD_CONTROL_NAMESPACE);
+    StorageSpace::new(StorageSpaceId(0x0004_001f), BRANCH_HEAD_CONTROL_NAMESPACE);
 
 /// The one mutable publication record for a branch.
 ///
-/// `generation` is the physical tracked-head generation currently serving
-/// `head_commit_id`. Serial normal commits retain it; a rewind, merge fence,
-/// or bootstrap gets a fresh generation and takes the historical fallback
-/// until a complete projection is published. `tracked_head_is_current` is the
-/// publication bit for that projection, so this atomic control record is the
-/// only read-side fence for a normal tracked branch. The optional checkpoint
-/// binds the sparse working-diff accelerator to this exact publication; it is
-/// not a second visibility record. `current_state_revision` advances for
-/// every in-place current-state mutation, including history-free untracked
-/// writes. It is private storage protocol state and turns the control's CAS
-/// into a real write fence even when the public branch ref does not move.
+/// `generation` names one complete physical hot-state snapshot serving
+/// `head_commit_id`. Serial commits retain it; lifecycle publications create
+/// a fresh complete generation and publish it atomically with this control.
+/// The optional checkpoint binds the sparse working-diff accelerator to that
+/// exact generation. `current_state_revision` advances for every in-place
+/// current-state mutation, including history-free untracked writes. It is
+/// private storage protocol state and turns the control's CAS into a real
+/// write fence even when the public branch ref does not move.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, musli::Encode, musli::Decode)]
 #[musli(packed)]
 pub(crate) struct BranchHeadControl {
     pub(crate) head_commit_id: CommitId,
     pub(crate) generation: CommitId,
-    pub(crate) tracked_head_is_current: bool,
     pub(crate) current_state_revision: u64,
     #[musli(with = storage_codec::option)]
     pub(crate) working_diff_checkpoint_commit_id: Option<CommitId>,
@@ -54,9 +50,9 @@ pub(crate) struct BranchHeadControl {
 
 impl BranchHeadControl {
     /// Returns the same public branch ref with a fresh private current-state
-    /// revision. A mutable group write must publish this alongside its exact
+    /// revision. A mutable hot-row write must publish this alongside its exact
     /// control precondition; otherwise two writers could both compare the
-    /// same unchanged control bytes and lose one group update.
+    /// same unchanged control bytes and lose one hot-state update.
     pub(crate) fn next_current_state_revision(mut self) -> Result<Self, LixError> {
         self.current_state_revision =
             self.current_state_revision.checked_add(1).ok_or_else(|| {
@@ -293,7 +289,6 @@ mod tests {
         let first = BranchHeadControl {
             head_commit_id: CommitId::for_test_label("first-head"),
             generation: CommitId::for_test_label("first-generation"),
-            tracked_head_is_current: true,
             current_state_revision: 0,
             working_diff_checkpoint_commit_id: None,
             created_at: LixTimestamp::expect_parse("first created_at", "2026-01-01T00:00:00Z"),
@@ -303,7 +298,6 @@ mod tests {
         let second = BranchHeadControl {
             head_commit_id: CommitId::for_test_label("second-head"),
             generation: CommitId::for_test_label("first-generation"),
-            tracked_head_is_current: true,
             current_state_revision: 1,
             working_diff_checkpoint_commit_id: None,
             created_at: first.created_at,

--- a/packages/engine/src/branch/refs.rs
+++ b/packages/engine/src/branch/refs.rs
@@ -193,7 +193,6 @@ mod tests {
             BranchHeadControl {
                 head_commit_id: commit_id,
                 generation: commit_id,
-                tracked_head_is_current: false,
                 current_state_revision: 0,
                 working_diff_checkpoint_commit_id: None,
                 created_at: LixTimestamp::expect_parse(

--- a/packages/engine/src/changelog/materialization.rs
+++ b/packages/engine/src/changelog/materialization.rs
@@ -59,7 +59,7 @@ pub(crate) async fn load_change_records<S>(
     change_ids: impl Iterator<Item = ChangeId>,
 ) -> Result<HashMap<ChangeId, ChangeRecord>, LixError>
 where
-    S: StorageAdapterRead,
+    S: StorageAdapterRead + ?Sized,
 {
     let mut unique = Vec::new();
     let mut seen = HashSet::new();
@@ -98,7 +98,7 @@ pub(crate) async fn materialize_change_payloads<S>(
     owner: &str,
 ) -> Result<HashMap<ChangeId, MaterializedChangePayload>, LixError>
 where
-    S: StorageAdapterRead,
+    S: StorageAdapterRead + ?Sized,
 {
     let mut unique = Vec::new();
     let mut seen = HashSet::new();
@@ -197,7 +197,7 @@ async fn load_json_values<S>(
     json_refs: &[JsonRef],
 ) -> Result<Vec<Option<Vec<u8>>>, LixError>
 where
-    S: StorageAdapterRead,
+    S: StorageAdapterRead + ?Sized,
 {
     if json_refs.is_empty() {
         return Ok(Vec::new());

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -992,9 +992,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn untracked_state_survives_checkpoint_replay_and_next_current_materialization() {
+    async fn untracked_state_survives_checkpoint_and_next_tracked_write() {
         let storage = Memory::new();
-        let receipt = Engine::initialize(storage.clone())
+        Engine::initialize(storage.clone())
             .await
             .expect("engine should initialize");
         let engine = Engine::new(storage.clone())
@@ -1017,25 +1017,26 @@ mod tests {
         session
             .create_checkpoint()
             .await
-            .expect("checkpoint should publish a replay-backed tracked head");
-        let read = StorageAdapter::new(storage.clone())
-            .begin_read(StorageReadOptions::default())
+            .expect("checkpoint should publish a complete hot state");
+
+        // A checkpoint publishes a full hot state immediately. Reads do not
+        // replay tracked history and then overlay retained untracked rows.
+        let checkpointed_row = session
+            .execute(
+                "SELECT value FROM json_pointer WHERE path = '/checkpointed'",
+                &[],
+            )
             .await
-            .expect("control read should open");
-        let control = crate::branch::BranchHeadControlContext::new()
-            .reader(read)
-            .load(&receipt.main_branch_id)
-            .await
-            .expect("main control should load")
-            .expect("main control should exist");
-        assert!(
-            !control.tracked_head_is_current,
-            "selected checkpoint publication deliberately serves tracked rows from history"
+            .expect("checkpointed tracked row should read from the hot state");
+        assert_eq!(
+            checkpointed_row.rows()[0]
+                .get::<serde_json::Value>("value")
+                .expect("checkpointed value should decode"),
+            json!({"source": "tracked"})
         );
 
-        // A replay-backed tracked head must not make workspace state
-        // unwritable. This mutates its retained current-state generation only;
-        // it neither advances the commit graph nor resets tracked state.
+        // A checkpointed branch remains writable. This history-free mutation
+        // updates the same complete hot generation without advancing history.
         session
             .execute(
                 "INSERT INTO json_pointer (path, value, lixcol_untracked) \
@@ -1043,14 +1044,14 @@ mod tests {
                 &[],
             )
             .await
-            .expect("untracked row should write while tracked state replays");
+            .expect("untracked row should write against the complete hot state");
         let workspace_row = session
             .execute(
                 "SELECT value FROM json_pointer WHERE path = '/workspace'",
                 &[],
             )
             .await
-            .expect("untracked row should read through the replay fallback");
+            .expect("untracked row should read from the complete hot state");
         assert_eq!(
             workspace_row.rows()[0]
                 .get::<serde_json::Value>("value")
@@ -1058,16 +1059,15 @@ mod tests {
             json!({"source": "untracked"})
         );
 
-        // The next tracked child rebuilds a complete hot current-state
-        // generation from history and carries the history-free member forward.
+        // The next tracked child carries the history-free member forward.
         session
             .execute(
                 "INSERT INTO json_pointer (path, value) \
-                 VALUES ('/after-replay', lix_json('{\"source\":\"tracked\"}'))",
+                 VALUES ('/after-checkpoint', lix_json('{\"source\":\"tracked\"}'))",
                 &[],
             )
             .await
-            .expect("tracked child should rematerialize current state");
+            .expect("tracked child should publish the next complete hot state");
         let rows = session
             .execute("SELECT path FROM json_pointer ORDER BY path", &[])
             .await
@@ -1077,21 +1077,7 @@ mod tests {
                 .iter()
                 .map(|row| row.get::<String>("path").expect("row path"))
                 .collect::<Vec<_>>(),
-            ["/after-replay", "/checkpointed", "/workspace"]
-        );
-        let read = StorageAdapter::new(storage)
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("current-control read should open");
-        assert!(
-            crate::branch::BranchHeadControlContext::new()
-                .reader(read)
-                .load(&receipt.main_branch_id)
-                .await
-                .expect("main control should load")
-                .expect("main control should exist")
-                .tracked_head_is_current,
-            "the tracked child must publish one complete current-state generation"
+            ["/after-checkpoint", "/checkpointed", "/workspace"]
         );
     }
 
@@ -1177,21 +1163,21 @@ mod tests {
         let read = storage_adapter
             .begin_read(StorageReadOptions::default())
             .await
-            .expect("read initialized head groups");
-        let groups = ScanPlan::prefix(
-            crate::live_state::TRACKED_HEAD_GROUP_SPACE,
+            .expect("read initialized hot rows");
+        let hot_rows = ScanPlan::prefix(
+            crate::live_state::HOT_ROW_SPACE,
             StoragePrefix {
                 bytes: Bytes::new(),
             },
         )
         .collect(&read, StorageScanOptions::default())
         .await
-        .expect("scan initialized head groups")
+        .expect("scan initialized hot rows")
         .value
         .entries;
         assert!(
-            !groups.is_empty(),
-            "initialized repository must have head groups"
+            !hot_rows.is_empty(),
+            "initialized repository must have hot rows"
         );
 
         let mut writes = storage_adapter.new_write_set();
@@ -1200,10 +1186,10 @@ mod tests {
             crate::init::REPOSITORY_PROTOCOL_KEY,
             &b"tracked-direct-plane.v8"[..],
         );
-        for group in groups {
+        for hot_row in hot_rows {
             writes.put(
-                crate::live_state::TRACKED_HEAD_GROUP_SPACE,
-                group.key,
+                crate::live_state::HOT_ROW_SPACE,
+                hot_row.key,
                 StorageValue {
                     bytes: Bytes::from_static(b"predecessor-head-bytes"),
                 },

--- a/packages/engine/src/functions/state.rs
+++ b/packages/engine/src/functions/state.rs
@@ -119,7 +119,7 @@ pub(crate) async fn stage_sequence(
             &mut working_diff_coverage,
         )
         .await?;
-    // The grouped current-state mutation is fenced by an actual control-byte
+    // The hot-state mutation is fenced by an actual control-byte
     // change. Merely restaging the old control would let two writers both
     // satisfy the same CAS after the first write, losing one group update.
     stage_branch_head_control(
@@ -151,26 +151,9 @@ async fn load_key_value_row(
         metadata: false,
     };
     let reader = TrackedHeadContext::new().reader(read);
-    let rows = if control.tracked_head_is_current {
-        reader
-            .load_projected_live_rows_if_control_current(
-                GLOBAL_BRANCH_ID,
-                control,
-                &keys,
-                &projection,
-            )
-            .await?
-            .unwrap_or_default()
-    } else {
-        reader
-            .load_untracked_projected_rows_for_generation(
-                GLOBAL_BRANCH_ID,
-                control.generation,
-                &keys,
-                &projection,
-            )
-            .await?
-    };
+    let rows = reader
+        .load_projected_live_rows(GLOBAL_BRANCH_ID, control, &keys, &projection)
+        .await?;
     Ok(rows
         .into_iter()
         .next()

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -39,7 +39,7 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 
 /// Repository-wide compatibility gate for physical storage protocols.
 ///
-/// V12 makes the packed current-state generation authoritative for both
+/// V15 makes the complete hot current-state generation authoritative for both
 /// tracked and untracked rows. Untracked values have no separate index,
 /// presence marker, or standalone changelog record. Opening an older store
 /// must fail closed rather than mixing its former visibility rules with the
@@ -47,7 +47,7 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"unified-current-state.v12";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"live-state.hot.v15";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately
@@ -91,7 +91,7 @@ pub(crate) async fn repository_protocol_status(
 pub(crate) fn unsupported_repository_protocol_error() -> LixError {
     LixError::new(
         "LIX_ERROR_UNSUPPORTED_STORAGE_FORMAT",
-        "repository uses an unsupported unified current-state storage protocol; recreate the repository",
+        "repository uses an unsupported live-state hot-index storage protocol; recreate the repository",
     )
 }
 
@@ -232,7 +232,6 @@ pub(crate) fn plan_init_seed(functions: FunctionProviderHandle) -> Result<InitSe
         control: BranchHeadControl {
             head_commit_id: initial_commit_id,
             generation: initial_commit_id,
-            tracked_head_is_current: true,
             current_state_revision: 0,
             working_diff_checkpoint_commit_id: Some(initial_commit_id),
             created_at: timestamp,
@@ -252,7 +251,6 @@ pub(crate) fn plan_init_seed(functions: FunctionProviderHandle) -> Result<InitSe
         control: BranchHeadControl {
             head_commit_id: initial_commit_id,
             generation: initial_commit_id,
-            tracked_head_is_current: true,
             current_state_revision: 0,
             working_diff_checkpoint_commit_id: Some(initial_commit_id),
             created_at: timestamp,
@@ -358,10 +356,10 @@ where
             .stage_commit_root(&receipt.initial_commit_id, None, deltas)
             .await?;
 
-        // Seed both visible branches with a complete V12 current-state generation.
+        // Seed both visible branches with a complete hot current-state generation.
         // The initial commit is shared, but the branch-scoped marker and
         // groups are intentionally independent so normal reads never need a
-        // historical fallback immediately after initialization.
+        // reconstruction path immediately after initialization.
         let tracked_head_deltas = authored_changes
             .iter()
             .map(|change| CurrentStateDeltaRef {
@@ -408,7 +406,7 @@ where
                     &absence_guards,
                     None,
                     None,
-                    None,
+                    Some(plan.commit.id),
                     &mut working_diff_coverage,
                 )
                 .await?;
@@ -417,7 +415,7 @@ where
                 &branch.branch_id,
                 TrackedWorkingDiffEpoch {
                     checkpoint_commit_id: plan.commit.id,
-                    generation: Some(plan.commit.id),
+                    generation: plan.commit.id,
                     coverage: working_diff_coverage,
                 },
             )?;

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -18,8 +18,7 @@ use crate::live_state::{
 };
 use crate::storage_adapter::StorageAdapterRead;
 use crate::tracked_state::{
-    MaterializedTrackedStateRow, TrackedStateContext, TrackedStateFilter, TrackedStateReadColumns,
-    TrackedStateScanRequest,
+    TrackedStateContext, TrackedStateFilter, TrackedStateReadColumns, TrackedStateScanRequest,
 };
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -33,11 +32,10 @@ const COMMIT_EDGE_SCHEMA_KEY: &str = "lix_commit_edge";
 
 /// Serving facade for visible live-state reads.
 ///
-/// Normal rows are resolved from one durable current-state projection. Each
-/// packed member carries its own tracked|untracked retention, so readers do
-/// not route through a separate retention index or merge retention candidates.
+/// Normal rows are resolved from one durable hot-state projection. Each row
+/// carries its own tracked|untracked retention, so readers do not route
+/// through a separate retention index or merge retention candidates.
 pub(crate) struct LiveStateContext {
-    tracked_state: TrackedStateContext,
     tracked_head: TrackedHeadContext,
     commit_graph: CommitGraphContext,
     filesystem_path_index_cache: std::sync::Arc<FilesystemPathIndexCache>,
@@ -45,11 +43,10 @@ pub(crate) struct LiveStateContext {
 
 impl LiveStateContext {
     pub(crate) fn new(
-        tracked_state: TrackedStateContext,
+        _tracked_state: TrackedStateContext,
         commit_graph: CommitGraphContext,
     ) -> Self {
         Self {
-            tracked_state,
             tracked_head: TrackedHeadContext::new(),
             commit_graph,
             filesystem_path_index_cache: std::sync::Arc::new(FilesystemPathIndexCache::default()),
@@ -63,7 +60,6 @@ impl LiveStateContext {
     {
         LiveStateStoreReader {
             store,
-            tracked_state: self.tracked_state.clone(),
             tracked_head: self.tracked_head,
             commit_graph: self.commit_graph.clone(),
             filesystem_path_index_cache: std::sync::Arc::clone(&self.filesystem_path_index_cache),
@@ -84,7 +80,6 @@ impl LiveStateContext {
 /// Visible live-state reader backed by a caller-provided KV store.
 pub(crate) struct LiveStateStoreReader<S> {
     store: S,
-    tracked_state: TrackedStateContext,
     tracked_head: TrackedHeadContext,
     commit_graph: CommitGraphContext,
     filesystem_path_index_cache: std::sync::Arc<FilesystemPathIndexCache>,
@@ -98,15 +93,14 @@ where
     ///
     /// `None` means the normal materialized visibility path remains
     /// authoritative: a global branch projection, multiple result branch
-    /// scopes, commit-derived state, or an unavailable current-state
-    /// generation all deliberately fall back rather than approximating
-    /// visibility.
+    /// scopes, or commit-derived state all require its full visibility
+    /// semantics.
     pub(crate) async fn scan_direct_entity_snapshots(
         &self,
         request: &LiveStateScanRequest,
     ) -> Result<Option<Vec<Option<Bytes>>>, LixError> {
-        // V12 carries tracked and untracked members in one current-state
-        // group, so this route never probes a separate retention index or marker.
+        // The hot index carries tracked and untracked rows in one serving
+        // plane, so this route never probes a separate retention index.
         if request.filter.untracked.is_some()
             || request_may_include_commit_derived(request)
             || request
@@ -138,25 +132,24 @@ where
         if requested_branch_id != GLOBAL_BRANCH_ID
             && let Some(global_control) = scope.branch_heads.get(GLOBAL_BRANCH_ID).copied()
         {
-            let Some(global_has_rows) = tracked_head
-                .has_schema_rows_if_control_current(GLOBAL_BRANCH_ID, global_control, schema_key)
-                .await?
-            else {
-                return Ok(None);
-            };
+            let global_has_rows = tracked_head
+                .has_schema_rows(GLOBAL_BRANCH_ID, global_control, schema_key)
+                .await?;
             if global_has_rows {
                 return Ok(None);
             }
         }
-        tracked_head
-            .scan_entity_snapshots_if_control_current(
-                requested_branch_id,
-                requested_control,
-                schema_key,
-                &request.filter.entity_pks,
-                request.limit,
-            )
-            .await
+        Ok(Some(
+            tracked_head
+                .scan_entity_snapshots(
+                    requested_branch_id,
+                    requested_control,
+                    schema_key,
+                    &request.filter.entity_pks,
+                    request.limit,
+                )
+                .await?,
+        ))
     }
 
     pub(crate) async fn scan_rows(
@@ -166,7 +159,7 @@ where
         let store = &self.store;
         let reads_tracked = !is_commit_derived_only_request(request);
         let scope = scan_scope(store, request, reads_tracked).await?;
-        if let Some(rows) = self.scan_direct_tracked_pk_groups(request, &scope).await? {
+        if let Some(rows) = self.scan_direct_entity_pk_rows(request, &scope).await? {
             return Ok(rows);
         }
         let commit_derived_rows = if request.filter.untracked != Some(true) {
@@ -174,15 +167,15 @@ where
         } else {
             Vec::new()
         };
-        let mut tracked_branch_rows = if !is_commit_derived_only_request(request) {
-            self.scan_tracked_branch_rows(request, &scope).await?
+        let mut hot_branch_rows = if !is_commit_derived_only_request(request) {
+            self.scan_hot_branch_rows(request, &scope).await?
         } else {
             Vec::new()
         };
         if request.filter.untracked != Some(false) {
             let branch_ref_rows = scan_direct_branch_ref_rows(store, request, &scope).await?;
             if !branch_ref_rows.is_empty() {
-                tracked_branch_rows.push(TrackedBranchRows {
+                hot_branch_rows.push(HotBranchRows {
                     branch_id: GLOBAL_BRANCH_ID.to_string(),
                     rows: branch_ref_rows,
                     ordered_unique: false,
@@ -193,24 +186,24 @@ where
         // resolver, so apply the retention predicate before taking that fast
         // path. Otherwise `untracked = Some(..)` accidentally returned both
         // member kinds from an already-unified group.
-        for branch_rows in &mut tracked_branch_rows {
+        for branch_rows in &mut hot_branch_rows {
             branch_rows
                 .rows
                 .retain(|row| current_row_matches_retention(row, request.filter.untracked));
         }
         if commit_derived_rows.is_empty()
             && let Some(index) =
-                ordered_unique_branch_row_index(&tracked_branch_rows, &scope.projection_branch_ids)
+                ordered_unique_branch_row_index(&hot_branch_rows, &scope.projection_branch_ids)
         {
             return Ok(finalize_ordered_unique_rows(
-                std::mem::take(&mut tracked_branch_rows[index].rows),
+                std::mem::take(&mut hot_branch_rows[index].rows),
                 request.filter.include_tombstones,
                 request.limit,
             ));
         }
         let mut rows = commit_derived_rows;
         rows.extend(
-            tracked_branch_rows
+            hot_branch_rows
                 .into_iter()
                 .flat_map(|branch_rows| branch_rows.rows),
         );
@@ -227,10 +220,10 @@ where
         ))
     }
 
-    /// Serves finite entity-PK scans from packed current-state groups. Every
-    /// member already has its retention tag, so an unrelated untracked row
-    /// cannot route the selected tracked identities through a separate scan.
-    async fn scan_direct_tracked_pk_groups(
+    /// Serves finite entity-PK scans from the hot current-state index. Every
+    /// row already has its retention tag, so an unrelated untracked row
+    /// cannot route selected tracked identities through a separate scan.
+    async fn scan_direct_entity_pk_rows(
         &self,
         request: &LiveStateScanRequest,
         scope: &LiveStateScanScope,
@@ -265,14 +258,11 @@ where
             return Ok(None);
         };
         let tracked_request = tracked_scan_request_from_live(request);
-        let Some(rows_by_branch) = self
+        let rows_by_branch = self
             .tracked_head
             .reader(&self.store)
-            .scan_live_rows_for_current_controls(&controls, &tracked_request)
-            .await?
-        else {
-            return Ok(None);
-        };
+            .scan_live_rows_for_controls(&controls, &tracked_request)
+            .await?;
         let rows = rows_by_branch
             .into_iter()
             .flat_map(|(_, rows)| rows)
@@ -357,11 +347,11 @@ where
             },
             ..Default::default()
         };
-        // Current-state groups are authoritative for both retention modes.
+        // The hot current-state rows are authoritative for both retention modes.
         // Even an untracked-only exact batch therefore needs the branch
         // controls that select the active generation; treating that request
         // as "not tracked" used to skip the controls entirely and made the
-        // workspace selector (an untracked row) invisible after V12 init.
+        // workspace selector (an untracked row) invisible after hot-index init.
         let scope = scan_scope(&self.store, &scope_request, true).await?;
         let visible_branch_ids = scope
             .projection_branch_ids
@@ -407,7 +397,6 @@ where
         let current_batches = stream::iter(identities_by_branch)
             .map(|(branch_id, identities)| {
                 let control = scope.branch_heads[&branch_id];
-                let commit_id = control.head_commit_id.to_string();
                 let projection = projection.clone();
                 async move {
                     let keys = identities
@@ -418,40 +407,11 @@ where
                             file_id: identity.file_id.clone(),
                         })
                         .collect::<Vec<_>>();
-                    let source = tracked_source_from_branch_id(&branch_id);
-                    let rows = if let Some(rows) = self
+                    let rows = self
                         .tracked_head
                         .reader(&self.store)
-                        .load_projected_live_rows_if_control_current(
-                            &branch_id,
-                            control,
-                            &keys,
-                            &projection,
-                        )
-                        .await?
-                    {
-                        rows
-                    } else {
-                        let untracked_rows = self
-                            .tracked_head
-                            .reader(&self.store)
-                            .load_untracked_projected_rows_for_generation(
-                                &branch_id,
-                                control.generation,
-                                &keys,
-                                &projection,
-                            )
-                            .await?;
-                        self.tracked_state
-                            .reader(&self.store)
-                            .load_projected_rows_at_commit(&commit_id, &keys, &projection)
-                            .await?
-                            .into_iter()
-                            .map(|row| row.map(|row| project_tracked_row(row, &branch_id, source)))
-                            .zip(untracked_rows)
-                            .map(|(tracked, untracked)| untracked.or(tracked))
-                            .collect()
-                    };
+                        .load_projected_live_rows(&branch_id, control, &keys, &projection)
+                        .await?;
                     Ok::<_, LixError>((identities, rows))
                 }
             })
@@ -521,27 +481,27 @@ where
         let scope = scan_scope(store, request, reads_tracked).await?;
         let commit_derived_rows =
             scan_commit_derived_rows(store, &self.commit_graph, request, &scope).await?;
-        let mut tracked_branch_rows = if !is_commit_derived_only_request(request) {
-            self.scan_tracked_branch_rows(request, &scope).await?
+        let mut hot_branch_rows = if !is_commit_derived_only_request(request) {
+            self.scan_hot_branch_rows(request, &scope).await?
         } else {
             Vec::new()
         };
-        for branch_rows in &mut tracked_branch_rows {
+        for branch_rows in &mut hot_branch_rows {
             branch_rows.rows.retain(|row| !row.untracked);
         }
         if commit_derived_rows.is_empty()
             && let Some(index) =
-                ordered_unique_branch_row_index(&tracked_branch_rows, &scope.projection_branch_ids)
+                ordered_unique_branch_row_index(&hot_branch_rows, &scope.projection_branch_ids)
         {
             return Ok(finalize_ordered_unique_rows(
-                std::mem::take(&mut tracked_branch_rows[index].rows),
+                std::mem::take(&mut hot_branch_rows[index].rows),
                 request.filter.include_tombstones,
                 request.limit,
             ));
         }
         let mut rows = commit_derived_rows;
         rows.extend(
-            tracked_branch_rows
+            hot_branch_rows
                 .into_iter()
                 .flat_map(|branch_rows| branch_rows.rows),
         );
@@ -558,11 +518,11 @@ where
         ))
     }
 
-    async fn scan_tracked_branch_rows(
+    async fn scan_hot_branch_rows(
         &self,
         request: &LiveStateScanRequest,
         scope: &LiveStateScanScope,
-    ) -> Result<Vec<TrackedBranchRows>, LixError> {
+    ) -> Result<Vec<HotBranchRows>, LixError> {
         let store = &self.store;
         let tracked_request = tracked_scan_request_from_live(request);
         let branches = scope
@@ -579,51 +539,15 @@ where
             .map(|(branch_id, control)| {
                 let tracked_request = tracked_request.clone();
                 async move {
-                    let (rows, ordered_unique) = if let Some(rows) = self
+                    let rows = self
                         .tracked_head
                         .reader(store)
-                        .scan_live_rows_if_control_current(&branch_id, control, &tracked_request)
-                        .await?
-                    {
-                        (rows, true)
-                    } else {
-                        let mut rows = self
-                            .tracked_state
-                            .reader(store)
-                            .scan_rows_at_commit(
-                                &control.head_commit_id.to_string(),
-                                &tracked_request,
-                            )
-                            .await?
-                            .into_iter()
-                            .map(|row| {
-                                project_tracked_row(
-                                    row,
-                                    &branch_id,
-                                    tracked_source_from_branch_id(&branch_id),
-                                )
-                            })
-                            .collect::<Vec<_>>();
-                        // Lifecycle fallback reconstructs only tracked
-                        // history. The old serving generation remains the
-                        // workspace source of truth for untracked members
-                        // until the next complete generation is published.
-                        rows.extend(
-                            self.tracked_head
-                                .reader(store)
-                                .scan_untracked_rows_for_generation(
-                                    &branch_id,
-                                    control.generation,
-                                    &tracked_request,
-                                )
-                                .await?,
-                        );
-                        (rows, false)
-                    };
-                    Ok::<_, LixError>(TrackedBranchRows {
+                        .scan_live_rows(&branch_id, control, &tracked_request)
+                        .await?;
+                    Ok::<_, LixError>(HotBranchRows {
                         branch_id: branch_id.clone(),
                         rows,
-                        ordered_unique,
+                        ordered_unique: true,
                     })
                 }
             })
@@ -953,24 +877,22 @@ struct LiveStateScanScope {
     branch_heads: BranchHeads,
 }
 
-/// Rows read from one durable tracked branch source.
+/// Rows read from one durable hot-state branch source.
 ///
-/// A matching tracked-head projection is storage-key ordered by visible
-/// identity and has one row per identity. Immutable-root fallback rows retain
-/// their existing, more general materialization behavior and therefore never
-/// claim this fast-path contract.
-struct TrackedBranchRows {
+/// A matching hot-state projection is storage-key ordered by visible identity
+/// and has one row per identity.
+struct HotBranchRows {
     branch_id: String,
     rows: Vec<MaterializedLiveStateRow>,
     ordered_unique: bool,
 }
 
 /// Returns the only nonempty branch candidate when it can be served without
-/// overlay arbitration. Global rows, multiple requested branches, an
-/// immutable-root fallback, and staged/untracked candidates all stay on the
-/// general visibility path.
+/// branch/global visibility resolution. Global rows, multiple requested
+/// branches, and synthesized branch-ref candidates all stay on the general
+/// visibility path.
 fn ordered_unique_branch_row_index(
-    branch_rows: &[TrackedBranchRows],
+    branch_rows: &[HotBranchRows],
     projection_branch_ids: &[String],
 ) -> Option<usize> {
     let [requested_branch_id] = projection_branch_ids else {
@@ -1124,48 +1046,6 @@ async fn load_branch_head_control_ids(
         .collect())
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum TrackedRowSource {
-    Global,
-    Branch,
-}
-
-fn tracked_source_from_branch_id(branch_id: &str) -> TrackedRowSource {
-    if branch_id == GLOBAL_BRANCH_ID {
-        TrackedRowSource::Global
-    } else {
-        TrackedRowSource::Branch
-    }
-}
-
-fn project_tracked_row(
-    row: MaterializedTrackedStateRow,
-    view_branch_id: &str,
-    source: TrackedRowSource,
-) -> MaterializedLiveStateRow {
-    MaterializedLiveStateRow {
-        entity_pk: row.entity_pk,
-        schema_key: row.schema_key,
-        file_id: row.file_id,
-        snapshot_content: row.snapshot_content,
-        metadata: row.metadata,
-        deleted: row.deleted,
-        created_at: crate::common::LixTimestamp::expect_parse(
-            "tracked-state row created_at",
-            &row.created_at,
-        ),
-        updated_at: crate::common::LixTimestamp::expect_parse(
-            "tracked-state row updated_at",
-            &row.updated_at,
-        ),
-        global: source == TrackedRowSource::Global,
-        change_id: Some(row.change_id),
-        commit_id: Some(row.commit_id),
-        untracked: false,
-        branch_id: view_branch_id.into(),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1179,7 +1059,9 @@ mod tests {
     };
     use crate::storage_adapter::{Memory, StorageReadOptions, StorageWriteOptions};
     use crate::storage_adapter::{StorageAdapter, StorageWriteSet};
-    use crate::tracked_state::{TrackedStateDeltaRef, TrackedStateScanRequest};
+    use crate::tracked_state::{
+        MaterializedTrackedStateRow, TrackedStateDeltaRef, TrackedStateScanRequest,
+    };
     use serde_json::json;
 
     const COMMIT_SCHEMA_KEY: &str = "lix_commit";
@@ -1271,7 +1153,7 @@ mod tests {
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
-            .expect("open packed-head write read");
+            .expect("open hot-state write read");
         let mut writes = StorageWriteSet::new();
         crate::init::stage_repository_protocol(&mut writes);
         let deltas = rows
@@ -1304,41 +1186,12 @@ mod tests {
                 None,
             )
             .await
-            .expect("stage packed direct head");
+            .expect("stage direct hot state");
         drop(read);
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
-            .expect("commit packed direct head");
-    }
-
-    async fn stage_direct_head_control(
-        storage: &StorageAdapter,
-        branch_id: &str,
-        head: CommitId,
-        tracked_head_is_current: bool,
-    ) {
-        let mut writes = StorageWriteSet::new();
-        crate::init::stage_repository_protocol(&mut writes);
-        crate::branch::stage_branch_head_control(
-            &mut writes,
-            branch_id,
-            BranchHeadControl {
-                head_commit_id: head,
-                generation: head,
-                tracked_head_is_current,
-                current_state_revision: 0,
-                working_diff_checkpoint_commit_id: None,
-                created_at: ts("2026-01-01T00:00:00Z"),
-                updated_at: ts("2026-01-01T00:00:00Z"),
-                ref_change_id: ChangeId::for_test_label(&format!("{branch_id}-branch-ref")),
-            },
-        )
-        .expect("stage direct branch control");
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("commit direct branch control");
+            .expect("commit direct hot state");
     }
 
     fn finite_pk_scan_request(
@@ -1357,7 +1210,7 @@ mod tests {
         }
     }
 
-    async fn scan_direct_tracked_pk_groups_for_test(
+    async fn scan_direct_entity_pk_rows_for_test(
         live_state: &LiveStateContext,
         storage: &StorageAdapter,
         request: &LiveStateScanRequest,
@@ -1365,11 +1218,11 @@ mod tests {
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
-            .expect("open direct grouped scan read");
+            .expect("open direct hot-state scan read");
         let scope = scan_scope(&read, request, true).await?;
         live_state
             .reader(read)
-            .scan_direct_tracked_pk_groups(request, &scope)
+            .scan_direct_entity_pk_rows(request, &scope)
             .await
     }
 
@@ -1418,7 +1271,7 @@ mod tests {
     #[test]
     fn ordered_head_fast_path_requires_one_matching_branch_candidate() {
         let requested_branch_ids = vec!["branch".to_string()];
-        let branch = TrackedBranchRows {
+        let branch = HotBranchRows {
             branch_id: "branch".to_string(),
             rows: vec![tracked_row_at_with_commit(
                 "branch", "branch", None, "branch",
@@ -1430,14 +1283,14 @@ mod tests {
             Some(0)
         );
 
-        let branch = TrackedBranchRows {
+        let branch = HotBranchRows {
             branch_id: "branch".to_string(),
             rows: vec![tracked_row_at_with_commit(
                 "branch", "branch", None, "branch",
             )],
             ordered_unique: true,
         };
-        let global = TrackedBranchRows {
+        let global = HotBranchRows {
             branch_id: GLOBAL_BRANCH_ID.to_string(),
             rows: vec![tracked_row_at_with_commit(
                 GLOBAL_BRANCH_ID,
@@ -1450,10 +1303,10 @@ mod tests {
         assert_eq!(
             ordered_unique_branch_row_index(&[branch, global], &requested_branch_ids),
             None,
-            "a global candidate needs normal overlay arbitration"
+            "a global candidate needs normal branch/global resolution"
         );
 
-        let immutable_fallback = TrackedBranchRows {
+        let unordered_candidate = HotBranchRows {
             branch_id: "branch".to_string(),
             rows: vec![tracked_row_at_with_commit(
                 "branch", "branch", None, "branch",
@@ -1461,9 +1314,9 @@ mod tests {
             ordered_unique: false,
         };
         assert_eq!(
-            ordered_unique_branch_row_index(&[immutable_fallback], &requested_branch_ids),
+            ordered_unique_branch_row_index(&[unordered_candidate], &requested_branch_ids),
             None,
-            "the immutable-root fallback does not make the table ordering promise"
+            "an unordered candidate does not make the table ordering promise"
         );
     }
 
@@ -1502,9 +1355,9 @@ mod tests {
                 std::slice::from_ref(&local_pk),
             )
             .await
-            .expect("global-overlaid entity scan should execute")
+            .expect("global entity scan should execute")
             .is_none(),
-            "a global tracked row requires the established overlay resolver"
+            "a global tracked row requires the established branch/global resolver"
         );
     }
 
@@ -1601,7 +1454,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn finite_pk_group_scan_returns_all_file_id_siblings() {
+    async fn finite_pk_hot_scan_returns_all_file_id_siblings() {
         let storage = StorageAdapter::new(Memory::new());
         let live_state = live_state_context();
         let entity_pk = EntityPk::single("shared-entity");
@@ -1624,16 +1477,16 @@ mod tests {
         stage_direct_tracked_head_rows(
             &storage,
             GLOBAL_BRANCH_ID,
-            CommitId::for_test_label("grouped-siblings"),
+            CommitId::for_test_label("hot-row-siblings"),
             &rows,
         )
         .await;
 
         let request = finite_pk_scan_request(GLOBAL_BRANCH_ID, "schema", vec![entity_pk]);
-        let direct = scan_direct_tracked_pk_groups_for_test(&live_state, &storage, &request)
+        let direct = scan_direct_entity_pk_rows_for_test(&live_state, &storage, &request)
             .await
-            .expect("direct grouped scan should execute")
-            .expect("finite tracked primary-key scan should use grouped route");
+            .expect("direct hot-state scan should execute")
+            .expect("finite tracked primary-key scan should use the hot route");
         let file_values = direct
             .iter()
             .map(|row| (row.file_id.as_deref(), row.snapshot_content.as_deref()))
@@ -1653,7 +1506,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn finite_pk_group_scan_resolves_branch_override_and_tombstone_against_global() {
+    async fn finite_pk_hot_scan_resolves_branch_override_and_tombstone_against_global() {
         let storage = StorageAdapter::new(Memory::new());
         let live_state = live_state_context();
         let entity_pk = EntityPk::single("shared-entity");
@@ -1685,10 +1538,10 @@ mod tests {
         .await;
 
         let request = finite_pk_scan_request("branch-a", "schema", vec![entity_pk.clone()]);
-        let direct = scan_direct_tracked_pk_groups_for_test(&live_state, &storage, &request)
+        let direct = scan_direct_entity_pk_rows_for_test(&live_state, &storage, &request)
             .await
-            .expect("direct grouped scan should execute")
-            .expect("current branch and global controls should use grouped route");
+            .expect("direct hot-state scan should execute")
+            .expect("current branch and global controls should use the hot route");
         assert_eq!(direct.len(), 1);
         assert_eq!(direct[0].branch_id.as_ref(), "branch-a");
         assert!(!direct[0].global);
@@ -1717,10 +1570,10 @@ mod tests {
         )
         .await;
 
-        let hidden = scan_direct_tracked_pk_groups_for_test(&live_state, &storage, &request)
+        let hidden = scan_direct_entity_pk_rows_for_test(&live_state, &storage, &request)
             .await
-            .expect("direct grouped tombstone scan should execute")
-            .expect("current controls should retain the grouped route");
+            .expect("direct hot-state tombstone scan should execute")
+            .expect("current controls should retain the hot route");
         assert!(hidden.is_empty(), "local tombstone must hide global row");
         assert!(
             scan_rows_for_test(&live_state, &storage, &request)
@@ -1732,10 +1585,10 @@ mod tests {
         let mut including_tombstones = request.clone();
         including_tombstones.filter.include_tombstones = true;
         let tombstones =
-            scan_direct_tracked_pk_groups_for_test(&live_state, &storage, &including_tombstones)
+            scan_direct_entity_pk_rows_for_test(&live_state, &storage, &including_tombstones)
                 .await
-                .expect("direct grouped tombstone scan should execute")
-                .expect("current controls should retain the grouped route");
+                .expect("direct hot-state tombstone scan should execute")
+                .expect("current controls should retain the hot route");
         assert_eq!(tombstones.len(), 1);
         assert!(tombstones[0].deleted);
         assert!(!tombstones[0].global);
@@ -1743,7 +1596,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn finite_pk_group_scan_serves_mixed_current_state() {
+    async fn finite_pk_hot_scan_serves_mixed_current_state() {
         let storage = StorageAdapter::new(Memory::new());
         let live_state = live_state_context();
         let tracked_pk = EntityPk::single("tracked-entity");
@@ -1768,11 +1621,11 @@ mod tests {
             vec![tracked_pk.clone(), untracked_pk.clone()],
         );
         assert!(
-            scan_direct_tracked_pk_groups_for_test(&live_state, &storage, &request)
+            scan_direct_entity_pk_rows_for_test(&live_state, &storage, &request)
                 .await
-                .expect("initial direct grouped scan should execute")
+                .expect("initial direct hot-state scan should execute")
                 .is_some(),
-            "the grouped current state serves tracked-only rows directly"
+            "the hot current state serves tracked-only rows directly"
         );
 
         let read = storage
@@ -1796,10 +1649,10 @@ mod tests {
         )
         .await;
 
-        let direct = scan_direct_tracked_pk_groups_for_test(&live_state, &storage, &request)
+        let direct = scan_direct_entity_pk_rows_for_test(&live_state, &storage, &request)
             .await
-            .expect("mixed grouped scan should execute")
-            .expect("one current-state group serves both retention modes");
+            .expect("mixed hot-state scan should execute")
+            .expect("one hot index serves both retention modes");
         assert_eq!(direct.len(), 2);
         let rows = scan_rows_for_test(&live_state, &storage, &request)
             .await
@@ -1857,9 +1710,9 @@ mod tests {
         let mut request = finite_pk_scan_request(GLOBAL_BRANCH_ID, "schema", vec![entity_pk]);
         request.filter.file_ids = vec![NullableKeyFilter::Value("file-a".to_string())];
         assert!(
-            scan_direct_tracked_pk_groups_for_test(&live_state, &storage, &request)
+            scan_direct_entity_pk_rows_for_test(&live_state, &storage, &request)
                 .await
-                .expect("file-filtered direct grouped scan should execute")
+                .expect("file-filtered direct hot-state scan should execute")
                 .is_none(),
             "an explicit file-id predicate must retain the member projection route"
         );
@@ -1871,61 +1724,6 @@ mod tests {
         assert_eq!(
             rows[0].snapshot_content.as_deref(),
             Some(r#"{"value":"a"}"#)
-        );
-    }
-
-    #[tokio::test]
-    async fn noncurrent_control_falls_back_to_historical_root_for_finite_pk_scan() {
-        let storage = StorageAdapter::new(Memory::new());
-        let live_state = live_state_context();
-        let entity_pk = EntityPk::single("historical-entity");
-        let mut historical = tracked_row_at_with_commit(
-            GLOBAL_BRANCH_ID,
-            "historical",
-            Some("history-change"),
-            "history-head",
-        );
-        historical.schema_key = "schema".to_string();
-        historical.entity_pk = entity_pk.clone();
-
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("open historical root write read");
-        let mut writes = StorageWriteSet::new();
-        let mut json_writer = JsonStoreContext::new().writer();
-        stage_materialized_live_rows(&read, &mut writes, &mut json_writer, &[historical])
-            .await
-            .expect("historical tracked root should stage");
-        drop(read);
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("historical tracked root should commit");
-        stage_direct_head_control(
-            &storage,
-            GLOBAL_BRANCH_ID,
-            CommitId::for_test_label("history-head"),
-            false,
-        )
-        .await;
-
-        let request = finite_pk_scan_request(GLOBAL_BRANCH_ID, "schema", vec![entity_pk]);
-        assert!(
-            scan_direct_tracked_pk_groups_for_test(&live_state, &storage, &request)
-                .await
-                .expect("noncurrent grouped scan should execute")
-                .is_none(),
-            "a noncurrent control must request the historical fallback"
-        );
-        let rows = scan_rows_for_test(&live_state, &storage, &request)
-            .await
-            .expect("historical fallback scan should execute");
-        assert_eq!(rows.len(), 1);
-        assert!(!rows[0].untracked);
-        assert_eq!(
-            rows[0].snapshot_content.as_deref(),
-            Some(r#"{"value":"historical"}"#)
         );
     }
 
@@ -2005,10 +1803,10 @@ mod tests {
                 .push(row);
         }
 
-        // A branch ref selects a fresh current-state generation. Its tracked
+        // A branch ref selects a fresh hot-state generation. Its tracked
         // portion is reconstructed from the immutable root and its untracked
-        // portion is materialized into the same groups; no flat overlay or
-        // changelog record is involved for untracked rows.
+        // portion is materialized into the same snapshot; untracked rows have
+        // no changelog record.
         for (branch_id, (head_commit_id, created_at, updated_at)) in branch_refs {
             let branch_rows = rows_by_branch.remove(&branch_id).unwrap_or_default();
             let head_commit_id_text = head_commit_id.to_string();
@@ -2093,7 +1891,6 @@ mod tests {
                 BranchHeadControl {
                     head_commit_id,
                     generation,
-                    tracked_head_is_current: true,
                     current_state_revision: 0,
                     working_diff_checkpoint_commit_id: None,
                     created_at,
@@ -2804,7 +2601,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn scan_rows_overlays_requested_branch_over_global() {
+    async fn scan_rows_resolves_requested_branch_over_global() {
         let storage = StorageAdapter::new(Memory::new());
         let live_state = live_state_context();
 

--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -14,10 +14,10 @@ pub(crate) use reader::load_exact_rows_via_scan_for_test;
 pub(crate) use tracked_head::TrackedHeadDeltaRef;
 #[allow(unused_imports)]
 pub(crate) use tracked_head::{
-    CurrentStateDeltaRef, TRACKED_HEAD_GROUP_SPACE, TRACKED_HEAD_MEMBER_SPACE,
-    TRACKED_WORKING_DIFF_GROUP_SPACE, TRACKED_WORKING_DIFF_MARKER_SPACE, TrackedHeadContext,
-    TrackedWorkingDiff, TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage,
-    stage_collect_stale_working_diff_indexes, stage_tracked_working_diff_epoch,
+    CurrentStateDeltaRef, HOT_DIFF_SPACE, HOT_FILE_SPACE, HOT_ROW_SPACE, HotTrackedSnapshot,
+    TRACKED_WORKING_DIFF_MARKER_SPACE, TrackedHeadContext, TrackedWorkingDiff,
+    TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage, stage_collect_stale_working_diff_indexes,
+    stage_tracked_working_diff_epoch,
 };
 #[allow(unused_imports)]
 pub(crate) use types::{

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -1,18 +1,17 @@
-//! Materialized current serving state for one branch head.
+//! Unified, materialized live state for one branch head.
 //!
-//! Commit roots are sparse historical checkpoints. This table is the durable,
-//! generation-keyed serving state for one branch head, letting the normal
-//! live-state path range scan rows and hydrate JSON directly without replaying
-//! changelog history. A member is either `tracked` (and has a commit-backed
-//! history record) or `untracked` (and exists only here). The branch control
-//! binds a generation to the branch ref's commit. Any mismatch is a
-//! direct-plane miss and callers take the historical fallback for the tracked
-//! portion; untracked members never participate in that fallback.
+//! The V15 hot index has one row per full identity. Each row is tagged
+//! `tracked` or `untracked`: tracked mutations also enter history, while
+//! untracked mutations exist only in this serving plane. Normal reads consult
+//! this single index rather than merging a tracked snapshot with an untracked
+//! overlay.
+
+mod hot;
+
+pub(crate) use hot::{HOT_DIFF_SPACE, HOT_FILE_SPACE, HOT_ROW_SPACE, HotTrackedSnapshot};
 
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
-use std::ops::Range;
-
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -25,15 +24,16 @@ use crate::branch::{BranchHeadControl, BranchHeadControlContext};
 use crate::changelog::{ChangeId, ChangeRecordProjection, CommitId};
 use crate::common::LixTimestamp;
 use crate::entity_pk::EntityPk;
+#[cfg(test)]
+use crate::json_store::JsonSlot;
 use crate::json_store::{
-    JsonLoadRequestRef, JsonReadScopeRef, JsonRef, JsonSlot, JsonSlotRef, JsonStoreContext,
-    JsonStoreWriter,
+    JsonLoadRequestRef, JsonReadScopeRef, JsonRef, JsonSlotRef, JsonStoreContext, JsonStoreWriter,
 };
 use crate::live_state::MaterializedLiveStateRow;
 use crate::storage_adapter::{
     PointReadPlan, ScanPlan, StorageAdapterRead, StorageCoreProjection, StorageGetOptions,
-    StorageKey, StoragePrefix, StorageProjectedValue, StorageReadEntry, StorageScanOptions,
-    StorageSpace, StorageSpaceId, StorageValue, StorageWriteSet,
+    StorageKey, StoragePrefix, StorageProjectedValue, StorageScanOptions, StorageSpace,
+    StorageSpaceId, StorageValue, StorageWriteSet,
 };
 use crate::storage_codec;
 use crate::tracked_state::{
@@ -42,63 +42,26 @@ use crate::tracked_state::{
     TrackedStateKey, TrackedStateScanRequest,
 };
 
-// V12 makes the durable current-state generation authoritative for normal
-// current reads.
-// A physical record owns every file-backed member of one logical entity PK.
-// Public entity reads know `(branch, schema, entity_pk)` but intentionally do
-// not invent a `file_id`; keeping those members together lets that common
-// lookup be a RocksDB point get rather than a prefix scan. Repositories use a
-// protocol gate, so predecessor bytes are never interpreted as current-state
-// groups.
-pub(crate) const TRACKED_HEAD_GROUP_NAMESPACE: &str = "live_state.current_group.v12";
-pub(crate) const TRACKED_HEAD_MEMBER_NAMESPACE: &str = "live_state.current_file_member.v12";
-pub(crate) const TRACKED_HEAD_GROUP_SPACE: StorageSpace =
-    StorageSpace::new(StorageSpaceId(0x0004_0012), TRACKED_HEAD_GROUP_NAMESPACE);
-/// File-id projection for explicit file-backed identities.
-///
-/// The group value remains authoritative for normal logical-PK reads. This
-/// narrow projection avoids turning `file_id = ?` reads into an unbounded
-/// group-value fetch when a logical PK has many file members. Its physical
-/// order is `(branch, generation, schema, file_id, entity_pk)`, so both an
-/// exact full identity and a schema-scoped file-id scan avoid unpacking
-/// unrelated entity groups.
-pub(crate) const TRACKED_HEAD_MEMBER_SPACE: StorageSpace =
-    StorageSpace::new(StorageSpaceId(0x0004_0013), TRACKED_HEAD_MEMBER_NAMESPACE);
-/// Sparse enumeration index for the first-before summaries co-located in
-/// current-state groups. It contains no row payload: the authoritative row
-/// and its immutable baseline remain one physical group record.
-pub(crate) const TRACKED_WORKING_DIFF_GROUP_NAMESPACE: &str =
-    "live_state.current_working_diff_group.v12";
-pub(crate) const TRACKED_WORKING_DIFF_MARKER_NAMESPACE: &str =
-    "live_state.current_working_diff_marker.v12";
-pub(crate) const TRACKED_WORKING_DIFF_GROUP_SPACE: StorageSpace = StorageSpace::new(
-    StorageSpaceId(0x0004_0016),
-    TRACKED_WORKING_DIFF_GROUP_NAMESPACE,
-);
+pub(crate) const TRACKED_WORKING_DIFF_MARKER_NAMESPACE: &str = "live_state.hot_diff_marker.v15";
 pub(crate) const TRACKED_WORKING_DIFF_MARKER_SPACE: StorageSpace = StorageSpace::new(
-    StorageSpaceId(0x0004_0018),
+    StorageSpaceId(0x0004_001e),
     TRACKED_WORKING_DIFF_MARKER_NAMESPACE,
 );
 
 /// The active checkpoint epoch for the sparse working-diff indexes.
 ///
-/// `None` is the freshly published checkpoint state: it is known empty until
-/// the first ordinary child bootstraps a complete current-state generation.
-/// Once initialized, the generation is immutable for serial normal commits;
-/// the branch control publishes the moving head.
+/// A current protocol marker always names the complete hot generation that
+/// owns it. Older marker encodings are rejected as malformed auxiliary data,
+/// which selects canonical diff replay and lets GC reclaim them.
 #[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
 #[musli(packed)]
 pub(crate) struct TrackedWorkingDiffEpoch {
     pub(crate) checkpoint_commit_id: CommitId,
-    // Musli's built-in packed Option encoding is terminal-field oriented.
-    // This explicit bool-prefixed representation keeps `coverage` readable
-    // when a freshly published checkpoint has no generation yet.
-    #[musli(with = storage_codec::option)]
-    pub(crate) generation: Option<CommitId>,
+    pub(crate) generation: CommitId,
     pub(crate) coverage: WorkingDiffIndexCoverage,
 }
 
-/// A tiny atomic coverage proof for the current checkpoint's group index.
+/// A tiny atomic coverage proof for the current checkpoint's sparse row index.
 ///
 /// Count catches loss or duplication; the XOR of BLAKE3 key hashes also
 /// catches a same-count replacement without adding another read structure.
@@ -141,32 +104,6 @@ pub(crate) struct TrackedWorkingDiff {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum WorkingDiffBaseline {
-    Clean,
-    Absent(CommitId),
-    Present {
-        checkpoint_commit_id: CommitId,
-        version: WorkingDiffVersion,
-    },
-}
-
-impl WorkingDiffBaseline {
-    fn is_for_checkpoint(self, checkpoint_commit_id: Option<CommitId>) -> bool {
-        match (self, checkpoint_commit_id) {
-            (
-                Self::Absent(baseline_checkpoint_id)
-                | Self::Present {
-                    checkpoint_commit_id: baseline_checkpoint_id,
-                    ..
-                },
-                Some(checkpoint_commit_id),
-            ) => baseline_checkpoint_id == checkpoint_commit_id,
-            _ => false,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct WorkingDiffVersion {
     change_id: ChangeId,
     commit_id: CommitId,
@@ -177,11 +114,37 @@ struct WorkingDiffVersion {
     metadata: WorkingDiffSlotFingerprint,
 }
 
+/// Checkpoint-relative state carried by the authoritative hot row.
+///
+/// The hot diff index is deliberately only a sparse enumeration aid.  The
+/// row itself owns the first-before image, so a normal tracked write can
+/// decide whether it is the first mutation from the primary row it already
+/// loaded for validation.  That eliminates a second point-read batch against
+/// the diff index from the CRUD write path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WorkingDiffBaseline {
+    /// No active checkpoint owns this generation.
+    Disabled,
+    /// This tracked row was present when the active checkpoint was published
+    /// and has not changed since.
+    Clean,
+    /// The first mutation after the checkpoint created this identity.
+    BeforeAbsent,
+    /// The first mutation after the checkpoint replaced this tracked value.
+    BeforePresent(WorkingDiffVersion),
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct WorkingDiffSlotFingerprint {
     kind: u8,
     hash: [u8; JSON_REF_BYTES],
 }
+
+const WORKING_DIFF_SLOT_NONE: u8 = 0;
+const WORKING_DIFF_SLOT_REF: u8 = 1;
+const WORKING_DIFF_SLOT_INLINE: u8 = 2;
+const WORKING_DIFF_VERSION_BYTES: usize =
+    16 + 16 + 1 + 8 + 8 + 1 + JSON_REF_BYTES + 1 + JSON_REF_BYTES;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, musli::Encode, musli::Decode)]
 #[musli(packed)]
@@ -192,20 +155,6 @@ struct HeadIdentity {
     entity_pk: EntityPk,
     #[musli(with = storage_codec::option)]
     file_id: Option<String>,
-}
-
-/// The physical current-state key for all current members of one logical
-/// entity PK.
-///
-/// `file_id` is deliberately not a key part. It remains part of the packed
-/// group value so a tombstone or a file-backed variant affects only its own
-/// full row identity.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-struct HeadGroupIdentity {
-    branch_id: String,
-    generation: CommitId,
-    schema_key: String,
-    entity_pk: EntityPk,
 }
 
 /// The portion of a head-row key that varies within one branch generation.
@@ -228,22 +177,14 @@ impl HeadIdentity {
             file_id: self.file_id,
         }
     }
-
-    fn group_identity(&self) -> HeadGroupIdentity {
-        HeadGroupIdentity {
-            branch_id: self.branch_id.clone(),
-            generation: self.generation,
-            schema_key: self.schema_key.clone(),
-            entity_pk: self.entity_pk.clone(),
-        }
-    }
 }
 
-/// Write-side representation of a v4 current-state row.
+/// Test-only owned representation of a hot current-state row.
 ///
 /// This exists only while a transaction is being staged. Read-side code uses
 /// [`HeadValueView`], which parses the fixed header directly from RocksDB's
 /// returned bytes and never builds this allocation-heavy representation.
+#[cfg(test)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct HeadValue {
     change_id: Option<ChangeId>,
@@ -256,6 +197,7 @@ struct HeadValue {
     metadata: JsonSlot,
 }
 
+#[cfg(test)]
 impl HeadValue {
     fn as_ref(&self) -> HeadValueRef<'_> {
         HeadValueRef {
@@ -267,6 +209,7 @@ impl HeadValue {
             updated_at: self.updated_at,
             snapshot: self.snapshot.as_ref_slot(),
             metadata: self.metadata.as_ref_slot(),
+            working_diff_baseline: WorkingDiffBaseline::Disabled,
         }
     }
 }
@@ -281,6 +224,7 @@ struct HeadValueRef<'a> {
     updated_at: LixTimestamp,
     snapshot: JsonSlotRef<'a>,
     metadata: JsonSlotRef<'a>,
+    working_diff_baseline: WorkingDiffBaseline,
 }
 
 #[derive(Debug, Clone, Copy, musli::Encode)]
@@ -356,7 +300,11 @@ pub(crate) struct CurrentStateDeltaRef<'a> {
 }
 
 impl<'a> CurrentStateDeltaRef<'a> {
-    fn value_ref(&self, created_at: LixTimestamp) -> HeadValueRef<'a> {
+    fn value_ref(
+        &self,
+        created_at: LixTimestamp,
+        working_diff_baseline: WorkingDiffBaseline,
+    ) -> HeadValueRef<'a> {
         HeadValueRef {
             change_id: self.change_id,
             commit_id: self.commit_id,
@@ -374,6 +322,7 @@ impl<'a> CurrentStateDeltaRef<'a> {
             } else {
                 self.metadata
             },
+            working_diff_baseline,
         }
     }
 
@@ -404,11 +353,11 @@ impl TrackedHeadContext {
     }
 
     #[expect(clippy::unused_self)]
-    pub(crate) fn reader<S>(&self, store: S) -> TrackedHeadStoreReader<S>
+    pub(crate) fn reader<S>(&self, store: S) -> hot::HotStateStoreReader<S>
     where
         S: StorageAdapterRead,
     {
-        TrackedHeadStoreReader { store }
+        hot::HotStateStoreReader { store }
     }
 
     #[expect(clippy::unused_self)]
@@ -416,16 +365,16 @@ impl TrackedHeadContext {
         &'a self,
         store: &'a S,
         writes: &'a mut StorageWriteSet,
-    ) -> TrackedHeadWriter<'a, S>
+    ) -> hot::HotStateWriter<'a, S>
     where
         S: StorageAdapterRead + ?Sized,
     {
-        TrackedHeadWriter { store, writes }
+        hot::HotStateWriter { store, writes }
     }
 
     /// Reclaims derived current-state generations that no durable branch
     /// control can select and returns their history-free payload refs. Both
-    /// the authoritative groups and their explicit file-id projections are
+    /// the authoritative hot rows and their explicit file-id projections are
     /// generation-scoped, so the control is the one ownership root for both
     /// spaces. The caller compares the returned refs with its complete live
     /// payload set before staging physical JSON deletion.
@@ -443,26 +392,7 @@ impl TrackedHeadContext {
     where
         S: StorageAdapterRead + ?Sized,
     {
-        let active = active_current_state_generations(controls);
-        let mut stale_untracked_refs = BTreeSet::new();
-        stage_collect_stale_current_state_group_space(
-            store,
-            writes,
-            &active,
-            &mut stale_untracked_refs,
-        )
-        .await?;
-        stage_collect_stale_current_state_member_space(
-            store,
-            writes,
-            &active,
-            &mut stale_untracked_refs,
-        )
-        .await?;
-        Ok(stale_untracked_refs
-            .into_iter()
-            .map(JsonRef::from_hash_bytes)
-            .collect())
+        hot::stage_collect_stale_hot_generations(store, writes, controls).await
     }
 }
 
@@ -478,751 +408,6 @@ fn active_current_state_generations(
         .collect()
 }
 
-/// Direct materializer for the current tracked branch generation.
-pub(crate) struct TrackedHeadStoreReader<S> {
-    store: S,
-}
-
-impl<S> TrackedHeadStoreReader<S>
-where
-    S: StorageAdapterRead,
-{
-    /// Serves a projection published by the supplied atomic branch control.
-    ///
-    /// V12 publishes the group generation and its currentness bit in the
-    /// branch control itself. A control whose projection is not complete is a
-    /// clean historical fallback; a current control can read its generation
-    /// without a second marker lookup.
-    pub(crate) async fn scan_live_rows_if_control_current(
-        &self,
-        branch_id: &str,
-        control: BranchHeadControl,
-        request: &TrackedStateScanRequest,
-    ) -> Result<Option<Vec<MaterializedLiveStateRow>>, LixError> {
-        if !control.tracked_head_is_current {
-            return Ok(None);
-        }
-        self.scan_live_rows_for_generation(branch_id, control.generation, request)
-            .await
-    }
-
-    /// Batch-loads complete logical-PK groups from already-observed current
-    /// branch controls. A normal entity mutation knows a finite set of public
-    /// primary keys but not necessarily a file id, so the packed group is the
-    /// only correct point-read unit: all file-backed members must remain
-    /// candidates for UPDATE/DELETE.
-    ///
-    /// `None` is a conservative route miss. Callers retain the established
-    /// branch-by-branch reader for incomplete controls, broad scans, and
-    /// explicit file-id predicates.
-    pub(crate) async fn scan_live_rows_for_current_controls(
-        &self,
-        controls: &[(String, BranchHeadControl)],
-        request: &TrackedStateScanRequest,
-    ) -> Result<Option<Vec<(String, Vec<MaterializedLiveStateRow>)>>, LixError> {
-        if controls.is_empty()
-            || controls
-                .iter()
-                .any(|(_, control)| !control.tracked_head_is_current)
-            || request.filter.schema_keys.is_empty()
-            || request.filter.entity_pks.is_empty()
-            || !request.filter.file_ids.is_empty()
-            // This internal batch feeds the outer visibility resolver. It
-            // must retain all tombstones and defer limiting until branch and
-            // global overlays have been arbitrated.
-            || !request.filter.include_tombstones
-            || request.limit.is_some()
-        {
-            return Ok(None);
-        }
-
-        let groups =
-            controls
-                .iter()
-                .flat_map(|(branch_id, control)| {
-                    request
-                        .filter
-                        .schema_keys
-                        .iter()
-                        .flat_map(move |schema_key| {
-                            request.filter.entity_pks.iter().map(move |entity_pk| {
-                                HeadGroupIdentity {
-                                    branch_id: branch_id.clone(),
-                                    generation: control.generation,
-                                    schema_key: schema_key.clone(),
-                                    entity_pk: entity_pk.clone(),
-                                }
-                            })
-                        })
-                })
-                .collect::<BTreeSet<_>>()
-                .into_iter()
-                .collect::<Vec<_>>();
-        let values = load_group_bytes(&self.store, &groups).await?;
-        let mut entries_by_branch = BTreeMap::<String, Vec<(HeadRowIdentity, Bytes)>>::new();
-        for (group, value) in groups.into_iter().zip(values) {
-            let Some(value) = value else {
-                continue;
-            };
-            let entries = entries_by_branch
-                .entry(group.branch_id.clone())
-                .or_default();
-            // `groups` was built directly from the requested schema and
-            // entity-PK sets, and this path rejects file-id predicates above.
-            // Rechecking those sets for every member would turn a 10k-PK
-            // multi-get into a quadratic membership scan.
-            extend_group_entries(entries, group, value, |_| true, None)?;
-        }
-
-        let projection = ChangeRecordProjection::from_columns(&request.read_columns.columns);
-        let mut rows_by_branch = Vec::with_capacity(entries_by_branch.len());
-        for (branch_id, entries) in entries_by_branch {
-            let rows =
-                materialize_live_entries(&self.store, entries, projection, &branch_id).await?;
-            rows_by_branch.push((branch_id, rows));
-        }
-        Ok(Some(rows_by_branch))
-    }
-
-    /// Returns whether the serving generation has any rows for one entity
-    /// schema. A caller uses this as an inexpensive global-overlay proof
-    /// before taking the direct local entity lane.
-    pub(crate) async fn has_schema_rows_if_control_current(
-        &self,
-        branch_id: &str,
-        control: BranchHeadControl,
-        schema_key: &str,
-    ) -> Result<Option<bool>, LixError> {
-        if !control.tracked_head_is_current {
-            return Ok(None);
-        }
-        self.has_schema_rows_for_generation(branch_id, control.generation, schema_key)
-            .await
-    }
-
-    /// Streams one local entity schema directly from packed tracked-head
-    /// members into snapshot bytes. A caller may either scan the whole schema
-    /// or provide exact entity PKs. This intentionally omits all logical row
-    /// identities: entity projection only consumes snapshots, and avoiding
-    /// entity-PK/schema/file-id materialization is the hot-path win. Callers
-    /// must prove no untracked or global overlay can contribute.
-    pub(crate) async fn scan_entity_snapshots_if_control_current(
-        &self,
-        branch_id: &str,
-        control: BranchHeadControl,
-        schema_key: &str,
-        entity_pks: &[EntityPk],
-        limit: Option<usize>,
-    ) -> Result<Option<Vec<Option<Bytes>>>, LixError> {
-        if !control.tracked_head_is_current {
-            return Ok(None);
-        }
-        self.scan_entity_snapshots_for_generation(
-            branch_id,
-            control.generation,
-            schema_key,
-            entity_pks,
-            limit,
-        )
-        .await
-    }
-
-    /// Returns `None` when this branch has no projection for the canonical
-    /// branch ref. That is a direct-plane miss, not empty tracked state.
-    #[cfg(test)]
-    pub(crate) async fn scan_live_rows_if_current(
-        &self,
-        branch_id: &str,
-        expected_head: &str,
-        request: &TrackedStateScanRequest,
-    ) -> Result<Option<Vec<MaterializedLiveStateRow>>, LixError> {
-        let Some(control) = self.control_if_current(branch_id, expected_head).await? else {
-            return Ok(None);
-        };
-        self.scan_live_rows_for_generation(branch_id, control.generation, request)
-            .await
-    }
-
-    async fn scan_live_rows_for_generation(
-        &self,
-        branch_id: &str,
-        generation: CommitId,
-        request: &TrackedStateScanRequest,
-    ) -> Result<Option<Vec<MaterializedLiveStateRow>>, LixError> {
-        let entries =
-            scan_entries(&self.store, branch_id, generation, &request.filter, None).await?;
-        let projection = ChangeRecordProjection::from_columns(&request.read_columns.columns);
-        let mut rows =
-            materialize_live_entries(&self.store, entries, projection, branch_id).await?;
-        if !request.filter.include_tombstones {
-            rows.retain(|row| !row.deleted);
-        }
-        if let Some(limit) = request.limit {
-            rows.truncate(limit);
-        }
-        Ok(Some(rows))
-    }
-
-    /// Reads only the history-free members from a physical generation without
-    /// consulting `tracked_head_is_current`. A branch ref may temporarily use
-    /// historical replay for its tracked portion after a lifecycle move, but
-    /// its untracked members remain live workspace state and must survive that
-    /// move. Normal current controls never take this route.
-    pub(crate) async fn scan_untracked_rows_for_generation(
-        &self,
-        branch_id: &str,
-        generation: CommitId,
-        request: &TrackedStateScanRequest,
-    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-        let mut rows = self
-            .scan_live_rows_for_generation(branch_id, generation, request)
-            .await?
-            .unwrap_or_default();
-        rows.retain(|row| row.untracked);
-        Ok(rows)
-    }
-
-    /// Exact counterpart to [`Self::scan_untracked_rows_for_generation`].
-    /// This is used only while a branch's tracked generation is being rebuilt;
-    /// current controls use the one-plane batch reader above.
-    pub(crate) async fn load_untracked_projected_rows_for_generation(
-        &self,
-        branch_id: &str,
-        generation: CommitId,
-        keys: &[TrackedStateKey],
-        projection: &ChangeRecordProjection,
-    ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-        Ok(self
-            .load_projected_live_rows_for_generation(branch_id, generation, keys, projection)
-            .await?
-            .unwrap_or_default()
-            .into_iter()
-            .map(|row| row.filter(|row| row.untracked))
-            .collect())
-    }
-
-    async fn has_schema_rows_for_generation(
-        &self,
-        branch_id: &str,
-        generation: CommitId,
-        schema_key: &str,
-    ) -> Result<Option<bool>, LixError> {
-        let entries = ScanPlan::prefix(
-            TRACKED_HEAD_GROUP_SPACE,
-            StoragePrefix {
-                bytes: Bytes::from(schema_group_prefix(branch_id, generation, schema_key)),
-            },
-        )
-        .collect(
-            &self.store,
-            StorageScanOptions {
-                projection: StorageCoreProjection::KeyOnly,
-                limit_rows: 1,
-                ..StorageScanOptions::default()
-            },
-        )
-        .await?;
-        Ok(Some(!entries.value.entries.is_empty()))
-    }
-
-    async fn scan_entity_snapshots_for_generation(
-        &self,
-        branch_id: &str,
-        generation: CommitId,
-        schema_key: &str,
-        entity_pks: &[EntityPk],
-        limit: Option<usize>,
-    ) -> Result<Option<Vec<Option<Bytes>>>, LixError> {
-        Ok(Some(
-            scan_entity_snapshots(
-                &self.store,
-                branch_id,
-                generation,
-                schema_key,
-                entity_pks,
-                limit,
-            )
-            .await?,
-        ))
-    }
-
-    /// Like the immutable-root point batch, preserves input cardinality and
-    /// returns tombstones for the visibility layer to resolve.
-    #[cfg(test)]
-    pub(crate) async fn load_projected_live_rows_if_current(
-        &self,
-        branch_id: &str,
-        expected_head: &str,
-        keys: &[TrackedStateKey],
-        projection: &ChangeRecordProjection,
-    ) -> Result<Option<Vec<Option<MaterializedLiveStateRow>>>, LixError> {
-        let Some(control) = self.control_if_current(branch_id, expected_head).await? else {
-            return Ok(None);
-        };
-        self.load_projected_live_rows_for_generation(
-            branch_id,
-            control.generation,
-            keys,
-            projection,
-        )
-        .await
-    }
-
-    async fn load_projected_live_rows_for_generation(
-        &self,
-        branch_id: &str,
-        generation: CommitId,
-        keys: &[TrackedStateKey],
-        projection: &ChangeRecordProjection,
-    ) -> Result<Option<Vec<Option<MaterializedLiveStateRow>>>, LixError> {
-        if keys.is_empty() {
-            return Ok(Some(Vec::new()));
-        }
-
-        let mut output_indices = BTreeMap::<HeadIdentity, Vec<usize>>::new();
-        for (index, key) in keys.iter().enumerate() {
-            output_indices
-                .entry(HeadIdentity {
-                    branch_id: branch_id.to_string(),
-                    generation,
-                    schema_key: key.schema_key.clone(),
-                    entity_pk: key.entity_pk.clone(),
-                    file_id: key.file_id.clone(),
-                })
-                .or_default()
-                .push(index);
-        }
-        let groups = output_indices
-            .keys()
-            .filter(|identity| identity.file_id.is_none())
-            .map(HeadIdentity::group_identity)
-            .collect::<BTreeSet<_>>()
-            .into_iter()
-            .collect::<Vec<_>>();
-        let member_identities = output_indices
-            .keys()
-            .filter(|identity| identity.file_id.is_some())
-            .cloned()
-            .collect::<Vec<_>>();
-        let values = load_group_bytes(&self.store, &groups).await?;
-        let mut entries = Vec::new();
-        for (group, value) in groups.into_iter().zip(values) {
-            let Some(value) = value else {
-                continue;
-            };
-            for member in decode_head_group_members(&value)? {
-                let identity = HeadIdentity {
-                    branch_id: group.branch_id.clone(),
-                    generation: group.generation,
-                    schema_key: group.schema_key.clone(),
-                    entity_pk: group.entity_pk.clone(),
-                    file_id: member.file_id,
-                };
-                if output_indices.contains_key(&identity) {
-                    entries.push((identity.into_row_identity(), member.value));
-                }
-            }
-        }
-        let member_values = load_member_bytes(&self.store, &member_identities).await?;
-        for (identity, value) in member_identities.into_iter().zip(member_values) {
-            if let Some(value) = value {
-                entries.push((identity.into_row_identity(), value));
-            }
-        }
-        let rows = materialize_live_entries(&self.store, entries, *projection, branch_id).await?;
-        let rows_by_identity = rows
-            .into_iter()
-            .map(|row| {
-                (
-                    HeadRowIdentity {
-                        schema_key: row.schema_key.clone(),
-                        entity_pk: row.entity_pk.clone(),
-                        file_id: row.file_id.clone(),
-                    },
-                    row,
-                )
-            })
-            .collect::<BTreeMap<_, _>>();
-        let mut output = vec![None; keys.len()];
-        for (identity, indices) in output_indices {
-            if let Some(row) = rows_by_identity.get(&identity.into_row_identity()) {
-                for index in indices {
-                    output[index] = Some(row.clone());
-                }
-            }
-        }
-        Ok(Some(output))
-    }
-
-    /// Current-state control-plane variant of
-    /// [`Self::load_projected_live_rows_if_current`].
-    pub(crate) async fn load_projected_live_rows_if_control_current(
-        &self,
-        branch_id: &str,
-        control: BranchHeadControl,
-        keys: &[TrackedStateKey],
-        projection: &ChangeRecordProjection,
-    ) -> Result<Option<Vec<Option<MaterializedLiveStateRow>>>, LixError> {
-        if !control.tracked_head_is_current {
-            return Ok(None);
-        }
-        self.load_projected_live_rows_for_generation(
-            branch_id,
-            control.generation,
-            keys,
-            projection,
-        )
-        .await
-    }
-
-    /// Loads the checkpoint epoch marker without treating it as visibility.
-    /// Commit staging combines it with a coherent current-state branch-control
-    /// observation before deciding whether it can preserve first-before
-    /// summaries.
-    pub(crate) async fn working_diff_epoch(
-        &self,
-        branch_id: &str,
-    ) -> Result<Option<TrackedWorkingDiffEpoch>, LixError> {
-        load_tracked_working_diff_epoch(&self.store, branch_id).await
-    }
-
-    /// Returns every out-of-band JSON payload owned by an active untracked
-    /// current-state generation. Tracked payloads are rooted through
-    /// changelog reachability; untracked members deliberately have no
-    /// changelog fact, so repository GC asks this one authoritative plane
-    /// directly.
-    ///
-    /// A generation without a matching branch control is derived, stale
-    /// serving state. It must neither keep an untracked payload live nor be
-    /// scanned as part of normal repository GC. Controls that are temporarily
-    /// non-current still retain their generation here: that generation is the
-    /// branch's workspace state while its tracked portion falls back to
-    /// historical replay.
-    pub(crate) async fn untracked_json_refs(
-        &self,
-        controls: &[(String, BranchHeadControl)],
-    ) -> Result<Vec<JsonRef>, LixError> {
-        let mut refs = BTreeSet::<[u8; JSON_REF_BYTES]>::new();
-        for (branch_id, generation) in active_current_state_generations(controls) {
-            let plan = ScanPlan::prefix(
-                TRACKED_HEAD_GROUP_SPACE,
-                StoragePrefix {
-                    bytes: Bytes::from(encode_scope_prefix(&branch_id, generation)),
-                },
-            );
-            let mut resume_after = None;
-            loop {
-                let page = plan
-                    .collect(
-                        &self.store,
-                        StorageScanOptions {
-                            resume_after: resume_after.clone(),
-                            ..StorageScanOptions::default()
-                        },
-                    )
-                    .await?;
-                resume_after = page.value.entries.last().map(|entry| entry.key.clone());
-                for entry in page.value.entries {
-                    let value = full_value_bytes(entry.value)?;
-                    collect_untracked_json_refs_from_group(value.as_ref(), &mut refs)?;
-                }
-                if !page.value.has_more || resume_after.is_none() {
-                    break;
-                }
-            }
-        }
-        Ok(refs.into_iter().map(JsonRef::from_hash_bytes).collect())
-    }
-
-    /// Returns an O(ever-dirty groups since checkpoint) tracked diff only when the sparse
-    /// working-diff epoch and the current serving generation agree. Any
-    /// missing, stale, or malformed auxiliary record returns `None`, leaving
-    /// the canonical historical replay path authoritative.
-    pub(crate) async fn working_diff_if_control_current(
-        &self,
-        branch_id: &str,
-        control: BranchHeadControl,
-        request: &TrackedStateDiffRequest,
-    ) -> Result<Option<TrackedWorkingDiff>, LixError> {
-        // The epoch is an accelerator, not a source of visibility. A
-        // malformed or unavailable auxiliary record selects canonical replay
-        // instead of making a valid SQL query fail.
-        if !control.tracked_head_is_current {
-            return Ok(None);
-        }
-        let Ok(Some(epoch)) = self.working_diff_epoch(branch_id).await else {
-            return Ok(None);
-        };
-        let Some(generation) = epoch.generation else {
-            return Ok((epoch.checkpoint_commit_id == control.head_commit_id
-                && control.working_diff_checkpoint_commit_id == Some(epoch.checkpoint_commit_id))
-            .then_some(TrackedWorkingDiff {
-                checkpoint_commit_id: epoch.checkpoint_commit_id,
-                diff: TrackedStateDiff::default(),
-            }));
-        };
-        if generation != control.generation
-            || control.working_diff_checkpoint_commit_id != Some(epoch.checkpoint_commit_id)
-        {
-            return Ok(None);
-        }
-        let Some(entries) = working_diff_entries_from_current_head(
-            &self.store,
-            branch_id,
-            epoch.checkpoint_commit_id,
-            generation,
-            epoch.coverage,
-            &request.filter,
-        )
-        .await?
-        else {
-            return Ok(None);
-        };
-        Ok(Some(TrackedWorkingDiff {
-            checkpoint_commit_id: epoch.checkpoint_commit_id,
-            diff: TrackedStateDiff { entries },
-        }))
-    }
-
-    #[cfg(test)]
-    async fn control_if_current(
-        &self,
-        branch_id: &str,
-        expected_head: &str,
-    ) -> Result<Option<BranchHeadControl>, LixError> {
-        let expected_head = CommitId::parse_lix(expected_head, "tracked-head expected commit")?;
-        let control = BranchHeadControlContext::new()
-            .reader(&self.store)
-            .load(branch_id)
-            .await?;
-        Ok(control.filter(|control| {
-            control.tracked_head_is_current && control.head_commit_id == expected_head
-        }))
-    }
-}
-
-/// Writer for an atomic branch-head projection update.
-pub(crate) struct TrackedHeadWriter<'a, S: ?Sized> {
-    store: &'a S,
-    writes: &'a mut StorageWriteSet,
-}
-
-impl<S> TrackedHeadWriter<'_, S>
-where
-    S: StorageAdapterRead + ?Sized,
-{
-    /// Incrementally updates a matching parent generation, or creates a fresh
-    /// generation from a caller-provided parent snapshot after branch movement.
-    #[cfg(any(test, feature = "storage-benches"))]
-    pub(crate) async fn stage_commit(
-        &mut self,
-        branch_id: &str,
-        parent_generation: Option<CommitId>,
-        new_head: CommitId,
-        deltas: &[TrackedHeadDeltaRef<'_>],
-        absence_guards: &BTreeSet<TrackedStateKey>,
-        parent_rows: Option<Vec<MaterializedTrackedStateRow>>,
-    ) -> Result<CommitId, LixError> {
-        let mut working_diff_coverage = WorkingDiffIndexCoverage::default();
-        let generation = self
-            .stage_commit_with_working_diff(
-                branch_id,
-                parent_generation,
-                new_head,
-                deltas,
-                absence_guards,
-                parent_rows,
-                None,
-                &mut working_diff_coverage,
-            )
-            .await?;
-        #[cfg(test)]
-        stage_test_current_control(self.writes, branch_id, new_head, generation, None)?;
-        Ok(generation)
-    }
-
-    /// Internal variant used only when an active checkpoint epoch makes the
-    /// packed-group baseline authoritative for `lix_working_change`.
-    #[cfg(any(test, feature = "storage-benches"))]
-    pub(crate) async fn stage_commit_with_working_diff(
-        &mut self,
-        branch_id: &str,
-        parent_generation: Option<CommitId>,
-        new_head: CommitId,
-        deltas: &[TrackedHeadDeltaRef<'_>],
-        absence_guards: &BTreeSet<TrackedStateKey>,
-        parent_rows: Option<Vec<MaterializedTrackedStateRow>>,
-        working_diff_capture_checkpoint_commit_id: Option<CommitId>,
-        working_diff_coverage: &mut WorkingDiffIndexCoverage,
-    ) -> Result<CommitId, LixError> {
-        let deltas = deltas
-            .iter()
-            .map(TrackedHeadDeltaRef::as_current)
-            .collect::<Vec<_>>();
-        self.stage_current_state_with_working_diff(
-            branch_id,
-            parent_generation,
-            new_head,
-            &deltas,
-            absence_guards,
-            parent_rows,
-            None,
-            working_diff_capture_checkpoint_commit_id,
-            working_diff_coverage,
-        )
-        .await
-    }
-
-    /// Updates the single authoritative current-state plane. Tracked and
-    /// untracked rows share the same packed groups; only tracked members
-    /// contribute to a commit or to the working-diff accelerator.
-    pub(crate) async fn stage_current_state_with_working_diff(
-        &mut self,
-        branch_id: &str,
-        parent_generation: Option<CommitId>,
-        new_head: CommitId,
-        deltas: &[CurrentStateDeltaRef<'_>],
-        absence_guards: &BTreeSet<TrackedStateKey>,
-        parent_rows: Option<Vec<MaterializedTrackedStateRow>>,
-        preserved_untracked_rows: Option<Vec<MaterializedLiveStateRow>>,
-        working_diff_capture_checkpoint_commit_id: Option<CommitId>,
-        working_diff_coverage: &mut WorkingDiffIndexCoverage,
-    ) -> Result<CommitId, LixError> {
-        let matches_parent = parent_generation.is_some();
-        let generation = parent_generation.unwrap_or(new_head);
-        // Sorting borrowed deltas establishes both the exact-mutation
-        // uniqueness check and the group order needed for a streaming merge.
-        // The normal matching-generation path must never reconstruct every
-        // current-state member in an owned BTreeMap just to change one member.
-        let mut sorted_deltas = deltas.iter().collect::<Vec<_>>();
-        for delta in &sorted_deltas {
-            delta.validate()?;
-        }
-        sorted_deltas.sort_unstable_by(|left, right| compare_head_deltas(left, right));
-        for pair in sorted_deltas.windows(2) {
-            if compare_head_deltas(pair[0], pair[1]) == Ordering::Equal {
-                return Err(current_state_duplicate_delta_error(pair[1]));
-            }
-        }
-
-        if matches_parent {
-            let groups = group_sorted_head_deltas(branch_id, generation, &sorted_deltas);
-            let previous_groups =
-                load_group_bytes(self.store, groups.iter().map(|group| &group.identity)).await?;
-
-            self.writes
-                .reserve_space(TRACKED_HEAD_GROUP_SPACE, groups.len(), 0);
-            self.writes.reserve_space(
-                TRACKED_HEAD_MEMBER_SPACE,
-                sorted_deltas
-                    .iter()
-                    .filter(|delta| delta.file_id.is_some())
-                    .count(),
-                0,
-            );
-            // A normal tracked mutation never inserts into this set. The
-            // incremental parser already visits the previous member for a
-            // matching identity, so collecting retired untracked refs here
-            // adds neither a storage read nor an allocation to the tracked
-            // hot path.
-            let mut retired_untracked_json_refs = BTreeSet::new();
-            let mut next_groups = Vec::new();
-            next_groups
-                .try_reserve(groups.len())
-                .map_err(|_| head_group_error("cannot reserve staged group outputs"))?;
-            for (group, previous) in groups.iter().zip(previous_groups) {
-                next_groups.push(encode_incremental_group(
-                    previous.as_deref(),
-                    &sorted_deltas[group.deltas.clone()],
-                    absence_guards,
-                    working_diff_capture_checkpoint_commit_id,
-                    &mut retired_untracked_json_refs,
-                )?);
-            }
-            for (group, next) in groups.iter().zip(next_groups) {
-                let became_dirty_group = next.became_dirty_group;
-                match next.bytes {
-                    Some(bytes) => stage_put_group_bytes(self.writes, &group.identity, bytes),
-                    None => stage_delete_group(self.writes, &group.identity),
-                }
-                for (file_id, value) in next.explicit_member_projections {
-                    stage_put_file_member_bytes(self.writes, &group.identity, file_id, &value);
-                }
-                for file_id in next.deleted_member_projections {
-                    stage_delete_file_member(self.writes, &group.identity, file_id);
-                }
-                if became_dirty_group {
-                    stage_put_working_diff_group_index(
-                        self.writes,
-                        working_diff_coverage,
-                        working_diff_capture_checkpoint_commit_id.expect(
-                            "a newly dirty group requires an active working-diff checkpoint",
-                        ),
-                        &group.identity,
-                    )?;
-                }
-            }
-            JsonStoreWriter::stage_untracked_reclaim_candidates(
-                self.writes,
-                retired_untracked_json_refs
-                    .into_iter()
-                    .map(JsonRef::from_hash_bytes),
-            );
-        } else {
-            stage_bootstrap_groups(
-                self.writes,
-                branch_id,
-                generation,
-                &sorted_deltas,
-                absence_guards,
-                parent_rows.unwrap_or_default(),
-                preserved_untracked_rows.unwrap_or_default(),
-                working_diff_capture_checkpoint_commit_id,
-                working_diff_coverage,
-            )?;
-        }
-        Ok(generation)
-    }
-}
-
-/// One contiguous range of sorted mutations for a physical current-state
-/// group.
-///
-/// The range borrows the transaction's deltas, while the group identity is
-/// owned once. This is intentionally not a map of decoded members: matching
-/// generation commits merge the encoded old group directly into its next
-/// value.
-struct HeadGroupMutation {
-    identity: HeadGroupIdentity,
-    deltas: Range<usize>,
-}
-
-/// Fully validated replacement bytes for one matching-generation group.
-///
-/// Keeping these short-lived outputs until every group has validated makes
-/// `stage_commit` all-or-nothing for the existing serving generation without
-/// rebuilding decoded member maps.
-struct EncodedHeadGroup<'a> {
-    bytes: Option<Vec<u8>>,
-    explicit_member_projections: Vec<(&'a str, Vec<u8>)>,
-    deleted_member_projections: Vec<&'a str>,
-    became_dirty_group: bool,
-}
-
-fn compare_head_deltas(
-    left: &CurrentStateDeltaRef<'_>,
-    right: &CurrentStateDeltaRef<'_>,
-) -> Ordering {
-    left.schema_key
-        .cmp(right.schema_key)
-        .then_with(|| left.entity_pk.cmp(right.entity_pk))
-        .then_with(|| left.file_id.cmp(&right.file_id))
-}
-
-fn same_head_group(left: &CurrentStateDeltaRef<'_>, right: &CurrentStateDeltaRef<'_>) -> bool {
-    left.schema_key == right.schema_key && left.entity_pk == right.entity_pk
-}
-
 fn current_state_duplicate_delta_error(delta: &CurrentStateDeltaRef<'_>) -> LixError {
     LixError::new(
         LixError::CODE_INTERNAL_ERROR,
@@ -1233,419 +418,6 @@ fn current_state_duplicate_delta_error(delta: &CurrentStateDeltaRef<'_>) -> LixE
     )
 }
 
-fn group_sorted_head_deltas(
-    branch_id: &str,
-    generation: CommitId,
-    deltas: &[&CurrentStateDeltaRef<'_>],
-) -> Vec<HeadGroupMutation> {
-    let mut groups = Vec::new();
-    let mut start = 0;
-    while start < deltas.len() {
-        let first = deltas[start];
-        let mut end = start + 1;
-        while end < deltas.len() && same_head_group(first, deltas[end]) {
-            end += 1;
-        }
-        groups.push(HeadGroupMutation {
-            identity: HeadGroupIdentity {
-                branch_id: branch_id.to_string(),
-                generation,
-                schema_key: first.schema_key.to_string(),
-                entity_pk: first.entity_pk.clone(),
-            },
-            deltas: start..end,
-        });
-        start = end;
-    }
-    groups
-}
-
-/// Builds a fresh current-state generation after a branch movement.
-///
-/// This path necessarily starts from materialized parent rows, so it retains
-/// the simple owned-map implementation. Ordinary commits keep their parent
-/// generation and use [`encode_incremental_group`] instead.
-fn stage_bootstrap_groups(
-    writes: &mut StorageWriteSet,
-    branch_id: &str,
-    generation: CommitId,
-    deltas: &[&CurrentStateDeltaRef<'_>],
-    absence_guards: &BTreeSet<TrackedStateKey>,
-    parent_rows: Vec<MaterializedTrackedStateRow>,
-    preserved_untracked_rows: Vec<MaterializedLiveStateRow>,
-    working_diff_checkpoint_commit_id: Option<CommitId>,
-    working_diff_coverage: &mut WorkingDiffIndexCoverage,
-) -> Result<(), LixError> {
-    let mut groups = BTreeMap::<HeadGroupIdentity, BTreeMap<Option<String>, Vec<u8>>>::new();
-    let mut baselines =
-        BTreeMap::<HeadGroupIdentity, BTreeMap<Option<String>, WorkingDiffBaseline>>::new();
-    for row in parent_rows {
-        let MaterializedTrackedStateRow {
-            entity_pk,
-            schema_key,
-            file_id,
-            snapshot_content,
-            metadata,
-            deleted,
-            created_at,
-            updated_at,
-            change_id,
-            commit_id,
-        } = row;
-        let key = TrackedStateKey {
-            schema_key: schema_key.clone(),
-            entity_pk: entity_pk.clone(),
-            file_id: file_id.clone(),
-        };
-        if absence_guards.contains(&key) && !deleted {
-            return Err(tracked_head_duplicate_insert_error(&key));
-        }
-        let identity = HeadGroupIdentity {
-            branch_id: branch_id.to_string(),
-            generation,
-            schema_key,
-            entity_pk,
-        };
-        let value = HeadValue {
-            change_id: Some(change_id),
-            commit_id: Some(commit_id),
-            untracked: false,
-            deleted,
-            created_at: LixTimestamp::expect_parse("tracked-head parent created_at", &created_at),
-            updated_at: LixTimestamp::expect_parse("tracked-head parent updated_at", &updated_at),
-            snapshot: snapshot_content
-                .as_deref()
-                .map_or(JsonSlot::None, JsonSlot::from_json),
-            metadata: metadata
-                .as_deref()
-                .map_or(JsonSlot::None, JsonSlot::from_json),
-        };
-        let members = groups.entry(identity.clone()).or_default();
-        if members
-            .insert(file_id.clone(), encode_head_value(&value.as_ref())?)
-            .is_some()
-        {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                "tracked-head bootstrap contains duplicate full row identity",
-            ));
-        }
-        baselines
-            .entry(identity)
-            .or_default()
-            .insert(file_id, WorkingDiffBaseline::Clean);
-    }
-
-    // A fresh tracked generation is a branch lifecycle operation, not an
-    // untracked-state reset. Copy history-free members from the previously
-    // serving generation before applying this transaction's mutations. The
-    // values are intentionally re-encoded rather than copied as opaque bytes
-    // because the new generation must retain the same group invariants and
-    // file-member projections as an ordinary current-state publication.
-    for row in preserved_untracked_rows {
-        if !row.untracked || row.deleted {
-            return Err(head_group_error(
-                "bootstrap preserved state must contain only live untracked members",
-            ));
-        }
-        let key = TrackedStateKey {
-            schema_key: row.schema_key.clone(),
-            entity_pk: row.entity_pk.clone(),
-            file_id: row.file_id.clone(),
-        };
-        if absence_guards.contains(&key) {
-            return Err(tracked_head_duplicate_insert_error(&key));
-        }
-        let identity = HeadGroupIdentity {
-            branch_id: branch_id.to_string(),
-            generation,
-            schema_key: row.schema_key,
-            entity_pk: row.entity_pk,
-        };
-        let value = HeadValue {
-            change_id: None,
-            commit_id: None,
-            untracked: true,
-            deleted: false,
-            created_at: row.created_at,
-            updated_at: row.updated_at,
-            snapshot: row
-                .snapshot_content
-                .as_deref()
-                .map_or(JsonSlot::None, JsonSlot::from_json),
-            metadata: row
-                .metadata
-                .as_deref()
-                .map_or(JsonSlot::None, JsonSlot::from_json),
-        };
-        let members = groups.entry(identity.clone()).or_default();
-        if members
-            .insert(row.file_id.clone(), encode_head_value(&value.as_ref())?)
-            .is_some()
-        {
-            return Err(LixError::new(
-                LixError::CODE_UNIQUE,
-                "cannot materialize a tracked and untracked current row with the same identity",
-            ));
-        }
-        baselines
-            .entry(identity)
-            .or_default()
-            .insert(row.file_id, WorkingDiffBaseline::Clean);
-    }
-
-    let mut dirty_groups = BTreeSet::new();
-    for delta in deltas {
-        delta.validate()?;
-        let group = HeadGroupIdentity {
-            branch_id: branch_id.to_string(),
-            generation,
-            schema_key: delta.schema_key.to_string(),
-            entity_pk: delta.entity_pk.clone(),
-        };
-        let file_id = delta.file_id.map(str::to_string);
-        let members = groups.entry(group.clone()).or_default();
-        let baseline_members = baselines.entry(group.clone()).or_default();
-        let baseline = match members.get(&file_id) {
-            Some(existing) => {
-                let existing = decode_head_value(existing)?;
-                reject_guarded_live_member(absence_guards, delta, existing)?;
-                reject_retention_change(delta, existing)?;
-                working_diff_baseline_for_existing_value(
-                    existing,
-                    working_diff_checkpoint_commit_id,
-                )
-            }
-            None => {
-                working_diff_baseline_for_absent_delta(delta, working_diff_checkpoint_commit_id)
-            }
-        };
-        if delta.physically_deletes() {
-            members.remove(&file_id);
-            baseline_members.remove(&file_id);
-            continue;
-        }
-        let created_at = match members.get(&file_id) {
-            Some(existing) => decode_head_value(existing)?.created_at,
-            None => delta.created_at,
-        };
-        members.insert(
-            file_id.clone(),
-            encode_head_value(&delta.value_ref(created_at))?,
-        );
-        baseline_members.insert(file_id.clone(), baseline);
-        if !delta.untracked && working_diff_checkpoint_commit_id.is_some() {
-            dirty_groups.insert(group.clone());
-        }
-    }
-
-    writes.reserve_space(TRACKED_HEAD_GROUP_SPACE, groups.len(), 0);
-    let explicit_member_count = groups
-        .values()
-        .map(|members| members.keys().filter(|file_id| file_id.is_some()).count())
-        .sum();
-    writes.reserve_space(TRACKED_HEAD_MEMBER_SPACE, explicit_member_count, 0);
-    for (identity, members) in groups {
-        if members.is_empty() {
-            continue;
-        }
-        let member_baselines = baselines
-            .get(&identity)
-            .ok_or_else(|| head_group_error("bootstrap group is missing working-diff baselines"))?;
-        stage_put_group_members_with_baselines(writes, &identity, &members, member_baselines)?;
-        for (file_id, value) in &members {
-            if file_id.is_some() {
-                stage_put_member_bytes(writes, &identity, file_id.as_deref(), value)?;
-            }
-        }
-    }
-    if let Some(checkpoint_commit_id) = working_diff_checkpoint_commit_id {
-        for group in &dirty_groups {
-            stage_put_working_diff_group_index(
-                writes,
-                working_diff_coverage,
-                checkpoint_commit_id,
-                group,
-            )?;
-        }
-    }
-    Ok(())
-}
-
-/// Merges one existing current-state group and its sorted mutations without decoding the
-/// whole group into owned member values. Every old member is still parsed and
-/// validated before it is copied, so an unrelated malformed sibling cannot be
-/// silently republished.
-fn encode_incremental_group<'a>(
-    previous: Option<&[u8]>,
-    deltas: &[&CurrentStateDeltaRef<'a>],
-    absence_guards: &BTreeSet<TrackedStateKey>,
-    working_diff_checkpoint_commit_id: Option<CommitId>,
-    retired_untracked_json_refs: &mut BTreeSet<[u8; JSON_REF_BYTES]>,
-) -> Result<EncodedHeadGroup<'a>, LixError> {
-    debug_assert!(!deltas.is_empty());
-    debug_assert!(
-        deltas
-            .windows(2)
-            .all(|pair| compare_head_deltas(pair[0], pair[1]) == Ordering::Less)
-    );
-
-    let mut cursor = previous.map(HeadGroupMembers::new).transpose()?;
-    let mut current = next_head_group_member(&mut cursor)?;
-    let mut encoded = Vec::new();
-    encoded
-        .try_reserve(previous.map_or(HEAD_GROUP_HEADER_BYTES, <[u8]>::len))
-        .map_err(|_| head_group_error("cannot reserve group value bytes"))?;
-    encoded.push(HEAD_GROUP_VALUE_VERSION);
-    encoded.extend_from_slice(&[0; 4]);
-    let mut member_count = 0usize;
-    let mut previous_has_current_dirty_member = false;
-    let mut became_current_dirty_member = false;
-    let mut explicit_member_projections = Vec::new();
-    let mut deleted_member_projections = Vec::new();
-    explicit_member_projections
-        .try_reserve(
-            deltas
-                .iter()
-                .filter(|delta| delta.file_id.is_some())
-                .count(),
-        )
-        .map_err(|_| head_group_error("cannot reserve explicit member projections"))?;
-
-    for delta in deltas {
-        loop {
-            let Some(member) = current else {
-                if delta.physically_deletes() {
-                    if let Some(file_id) = delta.file_id {
-                        deleted_member_projections.push(file_id);
-                    }
-                    break;
-                }
-                append_delta_head_group_member(
-                    &mut encoded,
-                    delta,
-                    delta.created_at,
-                    working_diff_baseline_for_absent_delta(
-                        delta,
-                        working_diff_checkpoint_commit_id,
-                    ),
-                    &mut explicit_member_projections,
-                )?;
-                became_current_dirty_member |=
-                    !delta.untracked && working_diff_checkpoint_commit_id.is_some();
-                increment_head_group_member_count(&mut member_count)?;
-                break;
-            };
-            match member.file_id.cmp(&delta.file_id) {
-                Ordering::Less => {
-                    previous_has_current_dirty_member |= member
-                        .baseline
-                        .is_for_checkpoint(working_diff_checkpoint_commit_id);
-                    append_head_group_member(
-                        &mut encoded,
-                        member.file_id,
-                        member.value,
-                        member.baseline,
-                    )?;
-                    increment_head_group_member_count(&mut member_count)?;
-                    current = next_head_group_member(&mut cursor)?;
-                }
-                Ordering::Equal => {
-                    reject_guarded_live_member(absence_guards, delta, member.head)?;
-                    reject_retention_change(delta, member.head)?;
-                    if member.head.untracked {
-                        collect_retired_untracked_json_refs(
-                            member.head,
-                            delta,
-                            retired_untracked_json_refs,
-                        );
-                    }
-                    if delta.physically_deletes() {
-                        if let Some(file_id) = delta.file_id {
-                            deleted_member_projections.push(file_id);
-                        }
-                        current = next_head_group_member(&mut cursor)?;
-                        break;
-                    }
-                    let (baseline, became_dirty) = working_diff_baseline_for_existing_delta(
-                        member.baseline,
-                        member.head,
-                        delta,
-                        working_diff_checkpoint_commit_id,
-                    );
-                    previous_has_current_dirty_member |= member
-                        .baseline
-                        .is_for_checkpoint(working_diff_checkpoint_commit_id);
-                    append_delta_head_group_member(
-                        &mut encoded,
-                        delta,
-                        member.head.created_at,
-                        baseline,
-                        &mut explicit_member_projections,
-                    )?;
-                    if became_dirty {
-                        became_current_dirty_member = true;
-                    }
-                    increment_head_group_member_count(&mut member_count)?;
-                    current = next_head_group_member(&mut cursor)?;
-                    break;
-                }
-                Ordering::Greater => {
-                    if delta.physically_deletes() {
-                        if let Some(file_id) = delta.file_id {
-                            deleted_member_projections.push(file_id);
-                        }
-                        break;
-                    }
-                    append_delta_head_group_member(
-                        &mut encoded,
-                        delta,
-                        delta.created_at,
-                        working_diff_baseline_for_absent_delta(
-                            delta,
-                            working_diff_checkpoint_commit_id,
-                        ),
-                        &mut explicit_member_projections,
-                    )?;
-                    became_current_dirty_member |=
-                        !delta.untracked && working_diff_checkpoint_commit_id.is_some();
-                    increment_head_group_member_count(&mut member_count)?;
-                    break;
-                }
-            }
-        }
-    }
-    while let Some(member) = current {
-        previous_has_current_dirty_member |= member
-            .baseline
-            .is_for_checkpoint(working_diff_checkpoint_commit_id);
-        append_head_group_member(&mut encoded, member.file_id, member.value, member.baseline)?;
-        increment_head_group_member_count(&mut member_count)?;
-        current = next_head_group_member(&mut cursor)?;
-    }
-
-    let bytes = if member_count == 0 {
-        None
-    } else {
-        let member_count = u32::try_from(member_count)
-            .map_err(|_| head_group_error("member count exceeds u32"))?;
-        encoded[1..HEAD_GROUP_HEADER_BYTES].copy_from_slice(&member_count.to_be_bytes());
-        Some(encoded)
-    };
-    Ok(EncodedHeadGroup {
-        bytes,
-        explicit_member_projections,
-        deleted_member_projections,
-        became_dirty_group: working_diff_checkpoint_commit_id.is_some()
-            && !previous_has_current_dirty_member
-            && became_current_dirty_member,
-    })
-}
-
-/// Records the out-of-band payload hashes that a matching untracked member
-/// stops owning. The hash is a content-addressed store key, not a row-local
-/// allocation, so the writer must only record a durable reclamation hint; GC
-/// later checks it against all active current-state and changelog owners.
 fn collect_retired_untracked_json_refs(
     existing: HeadValueView<'_>,
     delta: &CurrentStateDeltaRef<'_>,
@@ -1667,71 +439,6 @@ fn collect_retired_untracked_json_refs(
             retired.insert(*old_ref.as_hash_array());
         }
     }
-}
-
-fn working_diff_baseline_for_absent_delta(
-    delta: &CurrentStateDeltaRef<'_>,
-    checkpoint_commit_id: Option<CommitId>,
-) -> WorkingDiffBaseline {
-    if delta.untracked {
-        WorkingDiffBaseline::Clean
-    } else {
-        checkpoint_commit_id.map_or(WorkingDiffBaseline::Clean, WorkingDiffBaseline::Absent)
-    }
-}
-
-fn working_diff_baseline_for_existing_value(
-    prior_value: HeadValueView<'_>,
-    checkpoint_commit_id: Option<CommitId>,
-) -> WorkingDiffBaseline {
-    match (prior_value.working_diff_version(), checkpoint_commit_id) {
-        (Some(version), Some(checkpoint_commit_id)) => WorkingDiffBaseline::Present {
-            checkpoint_commit_id,
-            version,
-        },
-        _ => WorkingDiffBaseline::Clean,
-    }
-}
-
-fn working_diff_baseline_for_existing_delta(
-    prior: WorkingDiffBaseline,
-    prior_value: HeadValueView<'_>,
-    delta: &CurrentStateDeltaRef<'_>,
-    checkpoint_commit_id: Option<CommitId>,
-) -> (WorkingDiffBaseline, bool) {
-    if delta.untracked || prior_value.untracked {
-        return (WorkingDiffBaseline::Clean, false);
-    }
-    match checkpoint_commit_id {
-        Some(checkpoint_commit_id) if !prior.is_for_checkpoint(Some(checkpoint_commit_id)) => {
-            let version = prior_value
-                .working_diff_version()
-                .expect("tracked current-state member has a diff version");
-            (
-                WorkingDiffBaseline::Present {
-                    checkpoint_commit_id,
-                    version,
-                },
-                true,
-            )
-        }
-        _ => (prior, false),
-    }
-}
-
-fn increment_head_group_member_count(member_count: &mut usize) -> Result<(), LixError> {
-    *member_count = member_count
-        .checked_add(1)
-        .ok_or_else(|| head_group_error("member count overflow"))?;
-    Ok(())
-}
-
-fn next_head_group_member<'a>(
-    cursor: &mut Option<HeadGroupMembers<'a>>,
-) -> Result<Option<HeadGroupMemberView<'a>>, LixError> {
-    cursor
-        .as_mut()
-        .map_or(Ok(None), HeadGroupMembers::next_member)
 }
 
 fn reject_guarded_live_member(
@@ -1786,24 +493,6 @@ fn reject_retention_change(
     Ok(())
 }
 
-fn append_delta_head_group_member<'a>(
-    encoded: &mut Vec<u8>,
-    delta: &CurrentStateDeltaRef<'a>,
-    created_at: LixTimestamp,
-    baseline: WorkingDiffBaseline,
-    explicit_member_projections: &mut Vec<(&'a str, Vec<u8>)>,
-) -> Result<(), LixError> {
-    let value = encode_head_value(&delta.value_ref(created_at))?;
-    append_head_group_member(encoded, delta.file_id, &value, baseline)?;
-    // The group is authoritative. An unchanged explicit projection already
-    // belongs to this generation, so only rewrite projections whose member
-    // changed in this commit.
-    if let Some(file_id) = delta.file_id {
-        explicit_member_projections.push((file_id, value));
-    }
-    Ok(())
-}
-
 fn tracked_head_duplicate_insert_error(key: &TrackedStateKey) -> LixError {
     let entity_pk = key
         .entity_pk
@@ -1816,280 +505,6 @@ fn tracked_head_duplicate_insert_error(key: &TrackedStateKey) -> LixError {
             key.schema_key
         ),
     )
-}
-
-/// Loads packed current-state groups without materializing their members.
-async fn load_group_bytes<'a>(
-    store: &(impl StorageAdapterRead + ?Sized),
-    identities: impl IntoIterator<Item = &'a HeadGroupIdentity>,
-) -> Result<Vec<Option<Bytes>>, LixError> {
-    let keys = identities
-        .into_iter()
-        .map(|identity| StorageKey(Bytes::from(encode_group_key(identity))))
-        .collect::<Vec<_>>();
-    if keys.is_empty() {
-        return Ok(Vec::new());
-    }
-    let result = PointReadPlan::new(TRACKED_HEAD_GROUP_SPACE, &keys)
-        .materialize(store, StorageGetOptions::default())
-        .await?;
-    result
-        .value
-        .into_iter()
-        .map(|value| value.map(full_value_bytes).transpose())
-        .collect()
-}
-
-/// Loads the explicit-file member projection. Its physical access pattern is
-/// intentionally the same single-key point lookup as the prior member layout so file-id queries
-/// do not become proportional to the size of their logical PK group.
-async fn load_member_bytes(
-    store: &(impl StorageAdapterRead + ?Sized),
-    identities: &[HeadIdentity],
-) -> Result<Vec<Option<Bytes>>, LixError> {
-    if identities.is_empty() {
-        return Ok(Vec::new());
-    }
-    debug_assert!(identities.iter().all(|identity| identity.file_id.is_some()));
-    let keys = identities
-        .iter()
-        .map(|identity| StorageKey(Bytes::from(encode_member_key(identity))))
-        .collect::<Vec<_>>();
-    let result = PointReadPlan::new(TRACKED_HEAD_MEMBER_SPACE, &keys)
-        .materialize(store, StorageGetOptions::default())
-        .await?;
-    result
-        .value
-        .into_iter()
-        .map(|value| value.map(full_value_bytes).transpose())
-        .collect()
-}
-
-async fn scan_entries(
-    store: &(impl StorageAdapterRead + ?Sized),
-    branch_id: &str,
-    generation: CommitId,
-    filter: &TrackedStateFilter,
-    limit: Option<usize>,
-) -> Result<Vec<(HeadRowIdentity, Bytes)>, LixError> {
-    if let Some(identities) = exact_explicit_member_identities(branch_id, generation, filter) {
-        let values = load_member_bytes(store, &identities).await?;
-        return Ok(identities
-            .into_iter()
-            .zip(values)
-            .filter_map(|(identity, value)| {
-                value.map(|value| (identity.into_row_identity(), value))
-            })
-            .take(limit.unwrap_or(usize::MAX))
-            .collect());
-    }
-    if let Some(prefixes) = explicit_member_scan_prefixes(branch_id, generation, filter) {
-        let mut rows = scan_explicit_member_entries(store, prefixes, filter).await?;
-        // Member projection keys are ordered by `file_id` before `entity_pk`.
-        // Restore the public logical order when callers request multiple file
-        // ids; the group route below is already ordered that way.
-        rows.sort_by(|(left, _), (right, _)| left.cmp(right));
-        rows.dedup_by(|(left, _), (right, _)| left == right);
-        if let Some(limit) = limit {
-            rows.truncate(limit);
-        }
-        return Ok(rows);
-    }
-    if let Some(groups) = exact_group_identities(branch_id, generation, filter) {
-        let values = load_group_bytes(store, &groups).await?;
-        let mut rows = Vec::new();
-        for (group, value) in groups.into_iter().zip(values) {
-            let Some(value) = value else {
-                continue;
-            };
-            extend_group_entries(
-                &mut rows,
-                group,
-                value,
-                |identity| matches_file_filter(identity.file_id.as_ref(), &filter.file_ids),
-                limit,
-            )?;
-            if limit.is_some_and(|limit| rows.len() >= limit) {
-                return Ok(rows);
-            }
-        }
-        return Ok(rows);
-    }
-
-    let scope = encode_scope_prefix(branch_id, generation);
-    let mut prefixes = scan_prefixes(&scope, filter);
-    prefixes.sort();
-    prefixes.dedup();
-    let mut rows = Vec::new();
-    for prefix in prefixes {
-        let plan = ScanPlan::prefix(
-            TRACKED_HEAD_GROUP_SPACE,
-            StoragePrefix {
-                bytes: Bytes::from(prefix),
-            },
-        );
-        let mut resume_after = None;
-        loop {
-            let remaining = limit.map(|limit| limit.saturating_sub(rows.len()));
-            if matches!(remaining, Some(0)) {
-                return Ok(rows);
-            }
-            let page = plan
-                .collect(
-                    store,
-                    StorageScanOptions {
-                        resume_after: resume_after.clone(),
-                        limit_rows: remaining
-                            .unwrap_or_else(|| StorageScanOptions::default().limit_rows),
-                        ..StorageScanOptions::default()
-                    },
-                )
-                .await?;
-            resume_after = page.value.entries.last().map(|entry| entry.key.clone());
-            for entry in page.value.entries {
-                let identity = decode_group_key_in_scope(entry.key.0.as_ref(), &scope)?;
-                extend_group_entries(
-                    &mut rows,
-                    HeadGroupIdentity {
-                        branch_id: branch_id.to_string(),
-                        generation,
-                        schema_key: identity.schema_key,
-                        entity_pk: identity.entity_pk,
-                    },
-                    full_value_bytes(entry.value)?,
-                    |identity| matches_filter(identity, filter),
-                    limit,
-                )?;
-                if limit.is_some_and(|limit| rows.len() >= limit) {
-                    return Ok(rows);
-                }
-            }
-            if !page.value.has_more || resume_after.is_none() {
-                break;
-            }
-        }
-    }
-    Ok(rows)
-}
-
-/// Entity projection consumes only snapshot payloads. It can scan a schema or
-/// point-read exact groups, retaining member bytes without allocating logical
-/// row identities or intermediate JSON strings. Both physical paths preserve
-/// ascending logical primary-key order. Every live member is retained;
-/// file-backed siblings for one primary key are adjacent but intentionally
-/// have no extra tie ordering contract.
-async fn scan_entity_snapshots(
-    store: &(impl StorageAdapterRead + ?Sized),
-    branch_id: &str,
-    generation: CommitId,
-    schema_key: &str,
-    entity_pks: &[EntityPk],
-    limit: Option<usize>,
-) -> Result<Vec<Option<Bytes>>, LixError> {
-    if matches!(limit, Some(0)) {
-        return Ok(Vec::new());
-    }
-    let mut snapshots = Vec::new();
-    let mut json_refs = Vec::new();
-    let mut deferred = Vec::new();
-    if entity_pks.is_empty() {
-        let plan = ScanPlan::prefix(
-            TRACKED_HEAD_GROUP_SPACE,
-            StoragePrefix {
-                bytes: Bytes::from(schema_group_prefix(branch_id, generation, schema_key)),
-            },
-        );
-        let mut resume_after = None;
-        loop {
-            let page = plan
-                .collect(
-                    store,
-                    StorageScanOptions {
-                        resume_after: resume_after.clone(),
-                        ..StorageScanOptions::default()
-                    },
-                )
-                .await?;
-            resume_after = page.value.entries.last().map(|entry| entry.key.clone());
-            for entry in page.value.entries {
-                if append_entity_snapshot_members(
-                    &mut snapshots,
-                    &mut json_refs,
-                    &mut deferred,
-                    full_value_bytes(entry.value)?,
-                    limit,
-                )? {
-                    return materialize_entity_snapshot_refs(store, snapshots, json_refs, deferred)
-                        .await;
-                }
-            }
-            if !page.value.has_more || resume_after.is_none() {
-                break;
-            }
-        }
-    } else {
-        let mut groups = entity_pks
-            .iter()
-            .cloned()
-            .map(|entity_pk| HeadGroupIdentity {
-                branch_id: branch_id.to_string(),
-                generation,
-                schema_key: schema_key.to_string(),
-                entity_pk,
-            })
-            .collect::<Vec<_>>();
-        groups.sort();
-        groups.dedup();
-        let values = load_group_bytes(store, &groups).await?;
-        for value in values.into_iter().flatten() {
-            if append_entity_snapshot_members(
-                &mut snapshots,
-                &mut json_refs,
-                &mut deferred,
-                value,
-                limit,
-            )? {
-                break;
-            }
-        }
-    }
-    materialize_entity_snapshot_refs(store, snapshots, json_refs, deferred).await
-}
-
-/// Appends every live member of one packed group without constructing logical
-/// identities. Returns whether the caller's row limit has been reached.
-fn append_entity_snapshot_members(
-    snapshots: &mut Vec<Option<Bytes>>,
-    json_refs: &mut Vec<JsonRef>,
-    deferred: &mut Vec<(usize, JsonRef)>,
-    value: Bytes,
-    limit: Option<usize>,
-) -> Result<bool, LixError> {
-    let mut members = HeadGroupMembers::new(value.as_ref())?;
-    while let Some(member) = members.next_member()? {
-        // `HeadGroupMembers` validates and decodes the fixed-header member
-        // once as it advances. Snapshot serving needs that same borrowed view,
-        // so do not reparse every member into a materialized live-state row.
-        let head = member.head;
-        if head.deleted {
-            continue;
-        }
-        let row_index = snapshots.len();
-        let snapshot = match head.snapshot {
-            HeadSlotView::None => None,
-            HeadSlotView::Inline(snapshot) => Some(value.slice_ref(snapshot.as_bytes())),
-            HeadSlotView::Ref(json_ref) => {
-                json_refs.push(json_ref);
-                deferred.push((row_index, json_ref));
-                None
-            }
-        };
-        snapshots.push(snapshot);
-        if limit.is_some_and(|limit| snapshots.len() >= limit) {
-            return Ok(true);
-        }
-    }
-    Ok(false)
 }
 
 async fn materialize_entity_snapshot_refs(
@@ -2130,354 +545,6 @@ async fn materialize_entity_snapshot_refs(
     Ok(snapshots)
 }
 
-/// Reads the checkpoint's sparse dirty-group index and resolves before images
-/// from authoritative current-state group values. The index is auxiliary: its complete
-/// key coverage is verified before any result is returned, so a bad record is
-/// a fallback (`None`), never an empty diff.
-async fn working_diff_entries_from_current_head(
-    store: &(impl StorageAdapterRead + ?Sized),
-    branch_id: &str,
-    checkpoint_commit_id: CommitId,
-    generation: CommitId,
-    expected_coverage: WorkingDiffIndexCoverage,
-    filter: &TrackedStateFilter,
-) -> Result<Option<Vec<TrackedStateDiffEntry>>, LixError> {
-    let (groups, require_current_dirty_member) =
-        match exact_group_identities(branch_id, generation, filter) {
-            Some(groups) => (groups, false),
-            None => {
-                let Some(groups) = scan_working_diff_group_index(
-                    store,
-                    branch_id,
-                    checkpoint_commit_id,
-                    generation,
-                    expected_coverage,
-                    filter,
-                )
-                .await?
-                else {
-                    return Ok(None);
-                };
-                (groups, true)
-            }
-        };
-
-    let values = load_group_bytes(store, &groups).await?;
-    let mut dirty_rows = Vec::new();
-    for (group, value) in groups.into_iter().zip(values) {
-        let Some(value) = value else {
-            return Ok(None);
-        };
-        let Ok(members) = decode_head_group_members(&value) else {
-            return Ok(None);
-        };
-        let mut has_current_dirty_member = false;
-        for member in members {
-            let Ok(after) = decode_head_value(&member.value) else {
-                return Ok(None);
-            };
-            if after.untracked {
-                if member.baseline != WorkingDiffBaseline::Clean {
-                    return Ok(None);
-                }
-                continue;
-            }
-            if !member
-                .baseline
-                .is_for_checkpoint(Some(checkpoint_commit_id))
-            {
-                continue;
-            }
-            has_current_dirty_member = true;
-            let identity = HeadRowIdentity {
-                schema_key: group.schema_key.clone(),
-                entity_pk: group.entity_pk.clone(),
-                file_id: member.file_id,
-            };
-            // Both the exact-group route and the dirty-group index already
-            // prove this group's schema and entity PK. Only its member
-            // identity can still be filtered here.
-            if matches_file_filter(identity.file_id.as_ref(), &filter.file_ids) {
-                let Some(after) = after.working_diff_version() else {
-                    return Ok(None);
-                };
-                dirty_rows.push((identity, member.baseline, after));
-            }
-        }
-        if require_current_dirty_member && !has_current_dirty_member {
-            return Ok(None);
-        }
-    }
-
-    Ok(Some(
-        dirty_rows
-            .into_iter()
-            .filter_map(|(identity, baseline, after)| {
-                classify_working_diff_entry(identity, baseline, after)
-            })
-            .collect(),
-    ))
-}
-
-async fn scan_working_diff_group_index(
-    store: &(impl StorageAdapterRead + ?Sized),
-    branch_id: &str,
-    checkpoint_commit_id: CommitId,
-    generation: CommitId,
-    expected_coverage: WorkingDiffIndexCoverage,
-    filter: &TrackedStateFilter,
-) -> Result<Option<Vec<HeadGroupIdentity>>, LixError> {
-    let scope = encode_working_diff_scope_prefix(branch_id, checkpoint_commit_id, generation);
-    let plan = ScanPlan::prefix(
-        TRACKED_WORKING_DIFF_GROUP_SPACE,
-        StoragePrefix {
-            bytes: Bytes::from(scope.clone()),
-        },
-    );
-    let mut actual_coverage = WorkingDiffIndexCoverage::default();
-    let mut found = Vec::new();
-    let mut resume_after = None;
-    loop {
-        let page = plan
-            .collect(
-                store,
-                StorageScanOptions {
-                    resume_after: resume_after.clone(),
-                    ..StorageScanOptions::default()
-                },
-            )
-            .await?;
-        resume_after = page.value.entries.last().map(|entry| entry.key.clone());
-        for entry in page.value.entries {
-            if !is_working_diff_index_value(&entry.value)
-                || actual_coverage
-                    .add_encoded_group_key(entry.key.0.as_ref())
-                    .is_none()
-            {
-                return Ok(None);
-            }
-            let Ok(identity) = decode_working_diff_group_key_in_scope(entry.key.0.as_ref(), &scope)
-            else {
-                return Ok(None);
-            };
-            if matches_group_filter(&identity, filter) {
-                found.push(HeadGroupIdentity {
-                    branch_id: branch_id.to_string(),
-                    generation,
-                    schema_key: identity.schema_key,
-                    entity_pk: identity.entity_pk,
-                });
-            }
-        }
-        if !page.value.has_more || resume_after.is_none() {
-            break;
-        }
-    }
-    if actual_coverage != expected_coverage {
-        return Ok(None);
-    }
-    found.sort();
-    found.dedup();
-    Ok(Some(found))
-}
-
-fn is_working_diff_index_value(value: &StorageProjectedValue) -> bool {
-    matches!(value, StorageProjectedValue::FullValue(bytes) if bytes.as_ref() == WORKING_DIFF_INDEX_VALUE)
-}
-
-fn classify_working_diff_entry(
-    identity: HeadRowIdentity,
-    baseline: WorkingDiffBaseline,
-    after_version: WorkingDiffVersion,
-) -> Option<TrackedStateDiffEntry> {
-    let before_version = match baseline {
-        WorkingDiffBaseline::Clean => return None,
-        WorkingDiffBaseline::Absent(_) => None,
-        WorkingDiffBaseline::Present { version, .. } => Some(version),
-    };
-    let before = before_version.map(|version| version.into_diff_row(&identity));
-    let after = after_version.into_diff_row(&identity);
-    let identity = TrackedStateDiffIdentity {
-        schema_key: identity.schema_key,
-        entity_pk: identity.entity_pk,
-        file_id: identity.file_id,
-    };
-    match (
-        before.as_ref().filter(|row| !row.deleted),
-        (!after.deleted).then_some(&after),
-    ) {
-        (None, None) => None,
-        (None, Some(_)) => Some(TrackedStateDiffEntry {
-            identity,
-            kind: TrackedStateDiffKind::Added,
-            before,
-            after: Some(after),
-        }),
-        (Some(_), None) => Some(TrackedStateDiffEntry {
-            identity,
-            kind: TrackedStateDiffKind::Removed,
-            before,
-            after: Some(after),
-        }),
-        (Some(_), Some(_))
-            if before_version.is_some_and(|version| version.payload_eq(after_version)) =>
-        {
-            None
-        }
-        (Some(_), Some(_)) => Some(TrackedStateDiffEntry {
-            identity,
-            kind: TrackedStateDiffKind::Modified,
-            before,
-            after: Some(after),
-        }),
-    }
-}
-
-fn matches_group_filter(identity: &HeadRowIdentity, filter: &TrackedStateFilter) -> bool {
-    (filter.schema_keys.is_empty() || filter.schema_keys.contains(&identity.schema_key))
-        && (filter.entity_pks.is_empty() || filter.entity_pks.contains(&identity.entity_pk))
-}
-
-fn exact_group_identities(
-    branch_id: &str,
-    generation: CommitId,
-    filter: &TrackedStateFilter,
-) -> Option<Vec<HeadGroupIdentity>> {
-    if filter.schema_keys.is_empty() || filter.entity_pks.is_empty() {
-        return None;
-    }
-    let mut identities = Vec::with_capacity(filter.schema_keys.len() * filter.entity_pks.len());
-    for schema_key in &filter.schema_keys {
-        for entity_pk in &filter.entity_pks {
-            identities.push(HeadGroupIdentity {
-                branch_id: branch_id.to_string(),
-                generation,
-                schema_key: schema_key.clone(),
-                entity_pk: entity_pk.clone(),
-            });
-        }
-    }
-    identities.sort();
-    identities.dedup();
-    Some(identities)
-}
-
-fn exact_explicit_member_identities(
-    branch_id: &str,
-    generation: CommitId,
-    filter: &TrackedStateFilter,
-) -> Option<Vec<HeadIdentity>> {
-    exact_group_identities(branch_id, generation, filter)?;
-    if filter.file_ids.is_empty()
-        || filter
-            .file_ids
-            .iter()
-            .any(|file_id| !matches!(file_id, NullableKeyFilter::Value(_)))
-    {
-        return None;
-    }
-    let mut identities = Vec::with_capacity(
-        filter.schema_keys.len() * filter.entity_pks.len() * filter.file_ids.len(),
-    );
-    for schema_key in &filter.schema_keys {
-        for entity_pk in &filter.entity_pks {
-            for file_id in &filter.file_ids {
-                let NullableKeyFilter::Value(file_id) = file_id else {
-                    unreachable!("explicit member filter checked above");
-                };
-                identities.push(HeadIdentity {
-                    branch_id: branch_id.to_string(),
-                    generation,
-                    schema_key: schema_key.clone(),
-                    entity_pk: entity_pk.clone(),
-                    file_id: Some(file_id.clone()),
-                });
-            }
-        }
-    }
-    identities.sort();
-    identities.dedup();
-    Some(identities)
-}
-
-/// A schema-scoped `file_id = ?` lookup cannot use the grouped primary
-/// serving record without decoding every logical PK in that schema. Explicit
-/// member rows use a file-id-first suffix solely for this access pattern.
-///
-/// Exact `(schema, entity_pk, file_id)` requests take the point-read route
-/// above. If the schema is unknown, no useful member-space prefix exists and
-/// we correctly retain the general group scan fallback.
-fn explicit_member_scan_prefixes(
-    branch_id: &str,
-    generation: CommitId,
-    filter: &TrackedStateFilter,
-) -> Option<Vec<Vec<u8>>> {
-    if filter.schema_keys.is_empty()
-        || filter.file_ids.is_empty()
-        || !filter.entity_pks.is_empty()
-        || filter
-            .file_ids
-            .iter()
-            .any(|file_id| !matches!(file_id, NullableKeyFilter::Value(_)))
-    {
-        return None;
-    }
-    let mut prefixes = Vec::with_capacity(filter.schema_keys.len() * filter.file_ids.len());
-    for schema_key in &filter.schema_keys {
-        for file_id in &filter.file_ids {
-            let NullableKeyFilter::Value(file_id) = file_id else {
-                unreachable!("explicit member scan filter checked above");
-            };
-            let mut prefix = encode_scope_prefix(branch_id, generation);
-            write_key_string(&mut prefix, schema_key, KEY_PART_FINAL);
-            write_file_id(&mut prefix, Some(file_id));
-            prefixes.push(prefix);
-        }
-    }
-    prefixes.sort();
-    prefixes.dedup();
-    Some(prefixes)
-}
-
-async fn scan_explicit_member_entries(
-    store: &(impl StorageAdapterRead + ?Sized),
-    prefixes: Vec<Vec<u8>>,
-    filter: &TrackedStateFilter,
-) -> Result<Vec<(HeadRowIdentity, Bytes)>, LixError> {
-    let mut rows = Vec::new();
-    for prefix in prefixes {
-        let plan = ScanPlan::prefix(
-            TRACKED_HEAD_MEMBER_SPACE,
-            StoragePrefix {
-                bytes: Bytes::from(prefix),
-            },
-        );
-        let mut resume_after = None;
-        loop {
-            let page = plan
-                .collect(
-                    store,
-                    StorageScanOptions {
-                        resume_after: resume_after.clone(),
-                        ..StorageScanOptions::default()
-                    },
-                )
-                .await?;
-            resume_after = page.value.entries.last().map(|entry| entry.key.clone());
-            for entry in page.value.entries {
-                let identity = decode_member_key(entry.key.0.as_ref())?.into_row_identity();
-                if matches_filter(&identity, filter) {
-                    rows.push((identity, full_value_bytes(entry.value)?));
-                }
-            }
-            if !page.value.has_more || resume_after.is_none() {
-                break;
-            }
-        }
-    }
-    Ok(rows)
-}
-
 fn scan_prefixes(scope: &[u8], filter: &TrackedStateFilter) -> Vec<Vec<u8>> {
     if filter.schema_keys.is_empty() {
         return vec![scope.to_vec()];
@@ -2497,35 +564,6 @@ fn scan_prefixes(scope: &[u8], filter: &TrackedStateFilter) -> Vec<Vec<u8>> {
         }
     }
     prefixes
-}
-
-fn schema_group_prefix(branch_id: &str, generation: CommitId, schema_key: &str) -> Vec<u8> {
-    let mut prefix = encode_scope_prefix(branch_id, generation);
-    write_key_string(&mut prefix, schema_key, KEY_PART_FINAL);
-    prefix
-}
-
-fn extend_group_entries(
-    rows: &mut Vec<(HeadRowIdentity, Bytes)>,
-    group: HeadGroupIdentity,
-    value: Bytes,
-    member_matches: impl Fn(&HeadRowIdentity) -> bool,
-    limit: Option<usize>,
-) -> Result<(), LixError> {
-    for member in decode_head_group_members(&value)? {
-        let identity = HeadRowIdentity {
-            schema_key: group.schema_key.clone(),
-            entity_pk: group.entity_pk.clone(),
-            file_id: member.file_id,
-        };
-        if member_matches(&identity) {
-            rows.push((identity, member.value));
-            if limit.is_some_and(|limit| rows.len() >= limit) {
-                break;
-            }
-        }
-    }
-    Ok(())
 }
 
 fn matches_filter(identity: &HeadRowIdentity, filter: &TrackedStateFilter) -> bool {
@@ -2561,7 +599,6 @@ fn stage_test_current_control(
         BranchHeadControl {
             head_commit_id,
             generation,
-            tracked_head_is_current: true,
             current_state_revision: 0,
             working_diff_checkpoint_commit_id,
             created_at: timestamp,
@@ -2572,7 +609,7 @@ fn stage_test_current_control(
 }
 
 /// Publishes the checkpoint epoch that owns the sparse working-diff indexes.
-/// The surrounding branch-control CAS makes this marker, the current-state groups,
+/// The surrounding branch-control CAS makes this marker, the current hot rows,
 /// and the current branch head one atomic visibility boundary.
 pub(crate) fn stage_tracked_working_diff_epoch(
     writes: &mut StorageWriteSet,
@@ -2637,18 +674,7 @@ where
         .into_iter()
         .collect::<BTreeMap<_, _>>();
     let active = stage_active_working_diff_scopes(store, writes, &controls).await?;
-    stage_collect_stale_derived_space(store, writes, TRACKED_WORKING_DIFF_GROUP_SPACE, |entry| {
-        is_working_diff_index_value(&entry.value)
-            && decode_working_diff_group_key(entry.key.0.as_ref()).is_ok_and(
-                |(checkpoint_commit_id, identity)| {
-                    active.get(&identity.branch_id).is_some_and(|scope| {
-                        scope.checkpoint_commit_id == checkpoint_commit_id
-                            && scope.generation == identity.generation
-                    })
-                },
-            )
-    })
-    .await
+    hot::stage_collect_stale_hot_diff_records(store, writes, &active).await
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -2715,36 +741,19 @@ where
                 writes.delete(TRACKED_WORKING_DIFF_MARKER_SPACE, entry.key);
                 continue;
             };
-            let valid = match epoch.generation {
-                // A checkpoint reset is known empty and deliberately leaves
-                // the prior serving group generation intact until its first
-                // ordinary child captures a new baseline.
-                None => {
-                    epoch.checkpoint_commit_id == control.head_commit_id
-                        && (!control.tracked_head_is_current
-                            || control.working_diff_checkpoint_commit_id
-                                == Some(epoch.checkpoint_commit_id))
-                }
-                Some(generation) if generation == control.generation => {
-                    control.tracked_head_is_current
-                        && control.working_diff_checkpoint_commit_id
-                            == Some(epoch.checkpoint_commit_id)
-                }
-                Some(_) => false,
-            };
+            let valid = epoch.generation == control.generation
+                && control.working_diff_checkpoint_commit_id == Some(epoch.checkpoint_commit_id);
             if !valid || active.contains_key(&key.branch_id) {
                 writes.delete(TRACKED_WORKING_DIFF_MARKER_SPACE, entry.key);
                 continue;
             }
-            if let Some(generation) = epoch.generation {
-                active.insert(
-                    key.branch_id,
-                    ActiveWorkingDiffScope {
-                        checkpoint_commit_id: epoch.checkpoint_commit_id,
-                        generation,
-                    },
-                );
-            }
+            active.insert(
+                key.branch_id,
+                ActiveWorkingDiffScope {
+                    checkpoint_commit_id: epoch.checkpoint_commit_id,
+                    generation: epoch.generation,
+                },
+            );
         }
         if !page.value.has_more || resume_after.is_none() {
             break;
@@ -2753,329 +762,17 @@ where
     Ok(active)
 }
 
-/// Deletes stale authoritative groups and records the history-free payloads
-/// they used to own. Stale bytes are intentionally tolerated here: no valid
-/// control can select them, so cleanup must not turn a corrupt abandoned
-/// generation into a permanent GC failure.
-async fn stage_collect_stale_current_state_group_space(
-    store: &(impl StorageAdapterRead + ?Sized),
-    writes: &mut StorageWriteSet,
-    active: &BTreeSet<(String, CommitId)>,
-    stale_untracked_refs: &mut BTreeSet<[u8; JSON_REF_BYTES]>,
-) -> Result<(), LixError> {
-    let plan = ScanPlan::prefix(
-        TRACKED_HEAD_GROUP_SPACE,
-        StoragePrefix {
-            bytes: Bytes::new(),
-        },
-    );
-    let mut resume_after = None;
-    loop {
-        let page = plan
-            .collect(
-                store,
-                StorageScanOptions {
-                    resume_after: resume_after.clone(),
-                    ..StorageScanOptions::default()
-                },
-            )
-            .await?;
-        resume_after = page.value.entries.last().map(|entry| entry.key.clone());
-        for entry in page.value.entries {
-            let is_active = decode_group_key(entry.key.0.as_ref())
-                .is_ok_and(|identity| active.contains(&(identity.branch_id, identity.generation)));
-            if is_active {
-                continue;
-            }
-            if let StorageProjectedValue::FullValue(bytes) = &entry.value {
-                // The group will be deleted regardless. Only a completely
-                // decoded stale group can contribute a payload deletion
-                // candidate; malformed abandoned bytes remain safe offline
-                // repair debt instead of making background GC fail.
-                let _ =
-                    collect_untracked_json_refs_from_group(bytes.as_ref(), stale_untracked_refs);
-            }
-            writes.delete(TRACKED_HEAD_GROUP_SPACE, entry.key);
-        }
-        if !page.value.has_more || resume_after.is_none() {
-            break;
-        }
-    }
-    Ok(())
-}
-
-/// Deletes stale explicit-file projections. They duplicate authoritative
-/// group values, but collecting their refs as well covers an orphaned
-/// projection whose group was lost before this sweep.
-async fn stage_collect_stale_current_state_member_space(
-    store: &(impl StorageAdapterRead + ?Sized),
-    writes: &mut StorageWriteSet,
-    active: &BTreeSet<(String, CommitId)>,
-    stale_untracked_refs: &mut BTreeSet<[u8; JSON_REF_BYTES]>,
-) -> Result<(), LixError> {
-    let plan = ScanPlan::prefix(
-        TRACKED_HEAD_MEMBER_SPACE,
-        StoragePrefix {
-            bytes: Bytes::new(),
-        },
-    );
-    let mut resume_after = None;
-    loop {
-        let page = plan
-            .collect(
-                store,
-                StorageScanOptions {
-                    resume_after: resume_after.clone(),
-                    ..StorageScanOptions::default()
-                },
-            )
-            .await?;
-        resume_after = page.value.entries.last().map(|entry| entry.key.clone());
-        for entry in page.value.entries {
-            let is_active = decode_member_key(entry.key.0.as_ref())
-                .is_ok_and(|identity| active.contains(&(identity.branch_id, identity.generation)));
-            if is_active {
-                continue;
-            }
-            if let StorageProjectedValue::FullValue(bytes) = &entry.value {
-                if let Ok(head) = decode_head_value(bytes.as_ref()) {
-                    collect_untracked_json_refs_from_head(head, stale_untracked_refs);
-                }
-            }
-            writes.delete(TRACKED_HEAD_MEMBER_SPACE, entry.key);
-        }
-        if !page.value.has_more || resume_after.is_none() {
-            break;
-        }
-    }
-    Ok(())
-}
-
-fn collect_untracked_json_refs_from_group(
-    bytes: &[u8],
-    refs: &mut BTreeSet<[u8; JSON_REF_BYTES]>,
-) -> Result<(), LixError> {
-    let mut members = HeadGroupMembers::new(bytes)?;
-    while let Some(member) = members.next_member()? {
-        collect_untracked_json_refs_from_head(member.head, refs);
-    }
-    Ok(())
-}
-
-fn collect_untracked_json_refs_from_head(
-    head: HeadValueView<'_>,
-    refs: &mut BTreeSet<[u8; JSON_REF_BYTES]>,
-) {
-    if !head.untracked {
-        return;
-    }
-    for slot in [head.snapshot, head.metadata] {
-        if let HeadSlotView::Ref(json_ref) = slot {
-            refs.insert(*json_ref.as_hash_array());
-        }
-    }
-}
-
-/// Deletes records from a derived storage plane unless their key is still
-/// reachable from an authoritative control record. Malformed keys are also
-/// derived garbage: they cannot be selected by a valid reader.
-async fn stage_collect_stale_derived_space(
-    store: &(impl StorageAdapterRead + ?Sized),
-    writes: &mut StorageWriteSet,
-    space: StorageSpace,
-    is_active: impl Fn(&StorageReadEntry) -> bool,
-) -> Result<(), LixError> {
-    let plan = ScanPlan::prefix(
-        space,
-        StoragePrefix {
-            bytes: Bytes::new(),
-        },
-    );
-    let mut resume_after = None;
-    loop {
-        let page = plan
-            .collect(
-                store,
-                StorageScanOptions {
-                    resume_after: resume_after.clone(),
-                    ..StorageScanOptions::default()
-                },
-            )
-            .await?;
-        resume_after = page.value.entries.last().map(|entry| entry.key.clone());
-        for entry in page.value.entries {
-            if !is_active(&entry) {
-                writes.delete(space, entry.key);
-            }
-        }
-        if !page.value.has_more || resume_after.is_none() {
-            break;
-        }
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 fn stage_put(
     writes: &mut StorageWriteSet,
     identity: &HeadIdentity,
     value: &HeadValue,
 ) -> Result<(), LixError> {
-    stage_put_ref(writes, identity, &value.as_ref())
-}
-
-#[cfg(test)]
-fn stage_put_ref(
-    writes: &mut StorageWriteSet,
-    identity: &HeadIdentity,
-    value: &HeadValueRef<'_>,
-) -> Result<(), LixError> {
-    let mut members = BTreeMap::new();
-    members.insert(identity.file_id.clone(), encode_head_value(value)?);
-    stage_put_group_members(writes, &identity.group_identity(), &members)?;
-    if identity.file_id.is_some() {
-        stage_put_member_bytes(
-            writes,
-            &identity.group_identity(),
-            identity.file_id.as_deref(),
-            &members[&identity.file_id],
-        )?;
-    }
-    Ok(())
-}
-
-#[cfg(test)]
-fn stage_put_group_members(
-    writes: &mut StorageWriteSet,
-    identity: &HeadGroupIdentity,
-    members: &BTreeMap<Option<String>, Vec<u8>>,
-) -> Result<(), LixError> {
-    stage_put_group_bytes(writes, identity, encode_head_group_members(members)?);
-    Ok(())
-}
-
-fn stage_put_group_members_with_baselines(
-    writes: &mut StorageWriteSet,
-    identity: &HeadGroupIdentity,
-    members: &BTreeMap<Option<String>, Vec<u8>>,
-    baselines: &BTreeMap<Option<String>, WorkingDiffBaseline>,
-) -> Result<(), LixError> {
-    stage_put_group_bytes(
-        writes,
-        identity,
-        encode_head_group_members_with_baselines(members, baselines)?,
-    );
-    Ok(())
-}
-
-fn stage_put_group_bytes(
-    writes: &mut StorageWriteSet,
-    identity: &HeadGroupIdentity,
-    bytes: Vec<u8>,
-) {
-    writes.put(
-        TRACKED_HEAD_GROUP_SPACE,
-        StorageKey(Bytes::from(encode_group_key(identity))),
-        StorageValue {
-            bytes: Bytes::from(bytes),
-        },
-    );
-}
-
-fn stage_delete_group(writes: &mut StorageWriteSet, identity: &HeadGroupIdentity) {
-    writes.delete(
-        TRACKED_HEAD_GROUP_SPACE,
-        StorageKey(Bytes::from(encode_group_key(identity))),
-    );
-}
-
-const WORKING_DIFF_INDEX_VALUE: &[u8] = b"\x01";
-
-fn stage_put_working_diff_group_index(
-    writes: &mut StorageWriteSet,
-    coverage: &mut WorkingDiffIndexCoverage,
-    checkpoint_commit_id: CommitId,
-    identity: &HeadGroupIdentity,
-) -> Result<(), LixError> {
-    let key = encode_working_diff_group_key(checkpoint_commit_id, identity);
-    coverage
-        .add_encoded_group_key(&key)
-        .ok_or_else(|| head_group_error("working-diff group index count exceeds u64"))?;
-    writes.put(
-        TRACKED_WORKING_DIFF_GROUP_SPACE,
-        StorageKey(Bytes::from(key)),
-        StorageValue {
-            bytes: Bytes::from_static(WORKING_DIFF_INDEX_VALUE),
-        },
-    );
-    Ok(())
-}
-
-fn stage_put_member_bytes(
-    writes: &mut StorageWriteSet,
-    group: &HeadGroupIdentity,
-    file_id: Option<&str>,
-    value: &[u8],
-) -> Result<(), LixError> {
-    let Some(file_id) = file_id else {
-        return Err(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            "tracked-head explicit member projection requires a file_id",
-        ));
-    };
-    stage_put_file_member_bytes(writes, group, file_id, value);
-    Ok(())
-}
-
-fn stage_put_file_member_bytes(
-    writes: &mut StorageWriteSet,
-    group: &HeadGroupIdentity,
-    file_id: &str,
-    value: &[u8],
-) {
-    let identity = HeadIdentity {
-        branch_id: group.branch_id.clone(),
-        generation: group.generation,
-        schema_key: group.schema_key.clone(),
-        entity_pk: group.entity_pk.clone(),
-        file_id: Some(file_id.to_string()),
-    };
-    writes.put(
-        TRACKED_HEAD_MEMBER_SPACE,
-        StorageKey(Bytes::from(encode_member_key(&identity))),
-        StorageValue {
-            bytes: Bytes::copy_from_slice(value),
-        },
-    );
-}
-
-fn stage_delete_file_member(
-    writes: &mut StorageWriteSet,
-    group: &HeadGroupIdentity,
-    file_id: &str,
-) {
-    let identity = HeadIdentity {
-        branch_id: group.branch_id.clone(),
-        generation: group.generation,
-        schema_key: group.schema_key.clone(),
-        entity_pk: group.entity_pk.clone(),
-        file_id: Some(file_id.to_string()),
-    };
-    writes.delete(
-        TRACKED_HEAD_MEMBER_SPACE,
-        StorageKey(Bytes::from(encode_member_key(&identity))),
-    );
+    hot::stage_test_hot_value(writes, identity, value)
 }
 
 fn working_diff_marker_key(branch_id: &str) -> Result<Vec<u8>, LixError> {
     storage_codec::encode("tracked working-diff marker key", &BranchRef { branch_id })
-}
-
-fn encode_group_key(identity: &HeadGroupIdentity) -> Vec<u8> {
-    let mut out = encode_scope_prefix(&identity.branch_id, identity.generation);
-    write_key_string(&mut out, &identity.schema_key, KEY_PART_FINAL);
-    write_entity_pk(&mut out, &identity.entity_pk);
-    out
 }
 
 fn encode_working_diff_scope_prefix(
@@ -3088,159 +785,6 @@ fn encode_working_diff_scope_prefix(
     out.extend_from_slice(checkpoint_commit_id.as_uuid().as_bytes());
     out.extend_from_slice(generation.as_uuid().as_bytes());
     out
-}
-
-fn encode_working_diff_group_key(
-    checkpoint_commit_id: CommitId,
-    identity: &HeadGroupIdentity,
-) -> Vec<u8> {
-    let mut out = encode_working_diff_scope_prefix(
-        &identity.branch_id,
-        checkpoint_commit_id,
-        identity.generation,
-    );
-    write_key_string(&mut out, &identity.schema_key, KEY_PART_FINAL);
-    write_entity_pk(&mut out, &identity.entity_pk);
-    out
-}
-
-fn encode_member_key(identity: &HeadIdentity) -> Vec<u8> {
-    debug_assert!(identity.file_id.is_some());
-    let mut out = encode_scope_prefix(&identity.branch_id, identity.generation);
-    write_key_string(&mut out, &identity.schema_key, KEY_PART_FINAL);
-    write_file_id(&mut out, identity.file_id.as_deref());
-    write_entity_pk(&mut out, &identity.entity_pk);
-    out
-}
-
-fn decode_group_key(bytes: &[u8]) -> Result<HeadGroupIdentity, LixError> {
-    let mut offset = 0usize;
-    let (branch_id, branch_terminator) = read_key_string(bytes, &mut offset, "branch id")?;
-    if branch_terminator != KEY_PART_FINAL {
-        return Err(key_codec_error("branch id has an invalid terminator"));
-    }
-    let generation = read_generation(bytes, &mut offset)?;
-    let (schema_key, schema_terminator) = read_key_string(bytes, &mut offset, "schema key")?;
-    if schema_terminator != KEY_PART_FINAL {
-        return Err(key_codec_error("schema key has an invalid terminator"));
-    }
-    let entity_pk = read_entity_pk(bytes, &mut offset)?;
-    if offset != bytes.len() {
-        return Err(key_codec_error("group key has trailing bytes"));
-    }
-    Ok(HeadGroupIdentity {
-        branch_id,
-        generation,
-        schema_key,
-        entity_pk,
-    })
-}
-
-fn decode_working_diff_group_key(bytes: &[u8]) -> Result<(CommitId, HeadGroupIdentity), LixError> {
-    let mut offset = 0usize;
-    let (branch_id, branch_terminator) = read_key_string(bytes, &mut offset, "branch id")?;
-    if branch_terminator != KEY_PART_FINAL {
-        return Err(key_codec_error("branch id has an invalid terminator"));
-    }
-    let checkpoint_commit_id = read_generation(bytes, &mut offset)?;
-    let generation = read_generation(bytes, &mut offset)?;
-    let (schema_key, schema_terminator) = read_key_string(bytes, &mut offset, "schema key")?;
-    if schema_terminator != KEY_PART_FINAL {
-        return Err(key_codec_error("schema key has an invalid terminator"));
-    }
-    let entity_pk = read_entity_pk(bytes, &mut offset)?;
-    if offset != bytes.len() {
-        return Err(key_codec_error("working-diff group key has trailing bytes"));
-    }
-    Ok((
-        checkpoint_commit_id,
-        HeadGroupIdentity {
-            branch_id,
-            generation,
-            schema_key,
-            entity_pk,
-        },
-    ))
-}
-
-fn decode_member_key(bytes: &[u8]) -> Result<HeadIdentity, LixError> {
-    let mut offset = 0usize;
-    let (branch_id, branch_terminator) = read_key_string(bytes, &mut offset, "branch id")?;
-    if branch_terminator != KEY_PART_FINAL {
-        return Err(key_codec_error("branch id has an invalid terminator"));
-    }
-    let generation = read_generation(bytes, &mut offset)?;
-    let (schema_key, schema_terminator) = read_key_string(bytes, &mut offset, "schema key")?;
-    if schema_terminator != KEY_PART_FINAL {
-        return Err(key_codec_error("schema key has an invalid terminator"));
-    }
-    let file_id = read_file_id(bytes, &mut offset)?;
-    if file_id.is_none() {
-        return Err(key_codec_error("member key must contain a file id"));
-    }
-    let entity_pk = read_entity_pk(bytes, &mut offset)?;
-    if offset != bytes.len() {
-        return Err(key_codec_error("member key has trailing bytes"));
-    }
-    Ok(HeadIdentity {
-        branch_id,
-        generation,
-        schema_key,
-        entity_pk,
-        file_id,
-    })
-}
-
-/// Decodes only the mutable suffix of a group key from a prefix-scoped scan.
-///
-/// `ScanPlan::prefix` already constrains the branch and generation. We still
-/// verify the fixed scope before parsing the suffix so a malformed storage key
-/// cannot be interpreted as a row from the wrong generation.
-fn decode_group_key_in_scope(bytes: &[u8], scope: &[u8]) -> Result<HeadRowIdentity, LixError> {
-    if !bytes.starts_with(scope) {
-        return Err(key_codec_error(
-            "does not begin with the scanned branch-generation scope",
-        ));
-    }
-    let mut offset = scope.len();
-    let (schema_key, schema_terminator) = read_key_string(bytes, &mut offset, "schema key")?;
-    if schema_terminator != KEY_PART_FINAL {
-        return Err(key_codec_error("schema key has an invalid terminator"));
-    }
-    let entity_pk = read_entity_pk(bytes, &mut offset)?;
-    if offset != bytes.len() {
-        return Err(key_codec_error("group key has trailing bytes"));
-    }
-    Ok(HeadRowIdentity {
-        schema_key,
-        entity_pk,
-        file_id: None,
-    })
-}
-
-fn decode_working_diff_group_key_in_scope(
-    bytes: &[u8],
-    scope: &[u8],
-) -> Result<HeadRowIdentity, LixError> {
-    if !bytes.starts_with(scope) {
-        return Err(key_codec_error(
-            "does not begin with the scanned working-diff checkpoint-generation scope",
-        ));
-    }
-    let mut offset = scope.len();
-    let (schema_key, schema_terminator) = read_key_string(bytes, &mut offset, "schema key")?;
-    if schema_terminator != KEY_PART_FINAL {
-        return Err(key_codec_error("schema key has an invalid terminator"));
-    }
-    let entity_pk = read_entity_pk(bytes, &mut offset)?;
-    if offset != bytes.len() {
-        return Err(key_codec_error("working-diff group key has trailing bytes"));
-    }
-    Ok(HeadRowIdentity {
-        schema_key,
-        entity_pk,
-        file_id: None,
-    })
 }
 
 const KEY_ESCAPE: u8 = 0xff;
@@ -3420,228 +964,11 @@ fn key_codec_error(message: &str) -> LixError {
     )
 }
 
-/// v12 packs all file-backed members of one logical entity PK into one
-/// canonical current-state group. The individual member payload is the proven
-/// fixed-header v3 value below; only the outer framing is new.
+/// Fixed-width fingerprints embedded in the V5 hot-row checkpoint baseline.
 ///
-/// ```text
-///  0      group format version (4)
-///  1..5   member count (big endian u32)
-///  repeated:
-///    0      file-id tag (0 = none, 1 = UTF-8 string)
-///    1..5   file-id byte length when tag = 1 (big endian u32)
-///    ...    file-id UTF-8 bytes when tag = 1
-///    ...    v4 member byte length (big endian u32)
-///    ...    v4 member bytes
-/// ```
-///
-/// Members are strictly sorted by Rust's `Option<String>` ordering. This
-/// makes scans deterministic and, more importantly, rejects silently
-/// duplicated full identities at the storage boundary.
-const HEAD_GROUP_VALUE_VERSION: u8 = 4;
-const HEAD_GROUP_HEADER_BYTES: usize = 5;
-const WORKING_DIFF_BASELINE_CLEAN: u8 = 0;
-const WORKING_DIFF_BASELINE_ABSENT: u8 = 1;
-const WORKING_DIFF_BASELINE_PRESENT: u8 = 2;
-const WORKING_DIFF_SLOT_NONE: u8 = 0;
-const WORKING_DIFF_SLOT_REF: u8 = 1;
-const WORKING_DIFF_SLOT_INLINE: u8 = 2;
-const WORKING_DIFF_VERSION_BYTES: usize =
-    16 + 16 + 1 + 8 + 8 + 1 + JSON_REF_BYTES + 1 + JSON_REF_BYTES;
-
-struct HeadGroupMemberBytes {
-    file_id: Option<String>,
-    value: Bytes,
-    baseline: WorkingDiffBaseline,
-}
-
-/// A validated, borrowed member from a current-state group value.
-///
-/// The incremental writer uses this cursor to copy untouched member bytes
-/// directly into the next group while retaining the old fixed-header value
-/// needed to preserve `created_at` on a changed identity.
-#[derive(Clone, Copy)]
-struct HeadGroupMemberView<'a> {
-    file_id: Option<&'a str>,
-    value: &'a [u8],
-    head: HeadValueView<'a>,
-    baseline: WorkingDiffBaseline,
-}
-
-/// Streaming parser for the authoritative current-state group bytes.
-///
-/// Unlike the reader-side decoder, this does not allocate a `String`,
-/// `Bytes`, or map for every member. It still enforces the complete wire
-/// contract while every member is consumed, including untouched siblings.
-struct HeadGroupMembers<'a> {
-    bytes: &'a [u8],
-    offset: usize,
-    remaining: usize,
-    prior_file_id: Option<Option<&'a str>>,
-}
-
-impl<'a> HeadGroupMembers<'a> {
-    fn new(bytes: &'a [u8]) -> Result<Self, LixError> {
-        if bytes.len() < HEAD_GROUP_HEADER_BYTES {
-            return Err(head_group_error("value is shorter than the fixed header"));
-        }
-        if bytes[0] != HEAD_GROUP_VALUE_VERSION {
-            return Err(head_group_error(&format!(
-                "unsupported group format version {}",
-                bytes[0]
-            )));
-        }
-        let remaining = usize::try_from(read_u32(&bytes[1..5], "group member count")?)
-            .map_err(|_| head_group_error("member count exceeds usize"))?;
-        Ok(Self {
-            bytes,
-            offset: HEAD_GROUP_HEADER_BYTES,
-            remaining,
-            prior_file_id: None,
-        })
-    }
-
-    fn next_member(&mut self) -> Result<Option<HeadGroupMemberView<'a>>, LixError> {
-        if self.remaining == 0 {
-            if self.offset != self.bytes.len() {
-                return Err(head_group_error("has trailing bytes"));
-            }
-            return Ok(None);
-        }
-
-        let tag = *self
-            .bytes
-            .get(self.offset)
-            .ok_or_else(|| head_group_error("is truncated before member file id"))?;
-        self.offset += 1;
-        let file_id = match tag {
-            FILE_ID_NONE => None,
-            FILE_ID_SOME => {
-                let file_id_len =
-                    read_group_u32(self.bytes, &mut self.offset, "member file-id length")?;
-                let file_id_end = self
-                    .offset
-                    .checked_add(file_id_len)
-                    .ok_or_else(|| head_group_error("member file-id length overflow"))?;
-                let file_id = self
-                    .bytes
-                    .get(self.offset..file_id_end)
-                    .ok_or_else(|| head_group_error("is truncated in member file id"))?;
-                self.offset = file_id_end;
-                Some(std::str::from_utf8(file_id).map_err(|error| {
-                    head_group_error(&format!("member file id is not UTF-8: {error}"))
-                })?)
-            }
-            _ => return Err(head_group_error("has an invalid member file-id tag")),
-        };
-        if self.prior_file_id.is_some_and(|prior| prior >= file_id) {
-            return Err(head_group_error(
-                "members are not strictly ordered by file id",
-            ));
-        }
-
-        let value_len = read_group_u32(self.bytes, &mut self.offset, "member value length")?;
-        let value_end = self
-            .offset
-            .checked_add(value_len)
-            .ok_or_else(|| head_group_error("member value length overflow"))?;
-        let value = self
-            .bytes
-            .get(self.offset..value_end)
-            .ok_or_else(|| head_group_error("is truncated in member value"))?;
-        let head = decode_head_value(value)?;
-        self.offset = value_end;
-        let baseline = decode_working_diff_baseline(self.bytes, &mut self.offset)?;
-        if head.untracked && baseline != WorkingDiffBaseline::Clean {
-            return Err(head_group_error(
-                "untracked current-state member has a working-diff baseline",
-            ));
-        }
-        self.remaining -= 1;
-        self.prior_file_id = Some(file_id);
-        Ok(Some(HeadGroupMemberView {
-            file_id,
-            value,
-            head,
-            baseline,
-        }))
-    }
-}
-
-fn append_head_group_member(
-    encoded: &mut Vec<u8>,
-    file_id: Option<&str>,
-    value: &[u8],
-    baseline: WorkingDiffBaseline,
-) -> Result<(), LixError> {
-    let file_id_bytes = match file_id {
-        None => 0,
-        Some(file_id) => {
-            u32::try_from(file_id.len()).map_err(|_| head_group_error("file id exceeds u32"))?;
-            4usize
-                .checked_add(file_id.len())
-                .ok_or_else(|| head_group_error("group value length overflow"))?
-        }
-    };
-    u32::try_from(value.len()).map_err(|_| head_group_error("member value exceeds u32"))?;
-    let member_len = 1usize
-        .checked_add(file_id_bytes)
-        .and_then(|length| length.checked_add(4))
-        .and_then(|length| length.checked_add(value.len()))
-        .and_then(|length| length.checked_add(working_diff_baseline_len(baseline)))
-        .ok_or_else(|| head_group_error("group value length overflow"))?;
-    encoded
-        .len()
-        .checked_add(member_len)
-        .ok_or_else(|| head_group_error("group value length overflow"))?;
-    encoded
-        .try_reserve(member_len)
-        .map_err(|_| head_group_error("cannot reserve group value bytes"))?;
-
-    match file_id {
-        None => encoded.push(FILE_ID_NONE),
-        Some(file_id) => {
-            encoded.push(FILE_ID_SOME);
-            let file_id_len = u32::try_from(file_id.len())
-                .map_err(|_| head_group_error("file id exceeds u32"))?;
-            encoded.extend_from_slice(&file_id_len.to_be_bytes());
-            encoded.extend_from_slice(file_id.as_bytes());
-        }
-    }
-    let value_len =
-        u32::try_from(value.len()).map_err(|_| head_group_error("member value exceeds u32"))?;
-    encoded.extend_from_slice(&value_len.to_be_bytes());
-    encoded.extend_from_slice(value);
-    encode_working_diff_baseline(encoded, baseline);
-    Ok(())
-}
-
-fn working_diff_baseline_len(baseline: WorkingDiffBaseline) -> usize {
-    match baseline {
-        WorkingDiffBaseline::Clean => 1,
-        WorkingDiffBaseline::Absent(_) => 1 + UUID_BYTES,
-        WorkingDiffBaseline::Present { .. } => 1 + UUID_BYTES + WORKING_DIFF_VERSION_BYTES,
-    }
-}
-
-fn encode_working_diff_baseline(encoded: &mut Vec<u8>, baseline: WorkingDiffBaseline) {
-    match baseline {
-        WorkingDiffBaseline::Clean => encoded.push(WORKING_DIFF_BASELINE_CLEAN),
-        WorkingDiffBaseline::Absent(checkpoint_commit_id) => {
-            encoded.push(WORKING_DIFF_BASELINE_ABSENT);
-            encoded.extend_from_slice(checkpoint_commit_id.as_uuid().as_bytes());
-        }
-        WorkingDiffBaseline::Present {
-            checkpoint_commit_id,
-            version,
-        } => {
-            encoded.push(WORKING_DIFF_BASELINE_PRESENT);
-            encoded.extend_from_slice(checkpoint_commit_id.as_uuid().as_bytes());
-            encode_working_diff_version(encoded, version);
-        }
-    }
-}
-
+/// The sparse hot-diff index stores keys only.  The corresponding authoritative
+/// hot row stores the first tracked before-image, which keeps the accelerator
+/// compact without requiring a second write-path point read.
 fn encode_working_diff_version(encoded: &mut Vec<u8>, version: WorkingDiffVersion) {
     encoded.extend_from_slice(version.change_id.as_uuid().as_bytes());
     encoded.extend_from_slice(version.commit_id.as_uuid().as_bytes());
@@ -3655,37 +982,6 @@ fn encode_working_diff_version(encoded: &mut Vec<u8>, version: WorkingDiffVersio
 fn encode_working_diff_slot(encoded: &mut Vec<u8>, slot: WorkingDiffSlotFingerprint) {
     encoded.push(slot.kind);
     encoded.extend_from_slice(&slot.hash);
-}
-
-fn decode_working_diff_baseline(
-    bytes: &[u8],
-    offset: &mut usize,
-) -> Result<WorkingDiffBaseline, LixError> {
-    let tag = *bytes
-        .get(*offset)
-        .ok_or_else(|| head_group_error("is truncated before working-diff baseline"))?;
-    *offset += 1;
-    match tag {
-        WORKING_DIFF_BASELINE_CLEAN => Ok(WorkingDiffBaseline::Clean),
-        WORKING_DIFF_BASELINE_ABSENT => Ok(WorkingDiffBaseline::Absent(CommitId::new(
-            uuid_from_working_diff_bytes(
-                take_working_diff_bytes(bytes, offset, UUID_BYTES)?,
-                "baseline checkpoint id",
-            )?,
-        ))),
-        WORKING_DIFF_BASELINE_PRESENT => {
-            let checkpoint_commit_id = CommitId::new(uuid_from_working_diff_bytes(
-                take_working_diff_bytes(bytes, offset, UUID_BYTES)?,
-                "baseline checkpoint id",
-            )?);
-            let version = decode_working_diff_version(bytes, offset)?;
-            Ok(WorkingDiffBaseline::Present {
-                checkpoint_commit_id,
-                version,
-            })
-        }
-        _ => Err(head_group_error("has an invalid working-diff baseline tag")),
-    }
 }
 
 fn decode_working_diff_version(
@@ -3704,22 +1000,22 @@ fn decode_working_diff_version(
     )?);
     let deleted = match *take_working_diff_bytes(payload, &mut field_offset, 1)?
         .first()
-        .ok_or_else(|| head_group_error("working-diff deletion flag is missing"))?
+        .ok_or_else(|| working_diff_error("deletion flag is missing"))?
     {
         0 => false,
         1 => true,
-        _ => return Err(head_group_error("working-diff deletion flag is invalid")),
+        _ => return Err(working_diff_error("deletion flag is invalid")),
     };
     let created_at = LixTimestamp::from_packed(read_u64(
         take_working_diff_bytes(payload, &mut field_offset, 8)?,
-        "working-diff created_at",
+        "created_at",
     )?)
-    .map_err(|error| head_group_error(&format!("invalid working-diff created_at: {error}")))?;
+    .map_err(|error| working_diff_error(&format!("invalid created_at: {error}")))?;
     let updated_at = LixTimestamp::from_packed(read_u64(
         take_working_diff_bytes(payload, &mut field_offset, 8)?,
-        "working-diff updated_at",
+        "updated_at",
     )?)
-    .map_err(|error| head_group_error(&format!("invalid working-diff updated_at: {error}")))?;
+    .map_err(|error| working_diff_error(&format!("invalid updated_at: {error}")))?;
     let snapshot = decode_working_diff_slot(payload, &mut field_offset, "snapshot")?;
     let metadata = decode_working_diff_slot(payload, &mut field_offset, "metadata")?;
     debug_assert_eq!(field_offset, WORKING_DIFF_VERSION_BYTES);
@@ -3741,21 +1037,19 @@ fn decode_working_diff_slot(
 ) -> Result<WorkingDiffSlotFingerprint, LixError> {
     let kind = *take_working_diff_bytes(bytes, offset, 1)?
         .first()
-        .ok_or_else(|| head_group_error(&format!("working-diff {field} kind is missing")))?;
+        .ok_or_else(|| working_diff_error(&format!("{field} kind is missing")))?;
     if !matches!(
         kind,
         WORKING_DIFF_SLOT_NONE | WORKING_DIFF_SLOT_REF | WORKING_DIFF_SLOT_INLINE
     ) {
-        return Err(head_group_error(&format!(
-            "working-diff {field} slot kind is invalid"
-        )));
+        return Err(working_diff_error(&format!("{field} slot kind is invalid")));
     }
     let hash: [u8; JSON_REF_BYTES] = take_working_diff_bytes(bytes, offset, JSON_REF_BYTES)?
         .try_into()
-        .map_err(|_| head_group_error(&format!("working-diff {field} hash is invalid")))?;
+        .map_err(|_| working_diff_error(&format!("{field} hash is invalid")))?;
     if kind == WORKING_DIFF_SLOT_NONE && hash != [0; JSON_REF_BYTES] {
-        return Err(head_group_error(&format!(
-            "working-diff {field} none slot must have a zero hash"
+        return Err(working_diff_error(&format!(
+            "{field} none slot must have a zero hash"
         )));
     }
     Ok(WorkingDiffSlotFingerprint { kind, hash })
@@ -3768,10 +1062,10 @@ fn take_working_diff_bytes<'a>(
 ) -> Result<&'a [u8], LixError> {
     let end = offset
         .checked_add(length)
-        .ok_or_else(|| head_group_error("working-diff value offset overflow"))?;
+        .ok_or_else(|| working_diff_error("value offset overflow"))?;
     let value = bytes
         .get(*offset..end)
-        .ok_or_else(|| head_group_error("is truncated in working-diff value"))?;
+        .ok_or_else(|| working_diff_error("value is truncated"))?;
     *offset = end;
     Ok(value)
 }
@@ -3779,217 +1073,54 @@ fn take_working_diff_bytes<'a>(
 fn uuid_from_working_diff_bytes(bytes: &[u8], field: &str) -> Result<uuid::Uuid, LixError> {
     let bytes: [u8; UUID_BYTES] = bytes
         .try_into()
-        .map_err(|_| head_group_error(&format!("working-diff {field} has invalid width")))?;
+        .map_err(|_| working_diff_error(&format!("{field} has invalid width")))?;
     Ok(uuid::Uuid::from_bytes(bytes))
 }
 
-#[cfg(test)]
-fn encode_head_group_members(
-    members: &BTreeMap<Option<String>, Vec<u8>>,
-) -> Result<Vec<u8>, LixError> {
-    let baselines = members
-        .keys()
-        .cloned()
-        .map(|file_id| (file_id, WorkingDiffBaseline::Clean))
-        .collect::<BTreeMap<_, _>>();
-    encode_head_group_members_with_baselines(members, &baselines)
-}
-
-fn encode_head_group_members_with_baselines(
-    members: &BTreeMap<Option<String>, Vec<u8>>,
-    baselines: &BTreeMap<Option<String>, WorkingDiffBaseline>,
-) -> Result<Vec<u8>, LixError> {
-    let member_count =
-        u32::try_from(members.len()).map_err(|_| head_group_error("member count exceeds u32"))?;
-    let payload_len = members.iter().try_fold(0usize, |total, (file_id, value)| {
-        let baseline = baselines
-            .get(file_id)
-            .copied()
-            .ok_or_else(|| head_group_error("is missing a working-diff baseline for one member"))?;
-        let file_id_len = file_id.as_ref().map_or(0, String::len);
-        u32::try_from(file_id_len).map_err(|_| head_group_error("file id exceeds u32"))?;
-        let file_id_bytes = if file_id.is_some() {
-            4usize
-                .checked_add(file_id_len)
-                .ok_or_else(|| head_group_error("group value length overflow"))?
-        } else {
-            0
-        };
-        u32::try_from(value.len()).map_err(|_| head_group_error("member value exceeds u32"))?;
-        decode_head_value(value)?;
-        let member_len = 1usize
-            .checked_add(file_id_bytes)
-            .and_then(|length| length.checked_add(4))
-            .and_then(|length| length.checked_add(value.len()))
-            .and_then(|length| length.checked_add(working_diff_baseline_len(baseline)))
-            .ok_or_else(|| head_group_error("group value length overflow"))?;
-        total
-            .checked_add(member_len)
-            .ok_or_else(|| head_group_error("group value length overflow"))
-    })?;
-    let capacity = HEAD_GROUP_HEADER_BYTES
-        .checked_add(payload_len)
-        .ok_or_else(|| head_group_error("group value length overflow"))?;
-    let mut encoded = Vec::with_capacity(capacity);
-    encoded.push(HEAD_GROUP_VALUE_VERSION);
-    encoded.extend_from_slice(&member_count.to_be_bytes());
-    for (file_id, value) in members {
-        let baseline = baselines
-            .get(file_id)
-            .copied()
-            .ok_or_else(|| head_group_error("is missing a working-diff baseline for one member"))?;
-        match file_id {
-            None => encoded.push(FILE_ID_NONE),
-            Some(file_id) => {
-                encoded.push(FILE_ID_SOME);
-                let file_id_len = u32::try_from(file_id.len())
-                    .map_err(|_| head_group_error("file id exceeds u32"))?;
-                encoded.extend_from_slice(&file_id_len.to_be_bytes());
-                encoded.extend_from_slice(file_id.as_bytes());
-            }
-        }
-        let value_len =
-            u32::try_from(value.len()).map_err(|_| head_group_error("member value exceeds u32"))?;
-        encoded.extend_from_slice(&value_len.to_be_bytes());
-        encoded.extend_from_slice(value);
-        encode_working_diff_baseline(&mut encoded, baseline);
-    }
-    debug_assert_eq!(encoded.len(), capacity);
-    Ok(encoded)
-}
-
-fn decode_head_group_members(bytes: &[u8]) -> Result<Vec<HeadGroupMemberBytes>, LixError> {
-    if bytes.len() < HEAD_GROUP_HEADER_BYTES {
-        return Err(head_group_error("value is shorter than the fixed header"));
-    }
-    if bytes[0] != HEAD_GROUP_VALUE_VERSION {
-        return Err(head_group_error(&format!(
-            "unsupported group format version {}",
-            bytes[0]
-        )));
-    }
-    let member_count = usize::try_from(read_u32(&bytes[1..5], "group member count")?)
-        .map_err(|_| head_group_error("member count exceeds usize"))?;
-    let mut offset = HEAD_GROUP_HEADER_BYTES;
-    let mut prior_file_id = None::<Option<String>>;
-    let mut members = Vec::with_capacity(member_count);
-    for _ in 0..member_count {
-        let tag = *bytes
-            .get(offset)
-            .ok_or_else(|| head_group_error("is truncated before member file id"))?;
-        offset += 1;
-        let file_id = match tag {
-            FILE_ID_NONE => None,
-            FILE_ID_SOME => {
-                let file_id_len = read_group_u32(bytes, &mut offset, "member file-id length")?;
-                let file_id_end = offset
-                    .checked_add(file_id_len)
-                    .ok_or_else(|| head_group_error("member file-id length overflow"))?;
-                let file_id = bytes
-                    .get(offset..file_id_end)
-                    .ok_or_else(|| head_group_error("is truncated in member file id"))?;
-                offset = file_id_end;
-                Some(
-                    std::str::from_utf8(file_id)
-                        .map_err(|error| {
-                            head_group_error(&format!("member file id is not UTF-8: {error}"))
-                        })?
-                        .to_string(),
-                )
-            }
-            _ => return Err(head_group_error("has an invalid member file-id tag")),
-        };
-        if prior_file_id
-            .as_ref()
-            .is_some_and(|prior| prior >= &file_id)
-        {
-            return Err(head_group_error(
-                "members are not strictly ordered by file id",
-            ));
-        }
-        let value_len = read_group_u32(bytes, &mut offset, "member value length")?;
-        let value_end = offset
-            .checked_add(value_len)
-            .ok_or_else(|| head_group_error("member value length overflow"))?;
-        let value = bytes
-            .get(offset..value_end)
-            .ok_or_else(|| head_group_error("is truncated in member value"))?;
-        let head = decode_head_value(value)?;
-        offset = value_end;
-        let baseline = decode_working_diff_baseline(bytes, &mut offset)?;
-        if head.untracked && baseline != WorkingDiffBaseline::Clean {
-            return Err(head_group_error(
-                "untracked current-state member has a working-diff baseline",
-            ));
-        }
-        prior_file_id = Some(file_id.clone());
-        members.push(HeadGroupMemberBytes {
-            file_id,
-            value: Bytes::copy_from_slice(value),
-            baseline,
-        });
-    }
-    if offset != bytes.len() {
-        return Err(head_group_error("has trailing bytes"));
-    }
-    Ok(members)
-}
-
-fn read_group_u32(bytes: &[u8], offset: &mut usize, field: &str) -> Result<usize, LixError> {
-    let end = offset
-        .checked_add(4)
-        .ok_or_else(|| head_group_error(&format!("{field} offset overflow")))?;
-    let value = read_u32(
-        bytes
-            .get(*offset..end)
-            .ok_or_else(|| head_group_error(&format!("is truncated before {field}")))?,
-        field,
-    )?;
-    *offset = end;
-    usize::try_from(value).map_err(|_| head_group_error(&format!("{field} exceeds usize")))
-}
-
-fn head_group_error(message: &str) -> LixError {
+fn working_diff_error(message: &str) -> LixError {
     LixError::new(
         LixError::CODE_INTERNAL_ERROR,
-        format!("invalid current-state group: {message}"),
+        format!("invalid hot working-diff version: {message}"),
     )
 }
 
-/// v4 current-state values are intentionally a small, fixed-header wire record rather
+/// V5 current-state values are intentionally a small, fixed-header wire record rather
 /// than a general Musli struct. The normal read path needs only these fields,
 /// and decoding a Musli `JsonSlot` first allocated an intermediate value for
 /// every row before it was copied into a live-state row.
 ///
 /// ```text
-///  0      format version (4)
-///  1      deleted + untracked + snapshot/metadata kinds
+///  0      format version (5)
+///  1      deleted + untracked + snapshot/metadata kinds + diff baseline kind
 ///  2..18  change UUID
 /// 18..34  commit UUID
 /// 34..42  created_at packed timestamp (big endian)
 /// 42..50  updated_at packed timestamp (big endian)
 /// 50..54  snapshot payload byte length (big endian u32)
 /// 54..58  metadata payload byte length (big endian u32)
-/// 58..    snapshot payload, then metadata payload
+/// 58..    snapshot payload, metadata payload, then an optional fixed
+///          checkpoint before-image when the baseline kind is BeforePresent
 /// ```
 ///
 /// Slot payloads are either inline UTF-8 JSON or a fixed 32-byte `JsonRef`.
 /// This makes parsing bounded and lets the scan path build the final
 /// `MaterializedLiveStateRow` in one pass.
-const HEAD_VALUE_VERSION: u8 = 4;
+const HEAD_VALUE_VERSION: u8 = 5;
 const HEAD_VALUE_HEADER_BYTES: usize = 58;
 const HEAD_VALUE_DELETED: u8 = 0b0000_0001;
 const HEAD_VALUE_SNAPSHOT_SHIFT: u8 = 1;
 const HEAD_VALUE_METADATA_SHIFT: u8 = 3;
 const HEAD_VALUE_UNTRACKED: u8 = 0b0010_0000;
+const HEAD_VALUE_WORKING_DIFF_SHIFT: u8 = 6;
 const HEAD_VALUE_SLOT_MASK: u8 = 0b11;
-const HEAD_VALUE_ALLOWED_FLAGS: u8 = HEAD_VALUE_DELETED
-    | HEAD_VALUE_UNTRACKED
-    | (HEAD_VALUE_SLOT_MASK << HEAD_VALUE_SNAPSHOT_SHIFT)
-    | (HEAD_VALUE_SLOT_MASK << HEAD_VALUE_METADATA_SHIFT);
+const HEAD_VALUE_WORKING_DIFF_MASK: u8 = 0b11;
 const HEAD_SLOT_NONE: u8 = 0;
 const HEAD_SLOT_REF: u8 = 1;
 const HEAD_SLOT_INLINE: u8 = 2;
+const HEAD_WORKING_DIFF_DISABLED: u8 = 0;
+const HEAD_WORKING_DIFF_CLEAN: u8 = 1;
+const HEAD_WORKING_DIFF_BEFORE_ABSENT: u8 = 2;
+const HEAD_WORKING_DIFF_BEFORE_PRESENT: u8 = 3;
 const UUID_BYTES: usize = 16;
 const JSON_REF_BYTES: usize = 32;
 
@@ -4010,6 +1141,7 @@ struct HeadValueView<'a> {
     updated_at: LixTimestamp,
     snapshot: HeadSlotView<'a>,
     metadata: HeadSlotView<'a>,
+    working_diff_baseline: WorkingDiffBaseline,
 }
 
 impl HeadValueView<'_> {
@@ -4066,7 +1198,78 @@ fn working_diff_slot_fingerprint(slot: HeadSlotView<'_>) -> WorkingDiffSlotFinge
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+enum HeadSlotEncode<'a> {
+    None,
+    Ref(JsonRef),
+    Inline(&'a str),
+}
+
+impl<'a> From<JsonSlotRef<'a>> for HeadSlotEncode<'a> {
+    fn from(value: JsonSlotRef<'a>) -> Self {
+        match value {
+            JsonSlotRef::None => Self::None,
+            JsonSlotRef::Ref(value) => Self::Ref(*value),
+            JsonSlotRef::Inline(value) => Self::Inline(value),
+        }
+    }
+}
+
+impl<'a> From<HeadSlotView<'a>> for HeadSlotEncode<'a> {
+    fn from(value: HeadSlotView<'a>) -> Self {
+        match value {
+            HeadSlotView::None => Self::None,
+            HeadSlotView::Ref(value) => Self::Ref(value),
+            HeadSlotView::Inline(value) => Self::Inline(value),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct HeadValueEncode<'a> {
+    change_id: Option<ChangeId>,
+    commit_id: Option<CommitId>,
+    untracked: bool,
+    deleted: bool,
+    created_at: LixTimestamp,
+    updated_at: LixTimestamp,
+    snapshot: HeadSlotEncode<'a>,
+    metadata: HeadSlotEncode<'a>,
+    working_diff_baseline: WorkingDiffBaseline,
+}
+
 fn encode_head_value(value: &HeadValueRef<'_>) -> Result<Vec<u8>, LixError> {
+    encode_head_value_parts(HeadValueEncode {
+        change_id: value.change_id,
+        commit_id: value.commit_id,
+        untracked: value.untracked,
+        deleted: value.deleted,
+        created_at: value.created_at,
+        updated_at: value.updated_at,
+        snapshot: value.snapshot.into(),
+        metadata: value.metadata.into(),
+        working_diff_baseline: value.working_diff_baseline,
+    })
+}
+
+fn reencode_head_value_with_baseline(
+    value: HeadValueView<'_>,
+    working_diff_baseline: WorkingDiffBaseline,
+) -> Result<Vec<u8>, LixError> {
+    encode_head_value_parts(HeadValueEncode {
+        change_id: value.change_id,
+        commit_id: value.commit_id,
+        untracked: value.untracked,
+        deleted: value.deleted,
+        created_at: value.created_at,
+        updated_at: value.updated_at,
+        snapshot: value.snapshot.into(),
+        metadata: value.metadata.into(),
+        working_diff_baseline,
+    })
+}
+
+fn encode_head_value_parts(value: HeadValueEncode<'_>) -> Result<Vec<u8>, LixError> {
     let snapshot_kind = encoded_slot_kind(value.snapshot);
     let metadata_kind = encoded_slot_kind(value.metadata);
     if value.deleted && (snapshot_kind != HEAD_SLOT_NONE || metadata_kind != HEAD_SLOT_NONE) {
@@ -4097,11 +1300,24 @@ fn encode_head_value(value: &HeadValueRef<'_>) -> Result<Vec<u8>, LixError> {
             ));
         }
     }
+    if value.untracked && value.working_diff_baseline != WorkingDiffBaseline::Disabled {
+        return Err(head_value_error(
+            "untracked current-state rows must not carry a working-diff baseline",
+        ));
+    }
     let snapshot_len = encoded_slot_len(value.snapshot);
     let metadata_len = encoded_slot_len(value.metadata);
     let capacity = HEAD_VALUE_HEADER_BYTES
         .checked_add(snapshot_len)
         .and_then(|bytes| bytes.checked_add(metadata_len))
+        .and_then(|bytes| {
+            bytes.checked_add(match value.working_diff_baseline {
+                WorkingDiffBaseline::BeforePresent(_) => WORKING_DIFF_VERSION_BYTES,
+                WorkingDiffBaseline::Disabled
+                | WorkingDiffBaseline::Clean
+                | WorkingDiffBaseline::BeforeAbsent => 0,
+            })
+        })
         .ok_or_else(|| head_value_error("encoded row length overflow"))?;
     let mut bytes = Vec::with_capacity(capacity);
     bytes.push(HEAD_VALUE_VERSION);
@@ -4111,6 +1327,8 @@ fn encode_head_value(value: &HeadValueRef<'_>) -> Result<Vec<u8>, LixError> {
     }
     flags |= snapshot_kind << HEAD_VALUE_SNAPSHOT_SHIFT;
     flags |= metadata_kind << HEAD_VALUE_METADATA_SHIFT;
+    flags |= encode_working_diff_baseline_tag(value.working_diff_baseline)
+        << HEAD_VALUE_WORKING_DIFF_SHIFT;
     bytes.push(flags);
     bytes.extend_from_slice(value.change_id.unwrap_or_default().as_uuid().as_bytes());
     bytes.extend_from_slice(value.commit_id.unwrap_or_default().as_uuid().as_bytes());
@@ -4118,41 +1336,53 @@ fn encode_head_value(value: &HeadValueRef<'_>) -> Result<Vec<u8>, LixError> {
     bytes.extend_from_slice(&value.updated_at.packed().to_be_bytes());
     bytes.extend_from_slice(
         &u32::try_from(snapshot_len)
-            .map_err(|_| head_value_error("snapshot payload exceeds v3 u32 limit"))?
+            .map_err(|_| head_value_error("snapshot payload exceeds v5 u32 limit"))?
             .to_be_bytes(),
     );
     bytes.extend_from_slice(
         &u32::try_from(metadata_len)
-            .map_err(|_| head_value_error("metadata payload exceeds v3 u32 limit"))?
+            .map_err(|_| head_value_error("metadata payload exceeds v5 u32 limit"))?
             .to_be_bytes(),
     );
     append_slot_payload(&mut bytes, value.snapshot);
     append_slot_payload(&mut bytes, value.metadata);
+    if let WorkingDiffBaseline::BeforePresent(version) = value.working_diff_baseline {
+        encode_working_diff_version(&mut bytes, version);
+    }
     debug_assert_eq!(bytes.len(), capacity);
     Ok(bytes)
 }
 
-fn encoded_slot_kind(slot: JsonSlotRef<'_>) -> u8 {
-    match slot {
-        JsonSlotRef::None => HEAD_SLOT_NONE,
-        JsonSlotRef::Ref(_) => HEAD_SLOT_REF,
-        JsonSlotRef::Inline(_) => HEAD_SLOT_INLINE,
+fn encode_working_diff_baseline_tag(baseline: WorkingDiffBaseline) -> u8 {
+    match baseline {
+        WorkingDiffBaseline::Disabled => HEAD_WORKING_DIFF_DISABLED,
+        WorkingDiffBaseline::Clean => HEAD_WORKING_DIFF_CLEAN,
+        WorkingDiffBaseline::BeforeAbsent => HEAD_WORKING_DIFF_BEFORE_ABSENT,
+        WorkingDiffBaseline::BeforePresent(_) => HEAD_WORKING_DIFF_BEFORE_PRESENT,
     }
 }
 
-fn encoded_slot_len(slot: JsonSlotRef<'_>) -> usize {
+fn encoded_slot_kind(slot: HeadSlotEncode<'_>) -> u8 {
     match slot {
-        JsonSlotRef::None => 0,
-        JsonSlotRef::Ref(_) => JSON_REF_BYTES,
-        JsonSlotRef::Inline(json) => json.len(),
+        HeadSlotEncode::None => HEAD_SLOT_NONE,
+        HeadSlotEncode::Ref(_) => HEAD_SLOT_REF,
+        HeadSlotEncode::Inline(_) => HEAD_SLOT_INLINE,
     }
 }
 
-fn append_slot_payload(bytes: &mut Vec<u8>, slot: JsonSlotRef<'_>) {
+fn encoded_slot_len(slot: HeadSlotEncode<'_>) -> usize {
     match slot {
-        JsonSlotRef::None => {}
-        JsonSlotRef::Ref(json_ref) => bytes.extend_from_slice(json_ref.as_hash_bytes()),
-        JsonSlotRef::Inline(json) => bytes.extend_from_slice(json.as_bytes()),
+        HeadSlotEncode::None => 0,
+        HeadSlotEncode::Ref(_) => JSON_REF_BYTES,
+        HeadSlotEncode::Inline(json) => json.len(),
+    }
+}
+
+fn append_slot_payload(bytes: &mut Vec<u8>, slot: HeadSlotEncode<'_>) {
+    match slot {
+        HeadSlotEncode::None => {}
+        HeadSlotEncode::Ref(json_ref) => bytes.extend_from_slice(json_ref.as_hash_bytes()),
+        HeadSlotEncode::Inline(json) => bytes.extend_from_slice(json.as_bytes()),
     }
 }
 
@@ -4167,7 +1397,7 @@ fn full_value_bytes(value: StorageProjectedValue) -> Result<Bytes, LixError> {
 
 fn decode_head_value(bytes: &[u8]) -> Result<HeadValueView<'_>, LixError> {
     if bytes.len() < HEAD_VALUE_HEADER_BYTES {
-        return Err(head_value_error("row is shorter than the v4 fixed header"));
+        return Err(head_value_error("row is shorter than the v5 fixed header"));
     }
     if bytes[0] != HEAD_VALUE_VERSION {
         return Err(head_value_error(&format!(
@@ -4176,9 +1406,6 @@ fn decode_head_value(bytes: &[u8]) -> Result<HeadValueView<'_>, LixError> {
         )));
     }
     let flags = bytes[1];
-    if flags & !HEAD_VALUE_ALLOWED_FLAGS != 0 {
-        return Err(head_value_error("row has unknown v4 flag bits"));
-    }
     let snapshot_kind = (flags >> HEAD_VALUE_SNAPSHOT_SHIFT) & HEAD_VALUE_SLOT_MASK;
     let metadata_kind = (flags >> HEAD_VALUE_METADATA_SHIFT) & HEAD_VALUE_SLOT_MASK;
     let change_uuid = uuid_from_head_bytes(&bytes[2..18], "change id")?;
@@ -4197,11 +1424,6 @@ fn decode_head_value(bytes: &[u8]) -> Result<HeadValueView<'_>, LixError> {
     let metadata_end = snapshot_end
         .checked_add(metadata_len)
         .ok_or_else(|| head_value_error("metadata payload length overflow"))?;
-    if metadata_end != bytes.len() {
-        return Err(head_value_error(
-            "row payload lengths do not match the buffer",
-        ));
-    }
     let snapshot = decode_slot(
         snapshot_kind,
         &bytes[HEAD_VALUE_HEADER_BYTES..snapshot_end],
@@ -4212,6 +1434,22 @@ fn decode_head_value(bytes: &[u8]) -> Result<HeadValueView<'_>, LixError> {
         &bytes[snapshot_end..metadata_end],
         "metadata",
     )?;
+    let baseline_tag = (flags >> HEAD_VALUE_WORKING_DIFF_SHIFT) & HEAD_VALUE_WORKING_DIFF_MASK;
+    let mut baseline_offset = metadata_end;
+    let working_diff_baseline = match baseline_tag {
+        HEAD_WORKING_DIFF_DISABLED => WorkingDiffBaseline::Disabled,
+        HEAD_WORKING_DIFF_CLEAN => WorkingDiffBaseline::Clean,
+        HEAD_WORKING_DIFF_BEFORE_ABSENT => WorkingDiffBaseline::BeforeAbsent,
+        HEAD_WORKING_DIFF_BEFORE_PRESENT => WorkingDiffBaseline::BeforePresent(
+            decode_working_diff_version(bytes, &mut baseline_offset)?,
+        ),
+        _ => unreachable!("two-bit working-diff baseline tag is exhaustive"),
+    };
+    if baseline_offset != bytes.len() {
+        return Err(head_value_error(
+            "row payload lengths do not match the buffer",
+        ));
+    }
     let deleted = flags & HEAD_VALUE_DELETED != 0;
     let untracked = flags & HEAD_VALUE_UNTRACKED != 0;
     if deleted && (snapshot != HeadSlotView::None || metadata != HeadSlotView::None) {
@@ -4228,6 +1466,11 @@ fn decode_head_value(bytes: &[u8]) -> Result<HeadValueView<'_>, LixError> {
         if change_uuid != uuid::Uuid::nil() || commit_uuid != uuid::Uuid::nil() {
             return Err(head_value_error(
                 "untracked current-state rows must use nil change and commit ids",
+            ));
+        }
+        if working_diff_baseline != WorkingDiffBaseline::Disabled {
+            return Err(head_value_error(
+                "untracked current-state rows must not carry a working-diff baseline",
             ));
         }
         (None, None)
@@ -4251,13 +1494,14 @@ fn decode_head_value(bytes: &[u8]) -> Result<HeadValueView<'_>, LixError> {
         updated_at,
         snapshot,
         metadata,
+        working_diff_baseline,
     })
 }
 
 fn uuid_from_head_bytes(bytes: &[u8], field: &str) -> Result<uuid::Uuid, LixError> {
     let bytes: [u8; UUID_BYTES] = bytes.try_into().map_err(|_| {
         head_value_error(&format!(
-            "{field} must have {UUID_BYTES} bytes in the v3 header"
+            "{field} must have {UUID_BYTES} bytes in the v5 header"
         ))
     })?;
     Ok(uuid::Uuid::from_bytes(bytes))
@@ -4308,7 +1552,7 @@ fn decode_slot<'a>(kind: u8, bytes: &'a [u8], field: &str) -> Result<HeadSlotVie
 fn head_value_error(message: &str) -> LixError {
     LixError::new(
         LixError::CODE_INTERNAL_ERROR,
-        format!("invalid tracked-head v3 row: {message}"),
+        format!("invalid hot live-state row: {message}"),
     )
 }
 
@@ -4324,7 +1568,7 @@ struct DeferredJson {
     json_ref: JsonRef,
 }
 
-/// Builds serving rows directly from a v3 wire value. The only allocations
+/// Builds serving rows directly from a V5 hot-row value. The only allocations
 /// here are the final `String` fields and identities which the public row type
 /// requires; there is no `HeadValue`/`MaterializedTrackedStateRow` staging
 /// layer to drop after each scan.
@@ -4472,8 +1716,124 @@ mod tests {
         }
     }
 
+    fn working_diff_control(
+        head_commit_id: CommitId,
+        generation: CommitId,
+        checkpoint_commit_id: CommitId,
+    ) -> BranchHeadControl {
+        BranchHeadControl {
+            head_commit_id,
+            generation,
+            current_state_revision: 0,
+            working_diff_checkpoint_commit_id: Some(checkpoint_commit_id),
+            created_at: ts("2026-01-01T00:00:00Z"),
+            updated_at: ts("2026-01-01T00:00:00Z"),
+            ref_change_id: ChangeId::for_test_label("working-diff-branch-ref"),
+        }
+    }
+
+    fn working_diff_delta<'a>(
+        entity_pk: &'a EntityPk,
+        file_id: Option<&'a str>,
+        change: &str,
+        commit_id: CommitId,
+        deleted: bool,
+        snapshot: &'a str,
+        metadata: Option<&'a str>,
+        updated_at: &str,
+    ) -> TrackedHeadDeltaRef<'a> {
+        TrackedHeadDeltaRef {
+            schema_key: "schema",
+            file_id,
+            entity_pk,
+            change_id: ChangeId::for_test_label(change),
+            commit_id,
+            deleted,
+            created_at: ts("2026-01-01T00:00:00Z"),
+            updated_at: ts(updated_at),
+            snapshot: JsonSlotRef::Inline(snapshot),
+            metadata: metadata.map_or(JsonSlotRef::None, JsonSlotRef::Inline),
+        }
+    }
+
+    async fn publish_working_diff_commit(
+        storage: &StorageAdapter<Memory>,
+        branch_id: &str,
+        parent_generation: Option<CommitId>,
+        head_commit_id: CommitId,
+        deltas: &[TrackedHeadDeltaRef<'_>],
+        checkpoint_commit_id: CommitId,
+        coverage: &mut WorkingDiffIndexCoverage,
+    ) {
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open working-diff write read");
+        let mut writes = StorageWriteSet::new();
+        let generation = TrackedHeadContext::new()
+            .writer(&read, &mut writes)
+            .stage_commit_with_working_diff(
+                branch_id,
+                parent_generation,
+                head_commit_id,
+                deltas,
+                &BTreeSet::new(),
+                None,
+                Some(checkpoint_commit_id),
+                coverage,
+            )
+            .await
+            .expect("stage working-diff current state");
+        assert_eq!(generation, parent_generation.unwrap_or(head_commit_id));
+        stage_tracked_working_diff_epoch(
+            &mut writes,
+            branch_id,
+            TrackedWorkingDiffEpoch {
+                checkpoint_commit_id,
+                generation,
+                coverage: *coverage,
+            },
+        )
+        .expect("stage working-diff epoch");
+        stage_branch_head_control(
+            &mut writes,
+            branch_id,
+            working_diff_control(head_commit_id, generation, checkpoint_commit_id),
+        )
+        .expect("stage working-diff control");
+        drop(read);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit working-diff current state");
+    }
+
+    async fn read_working_diff(
+        storage: &StorageAdapter<Memory>,
+        branch_id: &str,
+        head_commit_id: CommitId,
+        generation: CommitId,
+        checkpoint_commit_id: CommitId,
+        request: &TrackedStateDiffRequest,
+    ) -> TrackedWorkingDiff {
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open working-diff read");
+        TrackedHeadContext::new()
+            .reader(read)
+            .working_diff_for_control(
+                branch_id,
+                working_diff_control(head_commit_id, generation, checkpoint_commit_id),
+                request,
+            )
+            .await
+            .expect("read working diff")
+            .expect("working diff must be current")
+    }
+
     #[test]
-    fn v3_value_codec_roundtrips_fixed_header_inline_and_ref_slots() {
+    fn v5_value_codec_roundtrips_fixed_header_inline_and_ref_slots() {
         let snapshot_ref = JsonRef::from_hash_bytes([7; JSON_REF_BYTES]);
         let value = HeadValueRef {
             change_id: Some(ChangeId::for_test_label("change")),
@@ -4484,15 +1844,16 @@ mod tests {
             updated_at: ts("2026-01-02T00:00:00Z"),
             snapshot: JsonSlotRef::Inline("{\"snapshot\":true}"),
             metadata: JsonSlotRef::Ref(&snapshot_ref),
+            working_diff_baseline: WorkingDiffBaseline::Disabled,
         };
 
-        let bytes = encode_head_value(&value).expect("encode v3 row");
+        let bytes = encode_head_value(&value).expect("encode v5 row");
         assert_eq!(bytes[0], HEAD_VALUE_VERSION);
         assert_eq!(
             bytes.len(),
             HEAD_VALUE_HEADER_BYTES + "{\"snapshot\":true}".len() + JSON_REF_BYTES
         );
-        let decoded = decode_head_value(&bytes).expect("decode v3 row");
+        let decoded = decode_head_value(&bytes).expect("decode v5 row");
         assert_eq!(decoded.change_id, value.change_id);
         assert_eq!(decoded.commit_id, value.commit_id);
         assert_eq!(decoded.created_at, value.created_at);
@@ -4505,44 +1866,44 @@ mod tests {
     }
 
     #[test]
-    fn v6_group_codec_roundtrips_sorted_members_and_rejects_corruption() {
-        let mut members = BTreeMap::new();
-        members.insert(
-            None,
-            encode_head_value(&head_value("none", CommitId::for_test_label("head")).as_ref())
-                .expect("encode none member"),
-        );
-        members.insert(
-            Some("file-a".to_string()),
-            encode_head_value(&head_value("file-a", CommitId::for_test_label("head")).as_ref())
-                .expect("encode file-a member"),
-        );
-        members.insert(
-            Some("file-b".to_string()),
-            encode_head_value(&head_value("file-b", CommitId::for_test_label("head")).as_ref())
-                .expect("encode file-b member"),
-        );
+    fn v5_value_codec_embeds_a_tracked_first_before_baseline() {
+        let baseline = WorkingDiffVersion {
+            change_id: ChangeId::for_test_label("before-change"),
+            commit_id: CommitId::for_test_label("before-commit"),
+            deleted: false,
+            created_at: ts("2026-01-01T00:00:00Z"),
+            updated_at: ts("2026-01-01T00:00:01Z"),
+            snapshot: WorkingDiffSlotFingerprint {
+                kind: WORKING_DIFF_SLOT_INLINE,
+                hash: [3; JSON_REF_BYTES],
+            },
+            metadata: WorkingDiffSlotFingerprint {
+                kind: WORKING_DIFF_SLOT_NONE,
+                hash: [0; JSON_REF_BYTES],
+            },
+        };
+        let value = HeadValueRef {
+            change_id: Some(ChangeId::for_test_label("current-change")),
+            commit_id: Some(CommitId::for_test_label("current-commit")),
+            untracked: false,
+            deleted: false,
+            created_at: ts("2026-01-01T00:00:00Z"),
+            updated_at: ts("2026-01-02T00:00:00Z"),
+            snapshot: JsonSlotRef::Inline("{\"current\":true}"),
+            metadata: JsonSlotRef::None,
+            working_diff_baseline: WorkingDiffBaseline::BeforePresent(baseline),
+        };
 
-        let encoded = encode_head_group_members(&members).expect("encode group");
-        let decoded = decode_head_group_members(&encoded).expect("decode group");
-        assert_eq!(decoded.len(), 3);
-        assert_eq!(decoded[0].file_id, None);
-        assert_eq!(decoded[1].file_id.as_deref(), Some("file-a"));
-        assert_eq!(decoded[2].file_id.as_deref(), Some("file-b"));
+        let bytes = encode_head_value(&value).expect("encode v5 row with baseline");
         assert_eq!(
-            decode_head_value(&decoded[2].value)
-                .expect("member should preserve v3 payload")
-                .change_id,
-            Some(ChangeId::for_test_label("file-b"))
+            bytes.len(),
+            HEAD_VALUE_HEADER_BYTES + "{\"current\":true}".len() + WORKING_DIFF_VERSION_BYTES
         );
-
-        let mut trailing = encoded.clone();
-        trailing.push(0);
-        assert!(decode_head_group_members(&trailing).is_err());
-
-        let mut bad_version = encoded;
-        bad_version[0] = HEAD_GROUP_VALUE_VERSION + 1;
-        assert!(decode_head_group_members(&bad_version).is_err());
+        let decoded = decode_head_value(&bytes).expect("decode v5 row with baseline");
+        assert_eq!(
+            decoded.working_diff_baseline,
+            WorkingDiffBaseline::BeforePresent(baseline)
+        );
     }
 
     #[test]
@@ -4585,7 +1946,373 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn working_diff_restarts_after_a_noop_checkpoint_and_verifies_coverage() {
+    async fn working_diff_absent_delete_then_reinsert_is_added() {
+        let storage = StorageAdapter::new(Memory::new());
+        let branch_id = "branch";
+        let checkpoint = CommitId::for_test_label("checkpoint");
+        let delete_head = CommitId::for_test_label("delete");
+        let reinsert_head = CommitId::for_test_label("reinsert");
+        let entity_pk = EntityPk::single("row");
+        let mut coverage = WorkingDiffIndexCoverage::default();
+
+        publish_working_diff_commit(
+            &storage,
+            branch_id,
+            None,
+            checkpoint,
+            &[],
+            checkpoint,
+            &mut coverage,
+        )
+        .await;
+
+        let delete = [working_diff_delta(
+            &entity_pk,
+            None,
+            "delete-absent",
+            delete_head,
+            true,
+            "{\"ignored\":true}",
+            None,
+            "2026-01-02T00:00:00Z",
+        )];
+        publish_working_diff_commit(
+            &storage,
+            branch_id,
+            Some(checkpoint),
+            delete_head,
+            &delete,
+            checkpoint,
+            &mut coverage,
+        )
+        .await;
+        let after_delete = read_working_diff(
+            &storage,
+            branch_id,
+            delete_head,
+            checkpoint,
+            checkpoint,
+            &TrackedStateDiffRequest::default(),
+        )
+        .await;
+        assert!(
+            after_delete.diff.entries.is_empty(),
+            "deleting an identity that was absent at the checkpoint is net empty"
+        );
+
+        let reinsert = [working_diff_delta(
+            &entity_pk,
+            None,
+            "reinsert",
+            reinsert_head,
+            false,
+            "{\"value\":\"present\"}",
+            None,
+            "2026-01-03T00:00:00Z",
+        )];
+        publish_working_diff_commit(
+            &storage,
+            branch_id,
+            Some(checkpoint),
+            reinsert_head,
+            &reinsert,
+            checkpoint,
+            &mut coverage,
+        )
+        .await;
+
+        let diff = read_working_diff(
+            &storage,
+            branch_id,
+            reinsert_head,
+            checkpoint,
+            checkpoint,
+            &TrackedStateDiffRequest::default(),
+        )
+        .await;
+        assert_eq!(coverage.group_count, 1, "one identity stays dirty");
+        assert_eq!(diff.checkpoint_commit_id, checkpoint);
+        assert_eq!(diff.diff.entries.len(), 1);
+        let entry = &diff.diff.entries[0];
+        assert_eq!(entry.kind, TrackedStateDiffKind::Added);
+        assert!(entry.before.is_none());
+        assert_eq!(
+            entry
+                .after
+                .as_ref()
+                .expect("added entry has an after row")
+                .change_id,
+            ChangeId::for_test_label("reinsert")
+        );
+    }
+
+    #[tokio::test]
+    async fn working_diff_clean_delete_then_restore_is_net_empty() {
+        let storage = StorageAdapter::new(Memory::new());
+        let branch_id = "branch";
+        let checkpoint = CommitId::for_test_label("checkpoint");
+        let delete_head = CommitId::for_test_label("delete");
+        let restore_head = CommitId::for_test_label("restore");
+        let entity_pk = EntityPk::single("row");
+        let mut coverage = WorkingDiffIndexCoverage::default();
+
+        let initial = [working_diff_delta(
+            &entity_pk,
+            None,
+            "initial",
+            checkpoint,
+            false,
+            "{\"value\":\"one\"}",
+            None,
+            "2026-01-01T00:00:00Z",
+        )];
+        publish_working_diff_commit(
+            &storage,
+            branch_id,
+            None,
+            checkpoint,
+            &initial,
+            checkpoint,
+            &mut coverage,
+        )
+        .await;
+
+        let delete = [working_diff_delta(
+            &entity_pk,
+            None,
+            "delete",
+            delete_head,
+            true,
+            "{\"ignored\":true}",
+            None,
+            "2026-01-02T00:00:00Z",
+        )];
+        publish_working_diff_commit(
+            &storage,
+            branch_id,
+            Some(checkpoint),
+            delete_head,
+            &delete,
+            checkpoint,
+            &mut coverage,
+        )
+        .await;
+
+        let restore = [working_diff_delta(
+            &entity_pk,
+            None,
+            "restore",
+            restore_head,
+            false,
+            "{\"value\":\"one\"}",
+            None,
+            "2026-01-03T00:00:00Z",
+        )];
+        publish_working_diff_commit(
+            &storage,
+            branch_id,
+            Some(checkpoint),
+            restore_head,
+            &restore,
+            checkpoint,
+            &mut coverage,
+        )
+        .await;
+
+        let diff = read_working_diff(
+            &storage,
+            branch_id,
+            restore_head,
+            checkpoint,
+            checkpoint,
+            &TrackedStateDiffRequest::default(),
+        )
+        .await;
+        assert_eq!(
+            coverage.group_count, 1,
+            "the restore must not duplicate the dirty key"
+        );
+        assert!(
+            diff.diff.entries.is_empty(),
+            "matching checkpoint payloads are net empty even after a tombstone"
+        );
+    }
+
+    #[tokio::test]
+    async fn working_diff_metadata_only_mutation_is_modified() {
+        let storage = StorageAdapter::new(Memory::new());
+        let branch_id = "branch";
+        let checkpoint = CommitId::for_test_label("checkpoint");
+        let update_head = CommitId::for_test_label("metadata-update");
+        let entity_pk = EntityPk::single("row");
+        let mut coverage = WorkingDiffIndexCoverage::default();
+
+        let initial = [working_diff_delta(
+            &entity_pk,
+            None,
+            "initial",
+            checkpoint,
+            false,
+            "{\"value\":\"same\"}",
+            Some("{\"label\":\"before\"}"),
+            "2026-01-01T00:00:00Z",
+        )];
+        publish_working_diff_commit(
+            &storage,
+            branch_id,
+            None,
+            checkpoint,
+            &initial,
+            checkpoint,
+            &mut coverage,
+        )
+        .await;
+
+        let update = [working_diff_delta(
+            &entity_pk,
+            None,
+            "metadata-update",
+            update_head,
+            false,
+            "{\"value\":\"same\"}",
+            Some("{\"label\":\"after\"}"),
+            "2026-01-02T00:00:00Z",
+        )];
+        publish_working_diff_commit(
+            &storage,
+            branch_id,
+            Some(checkpoint),
+            update_head,
+            &update,
+            checkpoint,
+            &mut coverage,
+        )
+        .await;
+
+        let diff = read_working_diff(
+            &storage,
+            branch_id,
+            update_head,
+            checkpoint,
+            checkpoint,
+            &TrackedStateDiffRequest::default(),
+        )
+        .await;
+        assert_eq!(diff.diff.entries.len(), 1);
+        let entry = &diff.diff.entries[0];
+        assert_eq!(entry.kind, TrackedStateDiffKind::Modified);
+        assert_eq!(
+            entry
+                .before
+                .as_ref()
+                .expect("modified entry has a before row")
+                .change_id,
+            ChangeId::for_test_label("initial")
+        );
+        assert_eq!(
+            entry
+                .after
+                .as_ref()
+                .expect("modified entry has an after row")
+                .change_id,
+            ChangeId::for_test_label("metadata-update")
+        );
+    }
+
+    #[tokio::test]
+    async fn working_diff_file_id_mutation_after_checkpoint_is_modified() {
+        let storage = StorageAdapter::new(Memory::new());
+        let branch_id = "branch";
+        let checkpoint = CommitId::for_test_label("checkpoint");
+        let update_head = CommitId::for_test_label("file-update");
+        let entity_pk = EntityPk::single("row");
+        let file_id = "files/app.json";
+        let mut coverage = WorkingDiffIndexCoverage::default();
+
+        let initial = [working_diff_delta(
+            &entity_pk,
+            Some(file_id),
+            "initial-file",
+            checkpoint,
+            false,
+            "{\"value\":\"before\"}",
+            None,
+            "2026-01-01T00:00:00Z",
+        )];
+        publish_working_diff_commit(
+            &storage,
+            branch_id,
+            None,
+            checkpoint,
+            &initial,
+            checkpoint,
+            &mut coverage,
+        )
+        .await;
+
+        let update = [working_diff_delta(
+            &entity_pk,
+            Some(file_id),
+            "updated-file",
+            update_head,
+            false,
+            "{\"value\":\"after\"}",
+            None,
+            "2026-01-02T00:00:00Z",
+        )];
+        publish_working_diff_commit(
+            &storage,
+            branch_id,
+            Some(checkpoint),
+            update_head,
+            &update,
+            checkpoint,
+            &mut coverage,
+        )
+        .await;
+
+        let request = TrackedStateDiffRequest {
+            filter: TrackedStateFilter {
+                schema_keys: vec!["schema".to_string()],
+                entity_pks: vec![entity_pk.clone()],
+                file_ids: vec![NullableKeyFilter::Value(file_id.to_string())],
+                ..Default::default()
+            },
+        };
+        let diff = read_working_diff(
+            &storage,
+            branch_id,
+            update_head,
+            checkpoint,
+            checkpoint,
+            &request,
+        )
+        .await;
+        assert_eq!(diff.diff.entries.len(), 1);
+        let entry = &diff.diff.entries[0];
+        assert_eq!(entry.kind, TrackedStateDiffKind::Modified);
+        assert_eq!(entry.identity.entity_pk, entity_pk);
+        assert_eq!(entry.identity.file_id.as_deref(), Some(file_id));
+        assert_eq!(
+            entry
+                .before
+                .as_ref()
+                .expect("modified file entry has a before row")
+                .change_id,
+            ChangeId::for_test_label("initial-file")
+        );
+        assert_eq!(
+            entry
+                .after
+                .as_ref()
+                .expect("modified file entry has an after row")
+                .change_id,
+            ChangeId::for_test_label("updated-file")
+        );
+    }
+
+    #[tokio::test]
+    async fn working_diff_restarts_after_a_checkpoint_generation_and_verifies_coverage() {
         let storage = StorageAdapter::new(Memory::new());
         let branch_id = "branch";
         let checkpoint = CommitId::for_test_label("checkpoint");
@@ -4593,18 +2320,11 @@ mod tests {
         let no_op_checkpoint = CommitId::for_test_label("no-op-checkpoint");
         let second_head = CommitId::for_test_label("second-head");
         let entity_pk = EntityPk::single("row");
-        let control = |head_commit_id| BranchHeadControl {
+        let control = |head_commit_id, generation, checkpoint_commit_id| BranchHeadControl {
             head_commit_id,
-            generation: checkpoint,
-            tracked_head_is_current: true,
+            generation,
             current_state_revision: 0,
-            working_diff_checkpoint_commit_id: Some(
-                if head_commit_id == checkpoint || head_commit_id == first_head {
-                    checkpoint
-                } else {
-                    no_op_checkpoint
-                },
-            ),
+            working_diff_checkpoint_commit_id: Some(checkpoint_commit_id),
             created_at: ts("2026-01-01T00:00:00Z"),
             updated_at: ts("2026-01-01T00:00:00Z"),
             ref_change_id: ChangeId::for_test_label("branch-ref"),
@@ -4636,7 +2356,7 @@ mod tests {
                 }],
                 &BTreeSet::new(),
                 None,
-                None,
+                Some(checkpoint),
                 &mut initial_coverage,
             )
             .await
@@ -4647,13 +2367,17 @@ mod tests {
             branch_id,
             TrackedWorkingDiffEpoch {
                 checkpoint_commit_id: checkpoint,
-                generation: Some(checkpoint),
+                generation: checkpoint,
                 coverage: initial_coverage,
             },
         )
         .expect("stage initial epoch");
-        stage_branch_head_control(&mut writes, branch_id, control(checkpoint))
-            .expect("stage initial control");
+        stage_branch_head_control(
+            &mut writes,
+            branch_id,
+            control(checkpoint, checkpoint, checkpoint),
+        )
+        .expect("stage initial control");
         drop(read);
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -4696,13 +2420,17 @@ mod tests {
             branch_id,
             TrackedWorkingDiffEpoch {
                 checkpoint_commit_id: checkpoint,
-                generation: Some(checkpoint),
+                generation: checkpoint,
                 coverage: first_coverage,
             },
         )
         .expect("stage first epoch");
-        stage_branch_head_control(&mut writes, branch_id, control(first_head))
-            .expect("stage first control");
+        stage_branch_head_control(
+            &mut writes,
+            branch_id,
+            control(first_head, checkpoint, checkpoint),
+        )
+        .expect("stage first control");
         drop(read);
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -4715,9 +2443,9 @@ mod tests {
             .expect("open first direct read");
         let first_diff = TrackedHeadContext::new()
             .reader(read)
-            .working_diff_if_control_current(
+            .working_diff_for_control(
                 branch_id,
-                control(first_head),
+                control(first_head, checkpoint, checkpoint),
                 &TrackedStateDiffRequest::default(),
             )
             .await
@@ -4738,22 +2466,58 @@ mod tests {
             ChangeId::for_test_label("initial-change")
         );
 
-        // A net-zero checkpoint keeps the existing serving generation but
-        // starts a new diff epoch. Old first-before summaries stay harmless:
-        // the next mutation tags its own checkpoint and gets a new index key.
+        // A checkpoint republishes a complete serving generation. Its tracked
+        // rows are all Clean in that new generation, so the old first-before
+        // baselines are neither read nor inherited by the next epoch.
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open no-op checkpoint write read");
         let mut writes = StorageWriteSet::new();
+        let mut no_op_coverage = WorkingDiffIndexCoverage::default();
+        TrackedHeadContext::new()
+            .writer(&read, &mut writes)
+            .stage_commit_with_working_diff(
+                branch_id,
+                None,
+                no_op_checkpoint,
+                &[],
+                &BTreeSet::new(),
+                Some(vec![MaterializedTrackedStateRow {
+                    entity_pk: entity_pk.clone(),
+                    schema_key: "schema".to_string(),
+                    file_id: None,
+                    snapshot_content: Some("{\"value\":\"two\"}".to_string()),
+                    metadata: None,
+                    deleted: false,
+                    created_at: "2026-01-01T00:00:00Z".to_string(),
+                    updated_at: "2026-01-02T00:00:00Z".to_string(),
+                    change_id: ChangeId::for_test_label("first-change"),
+                    commit_id: first_head,
+                }]),
+                Some(no_op_checkpoint),
+                &mut no_op_coverage,
+            )
+            .await
+            .expect("stage no-op checkpoint generation");
+        assert_eq!(no_op_coverage, WorkingDiffIndexCoverage::default());
         stage_tracked_working_diff_epoch(
             &mut writes,
             branch_id,
             TrackedWorkingDiffEpoch {
                 checkpoint_commit_id: no_op_checkpoint,
-                generation: None,
-                coverage: WorkingDiffIndexCoverage::default(),
+                generation: no_op_checkpoint,
+                coverage: no_op_coverage,
             },
         )
         .expect("reset no-op checkpoint epoch");
-        stage_branch_head_control(&mut writes, branch_id, control(no_op_checkpoint))
-            .expect("stage no-op checkpoint control");
+        stage_branch_head_control(
+            &mut writes,
+            branch_id,
+            control(no_op_checkpoint, no_op_checkpoint, no_op_checkpoint),
+        )
+        .expect("stage no-op checkpoint control");
+        drop(read);
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
@@ -4771,7 +2535,7 @@ mod tests {
                 .expect("no-op checkpoint epoch should decode"),
             Some(TrackedWorkingDiffEpoch {
                 checkpoint_commit_id: no_op_checkpoint,
-                generation: None,
+                generation: no_op_checkpoint,
                 coverage: WorkingDiffIndexCoverage::default(),
             })
         );
@@ -4781,9 +2545,9 @@ mod tests {
             .expect("open no-op checkpoint read");
         let empty_diff = TrackedHeadContext::new()
             .reader(read)
-            .working_diff_if_control_current(
+            .working_diff_for_control(
                 branch_id,
-                control(no_op_checkpoint),
+                control(no_op_checkpoint, no_op_checkpoint, no_op_checkpoint),
                 &TrackedStateDiffRequest::default(),
             )
             .await
@@ -4801,7 +2565,7 @@ mod tests {
             .writer(&read, &mut writes)
             .stage_commit_with_working_diff(
                 branch_id,
-                Some(checkpoint),
+                Some(no_op_checkpoint),
                 second_head,
                 &[TrackedHeadDeltaRef {
                     schema_key: "schema",
@@ -4827,13 +2591,17 @@ mod tests {
             branch_id,
             TrackedWorkingDiffEpoch {
                 checkpoint_commit_id: no_op_checkpoint,
-                generation: Some(checkpoint),
+                generation: no_op_checkpoint,
                 coverage: second_coverage,
             },
         )
         .expect("stage second epoch");
-        stage_branch_head_control(&mut writes, branch_id, control(second_head))
-            .expect("stage second control");
+        stage_branch_head_control(
+            &mut writes,
+            branch_id,
+            control(second_head, no_op_checkpoint, no_op_checkpoint),
+        )
+        .expect("stage second control");
         drop(read);
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -4846,9 +2614,9 @@ mod tests {
             .expect("open second direct read");
         let second_diff = TrackedHeadContext::new()
             .reader(read)
-            .working_diff_if_control_current(
+            .working_diff_for_control(
                 branch_id,
-                control(second_head),
+                control(second_head, no_op_checkpoint, no_op_checkpoint),
                 &TrackedStateDiffRequest::default(),
             )
             .await
@@ -4880,7 +2648,7 @@ mod tests {
             branch_id,
             TrackedWorkingDiffEpoch {
                 checkpoint_commit_id: stale_checkpoint,
-                generation: Some(checkpoint),
+                generation: no_op_checkpoint,
                 coverage: second_coverage,
             },
         )
@@ -4905,7 +2673,11 @@ mod tests {
             assert!(
                 TrackedHeadContext::new()
                     .reader(read)
-                    .working_diff_if_control_current(branch_id, control(second_head), &request)
+                    .working_diff_for_control(
+                        branch_id,
+                        control(second_head, no_op_checkpoint, no_op_checkpoint),
+                        &request,
+                    )
                     .await
                     .expect("stale epoch should not error")
                     .is_none(),
@@ -4919,7 +2691,7 @@ mod tests {
             branch_id,
             TrackedWorkingDiffEpoch {
                 checkpoint_commit_id: no_op_checkpoint,
-                generation: Some(checkpoint),
+                generation: no_op_checkpoint,
                 coverage: WorkingDiffIndexCoverage::default(),
             },
         )
@@ -4935,9 +2707,9 @@ mod tests {
         assert!(
             TrackedHeadContext::new()
                 .reader(read)
-                .working_diff_if_control_current(
+                .working_diff_for_control(
                     branch_id,
-                    control(second_head),
+                    control(second_head, no_op_checkpoint, no_op_checkpoint),
                     &TrackedStateDiffRequest::default(),
                 )
                 .await
@@ -4956,7 +2728,6 @@ mod tests {
         let control = BranchHeadControl {
             head_commit_id: head,
             generation,
-            tracked_head_is_current: true,
             current_state_revision: 0,
             working_diff_checkpoint_commit_id: None,
             created_at: ts("2026-01-01T00:00:00Z"),
@@ -5028,16 +2799,9 @@ mod tests {
         ];
         let snapshots = TrackedHeadContext::new()
             .reader(read)
-            .scan_entity_snapshots_if_control_current(
-                branch_id,
-                control,
-                "schema",
-                &exact_entity_pks,
-                None,
-            )
+            .scan_entity_snapshots(branch_id, control, "schema", &exact_entity_pks, None)
             .await
-            .expect("direct entity snapshots should read")
-            .expect("matching control should serve snapshots");
+            .expect("direct entity snapshots should read");
         assert_eq!(snapshots.len(), 1, "tombstone must not reach SQL rows");
         assert_eq!(
             snapshots[0]
@@ -5053,10 +2817,9 @@ mod tests {
             .expect("open limited direct entity snapshot read");
         let snapshots = TrackedHeadContext::new()
             .reader(read)
-            .scan_entity_snapshots_if_control_current(branch_id, control, "schema", &[], Some(1))
+            .scan_entity_snapshots(branch_id, control, "schema", &[], Some(1))
             .await
-            .expect("limited direct entity snapshots should read")
-            .expect("matching control should serve snapshots");
+            .expect("limited direct entity snapshots should read");
         assert_eq!(snapshots.len(), 1);
         assert_eq!(
             snapshots[0]
@@ -5131,14 +2894,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn explicit_file_id_reads_use_single_member_projection() {
+    async fn file_id_reads_use_file_first_hot_projection() {
         let storage = StorageAdapter::new(Memory::new());
         let branch_id = "branch";
         let head = CommitId::for_test_label("head");
         let control = BranchHeadControl {
             head_commit_id: head,
             generation: head,
-            tracked_head_is_current: true,
             current_state_revision: 0,
             working_diff_checkpoint_commit_id: None,
             created_at: ts("2026-01-01T00:00:00Z"),
@@ -5206,52 +2968,30 @@ mod tests {
             .writer(&read, &mut writes)
             .stage_commit(branch_id, None, head, &deltas, &BTreeSet::new(), None)
             .await
-            .expect("stage grouped head");
+            .expect("stage hot head");
         drop(read);
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
-            .expect("commit grouped head");
+            .expect("commit hot head");
 
-        let group = HeadGroupIdentity {
-            branch_id: branch_id.to_string(),
-            generation: head,
-            schema_key: "schema".to_string(),
-            entity_pk: entity_pk.clone(),
-        };
-        let second_group = HeadGroupIdentity {
-            branch_id: branch_id.to_string(),
-            generation: head,
-            schema_key: "schema".to_string(),
-            entity_pk: second_entity_pk.clone(),
-        };
-        let explicit_member = HeadIdentity {
-            branch_id: branch_id.to_string(),
-            generation: head,
-            schema_key: "schema".to_string(),
-            entity_pk: entity_pk.clone(),
-            file_id: Some("file-b".to_string()),
-        };
-        let member_read = storage
+        let projection_read = storage
             .begin_read(StorageReadOptions::default())
             .await
-            .expect("open member verification read");
-        let member = PointReadPlan::new(
-            TRACKED_HEAD_MEMBER_SPACE,
-            &[StorageKey(Bytes::from(encode_member_key(&explicit_member)))],
+            .expect("open file projection verification read");
+        let projection_rows = ScanPlan::prefix(
+            HOT_FILE_SPACE,
+            StoragePrefix {
+                bytes: Bytes::new(),
+            },
         )
-        .materialize(&member_read, StorageGetOptions::default())
+        .collect(&projection_read, StorageScanOptions::default())
         .await
-        .expect("member projection should load")
+        .expect("file projection should scan")
         .value
-        .into_iter()
-        .next()
-        .flatten();
-        assert!(
-            member.is_some(),
-            "explicit file member needs a point record"
-        );
-        drop(member_read);
+        .entries;
+        assert_eq!(projection_rows.len(), 3, "every file row has a projection");
+        drop(projection_read);
 
         let read = storage
             .begin_read(StorageReadOptions::default())
@@ -5281,8 +3021,7 @@ mod tests {
             vec![None, Some("file-a"), Some("file-b")]
         );
 
-        // Exact group keys establish schema and entity PK, but file-id
-        // predicates still select individual members within that group.
+        // A null-file predicate selects only the null-file hot row.
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
@@ -5308,22 +3047,35 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].file_id, None);
 
-        // Remove only the group to prove the exact-file read never needs to
-        // fetch/parse sibling members. This is intentionally an impossible
-        // committed state in production; it validates the physical route.
+        // Remove every authoritative primary row to prove that file-id reads
+        // are served by the complete file-first projection. This intentionally
+        // creates an impossible committed state; it validates the physical
+        // read route without depending on sibling-row decoding.
+        let primary_read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open primary hot-row verification read");
+        let primary_rows = ScanPlan::prefix(
+            HOT_ROW_SPACE,
+            StoragePrefix {
+                bytes: Bytes::new(),
+            },
+        )
+        .collect(&primary_read, StorageScanOptions::default())
+        .await
+        .expect("primary hot rows should scan")
+        .value
+        .entries;
+        assert_eq!(primary_rows.len(), 4);
+        drop(primary_read);
         let mut writes = StorageWriteSet::new();
-        writes.delete(
-            TRACKED_HEAD_GROUP_SPACE,
-            StorageKey(Bytes::from(encode_group_key(&group))),
-        );
-        writes.delete(
-            TRACKED_HEAD_GROUP_SPACE,
-            StorageKey(Bytes::from(encode_group_key(&second_group))),
-        );
+        for row in primary_rows {
+            writes.delete(HOT_ROW_SPACE, row.key);
+        }
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
-            .expect("remove group for route proof");
+            .expect("remove primary rows for route proof");
 
         let read = storage
             .begin_read(StorageReadOptions::default())
@@ -5350,7 +3102,7 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].file_id.as_deref(), Some("file-b"));
 
-        // A schema-scoped `file_id = ?` query also stays on the member
+        // A schema-scoped `file_id = ?` query also stays on the file-first
         // projection. This is the access pattern used by filesystem-backed
         // entity scans, where the entity PK is not known before the query.
         let read = storage
@@ -5386,16 +3138,16 @@ mod tests {
                 .all(|row| row.file_id.as_deref() == Some("file-b"))
         );
 
-        // The v6 control plane only validates the generation marker. Exact
-        // file identity and schema-scoped file-id reads must still route to
-        // the v6 member projection even when every backing group is absent.
+        // The branch control validates the published hot generation. Exact
+        // file identity and schema-scoped file-id reads still route to the
+        // V15 file projection even when every primary row is absent.
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
-            .expect("open v6 file-id scan");
+            .expect("open control-gated file-id scan");
         let rows = TrackedHeadContext::new()
             .reader(read)
-            .scan_live_rows_if_control_current(
+            .scan_live_rows(
                 branch_id,
                 control,
                 &TrackedStateScanRequest {
@@ -5408,8 +3160,7 @@ mod tests {
                 },
             )
             .await
-            .expect("v6 file-id scan should execute")
-            .expect("matching v6 control and marker");
+            .expect("control-bound file-id scan should execute");
         assert_eq!(rows.len(), 2);
         assert!(
             rows.iter()
@@ -5436,17 +3187,17 @@ mod tests {
             .expect("exact file read should execute")
             .expect("marker should match");
         assert_eq!(rows.len(), 1);
-        let row = rows[0].as_ref().expect("explicit member should resolve");
+        let row = rows[0].as_ref().expect("explicit file row should resolve");
         assert_eq!(row.file_id.as_deref(), Some("file-b"));
         assert_eq!(row.snapshot_content.as_deref(), Some("{\"value\":\"b\"}"));
 
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
-            .expect("open v6 exact file read");
+            .expect("open control-gated exact file read");
         let rows = TrackedHeadContext::new()
             .reader(read)
-            .load_projected_live_rows_if_control_current(
+            .load_projected_live_rows(
                 branch_id,
                 control,
                 &[TrackedStateKey {
@@ -5457,93 +3208,13 @@ mod tests {
                 &ChangeRecordProjection::full(),
             )
             .await
-            .expect("v6 exact file read should execute")
-            .expect("matching v6 control and marker");
+            .expect("control-bound exact file read should execute");
         assert_eq!(rows.len(), 1);
         let row = rows[0]
             .as_ref()
-            .expect("v6 explicit member should resolve without its group");
+            .expect("explicit file row should resolve through its projection");
         assert_eq!(row.file_id.as_deref(), Some("file-b"));
         assert_eq!(row.snapshot_content.as_deref(), Some("{\"value\":\"b\"}"));
-    }
-
-    #[test]
-    fn group_and_member_keys_roundtrip_and_preserve_logical_order() {
-        let generation = CommitId::for_test_label("generation");
-        let strings = ["", "\0", "a", "a\0", "a\u{1}", "z", "é"];
-        let mut groups = Vec::new();
-        for schema_key in strings {
-            for entity_first in strings {
-                for entity_pk in [
-                    EntityPk::single(entity_first),
-                    EntityPk::from_parts(vec![entity_first.to_string(), "tail".to_string()])
-                        .expect("tuple entity key should be valid"),
-                ] {
-                    groups.push(HeadGroupIdentity {
-                        branch_id: "branch\0name".to_string(),
-                        generation,
-                        schema_key: schema_key.to_string(),
-                        entity_pk: entity_pk.clone(),
-                    });
-                }
-            }
-        }
-        groups.sort();
-        groups.dedup();
-
-        for identity in &groups {
-            let encoded = encode_group_key(identity);
-            assert_eq!(
-                decode_group_key(&encoded).expect("group key should decode"),
-                *identity
-            );
-            let scope = encode_scope_prefix(&identity.branch_id, identity.generation);
-            assert_eq!(
-                decode_group_key_in_scope(&encoded, &scope)
-                    .expect("scope-decoded row key should decode"),
-                HeadRowIdentity {
-                    schema_key: identity.schema_key.clone(),
-                    entity_pk: identity.entity_pk.clone(),
-                    file_id: None,
-                }
-            );
-        }
-
-        let mut by_encoded = groups
-            .iter()
-            .cloned()
-            .map(|identity| (encode_group_key(&identity), identity))
-            .collect::<Vec<_>>();
-        by_encoded.sort_by(|left, right| left.0.cmp(&right.0));
-        assert_eq!(
-            by_encoded
-                .iter()
-                .map(|(_, identity)| identity)
-                .collect::<Vec<_>>(),
-            groups.iter().collect::<Vec<_>>()
-        );
-        for (index, (encoded, _)) in by_encoded.iter().enumerate() {
-            for (other_index, (other, _)) in by_encoded.iter().enumerate() {
-                if index != other_index {
-                    assert!(
-                        !other.starts_with(encoded),
-                        "complete row key {index} prefixes row key {other_index}"
-                    );
-                }
-            }
-        }
-
-        let member = HeadIdentity {
-            branch_id: "branch\0name".to_string(),
-            generation,
-            schema_key: "schema".to_string(),
-            entity_pk: EntityPk::single("entity"),
-            file_id: Some("file\0id".to_string()),
-        };
-        assert_eq!(
-            decode_member_key(&encode_member_key(&member)).expect("member key should decode"),
-            member
-        );
     }
 
     #[tokio::test]
@@ -5782,49 +3453,38 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn incremental_group_merge_preserves_untouched_members_and_file_projections() {
+    async fn incremental_row_update_preserves_siblings_and_file_projection() {
         let storage = StorageAdapter::new(Memory::new());
         let branch_id = "branch";
         let generation = CommitId::for_test_label("first-head");
         let second_head = CommitId::for_test_label("second-head");
         let entity_pk = EntityPk::single("row");
-        let group = HeadGroupIdentity {
-            branch_id: branch_id.to_string(),
-            generation,
-            schema_key: "schema".to_string(),
-            entity_pk: entity_pk.clone(),
-        };
 
-        let mut members = BTreeMap::new();
-        members.insert(
-            None,
-            encode_head_value(&head_value("none-first", generation).as_ref())
-                .expect("encode none member"),
-        );
-        members.insert(
-            Some("file-a".to_string()),
-            encode_head_value(&head_value("file-a-first", generation).as_ref())
-                .expect("encode file-a member"),
-        );
-        members.insert(
-            Some("file-b".to_string()),
-            encode_head_value(&head_value("file-b-first", generation).as_ref())
-                .expect("encode file-b member"),
-        );
         let mut writes = StorageWriteSet::new();
-        stage_put_group_members(&mut writes, &group, &members).expect("stage initial group");
-        for (file_id, value) in &members {
-            if file_id.is_some() {
-                stage_put_member_bytes(&mut writes, &group, file_id.as_deref(), value)
-                    .expect("stage initial explicit member");
-            }
+        for (file_id, change_id) in [
+            (None, "none-first"),
+            (Some("file-a"), "file-a-first"),
+            (Some("file-b"), "file-b-first"),
+        ] {
+            stage_put(
+                &mut writes,
+                &HeadIdentity {
+                    branch_id: branch_id.to_string(),
+                    generation,
+                    schema_key: "schema".to_string(),
+                    entity_pk: entity_pk.clone(),
+                    file_id: file_id.map(str::to_string),
+                },
+                &head_value(change_id, generation),
+            )
+            .expect("stage initial hot row");
         }
         stage_test_current_control(&mut writes, branch_id, generation, generation, None)
             .expect("stage initial current control");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
-            .expect("commit initial group");
+            .expect("commit initial hot rows");
 
         let read = storage
             .begin_read(StorageReadOptions::default())
@@ -5853,12 +3513,12 @@ mod tests {
                 None,
             )
             .await
-            .expect("stage streamed update");
+            .expect("stage direct row update");
         drop(read);
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
-            .expect("commit streamed update");
+            .expect("commit direct row update");
 
         let read = storage
             .begin_read(StorageReadOptions::default())
@@ -5872,21 +3532,21 @@ mod tests {
                 &TrackedStateScanRequest::default(),
             )
             .await
-            .expect("scan streamed group")
+            .expect("scan hot rows")
             .expect("matching marker");
         assert_eq!(rows.len(), 3);
         let none = rows
             .iter()
             .find(|row| row.file_id.is_none())
-            .expect("none member remains");
+            .expect("null-file row remains");
         let file_a = rows
             .iter()
             .find(|row| row.file_id.as_deref() == Some("file-a"))
-            .expect("changed member remains");
+            .expect("changed file row remains");
         let file_b = rows
             .iter()
             .find(|row| row.file_id.as_deref() == Some("file-b"))
-            .expect("untouched member remains");
+            .expect("untouched file row remains");
         assert_eq!(none.change_id, Some(ChangeId::for_test_label("none-first")));
         assert_eq!(
             file_a.change_id,
@@ -5899,89 +3559,119 @@ mod tests {
         assert_eq!(file_a.created_at, ts("2026-01-01T00:00:00Z"));
         assert_eq!(file_a.updated_at, ts("2026-01-02T00:00:00Z"));
 
-        let identities = ["file-a", "file-b"].map(|file_id| HeadIdentity {
-            branch_id: branch_id.to_string(),
-            generation,
-            schema_key: "schema".to_string(),
-            entity_pk: entity_pk.clone(),
-            file_id: Some(file_id.to_string()),
-        });
-        let keys = identities
-            .iter()
-            .map(|identity| StorageKey(Bytes::from(encode_member_key(identity))))
-            .collect::<Vec<_>>();
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
-            .expect("open projection verification read");
-        let projections = PointReadPlan::new(TRACKED_HEAD_MEMBER_SPACE, &keys)
-            .materialize(&read, StorageGetOptions::default())
-            .await
-            .expect("load explicit member projections")
-            .value;
-        for (identity, projection) in identities.into_iter().zip(projections) {
-            let value = full_value_bytes(projection.expect("projection remains present"))
-                .expect("projection has full bytes");
-            let value = decode_head_value(&value).expect("projection decodes");
-            let expected_change = if identity.file_id.as_deref() == Some("file-a") {
-                ChangeId::for_test_label("file-a-second")
-            } else {
-                ChangeId::for_test_label("file-b-first")
-            };
-            assert_eq!(value.change_id, Some(expected_change));
-        }
+            .expect("open file-projection verification read");
+        let projections = ScanPlan::prefix(
+            HOT_FILE_SPACE,
+            StoragePrefix {
+                bytes: Bytes::new(),
+            },
+        )
+        .collect(&read, StorageScanOptions::default())
+        .await
+        .expect("scan file projection")
+        .value
+        .entries;
+        assert_eq!(projections.len(), 2);
+        let projection_changes = projections
+            .into_iter()
+            .map(|projection| {
+                let bytes = full_value_bytes(projection.value).expect("projection has full bytes");
+                decode_head_value(&bytes)
+                    .expect("projection decodes")
+                    .change_id
+                    .expect("tracked projection has a change id")
+            })
+            .collect::<Vec<_>>();
+        assert!(projection_changes.contains(&ChangeId::for_test_label("file-a-second")));
+        assert!(projection_changes.contains(&ChangeId::for_test_label("file-b-first")));
     }
 
     #[tokio::test]
-    async fn incremental_group_rejects_corrupt_untouched_member_before_staging_publication() {
+    async fn incremental_row_update_does_not_decode_unrelated_hot_rows() {
         let storage = StorageAdapter::new(Memory::new());
         let branch_id = "branch";
         let generation = CommitId::for_test_label("first-head");
         let second_head = CommitId::for_test_label("second-head");
         let entity_pk = EntityPk::single("row");
-        let group = HeadGroupIdentity {
-            branch_id: branch_id.to_string(),
-            generation,
-            schema_key: "schema".to_string(),
-            entity_pk: entity_pk.clone(),
-        };
-        let mut members = BTreeMap::new();
-        members.insert(
-            None,
-            encode_head_value(&head_value("none", generation).as_ref())
-                .expect("encode none member"),
-        );
-        members.insert(
-            Some("file-a".to_string()),
-            encode_head_value(&head_value("file-a", generation).as_ref())
-                .expect("encode file-a member"),
-        );
-        members.insert(
-            Some("file-b".to_string()),
-            encode_head_value(&head_value("file-b", generation).as_ref())
-                .expect("encode file-b member"),
-        );
-        let mut corrupt = encode_head_group_members(&members).expect("encode corrupt base group");
-        corrupt.push(0);
+        let unrelated_pk = EntityPk::single("unrelated");
+
         let mut initial_writes = StorageWriteSet::new();
-        initial_writes.put(
-            TRACKED_HEAD_GROUP_SPACE,
-            StorageKey(Bytes::from(encode_group_key(&group))),
-            StorageValue {
-                bytes: Bytes::from(corrupt),
+        stage_put(
+            &mut initial_writes,
+            &HeadIdentity {
+                branch_id: branch_id.to_string(),
+                generation,
+                schema_key: "schema".to_string(),
+                entity_pk: entity_pk.clone(),
+                file_id: Some("file-a".to_string()),
             },
-        );
+            &head_value("file-a-first", generation),
+        )
+        .expect("stage target hot row");
+        stage_put(
+            &mut initial_writes,
+            &HeadIdentity {
+                branch_id: branch_id.to_string(),
+                generation,
+                schema_key: "schema".to_string(),
+                entity_pk: unrelated_pk,
+                file_id: None,
+            },
+            &head_value("unrelated", generation),
+        )
+        .expect("stage unrelated hot row");
+        stage_test_current_control(&mut initial_writes, branch_id, generation, generation, None)
+            .expect("stage initial control");
         storage
             .commit_write_set(initial_writes, StorageWriteOptions::default())
             .await
-            .expect("commit corrupt group fixture");
+            .expect("commit initial hot rows");
 
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
-            .expect("open incremental read");
+            .expect("open corruption fixture read");
+        let unrelated_key = ScanPlan::prefix(
+            HOT_ROW_SPACE,
+            StoragePrefix {
+                bytes: Bytes::new(),
+            },
+        )
+        .collect(&read, StorageScanOptions::default())
+        .await
+        .expect("scan hot rows for fixture")
+        .value
+        .entries
+        .into_iter()
+        .find_map(|entry| {
+            let value = full_value_bytes(entry.value).ok()?;
+            let value = decode_head_value(&value).ok()?;
+            (value.change_id == Some(ChangeId::for_test_label("unrelated"))).then_some(entry.key)
+        })
+        .expect("find unrelated row key");
+        drop(read);
+        let mut corrupt_writes = StorageWriteSet::new();
+        corrupt_writes.put(
+            HOT_ROW_SPACE,
+            unrelated_key,
+            StorageValue {
+                bytes: Bytes::from_static(b"corrupt unrelated hot row"),
+            },
+        );
+        storage
+            .commit_write_set(corrupt_writes, StorageWriteOptions::default())
+            .await
+            .expect("commit corrupt unrelated row");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open targeted incremental read");
         let mut writes = StorageWriteSet::new();
-        let error = TrackedHeadContext::new()
+        TrackedHeadContext::new()
             .writer(&read, &mut writes)
             .stage_commit(
                 branch_id,
@@ -6003,10 +3693,39 @@ mod tests {
                 None,
             )
             .await
-            .expect_err("corrupt untouched member must reject the whole group");
-        assert!(error.message.contains("trailing bytes"));
-        assert_eq!(writes.stats().staged_puts, 0);
-        assert_eq!(writes.stats().staged_deletes, 0);
+            .expect("unrelated corrupt row must not block a direct update");
+        drop(read);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit direct hot-row update");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open exact file verification read");
+        let rows = TrackedHeadContext::new()
+            .reader(read)
+            .load_projected_live_rows_if_current(
+                branch_id,
+                &second_head.to_string(),
+                &[TrackedStateKey {
+                    schema_key: "schema".to_string(),
+                    entity_pk,
+                    file_id: Some("file-a".to_string()),
+                }],
+                &ChangeRecordProjection::full(),
+            )
+            .await
+            .expect("exact file read should execute")
+            .expect("matching current control");
+        assert_eq!(
+            rows[0]
+                .as_ref()
+                .expect("target file row survives")
+                .change_id,
+            Some(ChangeId::for_test_label("file-a-second"))
+        );
     }
 
     #[tokio::test]
@@ -6244,10 +3963,10 @@ mod tests {
             },
         );
         writes.put(
-            TRACKED_WORKING_DIFF_GROUP_SPACE,
+            HOT_DIFF_SPACE,
             malformed_index_key.clone(),
             StorageValue {
-                bytes: Bytes::from_static(WORKING_DIFF_INDEX_VALUE),
+                bytes: Bytes::from_static(b"not-a-hot-diff-before-image"),
             },
         );
         storage
@@ -6277,7 +3996,7 @@ mod tests {
             .expect("open cleanup verification read");
         for (space, key) in [
             (TRACKED_WORKING_DIFF_MARKER_SPACE, malformed_epoch_key),
-            (TRACKED_WORKING_DIFF_GROUP_SPACE, malformed_index_key),
+            (HOT_DIFF_SPACE, malformed_index_key),
         ] {
             let value = PointReadPlan::new(space, &[key])
                 .materialize(&read, StorageGetOptions::default())
@@ -6289,192 +4008,6 @@ mod tests {
                 .flatten();
             assert!(value.is_none(), "malformed auxiliary key must be reclaimed");
         }
-    }
-
-    #[tokio::test]
-    async fn working_diff_gc_keeps_only_control_bound_active_scopes() {
-        let storage = StorageAdapter::new(Memory::new());
-        let timestamp = ts("2026-01-01T00:00:00Z");
-        let active_generation = CommitId::for_test_label("active-generation");
-        let active_checkpoint = CommitId::for_test_label("active-checkpoint");
-        let active_group = HeadGroupIdentity {
-            branch_id: "active".to_string(),
-            generation: active_generation,
-            schema_key: "schema".to_string(),
-            entity_pk: EntityPk::single("active-row"),
-        };
-        let stale_generation = CommitId::for_test_label("stale-generation");
-        let stale_checkpoint = CommitId::for_test_label("stale-checkpoint");
-        let stale_group = HeadGroupIdentity {
-            branch_id: "stale".to_string(),
-            generation: stale_generation,
-            schema_key: "schema".to_string(),
-            entity_pk: EntityPk::single("stale-row"),
-        };
-        let orphan_generation = CommitId::for_test_label("orphan-generation");
-        let orphan_checkpoint = CommitId::for_test_label("orphan-checkpoint");
-        let orphan_group = HeadGroupIdentity {
-            branch_id: "deleted".to_string(),
-            generation: orphan_generation,
-            schema_key: "schema".to_string(),
-            entity_pk: EntityPk::single("orphan-row"),
-        };
-
-        let mut writes = StorageWriteSet::new();
-        let active_control = BranchHeadControl {
-            head_commit_id: active_generation,
-            generation: active_generation,
-            tracked_head_is_current: true,
-            current_state_revision: 0,
-            working_diff_checkpoint_commit_id: Some(active_checkpoint),
-            created_at: timestamp,
-            updated_at: timestamp,
-            ref_change_id: ChangeId::for_test_label("active-ref"),
-        };
-        stage_tracked_working_diff_epoch(
-            &mut writes,
-            "active",
-            TrackedWorkingDiffEpoch {
-                checkpoint_commit_id: active_checkpoint,
-                generation: Some(active_generation),
-                coverage: WorkingDiffIndexCoverage::default(),
-            },
-        )
-        .expect("stage active epoch");
-        stage_branch_head_control(&mut writes, "active", active_control)
-            .expect("stage active control");
-
-        let stale_control = BranchHeadControl {
-            head_commit_id: stale_generation,
-            generation: stale_generation,
-            tracked_head_is_current: false,
-            current_state_revision: 0,
-            working_diff_checkpoint_commit_id: None,
-            created_at: timestamp,
-            updated_at: timestamp,
-            ref_change_id: ChangeId::for_test_label("stale-ref"),
-        };
-        stage_tracked_working_diff_epoch(
-            &mut writes,
-            "stale",
-            TrackedWorkingDiffEpoch {
-                checkpoint_commit_id: stale_checkpoint,
-                generation: Some(stale_generation),
-                coverage: WorkingDiffIndexCoverage::default(),
-            },
-        )
-        .expect("stage stale epoch");
-        stage_branch_head_control(&mut writes, "stale", stale_control)
-            .expect("stage stale control");
-
-        stage_tracked_working_diff_epoch(
-            &mut writes,
-            "deleted",
-            TrackedWorkingDiffEpoch {
-                checkpoint_commit_id: orphan_checkpoint,
-                generation: Some(orphan_generation),
-                coverage: WorkingDiffIndexCoverage::default(),
-            },
-        )
-        .expect("stage orphan epoch");
-
-        let mut coverage = WorkingDiffIndexCoverage::default();
-        for (checkpoint, group) in [
-            (active_checkpoint, &active_group),
-            (stale_checkpoint, &stale_group),
-            (orphan_checkpoint, &orphan_group),
-        ] {
-            stage_put_working_diff_group_index(&mut writes, &mut coverage, checkpoint, group)
-                .expect("stage working-diff index");
-        }
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("commit working-diff GC fixture");
-
-        let read = crate::storage_adapter::SharedStorageAdapterRead::new(
-            storage
-                .begin_read(StorageReadOptions::default())
-                .await
-                .expect("open working-diff GC read"),
-        );
-        let mut gc_writes = StorageWriteSet::new();
-        stage_collect_stale_working_diff_indexes(&read, &mut gc_writes)
-            .await
-            .expect("stage working-diff GC");
-        drop(read);
-        storage
-            .commit_write_set(gc_writes, StorageWriteOptions::default())
-            .await
-            .expect("commit working-diff GC");
-
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("open working-diff GC verification read");
-        let active_epoch = PointReadPlan::new(
-            TRACKED_WORKING_DIFF_MARKER_SPACE,
-            &[StorageKey(Bytes::from(
-                working_diff_marker_key("active").expect("active working-diff marker key"),
-            ))],
-        )
-        .materialize(&read, StorageGetOptions::default())
-        .await
-        .expect("read active epoch")
-        .value
-        .into_iter()
-        .next()
-        .flatten();
-        assert!(active_epoch.is_some(), "active epoch must survive GC");
-
-        for (branch_id, checkpoint, group) in [
-            ("stale", stale_checkpoint, &stale_group),
-            ("deleted", orphan_checkpoint, &orphan_group),
-        ] {
-            let epoch = PointReadPlan::new(
-                TRACKED_WORKING_DIFF_MARKER_SPACE,
-                &[StorageKey(Bytes::from(
-                    working_diff_marker_key(branch_id).expect("working-diff marker key"),
-                ))],
-            )
-            .materialize(&read, StorageGetOptions::default())
-            .await
-            .expect("read stale epoch")
-            .value
-            .into_iter()
-            .next()
-            .flatten();
-            assert!(epoch.is_none(), "inactive epoch must be reclaimed");
-            let index = PointReadPlan::new(
-                TRACKED_WORKING_DIFF_GROUP_SPACE,
-                &[StorageKey(Bytes::from(encode_working_diff_group_key(
-                    checkpoint, group,
-                )))],
-            )
-            .materialize(&read, StorageGetOptions::default())
-            .await
-            .expect("read stale index")
-            .value
-            .into_iter()
-            .next()
-            .flatten();
-            assert!(index.is_none(), "inactive index must be reclaimed");
-        }
-        let active_index = PointReadPlan::new(
-            TRACKED_WORKING_DIFF_GROUP_SPACE,
-            &[StorageKey(Bytes::from(encode_working_diff_group_key(
-                active_checkpoint,
-                &active_group,
-            )))],
-        )
-        .materialize(&read, StorageGetOptions::default())
-        .await
-        .expect("read active index")
-        .value
-        .into_iter()
-        .next()
-        .flatten();
-        assert!(active_index.is_some(), "active index must survive GC");
     }
 
     #[tokio::test]
@@ -6503,9 +4036,6 @@ mod tests {
         let active_control = BranchHeadControl {
             head_commit_id: active_generation,
             generation: active_generation,
-            // A lifecycle fallback still owns the same untracked workspace
-            // state even while its tracked portion is rebuilt.
-            tracked_head_is_current: false,
             current_state_revision: 0,
             working_diff_checkpoint_commit_id: None,
             created_at: timestamp,
@@ -6526,9 +4056,9 @@ mod tests {
         };
         let mut writes = StorageWriteSet::new();
         stage_put(&mut writes, &active_identity, &untracked(active_snapshot))
-            .expect("stage active untracked member");
+            .expect("stage active untracked hot row");
         stage_put(&mut writes, &stale_identity, &untracked(stale_snapshot))
-            .expect("stage stale untracked member");
+            .expect("stage stale untracked hot row");
         stage_branch_head_control(&mut writes, branch_id, active_control)
             .expect("stage active branch control");
         storage
@@ -6565,39 +4095,31 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("open current-state GC verification read");
-        for (label, identity, expected) in [
-            ("active", &active_identity, true),
-            ("stale", &stale_identity, false),
+        for (label, space) in [
+            ("primary hot row", HOT_ROW_SPACE),
+            ("file-first hot projection", HOT_FILE_SPACE),
         ] {
-            let group = PointReadPlan::new(
-                TRACKED_HEAD_GROUP_SPACE,
-                &[StorageKey(Bytes::from(encode_group_key(
-                    &identity.group_identity(),
-                )))],
+            let entries = ScanPlan::prefix(
+                space,
+                StoragePrefix {
+                    bytes: Bytes::new(),
+                },
             )
-            .materialize(&read, StorageGetOptions::default())
+            .collect(&read, StorageScanOptions::default())
             .await
-            .expect("read current-state group")
+            .expect("scan current-state hot storage")
             .value
-            .into_iter()
-            .next()
-            .flatten()
-            .is_some();
-            assert_eq!(group, expected, "{label} group reachability");
-
-            let member = PointReadPlan::new(
-                TRACKED_HEAD_MEMBER_SPACE,
-                &[StorageKey(Bytes::from(encode_member_key(identity)))],
-            )
-            .materialize(&read, StorageGetOptions::default())
-            .await
-            .expect("read current-state member projection")
-            .value
-            .into_iter()
-            .next()
-            .flatten()
-            .is_some();
-            assert_eq!(member, expected, "{label} member reachability");
+            .entries;
+            assert_eq!(entries.len(), 1, "only active {label} survives GC");
+            let encoded =
+                full_value_bytes(entries.into_iter().next().expect("one hot value").value)
+                    .expect("hot value is present");
+            let value = decode_head_value(&encoded).expect("active hot value decodes");
+            assert!(value.untracked, "active hot value remains untracked");
+            match value.snapshot {
+                HeadSlotView::Ref(snapshot) => assert_eq!(snapshot, active_snapshot),
+                _ => panic!("active hot value must retain its JSON reference"),
+            }
         }
     }
 }

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -1,0 +1,2261 @@
+//! V15 row-addressable current state.
+//!
+//! V12 packed every file member of one logical entity into a group. That made
+//! a logical-PK lookup cheap, but it also made every normal commit read,
+//! decode, merge, and rewrite each predecessor group. V15 keeps the same
+//! fixed row value codec and branch-control publication fence, while making a
+//! full row identity the physical mutation unit.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use bytes::Bytes;
+
+use super::*;
+
+pub(crate) const HOT_ROW_NAMESPACE: &str = "live_state.hot_row.v15";
+pub(crate) const HOT_FILE_NAMESPACE: &str = "live_state.hot_file.v15";
+pub(crate) const HOT_DIFF_NAMESPACE: &str = "live_state.hot_diff.v15";
+pub(crate) const HOT_ROW_SPACE: StorageSpace =
+    StorageSpace::new(StorageSpaceId(0x0004_001b), HOT_ROW_NAMESPACE);
+/// File-id-first projection. The primary hot row remains authoritative.
+pub(crate) const HOT_FILE_SPACE: StorageSpace =
+    StorageSpace::new(StorageSpaceId(0x0004_001c), HOT_FILE_NAMESPACE);
+/// Reserved for the row-level first-before working-diff index.
+pub(crate) const HOT_DIFF_SPACE: StorageSpace =
+    StorageSpace::new(StorageSpaceId(0x0004_001d), HOT_DIFF_NAMESPACE);
+
+/// Direct reader for one published hot generation.
+pub(crate) struct HotStateStoreReader<S> {
+    pub(super) store: S,
+}
+
+impl<S> HotStateStoreReader<S>
+where
+    S: StorageAdapterRead,
+{
+    pub(crate) async fn scan_live_rows(
+        &self,
+        branch_id: &str,
+        control: BranchHeadControl,
+        request: &TrackedStateScanRequest,
+    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        self.scan_live_rows_for_generation(branch_id, control.generation, request)
+            .await
+    }
+
+    pub(crate) async fn scan_live_rows_for_controls(
+        &self,
+        controls: &[(String, BranchHeadControl)],
+        request: &TrackedStateScanRequest,
+    ) -> Result<Vec<(String, Vec<MaterializedLiveStateRow>)>, LixError> {
+        let mut rows = Vec::with_capacity(controls.len());
+        for (branch_id, control) in controls {
+            let branch_rows = self
+                .scan_live_rows_for_generation(branch_id, control.generation, request)
+                .await?;
+            rows.push((branch_id.clone(), branch_rows));
+        }
+        Ok(rows)
+    }
+
+    pub(crate) async fn has_schema_rows(
+        &self,
+        branch_id: &str,
+        control: BranchHeadControl,
+        schema_key: &str,
+    ) -> Result<bool, LixError> {
+        let mut prefix = hot_scope_prefix(branch_id, control.generation);
+        write_key_string(&mut prefix, schema_key, KEY_PART_FINAL);
+        let page = ScanPlan::prefix(
+            HOT_ROW_SPACE,
+            StoragePrefix {
+                bytes: Bytes::from(prefix),
+            },
+        )
+        .collect(
+            &self.store,
+            StorageScanOptions {
+                projection: StorageCoreProjection::KeyOnly,
+                limit_rows: 1,
+                ..StorageScanOptions::default()
+            },
+        )
+        .await?;
+        Ok(!page.value.entries.is_empty())
+    }
+
+    pub(crate) async fn scan_entity_snapshots(
+        &self,
+        branch_id: &str,
+        control: BranchHeadControl,
+        schema_key: &str,
+        entity_pks: &[EntityPk],
+        limit: Option<usize>,
+    ) -> Result<Vec<Option<Bytes>>, LixError> {
+        self.scan_entity_snapshots_for_generation(
+            branch_id,
+            control.generation,
+            schema_key,
+            entity_pks,
+            limit,
+        )
+        .await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn scan_live_rows_if_current(
+        &self,
+        branch_id: &str,
+        expected_head: &str,
+        request: &TrackedStateScanRequest,
+    ) -> Result<Option<Vec<MaterializedLiveStateRow>>, LixError> {
+        let expected_head = CommitId::parse_lix(expected_head, "hot-state expected commit")?;
+        let control = BranchHeadControlContext::new()
+            .reader(&self.store)
+            .load(branch_id)
+            .await?;
+        let Some(control) = control.filter(|control| control.head_commit_id == expected_head)
+        else {
+            return Ok(None);
+        };
+        Ok(Some(
+            self.scan_live_rows_for_generation(branch_id, control.generation, request)
+                .await?,
+        ))
+    }
+
+    async fn scan_live_rows_for_generation(
+        &self,
+        branch_id: &str,
+        generation: CommitId,
+        request: &TrackedStateScanRequest,
+    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        // A storage prefix is ordered by identity, but tombstones are filtered
+        // only after decoding the value. Applying SQL LIMIT to the raw scan
+        // would therefore let one tombstone hide a later live row.
+        let entries =
+            hot_scan_entries(&self.store, branch_id, generation, &request.filter, None).await?;
+        let projection = ChangeRecordProjection::from_columns(&request.read_columns.columns);
+        let mut rows =
+            materialize_live_entries(&self.store, entries, projection, branch_id).await?;
+        if !request.filter.include_tombstones {
+            rows.retain(|row| !row.deleted);
+        }
+        if let Some(limit) = request.limit {
+            rows.truncate(limit);
+        }
+        Ok(rows)
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn load_projected_live_rows_if_current(
+        &self,
+        branch_id: &str,
+        expected_head: &str,
+        keys: &[TrackedStateKey],
+        projection: &ChangeRecordProjection,
+    ) -> Result<Option<Vec<Option<MaterializedLiveStateRow>>>, LixError> {
+        let expected_head = CommitId::parse_lix(expected_head, "hot-state expected commit")?;
+        let control = BranchHeadControlContext::new()
+            .reader(&self.store)
+            .load(branch_id)
+            .await?;
+        let Some(control) = control.filter(|control| control.head_commit_id == expected_head)
+        else {
+            return Ok(None);
+        };
+        Ok(Some(
+            self.load_projected_live_rows_for_generation(
+                branch_id,
+                control.generation,
+                keys,
+                projection,
+            )
+            .await?,
+        ))
+    }
+
+    pub(crate) async fn load_projected_live_rows(
+        &self,
+        branch_id: &str,
+        control: BranchHeadControl,
+        keys: &[TrackedStateKey],
+        projection: &ChangeRecordProjection,
+    ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+        self.load_projected_live_rows_for_generation(
+            branch_id,
+            control.generation,
+            keys,
+            projection,
+        )
+        .await
+    }
+
+    async fn load_projected_live_rows_for_generation(
+        &self,
+        branch_id: &str,
+        generation: CommitId,
+        keys: &[TrackedStateKey],
+        projection: &ChangeRecordProjection,
+    ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+        if keys.is_empty() {
+            return Ok(Vec::new());
+        }
+        let identities = keys
+            .iter()
+            .map(|key| HeadIdentity {
+                branch_id: branch_id.to_string(),
+                generation,
+                schema_key: key.schema_key.clone(),
+                entity_pk: key.entity_pk.clone(),
+                file_id: key.file_id.clone(),
+            })
+            .collect::<Vec<_>>();
+        let values = hot_load_identity_bytes(&self.store, &identities).await?;
+        let entries = identities
+            .iter()
+            .cloned()
+            .zip(values)
+            .filter_map(|(identity, value)| {
+                value.map(|value| (identity.into_row_identity(), value))
+            })
+            .collect::<Vec<_>>();
+        let rows = materialize_live_entries(&self.store, entries, *projection, branch_id).await?;
+        let rows_by_identity = rows
+            .into_iter()
+            .map(|row| {
+                (
+                    HeadRowIdentity {
+                        schema_key: row.schema_key.clone(),
+                        entity_pk: row.entity_pk.clone(),
+                        file_id: row.file_id.clone(),
+                    },
+                    row,
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        Ok(identities
+            .iter()
+            .map(|identity| {
+                rows_by_identity
+                    .get(&identity.clone().into_row_identity())
+                    .cloned()
+            })
+            .collect())
+    }
+
+    pub(crate) async fn working_diff_epoch(
+        &self,
+        branch_id: &str,
+    ) -> Result<Option<TrackedWorkingDiffEpoch>, LixError> {
+        load_tracked_working_diff_epoch(&self.store, branch_id).await
+    }
+
+    pub(crate) async fn untracked_json_refs(
+        &self,
+        controls: &[(String, BranchHeadControl)],
+    ) -> Result<Vec<JsonRef>, LixError> {
+        let mut refs = BTreeSet::new();
+        for (branch_id, control) in controls {
+            let scope = hot_scope_prefix(branch_id, control.generation);
+            let plan = ScanPlan::prefix(
+                HOT_ROW_SPACE,
+                StoragePrefix {
+                    bytes: Bytes::from(scope),
+                },
+            );
+            let mut resume_after = None;
+            loop {
+                let page = plan
+                    .collect(
+                        &self.store,
+                        StorageScanOptions {
+                            resume_after: resume_after.clone(),
+                            ..StorageScanOptions::default()
+                        },
+                    )
+                    .await?;
+                resume_after = page.value.entries.last().map(|entry| entry.key.clone());
+                for entry in page.value.entries {
+                    let bytes = full_value_bytes(entry.value)?;
+                    let value = decode_head_value(&bytes)?;
+                    collect_hot_untracked_refs(value, &mut refs);
+                }
+                if !page.value.has_more || resume_after.is_none() {
+                    break;
+                }
+            }
+        }
+        Ok(refs.into_iter().map(JsonRef::from_hash_bytes).collect())
+    }
+
+    pub(crate) async fn working_diff_for_control(
+        &self,
+        branch_id: &str,
+        control: BranchHeadControl,
+        request: &TrackedStateDiffRequest,
+    ) -> Result<Option<TrackedWorkingDiff>, LixError> {
+        let Ok(Some(epoch)) = self.working_diff_epoch(branch_id).await else {
+            return Ok(None);
+        };
+        let generation = epoch.generation;
+        if generation != control.generation
+            || control.working_diff_checkpoint_commit_id != Some(epoch.checkpoint_commit_id)
+        {
+            return Ok(None);
+        }
+        let Some(entries) = hot_working_diff_entries(
+            &self.store,
+            branch_id,
+            epoch.checkpoint_commit_id,
+            generation,
+            epoch.coverage,
+            &request.filter,
+        )
+        .await?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(TrackedWorkingDiff {
+            checkpoint_commit_id: epoch.checkpoint_commit_id,
+            diff: TrackedStateDiff { entries },
+        }))
+    }
+
+    async fn scan_entity_snapshots_for_generation(
+        &self,
+        branch_id: &str,
+        generation: CommitId,
+        schema_key: &str,
+        entity_pks: &[EntityPk],
+        limit: Option<usize>,
+    ) -> Result<Vec<Option<Bytes>>, LixError> {
+        if matches!(limit, Some(0)) {
+            return Ok(Vec::new());
+        }
+        let entries = hot_scan_entries(
+            &self.store,
+            branch_id,
+            generation,
+            &TrackedStateFilter {
+                schema_keys: vec![schema_key.to_string()],
+                entity_pks: entity_pks.to_vec(),
+                include_tombstones: false,
+                ..TrackedStateFilter::default()
+            },
+            None,
+        )
+        .await?;
+        let mut snapshots = Vec::new();
+        let mut json_refs = Vec::new();
+        let mut deferred = Vec::new();
+        for (_, bytes) in entries {
+            let value = decode_head_value(&bytes)?;
+            if value.deleted {
+                continue;
+            }
+            let row_index = snapshots.len();
+            match value.snapshot {
+                HeadSlotView::None => snapshots.push(None),
+                HeadSlotView::Inline(snapshot) => {
+                    snapshots.push(Some(bytes.slice_ref(snapshot.as_bytes())));
+                }
+                HeadSlotView::Ref(json_ref) => {
+                    snapshots.push(None);
+                    json_refs.push(json_ref);
+                    deferred.push((row_index, json_ref));
+                }
+            }
+            if limit.is_some_and(|limit| snapshots.len() >= limit) {
+                break;
+            }
+        }
+        materialize_entity_snapshot_refs(&self.store, snapshots, json_refs, deferred).await
+    }
+}
+
+/// An owned tracked snapshot used only while a lifecycle publication is being
+/// staged. Normal commits mutate the published hot generation in place; a
+/// checkpoint, merge, or branch move instead builds one complete replacement
+/// generation before the branch control makes it visible.
+///
+/// The snapshot deliberately stores the already encoded row values. That
+/// keeps large JSON slots as refs/inline values and makes a root staged in
+/// this write set usable as the parent of another root without reading the
+/// uncommitted write set back through storage.
+#[derive(Clone, Default)]
+pub(crate) struct HotTrackedSnapshot {
+    rows: BTreeMap<HeadRowIdentity, Vec<u8>>,
+}
+
+impl HotTrackedSnapshot {
+    pub(crate) fn from_materialized_rows(
+        tracked_rows: Vec<MaterializedTrackedStateRow>,
+    ) -> Result<Self, LixError> {
+        let mut rows = BTreeMap::new();
+        for row in tracked_rows {
+            let identity = HeadRowIdentity {
+                schema_key: row.schema_key,
+                entity_pk: row.entity_pk,
+                file_id: row.file_id,
+            };
+            let value = HeadValueRef {
+                change_id: Some(row.change_id),
+                commit_id: Some(row.commit_id),
+                untracked: false,
+                deleted: row.deleted,
+                created_at: LixTimestamp::expect_parse(
+                    "hot tracked snapshot created_at",
+                    &row.created_at,
+                ),
+                updated_at: LixTimestamp::expect_parse(
+                    "hot tracked snapshot updated_at",
+                    &row.updated_at,
+                ),
+                snapshot: row
+                    .snapshot_content
+                    .as_deref()
+                    .map_or(JsonSlotRef::None, JsonSlotRef::Inline),
+                metadata: row
+                    .metadata
+                    .as_deref()
+                    .map_or(JsonSlotRef::None, JsonSlotRef::Inline),
+                working_diff_baseline: WorkingDiffBaseline::Disabled,
+            };
+            if rows.insert(identity, encode_head_value(&value)?).is_some() {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked hot snapshot contains duplicate row identity",
+                ));
+            }
+        }
+        Ok(Self { rows })
+    }
+}
+
+/// Writer for row-addressable current state.
+pub(crate) struct HotStateWriter<'a, S: ?Sized> {
+    pub(super) store: &'a S,
+    pub(super) writes: &'a mut StorageWriteSet,
+}
+
+impl<S> HotStateWriter<'_, S>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    #[cfg(any(test, feature = "storage-benches"))]
+    pub(crate) async fn stage_commit(
+        &mut self,
+        branch_id: &str,
+        parent_generation: Option<CommitId>,
+        new_head: CommitId,
+        deltas: &[TrackedHeadDeltaRef<'_>],
+        absence_guards: &BTreeSet<TrackedStateKey>,
+        parent_rows: Option<Vec<MaterializedTrackedStateRow>>,
+    ) -> Result<CommitId, LixError> {
+        let deltas = deltas
+            .iter()
+            .map(TrackedHeadDeltaRef::as_current)
+            .collect::<Vec<_>>();
+        let mut coverage = WorkingDiffIndexCoverage::default();
+        let generation = self
+            .stage_current_state_with_working_diff(
+                branch_id,
+                parent_generation,
+                new_head,
+                &deltas,
+                absence_guards,
+                parent_rows,
+                None,
+                None,
+                &mut coverage,
+            )
+            .await?;
+        #[cfg(test)]
+        stage_test_current_control(self.writes, branch_id, new_head, generation, None)?;
+        Ok(generation)
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn stage_commit_with_working_diff(
+        &mut self,
+        branch_id: &str,
+        parent_generation: Option<CommitId>,
+        new_head: CommitId,
+        deltas: &[TrackedHeadDeltaRef<'_>],
+        absence_guards: &BTreeSet<TrackedStateKey>,
+        parent_rows: Option<Vec<MaterializedTrackedStateRow>>,
+        working_diff_capture_checkpoint_commit_id: Option<CommitId>,
+        coverage: &mut WorkingDiffIndexCoverage,
+    ) -> Result<CommitId, LixError> {
+        let deltas = deltas
+            .iter()
+            .map(TrackedHeadDeltaRef::as_current)
+            .collect::<Vec<_>>();
+        self.stage_current_state_with_working_diff(
+            branch_id,
+            parent_generation,
+            new_head,
+            &deltas,
+            absence_guards,
+            parent_rows,
+            None,
+            working_diff_capture_checkpoint_commit_id,
+            coverage,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn stage_current_state_with_working_diff(
+        &mut self,
+        branch_id: &str,
+        parent_generation: Option<CommitId>,
+        new_head: CommitId,
+        deltas: &[CurrentStateDeltaRef<'_>],
+        absence_guards: &BTreeSet<TrackedStateKey>,
+        parent_rows: Option<Vec<MaterializedTrackedStateRow>>,
+        preserved_untracked_rows: Option<Vec<MaterializedLiveStateRow>>,
+        working_diff_capture_checkpoint_commit_id: Option<CommitId>,
+        coverage: &mut WorkingDiffIndexCoverage,
+    ) -> Result<CommitId, LixError> {
+        let generation = parent_generation.unwrap_or(new_head);
+        let mut sorted = deltas.iter().collect::<Vec<_>>();
+        for delta in &sorted {
+            delta.validate()?;
+        }
+        sorted.sort_unstable_by(|left, right| compare_hot_deltas(left, right));
+        for pair in sorted.windows(2) {
+            if compare_hot_deltas(pair[0], pair[1]).is_eq() {
+                return Err(current_state_duplicate_delta_error(pair[1]));
+            }
+        }
+
+        if parent_generation.is_none() {
+            stage_hot_bootstrap(
+                self.writes,
+                branch_id,
+                generation,
+                parent_rows.unwrap_or_default(),
+                preserved_untracked_rows.unwrap_or_default(),
+                &sorted,
+                absence_guards,
+                working_diff_capture_checkpoint_commit_id,
+                coverage,
+            )?;
+            return Ok(generation);
+        }
+
+        let identities = sorted
+            .iter()
+            .map(|delta| {
+                hot_identity(
+                    branch_id,
+                    generation,
+                    delta.schema_key,
+                    delta.entity_pk,
+                    delta.file_id,
+                )
+            })
+            .collect::<Vec<_>>();
+        // Mutation validation must use primary rows rather than the file-id
+        // projection. The projection is an equally-valued read accelerator,
+        // not an ownership record.
+        let previous_values = hot_load_primary_identity_bytes(self.store, &identities).await?;
+        let mut created_ats = Vec::with_capacity(sorted.len());
+        let mut retired_untracked_json_refs = BTreeSet::new();
+        let delta_keys = sorted
+            .iter()
+            .map(|delta| TrackedStateKey {
+                schema_key: delta.schema_key.to_string(),
+                entity_pk: delta.entity_pk.clone(),
+                file_id: delta.file_id.map(str::to_string),
+            })
+            .collect::<BTreeSet<_>>();
+        for (delta, previous) in sorted.iter().zip(&previous_values) {
+            let Some(previous) = previous else {
+                created_ats.push(delta.created_at);
+                continue;
+            };
+            let existing = decode_head_value(previous)?;
+            reject_guarded_live_member(absence_guards, delta, existing)?;
+            reject_retention_change(delta, existing)?;
+            if existing.untracked {
+                collect_retired_untracked_json_refs(
+                    existing,
+                    delta,
+                    &mut retired_untracked_json_refs,
+                );
+            }
+            created_ats.push(existing.created_at);
+        }
+        let unmatched_guards = absence_guards
+            .iter()
+            .filter(|key| !delta_keys.contains(*key))
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        reject_hot_absence_guards(self.store, branch_id, generation, &unmatched_guards).await?;
+
+        // Build every fallible output before mutating the write set. The
+        // required primary-row batch above now supplies both mutation
+        // validation and the checkpoint first-before decision.  `HOT_DIFF`
+        // is an empty dirty-key index, so there is deliberately no second
+        // point-read batch against it here.
+        let mut next_coverage = *coverage;
+        let mut diff_keys = Vec::new();
+        let mut next_values = Vec::with_capacity(sorted.len());
+        for ((delta, identity), (created_at, previous)) in sorted
+            .iter()
+            .zip(&identities)
+            .zip(created_ats.iter().zip(&previous_values))
+        {
+            // Ordinary commits have no active checkpoint, so their baseline
+            // is always disabled. Do not decode the row a second time merely
+            // to rediscover that fact; the first decode above already handled
+            // retention validation and `created_at` preservation.
+            let (working_diff_baseline, newly_dirty) =
+                if working_diff_capture_checkpoint_commit_id.is_some() && !delta.untracked {
+                    let previous = previous.as_deref().map(decode_head_value).transpose()?;
+                    next_hot_working_diff_baseline(
+                        working_diff_capture_checkpoint_commit_id,
+                        delta,
+                        previous,
+                    )?
+                } else {
+                    (WorkingDiffBaseline::Disabled, false)
+                };
+            if newly_dirty {
+                let checkpoint_commit_id = working_diff_capture_checkpoint_commit_id
+                    .expect("a newly dirty hot row requires an active checkpoint");
+                let key = encode_hot_diff_key(checkpoint_commit_id, identity);
+                next_coverage
+                    .add_encoded_group_key(&key)
+                    .ok_or_else(|| head_value_error("hot working-diff index count exceeds u64"))?;
+                diff_keys.push(key);
+            }
+            next_values.push(
+                (!delta.physically_deletes())
+                    .then(|| {
+                        encode_head_value(&delta.value_ref(*created_at, working_diff_baseline))
+                    })
+                    .transpose()?,
+            );
+        }
+
+        self.writes.reserve_space(
+            HOT_ROW_SPACE,
+            next_values.iter().filter(|value| value.is_some()).count(),
+            next_values.iter().filter(|value| value.is_none()).count(),
+        );
+        self.writes.reserve_space(
+            HOT_FILE_SPACE,
+            identities
+                .iter()
+                .zip(&next_values)
+                .filter(|(identity, value)| identity.file_id.is_some() && value.is_some())
+                .count(),
+            identities
+                .iter()
+                .zip(&next_values)
+                .filter(|(identity, value)| identity.file_id.is_some() && value.is_none())
+                .count(),
+        );
+        self.writes
+            .reserve_space(HOT_DIFF_SPACE, diff_keys.len(), 0);
+        for key in diff_keys {
+            self.writes.put(
+                HOT_DIFF_SPACE,
+                StorageKey(Bytes::from(key)),
+                StorageValue {
+                    bytes: Bytes::new(),
+                },
+            );
+        }
+        for (identity, value) in identities.iter().zip(next_values) {
+            stage_hot_value(self.writes, identity, value);
+        }
+        JsonStoreWriter::stage_untracked_reclaim_candidates(
+            self.writes,
+            retired_untracked_json_refs
+                .into_iter()
+                .map(JsonRef::from_hash_bytes),
+        );
+        *coverage = next_coverage;
+        Ok(generation)
+    }
+
+    /// Publishes a complete replacement generation for a lifecycle event.
+    ///
+    /// The supplied snapshot is the target commit's tracked portion.  Any
+    /// branch-local untracked rows are copied from the previous generation,
+    /// then this transaction's untracked mutations are applied before its
+    /// tracked mutations.  That order admits the one legitimate mixed case:
+    /// deleting an untracked row and selecting a tracked row with the same
+    /// identity in the same atomic publication.  Every other retention
+    /// collision fails before the new control can become visible.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn stage_complete_current_state_with_working_diff(
+        &mut self,
+        branch_id: &str,
+        generation: CommitId,
+        parent_tracked: HotTrackedSnapshot,
+        preserved_untracked_generation: Option<CommitId>,
+        tracked_deltas: &[CurrentStateDeltaRef<'_>],
+        untracked_deltas: &[CurrentStateDeltaRef<'_>],
+        absence_guards: &BTreeSet<TrackedStateKey>,
+        working_diff_capture_checkpoint_commit_id: Option<CommitId>,
+        coverage: &mut WorkingDiffIndexCoverage,
+    ) -> Result<HotTrackedSnapshot, LixError> {
+        let mut rows = parent_tracked.rows;
+        let mut untracked_rows = match preserved_untracked_generation {
+            Some(previous_generation) => {
+                load_hot_untracked_generation(self.store, branch_id, previous_generation).await?
+            }
+            None => BTreeMap::new(),
+        };
+
+        let sorted_untracked = sorted_lifecycle_hot_deltas(untracked_deltas, true)?;
+        let sorted_tracked = sorted_lifecycle_hot_deltas(tracked_deltas, false)?;
+        reject_lifecycle_retention_collisions(&sorted_untracked, &sorted_tracked)?;
+
+        let mut retired_untracked_json_refs = BTreeSet::new();
+        for delta in &sorted_untracked {
+            apply_complete_hot_snapshot_delta(
+                &mut untracked_rows,
+                delta,
+                absence_guards,
+                &mut retired_untracked_json_refs,
+            )?;
+        }
+        merge_final_untracked_rows(&mut rows, untracked_rows)?;
+        for delta in &sorted_tracked {
+            apply_complete_hot_snapshot_delta(
+                &mut rows,
+                delta,
+                absence_guards,
+                &mut retired_untracked_json_refs,
+            )?;
+        }
+
+        // A replacement generation cannot inherit a checkpoint baseline from
+        // its source: that before image belongs to the retired generation.
+        // The one exception is publishing the checkpoint itself, where every
+        // final tracked row is the clean baseline by definition.
+        let tracked_baseline = if working_diff_capture_checkpoint_commit_id.is_some() {
+            WorkingDiffBaseline::Clean
+        } else {
+            WorkingDiffBaseline::Disabled
+        };
+        normalize_complete_hot_snapshot_baselines(&mut rows, tracked_baseline)?;
+
+        let mut final_tracked = BTreeMap::new();
+        for (identity, bytes) in &rows {
+            if !decode_head_value(bytes)?.untracked {
+                final_tracked.insert(identity.clone(), bytes.clone());
+            }
+        }
+
+        self.writes.reserve_space(HOT_ROW_SPACE, rows.len(), 0);
+        self.writes.reserve_space(
+            HOT_FILE_SPACE,
+            rows.keys()
+                .filter(|identity| identity.file_id.is_some())
+                .count(),
+            0,
+        );
+        for (identity, bytes) in rows {
+            let full = HeadIdentity {
+                branch_id: branch_id.to_string(),
+                generation,
+                schema_key: identity.schema_key,
+                entity_pk: identity.entity_pk,
+                file_id: identity.file_id,
+            };
+            stage_hot_value(self.writes, &full, Some(bytes));
+        }
+        JsonStoreWriter::stage_untracked_reclaim_candidates(
+            self.writes,
+            retired_untracked_json_refs
+                .into_iter()
+                .map(JsonRef::from_hash_bytes),
+        );
+        *coverage = WorkingDiffIndexCoverage::default();
+        Ok(HotTrackedSnapshot {
+            rows: final_tracked,
+        })
+    }
+}
+
+/// Selects the baseline for one primary-row mutation and whether the sparse
+/// dirty-key index needs its first entry. The current primary row is already
+/// loaded for retention and insert validation, so this must remain purely
+/// in-memory: adding a `HOT_DIFF` lookup here would recreate the avoidable
+/// second read batch this layout removes.
+fn next_hot_working_diff_baseline(
+    active_checkpoint_commit_id: Option<CommitId>,
+    delta: &CurrentStateDeltaRef<'_>,
+    previous: Option<HeadValueView<'_>>,
+) -> Result<(WorkingDiffBaseline, bool), LixError> {
+    if delta.untracked || active_checkpoint_commit_id.is_none() {
+        return Ok((WorkingDiffBaseline::Disabled, false));
+    }
+    let Some(previous) = previous else {
+        return Ok((WorkingDiffBaseline::BeforeAbsent, true));
+    };
+    if previous.untracked {
+        return Err(head_value_error(
+            "tracked mutation has an untracked primary before image",
+        ));
+    }
+    match previous.working_diff_baseline {
+        WorkingDiffBaseline::Clean => {
+            let before = previous
+                .working_diff_version()
+                .ok_or_else(|| head_value_error("tracked mutation has no working-diff version"))?;
+            Ok((WorkingDiffBaseline::BeforePresent(before), true))
+        }
+        WorkingDiffBaseline::BeforeAbsent => Ok((WorkingDiffBaseline::BeforeAbsent, false)),
+        WorkingDiffBaseline::BeforePresent(before) => {
+            Ok((WorkingDiffBaseline::BeforePresent(before), false))
+        }
+        WorkingDiffBaseline::Disabled => Err(head_value_error(
+            "active checkpoint generation contains a tracked row without a baseline",
+        )),
+    }
+}
+
+async fn load_hot_untracked_generation(
+    store: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    generation: CommitId,
+) -> Result<BTreeMap<HeadRowIdentity, Vec<u8>>, LixError> {
+    let entries = hot_scan_entries(
+        store,
+        branch_id,
+        generation,
+        &TrackedStateFilter {
+            include_tombstones: true,
+            ..TrackedStateFilter::default()
+        },
+        None,
+    )
+    .await?;
+    let mut rows = BTreeMap::new();
+    for (identity, bytes) in entries {
+        let value = decode_head_value(&bytes)?;
+        if !value.untracked {
+            continue;
+        }
+        if value.deleted {
+            return Err(head_value_error(
+                "untracked hot row must be physically removed rather than tombstoned",
+            ));
+        }
+        if rows.insert(identity.clone(), bytes.to_vec()).is_some() {
+            return Err(LixError::new(
+                LixError::CODE_UNIQUE,
+                format!(
+                    "hot generation contains duplicate untracked identity in schema '{}' entity_pk {:?}",
+                    identity.schema_key, identity.entity_pk
+                ),
+            ));
+        }
+    }
+    Ok(rows)
+}
+
+fn merge_final_untracked_rows(
+    rows: &mut BTreeMap<HeadRowIdentity, Vec<u8>>,
+    untracked_rows: BTreeMap<HeadRowIdentity, Vec<u8>>,
+) -> Result<(), LixError> {
+    for (identity, bytes) in untracked_rows {
+        if rows.insert(identity.clone(), bytes).is_some() {
+            return Err(LixError::new(
+                LixError::CODE_UNIQUE,
+                format!(
+                    "cannot materialize tracked and untracked hot rows with the same identity in schema '{}' entity_pk {:?}",
+                    identity.schema_key, identity.entity_pk
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn sorted_lifecycle_hot_deltas<'a>(
+    deltas: &'a [CurrentStateDeltaRef<'a>],
+    expect_untracked: bool,
+) -> Result<Vec<&'a CurrentStateDeltaRef<'a>>, LixError> {
+    let mut sorted = Vec::with_capacity(deltas.len());
+    for delta in deltas {
+        delta.validate()?;
+        if delta.untracked != expect_untracked {
+            return Err(head_value_error(if expect_untracked {
+                "untracked lifecycle delta was marked tracked"
+            } else {
+                "tracked lifecycle delta was marked untracked"
+            }));
+        }
+        sorted.push(delta);
+    }
+    sorted.sort_unstable_by(|left, right| compare_hot_deltas(left, right));
+    for pair in sorted.windows(2) {
+        if compare_hot_deltas(pair[0], pair[1]).is_eq() {
+            return Err(current_state_duplicate_delta_error(pair[1]));
+        }
+    }
+    Ok(sorted)
+}
+
+fn reject_lifecycle_retention_collisions(
+    untracked: &[&CurrentStateDeltaRef<'_>],
+    tracked: &[&CurrentStateDeltaRef<'_>],
+) -> Result<(), LixError> {
+    let mut untracked_index = 0;
+    let mut tracked_index = 0;
+    while untracked_index < untracked.len() && tracked_index < tracked.len() {
+        match compare_hot_deltas(untracked[untracked_index], tracked[tracked_index]) {
+            Ordering::Less => untracked_index += 1,
+            Ordering::Greater => tracked_index += 1,
+            Ordering::Equal => {
+                if !untracked[untracked_index].physically_deletes() {
+                    return Err(current_state_duplicate_delta_error(tracked[tracked_index]));
+                }
+                untracked_index += 1;
+                tracked_index += 1;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn apply_complete_hot_snapshot_delta(
+    rows: &mut BTreeMap<HeadRowIdentity, Vec<u8>>,
+    delta: &CurrentStateDeltaRef<'_>,
+    absence_guards: &BTreeSet<TrackedStateKey>,
+    retired_untracked_json_refs: &mut BTreeSet<[u8; JSON_REF_BYTES]>,
+) -> Result<(), LixError> {
+    let identity = HeadRowIdentity {
+        schema_key: delta.schema_key.to_string(),
+        entity_pk: delta.entity_pk.clone(),
+        file_id: delta.file_id.map(str::to_string),
+    };
+    let previous = rows.get(&identity).map(Vec::as_slice);
+    if let Some(previous) = previous {
+        let existing = decode_head_value(previous)?;
+        reject_guarded_live_member(absence_guards, delta, existing)?;
+        reject_retention_change(delta, existing)?;
+        if existing.untracked {
+            collect_retired_untracked_json_refs(existing, delta, retired_untracked_json_refs);
+        }
+    }
+    if delta.physically_deletes() {
+        rows.remove(&identity);
+    } else {
+        let created_at = previous
+            .map(decode_head_value)
+            .transpose()?
+            .map_or(delta.created_at, |value| value.created_at);
+        rows.insert(
+            identity,
+            encode_head_value(&delta.value_ref(created_at, WorkingDiffBaseline::Disabled))?,
+        );
+    }
+    Ok(())
+}
+
+fn normalize_complete_hot_snapshot_baselines(
+    rows: &mut BTreeMap<HeadRowIdentity, Vec<u8>>,
+    tracked_baseline: WorkingDiffBaseline,
+) -> Result<(), LixError> {
+    for bytes in rows.values_mut() {
+        let value = decode_head_value(bytes)?;
+        if value.untracked {
+            continue;
+        }
+        *bytes = reencode_head_value_with_baseline(value, tracked_baseline)?;
+    }
+    Ok(())
+}
+
+fn compare_hot_deltas(
+    left: &CurrentStateDeltaRef<'_>,
+    right: &CurrentStateDeltaRef<'_>,
+) -> Ordering {
+    left.schema_key
+        .cmp(right.schema_key)
+        .then_with(|| left.entity_pk.cmp(right.entity_pk))
+        .then_with(|| left.file_id.cmp(&right.file_id))
+}
+
+fn hot_identity(
+    branch_id: &str,
+    generation: CommitId,
+    schema_key: &str,
+    entity_pk: &EntityPk,
+    file_id: Option<&str>,
+) -> HeadIdentity {
+    HeadIdentity {
+        branch_id: branch_id.to_string(),
+        generation,
+        schema_key: schema_key.to_string(),
+        entity_pk: entity_pk.clone(),
+        file_id: file_id.map(str::to_string),
+    }
+}
+
+fn stage_hot_value(writes: &mut StorageWriteSet, identity: &HeadIdentity, value: Option<Vec<u8>>) {
+    let Some(value) = value else {
+        writes.delete(
+            HOT_ROW_SPACE,
+            StorageKey(Bytes::from(encode_hot_row_key(identity))),
+        );
+        if identity.file_id.is_some() {
+            writes.delete(
+                HOT_FILE_SPACE,
+                StorageKey(Bytes::from(encode_hot_file_key(identity))),
+            );
+        }
+        return;
+    };
+    writes.put(
+        HOT_ROW_SPACE,
+        StorageKey(Bytes::from(encode_hot_row_key(identity))),
+        StorageValue {
+            bytes: Bytes::from(value.clone()),
+        },
+    );
+    if identity.file_id.is_some() {
+        writes.put(
+            HOT_FILE_SPACE,
+            StorageKey(Bytes::from(encode_hot_file_key(identity))),
+            StorageValue {
+                bytes: Bytes::from(value),
+            },
+        );
+    }
+}
+
+#[cfg(test)]
+pub(super) fn stage_test_hot_value(
+    writes: &mut StorageWriteSet,
+    identity: &HeadIdentity,
+    value: &HeadValue,
+) -> Result<(), LixError> {
+    stage_hot_value(writes, identity, Some(encode_head_value(&value.as_ref())?));
+    Ok(())
+}
+
+fn stage_hot_bootstrap(
+    writes: &mut StorageWriteSet,
+    branch_id: &str,
+    generation: CommitId,
+    parent_rows: Vec<MaterializedTrackedStateRow>,
+    preserved_untracked_rows: Vec<MaterializedLiveStateRow>,
+    deltas: &[&CurrentStateDeltaRef<'_>],
+    absence_guards: &BTreeSet<TrackedStateKey>,
+    working_diff_capture_checkpoint_commit_id: Option<CommitId>,
+    coverage: &mut WorkingDiffIndexCoverage,
+) -> Result<(), LixError> {
+    let mut rows = BTreeMap::<HeadRowIdentity, Vec<u8>>::new();
+    let tracked_baseline = if working_diff_capture_checkpoint_commit_id.is_some() {
+        WorkingDiffBaseline::Clean
+    } else {
+        WorkingDiffBaseline::Disabled
+    };
+    for row in parent_rows {
+        let key = TrackedStateKey {
+            schema_key: row.schema_key.clone(),
+            entity_pk: row.entity_pk.clone(),
+            file_id: row.file_id.clone(),
+        };
+        if absence_guards.contains(&key) && !row.deleted {
+            return Err(tracked_head_duplicate_insert_error(&key));
+        }
+        let identity = HeadRowIdentity {
+            schema_key: row.schema_key,
+            entity_pk: row.entity_pk,
+            file_id: row.file_id,
+        };
+        let value = HeadValueRef {
+            change_id: Some(row.change_id),
+            commit_id: Some(row.commit_id),
+            untracked: false,
+            deleted: row.deleted,
+            created_at: LixTimestamp::expect_parse("hot bootstrap created_at", &row.created_at),
+            updated_at: LixTimestamp::expect_parse("hot bootstrap updated_at", &row.updated_at),
+            snapshot: row
+                .snapshot_content
+                .as_deref()
+                .map_or(JsonSlotRef::None, JsonSlotRef::Inline),
+            metadata: row
+                .metadata
+                .as_deref()
+                .map_or(JsonSlotRef::None, JsonSlotRef::Inline),
+            working_diff_baseline: tracked_baseline,
+        };
+        if rows.insert(identity, encode_head_value(&value)?).is_some() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "hot bootstrap contains duplicate tracked row identity",
+            ));
+        }
+    }
+    for row in preserved_untracked_rows {
+        if !row.untracked || row.deleted {
+            return Err(head_value_error(
+                "hot bootstrap preserved state must contain only live untracked rows",
+            ));
+        }
+        let key = TrackedStateKey {
+            schema_key: row.schema_key.clone(),
+            entity_pk: row.entity_pk.clone(),
+            file_id: row.file_id.clone(),
+        };
+        if absence_guards.contains(&key) {
+            return Err(tracked_head_duplicate_insert_error(&key));
+        }
+        let identity = HeadRowIdentity {
+            schema_key: row.schema_key,
+            entity_pk: row.entity_pk,
+            file_id: row.file_id,
+        };
+        let value = HeadValueRef {
+            change_id: None,
+            commit_id: None,
+            untracked: true,
+            deleted: false,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+            snapshot: row
+                .snapshot_content
+                .as_deref()
+                .map_or(JsonSlotRef::None, JsonSlotRef::Inline),
+            metadata: row
+                .metadata
+                .as_deref()
+                .map_or(JsonSlotRef::None, JsonSlotRef::Inline),
+            working_diff_baseline: WorkingDiffBaseline::Disabled,
+        };
+        if rows.insert(identity, encode_head_value(&value)?).is_some() {
+            return Err(LixError::new(
+                LixError::CODE_UNIQUE,
+                "cannot materialize tracked and untracked hot rows with the same identity",
+            ));
+        }
+    }
+    let mut retired_untracked_json_refs = BTreeSet::new();
+    for delta in deltas {
+        let identity = HeadRowIdentity {
+            schema_key: delta.schema_key.to_string(),
+            entity_pk: delta.entity_pk.clone(),
+            file_id: delta.file_id.map(str::to_string),
+        };
+        let previous = rows.get(&identity).map(Vec::as_slice);
+        if let Some(previous) = previous {
+            let existing = decode_head_value(previous)?;
+            reject_guarded_live_member(absence_guards, delta, existing)?;
+            reject_retention_change(delta, existing)?;
+            if existing.untracked {
+                collect_retired_untracked_json_refs(
+                    existing,
+                    delta,
+                    &mut retired_untracked_json_refs,
+                );
+            }
+        }
+        if delta.physically_deletes() {
+            rows.remove(&identity);
+        } else {
+            let created_at = previous
+                .map(decode_head_value)
+                .transpose()?
+                .map_or(delta.created_at, |value| value.created_at);
+            rows.insert(
+                identity,
+                encode_head_value(&delta.value_ref(
+                    created_at,
+                    if delta.untracked {
+                        WorkingDiffBaseline::Disabled
+                    } else {
+                        tracked_baseline
+                    },
+                ))?,
+            );
+        }
+    }
+    writes.reserve_space(HOT_ROW_SPACE, rows.len(), 0);
+    writes.reserve_space(
+        HOT_FILE_SPACE,
+        rows.keys()
+            .filter(|identity| identity.file_id.is_some())
+            .count(),
+        0,
+    );
+    for (identity, bytes) in rows {
+        let full = HeadIdentity {
+            branch_id: branch_id.to_string(),
+            generation,
+            schema_key: identity.schema_key,
+            entity_pk: identity.entity_pk,
+            file_id: identity.file_id,
+        };
+        stage_hot_value(writes, &full, Some(bytes));
+    }
+    JsonStoreWriter::stage_untracked_reclaim_candidates(
+        writes,
+        retired_untracked_json_refs
+            .into_iter()
+            .map(JsonRef::from_hash_bytes),
+    );
+    *coverage = WorkingDiffIndexCoverage::default();
+    Ok(())
+}
+
+async fn reject_hot_absence_guards(
+    store: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    generation: CommitId,
+    guards: &BTreeSet<TrackedStateKey>,
+) -> Result<(), LixError> {
+    if guards.is_empty() {
+        return Ok(());
+    }
+    let identities = guards
+        .iter()
+        .map(|key| {
+            hot_identity(
+                branch_id,
+                generation,
+                &key.schema_key,
+                &key.entity_pk,
+                key.file_id.as_deref(),
+            )
+        })
+        .collect::<Vec<_>>();
+    for (identity, value) in identities
+        .iter()
+        .zip(hot_load_primary_identity_bytes(store, &identities).await?)
+    {
+        let Some(value) = value else {
+            continue;
+        };
+        let value = decode_head_value(&value)?;
+        if !value.deleted {
+            return Err(tracked_head_duplicate_insert_error(&TrackedStateKey {
+                schema_key: identity.schema_key.clone(),
+                entity_pk: identity.entity_pk.clone(),
+                file_id: identity.file_id.clone(),
+            }));
+        }
+    }
+    Ok(())
+}
+
+async fn hot_load_identity_bytes(
+    store: &(impl StorageAdapterRead + ?Sized),
+    identities: &[HeadIdentity],
+) -> Result<Vec<Option<Bytes>>, LixError> {
+    if identities.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut output = vec![None; identities.len()];
+    for (is_file, space) in [(false, HOT_ROW_SPACE), (true, HOT_FILE_SPACE)] {
+        let indices = identities
+            .iter()
+            .enumerate()
+            .filter_map(|(index, identity)| {
+                (identity.file_id.is_some() == is_file).then_some(index)
+            })
+            .collect::<Vec<_>>();
+        if indices.is_empty() {
+            continue;
+        }
+        let keys = indices
+            .iter()
+            .map(|&index| {
+                let identity = &identities[index];
+                StorageKey(Bytes::from(if is_file {
+                    encode_hot_file_key(identity)
+                } else {
+                    encode_hot_row_key(identity)
+                }))
+            })
+            .collect::<Vec<_>>();
+        let values = PointReadPlan::new(space, &keys)
+            .materialize(store, StorageGetOptions::default())
+            .await?
+            .value;
+        for (index, value) in indices.into_iter().zip(values) {
+            output[index] = value.map(full_value_bytes).transpose()?;
+        }
+    }
+    Ok(output)
+}
+
+/// Loads the authoritative primary row for every identity. File-backed
+/// identities normally read through `HOT_FILE_SPACE`, but mutation validation
+/// and diff capture must never treat that duplicate projection as ownership.
+async fn hot_load_primary_identity_bytes(
+    store: &(impl StorageAdapterRead + ?Sized),
+    identities: &[HeadIdentity],
+) -> Result<Vec<Option<Bytes>>, LixError> {
+    if identities.is_empty() {
+        return Ok(Vec::new());
+    }
+    let keys = identities
+        .iter()
+        .map(|identity| StorageKey(Bytes::from(encode_hot_row_key(identity))))
+        .collect::<Vec<_>>();
+    PointReadPlan::new(HOT_ROW_SPACE, &keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?
+        .value
+        .into_iter()
+        .map(|value| value.map(full_value_bytes).transpose())
+        .collect()
+}
+
+fn working_diff_baseline_before(
+    baseline: WorkingDiffBaseline,
+) -> Option<Option<WorkingDiffVersion>> {
+    match baseline {
+        WorkingDiffBaseline::BeforeAbsent => Some(None),
+        WorkingDiffBaseline::BeforePresent(version) => Some(Some(version)),
+        WorkingDiffBaseline::Disabled | WorkingDiffBaseline::Clean => None,
+    }
+}
+
+/// Resolves a checkpoint diff from row-local first-before images. Broad diffs
+/// enumerate the sparse dirty-key index; finite PK queries read only the
+/// primary rows that can answer the request.
+async fn hot_working_diff_entries(
+    store: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    checkpoint_commit_id: CommitId,
+    generation: CommitId,
+    expected_coverage: WorkingDiffIndexCoverage,
+    filter: &TrackedStateFilter,
+) -> Result<Option<Vec<TrackedStateDiffEntry>>, LixError> {
+    if !filter.schema_keys.is_empty() && !filter.entity_pks.is_empty() {
+        return hot_working_diff_entries_for_finite_filter(store, branch_id, generation, filter)
+            .await;
+    }
+
+    let scope = encode_working_diff_scope_prefix(branch_id, checkpoint_commit_id, generation);
+    let plan = ScanPlan::prefix(
+        HOT_DIFF_SPACE,
+        StoragePrefix {
+            bytes: Bytes::from(scope.clone()),
+        },
+    );
+    let mut actual_coverage = WorkingDiffIndexCoverage::default();
+    let mut selected = Vec::<HeadIdentity>::new();
+    let mut resume_after = None;
+    loop {
+        let page = plan
+            .collect(
+                store,
+                StorageScanOptions {
+                    resume_after: resume_after.clone(),
+                    ..StorageScanOptions::default()
+                },
+            )
+            .await?;
+        resume_after = page.value.entries.last().map(|entry| entry.key.clone());
+        for entry in page.value.entries {
+            let Ok(bytes) = full_value_bytes(entry.value) else {
+                return Ok(None);
+            };
+            if !bytes.is_empty() {
+                return Ok(None);
+            }
+            if actual_coverage
+                .add_encoded_group_key(entry.key.0.as_ref())
+                .is_none()
+            {
+                return Ok(None);
+            }
+            let Ok(identity) = decode_hot_diff_key_in_scope(entry.key.0.as_ref(), &scope) else {
+                return Ok(None);
+            };
+            if matches_filter(&identity, filter) {
+                selected.push(HeadIdentity {
+                    branch_id: branch_id.to_string(),
+                    generation,
+                    schema_key: identity.schema_key,
+                    entity_pk: identity.entity_pk,
+                    file_id: identity.file_id,
+                });
+            }
+        }
+        if !page.value.has_more || resume_after.is_none() {
+            break;
+        }
+    }
+    if actual_coverage != expected_coverage {
+        return Ok(None);
+    }
+    let identities = selected.clone();
+    let after_values = hot_load_primary_identity_bytes(store, &identities).await?;
+    let mut entries = Vec::new();
+    for (identity, after) in selected.into_iter().zip(after_values) {
+        let Some(after) = after else {
+            return Ok(None);
+        };
+        let Ok(after) = decode_head_value(&after) else {
+            return Ok(None);
+        };
+        if after.untracked {
+            return Ok(None);
+        }
+        let Some(before) = working_diff_baseline_before(after.working_diff_baseline) else {
+            return Ok(None);
+        };
+        let Some(after) = after.working_diff_version() else {
+            return Ok(None);
+        };
+        if let Some(entry) =
+            classify_hot_working_diff_entry(identity.into_row_identity(), before, after)
+        {
+            entries.push(entry);
+        }
+    }
+    Ok(Some(entries))
+}
+
+async fn hot_working_diff_entries_for_finite_filter(
+    store: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    generation: CommitId,
+    filter: &TrackedStateFilter,
+) -> Result<Option<Vec<TrackedStateDiffEntry>>, LixError> {
+    let rows = hot_scan_entries(store, branch_id, generation, filter, None).await?;
+    let mut entries = Vec::new();
+    for (identity, bytes) in rows {
+        let Ok(after) = decode_head_value(&bytes) else {
+            return Ok(None);
+        };
+        if after.untracked {
+            continue;
+        }
+        let baseline = after.working_diff_baseline;
+        if baseline == WorkingDiffBaseline::Clean {
+            continue;
+        }
+        let Some(before) = working_diff_baseline_before(baseline) else {
+            return Ok(None);
+        };
+        let Some(after) = after.working_diff_version() else {
+            return Ok(None);
+        };
+        if let Some(entry) = classify_hot_working_diff_entry(identity, before, after) {
+            entries.push(entry);
+        }
+    }
+    Ok(Some(entries))
+}
+
+fn classify_hot_working_diff_entry(
+    identity: HeadRowIdentity,
+    before: Option<WorkingDiffVersion>,
+    after: WorkingDiffVersion,
+) -> Option<TrackedStateDiffEntry> {
+    let before_row = before.map(|version| version.into_diff_row(&identity));
+    let after_row = after.into_diff_row(&identity);
+    let diff_identity = TrackedStateDiffIdentity {
+        schema_key: identity.schema_key,
+        entity_pk: identity.entity_pk,
+        file_id: identity.file_id,
+    };
+    match (
+        before_row.as_ref().filter(|row| !row.deleted),
+        (!after_row.deleted).then_some(&after_row),
+    ) {
+        (None, None) => None,
+        (None, Some(_)) => Some(TrackedStateDiffEntry {
+            identity: diff_identity,
+            kind: TrackedStateDiffKind::Added,
+            before: before_row,
+            after: Some(after_row),
+        }),
+        (Some(_), None) => Some(TrackedStateDiffEntry {
+            identity: diff_identity,
+            kind: TrackedStateDiffKind::Removed,
+            before: before_row,
+            after: Some(after_row),
+        }),
+        (Some(_), Some(_)) if before.is_some_and(|version| version.payload_eq(after)) => None,
+        (Some(_), Some(_)) => Some(TrackedStateDiffEntry {
+            identity: diff_identity,
+            kind: TrackedStateDiffKind::Modified,
+            before: before_row,
+            after: Some(after_row),
+        }),
+    }
+}
+
+async fn hot_scan_entries(
+    store: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    generation: CommitId,
+    filter: &TrackedStateFilter,
+    limit: Option<usize>,
+) -> Result<Vec<(HeadRowIdentity, Bytes)>, LixError> {
+    // The null-file member is a true point key. A logical-PK scan can use a
+    // single MultiGet only when this schema has no file-backed members; if it
+    // does, fall through to the complete primary-prefix route so UPDATE and
+    // DELETE still see every candidate member.
+    if let Some(identities) = hot_exact_identities(branch_id, generation, filter) {
+        let may_use_null_point_batch = !filter.file_ids.is_empty()
+            || !hot_schema_has_file_members(store, branch_id, generation, &filter.schema_keys)
+                .await?;
+        if may_use_null_point_batch {
+            let values = hot_load_identity_bytes(store, &identities).await?;
+            return Ok(identities
+                .into_iter()
+                .zip(values)
+                .filter_map(|(identity, value)| {
+                    value.map(|value| (identity.into_row_identity(), value))
+                })
+                .take(limit.unwrap_or(usize::MAX))
+                .collect());
+        }
+    }
+
+    // The primary hot index is ordered by logical PK. Filesystem queries such
+    // as `WHERE file_id = ?` need the inverse order, otherwise one matching
+    // file would force a scan of every entity in its schema. Keep the full
+    // value in the file projection so this is a direct serving route rather
+    // than an index lookup followed by a second primary read.
+    if let Some(prefixes) = hot_file_scan_prefixes(branch_id, generation, filter) {
+        return scan_hot_file_entries(store, branch_id, generation, prefixes, filter, limit).await;
+    }
+
+    let scope = hot_scope_prefix(branch_id, generation);
+    let mut prefixes = scan_prefixes(&scope, filter);
+    prefixes.sort();
+    prefixes.dedup();
+    let mut rows = Vec::new();
+    for prefix in prefixes {
+        let plan = ScanPlan::prefix(
+            HOT_ROW_SPACE,
+            StoragePrefix {
+                bytes: Bytes::from(prefix),
+            },
+        );
+        let mut resume_after = None;
+        loop {
+            let remaining = limit.map(|limit| limit.saturating_sub(rows.len()));
+            if matches!(remaining, Some(0)) {
+                return Ok(rows);
+            }
+            let page = plan
+                .collect(
+                    store,
+                    StorageScanOptions {
+                        resume_after: resume_after.clone(),
+                        limit_rows: remaining
+                            .unwrap_or_else(|| StorageScanOptions::default().limit_rows),
+                        ..StorageScanOptions::default()
+                    },
+                )
+                .await?;
+            resume_after = page.value.entries.last().map(|entry| entry.key.clone());
+            for entry in page.value.entries {
+                let identity = decode_hot_row_key_in_scope(entry.key.0.as_ref(), &scope)?;
+                if matches_filter(&identity, filter) {
+                    rows.push((identity, full_value_bytes(entry.value)?));
+                    if limit.is_some_and(|limit| rows.len() >= limit) {
+                        return Ok(rows);
+                    }
+                }
+            }
+            if !page.value.has_more || resume_after.is_none() {
+                break;
+            }
+        }
+    }
+    Ok(rows)
+}
+
+fn hot_file_scan_prefixes(
+    branch_id: &str,
+    generation: CommitId,
+    filter: &TrackedStateFilter,
+) -> Option<Vec<Vec<u8>>> {
+    if filter.schema_keys.is_empty()
+        || filter.file_ids.is_empty()
+        || !filter.entity_pks.is_empty()
+        || filter
+            .file_ids
+            .iter()
+            .any(|file_id| !matches!(file_id, NullableKeyFilter::Value(_)))
+    {
+        return None;
+    }
+    let mut prefixes = Vec::with_capacity(filter.schema_keys.len() * filter.file_ids.len());
+    for schema_key in &filter.schema_keys {
+        for file_id in &filter.file_ids {
+            let NullableKeyFilter::Value(file_id) = file_id else {
+                unreachable!("file-id projection predicate was checked above");
+            };
+            let mut prefix = hot_scope_prefix(branch_id, generation);
+            write_key_string(&mut prefix, schema_key, KEY_PART_FINAL);
+            write_file_id(&mut prefix, Some(file_id));
+            prefixes.push(prefix);
+        }
+    }
+    prefixes.sort();
+    prefixes.dedup();
+    Some(prefixes)
+}
+
+async fn scan_hot_file_entries(
+    store: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    generation: CommitId,
+    prefixes: Vec<Vec<u8>>,
+    filter: &TrackedStateFilter,
+    limit: Option<usize>,
+) -> Result<Vec<(HeadRowIdentity, Bytes)>, LixError> {
+    let scope = hot_scope_prefix(branch_id, generation);
+    let mut rows = Vec::new();
+    for prefix in prefixes {
+        let plan = ScanPlan::prefix(
+            HOT_FILE_SPACE,
+            StoragePrefix {
+                bytes: Bytes::from(prefix),
+            },
+        );
+        let mut resume_after = None;
+        loop {
+            let page = plan
+                .collect(
+                    store,
+                    StorageScanOptions {
+                        resume_after: resume_after.clone(),
+                        ..StorageScanOptions::default()
+                    },
+                )
+                .await?;
+            resume_after = page.value.entries.last().map(|entry| entry.key.clone());
+            for entry in page.value.entries {
+                let identity = decode_hot_file_key_in_scope(entry.key.0.as_ref(), &scope)?;
+                if matches_filter(&identity, filter) {
+                    rows.push((identity, full_value_bytes(entry.value)?));
+                }
+            }
+            if !page.value.has_more || resume_after.is_none() {
+                break;
+            }
+        }
+    }
+    // A file projection is ordered `(schema, file_id, entity_pk)`, while SQL
+    // rows are ordered `(schema, entity_pk, file_id)`. Restore the public
+    // order after multi-file scans and defend against repeated predicates.
+    rows.sort_by(|left, right| left.0.cmp(&right.0));
+    rows.dedup_by(|left, right| left.0 == right.0);
+    if let Some(limit) = limit {
+        rows.truncate(limit);
+    }
+    Ok(rows)
+}
+
+async fn hot_schema_has_file_members(
+    store: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    generation: CommitId,
+    schema_keys: &[String],
+) -> Result<bool, LixError> {
+    // Exact identity batches always name their schema. Broad scans deliberately
+    // take the primary-prefix route, which already sees all file members.
+    if schema_keys.is_empty() {
+        return Ok(true);
+    }
+    for schema_key in schema_keys {
+        let mut prefix = hot_scope_prefix(branch_id, generation);
+        write_key_string(&mut prefix, schema_key, KEY_PART_FINAL);
+        let page = ScanPlan::prefix(
+            HOT_FILE_SPACE,
+            StoragePrefix {
+                bytes: Bytes::from(prefix),
+            },
+        )
+        .collect(
+            store,
+            StorageScanOptions {
+                projection: StorageCoreProjection::KeyOnly,
+                limit_rows: 1,
+                ..StorageScanOptions::default()
+            },
+        )
+        .await?;
+        if !page.value.entries.is_empty() {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn hot_exact_identities(
+    branch_id: &str,
+    generation: CommitId,
+    filter: &TrackedStateFilter,
+) -> Option<Vec<HeadIdentity>> {
+    if filter.schema_keys.is_empty() || filter.entity_pks.is_empty() {
+        return None;
+    }
+    let file_ids = if filter.file_ids.is_empty() {
+        // A full logical-PK lookup can contain file-backed variants. It is
+        // still a direct point batch for the overwhelmingly common null-file
+        // schemas; schemas with a file projection fall back to the prefix
+        // route below.
+        vec![None]
+    } else {
+        filter
+            .file_ids
+            .iter()
+            .map(|file_id| match file_id {
+                NullableKeyFilter::Null => Some(None),
+                NullableKeyFilter::Value(value) => Some(Some(value.clone())),
+                NullableKeyFilter::Any => None,
+            })
+            .collect::<Option<Vec<_>>>()?
+    };
+    let mut identities = Vec::new();
+    for schema_key in &filter.schema_keys {
+        for entity_pk in &filter.entity_pks {
+            for file_id in &file_ids {
+                identities.push(HeadIdentity {
+                    branch_id: branch_id.to_string(),
+                    generation,
+                    schema_key: schema_key.clone(),
+                    entity_pk: entity_pk.clone(),
+                    file_id: file_id.clone(),
+                });
+            }
+        }
+    }
+    identities.sort();
+    identities.dedup();
+    Some(identities)
+}
+
+fn hot_scope_prefix(branch_id: &str, generation: CommitId) -> Vec<u8> {
+    encode_scope_prefix(branch_id, generation)
+}
+
+fn encode_hot_row_key(identity: &HeadIdentity) -> Vec<u8> {
+    let mut key = hot_scope_prefix(&identity.branch_id, identity.generation);
+    write_key_string(&mut key, &identity.schema_key, KEY_PART_FINAL);
+    write_entity_pk(&mut key, &identity.entity_pk);
+    write_file_id(&mut key, identity.file_id.as_deref());
+    key
+}
+
+fn encode_hot_file_key(identity: &HeadIdentity) -> Vec<u8> {
+    debug_assert!(identity.file_id.is_some());
+    let mut key = hot_scope_prefix(&identity.branch_id, identity.generation);
+    write_key_string(&mut key, &identity.schema_key, KEY_PART_FINAL);
+    write_file_id(&mut key, identity.file_id.as_deref());
+    write_entity_pk(&mut key, &identity.entity_pk);
+    key
+}
+
+fn encode_hot_diff_key(checkpoint_commit_id: CommitId, identity: &HeadIdentity) -> Vec<u8> {
+    let mut key = encode_working_diff_scope_prefix(
+        &identity.branch_id,
+        checkpoint_commit_id,
+        identity.generation,
+    );
+    write_key_string(&mut key, &identity.schema_key, KEY_PART_FINAL);
+    write_entity_pk(&mut key, &identity.entity_pk);
+    write_file_id(&mut key, identity.file_id.as_deref());
+    key
+}
+
+fn decode_hot_row_key_in_scope(bytes: &[u8], scope: &[u8]) -> Result<HeadRowIdentity, LixError> {
+    if !bytes.starts_with(scope) {
+        return Err(key_codec_error(
+            "hot row does not begin with its scanned scope",
+        ));
+    }
+    let mut offset = scope.len();
+    let (schema_key, schema_terminator) = read_key_string(bytes, &mut offset, "schema key")?;
+    if schema_terminator != KEY_PART_FINAL {
+        return Err(key_codec_error(
+            "hot row schema key has an invalid terminator",
+        ));
+    }
+    let entity_pk = read_entity_pk(bytes, &mut offset)?;
+    let file_id = read_file_id(bytes, &mut offset)?;
+    if offset != bytes.len() {
+        return Err(key_codec_error("hot row key has trailing bytes"));
+    }
+    Ok(HeadRowIdentity {
+        schema_key,
+        entity_pk,
+        file_id,
+    })
+}
+
+fn decode_hot_row_key(bytes: &[u8]) -> Result<HeadIdentity, LixError> {
+    let mut offset = 0;
+    let (branch_id, branch_terminator) = read_key_string(bytes, &mut offset, "branch id")?;
+    if branch_terminator != KEY_PART_FINAL {
+        return Err(key_codec_error(
+            "hot row branch id has an invalid terminator",
+        ));
+    }
+    let generation = read_generation(bytes, &mut offset)?;
+    let (schema_key, schema_terminator) = read_key_string(bytes, &mut offset, "schema key")?;
+    if schema_terminator != KEY_PART_FINAL {
+        return Err(key_codec_error(
+            "hot row schema key has an invalid terminator",
+        ));
+    }
+    let entity_pk = read_entity_pk(bytes, &mut offset)?;
+    let file_id = read_file_id(bytes, &mut offset)?;
+    if offset != bytes.len() {
+        return Err(key_codec_error("hot row key has trailing bytes"));
+    }
+    Ok(HeadIdentity {
+        branch_id,
+        generation,
+        schema_key,
+        entity_pk,
+        file_id,
+    })
+}
+
+fn decode_hot_file_key_in_scope(bytes: &[u8], scope: &[u8]) -> Result<HeadRowIdentity, LixError> {
+    if !bytes.starts_with(scope) {
+        return Err(key_codec_error(
+            "hot file row does not begin with its scanned scope",
+        ));
+    }
+    let mut offset = scope.len();
+    let (schema_key, schema_terminator) = read_key_string(bytes, &mut offset, "schema key")?;
+    if schema_terminator != KEY_PART_FINAL {
+        return Err(key_codec_error(
+            "hot file row schema key has an invalid terminator",
+        ));
+    }
+    let Some(file_id) = read_file_id(bytes, &mut offset)? else {
+        return Err(key_codec_error("hot file row is missing its file id"));
+    };
+    let entity_pk = read_entity_pk(bytes, &mut offset)?;
+    if offset != bytes.len() {
+        return Err(key_codec_error("hot file row key has trailing bytes"));
+    }
+    Ok(HeadRowIdentity {
+        schema_key,
+        entity_pk,
+        file_id: Some(file_id),
+    })
+}
+
+fn decode_hot_file_key(bytes: &[u8]) -> Result<HeadIdentity, LixError> {
+    let mut offset = 0;
+    let (branch_id, branch_terminator) = read_key_string(bytes, &mut offset, "branch id")?;
+    if branch_terminator != KEY_PART_FINAL {
+        return Err(key_codec_error(
+            "hot file row branch id has an invalid terminator",
+        ));
+    }
+    let generation = read_generation(bytes, &mut offset)?;
+    let (schema_key, schema_terminator) = read_key_string(bytes, &mut offset, "schema key")?;
+    if schema_terminator != KEY_PART_FINAL {
+        return Err(key_codec_error(
+            "hot file row schema key has an invalid terminator",
+        ));
+    }
+    let Some(file_id) = read_file_id(bytes, &mut offset)? else {
+        return Err(key_codec_error("hot file row is missing its file id"));
+    };
+    let entity_pk = read_entity_pk(bytes, &mut offset)?;
+    if offset != bytes.len() {
+        return Err(key_codec_error("hot file row key has trailing bytes"));
+    }
+    Ok(HeadIdentity {
+        branch_id,
+        generation,
+        schema_key,
+        entity_pk,
+        file_id: Some(file_id),
+    })
+}
+
+fn decode_hot_diff_key_in_scope(bytes: &[u8], scope: &[u8]) -> Result<HeadRowIdentity, LixError> {
+    decode_hot_row_key_in_scope(bytes, scope)
+}
+
+fn decode_hot_diff_key(bytes: &[u8]) -> Result<(CommitId, HeadIdentity), LixError> {
+    let mut offset = 0;
+    let (branch_id, branch_terminator) = read_key_string(bytes, &mut offset, "branch id")?;
+    if branch_terminator != KEY_PART_FINAL {
+        return Err(key_codec_error(
+            "hot diff branch id has an invalid terminator",
+        ));
+    }
+    let checkpoint_commit_id = read_generation(bytes, &mut offset)?;
+    let generation = read_generation(bytes, &mut offset)?;
+    let (schema_key, schema_terminator) = read_key_string(bytes, &mut offset, "schema key")?;
+    if schema_terminator != KEY_PART_FINAL {
+        return Err(key_codec_error(
+            "hot diff schema key has an invalid terminator",
+        ));
+    }
+    let entity_pk = read_entity_pk(bytes, &mut offset)?;
+    let file_id = read_file_id(bytes, &mut offset)?;
+    if offset != bytes.len() {
+        return Err(key_codec_error("hot diff key has trailing bytes"));
+    }
+    Ok((
+        checkpoint_commit_id,
+        HeadIdentity {
+            branch_id,
+            generation,
+            schema_key,
+            entity_pk,
+            file_id,
+        },
+    ))
+}
+
+fn collect_hot_untracked_refs(value: HeadValueView<'_>, refs: &mut BTreeSet<[u8; JSON_REF_BYTES]>) {
+    if !value.untracked {
+        return;
+    }
+    for slot in [value.snapshot, value.metadata] {
+        if let HeadSlotView::Ref(json_ref) = slot {
+            refs.insert(*json_ref.as_hash_array());
+        }
+    }
+}
+
+pub(crate) async fn stage_collect_stale_hot_generations<S>(
+    store: &S,
+    writes: &mut StorageWriteSet,
+    controls: &[(String, BranchHeadControl)],
+) -> Result<Vec<JsonRef>, LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    let active = active_current_state_generations(controls);
+    let mut stale_untracked_refs = BTreeSet::new();
+    stage_collect_stale_hot_space(
+        store,
+        writes,
+        HOT_ROW_SPACE,
+        decode_hot_row_key,
+        &active,
+        &mut stale_untracked_refs,
+    )
+    .await?;
+    // The file projection duplicates primary values. Sweep it independently
+    // so an orphaned projection cannot keep a history-free JSON payload alive
+    // after its branch generation becomes unreachable.
+    stage_collect_stale_hot_space(
+        store,
+        writes,
+        HOT_FILE_SPACE,
+        decode_hot_file_key,
+        &active,
+        &mut stale_untracked_refs,
+    )
+    .await?;
+    Ok(stale_untracked_refs
+        .into_iter()
+        .map(JsonRef::from_hash_bytes)
+        .collect())
+}
+
+async fn stage_collect_stale_hot_space(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    space: StorageSpace,
+    decode_key: fn(&[u8]) -> Result<HeadIdentity, LixError>,
+    active: &BTreeSet<(String, CommitId)>,
+    stale_untracked_refs: &mut BTreeSet<[u8; JSON_REF_BYTES]>,
+) -> Result<(), LixError> {
+    let plan = ScanPlan::prefix(
+        space,
+        StoragePrefix {
+            bytes: Bytes::new(),
+        },
+    );
+    let mut resume_after = None;
+    loop {
+        let page = plan
+            .collect(
+                store,
+                StorageScanOptions {
+                    resume_after: resume_after.clone(),
+                    ..StorageScanOptions::default()
+                },
+            )
+            .await?;
+        resume_after = page.value.entries.last().map(|entry| entry.key.clone());
+        for entry in page.value.entries {
+            let active_generation = decode_key(entry.key.0.as_ref())
+                .is_ok_and(|identity| active.contains(&(identity.branch_id, identity.generation)));
+            if active_generation {
+                continue;
+            }
+            if let StorageProjectedValue::FullValue(bytes) = &entry.value
+                && let Ok(value) = decode_head_value(bytes)
+            {
+                collect_hot_untracked_refs(value, stale_untracked_refs);
+            }
+            writes.delete(space, entry.key);
+        }
+        if !page.value.has_more || resume_after.is_none() {
+            break;
+        }
+    }
+    Ok(())
+}
+
+pub(crate) async fn stage_collect_stale_hot_diff_records<S>(
+    store: &S,
+    writes: &mut StorageWriteSet,
+    active: &BTreeMap<String, ActiveWorkingDiffScope>,
+) -> Result<(), LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    let plan = ScanPlan::prefix(
+        HOT_DIFF_SPACE,
+        StoragePrefix {
+            bytes: Bytes::new(),
+        },
+    );
+    let mut resume_after = None;
+    loop {
+        let page = plan
+            .collect(
+                store,
+                StorageScanOptions {
+                    resume_after: resume_after.clone(),
+                    ..StorageScanOptions::default()
+                },
+            )
+            .await?;
+        resume_after = page.value.entries.last().map(|entry| entry.key.clone());
+        for entry in page.value.entries {
+            let keep = match (
+                decode_hot_diff_key(entry.key.0.as_ref()),
+                full_value_bytes(entry.value),
+            ) {
+                (Ok((checkpoint_commit_id, identity)), Ok(bytes))
+                    if active.get(&identity.branch_id).is_some_and(|scope| {
+                        scope.checkpoint_commit_id == checkpoint_commit_id
+                            && scope.generation == identity.generation
+                    }) =>
+                {
+                    bytes.is_empty()
+                }
+                _ => false,
+            };
+            if !keep {
+                writes.delete(HOT_DIFF_SPACE, entry.key);
+            }
+        }
+        if !page.value.has_more || resume_after.is_none() {
+            break;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+
+    use super::*;
+    use crate::branch::{BranchHeadControl, stage_branch_head_control};
+    use crate::storage_adapter::{Memory, StorageAdapter, StorageReadOptions, StorageWriteOptions};
+
+    fn timestamp() -> LixTimestamp {
+        LixTimestamp::expect_parse("hot working-diff test timestamp", "2026-01-01T00:00:00Z")
+    }
+
+    fn diff_identity(branch_id: &str, generation: CommitId, entity: &str) -> HeadIdentity {
+        HeadIdentity {
+            branch_id: branch_id.to_string(),
+            generation,
+            schema_key: "schema".to_string(),
+            entity_pk: EntityPk::single(entity),
+            file_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn working_diff_gc_keeps_only_control_bound_hot_records() {
+        let storage = StorageAdapter::new(Memory::new());
+        let active_generation = CommitId::for_test_label("active-generation");
+        let active_checkpoint = CommitId::for_test_label("active-checkpoint");
+        let stale_generation = CommitId::for_test_label("stale-generation");
+        let stale_checkpoint = CommitId::for_test_label("stale-checkpoint");
+        let orphan_generation = CommitId::for_test_label("orphan-generation");
+        let orphan_checkpoint = CommitId::for_test_label("orphan-checkpoint");
+
+        let active_identity = diff_identity("active", active_generation, "active-row");
+        let stale_identity = diff_identity("stale", stale_generation, "stale-row");
+        let orphan_identity = diff_identity("deleted", orphan_generation, "orphan-row");
+        let active_key = encode_hot_diff_key(active_checkpoint, &active_identity);
+        let stale_key = encode_hot_diff_key(stale_checkpoint, &stale_identity);
+        let orphan_key = encode_hot_diff_key(orphan_checkpoint, &orphan_identity);
+
+        let mut writes = StorageWriteSet::new();
+        stage_tracked_working_diff_epoch(
+            &mut writes,
+            "active",
+            TrackedWorkingDiffEpoch {
+                checkpoint_commit_id: active_checkpoint,
+                generation: active_generation,
+                coverage: WorkingDiffIndexCoverage::default(),
+            },
+        )
+        .expect("stage active epoch");
+        stage_branch_head_control(
+            &mut writes,
+            "active",
+            BranchHeadControl {
+                head_commit_id: active_generation,
+                generation: active_generation,
+                current_state_revision: 0,
+                working_diff_checkpoint_commit_id: Some(active_checkpoint),
+                created_at: timestamp(),
+                updated_at: timestamp(),
+                ref_change_id: ChangeId::for_test_label("active-ref"),
+            },
+        )
+        .expect("stage active control");
+
+        stage_tracked_working_diff_epoch(
+            &mut writes,
+            "stale",
+            TrackedWorkingDiffEpoch {
+                checkpoint_commit_id: stale_checkpoint,
+                generation: stale_generation,
+                coverage: WorkingDiffIndexCoverage::default(),
+            },
+        )
+        .expect("stage stale epoch");
+        stage_branch_head_control(
+            &mut writes,
+            "stale",
+            BranchHeadControl {
+                head_commit_id: stale_generation,
+                generation: stale_generation,
+                current_state_revision: 0,
+                working_diff_checkpoint_commit_id: None,
+                created_at: timestamp(),
+                updated_at: timestamp(),
+                ref_change_id: ChangeId::for_test_label("stale-ref"),
+            },
+        )
+        .expect("stage stale control");
+
+        stage_tracked_working_diff_epoch(
+            &mut writes,
+            "deleted",
+            TrackedWorkingDiffEpoch {
+                checkpoint_commit_id: orphan_checkpoint,
+                generation: orphan_generation,
+                coverage: WorkingDiffIndexCoverage::default(),
+            },
+        )
+        .expect("stage orphan epoch");
+
+        for key in [&active_key, &stale_key, &orphan_key] {
+            writes.put(
+                HOT_DIFF_SPACE,
+                StorageKey(Bytes::copy_from_slice(key)),
+                StorageValue {
+                    bytes: Bytes::new(),
+                },
+            );
+        }
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit hot working-diff GC fixture");
+
+        let read = crate::storage_adapter::SharedStorageAdapterRead::new(
+            storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("open hot working-diff GC read"),
+        );
+        let mut gc_writes = StorageWriteSet::new();
+        stage_collect_stale_working_diff_indexes(&read, &mut gc_writes)
+            .await
+            .expect("stage hot working-diff GC");
+        drop(read);
+        storage
+            .commit_write_set(gc_writes, StorageWriteOptions::default())
+            .await
+            .expect("commit hot working-diff GC");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open hot working-diff GC verification read");
+        let active_epoch = PointReadPlan::new(
+            TRACKED_WORKING_DIFF_MARKER_SPACE,
+            &[StorageKey(Bytes::from(
+                working_diff_marker_key("active").expect("active working-diff marker key"),
+            ))],
+        )
+        .materialize(&read, StorageGetOptions::default())
+        .await
+        .expect("read active epoch")
+        .value
+        .into_iter()
+        .next()
+        .flatten();
+        assert!(active_epoch.is_some(), "active epoch must survive GC");
+
+        for (branch_id, key) in [("stale", stale_key), ("deleted", orphan_key)] {
+            let epoch = PointReadPlan::new(
+                TRACKED_WORKING_DIFF_MARKER_SPACE,
+                &[StorageKey(Bytes::from(
+                    working_diff_marker_key(branch_id).expect("working-diff marker key"),
+                ))],
+            )
+            .materialize(&read, StorageGetOptions::default())
+            .await
+            .expect("read stale epoch")
+            .value
+            .into_iter()
+            .next()
+            .flatten();
+            assert!(epoch.is_none(), "inactive epoch must be reclaimed");
+            let record = PointReadPlan::new(HOT_DIFF_SPACE, &[StorageKey(Bytes::from(key))])
+                .materialize(&read, StorageGetOptions::default())
+                .await
+                .expect("read stale hot record")
+                .value
+                .into_iter()
+                .next()
+                .flatten();
+            assert!(record.is_none(), "inactive hot record must be reclaimed");
+        }
+
+        let active_record =
+            PointReadPlan::new(HOT_DIFF_SPACE, &[StorageKey(Bytes::from(active_key))])
+                .materialize(&read, StorageGetOptions::default())
+                .await
+                .expect("read active hot record")
+                .value
+                .into_iter()
+                .next()
+                .flatten();
+        assert!(active_record.is_some(), "active hot record must survive GC");
+    }
+}

--- a/packages/engine/src/sql2/providers/working_change.rs
+++ b/packages/engine/src/sql2/providers/working_change.rs
@@ -149,7 +149,7 @@ where
                             Some(control) if control.head_commit_id == head.commit_id => {
                                 tracked_head
                                     .reader(store.clone())
-                                    .working_diff_if_control_current(
+                                    .working_diff_for_control(
                                         &head.branch_id,
                                         control,
                                         &route.diff_request,

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -218,9 +218,9 @@ fn native_storage_spaces() -> &'static [crate::storage_adapter::StorageSpace] {
     &[
         crate::init::REPOSITORY_PROTOCOL_SPACE,
         crate::branch::BRANCH_HEAD_CONTROL_SPACE,
-        crate::live_state::TRACKED_HEAD_GROUP_SPACE,
-        crate::live_state::TRACKED_HEAD_MEMBER_SPACE,
-        crate::live_state::TRACKED_WORKING_DIFF_GROUP_SPACE,
+        crate::live_state::HOT_ROW_SPACE,
+        crate::live_state::HOT_FILE_SPACE,
+        crate::live_state::HOT_DIFF_SPACE,
         crate::live_state::TRACKED_WORKING_DIFF_MARKER_SPACE,
         crate::json_store::store::JSON_SPACE,
         crate::json_store::UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE,

--- a/packages/engine/src/test_support.rs
+++ b/packages/engine/src/test_support.rs
@@ -169,7 +169,6 @@ pub(crate) async fn seed_branch_head_with_rows(
         BranchHeadControl {
             head_commit_id: commit_id,
             generation,
-            tracked_head_is_current: true,
             current_state_revision: 0,
             working_diff_checkpoint_commit_id: None,
             created_at: test_timestamp(),

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -952,8 +952,7 @@ mod tests {
     use crate::init::REPOSITORY_PROTOCOL_SPACE;
     use crate::json_store::{UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE, store::JSON_SPACE};
     use crate::live_state::{
-        TRACKED_HEAD_GROUP_SPACE, TRACKED_HEAD_MEMBER_SPACE, TRACKED_WORKING_DIFF_GROUP_SPACE,
-        TRACKED_WORKING_DIFF_MARKER_SPACE,
+        HOT_DIFF_SPACE, HOT_FILE_SPACE, HOT_ROW_SPACE, TRACKED_WORKING_DIFF_MARKER_SPACE,
     };
     use crate::storage_adapter::{Memory, StorageAdapter, StorageReadOptions, StorageWriteOptions};
     use crate::tracked_state::codec::{EncodedLeafEntry, encode_key_ref, encode_value_ref};
@@ -1378,9 +1377,9 @@ mod tests {
         let spaces = [
             REPOSITORY_PROTOCOL_SPACE,
             BRANCH_HEAD_CONTROL_SPACE,
-            TRACKED_HEAD_GROUP_SPACE,
-            TRACKED_HEAD_MEMBER_SPACE,
-            TRACKED_WORKING_DIFF_GROUP_SPACE,
+            HOT_ROW_SPACE,
+            HOT_FILE_SPACE,
+            HOT_DIFF_SPACE,
             TRACKED_WORKING_DIFF_MARKER_SPACE,
             JSON_SPACE,
             UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE,

--- a/packages/engine/src/transaction/bench_support.rs
+++ b/packages/engine/src/transaction/bench_support.rs
@@ -361,10 +361,6 @@ where
         .await
         .expect("global branch control should load")
         .expect("global branch control should exist");
-    assert!(
-        control.tracked_head_is_current,
-        "global current-state generation should be complete before deterministic mode seeding"
-    );
     let snapshot = crate::json_store::JsonSlot::from_json(&snapshot_content);
     let mut working_diff_coverage = WorkingDiffIndexCoverage::default();
     TrackedHeadContext::new()
@@ -562,7 +558,6 @@ async fn seed_visible_schema_rows<StorageImpl>(
             BranchHeadControl {
                 head_commit_id: commit_id,
                 generation: commit_id,
-                tracked_head_is_current: true,
                 current_state_revision: 0,
                 working_diff_checkpoint_commit_id: None,
                 created_at: timestamp,

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -15,7 +15,7 @@ use crate::changelog::{
     ChangeId, ChangeRecord, ChangeRecordProjection, ChangelogContext, ChangelogReader,
     ChangelogWriter, CommitChangeRefSet, CommitId, CommitLoadRequest as ChangelogCommitLoadRequest,
     CommitProjection as ChangelogCommitProjection, CommitRecord, TransactionChangeRecordRef,
-    TransactionChangelogAppend,
+    TransactionChangelogAppend, materialize_change_payloads,
 };
 use crate::common::LixTimestamp;
 use crate::entity_pk::EntityPk;
@@ -23,20 +23,20 @@ use crate::filesystem::stage_path_index_revision;
 use crate::functions::FunctionContext;
 use crate::json_store::{JsonStoreContext, JsonWritePlacementRef, NormalizedJsonRef};
 use crate::live_state::{
-    TrackedHeadContext, TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage,
-    stage_tracked_working_diff_epoch,
+    HotTrackedSnapshot, MaterializedLiveStateRow, TrackedHeadContext, TrackedWorkingDiffEpoch,
+    WorkingDiffIndexCoverage, stage_tracked_working_diff_epoch,
 };
 use crate::storage_adapter::{StorageAdapterRead, StoragePrecondition, StorageWriteSet};
 use crate::tracked_state::{
-    TrackedStateContext, TrackedStateDeltaRef, TrackedStateFilter, TrackedStateKey,
-    TrackedStateKeyRef, TrackedStateReadColumns, TrackedStateRootMutationRef,
+    MaterializedTrackedStateRow, TrackedStateContext, TrackedStateDeltaRef, TrackedStateFilter,
+    TrackedStateKey, TrackedStateKeyRef, TrackedStateReadColumns, TrackedStateRootMutationRef,
     TrackedStateScanRequest, encode_key_ref, stage_commit_deltas,
 };
 use crate::transaction::staging::{
     PreparedInsertIdentity, PreparedStateRowIdentity, PreparedWriteSet,
 };
 use crate::transaction::types::{PreparedStateRow, StagedCommitChangeRef, StagedCommitChangeRefs};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use tracing::Instrument as _;
 
 type RowIndex = usize;
@@ -204,6 +204,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     reject_explicit_branch_ref_lifecycle_with_untracked_rows(
         read,
         &state_rows,
+        &engine_rows,
         &branch_control_observations,
     )
     .await?;
@@ -223,7 +224,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         "lix.perf.materialization.tracked_roots"
     ))
     .await?;
-    let normal_branch_controls = stage_tracked_head(
+    let staged_hot_heads = stage_tracked_head(
         read,
         &mut writes,
         &state_rows,
@@ -240,11 +241,19 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         "lix.perf.materialization.tracked_head"
     ))
     .await?;
-    stage_checkpoint_working_diff_epochs(&mut writes, &prepared_writes.checkpoint_publications)?;
-    stage_branch_head_control_publications(
+    stage_checkpoint_working_diff_epochs(
         &mut writes,
-        &normal_branch_controls,
+        &prepared_writes.checkpoint_publications,
+        &staged_hot_heads.controls,
+    )?;
+    stage_branch_head_control_publications(
+        read,
+        &mut writes,
+        &staged_hot_heads.controls,
+        &staged_hot_heads.tracked_snapshots,
         &state_rows,
+        &engine_rows,
+        &insert_identities,
         &prepared_writes.checkpoint_publications,
         &mut preconditions,
         &branch_control_observations,
@@ -356,7 +365,7 @@ async fn stage_changelog_commits(
     let changes = state_rows
         .iter()
         // Ordinary untracked members are intentionally current-state only in
-        // V12. `lix_branch_ref` is the one control-plane exception: its
+        // V15. `lix_branch_ref` is the one control-plane exception: its
         // published control retains a public ref_change_id, so that immutable
         // ledger fact must remain available to `lix_change` and GC even
         // though it is not a commit member.
@@ -745,9 +754,371 @@ fn stage_tracked_commit_delta_index(
     Ok(())
 }
 
-/// Stages the generation-keyed head projection only for normal prepared
-/// rows. Merge selected references use rootless first-parent replay until
-/// their next ordinary child commit bootstraps a generation.
+struct StagedHotHeads {
+    controls: BTreeMap<String, BranchHeadControl>,
+    tracked_snapshots: BTreeMap<CommitId, HotTrackedSnapshot>,
+}
+
+/// Returns the commit snapshots that must be materialized before publication.
+/// Normal serial commits stay on the O(changed-rows) hot mutation path.  A
+/// discontinuity (merge/selected refs, checkpoint, staged parent, or branch
+/// creation) instead needs a complete tracked snapshot so the serving control
+/// never points at a partially reconstructed view.
+fn lifecycle_snapshot_commit_ids(
+    state_rows: &[PreparedStateRow],
+    tracked_roots: &[PendingTrackedRoot],
+    staged_commits: &BTreeMap<CommitId, StagedChangelogCommit>,
+    observations: &BTreeMap<String, BranchHeadControlObservation>,
+    checkpoint_epochs: &BTreeMap<String, CommitId>,
+) -> Result<BTreeSet<CommitId>, LixError> {
+    let roots_by_id = tracked_roots
+        .iter()
+        .map(|root| (root.commit_id, root))
+        .collect::<BTreeMap<_, _>>();
+    let mut required = BTreeSet::new();
+    for root in tracked_roots {
+        let staged = staged_commits.get(&root.commit_id).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "tracked head for commit '{}' has no staged changelog facts",
+                    root.commit_id
+                ),
+            )
+        })?;
+        let parent_is_published = matches!(
+            (
+                root.parent_commit_id,
+                observations.get(&root.branch_id).and_then(|observation| observation.control),
+            ),
+            (Some(parent_commit_id), Some(control))
+                if control.head_commit_id == parent_commit_id
+        );
+        if !parent_is_published
+            || !staged.selected_change_refs.is_empty()
+            || checkpoint_epochs.get(&root.branch_id) == Some(&root.commit_id)
+        {
+            required.insert(root.commit_id);
+        }
+    }
+    for target in explicit_branch_head_targets(state_rows)?.into_values() {
+        if let Some(commit_id) = target.head_commit_id
+            && roots_by_id.contains_key(&commit_id)
+        {
+            required.insert(commit_id);
+        }
+    }
+
+    // If a required snapshot has a parent created in this transaction, that
+    // parent must itself be materialized in memory first.  This is an
+    // explicit transaction-local snapshot dependency, not a storage overlay.
+    loop {
+        let parents = required
+            .iter()
+            .filter_map(|commit_id| {
+                roots_by_id
+                    .get(commit_id)
+                    .and_then(|root| root.parent_commit_id)
+            })
+            .filter(|parent| roots_by_id.contains_key(parent))
+            .collect::<Vec<_>>();
+        let mut changed = false;
+        for parent in parents {
+            changed |= required.insert(parent);
+        }
+        if !changed {
+            break;
+        }
+    }
+    Ok(required)
+}
+
+/// Resolves the full tracked view for only the rare lifecycle commits selected
+/// by [`lifecycle_snapshot_commit_ids`].  Persisted ancestors come from the
+/// canonical tracked-state history.  Pending ancestors are replayed from the
+/// transaction's already validated first-parent deltas, so a same-write-set
+/// branch/ref target does not require reading an uncommitted write set.
+async fn build_lifecycle_tracked_snapshots(
+    read: &(impl StorageAdapterRead + ?Sized),
+    state_rows: &[PreparedStateRow],
+    tracked_row_indices_by_commit: &BTreeMap<CommitId, Vec<RowIndex>>,
+    tracked_roots: &[PendingTrackedRoot],
+    staged_commits: &BTreeMap<CommitId, StagedChangelogCommit>,
+    insert_identities: &BTreeMap<PreparedStateRowIdentity, PreparedInsertIdentity>,
+    required: &BTreeSet<CommitId>,
+) -> Result<BTreeMap<CommitId, HotTrackedSnapshot>, LixError> {
+    if required.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+
+    let roots_by_id = tracked_roots
+        .iter()
+        .map(|root| (root.commit_id, root))
+        .collect::<BTreeMap<_, _>>();
+    let mut prepared_by_change = HashMap::new();
+    for row in state_rows.iter().filter(|row| !row.untracked) {
+        let change_id = row.change_id.ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked lifecycle snapshot row is missing change_id",
+            )
+        })?;
+        let live = MaterializedLiveStateRow::from(row);
+        let tracked = MaterializedTrackedStateRow::try_from(&live)?;
+        if prepared_by_change.insert(change_id, tracked).is_some() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("tracked lifecycle snapshot contains duplicate change '{change_id}'"),
+            ));
+        }
+    }
+    let selected_change_ids = tracked_roots
+        .iter()
+        .filter(|root| required.contains(&root.commit_id))
+        .flat_map(|root| {
+            staged_commits
+                .get(&root.commit_id)
+                .into_iter()
+                .flat_map(|staged| staged.selected_change_refs.iter())
+        })
+        .map(|change_ref| change_ref.change_id)
+        .filter(|change_id| !prepared_by_change.contains_key(change_id))
+        .collect::<BTreeSet<_>>();
+    let selected_payloads = materialize_change_payloads(
+        read,
+        selected_change_ids.iter().copied(),
+        ChangeRecordProjection::full(),
+        "lifecycle tracked snapshot",
+    )
+    .await?;
+
+    let mut snapshots =
+        BTreeMap::<CommitId, BTreeMap<TrackedStateKey, MaterializedTrackedStateRow>>::new();
+    for root in tracked_roots_parent_first(tracked_roots)? {
+        if !required.contains(&root.commit_id) {
+            continue;
+        }
+        let mut rows = match root.parent_commit_id {
+            None => BTreeMap::new(),
+            Some(parent_commit_id) if snapshots.contains_key(&parent_commit_id) => snapshots
+                .get(&parent_commit_id)
+                .expect("snapshot presence was checked")
+                .clone(),
+            Some(parent_commit_id) if roots_by_id.contains_key(&parent_commit_id) => {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "lifecycle snapshot for '{}' is missing staged parent '{}'",
+                        root.commit_id, parent_commit_id
+                    ),
+                ));
+            }
+            Some(parent_commit_id) => {
+                load_persisted_lifecycle_tracked_snapshot(read, parent_commit_id).await?
+            }
+        };
+        let row_indices = tracked_row_indices_by_commit
+            .get(&root.commit_id)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        for &row_index in row_indices {
+            let row = &state_rows[row_index];
+            let live = MaterializedLiveStateRow::from(row);
+            let tracked = MaterializedTrackedStateRow::try_from(&live)?;
+            apply_lifecycle_tracked_snapshot_row(
+                &mut rows,
+                tracked,
+                tracked_row_requires_absence(row, insert_identities),
+            )?;
+        }
+        let staged = staged_commits.get(&root.commit_id).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "lifecycle snapshot for commit '{}' has no staged changelog facts",
+                    root.commit_id
+                ),
+            )
+        })?;
+        for change_ref in &staged.selected_change_refs {
+            let source = prepared_by_change.get(&change_ref.change_id);
+            let payload = selected_payloads.get(&change_ref.change_id);
+            let tracked =
+                lifecycle_selected_tracked_row(change_ref, root.commit_id, source, payload)?;
+            apply_lifecycle_tracked_snapshot_row(&mut rows, tracked, false)?;
+        }
+        snapshots.insert(root.commit_id, rows);
+    }
+
+    required
+        .iter()
+        .map(|commit_id| {
+            let rows = snapshots.get(commit_id).ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("lifecycle snapshot for commit '{commit_id}' was not built"),
+                )
+            })?;
+            Ok((
+                *commit_id,
+                HotTrackedSnapshot::from_materialized_rows(rows.values().cloned().collect())?,
+            ))
+        })
+        .collect()
+}
+
+async fn load_persisted_lifecycle_tracked_snapshot(
+    read: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+) -> Result<BTreeMap<TrackedStateKey, MaterializedTrackedStateRow>, LixError> {
+    let rows = TrackedStateContext::new()
+        .reader(read)
+        .scan_rows_at_commit(
+            &commit_id.to_string(),
+            &TrackedStateScanRequest {
+                filter: TrackedStateFilter {
+                    include_tombstones: true,
+                    ..TrackedStateFilter::default()
+                },
+                read_columns: TrackedStateReadColumns::default(),
+                limit: None,
+            },
+        )
+        .await?;
+    Ok(rows
+        .into_iter()
+        .map(|row| {
+            let key = TrackedStateKey {
+                schema_key: row.schema_key.clone(),
+                entity_pk: row.entity_pk.clone(),
+                file_id: row.file_id.clone(),
+            };
+            (key, row)
+        })
+        .collect())
+}
+
+fn lifecycle_selected_tracked_row(
+    change_ref: &StagedCommitChangeRef,
+    commit_id: CommitId,
+    prepared: Option<&MaterializedTrackedStateRow>,
+    payload: Option<&crate::changelog::MaterializedChangePayload>,
+) -> Result<MaterializedTrackedStateRow, LixError> {
+    let (schema_key, entity_pk, file_id, snapshot_content, metadata) = if let Some(row) = prepared {
+        (
+            row.schema_key.clone(),
+            row.entity_pk.clone(),
+            row.file_id.clone(),
+            row.snapshot_content.clone(),
+            row.metadata.clone(),
+        )
+    } else {
+        let payload = payload.ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "selected lifecycle change '{}' is missing from the changelog",
+                    change_ref.change_id
+                ),
+            )
+        })?;
+        let identity = payload.identity.as_ref().ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "selected lifecycle change '{}' omitted its identity",
+                    change_ref.change_id
+                ),
+            )
+        })?;
+        (
+            identity.schema_key.clone(),
+            identity.entity_pk.clone(),
+            identity.file_id.clone(),
+            payload.snapshot_content.clone(),
+            payload.metadata.clone(),
+        )
+    };
+    if schema_key != change_ref.schema_key
+        || entity_pk != change_ref.entity_pk
+        || file_id != change_ref.file_id
+        || snapshot_content.is_none() != change_ref.deleted
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "selected lifecycle change '{}' does not match its staged identity or deletion flag",
+                change_ref.change_id
+            ),
+        ));
+    }
+    Ok(MaterializedTrackedStateRow {
+        entity_pk,
+        schema_key,
+        file_id,
+        snapshot_content,
+        metadata,
+        deleted: change_ref.deleted,
+        created_at: change_ref.created_at.to_string(),
+        updated_at: change_ref.updated_at.to_string(),
+        change_id: change_ref.change_id,
+        commit_id,
+    })
+}
+
+fn apply_lifecycle_tracked_snapshot_row(
+    rows: &mut BTreeMap<TrackedStateKey, MaterializedTrackedStateRow>,
+    mut next: MaterializedTrackedStateRow,
+    require_absence: bool,
+) -> Result<(), LixError> {
+    let key = TrackedStateKey {
+        schema_key: next.schema_key.clone(),
+        entity_pk: next.entity_pk.clone(),
+        file_id: next.file_id.clone(),
+    };
+    if let Some(previous) = rows.get(&key) {
+        if require_absence && !previous.deleted {
+            return Err(lifecycle_duplicate_tracked_row_error(&key));
+        }
+        next.created_at.clone_from(&previous.created_at);
+    }
+    rows.insert(key, next);
+    Ok(())
+}
+
+fn lifecycle_duplicate_tracked_row_error(key: &TrackedStateKey) -> LixError {
+    let entity_pk = key
+        .entity_pk
+        .as_json_array_text()
+        .unwrap_or_else(|_| "<invalid entity_pk>".to_string());
+    LixError::new(
+        LixError::CODE_UNIQUE,
+        format!(
+            "primary-key constraint violation on schema '{}': INSERT would duplicate entity_pk '{entity_pk}'",
+            key.schema_key
+        ),
+    )
+}
+
+fn lifecycle_generation(
+    branch_id: &str,
+    head_commit_id: CommitId,
+    ref_change_id: ChangeId,
+) -> CommitId {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"lix.live_state.lifecycle_generation.v1");
+    hasher.update(&(branch_id.len() as u64).to_be_bytes());
+    hasher.update(branch_id.as_bytes());
+    hasher.update(head_commit_id.as_uuid().as_bytes());
+    hasher.update(ref_change_id.as_uuid().as_bytes());
+    let mut bytes = [0_u8; 16];
+    bytes.copy_from_slice(&hasher.finalize().as_bytes()[..16]);
+    CommitId::new(uuid::Uuid::from_bytes(bytes))
+}
+
+/// Stages the hot serving plane.  Serial normal commits mutate their current
+/// generation; every lifecycle discontinuity publishes a complete fresh
+/// generation before its branch control is made visible.
 async fn stage_tracked_head(
     read: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
@@ -759,9 +1130,30 @@ async fn stage_tracked_head(
     insert_identities: &BTreeMap<PreparedStateRowIdentity, PreparedInsertIdentity>,
     observations: &BTreeMap<String, BranchHeadControlObservation>,
     checkpoint_epochs: &BTreeMap<String, CommitId>,
-) -> Result<BTreeMap<String, BranchHeadControl>, LixError> {
+) -> Result<StagedHotHeads, LixError> {
+    let lifecycle_ids = lifecycle_snapshot_commit_ids(
+        state_rows,
+        tracked_roots,
+        staged_commits,
+        observations,
+        checkpoint_epochs,
+    )?;
+    let mut tracked_snapshots = build_lifecycle_tracked_snapshots(
+        read,
+        state_rows,
+        tracked_row_indices_by_commit,
+        tracked_roots,
+        staged_commits,
+        insert_identities,
+        &lifecycle_ids,
+    )
+    .await?;
+    let explicit_branches = explicit_branch_head_targets(state_rows)?
+        .into_keys()
+        .collect::<BTreeSet<_>>();
     let tracked_head = TrackedHeadContext::new();
     let mut controls = BTreeMap::new();
+
     for root in tracked_roots_parent_first(tracked_roots)? {
         let staged = staged_commits.get(&root.commit_id).ok_or_else(|| {
             LixError::new(
@@ -782,110 +1174,26 @@ async fn stage_tracked_head(
                         root.branch_id
                     ),
                 )
-        })?
-        .control;
-        if !staged.selected_change_refs.is_empty() {
-            reject_selected_tracked_refs_with_untracked_rows(
-                read,
-                &root.branch_id,
-                parent_control,
-                &staged.selected_change_refs,
-                state_rows,
-                engine_rows,
-            )
-            .await?;
-            // A selected-reference publication deliberately leaves the
-            // tracked portion on historical replay, but it must not sever
-            // the mutable workspace members from their previous physical
-            // generation. Apply any same-transaction untracked mutation to
-            // that generation and keep its id in the noncurrent control; the
-            // lifecycle fallback reader combines it with the selected tracked
-            // snapshot until the next ordinary child bootstraps a full group.
-            let deltas = state_rows
-                .iter()
-                .filter(|row| {
-                    row.untracked
-                        && row.branch_id == root.branch_id
-                        && row.schema_key != BRANCH_REF_SCHEMA_KEY
-                })
-                .map(current_state_delta_from_state_row)
-                .chain(
-                    engine_rows
-                        .iter()
-                        .filter(|row| row.branch_id == root.branch_id)
-                        .map(|row| Ok(current_state_delta_from_engine_row(row))),
-                )
-                .collect::<Result<Vec<_>, LixError>>()?;
-            let absence_guards = state_rows
-                .iter()
-                .filter(|row| {
-                    row.untracked
-                        && row.branch_id == root.branch_id
-                        && row.schema_key != BRANCH_REF_SCHEMA_KEY
-                        && row.snapshot.is_some()
-                        && insert_identities.contains_key(&PreparedStateRowIdentity::from(*row))
-                })
-                .map(|row| TrackedStateKey {
-                    schema_key: row.schema_key.clone(),
-                    file_id: row.file_id.clone(),
-                    entity_pk: row.entity_pk.clone(),
-                })
-                .collect::<BTreeSet<_>>();
-            let fallback_generation =
-                parent_control.map_or(root.commit_id, |control| control.generation);
-            if !deltas.is_empty() {
-                let control = parent_control.ok_or_else(|| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        format!(
-                            "cannot stage untracked state while selected-reference publishing new branch '{}'",
-                            root.branch_id
-                        ),
-                    )
-                })?;
-                let mut working_diff_coverage = WorkingDiffIndexCoverage::default();
-                tracked_head
-                    .writer(read, writes)
-                    .stage_current_state_with_working_diff(
-                        &root.branch_id,
-                        Some(control.generation),
-                        control.head_commit_id,
-                        &deltas,
-                        &absence_guards,
-                        None,
-                        None,
-                        None,
-                        &mut working_diff_coverage,
-                    )
-                    .await?;
-            }
-            insert_direct_branch_control(
-                &mut controls,
-                &root.branch_id,
-                normal_branch_head_control(root, parent_control, fallback_generation, false, None)?,
-            )?;
-            continue;
-        }
+            })?
+            .control;
         let state_row_indices = tracked_row_indices_by_commit
             .get(&root.commit_id)
             .map(Vec::as_slice)
             .unwrap_or_default();
-        let mut deltas = state_row_indices
+        let tracked_deltas = state_row_indices
             .iter()
             .map(|&row_index| current_state_delta_from_state_row(&state_rows[row_index]))
             .collect::<Result<Vec<_>, _>>()?;
-        deltas.extend(
-            state_rows
-                .iter()
-                .filter(|row| {
-                    row.untracked
-                        && row.branch_id == root.branch_id
-                        && row.schema_key != BRANCH_REF_SCHEMA_KEY
-                })
-                .map(current_state_delta_from_state_row)
-                .collect::<Result<Vec<_>, _>>()?,
-        );
-        deltas.extend(
+        let mut untracked_deltas = state_rows
+            .iter()
+            .filter(|row| {
+                row.untracked
+                    && row.branch_id == root.branch_id
+                    && row.schema_key != BRANCH_REF_SCHEMA_KEY
+            })
+            .map(current_state_delta_from_state_row)
+            .collect::<Result<Vec<_>, _>>()?;
+        untracked_deltas.extend(
             engine_rows
                 .iter()
                 .filter(|row| row.branch_id == root.branch_id)
@@ -905,28 +1213,64 @@ async fn stage_tracked_head(
                 entity_pk: row.entity_pk.clone(),
             })
             .collect::<BTreeSet<_>>();
-
-        // The branch control is the durable authority for current state.
-        // A serial normal child can reuse its physical generation only when
-        // that control says the parent's tracked-head projection is complete.
         let parent_generation = match (root.parent_commit_id, parent_control) {
             (Some(parent_commit_id), Some(control))
-                if control.head_commit_id == parent_commit_id
-                    && control.tracked_head_is_current =>
+                if control.head_commit_id == parent_commit_id =>
             {
                 Some(control.generation)
             }
             _ => None,
         };
-        // The working-diff epoch is valid only when it names the exact
-        // parent generation being materialized. A just-published checkpoint
-        // has no active diff generation yet; its first ordinary child either
-        // reuses an already materialized serving generation or bootstraps one.
-        let checkpoint_epoch_commit_id = checkpoint_epochs.get(&root.branch_id).copied();
-        // A checkpoint starts a known-empty interval. It owns the marker
-        // publication below, so it must not inherit and then advance the
-        // prior interval's marker while staging its head groups.
-        let working_diff_epoch = if checkpoint_epoch_commit_id.is_some() {
+        let checkpoint_commit_id = checkpoint_epochs.get(&root.branch_id).copied();
+
+        if let Some(final_tracked) = tracked_snapshots.get(&root.commit_id).cloned() {
+            if !staged.selected_change_refs.is_empty() {
+                reject_selected_tracked_refs_with_untracked_rows(
+                    read,
+                    &root.branch_id,
+                    parent_control,
+                    &staged.selected_change_refs,
+                    state_rows,
+                    engine_rows,
+                )
+                .await?;
+            }
+            let generation =
+                lifecycle_generation(&root.branch_id, root.commit_id, root.ref_change_id);
+            let mut coverage = WorkingDiffIndexCoverage::default();
+            let final_tracked = tracked_head
+                .writer(read, writes)
+                .stage_complete_current_state_with_working_diff(
+                    &root.branch_id,
+                    generation,
+                    final_tracked,
+                    parent_control.map(|control| control.generation),
+                    &[],
+                    &untracked_deltas,
+                    &absence_guards,
+                    checkpoint_commit_id,
+                    &mut coverage,
+                )
+                .await?;
+            tracked_snapshots.insert(root.commit_id, final_tracked);
+            insert_direct_branch_control(
+                &mut controls,
+                &root.branch_id,
+                normal_branch_head_control(root, parent_control, generation, checkpoint_commit_id)?,
+            )?;
+            continue;
+        }
+
+        let parent_generation = parent_generation.ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "normal hot publication for '{}' lacks a complete parent generation",
+                    root.commit_id
+                ),
+            )
+        })?;
+        let working_diff_epoch = if checkpoint_commit_id.is_some() {
             None
         } else {
             match (root.parent_commit_id, parent_control) {
@@ -940,16 +1284,8 @@ async fn stage_tracked_head(
                     {
                         Ok(Some(epoch))
                             if epoch.generation == parent_generation
-                                && parent_generation == Some(control.generation)
-                                && control.tracked_head_is_current =>
-                        {
-                            (control.working_diff_checkpoint_commit_id
-                                == Some(epoch.checkpoint_commit_id))
-                            .then_some(epoch)
-                        }
-                        Ok(Some(epoch))
-                            if epoch.generation.is_none()
-                                && epoch.checkpoint_commit_id == parent_commit_id =>
+                                && control.working_diff_checkpoint_commit_id
+                                    == Some(epoch.checkpoint_commit_id) =>
                         {
                             Some(epoch)
                         }
@@ -963,100 +1299,32 @@ async fn stage_tracked_head(
             .as_ref()
             .map(|epoch| epoch.checkpoint_commit_id);
         let working_diff_checkpoint_commit_id =
-            checkpoint_epoch_commit_id.or(working_diff_capture_checkpoint_commit_id);
-        let mut working_diff_coverage = working_diff_epoch
+            checkpoint_commit_id.or(working_diff_capture_checkpoint_commit_id);
+        let mut coverage = working_diff_epoch
             .as_ref()
-            .filter(|epoch| epoch.generation.is_some() && epoch.generation == parent_generation)
             .map(|epoch| epoch.coverage)
             .unwrap_or_default();
-        let parent_is_current = parent_generation.is_some();
-        let parent_rows = if parent_is_current || root.parent_commit_id.is_none() {
-            None
-        } else if let Some(parent_commit_id) = root.parent_commit_id {
-            // A parent staged earlier in this same write set is not visible
-            // through `read`; publish no partial generation. Once committed,
-            // current reads safely take the changelog-replay fallback until a
-            // following ordinary child bootstraps a complete current-state
-            // generation.
-            if tracked_roots
-                .iter()
-                .any(|candidate| candidate.commit_id == parent_commit_id)
-            {
-                insert_direct_branch_control(
-                    &mut controls,
-                    &root.branch_id,
-                    normal_branch_head_control(root, parent_control, root.commit_id, false, None)?,
-                )?;
-                continue;
-            }
-            Some(
-                TrackedStateContext::new()
-                    .reader(read)
-                    .scan_rows_at_commit(
-                        &parent_commit_id.to_string(),
-                        &TrackedStateScanRequest {
-                            filter: TrackedStateFilter {
-                                include_tombstones: true,
-                                ..TrackedStateFilter::default()
-                            },
-                            read_columns: TrackedStateReadColumns::default(),
-                            limit: None,
-                        },
-                    )
-                    .await?,
+        let mut deltas = tracked_deltas;
+        deltas.extend(untracked_deltas);
+        let generation = tracked_head
+            .writer(read, writes)
+            .stage_current_state_with_working_diff(
+                &root.branch_id,
+                Some(parent_generation),
+                root.commit_id,
+                &deltas,
+                &absence_guards,
+                None,
+                None,
+                working_diff_capture_checkpoint_commit_id,
+                &mut coverage,
             )
-        } else {
-            None
-        };
-        // A fresh tracked generation replaces only the versioned portion of
-        // the branch. Copy the prior generation's history-free members into
-        // the new group so checkpoint/bootstrap reconstruction cannot erase
-        // untracked state merely because its tracked head needed rebuilding.
-        let preserved_untracked_rows = if parent_generation.is_none() {
-            match parent_control {
-                Some(control) => Some(
-                    tracked_head
-                        .reader(read)
-                        .scan_untracked_rows_for_generation(
-                            &root.branch_id,
-                            control.generation,
-                            &TrackedStateScanRequest {
-                                filter: TrackedStateFilter {
-                                    include_tombstones: true,
-                                    ..TrackedStateFilter::default()
-                                },
-                                read_columns: TrackedStateReadColumns::default(),
-                                limit: None,
-                            },
-                        )
-                        .await?,
-                ),
-                None => None,
-            }
-        } else {
-            None
-        };
-        let generation = {
-            let mut writer = tracked_head.writer(read, writes);
-            writer
-                .stage_current_state_with_working_diff(
-                    &root.branch_id,
-                    parent_generation,
-                    root.commit_id,
-                    &deltas,
-                    &absence_guards,
-                    parent_rows,
-                    preserved_untracked_rows,
-                    working_diff_capture_checkpoint_commit_id,
-                    &mut working_diff_coverage,
-                )
-                .await?
-        };
+            .await?;
         if let Some(epoch) = working_diff_epoch {
             let next_epoch = TrackedWorkingDiffEpoch {
                 checkpoint_commit_id: epoch.checkpoint_commit_id,
-                generation: Some(generation),
-                coverage: working_diff_coverage,
+                generation,
+                coverage,
             };
             if next_epoch != epoch {
                 stage_tracked_working_diff_epoch(writes, &root.branch_id, next_epoch)?;
@@ -1069,19 +1337,14 @@ async fn stage_tracked_head(
                 root,
                 parent_control,
                 generation,
-                true,
                 working_diff_checkpoint_commit_id,
             )?,
         )?;
     }
 
-    // A history-free transaction has no `PendingTrackedRoot`, but it still
-    // mutates the same authoritative packed current state. Its generation
-    // remains writable even while the tracked portion is temporarily served
-    // by historical replay after a branch move: that fallback reads these
-    // untracked members from the retained generation. Publishing the bumped
-    // private revision makes the control CAS a real fence for this in-place
-    // mutation without moving the branch head.
+    // An untracked-only transaction touches the same hot rows without
+    // creating a commit.  Explicit branch ref publication handles its own
+    // branch-local untracked mutations in the fresh generation below.
     let rooted_branches = tracked_roots
         .iter()
         .map(|root| root.branch_id.as_str())
@@ -1091,7 +1354,9 @@ async fn stage_tracked_head(
         .filter(|row| row.untracked && row.schema_key != BRANCH_REF_SCHEMA_KEY)
         .map(|row| row.branch_id.as_str())
         .chain(engine_rows.iter().map(|row| row.branch_id.as_str()))
-        .filter(|branch_id| !rooted_branches.contains(branch_id))
+        .filter(|branch_id| {
+            !rooted_branches.contains(branch_id) && !explicit_branches.contains(*branch_id)
+        })
         .collect::<BTreeSet<_>>();
     for branch_id in current_only_branches {
         let control = observations
@@ -1135,7 +1400,7 @@ async fn stage_tracked_head(
                 entity_pk: row.entity_pk.clone(),
             })
             .collect::<BTreeSet<_>>();
-        let mut working_diff_coverage = WorkingDiffIndexCoverage::default();
+        let mut coverage = WorkingDiffIndexCoverage::default();
         tracked_head
             .writer(read, writes)
             .stage_current_state_with_working_diff(
@@ -1147,7 +1412,7 @@ async fn stage_tracked_head(
                 None,
                 None,
                 None,
-                &mut working_diff_coverage,
+                &mut coverage,
             )
             .await?;
         insert_direct_branch_control(
@@ -1156,14 +1421,15 @@ async fn stage_tracked_head(
             control.next_current_state_revision()?,
         )?;
     }
-    Ok(controls)
+    Ok(StagedHotHeads {
+        controls,
+        tracked_snapshots,
+    })
 }
 
-/// A selected historical change becomes visible through the new tracked head
-/// while a selected-reference publication retains the old generation's
-/// untracked members. The two retention modes must never own the same logical
-/// identity: the fallback reader deliberately gives an untracked member
-/// precedence, which would otherwise hide the newly selected tracked change.
+/// A selected historical change becomes visible through a newly materialized
+/// hot generation while that publication retains the branch's untracked
+/// members. The two retention modes must never own the same logical identity.
 ///
 /// This is a merge/checkpoint lifecycle fence, not a normal CRUD-path check.
 /// Point-loading only the selected identities keeps large untracked workspaces
@@ -1192,9 +1458,9 @@ async fn reject_selected_tracked_refs_with_untracked_rows(
     let mut untracked_identities = if let Some(control) = control {
         TrackedHeadContext::new()
             .reader(read)
-            .load_untracked_projected_rows_for_generation(
+            .load_projected_live_rows(
                 branch_id,
-                control.generation,
+                control,
                 &selected_keys,
                 &ChangeRecordProjection {
                     snapshot_content: false,
@@ -1204,6 +1470,7 @@ async fn reject_selected_tracked_refs_with_untracked_rows(
             .await?
             .into_iter()
             .flatten()
+            .filter(|row| row.untracked)
             .map(|row| TrackedStateKey {
                 schema_key: row.schema_key,
                 file_id: row.file_id,
@@ -1214,36 +1481,12 @@ async fn reject_selected_tracked_refs_with_untracked_rows(
         BTreeSet::new()
     };
 
-    // Include mutations in this publication, so an untracked INSERT cannot
-    // collide with a selected tracked change in the same transaction. A
-    // physical untracked delete, on the other hand, removes the identity and
-    // makes the selected tracked change safe to publish.
-    for row in state_rows.iter().filter(|row| {
-        row.untracked && row.branch_id == branch_id && row.schema_key != BRANCH_REF_SCHEMA_KEY
-    }) {
-        let identity = TrackedStateKey {
-            schema_key: row.schema_key.clone(),
-            file_id: row.file_id.clone(),
-            entity_pk: row.entity_pk.clone(),
-        };
-        if row.snapshot.is_some() {
-            untracked_identities.insert(identity);
-        } else {
-            untracked_identities.remove(&identity);
-        }
-    }
-    for row in engine_rows.iter().filter(|row| row.branch_id == branch_id) {
-        let identity = TrackedStateKey {
-            schema_key: row.change.schema_key.clone(),
-            file_id: row.change.file_id.clone(),
-            entity_pk: row.change.entity_pk.clone(),
-        };
-        if row.change.snapshot == crate::json_store::JsonSlot::None {
-            untracked_identities.remove(&identity);
-        } else {
-            untracked_identities.insert(identity);
-        }
-    }
+    apply_pending_untracked_identities(
+        &mut untracked_identities,
+        branch_id,
+        state_rows,
+        engine_rows,
+    );
 
     let Some(identity) = selected_identities
         .iter()
@@ -1254,6 +1497,45 @@ async fn reject_selected_tracked_refs_with_untracked_rows(
     Err(selected_tracked_ref_untracked_collision_error(
         branch_id, identity,
     ))
+}
+
+/// Applies the transaction's history-free mutations to an identity set.
+///
+/// Lifecycle decisions use the final current state, not merely whether an
+/// untracked row was mentioned by the transaction. A physical untracked
+/// delete therefore removes its identity before either decision is made.
+fn apply_pending_untracked_identities(
+    identities: &mut BTreeSet<TrackedStateKey>,
+    branch_id: &str,
+    state_rows: &[PreparedStateRow],
+    engine_rows: &[EngineCurrentRow],
+) {
+    for row in state_rows.iter().filter(|row| {
+        row.untracked && row.branch_id == branch_id && row.schema_key != BRANCH_REF_SCHEMA_KEY
+    }) {
+        let identity = TrackedStateKey {
+            schema_key: row.schema_key.clone(),
+            file_id: row.file_id.clone(),
+            entity_pk: row.entity_pk.clone(),
+        };
+        if row.snapshot.is_some() {
+            identities.insert(identity);
+        } else {
+            identities.remove(&identity);
+        }
+    }
+    for row in engine_rows.iter().filter(|row| row.branch_id == branch_id) {
+        let identity = TrackedStateKey {
+            schema_key: row.change.schema_key.clone(),
+            file_id: row.change.file_id.clone(),
+            entity_pk: row.change.entity_pk.clone(),
+        };
+        if row.change.snapshot == crate::json_store::JsonSlot::None {
+            identities.remove(&identity);
+        } else {
+            identities.insert(identity);
+        }
+    }
 }
 
 fn selected_tracked_ref_untracked_collision_error(
@@ -1277,13 +1559,14 @@ fn selected_tracked_ref_untracked_collision_error(
     }))
 }
 
-/// A selected-ref checkpoint has after images but no trustworthy first-before
-/// values. Reset its working-diff epoch to the known-empty state instead; the
-/// first ordinary child bootstraps a fresh current-state generation and
-/// captures its own preimages.
+/// A checkpoint materializes one complete hot generation. Every tracked row
+/// in that generation is encoded as a clean row-local baseline, so its sparse
+/// dirty-key index starts empty and later ordinary writes capture their own
+/// first-before images without querying a separate diff store.
 fn stage_checkpoint_working_diff_epochs(
     writes: &mut StorageWriteSet,
     publications: &[crate::gc::CheckpointPublication],
+    controls: &BTreeMap<String, BranchHeadControl>,
 ) -> Result<(), LixError> {
     let mut branches = BTreeSet::new();
     for publication in publications {
@@ -1297,12 +1580,30 @@ fn stage_checkpoint_working_diff_epochs(
                 ),
             ));
         }
+        let control = controls.get(&recovery.branch_id).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "checkpoint '{}' has no complete hot control for '{}'",
+                    recovery.checkpoint_commit_id, recovery.branch_id
+                ),
+            )
+        })?;
+        if control.head_commit_id != recovery.checkpoint_commit_id {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "checkpoint '{}' does not match staged hot control '{}' for '{}'",
+                    recovery.checkpoint_commit_id, control.head_commit_id, recovery.branch_id
+                ),
+            ));
+        }
         stage_tracked_working_diff_epoch(
             writes,
             &recovery.branch_id,
             TrackedWorkingDiffEpoch {
                 checkpoint_commit_id: recovery.checkpoint_commit_id,
-                generation: None,
+                generation: control.generation,
                 coverage: WorkingDiffIndexCoverage::default(),
             },
         )?;
@@ -1314,7 +1615,6 @@ fn normal_branch_head_control(
     root: &PendingTrackedRoot,
     previous: Option<BranchHeadControl>,
     generation: CommitId,
-    tracked_head_is_current: bool,
     working_diff_checkpoint_commit_id: Option<CommitId>,
 ) -> Result<BranchHeadControl, LixError> {
     let current_state_revision = match previous {
@@ -1332,11 +1632,8 @@ fn normal_branch_head_control(
     Ok(BranchHeadControl {
         head_commit_id: root.commit_id,
         generation,
-        tracked_head_is_current,
         current_state_revision,
-        working_diff_checkpoint_commit_id: tracked_head_is_current
-            .then_some(working_diff_checkpoint_commit_id)
-            .flatten(),
+        working_diff_checkpoint_commit_id,
         created_at: previous.map_or(root.ref_updated_at, |control| control.created_at),
         updated_at: root.ref_updated_at,
         ref_change_id: root.ref_change_id,
@@ -1362,16 +1659,21 @@ fn insert_direct_branch_control(
 /// Publishes every current-state branch control under an exact-byte CAS token.
 ///
 /// Normal tracked commits arrive as `normal_controls`, built from the same
-/// parent/generation decision that wrote the current-state group marker. Explicit branch
+/// parent/generation decision that wrote the current-state hot rows. Explicit branch
 /// management still enters the prepared-row pipeline for validation and
 /// changelog compatibility, but its authoritative moving head is lowered
 /// here as well. This deliberately keeps the rare lifecycle lane compatible
 /// while removing automatic `lix_branch_ref` materialization from normal
 /// CRUD commits.
+#[allow(clippy::too_many_arguments)]
 async fn stage_branch_head_control_publications(
+    read: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
     normal_controls: &BTreeMap<String, BranchHeadControl>,
+    tracked_snapshots: &BTreeMap<CommitId, HotTrackedSnapshot>,
     state_rows: &[PreparedStateRow],
+    engine_rows: &[EngineCurrentRow],
+    insert_identities: &BTreeMap<PreparedStateRowIdentity, PreparedInsertIdentity>,
     checkpoint_publications: &[crate::gc::CheckpointPublication],
     preconditions: &mut Vec<StoragePrecondition>,
     observations: &BTreeMap<String, BranchHeadControlObservation>,
@@ -1382,6 +1684,7 @@ async fn stage_branch_head_control_publications(
         .iter()
         .map(|(branch_id, control)| (branch_id.clone(), Some(*control)))
         .collect::<BTreeMap<String, Option<BranchHeadControl>>>();
+    let tracked_head = TrackedHeadContext::new();
 
     for (branch_id, target) in explicit_targets {
         if publications.contains_key(&branch_id) {
@@ -1403,34 +1706,87 @@ async fn stage_branch_head_control_publications(
                 )
             })?
             .control;
-        let desired = target
-            .head_commit_id
-            .map(|head_commit_id| BranchHeadControl {
-                head_commit_id,
-                // A ref move invalidates only the tracked projection. Retain
-                // the old physical generation while it is noncurrent so the
-                // lifecycle fallback can still read its history-free
-                // workspace members; the next ordinary child bootstraps a
-                // fresh complete generation and carries them forward.
-                generation: existing.map_or(head_commit_id, |control| control.generation),
-                tracked_head_is_current: existing
-                    .filter(|control| control.head_commit_id == head_commit_id)
-                    .is_some_and(|control| control.tracked_head_is_current),
-                // A ref-only publication has no current-group mutation. Keep
-                // the current-state CAS revision unchanged; the ref metadata
-                // itself changes the control bytes and therefore still fences
-                // concurrent publication.
-                current_state_revision: existing
-                    .map_or(0, |control| control.current_state_revision),
-                working_diff_checkpoint_commit_id: existing
-                    .filter(|control| control.head_commit_id == head_commit_id)
-                    .and_then(|control| control.working_diff_checkpoint_commit_id),
-                // The direct branch-ref projection preserves creation time on
-                // replacement. The control record owns that same public fact.
-                created_at: existing.map_or(target.created_at, |control| control.created_at),
-                updated_at: target.updated_at,
-                ref_change_id: target.ref_change_id,
-            });
+        let desired = match target.head_commit_id {
+            None => None,
+            Some(head_commit_id) => {
+                let tracked = if let Some(snapshot) = tracked_snapshots.get(&head_commit_id) {
+                    snapshot.clone()
+                } else {
+                    let rows =
+                        load_persisted_lifecycle_tracked_snapshot(read, head_commit_id).await?;
+                    HotTrackedSnapshot::from_materialized_rows(rows.into_values().collect())?
+                };
+                let mut untracked_deltas = state_rows
+                    .iter()
+                    .filter(|row| {
+                        row.untracked
+                            && row.branch_id == branch_id
+                            && row.schema_key != BRANCH_REF_SCHEMA_KEY
+                    })
+                    .map(current_state_delta_from_state_row)
+                    .collect::<Result<Vec<_>, _>>()?;
+                untracked_deltas.extend(
+                    engine_rows
+                        .iter()
+                        .filter(|row| row.branch_id == branch_id)
+                        .map(current_state_delta_from_engine_row),
+                );
+                let absence_guards = state_rows
+                    .iter()
+                    .filter(|row| {
+                        row.untracked
+                            && row.branch_id == branch_id
+                            && row.schema_key != BRANCH_REF_SCHEMA_KEY
+                            && row.snapshot.is_some()
+                            && insert_identities.contains_key(&PreparedStateRowIdentity::from(*row))
+                    })
+                    .map(|row| TrackedStateKey {
+                        schema_key: row.schema_key.clone(),
+                        file_id: row.file_id.clone(),
+                        entity_pk: row.entity_pk.clone(),
+                    })
+                    .collect::<BTreeSet<_>>();
+                let generation =
+                    lifecycle_generation(&branch_id, head_commit_id, target.ref_change_id);
+                let mut coverage = WorkingDiffIndexCoverage::default();
+                tracked_head
+                    .writer(read, writes)
+                    .stage_complete_current_state_with_working_diff(
+                        &branch_id,
+                        generation,
+                        tracked,
+                        existing.map(|control| control.generation),
+                        &[],
+                        &untracked_deltas,
+                        &absence_guards,
+                        None,
+                        &mut coverage,
+                    )
+                    .await?;
+                Some(BranchHeadControl {
+                    head_commit_id,
+                    generation,
+                    current_state_revision: match existing {
+                        Some(control) => {
+                            control
+                                .current_state_revision
+                                .checked_add(1)
+                                .ok_or_else(|| {
+                                    LixError::new(
+                                        LixError::CODE_INTERNAL_ERROR,
+                                        "branch current-state revision overflowed",
+                                    )
+                                })?
+                        }
+                        None => 0,
+                    },
+                    working_diff_checkpoint_commit_id: None,
+                    created_at: existing.map_or(target.created_at, |control| control.created_at),
+                    updated_at: target.updated_at,
+                    ref_change_id: target.ref_change_id,
+                })
+            }
+        };
         publications.insert(branch_id, desired);
     }
 
@@ -1462,12 +1818,7 @@ async fn stage_branch_head_control_publications(
                     ),
                 ));
             }
-            // A no-op checkpoint keeps its materialized serving generation,
-            // but resets the sparse diff epoch to a known-empty state. Bind
-            // that reset in the same authoritative control publication.
-            control.working_diff_checkpoint_commit_id = control
-                .tracked_head_is_current
-                .then_some(*checkpoint_commit_id);
+            control.working_diff_checkpoint_commit_id = Some(*checkpoint_commit_id);
         }
         let observation = observations.get(branch_id).ok_or_else(|| {
             LixError::new(
@@ -1576,41 +1927,39 @@ fn explicit_branch_head_targets(
     Ok(targets)
 }
 
-/// Rejects a branch-ref delete or move when branch-local untracked state is
-/// present. Retaining that state while replaying a different tracked head
-/// would permit an untracked identity to hide a newly visible tracked one;
-/// deleting the control would instead orphan the untracked generation.
+/// A destructive branch-ref change cannot preserve branch-local untracked
+/// rows. Deletion would orphan their only serving scope and repointing would
+/// attach them to unrelated tracked history. Assigning the already-published
+/// head is not destructive, so it keeps local untracked state intact.
 ///
 /// The observed branch-control token is published as an exact-byte CAS below,
 /// so a concurrent untracked mutation makes this safety decision retry rather
-/// than racing a ref move.
+/// than racing a deletion.
 async fn reject_explicit_branch_ref_lifecycle_with_untracked_rows(
     read: &(impl StorageAdapterRead + ?Sized),
     state_rows: &[PreparedStateRow],
+    engine_rows: &[EngineCurrentRow],
     observations: &BTreeMap<String, BranchHeadControlObservation>,
 ) -> Result<(), LixError> {
     let targets = explicit_branch_head_targets(state_rows)?;
     let current_state = TrackedHeadContext::new().reader(read);
     for (branch_id, target) in targets {
-        if branch_id == crate::GLOBAL_BRANCH_ID {
-            continue;
-        }
         let Some(existing) = observations
             .get(&branch_id)
             .and_then(|observation| observation.control)
         else {
             continue;
         };
-        if target.head_commit_id == Some(existing.head_commit_id) {
+        let destructive = target
+            .head_commit_id
+            .is_none_or(|head_commit_id| head_commit_id != existing.head_commit_id);
+        if !destructive {
             continue;
         }
-        let has_pending_untracked = state_rows.iter().any(|row| {
-            row.untracked && row.schema_key != BRANCH_REF_SCHEMA_KEY && row.branch_id == branch_id
-        });
-        let has_persisted_untracked = !current_state
-            .scan_untracked_rows_for_generation(
+        let mut untracked_identities = current_state
+            .scan_live_rows(
                 &branch_id,
-                existing.generation,
+                existing,
                 &TrackedStateScanRequest {
                     filter: TrackedStateFilter {
                         include_tombstones: true,
@@ -1621,8 +1970,21 @@ async fn reject_explicit_branch_ref_lifecycle_with_untracked_rows(
                 },
             )
             .await?
-            .is_empty();
-        if has_pending_untracked || has_persisted_untracked {
+            .into_iter()
+            .filter(|row| row.untracked)
+            .map(|row| TrackedStateKey {
+                schema_key: row.schema_key,
+                entity_pk: row.entity_pk,
+                file_id: row.file_id,
+            })
+            .collect();
+        apply_pending_untracked_identities(
+            &mut untracked_identities,
+            &branch_id,
+            state_rows,
+            engine_rows,
+        );
+        if !untracked_identities.is_empty() {
             return Err(branch_ref_with_untracked_rows_error(
                 &branch_id,
                 target.head_commit_id.is_none(),
@@ -2208,7 +2570,9 @@ mod tests {
                     .v10_marker_get_many_calls
                     .fetch_add(1, Ordering::Relaxed);
             }
-            if space == crate::live_state::TRACKED_HEAD_GROUP_SPACE.id {
+            if space == crate::live_state::HOT_ROW_SPACE.id
+                || space == crate::live_state::HOT_FILE_SPACE.id
+            {
                 self.counts
                     .row_get_many_calls
                     .fetch_add(1, Ordering::Relaxed);
@@ -2232,7 +2596,9 @@ mod tests {
             range: KeyRange,
             opts: ScanOptions,
         ) -> Result<ScanChunk, StorageError> {
-            if space == crate::live_state::TRACKED_HEAD_GROUP_SPACE.id {
+            if space == crate::live_state::HOT_ROW_SPACE.id
+                || space == crate::live_state::HOT_FILE_SPACE.id
+            {
                 self.counts.row_scan_calls.fetch_add(1, Ordering::Relaxed);
             }
             if space == TRACKED_STATE_TREE_CHUNK_SPACE_ID {
@@ -2496,7 +2862,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn direct_branch_ref_delete_rejects_persisted_local_untracked_rows() {
+    async fn direct_branch_ref_delete_requires_final_untracked_state_to_be_empty() {
         let storage = StorageAdapter::new(Memory::new());
         let binary_cas = BinaryCasContext::new();
         let branch_ctx = BranchContext::new();
@@ -2566,6 +2932,65 @@ mod tests {
         .expect_err("branch-ref delete must reject persisted local untracked state");
         assert_eq!(error.code, LixError::CODE_INVALID_PARAM);
         assert!(error.message.contains("branch-local untracked"));
+
+        // The same atomic publication is valid once it physically removes
+        // the branch-local untracked member. Branch deletion reasons about
+        // final current state, not an intermediate overlay.
+        let mut untracked_delete = tracked_branch_row(branch_id, "delete-persisted-untracked");
+        untracked_delete.untracked = true;
+        untracked_delete.commit_id = None;
+        untracked_delete.global = false;
+        untracked_delete.snapshot = None;
+        let mut cleanup_branch_ref_delete =
+            untracked_global_row("delete-persisted-branch-ref-after-cleanup");
+        cleanup_branch_ref_delete.entity_pk = EntityPk::single(branch_id);
+        cleanup_branch_ref_delete.schema_key = BRANCH_REF_SCHEMA_KEY.to_string();
+        cleanup_branch_ref_delete.snapshot = None;
+        let mut cleanup_read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("atomic cleanup read should open");
+        let (cleanup_writes, cleanup_preconditions) = commit_prepared_writes(
+            &binary_cas,
+            &branch_ctx,
+            None,
+            &mut cleanup_read,
+            PreparedWriteSet {
+                insert_identities: BTreeMap::new(),
+                state_rows: vec![cleanup_branch_ref_delete, untracked_delete],
+                commit_change_refs_by_branch: BTreeMap::new(),
+                first_commit_parent_override_by_branch: BTreeMap::new(),
+                checkpoint_publications: Vec::new(),
+                extra_commit_parents_by_branch: BTreeMap::new(),
+                file_data_writes: Vec::new(),
+            },
+        )
+        .await
+        .expect("branch-ref delete should stage after atomic untracked cleanup");
+        storage
+            .commit_write_set(
+                cleanup_writes,
+                StorageWriteOptions {
+                    preconditions: cleanup_preconditions,
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect("branch-ref delete should commit after atomic untracked cleanup");
+        assert!(
+            BranchHeadControlContext::new()
+                .reader(
+                    storage
+                        .begin_read(StorageReadOptions::default())
+                        .await
+                        .expect("branch-control verification read should open"),
+                )
+                .load(branch_id)
+                .await
+                .expect("branch control should load")
+                .is_none(),
+            "branch deletion must remove its current-state control"
+        );
     }
 
     #[tokio::test]
@@ -3567,7 +3992,7 @@ mod tests {
             "branch-a",
             TrackedWorkingDiffEpoch {
                 checkpoint_commit_id: commit_id("wrong-checkpoint"),
-                generation: Some(first_commit),
+                generation: first_commit,
                 coverage: WorkingDiffIndexCoverage::default(),
             },
         )
@@ -3628,7 +4053,7 @@ mod tests {
         assert!(
             TrackedHeadContext::new()
                 .reader(read)
-                .working_diff_if_control_current(
+                .working_diff_for_control(
                     "branch-a",
                     control,
                     &crate::tracked_state::TrackedStateDiffRequest::default(),
@@ -3733,17 +4158,9 @@ mod tests {
             .expect("branch controls should load");
         let global_control = controls[0].expect("global control must exist");
         assert_eq!(global_control.head_commit_id, commit_id("global-head"));
-        assert!(
-            global_control.tracked_head_is_current,
-            "the global control must publish its current tracked-head generation"
-        );
         assert_eq!(global_control.working_diff_checkpoint_commit_id, None);
         let branch_control = controls[1].expect("branch control must exist");
         assert_eq!(branch_control.head_commit_id, commit_id("branch-head"));
-        assert!(
-            branch_control.tracked_head_is_current,
-            "the branch control must publish its current tracked-head generation"
-        );
         assert_eq!(branch_control.working_diff_checkpoint_commit_id, None);
 
         let counts = Arc::new(TrackedHeadReadCounts::default());

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -3709,7 +3709,7 @@ where
         }
         TrackedHeadContext::new()
             .reader(read)
-            .working_diff_if_control_current(branch_id, control, request)
+            .working_diff_for_control(branch_id, control, request)
             .await
     }
 


### PR DESCRIPTION
## What changed

- Replaces packed current-state groups with V15 row-addressable hot state: one authoritative row per full entity identity, carrying either tracked or untracked state.
- Retains a full-value file-id projection, so exact file identity reads do not decode sibling rows.
- Makes working diff sparse: the hot row holds its first-before image and the diff index holds dirty keys only.
- Hard-cuts the storage protocol to `live-state.hot.v15`; older layouts fail closed.
- Publishes branch controls with exact-byte CAS and restores destructive branch-repoint rejection when branch-local untracked state exists.

## Why

The normal tracked write path no longer reads, decodes, merges, and rewrites a packed sibling group for every changed entity. Current state is now the direct serving plane for both tracked and untracked rows; untracked never enters history or working diff.

## Benchmark baseline

This PR establishes the current-layout baseline for subsequent changes; it intentionally does **not** compare against an older layout.

10k tracked rows, RocksDB for Lix, standalone SQLite control:

| Operation | Median |
| --- | ---: |
| Lix direct transaction update-all | 109.9 ms |
| Lix bound SQL update-all | 355.4 ms |
| Standalone SQLite literal update-all | 28.6 ms |
| Lix SQL read-all (owned public result) | 18.35 ms |
| Standalone SQLite read-all (same public result shape) | 7.33 ms |
| Lix SQL read-many (100 PKs) | 1.443 ms |
| Standalone SQLite literal read-many (100 PKs, public result) | 0.256 ms |

The next stacked layout cut will be measured only against these values.

## Validation

- `cargo test -p lix_engine --features all-simulations` (758 passed, 0 failed, 2 ignored)
- `cargo clippy -p lix_engine --features storage-benches -- -D warnings`
- Focused destructive branch-ref/untracked lifecycle integration test
- `git diff --check`