### PR TITLE
perf(slatedb): batch snapshot cache lookups

### DIFF
--- a/packages/engine-benchmarks/benches/small_blob_cas.rs
+++ b/packages/engine-benchmarks/benches/small_blob_cas.rs
@@ -4,8 +4,8 @@ use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use lix_engine::storage::{
-    GetOptions, Key, ProjectedValue, PutBatch, PutEntry, ReadDurability, ReadOptions, SpaceId,
-    Storage, StorageWrite, StoredValue, WriteOptions,
+    CoreProjection, GetOptions, Key, ProjectedValue, PutBatch, PutEntry, ReadDurability,
+    ReadOptions, SpaceId, Storage, StorageWrite, StoredValue, WriteOptions,
 };
 use lix_engine::storage_adapter::{StorageAdapter, StorageAdapterRead};
 use lix_engine::storage_bench::{
@@ -23,10 +23,14 @@ const OPERATIONS: &[Operation] = &[
     Operation::DedupeWrite,
     Operation::HotRead,
     Operation::DurableSingletonRead,
+    Operation::VisibleHotBatchRead,
 ];
 const DEFAULT_WARMUPS: usize = 20;
 const DEFAULT_SAMPLES: usize = 200;
 const DIRECT_SINGLETON_SPACE: SpaceId = SpaceId(0x00ff_0002);
+const DIRECT_BATCH_SPACE: SpaceId = SpaceId(0x00ff_0004);
+const DIRECT_BATCH_KEYS: usize = 1024;
+const DIRECT_BATCH_KEY_SUFFIX: &str = "0123456789abcdef0123456789abcdef0123456789abcdef";
 
 #[derive(Clone, Copy, Debug)]
 enum Backend {
@@ -49,6 +53,7 @@ enum Operation {
     DedupeWrite,
     HotRead,
     DurableSingletonRead,
+    VisibleHotBatchRead,
 }
 
 impl Display for Operation {
@@ -58,6 +63,7 @@ impl Display for Operation {
             Self::DedupeWrite => formatter.write_str("dedupe_write"),
             Self::HotRead => formatter.write_str("hot_read"),
             Self::DurableSingletonRead => formatter.write_str("durable_singleton_read"),
+            Self::VisibleHotBatchRead => formatter.write_str("visible_hot_batch_read"),
         }
     }
 }
@@ -193,6 +199,7 @@ struct BackendFixture<S: Storage> {
     stable_hash: String,
     direct_key: Key,
     direct_value_len: usize,
+    direct_batch_keys: Vec<Key>,
 }
 
 impl<S> BackendFixture<S>
@@ -206,6 +213,7 @@ where
         operation: Operation,
         direct_key: Key,
         direct_value_len: usize,
+        direct_batch_keys: Vec<Key>,
     ) -> Self {
         let storage = StorageAdapter::new(storage);
         let stable_bytes = deterministic_bytes(size, 0x5a17);
@@ -227,6 +235,7 @@ where
             stable_hash,
             direct_key,
             direct_value_len,
+            direct_batch_keys,
         }
     }
 
@@ -250,12 +259,19 @@ where
                 bytes: None,
                 expected_hash: None,
             },
+            Operation::VisibleHotBatchRead => PreparedOperation {
+                bytes: None,
+                expected_hash: None,
+            },
         }
     }
 
     async fn execute(&self, prepared: PreparedOperation) -> usize {
         if matches!(self.operation, Operation::DurableSingletonRead) {
             return self.read_durable_singleton().await;
+        }
+        if matches!(self.operation, Operation::VisibleHotBatchRead) {
+            return self.read_visible_hot_batch().await;
         }
         match prepared.bytes {
             Some(bytes) => {
@@ -311,6 +327,32 @@ where
         }
     }
 
+    async fn read_visible_hot_batch(&self) -> usize {
+        let read = self
+            .storage
+            .begin_read(ReadOptions::default())
+            .await
+            .expect("open visible hot batch read");
+        let values = read
+            .get_many(
+                DIRECT_BATCH_SPACE,
+                &self.direct_batch_keys,
+                GetOptions {
+                    projection: CoreProjection::KeyOnly,
+                },
+            )
+            .await
+            .expect("read visible hot batch values")
+            .values;
+        assert_eq!(values.len(), self.direct_batch_keys.len());
+        assert!(
+            values
+                .iter()
+                .all(|value| matches!(value, Some(ProjectedValue::KeyOnly)))
+        );
+        values.len()
+    }
+
     async fn layout(&self) -> Layout {
         let read = self
             .storage
@@ -341,6 +383,9 @@ impl Fixture {
         let direct_key = Key(Bytes::from_static(b"direct-singleton"));
         let direct_value = Bytes::from(vec![0xa5; size]);
         let direct_value_len = direct_value.len();
+        let direct_batch_keys = matches!(operation, Operation::VisibleHotBatchRead)
+            .then(direct_batch_keys)
+            .unwrap_or_default();
         match backend {
             Backend::Rocks => {
                 let storage = RocksDB::open(&database_path).expect("open benchmark RocksDB");
@@ -350,6 +395,9 @@ impl Fixture {
                         .flush()
                         .expect("flush direct durable RocksDB seed value");
                 }
+                if matches!(operation, Operation::VisibleHotBatchRead) {
+                    seed_direct_batch_values(&storage, &direct_batch_keys).await;
+                }
                 Self::Rocks(
                     BackendFixture::create(
                         storage,
@@ -358,6 +406,7 @@ impl Fixture {
                         operation,
                         direct_key,
                         direct_value_len,
+                        direct_batch_keys,
                     )
                     .await,
                 )
@@ -371,6 +420,9 @@ impl Fixture {
                         .await
                         .expect("flush direct durable SlateDB seed value");
                 }
+                if matches!(operation, Operation::VisibleHotBatchRead) {
+                    seed_direct_batch_values(&storage, &direct_batch_keys).await;
+                }
                 Self::Slate(
                     BackendFixture::create(
                         storage,
@@ -379,6 +431,7 @@ impl Fixture {
                         operation,
                         direct_key,
                         direct_value_len,
+                        direct_batch_keys,
                     )
                     .await,
                 )
@@ -439,6 +492,48 @@ where
         .commit()
         .await
         .expect("commit direct durable seed value");
+}
+
+async fn seed_direct_batch_values<S>(storage: &S, keys: &[Key])
+where
+    S: Storage,
+{
+    let mut write = storage
+        .begin_write(WriteOptions::default())
+        .await
+        .expect("begin direct batch seed write");
+    write
+        .put_many(
+            DIRECT_BATCH_SPACE,
+            PutBatch {
+                entries: keys
+                    .iter()
+                    .cloned()
+                    .map(|key| PutEntry {
+                        key,
+                        value: StoredValue {
+                            bytes: Bytes::from_static(b"batch-value"),
+                        },
+                    })
+                    .collect(),
+            },
+        )
+        .await
+        .expect("stage direct batch seed values");
+    write
+        .commit()
+        .await
+        .expect("commit direct batch seed values");
+}
+
+fn direct_batch_keys() -> Vec<Key> {
+    (0..DIRECT_BATCH_KEYS)
+        .map(|index| {
+            Key(Bytes::from(format!(
+                "hot-batch-{index:04}-{DIRECT_BATCH_KEY_SUFFIX}"
+            )))
+        })
+        .collect()
 }
 
 #[derive(Default)]

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -116,7 +116,7 @@ struct SnapshotPointCache {
 
 #[derive(Default)]
 struct SnapshotPointCacheState {
-    entries: HashMap<SnapshotPointCacheKey, SnapshotPointCacheValue>,
+    entries: HashMap<u64, HashMap<Key, SnapshotPointCacheValue>>,
     eviction_order: VecDeque<SnapshotPointCacheKey>,
     used_bytes: usize,
 }
@@ -142,16 +142,32 @@ impl SnapshotPointCache {
 
     /// `Some(None)` is a cached missing point; outer `None` is a cache miss.
     fn get(&self, sequence: u64, key: &Key) -> Option<Option<Bytes>> {
-        let cache_key = SnapshotPointCacheKey {
-            sequence,
-            key: key.clone(),
-        };
         self.state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .entries
-            .get(&cache_key)
+            .get(&sequence)
+            .and_then(|entries| entries.get(key))
             .map(|entry| entry.value.clone())
+    }
+
+    /// `Some(None)` is a cached missing point; outer `None` is a cache miss.
+    ///
+    /// A multi-key read does not mutate recency on hits, so inspect its whole
+    /// snapshot-key set under one lock instead of acquiring the cache mutex
+    /// once for every requested key.
+    fn get_many(&self, sequence: u64, keys: &[Key], values: &mut [Option<Option<Bytes>>]) {
+        debug_assert_eq!(keys.len(), values.len());
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let entries = state.entries.get(&sequence);
+        for (key, value) in keys.iter().zip(values) {
+            *value = entries
+                .and_then(|entries| entries.get(key))
+                .map(|entry| entry.value.clone());
+        }
     }
 
     fn insert(&self, sequence: u64, key: Key, value: Option<Bytes>) {
@@ -162,8 +178,7 @@ impl SnapshotPointCache {
         if value_bytes > SNAPSHOT_POINT_CACHE_MAX_VALUE_BYTES {
             return;
         }
-        let cache_key = SnapshotPointCacheKey { sequence, key };
-        let weight = cache_key.key.0.len().saturating_add(value_bytes);
+        let weight = key.0.len().saturating_add(value_bytes);
         if weight > SNAPSHOT_POINT_CACHE_BYTES {
             return;
         }
@@ -172,24 +187,43 @@ impl SnapshotPointCache {
             .state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if state.entries.contains_key(&cache_key) {
+        if state
+            .entries
+            .get(&sequence)
+            .is_some_and(|entries| entries.contains_key(&key))
+        {
             return;
         }
         while state.used_bytes.saturating_add(weight) > SNAPSHOT_POINT_CACHE_BYTES
-            || state.entries.len() >= SNAPSHOT_POINT_CACHE_ENTRIES
+            || state.eviction_order.len() >= SNAPSHOT_POINT_CACHE_ENTRIES
         {
             let Some(evicted_key) = state.eviction_order.pop_front() else {
                 break;
             };
-            if let Some(evicted) = state.entries.remove(&evicted_key) {
-                state.used_bytes = state.used_bytes.saturating_sub(evicted.weight);
+            let (evicted_weight, remove_sequence) = state
+                .entries
+                .get_mut(&evicted_key.sequence)
+                .map_or((None, false), |entries| {
+                    let evicted_weight = entries.remove(&evicted_key.key).map(|entry| entry.weight);
+                    (evicted_weight, entries.is_empty())
+                });
+            if let Some(weight) = evicted_weight {
+                state.used_bytes = state.used_bytes.saturating_sub(weight);
+            }
+            if remove_sequence {
+                state.entries.remove(&evicted_key.sequence);
             }
         }
         state.used_bytes = state.used_bytes.saturating_add(weight);
-        state.eviction_order.push_back(cache_key.clone());
+        state.eviction_order.push_back(SnapshotPointCacheKey {
+            sequence,
+            key: key.clone(),
+        });
         state
             .entries
-            .insert(cache_key, SnapshotPointCacheValue { value, weight });
+            .entry(sequence)
+            .or_default()
+            .insert(key, SnapshotPointCacheValue { value, weight });
     }
 }
 
@@ -491,10 +525,9 @@ impl StorageRead for SlateDBRead {
                 let cache = self.point_cache.clone();
                 let mut values = vec![None; physical_keys.len()];
                 let mut missing = Vec::new();
+                cache.get_many(sequence, &physical_keys, &mut values);
                 for (index, key) in physical_keys.iter().enumerate() {
-                    if let Some(value) = cache.get(sequence, key) {
-                        values[index] = Some(value);
-                    } else {
+                    if values[index].is_none() {
                         missing.push((index, key.clone()));
                     }
                 }
@@ -1853,6 +1886,58 @@ mod tests {
                 b"first"
             )))],
             "an old snapshot must not observe the value cached for a newer sequence"
+        );
+    }
+
+    #[test]
+    fn snapshot_point_cache_batch_preserves_hits_misses_and_duplicates() {
+        let cache = SnapshotPointCache::new();
+        let present = Key(Bytes::from_static(b"present"));
+        let missing = Key(Bytes::from_static(b"cached-missing"));
+        let unseen = Key(Bytes::from_static(b"unseen"));
+        let value = Bytes::from_static(b"value");
+        cache.insert(7, present.clone(), Some(value.clone()));
+        cache.insert(7, missing.clone(), None);
+
+        let keys = [present.clone(), missing.clone(), unseen, present.clone()];
+        let mut values = vec![None; keys.len()];
+        cache.get_many(7, &keys, &mut values);
+        assert_eq!(
+            values,
+            vec![
+                Some(Some(value.clone())),
+                Some(None),
+                None,
+                Some(Some(value))
+            ]
+        );
+        let keys = [present, missing];
+        let mut values = vec![None; keys.len()];
+        cache.get_many(8, &keys, &mut values);
+        assert_eq!(values, vec![None, None]);
+    }
+
+    #[test]
+    fn snapshot_point_cache_limits_entries_with_one_snapshot_bucket() {
+        let cache = SnapshotPointCache::new();
+        let first = Key(Bytes::from_static(b"cache-entry-0000"));
+        for index in 0..=SNAPSHOT_POINT_CACHE_ENTRIES {
+            cache.insert(
+                7,
+                Key(Bytes::from(format!("cache-entry-{index:04}"))),
+                Some(Bytes::from_static(b"value")),
+            );
+        }
+
+        assert_eq!(cache.get(7, &first), None);
+        assert_eq!(
+            cache.get(
+                7,
+                &Key(Bytes::from(format!(
+                    "cache-entry-{SNAPSHOT_POINT_CACHE_ENTRIES:04}"
+                )))
+            ),
+            Some(Some(Bytes::from_static(b"value")))
         );
     }
 


### PR DESCRIPTION
## Summary

- Store snapshot-point-cache entries in per-sequence buckets so cache probes borrow the caller's key instead of cloning a composite `(sequence, key)` lookup key.
- Probe a visible multi-key request under one cache lock and fill the adapter's existing result slots directly.
- Preserve global byte/entry limits through the existing eviction order, including cached negative values, duplicate request slots, sequence isolation, cache-miss fetching, and the durable-read path.

## Benchmark evidence

Pinned SlateDB visible hot-cache batch reads: 1,024 distinct preseeded raw keys (60-byte logical keys), `KeyOnly` projection, 500 warmups, 5,000 samples per alternating run.

| Run | Baseline p50 | Candidate p50 | Improvement |
| --- | ---: | ---: | ---: |
| 1 | 139.14 µs | 102.57 µs | 26.3% |
| 2 | 140.42 µs | 104.61 µs | 25.5% |
| 3 | 138.86 µs | 103.83 µs | 25.2% |

Median p50: **139.14 µs → 103.83 µs (25.4% faster)**, clearing the 10% bar.

This is a SlateDB adapter-attribution benchmark for the visible snapshot-cache hit path, not a mismatched cross-backend claim.

## Base / dependency

Standalone PR with no stack dependency. Rebased cleanly onto current `origin/main` at `d16dd12c56e4a4c593c06525b5e25dbb95728dc0` (#837).

## Validation

- `cargo test -p lix_slatedb_storage --release` — 24 unit tests plus 8 storage/conformance tests passed.
- `cargo clippy -p lix_slatedb_storage --all-targets --release -- -D warnings` — passed.
- `cargo fmt --all -- --check` and `git diff --check` — passed after rebase.
- The exact benchmark target compiled and ran for the paired measurements.