### PR TITLE
perf: reuse bounded plugin actors during Git replay

### DIFF
--- a/.changenotes/reuse-bounded-actors-during-git-replay.md
+++ b/.changenotes/reuse-bounded-actors-during-git-replay.md
@@ -1,0 +1,8 @@
+---
+type: patch
+---
+
+Speed up Git replay by reusing plugin actors across serialized commit batches
+that fit the engine's live-Store bound. Import batches clear session
+acknowledgements after committing, so evicted actors safely cold-open instead
+of turning later authoritative imports into stale-observation errors.

--- a/packages/cli/src/commands/exp/git_replay.rs
+++ b/packages/cli/src/commands/exp/git_replay.rs
@@ -17,6 +17,10 @@ use zip::write::SimpleFileOptions;
 
 const PROGRESS_EVERY: usize = 10;
 const DEFAULT_INSERT_BATCH_ROWS: usize = 100;
+// The replay opens Lix with the default four-Store v2 actor bound. Batches
+// that fit can populate the bounded cache; broader imports retire candidates
+// as they go so one transaction never exhausts admission.
+const RETAINED_PLUGIN_ACTOR_BATCH_LIMIT: usize = 4;
 // Four SHA-256 `<oid>\n` requests are 260 bytes, below POSIX `PIPE_BUF`.
 // Keeping each flush below that floor lets the caller enqueue a small request
 // window before draining responses without depending on a platform's larger
@@ -311,7 +315,12 @@ pub fn run(args: ExpGitReplayArgs) -> Result<(), CliError> {
             marker_only += 1;
         }
         let execute_started = Instant::now();
-        execute_statements_as_transaction(&lix, &statements, commit_sha)?;
+        execute_statements_as_transaction(
+            &lix,
+            &statements,
+            commit_sha,
+            inserts.saturating_add(updates) <= RETAINED_PLUGIN_ACTOR_BATCH_LIMIT,
+        )?;
         let execute_ms = duration_to_ms(execute_started.elapsed());
         phase_totals.execute_ms += execute_ms;
         applied += 1;
@@ -455,6 +464,7 @@ fn execute_statements_as_transaction(
     lix: &RocksLix,
     statements: &[SqlStatement],
     commit_sha: &str,
+    retain_plugin_actors: bool,
 ) -> Result<(), CliError> {
     let batch = statements
         .iter()
@@ -464,7 +474,10 @@ fn execute_statements_as_transaction(
         })
         .collect::<Vec<_>>();
 
-    db::block_on(lix.execute_batch_for_single_writer_ingest(&batch))
+    db::block_on(lix.execute_batch_for_single_writer_ingest(
+        &batch,
+        retain_plugin_actors,
+    ))
     .map_err(|error| {
         let sql_preview = batch
             .first()
@@ -657,7 +670,7 @@ fn seed_parent_tree(
     let prepared = prepare_commit_changes(state, &changes, &blob_by_oid)?;
     let statements = build_replay_commit_statements(&prepared, DEFAULT_INSERT_BATCH_ROWS);
     if !statements.is_empty() {
-        execute_statements_as_transaction(lix, &statements, parent_commit)?;
+        execute_statements_as_transaction(lix, &statements, parent_commit, false)?;
     }
     if verify_state {
         apply_prepared_to_expected_state(expected_state_by_id, &prepared);

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -1099,26 +1099,36 @@ where
     /// Executes one atomic import batch whose caller serializes every writer
     /// that could transition the same plugin-owned files.
     ///
-    /// Unlike ordinary execution, this deliberately retires each plugin actor
-    /// after its durable rows and materialization proof have been staged. It
-    /// bounds a one-shot import's private Wasm Stores independently of the
-    /// number of files in the batch. Do not use it for concurrent mutation
-    /// workloads: ordinary execution retains file actor leases through commit
-    /// to compose concurrent semantic transitions.
+    /// The caller may retain actors when the batch fits the configured live
+    /// Store bound, or retire them for a broad one-shot import. Retained actors
+    /// remain bounded cache candidates but are not session acknowledgements
+    /// across batches. Do not use this for concurrent mutation workloads:
+    /// ordinary execution retains acknowledged actor leases through commit to
+    /// compose concurrent semantic transitions.
     #[doc(hidden)]
     pub async fn execute_batch_for_single_writer_ingest(
         &self,
         statements: &[ExecuteBatchStatement],
+        retain_plugin_actors: bool,
     ) -> Result<Vec<ExecuteResult>, LixError> {
-        self.execute_batch_with_options_and_metadata_inner(
-            statements,
-            ExecuteOptions::default(),
-            vec![ExecuteStatementMetadata::default(); statements.len()],
-            None,
-            false,
-            false,
-        )
-        .await
+        let result = self
+            .execute_batch_with_options_and_metadata_inner(
+                statements,
+                ExecuteOptions::default(),
+                vec![ExecuteStatementMetadata::default(); statements.len()],
+                None,
+                false,
+                retain_plugin_actors,
+            )
+            .await;
+        // A serialized importer submits authoritative successor bytes rather
+        // than edits based on a session acknowledgement. Keep any bounded
+        // private actors as reusable cold-open candidates, but never expose
+        // their observations as acknowledgement authority across batches:
+        // normal cache eviction would otherwise turn a later import into a
+        // stale-observation error instead of a safe cold open.
+        self.file_views.clear();
+        result
     }
 
     #[doc(hidden)]
@@ -3028,6 +3038,46 @@ mod tests {
             sql: sql.to_string(),
             params: Vec::new(),
         }
+    }
+
+    #[tokio::test]
+    async fn single_writer_ingest_never_carries_acknowledgement_authority_across_batches() {
+        let session = open_session().await;
+        let view_key = sql2::SessionFileViewKey::new("branch", "file");
+        session.file_views.remember_plugin_file_view(
+            view_key.clone(),
+            sql2::SessionPluginFileView {
+                path: "/file.txt".to_string(),
+                plugin_key: "plugin".to_string(),
+                plugin_generation: "generation".to_string(),
+                owner_change_id: "owner".to_string(),
+                observation: None,
+            },
+        );
+        assert!(
+            session
+                .file_views
+                .has_plugin_file_at_path("branch", "/file.txt")
+        );
+
+        session
+            .execute_batch_for_single_writer_ingest(
+                &[batch_statement(
+                    "INSERT INTO lix_key_value (key, value) \
+                     VALUES ('single-writer-ingest', lix_json('{}'))",
+                )],
+                true,
+            )
+            .await
+            .expect("serialized ingest should commit");
+
+        assert!(
+            session
+                .file_views
+                .plugin_file_view(&view_key, "plugin", "generation", "owner")
+                .is_none(),
+            "serialized ingestion may cache actors but must clear session acknowledgement authority"
+        );
     }
 
     #[test]

--- a/packages/rs-sdk/src/lix.rs
+++ b/packages/rs-sdk/src/lix.rs
@@ -300,9 +300,10 @@ where
     pub async fn execute_batch_for_single_writer_ingest(
         &self,
         statements: &[ExecuteBatchStatement],
+        retain_plugin_actors: bool,
     ) -> Result<Vec<ExecuteResult>, LixError> {
         self.session
-            .execute_batch_for_single_writer_ingest(statements)
+            .execute_batch_for_single_writer_ingest(statements, retain_plugin_actors)
             .await
     }
 


### PR DESCRIPTION
## Summary

- let serialized single-writer ingestion retain plugin actors when a batch fits the configured live-Store bound
- clear session file-view acknowledgement authority after every ingest batch, including errors, so eviction produces a safe cold open rather than a stale-observation failure
- retain actors for OpenClaw replay commits touching at most four inserted/updated files; broad batches keep the bounded retire-as-you-go path

This removes repeated Git-text cold reconstruction for the common narrow-commit case without weakening the existing live-Store bound or carrying acknowledgement semantics between authoritative import batches.

## Real-workload result

Frozen `openclaw/openclaw` first-parent history, first 100 commits from the root through `948ff7f035f68810244c1698c9b090443cb5e7c2`, RocksDB storage, release build, Git-text plugin installed, replay timing excludes plugin installation and final RocksDB flush.

| revision | samples | median replay time |
| --- | ---: | ---: |
| exact `origin/main` (`e03ebaff`) | 5 | 2421.835 ms |
| this branch | 20 | 2134.970 ms |

That is an **11.8% end-to-end replay-time reduction**. Peak RSS remains effectively unchanged at about 171–172 MB. RocksDB size is unchanged at about 18.0 MB.

Git's matching `fast-export | fast-import` workload remains substantially faster; this PR is one measured cut toward closing that gap.

## Correctness and safety

A fresh packaged release replay with `--verify-state` applied and verified all 100/100 commits and matched the final Git tree manifest. The hybrid policy is intentional: retaining actors across a batch broader than the four-Store bound exhausts admission, while retaining file-view acknowledgements across batches can produce stale-observation errors after normal cache eviction. This change retains only bounded actor cache candidates and always clears the latter authority.

## Validation

- `cargo test -p lix_engine`
- `cargo test -p lix_engine --features all-simulations`
- `cargo clippy -p lix_engine --all-targets --features all-simulations -- -D warnings`
- `cargo test -p lix_sdk`
- `cargo test -p lix_cli git_replay`
- `cargo fmt --check`
- release `lix exp git-replay ... --num-commits 100 --verify-state`: 100/100 states plus final Git tree manifest verified
