### PR TITLE
perf(text-v2): skip redundant update rebuild

### DIFF
--- a/.changenotes/skip-git-text-update-rebuild.md
+++ b/.changenotes/skip-git-text-update-rebuild.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Speed up Git-text file updates by retaining the validated splice result and
+construction-ordered line table instead of sorting, rendering, and validating
+the complete successor document again.

--- a/plugins/text-v2/src/core.rs
+++ b/plugins/text-v2/src/core.rs
@@ -165,7 +165,15 @@ impl Document {
             });
         }
 
-        let document = Self::from_lines(lines)?;
+        // The splice result and each constructed line were validated above.
+        // Reconciled order keys follow successor byte order, while reused and
+        // host-allocated IDs are already collision checked. Preserve that
+        // exact owned state instead of sorting, rendering, and validating the
+        // complete document a second time.
+        let document = Self(Arc::new(DocumentInner {
+            bytes: Arc::new(bytes),
+            lines,
+        }));
         let changes = self.changes_to(&document)?;
         Ok((document, changes))
     }


### PR DESCRIPTION
## What changed

Git-text `file_changed` now retains the already validated splice result and the line table constructed in successor byte order.

The old path immediately routed that state through the generic entity reconstruction constructor, which populated two uniqueness trees, sorted the already ordered line vector, rendered the complete file again, and validated the duplicate byte buffer. That constructor remains unchanged for entity-driven reconstruction, where those operations are required.

## Real workload result

I benchmarked a one-byte splice in OpenClaw's `coverage/src/index.ts.html` at commit `938e237411f8a5211a098c8dc6432f4c6901837b` (295,016 bytes, 6,475 lines). Each sample performs 100 updates from the same parsed document in a release-native text plugin build; seven fresh process samples were collected per revision.

- main median: 791.553 ms / 100 updates
- this branch median: 502.053 ms / 100 updates
- reduction: 36.6%

Across the complete first 100 OpenClaw commits, median replay moved only about 2.8%; this PR therefore claims only the measured Git-text update axis.

## Correctness

The successor bytes are produced and Git-text validated before line construction. Reused IDs come from the accepted document, new host IDs are collision checked, and reconciled order keys are emitted in successor byte order.

The packaged Wasm plugin replayed the first 100 OpenClaw commits into RocksDB with `--verify-state`: all 100 per-commit states passed and the final Git tree manifest matched.

## Checks

- `cargo test -p plugin_git_text_v2`
- `cargo clippy -p plugin_git_text_v2 --all-targets -- -D warnings`
- release `lix exp git-replay --num-commits 100 --verify-state`
