### PR TITLE
fix(cli): bound Git replay plugin actors

### DIFF
--- a/.changenotes/bound-git-replay-plugin-actors.md
+++ b/.changenotes/bound-git-replay-plugin-actors.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Git history replay can now ingest large atomic text commits without exhausting the bounded WebAssembly actor cache.
+
+Replay keeps durable Git-text rows and materialization proofs while retiring one-shot file actors immediately after their output is staged.

--- a/packages/cli/src/commands/exp/git_replay.rs
+++ b/packages/cli/src/commands/exp/git_replay.rs
@@ -464,7 +464,8 @@ fn execute_statements_as_transaction(
         })
         .collect::<Vec<_>>();
 
-    db::block_on(lix.execute_batch(&batch)).map_err(|error| {
+    db::block_on(lix.execute_batch_for_single_writer_ingest(&batch))
+    .map_err(|error| {
         let sql_preview = batch
             .first()
             .map(|statement| statement.sql.chars().take(160).collect::<String>())
@@ -2737,6 +2738,173 @@ mod tests {
             binary_rows.rows().is_empty(),
             "NUL-bearing file must remain a raw binary blob"
         );
+        db::block_on(lix.close()).expect("reopened Lix should close");
+
+        fs::remove_dir_all(&fixture).expect("fixture directory should be removable");
+    }
+
+    #[test]
+    fn rocksdb_replay_bounds_text_actor_lifecycle_across_hundred_commits() {
+        const TEXT_FILES: usize = 5;
+
+        let fixture = unique_temp_dir();
+        let repo = fixture.join("repo");
+        let output = fixture.join("replay.rocksdb");
+        let profile = fixture.join("profile.json");
+        fs::create_dir_all(&repo).expect("fixture repository should be created");
+        git_ok(&repo, &["init", "-q", "-b", "main"]);
+        git_ok(&repo, &["config", "user.email", "replay@example.test"]);
+        git_ok(&repo, &["config", "user.name", "Replay Test"]);
+
+        let mut expected_final = Vec::with_capacity(TEXT_FILES);
+        for index in 0..TEXT_FILES {
+            let bytes = format!("root-{index}\n").into_bytes();
+            fs::write(repo.join(format!("bulk-{index:02}.txt")), &bytes)
+                .expect("root text fixture should write");
+            expected_final.push(bytes);
+        }
+        git_ok(&repo, &["add", "-A"]);
+        git_ok(&repo, &["commit", "-qm", "root five text files"]);
+
+        // This one atomic replay batch updates every file that was just
+        // imported. It exercises the cold-open Existing path as well as the
+        // five New actors in the root commit.
+        for (index, bytes) in expected_final.iter_mut().enumerate() {
+            *bytes = format!("second-{index}\n").into_bytes();
+            fs::write(repo.join(format!("bulk-{index:02}.txt")), bytes)
+                .expect("second text fixture should write");
+        }
+        git_ok(&repo, &["add", "-A"]);
+        git_ok(&repo, &["commit", "-qm", "update five text files"]);
+
+        for revision in 2..100 {
+            let index = revision % TEXT_FILES;
+            let path = format!("bulk-{index:02}.txt");
+            let bytes = format!("revision-{revision}-{index}\n").into_bytes();
+            fs::write(repo.join(&path), &bytes).expect("history text fixture should write");
+            expected_final[index] = bytes;
+            let message = format!("revision {revision}");
+            git_ok(&repo, &["add", &path]);
+            git_ok(&repo, &["commit", "-qm", &message]);
+        }
+
+        run(ExpGitReplayArgs {
+            repo_path: repo,
+            output_rocksdb_path: output.clone(),
+            branch: "main".to_string(),
+            from_commit: None,
+            num_commits: Some(100),
+            verify_state: true,
+            force: false,
+            profile_json: Some(profile.clone()),
+        })
+        .expect("100-commit replay with five semantic files should complete");
+
+        let profile_json: serde_json::Value =
+            serde_json::from_slice(&fs::read(&profile).expect("replay profile should be written"))
+                .expect("replay profile should be valid JSON");
+        assert_eq!(
+            profile_json
+                .get("num_commits_requested")
+                .and_then(serde_json::Value::as_u64),
+            Some(100)
+        );
+        assert_eq!(
+            profile_json
+                .get("commits_replayed")
+                .and_then(serde_json::Value::as_u64),
+            Some(100)
+        );
+        assert_eq!(
+            profile_json
+                .get("commits_applied")
+                .and_then(serde_json::Value::as_u64),
+            Some(100)
+        );
+        assert_eq!(
+            profile_json
+                .get("commits_marker_only")
+                .and_then(serde_json::Value::as_u64),
+            Some(0)
+        );
+        assert_eq!(
+            profile_json
+                .get("changed_paths_total")
+                .and_then(serde_json::Value::as_u64),
+            Some(108)
+        );
+        let commits = profile_json
+            .get("commits")
+            .and_then(serde_json::Value::as_array)
+            .expect("profile commits should be an array");
+        assert_eq!(commits.len(), 100);
+        assert_eq!(
+            commits[0]
+                .get("inserts")
+                .and_then(serde_json::Value::as_u64),
+            Some(TEXT_FILES as u64)
+        );
+        assert_eq!(
+            commits[0]
+                .get("updates")
+                .and_then(serde_json::Value::as_u64),
+            Some(0)
+        );
+        assert_eq!(
+            commits[0]
+                .get("statement_count")
+                .and_then(serde_json::Value::as_u64),
+            Some(2),
+            "five inserts and the replay marker must share one atomic batch"
+        );
+        assert_eq!(
+            commits[1]
+                .get("updates")
+                .and_then(serde_json::Value::as_u64),
+            Some(TEXT_FILES as u64)
+        );
+        assert_eq!(
+            commits[1]
+                .get("statement_count")
+                .and_then(serde_json::Value::as_u64),
+            Some(TEXT_FILES as u64 + 1),
+            "five updates and the replay marker must share one atomic batch"
+        );
+
+        let storage = RocksDB::open(&output).expect("replay RocksDB should reopen");
+        let lix = db::block_on(open_lix_with_storage(storage))
+            .expect("replay Lix should reopen with installed plugin");
+        for (index, expected) in expected_final.iter().enumerate() {
+            let path = format!("/bulk-{index:02}.txt");
+            let file_rows = db::block_on(lix.execute(
+                "SELECT data FROM lix_file WHERE path = ?",
+                &[Value::Text(path.clone())],
+            ))
+            .expect("reopened rendered text file should query");
+            assert_eq!(file_rows.rows().len(), 1, "expected one row for {path}");
+            let rendered = value_to_optional_blob(
+                file_rows.rows()[0]
+                    .get_index(0)
+                    .expect("rendered file row should contain data"),
+                "reopened rendered text data",
+            )
+            .expect("rendered text data should be a blob");
+            assert_eq!(
+                rendered,
+                Some(expected.as_slice()),
+                "wrong bytes for {path}"
+            );
+
+            let semantic_rows = db::block_on(lix.execute(
+                "SELECT lixcol_entity_pk FROM git_text_line_v2 WHERE lixcol_file_id = ?",
+                &[Value::Text(path.clone())],
+            ))
+            .expect("reopened Git-text rows should query");
+            assert!(
+                !semantic_rows.rows().is_empty(),
+                "text semantic rows should persist for {path}"
+            );
+        }
         db::block_on(lix.close()).expect("reopened Lix should close");
 
         fs::remove_dir_all(&fixture).expect("fixture directory should be removable");

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -1096,12 +1096,57 @@ where
         .await
     }
 
+    /// Executes one atomic import batch whose caller serializes every writer
+    /// that could transition the same plugin-owned files.
+    ///
+    /// Unlike ordinary execution, this deliberately retires each plugin actor
+    /// after its durable rows and materialization proof have been staged. It
+    /// bounds a one-shot import's private Wasm Stores independently of the
+    /// number of files in the batch. Do not use it for concurrent mutation
+    /// workloads: ordinary execution retains file actor leases through commit
+    /// to compose concurrent semantic transitions.
+    #[doc(hidden)]
+    pub async fn execute_batch_for_single_writer_ingest(
+        &self,
+        statements: &[ExecuteBatchStatement],
+    ) -> Result<Vec<ExecuteResult>, LixError> {
+        self.execute_batch_with_options_and_metadata_inner(
+            statements,
+            ExecuteOptions::default(),
+            vec![ExecuteStatementMetadata::default(); statements.len()],
+            None,
+            false,
+            false,
+        )
+        .await
+    }
+
     #[doc(hidden)]
     pub async fn execute_batch_with_options_and_metadata(
         &self,
         statements: &[ExecuteBatchStatement],
         options: ExecuteOptions,
         statement_metadata: Vec<ExecuteStatementMetadata>,
+    ) -> Result<Vec<ExecuteResult>, LixError> {
+        self.execute_batch_with_options_and_metadata_inner(
+            statements,
+            options,
+            statement_metadata,
+            None,
+            false,
+            true,
+        )
+        .await
+    }
+
+    async fn execute_batch_with_options_and_metadata_inner(
+        &self,
+        statements: &[ExecuteBatchStatement],
+        options: ExecuteOptions,
+        statement_metadata: Vec<ExecuteStatementMetadata>,
+        idempotency: Option<ExecuteIdempotency>,
+        require_idempotency_for_writes: bool,
+        retain_plugin_actor_publications: bool,
     ) -> Result<Vec<ExecuteResult>, LixError> {
         let telemetry = start_batch(
             self.telemetry.as_ref(),
@@ -1112,8 +1157,9 @@ where
             statements,
             options,
             statement_metadata,
-            None,
-            false,
+            idempotency,
+            require_idempotency_for_writes,
+            retain_plugin_actor_publications,
         );
         let result = match telemetry.as_ref() {
             Some(telemetry) => telemetry.instrument(operation).await,
@@ -1136,26 +1182,15 @@ where
         statement_metadata: Vec<ExecuteStatementMetadata>,
         idempotency: Option<ExecuteIdempotency>,
     ) -> Result<Vec<ExecuteResult>, LixError> {
-        let telemetry = start_batch(
-            self.telemetry.as_ref(),
-            TelemetrySpanKind::SqlBatch,
-            statements.len(),
-        );
-        let operation = self.execute_batch_with_options_inner(
+        self.execute_batch_with_options_and_metadata_inner(
             statements,
             options,
             statement_metadata,
             idempotency,
             true,
-        );
-        let result = match telemetry.as_ref() {
-            Some(telemetry) => telemetry.instrument(operation).await,
-            None => operation.await,
-        };
-        if let Some(telemetry) = telemetry {
-            finish_operation(telemetry, &result);
-        }
-        result
+            true,
+        )
+        .await
     }
 
     async fn execute_batch_with_options_inner(
@@ -1165,6 +1200,7 @@ where
         statement_metadata: Vec<ExecuteStatementMetadata>,
         idempotency: Option<ExecuteIdempotency>,
         require_idempotency_for_writes: bool,
+        retain_plugin_actor_publications: bool,
     ) -> Result<Vec<ExecuteResult>, LixError> {
         self.ensure_open()?;
         if statements.is_empty() {
@@ -1221,6 +1257,7 @@ where
                             options,
                             statement_metadata,
                             None,
+                            retain_plugin_actor_publications,
                         )
                         .await;
                 }
@@ -1238,6 +1275,7 @@ where
                             options,
                             statement_metadata,
                             None,
+                            retain_plugin_actor_publications,
                         )
                         .await;
                 };
@@ -1253,6 +1291,7 @@ where
                         options,
                         statement_metadata,
                         Some(idempotency.clone()),
+                        retain_plugin_actor_publications,
                     )
                     .await;
                 match result {
@@ -1291,10 +1330,12 @@ where
         options: ExecuteOptions,
         statement_metadata: Vec<ExecuteStatementMetadata>,
         idempotency: Option<ExecuteIdempotency>,
+        retain_plugin_actor_publications: bool,
     ) -> Result<Vec<ExecuteResult>, LixError> {
         let telemetry_sink = self.telemetry.clone();
         self.with_write_transaction(move |transaction| {
             Box::pin(async move {
+                transaction.set_retain_plugin_actor_publications(retain_plugin_actor_publications);
                 let mut results = Vec::with_capacity(statements.len());
                 for (statement_index, ((statement, parsed), metadata)) in statements
                     .iter()

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -302,6 +302,7 @@ pub(crate) struct Transaction<StorageImpl: Storage = Memory> {
     origin_key: Option<String>,
     idempotency_receipt: Option<(crate::storage_adapter::StorageKey, Vec<u8>)>,
     session_file_views: SessionFileViews,
+    retain_plugin_actor_publications: bool,
     pending_file_view_mutations: BTreeMap<SessionFileViewKey, SessionFileViewMutation>,
     pending_plugin_actor_publications: Vec<PendingPluginActorPublication>,
     plugin_generation_read_guard: Option<tokio::sync::OwnedRwLockReadGuard<()>>,
@@ -552,6 +553,7 @@ where
                 origin_key: None,
                 idempotency_receipt: None,
                 session_file_views,
+                retain_plugin_actor_publications: true,
                 pending_file_view_mutations: BTreeMap::new(),
                 pending_plugin_actor_publications: Vec::new(),
                 plugin_generation_read_guard: None,
@@ -782,6 +784,14 @@ where
 
     pub(crate) fn trust_serialized_filesystem_planner(&mut self) {
         self.trust_filesystem_planner = true;
+    }
+
+    /// Bulk import only needs the durable rows produced by a plugin, not a
+    /// warm private Wasm document for every imported file. Retaining those
+    /// documents through one atomic commit can exceed the engine-wide actor
+    /// bound before the transaction is allowed to publish them.
+    pub(crate) fn set_retain_plugin_actor_publications(&mut self, retain: bool) {
+        self.retain_plugin_actor_publications = retain;
     }
 
     /// Rolls back the storage transaction.
@@ -3394,6 +3404,11 @@ where
             reconciliation
                 .materialization_versions
                 .insert(file_key.clone(), materialization_version);
+            let publication = if self.retain_plugin_actor_publications {
+                publication
+            } else {
+                publication.into_uncached().await
+            };
             reconciliation.actor_publications.push(publication);
             reconciled_file_keys.insert(file_key);
         }
@@ -3692,6 +3707,11 @@ where
                     .prepared_semantic_rows
                     .insert(source, prepared)?;
             }
+            let publication = if self.retain_plugin_actor_publications {
+                publication
+            } else {
+                publication.into_uncached().await
+            };
             reconciliation.actor_publications.push(publication);
             reconciled_file_keys.insert(file_key);
         }
@@ -5215,9 +5235,49 @@ enum PendingPluginActorPublication {
         semantic_root: Arc<str>,
         view: PendingPluginActorView,
     },
+    /// The plugin transition has already produced its durable rows, but bulk
+    /// ingestion deliberately does not keep its private Wasm Store alive.
+    /// Keeping this marker preserves the normal one-transition-per-file
+    /// validation and gives the session a non-authoritative file view after
+    /// commit, forcing a cold open before any later edit.
+    Uncached {
+        path: String,
+        view: PendingPluginActorView,
+    },
 }
 
 impl PendingPluginActorPublication {
+    async fn into_uncached(self) -> Self {
+        match self {
+            Self::Existing {
+                lease,
+                successor_key,
+                view,
+            } => {
+                let _ = lease.discard_successor().await;
+                Self::Uncached {
+                    path: successor_key.path,
+                    view,
+                }
+            }
+            Self::New {
+                mut store,
+                key,
+                document,
+                view,
+                ..
+            } => {
+                let _ = store.actor_mut().drop_document(document).await;
+                let _ = store.actor_mut().retire().await;
+                Self::Uncached {
+                    path: key.path,
+                    view,
+                }
+            }
+            publication @ Self::Uncached { .. } => publication,
+        }
+    }
+
     async fn discard(self) {
         match self {
             Self::Existing { lease, .. } => {
@@ -5231,6 +5291,7 @@ impl PendingPluginActorPublication {
                 let _ = store.actor_mut().drop_document(document).await;
                 let _ = store.actor_mut().retire().await;
             }
+            Self::Uncached { .. } => {}
         }
     }
 
@@ -5242,7 +5303,11 @@ impl PendingPluginActorPublication {
                 view,
             } => {
                 let path = successor_key.path.clone();
-                (lease.commit_successor_as(successor_key).await?, view, path)
+                (
+                    Some(lease.commit_successor_as(successor_key).await?),
+                    view,
+                    path,
+                )
             }
             Self::New {
                 cache,
@@ -5255,11 +5320,12 @@ impl PendingPluginActorPublication {
             } => {
                 let path = key.path.clone();
                 (
-                    cache.install(key, store, document, bytes, semantic_root),
+                    Some(cache.install(key, store, document, bytes, semantic_root)),
                     view,
                     path,
                 )
             }
+            Self::Uncached { path, view } => (None, view, path),
         };
         Ok((
             view.session_key,
@@ -5268,14 +5334,16 @@ impl PendingPluginActorPublication {
                 plugin_key: view.plugin_key,
                 plugin_generation: view.plugin_generation,
                 owner_change_id: view.owner_change_id,
-                observation: Some(observation),
+                observation,
             },
         ))
     }
 
     fn session_key(&self) -> &SessionFileViewKey {
         match self {
-            Self::Existing { view, .. } | Self::New { view, .. } => &view.session_key,
+            Self::Existing { view, .. } | Self::New { view, .. } | Self::Uncached { view, .. } => {
+                &view.session_key
+            }
         }
     }
 }

--- a/packages/rs-sdk/src/lix.rs
+++ b/packages/rs-sdk/src/lix.rs
@@ -296,6 +296,16 @@ where
             .await
     }
 
+    #[doc(hidden)]
+    pub async fn execute_batch_for_single_writer_ingest(
+        &self,
+        statements: &[ExecuteBatchStatement],
+    ) -> Result<Vec<ExecuteResult>, LixError> {
+        self.session
+            .execute_batch_for_single_writer_ingest(statements)
+            .await
+    }
+
     /// Classifies an atomic SQL batch for a caller that owns its transport
     /// lifecycle.
     pub fn execute_batch_disposition(


### PR DESCRIPTION
## Summary

Git replay now treats text-plugin actors as bounded ingestion workers. After a file's semantic rows and materialization proof are staged in the atomic transaction, replay retires its private Wasm store instead of retaining it for post-commit cache publication.

Ordinary execution keeps its existing warm actor leases through commit, preserving concurrent semantic-transition composition. Replay publishes an uncached view, so a later edit cold-opens the durable semantic state.

The regression replays 100 commits through RocksDB, including atomic commits that create and then update five text files, verifies the final rendered bytes, and verifies durable `git_text_line_v2` rows after reopening.

## Why

Frozen OpenClaw root-history replay previously aborted at commit 2 (`16dfc1a5...`), where one atomic commit creates six text files. The fifth plugin actor exhausted the engine's four-live-Store limit before the transaction could commit.

## Memory bound

For that six-file batch, increasing the current limit from four to six would permit six configured 128 MiB guest-store ceilings (768 MiB). This replay lifecycle keeps one active store at a time (128 MiB): an **83.3% lower configured guest-memory ceiling** for the batch.

This is a structural capacity bound, not a sampled RSS claim.

## Validation

- `cargo test -p lix_cli --lib rocksdb_replay_bounds_text_actor_lifecycle_across_hundred_commits -- --nocapture`
  - post-rebase: 100/100 commits verified; 1.215 s replay phase
- `cargo clippy -p lix_cli --tests -- -D warnings`
- `cargo clippy -p lix_engine --lib -- -D warnings`
- `git diff --check origin/main...HEAD`
