### PR TITLE
perf(slatedb): reuse snapshot points for mutation preconditions

### DIFF
--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -376,7 +376,7 @@ impl Storage for SlateDB {
     ) -> impl Future<Output = Result<Self::Write<'_>, StorageError>> + Send {
         async move {
             let writer_permit = self.write_gate.acquire().await;
-            check_preconditions(&self.worker, &opts.preconditions).await?;
+            check_preconditions(&self.worker, &self.point_cache, &opts.preconditions).await?;
             Ok(SlateDBWrite {
                 worker: self.worker.clone(),
                 _writer_permit: writer_permit,
@@ -394,12 +394,14 @@ impl Storage for SlateDB {
 
 async fn check_preconditions(
     worker: &SlateDBWorker,
+    point_cache: &SnapshotPointCache,
     preconditions: &[Precondition],
 ) -> Result<(), StorageError> {
     if preconditions.is_empty() {
         return Ok(());
     }
     let preconditions = preconditions.to_vec();
+    let point_cache = point_cache.clone();
     let matches = worker
         .call_read(move |db| async move {
             let snapshot = db.snapshot().await.map_err(slatedb_error)?;
@@ -422,12 +424,9 @@ async fn check_preconditions(
                     // receipt predicate). Evaluate each contiguous point run
                     // against this snapshot in one read operation rather than
                     // serializing a worker entry for every predicate.
-                    let values = get_snapshot_values(
-                        Arc::clone(&snapshot),
-                        point_keys,
-                        ReadDurability::Visible,
-                    )
-                    .await?;
+                    let values =
+                        get_cached_snapshot_values(Arc::clone(&snapshot), point_keys, &point_cache)
+                            .await?;
                     matches.extend(values.iter().enumerate().map(|(offset, value)| {
                         point_precondition_matches(&preconditions[start + offset], value.as_ref())
                     }));
@@ -466,6 +465,36 @@ async fn check_preconditions(
     } else {
         Err(StorageError::PreconditionFailed(failures))
     }
+}
+
+async fn get_cached_snapshot_values(
+    snapshot: Arc<DbSnapshot>,
+    keys: Vec<Key>,
+    point_cache: &SnapshotPointCache,
+) -> Result<Vec<Option<Bytes>>, StorageError> {
+    let sequence = snapshot.seq();
+    let mut values = vec![None; keys.len()];
+    point_cache.get_many(sequence, &keys, &mut values);
+    let missing = keys
+        .iter()
+        .enumerate()
+        .filter_map(|(index, key)| values[index].is_none().then_some((index, key.clone())))
+        .collect::<Vec<_>>();
+    if !missing.is_empty() {
+        let missing_keys = missing
+            .iter()
+            .map(|(_, key)| key.clone())
+            .collect::<Vec<_>>();
+        let fetched = get_snapshot_values(snapshot, missing_keys, ReadDurability::Visible).await?;
+        for ((index, key), value) in missing.into_iter().zip(fetched) {
+            point_cache.insert(sequence, key, value.clone());
+            values[index] = Some(value);
+        }
+    }
+    Ok(values
+        .into_iter()
+        .map(|value| value.expect("all SlateDB point-cache misses are filled"))
+        .collect())
 }
 
 fn point_precondition_physical_key(


### PR DESCRIPTION
## What

Reuse the bounded snapshot point cache while evaluating batched mutation preconditions. Cache identity remains snapshot sequence plus physical key, so newer publications cannot leak into an older check.

## Why

Tracked CRUD writes repeatedly validate the same branch-head, revision, and optional idempotency receipt points. The read path already cached these immutable snapshot points, but mutation preconditions bypassed it and paid another SlateDB point lookup.

## Benchmark

Direct release benchmark, warm cache, 100 warmups and 2,001 samples, p50:

| case | main | this PR | improvement |
| --- | ---: | ---: | ---: |
| ordinary visible preconditions | 4.18 us | 1.29 us | 69.1% |
| idempotent preconditions | 5.88 us | 1.42 us | 75.9% |

The broader 201-sample 4 KiB and 32 KiB matrix showed 69–70% and 75–76% improvements respectively.

## Correctness

- Cache keys include immutable SlateDB snapshot sequence and physical key.
- Missing values are cached distinctly from cache misses.
- Batch lookup preserves duplicate keys and failure indexes.
- Existing byte, entry, and per-value bounds remain unchanged.

## Validation

- cargo fmt --all -- --check
- cargo test -p lix_slatedb_storage (33 passed)
- cargo clippy -p lix_slatedb_storage --all-targets -- -D warnings