### PR TITLE
perf(slatedb): eliminate multithreaded read runtime hop

### DIFF
--- a/packages/engine-benchmarks/tests/exact_file_read_benchmark.rs
+++ b/packages/engine-benchmarks/tests/exact_file_read_benchmark.rs
@@ -25,6 +25,19 @@ const CORPUS_FILE_DATA_HEX: &str = "43434343434343434343434343434343";
 #[tokio::test(flavor = "current_thread")]
 #[ignore = "manual performance probe; run with --ignored --nocapture"]
 async fn exact_file_read_benchmark_probe() {
+    run_exact_file_read_benchmark_probe().await;
+}
+
+/// Matches the multithreaded executor used by the service, which lets the
+/// SlateDB adapter keep request reads on the request runtime instead of
+/// crossing into its lifecycle manager runtime.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "manual performance probe; run with --ignored --nocapture"]
+async fn exact_file_read_multithread_benchmark_probe() {
+    run_exact_file_read_benchmark_probe().await;
+}
+
+async fn run_exact_file_read_benchmark_probe() {
     let file_count = file_count_from_env();
     run_backend("memory", Memory::new(), file_count).await;
 

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -705,9 +705,36 @@ impl SlateDBWorker {
     /// Writes and flushes deliberately continue through [`Self::call`]: after
     /// a caller drops its future, letting a mutating operation finish preserves
     /// a single, well-defined publication and durability outcome. Reads have
-    /// no such side effects, so canceling them also releases the in-flight
-    /// guard that manager shutdown waits on.
+    /// no such side effects, so run them on the caller's multithreaded
+    /// executor. That keeps SlateDB's own async work local to the request and
+    /// avoids a manager-task spawn plus oneshot round trip for every snapshot,
+    /// point read, and scan page. A current-thread runtime keeps using the
+    /// manager: an ObjectStore is allowed to perform synchronous work before
+    /// its first yield, and that must not monopolize its only executor thread.
+    /// Canceling either path drops the read future and the in-flight guard that
+    /// manager shutdown waits on.
     async fn call_read<R, F, Fut>(&self, operation: F) -> Result<R, StorageError>
+    where
+        R: Send + 'static,
+        F: FnOnce(Arc<Db>) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<R, StorageError>> + Send + 'static,
+    {
+        if !matches!(
+            Handle::try_current(),
+            Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread
+        ) {
+            return self.call_read_on_manager(operation).await;
+        }
+        // Manager shutdown waits for this guard. The guard is deliberately
+        // independent of `SlateDBWorkerInner`: the operation may retain only
+        // the database Arc while the last storage handle is being dropped.
+        // Keeping the guard in this caller future prevents the synchronous
+        // manager close from racing that operation.
+        let _in_flight = self.inner.in_flight.enter();
+        operation(Arc::clone(&self.inner.db)).await
+    }
+
+    async fn call_read_on_manager<R, F, Fut>(&self, operation: F) -> Result<R, StorageError>
     where
         R: Send + 'static,
         F: FnOnce(Arc<Db>) -> Fut + Send + 'static,
@@ -1200,6 +1227,10 @@ mod tests {
     use std::ops::Range;
     use std::sync::atomic::AtomicBool;
     use std::time::{Duration, Instant};
+
+    tokio::task_local! {
+        static CALLER_READ_MARKER: ();
+    }
 
     #[test]
     fn uses_lz4_compression_by_default() {
@@ -1891,6 +1922,32 @@ mod tests {
             panic!("storage close should wait only for the cancelled read to drain: {error:?}");
         }
         closer.join().expect("join storage closer");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn read_operation_stays_on_the_callers_executor() {
+        let storage = SlateDB::open_object_store_with_options(
+            "test-caller-runtime-read",
+            Arc::new(InMemory::new()),
+            SlateDBObjectStoreOptions::default(),
+        )
+        .expect("open caller-runtime read storage");
+
+        CALLER_READ_MARKER
+            .scope((), async {
+                storage
+                    .worker
+                    .call_read(|_db| async move {
+                        assert!(
+                            CALLER_READ_MARKER.try_with(|()| ()).is_ok(),
+                            "read work must retain the caller task context"
+                        );
+                        Ok::<(), StorageError>(())
+                    })
+                    .await
+                    .expect("run read on caller executor");
+            })
+            .await;
     }
 
     fn block_on<T>(future: impl Future<Output = T>) -> T {


### PR DESCRIPTION
## Summary

- Run SlateDB read-only work on the caller's multithreaded Tokio executor instead of spawning it through the dedicated lifecycle manager.
- Keep the lifecycle manager path for current-thread and non-Tokio callers, where an ObjectStore can do synchronous work before its first yield.
- Add an ignored multithreaded exact-file-read probe so the service-shaped path stays measurable.

## Profile evidence

Fresh isolated release binaries; 300 warmed samples per shape, two-worker Tokio runtime, two-file corpus. Baseline was `origin/main` at `ae6a3878c`; candidate is this commit. p50 nanoseconds:

| shape | Slate baseline | Slate candidate | improvement | candidate Slate / Rocks |
| --- | ---: | ---: | ---: | ---: |
| scalar_text | 594,237 | 319,039 | 46.3% | 1.02x |
| id_by_id_4k | 850,997 | 465,049 | 45.4% | 1.00x |
| data_by_id_4k | 830,648 | 116,799 | 85.9% | 1.41x |
| data_by_path_4k | 595,908 | 118,359 | 80.1% | 1.48x |
| change_id_by_id_4k | 319,750 | 53,079 | 83.4% | 1.51x |
| data_by_id_1m | 1,021,036 | 355,598 | 65.2% | 1.11x |
| data_by_path_1m | 1,075,116 | 355,739 | 66.9% | 1.11x |

Every affected SlateDB file-read p50 improves by more than 10%. This is deliberately the first stack member: it removes the common scheduling floor while preserving the executor-safety fallback; the remaining small-value gap is addressed by the follow-up cache/read-path PR.

## Validation

- `cargo fmt --check`
- `cargo test -p lix_slatedb_storage --release`
- `cargo test -p lix_engine --features all-simulations` (2,107 active tests)
- `cargo test -p lix_engine_benchmarks --release --features slatedb --test exact_file_read_benchmark exact_file_read_multithread_benchmark_probe -- --ignored --nocapture`