### PR TITLE
perf(slatedb): scan single publication directly

### DIFF
--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -2214,11 +2214,18 @@ async fn scan_snapshot_with_writes(
     page_size: usize,
     projection: CoreProjection,
 ) -> Result<ScanChunk, StorageError> {
-    let scan_options = slatedb_scan_options(durability);
-    let mut base_iter = snapshot
-        .scan_with_options(bounds.range(), &scan_options)
-        .await
-        .map_err(slatedb_error)?;
+    if let [write] = visible_writes.as_slice() {
+        return scan_snapshot_with_single_write(
+            snapshot,
+            bounds,
+            durability,
+            Arc::clone(write),
+            page_size,
+            projection,
+        )
+        .await;
+    }
+
     let mut overlay = BTreeMap::new();
     for write in visible_writes {
         for (key, value) in &*write.overlay {
@@ -2227,7 +2234,105 @@ async fn scan_snapshot_with_writes(
             }
         }
     }
-    let mut overlay = overlay.into_iter().peekable();
+    merge_snapshot_with_overlay(
+        snapshot,
+        &bounds,
+        durability,
+        overlay.into_iter(),
+        page_size,
+        projection,
+    )
+    .await
+}
+
+async fn scan_snapshot_with_single_write(
+    snapshot: Arc<DbSnapshot>,
+    bounds: EncodedBounds,
+    durability: ReadDurability,
+    write: Arc<PublishedWrite>,
+    page_size: usize,
+    projection: CoreProjection,
+) -> Result<ScanChunk, StorageError> {
+    let scan_options = slatedb_scan_options(durability);
+    let mut base_iter = snapshot
+        .scan_with_options(bounds.range(), &scan_options)
+        .await
+        .map_err(slatedb_error)?;
+    let mut overlay_iter = write.overlay.iter().peekable();
+    let mut overlay_row = next_bounded_overlay(&mut overlay_iter, &bounds);
+    let mut base_row = base_iter.next().await.map_err(slatedb_error)?;
+    let mut rows = Vec::with_capacity(page_size.saturating_add(1));
+    while rows.len() <= page_size {
+        let next = match (base_row.as_ref(), overlay_row.as_ref()) {
+            (Some(base_entry), Some((overlay_key, _))) => {
+                match base_entry.key.cmp(&overlay_key.0) {
+                    std::cmp::Ordering::Less => {
+                        let row = (Key(base_entry.key.clone()), Some(base_entry.value.clone()));
+                        base_row = base_iter.next().await.map_err(slatedb_error)?;
+                        Some(row)
+                    }
+                    std::cmp::Ordering::Equal => {
+                        let row = overlay_row.take();
+                        overlay_row = next_bounded_overlay(&mut overlay_iter, &bounds);
+                        base_row = base_iter.next().await.map_err(slatedb_error)?;
+                        row
+                    }
+                    std::cmp::Ordering::Greater => {
+                        let row = overlay_row.take();
+                        overlay_row = next_bounded_overlay(&mut overlay_iter, &bounds);
+                        row
+                    }
+                }
+            }
+            (Some(base_entry), None) => {
+                let row = (Key(base_entry.key.clone()), Some(base_entry.value.clone()));
+                base_row = base_iter.next().await.map_err(slatedb_error)?;
+                Some(row)
+            }
+            (None, Some(_)) => {
+                let row = overlay_row.take();
+                overlay_row = next_bounded_overlay(&mut overlay_iter, &bounds);
+                row
+            }
+            (None, None) => None,
+        };
+        let Some((key, value)) = next else {
+            break;
+        };
+        if let Some(value) = value {
+            rows.push((key, value));
+        }
+    }
+
+    project_scan_rows(rows, page_size, projection)
+}
+
+fn next_bounded_overlay(
+    overlay: &mut std::iter::Peekable<std::collections::btree_map::Iter<'_, Key, Option<Bytes>>>,
+    bounds: &EncodedBounds,
+) -> Option<(Key, Option<Bytes>)> {
+    for (key, value) in overlay.by_ref() {
+        if bounds.contains(key) {
+            return Some((key.clone(), value.clone()));
+        }
+    }
+    None
+}
+
+async fn merge_snapshot_with_overlay(
+    snapshot: Arc<DbSnapshot>,
+    bounds: &EncodedBounds,
+    durability: ReadDurability,
+    overlay: impl Iterator<Item = (Key, Option<Bytes>)>,
+    page_size: usize,
+    projection: CoreProjection,
+) -> Result<ScanChunk, StorageError> {
+    let scan_options = slatedb_scan_options(durability);
+    let mut base_iter = snapshot
+        .scan_with_options(bounds.range(), &scan_options)
+        .await
+        .map_err(slatedb_error)?;
+    let mut overlay = overlay.peekable();
     let mut base_row = base_iter.next().await.map_err(slatedb_error)?;
     let mut rows = Vec::with_capacity(page_size.saturating_add(1));
     while rows.len() <= page_size {
@@ -2265,6 +2370,14 @@ async fn scan_snapshot_with_writes(
         }
     }
 
+    project_scan_rows(rows, page_size, projection)
+}
+
+fn project_scan_rows(
+    rows: Vec<(Key, Bytes)>,
+    page_size: usize,
+    projection: CoreProjection,
+) -> Result<ScanChunk, StorageError> {
     let has_more = rows.len() > page_size;
     let entries = rows
         .into_iter()


### PR DESCRIPTION
## What changed

- Add a direct scan path for the common case where a read view contains one visible SlateDB publication.
- Merge that publication's already-sorted overlay directly with the base snapshot instead of cloning every entry into a second `BTreeMap`.
- Keep the existing overlay-folding path unchanged for views containing multiple publications.
- Share result projection and page lookahead semantics between both paths.

## Why

After a transaction publishes one write, the write pipeline already owns its overlay as an ordered `BTreeMap`. SlateDB scans rebuilt that map entry-by-entry before merging it with the snapshot. For a 1,000-row CRUD scan this added 1,000 logarithmic inserts, allocations, and key/value clones that did not change ordering or visibility.

## Performance

This PR is stacked on #863, and #863's release binary is the direct baseline.

Nine order-alternated run pairs, 31 independently seeded samples per run, 1,000-row SlateDB transaction workload:

| operation | #863 baseline | this PR | change |
| --- | ---: | ---: | ---: |
| read all | 1.097 ms | 0.967 ms | **11.9% faster** |
| update all | 8.641 ms | 7.872 ms | 8.9% faster |

The reported values are the medians of each side's nine per-run medians. RocksDB does not execute this code path, so its adapter behavior is unchanged.

Five order-alternated SlateDB merge-commit controls also did not regress: median p50 moved 2.498 ms → 2.364 ms (5.4% faster).

## Correctness and validation

The fast path preserves the same ordered snapshot/overlay merge rules, including overlay replacement, tombstones, bounds, projection, page lookahead, and base-only rows. Existing multi-publication behavior remains on the old fold path.

- `cargo test -p lix_slatedb_storage --all-features` (26 unit + 8 integration tests, plus doc tests)
- `cargo clippy -p lix_slatedb_storage --all-targets --all-features -- -D warnings`
- `rustfmt --edition 2024 packages/slatedb-storage/src/slatedb.rs`
- `git diff --check`
- Paired alternating CRUD and merge release benchmarks described above