### PR TITLE
perf(slatedb): batch mutation preconditions

### DIFF
--- a/packages/engine-benchmarks/benches/small_blob_cas.rs
+++ b/packages/engine-benchmarks/benches/small_blob_cas.rs
@@ -4,8 +4,8 @@ use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use lix_engine::storage::{
-    CoreProjection, GetOptions, Key, ProjectedValue, PutBatch, PutEntry, ReadDurability,
-    ReadOptions, SpaceId, Storage, StorageWrite, StoredValue, WriteOptions,
+    CoreProjection, GetOptions, Key, Precondition, ProjectedValue, PutBatch, PutEntry,
+    ReadDurability, ReadOptions, SpaceId, Storage, StorageWrite, StoredValue, WriteOptions,
 };
 use lix_engine::storage_adapter::{StorageAdapter, StorageAdapterRead};
 use lix_engine::storage_bench::{
@@ -24,6 +24,8 @@ const OPERATIONS: &[Operation] = &[
     Operation::HotRead,
     Operation::DurableSingletonRead,
     Operation::VisibleHotBatchRead,
+    Operation::VisiblePreconditionBatch,
+    Operation::VisibleIdempotentPreconditionBatch,
 ];
 const DEFAULT_WARMUPS: usize = 20;
 const DEFAULT_SAMPLES: usize = 200;
@@ -31,6 +33,9 @@ const DIRECT_SINGLETON_SPACE: SpaceId = SpaceId(0x00ff_0002);
 const DIRECT_BATCH_SPACE: SpaceId = SpaceId(0x00ff_0004);
 const DIRECT_BATCH_KEYS: usize = 1024;
 const DIRECT_BATCH_KEY_SUFFIX: &str = "0123456789abcdef0123456789abcdef0123456789abcdef";
+const DIRECT_PRECONDITION_SPACE: SpaceId = SpaceId(0x00ff_0005);
+const DIRECT_PRECONDITION_VALUE: &[u8] = b"precondition-value";
+const DIRECT_IDEMPOTENCY_RECEIPT_KEY: &[u8] = b"idempotency-receipt";
 
 #[derive(Clone, Copy, Debug)]
 enum Backend {
@@ -54,6 +59,8 @@ enum Operation {
     HotRead,
     DurableSingletonRead,
     VisibleHotBatchRead,
+    VisiblePreconditionBatch,
+    VisibleIdempotentPreconditionBatch,
 }
 
 impl Display for Operation {
@@ -64,6 +71,10 @@ impl Display for Operation {
             Self::HotRead => formatter.write_str("hot_read"),
             Self::DurableSingletonRead => formatter.write_str("durable_singleton_read"),
             Self::VisibleHotBatchRead => formatter.write_str("visible_hot_batch_read"),
+            Self::VisiblePreconditionBatch => formatter.write_str("visible_precondition_batch"),
+            Self::VisibleIdempotentPreconditionBatch => {
+                formatter.write_str("visible_idempotent_precondition_batch")
+            }
         }
     }
 }
@@ -200,6 +211,7 @@ struct BackendFixture<S: Storage> {
     direct_key: Key,
     direct_value_len: usize,
     direct_batch_keys: Vec<Key>,
+    direct_precondition_keys: Vec<Key>,
 }
 
 impl<S> BackendFixture<S>
@@ -214,6 +226,7 @@ where
         direct_key: Key,
         direct_value_len: usize,
         direct_batch_keys: Vec<Key>,
+        direct_precondition_keys: Vec<Key>,
     ) -> Self {
         let storage = StorageAdapter::new(storage);
         let stable_bytes = deterministic_bytes(size, 0x5a17);
@@ -236,6 +249,7 @@ where
             direct_key,
             direct_value_len,
             direct_batch_keys,
+            direct_precondition_keys,
         }
     }
 
@@ -263,6 +277,12 @@ where
                 bytes: None,
                 expected_hash: None,
             },
+            Operation::VisiblePreconditionBatch | Operation::VisibleIdempotentPreconditionBatch => {
+                PreparedOperation {
+                    bytes: None,
+                    expected_hash: None,
+                }
+            }
         }
     }
 
@@ -272,6 +292,12 @@ where
         }
         if matches!(self.operation, Operation::VisibleHotBatchRead) {
             return self.read_visible_hot_batch().await;
+        }
+        if matches!(
+            self.operation,
+            Operation::VisiblePreconditionBatch | Operation::VisibleIdempotentPreconditionBatch
+        ) {
+            return self.check_visible_preconditions().await;
         }
         match prepared.bytes {
             Some(bytes) => {
@@ -353,6 +379,45 @@ where
         values.len()
     }
 
+    async fn check_visible_preconditions(&self) -> usize {
+        let idempotent = matches!(
+            self.operation,
+            Operation::VisibleIdempotentPreconditionBatch
+        );
+        let mut preconditions = self
+            .direct_precondition_keys
+            .iter()
+            .cloned()
+            .map(|key| Precondition::KeyValueEquals {
+                space: DIRECT_PRECONDITION_SPACE,
+                key,
+                expected: Bytes::from_static(DIRECT_PRECONDITION_VALUE),
+            })
+            .collect::<Vec<_>>();
+        if idempotent {
+            preconditions.push(Precondition::KeyAbsent {
+                space: DIRECT_PRECONDITION_SPACE,
+                key: Key(Bytes::from_static(DIRECT_IDEMPOTENCY_RECEIPT_KEY)),
+            });
+        }
+        let checked = preconditions.len();
+        let write = self
+            .storage
+            .prepare_write_set(
+                self.storage.new_write_set(),
+                WriteOptions {
+                    idempotency_key: idempotent
+                        .then(|| Bytes::from_static(DIRECT_IDEMPOTENCY_RECEIPT_KEY)),
+                    preconditions,
+                    ..WriteOptions::default()
+                },
+            )
+            .await
+            .expect("check direct visible preconditions");
+        drop(write);
+        checked
+    }
+
     async fn layout(&self) -> Layout {
         let read = self
             .storage
@@ -386,6 +451,12 @@ impl Fixture {
         let direct_batch_keys = matches!(operation, Operation::VisibleHotBatchRead)
             .then(direct_batch_keys)
             .unwrap_or_default();
+        let direct_precondition_keys = matches!(
+            operation,
+            Operation::VisiblePreconditionBatch | Operation::VisibleIdempotentPreconditionBatch
+        )
+        .then(direct_precondition_keys)
+        .unwrap_or_default();
         match backend {
             Backend::Rocks => {
                 let storage = RocksDB::open(&database_path).expect("open benchmark RocksDB");
@@ -398,6 +469,13 @@ impl Fixture {
                 if matches!(operation, Operation::VisibleHotBatchRead) {
                     seed_direct_batch_values(&storage, &direct_batch_keys).await;
                 }
+                if matches!(
+                    operation,
+                    Operation::VisiblePreconditionBatch
+                        | Operation::VisibleIdempotentPreconditionBatch
+                ) {
+                    seed_direct_precondition_values(&storage, &direct_precondition_keys).await;
+                }
                 Self::Rocks(
                     BackendFixture::create(
                         storage,
@@ -407,6 +485,7 @@ impl Fixture {
                         direct_key,
                         direct_value_len,
                         direct_batch_keys,
+                        direct_precondition_keys,
                     )
                     .await,
                 )
@@ -423,6 +502,13 @@ impl Fixture {
                 if matches!(operation, Operation::VisibleHotBatchRead) {
                     seed_direct_batch_values(&storage, &direct_batch_keys).await;
                 }
+                if matches!(
+                    operation,
+                    Operation::VisiblePreconditionBatch
+                        | Operation::VisibleIdempotentPreconditionBatch
+                ) {
+                    seed_direct_precondition_values(&storage, &direct_precondition_keys).await;
+                }
                 Self::Slate(
                     BackendFixture::create(
                         storage,
@@ -432,6 +518,7 @@ impl Fixture {
                         direct_key,
                         direct_value_len,
                         direct_batch_keys,
+                        direct_precondition_keys,
                     )
                     .await,
                 )
@@ -534,6 +621,45 @@ fn direct_batch_keys() -> Vec<Key> {
             )))
         })
         .collect()
+}
+
+fn direct_precondition_keys() -> Vec<Key> {
+    ["branch-head", "tracked-mutation-revision"]
+        .into_iter()
+        .map(|key| Key(Bytes::from_static(key.as_bytes())))
+        .collect()
+}
+
+async fn seed_direct_precondition_values<S>(storage: &S, keys: &[Key])
+where
+    S: Storage,
+{
+    let mut write = storage
+        .begin_write(WriteOptions::default())
+        .await
+        .expect("begin direct precondition seed write");
+    write
+        .put_many(
+            DIRECT_PRECONDITION_SPACE,
+            PutBatch {
+                entries: keys
+                    .iter()
+                    .cloned()
+                    .map(|key| PutEntry {
+                        key,
+                        value: StoredValue {
+                            bytes: Bytes::from_static(DIRECT_PRECONDITION_VALUE),
+                        },
+                    })
+                    .collect(),
+            },
+        )
+        .await
+        .expect("stage direct precondition seed values");
+    write
+        .commit()
+        .await
+        .expect("commit direct precondition seed values");
 }
 
 #[derive(Default)]

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -399,48 +399,68 @@ async fn check_preconditions(
     if preconditions.is_empty() {
         return Ok(());
     }
-    let snapshot = worker
-        .call_read(|db| async move { db.snapshot().await.map_err(slatedb_error) })
+    let preconditions = preconditions.to_vec();
+    let matches = worker
+        .call_read(move |db| async move {
+            let snapshot = db.snapshot().await.map_err(slatedb_error)?;
+            let mut matches = Vec::with_capacity(preconditions.len());
+            let mut index = 0;
+            while index < preconditions.len() {
+                let start = index;
+                let mut point_keys = Vec::new();
+                while index < preconditions.len() {
+                    let Some(key) = point_precondition_physical_key(&preconditions[index])? else {
+                        break;
+                    };
+                    point_keys.push(key);
+                    index += 1;
+                }
+
+                if !point_keys.is_empty() {
+                    // A tracked mutation normally supplies a branch-head and a
+                    // revision predicate (and idempotent mutations add a
+                    // receipt predicate). Evaluate each contiguous point run
+                    // against this snapshot in one read operation rather than
+                    // serializing a worker entry for every predicate.
+                    let values = get_snapshot_values(
+                        Arc::clone(&snapshot),
+                        point_keys,
+                        ReadDurability::Visible,
+                    )
+                    .await?;
+                    matches.extend(values.iter().enumerate().map(|(offset, value)| {
+                        point_precondition_matches(&preconditions[start + offset], value.as_ref())
+                    }));
+                    continue;
+                }
+
+                let matches_precondition = match &preconditions[index] {
+                    Precondition::RangeEmpty { space, range } => {
+                        let bounds =
+                            EncodedBounds::new(physical_range(*space, range.clone())?, None);
+                        collect_snapshot_keys(Arc::clone(&snapshot), bounds)
+                            .await?
+                            .is_empty()
+                    }
+                    Precondition::BranchEquals { .. } => false,
+                    Precondition::KeyAbsent { .. }
+                    | Precondition::KeyPresent { .. }
+                    | Precondition::KeyValueHashEquals { .. }
+                    | Precondition::KeyValueEquals { .. } => {
+                        unreachable!("point preconditions are collected above")
+                    }
+                };
+                matches.push(matches_precondition);
+                index += 1;
+            }
+            Ok(matches)
+        })
         .await?;
-    let mut failures = Vec::new();
-    for (index, precondition) in preconditions.iter().enumerate() {
-        let matches = match precondition {
-            Precondition::KeyAbsent { space, key } => {
-                snapshot_value(worker, Arc::clone(&snapshot), *space, key)
-                    .await?
-                    .is_none()
-            }
-            Precondition::KeyPresent { space, key } => {
-                snapshot_value(worker, Arc::clone(&snapshot), *space, key)
-                    .await?
-                    .is_some()
-            }
-            Precondition::KeyValueHashEquals { space, key, hash } => {
-                snapshot_value(worker, Arc::clone(&snapshot), *space, key)
-                    .await?
-                    .is_some_and(|value| blake3::hash(&value).as_bytes() == hash)
-            }
-            Precondition::KeyValueEquals {
-                space,
-                key,
-                expected,
-            } => snapshot_value(worker, Arc::clone(&snapshot), *space, key)
-                .await?
-                .is_some_and(|value| value == *expected),
-            Precondition::RangeEmpty { space, range } => {
-                let bounds = EncodedBounds::new(physical_range(*space, range.clone())?, None);
-                let snapshot = Arc::clone(&snapshot);
-                worker
-                    .call_read(move |_db| collect_snapshot_keys(snapshot, bounds))
-                    .await?
-                    .is_empty()
-            }
-            Precondition::BranchEquals { .. } => false,
-        };
-        if !matches {
-            failures.push(PreconditionFailure { index });
-        }
-    }
+    let failures = matches
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, matches)| (!matches).then_some(PreconditionFailure { index }))
+        .collect::<Vec<_>>();
     if failures.is_empty() {
         Ok(())
     } else {
@@ -448,19 +468,32 @@ async fn check_preconditions(
     }
 }
 
-async fn snapshot_value(
-    worker: &SlateDBWorker,
-    snapshot: Arc<DbSnapshot>,
-    space: SpaceId,
-    key: &Key,
-) -> Result<Option<Bytes>, StorageError> {
-    let key = physical_key(space, key)?;
-    Ok(worker
-        .call_read(move |_db| get_snapshot_values(snapshot, vec![key], ReadDurability::Visible))
-        .await?
-        .into_iter()
-        .next()
-        .flatten())
+fn point_precondition_physical_key(
+    precondition: &Precondition,
+) -> Result<Option<Key>, StorageError> {
+    match precondition {
+        Precondition::KeyAbsent { space, key }
+        | Precondition::KeyPresent { space, key }
+        | Precondition::KeyValueHashEquals { space, key, .. }
+        | Precondition::KeyValueEquals { space, key, .. } => physical_key(*space, key).map(Some),
+        Precondition::RangeEmpty { .. } | Precondition::BranchEquals { .. } => Ok(None),
+    }
+}
+
+fn point_precondition_matches(precondition: &Precondition, value: Option<&Bytes>) -> bool {
+    match precondition {
+        Precondition::KeyAbsent { .. } => value.is_none(),
+        Precondition::KeyPresent { .. } => value.is_some(),
+        Precondition::KeyValueHashEquals { hash, .. } => {
+            value.is_some_and(|value| blake3::hash(value.as_ref()).as_bytes() == hash)
+        }
+        Precondition::KeyValueEquals { expected, .. } => {
+            value.is_some_and(|value| value == expected)
+        }
+        Precondition::RangeEmpty { .. } | Precondition::BranchEquals { .. } => {
+            unreachable!("only point preconditions have batched snapshot values")
+        }
+    }
 }
 
 impl StorageRead for SlateDBRead {
@@ -1799,6 +1832,110 @@ mod tests {
             .expect("read singleton missing key")
             .values,
             vec![None]
+        );
+    }
+
+    #[test]
+    fn batched_point_preconditions_preserve_duplicate_and_mixed_failure_indexes() {
+        let storage = SlateDB::open_object_store_with_options(
+            "test-batched-point-preconditions",
+            Arc::new(InMemory::new()),
+            SlateDBObjectStoreOptions::default(),
+        )
+        .expect("open memory object-store slatedb storage");
+        let space = SpaceId(7);
+        let present = Key(Bytes::from_static(b"present"));
+        let missing = Key(Bytes::from_static(b"missing"));
+        let value = Bytes::from_static(b"value");
+        let value_hash = *blake3::hash(&value).as_bytes();
+
+        let mut seed =
+            block_on(storage.begin_write(WriteOptions::default())).expect("begin seed write");
+        block_on(seed.put_many(
+            space,
+            PutBatch {
+                entries: vec![PutEntry {
+                    key: present.clone(),
+                    value: StoredValue {
+                        bytes: value.clone(),
+                    },
+                }],
+            },
+        ))
+        .expect("stage seed value");
+        block_on(seed.commit()).expect("commit seed value");
+
+        let passing = block_on(storage.begin_write(WriteOptions {
+            preconditions: vec![
+                Precondition::KeyValueEquals {
+                    space,
+                    key: present.clone(),
+                    expected: value.clone(),
+                },
+                Precondition::KeyPresent {
+                    space,
+                    key: present.clone(),
+                },
+                Precondition::KeyAbsent {
+                    space,
+                    key: missing.clone(),
+                },
+            ],
+            ..WriteOptions::default()
+        }))
+        .expect("all batched point preconditions pass");
+        drop(passing);
+
+        let error = block_on(storage.begin_write(WriteOptions {
+            preconditions: vec![
+                Precondition::KeyValueEquals {
+                    space,
+                    key: present.clone(),
+                    expected: value,
+                },
+                Precondition::KeyAbsent {
+                    space,
+                    key: present.clone(),
+                },
+                Precondition::RangeEmpty {
+                    space,
+                    range: KeyRange {
+                        lower: Bound::Included(present.clone()),
+                        upper: Bound::Included(present.clone()),
+                    },
+                },
+                Precondition::KeyPresent {
+                    space,
+                    key: missing,
+                },
+                Precondition::KeyAbsent {
+                    space,
+                    key: present.clone(),
+                },
+                Precondition::BranchEquals {
+                    ref_key: Key(Bytes::from_static(b"branch-ref")),
+                    expected: Bytes::from_static(b"ignored"),
+                },
+                Precondition::KeyValueHashEquals {
+                    space,
+                    key: present,
+                    hash: value_hash,
+                },
+            ],
+            ..WriteOptions::default()
+        }))
+        .err()
+        .expect("mixed failed preconditions report every original index");
+
+        assert_eq!(
+            error,
+            StorageError::PreconditionFailed(vec![
+                PreconditionFailure { index: 1 },
+                PreconditionFailure { index: 2 },
+                PreconditionFailure { index: 3 },
+                PreconditionFailure { index: 4 },
+                PreconditionFailure { index: 5 },
+            ])
         );
     }
 


### PR DESCRIPTION
## What

Evaluate contiguous SlateDB point preconditions from one snapshot in one read operation. This removes the per-predicate read-operation boundary while retaining ordered failure indexes, duplicate keys, range/branch behavior, and the existing visible-read semantics.

Adds direct reproducible two-guard tracked-mutation and three-guard idempotency-shaped benchmark operations, plus a mixed/duplicate precondition regression test.

## Why

Tracked mutations usually perform branch-head and mutation-revision predicates; idempotent mutations add a receipt predicate. Previously those checks were serialized through individual snapshot reads.

## Performance

Pinned CPU, 1,000 warmups and 5,000 samples per run, SlateDB local-file backend:

- two guards: 4.92/4.93 µs baseline p50 → 3.93/4.01 µs candidate p50 (18.5–20.1% faster)
- three guards: 6.76 µs → 5.68 µs p50 in a paired run (16.0% faster)

Base: `main` at `e159172162aab06c69e92a7d399686b69cfaf1ce`. No stack dependency.

## Validation

- `cargo test -p lix_slatedb_storage --release`
- `cargo clippy -p lix_slatedb_storage --all-targets --release -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- focused post-rebase precondition regression test