### PR TITLE
perf(engine): reduce tracked write ownership churn

### DIFF
--- a/.changenotes/reduce-tracked-write-cloning.md
+++ b/.changenotes/reduce-tracked-write-cloning.md
@@ -1,0 +1,11 @@
+---
+type: patch
+---
+
+Large tracked writes now avoid cloning rows, branch IDs, absence-guard
+identities, hot-head payloads, and encoded storage keys when the commit path
+does not need owned copies.
+
+Against the same RocksDB fixture on 10,000 rows, process-median transaction
+latency improved from 107.561 ms to 87.848 ms for inserts (18.3%) and from
+116.695 ms to 103.957 ms for updates (10.9%).

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -549,7 +549,7 @@ where
         let identities = sorted
             .iter()
             .map(|delta| {
-                hot_identity(
+                encode_hot_mutation_identity(
                     branch_id,
                     generation,
                     delta.schema_key,
@@ -561,17 +561,10 @@ where
         // Mutation validation must use primary rows rather than the file-id
         // projection. The projection is an equally-valued read accelerator,
         // not an ownership record.
-        let previous_values = hot_load_primary_identity_bytes(self.store, &identities).await?;
+        let previous_values =
+            hot_load_primary_mutation_identity_bytes(self.store, &identities).await?;
         let mut created_ats = Vec::with_capacity(sorted.len());
         let mut retired_untracked_json_refs = BTreeSet::new();
-        let delta_keys = sorted
-            .iter()
-            .map(|delta| TrackedStateKey {
-                schema_key: delta.schema_key.to_string(),
-                entity_pk: delta.entity_pk.clone(),
-                file_id: delta.file_id.map(str::to_string),
-            })
-            .collect::<BTreeSet<_>>();
         for (delta, previous) in sorted.iter().zip(&previous_values) {
             let Some(previous) = previous else {
                 created_ats.push(delta.created_at);
@@ -589,11 +582,23 @@ where
             }
             created_ats.push(existing.created_at);
         }
-        let unmatched_guards = absence_guards
-            .iter()
-            .filter(|key| !delta_keys.contains(*key))
-            .cloned()
-            .collect::<BTreeSet<_>>();
+        let unmatched_guards = if absence_guards.is_empty() {
+            BTreeSet::new()
+        } else {
+            let delta_keys = sorted
+                .iter()
+                .map(|delta| TrackedStateKey {
+                    schema_key: delta.schema_key.to_string(),
+                    entity_pk: delta.entity_pk.clone(),
+                    file_id: delta.file_id.map(str::to_string),
+                })
+                .collect::<BTreeSet<_>>();
+            absence_guards
+                .iter()
+                .filter(|key| !delta_keys.contains(*key))
+                .cloned()
+                .collect::<BTreeSet<_>>()
+        };
         reject_hot_absence_guards(self.store, branch_id, generation, &unmatched_guards).await?;
 
         // Build every fallible output before mutating the write set. The
@@ -604,10 +609,8 @@ where
         let mut next_coverage = *coverage;
         let mut diff_keys = Vec::new();
         let mut next_values = Vec::with_capacity(sorted.len());
-        for ((delta, identity), (created_at, previous)) in sorted
-            .iter()
-            .zip(&identities)
-            .zip(created_ats.iter().zip(&previous_values))
+        for (delta, (created_at, previous)) in
+            sorted.iter().zip(created_ats.iter().zip(&previous_values))
         {
             // Ordinary commits have no active checkpoint, so their baseline
             // is always disabled. Do not decode the row a second time merely
@@ -627,7 +630,14 @@ where
             if newly_dirty {
                 let checkpoint_commit_id = working_diff_capture_checkpoint_commit_id
                     .expect("a newly dirty hot row requires an active checkpoint");
-                let key = encode_hot_diff_key(checkpoint_commit_id, identity);
+                let key = encode_hot_diff_key_parts(
+                    branch_id,
+                    checkpoint_commit_id,
+                    generation,
+                    delta.schema_key,
+                    delta.entity_pk,
+                    delta.file_id,
+                );
                 next_coverage
                     .add_encoded_group_key(&key)
                     .ok_or_else(|| head_value_error("hot working-diff index count exceeds u64"))?;
@@ -652,12 +662,12 @@ where
             identities
                 .iter()
                 .zip(&next_values)
-                .filter(|(identity, value)| identity.file_id.is_some() && value.is_some())
+                .filter(|(identity, value)| identity.file_key.is_some() && value.is_some())
                 .count(),
             identities
                 .iter()
                 .zip(&next_values)
-                .filter(|(identity, value)| identity.file_id.is_some() && value.is_none())
+                .filter(|(identity, value)| identity.file_key.is_some() && value.is_none())
                 .count(),
         );
         self.writes
@@ -672,7 +682,7 @@ where
             );
         }
         for (identity, value) in identities.iter().zip(next_values) {
-            stage_hot_value(self.writes, identity, value);
+            stage_hot_mutation_value(self.writes, identity, value);
         }
         JsonStoreWriter::stage_untracked_reclaim_candidates(
             self.writes,
@@ -1005,6 +1015,87 @@ fn hot_identity(
     }
 }
 
+struct EncodedHotMutationIdentity {
+    row_key: Bytes,
+    file_key: Option<Bytes>,
+}
+
+fn encode_hot_mutation_identity(
+    branch_id: &str,
+    generation: CommitId,
+    schema_key: &str,
+    entity_pk: &EntityPk,
+    file_id: Option<&str>,
+) -> EncodedHotMutationIdentity {
+    EncodedHotMutationIdentity {
+        row_key: Bytes::from(encode_hot_row_key_parts(
+            branch_id, generation, schema_key, entity_pk, file_id,
+        )),
+        file_key: file_id.map(|_| {
+            Bytes::from(encode_hot_file_key_parts(
+                branch_id, generation, schema_key, entity_pk, file_id,
+            ))
+        }),
+    }
+}
+
+async fn hot_load_primary_mutation_identity_bytes(
+    store: &(impl StorageAdapterRead + ?Sized),
+    identities: &[EncodedHotMutationIdentity],
+) -> Result<Vec<Option<Bytes>>, LixError> {
+    if identities.is_empty() {
+        return Ok(Vec::new());
+    }
+    let keys = identities
+        .iter()
+        .map(|identity| StorageKey(identity.row_key.clone()))
+        .collect::<Vec<_>>();
+    PointReadPlan::new(HOT_ROW_SPACE, &keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?
+        .value
+        .into_iter()
+        .map(|value| value.map(full_value_bytes).transpose())
+        .collect()
+}
+
+fn stage_hot_mutation_value(
+    writes: &mut StorageWriteSet,
+    identity: &EncodedHotMutationIdentity,
+    value: Option<Vec<u8>>,
+) {
+    let Some(value) = value else {
+        writes.delete(HOT_ROW_SPACE, StorageKey(identity.row_key.clone()));
+        if let Some(file_key) = &identity.file_key {
+            writes.delete(HOT_FILE_SPACE, StorageKey(file_key.clone()));
+        }
+        return;
+    };
+    if let Some(file_key) = &identity.file_key {
+        let value = Bytes::from(value);
+        writes.put(
+            HOT_ROW_SPACE,
+            StorageKey(identity.row_key.clone()),
+            StorageValue {
+                bytes: value.clone(),
+            },
+        );
+        writes.put(
+            HOT_FILE_SPACE,
+            StorageKey(file_key.clone()),
+            StorageValue { bytes: value },
+        );
+    } else {
+        writes.put(
+            HOT_ROW_SPACE,
+            StorageKey(identity.row_key.clone()),
+            StorageValue {
+                bytes: Bytes::from(value),
+            },
+        );
+    }
+}
+
 fn stage_hot_value(writes: &mut StorageWriteSet, identity: &HeadIdentity, value: Option<Vec<u8>>) {
     let Some(value) = value else {
         writes.delete(
@@ -1019,17 +1110,24 @@ fn stage_hot_value(writes: &mut StorageWriteSet, identity: &HeadIdentity, value:
         }
         return;
     };
-    writes.put(
-        HOT_ROW_SPACE,
-        StorageKey(Bytes::from(encode_hot_row_key(identity))),
-        StorageValue {
-            bytes: Bytes::from(value.clone()),
-        },
-    );
     if identity.file_id.is_some() {
+        let value = Bytes::from(value);
+        writes.put(
+            HOT_ROW_SPACE,
+            StorageKey(Bytes::from(encode_hot_row_key(identity))),
+            StorageValue {
+                bytes: value.clone(),
+            },
+        );
         writes.put(
             HOT_FILE_SPACE,
             StorageKey(Bytes::from(encode_hot_file_key(identity))),
+            StorageValue { bytes: value },
+        );
+    } else {
+        writes.put(
+            HOT_ROW_SPACE,
+            StorageKey(Bytes::from(encode_hot_row_key(identity))),
             StorageValue {
                 bytes: Bytes::from(value),
             },
@@ -1748,31 +1846,79 @@ fn hot_scope_prefix(branch_id: &str, generation: CommitId) -> Vec<u8> {
 }
 
 fn encode_hot_row_key(identity: &HeadIdentity) -> Vec<u8> {
-    let mut key = hot_scope_prefix(&identity.branch_id, identity.generation);
-    write_key_string(&mut key, &identity.schema_key, KEY_PART_FINAL);
-    write_entity_pk(&mut key, &identity.entity_pk);
-    write_file_id(&mut key, identity.file_id.as_deref());
+    encode_hot_row_key_parts(
+        &identity.branch_id,
+        identity.generation,
+        &identity.schema_key,
+        &identity.entity_pk,
+        identity.file_id.as_deref(),
+    )
+}
+
+fn encode_hot_row_key_parts(
+    branch_id: &str,
+    generation: CommitId,
+    schema_key: &str,
+    entity_pk: &EntityPk,
+    file_id: Option<&str>,
+) -> Vec<u8> {
+    let mut key = hot_scope_prefix(branch_id, generation);
+    write_key_string(&mut key, schema_key, KEY_PART_FINAL);
+    write_entity_pk(&mut key, entity_pk);
+    write_file_id(&mut key, file_id);
     key
 }
 
 fn encode_hot_file_key(identity: &HeadIdentity) -> Vec<u8> {
     debug_assert!(identity.file_id.is_some());
-    let mut key = hot_scope_prefix(&identity.branch_id, identity.generation);
-    write_key_string(&mut key, &identity.schema_key, KEY_PART_FINAL);
-    write_file_id(&mut key, identity.file_id.as_deref());
-    write_entity_pk(&mut key, &identity.entity_pk);
+    encode_hot_file_key_parts(
+        &identity.branch_id,
+        identity.generation,
+        &identity.schema_key,
+        &identity.entity_pk,
+        identity.file_id.as_deref(),
+    )
+}
+
+fn encode_hot_file_key_parts(
+    branch_id: &str,
+    generation: CommitId,
+    schema_key: &str,
+    entity_pk: &EntityPk,
+    file_id: Option<&str>,
+) -> Vec<u8> {
+    debug_assert!(file_id.is_some());
+    let mut key = hot_scope_prefix(branch_id, generation);
+    write_key_string(&mut key, schema_key, KEY_PART_FINAL);
+    write_file_id(&mut key, file_id);
+    write_entity_pk(&mut key, entity_pk);
     key
 }
 
+#[cfg(test)]
 fn encode_hot_diff_key(checkpoint_commit_id: CommitId, identity: &HeadIdentity) -> Vec<u8> {
-    let mut key = encode_working_diff_scope_prefix(
+    encode_hot_diff_key_parts(
         &identity.branch_id,
         checkpoint_commit_id,
         identity.generation,
-    );
-    write_key_string(&mut key, &identity.schema_key, KEY_PART_FINAL);
-    write_entity_pk(&mut key, &identity.entity_pk);
-    write_file_id(&mut key, identity.file_id.as_deref());
+        &identity.schema_key,
+        &identity.entity_pk,
+        identity.file_id.as_deref(),
+    )
+}
+
+fn encode_hot_diff_key_parts(
+    branch_id: &str,
+    checkpoint_commit_id: CommitId,
+    generation: CommitId,
+    schema_key: &str,
+    entity_pk: &EntityPk,
+    file_id: Option<&str>,
+) -> Vec<u8> {
+    let mut key = encode_working_diff_scope_prefix(branch_id, checkpoint_commit_id, generation);
+    write_key_string(&mut key, schema_key, KEY_PART_FINAL);
+    write_entity_pk(&mut key, entity_pk);
+    write_file_id(&mut key, file_id);
     key
 }
 

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -2660,7 +2660,7 @@ pub(crate) async fn resolve_prepared_commit_parent_heads(
     let branch_ref = branch_ctx.ref_reader(read);
     let mut parent_heads = BTreeMap::new();
     for branch_id in required_branch_ids {
-        let head = branch_ref.load_head_commit_id(&branch_id).await?;
+        let head = branch_ref.load_head_commit_id(branch_id).await?;
         if require_existing_non_global_targets
             && branch_id != crate::GLOBAL_BRANCH_ID
             && head.is_none()

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -1386,20 +1386,24 @@ async fn stage_tracked_head(
                 .filter(|row| row.branch_id == root.branch_id)
                 .map(current_state_delta_from_engine_row),
         );
-        let absence_guards = state_rows
-            .iter()
-            .filter(|row| {
-                row.branch_id == root.branch_id
-                    && row.schema_key != BRANCH_REF_SCHEMA_KEY
-                    && row.snapshot.is_some()
-                    && insert_identities.contains_key(&PreparedStateRowIdentity::from(*row))
-            })
-            .map(|row| TrackedStateKey {
-                schema_key: row.schema_key.clone(),
-                file_id: row.file_id.clone(),
-                entity_pk: row.entity_pk.clone(),
-            })
-            .collect::<BTreeSet<_>>();
+        let absence_guards = if insert_identities.is_empty() {
+            BTreeSet::new()
+        } else {
+            state_rows
+                .iter()
+                .filter(|row| {
+                    row.branch_id == root.branch_id
+                        && row.schema_key != BRANCH_REF_SCHEMA_KEY
+                        && row.snapshot.is_some()
+                        && insert_identities.contains_key(&PreparedStateRowIdentity::from(*row))
+                })
+                .map(|row| TrackedStateKey {
+                    schema_key: row.schema_key.clone(),
+                    file_id: row.file_id.clone(),
+                    entity_pk: row.entity_pk.clone(),
+                })
+                .collect()
+        };
         let parent_generation = match (root.parent_commit_id, parent_control) {
             (Some(parent_commit_id), Some(control))
                 if control.head_commit_id == parent_commit_id =>
@@ -1572,21 +1576,25 @@ async fn stage_tracked_head(
                 .filter(|row| row.branch_id == branch_id)
                 .map(current_state_delta_from_engine_row),
         );
-        let absence_guards = state_rows
-            .iter()
-            .filter(|row| {
-                row.untracked
-                    && row.branch_id == branch_id
-                    && row.schema_key != BRANCH_REF_SCHEMA_KEY
-                    && row.snapshot.is_some()
-                    && insert_identities.contains_key(&PreparedStateRowIdentity::from(*row))
-            })
-            .map(|row| TrackedStateKey {
-                schema_key: row.schema_key.clone(),
-                file_id: row.file_id.clone(),
-                entity_pk: row.entity_pk.clone(),
-            })
-            .collect::<BTreeSet<_>>();
+        let absence_guards = if insert_identities.is_empty() {
+            BTreeSet::new()
+        } else {
+            state_rows
+                .iter()
+                .filter(|row| {
+                    row.untracked
+                        && row.branch_id == branch_id
+                        && row.schema_key != BRANCH_REF_SCHEMA_KEY
+                        && row.snapshot.is_some()
+                        && insert_identities.contains_key(&PreparedStateRowIdentity::from(*row))
+                })
+                .map(|row| TrackedStateKey {
+                    schema_key: row.schema_key.clone(),
+                    file_id: row.file_id.clone(),
+                    entity_pk: row.entity_pk.clone(),
+                })
+                .collect()
+        };
         let mut coverage = WorkingDiffIndexCoverage::default();
         tracked_head
             .writer(read, writes)
@@ -1918,21 +1926,26 @@ async fn stage_branch_head_control_publications(
                         .filter(|row| row.branch_id == branch_id)
                         .map(current_state_delta_from_engine_row),
                 );
-                let absence_guards = state_rows
-                    .iter()
-                    .filter(|row| {
-                        row.untracked
-                            && row.branch_id == branch_id
-                            && row.schema_key != BRANCH_REF_SCHEMA_KEY
-                            && row.snapshot.is_some()
-                            && insert_identities.contains_key(&PreparedStateRowIdentity::from(*row))
-                    })
-                    .map(|row| TrackedStateKey {
-                        schema_key: row.schema_key.clone(),
-                        file_id: row.file_id.clone(),
-                        entity_pk: row.entity_pk.clone(),
-                    })
-                    .collect::<BTreeSet<_>>();
+                let absence_guards = if insert_identities.is_empty() {
+                    BTreeSet::new()
+                } else {
+                    state_rows
+                        .iter()
+                        .filter(|row| {
+                            row.untracked
+                                && row.branch_id == branch_id
+                                && row.schema_key != BRANCH_REF_SCHEMA_KEY
+                                && row.snapshot.is_some()
+                                && insert_identities
+                                    .contains_key(&PreparedStateRowIdentity::from(*row))
+                        })
+                        .map(|row| TrackedStateKey {
+                            schema_key: row.schema_key.clone(),
+                            file_id: row.file_id.clone(),
+                            entity_pk: row.entity_pk.clone(),
+                        })
+                        .collect()
+                };
                 let generation =
                     lifecycle_generation(&branch_id, head_commit_id, target.ref_change_id);
                 let mut coverage = WorkingDiffIndexCoverage::default();
@@ -2360,24 +2373,28 @@ async fn stage_tracked_roots(
                 tracked_delta_from_selected_change_ref(change_ref, root.commit_id)
             }))
             .collect::<Result<Vec<_>, _>>()?;
-        let absence_guards = state_row_indices
-            .iter()
-            .filter_map(|&row_index| {
-                let row = &state_rows[row_index];
-                if row.snapshot.is_none() || row.untracked {
-                    return None;
-                }
-                let insert = insert_identities.get(&PreparedStateRowIdentity::from(row))?;
-                if insert.untracked() {
-                    return None;
-                }
-                Some(TrackedStateKey {
-                    schema_key: row.schema_key.clone(),
-                    file_id: row.file_id.clone(),
-                    entity_pk: row.entity_pk.clone(),
+        let absence_guards = if insert_identities.is_empty() {
+            BTreeSet::new()
+        } else {
+            state_row_indices
+                .iter()
+                .filter_map(|&row_index| {
+                    let row = &state_rows[row_index];
+                    if row.snapshot.is_none() || row.untracked {
+                        return None;
+                    }
+                    let insert = insert_identities.get(&PreparedStateRowIdentity::from(row))?;
+                    if insert.untracked() {
+                        return None;
+                    }
+                    Some(TrackedStateKey {
+                        schema_key: row.schema_key.clone(),
+                        file_id: row.file_id.clone(),
+                        entity_pk: row.entity_pk.clone(),
+                    })
                 })
-            })
-            .collect::<BTreeSet<_>>();
+                .collect()
+        };
         // Commit facts are canonical in changelog.commit and live-state derives
         // lix_commit rows from the commit graph. Keeping them out of this tree
         // also preserves the one-mutation path for ordinary singleton writes.
@@ -2613,32 +2630,32 @@ pub(crate) async fn resolve_prepared_commit_parent_heads(
     let commit_parent_branch_ids = prepared_writes
         .commit_change_refs_by_branch
         .keys()
-        .cloned()
+        .map(String::as_str)
         .collect::<BTreeSet<_>>();
     let mut required_branch_ids = prepared_writes
         .state_rows
         .iter()
-        .map(|row| row.branch_id.clone())
+        .map(|row| row.branch_id.as_str())
         .chain(
             prepared_writes
                 .file_data_writes
                 .iter()
-                .map(|write| write.branch_id.clone()),
+                .map(|write| write.branch_id.as_str()),
         )
         .chain(
             prepared_writes
                 .first_commit_parent_override_by_branch
                 .keys()
-                .cloned(),
+                .map(String::as_str),
         )
         .chain(
             prepared_writes
                 .extra_commit_parents_by_branch
                 .keys()
-                .cloned(),
+                .map(String::as_str),
         )
         .collect::<BTreeSet<_>>();
-    required_branch_ids.extend(commit_parent_branch_ids.iter().cloned());
+    required_branch_ids.extend(commit_parent_branch_ids.iter().copied());
 
     let branch_ref = branch_ctx.ref_reader(read);
     let mut parent_heads = BTreeMap::new();
@@ -2648,10 +2665,14 @@ pub(crate) async fn resolve_prepared_commit_parent_heads(
             && branch_id != crate::GLOBAL_BRANCH_ID
             && head.is_none()
         {
-            return Err(LixError::branch_not_found(branch_id, "commit", "target"));
+            return Err(LixError::branch_not_found(
+                branch_id.to_string(),
+                "commit",
+                "target",
+            ));
         }
         if commit_parent_branch_ids.contains(&branch_id) {
-            parent_heads.insert(branch_id, head);
+            parent_heads.insert(branch_id.to_string(), head);
         }
     }
     Ok(parent_heads)

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -900,11 +900,8 @@ where
         &mut self,
         write: &PreparedTransactionWrite,
     ) -> Result<(), LixError> {
-        let prospective_rows = prepared_transaction_write_rows(write)
-            .iter()
-            .map(MaterializedLiveStateRow::from)
-            .collect::<Vec<_>>();
-        if !prospective_rows.iter().any(|row| {
+        let prepared_rows = prepared_transaction_write_rows(write);
+        if !prepared_rows.iter().any(|row| {
             !row.global
                 && !row.untracked
                 && matches!(
@@ -914,6 +911,10 @@ where
         }) {
             return Ok(());
         }
+        let prospective_rows = prepared_rows
+            .iter()
+            .map(MaterializedLiveStateRow::from)
+            .collect::<Vec<_>>();
         let staged = self.staged_writes.staging_overlay()?;
         let prospective = ProspectiveStagedRows {
             staged: staged.clone(),


### PR DESCRIPTION
## Summary

Reduce bulk tracked-write ownership churn without changing the storage contract:

- reject non-filesystem preflight work before materializing owned live-state rows
- borrow repeated branch IDs while resolving parent heads
- skip absence-guard identity/key construction when a write has no inserts/guards
- encode hot-head storage keys once per mutation
- share immutable hot-head payload bytes between primary and file projections

## Benchmarks

Pinned CPU, order-balanced base/candidate processes, 10,000 tracked rows, RocksDB transaction layer. CRUD was rerun against current `main` at `e03ebaffd`.

| operation | main median | PR median | change |
|---|---:|---:|---:|
| insert all | 107.561 ms | 87.848 ms | **18.3% faster** |
| update all | 116.695 ms | 103.957 ms | **10.9% faster** |
| delete all | 116.008 ms | 107.106 ms | 7.7% faster |
| update one | 344.983 µs | 350.881 µs | 1.7% slower (noise) |
| delete one | 499.035 µs | 503.541 µs | 0.9% slower (noise) |

The update-all paired-median improvement was 10.3%; insert-all was 17.1%.

Order-balanced matched regression guards:

- populated working diff: paired median 0.3% faster
- historical checkpoint-to-head diff: paired median 1.0% faster
- 10k-row semantic CSV merge: paired median 0.5% faster

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -j 2 -p lix_engine --features all-simulations`
