### PR TITLE
perf(engine): fast-path file data and metadata updates

### DIFF
--- a/.changenotes/fast-file-data-metadata-update-by-id.md
+++ b/.changenotes/fast-file-data-metadata-update-by-id.md
@@ -1,0 +1,6 @@
+---
+type: patch
+---
+
+Route `lix_file` updates that set data and metadata by file ID through the
+direct write executor instead of DataFusion.

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -78,6 +78,7 @@ pub(crate) async fn try_execute_bound_public_write(
 struct FastFileDataUpdateShape {
     id: BoundExpr,
     data: BoundExpr,
+    metadata: Option<BoundExpr>,
     data_parameter_index: Option<usize>,
 }
 
@@ -90,14 +91,27 @@ async fn execute_file_data_update(
     let id = eval_fast_file_nullable_text(&shape.id, params, "id")?;
     let data = eval_fast_file_blob(&shape.data, params, "data")?;
     let splice_provenance = fast_file_data_update_splice_provenance(shape, metadata);
-    crate::sql2::providers::execute_fast_lix_file_data_update_by_id(
-        ctx,
-        id,
-        data,
-        splice_provenance,
-        metadata.mutation_identity(),
-    )
-    .await
+    if let Some(metadata_expr) = &shape.metadata {
+        let row_metadata = eval_fast_file_metadata(metadata_expr, params)?;
+        crate::sql2::providers::execute_fast_lix_file_data_update_by_id_with_metadata(
+            ctx,
+            id,
+            data,
+            row_metadata,
+            splice_provenance,
+            metadata.mutation_identity(),
+        )
+        .await
+    } else {
+        crate::sql2::providers::execute_fast_lix_file_data_update_by_id(
+            ctx,
+            id,
+            data,
+            splice_provenance,
+            metadata.mutation_identity(),
+        )
+        .await
+    }
 }
 
 fn fast_file_data_update_splice_provenance(
@@ -119,18 +133,36 @@ fn fast_file_data_update_shape(
         || !matches!(plan.bound.input, BoundWriteInput::None)
         || plan.bound.conflict.is_some()
         || !matches!(plan.bound.branch_scope, BranchScope::Active { .. })
-        || plan.bound.assignments.len() != 1
+        || !(1..=2).contains(&plan.bound.assignments.len())
     {
         return None;
     }
-    let assignment = &plan.bound.assignments[0];
-    if assignment.column.name != "data" || !fast_file_blob_expr_supported(&assignment.value) {
+    let assignment = plan
+        .bound
+        .assignments
+        .iter()
+        .find(|assignment| assignment.column.name == "data")?;
+    let metadata = plan
+        .bound
+        .assignments
+        .iter()
+        .find(|assignment| assignment.column.name == "lixcol_metadata")
+        .map(|assignment| assignment.value.clone());
+    if !fast_file_blob_expr_supported(&assignment.value)
+        || metadata
+            .as_ref()
+            .is_some_and(|expr| !fast_file_metadata_expr_supported(expr))
+        || plan.bound.assignments.iter().any(|assignment| {
+            assignment.column.name != "data" && assignment.column.name != "lixcol_metadata"
+        })
+    {
         return None;
     }
     let id = fast_file_id_predicate_value(&plan.bound.predicate)?;
     Some(FastFileDataUpdateShape {
         id: id.clone(),
         data: assignment.value.clone(),
+        metadata,
         data_parameter_index: match &assignment.value {
             BoundExpr::Param(param) => Some(param.index),
             BoundExpr::Literal(_) => None,
@@ -3380,6 +3412,7 @@ mod splice_provenance_tests {
         let shape = FastFileDataUpdateShape {
             id: BoundExpr::Param(BoundParamRef { index: 2 }),
             data: BoundExpr::Param(BoundParamRef { index: 3 }),
+            metadata: None,
             data_parameter_index: Some(3),
         };
 
@@ -3398,6 +3431,7 @@ mod splice_provenance_tests {
         let parameter_shape = FastFileDataUpdateShape {
             id: BoundExpr::Param(BoundParamRef { index: 1 }),
             data: BoundExpr::Param(BoundParamRef { index: 2 }),
+            metadata: None,
             data_parameter_index: Some(2),
         };
         assert_eq!(
@@ -3408,6 +3442,7 @@ mod splice_provenance_tests {
         let literal_shape = FastFileDataUpdateShape {
             id: BoundExpr::Param(BoundParamRef { index: 1 }),
             data: BoundExpr::Literal(crate::sql2::bind::expr::BoundLiteral::Blob(vec![1])),
+            metadata: None,
             data_parameter_index: None,
         };
         assert_eq!(

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -5366,6 +5366,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_sql_file_data_and_metadata_update_by_id_uses_fast_path() {
+        let rows = vec![
+            live_file_row("file-readme", "branch-a", None, "readme.md"),
+            live_blob_ref_row("file-readme", "branch-a", b"old"),
+        ];
+        let (mut fast_ctx, fast_staged, _) = counting_write_context(rows.clone());
+        let (mut datafusion_ctx, datafusion_staged, _) = counting_write_context(rows);
+        let sql = "UPDATE lix_file SET data = $1, lixcol_metadata = $2 WHERE id = $3";
+        let params = [
+            Value::Blob(b"parameterized".to_vec().into()),
+            Value::Json(serde_json::json!({"source": "git"})),
+            Value::Text("file-readme".to_string()),
+        ];
+
+        let (fast_result, fast_path) =
+            execute_write_sql_trace(&mut fast_ctx, sql, &params, WriteExecutorMode::ForceFast)
+                .await
+                .expect("data and metadata update should use the fast path");
+        let (datafusion_result, datafusion_path) = execute_write_sql_trace(
+            &mut datafusion_ctx,
+            sql,
+            &params,
+            WriteExecutorMode::ForceDataFusion,
+        )
+        .await
+        .expect("reference data and metadata update should succeed");
+
+        assert_eq!(fast_path, WriteExecutorPath::Fast);
+        assert_eq!(datafusion_path, WriteExecutorPath::DataFusion);
+        assert_eq!(fast_result.rows, vec![vec![Value::Integer(1)]]);
+        assert_eq!(fast_result.rows, datafusion_result.rows);
+        let fast_rows = fast_staged.lock().expect("fast writes lock").deltas[0]
+            .pending_write_overlay()
+            .expect("fast staged delta should project")
+            .visible_all_semantic_rows();
+        let datafusion_rows = datafusion_staged
+            .lock()
+            .expect("DataFusion writes lock")
+            .deltas[0]
+            .pending_write_overlay()
+            .expect("DataFusion staged delta should project")
+            .visible_all_semantic_rows();
+        assert_eq!(fast_rows, datafusion_rows);
+    }
+
+    #[tokio::test]
     async fn execute_sql_file_data_update_by_id_treats_null_id_as_no_match() {
         let rows = vec![live_file_row("file-readme", "branch-a", None, "readme.md")];
         let (mut fast_ctx, fast_staged, fast_scans) = counting_write_context(rows);

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -2656,6 +2656,44 @@ pub(crate) async fn execute_fast_lix_file_data_update_by_id(
     splice_provenance: Option<RequestBlobSpliceProvenance>,
     mutation_identity: Option<MutationIdentity>,
 ) -> Result<u64, LixError> {
+    execute_fast_lix_file_data_update_by_id_impl(
+        ctx,
+        file_id,
+        data,
+        None,
+        splice_provenance,
+        mutation_identity,
+    )
+    .await
+}
+
+pub(crate) async fn execute_fast_lix_file_data_update_by_id_with_metadata(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    file_id: Option<String>,
+    data: crate::Blob,
+    metadata: Option<TransactionJson>,
+    splice_provenance: Option<RequestBlobSpliceProvenance>,
+    mutation_identity: Option<MutationIdentity>,
+) -> Result<u64, LixError> {
+    execute_fast_lix_file_data_update_by_id_impl(
+        ctx,
+        file_id,
+        data,
+        Some(metadata),
+        splice_provenance,
+        mutation_identity,
+    )
+    .await
+}
+
+async fn execute_fast_lix_file_data_update_by_id_impl(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    file_id: Option<String>,
+    data: crate::Blob,
+    metadata_update: Option<Option<TransactionJson>>,
+    splice_provenance: Option<RequestBlobSpliceProvenance>,
+    mutation_identity: Option<MutationIdentity>,
+) -> Result<u64, LixError> {
     let active_branch_id = ctx.active_branch_id().to_string();
     ctx.load_branch_head(&active_branch_id)
         .await?
@@ -2741,6 +2779,17 @@ pub(crate) async fn execute_fast_lix_file_data_update_by_id(
         let mut context = existing.row_context();
         if context.global {
             context.branch_id = GLOBAL_BRANCH_ID.to_string();
+        }
+        if let Some(metadata) = &metadata_update {
+            context.metadata.clone_from(metadata);
+            staged
+                .state_rows
+                .push(file_descriptor_row(FileDescriptorRowInput {
+                    id: existing.id.clone(),
+                    directory_id: existing.directory_id.clone(),
+                    name: existing.name.clone(),
+                    context: context.clone(),
+                }));
         }
         stage_lix_file_data_update_write(
             &mut staged,

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -38,7 +38,8 @@ use datafusion::logical_expr::TableSource;
 pub(crate) use file::{
     ExactLixFileReadColumn, ExactLixFileReadSelector, FastLixFilePathWriteConflict,
     execute_exact_lix_file_batch_read, execute_exact_lix_file_read,
-    execute_fast_lix_file_data_update_by_id, execute_fast_lix_file_path_writes,
+    execute_fast_lix_file_data_update_by_id, execute_fast_lix_file_data_update_by_id_with_metadata,
+    execute_fast_lix_file_path_writes,
 };
 #[cfg(test)]
 pub(crate) use filesystem_working_change::filesystem_working_change_schema;


### PR DESCRIPTION
## Summary

- recognize `UPDATE lix_file SET data = ..., lixcol_metadata = ... WHERE id = ...` in the bound public write executor
- update the descriptor metadata and file data atomically through the existing direct ID-update path
- preserve data-only behavior, metadata clearing, splice provenance, and mutation identity
- add semantic parity coverage against the forced DataFusion executor

## Performance

Release-mode isolated A/B on the OpenClaw replay query shape, 200 executions with identical seeded state:

| executor | 200 updates |
| --- | ---: |
| DataFusion | 58.460 ms |
| direct fast path | 4.939 ms |

That is **91.6% lower latency / 11.8× faster** for this query shape.

On the full 100-commit `openclaw/openclaw` RocksDB replay, this route is only one component of the workload: repeated release runs were 2.279–2.437 s versus the 2.395 s reference. The isolated query improvement is decisive; the end-to-end replay remains dominated by inserts and deletes and will be optimized separately.

## Correctness

- fast and forced-DataFusion execution produce identical complete staged semantic rows
- OpenClaw replay verified 100/100 commits plus the final Git tree manifest against RocksDB

## Validation

- `cargo test -p lix_engine`
- `cargo test -p lix_engine --features all-simulations`
- `cargo clippy -p lix_engine --all-targets --features all-simulations -- -D warnings`
- release-mode OpenClaw 100-commit RocksDB replay with `--verify-state`