### PR TITLE
perf(slatedb): remove duplicate point publications

### DIFF
--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -437,7 +437,6 @@ struct WritePipelineState {
     queued: VecDeque<QueuedWrite>,
     draining: bool,
     visible: VecDeque<Arc<PublishedWrite>>,
-    point_publications: HashMap<Key, VecDeque<PointPublication>>,
     active_views: BTreeMap<(u64, u64), usize>,
     next_publication_id: u64,
     terminal_error: Option<StorageError>,
@@ -455,12 +454,6 @@ struct PublishedWrite {
     publication_id: u64,
     overlay: Arc<BTreeMap<Key, Option<Bytes>>>,
     persisted_sequence: AtomicU64,
-}
-
-struct PointPublication {
-    publication_id: u64,
-    write: Arc<PublishedWrite>,
-    value: Option<Bytes>,
 }
 
 struct PublicationView {
@@ -592,18 +585,12 @@ impl WritePipeline {
             .state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        while state.visible.front().is_some_and(|write| {
-            let persisted = write.persisted_sequence.load(Ordering::Acquire);
-            persisted != PENDING_WRITE_SEQUENCE && persisted <= snapshot_sequence
-        }) {
-            state.visible.pop_front();
-        }
+        cleanup_publications(&mut state, snapshot_sequence);
         let publication_id = state.next_publication_id;
         *state
             .active_views
             .entry((snapshot_sequence, publication_id))
             .or_default() += 1;
-        cleanup_point_publications(&mut state);
         PublicationView {
             pipeline: self.clone(),
             snapshot_sequence,
@@ -641,16 +628,14 @@ impl WritePipeline {
         self.state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .point_publications
-            .get(key)?
+            .visible
             .iter()
             .rev()
-            .find(|publication| {
-                let persisted = publication.write.persisted_sequence.load(Ordering::Acquire);
-                publication.publication_id <= publication_id
-                    && (persisted == PENDING_WRITE_SEQUENCE || persisted > snapshot_sequence)
+            .find_map(|write| {
+                publication_visible_to_view(write, snapshot_sequence, publication_id)
+                    .then(|| write.overlay.get(key).cloned())
+                    .flatten()
             })
-            .map(|publication| publication.value.clone())
     }
 }
 
@@ -669,22 +654,34 @@ impl Drop for PublicationView {
         if remove {
             state.active_views.remove(&key);
         }
-        cleanup_point_publications(&mut state);
+        cleanup_publications(&mut state, u64::MAX);
     }
 }
 
-fn cleanup_point_publications(state: &mut WritePipelineState) {
-    let active_views = state.active_views.keys().copied().collect::<Vec<_>>();
-    state.point_publications.retain(|_, publications| {
-        publications.retain(|publication| {
-            let persisted = publication.write.persisted_sequence.load(Ordering::Acquire);
-            persisted == PENDING_WRITE_SEQUENCE
-                || active_views.iter().any(|(snapshot, captured)| {
-                    publication.publication_id <= *captured && persisted > *snapshot
+fn publication_visible_to_view(
+    write: &PublishedWrite,
+    snapshot_sequence: u64,
+    publication_id: u64,
+) -> bool {
+    let persisted = write.persisted_sequence.load(Ordering::Acquire);
+    write.publication_id <= publication_id
+        && (persisted == PENDING_WRITE_SEQUENCE || persisted > snapshot_sequence)
+}
+
+fn cleanup_publications(state: &mut WritePipelineState, newest_snapshot_sequence: u64) {
+    while state.visible.front().is_some_and(|write| {
+        let persisted = write.persisted_sequence.load(Ordering::Acquire);
+        persisted != PENDING_WRITE_SEQUENCE
+            && persisted <= newest_snapshot_sequence
+            && !state
+                .active_views
+                .keys()
+                .any(|(snapshot_sequence, publication_id)| {
+                    publication_visible_to_view(write, *snapshot_sequence, *publication_id)
                 })
-        });
-        !publications.is_empty()
-    });
+    }) {
+        state.visible.pop_front();
+    }
 }
 
 impl SnapshotPointCache {
@@ -1512,17 +1509,6 @@ impl StorageWrite for SlateDBWrite {
                 });
                 state.tail = Some(Arc::clone(&completion));
                 state.visible.push_back(Arc::clone(&published));
-                for (key, value) in &*overlay {
-                    state
-                        .point_publications
-                        .entry(key.clone())
-                        .or_default()
-                        .push_back(PointPublication {
-                            publication_id,
-                            write: Arc::clone(&published),
-                            value: value.clone(),
-                        });
-                }
                 state.queued.push_back(QueuedWrite {
                     overlay,
                     published,
@@ -3342,6 +3328,85 @@ mod tests {
 
         drop(blocked_write);
         block_on(storage.flush()).expect("flush visible value");
+    }
+
+    #[test]
+    fn persisted_publication_remains_visible_to_an_older_active_view() {
+        let store = Arc::new(BlockingStore::new(Arc::new(InMemory::new())));
+        let storage = SlateDB::open_object_store_with_options(
+            "test-active-publication-view",
+            store.clone(),
+            SlateDBObjectStoreOptions::default(),
+        )
+        .expect("open active-publication storage");
+        let space = SpaceId(8);
+        let key = Key(Bytes::from_static(b"active-view"));
+        let value = Bytes::from_static(b"value");
+
+        let blocked_write = store.block_next_write();
+        let mut write =
+            block_on(storage.begin_write(WriteOptions::default())).expect("begin blocked write");
+        block_on(write.put_many(
+            space,
+            PutBatch {
+                entries: vec![PutEntry {
+                    key: key.clone(),
+                    value: StoredValue {
+                        bytes: value.clone(),
+                    },
+                }],
+            },
+        ))
+        .expect("stage blocked value");
+        block_on(write.commit()).expect("publish blocked value");
+        blocked_write.wait_for_entries(1, "SlateDB WAL write");
+
+        let older = block_on(storage.begin_read(ReadOptions::default()))
+            .expect("capture pre-persistence view");
+        drop(blocked_write);
+        block_on(storage.flush()).expect("persist publication");
+        let newer =
+            block_on(storage.begin_read(ReadOptions::default())).expect("capture persisted view");
+
+        assert_eq!(
+            block_on(older.get_many(&[GetManyRequest {
+                space,
+                keys: std::slice::from_ref(&key),
+                opts: GetOptions::default(),
+            }]))
+            .expect("read publication through older point view")
+            .values,
+            vec![Some(ProjectedValue::FullValue(value.clone()))]
+        );
+        assert_eq!(
+            block_on(older.scan(
+                space,
+                KeyRange {
+                    lower: Bound::Unbounded,
+                    upper: Bound::Unbounded,
+                },
+                ScanOptions::default(),
+            ))
+            .expect("read publication through older scan view")
+            .entries,
+            vec![ReadEntry {
+                key,
+                value: ProjectedValue::FullValue(value),
+            }]
+        );
+
+        drop(older);
+        assert!(
+            storage
+                .write_pipeline
+                .state
+                .lock()
+                .expect("lock publication state")
+                .visible
+                .is_empty(),
+            "publication is reclaimed after its last dependent view"
+        );
+        drop(newer);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Remove SlateDB's per-key `point_publications` index.
- Resolve point overlays directly from the existing ordered publication overlays, newest-first.
- Retain persisted publications only while an active older snapshot still needs them, then reclaim the whole publication at once.
- Add a blocked-WAL race test proving that point reads and scans from an older active view remain correct after persistence and a newer snapshot capture.

## Why

Every SlateDB commit already stores its complete ordered overlay in `PublishedWrite`, but publication also copied every key and value into a second hash index. A 1,000-row mutation therefore performed 1,000 hash-map insertions, allocated per-key publication queues, cloned keys and values, and later walked the duplicate structure for cleanup.

The normal publication depth is tiny. Looking up a point in each visible publication's `BTreeMap` is cheaper than building and maintaining a second index for every committed key, while the publication itself is the natural unit of visibility and reclamation.

## Performance

This PR is stacked on #864, and #864's release binary is the direct baseline.

Seven order-alternated run pairs, 31 independently seeded samples per run, 1,000-row SlateDB transaction workload:

| operation | #864 baseline | this PR | change |
| --- | ---: | ---: | ---: |
| update one | 173.969 µs | 87.540 µs | **49.7% faster** |
| update all | 8.851 ms | 7.157 ms | **19.1% faster** |
| read many (10) | 397.779 µs | 211.020 µs | **46.9% faster** |
| read one | 67.960 µs | 47.569 µs | **30.0% faster** |
| read all | 955.687 µs | 924.727 µs | 3.2% faster |

The reported values are the medians of each side's seven per-run medians. Seed setup is excluded from each timed operation, but publication draining intentionally remains asynchronous as it does in production; removing the duplicate index lets the preceding publication settle sooner as well as making the measured update commit cheaper.

Five order-alternated SlateDB merge-commit controls improved too: median p50 moved 2.509 ms → 2.105 ms (**16.1% faster**). RocksDB does not execute this adapter path and is unchanged.

## Correctness

Publication visibility is now defined once: a publication is visible when it was captured by the view and is not represented by that view's snapshot sequence. Persisted publications are retained while any active view satisfies that predicate. The new blocked-WAL test holds an older pre-persistence view across flush and a newer capture, verifies both point and scan results, then verifies reclamation after the dependent view drops.

## Validation

- `cargo test -p lix_slatedb_storage --all-features` (27 unit + 8 integration tests, plus doc tests)
- `cargo clippy -p lix_slatedb_storage --all-targets --all-features -- -D warnings`
- `rustfmt --edition 2024 packages/slatedb-storage/src/slatedb.rs`
- `git diff --check`
- Paired alternating CRUD and merge release benchmarks described above