### PR TITLE
perf: use mimalloc in native entrypoints

### DIFF
--- a/.changenotes/use-mimalloc-native-entrypoints.md
+++ b/.changenotes/use-mimalloc-native-entrypoints.md
@@ -1,0 +1,10 @@
+---
+type: patch
+---
+
+Improved native Lix write performance by using mimalloc, an allocator better
+suited to its allocation-heavy SQL and storage pipeline.
+
+Bulk tracked updates, inserts, and deletes now spend less CPU time in allocator
+bookkeeping. WebAssembly builds and Rust applications embedding the Lix engine
+continue to use their host-selected allocator.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3203,6 +3203,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3274,6 +3283,7 @@ dependencies = [
  "comfy-table",
  "lix_rocksdb_storage",
  "lix_sdk",
+ "mimalloc",
  "plugin_git_text_v2",
  "serde",
  "serde_json",
@@ -3331,6 +3341,7 @@ dependencies = [
  "lix_rocksdb_storage",
  "lix_slatedb_storage",
  "lix_sqlite_storage",
+ "mimalloc",
  "object_store 0.14.0",
  "rusqlite",
  "rustc-hash",
@@ -3351,6 +3362,7 @@ dependencies = [
  "getrandom 0.3.4",
  "js-sys",
  "lix_sdk",
+ "mimalloc",
  "napi",
  "napi-derive",
  "serde",
@@ -3406,6 +3418,7 @@ dependencies = [
  "lix_slatedb_storage",
  "lix_sqlite_storage",
  "lru",
+ "mimalloc",
  "notify-debouncer-full",
  "plugin_csv_v2",
  "rusqlite",
@@ -3627,6 +3640,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
  "rustix",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ lix_order_key = { path = "plugins/order-key", version = "0.8.4" }
 lix_plugin_api_v2 = { path = "packages/plugin-api", version = "0.8.4" }
 lix_sdk = { path = "packages/rs-sdk", version = "0.8.4" }
 lix_server_protocol = { path = "packages/server-protocol", version = "0.8.4" }
+mimalloc = { version = "0.1.52", features = ["local_dynamic_tls"] }
 
 [workspace.lints.rust]
 missing_copy_implementations = "warn"

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -34,3 +34,6 @@ bytes = "1"
 sha2 = "0.10"
 tokio = { version = "1", features = ["rt"] }
 zip = { version = "8", default-features = false }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+mimalloc.workspace = true

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -1,3 +1,7 @@
+#[cfg(not(target_family = "wasm"))]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn main() {
     if lix_cli::run().is_err() {
         std::process::exit(1);

--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -27,6 +27,9 @@ lix_sqlite_storage = { workspace = true, optional = true }
 object_store = { version = "0.14", default-features = false, optional = true }
 rusqlite = { version = "0.32", features = ["bundled"], optional = true }
 
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+mimalloc.workspace = true
+
 [dev-dependencies]
 ahash = "0.8"
 async-trait = "0.1"

--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -3,6 +3,10 @@ use std::time::{Duration, Instant};
 use criterion::measurement::WallTime;
 use criterion::{BatchSize, BenchmarkGroup, Criterion, black_box, criterion_group, criterion_main};
 
+#[cfg(not(target_family = "wasm"))]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 mod accounting;
 mod io_stats;
 mod kv_layout;

--- a/packages/engine-benchmarks/benches/tracked_working_diff.rs
+++ b/packages/engine-benchmarks/benches/tracked_working_diff.rs
@@ -20,6 +20,10 @@ use std::fmt::Write as _;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
+#[cfg(not(target_family = "wasm"))]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use lix_engine::storage_adapter::StorageAdapter;
 use lix_engine::storage_bench::diff_tracked_commits_for_bench;
 use lix_engine::{

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -38,9 +38,8 @@ use datafusion::logical_expr::TableSource;
 pub(crate) use file::{
     ExactLixFileReadColumn, ExactLixFileReadSelector, FastLixFilePathWriteConflict,
     execute_exact_lix_file_batch_read, execute_exact_lix_file_read,
-    execute_fast_lix_file_data_update_by_id, execute_fast_lix_file_id_path_writes,
-    execute_fast_lix_file_data_update_by_id_with_metadata,
-    execute_fast_lix_file_path_writes,
+    execute_fast_lix_file_data_update_by_id, execute_fast_lix_file_data_update_by_id_with_metadata,
+    execute_fast_lix_file_id_path_writes, execute_fast_lix_file_path_writes,
 };
 #[cfg(test)]
 pub(crate) use filesystem_working_change::filesystem_working_change_schema;

--- a/packages/js-sdk/Cargo.toml
+++ b/packages/js-sdk/Cargo.toml
@@ -29,6 +29,7 @@ lix_sdk = { path = "../rs-sdk", version = "0.8.4", default-features = false, fea
 napi = { version = "3.9.0", default-features = false, features = ["napi6", "serde-json"] }
 napi-derive = "3.5.6"
 tokio = { version = "1", features = ["rt", "sync"] }
+mimalloc.workspace = true
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 lix_sdk = { path = "../rs-sdk", version = "0.8.4", default-features = false }

--- a/packages/js-sdk/native/lib.rs
+++ b/packages/js-sdk/native/lib.rs
@@ -1,4 +1,8 @@
 #[cfg(not(target_family = "wasm"))]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[cfg(not(target_family = "wasm"))]
 mod napi;
 mod telemetry;
 #[cfg(target_family = "wasm")]

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -47,6 +47,9 @@ tokio = { version = "1", features = ["rt", "macros"] }
 wasm-encoder = "0.248"
 zip = { version = "8", default-features = false }
 
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
+mimalloc.workspace = true
+
 [features]
 default = ["default_wasm_runtime"]
 checkpoint_backends = [

--- a/packages/rs-sdk/benches/profile_merge_10k.rs
+++ b/packages/rs-sdk/benches/profile_merge_10k.rs
@@ -16,6 +16,10 @@ use std::io::{Cursor, Write as _};
 use std::path::Path;
 use std::time::Instant;
 
+#[cfg(not(target_family = "wasm"))]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 const INITIAL_ROW_COUNT: usize = 10_000;
 const NEW_ROW_COUNT: usize = 10_000;
 const CSV_PATH: &str = "/large-merge.csv";


### PR DESCRIPTION
## Summary

- use one shared mimalloc allocator contract for Lix-owned native entrypoints: CLI, native JS addon, CRUD/diff benchmark executables, and merge profiling
- compile mimalloc with local-dynamic TLS so the Node addon can be loaded after Node and its native dependencies have already consumed ELF TLS space
- keep WebAssembly and reusable Rust engine/library embedders on their host-selected allocator

The write profile puts allocator bookkeeping at the top of aggregate CPU cost. Jemalloc cleared the performance bar but failed the native JS CI at `dlopen` with `cannot allocate memory in static TLS block`. Mimalloc preserves the performance cut and safely loads as a late native addon.

## Balanced A/B evidence

Both sides below were built from `86f7600a204c18f92fd7a6e7e8c14ec00462dcea`; the candidate differed only by this allocator cut. Measurements were pinned to CPU 2 and process order was balanced.

| workload | glibc median | mimalloc median | change |
| --- | ---: | ---: | ---: |
| bound UPDATE, 10k prepared parameter sets | 355.513 ms | 277.789 ms | **-21.9%** |
| direct transaction UPDATE, 10k | 107.310 ms | 86.217 ms | **-19.7%** |
| tracked INSERT, 10k | 110.192 ms | 79.522 ms | **-27.8%** |
| tracked DELETE, 10k | 94.028 ms | 79.140 ms | **-15.8%** |
| serving-head working diff, 1k-commit fixture | 0.760 ms | 0.601 ms | **-20.9%** |
| semantic CSV merge, 10k old + 10k new rows | 445.893 ms | 360.022 ms | **-19.3%** |

The branch is rebased onto current `origin/main` at `6c8705d2b8b395f03408858e15e5b306a4717053`. A latest-main rerun is in progress because main advanced after the balanced A/B binaries were built.

This does not claim the 2x-SQLite goal is reached. The next stacked cut is set-at-a-time lowering of homogeneous `executeBatch` writes into one internal Arrow `RecordBatch`.

## Validation

- exact CI-native sequence: clean, build native addon, build TypeScript/plugins, then Vitest: **129/129 passed**
- direct Node `require('./lix_js_sdk.node')`: passed
- `cargo test -j2 -p lix_engine --features all-simulations`
- `cargo check -j2 -p lix_js_sdk -p lix_cli`
- `cargo check -j2 -p lix_js_sdk --target wasm32-unknown-unknown`
- `cargo fmt --all -- --check`
- `git diff --check`
- release-build and execute CRUD, working-diff, and semantic-merge harnesses

The WASM check emits two pre-existing dead-code warnings in `observe_invalidation`; mimalloc is not linked into WASM.