### PR TITLE
perf(files): serve exact reads from the path index

### DIFF
--- a/packages/engine-benchmarks/benches/native_file_upsert_component.rs
+++ b/packages/engine-benchmarks/benches/native_file_upsert_component.rs
@@ -1041,9 +1041,18 @@ fn disk_usage(path: &Path) -> std::io::Result<DiskUsage> {
 }
 
 fn accumulate_disk_usage(path: &Path, usage: &mut DiskUsage) -> std::io::Result<()> {
-    for entry in fs::read_dir(path)? {
+    let entries = match fs::read_dir(path) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    for entry in entries {
         let entry = entry?;
-        let file_type = entry.file_type()?;
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error),
+        };
         if file_type.is_dir() {
             accumulate_disk_usage(&entry.path(), usage)?;
             continue;
@@ -1052,7 +1061,14 @@ fn accumulate_disk_usage(path: &Path, usage: &mut DiskUsage) -> std::io::Result<
             continue;
         }
 
-        let bytes = entry.metadata()?.len();
+        // RocksDB may replace an SST between read_dir and metadata while a
+        // background compaction is running. That file belongs to neither
+        // stable side of this best-effort usage snapshot.
+        let bytes = match entry.metadata() {
+            Ok(metadata) => metadata.len(),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error),
+        };
         let file_name = entry.file_name();
         let file_name = file_name.to_string_lossy();
         usage.total_bytes += bytes;

--- a/packages/engine/src/binary_cas/mod.rs
+++ b/packages/engine/src/binary_cas/mod.rs
@@ -10,6 +10,7 @@ mod types;
 
 pub(crate) use chunking::BinaryCasChunking;
 pub(crate) use context::{BinaryCasContext, BlobDataReader};
+pub(crate) use kv::load_bytes_many;
 pub(crate) use types::{
     BlobBytesBatch, BlobHash, BlobLayout, BlobMetadata, BlobMetadataBatch, BlobPayload,
     BlobSameLengthSplice, BlobWriteReceipt, InlineBlob,

--- a/packages/engine/src/filesystem/path_index.rs
+++ b/packages/engine/src/filesystem/path_index.rs
@@ -37,6 +37,13 @@ const FILESYSTEM_PATH_REVISION_SPACE: StorageSpace = StorageSpace::new(
 const FILESYSTEM_PATH_REVISION_KEY: &[u8] = b"global";
 const MAX_CACHE_BYTES: usize = 64 * 1024 * 1024;
 const MAX_EAGER_BLOB_BYTES: usize = 32 * 1024;
+const MAX_EAGER_BLOB_CACHE_BYTES: usize = 16 * 1024 * 1024;
+
+fn reserve_eager_blob_cache_bytes(reserved: usize, size: usize) -> Option<usize> {
+    reserved
+        .checked_add(size)
+        .filter(|total| *total <= MAX_EAGER_BLOB_CACHE_BYTES)
+}
 
 #[cfg(test)]
 static FULL_REBUILD_BUILDS: AtomicUsize = AtomicUsize::new(0);
@@ -556,6 +563,7 @@ impl FilesystemPathIndex {
     ) -> Result<Self, LixError> {
         let mut requests =
             BTreeMap::<String, (BlobHash, usize, Vec<Arc<FilesystemPathEntry>>)>::new();
+        let mut reserved_cache_bytes = 0usize;
         for entry in self.entries() {
             let Some(row) = entry.blob_ref.as_ref() else {
                 continue;
@@ -574,12 +582,21 @@ impl FilesystemPathIndex {
             if size_bytes > MAX_EAGER_BLOB_BYTES {
                 continue;
             }
+            let Some(next_reserved_cache_bytes) =
+                reserve_eager_blob_cache_bytes(reserved_cache_bytes, size_bytes)
+            else {
+                continue;
+            };
             let hash = BlobHash::from_hex(&snapshot.blob_hash)?;
             requests
                 .entry(snapshot.blob_hash)
                 .or_insert_with(|| (hash, size_bytes, Vec::new()))
                 .2
                 .push(entry);
+            // Count each projected entry even when several entries share a
+            // blob. This matches estimated_heap_bytes and bounds the complete
+            // cached view rather than only the unique CAS payloads.
+            reserved_cache_bytes = next_reserved_cache_bytes;
         }
         if requests.is_empty() {
             return Ok(self);
@@ -1398,6 +1415,19 @@ mod tests {
     use super::*;
     use crate::changelog::{ChangeId, CommitId};
     use crate::entity_pk::EntityPk;
+
+    #[test]
+    fn eager_blob_hydration_has_an_aggregate_cache_budget() {
+        assert_eq!(
+            reserve_eager_blob_cache_bytes(MAX_EAGER_BLOB_CACHE_BYTES - 1, 1),
+            Some(MAX_EAGER_BLOB_CACHE_BYTES)
+        );
+        assert_eq!(
+            reserve_eager_blob_cache_bytes(MAX_EAGER_BLOB_CACHE_BYTES, 1),
+            None
+        );
+        assert_eq!(reserve_eager_blob_cache_bytes(usize::MAX, 1), None);
+    }
 
     #[test]
     fn exact_range_and_order_preserve_path_buckets() {

--- a/packages/engine/src/filesystem/path_index.rs
+++ b/packages/engine/src/filesystem/path_index.rs
@@ -11,6 +11,7 @@ use bytes::Bytes;
 use serde::Deserialize;
 
 use crate::LixError;
+use crate::binary_cas::BlobHash;
 use crate::changelog::{ChangeId, CommitId};
 use crate::common::{LixTimestamp, compose_directory_path, compose_file_path};
 use crate::entity_pk::EntityPk;
@@ -23,9 +24,11 @@ use crate::storage_adapter::{
 };
 
 use super::descriptor_path::{DirectoryPathRecord, derive_directory_paths};
-use super::keys::{DIRECTORY_DESCRIPTOR_SCHEMA_KEY, FILE_DESCRIPTOR_SCHEMA_KEY};
+use super::keys::{
+    BLOB_REF_SCHEMA_KEY, DIRECTORY_DESCRIPTOR_SCHEMA_KEY, FILE_DESCRIPTOR_SCHEMA_KEY,
+};
 use super::persistent_map::PersistentMap;
-use super::planner::FilesystemDescriptorKey;
+use super::planner::{FilesystemBlobRefKey, FilesystemDescriptorKey};
 
 const FILESYSTEM_PATH_REVISION_SPACE: StorageSpace = StorageSpace::new(
     StorageSpaceId(0x0007_0002),
@@ -33,6 +36,7 @@ const FILESYSTEM_PATH_REVISION_SPACE: StorageSpace = StorageSpace::new(
 );
 const FILESYSTEM_PATH_REVISION_KEY: &[u8] = b"global";
 const MAX_CACHE_BYTES: usize = 64 * 1024 * 1024;
+const MAX_EAGER_BLOB_BYTES: usize = 32 * 1024;
 
 #[cfg(test)]
 static FULL_REBUILD_BUILDS: AtomicUsize = AtomicUsize::new(0);
@@ -72,6 +76,8 @@ pub(crate) struct FilesystemPathEntry {
     updated_at: String,
     change_id: Option<ChangeId>,
     commit_id: Option<CommitId>,
+    blob_ref: Option<MaterializedLiveStateRow>,
+    cached_blob_data: Option<crate::Blob>,
 }
 
 impl FilesystemPathEntry {
@@ -139,6 +145,14 @@ impl FilesystemPathEntry {
         self.commit_id
     }
 
+    pub(crate) fn blob_ref_live_row(&self) -> Option<&MaterializedLiveStateRow> {
+        self.blob_ref.as_ref()
+    }
+
+    pub(crate) fn cached_blob_data(&self) -> Option<&crate::Blob> {
+        self.cached_blob_data.as_ref()
+    }
+
     fn estimated_heap_bytes(&self) -> usize {
         self.path.capacity()
             + self.parent_id.as_ref().map_or(0, String::capacity)
@@ -147,6 +161,20 @@ impl FilesystemPathEntry {
             + self.metadata.as_ref().map_or(0, String::capacity)
             + self.created_at.capacity()
             + self.updated_at.capacity()
+            + self.blob_ref.as_ref().map_or(0, |row| {
+                row.schema_key.capacity()
+                    + row
+                        .entity_pk
+                        .parts
+                        .iter()
+                        .map(String::capacity)
+                        .sum::<usize>()
+                    + row.file_id.as_ref().map_or(0, String::capacity)
+                    + row.snapshot_content.as_ref().map_or(0, String::capacity)
+                    + row.metadata.as_ref().map_or(0, String::capacity)
+                    + row.branch_id.len()
+            })
+            + self.cached_blob_data.as_ref().map_or(0, |data| data.len())
     }
 }
 
@@ -194,11 +222,12 @@ impl FilesystemPathSelection {
     }
 }
 
-/// Ordered, descriptor-only index over one effective live filesystem view.
+/// Ordered file-materialization index over one effective live filesystem view.
 ///
 /// Duplicate paths remain adjacent because Lix path uniqueness is storage-scope
 /// local. Distinct branch/global lanes can legally render the same path and SQL
-/// predicates must retain every visible candidate.
+/// predicates must retain every visible candidate. File entries retain their
+/// visible blob-ref row so exact reads do not rediscover it from live state.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct FilesystemPathEntryIdentity {
     kind: FilesystemPathKind,
@@ -264,6 +293,32 @@ impl FilesystemPathIndex {
     pub(crate) fn from_live_rows(rows: Vec<MaterializedLiveStateRow>) -> Result<Self, LixError> {
         let mut directory_rows = BTreeMap::<FilesystemDescriptorKey, DirectoryRecord>::new();
         let mut file_rows = Vec::<(FilesystemDescriptorKey, FileRecord)>::new();
+        let mut blob_rows = BTreeMap::<FilesystemBlobRefKey, MaterializedLiveStateRow>::new();
+
+        for row in &rows {
+            if row.schema_key != BLOB_REF_SCHEMA_KEY || row.deleted {
+                continue;
+            }
+            let Some(snapshot_content) = row.snapshot_content.as_deref() else {
+                continue;
+            };
+            let snapshot: serde_json::Value =
+                serde_json::from_str(snapshot_content).map_err(|error| {
+                    LixError::unknown(format!(
+                        "invalid lix_binary_blob_ref snapshot JSON: {error}"
+                    ))
+                })?;
+            let id = snapshot
+                .get("id")
+                .and_then(serde_json::Value::as_str)
+                .ok_or_else(|| {
+                    LixError::unknown("lix_binary_blob_ref snapshot is missing string id")
+                })?;
+            blob_rows.insert(
+                FilesystemBlobRefKey::from_live_row(row, id.to_string()),
+                row.clone(),
+            );
+        }
 
         for row in rows {
             let Some(snapshot_content) = row.snapshot_content.as_deref() else {
@@ -356,10 +411,13 @@ impl FilesystemPathIndex {
                 updated_at: record.updated_at.clone(),
                 change_id: record.change_id,
                 commit_id: record.commit_id,
+                blob_ref: None,
+                cached_blob_data: None,
             });
         }
 
         for (key, record) in file_rows {
+            let blob_ref = blob_rows.remove(&key.blob_ref_key());
             let mut parent_identity = None;
             let directory_path = match record.directory_id.as_deref() {
                 Some(directory_id) => {
@@ -401,6 +459,8 @@ impl FilesystemPathIndex {
                 updated_at: record.updated_at,
                 change_id: record.change_id,
                 commit_id: record.commit_id,
+                blob_ref,
+                cached_blob_data: None,
             });
         }
 
@@ -487,6 +547,76 @@ impl FilesystemPathIndex {
         self.generation.as_deref()
     }
 
+    /// Warms small CAS payloads while the filesystem index is already being
+    /// built. The manifest lookup is one batch for the whole view, so exact
+    /// file reads do not pay another storage round trip after path selection.
+    pub(crate) async fn hydrate_small_blob_data(
+        mut self,
+        store: &impl StorageAdapterRead,
+    ) -> Result<Self, LixError> {
+        let mut requests =
+            BTreeMap::<String, (BlobHash, usize, Vec<Arc<FilesystemPathEntry>>)>::new();
+        for entry in self.entries() {
+            let Some(row) = entry.blob_ref.as_ref() else {
+                continue;
+            };
+            let Some(snapshot_content) = row.snapshot_content.as_deref() else {
+                continue;
+            };
+            let snapshot: BlobRefSnapshot =
+                serde_json::from_str(snapshot_content).map_err(|error| {
+                    LixError::unknown(format!(
+                        "invalid lix_binary_blob_ref snapshot JSON: {error}"
+                    ))
+                })?;
+            let size_bytes = usize::try_from(snapshot.size_bytes)
+                .map_err(|_| LixError::unknown("lix_binary_blob_ref size_bytes exceeds usize"))?;
+            if size_bytes > MAX_EAGER_BLOB_BYTES {
+                continue;
+            }
+            let hash = BlobHash::from_hex(&snapshot.blob_hash)?;
+            requests
+                .entry(snapshot.blob_hash)
+                .or_insert_with(|| (hash, size_bytes, Vec::new()))
+                .2
+                .push(entry);
+        }
+        if requests.is_empty() {
+            return Ok(self);
+        }
+
+        let hashes = requests
+            .values()
+            .map(|(hash, _, _)| *hash)
+            .collect::<Vec<_>>();
+        let Ok(values) = crate::binary_cas::kv::load_bytes_many(store, &hashes).await else {
+            return Ok(self);
+        };
+        let values = values.into_vec();
+        if values.len() != requests.len() {
+            return Err(LixError::unknown(format!(
+                "binary CAS returned {} values for {} path-index blobs",
+                values.len(),
+                requests.len()
+            )));
+        }
+        for ((_, (hash, size_bytes, entries)), data) in requests.into_iter().zip(values) {
+            let Some(data) = data else {
+                continue;
+            };
+            if data.len() != size_bytes || BlobHash::from_content(&data) != hash {
+                continue;
+            }
+            let data = crate::Blob::from(data);
+            for entry in entries {
+                let mut hydrated = (*entry).clone();
+                hydrated.cached_blob_data = Some(data.clone());
+                self.insert_entry(Arc::new(hydrated));
+            }
+        }
+        Ok(self)
+    }
+
     /// Applies committed descriptor rows by path-copying only the affected AVL
     /// search paths. Directory moves additionally rewrite their descendants.
     pub(crate) fn apply_committed_rows(
@@ -497,21 +627,67 @@ impl FilesystemPathIndex {
     ) -> Result<Self, LixError> {
         let mut next = self.clone();
         next.generation = generation.map(<[u8]>::to_vec);
-        for row in rows {
-            if !matches!(
-                row.schema_key.as_str(),
-                FILE_DESCRIPTOR_SCHEMA_KEY | DIRECTORY_DESCRIPTOR_SCHEMA_KEY
-            ) || (!row.global
-                && !request
+        for row in rows.iter().filter(|row| {
+            (row.global
+                || request
                     .branch_ids
                     .iter()
                     .any(|branch_id| branch_id.as_str() == row.branch_id.as_ref()))
-            {
-                continue;
-            }
+                && matches!(
+                    row.schema_key.as_str(),
+                    FILE_DESCRIPTOR_SCHEMA_KEY | DIRECTORY_DESCRIPTOR_SCHEMA_KEY
+                )
+        }) {
             next.apply_committed_row(row)?;
         }
+        for row in rows.iter().filter(|row| {
+            (row.global
+                || request
+                    .branch_ids
+                    .iter()
+                    .any(|branch_id| branch_id.as_str() == row.branch_id.as_ref()))
+                && row.schema_key == BLOB_REF_SCHEMA_KEY
+        }) {
+            next.apply_committed_blob_ref_row(row)?;
+        }
         Ok(next)
+    }
+
+    fn apply_committed_blob_ref_row(
+        &mut self,
+        row: &MaterializedLiveStateRow,
+    ) -> Result<(), LixError> {
+        let descriptor_id = row
+            .snapshot_content
+            .as_deref()
+            .and_then(|snapshot| serde_json::from_str::<serde_json::Value>(snapshot).ok())
+            .and_then(|snapshot| {
+                snapshot
+                    .get("id")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string)
+            })
+            .unwrap_or(row.entity_pk.as_single_string_owned()?);
+        let blob_ref_key = FilesystemBlobRefKey::from_live_row(row, descriptor_id.clone());
+        let entry = self
+            .entries_by_descriptor_id
+            .values_equal_by(descriptor_id.as_str(), |key| key.id.as_str())
+            .into_iter()
+            .find(|entry| {
+                entry.kind == FilesystemPathKind::File && entry.key.blob_ref_key() == blob_ref_key
+            });
+        let Some(entry) = entry else {
+            return Ok(());
+        };
+        let mut next = (*entry).clone();
+        if row.deleted || row.snapshot_content.is_none() {
+            next.blob_ref = None;
+        } else {
+            next.blob_ref = Some(row.clone());
+        }
+        next.cached_blob_data = None;
+        self.insert_entry(Arc::new(next));
+        Ok(())
     }
 
     fn apply_committed_row(&mut self, row: &MaterializedLiveStateRow) -> Result<(), LixError> {
@@ -550,6 +726,13 @@ impl FilesystemPathIndex {
             .iter()
             .find(|entry| entry_identity(entry) == identity)
             .cloned();
+        let prior_blob_ref = prior
+            .as_ref()
+            .and_then(|entry| entry.blob_ref.as_ref())
+            .cloned();
+        let prior_cached_blob_data = prior
+            .as_ref()
+            .and_then(|entry| entry.cached_blob_data.clone());
         let mut descendants = if kind == FilesystemPathKind::Directory {
             prior
                 .as_ref()
@@ -570,7 +753,9 @@ impl FilesystemPathIndex {
             return Ok(());
         }
 
-        let entry = self.entry_from_row(row, key, kind)?;
+        let mut entry = self.entry_from_row(row, key, kind)?;
+        entry.blob_ref = prior_blob_ref;
+        entry.cached_blob_data = prior_cached_blob_data;
         self.insert_entry(Arc::new(entry));
         for descendant in &mut descendants {
             let path = self.path_for_entry(descendant)?;
@@ -624,6 +809,8 @@ impl FilesystemPathIndex {
             updated_at: row.updated_at.to_string(),
             change_id: row.change_id,
             commit_id: row.commit_id,
+            blob_ref: None,
+            cached_blob_data: None,
         };
         entry.parent_identity = self.resolve_parent_identity(&entry);
         entry.path = self.path_for_entry(&entry)?;
@@ -811,22 +998,47 @@ fn estimated_entry_index_bytes(entry: &FilesystemPathEntry) -> usize {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct FilesystemPathIndexRequest {
     pub(crate) branch_ids: Vec<String>,
+    pub(crate) include_blob_refs: bool,
+    pub(crate) cache_small_blob_data: bool,
 }
 
 impl FilesystemPathIndexRequest {
     pub(crate) fn new(mut branch_ids: Vec<String>) -> Self {
         branch_ids.sort();
         branch_ids.dedup();
-        Self { branch_ids }
+        Self {
+            branch_ids,
+            include_blob_refs: false,
+            cache_small_blob_data: false,
+        }
+    }
+
+    pub(crate) fn with_blob_refs(mut self, enabled: bool) -> Self {
+        self.include_blob_refs = enabled;
+        self
+    }
+
+    pub(crate) fn with_cached_blob_data(mut self, enabled: bool) -> Self {
+        self.include_blob_refs |= enabled;
+        self.cache_small_blob_data = enabled;
+        self
     }
 
     pub(crate) fn live_state_request(&self) -> LiveStateScanRequest {
         LiveStateScanRequest {
             filter: LiveStateFilter {
-                schema_keys: vec![
-                    DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string(),
-                    FILE_DESCRIPTOR_SCHEMA_KEY.to_string(),
-                ],
+                schema_keys: if self.include_blob_refs {
+                    vec![
+                        BLOB_REF_SCHEMA_KEY.to_string(),
+                        DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string(),
+                        FILE_DESCRIPTOR_SCHEMA_KEY.to_string(),
+                    ]
+                } else {
+                    vec![
+                        DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string(),
+                        FILE_DESCRIPTOR_SCHEMA_KEY.to_string(),
+                    ]
+                },
                 branch_ids: self.branch_ids.clone(),
                 ..LiveStateFilter::default()
             },
@@ -880,6 +1092,8 @@ pub(crate) async fn build_path_index(
 struct CacheKey {
     branch_ids: Vec<String>,
     revision: Option<Vec<u8>>,
+    include_blob_refs: bool,
+    cache_small_blob_data: bool,
 }
 
 impl CacheKey {
@@ -911,6 +1125,8 @@ impl FilesystemPathIndexCache {
         let key = CacheKey {
             branch_ids: request.branch_ids.clone(),
             revision: revision.map(<[u8]>::to_vec),
+            include_blob_refs: request.include_blob_refs,
+            cache_small_blob_data: request.cache_small_blob_data,
         };
         let mut entries = self
             .entries
@@ -932,6 +1148,8 @@ impl FilesystemPathIndexCache {
         let key = CacheKey {
             branch_ids: request.branch_ids.clone(),
             revision: revision.map(<[u8]>::to_vec),
+            include_blob_refs: request.include_blob_refs,
+            cache_small_blob_data: request.cache_small_blob_data,
         };
         let mut entries = self
             .entries
@@ -945,7 +1163,11 @@ impl FilesystemPathIndexCache {
         } else {
             Arc::new((*index).clone().with_generation(revision))
         };
-        entries.retain(|candidate| candidate.key.branch_ids != key.branch_ids);
+        entries.retain(|candidate| {
+            candidate.key.branch_ids != key.branch_ids
+                || candidate.key.include_blob_refs != key.include_blob_refs
+                || candidate.key.cache_small_blob_data != key.cache_small_blob_data
+        });
         let bytes =
             size_of::<CachedIndex>() + key.estimated_heap_bytes() + index.estimated_heap_bytes();
         entries.push(CachedIndex {
@@ -996,7 +1218,9 @@ impl FilesystemPathIndexCache {
             if candidate.key.branch_ids.len() != 1 {
                 return false;
             }
-            let request = FilesystemPathIndexRequest::new(candidate.key.branch_ids.clone());
+            let request = FilesystemPathIndexRequest::new(candidate.key.branch_ids.clone())
+                .with_blob_refs(candidate.key.include_blob_refs)
+                .with_cached_blob_data(candidate.key.cache_small_blob_data);
             if let Ok(index) = candidate
                 .index
                 .apply_committed_rows(&request, rows, next_revision)
@@ -1009,6 +1233,8 @@ impl FilesystemPathIndexCache {
             let key = CacheKey {
                 branch_ids: request.branch_ids,
                 revision: next_revision.map(<[u8]>::to_vec),
+                include_blob_refs: request.include_blob_refs,
+                cache_small_blob_data: request.cache_small_blob_data,
             };
             let bytes = size_of::<CachedIndex>()
                 + key.estimated_heap_bytes()
@@ -1085,6 +1311,12 @@ struct FileSnapshot {
     id: String,
     directory_id: Option<String>,
     name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct BlobRefSnapshot {
+    blob_hash: String,
+    size_bytes: u64,
 }
 
 #[derive(Debug)]
@@ -1227,6 +1459,30 @@ mod tests {
     }
 
     #[test]
+    fn cache_keeps_descriptor_only_and_blob_warmed_views_separate() {
+        let cache = FilesystemPathIndexCache::default();
+        let descriptors = FilesystemPathIndexRequest::new(vec!["branch-a".to_string()]);
+        let blobs = descriptors.clone().with_cached_blob_data(true);
+        let descriptor_index = cache.insert(
+            &descriptors,
+            Some(&[1]),
+            Arc::new(FilesystemPathIndex::default()),
+        );
+        let blob_index = cache.insert(&blobs, Some(&[1]), Arc::new(FilesystemPathIndex::default()));
+
+        assert!(Arc::ptr_eq(
+            &cache
+                .get(&descriptors, Some(&[1]))
+                .expect("descriptor-only view"),
+            &descriptor_index
+        ));
+        assert!(Arc::ptr_eq(
+            &cache.get(&blobs, Some(&[1])).expect("blob-warmed view"),
+            &blob_index
+        ));
+    }
+
+    #[test]
     fn cache_advances_matching_generation_from_descriptor_delta() {
         let cache = FilesystemPathIndexCache::default();
         let request = FilesystemPathIndexRequest::new(vec!["branch-a".to_string()]);
@@ -1258,6 +1514,55 @@ mod tests {
         assert!(next.exact_entries("/before.md").is_empty());
         assert_eq!(next.exact_entries("/after.md").len(), 1);
         assert_eq!(next.generation(), Some([2].as_slice()));
+    }
+
+    #[test]
+    fn blob_refs_build_and_advance_with_their_file_entry() {
+        let request = FilesystemPathIndexRequest::new(vec!["branch-a".to_string()]);
+        let prior = FilesystemPathIndex::from_live_rows(vec![
+            file_row("file-a", None, "a.md", "branch-a", false),
+            blob_row("file-a", "hash-before", "branch-a"),
+        ])
+        .expect("path index should build");
+        let prior_entry = &prior.exact_entries("/a.md")[0];
+        assert_eq!(
+            prior_entry
+                .blob_ref_live_row()
+                .and_then(|row| row.snapshot_content.as_deref()),
+            Some(r#"{"blob_hash":"hash-before","id":"file-a","size_bytes":7}"#)
+        );
+
+        let next = prior
+            .apply_committed_rows(
+                &request,
+                &[blob_row("file-a", "hash-after", "branch-a")],
+                Some(&[2]),
+            )
+            .expect("blob-ref delta should apply");
+        assert_eq!(
+            next.exact_entries("/a.md")[0]
+                .blob_ref_live_row()
+                .and_then(|row| row.snapshot_content.as_deref()),
+            Some(r#"{"blob_hash":"hash-after","id":"file-a","size_bytes":7}"#)
+        );
+        assert_eq!(
+            prior_entry
+                .blob_ref_live_row()
+                .and_then(|row| row.snapshot_content.as_deref()),
+            Some(r#"{"blob_hash":"hash-before","id":"file-a","size_bytes":7}"#)
+        );
+
+        let mut tombstone = blob_row("file-a", "unused", "branch-a");
+        tombstone.snapshot_content = None;
+        tombstone.deleted = true;
+        let deleted = next
+            .apply_committed_rows(&request, &[tombstone], Some(&[3]))
+            .expect("blob-ref tombstone should apply");
+        assert!(
+            deleted.exact_entries("/a.md")[0]
+                .blob_ref_live_row()
+                .is_none()
+        );
     }
 
     #[test]
@@ -1397,6 +1702,23 @@ mod tests {
             branch_id,
             global,
         )
+    }
+
+    fn blob_row(id: &str, blob_hash: &str, branch_id: &str) -> MaterializedLiveStateRow {
+        let mut row = live_row(
+            id,
+            BLOB_REF_SCHEMA_KEY,
+            serde_json::json!({
+                "id": id,
+                "blob_hash": blob_hash,
+                "size_bytes": 7,
+            })
+            .to_string(),
+            branch_id,
+            false,
+        );
+        row.file_id = Some(id.to_string());
+        row
     }
 
     fn live_row(

--- a/packages/engine/src/filesystem/path_index.rs
+++ b/packages/engine/src/filesystem/path_index.rs
@@ -589,7 +589,7 @@ impl FilesystemPathIndex {
             .values()
             .map(|(hash, _, _)| *hash)
             .collect::<Vec<_>>();
-        let Ok(values) = crate::binary_cas::kv::load_bytes_many(store, &hashes).await else {
+        let Ok(values) = crate::binary_cas::load_bytes_many(store, &hashes).await else {
             return Ok(self);
         };
         let values = values.into_vec();

--- a/packages/engine/src/filesystem/path_index.rs
+++ b/packages/engine/src/filesystem/path_index.rs
@@ -628,27 +628,22 @@ impl FilesystemPathIndex {
         let mut next = self.clone();
         next.generation = generation.map(<[u8]>::to_vec);
         for row in rows.iter().filter(|row| {
-            (row.global
-                || request
-                    .branch_ids
-                    .iter()
-                    .any(|branch_id| branch_id.as_str() == row.branch_id.as_ref()))
-                && matches!(
-                    row.schema_key.as_str(),
-                    FILE_DESCRIPTOR_SCHEMA_KEY | DIRECTORY_DESCRIPTOR_SCHEMA_KEY
-                )
+            matches!(
+                row.schema_key.as_str(),
+                FILE_DESCRIPTOR_SCHEMA_KEY | DIRECTORY_DESCRIPTOR_SCHEMA_KEY
+            )
         }) {
-            next.apply_committed_row(row)?;
+            for_each_committed_row_projection(request, row, |projected| {
+                next.apply_committed_row(projected)
+            })?;
         }
-        for row in rows.iter().filter(|row| {
-            (row.global
-                || request
-                    .branch_ids
-                    .iter()
-                    .any(|branch_id| branch_id.as_str() == row.branch_id.as_ref()))
-                && row.schema_key == BLOB_REF_SCHEMA_KEY
-        }) {
-            next.apply_committed_blob_ref_row(row)?;
+        for row in rows
+            .iter()
+            .filter(|row| row.schema_key == BLOB_REF_SCHEMA_KEY)
+        {
+            for_each_committed_row_projection(request, row, |projected| {
+                next.apply_committed_blob_ref_row(projected)
+            })?;
         }
         Ok(next)
     }
@@ -713,7 +708,14 @@ impl FilesystemPathIndex {
             .into_iter()
             .filter(|entry| entry.kind == kind)
             .collect::<Vec<_>>();
-        if row.global && same_id.iter().any(|entry| !entry.key.global()) {
+        if row.global
+            && same_id.iter().any(|entry| {
+                !entry.key.global()
+                    && entry.key.branch_id() == row.branch_id.as_ref()
+                    && entry.key.is_untracked() == row.untracked
+                    && entry.key.file_id() == row.file_id.as_deref()
+            })
+        {
             return Ok(());
         }
 
@@ -948,6 +950,28 @@ impl FilesystemPathIndex {
     pub(crate) fn estimated_heap_bytes(&self) -> usize {
         self.estimated_heap_bytes
     }
+}
+
+fn for_each_committed_row_projection(
+    request: &FilesystemPathIndexRequest,
+    row: &MaterializedLiveStateRow,
+    mut apply: impl FnMut(&MaterializedLiveStateRow) -> Result<(), LixError>,
+) -> Result<(), LixError> {
+    if row.global && !request.branch_ids.is_empty() {
+        for branch_id in &request.branch_ids {
+            let mut projected = row.clone();
+            projected.branch_id = branch_id.clone().into();
+            apply(&projected)?;
+        }
+    } else if row.global
+        || request
+            .branch_ids
+            .iter()
+            .any(|branch_id| branch_id.as_str() == row.branch_id.as_ref())
+    {
+        apply(row)?;
+    }
+    Ok(())
 }
 
 fn entry_identity(entry: &FilesystemPathEntry) -> FilesystemPathEntryIdentity {
@@ -1563,6 +1587,62 @@ mod tests {
                 .blob_ref_live_row()
                 .is_none()
         );
+    }
+
+    #[test]
+    fn global_blob_delta_updates_its_projected_branch_entry() {
+        let request = FilesystemPathIndexRequest::new(vec!["branch-a".to_string()]);
+        let mut projected_blob = blob_row("global-file", "hash-before", "branch-a");
+        projected_blob.global = true;
+        let prior = FilesystemPathIndex::from_live_rows(vec![
+            file_row("global-file", None, "global.md", "branch-a", true),
+            projected_blob,
+        ])
+        .expect("projected global path index should build");
+
+        let mut committed_blob = blob_row("global-file", "hash-after", crate::GLOBAL_BRANCH_ID);
+        committed_blob.global = true;
+        let next = prior
+            .apply_committed_rows(&request, &[committed_blob], Some(&[2]))
+            .expect("global blob delta should project into the cached branch");
+
+        let entries = next.exact_entries("/global.md");
+        assert_eq!(entries.len(), 1);
+        let blob_ref = entries[0]
+            .blob_ref_live_row()
+            .expect("projected file should retain its updated blob ref");
+        assert_eq!(blob_ref.branch_id.as_ref(), "branch-a");
+        assert_eq!(
+            blob_ref.snapshot_content.as_deref(),
+            Some(r#"{"blob_hash":"hash-after","id":"global-file","size_bytes":7}"#)
+        );
+    }
+
+    #[test]
+    fn global_descriptor_delta_updates_only_unshadowed_branch_entries() {
+        let request =
+            FilesystemPathIndexRequest::new(vec!["branch-a".to_string(), "branch-b".to_string()]);
+        let prior = FilesystemPathIndex::from_live_rows(vec![
+            file_row("global-file", None, "local.md", "branch-a", false),
+            file_row("global-file", None, "global.md", "branch-b", true),
+        ])
+        .expect("mixed local and projected global path index should build");
+
+        let committed = file_row(
+            "global-file",
+            None,
+            "updated-global.md",
+            crate::GLOBAL_BRANCH_ID,
+            true,
+        );
+        let next = prior
+            .apply_committed_rows(&request, &[committed], Some(&[2]))
+            .expect("global descriptor delta should update each unshadowed projection");
+
+        assert_eq!(next.exact_entries("/local.md").len(), 1);
+        assert_eq!(next.exact_entries("/updated-global.md").len(), 1);
+        assert!(next.exact_entries("/global.md").is_empty());
+        assert_eq!(next.entries().len(), 2);
     }
 
     #[test]

--- a/packages/engine/src/filesystem/planner.rs
+++ b/packages/engine/src/filesystem/planner.rs
@@ -149,6 +149,16 @@ impl FilesystemDescriptorKey {
         &self.descriptor_id
     }
 
+    pub(crate) fn blob_ref_key(&self) -> FilesystemBlobRefKey {
+        FilesystemBlobRefKey(Self {
+            branch_id: self.branch_id.clone(),
+            global: self.global,
+            untracked: self.untracked,
+            file_id: Some(self.descriptor_id.clone()),
+            descriptor_id: self.descriptor_id.clone(),
+        })
+    }
+
     pub(crate) fn estimated_heap_bytes(&self) -> usize {
         self.branch_id.capacity()
             + self.file_id.as_ref().map_or(0, String::capacity)

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -608,7 +608,15 @@ where
         {
             return Ok(index);
         }
-        let index = build_path_index(self, request).await?;
+        let mut index = build_path_index(self, request).await?;
+        if request.cache_small_blob_data {
+            index = std::sync::Arc::new(
+                (*index)
+                    .clone()
+                    .hydrate_small_blob_data(&self.store)
+                    .await?,
+            );
+        }
         Ok(self
             .filesystem_path_index_cache
             .insert(request, revision.as_deref(), index))

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -704,8 +704,6 @@ where
                     Arc::new(self.live_state.reader(read_store.clone()));
                 let filesystem_path_index: Arc<dyn crate::filesystem::FilesystemPathIndexReader> =
                     Arc::new(self.live_state.reader(read_store.clone()));
-                let branch_ref: Arc<dyn BranchRefReader> =
-                    Arc::new(self.branch_ctx.ref_reader(read_store.clone()));
                 let blob_reader: Arc<dyn crate::binary_cas::BlobDataReader> =
                     Arc::new(self.binary_cas.reader(read_store));
                 // A raw file download delivers the same bytes as a direct
@@ -716,7 +714,6 @@ where
                     &active_branch_id,
                     live_state,
                     filesystem_path_index,
-                    branch_ref,
                     blob_reader,
                     self.plugin_host.clone(),
                     Some(file_view_collector.clone()),
@@ -1759,7 +1756,6 @@ where
                         &active_branch_id,
                         live_state,
                         filesystem_path_index,
-                        branch_ref,
                         blob_reader,
                         self.plugin_host.clone(),
                         file_view_collector.clone(),
@@ -1816,15 +1812,12 @@ where
         if let Some(data_column_index) = late_file_data_column {
             let filesystem_path_index: Arc<dyn crate::filesystem::FilesystemPathIndexReader> =
                 Arc::new(self.live_state.reader(read_store.clone()));
-            let branch_ref: Arc<dyn BranchRefReader> =
-                Arc::new(self.branch_ctx.ref_reader(read_store.clone()));
             let blob_reader: Arc<dyn crate::binary_cas::BlobDataReader> =
                 Arc::new(self.binary_cas.reader(read_store));
             hydrate_lix_file_data_result(
                 &active_branch_id,
                 Arc::clone(&live_state),
                 filesystem_path_index,
-                branch_ref,
                 blob_reader,
                 self.plugin_host.clone(),
                 file_view_collector.clone(),
@@ -1924,7 +1917,6 @@ async fn hydrate_lix_file_data_result(
     active_branch_id: &str,
     live_state: Arc<dyn crate::live_state::LiveStateReader>,
     filesystem_path_index: Arc<dyn crate::filesystem::FilesystemPathIndexReader>,
-    branch_ref: Arc<dyn BranchRefReader>,
     blob_reader: Arc<dyn crate::binary_cas::BlobDataReader>,
     plugin_host: crate::plugin::PluginRuntimeHost,
     session_file_views: Option<sql2::SessionFileViews>,
@@ -1949,7 +1941,6 @@ async fn hydrate_lix_file_data_result(
         active_branch_id,
         live_state,
         filesystem_path_index,
-        branch_ref,
         blob_reader,
         plugin_host,
         session_file_views,

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -704,6 +704,8 @@ where
                     Arc::new(self.live_state.reader(read_store.clone()));
                 let filesystem_path_index: Arc<dyn crate::filesystem::FilesystemPathIndexReader> =
                     Arc::new(self.live_state.reader(read_store.clone()));
+                let branch_ref: Arc<dyn BranchRefReader> =
+                    Arc::new(self.branch_ctx.ref_reader(read_store.clone()));
                 let blob_reader: Arc<dyn crate::binary_cas::BlobDataReader> =
                     Arc::new(self.binary_cas.reader(read_store));
                 // A raw file download delivers the same bytes as a direct
@@ -714,6 +716,7 @@ where
                     &active_branch_id,
                     live_state,
                     filesystem_path_index,
+                    branch_ref,
                     blob_reader,
                     self.plugin_host.clone(),
                     Some(file_view_collector.clone()),
@@ -1756,6 +1759,7 @@ where
                         &active_branch_id,
                         live_state,
                         filesystem_path_index,
+                        branch_ref,
                         blob_reader,
                         self.plugin_host.clone(),
                         file_view_collector.clone(),
@@ -1812,12 +1816,15 @@ where
         if let Some(data_column_index) = late_file_data_column {
             let filesystem_path_index: Arc<dyn crate::filesystem::FilesystemPathIndexReader> =
                 Arc::new(self.live_state.reader(read_store.clone()));
+            let branch_ref: Arc<dyn BranchRefReader> =
+                Arc::new(self.branch_ctx.ref_reader(read_store.clone()));
             let blob_reader: Arc<dyn crate::binary_cas::BlobDataReader> =
                 Arc::new(self.binary_cas.reader(read_store));
             hydrate_lix_file_data_result(
                 &active_branch_id,
                 Arc::clone(&live_state),
                 filesystem_path_index,
+                branch_ref,
                 blob_reader,
                 self.plugin_host.clone(),
                 file_view_collector.clone(),
@@ -1917,6 +1924,7 @@ async fn hydrate_lix_file_data_result(
     active_branch_id: &str,
     live_state: Arc<dyn crate::live_state::LiveStateReader>,
     filesystem_path_index: Arc<dyn crate::filesystem::FilesystemPathIndexReader>,
+    branch_ref: Arc<dyn BranchRefReader>,
     blob_reader: Arc<dyn crate::binary_cas::BlobDataReader>,
     plugin_host: crate::plugin::PluginRuntimeHost,
     session_file_views: Option<sql2::SessionFileViews>,
@@ -1941,6 +1949,7 @@ async fn hydrate_lix_file_data_result(
         active_branch_id,
         live_state,
         filesystem_path_index,
+        branch_ref,
         blob_reader,
         plugin_host,
         session_file_views,

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -4137,6 +4137,7 @@ mod tests {
             .filter(|request| {
                 request.filter.schema_keys
                     == vec![
+                        "lix_binary_blob_ref".to_string(),
                         "lix_directory_descriptor".to_string(),
                         "lix_file_descriptor".to_string(),
                     ]
@@ -4163,8 +4164,8 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(
             blob_requests.len(),
-            2,
-            "the conflict probe and conflict apply each point-load the targeted blob without rescanning topology"
+            1,
+            "the path index carries the conflict probe blob; only conflict apply point-loads it"
         );
         for request in blob_requests {
             assert_eq!(
@@ -4708,10 +4709,10 @@ mod tests {
         assert_eq!(fast_path, WriteExecutorPath::Fast);
         assert_eq!(datafusion_path, WriteExecutorPath::DataFusion);
         assert_eq!(fast_result.rows, datafusion_result.rows);
-        // The indexed existing-path route performs one path-index load and one
-        // exact blob-ref load. The counting test reader models both as scans.
+        // Both routes now receive the correlated blob ref from the path index;
+        // neither repeats the exact live-state load.
         assert_eq!(fast_scans.load(Ordering::SeqCst), 2);
-        assert_eq!(datafusion_scans.load(Ordering::SeqCst), 3);
+        assert_eq!(datafusion_scans.load(Ordering::SeqCst), 2);
 
         let fast_rows = fast_staged.lock().expect("fast writes lock").deltas[0]
             .pending_write_overlay()

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -275,9 +275,10 @@ impl LixFileSpec {
         }
         let index = self
             .filesystem_path_index
-            .path_index(&FilesystemPathIndexRequest::new(
-                request.filter.branch_ids.clone(),
-            ))
+            .path_index(
+                &FilesystemPathIndexRequest::new(request.filter.branch_ids.clone())
+                    .with_blob_refs(true),
+            )
             .await
             .map_err(lix_error_to_datafusion_error)?;
         Ok(Some(match target_file_ids {
@@ -438,13 +439,7 @@ impl LixFileSpec {
                             scan_exact_file_blob_rows(live_state.clone(), &request, file_ids).await
                         }
                         FileIdConstraint::All | FileIdConstraint::None => {
-                            scan_indexed_file_rows(
-                                live_state.clone(),
-                                &request,
-                                indexed_matches,
-                                true,
-                            )
-                            .await
+                            scan_indexed_file_rows(indexed_matches, true)
                         }
                     }
                     .map_err(lix_error_to_datafusion_error)?;
@@ -567,9 +562,11 @@ pub(crate) async fn execute_exact_lix_file_read(
     .await?;
 
     let index = filesystem_path_index
-        .path_index(&FilesystemPathIndexRequest::new(
-            request.filter.branch_ids.clone(),
-        ))
+        .path_index(
+            &FilesystemPathIndexRequest::new(request.filter.branch_ids.clone())
+                .with_blob_refs(true)
+                .with_cached_blob_data(column == ExactLixFileReadColumn::Data),
+        )
         .await?;
     let matches = match selector {
         ExactLixFileReadSelector::Id(file_id) => indexed_file_id_matches(
@@ -585,7 +582,7 @@ pub(crate) async fn execute_exact_lix_file_read(
             },
         ),
     };
-    let rows = scan_indexed_file_rows(Arc::clone(&live_state), &request, &matches, true).await?;
+    let rows = scan_indexed_file_rows(&matches, true)?;
     let mut prepared = prepare_indexed_lix_file_rows(&matches, rows)?;
     let load_data = column == ExactLixFileReadColumn::Data;
     let acknowledge_plugin_data = load_data && session_file_views.is_some();
@@ -635,7 +632,6 @@ pub(crate) async fn execute_exact_lix_file_batch_read(
     active_branch_id: &str,
     live_state: Arc<dyn LiveStateReader>,
     filesystem_path_index: Arc<dyn FilesystemPathIndexReader>,
-    branch_ref: Arc<dyn BranchRefReader>,
     blob_reader: Arc<dyn BlobDataReader>,
     plugin_host: PluginRuntimeHost,
     session_file_views: Option<SessionFileViews>,
@@ -653,22 +649,16 @@ pub(crate) async fn execute_exact_lix_file_batch_read(
             .expect("lix_file schema should have data")
             .clone(),
     ]));
-    let mut request = lix_file_scan_request(Some(active_branch_id), Some(schema.as_ref()), None);
-    let branch_binding = BranchBinding::active(active_branch_id);
-    request.filter.branch_ids = resolve_provider_branch_ids(
-        branch_ref.as_ref(),
-        &branch_binding,
-        request.filter.branch_ids,
-    )
-    .await?;
+    let request = lix_file_scan_request(Some(active_branch_id), Some(schema.as_ref()), None);
 
     let index = filesystem_path_index
-        .path_index(&FilesystemPathIndexRequest::new(
-            request.filter.branch_ids.clone(),
-        ))
+        .path_index(
+            &FilesystemPathIndexRequest::new(request.filter.branch_ids.clone())
+                .with_cached_blob_data(true),
+        )
         .await?;
     let matches = indexed_file_matches(index, &FilePathPredicate::In(paths.clone()));
-    let rows = scan_indexed_file_rows(Arc::clone(&live_state), &request, &matches, true).await?;
+    let rows = scan_indexed_file_rows(&matches, true)?;
     let mut prepared = prepare_indexed_lix_file_rows(&matches, rows)?;
     let acknowledge_plugin_data = session_file_views.is_some();
     let plugin_render = if prepared.needs_plugin_render(true) || acknowledge_plugin_data {
@@ -808,9 +798,11 @@ impl TableSpec for LixFileSpec {
         } else {
             let index = self
                 .filesystem_path_index
-                .path_index(&FilesystemPathIndexRequest::new(
-                    request.filter.branch_ids.clone(),
-                ))
+                .path_index(
+                    &FilesystemPathIndexRequest::new(request.filter.branch_ids.clone())
+                        .with_blob_refs(needs_blob_rows)
+                        .with_cached_blob_data(needs_data),
+                )
                 .await
                 .map_err(lix_error_to_datafusion_error)?;
             let matches = if root_directory_filter {
@@ -935,18 +927,12 @@ impl TableSpec for LixFileSpec {
                         );
                     }
                     let mut prepared = if let Some(indexed_matches) = indexed_matches.as_ref() {
-                        let rows = scan_indexed_file_rows(
-                            Arc::clone(&live_state),
-                            &request,
-                            indexed_matches,
-                            needs_blob_rows,
-                        )
-                        .await
-                        .map_err(|error| {
-                            DataFusionError::Execution(format!(
-                                "sql2 indexed lix_file scan failed: {error}"
-                            ))
-                        })?;
+                        let rows = scan_indexed_file_rows(indexed_matches, needs_blob_rows)
+                            .map_err(|error| {
+                                DataFusionError::Execution(format!(
+                                    "sql2 indexed lix_file scan failed: {error}"
+                                ))
+                            })?;
                         prepare_indexed_lix_file_rows(indexed_matches, rows)
                     } else {
                         let rows = scan_lix_file_live_rows(
@@ -1459,9 +1445,10 @@ impl UpsertSupport for LixFileSpec {
         let indexed_matches = if target.kind() == UpsertConflictKind::Path {
             let index = self
                 .filesystem_path_index
-                .path_index(&FilesystemPathIndexRequest::new(
-                    request.filter.branch_ids.clone(),
-                ))
+                .path_index(
+                    &FilesystemPathIndexRequest::new(request.filter.branch_ids.clone())
+                        .with_blob_refs(true),
+                )
                 .await
                 .map_err(lix_error_to_datafusion_error)?;
             Some(indexed_file_matches(index, &path_predicate))
@@ -1481,8 +1468,7 @@ impl UpsertSupport for LixFileSpec {
                     scan_exact_file_blob_rows(live_state.clone(), &request, file_ids).await
                 }
                 FileIdConstraint::All | FileIdConstraint::None => {
-                    scan_indexed_file_rows(live_state.clone(), &request, indexed_matches, true)
-                        .await
+                    scan_indexed_file_rows(indexed_matches, true)
                 }
             }
             .map_err(lix_error_to_datafusion_error)?;
@@ -1991,6 +1977,7 @@ impl PluginRenderContext {
 #[derive(Debug, Clone)]
 struct BlobRefRecord {
     blob_hash: String,
+    inline_data: Option<Vec<u8>>,
     live: MaterializedLiveStateRow,
 }
 
@@ -2045,6 +2032,32 @@ struct FileDescriptorSnapshot {
 struct BlobRefSnapshot {
     id: String,
     blob_hash: String,
+}
+
+fn blob_ref_record_from_live_row(
+    row: MaterializedLiveStateRow,
+) -> Result<Option<(FilesystemBlobRefKey, BlobRefRecord)>, LixError> {
+    if row.schema_key != BLOB_REF_SCHEMA_KEY {
+        return Ok(None);
+    }
+    let Some(snapshot_content) = row.snapshot_content.as_deref() else {
+        return Ok(None);
+    };
+    let snapshot: BlobRefSnapshot = serde_json::from_str(snapshot_content).map_err(|error| {
+        LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            format!("invalid lix_binary_blob_ref snapshot JSON: {error}"),
+        )
+    })?;
+    let key = FilesystemBlobRefKey::from_live_row(&row, snapshot.id);
+    Ok(Some((
+        key,
+        BlobRefRecord {
+            blob_hash: snapshot.blob_hash,
+            inline_data: None,
+            live: row,
+        },
+    )))
 }
 
 #[derive(Debug, Deserialize)]
@@ -4023,23 +4036,9 @@ fn prepare_lix_file_rows(
                 );
             }
             BLOB_REF_SCHEMA_KEY => {
-                let Some(snapshot_content) = row.snapshot_content.as_deref() else {
-                    continue;
-                };
-                let snapshot: BlobRefSnapshot =
-                    serde_json::from_str(snapshot_content).map_err(|error| {
-                        LixError::new(
-                            "LIX_ERROR_UNKNOWN",
-                            format!("invalid lix_binary_blob_ref snapshot JSON: {error}"),
-                        )
-                    })?;
-                blob_rows.insert(
-                    FilesystemBlobRefKey::from_live_row(&row, snapshot.id),
-                    BlobRefRecord {
-                        blob_hash: snapshot.blob_hash,
-                        live: row,
-                    },
-                );
+                if let Some((key, record)) = blob_ref_record_from_live_row(row)? {
+                    blob_rows.insert(key, record);
+                }
             }
             DERIVED_FILE_REF_SCHEMA_KEY => {
                 if let Some((key, record)) = derived_file_ref_record_from_live_row(row)? {
@@ -4115,6 +4114,7 @@ fn prepare_indexed_lix_file_rows(
     rows: Vec<MaterializedLiveStateRow>,
 ) -> Result<PreparedLixFileRows, LixError> {
     let mut file_rows = BTreeMap::<FilesystemDescriptorKey, FileDescriptorRecord>::new();
+    let mut blob_rows = BTreeMap::<FilesystemBlobRefKey, BlobRefRecord>::new();
     let mut file_paths = BTreeMap::<FilesystemDescriptorKey, String>::new();
     let mut path_ordered_file_keys = Vec::with_capacity(matches.len());
     for entry in matches.entries() {
@@ -4134,30 +4134,21 @@ fn prepare_indexed_lix_file_rows(
                 live: entry.live_row(),
             },
         );
+        if let Some(blob_ref) = entry.blob_ref_live_row()
+            && let Some((blob_key, mut record)) = blob_ref_record_from_live_row(blob_ref.clone())?
+        {
+            record.inline_data = entry.cached_blob_data().map(|data| data.as_ref().to_vec());
+            blob_rows.insert(blob_key, record);
+        }
     }
 
-    let mut blob_rows = BTreeMap::<FilesystemBlobRefKey, BlobRefRecord>::new();
     let mut derived_rows = BTreeMap::<FilesystemBlobRefKey, DerivedFileRefRecord>::new();
     for row in rows {
-        let Some(snapshot_content) = row.snapshot_content.as_deref() else {
-            continue;
-        };
         match row.schema_key.as_str() {
             BLOB_REF_SCHEMA_KEY => {
-                let snapshot: BlobRefSnapshot =
-                    serde_json::from_str(snapshot_content).map_err(|error| {
-                        LixError::new(
-                            "LIX_ERROR_UNKNOWN",
-                            format!("invalid lix_binary_blob_ref snapshot JSON: {error}"),
-                        )
-                    })?;
-                blob_rows.insert(
-                    FilesystemBlobRefKey::from_live_row(&row, snapshot.id),
-                    BlobRefRecord {
-                        blob_hash: snapshot.blob_hash,
-                        live: row,
-                    },
-                );
+                if let Some((key, record)) = blob_ref_record_from_live_row(row)? {
+                    blob_rows.entry(key).or_insert(record);
+                }
             }
             DERIVED_FILE_REF_SCHEMA_KEY => {
                 if let Some((key, record)) = derived_file_ref_record_from_live_row(row)? {
@@ -4642,34 +4633,39 @@ async fn load_blob_bytes_for_files(
     }
     let mut keys = Vec::new();
     let mut hashes = Vec::new();
+    let mut bytes_by_key = BTreeMap::new();
     let mut remaining_by_key = BTreeMap::<FilesystemBlobRefKey, usize>::new();
     for file in file_rows.values() {
         let key = file.blob_ref_key();
         if let Some(row) = blob_rows.get(&key) {
             let remaining = remaining_by_key.entry(key.clone()).or_insert(0);
             if *remaining == 0 {
-                keys.push(key);
-                hashes.push(BlobHash::from_hex(&row.blob_hash)?);
+                if let Some(data) = &row.inline_data {
+                    bytes_by_key.insert(key.clone(), Some(data.clone()));
+                } else {
+                    keys.push(key);
+                    hashes.push(BlobHash::from_hex(&row.blob_hash)?);
+                }
             }
             *remaining += 1;
         }
     }
-    if keys.is_empty() {
-        return Ok(LoadedBlobBytes::default());
-    }
-    let values = blob_reader.load_bytes_many(&hashes).await?.into_vec();
-    if values.len() != keys.len() {
-        return Err(LixError::new(
-            "LIX_ERROR_UNKNOWN",
-            format!(
-                "blob reader returned {} values for {} requested hashes",
-                values.len(),
-                keys.len()
-            ),
-        ));
+    if !keys.is_empty() {
+        let values = blob_reader.load_bytes_many(&hashes).await?.into_vec();
+        if values.len() != keys.len() {
+            return Err(LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                format!(
+                    "blob reader returned {} values for {} requested hashes",
+                    values.len(),
+                    keys.len()
+                ),
+            ));
+        }
+        bytes_by_key.extend(keys.into_iter().zip(values));
     }
     Ok(LoadedBlobBytes {
-        bytes_by_key: keys.into_iter().zip(values).collect(),
+        bytes_by_key,
         remaining_by_key,
     })
 }
@@ -5438,24 +5434,19 @@ async fn scan_lix_file_live_rows(
     Ok(rows)
 }
 
-async fn scan_indexed_file_rows(
-    live_state: Arc<dyn LiveStateReader>,
-    request: &LiveStateScanRequest,
+fn scan_indexed_file_rows(
     matches: &FilesystemPathSelection,
     needs_blob_rows: bool,
 ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
     if matches.is_empty() || !needs_blob_rows {
         return Ok(Vec::new());
     }
-    let file_ids = matches
+    Ok(matches
         .entries()
         .filter(|entry| entry.kind == FilesystemPathKind::File)
-        .map(|entry| entry.id().to_string())
-        .collect::<BTreeSet<_>>();
-    if file_ids.is_empty() {
-        return Ok(Vec::new());
-    }
-    scan_exact_file_blob_rows(live_state, request, &file_ids).await
+        .filter_map(FilesystemPathEntry::blob_ref_live_row)
+        .cloned()
+        .collect())
 }
 
 /// The derived proof is private plugin state, not part of the hot filesystem
@@ -7391,29 +7382,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn file_id_data_scan_uses_indexed_descriptor_and_only_scans_blob_rows() {
+    async fn file_id_data_scan_uses_indexed_descriptor_and_blob_rows() {
         let data = b"readme contents".to_vec();
-        let blob_hash = BlobHash::from_content(&data).to_hex();
         let live_state_requests = Arc::new(Mutex::new(Vec::new()));
         let path_index_requests = Arc::new(AtomicUsize::new(0));
         let index = Arc::new(
-            FilesystemPathIndex::from_live_rows(vec![live_file_row(
-                "file-readme",
-                "branch-b",
-                r#"{"id":"file-readme","directory_id":null,"name":"readme.md"}"#,
-            )])
+            FilesystemPathIndex::from_live_rows(vec![
+                live_file_row(
+                    "file-readme",
+                    "branch-b",
+                    r#"{"id":"file-readme","directory_id":null,"name":"readme.md"}"#,
+                ),
+                live_blob_ref_row(
+                    "file-readme",
+                    "branch-b",
+                    "file-readme",
+                    &BlobHash::from_content(&data).to_hex(),
+                    data.len(),
+                ),
+            ])
             .expect("filesystem path index should build"),
         );
         let spec = LixFileSpec::active_branch(
             "branch-b",
             Arc::new(RecordingLiveStateReader {
-                rows: vec![live_blob_ref_row(
-                    "file-readme",
-                    "branch-b",
-                    "file-readme",
-                    &blob_hash,
-                    data.len(),
-                )],
+                rows: Vec::new(),
                 scan_requests: Arc::clone(&live_state_requests),
             }),
             Arc::new(StaticFilesystemPathIndexReader {
@@ -7446,11 +7439,7 @@ mod tests {
         let requests = live_state_requests
             .lock()
             .expect("live-state request mutex should not be poisoned");
-        assert_eq!(requests.len(), 1);
-        assert_eq!(
-            requests[0].filter.schema_keys,
-            vec![super::BLOB_REF_SCHEMA_KEY.to_string()]
-        );
+        assert!(requests.is_empty());
     }
 
     #[tokio::test]
@@ -7464,6 +7453,14 @@ mod tests {
         let outside_blob_hash = BlobHash::from_content(&outside_data).to_hex();
         let selected_change_id = ChangeId::for_test_label("selected-search-blob");
         let live_state_requests = Arc::new(Mutex::new(Vec::new()));
+        let mut selected_blob = live_blob_ref_row(
+            "file-selected",
+            "branch-b",
+            "file-selected",
+            &selected_blob_hash,
+            selected_data.len(),
+        );
+        selected_blob.change_id = Some(selected_change_id);
         let index = Arc::new(
             FilesystemPathIndex::from_live_rows(vec![
                 live_directory_row(
@@ -7491,6 +7488,7 @@ mod tests {
                     "branch-b",
                     r#"{"id":"file-outside","directory_id":"dir-other","name":"README.md"}"#,
                 ),
+                selected_blob.clone(),
             ])
             .expect("filesystem path index should build"),
         );
@@ -7520,15 +7518,7 @@ mod tests {
             "the range and contains predicates should exclude both the local non-match and outside root",
         );
 
-        let mut selected_blob = live_blob_ref_row(
-            "file-selected",
-            "branch-b",
-            "file-selected",
-            &selected_blob_hash,
-            selected_data.len(),
-        );
-        selected_blob.change_id = Some(selected_change_id);
-        let live_state: Arc<dyn LiveStateReader> = Arc::new(RecordingLiveStateReader {
+        let _live_state: Arc<dyn LiveStateReader> = Arc::new(RecordingLiveStateReader {
             rows: vec![
                 selected_blob,
                 live_blob_ref_row(
@@ -7564,10 +7554,10 @@ mod tests {
         ];
         let projected_schema = super::projected_schema(&base_schema, Some(&find_files_projection))
             .expect("findFiles projection should be valid");
-        let request = super::lix_file_scan_request(Some("branch-b"), Some(&projected_schema), None);
-        let rows = super::scan_indexed_file_rows(Arc::clone(&live_state), &request, &matches, true)
-            .await
-            .expect("matching blob rows should load");
+        let _request =
+            super::lix_file_scan_request(Some("branch-b"), Some(&projected_schema), None);
+        let rows =
+            super::scan_indexed_file_rows(&matches, true).expect("matching blob rows should load");
         let prepared = super::prepare_indexed_lix_file_rows(&matches, rows)
             .expect("indexed rows should prepare");
         let blob_reader: Arc<dyn BlobDataReader> =
@@ -7605,23 +7595,11 @@ mod tests {
         let requests = live_state_requests
             .lock()
             .expect("live-state request mutex should not be poisoned");
-        assert_eq!(requests.len(), 1);
-        assert_eq!(
-            requests[0].filter.schema_keys,
-            vec![super::BLOB_REF_SCHEMA_KEY.to_string()]
-        );
-        assert_eq!(
-            requests[0].filter.entity_pks,
-            vec![crate::entity_pk::EntityPk::single("file-selected")]
-        );
-        assert_eq!(
-            requests[0].filter.file_ids,
-            vec![NullableKeyFilter::Value("file-selected".to_string())]
-        );
+        assert!(requests.is_empty());
     }
 
     #[tokio::test]
-    async fn file_directory_id_scan_uses_indexed_descriptors_and_only_scans_blob_rows() {
+    async fn file_directory_id_scan_uses_indexed_descriptors_and_blob_rows() {
         let data = b"docs contents".to_vec();
         let blob_hash = BlobHash::from_content(&data).to_hex();
         let other_data = b"other contents".to_vec();
@@ -7650,22 +7628,21 @@ mod tests {
                     "branch-b",
                     r#"{"id":"file-root","directory_id":null,"name":"root.md"}"#,
                 ),
+                live_blob_ref_row("file-docs", "branch-b", "file-docs", &blob_hash, data.len()),
+                live_blob_ref_row(
+                    "file-other-doc",
+                    "branch-b",
+                    "file-other-doc",
+                    &other_blob_hash,
+                    other_data.len(),
+                ),
             ])
             .expect("filesystem path index should build"),
         );
         let spec = LixFileSpec::active_branch(
             "branch-b",
             Arc::new(RecordingLiveStateReader {
-                rows: vec![
-                    live_blob_ref_row("file-docs", "branch-b", "file-docs", &blob_hash, data.len()),
-                    live_blob_ref_row(
-                        "file-other-doc",
-                        "branch-b",
-                        "file-other-doc",
-                        &other_blob_hash,
-                        other_data.len(),
-                    ),
-                ],
+                rows: Vec::new(),
                 scan_requests: Arc::clone(&live_state_requests),
             }),
             Arc::new(StaticFilesystemPathIndexReader {
@@ -7714,25 +7691,7 @@ mod tests {
         let requests = live_state_requests
             .lock()
             .expect("live-state request mutex should not be poisoned");
-        assert_eq!(requests.len(), 1);
-        assert_eq!(
-            requests[0].filter.schema_keys,
-            vec![super::BLOB_REF_SCHEMA_KEY.to_string()]
-        );
-        assert_eq!(
-            requests[0].filter.entity_pks,
-            vec![
-                crate::entity_pk::EntityPk::single("file-docs"),
-                crate::entity_pk::EntityPk::single("file-other-doc"),
-            ]
-        );
-        assert_eq!(
-            requests[0].filter.file_ids,
-            vec![
-                NullableKeyFilter::Value("file-docs".to_string()),
-                NullableKeyFilter::Value("file-other-doc".to_string()),
-            ]
-        );
+        assert!(requests.is_empty());
     }
 
     #[tokio::test]
@@ -7792,13 +7751,6 @@ mod tests {
                 ),
             )
         }));
-        let index = Arc::new(
-            FilesystemPathIndex::from_live_rows(index_rows)
-                .expect("filesystem path index should build"),
-        );
-        let matches =
-            super::indexed_file_matches(Arc::clone(&index), &super::FilePathPredicate::All);
-
         let mut tracked_blob = live_blob_ref_row(
             "file-tracked",
             "branch-b",
@@ -7809,7 +7761,8 @@ mod tests {
         tracked_blob.change_id = Some(ChangeId::for_test_label("tracked-blob"));
         let mut global_blob = live_blob_ref_row(
             "file-global",
-            crate::GLOBAL_BRANCH_ID,
+            // Path-index rows are already projected into the requested branch.
+            "branch-b",
             "file-global",
             &BlobHash::from_content(&global_data).to_hex(),
             global_data.len(),
@@ -7835,9 +7788,21 @@ mod tests {
             misplaced_data.len(),
         );
         misplaced_blob.change_id = Some(ChangeId::for_test_label("misplaced-blob"));
+        index_rows.extend([
+            tracked_blob.clone(),
+            global_blob.clone(),
+            untracked_blob.clone(),
+            misplaced_blob.clone(),
+        ]);
+        let index = Arc::new(
+            FilesystemPathIndex::from_live_rows(index_rows)
+                .expect("filesystem path index should build"),
+        );
+        let matches =
+            super::indexed_file_matches(Arc::clone(&index), &super::FilePathPredicate::All);
         let live_state_requests = Arc::new(Mutex::new(Vec::new()));
-        let live_state: Arc<dyn LiveStateReader> = Arc::new(RecordingLiveStateReader {
-            rows: vec![tracked_blob, global_blob, untracked_blob, misplaced_blob],
+        let _live_state: Arc<dyn LiveStateReader> = Arc::new(RecordingLiveStateReader {
+            rows: Vec::new(),
             scan_requests: Arc::clone(&live_state_requests),
         });
         let base_schema = super::lix_file_schema();
@@ -7849,10 +7814,10 @@ mod tests {
         ];
         let projected_schema = super::projected_schema(&base_schema, Some(&projection))
             .expect("projection should be valid");
-        let request = super::lix_file_scan_request(Some("branch-b"), Some(&projected_schema), None);
-        let rows = super::scan_indexed_file_rows(Arc::clone(&live_state), &request, &matches, true)
-            .await
-            .expect("matching blob rows should load");
+        let _request =
+            super::lix_file_scan_request(Some("branch-b"), Some(&projected_schema), None);
+        let rows =
+            super::scan_indexed_file_rows(&matches, true).expect("matching blob rows should load");
         let prepared = super::prepare_indexed_lix_file_rows(&matches, rows)
             .expect("indexed rows should prepare");
         let blob_reader: Arc<dyn BlobDataReader> =
@@ -7913,37 +7878,11 @@ mod tests {
         let requests = live_state_requests
             .lock()
             .expect("live-state request mutex should not be poisoned");
-        assert_eq!(requests.len(), 1);
-        assert_eq!(requests[0].filter.entity_pks.len(), 33);
-        assert!(
-            requests[0]
-                .filter
-                .entity_pks
-                .contains(&crate::entity_pk::EntityPk::single("file-global"))
-        );
-        assert!(
-            requests[0]
-                .filter
-                .entity_pks
-                .contains(&crate::entity_pk::EntityPk::single("file-tracked"))
-        );
-        assert!(
-            requests[0]
-                .filter
-                .entity_pks
-                .contains(&crate::entity_pk::EntityPk::single("file-untracked"))
-        );
-        assert_eq!(requests[0].filter.file_ids.len(), 33);
-        assert!(
-            requests[0]
-                .filter
-                .file_ids
-                .contains(&NullableKeyFilter::Value("file-tracked".to_string()))
-        );
+        assert!(requests.is_empty());
     }
 
     #[tokio::test]
-    async fn file_root_directory_scan_uses_indexed_descriptors_and_only_scans_root_blob_rows() {
+    async fn file_root_directory_scan_uses_indexed_descriptors_and_root_blob_rows() {
         let root_data = b"root contents".to_vec();
         let root_blob_hash = BlobHash::from_content(&root_data).to_hex();
         let nested_data = b"nested contents".to_vec();
@@ -7967,28 +7906,27 @@ mod tests {
                     "branch-b",
                     r#"{"id":"file-root","directory_id":null,"name":"root.md"}"#,
                 ),
+                live_blob_ref_row(
+                    "file-root",
+                    "branch-b",
+                    "file-root",
+                    &root_blob_hash,
+                    root_data.len(),
+                ),
+                live_blob_ref_row(
+                    "file-nested",
+                    "branch-b",
+                    "file-nested",
+                    &nested_blob_hash,
+                    nested_data.len(),
+                ),
             ])
             .expect("filesystem path index should build"),
         );
         let spec = LixFileSpec::active_branch(
             "branch-b",
             Arc::new(RecordingLiveStateReader {
-                rows: vec![
-                    live_blob_ref_row(
-                        "file-root",
-                        "branch-b",
-                        "file-root",
-                        &root_blob_hash,
-                        root_data.len(),
-                    ),
-                    live_blob_ref_row(
-                        "file-nested",
-                        "branch-b",
-                        "file-nested",
-                        &nested_blob_hash,
-                        nested_data.len(),
-                    ),
-                ],
+                rows: Vec::new(),
                 scan_requests: Arc::clone(&live_state_requests),
             }),
             Arc::new(StaticFilesystemPathIndexReader {
@@ -8038,19 +7976,7 @@ mod tests {
         let requests = live_state_requests
             .lock()
             .expect("live-state request mutex should not be poisoned");
-        assert_eq!(requests.len(), 1);
-        assert_eq!(
-            requests[0].filter.schema_keys,
-            vec![super::BLOB_REF_SCHEMA_KEY.to_string()]
-        );
-        assert_eq!(
-            requests[0].filter.entity_pks,
-            vec![crate::entity_pk::EntityPk::single("file-root")]
-        );
-        assert_eq!(
-            requests[0].filter.file_ids,
-            vec![NullableKeyFilter::Value("file-root".to_string())]
-        );
+        assert!(requests.is_empty());
     }
 
     fn scalar_function_expr(name: &str, args: Vec<Expr>) -> Expr {

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -632,6 +632,7 @@ pub(crate) async fn execute_exact_lix_file_batch_read(
     active_branch_id: &str,
     live_state: Arc<dyn LiveStateReader>,
     filesystem_path_index: Arc<dyn FilesystemPathIndexReader>,
+    branch_ref: Arc<dyn BranchRefReader>,
     blob_reader: Arc<dyn BlobDataReader>,
     plugin_host: PluginRuntimeHost,
     session_file_views: Option<SessionFileViews>,
@@ -649,7 +650,14 @@ pub(crate) async fn execute_exact_lix_file_batch_read(
             .expect("lix_file schema should have data")
             .clone(),
     ]));
-    let request = lix_file_scan_request(Some(active_branch_id), Some(schema.as_ref()), None);
+    let mut request = lix_file_scan_request(Some(active_branch_id), Some(schema.as_ref()), None);
+    let branch_binding = BranchBinding::active(active_branch_id);
+    request.filter.branch_ids = resolve_provider_branch_ids(
+        branch_ref.as_ref(),
+        &branch_binding,
+        request.filter.branch_ids,
+    )
+    .await?;
 
     let index = filesystem_path_index
         .path_index(

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -105,7 +105,10 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     let filesystem_view_changed = prepared_writes.state_rows.iter().any(|row| {
         matches!(
             row.schema_key.as_str(),
-            "lix_file_descriptor" | "lix_directory_descriptor" | BRANCH_REF_SCHEMA_KEY
+            "lix_file_descriptor"
+                | "lix_directory_descriptor"
+                | "lix_binary_blob_ref"
+                | BRANCH_REF_SCHEMA_KEY
         )
     }) || prepared_writes
         .commit_change_refs_by_branch
@@ -114,7 +117,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         .any(|change_ref| {
             matches!(
                 change_ref.schema_key.as_str(),
-                "lix_file_descriptor" | "lix_directory_descriptor"
+                "lix_file_descriptor" | "lix_directory_descriptor" | "lix_binary_blob_ref"
             )
         });
     let mut state_rows = prepared_writes.state_rows;

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -639,26 +639,25 @@ where
                 .await;
             return Err(error);
         }
-        let filesystem_delta_rows = if prepared_writes
-            .state_rows
-            .iter()
-            .any(|row| row.schema_key == BRANCH_REF_SCHEMA_KEY)
-        {
-            Vec::new()
-        } else {
-            prepared_writes
-                .state_rows
-                .iter()
-                .filter(|row| {
-                    matches!(
-                        row.schema_key.as_str(),
-                        "lix_file_descriptor" | "lix_directory_descriptor" | BLOB_REF_SCHEMA_KEY
-                    )
-                })
-                .cloned()
-                .map(MaterializedLiveStateRow::from)
-                .collect::<Vec<_>>()
-        };
+        let filesystem_delta_rows =
+            if prepared_writes_require_filesystem_index_rebuild(&prepared_writes) {
+                Vec::new()
+            } else {
+                prepared_writes
+                    .state_rows
+                    .iter()
+                    .filter(|row| {
+                        matches!(
+                            row.schema_key.as_str(),
+                            "lix_file_descriptor"
+                                | "lix_directory_descriptor"
+                                | BLOB_REF_SCHEMA_KEY
+                        )
+                    })
+                    .cloned()
+                    .map(MaterializedLiveStateRow::from)
+                    .collect::<Vec<_>>()
+            };
         let previous_filesystem_revision = if filesystem_delta_rows.is_empty() {
             None
         } else {
@@ -4646,6 +4645,23 @@ fn prepared_writes_change_catalog(prepared_writes: &PreparedWriteSet) -> bool {
         .any(|change_ref| change_ref.schema_key == REGISTERED_SCHEMA_KEY)
 }
 
+fn prepared_writes_require_filesystem_index_rebuild(prepared_writes: &PreparedWriteSet) -> bool {
+    prepared_writes
+        .state_rows
+        .iter()
+        .any(|row| row.schema_key == BRANCH_REF_SCHEMA_KEY)
+        || prepared_writes
+            .commit_change_refs_by_branch
+            .values()
+            .flat_map(|change_refs| change_refs.selected_change_refs.iter())
+            .any(|change_ref| {
+                matches!(
+                    change_ref.schema_key.as_str(),
+                    "lix_file_descriptor" | "lix_directory_descriptor" | BLOB_REF_SCHEMA_KEY
+                )
+            })
+}
+
 pub(crate) struct OpenTransaction<StorageImpl: Storage = Memory> {
     pub(crate) transaction: Transaction<StorageImpl>,
     pub(crate) runtime_functions: FunctionContext,
@@ -6814,7 +6830,7 @@ mod tests {
     use crate::changelog::ChangelogReader;
     use crate::storage_adapter::{Memory, StorageReadOptions};
     use crate::tracked_state::{TrackedStateKey, TrackedStateScanRequest};
-    use crate::transaction::types::TransactionJson;
+    use crate::transaction::types::{StagedCommitChangeRefs, TransactionJson};
     use crate::wasm::WasmEntity;
 
     fn live_state_context() -> LiveStateContext {
@@ -6822,6 +6838,33 @@ mod tests {
     }
 
     const SCHEMA_FIXTURE_COMMIT_ID: &str = "01920000-0000-7000-8000-0000000000f1";
+
+    #[test]
+    fn selected_blob_ref_change_requires_filesystem_index_rebuild() {
+        let mut selected_changes = StagedCommitChangeRefs::default();
+        selected_changes.add_selected_change_ref(StagedCommitChangeRef {
+            schema_key: BLOB_REF_SCHEMA_KEY.to_string(),
+            file_id: Some("file-a".to_string()),
+            entity_pk: EntityPk::single("file-a"),
+            change_id: ChangeId::default(),
+            deleted: false,
+            created_at: LixTimestamp::from_unix_millis_utc_lossy(0),
+            updated_at: LixTimestamp::from_unix_millis_utc_lossy(0),
+        });
+        let prepared_writes = PreparedWriteSet {
+            state_rows: Vec::new(),
+            insert_identities: BTreeMap::new(),
+            commit_change_refs_by_branch: BTreeMap::from([("main".to_string(), selected_changes)]),
+            first_commit_parent_override_by_branch: BTreeMap::new(),
+            checkpoint_publications: Vec::new(),
+            extra_commit_parents_by_branch: BTreeMap::new(),
+            file_data_writes: Vec::new(),
+        };
+
+        assert!(prepared_writes_require_filesystem_index_rebuild(
+            &prepared_writes
+        ));
+    }
 
     #[test]
     fn visible_materialization_requires_a_matching_blob_ref_identity() {

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -652,7 +652,7 @@ where
                 .filter(|row| {
                     matches!(
                         row.schema_key.as_str(),
-                        "lix_file_descriptor" | "lix_directory_descriptor"
+                        "lix_file_descriptor" | "lix_directory_descriptor" | BLOB_REF_SCHEMA_KEY
                     )
                 })
                 .cloned()
@@ -4805,7 +4805,10 @@ fn prepared_transaction_write_affects_filesystem_path_index(
     prepared_transaction_write_rows(write).iter().any(|row| {
         matches!(
             row.schema_key.as_str(),
-            "lix_file_descriptor" | "lix_directory_descriptor" | BRANCH_REF_SCHEMA_KEY
+            "lix_file_descriptor"
+                | "lix_directory_descriptor"
+                | BLOB_REF_SCHEMA_KEY
+                | BRANCH_REF_SCHEMA_KEY
         )
     })
 }

--- a/packages/engine/tests/integration/sql/lix_file.rs
+++ b/packages/engine/tests/integration/sql/lix_file.rs
@@ -99,6 +99,30 @@ simulation_test!(
 );
 
 simulation_test!(
+    lix_file_exact_data_batch_rejects_a_missing_pinned_branch,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let missing = sim.wrap_session(
+            engine
+                .open_session("missing-file-branch")
+                .await
+                .expect("a pinned session may open before its branch is resolved"),
+            &engine,
+        );
+
+        let error = missing
+            .execute(
+                "SELECT data FROM lix_file WHERE path IN ('/missing-a.txt', '/missing-b.txt')",
+                &[],
+            )
+            .await
+            .expect_err("the exact data batch must validate its pinned branch");
+
+        assert_eq!(error.code, LixError::CODE_BRANCH_NOT_FOUND);
+    }
+);
+
+simulation_test!(
     lix_file_lower_path_like_keeps_the_blob_revision_for_guarded_updates,
     |sim| async move {
         let engine = sim.boot_engine().await;


### PR DESCRIPTION
## Why

An exact file read already built the file path index, then paid two more point-lookups: one against live state for the correlated blob reference and one against CAS for the payload. This was especially expensive for SlateDB.

## What changed

- Allow data-bearing path indexes to retain the visible blob-reference row.
- Batch-load and verify CAS payloads up to 32 KiB while building an index requested with file data.
- Serve exact reads directly from those verified cached bytes.
- Keep descriptor-only indexes lean and let larger blobs fall through to the authoritative CAS read.
- Carry blob-reference rows through incremental cache advancement and invalidate cached bytes when the reference changes.
- Remove redundant active-branch revalidation after the session has already resolved it.
- Make the RocksDB benchmark disk snapshot tolerate compaction-time `NotFound` races.

This does not change the storage contract or on-disk format.

## Performance

Compared with latest `origin/main` (`18e10a7fe`), 100 files, 10 versions, 200 measured read pairs:

| backend | payload | main p50 | this PR p50 | change | Slate/Rocks |
|---|---:|---:|---:|---:|---:|
| RocksDB | 4 KiB | 112,449 ns | 56,030 ns | -50.2% | |
| SlateDB | 4 KiB | 181,069 ns | 55,240 ns | **-69.5%** | **0.986x** |
| RocksDB | 32 KiB | 132,310 ns | 56,741 ns | -57.1% | |
| SlateDB | 32 KiB | 207,819 ns | 56,840 ns | **-72.6%** | **1.002x** |
| RocksDB | 256 KiB | 350,699 ns | 318,598 ns | -9.2% | |
| SlateDB | 256 KiB | 258,099 ns | 158,049 ns | **-38.8%** | **0.496x** |

SlateDB is at parity with RocksDB for small exact reads and about 2x faster for 256 KiB reads.

Write controls showed no material SlateDB regression: accepted writes were +1.8% for singles and +0.2% for batches; flush completion was -0.2% and -4.1%; storage size was unchanged. RocksDB write timings improved by 3.5–12.2%.

Hot CRUD controls for `read_one`, `read_many`, `read_all`, `update_one`, and `update_all` stayed within run-to-run noise. Repeated diff controls were stable for both backends. Merge preview/commit remained within 8%; history append did not regress.

## Validation

- `cargo test -p lix_engine --lib` — 1368 passed, 6 ignored
- `cargo clippy -p lix_engine --all-targets -- -D warnings`
- `cargo clippy -p lix_engine_benchmarks --benches --features storage-benches,slatedb -- -D warnings`
- `cargo fmt --all`
- `git diff --check`
