### PR TITLE
perf(engine): index pending tombstones

### DIFF
--- a/.changenotes/index-pending-tombstones.md
+++ b/.changenotes/index-pending-tombstones.md
@@ -1,0 +1,6 @@
+---
+type: patch
+---
+
+Large delete transactions now index pending tombstone identities instead of
+repeatedly scanning every deleted row during validation.

--- a/packages/engine/src/domain.rs
+++ b/packages/engine/src/domain.rs
@@ -186,7 +186,7 @@ pub(crate) enum DomainFileScope {
     Exact(Option<String>),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct DomainRowIdentity {
     domain: Domain,
     schema_key: String,

--- a/packages/engine/src/transaction/validation.rs
+++ b/packages/engine/src/transaction/validation.rs
@@ -7,7 +7,7 @@
     clippy::unnecessary_wraps
 )]
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use serde_json::Value as JsonValue;
 use tracing::Instrument as _;
@@ -1595,13 +1595,14 @@ struct PendingConstraintIndexes {
     fk_targets: BTreeMap<PendingForeignKeyTargetKey, Vec<PendingForeignKeyTarget>>,
     fk_references: BTreeMap<PendingForeignKeyReferenceTarget, Vec<PendingForeignKeyReference>>,
     tombstones: Vec<PendingTombstone>,
+    tombstone_identities: HashSet<DomainRowIdentity>,
 }
 
 impl PendingConstraintIndexes {
     fn remember_tombstone(&mut self, row: PreparedValidationRow<'_>) {
-        self.tombstones.push(PendingTombstone {
-            identity: row.domain_row_identity(),
-        });
+        let identity = row.domain_row_identity();
+        self.tombstone_identities.insert(identity.clone());
+        self.tombstones.push(PendingTombstone { identity });
     }
 
     fn remember_row(
@@ -1737,9 +1738,7 @@ impl PendingConstraintIndexes {
 
     fn tombstones_identity(&self, row: &MaterializedLiveStateRow) -> bool {
         let identity = DomainRowIdentity::from_live_row(row);
-        self.tombstones
-            .iter()
-            .any(|tombstone| tombstone.identity == identity)
+        self.tombstone_identities.contains(&identity)
     }
 
     fn has_identity_target(&self, identity: &DomainRowIdentity) -> bool {
@@ -1756,9 +1755,7 @@ impl PendingConstraintIndexes {
     }
 
     fn tombstones_target_identity(&self, identity: &DomainRowIdentity) -> bool {
-        self.tombstones
-            .iter()
-            .any(|tombstone| tombstone.identity == *identity)
+        self.tombstone_identities.contains(identity)
     }
 
     fn has_fk_target_key(&self, key: &PendingForeignKeyTargetKey) -> bool {


### PR DESCRIPTION
## Summary

Index pending transaction tombstones by exact domain-row identity. Validation previously searched the entire tombstone vector for every committed row it inspected, turning large semantic deletes into quadratic identity comparisons.

Stacked on #841, which now contains the correctness fix and the merged scan-batching change from #848. The complete stack was rebased on `origin/main` at `1a4292204127cc4a1324bf3d094005321431643f` immediately before opening.

## OpenClaw workload result

Frozen source repository: `openclaw/openclaw` at `d16c2dedd2b1ab508b4c2a2fa315ada27aa5d8e1`, with all blobs hydrated locally. Replay range: the first 100 first-parent commits, `f6dd362d39b8e30bd79ef7560aab9575712ccc11..948ff7f035f68810244c1698c9b090443cb5e7c2`, into a fresh RocksDB database. Wasmtime component cache was warm for both measurements; Git-text plugin setup is excluded by the replay profiler.

Compared with the parent stack (#848):

- Full replay: **14,522.018 ms → 12,485.439 ms (-14.0%)**
- Commit deleting 23 generated coverage files (`d0c9bff4ca59d9596675084bc23192886fd4dc6c`): **2,788.651 ms → 1,038.153 ms (-62.8%)**
- Peak RSS: 238,464 KiB → 238,864 KiB (+0.2%, effectively flat)
- Changed paths and applied commits: unchanged at 316 paths / 100 commits

Compared with the original Lix baseline before #848, the two performance cuts compound to **37.4% faster** (19,945.060 ms → 12,485.439 ms).

A state-verifying replay passed all 100 commits and the final Git tree manifest check.

## Validation

- `cargo test -p lix_engine`
- `cargo test -p lix_engine --features all-simulations`
- `cargo test -p lix_rocksdb_storage`
- `cargo clippy -p lix_engine --lib --tests -- -D warnings`
- `cargo fmt --all`
- `git diff --check`
- OpenClaw replay with `--verify-state`: 100/100 commits plus final tree manifest
- Post-rebase focused engine validation on `origin/main` `1a4292204`