### PR TITLE
perf(slatedb): reuse settled snapshots

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/kv_layout.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/kv_layout.rs
@@ -228,6 +228,10 @@ fn profile_storage(profile: StorageProfile) -> ProfileStorage {
             storage: StorageAdapter::new(storage),
             _dir: dir,
         },
+        #[cfg(feature = "slatedb")]
+        RawProfileStorage::SlateDB { .. } => {
+            unreachable!("SlateDB is currently profiled through the transaction CRUD layer")
+        }
     }
 }
 

--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -207,6 +207,7 @@ fn profile_operation(runtime: &tokio::runtime::Runtime, rows: &[WorkloadRow]) {
             }
         }
         Ok("transaction") | Err(_) => {
+            let profile = profile_transaction_storage();
             if let Some(repeats) = hot_repeats {
                 profile_hot_transaction_operations(
                     runtime,
@@ -214,6 +215,7 @@ fn profile_operation(runtime: &tokio::runtime::Runtime, rows: &[WorkloadRow]) {
                     operation,
                     read_many_pk_count,
                     repeats,
+                    profile,
                 );
             } else {
                 profile_transaction_operation(
@@ -222,6 +224,7 @@ fn profile_operation(runtime: &tokio::runtime::Runtime, rows: &[WorkloadRow]) {
                     operation,
                     read_many_pk_count,
                     sample_count,
+                    profile,
                 );
             }
         }
@@ -297,6 +300,18 @@ fn profile_sql_session_storage() -> StorageProfile {
     }
 }
 
+fn profile_transaction_storage() -> StorageProfile {
+    match std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_STORAGE").as_deref() {
+        Ok("sqlite") => StorageProfile::SQLite,
+        Ok("rocksdb") | Err(_) => StorageProfile::RocksDB,
+        #[cfg(feature = "slatedb")]
+        Ok("slatedb") => StorageProfile::SlateDB,
+        Ok(other) => panic!(
+            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_STORAGE '{other}'; expected rocksdb, sqlite, or slatedb"
+        ),
+    }
+}
+
 /// Keeps one seeded fixture alive for a repeatable profiling window. This
 /// deliberately trades representative cache behavior for a trace dominated
 /// by the operation itself rather than fixture construction.
@@ -306,14 +321,12 @@ fn profile_hot_transaction_operations(
     operation: TransactionBenchOp,
     read_many_pk_count: usize,
     repeats: usize,
+    profile: StorageProfile,
 ) {
     operation.assert_supports_hot_repeats();
     let repeats_u32 =
         u32::try_from(repeats).expect("LIX_TRACKED_STATE_CRUD_PROFILE_HOT_REPEATS must fit in u32");
-    let mut fixture = runtime.block_on(transaction_api::seeded_fixture(
-        StorageProfile::RocksDB,
-        rows,
-    ));
+    let mut fixture = runtime.block_on(transaction_api::seeded_fixture(profile, rows));
     let start = Instant::now();
     let mut row_count = 0;
     for _ in 0..repeats {
@@ -322,7 +335,8 @@ fn profile_hot_transaction_operations(
     let elapsed = start.elapsed();
     let profile_detail = profile_read_many_detail(operation, read_many_pk_count);
     println!(
-        "tracked_state_crud hot profile: transaction/lix_rocksdb/{}/{} repeats{profile_detail}: total={elapsed:?} per_operation={:?}",
+        "tracked_state_crud hot profile: transaction/{}/{}/{} repeats{profile_detail}: total={elapsed:?} per_operation={:?}",
+        profile.name(),
         profile_operation_name(operation),
         repeats,
         elapsed / repeats_u32,
@@ -473,19 +487,14 @@ fn profile_transaction_operation(
     operation: TransactionBenchOp,
     read_many_pk_count: usize,
     sample_count: usize,
+    profile: StorageProfile,
 ) {
     let mut samples = Vec::with_capacity(sample_count);
     for _ in 0..sample_count {
         let mut fixture = if operation.needs_seed() {
-            runtime.block_on(transaction_api::seeded_fixture(
-                StorageProfile::RocksDB,
-                rows,
-            ))
+            runtime.block_on(transaction_api::seeded_fixture(profile, rows))
         } else {
-            runtime.block_on(transaction_api::empty_fixture(
-                StorageProfile::RocksDB,
-                rows,
-            ))
+            runtime.block_on(transaction_api::empty_fixture(profile, rows))
         };
         let start = Instant::now();
         let result = runtime.block_on(operation.run(&mut fixture, read_many_pk_count));
@@ -493,7 +502,7 @@ fn profile_transaction_operation(
         black_box(result);
     }
     print_profile_samples(
-        "transaction/lix_rocksdb",
+        &format!("transaction/{}", profile.name()),
         operation,
         read_many_pk_count,
         samples,

--- a/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
@@ -82,6 +82,10 @@ pub(crate) async fn empty_fixture_with_read_many_pk_count(
             untracked_fixture,
             dir,
         )),
+        #[cfg(feature = "slatedb")]
+        ProfileStorage::SlateDB { .. } => {
+            unreachable!("SlateDB is currently profiled through the transaction CRUD layer")
+        }
     }
 }
 

--- a/packages/engine-benchmarks/benches/tracked_state_crud/storage.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/storage.rs
@@ -1,4 +1,6 @@
 pub(crate) use lix_rocksdb_storage::RocksDB;
+#[cfg(feature = "slatedb")]
+pub(crate) use lix_slatedb_storage::SlateDB;
 pub(crate) use lix_sqlite_storage::SQLite;
 use tempfile::TempDir;
 
@@ -6,6 +8,8 @@ use tempfile::TempDir;
 pub(crate) enum StorageProfile {
     SQLite,
     RocksDB,
+    #[cfg(feature = "slatedb")]
+    SlateDB,
 }
 
 pub(crate) const STORAGE_PROFILES: [StorageProfile; 2] =
@@ -16,13 +20,26 @@ impl StorageProfile {
         match self {
             Self::SQLite => "lix_sqlite",
             Self::RocksDB => "lix_rocksdb",
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB => "lix_slatedb",
         }
     }
 }
 
 pub(crate) enum ProfileStorage {
-    SQLite { storage: SQLite, _dir: TempDir },
-    RocksDB { storage: RocksDB, _dir: TempDir },
+    SQLite {
+        storage: SQLite,
+        _dir: TempDir,
+    },
+    RocksDB {
+        storage: RocksDB,
+        _dir: TempDir,
+    },
+    #[cfg(feature = "slatedb")]
+    SlateDB {
+        storage: SlateDB,
+        _dir: TempDir,
+    },
 }
 
 impl StorageProfile {
@@ -39,6 +56,13 @@ impl StorageProfile {
                 let storage = RocksDB::open(dir.path().join("bench.rocksdb"))
                     .expect("open rocksdb bench storage");
                 ProfileStorage::RocksDB { storage, _dir: dir }
+            }
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB => {
+                let dir = TempDir::new().expect("create slatedb bench tempdir");
+                let storage =
+                    SlateDB::open(dir.path().join("bench.slatedb")).expect("open slatedb storage");
+                ProfileStorage::SlateDB { storage, _dir: dir }
             }
         }
     }

--- a/packages/engine-benchmarks/benches/tracked_state_crud/transaction_api.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/transaction_api.rs
@@ -3,6 +3,8 @@ use lix_engine::transaction::bench::{
     BenchLayoutAccounting, BenchTransactionFixture, BenchTransactionRow, BenchWriteAccounting,
 };
 
+#[cfg(feature = "slatedb")]
+use crate::storage::SlateDB;
 use crate::storage::{ProfileStorage, RocksDB, SQLite, StorageProfile};
 use crate::workload::{WorkloadRow, snapshot_value};
 
@@ -13,6 +15,11 @@ pub(crate) enum TransactionFixture {
     },
     RocksDB {
         fixture: BenchTransactionFixture<RocksDB>,
+        _dir: tempfile::TempDir,
+    },
+    #[cfg(feature = "slatedb")]
+    SlateDB {
+        fixture: BenchTransactionFixture<SlateDB>,
         _dir: tempfile::TempDir,
     },
 }
@@ -34,6 +41,11 @@ pub(crate) async fn empty_fixture(
             fixture: BenchTransactionFixture::new(StorageAdapter::new(storage), rows).await,
             _dir: dir,
         },
+        #[cfg(feature = "slatedb")]
+        ProfileStorage::SlateDB { storage, _dir: dir } => TransactionFixture::SlateDB {
+            fixture: BenchTransactionFixture::new(StorageAdapter::new(storage), rows).await,
+            _dir: dir,
+        },
     }
 }
 
@@ -51,6 +63,8 @@ impl TransactionFixture {
         match self {
             Self::SQLite { fixture, .. } => fixture.seed().await,
             Self::RocksDB { fixture, .. } => fixture.seed().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB { fixture, .. } => fixture.seed().await,
         }
     }
 
@@ -58,6 +72,8 @@ impl TransactionFixture {
         match self {
             Self::SQLite { fixture, .. } => fixture.insert_all().await,
             Self::RocksDB { fixture, .. } => fixture.insert_all().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB { fixture, .. } => fixture.insert_all().await,
         }
     }
 
@@ -65,6 +81,8 @@ impl TransactionFixture {
         match self {
             Self::SQLite { fixture, .. } => fixture.insert_all_accounting().await,
             Self::RocksDB { fixture, .. } => fixture.insert_all_accounting().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB { fixture, .. } => fixture.insert_all_accounting().await,
         }
     }
 
@@ -72,6 +90,8 @@ impl TransactionFixture {
         match self {
             Self::SQLite { fixture, .. } => fixture.read_all().await,
             Self::RocksDB { fixture, .. } => fixture.read_all().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB { fixture, .. } => fixture.read_all().await,
         }
     }
 
@@ -79,6 +99,8 @@ impl TransactionFixture {
         match self {
             Self::SQLite { fixture, .. } => fixture.read_many_by_pk(count).await,
             Self::RocksDB { fixture, .. } => fixture.read_many_by_pk(count).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB { fixture, .. } => fixture.read_many_by_pk(count).await,
         }
     }
 
@@ -86,6 +108,8 @@ impl TransactionFixture {
         match self {
             Self::SQLite { fixture, .. } => fixture.read_one_by_pk().await,
             Self::RocksDB { fixture, .. } => fixture.read_one_by_pk().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB { fixture, .. } => fixture.read_one_by_pk().await,
         }
     }
 
@@ -93,6 +117,8 @@ impl TransactionFixture {
         match self {
             Self::SQLite { fixture, .. } => fixture.update_all().await,
             Self::RocksDB { fixture, .. } => fixture.update_all().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB { fixture, .. } => fixture.update_all().await,
         }
     }
 
@@ -100,6 +126,8 @@ impl TransactionFixture {
         match self {
             Self::SQLite { fixture, .. } => fixture.update_all_accounting().await,
             Self::RocksDB { fixture, .. } => fixture.update_all_accounting().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB { fixture, .. } => fixture.update_all_accounting().await,
         }
     }
 
@@ -107,6 +135,8 @@ impl TransactionFixture {
         match self {
             Self::SQLite { fixture, .. } => fixture.update_one_by_pk().await,
             Self::RocksDB { fixture, .. } => fixture.update_one_by_pk().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB { fixture, .. } => fixture.update_one_by_pk().await,
         }
     }
 
@@ -114,6 +144,8 @@ impl TransactionFixture {
         match self {
             Self::SQLite { fixture, .. } => fixture.update_one_by_pk_accounting().await,
             Self::RocksDB { fixture, .. } => fixture.update_one_by_pk_accounting().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB { fixture, .. } => fixture.update_one_by_pk_accounting().await,
         }
     }
 
@@ -121,6 +153,8 @@ impl TransactionFixture {
         match self {
             Self::SQLite { fixture, .. } => fixture.delete_all().await,
             Self::RocksDB { fixture, .. } => fixture.delete_all().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB { fixture, .. } => fixture.delete_all().await,
         }
     }
 
@@ -128,6 +162,8 @@ impl TransactionFixture {
         match self {
             Self::SQLite { fixture, .. } => fixture.delete_all_accounting().await,
             Self::RocksDB { fixture, .. } => fixture.delete_all_accounting().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB { fixture, .. } => fixture.delete_all_accounting().await,
         }
     }
 
@@ -135,6 +171,8 @@ impl TransactionFixture {
         match self {
             Self::SQLite { fixture, .. } => fixture.delete_one_by_pk().await,
             Self::RocksDB { fixture, .. } => fixture.delete_one_by_pk().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB { fixture, .. } => fixture.delete_one_by_pk().await,
         }
     }
 
@@ -142,6 +180,8 @@ impl TransactionFixture {
         match self {
             Self::SQLite { fixture, .. } => fixture.delete_one_by_pk_accounting().await,
             Self::RocksDB { fixture, .. } => fixture.delete_one_by_pk_accounting().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB { fixture, .. } => fixture.delete_one_by_pk_accounting().await,
         }
     }
 
@@ -149,6 +189,8 @@ impl TransactionFixture {
         match self {
             Self::SQLite { fixture, .. } => fixture.layout_accounting().await,
             Self::RocksDB { fixture, .. } => fixture.layout_accounting().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB { fixture, .. } => fixture.layout_accounting().await,
         }
     }
 }

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -441,6 +441,7 @@ struct WritePipelineState {
     active_views: BTreeMap<(u64, u64), usize>,
     next_publication_id: u64,
     terminal_error: Option<StorageError>,
+    latest_snapshot: Option<Arc<DbSnapshot>>,
 }
 
 struct QueuedWrite {
@@ -536,6 +537,54 @@ impl WritePipeline {
             .terminal_error
             .clone();
         error.map_or(Ok(()), Err)
+    }
+
+    async fn snapshot(&self, worker: &SlateDBWorker) -> Result<Arc<DbSnapshot>, StorageError> {
+        let publication_id = {
+            let state = self
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if let Some(snapshot) = state.latest_snapshot.clone() {
+                worker.check_open_fast()?;
+                return Ok(snapshot);
+            }
+            state.next_publication_id
+        };
+        let snapshot = worker
+            .call_read(|db| async move { db.snapshot().await.map_err(slatedb_error) })
+            .await?;
+        let cacheable = {
+            let state = self
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            state.next_publication_id == publication_id
+                && state
+                    .tail
+                    .as_ref()
+                    .is_none_or(|tail| tail.done.load(Ordering::Acquire))
+        };
+        if cacheable {
+            self.install_snapshot(Arc::clone(&snapshot));
+        } else {
+            worker.check_open_fast()?;
+        }
+        Ok(snapshot)
+    }
+
+    fn install_snapshot(&self, snapshot: Arc<DbSnapshot>) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if state
+            .latest_snapshot
+            .as_ref()
+            .is_none_or(|current| current.seq() <= snapshot.seq())
+        {
+            state.latest_snapshot = Some(snapshot);
+        }
     }
 
     fn capture(&self, snapshot_sequence: u64) -> PublicationView {
@@ -867,10 +916,7 @@ impl Storage for SlateDB {
     ) -> impl Future<Output = Result<Self::Read<'_>, StorageError>> + Send {
         async move {
             self.write_pipeline.terminal_error()?;
-            let snapshot = self
-                .worker
-                .call_read(|db| async move { db.snapshot().await.map_err(slatedb_error) })
-                .await?;
+            let snapshot = self.write_pipeline.snapshot(&self.worker).await?;
             let publication_view = if opts.durability == ReadDurability::Visible {
                 Some(self.write_pipeline.capture(snapshot.seq()))
             } else {
@@ -1448,6 +1494,12 @@ impl StorageWrite for SlateDBWrite {
                     .state
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
+                // A cached snapshot remains logically correct through the
+                // publication overlay, but it must not outlive that overlay
+                // after persistence. Force the next reader to fetch a current
+                // snapshot; `snapshot` caches it only when no publication
+                // raced the fetch and the write tail is complete.
+                state.latest_snapshot = None;
                 state.next_publication_id = state
                     .next_publication_id
                     .checked_add(1)


### PR DESCRIPTION
## What changed

- Cache a settled SlateDB snapshot in the write pipeline and reuse it across read transactions.
- Invalidate the cache whenever a write is published, preserving the publication-overlay and durability contract.
- Only install a fetched snapshot when no publication raced the fetch and the write tail is settled.
- Add a SlateDB profile mode to the tracked CRUD benchmark so the adapter can be measured through the same transaction workload as RocksDB.

## Why

A SlateDB read transaction always crossed the worker boundary to create a fresh database snapshot, even when the database had not changed. CRUD operations open multiple read transactions around one mutation, so repeated snapshot creation dominated small updates.

## Performance

Paired alternating release runs against `86f7600a204c18f92fd7a6e7e8c14ec00462dcea` (five runs per CRUD case, medians):

| operation | latest main | this PR | change |
| --- | ---: | ---: | ---: |
| SlateDB update one | 92.770 µs | 77.842 µs | **16.1% faster** |
| SlateDB read many (10) | 91.388 µs | 83.113 µs | 9.1% faster |
| SlateDB update all (1000) | 16.951 ms | 16.195 ms | 4.5% faster |
| SlateDB read one | 11.988 µs | 11.570 µs | 3.5% faster |
| SlateDB read all (1000) | 1.316 ms | 1.315 ms | flat |

RocksDB controls did not meaningfully regress: update-one moved 48.213 → 48.767 µs (+1.15%, within run noise), while update-all improved 11.496 → 11.183 ms. The implementation path is SlateDB-only.

A three-run alternating merge control also remained flat: SlateDB improved about 2.3%; RocksDB moved about +4.7% within run noise with identical RocksDB code.

## Validation

- `cargo test -p lix_slatedb_storage --all-features` (26 unit + 8 integration tests, plus doc tests)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo clippy -p lix_engine_benchmarks --bench tracked_state_crud --features 'storage-benches slatedb' -- -D warnings`
- Full workspace library/test run reached one unrelated server-protocol acknowledgement-loss test failure; that exact test passed immediately in isolation.
- `git diff --check`
- Paired alternating CRUD and merge release benchmarks described above