### PR TITLE
Enable bounded default SlateDB cache

### DIFF
--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -43,6 +43,8 @@ const POINT_READ_CONCURRENCY: usize = 64;
 const SNAPSHOT_POINT_CACHE_BYTES: usize = 16 * 1024 * 1024;
 const SNAPSHOT_POINT_CACHE_ENTRIES: usize = 4096;
 const SNAPSHOT_POINT_CACHE_MAX_VALUE_BYTES: usize = 64 * 1024;
+const DEFAULT_BLOCK_CACHE_BYTES: u64 = 16 * 1024 * 1024;
+const DEFAULT_METADATA_CACHE_BYTES: u64 = 4 * 1024 * 1024;
 const SCAN_BATCH_ROWS: usize = 1024;
 const SCAN_READ_AHEAD_BYTES: usize = 2 * 1024 * 1024;
 const SCAN_MAX_FETCH_TASKS: usize = 16;
@@ -1017,18 +1019,19 @@ fn open_slatedb(
                 scan_interval: None,
                 ..ObjectStoreCacheOptions::default()
             };
-            let db_cache = SplitCache::new()
-                .with_block_cache(moka_cache(cache.block_cache_bytes))
-                .with_meta_cache(moka_cache(cache.metadata_cache_bytes))
-                .build();
-            builder = builder
-                .with_settings(settings)
-                .with_db_cache(Arc::new(db_cache));
+            builder = builder.with_settings(settings).with_db_cache(db_cache(
+                cache.block_cache_bytes,
+                cache.metadata_cache_bytes,
+            ));
         } else {
-            // The SlateDB dependency is compiled with Moka support so cached
-            // callers can choose bounded capacities. Keep default construction
-            // cacheless instead of accepting SlateDB's much larger defaults.
-            builder = builder.with_settings(settings).with_db_cache_disabled();
+            // Keep the default bounded instead of accepting SlateDB's much
+            // larger cache defaults. This captures hot SST blocks and
+            // metadata for normal default reads without enabling the optional
+            // disk object cache.
+            builder = builder.with_settings(settings).with_db_cache(db_cache(
+                DEFAULT_BLOCK_CACHE_BYTES,
+                DEFAULT_METADATA_CACHE_BYTES,
+            ));
         }
         builder.build().await.map_err(slatedb_error)
     })
@@ -1082,6 +1085,15 @@ fn moka_cache(capacity: u64) -> Option<Arc<dyn DbCache>> {
         time_to_live: None,
         time_to_idle: None,
     })))
+}
+
+fn db_cache(block_cache_bytes: u64, metadata_cache_bytes: u64) -> Arc<dyn DbCache> {
+    Arc::new(
+        SplitCache::new()
+            .with_block_cache(moka_cache(block_cache_bytes))
+            .with_meta_cache(moka_cache(metadata_cache_bytes))
+            .build(),
+    )
 }
 
 fn physical_key(space: SpaceId, key: &Key) -> Result<Key, StorageError> {
@@ -1452,8 +1464,99 @@ mod tests {
 
     #[test]
     fn cached_open_does_not_preload_ssts() {
+        let cache_dir = tempfile::tempdir().expect("create disk-cache directory");
+        assert_open_does_not_preload_ssts(
+            "test-on-demand-disk-cache",
+            SlateDBObjectStoreOptions {
+                cache: Some(SlateDBCacheOptions {
+                    root_folder: cache_dir.path().join("object-cache"),
+                    max_disk_cache_bytes: 16 * 1024 * 1024,
+                    block_cache_bytes: 0,
+                    metadata_cache_bytes: 0,
+                }),
+            },
+        );
+    }
+
+    #[test]
+    fn default_memory_cache_does_not_preload_ssts() {
+        assert_open_does_not_preload_ssts(
+            "test-on-demand-memory-cache",
+            SlateDBObjectStoreOptions::default(),
+        );
+    }
+
+    fn assert_open_does_not_preload_ssts(db_path: &str, options: SlateDBObjectStoreOptions) {
         let inner = Arc::new(InMemory::new());
-        let db_path = "test-on-demand-disk-cache";
+        let db_path = db_path.to_string();
+        seed_compacted_sst(inner.clone(), &db_path);
+
+        let store = Arc::new(BlockingStore::new(inner));
+        let blocked_reads = store.block_compacted_reads();
+        let (opened_tx, opened_rx) = mpsc::channel();
+        let opener = std::thread::spawn(move || {
+            opened_tx
+                .send(SlateDB::open_object_store_with_options(
+                    db_path, store, options,
+                ))
+                .expect("send cached open result");
+        });
+
+        let opened = opened_rx.recv_timeout(Duration::from_secs(5));
+        drop(blocked_reads);
+        opener.join().expect("join cached opener");
+        let storage = opened
+            .expect("cached open must not wait for SST reads")
+            .expect("open cached SlateDB");
+        drop(storage);
+    }
+
+    #[test]
+    fn default_memory_cache_serves_a_warm_sst_read_without_object_store_access() {
+        let inner = Arc::new(InMemory::new());
+        let db_path = "test-default-memory-cache-hit";
+        seed_compacted_sst(inner.clone(), db_path);
+
+        let store = Arc::new(BlockingStore::new(inner));
+        let storage = SlateDB::open_object_store_with_options(
+            db_path,
+            store.clone(),
+            SlateDBObjectStoreOptions::default(),
+        )
+        .expect("open default-memory-cache storage");
+
+        let first = block_on(storage.worker.call_read(|db| async move {
+            let snapshot = db.snapshot().await.map_err(slatedb_error)?;
+            snapshot.get(b"key").await.map_err(slatedb_error)
+        }))
+        .expect("warm raw SlateDB SST read");
+        assert_eq!(first, Some(Bytes::from_static(b"value")));
+
+        let blocked_reads = store.block_sst_reads();
+        let reader_storage = storage;
+        let (result_tx, result_rx) = mpsc::channel();
+        let reader = std::thread::spawn(move || {
+            let result = block_on(reader_storage.worker.call_read(|db| async move {
+                let snapshot = db.snapshot().await.map_err(slatedb_error)?;
+                snapshot.get(b"key").await.map_err(slatedb_error)
+            }));
+            result_tx.send(result).expect("send warm raw read result");
+        });
+
+        let second = match result_rx.recv_timeout(Duration::from_secs(2)) {
+            Ok(result) => result.expect("warm raw read should succeed"),
+            Err(error) => {
+                drop(blocked_reads);
+                reader.join().expect("join blocked raw reader");
+                panic!("warm raw read touched the object store: {error}");
+            }
+        };
+        drop(blocked_reads);
+        reader.join().expect("join warm raw reader");
+        assert_eq!(second, Some(Bytes::from_static(b"value")));
+    }
+
+    fn seed_compacted_sst(inner: Arc<InMemory>, db_path: &str) {
         let physical_db_path = join_db_path(db_path, LZ4_FORMAT_PATH);
         Builder::new_current_thread()
             .enable_all()
@@ -1485,36 +1588,6 @@ mod tests {
                 .expect("flush raw SlateDB memtable");
                 db.close().await.expect("close raw SlateDB");
             });
-
-        let store = Arc::new(BlockingStore::new(inner));
-        let blocked_reads = store.block_compacted_reads();
-        let cache_dir = tempfile::tempdir().expect("create disk cache directory");
-        let cache_root = cache_dir.path().to_path_buf();
-        let (opened_tx, opened_rx) = mpsc::channel();
-        let opener = std::thread::spawn(move || {
-            opened_tx
-                .send(SlateDB::open_object_store_with_options(
-                    db_path,
-                    store,
-                    SlateDBObjectStoreOptions {
-                        cache: Some(SlateDBCacheOptions {
-                            root_folder: cache_root,
-                            max_disk_cache_bytes: 16 * 1024 * 1024,
-                            block_cache_bytes: 0,
-                            metadata_cache_bytes: 0,
-                        }),
-                    },
-                ))
-                .expect("send cached open result");
-        });
-
-        let opened = opened_rx.recv_timeout(Duration::from_secs(5));
-        drop(blocked_reads);
-        opener.join().expect("join cached opener");
-        let storage = opened
-            .expect("cached open must not wait for SST reads")
-            .expect("open cached SlateDB");
-        drop(storage);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Enable a bounded per-DB Moka cache for default SlateDB opens (16 MiB block / 4 MiB metadata).
- Preserve the existing `cache: Some(...)` capacities and optional disk object-cache behavior.
- Cover lazy startup and a warmed raw SST read that succeeds while object-store SST reads are blocked.

## Why
Default construction explicitly disabled SlateDB's DB cache to avoid its large upstream defaults. That made normal reopened reads repeatedly fetch immutable SST blocks. This keeps the default bounded and in memory only; it does not enable the optional disk/object cache.

## Benchmark evidence
Separate clean release target directories, 30 samples, 5,000 files and 5,000 history commits:

| Native component p50 | 233fcba baseline | This PR | Change |
| --- | ---: | ---: | ---: |
| Read JSON (4 KiB) | 2,611,942 ns | 322,038 ns | 87.7% lower |
| Read PDF (32 KiB) | 2,632,841 ns | 336,409 ns | 87.2% lower |
| Read binary (256 KiB) | 4,045,257 ns | 658,008 ns | 83.7% lower |
| Batch upsert accepted | 24,957,310 ns | 2,782,072 ns | 88.9% lower |
| Sequential upsert accepted | 87,957,914 ns | 7,352,747 ns | 91.6% lower |

The refreshed same-build SlateDB/RocksDB read comparison is improved but still above the overall 1.2x target: 2.50x / 2.16x / 1.78x for JSON/PDF/binary. That remaining gap is intentionally left to the next distinct optimization.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy -p lix_slatedb_storage --all-targets -- -D warnings`
- `cargo test -p lix_slatedb_storage --release` (22 unit + 8 integration)
- `cargo test -p lix_server_protocol --lib` (79 passed)

## Stack
Directly targets `main` at `233fcba7bbead0a4c010f25a8980e27c8197e832` (#832 merge); no PR dependencies.