### PR TITLE
perf(files): cache plugin registries by storage snapshot

### DIFF
--- a/packages/engine/src/plugin/component.rs
+++ b/packages/engine/src/plugin/component.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex};
 
 use crate::binary_cas::BlobHash;
@@ -44,6 +44,12 @@ struct CachedPluginV2Factory {
     factory: Arc<dyn WasmComponentV2Factory>,
 }
 
+#[derive(Default)]
+struct PluginRegistryReadCache {
+    snapshot: Option<u128>,
+    registries: BTreeMap<String, PluginRegistry>,
+}
+
 #[derive(Clone)]
 pub(crate) struct PluginRuntimeHost {
     wasm_runtime: Arc<dyn WasmRuntime>,
@@ -52,6 +58,7 @@ pub(crate) struct PluginRuntimeHost {
     plugin_actor_cache: PluginActorCache,
     plugin_v2_transition_counters: Arc<Mutex<WasmTransitionCounters>>,
     plugin_catalog_cache: Arc<Mutex<PluginCatalogCache>>,
+    plugin_registry_read_cache: Arc<Mutex<PluginRegistryReadCache>>,
     /// Ordinary plugin writes share this gate; lifecycle replacements take it
     /// exclusively. The guards live on transactions through durable commit,
     /// closing the owner-preflight/registry-swap race without serializing
@@ -81,6 +88,7 @@ impl PluginRuntimeHost {
             plugin_actor_cache: PluginActorCache::new(max_live_file_actors)?,
             plugin_v2_transition_counters: Arc::new(Mutex::new(WasmTransitionCounters::default())),
             plugin_catalog_cache: Arc::new(Mutex::new(PluginCatalogCache::default())),
+            plugin_registry_read_cache: Arc::new(Mutex::new(PluginRegistryReadCache::default())),
             plugin_generation_fence: Arc::new(tokio::sync::RwLock::new(())),
         })
     }
@@ -116,6 +124,52 @@ impl PluginRuntimeHost {
                 )
             })?
             .get_or_compile(registry)
+    }
+
+    pub(crate) fn cached_plugin_registries(
+        &self,
+        snapshot: u128,
+        branch_ids: &BTreeSet<String>,
+    ) -> Result<Option<BTreeMap<String, PluginRegistry>>, LixError> {
+        let cache = self.plugin_registry_read_cache.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "plugin registry read cache lock poisoned",
+            )
+        })?;
+        if cache.snapshot != Some(snapshot) {
+            return Ok(None);
+        }
+        let registries = branch_ids
+            .iter()
+            .map(|branch_id| {
+                cache
+                    .registries
+                    .get(branch_id)
+                    .cloned()
+                    .map(|registry| (branch_id.clone(), registry))
+            })
+            .collect::<Option<BTreeMap<_, _>>>();
+        Ok(registries)
+    }
+
+    pub(crate) fn cache_plugin_registries(
+        &self,
+        snapshot: u128,
+        registries: &BTreeMap<String, PluginRegistry>,
+    ) -> Result<(), LixError> {
+        let mut cache = self.plugin_registry_read_cache.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "plugin registry read cache lock poisoned",
+            )
+        })?;
+        if cache.snapshot != Some(snapshot) {
+            cache.snapshot = Some(snapshot);
+            cache.registries.clear();
+        }
+        cache.registries.extend(registries.clone());
+        Ok(())
     }
 
     pub(crate) fn actor_cache(&self) -> PluginActorCache {
@@ -222,6 +276,31 @@ mod tests {
                 .expect("custom limit should validate")
                 .max_memory_bytes,
             192 * 1024 * 1024
+        );
+    }
+
+    #[test]
+    fn plugin_registry_read_cache_isolated_by_snapshot() {
+        let host = PluginRuntimeHost::new(Arc::new(UnsupportedWasmRuntime));
+        let branches = BTreeSet::from(["branch-a".to_string()]);
+        let registries = BTreeMap::from([("branch-a".to_string(), PluginRegistry::empty())]);
+
+        assert!(
+            host.cached_plugin_registries(7, &branches)
+                .expect("inspect empty cache")
+                .is_none()
+        );
+        host.cache_plugin_registries(7, &registries)
+            .expect("cache registry");
+        assert_eq!(
+            host.cached_plugin_registries(7, &branches)
+                .expect("read matching snapshot"),
+            Some(registries)
+        );
+        assert!(
+            host.cached_plugin_registries(8, &branches)
+                .expect("read different snapshot")
+                .is_none()
         );
     }
 

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -10,8 +10,8 @@ use crate::sql_telemetry::{SqlStatementTelemetry, finish_operation, start_batch}
 use crate::sql2;
 use crate::storage_adapter::Storage;
 use crate::storage_adapter::{
-    SharedStorageAdapterRead, StorageAdapter, StorageAdapterReadScope, StorageReadDurability,
-    StorageReadOptions, StorageWriteOptions, StorageWriteSet,
+    SharedStorageAdapterRead, StorageAdapter, StorageAdapterRead, StorageAdapterReadScope,
+    StorageReadDurability, StorageReadOptions, StorageWriteOptions, StorageWriteSet,
 };
 use crate::telemetry::TelemetrySpanKind;
 use crate::transaction::{begin_commit_boundary, commit_at_boundary};
@@ -699,6 +699,7 @@ where
             read_scope,
             |read_store| async move {
                 let active_branch_id = self.active_branch_id_from_reader(&read_store).await?;
+                let plugin_cache_snapshot = read_store.snapshot_cache_key();
                 let live_state: Arc<dyn crate::live_state::LiveStateReader> =
                     Arc::new(self.live_state.reader(read_store.clone()));
                 let filesystem_path_index: Arc<dyn crate::filesystem::FilesystemPathIndexReader> =
@@ -719,6 +720,7 @@ where
                     blob_reader,
                     self.plugin_host.clone(),
                     Some(file_view_collector.clone()),
+                    plugin_cache_snapshot,
                     &paths,
                 )
                 .await?;
@@ -1751,6 +1753,7 @@ where
                         blob_reader,
                         self.plugin_host.clone(),
                         file_view_collector.clone(),
+                        None,
                         &paths,
                     )
                     .await?
@@ -1940,6 +1943,7 @@ async fn hydrate_lix_file_data_result(
         blob_reader,
         plugin_host,
         session_file_views,
+        None,
         &paths,
     )
     .await?;

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -639,6 +639,7 @@ pub(crate) async fn execute_exact_lix_file_batch_read(
     blob_reader: Arc<dyn BlobDataReader>,
     plugin_host: PluginRuntimeHost,
     session_file_views: Option<SessionFileViews>,
+    plugin_cache_snapshot: Option<u128>,
     paths: &BTreeSet<String>,
 ) -> Result<SqlQueryResult, LixError> {
     let base_schema = lix_file_schema();
@@ -671,12 +672,13 @@ pub(crate) async fn execute_exact_lix_file_batch_read(
     let mut prepared = prepare_indexed_lix_file_rows(&matches, rows)?;
     let acknowledge_plugin_data = session_file_views.is_some();
     let plugin_render = if prepared.needs_plugin_render(true) || acknowledge_plugin_data {
-        plugin_render_context_for_lix_file_scan(
+        plugin_render_context_for_lix_file_scan_cached(
             Arc::clone(&live_state),
             &request,
             plugin_host,
             &prepared,
             acknowledge_plugin_data,
+            plugin_cache_snapshot,
         )
         .await?
         .map(|context| context.with_session_file_views(session_file_views))
@@ -1630,7 +1632,7 @@ impl UpsertSupport for LixFileSpec {
         let plugin_rewrite_file_ids = if update_columns.updates_path() && !update_columns.data {
             let plugin_host = self.plugin_host.clone();
             let branches =
-                load_plugin_render_branches(Arc::clone(&live_state), &request, &plugin_host)
+                load_plugin_render_branches(Arc::clone(&live_state), &request, &plugin_host, None)
                     .await
                     .map_err(|error| {
                         DataFusionError::Execution(format!(
@@ -4970,11 +4972,32 @@ async fn plugin_render_context_for_lix_file_scan(
     prepared: &PreparedLixFileRows,
     include_blob_backed_candidates: bool,
 ) -> Result<Option<PluginRenderContext>, LixError> {
+    plugin_render_context_for_lix_file_scan_cached(
+        live_state,
+        request,
+        host,
+        prepared,
+        include_blob_backed_candidates,
+        None,
+    )
+    .await
+}
+
+async fn plugin_render_context_for_lix_file_scan_cached(
+    live_state: Arc<dyn LiveStateReader>,
+    request: &LiveStateScanRequest,
+    host: PluginRuntimeHost,
+    prepared: &PreparedLixFileRows,
+    include_blob_backed_candidates: bool,
+    cache_snapshot: Option<u128>,
+) -> Result<Option<PluginRenderContext>, LixError> {
     let candidates = prepared.plugin_owner_candidates(include_blob_backed_candidates);
     if candidates.is_empty() {
         return Ok(None);
     }
-    let branches = load_plugin_render_branches(Arc::clone(&live_state), request, &host).await?;
+    let branches =
+        load_plugin_render_branches(Arc::clone(&live_state), request, &host, cache_snapshot)
+            .await?;
     plugin_render_context_with_branches(
         live_state,
         host,
@@ -4989,6 +5012,7 @@ async fn load_plugin_render_branches(
     live_state: Arc<dyn LiveStateReader>,
     request: &LiveStateScanRequest,
     host: &PluginRuntimeHost,
+    cache_snapshot: Option<u128>,
 ) -> Result<BTreeMap<String, BranchPluginRenderContext>, LixError> {
     let branch_ids = request
         .filter
@@ -4997,38 +5021,56 @@ async fn load_plugin_render_branches(
         .filter(|branch_id| branch_id.as_str() != GLOBAL_BRANCH_ID)
         .cloned()
         .collect::<BTreeSet<_>>();
-    let registry_reads = branch_ids.into_iter().map(|branch_id| {
-        let live_state = Arc::clone(&live_state);
-        async move {
-            let rows = live_state
-                .scan_tracked_rows(&LiveStateScanRequest {
-                    filter: LiveStateFilter {
-                        schema_keys: vec!["lix_key_value".to_string()],
-                        entity_pks: vec![EntityPk::single(PLUGIN_REGISTRY_KEY)],
-                        branch_ids: vec![branch_id.clone()],
-                        file_ids: vec![crate::NullableKeyFilter::Null],
-                        untracked: Some(false),
-                        ..LiveStateFilter::default()
-                    },
-                    projection: plugin_control_live_state_projection(),
-                    limit: Some(1),
-                })
-                .await?;
-            let row = rows.into_iter().find(|row| {
-                row.schema_key == "lix_key_value"
-                    && row.entity_pk.as_single_string().ok() == Some(PLUGIN_REGISTRY_KEY)
-                    && row.file_id.is_none()
-                    && row.branch_id.as_ref() == branch_id.as_str()
-                    && !row.global
-                    && !row.untracked
+    let cached = match cache_snapshot {
+        Some(snapshot) => host.cached_plugin_registries(snapshot, &branch_ids)?,
+        None => None,
+    };
+    let registries = match cached {
+        Some(registries) => registries,
+        None => {
+            let registry_reads = branch_ids.iter().cloned().map(|branch_id| {
+                let live_state = Arc::clone(&live_state);
+                async move {
+                    let rows = live_state
+                        .scan_tracked_rows(&LiveStateScanRequest {
+                            filter: LiveStateFilter {
+                                schema_keys: vec!["lix_key_value".to_string()],
+                                entity_pks: vec![EntityPk::single(PLUGIN_REGISTRY_KEY)],
+                                branch_ids: vec![branch_id.clone()],
+                                file_ids: vec![crate::NullableKeyFilter::Null],
+                                untracked: Some(false),
+                                ..LiveStateFilter::default()
+                            },
+                            projection: plugin_control_live_state_projection(),
+                            limit: Some(1),
+                        })
+                        .await?;
+                    let row = rows.into_iter().find(|row| {
+                        row.schema_key == "lix_key_value"
+                            && row.entity_pk.as_single_string().ok() == Some(PLUGIN_REGISTRY_KEY)
+                            && row.file_id.is_none()
+                            && row.branch_id.as_ref() == branch_id.as_str()
+                            && !row.global
+                            && !row.untracked
+                    });
+                    let registry =
+                        PluginRegistry::from_optional_live_state_row(row.as_ref(), &branch_id)?;
+                    Ok::<_, LixError>((branch_id, registry))
+                }
             });
-            let registry = PluginRegistry::from_optional_live_state_row(row.as_ref(), &branch_id)?;
-            Ok::<_, LixError>((branch_id, registry))
+            let registries = try_join_all(registry_reads)
+                .await?
+                .into_iter()
+                .collect::<BTreeMap<_, _>>();
+            if let Some(snapshot) = cache_snapshot {
+                host.cache_plugin_registries(snapshot, &registries)?;
+            }
+            registries
         }
-    });
+    };
 
     let mut branches = BTreeMap::<String, BranchPluginRenderContext>::new();
-    for (branch_id, registry) in try_join_all(registry_reads).await? {
+    for (branch_id, registry) in registries {
         if registry.is_empty() {
             continue;
         }

--- a/packages/engine/src/storage/traits.rs
+++ b/packages/engine/src/storage/traits.rs
@@ -53,6 +53,13 @@ pub trait Storage: Send + Sync {
 /// Read handles must release snapshots and other resources from `Drop`;
 /// callers are not required to run asynchronous cleanup when a scope ends.
 pub trait StorageRead: Send + Sync {
+    /// Stable identity for this immutable read view within one open storage
+    /// instance. Adapters may expose this to key process-local derived caches;
+    /// `None` disables such caching.
+    fn snapshot_cache_key(&self) -> Option<u128> {
+        None
+    }
+
     /// Reads the requested keys of one space. The returned values have one
     /// slot per requested key, in caller order, and preserve duplicates.
     fn get_many(

--- a/packages/engine/src/storage_adapter/read_scope.rs
+++ b/packages/engine/src/storage_adapter/read_scope.rs
@@ -10,6 +10,10 @@ use crate::storage::{
 /// Implementations preserve one coherent storage read view while allowing
 /// independent point and scan requests to overlap.
 pub trait StorageAdapterRead: Send + Sync {
+    fn snapshot_cache_key(&self) -> Option<u128> {
+        None
+    }
+
     fn get_many(
         &self,
         space: SpaceId,
@@ -88,6 +92,10 @@ impl<R> StorageAdapterRead for StorageAdapterReadScope<R>
 where
     R: StorageRead,
 {
+    fn snapshot_cache_key(&self) -> Option<u128> {
+        self.read.snapshot_cache_key()
+    }
+
     fn get_many(
         &self,
         space: SpaceId,
@@ -111,6 +119,10 @@ impl<R> StorageAdapterRead for SharedStorageAdapterRead<R>
 where
     R: StorageRead,
 {
+    fn snapshot_cache_key(&self) -> Option<u128> {
+        self.read.snapshot_cache_key()
+    }
+
     fn get_many(
         &self,
         space: SpaceId,
@@ -134,6 +146,10 @@ impl<T> StorageAdapterRead for &T
 where
     T: StorageAdapterRead + ?Sized,
 {
+    fn snapshot_cache_key(&self) -> Option<u128> {
+        (*self).snapshot_cache_key()
+    }
+
     fn get_many(
         &self,
         space: SpaceId,

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -1073,6 +1073,14 @@ fn point_precondition_matches(precondition: &Precondition, value: Option<&Bytes>
 }
 
 impl StorageRead for SlateDBRead {
+    fn snapshot_cache_key(&self) -> Option<u128> {
+        let publication_id = self
+            .publication_view
+            .as_ref()
+            .map_or(0, |view| view.publication_id);
+        Some((u128::from(self.snapshot.seq()) << 64) | u128::from(publication_id))
+    }
+
     fn get_many(
         &self,
         space: SpaceId,
@@ -2844,6 +2852,9 @@ mod tests {
 
         let before_update =
             block_on(storage.begin_read(ReadOptions::default())).expect("begin old snapshot");
+        let before_update_cache_key = before_update
+            .snapshot_cache_key()
+            .expect("SlateDB read should expose a snapshot cache key");
         assert_eq!(
             block_on(before_update.get_many(
                 space,
@@ -2875,6 +2886,12 @@ mod tests {
 
         let after_update =
             block_on(storage.begin_read(ReadOptions::default())).expect("begin new snapshot");
+        assert_ne!(
+            before_update_cache_key,
+            after_update
+                .snapshot_cache_key()
+                .expect("updated SlateDB read should expose a snapshot cache key")
+        );
         assert_eq!(
             block_on(after_update.get_many(
                 space,


### PR DESCRIPTION
## Summary
- expose an optional, process-local identity for immutable storage read views
- have SlateDB identify reads by persisted sequence plus visible publication ID
- cache both empty and populated plugin registries by that exact snapshot identity
- use the cache only for native file reads that must acknowledge plugin state; all other backends and readers default to no cache
- invalidate without heuristics: a different persisted snapshot or pending visible publication has a different key

## Profile
A steady 4 KiB no-plugin native read on the parent spent approximately:

- branch resolution: 8 µs
- path selection: 5 µs
- blob-reference lookup: 56 µs
- plugin acknowledgement/empty-registry lookup: 43 µs
- CAS hydration: 59 µs

This PR removes the repeated 43 µs registry materialization without an extra revision read.

## Benchmark
`native_file_read_component`, release, 1,000 files, 100 commits, 30 paired samples per payload, compared with merged parent #851.

| payload | parent SlateDB p50 | this PR p50 | improvement | earlier RocksDB p50 | Slate/Rocks |
| --- | ---: | ---: | ---: | ---: | ---: |
| 4 KiB | 178.7 µs | 159.0 µs | 11.1% | 114.0 µs | 1.39× |
| 32 KiB | 173.1 µs | 153.6 µs | 11.2% | 138.2 µs | 1.11× |
| 256 KiB | 222.5 µs | 218.5 µs | 1.8% | 370.1 µs | 0.59× |

The targeted fixed-cost classes both clear the required 10% step; the large-payload class was already faster than RocksDB and remains so.

## Validation
- focused registry-cache snapshot invalidation test
- focused SlateDB old/new visible snapshot-key isolation test
- `cargo clippy -p lix_engine -p lix_slatedb_storage --all-targets -- -D warnings`
- `cargo fmt --all --check`
