### PR TITLE
perf(slatedb): acknowledge visible commits before WAL flush

### DIFF
--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -638,6 +638,11 @@ where
         }
         if let Some((key, value)) = transaction.idempotency_receipt.take() {
             writes.put(EXECUTE_IDEMPOTENCY_RECEIPT_SPACE, key.clone(), value);
+            // The mutation and this receipt share one atomic storage commit.
+            // A protocol acknowledgement may replay only from a durable
+            // receipt, so ask the storage to cross its durability boundary
+            // before it reports this commit as successful.
+            write_options.idempotency_key = Some(key.0.clone());
             write_options
                 .preconditions
                 .push(StoragePrecondition::KeyAbsent {

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -95,6 +95,7 @@ pub struct SlateDBRead {
 pub struct SlateDBWrite {
     worker: SlateDBWorker,
     _writer_permit: OwnedMutexGuard<()>,
+    await_durable: bool,
     base: Option<Arc<DbSnapshot>>,
     overlay: BTreeMap<Key, Option<Bytes>>,
     stats: WriteStats,
@@ -322,6 +323,10 @@ impl Storage for SlateDB {
             Ok(SlateDBWrite {
                 worker: self.worker.clone(),
                 _writer_permit: writer_permit,
+                // The engine sets this only for the atomic mutation plus
+                // idempotency-receipt commit. Its replay contract requires a
+                // durable receipt before the request can be acknowledged.
+                await_durable: opts.idempotency_key.is_some(),
                 base: None,
                 overlay: BTreeMap::new(),
                 stats: WriteStats::default(),
@@ -655,6 +660,7 @@ impl StorageWrite for SlateDBWrite {
             let Self {
                 worker,
                 _writer_permit: writer_permit,
+                await_durable,
                 overlay,
                 stats,
                 ..
@@ -679,16 +685,16 @@ impl StorageWrite for SlateDBWrite {
                     db.write_with_options(
                         batch,
                         &SlateDBWriteOptions {
-                            await_durable: false,
+                            await_durable,
                             ..SlateDBWriteOptions::default()
                         },
                     )
                     .await
                     .map_err(slatedb_error)?;
-                    // SlateDB owns WAL durability. Returning here makes the
-                    // commit visible immediately while its background flusher
-                    // batches this write with nearby commits. `flush()` is
-                    // the explicit remote-durability barrier.
+                    // Ordinary commits return after local publication while
+                    // SlateDB batches their WAL upload. Receipt-bearing
+                    // idempotent commits instead wait for that upload so a
+                    // durable replay proof exists before acknowledgement.
                     Ok(CommitResult {
                         commit_id: None,
                         stats,

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -679,15 +679,16 @@ impl StorageWrite for SlateDBWrite {
                     db.write_with_options(
                         batch,
                         &SlateDBWriteOptions {
-                            await_durable: true,
+                            await_durable: false,
                             ..SlateDBWriteOptions::default()
                         },
                     )
                     .await
                     .map_err(slatedb_error)?;
-                    // The configured SlateDB write contract waits for WAL
-                    // durability, so a successful Lix commit is not merely
-                    // visible in the local write pipeline.
+                    // SlateDB owns WAL durability. Returning here makes the
+                    // commit visible immediately while its background flusher
+                    // batches this write with nearby commits. `flush()` is
+                    // the explicit remote-durability barrier.
                     Ok(CommitResult {
                         commit_id: None,
                         stats,
@@ -1756,7 +1757,7 @@ mod tests {
     }
 
     #[test]
-    fn commit_waits_for_wal_durability_before_success() {
+    fn commit_is_visible_while_background_wal_flush_is_blocked() {
         let store = Arc::new(BlockingStore::new(Arc::new(InMemory::new())));
         let storage = SlateDB::open_object_store_with_options(
             "test-commit-visibility",
@@ -1768,39 +1769,40 @@ mod tests {
         let key = Key(Bytes::from_static(b"visible-before-durable"));
 
         let blocked_write = store.block_next_write();
-        let (commit_tx, commit_rx) = mpsc::channel();
-        let committer = std::thread::spawn(move || {
-            let mut write = block_on(storage.begin_write(WriteOptions::default()))
-                .expect("begin visibility write");
-            block_on(write.put_many(
-                space,
-                PutBatch {
-                    entries: vec![PutEntry {
-                        key,
-                        value: StoredValue {
-                            bytes: Bytes::from_static(b"value"),
-                        },
-                    }],
-                },
-            ))
-            .expect("stage visibility write");
-            commit_tx
-                .send(block_on(write.commit()))
-                .expect("send commit result");
-        });
+        let mut write =
+            block_on(storage.begin_write(WriteOptions::default())).expect("begin visibility write");
+        block_on(write.put_many(
+            space,
+            PutBatch {
+                entries: vec![PutEntry {
+                    key: key.clone(),
+                    value: StoredValue {
+                        bytes: Bytes::from_static(b"value"),
+                    },
+                }],
+            },
+        ))
+        .expect("stage visibility write");
+        block_on(write.commit()).expect("publish visibility value");
+
+        // The request has returned, but SlateDB's first background WAL upload
+        // is still in flight.
         blocked_write.wait_for_entries(1, "SlateDB WAL write");
+
+        let read = block_on(storage.begin_read(ReadOptions::default()))
+            .expect("begin visible in-memory read");
+        let values = block_on(read.get_many(space, &[key], GetOptions::default()))
+            .expect("read visible in-memory value")
+            .values;
         assert_eq!(
-            commit_rx.recv_timeout(Duration::from_millis(50)),
-            Err(mpsc::RecvTimeoutError::Timeout),
-            "commit must not acknowledge before SlateDB makes its WAL durable"
+            values,
+            vec![Some(ProjectedValue::FullValue(Bytes::from_static(
+                b"value"
+            )))]
         );
 
         drop(blocked_write);
-        commit_rx
-            .recv_timeout(Duration::from_secs(2))
-            .expect("commit should finish after WAL durability")
-            .expect("commit visibility value");
-        committer.join().expect("join visibility committer");
+        block_on(storage.flush()).expect("flush visible value");
     }
 
     #[test]
@@ -1842,6 +1844,11 @@ mod tests {
         });
 
         blocked_write.wait_for_entries(1, "SlateDB WAL write");
+        commit_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("commit should complete after local publication")
+            .expect("commit visible durable read row");
+        committer.join().expect("join durable read committer");
         let visible =
             block_on(storage.begin_read(ReadOptions::default())).expect("begin visible read");
         assert_eq!(
@@ -1865,11 +1872,7 @@ mod tests {
         );
 
         drop(blocked_write);
-        commit_rx
-            .recv_timeout(Duration::from_secs(2))
-            .expect("commit should complete after WAL durability")
-            .expect("commit durable read row");
-        committer.join().expect("join durable read committer");
+        block_on(storage.flush()).expect("flush published durable read row");
 
         let durable = block_on(storage.begin_read(ReadOptions {
             durability: ReadDurability::Durable,
@@ -1885,7 +1888,7 @@ mod tests {
     }
 
     #[test]
-    fn commit_failure_is_not_advertised_as_a_definite_abort() {
+    fn explicit_flush_reports_background_durability_failure() {
         let store = Arc::new(BlockingStore::new(Arc::new(InMemory::new())));
         let storage = SlateDB::open_object_store_with_options(
             "test-failed-commit",
@@ -1897,42 +1900,93 @@ mod tests {
         let key = Key(Bytes::from_static(b"rejected"));
 
         let blocked_write = store.block_next_write();
-        let (commit_tx, commit_rx) = mpsc::channel();
-        let committer = std::thread::spawn(move || {
-            let mut write = block_on(storage.begin_write(WriteOptions::default()))
-                .expect("begin failed commit write");
-            block_on(write.put_many(
-                space,
-                PutBatch {
-                    entries: vec![PutEntry {
-                        key,
-                        value: StoredValue {
-                            bytes: Bytes::from_static(b"not-durable"),
-                        },
-                    }],
-                },
-            ))
-            .expect("stage failed commit write");
-            commit_tx
-                .send(block_on(write.commit()))
-                .expect("send commit result");
-        });
-        blocked_write.wait_for_entries(1, "failing SlateDB WAL write");
-        assert_eq!(
-            commit_rx.recv_timeout(Duration::from_millis(50)),
-            Err(mpsc::RecvTimeoutError::Timeout),
-            "commit must wait for the WAL upload result"
-        );
+        let mut write =
+            block_on(storage.begin_write(WriteOptions::default())).expect("begin buffered write");
+        block_on(write.put_many(
+            space,
+            PutBatch {
+                entries: vec![PutEntry {
+                    key,
+                    value: StoredValue {
+                        bytes: Bytes::from_static(b"not-durable"),
+                    },
+                }],
+            },
+        ))
+        .expect("stage buffered write");
+        block_on(write.commit()).expect("publish buffered write");
+
+        blocked_write.wait_for_entries(1, "failing background WAL write");
         store.fail_writes();
         drop(blocked_write);
-        let commit_error = commit_rx
-            .recv_timeout(Duration::from_secs(2))
-            .expect("failed commit should finish after its WAL upload");
+        let flush_error = block_on(storage.flush()).expect_err("WAL flush must fail");
         assert!(
-            matches!(commit_error, Err(StorageError::CommitOutcomeUnknown(message)) if message.contains("injected write failure")),
-            "an attempted SlateDB commit failure must not claim that the write aborted"
+            matches!(flush_error, StorageError::Io(message) if message.contains("injected write failure")),
+            "flush should preserve the SlateDB write error"
         );
-        committer.join().expect("join failed committer");
+    }
+
+    #[test]
+    fn dropping_last_handle_waits_for_background_flush() {
+        let store = Arc::new(BlockingStore::new(Arc::new(InMemory::new())));
+        let db_path = "test-close-background-durability";
+        let space = SpaceId(8);
+        let key = Key(Bytes::from_static(b"background-commit"));
+        let value = Bytes::from_static(b"durable");
+        let storage = SlateDB::open_object_store_with_options(
+            db_path,
+            store.clone(),
+            SlateDBObjectStoreOptions::default(),
+        )
+        .expect("open close-test storage");
+        let mut write =
+            block_on(storage.begin_write(WriteOptions::default())).expect("begin close-test write");
+        block_on(write.put_many(
+            space,
+            PutBatch {
+                entries: vec![PutEntry {
+                    key: key.clone(),
+                    value: StoredValue {
+                        bytes: value.clone(),
+                    },
+                }],
+            },
+        ))
+        .expect("stage close-test value");
+
+        let blocked_write = store.block_next_write();
+        block_on(write.commit()).expect("publish close-test value");
+        blocked_write.wait_for_entries(1, "background commit WAL write");
+
+        let (closed_tx, closed_rx) = mpsc::channel();
+        let closer = std::thread::spawn(move || {
+            drop(storage);
+            let _ = closed_tx.send(());
+        });
+        assert!(
+            matches!(
+                closed_rx.recv_timeout(Duration::from_millis(50)),
+                Err(mpsc::RecvTimeoutError::Timeout)
+            ),
+            "close must wait for the background WAL flush"
+        );
+        drop(blocked_write);
+        closed_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("close should finish after WAL durability");
+        closer.join().expect("join close-test closer");
+
+        let reopened = SlateDB::open_object_store_with_options(
+            db_path,
+            store,
+            SlateDBObjectStoreOptions::default(),
+        )
+        .expect("reopen close-test storage");
+        let read =
+            block_on(reopened.begin_read(ReadOptions::default())).expect("begin close-test read");
+        let result = block_on(read.get_many(space, &[key], GetOptions::default()))
+            .expect("read close-test value");
+        assert_eq!(result.values, vec![Some(ProjectedValue::FullValue(value))]);
     }
 
     #[test]

--- a/packages/slatedb-storage/tests/storage.rs
+++ b/packages/slatedb-storage/tests/storage.rs
@@ -188,7 +188,7 @@ async fn cached_slatedb_rebuilds_after_local_cache_is_deleted() {
 }
 
 #[tokio::test]
-async fn cached_slatedb_reports_write_failure_from_commit() {
+async fn cached_slatedb_reports_failed_flush_after_accepting_write() {
     let object_store = Arc::new(InMemory::new());
     let db_path = "cached-slatedb-write-failure";
     let cache_parent = tempfile::tempdir().expect("create SlateDB failure cache parent");
@@ -222,9 +222,14 @@ async fn cached_slatedb_reports_write_failure_from_commit() {
         .expect("open cached failure-test storage");
         fault_store.fail_writes.store(true, Ordering::Relaxed);
 
-        let error = write_one(&storage, space, rejected_key.clone(), b"not-persisted")
+        write_one(&storage, space, rejected_key.clone(), b"not-persisted")
             .await
-            .expect_err("remote write failure must fail the commit");
+            .expect("commit should accept the visible write");
+
+        let error = storage
+            .flush()
+            .await
+            .expect_err("remote write failure must fail the explicit flush");
         assert!(format!("{error}").contains("not supported"));
     }
 
@@ -242,7 +247,7 @@ async fn cached_slatedb_reports_write_failure_from_commit() {
     let result = read
         .get_many(space, &[durable_key, rejected_key], GetOptions::default())
         .await
-        .expect("read durable values after rejected write");
+        .expect("read durable values after failed write");
 
     assert_eq!(
         result.values,
@@ -254,7 +259,7 @@ async fn cached_slatedb_reports_write_failure_from_commit() {
 }
 
 #[tokio::test]
-async fn slatedb_commit_makes_visible_value_durable() {
+async fn slatedb_explicit_flush_makes_visible_commit_durable() {
     let object_store = Arc::new(InMemory::new());
     let counting_store = Arc::new(FaultStore::new(object_store));
     let storage = SlateDB::open_object_store_with_options(
@@ -272,12 +277,13 @@ async fn slatedb_commit_makes_visible_value_durable() {
         b"value",
     )
     .await
-    .expect("commit durable value");
+    .expect("publish visible value");
 
+    storage.flush().await.expect("flush visible value");
     assert_eq!(
         counting_store.write_count(),
         1,
-        "the durable commit should require one WAL write"
+        "the visible commit should require one WAL write"
     );
     storage
         .flush()


### PR DESCRIPTION
## Base

Directly based on `main` at `b5060d013` (the merged #829 snapshot-cache PR). This has no stack dependency.

## Change

- Return normal SlateDB commits after atomic local publication with `await_durable: false`.
- Keep `SlateDB::flush()` as the explicit remote-WAL durability barrier for normal callers.
- Preserve the serial write worker, cancellation semantics, durable-read filtering, and terminal-error handling.
- Mark the atomic protocol idempotency-receipt write as durability-required, so only that mutation+receipt commit waits for WAL upload before acknowledgement or replay recovery.

## Correctness boundary

A successful normal commit is visible to ordinary reads but is not yet remote durable. Protocol SQL mutations carrying an Idempotency-Key are the exception: their receipt is the durable replay proof, so the same atomic commit waits for WAL durability. This preserves immediate acknowledgement-loss replay without weakening the protocol's Durable receipt read.

The tests cover:

- visible reads while the background WAL upload is blocked;
- Durable reads excluding the unpublished remote WAL state;
- explicit `flush()` surfacing a background WAL failure;
- dropping the final handle waiting for that background flush;
- single and batch idempotency replay after a post-commit acknowledgement loss.

## Profile evidence

Fresh release runs; baseline is detached current `main`, candidate is this commit. Values are p50 accepted latency.

| workload | main SlateDB | candidate SlateDB | improvement |
| --- | ---: | ---: | ---: |
| 100-commit changelog append — commit | 100.876 ms | 0.104 ms | 99.9% |
| 4 KiB production binary-CAS unique write | 101.269 ms | 0.109 ms | 99.9% |
| no-plugin native file — one 10-file batch | 98.156 ms | 16.561 ms | 83.1% |
| no-plugin native file — ten single-file commits | 1.008 s | 69.220 ms | 93.1% |

The native-file comparison used 30 paired samples with its built-in 99% confidence interval. Logical I/O is unchanged in the changelog run (4 `get_many` / 5 keys and 5 write batches / 5 puts per operation).

This deliberately removes the remote-WAL acknowledgement cost for ordinary commits; it does **not** yet claim 1.2× overall SlateDB/RocksDB parity. On the candidate, the native 10-file batch is 11.2× RocksDB and ten single-file commits are 22.5× RocksDB, so the next optimization can focus on the residual adapter/engine overhead rather than durability acknowledgement.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p lix_engine -p lix_slatedb_storage -p lix_server_protocol --all-targets -- -D warnings`
- `cargo test -p lix_server_protocol --lib` — 79 active tests, including both acknowledgement-loss replay cases
- `cargo test -p lix_slatedb_storage --release` — 26 tests
- Earlier PR validation: `cargo test -p lix_engine` and `cargo test -p lix_engine --features all-simulations`
- paired `changelog_history_append`, `small_blob_cas`, and `native_file_upsert_component` release profiles