### PR TITLE
feat(plugin): add Git-compatible semantic text rows

### DIFF
--- a/.changenotes/add-git-text-line-plugin.md
+++ b/.changenotes/add-git-text-line-plugin.md
@@ -1,0 +1,8 @@
+---
+type: patch
+---
+
+Adds the Git-compatible Component-v2 text plugin. It selects files with Git's
+bounded 8 KiB NUL-byte predicate and represents matching payloads as lossless,
+stable semantic line rows while leaving NUL-bearing files on the raw binary
+path.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
         run: |
           rustup target add wasm32-wasip2
           cargo build --release -p plugin_csv_v2 --target wasm32-wasip2
+          cargo build --release -p plugin_git_text_v2 --target wasm32-wasip2
 
   js-sdk-test:
     name: JS SDK ${{ matrix.name }} Test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3421,11 +3421,13 @@ name = "lix_sdk_tests"
 version = "0.8.4"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "codspeed-criterion-compat",
  "lix_rocksdb_storage",
  "lix_sdk",
  "plugin_csv_v2",
  "plugin_excalidraw_v2",
+ "plugin_git_text_v2",
  "plugin_json_incremental_v2",
  "plugin_markdown_incremental_v2",
  "rand 0.9.2",
@@ -4239,6 +4241,17 @@ dependencies = [
  "base64 0.22.1",
  "lix_order_key",
  "lix_plugin_api_v2",
+ "serde_json",
+]
+
+[[package]]
+name = "plugin_git_text_v2"
+version = "0.8.4"
+dependencies = [
+ "base64 0.22.1",
+ "lix_order_key",
+ "lix_plugin_api_v2",
+ "serde",
  "serde_json",
 ]
 

--- a/packages/engine/src/plugin/component.rs
+++ b/packages/engine/src/plugin/component.rs
@@ -287,14 +287,14 @@ mod tests {
             packet_pages: 2,
             durable_semantic_changes: 1,
             guest_linear_memory_high_water_bytes: 128,
-            host_full_content_classification_bytes: 10,
+            host_content_classification_bytes: 10,
             ..WasmTransitionCounters::default()
         });
         host.record_v2_transition_counters(WasmTransitionCounters {
             packet_pages: 3,
             private_document_cache_hits: 1,
             guest_linear_memory_high_water_bytes: 64,
-            host_full_content_classification_bytes: 7,
+            host_content_classification_bytes: 7,
             ..WasmTransitionCounters::default()
         });
 
@@ -303,7 +303,7 @@ mod tests {
         assert_eq!(counters.durable_semantic_changes, 1);
         assert_eq!(counters.private_document_cache_hits, 1);
         assert_eq!(counters.guest_linear_memory_high_water_bytes, 128);
-        assert_eq!(counters.host_full_content_classification_bytes, 17);
+        assert_eq!(counters.host_content_classification_bytes, 17);
 
         host.reset_v2_transition_counters();
         assert_eq!(

--- a/packages/engine/src/plugin/incremental.rs
+++ b/packages/engine/src/plugin/incremental.rs
@@ -416,6 +416,42 @@ pub(crate) fn transport_splice_preserves_utf8(
     std::str::from_utf8(&after[window_start..window_end]).is_ok()
 }
 
+/// Proves that a trusted transport splice preserves Git's text predicate
+/// without rescanning the full materialized file.
+///
+/// A file already owned by a `git_text` plugin is known to have no NUL byte
+/// in its first 8 KiB. The submitted result is bound to the transport splice,
+/// so checking only the same bounded prefix of the result is sufficient after
+/// a mutation. Unlike UTF-8 validity, Git's predicate has no code-point
+/// boundary context.
+pub(crate) fn transport_splice_preserves_git_text(
+    after: &[u8],
+    provenance: &RequestBlobSpliceProvenance,
+) -> bool {
+    const GIT_TEXT_SCAN_BYTES: usize = 8_000;
+
+    if !provenance.matches_result(after) {
+        return false;
+    }
+    let prefix = provenance.prefix_bytes();
+    let suffix = provenance.suffix_bytes();
+    let Some(insert_end) = prefix.checked_add(provenance.insert().len()) else {
+        return false;
+    };
+    let Some(expected_after_len) = insert_end.checked_add(suffix) else {
+        return false;
+    };
+    if expected_after_len != after.len()
+        || prefix > after.len()
+        || insert_end > after.len()
+        || provenance.insert() != &after[prefix..insert_end]
+    {
+        return false;
+    }
+
+    !after[..after.len().min(GIT_TEXT_SCAN_BYTES)].contains(&0)
+}
+
 fn validate_transport_splice(
     before: &[u8],
     after: &[u8],
@@ -2085,9 +2121,9 @@ fn merge_counter_snapshots(
         host_full_diff_bytes_compared: local
             .host_full_diff_bytes_compared
             .max(runtime.host_full_diff_bytes_compared),
-        host_full_content_classification_bytes: local
-            .host_full_content_classification_bytes
-            .max(runtime.host_full_content_classification_bytes),
+        host_content_classification_bytes: local
+            .host_content_classification_bytes
+            .max(runtime.host_content_classification_bytes),
         full_state_semantic_rows_materialized: local
             .full_state_semantic_rows_materialized
             .max(runtime.full_state_semantic_rows_materialized),
@@ -2372,6 +2408,35 @@ mod tests {
 
         let copied_after: Blob = after.to_vec().into();
         assert!(!transport_splice_preserves_utf8(&copied_after, &valid));
+    }
+
+    #[test]
+    fn git_text_splice_proof_checks_only_gits_bounded_nul_window() {
+        let before = vec![b'a'; 16_000];
+        let after: Blob = before.clone().into();
+        let valid = RequestBlobSpliceProvenance::new_validated_for_test(
+            &before,
+            &after,
+            16_000,
+            0,
+            Vec::new(),
+        );
+        assert!(transport_splice_preserves_git_text(&after, &valid));
+
+        let mut nul_in_window = after.to_vec();
+        nul_in_window[7_999] = 0;
+        let nul_in_window: Blob = nul_in_window.into();
+        let nul_provenance = RequestBlobSpliceProvenance::new_validated_for_test(
+            &before,
+            &nul_in_window,
+            7_999,
+            8_000,
+            vec![0],
+        );
+        assert!(!transport_splice_preserves_git_text(
+            &nul_in_window,
+            &nul_provenance
+        ));
     }
 
     #[test]

--- a/packages/engine/src/plugin/manifest.rs
+++ b/packages/engine/src/plugin/manifest.rs
@@ -38,19 +38,39 @@ pub struct PluginMatch {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PluginContentType {
+    /// A complete UTF-8 payload. Existing format plugins use this stricter
+    /// contract because their parsers consume Unicode text.
     Text,
+    /// A payload that is not valid UTF-8.
     Binary,
+    /// Git's text heuristic: no NUL byte in the first 8 KiB.
+    ///
+    /// This is intentionally separate from [`Self::Text`]. Git accepts
+    /// non-UTF-8, NUL-free payloads as text, while parsers such as JSON and
+    /// Markdown require valid UTF-8.
+    GitText,
 }
 
 impl PluginContentType {
-    /// Classifies file bytes only when a caller already has the payload.
-    /// Empty bytes are valid UTF-8 and therefore text, matching the bundled
-    /// text plugins' treatment of a newly-created empty file.
-    pub(crate) fn from_bytes(bytes: &[u8]) -> Self {
-        if std::str::from_utf8(bytes).is_ok() {
-            Self::Text
-        } else {
-            Self::Binary
+    /// The byte window Git uses to distinguish binary data for its text
+    /// operations. Keep this value local to the Git-compatible matcher so
+    /// UTF-8 format plugins retain their complete-payload contract.
+    pub(crate) const GIT_TEXT_SCAN_BYTES: usize = 8_000;
+
+    /// Returns whether a payload satisfies this matcher contract.
+    ///
+    /// `Text` and `GitText` are intentionally overlapping predicates: valid
+    /// UTF-8 without a NUL byte matches both. The registry resolves that overlap
+    /// by matcher specificity, so a format-specific UTF-8 plugin wins over the
+    /// catch-all Git-compatible passthrough.
+    pub(crate) fn matches_bytes(self, bytes: &[u8]) -> bool {
+        match self {
+            Self::Text => std::str::from_utf8(bytes).is_ok(),
+            Self::Binary => std::str::from_utf8(bytes).is_err(),
+            Self::GitText => !bytes
+                .iter()
+                .take(Self::GIT_TEXT_SCAN_BYTES)
+                .any(|byte| *byte == 0),
         }
     }
 }

--- a/packages/engine/src/plugin/mod.rs
+++ b/packages/engine/src/plugin/mod.rs
@@ -31,7 +31,8 @@ pub(crate) use incremental::{
     VecEntityChangeSource, VecEntityConflictSource, VecEntitySource, build_file_update_splices,
     drain_conflict_transition_resolutions, drain_entity_transition_edits,
     drain_file_transition_changes, host_entity_change_with_lazy_snapshot,
-    host_entity_with_lazy_snapshot, transport_splice_preserves_utf8,
+    host_entity_with_lazy_snapshot, transport_splice_preserves_git_text,
+    transport_splice_preserves_utf8,
 };
 pub(crate) use install::{PluginArchiveInstallPlan, plugin_install_plan_from_archive_path};
 pub(crate) use manifest::{

--- a/packages/engine/src/plugin/plugin_manifest.json
+++ b/packages/engine/src/plugin/plugin_manifest.json
@@ -37,7 +37,7 @@
         },
         "content_type": {
           "type": "string",
-          "enum": ["text", "binary"]
+          "enum": ["text", "binary", "git_text"]
         }
       }
     },

--- a/packages/engine/src/plugin/registry.rs
+++ b/packages/engine/src/plugin/registry.rs
@@ -695,18 +695,39 @@ impl CompiledPluginCatalog {
         path: &str,
         bytes: &[u8],
     ) -> (Option<&PluginRegistryEntry>, u64) {
-        let mut classified = None;
-        let selected = self.select_with_content_type(path, || {
-            Some(*classified.get_or_insert_with(|| PluginContentType::from_bytes(bytes)))
+        let mut utf8 = None;
+        let mut git_text = None;
+        let mut classified_bytes = 0u64;
+        let selected = self.select_with_content_type(path, |required| {
+            let matches = match required {
+                PluginContentType::Text | PluginContentType::Binary => {
+                    let is_utf8 = *utf8.get_or_insert_with(|| {
+                        classified_bytes = classified_bytes.saturating_add(bytes.len() as u64);
+                        std::str::from_utf8(bytes).is_ok()
+                    });
+                    match required {
+                        PluginContentType::Text => is_utf8,
+                        PluginContentType::Binary => !is_utf8,
+                        PluginContentType::GitText => {
+                            unreachable!("GitText is handled by its bounded classifier branch")
+                        }
+                    }
+                }
+                PluginContentType::GitText => *git_text.get_or_insert_with(|| {
+                    let scan_len = bytes.len().min(PluginContentType::GIT_TEXT_SCAN_BYTES);
+                    classified_bytes = classified_bytes.saturating_add(scan_len as u64);
+                    PluginContentType::GitText.matches_bytes(bytes)
+                }),
+            };
+            Some(matches)
         });
-        let classified_bytes = classified.map_or(0, |_| bytes.len() as u64);
         (selected, classified_bytes)
     }
 
     fn select_with_content_type(
         &self,
         path: &str,
-        mut file_content_type: impl FnMut() -> Option<PluginContentType>,
+        mut content_type_matches: impl FnMut(PluginContentType) -> Option<bool>,
     ) -> Option<&PluginRegistryEntry> {
         if path.is_empty() {
             return None;
@@ -720,7 +741,7 @@ impl CompiledPluginCatalog {
                 continue;
             }
             if let Some(required) = self.plugins[index].content_type()
-                && file_content_type().is_some_and(|actual| actual != required)
+                && !content_type_matches(required).unwrap_or(false)
             {
                 continue;
             }
@@ -1450,15 +1471,15 @@ mod tests {
 
     #[test]
     fn compiled_catalog_applies_content_type_only_when_known() {
-        assert_eq!(PluginContentType::from_bytes(b""), PluginContentType::Text);
-        assert_eq!(
-            PluginContentType::from_bytes(b"hello"),
-            PluginContentType::Text
-        );
-        assert_eq!(
-            PluginContentType::from_bytes(&[0xff, 0xfe]),
-            PluginContentType::Binary
-        );
+        assert!(PluginContentType::Text.matches_bytes(b""));
+        assert!(PluginContentType::Text.matches_bytes(b"hello"));
+        assert!(!PluginContentType::Text.matches_bytes(&[0xff, 0xfe]));
+        assert!(PluginContentType::Binary.matches_bytes(&[0xff, 0xfe]));
+        assert!(PluginContentType::GitText.matches_bytes(&[0xff, 0xfe]));
+        assert!(!PluginContentType::GitText.matches_bytes(b"text\0data"));
+        let mut nul_outside_git_window = vec![b'x'; PluginContentType::GIT_TEXT_SCAN_BYTES];
+        nul_outside_git_window.push(0);
+        assert!(PluginContentType::GitText.matches_bytes(&nul_outside_git_window));
 
         let text =
             entry_with_content_type("plugin_text", "*.data", Some(PluginContentType::Text), 'a');
@@ -1474,22 +1495,26 @@ mod tests {
         let classification_calls = Cell::new(0);
         assert!(
             text_only
-                .select_with_content_type("document.other", || {
+                .select_with_content_type("document.other", |required| {
                     classification_calls.set(classification_calls.get() + 1);
-                    Some(PluginContentType::Text)
+                    Some(required == PluginContentType::Text)
                 })
                 .is_none()
         );
         assert_eq!(classification_calls.get(), 0);
         assert_eq!(
             text_only
-                .select_with_content_type("document.data", || Some(PluginContentType::Text))
+                .select_with_content_type("document.data", |required| {
+                    Some(required == PluginContentType::Text)
+                })
                 .map(PluginRegistryEntry::key),
             Some("plugin_text")
         );
         assert!(
             text_only
-                .select_with_content_type("document.data", || Some(PluginContentType::Binary))
+                .select_with_content_type("document.data", |required| {
+                    Some(required == PluginContentType::Binary)
+                })
                 .is_none()
         );
 
@@ -1498,13 +1523,17 @@ mod tests {
                 .unwrap();
         assert_eq!(
             catalog
-                .select_with_content_type("document.data", || Some(PluginContentType::Text))
+                .select_with_content_type("document.data", |required| {
+                    Some(required == PluginContentType::Text)
+                })
                 .map(PluginRegistryEntry::key),
             Some("plugin_text")
         );
         assert_eq!(
             catalog
-                .select_with_content_type("document.data", || Some(PluginContentType::Binary))
+                .select_with_content_type("document.data", |required| {
+                    Some(required == PluginContentType::Binary)
+                })
                 .map(PluginRegistryEntry::key),
             Some("plugin_binary")
         );
@@ -1530,6 +1559,58 @@ mod tests {
         assert_eq!(classified_bytes, 0);
         assert!(catalog.matches_plugin("plugin_text", "document.data"));
         assert!(catalog.matches_plugin("plugin_binary", "document.data"));
+    }
+
+    #[test]
+    fn git_text_matcher_uses_git_nul_window_and_is_bounded() {
+        let git_text = entry_with_content_type(
+            "plugin_git_text",
+            "*",
+            Some(PluginContentType::GitText),
+            'a',
+        );
+        let utf8_specific = entry_with_content_type(
+            "plugin_utf8_specific",
+            "*.data",
+            Some(PluginContentType::Text),
+            'b',
+        );
+        let catalog = CompiledPluginCatalog::compile(
+            &PluginRegistry::new(vec![git_text, utf8_specific]).unwrap(),
+        )
+        .unwrap();
+
+        let large_non_utf8_text = std::iter::repeat_n(0xff, 1_048_576).collect::<Vec<_>>();
+        let (selected, classified_bytes) =
+            catalog.select_for_bytes_with_classification_work("asset.bin", &large_non_utf8_text);
+        assert_eq!(
+            selected.map(PluginRegistryEntry::key),
+            Some("plugin_git_text")
+        );
+        assert_eq!(
+            classified_bytes,
+            PluginContentType::GIT_TEXT_SCAN_BYTES as u64,
+            "Git classification must inspect only its fixed NUL window"
+        );
+        assert!(
+            classified_bytes * 100 < large_non_utf8_text.len() as u64,
+            "the Git-compatible matcher should inspect under 1% of this 1 MiB payload"
+        );
+
+        let (selected, _) =
+            catalog.select_for_bytes_with_classification_work("document.data", b"valid UTF-8 text");
+        assert_eq!(
+            selected.map(PluginRegistryEntry::key),
+            Some("plugin_utf8_specific"),
+            "a more-specific UTF-8 parser must win when both predicates match"
+        );
+
+        let (selected, _) =
+            catalog.select_for_bytes_with_classification_work("asset.bin", b"raw\0bytes");
+        assert!(
+            selected.is_none(),
+            "NUL-bearing data must remain a raw binary file"
+        );
     }
 
     #[test]

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -63,8 +63,8 @@ use crate::plugin::{
     local_mutation_identity, plugin_install_plan_from_archive_path,
     plugin_key_from_archive_file_id, plugin_state_live_state_projection,
     require_existing_id_authorities, reservation_tombstone_row, reserve_namespace_row,
-    transport_splice_preserves_utf8, validate_host_allocated_changes,
-    validate_namespace_reservation,
+    transport_splice_preserves_git_text, transport_splice_preserves_utf8,
+    validate_host_allocated_changes, validate_namespace_reservation,
 };
 use crate::session::{
     EXECUTE_IDEMPOTENCY_RECEIPT_SPACE, ExecuteIdempotency, ExecuteIdempotencyReceipt, SessionMode,
@@ -2288,7 +2288,7 @@ where
         }
 
         let mut selected_plugins = BTreeMap::<PluginFileWriteKey, PluginRegistryEntry>::new();
-        let mut full_content_classification_bytes = BTreeMap::<PluginFileWriteKey, u64>::new();
+        let mut content_classification_bytes = BTreeMap::<PluginFileWriteKey, u64>::new();
         let selection_span = tracing::debug_span!(
             target: "lix_perf",
             "lix.perf.plugin_selection"
@@ -2315,10 +2315,9 @@ where
 
             // A warm v2 actor already carries an exact, generation-bound
             // selection. Reuse it only while every matcher-relevant identity
-            // is unchanged. Text content constraints can be preserved by
-            // validating the trusted splice's bounded UTF-8 window; all
-            // inconclusive, binary, blind, cold, or path-reselected writes use
-            // the ordinary full-payload classifier below.
+            // is unchanged. UTF-8 and Git-text constraints have separate
+            // bounded trusted-splice proofs; all inconclusive, binary, blind,
+            // cold, or path-reselected writes use the ordinary classifier below.
             let warm_owned_plugin = owners.get(&file_key).and_then(|owner| {
                 let plugin = registry.plugin(owner.plugin_key())?;
                 if !catalog.matches_plugin(plugin.key(), path) {
@@ -2343,6 +2342,13 @@ where
                             }) && transport_splice_preserves_utf8(write.data(), provenance)
                         })
                     }
+                    Some(PluginContentType::GitText) => {
+                        write.splice_provenance().is_some_and(|provenance| {
+                            observation.bytes_sha256().is_some_and(|digest| {
+                                digest.matches_lower_hex(provenance.base_sha256())
+                            }) && transport_splice_preserves_git_text(write.data(), provenance)
+                        })
+                    }
                     Some(PluginContentType::Binary) => false,
                 };
                 content_type_still_matches.then_some(plugin)
@@ -2353,7 +2359,7 @@ where
                 |plugin| (Some(plugin), 0),
             );
             if classified_bytes != 0 {
-                full_content_classification_bytes.insert(file_key.clone(), classified_bytes);
+                content_classification_bytes.insert(file_key.clone(), classified_bytes);
             }
             let Some(plugin) = plugin else {
                 continue;
@@ -2912,7 +2918,7 @@ where
                         )
                     };
                 counters.host_full_diff_bytes_compared = host_full_diff_bytes_compared;
-                counters.host_full_content_classification_bytes = full_content_classification_bytes
+                counters.host_content_classification_bytes = content_classification_bytes
                     .get(&file_key)
                     .copied()
                     .unwrap_or(0);
@@ -2975,7 +2981,7 @@ where
                 .await?;
                 let changes = validated.changes;
                 let mut counters = validated.counters;
-                counters.host_full_content_classification_bytes = full_content_classification_bytes
+                counters.host_content_classification_bytes = content_classification_bytes
                     .get(&file_key)
                     .copied()
                     .unwrap_or(0);

--- a/packages/engine/src/wasm/component_v2.rs
+++ b/packages/engine/src/wasm/component_v2.rs
@@ -126,10 +126,12 @@ pub struct WasmTransitionCounters {
     /// Bytes examined by the host-only full-blob diff fallback. Validated
     /// transport splice provenance keeps this zero.
     pub host_full_diff_bytes_compared: u64,
-    /// Bytes examined by a host-only full-payload content-type classification.
-    /// Warm, provenance-backed text edits validate only their bounded splice
-    /// window and keep this zero.
-    pub host_full_content_classification_bytes: u64,
+    /// Bytes examined by host-only content-type classification. A matcher may
+    /// deliberately use a bounded predicate (for example Git's 8 KiB NUL
+    /// window), while a UTF-8 parser examines the complete payload. Warm,
+    /// provenance-backed edits keep this zero when their invariant proof is
+    /// sufficient.
+    pub host_content_classification_bytes: u64,
     pub full_state_semantic_rows_materialized: u64,
     pub change_payload_requests: u64,
     pub returned_change_payloads: u64,
@@ -180,9 +182,9 @@ impl WasmTransitionCounters {
         self.host_full_diff_bytes_compared = self
             .host_full_diff_bytes_compared
             .saturating_add(other.host_full_diff_bytes_compared);
-        self.host_full_content_classification_bytes = self
-            .host_full_content_classification_bytes
-            .saturating_add(other.host_full_content_classification_bytes);
+        self.host_content_classification_bytes = self
+            .host_content_classification_bytes
+            .saturating_add(other.host_content_classification_bytes);
         self.full_state_semantic_rows_materialized = self
             .full_state_semantic_rows_materialized
             .saturating_add(other.full_state_semantic_rows_materialized);

--- a/packages/rs-sdk-tests/Cargo.toml
+++ b/packages/rs-sdk-tests/Cargo.toml
@@ -18,8 +18,10 @@ plugin_csv_v2 = { path = "../../plugins/csv-v2", lib = true, artifact = "cdylib"
 plugin_markdown_incremental_v2 = { path = "../../plugins/markdown-v2", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
 plugin_excalidraw_v2 = { path = "../../plugins/excalidraw-v2", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
 plugin_json_incremental_v2 = { path = "../../plugins/json-v2", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
+plugin_git_text_v2 = { path = "../../plugins/text-v2", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
 
 async-trait = "0.1"
+base64 = "0.22"
 criterion = { package = "codspeed-criterion-compat", version = "4" }
 rand = { version = "0.9", features = ["small_rng"] }
 serde_json = "1"

--- a/packages/rs-sdk-tests/tests/e2e.rs
+++ b/packages/rs-sdk-tests/tests/e2e.rs
@@ -1332,7 +1332,7 @@ async fn v2_json_ten_mib_real_wasm_edit_stays_sparse_and_bounded() {
     assert_eq!(cold.source_read_calls, 10);
     assert_eq!(cold.component_import_calls, 10);
     assert_eq!(
-        cold.host_full_content_classification_bytes,
+        cold.host_content_classification_bytes,
         JSON_TEN_MIB_BYTES as u64,
     );
     assert_eq!(
@@ -1396,7 +1396,7 @@ async fn v2_json_ten_mib_real_wasm_edit_stays_sparse_and_bounded() {
     let warm = lix.plugin_v2_transition_counters();
 
     assert_eq!(warm.host_full_diff_bytes_compared, 0);
-    assert_eq!(warm.host_full_content_classification_bytes, 0);
+    assert_eq!(warm.host_content_classification_bytes, 0);
     assert_eq!(warm.source_read_calls, 0);
     assert_eq!(warm.source_bytes_read, 0);
     assert_eq!(warm.component_import_calls, 0);

--- a/packages/rs-sdk-tests/tests/git_text_plugin.rs
+++ b/packages/rs-sdk-tests/tests/git_text_plugin.rs
@@ -1,0 +1,324 @@
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use lix_sdk::{OpenLixOptions, Value, open_lix};
+use std::io::{Cursor, Write};
+use std::path::Path;
+
+const PLUGIN_KEY: &str = "plugin_git_text_v2";
+const GIT_TEXT_SCAN_BYTES: u64 = 8_000;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GitTextLine {
+    id: String,
+    order_key: String,
+    content_base64: String,
+}
+
+#[tokio::test]
+async fn git_text_plugin_persists_lossless_line_rows_and_leaves_binary_raw() {
+    let storage = lix_sdk::Memory::new();
+    let lix = open_lix(OpenLixOptions::new(storage.clone()))
+        .await
+        .expect("workspace should open");
+    install_plugin(&lix, &build_plugin_archive())
+        .await
+        .expect("Git text plugin should install");
+
+    // Git considers this text despite invalid UTF-8 because its first 8 KiB
+    // contain no NUL. The row payload is base64url so it remains byte-exact.
+    let git_text = [0xff, b'\n', 0xfe, b'\n'].to_vec();
+    let text_path = "/git-text.invalid-utf8";
+    lix.reset_plugin_v2_transition_counters();
+    write_file(&lix, text_path, &git_text)
+        .await
+        .expect("NUL-free Git text should write");
+    let counters = lix.plugin_v2_transition_counters();
+    assert_eq!(counters.source_bytes_read, git_text.len() as u64);
+    assert_eq!(counters.durable_semantic_changes, 2);
+    assert_eq!(
+        counters.host_content_classification_bytes,
+        git_text.len() as u64,
+        "small payloads need only Git's bounded NUL scan"
+    );
+
+    let text_file_id = file_id_at_path(&lix, text_path).await;
+    assert_plugin_owned(&lix, &text_file_id, true).await;
+    let text_rows = git_text_rows(&lix, &text_file_id).await;
+    assert_eq!(text_rows.len(), 2);
+    assert_eq!(render_rows(&text_rows), git_text);
+    assert_eq!(read_file(&lix, text_path).await, Some(git_text.clone()));
+
+    // A NUL within Git's scan window remains an ordinary raw binary file.
+    let binary = b"opaque\0payload".to_vec();
+    let binary_path = "/binary.dat";
+    write_file(&lix, binary_path, &binary)
+        .await
+        .expect("Git binary should write without the text plugin");
+    let binary_file_id = file_id_at_path(&lix, binary_path).await;
+    assert_plugin_owned(&lix, &binary_file_id, false).await;
+    assert_eq!(read_file(&lix, binary_path).await, Some(binary.clone()));
+
+    // Empty files are Git text too; their semantic representation is an
+    // intentionally empty line table rather than a synthetic blank line.
+    let empty_path = "/empty.txt";
+    write_file(&lix, empty_path, b"")
+        .await
+        .expect("empty Git text should write");
+    let empty_file_id = file_id_at_path(&lix, empty_path).await;
+    assert_plugin_owned(&lix, &empty_file_id, true).await;
+    assert!(git_text_rows(&lix, &empty_file_id).await.is_empty());
+    assert_eq!(read_file(&lix, empty_path).await, Some(Vec::new()));
+
+    lix.close().await.expect("workspace should close");
+    let reopened = open_lix(OpenLixOptions::new(storage))
+        .await
+        .expect("workspace should reopen");
+    assert_eq!(read_file(&reopened, text_path).await, Some(git_text));
+    assert_eq!(read_file(&reopened, binary_path).await, Some(binary));
+    assert_eq!(read_file(&reopened, empty_path).await, Some(Vec::new()));
+    assert_eq!(
+        render_rows(&git_text_rows(&reopened, &text_file_id).await),
+        [0xff, b'\n', 0xfe, b'\n']
+    );
+    // This write forces a cold actor to rebuild its document from durable
+    // rows after reopen, then proves the resulting semantic update is exact.
+    let reopened_successor = [0xff, b'\n', b'X', b'\n'].to_vec();
+    write_file(&reopened, text_path, &reopened_successor)
+        .await
+        .expect("cold row reconstruction should accept a later line edit");
+    let reopened_rows = git_text_rows(&reopened, &text_file_id).await;
+    assert_eq!(reopened_rows[0].id, text_rows[0].id);
+    assert_eq!(reopened_rows[1].id, text_rows[1].id);
+    assert_eq!(render_rows(&reopened_rows), reopened_successor);
+    reopened
+        .close()
+        .await
+        .expect("reopened workspace should close");
+}
+
+#[tokio::test]
+async fn git_text_plugin_reads_only_a_large_after_range_and_updates_one_line_row() {
+    const MIB: usize = 1024 * 1024;
+
+    let lix = open_lix(OpenLixOptions::new(lix_sdk::Memory::new()))
+        .await
+        .expect("workspace should open");
+    install_plugin(&lix, &build_plugin_archive())
+        .await
+        .expect("Git text plugin should install");
+
+    // This single line is deliberately large enough that the replacement is
+    // sent as an `AfterRange`, not copied through the inline Component input.
+    let mut before = vec![b'a'; 4 * MIB];
+    before.extend_from_slice(b"\nuntouched\n");
+    let path = "/large.txt";
+    write_file(&lix, path, &before)
+        .await
+        .expect("initial Git text should write");
+    let file_id = file_id_at_path(&lix, path).await;
+    let before_rows = git_text_rows(&lix, &file_id).await;
+    assert_eq!(before_rows.len(), 2);
+
+    let replacement_offset = MIB;
+    let replacement_len = MIB + 1;
+    let mut after = before.clone();
+    after[replacement_offset..replacement_offset + replacement_len].fill(b'b');
+
+    lix.reset_plugin_v2_transition_counters();
+    write_file(&lix, path, &after)
+        .await
+        .expect("large localized line edit should write");
+    let counters = lix.plugin_v2_transition_counters();
+    assert_eq!(
+        counters.source_bytes_read, replacement_len as u64,
+        "the plugin must read only the `AfterRange` insert, never the full 4 MiB successor"
+    );
+    assert!(
+        counters.source_bytes_read * 100 < before.len() as u64 * 30,
+        "the warm source read should stay below 30% of the full document"
+    );
+    assert_eq!(counters.durable_semantic_changes, 1);
+    assert_eq!(counters.full_document_reparses, 0);
+    assert_eq!(
+        counters.host_content_classification_bytes, GIT_TEXT_SCAN_BYTES,
+        "Git text selection must remain bounded even for a multi-megabyte file"
+    );
+
+    let after_rows = git_text_rows(&lix, &file_id).await;
+    assert_eq!(after_rows.len(), 2);
+    assert_eq!(after_rows[0].id, before_rows[0].id);
+    assert_eq!(after_rows[1], before_rows[1]);
+    assert_eq!(render_rows(&after_rows), after);
+    assert_eq!(read_file(&lix, path).await, Some(after));
+    lix.close().await.expect("workspace should close");
+}
+
+async fn install_plugin<StorageImpl>(
+    lix: &lix_sdk::Lix<StorageImpl>,
+    archive: &[u8],
+) -> Result<(), lix_sdk::LixError>
+where
+    StorageImpl: lix_sdk::Storage + Clone + Send + Sync + 'static,
+{
+    write_file(
+        lix,
+        &format!("/.lix/plugins/{PLUGIN_KEY}.lixplugin"),
+        archive,
+    )
+    .await
+}
+
+async fn write_file<StorageImpl>(
+    lix: &lix_sdk::Lix<StorageImpl>,
+    path: &str,
+    data: &[u8],
+) -> Result<(), lix_sdk::LixError>
+where
+    StorageImpl: lix_sdk::Storage + Clone + Send + Sync + 'static,
+{
+    lix.execute(
+        "INSERT INTO lix_file (path, data) VALUES ($1, $2) \
+         ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+        &[
+            Value::Text(path.to_owned()),
+            Value::Blob(data.to_vec().into()),
+        ],
+    )
+    .await?;
+    Ok(())
+}
+
+async fn read_file<StorageImpl>(lix: &lix_sdk::Lix<StorageImpl>, path: &str) -> Option<Vec<u8>>
+where
+    StorageImpl: lix_sdk::Storage + Clone + Send + Sync + 'static,
+{
+    let result = lix
+        .execute(
+            "SELECT data FROM lix_file WHERE path = $1",
+            &[Value::Text(path.to_owned())],
+        )
+        .await
+        .expect("file read should succeed");
+    result
+        .rows()
+        .first()
+        .map(|row| row.get::<Vec<u8>>("data").expect("data should be a blob"))
+}
+
+async fn file_id_at_path<StorageImpl>(lix: &lix_sdk::Lix<StorageImpl>, path: &str) -> String
+where
+    StorageImpl: lix_sdk::Storage + Clone + Send + Sync + 'static,
+{
+    let result = lix
+        .execute(
+            "SELECT id FROM lix_file WHERE path = $1",
+            &[Value::Text(path.to_owned())],
+        )
+        .await
+        .expect("file ID query should succeed");
+    assert_eq!(result.len(), 1, "expected one file at {path}");
+    result.rows()[0]
+        .get::<String>("id")
+        .expect("file id should be text")
+}
+
+async fn git_text_rows<StorageImpl>(
+    lix: &lix_sdk::Lix<StorageImpl>,
+    file_id: &str,
+) -> Vec<GitTextLine>
+where
+    StorageImpl: lix_sdk::Storage + Clone + Send + Sync + 'static,
+{
+    let result = lix
+        .execute(
+            "SELECT lixcol_entity_pk, id, order_key, content_base64 \
+             FROM git_text_line_v2 WHERE lixcol_file_id = $1",
+            &[Value::Text(file_id.to_owned())],
+        )
+        .await
+        .expect("Git text rows should query");
+    let mut rows = result
+        .rows()
+        .iter()
+        .map(|row| {
+            let id = row.get::<String>("id").expect("line id should be text");
+            assert_eq!(
+                row.get::<serde_json::Value>("lixcol_entity_pk")
+                    .expect("line primary key should be JSON"),
+                serde_json::json!([id.clone()]),
+                "line snapshot identity must equal its durable primary key"
+            );
+            GitTextLine {
+                id,
+                order_key: row
+                    .get::<String>("order_key")
+                    .expect("line order key should be text"),
+                content_base64: row
+                    .get::<String>("content_base64")
+                    .expect("line content should be text"),
+            }
+        })
+        .collect::<Vec<_>>();
+    rows.sort_by(|left, right| left.order_key.cmp(&right.order_key));
+    rows
+}
+
+fn render_rows(rows: &[GitTextLine]) -> Vec<u8> {
+    rows.iter()
+        .flat_map(|row| {
+            URL_SAFE_NO_PAD
+                .decode(&row.content_base64)
+                .expect("line content must be base64url")
+        })
+        .collect()
+}
+
+async fn assert_plugin_owned<StorageImpl>(
+    lix: &lix_sdk::Lix<StorageImpl>,
+    file_id: &str,
+    expected: bool,
+) where
+    StorageImpl: lix_sdk::Storage + Clone + Send + Sync + 'static,
+{
+    let owners = lix
+        .execute(
+            "SELECT key FROM lix_key_value \
+             WHERE lixcol_file_id = $1 AND key = 'lix_plugin_owner_v2'",
+            &[Value::Text(file_id.to_owned())],
+        )
+        .await
+        .expect("plugin owner query should succeed");
+    assert_eq!(owners.len() == 1, expected);
+}
+
+fn build_plugin_archive() -> Vec<u8> {
+    let wasm_path = Path::new(env!(
+        "CARGO_CDYLIB_FILE_PLUGIN_GIT_TEXT_V2_plugin_git_text_v2"
+    ));
+    let wasm = std::fs::read(wasm_path).unwrap_or_else(|error| {
+        panic!(
+            "failed to read bindep-built Git text plugin wasm at {}: {error}",
+            wasm_path.display()
+        )
+    });
+    let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    for (path, bytes) in [
+        (
+            "manifest.json",
+            include_str!("../../../plugins/text-v2/manifest.json").as_bytes(),
+        ),
+        (
+            "schema/git_text_line_v2.json",
+            include_str!("../../../plugins/text-v2/schema/git_text_line_v2.json").as_bytes(),
+        ),
+        ("plugin.wasm", wasm.as_slice()),
+    ] {
+        writer
+            .start_file(path, options)
+            .expect("archive entry should start");
+        writer.write_all(bytes).expect("archive entry should write");
+    }
+    writer.finish().expect("archive should finish").into_inner()
+}

--- a/plugins/text-v2/Cargo.toml
+++ b/plugins/text-v2/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "plugin_git_text_v2"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+description = "Git-compatible line-row plugin for the Lix Wasm Component v2 API"
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+documentation.workspace = true
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+base64 = "0.22"
+lix_order_key.workspace = true
+lix_plugin_api_v2 = { workspace = true }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/plugins/text-v2/README.md
+++ b/plugins/text-v2/README.md
@@ -1,0 +1,32 @@
+# Git text line-row Component v2 plugin
+
+This component is the Lix-native counterpart to Git's text classification. It
+matches paths whose first 8 KiB contain no NUL byte, the same bounded predicate
+Git uses before choosing text-oriented behavior.
+
+Each LF-delimited byte segment becomes one durable `git_text_line_v2` row. The
+line's bytes, including a trailing LF when present, are URL-safe base64 encoded
+so NUL-free but invalid UTF-8 Git text remains lossless. Rows have stable
+host-allocated IDs and fractional order keys: a localized line update changes
+that row only, an insertion adds one row, and a reorder updates only the rows
+whose order must move.
+
+The host also retains exact materialized bytes in its normal
+`lix_binary_blob_ref`/CAS path. NUL-bearing input inside Git's first-8-KiB
+window never selects this plugin and remains an ordinary raw binary file.
+
+Build it with:
+
+```sh
+cargo build --release -p plugin_git_text_v2 --target wasm32-wasip2
+```
+
+Package `manifest.json`, `schema/git_text_line_v2.json`, and the resulting
+`plugin.wasm` into a stored `.lixplugin` ZIP, then install it through the
+normal tracked plugin path:
+
+```text
+/.lix/plugins/plugin_git_text_v2.lixplugin
+```
+
+Plugin installation is setup work, not part of replay timing.

--- a/plugins/text-v2/manifest.json
+++ b/plugins/text-v2/manifest.json
@@ -1,0 +1,13 @@
+{
+  "key": "plugin_git_text_v2",
+  "runtime": "wasm-component-v2",
+  "api_version": "2.1.0",
+  "match": {
+    "path_glob": "*",
+    "content_type": "git_text"
+  },
+  "entry": "plugin.wasm",
+  "schemas": [
+    "schema/git_text_line_v2.json"
+  ]
+}

--- a/plugins/text-v2/schema/git_text_line_v2.json
+++ b/plugins/text-v2/schema/git_text_line_v2.json
@@ -1,0 +1,23 @@
+{
+  "x-lix-key": "git_text_line_v2",
+  "x-lix-primary-key": ["/id"],
+  "x-lix-id-allocation": "host-allocated",
+  "description": "One byte-exact Git-style text line. Newline bytes remain part of content_base64.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "order_key": {
+      "type": "string",
+      "pattern": "^[0-9a-f]+$"
+    },
+    "content_base64": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_-]+$"
+    }
+  },
+  "required": ["id", "order_key", "content_base64"],
+  "additionalProperties": false
+}

--- a/plugins/text-v2/src/bindings.rs
+++ b/plugins/text-v2/src/bindings.rs
@@ -1,0 +1,82 @@
+//! Public Component-v2 adapter for the Git text line model.
+#![allow(dead_code, unused_qualifications)]
+
+use lix_plugin_api_v2 as lix;
+
+use crate::core::{Document, InputSplice};
+
+struct GitTextPlugin;
+
+impl lix::FormatPlugin for GitTextPlugin {
+    type Document = Document;
+
+    fn open_file(input: lix::OpenFile<'_>) -> lix::Result<(Self::Document, lix::Changes)> {
+        let bytes = input.source.read_all()?;
+        let (document, changes) = Document::open_file(bytes, |ordinal| input.ids.id(ordinal))
+            .map_err(lix::Error::invalid_input)?;
+        Ok((document, lix::changes(changes.into_iter())))
+    }
+
+    fn open_entities(
+        mut input: lix::OpenEntities<'_>,
+    ) -> lix::Result<(Self::Document, lix::Edits)> {
+        // `accepted` is a host-verified materialization for this exact
+        // semantic root. The document rows are sufficient to recreate it, so
+        // do not read a potentially huge raw checkpoint merely to rediscover
+        // that the renderer agrees. A missing checkpoint instead means the
+        // host needs one insertion relative to an empty file.
+        let has_accepted = input.accepted.is_some();
+        let mut records = Vec::new();
+        while let Some(record) = input.entities.next()? {
+            records.push(record);
+        }
+        let document = Document::open_entities(records).map_err(lix::Error::invalid_input)?;
+        let edits = restore_edits(has_accepted, document.bytes());
+        Ok((document, lix::edits(edits.into_iter())))
+    }
+
+    fn file_changed(
+        document: &Self::Document,
+        update: lix::FileUpdate<'_>,
+    ) -> lix::Result<(Self::Document, lix::Changes)> {
+        let mut splices = Vec::with_capacity(update.edits.len());
+        for edit in &update.edits {
+            splices.push(InputSplice {
+                offset: edit.offset,
+                delete_len: edit.delete_len,
+                insert: update.read_insert(edit)?,
+            });
+        }
+        let (document, changes) = document
+            .file_changed(&splices, |ordinal| update.ids.id(ordinal))
+            .map_err(lix::Error::invalid_input)?;
+        Ok((document, lix::changes(changes.into_iter())))
+    }
+
+    fn entities_changed(
+        document: &Self::Document,
+        mut update: lix::EntityUpdate<'_>,
+    ) -> lix::Result<(Self::Document, lix::Edits)> {
+        let mut changes = Vec::new();
+        while let Some(change) = update.changes.next()? {
+            changes.push(change);
+        }
+        let (document, edits) = document
+            .entities_changed(changes)
+            .map_err(lix::Error::invalid_input)?;
+        Ok((document, lix::edits(edits.into_iter())))
+    }
+}
+
+fn restore_edits(has_accepted: bool, rendered: &[u8]) -> Vec<lix::ByteEdit> {
+    if !has_accepted {
+        return (!rendered.is_empty())
+            .then(|| lix::ByteEdit::new(0, 0, rendered.to_vec()))
+            .into_iter()
+            .collect();
+    }
+    Vec::new()
+}
+
+#[cfg(target_family = "wasm")]
+lix_plugin_api_v2::export_v2!(GitTextPlugin);

--- a/plugins/text-v2/src/core.rs
+++ b/plugins/text-v2/src/core.rs
@@ -1,0 +1,559 @@
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::sync::Arc;
+
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use lix_order_key::OrderKey;
+use lix_plugin_api_v2 as lix;
+use serde::{Deserialize, Serialize};
+
+pub(crate) const LINE_SCHEMA_KEY: &str = "git_text_line_v2";
+const GIT_TEXT_SCAN_BYTES: usize = 8_000;
+
+/// One verified base-relative splice received from the Component adapter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InputSplice {
+    pub(crate) offset: u64,
+    pub(crate) delete_len: u64,
+    pub(crate) insert: Vec<u8>,
+}
+
+/// Immutable, byte-exact state for a Git-style text document.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Document(Arc<DocumentInner>);
+
+#[derive(Debug, PartialEq, Eq)]
+struct DocumentInner {
+    bytes: Arc<Vec<u8>>,
+    lines: Vec<Line>,
+}
+
+/// A durable line entity. `bytes` includes its trailing LF when present.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Line {
+    id: String,
+    order_key: OrderKey,
+    bytes: Arc<Vec<u8>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LineSnapshot {
+    id: String,
+    order_key: String,
+    content_base64: String,
+}
+
+impl Document {
+    pub(crate) fn open_file(
+        bytes: Vec<u8>,
+        mut id_for_ordinal: impl FnMut(u64) -> String,
+    ) -> Result<(Self, Vec<lix::EntityChange>), String> {
+        validate_git_text(&bytes)?;
+        let chunks = split_lines(&bytes);
+        let order_keys = OrderKey::evenly_between(None, None, chunks.len())?;
+        let mut lines = Vec::with_capacity(chunks.len());
+        for (ordinal, (bytes, order_key)) in chunks.into_iter().zip(order_keys).enumerate() {
+            lines.push(Line {
+                id: id_for_ordinal(usize_to_u64(ordinal, "line ID ordinal")?),
+                order_key,
+                bytes: Arc::new(bytes),
+            });
+        }
+        let document = Self::from_lines(lines)?;
+        let changes = document.all_upserts()?;
+        Ok((document, changes))
+    }
+
+    pub(crate) fn open_entities(
+        records: impl IntoIterator<Item = lix::EntityRecord>,
+    ) -> Result<Self, String> {
+        let mut lines = Vec::new();
+        for record in records {
+            validate_entity_key(&record.schema_key, &record.entity_pk)?;
+            let line = Line::from_snapshot(&record.snapshot)?;
+            if record.entity_pk[0] != line.id {
+                return Err(format!(
+                    "line entity primary key '{}' does not match snapshot id '{}'",
+                    record.entity_pk[0], line.id
+                ));
+            }
+            lines.push(line);
+        }
+        Self::from_lines(lines)
+    }
+
+    pub(crate) fn file_changed(
+        &self,
+        splices: &[InputSplice],
+        mut id_for_ordinal: impl FnMut(u64) -> String,
+    ) -> Result<(Self, Vec<lix::EntityChange>), String> {
+        let bytes = apply_splices(self.bytes(), splices)?;
+        validate_git_text(&bytes)?;
+        let chunks = split_lines(&bytes);
+
+        // Exact byte matches preserve their entity identity even across a
+        // reorder. Remaining old/new positions are paired in order, which
+        // preserves an edited line's ID without inventing a parser-specific
+        // identity rule for arbitrary text.
+        let mut exact = BTreeMap::<&[u8], VecDeque<usize>>::new();
+        for (old_index, line) in self.lines().iter().enumerate() {
+            exact
+                .entry(line.bytes.as_slice())
+                .or_default()
+                .push_back(old_index);
+        }
+        let mut old_for_new = vec![None; chunks.len()];
+        let mut old_used = vec![false; self.lines().len()];
+        for (new_index, bytes) in chunks.iter().enumerate() {
+            let Some(candidates) = exact.get_mut(bytes.as_slice()) else {
+                continue;
+            };
+            let old_index = candidates
+                .pop_front()
+                .expect("a nonempty candidate queue was checked");
+            old_for_new[new_index] = Some(old_index);
+            old_used[old_index] = true;
+        }
+
+        let unmatched_old = old_used
+            .iter()
+            .enumerate()
+            .filter_map(|(index, used)| (!used).then_some(index))
+            .collect::<Vec<_>>();
+        let unmatched_new = old_for_new
+            .iter()
+            .enumerate()
+            .filter_map(|(index, old)| old.is_none().then_some(index))
+            .collect::<Vec<_>>();
+        for (old_index, new_index) in unmatched_old.into_iter().zip(unmatched_new) {
+            old_for_new[new_index] = Some(old_index);
+            old_used[old_index] = true;
+        }
+
+        let order_keys = self.reconciled_order_keys(&old_for_new)?;
+        let mut known_ids = self
+            .lines()
+            .iter()
+            .map(|line| line.id.clone())
+            .collect::<BTreeSet<_>>();
+        let mut next_ordinal = 0u64;
+        let mut lines = Vec::with_capacity(chunks.len());
+        for ((bytes, old_index), order_key) in chunks.into_iter().zip(old_for_new).zip(order_keys) {
+            let id = match old_index {
+                Some(old_index) => self.lines()[old_index].id.clone(),
+                None => {
+                    let id = id_for_ordinal(next_ordinal);
+                    next_ordinal = next_ordinal
+                        .checked_add(1)
+                        .ok_or_else(|| "line ID ordinal overflow".to_owned())?;
+                    if !known_ids.insert(id.clone()) {
+                        return Err(format!(
+                            "new line ID '{id}' collides with an existing line identity"
+                        ));
+                    }
+                    id
+                }
+            };
+            lines.push(Line {
+                id,
+                order_key,
+                bytes: Arc::new(bytes),
+            });
+        }
+
+        let document = Self::from_lines(lines)?;
+        let changes = self.changes_to(&document)?;
+        Ok((document, changes))
+    }
+
+    pub(crate) fn entities_changed(
+        &self,
+        changes: impl IntoIterator<Item = lix::EntityChange>,
+    ) -> Result<(Self, Vec<lix::ByteEdit>), String> {
+        let mut lines = self
+            .lines()
+            .iter()
+            .cloned()
+            .map(|line| (line.id.clone(), line))
+            .collect::<BTreeMap<_, _>>();
+
+        for change in changes {
+            validate_entity_key(&change.schema_key, &change.entity_pk)?;
+            let id = &change.entity_pk[0];
+            match change.snapshot {
+                Some(snapshot) => {
+                    let line = Line::from_snapshot(&snapshot)?;
+                    if line.id != *id {
+                        return Err(format!(
+                            "line entity primary key '{id}' does not match snapshot id '{}'",
+                            line.id
+                        ));
+                    }
+                    lines.insert(id.clone(), line);
+                }
+                None => {
+                    if lines.remove(id).is_none() {
+                        return Err(format!("cannot delete unknown line entity '{id}'"));
+                    }
+                }
+            }
+        }
+
+        let document = Self::from_lines(lines.into_values().collect())?;
+        let edits = self.renderer_edits_to(&document)?;
+        Ok((document, edits))
+    }
+
+    pub(crate) fn bytes(&self) -> &[u8] {
+        self.0.bytes.as_slice()
+    }
+
+    pub(crate) fn lines(&self) -> &[Line] {
+        &self.0.lines
+    }
+
+    fn from_lines(mut lines: Vec<Line>) -> Result<Self, String> {
+        let mut ids = BTreeSet::new();
+        let mut order_keys = BTreeSet::new();
+        for line in &lines {
+            if line.id.is_empty() {
+                return Err("line IDs must not be empty".to_owned());
+            }
+            validate_line_bytes(line.bytes.as_slice())?;
+            if !ids.insert(line.id.clone()) {
+                return Err(format!("duplicate line entity ID '{}'", line.id));
+            }
+            if !order_keys.insert(line.order_key.clone()) {
+                return Err(format!(
+                    "duplicate line order key '{}'",
+                    line.order_key.to_snapshot_string()
+                ));
+            }
+        }
+        lines.sort_by(|left, right| {
+            left.order_key
+                .cmp(&right.order_key)
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        let bytes = render_lines(&lines)?;
+        validate_git_text(&bytes)?;
+        Ok(Self(Arc::new(DocumentInner {
+            bytes: Arc::new(bytes),
+            lines,
+        })))
+    }
+
+    fn all_upserts(&self) -> Result<Vec<lix::EntityChange>, String> {
+        self.lines()
+            .iter()
+            .map(Line::upsert_change)
+            .collect::<Result<Vec<_>, _>>()
+    }
+
+    fn changes_to(&self, after: &Self) -> Result<Vec<lix::EntityChange>, String> {
+        let before = self
+            .lines()
+            .iter()
+            .map(|line| (line.id.as_str(), line))
+            .collect::<BTreeMap<_, _>>();
+        let after_by_id = after
+            .lines()
+            .iter()
+            .map(|line| (line.id.as_str(), line))
+            .collect::<BTreeMap<_, _>>();
+
+        let mut changes = Vec::new();
+        for line in self.lines() {
+            if !after_by_id.contains_key(line.id.as_str()) {
+                changes.push(lix::EntityChange::delete(
+                    LINE_SCHEMA_KEY,
+                    vec![line.id.clone()],
+                ));
+            }
+        }
+        for line in after.lines() {
+            let changed = before
+                .get(line.id.as_str())
+                .is_none_or(|before_line| before_line != &line);
+            if changed {
+                changes.push(line.upsert_change()?);
+            }
+        }
+        Ok(changes)
+    }
+
+    fn reconciled_order_keys(
+        &self,
+        old_for_new: &[Option<usize>],
+    ) -> Result<Vec<OrderKey>, String> {
+        let anchors = longest_increasing_old_indexes(old_for_new);
+        let mut order_keys = vec![None; old_for_new.len()];
+        for &position in &anchors {
+            let old_index =
+                old_for_new[position].expect("an order anchor always references an existing line");
+            order_keys[position] = Some(self.lines()[old_index].order_key.clone());
+        }
+
+        let mut previous = None;
+        let mut cursor = 0usize;
+        for anchor in anchors {
+            let next = order_keys[anchor]
+                .as_ref()
+                .expect("an order anchor key was assigned")
+                .clone();
+            let allocated =
+                OrderKey::evenly_between(previous.as_ref(), Some(&next), anchor - cursor)?;
+            for (position, key) in (cursor..anchor).zip(allocated) {
+                order_keys[position] = Some(key);
+            }
+            previous = Some(next);
+            cursor = anchor
+                .checked_add(1)
+                .ok_or_else(|| "line order cursor overflow".to_owned())?;
+        }
+        let allocated =
+            OrderKey::evenly_between(previous.as_ref(), None, old_for_new.len() - cursor)?;
+        for (position, key) in (cursor..old_for_new.len()).zip(allocated) {
+            order_keys[position] = Some(key);
+        }
+
+        order_keys
+            .into_iter()
+            .collect::<Option<Vec<_>>>()
+            .ok_or_else(|| "failed to assign an order key to every line".to_owned())
+    }
+
+    fn renderer_edits_to(&self, after: &Self) -> Result<Vec<lix::ByteEdit>, String> {
+        if self.bytes() == after.bytes() {
+            return Ok(Vec::new());
+        }
+
+        let same_layout = self.lines().len() == after.lines().len()
+            && self
+                .lines()
+                .iter()
+                .zip(after.lines())
+                .all(|(before, after)| {
+                    before.id == after.id && before.order_key == after.order_key
+                });
+        if same_layout {
+            let mut offset = 0u64;
+            let mut edits = Vec::new();
+            for (before, after) in self.lines().iter().zip(after.lines()) {
+                if before.bytes != after.bytes {
+                    edits.push(lix::ByteEdit::new(
+                        offset,
+                        usize_to_u64(before.bytes.len(), "line byte length")?,
+                        after.bytes.as_ref().clone(),
+                    ));
+                }
+                offset = offset
+                    .checked_add(usize_to_u64(before.bytes.len(), "line byte length")?)
+                    .ok_or_else(|| "line offset overflow".to_owned())?;
+            }
+            return Ok(edits);
+        }
+
+        let (prefix, suffix) = common_prefix_and_suffix(self.bytes(), after.bytes());
+        let delete_len = self
+            .bytes()
+            .len()
+            .checked_sub(prefix)
+            .and_then(|length| length.checked_sub(suffix))
+            .ok_or_else(|| "invalid common byte range".to_owned())?;
+        let insert_end = after
+            .bytes()
+            .len()
+            .checked_sub(suffix)
+            .ok_or_else(|| "invalid common byte suffix".to_owned())?;
+        Ok(vec![lix::ByteEdit::new(
+            usize_to_u64(prefix, "render edit offset")?,
+            usize_to_u64(delete_len, "render edit delete length")?,
+            after.bytes()[prefix..insert_end].to_vec(),
+        )])
+    }
+}
+
+impl Line {
+    #[cfg(test)]
+    pub(crate) fn id(&self) -> &str {
+        &self.id
+    }
+
+    #[cfg(test)]
+    pub(crate) fn order_key(&self) -> String {
+        self.order_key.to_snapshot_string()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn bytes(&self) -> &[u8] {
+        self.bytes.as_slice()
+    }
+
+    pub(crate) fn snapshot_bytes(&self) -> Result<Vec<u8>, String> {
+        serde_json::to_vec(&LineSnapshot {
+            id: self.id.clone(),
+            order_key: self.order_key.to_snapshot_string(),
+            content_base64: URL_SAFE_NO_PAD.encode(self.bytes.as_slice()),
+        })
+        .map_err(|error| format!("failed to serialize line snapshot: {error}"))
+    }
+
+    fn from_snapshot(snapshot: &[u8]) -> Result<Self, String> {
+        let snapshot = serde_json::from_slice::<LineSnapshot>(snapshot)
+            .map_err(|error| format!("line snapshot must be valid JSON: {error}"))?;
+        if snapshot.id.is_empty() {
+            return Err("line snapshot id must not be empty".to_owned());
+        }
+        let order_key = OrderKey::from_snapshot_string(&snapshot.order_key)
+            .map_err(|error| format!("invalid line order key: {error}"))?;
+        let bytes = URL_SAFE_NO_PAD
+            .decode(snapshot.content_base64)
+            .map_err(|error| format!("invalid line content_base64: {error}"))?;
+        validate_line_bytes(&bytes)?;
+        Ok(Self {
+            id: snapshot.id,
+            order_key,
+            bytes: Arc::new(bytes),
+        })
+    }
+
+    fn upsert_change(&self) -> Result<lix::EntityChange, String> {
+        Ok(lix::EntityChange::upsert(
+            LINE_SCHEMA_KEY,
+            vec![self.id.clone()],
+            self.snapshot_bytes()?,
+        ))
+    }
+}
+
+fn split_lines(bytes: &[u8]) -> Vec<Vec<u8>> {
+    if bytes.is_empty() {
+        return Vec::new();
+    }
+    bytes
+        .split_inclusive(|byte| *byte == b'\n')
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn validate_line_bytes(bytes: &[u8]) -> Result<(), String> {
+    let Some((_, prefix)) = bytes.split_last() else {
+        return Err("line entities must contain at least one byte".to_owned());
+    };
+    if prefix.contains(&b'\n') {
+        return Err(
+            "one Git text line may contain one trailing LF but no embedded LF bytes".to_owned(),
+        );
+    }
+    Ok(())
+}
+
+fn apply_splices(before: &[u8], splices: &[InputSplice]) -> Result<Vec<u8>, String> {
+    let mut after = Vec::with_capacity(before.len());
+    let mut cursor = 0usize;
+    for splice in splices {
+        let start = usize::try_from(splice.offset)
+            .map_err(|_| "splice offset exceeds this platform's address space".to_owned())?;
+        let delete_len = usize::try_from(splice.delete_len)
+            .map_err(|_| "splice delete length exceeds this platform's address space".to_owned())?;
+        let end = start
+            .checked_add(delete_len)
+            .ok_or_else(|| "splice range overflows".to_owned())?;
+        if start < cursor || end > before.len() {
+            return Err("file splices must be sorted, non-overlapping, and in bounds".to_owned());
+        }
+        after.extend_from_slice(&before[cursor..start]);
+        after.extend_from_slice(&splice.insert);
+        cursor = end;
+    }
+    after.extend_from_slice(&before[cursor..]);
+    Ok(after)
+}
+
+fn render_lines(lines: &[Line]) -> Result<Vec<u8>, String> {
+    let total = lines.iter().try_fold(0usize, |total, line| {
+        total
+            .checked_add(line.bytes.len())
+            .ok_or_else(|| "rendered text document is too large".to_owned())
+    })?;
+    let mut bytes = Vec::with_capacity(total);
+    for line in lines {
+        bytes.extend_from_slice(line.bytes.as_slice());
+    }
+    Ok(bytes)
+}
+
+fn validate_entity_key(schema_key: &str, entity_pk: &[String]) -> Result<(), String> {
+    if schema_key != LINE_SCHEMA_KEY {
+        return Err(format!(
+            "Git text plugin only accepts schema '{LINE_SCHEMA_KEY}', got '{schema_key}'"
+        ));
+    }
+    let [id] = entity_pk else {
+        return Err("Git text line entities need exactly one primary-key component".to_owned());
+    };
+    if id.is_empty() {
+        return Err("Git text line entity primary key must not be empty".to_owned());
+    }
+    Ok(())
+}
+
+fn validate_git_text(bytes: &[u8]) -> Result<(), String> {
+    if bytes[..bytes.len().min(GIT_TEXT_SCAN_BYTES)].contains(&0) {
+        return Err("Git text documents cannot contain NUL in their first 8 KiB".to_owned());
+    }
+    Ok(())
+}
+
+fn longest_increasing_old_indexes(old_for_new: &[Option<usize>]) -> Vec<usize> {
+    let mut tails = Vec::<usize>::new();
+    let mut predecessors = vec![None; old_for_new.len()];
+
+    for (position, old_index) in old_for_new.iter().enumerate() {
+        let Some(old_index) = old_index else {
+            continue;
+        };
+        let insertion = tails.partition_point(|tail_position| {
+            old_for_new[*tail_position].expect("LIS tails only contain matched positions")
+                < *old_index
+        });
+        if insertion != 0 {
+            predecessors[position] = Some(tails[insertion - 1]);
+        }
+        if insertion == tails.len() {
+            tails.push(position);
+        } else {
+            tails[insertion] = position;
+        }
+    }
+
+    let mut anchors = Vec::with_capacity(tails.len());
+    let mut current = tails.last().copied();
+    while let Some(position) = current {
+        anchors.push(position);
+        current = predecessors[position];
+    }
+    anchors.reverse();
+    anchors
+}
+
+fn common_prefix_and_suffix(before: &[u8], after: &[u8]) -> (usize, usize) {
+    let prefix = before
+        .iter()
+        .zip(after)
+        .take_while(|(left, right)| left == right)
+        .count();
+    let suffix = before[prefix..]
+        .iter()
+        .rev()
+        .zip(after[prefix..].iter().rev())
+        .take_while(|(left, right)| left == right)
+        .count();
+    (prefix, suffix)
+}
+
+fn usize_to_u64(value: usize, context: &str) -> Result<u64, String> {
+    u64::try_from(value).map_err(|_| format!("{context} exceeds u64"))
+}

--- a/plugins/text-v2/src/lib.rs
+++ b/plugins/text-v2/src/lib.rs
@@ -1,0 +1,17 @@
+//! Git-style line semantics for NUL-free text files.
+//!
+//! A line is a durable entity rather than a display-only diff hunk. The
+//! component preserves source bytes exactly, including invalid UTF-8 and final
+//! unterminated lines, by storing each LF-delimited byte segment as base64.
+
+mod bindings;
+mod core;
+
+pub const MANIFEST_JSON: &str = include_str!("../manifest.json");
+pub const SCHEMAS: [(&str, &str); 1] = [(
+    "schema/git_text_line_v2.json",
+    include_str!("../schema/git_text_line_v2.json"),
+)];
+
+#[cfg(test)]
+mod tests;

--- a/plugins/text-v2/src/tests.rs
+++ b/plugins/text-v2/src/tests.rs
@@ -1,0 +1,243 @@
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use lix_plugin_api_v2 as lix;
+use serde_json::{Value, json};
+
+use crate::core::{Document, InputSplice, LINE_SCHEMA_KEY, Line};
+
+fn open(bytes: &[u8]) -> (Document, Vec<lix::EntityChange>) {
+    Document::open_file(bytes.to_vec(), |ordinal| format!("line-{ordinal}"))
+        .expect("Git text document should open")
+}
+
+fn ids(document: &Document) -> Vec<String> {
+    document
+        .lines()
+        .iter()
+        .map(|line| line.id().to_owned())
+        .collect()
+}
+
+fn records(changes: &[lix::EntityChange]) -> Vec<lix::EntityRecord> {
+    changes
+        .iter()
+        .filter_map(|change| {
+            change.snapshot.as_ref().map(|snapshot| lix::EntityRecord {
+                schema_key: change.schema_key.clone(),
+                entity_pk: change.entity_pk.clone(),
+                snapshot: snapshot.clone(),
+            })
+        })
+        .collect()
+}
+
+fn snapshot_with_bytes(line: &Line, bytes: &[u8]) -> Vec<u8> {
+    let mut snapshot: Value = serde_json::from_slice(
+        &line
+            .snapshot_bytes()
+            .expect("line snapshot should serialize"),
+    )
+    .expect("line snapshot should be JSON");
+    snapshot["content_base64"] = json!(URL_SAFE_NO_PAD.encode(bytes));
+    serde_json::to_vec(&snapshot).expect("edited line snapshot should serialize")
+}
+
+fn apply_edits(before: &[u8], edits: &[lix::ByteEdit]) -> Vec<u8> {
+    let mut after = Vec::new();
+    let mut cursor = 0usize;
+    for edit in edits {
+        let offset = usize::try_from(edit.offset).expect("test offset fits usize");
+        let delete_len = usize::try_from(edit.delete_len).expect("test delete fits usize");
+        assert!(offset >= cursor);
+        assert!(offset + delete_len <= before.len());
+        after.extend_from_slice(&before[cursor..offset]);
+        after.extend_from_slice(edit.insert.as_slice());
+        cursor = offset + delete_len;
+    }
+    after.extend_from_slice(&before[cursor..]);
+    after
+}
+
+#[test]
+fn empty_document_has_zero_rows_and_nonempty_to_empty_tombstones_each_line() {
+    let (empty, initial) = open(b"");
+    assert!(initial.is_empty());
+    assert!(empty.lines().is_empty());
+    assert_eq!(empty.bytes(), b"");
+    let reopened = Document::open_entities(Vec::new()).expect("empty rows should render empty");
+    assert_eq!(reopened.bytes(), b"");
+
+    let (nonempty, _) = open(b"one\ntwo\n");
+    let (after, changes) = nonempty
+        .file_changed(
+            &[InputSplice {
+                offset: 0,
+                delete_len: u64::try_from(nonempty.bytes().len()).unwrap(),
+                insert: Vec::new(),
+            }],
+            |ordinal| format!("new-{ordinal}"),
+        )
+        .expect("deleting every line should succeed");
+    assert!(after.lines().is_empty());
+    assert_eq!(after.bytes(), b"");
+    assert_eq!(changes.len(), 2);
+    assert!(changes.iter().all(|change| change.snapshot.is_none()));
+}
+
+#[test]
+fn initial_rows_round_trip_invalid_utf8_and_final_unterminated_line_exactly() {
+    let source = [0xff, b'\n', b'a', b'\r', b'\n', 0xfe];
+    let (document, changes) = open(&source);
+    assert_eq!(document.lines().len(), 3);
+    assert_eq!(document.lines()[0].bytes(), &[0xff, b'\n']);
+    assert_eq!(document.lines()[1].bytes(), b"a\r\n");
+    assert_eq!(document.lines()[2].bytes(), &[0xfe]);
+
+    let reopened = Document::open_entities(records(&changes)).expect("line rows should reopen");
+    assert_eq!(reopened.bytes(), source);
+    assert_eq!(ids(&reopened), ids(&document));
+}
+
+#[test]
+fn localized_line_edit_preserves_that_lines_id_and_leaves_unrelated_rows_untouched() {
+    let (document, _) = open(b"alpha\nbeta\ngamma\n");
+    let before_ids = ids(&document);
+    let (after, changes) = document
+        .file_changed(
+            &[InputSplice {
+                offset: 6,
+                delete_len: 4,
+                insert: b"BETA".to_vec(),
+            }],
+            |ordinal| format!("new-{ordinal}"),
+        )
+        .expect("localized edit should reconcile");
+
+    assert_eq!(after.bytes(), b"alpha\nBETA\ngamma\n");
+    assert_eq!(ids(&after), before_ids);
+    assert_eq!(changes.len(), 1);
+    assert_eq!(changes[0].entity_pk, ["line-1"]);
+    assert!(changes[0].snapshot.is_some());
+}
+
+#[test]
+fn line_insertion_adds_one_row_without_rewriting_existing_line_entities() {
+    let (document, _) = open(b"alpha\nomega\n");
+    let before_ids = ids(&document);
+    let (after, changes) = document
+        .file_changed(
+            &[InputSplice {
+                offset: 6,
+                delete_len: 0,
+                insert: b"middle\n".to_vec(),
+            }],
+            |ordinal| format!("new-{ordinal}"),
+        )
+        .expect("line insertion should reconcile");
+
+    assert_eq!(after.bytes(), b"alpha\nmiddle\nomega\n");
+    assert_eq!(
+        ids(&after),
+        [
+            before_ids[0].clone(),
+            "new-0".to_owned(),
+            before_ids[1].clone()
+        ]
+    );
+    assert_eq!(changes.len(), 1);
+    assert_eq!(changes[0].entity_pk, ["new-0"]);
+    assert!(changes[0].snapshot.is_some());
+}
+
+#[test]
+fn reorder_preserves_ids_and_updates_only_the_moved_rows_order_key() {
+    let (document, _) = open(b"alpha\nbeta\ngamma\n");
+    let before_ids = ids(&document);
+    let (after, changes) = document
+        .file_changed(
+            &[InputSplice {
+                offset: 0,
+                delete_len: u64::try_from(document.bytes().len()).unwrap(),
+                insert: b"gamma\nalpha\nbeta\n".to_vec(),
+            }],
+            |ordinal| format!("new-{ordinal}"),
+        )
+        .expect("reorder should reconcile");
+
+    assert_eq!(after.bytes(), b"gamma\nalpha\nbeta\n");
+    assert_eq!(
+        ids(&after),
+        [
+            before_ids[2].clone(),
+            before_ids[0].clone(),
+            before_ids[1].clone()
+        ]
+    );
+    assert_eq!(changes.len(), 1);
+    assert_eq!(changes[0].entity_pk, [before_ids[2].clone()]);
+    let snapshot: Value = serde_json::from_slice(
+        changes[0]
+            .snapshot
+            .as_ref()
+            .expect("moved row should be upserted"),
+    )
+    .unwrap();
+    assert_ne!(snapshot["order_key"], document.lines()[2].order_key());
+}
+
+#[test]
+fn independent_semantic_line_updates_render_as_independent_exact_byte_edits() {
+    let (document, _) = open(b"alpha\nbeta\ngamma\n");
+    let alpha = &document.lines()[0];
+    let gamma = &document.lines()[2];
+    let semantic_changes = [
+        lix::EntityChange::upsert(
+            LINE_SCHEMA_KEY,
+            vec![alpha.id().to_owned()],
+            snapshot_with_bytes(alpha, b"ALPHA\n"),
+        ),
+        lix::EntityChange::upsert(
+            LINE_SCHEMA_KEY,
+            vec![gamma.id().to_owned()],
+            snapshot_with_bytes(gamma, b"GAMMA\n"),
+        ),
+    ];
+    let (after, edits) = document
+        .entities_changed(semantic_changes)
+        .expect("line entity updates should render");
+
+    assert_eq!(after.bytes(), b"ALPHA\nbeta\nGAMMA\n");
+    assert_eq!(edits.len(), 2);
+    assert_eq!(edits[0].offset, 0);
+    assert_eq!(edits[1].offset, 11);
+    assert_eq!(apply_edits(document.bytes(), &edits), after.bytes());
+}
+
+#[test]
+fn git_nul_window_rejects_early_nul_and_allows_nul_after_eight_kib() {
+    assert!(Document::open_file(b"text\0binary".to_vec(), |ordinal| ordinal.to_string()).is_err());
+
+    let mut source = vec![b'x'; 8_000];
+    source.extend_from_slice(b"\0still-git-text\n");
+    let (document, changes) =
+        Document::open_file(source.clone(), |ordinal| format!("line-{ordinal}"))
+            .expect("a NUL after Git's scan window remains text");
+    assert_eq!(document.bytes(), source);
+    let reopened = Document::open_entities(records(&changes)).expect("late-NUL row should reopen");
+    assert_eq!(reopened.bytes(), source);
+}
+
+#[test]
+fn semantic_rows_cannot_smuggle_multiple_logical_lines_into_one_entity() {
+    let (document, _) = open(b"alpha\nbeta\n");
+    let alpha = &document.lines()[0];
+    let malformed = snapshot_with_bytes(alpha, b"alpha\nbeta\n");
+    let error = document
+        .entities_changed([lix::EntityChange::upsert(
+            LINE_SCHEMA_KEY,
+            vec![alpha.id().to_owned()],
+            malformed,
+        )])
+        .expect_err("one row cannot represent multiple logical Git lines");
+    assert!(error.contains("embedded LF"));
+}


### PR DESCRIPTION
## Summary

- Adds a public Component-v2 `git_text` plugin that applies Git's bounded 8 KiB NUL-byte rule, preserves NUL-bearing files as raw binary, and models accepted text as lossless stable line rows.
- Uses base64url row content so invalid UTF-8 and final unterminated lines round-trip byte-for-byte. Reconciliation retains row identities across localized edits, inserts, and reorders.
- Makes content matching predicate-based: a specific UTF-8 format plugin still wins where it applies, while the generic Git-compatible plugin can accept non-UTF-8 NUL-free text.
- Adds bounded matcher telemetry and a 4 MiB warm-update integration test. The 1 MiB+1 replacement reads only the supplied range (<30% of the document) and produces one durable semantic-row change.

## Measured axis

A 1 MiB non-UTF-8, NUL-free payload now performs an 8,000-byte Git classifier scan instead of a full 1,048,576-byte UTF-8 validation: 99.24% less classification work. This PR deliberately does **not** claim a storage reduction: current engine materialization still retains the raw blob.

## Validation

- `cargo test -p plugin_git_text_v2 --lib`
- `cargo build --release -p plugin_git_text_v2 --target wasm32-wasip2`
- `cargo test -p lix_sdk_tests --test git_text_plugin -- --nocapture`
- `cargo check -p lix_engine --tests`
- `cargo clippy -p plugin_git_text_v2 --all-targets -- -D warnings`
- `cargo clippy -p lix_engine --lib -- -D warnings`

## Stack

Base: `main` at `51ceb33aad080b21db1f291873df9ef6a6694de6` (PR #822 merge); no parent dependency. A follow-up derived-materialization/native-replay benchmark will begin from current `main` after this lands, per coordination policy.