### PR TITLE
perf(text-v2): skip redundant cold-open rebuild

### DIFF
--- a/.changenotes/skip-git-text-cold-open-rebuild.md
+++ b/.changenotes/skip-git-text-cold-open-rebuild.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Speed up Git-text cold opens by retaining the already validated source buffer
+and construction-ordered line table instead of validating, sorting, rendering,
+and validating them again.

--- a/plugins/text-v2/src/core.rs
+++ b/plugins/text-v2/src/core.rs
@@ -60,7 +60,16 @@ impl Document {
                 bytes: Arc::new(bytes),
             });
         }
-        let document = Self::from_lines(lines)?;
+        // A cold open constructs lines in strict order from one already
+        // validated byte stream. Host ordinal IDs and evenly-spaced order
+        // keys are unique by construction, so routing this through
+        // `from_lines` would only revalidate every line, populate two trees,
+        // sort the already-sorted vector, render the original file again, and
+        // validate that duplicate byte buffer a second time.
+        let document = Self(Arc::new(DocumentInner {
+            bytes: Arc::new(bytes),
+            lines,
+        }));
         let changes = document.all_upserts()?;
         Ok((document, changes))
     }


### PR DESCRIPTION
## What changed

Git-text cold opens now retain the already validated source buffer and the line table built in strict order. They no longer route that data through the generic `from_lines` constructor, which revalidated every line, populated identity and order-key trees, sorted an already sorted vector, rendered the complete file again, and validated the duplicate buffer.

The generic constructor remains unchanged for entity-driven reconstruction, where those checks and ordering are required.

## Real workload result

I profiled `Document::open_file` in release mode against the largest Git-text file in OpenClaw commit `938e237411f8a5211a098c8dc6432f4c6901837b`: `coverage/src/index.ts.html` (295,016 bytes, 6,475 lines).

Across 15 fresh process executions:

- main median: 18.102 ms
- this branch median: 12.138 ms
- reduction: 32.9%

The complete one-commit RocksDB replay remains noisy and did not show a reliable end-to-end improvement, so this PR claims only the measured Git-text cold-open axis.

## Correctness

The source bytes, host ordinal identities, and evenly spaced order keys are all produced by the same cold-open pass. The existing semantic round-trip suite verifies byte-exact reconstruction (including invalid UTF-8 and an unterminated final line), sparse edits, reorders, duplicate lines, and renderer behavior.

The packaged plugin replayed and verified the exact OpenClaw commit: 31 changed paths, 27 inserts, 4 updates, and the final Git tree manifest matched RocksDB.

## Checks

- `cargo test -p plugin_git_text_v2`
- `cargo clippy -p plugin_git_text_v2 --all-targets -- -D warnings`
- release `lix exp git-replay` of the exact OpenClaw commit with `--verify-state`
