### PR TITLE
perf(slatedb): specialize singleton point reads

### DIFF
--- a/packages/engine-benchmarks/benches/small_blob_cas.rs
+++ b/packages/engine-benchmarks/benches/small_blob_cas.rs
@@ -2,12 +2,16 @@ use std::fmt::{self, Display, Formatter};
 use std::hint::black_box;
 use std::time::{Duration, Instant};
 
-use lix_engine::storage_adapter::StorageAdapter;
+use bytes::Bytes;
+use lix_engine::storage::{
+    GetOptions, Key, ProjectedValue, PutBatch, PutEntry, ReadDurability, ReadOptions, SpaceId,
+    Storage, StorageWrite, StoredValue, WriteOptions,
+};
+use lix_engine::storage_adapter::{StorageAdapter, StorageAdapterRead};
 use lix_engine::storage_bench::{
     binary_cas_write_accounting, layout_accounting, read_binary_cas_for_bench,
     reset_binary_cas_write_accounting, write_binary_cas_for_bench,
 };
-use lix_engine::{ReadOptions, Storage};
 use lix_rocksdb_storage::RocksDB;
 use lix_slatedb_storage::SlateDB;
 use tempfile::TempDir;
@@ -18,9 +22,11 @@ const OPERATIONS: &[Operation] = &[
     Operation::UniqueWrite,
     Operation::DedupeWrite,
     Operation::HotRead,
+    Operation::DurableSingletonRead,
 ];
 const DEFAULT_WARMUPS: usize = 20;
 const DEFAULT_SAMPLES: usize = 200;
+const DIRECT_SINGLETON_SPACE: SpaceId = SpaceId(0x00ff_0002);
 
 #[derive(Clone, Copy, Debug)]
 enum Backend {
@@ -42,6 +48,7 @@ enum Operation {
     UniqueWrite,
     DedupeWrite,
     HotRead,
+    DurableSingletonRead,
 }
 
 impl Display for Operation {
@@ -50,6 +57,7 @@ impl Display for Operation {
             Self::UniqueWrite => formatter.write_str("unique_write"),
             Self::DedupeWrite => formatter.write_str("dedupe_write"),
             Self::HotRead => formatter.write_str("hot_read"),
+            Self::DurableSingletonRead => formatter.write_str("durable_singleton_read"),
         }
     }
 }
@@ -76,6 +84,13 @@ async fn run() {
             }
             for &operation in OPERATIONS {
                 if !selected("LIX_SMALL_BLOB_OPERATIONS", &operation.to_string()) {
+                    continue;
+                }
+                // RocksDB intentionally rejects the explicit durable tier, so
+                // do not compare it to SlateDB with mismatched read semantics.
+                if matches!(operation, Operation::DurableSingletonRead)
+                    && !matches!(backend, Backend::Slate)
+                {
                     continue;
                 }
                 run_case(backend, size, operation, warmups, samples).await;
@@ -176,13 +191,22 @@ struct BackendFixture<S: Storage> {
     version: u64,
     stable_bytes: Vec<u8>,
     stable_hash: String,
+    direct_key: Key,
+    direct_value_len: usize,
 }
 
 impl<S> BackendFixture<S>
 where
     S: Storage,
 {
-    async fn create(storage: S, temp_dir: TempDir, size: usize, operation: Operation) -> Self {
+    async fn create(
+        storage: S,
+        temp_dir: TempDir,
+        size: usize,
+        operation: Operation,
+        direct_key: Key,
+        direct_value_len: usize,
+    ) -> Self {
         let storage = StorageAdapter::new(storage);
         let stable_bytes = deterministic_bytes(size, 0x5a17);
         let stable_hash = write_binary_cas_for_bench(&storage, &stable_bytes)
@@ -201,6 +225,8 @@ where
             version: 1,
             stable_bytes,
             stable_hash,
+            direct_key,
+            direct_value_len,
         }
     }
 
@@ -220,10 +246,17 @@ where
                 bytes: None,
                 expected_hash: Some(self.stable_hash.clone()),
             },
+            Operation::DurableSingletonRead => PreparedOperation {
+                bytes: None,
+                expected_hash: None,
+            },
         }
     }
 
     async fn execute(&self, prepared: PreparedOperation) -> usize {
+        if matches!(self.operation, Operation::DurableSingletonRead) {
+            return self.read_durable_singleton().await;
+        }
         match prepared.bytes {
             Some(bytes) => {
                 let hash = write_binary_cas_for_bench(&self.storage, &bytes)
@@ -244,6 +277,37 @@ where
                     .expect("benchmark blob should exist");
                 bytes.len()
             }
+        }
+    }
+
+    async fn read_durable_singleton(&self) -> usize {
+        let read = self
+            .storage
+            .begin_read(ReadOptions {
+                durability: ReadDurability::Durable,
+                ..ReadOptions::default()
+            })
+            .await
+            .expect("open durable singleton read");
+        let value = read
+            .get_many(
+                DIRECT_SINGLETON_SPACE,
+                std::slice::from_ref(&self.direct_key),
+                GetOptions::default(),
+            )
+            .await
+            .expect("read durable singleton value")
+            .values
+            .into_iter()
+            .next()
+            .flatten()
+            .expect("durable singleton value should exist");
+        match value {
+            ProjectedValue::FullValue(value) => {
+                assert_eq!(value.len(), self.direct_value_len);
+                value.len()
+            }
+            ProjectedValue::KeyOnly => panic!("durable singleton read returned key only"),
         }
     }
 
@@ -274,14 +338,50 @@ impl Fixture {
     async fn new(backend: Backend, size: usize, operation: Operation) -> Self {
         let temp_dir = tempfile::tempdir().expect("create small blob benchmark directory");
         let database_path = temp_dir.path().join("database");
+        let direct_key = Key(Bytes::from_static(b"direct-singleton"));
+        let direct_value = Bytes::from(vec![0xa5; size]);
+        let direct_value_len = direct_value.len();
         match backend {
             Backend::Rocks => {
                 let storage = RocksDB::open(&database_path).expect("open benchmark RocksDB");
-                Self::Rocks(BackendFixture::create(storage, temp_dir, size, operation).await)
+                if matches!(operation, Operation::DurableSingletonRead) {
+                    seed_direct_durable_value(&storage, &direct_key, &direct_value).await;
+                    storage
+                        .flush()
+                        .expect("flush direct durable RocksDB seed value");
+                }
+                Self::Rocks(
+                    BackendFixture::create(
+                        storage,
+                        temp_dir,
+                        size,
+                        operation,
+                        direct_key,
+                        direct_value_len,
+                    )
+                    .await,
+                )
             }
             Backend::Slate => {
                 let storage = SlateDB::open(&database_path).expect("open benchmark SlateDB");
-                Self::Slate(BackendFixture::create(storage, temp_dir, size, operation).await)
+                if matches!(operation, Operation::DurableSingletonRead) {
+                    seed_direct_durable_value(&storage, &direct_key, &direct_value).await;
+                    storage
+                        .flush()
+                        .await
+                        .expect("flush direct durable SlateDB seed value");
+                }
+                Self::Slate(
+                    BackendFixture::create(
+                        storage,
+                        temp_dir,
+                        size,
+                        operation,
+                        direct_key,
+                        direct_value_len,
+                    )
+                    .await,
+                )
             }
         }
     }
@@ -311,6 +411,34 @@ impl Fixture {
             Self::Slate(fixture) => fixture.layout().await,
         }
     }
+}
+
+async fn seed_direct_durable_value<S>(storage: &S, key: &Key, value: &Bytes)
+where
+    S: Storage,
+{
+    let mut write = storage
+        .begin_write(WriteOptions::default())
+        .await
+        .expect("begin direct durable seed write");
+    write
+        .put_many(
+            DIRECT_SINGLETON_SPACE,
+            PutBatch {
+                entries: vec![PutEntry {
+                    key: key.clone(),
+                    value: StoredValue {
+                        bytes: value.clone(),
+                    },
+                }],
+            },
+        )
+        .await
+        .expect("stage direct durable seed value");
+    write
+        .commit()
+        .await
+        .expect("commit direct durable seed value");
 }
 
 #[derive(Default)]

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -441,6 +441,45 @@ impl StorageRead for SlateDBRead {
                 return Ok(GetManyResult::new(Vec::new()));
             }
 
+            if let [key] = keys {
+                let key = physical_key(space, key)?;
+                let snapshot = Arc::clone(&self.snapshot);
+                let durability = self.durability;
+                let value = if durability == ReadDurability::Visible {
+                    let sequence = snapshot.seq();
+                    let cache = self.point_cache.clone();
+                    if let Some(value) = cache.get(sequence, &key) {
+                        // A cached value must still obey SlateDB's terminal close
+                        // boundary. This has no object-store I/O, but makes the
+                        // hit linearize at the same closed-state check as a real
+                        // snapshot read.
+                        self.worker
+                            .call_read(|db| async move {
+                                db.snapshot().await.map(|_| ()).map_err(slatedb_error)
+                            })
+                            .await?;
+                        value
+                    } else {
+                        let fetched_key = key.clone();
+                        let value = self
+                            .worker
+                            .call_read(move |_db| {
+                                get_snapshot_value(snapshot, fetched_key, durability)
+                            })
+                            .await?;
+                        cache.insert(sequence, key, value.clone());
+                        value
+                    }
+                } else {
+                    self.worker
+                        .call_read(move |_db| get_snapshot_value(snapshot, key, durability))
+                        .await?
+                };
+                return Ok(GetManyResult::new(vec![
+                    value.map(|value| project_value(value, opts.projection)),
+                ]));
+            }
+
             let physical_keys = keys
                 .iter()
                 .map(|key| physical_key(space, key))
@@ -1187,6 +1226,18 @@ async fn get_snapshot_values(
         .await
 }
 
+async fn get_snapshot_value(
+    snapshot: Arc<DbSnapshot>,
+    key: Key,
+    durability: ReadDurability,
+) -> Result<Option<Bytes>, StorageError> {
+    let read_options = slatedb_read_options(durability);
+    snapshot
+        .get_with_options(key.0, &read_options)
+        .await
+        .map_err(slatedb_error)
+}
+
 struct ScanBatch {
     iter: DbIterator,
     entries: Vec<(Key, ProjectedValue)>,
@@ -1690,9 +1741,32 @@ mod tests {
 
         let read = block_on(storage.begin_read(ReadOptions::default())).expect("begin read");
         let result =
-            block_on(read.get_many(space, &[key], GetOptions::default())).expect("read row");
+            block_on(read.get_many(space, std::slice::from_ref(&key), GetOptions::default()))
+                .expect("read row");
 
         assert_eq!(result.values, vec![Some(ProjectedValue::FullValue(value))]);
+        assert_eq!(
+            block_on(read.get_many(
+                space,
+                std::slice::from_ref(&key),
+                GetOptions {
+                    projection: CoreProjection::KeyOnly,
+                },
+            ))
+            .expect("read singleton key only")
+            .values,
+            vec![Some(ProjectedValue::KeyOnly)]
+        );
+        assert_eq!(
+            block_on(read.get_many(
+                space,
+                &[Key(Bytes::from_static(b"missing"))],
+                GetOptions::default(),
+            ))
+            .expect("read singleton missing key")
+            .values,
+            vec![None]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Specialize SlateDB `StorageRead::get_many` for exactly one key, avoiding the multi-key allocation and buffered stream path for a point read.
- Preserve physical-key translation, visible point-cache sequence semantics and terminal-close boundary, durable read routing, and projections.
- Add a preseeded `durable_singleton_read` benchmark that exercises the cache-bypassing raw singleton path.

## Benchmark evidence

Pinned SlateDB durable singleton reads (p50, preseeded distinct raw key):

| Shape | Baseline | Candidate | Change |
| --- | ---: | ---: | ---: |
| 4 KiB (median of 3 alternating pairs) | 2.47 µs | 2.16 µs | **12.6% faster** |
| 32 KiB | 2.51 µs | 2.22 µs | **11.6% faster** |

The 4 KiB paired runs were 2.47/2.42/2.48 µs baseline versus 2.16/2.15/2.16 µs candidate. This is SlateDB-only diagnostic evidence: RocksDB deliberately rejects the explicit `ReadDurability::Durable` tier, so it is not a mismatched cross-backend comparison.

## Base / dependency

Standalone PR with no stack dependency. Rebased cleanly onto current `origin/main` at `6f4a2d542858d4f2612cdde51deac3e433245c44` (#835).

## Validation

- `cargo test -p lix_slatedb_storage --release` — 22 unit + 8 conformance tests passed before the CLI-only rebase.
- `cargo clippy -p lix_slatedb_storage --all-targets --release -- -D warnings` — passed.
- `cargo fmt --all -- --check` and `git diff --check` — passed after rebase.
- Changed benchmark target compiled and ran after rebase.
- The local protocol build was still compiling when publication was requested; CI will run the complete protocol suite.