### PR TITLE
fix clippy match arms

### DIFF
--- a/packages/engine-benchmarks/benches/small_blob_cas.rs
+++ b/packages/engine-benchmarks/benches/small_blob_cas.rs
@@ -269,20 +269,13 @@ where
                 bytes: None,
                 expected_hash: Some(self.stable_hash.clone()),
             },
-            Operation::DurableSingletonRead => PreparedOperation {
+            Operation::DurableSingletonRead
+            | Operation::VisibleHotBatchRead
+            | Operation::VisiblePreconditionBatch
+            | Operation::VisibleIdempotentPreconditionBatch => PreparedOperation {
                 bytes: None,
                 expected_hash: None,
             },
-            Operation::VisibleHotBatchRead => PreparedOperation {
-                bytes: None,
-                expected_hash: None,
-            },
-            Operation::VisiblePreconditionBatch | Operation::VisibleIdempotentPreconditionBatch => {
-                PreparedOperation {
-                    bytes: None,
-                    expected_hash: None,
-                }
-            }
         }
     }
 


### PR DESCRIPTION
## What changed

Consolidate the benchmark operations that intentionally prepare the same empty payload into a single match arm.

## Why

The workspace Clippy job treats warnings as errors and rejected the duplicate `DurableSingletonRead` and `VisibleHotBatchRead` arms with `clippy::match_same_arms`.

## Impact

No runtime behavior changes. This is a benchmark-only structural cleanup that restores the Cargo Clippy CI job.

## Validation

- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`