### PR TITLE
perf(rocksdb): compress SST data with fast Zstd

### DIFF
--- a/.changenotes/compress-rocksdb-sst-files.md
+++ b/.changenotes/compress-rocksdb-sst-files.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Reduced RocksDB storage size by compressing SST data with fast Zstandard compression.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3222,6 +3222,7 @@ dependencies = [
  "cc",
  "libc",
  "libz-sys",
+ "zstd-sys",
 ]
 
 [[package]]

--- a/packages/rocksdb-storage/Cargo.toml
+++ b/packages/rocksdb-storage/Cargo.toml
@@ -26,7 +26,7 @@ lix_engine = { workspace = true }
 
 bytes = "1"
 blake3 = "1"
-rocksdb = { version = "0.24", default-features = false, features = ["bindgen-runtime"] }
+rocksdb = { version = "0.24", default-features = false, features = ["bindgen-runtime", "zstd"] }
 tempfile = "3"
 tokio = { version = "1", features = ["sync"] }
 

--- a/packages/rocksdb-storage/src/rocksdb.rs
+++ b/packages/rocksdb-storage/src/rocksdb.rs
@@ -629,6 +629,8 @@ fn open_rocksdb(path: &Path) -> Result<DB, StorageError> {
     options.create_if_missing(true);
     options.set_use_fsync(false);
     options.set_write_buffer_size(64 * 1024 * 1024);
+    options.set_compression_type(rocksdb::DBCompressionType::Zstd);
+    options.set_compression_options(-14, 1, 0, 0);
     let mut table_options = BlockBasedOptions::default();
     // Full whole-key filters let missing point reads skip unrelated SST data.
     table_options.set_bloom_filter(8.0, false);

--- a/packages/rocksdb-storage/tests/storage/rocksdb_specific.rs
+++ b/packages/rocksdb-storage/tests/storage/rocksdb_specific.rs
@@ -153,6 +153,34 @@ fn writes_large_values_to_blob_files() {
 }
 
 #[test]
+fn uses_fast_zstd_compression_for_sst_files() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let path = temp_dir.path().join("storage.rocksdb");
+    let storage = RocksDB::open(&path).expect("open storage");
+    put_one(
+        &storage,
+        SpaceId(0x0005_0003),
+        Key(Bytes::from_static(b"compressed-value")),
+        Bytes::from(vec![b'a'; 64 * 1024]),
+    );
+    storage.flush().expect("flush storage");
+    drop(storage);
+
+    let options = std::fs::read_to_string(latest_options_file(&path))
+        .expect("read persisted RocksDB options");
+    assert!(
+        options.contains("compression=kZSTD"),
+        "SST compression should use Zstd"
+    );
+    assert!(
+        options.contains("compression_opts={")
+            && options.contains("level=1;")
+            && options.contains("window_bits=-14;"),
+        "Zstd should use the fast level-1 configuration"
+    );
+}
+
+#[test]
 fn cross_process_open_reports_locked_database() {
     let temp_dir = tempfile::tempdir().expect("create temp dir");
     let path = temp_dir.path().join("storage.rocksdb");
@@ -234,6 +262,20 @@ fn rocksdb_blob_file_count(path: &std::path::Path) -> usize {
                 .is_some_and(|extension| extension == "blob")
         })
         .count()
+}
+
+fn latest_options_file(path: &std::path::Path) -> std::path::PathBuf {
+    std::fs::read_dir(path)
+        .expect("read rocksdb directory")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("OPTIONS-"))
+        })
+        .max()
+        .expect("rocksdb should persist an options file")
 }
 
 fn block_on<T>(future: impl Future<Output = T>) -> T {


### PR DESCRIPTION
## Summary

- enable RocksDB's Zstd support and compress SST blocks at level 1
- keep blob-file behavior unchanged
- assert the persisted RocksDB configuration uses `kZSTD` and the fast level-1 settings

## OpenClaw RocksDB replay benchmark

Compared release binaries built from the same `origin/main` SHA (`6c8705d2b8b395f03408858e15e5b306a4717053`). Replayed the first 100 first-parent commits from `openclaw/openclaw` into fresh RocksDB directories, alternating baseline/candidate order across 8 trials.

| Metric (median) | main | this PR | change |
| --- | ---: | ---: | ---: |
| Physical RocksDB bytes | 17,970,815 | 4,599,553 | **-74.4%** |
| SST bytes | 17,260,076 | 3,888,882 | **-77.5%** |
| Replay elapsed | 1,780.5 ms | 1,764.7 ms | -0.9% |
| Max RSS | 155,498 KiB | 154,440 KiB | -0.7% |
| Explicit final flush | 60.8 ms | 100.3 ms | +65.1% |

The explicit flush is slower, but end-to-end replay does not regress. Blob bytes remain unchanged (~665 KB).

## Correctness and validation

- `cargo fmt --package lix_rocksdb_storage --check`
- `cargo test --release -p lix_rocksdb_storage` (3 unit + 11 integration tests)
- 100/100 OpenClaw commits verified with `git-replay --verify-state`
- final Git tree manifest verified