### PR TITLE
perf: vectorize homogeneous bound updates

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write as _;
 
-use lix_engine::{Engine, ExecuteResult, SessionContext, Storage, Value};
+use lix_engine::{Engine, ExecuteBatchStatement, ExecuteResult, SessionContext, Storage, Value};
 
 use crate::storage::{ProfileStorage, RocksDB, SQLite, StorageProfile};
 use crate::workload::{WorkloadRow, sql_string};
@@ -42,7 +42,7 @@ pub(crate) struct GenericSqlFixture<StorageImpl: Storage> {
     select_one_by_pk_sql: String,
     update_one_by_pk_sql: String,
     update_all_sql_rows: Vec<String>,
-    bound_update_all_params: Vec<Vec<Value>>,
+    bound_update_all_batch: Vec<ExecuteBatchStatement>,
     delete_all_sql: String,
     delete_one_by_pk_sql: String,
     // Keep the storage path alive until after the session/storage is dropped.
@@ -275,23 +275,15 @@ where
 
     #[expect(clippy::cast_possible_truncation)]
     async fn update_all_bound(&self) -> usize {
-        let mut transaction = self
+        let results = self
             .session
-            .begin_transaction()
+            .execute_batch(&self.bound_update_all_batch)
             .await
-            .expect("begin tracked-state CRUD bound transaction");
-        let mut affected = 0;
-        for params in &self.bound_update_all_params {
-            affected += transaction
-                .execute(BOUND_UPDATE_ALL_SQL, params)
-                .await
-                .expect("execute tracked-state CRUD bound transaction SQL")
-                .rows_affected();
-        }
-        transaction
-            .commit()
-            .await
-            .expect("commit tracked-state CRUD bound transaction");
+            .expect("execute tracked-state CRUD bound update batch");
+        let affected = results
+            .iter()
+            .map(ExecuteResult::rows_affected)
+            .sum::<u64>();
         assert_eq!(affected as usize, self.row_count);
         affected as usize
     }
@@ -361,13 +353,14 @@ where
         select_one_by_pk_sql: select_by_pk_sql(&tracked_rows[mid..][..1]),
         update_one_by_pk_sql: update_row_sql(&tracked_rows[mid]),
         update_all_sql_rows: tracked_rows.iter().map(update_row_sql).collect(),
-        bound_update_all_params: tracked_rows
+        bound_update_all_batch: tracked_rows
             .iter()
-            .map(|row| {
-                vec![
+            .map(|row| ExecuteBatchStatement {
+                sql: BOUND_UPDATE_ALL_SQL.to_string(),
+                params: vec![
                     Value::Text(row.updated_value_json.clone()),
                     Value::Text(row.path.clone()),
-                ]
+                ],
             })
             .collect(),
         delete_all_sql: "DELETE FROM json_pointer".to_string(),

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -1348,6 +1348,21 @@ where
         self.with_write_transaction(move |transaction| {
             Box::pin(async move {
                 transaction.set_retain_plugin_actor_publications(retain_plugin_actor_publications);
+                if let Some(results) = try_execute_transaction_parameter_batch(
+                    transaction,
+                    &statements,
+                    &parsed,
+                    &options,
+                    &statement_metadata,
+                )
+                .await?
+                {
+                    if let Some(idempotency) = &idempotency {
+                        let receipt = ExecuteIdempotencyReceipt::batch(idempotency, &results)?;
+                        transaction.stage_execute_idempotency_receipt(idempotency, &receipt)?;
+                    }
+                    return Ok(results);
+                }
                 let mut results = Vec::with_capacity(statements.len());
                 for (statement_index, ((statement, parsed), metadata)) in statements
                     .iter()
@@ -2166,6 +2181,61 @@ where
         )
         .await
     }
+}
+
+async fn try_execute_transaction_parameter_batch<StorageImpl>(
+    transaction: &mut crate::transaction::Transaction<StorageImpl>,
+    statements: &[ExecuteBatchStatement],
+    parsed: &[DataFusionStatement],
+    options: &ExecuteOptions,
+    statement_metadata: &[ExecuteStatementMetadata],
+) -> Result<Option<Vec<ExecuteResult>>, LixError>
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let Some(first_statement) = statements.first() else {
+        return Ok(None);
+    };
+    if statements.len() < 2
+        || parsed.len() != statements.len()
+        || statement_metadata.len() != statements.len()
+        || statements
+            .iter()
+            .any(|statement| statement.sql != first_statement.sql)
+        || statement_metadata
+            .iter()
+            .any(|metadata| metadata != &ExecuteStatementMetadata::default())
+        || sql2::bind_statement_route(&parsed[0])? != sql2::BoundStatementRoute::Write
+    {
+        return Ok(None);
+    }
+
+    let parameter_rows = statements
+        .iter()
+        .map(|statement| statement.params.as_slice())
+        .collect::<Vec<_>>();
+    let Some(parameter_batch) = sql2::parameter_record_batch(&parameter_rows)? else {
+        return Ok(None);
+    };
+
+    let previous_origin_key = transaction.replace_origin_key(options.origin_key.clone());
+    let execution = async {
+        let plan = transaction.prepare_sql_write_logical_plan(&first_statement.sql, &parsed[0])?;
+        sql2::execute_write_logical_plan_parameter_batch(transaction, plan, &parameter_batch).await
+    }
+    .await;
+    transaction.replace_origin_key(previous_origin_key);
+
+    execution
+        .map(|results| {
+            results.map(|results| {
+                results
+                    .into_iter()
+                    .map(ExecuteResult::from_sql_write_result)
+                    .collect()
+            })
+        })
+        .map_err(|error| normalize_sql_surface_error(error, &first_statement.sql))
 }
 
 async fn execute_transaction_write_auto<StorageImpl>(
@@ -3367,6 +3437,264 @@ mod tests {
 
         assert_eq!(results[0].rows()[0].get::<i64>("value").unwrap(), 11);
         assert_eq!(results[1].rows()[0].get::<i64>("value").unwrap(), 22);
+    }
+
+    #[tokio::test]
+    async fn execute_batch_lowers_distinct_bound_entity_updates_once() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "x-lix-key": "parameter_batch_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": { "type": "string" }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+        session
+            .execute(
+                "INSERT INTO parameter_batch_probe (id, value) VALUES \
+                 ('a', 'old-a'), ('b', 'old-b')",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sql2::take_entity_update_parameter_batch_executions();
+        let sql = "UPDATE parameter_batch_probe SET value = $1 WHERE id = $2";
+        let results = session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("new-a".to_string()),
+                        Value::Text("a".to_string()),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("new-b".to_string()),
+                        Value::Text("b".to_string()),
+                    ],
+                },
+            ])
+            .await
+            .unwrap();
+
+        assert_eq!(sql2::take_entity_update_parameter_batch_executions(), 1);
+        assert_eq!(
+            results
+                .iter()
+                .map(ExecuteResult::rows_affected)
+                .collect::<Vec<_>>(),
+            vec![1, 1]
+        );
+        let rows = session
+            .execute(
+                "SELECT id, value FROM parameter_batch_probe ORDER BY id",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(rows.rows()[0].get::<String>("value").unwrap(), "new-a");
+        assert_eq!(rows.rows()[1].get::<String>("value").unwrap(), "new-b");
+    }
+
+    #[tokio::test]
+    async fn execute_batch_keeps_repeated_entity_identity_sequential() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "x-lix-key": "parameter_batch_repeat_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": { "type": "string" }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+        session
+            .execute(
+                "INSERT INTO parameter_batch_repeat_probe (id, value) VALUES ('a', 'old')",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sql2::take_entity_update_parameter_batch_executions();
+        let sql = "UPDATE parameter_batch_repeat_probe SET value = $1 WHERE id = $2";
+        session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("first".to_string()),
+                        Value::Text("a".to_string()),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("second".to_string()),
+                        Value::Text("a".to_string()),
+                    ],
+                },
+            ])
+            .await
+            .unwrap();
+
+        assert_eq!(sql2::take_entity_update_parameter_batch_executions(), 0);
+        let row = session
+            .execute(
+                "SELECT value FROM parameter_batch_repeat_probe WHERE id = 'a'",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(row.rows()[0].get::<String>("value").unwrap(), "second");
+    }
+
+    #[tokio::test]
+    async fn execute_batch_keeps_inter_row_constraints_on_sequential_execution() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "x-lix-key": "parameter_batch_constraint_probe",
+            "x-lix-primary-key": ["/id"],
+            "x-lix-unique": [["/value"]],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": { "type": "string" }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+        session
+            .execute(
+                "INSERT INTO parameter_batch_constraint_probe (id, value) VALUES \
+                 ('a', 'old-a'), ('b', 'old-b')",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sql2::take_entity_update_parameter_batch_executions();
+        let sql = "UPDATE parameter_batch_constraint_probe SET value = $1 WHERE id = $2";
+        session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("new-a".to_string()),
+                        Value::Text("a".to_string()),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("new-b".to_string()),
+                        Value::Text("b".to_string()),
+                    ],
+                },
+            ])
+            .await
+            .unwrap();
+
+        assert_eq!(sql2::take_entity_update_parameter_batch_executions(), 0);
+    }
+
+    #[tokio::test]
+    async fn execute_batch_parameter_batch_preserves_failing_statement_index() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "x-lix-key": "parameter_batch_error_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": { "type": "string" }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+        session
+            .execute(
+                "INSERT INTO parameter_batch_error_probe (id, value) VALUES \
+                 ('a', 'old-a'), ('b', 'old-b')",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sql2::take_entity_update_parameter_batch_executions();
+        let sql = "UPDATE parameter_batch_error_probe SET value = lix_json($1) WHERE id = $2";
+        let error = session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("\"new-a\"".to_string()),
+                        Value::Text("a".to_string()),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("not-json".to_string()),
+                        Value::Text("b".to_string()),
+                    ],
+                },
+            ])
+            .await
+            .expect_err("the second statement has invalid JSON");
+
+        assert_eq!(error.details.unwrap()["statementIndex"], 1);
+        assert_eq!(sql2::take_entity_update_parameter_batch_executions(), 0);
+        let rows = session
+            .execute(
+                "SELECT id, value FROM parameter_batch_error_probe ORDER BY id",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(rows.rows()[0].get::<String>("value").unwrap(), "old-a");
+        assert_eq!(rows.rows()[1].get::<String>("value").unwrap(), "old-b");
     }
 
     #[tokio::test]

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -1354,6 +1354,7 @@ where
                     &parsed,
                     &options,
                     &statement_metadata,
+                    telemetry_sink.as_ref(),
                 )
                 .await?
                 {
@@ -2189,6 +2190,7 @@ async fn try_execute_transaction_parameter_batch<StorageImpl>(
     parsed: &[DataFusionStatement],
     options: &ExecuteOptions,
     statement_metadata: &[ExecuteStatementMetadata],
+    telemetry_sink: Option<&Arc<dyn crate::telemetry::TelemetrySink>>,
 ) -> Result<Option<Vec<ExecuteResult>>, LixError>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
@@ -2226,7 +2228,7 @@ where
     .await;
     transaction.replace_origin_key(previous_origin_key);
 
-    execution
+    let result = execution
         .map(|results| {
             results.map(|results| {
                 results
@@ -2235,7 +2237,65 @@ where
                     .collect()
             })
         })
-        .map_err(|error| normalize_sql_surface_error(error, &first_statement.sql))
+        .map_err(|error| {
+            let error = normalize_sql_surface_error(error, &first_statement.sql);
+            if batch_statement_index(&error).is_some() {
+                error
+            } else {
+                with_batch_statement_index(error, 0)
+            }
+        });
+    finish_parameter_batch_statement_telemetry(telemetry_sink, statements, &result);
+    result
+}
+
+fn finish_parameter_batch_statement_telemetry(
+    telemetry_sink: Option<&Arc<dyn crate::telemetry::TelemetrySink>>,
+    statements: &[ExecuteBatchStatement],
+    result: &Result<Option<Vec<ExecuteResult>>, LixError>,
+) {
+    match result {
+        Ok(Some(results)) => {
+            for (statement_index, (statement, result)) in statements.iter().zip(results).enumerate()
+            {
+                let Some(telemetry) = SqlStatementTelemetry::start(
+                    telemetry_sink,
+                    &statement.sql,
+                    "batch",
+                    Some(statement_index),
+                ) else {
+                    continue;
+                };
+                telemetry.finish(&Ok(result.clone()));
+            }
+        }
+        Err(error) => {
+            let statement_index = batch_statement_index(error).unwrap_or(0);
+            let Some(statement) = statements.get(statement_index) else {
+                return;
+            };
+            let Some(telemetry) = SqlStatementTelemetry::start(
+                telemetry_sink,
+                &statement.sql,
+                "batch",
+                Some(statement_index),
+            ) else {
+                return;
+            };
+            telemetry.finish(&Err(error.clone()));
+        }
+        Ok(None) => {}
+    }
+}
+
+fn batch_statement_index(error: &LixError) -> Option<usize> {
+    error
+        .details
+        .as_ref()
+        .and_then(JsonValue::as_object)
+        .and_then(|details| details.get("statementIndex"))
+        .and_then(JsonValue::as_u64)
+        .and_then(|index| usize::try_from(index).ok())
 }
 
 async fn execute_transaction_write_auto<StorageImpl>(
@@ -3090,8 +3150,11 @@ fn sql_uses_public_filesystem_path_surface(sql: &str) -> bool {
 mod tests {
     use super::*;
     use crate::entity_pk::EntityPk;
+    use crate::telemetry::{
+        CallbackTelemetrySink, CompletedTelemetrySpan, TelemetrySpanKind, TelemetryValue,
+    };
     use crate::transaction::types::{TransactionJson, TransactionWriteRow};
-    use crate::{Engine, Memory};
+    use crate::{Engine, EngineOptions, Memory};
 
     async fn open_session() -> SessionContext<Memory> {
         let storage = Memory::default();
@@ -3101,6 +3164,26 @@ mod tests {
         let engine = Engine::new(storage)
             .await
             .expect("initialized storage should create engine");
+        engine
+            .open_workspace_session()
+            .await
+            .expect("workspace session should open")
+    }
+
+    async fn open_session_with_telemetry(
+        spans: Arc<std::sync::Mutex<Vec<CompletedTelemetrySpan>>>,
+    ) -> SessionContext<Memory> {
+        let storage = Memory::default();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("storage should initialize");
+        let sink = CallbackTelemetrySink::new(move |span| {
+            spans.lock().expect("telemetry span lock").push(span);
+        });
+        let engine =
+            Engine::new_with_options(storage, EngineOptions::new().with_telemetry(Arc::new(sink)))
+                .await
+                .expect("initialized storage should create engine");
         engine
             .open_workspace_session()
             .await
@@ -3575,6 +3658,71 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_batch_keeps_parameterless_updates_sequential() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "x-lix-key": "parameterless_batch_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": { "type": "string" }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+        session
+            .execute(
+                "INSERT INTO parameterless_batch_probe (id, value) VALUES ('a', 'old')",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sql2::take_entity_update_parameter_batch_executions();
+        let sql = "UPDATE parameterless_batch_probe SET value = 'new' WHERE id = 'a'";
+        let results = session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: Vec::new(),
+                },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: Vec::new(),
+                },
+            ])
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(
+            results
+                .iter()
+                .map(ExecuteResult::rows_affected)
+                .collect::<Vec<_>>(),
+            vec![1, 1]
+        );
+        assert_eq!(sql2::take_entity_update_parameter_batch_executions(), 0);
+        let row = session
+            .execute(
+                "SELECT value FROM parameterless_batch_probe WHERE id = 'a'",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(row.rows()[0].get::<String>("value").unwrap(), "new");
+    }
+
+    #[tokio::test]
     async fn execute_batch_keeps_inter_row_constraints_on_sequential_execution() {
         let session = open_session().await;
         let schema = serde_json::json!({
@@ -3695,6 +3843,130 @@ mod tests {
             .unwrap();
         assert_eq!(rows.rows()[0].get::<String>("value").unwrap(), "old-a");
         assert_eq!(rows.rows()[1].get::<String>("value").unwrap(), "old-b");
+    }
+
+    #[tokio::test]
+    async fn execute_batch_parameter_batch_indexes_parameter_count_errors() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "x-lix-key": "parameter_batch_count_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": { "type": "string" }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+
+        let sql = "UPDATE parameter_batch_count_probe SET value = $1 WHERE id = $2";
+        let error = session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("new-a".to_string()),
+                        Value::Text("a".to_string()),
+                        Value::Text("extra".to_string()),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("new-b".to_string()),
+                        Value::Text("b".to_string()),
+                        Value::Text("extra".to_string()),
+                    ],
+                },
+            ])
+            .await
+            .expect_err("extra parameters must be rejected");
+
+        assert_eq!(error.details.unwrap()["statementIndex"], 0);
+    }
+
+    #[tokio::test]
+    async fn execute_batch_parameter_batch_emits_statement_telemetry() {
+        let spans = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let session = open_session_with_telemetry(Arc::clone(&spans)).await;
+        let schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "x-lix-key": "parameter_batch_telemetry_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": { "type": "string" }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+        session
+            .execute(
+                "INSERT INTO parameter_batch_telemetry_probe (id, value) VALUES \
+                 ('a', 'old-a'), ('b', 'old-b')",
+                &[],
+            )
+            .await
+            .unwrap();
+        spans.lock().expect("telemetry span lock").clear();
+
+        let sql = "UPDATE parameter_batch_telemetry_probe SET value = $1 WHERE id = $2";
+        session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("new-a".to_string()),
+                        Value::Text("a".to_string()),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("new-b".to_string()),
+                        Value::Text("b".to_string()),
+                    ],
+                },
+            ])
+            .await
+            .unwrap();
+
+        let spans = spans.lock().expect("telemetry span lock");
+        let query_spans = spans
+            .iter()
+            .filter(|span| span.start.kind == TelemetrySpanKind::SqlQuery)
+            .collect::<Vec<_>>();
+        assert_eq!(query_spans.len(), 2);
+        for (index, span) in query_spans.into_iter().enumerate() {
+            assert!(span.start.attributes.iter().any(|attribute| {
+                attribute.key == "lix.sql.fingerprint"
+                    && matches!(&attribute.value, TelemetryValue::String(value) if !value.is_empty())
+            }));
+            assert!(span.start.attributes.iter().any(|attribute| {
+                attribute.key == "lix.batch.index"
+                    && attribute.value == TelemetryValue::U64(index as u64)
+            }));
+            assert!(span.end.attributes.iter().any(|attribute| {
+                attribute.key == "lix.rows_affected" && attribute.value == TelemetryValue::U64(1)
+            }));
+        }
     }
 
     #[tokio::test]

--- a/packages/engine/src/sql2/catalog/entity_surface.rs
+++ b/packages/engine/src/sql2/catalog/entity_surface.rs
@@ -44,6 +44,12 @@ pub(crate) struct EntitySurfaceSpec {
     pub(crate) primary_key_paths: Vec<Vec<String>>,
     pub(crate) columns: Vec<EntitySurfaceColumn>,
     pub(crate) defaults: crate::catalog::DefaultPlan,
+    /// Whether changing one row can invalidate another row.
+    ///
+    /// Homogeneous point updates may be lowered into one physical write batch
+    /// only when every row is independent. JSON Schema validation is row-local;
+    /// uniqueness and foreign-key declarations are the inter-row exceptions.
+    pub(crate) has_inter_row_constraints: bool,
 }
 
 impl EntitySurfaceSpec {
@@ -132,6 +138,14 @@ pub(crate) fn derive_entity_surface_spec_from_schema(
         primary_key_paths,
         columns,
         defaults: crate::catalog::DefaultPlan::from_schema(schema),
+        has_inter_row_constraints: ["x-lix-unique", "x-lix-foreign-keys"].into_iter().any(
+            |keyword| {
+                schema
+                    .get(keyword)
+                    .and_then(JsonValue::as_array)
+                    .is_some_and(|values| !values.is_empty())
+            },
+        ),
     })
 }
 

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -28,12 +28,14 @@ use crate::{LixError, NullableKeyFilter, Value, parse_row_metadata_value};
 use super::SqlWriteResult;
 
 #[cfg(test)]
-static ENTITY_UPDATE_PARAMETER_BATCH_EXECUTIONS: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
+std::thread_local! {
+    static ENTITY_UPDATE_PARAMETER_BATCH_EXECUTIONS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+}
 
 #[cfg(test)]
 pub(crate) fn take_entity_update_parameter_batch_executions() -> usize {
-    ENTITY_UPDATE_PARAMETER_BATCH_EXECUTIONS.swap(0, std::sync::atomic::Ordering::Relaxed)
+    ENTITY_UPDATE_PARAMETER_BATCH_EXECUTIONS.with(|executions| executions.replace(0))
 }
 
 #[cfg(test)]
@@ -145,7 +147,9 @@ pub(crate) async fn try_execute_entity_update_parameter_batch(
     }
     stage_rows(ctx, TransactionWriteMode::Replace, write_rows).await?;
     #[cfg(test)]
-    ENTITY_UPDATE_PARAMETER_BATCH_EXECUTIONS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    ENTITY_UPDATE_PARAMETER_BATCH_EXECUTIONS.with(|executions| {
+        executions.set(executions.get() + 1);
+    });
     Ok(Some(
         affected_by_statement
             .into_iter()

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -1,4 +1,5 @@
 use datafusion::arrow::datatypes::DataType;
+use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::ScalarValue;
 use serde_json::Value as JsonValue;
 
@@ -27,6 +28,15 @@ use crate::{LixError, NullableKeyFilter, Value, parse_row_metadata_value};
 use super::SqlWriteResult;
 
 #[cfg(test)]
+static ENTITY_UPDATE_PARAMETER_BATCH_EXECUTIONS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+#[cfg(test)]
+pub(crate) fn take_entity_update_parameter_batch_executions() -> usize {
+    ENTITY_UPDATE_PARAMETER_BATCH_EXECUTIONS.swap(0, std::sync::atomic::Ordering::Relaxed)
+}
+
+#[cfg(test)]
 pub(crate) fn supports_bound_public_write(plan: &LogicalWritePlan) -> bool {
     match &plan.bound.target {
         BoundWriteTarget::Entity(_) => bound_public_write_shape_supported(plan),
@@ -41,6 +51,125 @@ pub(crate) fn supports_bound_public_write(plan: &LogicalWritePlan) -> bool {
 pub(crate) enum BoundPublicWriteExecution {
     Executed(SqlWriteResult),
     Unsupported,
+}
+
+/// Executes a certified run of independent point updates as one physical
+/// scan/stage operation.
+///
+/// `executeBatch` remains sequential at its public boundary. This route is
+/// narrower: every logical statement must target a distinct primary key in
+/// the same unconstrained entity surface, so evaluating them together is
+/// observationally equivalent to evaluating them one at a time.
+pub(crate) async fn try_execute_entity_update_parameter_batch(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    plan: &LogicalWritePlan,
+    parameter_batch: &RecordBatch,
+) -> Result<Option<Vec<SqlWriteResult>>, LixError> {
+    let BoundWriteTarget::Entity(EntityWriteSurface::Base { schema_key }) = &plan.bound.target
+    else {
+        return Ok(None);
+    };
+    if plan.bound.op != BoundWriteOp::Update
+        || !matches!(plan.bound.input, BoundWriteInput::None)
+        || plan.bound.conflict.is_some()
+        || plan.bound.returning.is_some()
+        || !matches!(plan.bound.branch_scope, BranchScope::Active { .. })
+        || !matches!(plan.filters.rows, FilterSet::All)
+        || plan_references_active_branch_commit_id(plan)
+    {
+        return Ok(None);
+    }
+
+    let spec = entity_spec(ctx, schema_key)?;
+    if spec.has_inter_row_constraints
+        || plan.bound.assignments.iter().any(|assignment| {
+            spec.primary_key_paths
+                .iter()
+                .any(|path| path.as_slice() == [assignment.column.name.as_str()])
+        })
+    {
+        return Ok(None);
+    }
+    validate_bound_write_supported(plan, &spec)?;
+
+    let mut parameter_rows = Vec::with_capacity(parameter_batch.num_rows());
+    let mut entity_pks = Vec::with_capacity(parameter_batch.num_rows());
+    let mut unique_entity_pks = std::collections::BTreeSet::new();
+    for row_index in 0..parameter_batch.num_rows() {
+        let params = super::write::parameter_row(parameter_batch, row_index)
+            .map_err(|error| with_parameter_batch_statement_index(error, row_index))?;
+        let Some(mut row_entity_pks) =
+            bound_entity_pks_from_primary_key_predicate(&spec, &plan.bound.predicate, &params)
+        else {
+            return Ok(None);
+        };
+        if row_entity_pks.len() != 1 {
+            return Ok(None);
+        }
+        let entity_pk = row_entity_pks.pop().expect("one point-update identity");
+        if !unique_entity_pks.insert(entity_pk.clone()) {
+            // Repeated identities observe earlier staged writes and are not
+            // independent statements.
+            return Ok(None);
+        }
+        parameter_rows.push(params);
+        entity_pks.push(entity_pk);
+    }
+
+    let candidates =
+        scan_entity_candidates_for_pks(ctx, plan, &spec, unique_entity_pks.into_iter().collect())
+            .await?;
+    let mut candidates_by_pk = std::collections::BTreeMap::<EntityPk, Vec<_>>::new();
+    for candidate in candidates {
+        candidates_by_pk
+            .entry(candidate.entity_pk.clone())
+            .or_default()
+            .push(candidate);
+    }
+
+    let mut affected_by_statement = Vec::with_capacity(parameter_rows.len());
+    let mut write_rows = Vec::with_capacity(parameter_rows.len());
+    for (row_index, (entity_pk, params)) in entity_pks.into_iter().zip(&parameter_rows).enumerate()
+    {
+        let mut affected = 0;
+        for candidate in candidates_by_pk.remove(&entity_pk).unwrap_or_default() {
+            if let Some(write_row) =
+                entity_update_row(ctx, plan, &spec, &candidate, params, None)
+                    .map_err(|error| with_parameter_batch_statement_index(error, row_index))?
+            {
+                write_rows.push(write_row);
+                affected += 1;
+            }
+        }
+        affected_by_statement.push(affected);
+    }
+    stage_rows(ctx, TransactionWriteMode::Replace, write_rows).await?;
+    #[cfg(test)]
+    ENTITY_UPDATE_PARAMETER_BATCH_EXECUTIONS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    Ok(Some(
+        affected_by_statement
+            .into_iter()
+            .map(SqlWriteResult::affected)
+            .collect(),
+    ))
+}
+
+fn with_parameter_batch_statement_index(mut error: LixError, statement_index: usize) -> LixError {
+    let mut details = match error.details.take() {
+        Some(JsonValue::Object(details)) => details,
+        Some(details) => {
+            let mut wrapped = serde_json::Map::new();
+            wrapped.insert("cause".to_string(), details);
+            wrapped
+        }
+        None => serde_json::Map::new(),
+    };
+    details.insert(
+        "statementIndex".to_string(),
+        JsonValue::from(statement_index),
+    );
+    error.details = Some(JsonValue::Object(details));
+    error
 }
 
 pub(crate) async fn try_execute_bound_public_write(
@@ -826,69 +955,85 @@ async fn entity_update(
     let candidates = scan_entity_candidates(ctx, plan, spec, params).await?;
     let mut write_rows = Vec::new();
     for candidate in candidates {
-        let Some(snapshot) = candidate_snapshot(&candidate)? else {
-            continue;
-        };
-        let original_context = EntityEvalContext::live(&snapshot, &candidate, spec);
-        if !predicate_matches(
-            &plan.bound.predicate,
-            &original_context,
-            spec,
-            ctx,
-            params,
-            active_branch_commit_id,
-        )? {
-            continue;
+        if let Some(write_row) =
+            entity_update_row(ctx, plan, spec, &candidate, params, active_branch_commit_id)?
+        {
+            write_rows.push(write_row);
         }
-        reject_projected_global_write(plan, &candidate, "UPDATE")?;
-        let mut updated = snapshot.clone();
-        let mut visible_assignments = Vec::new();
-        for assignment in &plan.bound.assignments {
-            if let Some(column) = spec.visible_column(&assignment.column.name) {
-                reject_direct_blob_json_value(&assignment.value, column.column_type, params)?;
-                let value = eval_expr_value(
-                    &assignment.value,
-                    &original_context,
-                    ctx,
-                    params,
-                    active_branch_commit_id,
-                )?;
-                visible_assignments.push((
-                    column.name.clone(),
-                    entity_json_value(
-                        &assignment.value,
-                        value,
-                        column.column_type,
-                        &spec.schema_key,
-                        &column.name,
-                    )?,
-                ));
-            } else if assignment.column.name == "lixcol_metadata" {
-                // handled below from the assignment list
-            } else {
-                return Err(LixError::new(
-                    LixError::CODE_UNSUPPORTED_SQL,
-                    format!(
-                        "bound entity UPDATE does not support assignment to '{}'",
-                        assignment.column.name
-                    ),
-                ));
-            }
-        }
-        for (column_name, value) in visible_assignments {
-            updated[&column_name] = value;
-        }
-        write_rows.push(entity_replace_row_from_live(
-            ctx,
-            spec,
-            &candidate,
-            Some(updated),
-            plan.bound.assignments.as_slice(),
-            params,
-            active_branch_commit_id,
-        )?);
     }
     stage_rows(ctx, TransactionWriteMode::Replace, write_rows).await
+}
+
+fn entity_update_row(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    plan: &LogicalWritePlan,
+    spec: &EntitySurfaceSpec,
+    candidate: &crate::live_state::MaterializedLiveStateRow,
+    params: &[Value],
+    active_branch_commit_id: Option<&CommitId>,
+) -> Result<Option<TransactionWriteRow>, LixError> {
+    let Some(snapshot) = candidate_snapshot(candidate)? else {
+        return Ok(None);
+    };
+    let original_context = EntityEvalContext::live(&snapshot, candidate, spec);
+    if !predicate_matches(
+        &plan.bound.predicate,
+        &original_context,
+        spec,
+        ctx,
+        params,
+        active_branch_commit_id,
+    )? {
+        return Ok(None);
+    }
+    reject_projected_global_write(plan, candidate, "UPDATE")?;
+    let mut updated = snapshot.clone();
+    let mut visible_assignments = Vec::new();
+    for assignment in &plan.bound.assignments {
+        if let Some(column) = spec.visible_column(&assignment.column.name) {
+            reject_direct_blob_json_value(&assignment.value, column.column_type, params)?;
+            let value = eval_expr_value(
+                &assignment.value,
+                &original_context,
+                ctx,
+                params,
+                active_branch_commit_id,
+            )?;
+            visible_assignments.push((
+                column.name.clone(),
+                entity_json_value(
+                    &assignment.value,
+                    value,
+                    column.column_type,
+                    &spec.schema_key,
+                    &column.name,
+                )?,
+            ));
+        } else if assignment.column.name == "lixcol_metadata" {
+            // handled below from the assignment list
+        } else {
+            return Err(LixError::new(
+                LixError::CODE_UNSUPPORTED_SQL,
+                format!(
+                    "bound entity UPDATE does not support assignment to '{}'",
+                    assignment.column.name
+                ),
+            ));
+        }
+    }
+    for (column_name, value) in visible_assignments {
+        updated[&column_name] = value;
+    }
+    entity_replace_row_from_live(
+        ctx,
+        spec,
+        candidate,
+        Some(updated),
+        plan.bound.assignments.as_slice(),
+        params,
+        active_branch_commit_id,
+    )
+    .map(Some)
 }
 
 async fn entity_delete(
@@ -1324,6 +1469,25 @@ async fn scan_entity_candidates(
         request.filter.entity_pks = entity_pks;
     }
     ctx.scan_live_state(&request).await
+}
+
+async fn scan_entity_candidates_for_pks(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    plan: &LogicalWritePlan,
+    spec: &EntitySurfaceSpec,
+    entity_pks: Vec<EntityPk>,
+) -> Result<Vec<crate::live_state::MaterializedLiveStateRow>, LixError> {
+    ctx.scan_live_state(&LiveStateScanRequest {
+        filter: LiveStateFilter {
+            schema_keys: vec![spec.schema_key.clone()],
+            entity_pks,
+            branch_ids: scan_branch_ids(&plan.bound.branch_scope)?,
+            include_tombstones: false,
+            ..LiveStateFilter::default()
+        },
+        ..LiveStateScanRequest::default()
+    })
+    .await
 }
 
 fn bound_entity_pks_from_primary_key_predicate(

--- a/packages/engine/src/sql2/exec/mod.rs
+++ b/packages/engine/src/sql2/exec/mod.rs
@@ -45,10 +45,14 @@ pub(crate) use write::{
 };
 pub(crate) use write::{
     WriteLogicalPlan as SqlWriteLogicalPlan, create_write_logical_plan_from_template,
-    create_write_plan_template_from_parsed, execute_write_logical_plan_result_with_metadata,
+    create_write_plan_template_from_parsed, execute_write_logical_plan_parameter_batch,
+    execute_write_logical_plan_result_with_metadata, parameter_record_batch,
 };
 
 pub(crate) enum SqlLogicalPlan {
     DataFusion(SqlDataFusionLogicalPlan),
     Write(SqlWriteLogicalPlan),
 }
+
+#[cfg(test)]
+pub(crate) use bound_public_write::take_entity_update_parameter_batch_executions;

--- a/packages/engine/src/sql2/exec/write.rs
+++ b/packages/engine/src/sql2/exec/write.rs
@@ -133,14 +133,20 @@ pub(crate) fn parameter_record_batch(rows: &[&[Value]]) -> Result<Option<RecordB
     if rows.iter().any(|row| row.len() != first.len()) {
         return Ok(None);
     }
+    if first.is_empty() {
+        // An empty-schema RecordBatch has no array from which Arrow can infer
+        // row cardinality. Keep parameterless statements on sequential
+        // execution rather than silently turning a non-empty batch into zero
+        // rows.
+        return Ok(None);
+    }
 
     let mut fields = Vec::with_capacity(first.len());
     let mut columns = Vec::with_capacity(first.len());
     for column_index in 0..first.len() {
         let Some(kind) = rows
             .iter()
-            .filter_map(|row| ParameterKind::from_value(&row[column_index]))
-            .next()
+            .find_map(|row| ParameterKind::from_value(&row[column_index]))
         else {
             // Arrow's untyped Null column cannot retain the SQL parameter's
             // eventual type. Keep an all-null column on sequential execution.

--- a/packages/engine/src/sql2/exec/write.rs
+++ b/packages/engine/src/sql2/exec/write.rs
@@ -1,9 +1,13 @@
 //! Write execution for bound sql2 plans.
 
 use std::collections::BTreeSet;
+use std::sync::Arc;
 
 use serde_json::json;
 
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::ScalarValue;
 use datafusion::sql::parser::Statement as DataFusionStatement;
 
 use super::{SqlLogicalPlan, SqlWriteResult};
@@ -115,6 +119,191 @@ pub(crate) async fn execute_write_logical_plan_result_with_metadata(
     )
     .await
     .map(|(result, _path)| result)
+}
+
+/// Transposes row-oriented public `executeBatch` parameters into the
+/// column-oriented carrier used by the physical batch executor.
+///
+/// A mixed-type column is deliberately not coerced: its statements retain the
+/// ordinary sequential path and therefore the exact per-statement type errors.
+pub(crate) fn parameter_record_batch(rows: &[&[Value]]) -> Result<Option<RecordBatch>, LixError> {
+    let Some(first) = rows.first() else {
+        return Ok(None);
+    };
+    if rows.iter().any(|row| row.len() != first.len()) {
+        return Ok(None);
+    }
+
+    let mut fields = Vec::with_capacity(first.len());
+    let mut columns = Vec::with_capacity(first.len());
+    for column_index in 0..first.len() {
+        let Some(kind) = rows
+            .iter()
+            .filter_map(|row| ParameterKind::from_value(&row[column_index]))
+            .next()
+        else {
+            // Arrow's untyped Null column cannot retain the SQL parameter's
+            // eventual type. Keep an all-null column on sequential execution.
+            return Ok(None);
+        };
+        if rows.iter().any(|row| {
+            ParameterKind::from_value(&row[column_index]).is_some_and(|candidate| candidate != kind)
+        }) {
+            return Ok(None);
+        }
+        let scalars = rows
+            .iter()
+            .map(|row| kind.scalar(&row[column_index]))
+            .collect::<Result<Vec<_>, _>>()?;
+        let array = ScalarValue::iter_to_array(scalars).map_err(|error| {
+            LixError::unknown(format!("failed to lower SQL parameter column: {error}"))
+        })?;
+        let field = Field::new(
+            format!("${}", column_index + 1),
+            kind.data_type(),
+            rows.iter()
+                .any(|row| matches!(row[column_index], Value::Null)),
+        );
+        fields.push(if kind == ParameterKind::Json {
+            crate::sql2::result_metadata::mark_json_field(field)
+        } else {
+            field
+        });
+        columns.push(array);
+    }
+
+    RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
+        .map(Some)
+        .map_err(|error| {
+            LixError::unknown(format!("failed to construct SQL parameter batch: {error}"))
+        })
+}
+
+pub(super) fn parameter_row(batch: &RecordBatch, row_index: usize) -> Result<Vec<Value>, LixError> {
+    if row_index >= batch.num_rows() {
+        return Err(LixError::unknown(format!(
+            "SQL parameter row {row_index} is outside a {} row batch",
+            batch.num_rows()
+        )));
+    }
+    batch
+        .columns()
+        .iter()
+        .enumerate()
+        .map(|(column_index, array)| {
+            let scalar = ScalarValue::try_from_array(array, row_index).map_err(|error| {
+                LixError::unknown(format!(
+                    "failed to read SQL parameter ${} from Arrow batch: {error}",
+                    column_index + 1
+                ))
+            })?;
+            scalar_parameter_value(
+                scalar,
+                crate::sql2::result_metadata::field_is_json(batch.schema().field(column_index)),
+            )
+        })
+        .collect()
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ParameterKind {
+    Boolean,
+    Integer,
+    Real,
+    Text,
+    Json,
+    Blob,
+}
+
+impl ParameterKind {
+    fn from_value(value: &Value) -> Option<Self> {
+        match value {
+            Value::Null => None,
+            Value::Boolean(_) => Some(Self::Boolean),
+            Value::Integer(_) => Some(Self::Integer),
+            Value::Real(_) => Some(Self::Real),
+            Value::Text(_) => Some(Self::Text),
+            Value::Json(_) => Some(Self::Json),
+            Value::Blob(_) => Some(Self::Blob),
+        }
+    }
+
+    fn data_type(self) -> DataType {
+        match self {
+            Self::Boolean => DataType::Boolean,
+            Self::Integer => DataType::Int64,
+            Self::Real => DataType::Float64,
+            Self::Text | Self::Json => DataType::Utf8,
+            Self::Blob => DataType::LargeBinary,
+        }
+    }
+
+    fn scalar(self, value: &Value) -> Result<ScalarValue, LixError> {
+        match (self, value) {
+            (Self::Boolean, Value::Boolean(value)) => Ok(ScalarValue::Boolean(Some(*value))),
+            (Self::Integer, Value::Integer(value)) => Ok(ScalarValue::Int64(Some(*value))),
+            (Self::Real, Value::Real(value)) => Ok(ScalarValue::Float64(Some(*value))),
+            (Self::Text, Value::Text(value)) => Ok(ScalarValue::Utf8(Some(value.clone()))),
+            (Self::Json, Value::Json(value)) => Ok(ScalarValue::Utf8(Some(value.to_string()))),
+            (Self::Blob, Value::Blob(value)) => Ok(ScalarValue::LargeBinary(Some(value.to_vec()))),
+            (Self::Boolean, Value::Null) => Ok(ScalarValue::Boolean(None)),
+            (Self::Integer, Value::Null) => Ok(ScalarValue::Int64(None)),
+            (Self::Real, Value::Null) => Ok(ScalarValue::Float64(None)),
+            (Self::Text | Self::Json, Value::Null) => Ok(ScalarValue::Utf8(None)),
+            (Self::Blob, Value::Null) => Ok(ScalarValue::LargeBinary(None)),
+            _ => Err(LixError::unknown(
+                "heterogeneous SQL parameter column reached Arrow lowering",
+            )),
+        }
+    }
+}
+
+fn scalar_parameter_value(scalar: ScalarValue, is_json: bool) -> Result<Value, LixError> {
+    match scalar {
+        ScalarValue::Boolean(Some(value)) => Ok(Value::Boolean(value)),
+        ScalarValue::Int64(Some(value)) => Ok(Value::Integer(value)),
+        ScalarValue::Float64(Some(value)) => Ok(Value::Real(value)),
+        ScalarValue::Utf8(Some(value)) if is_json => serde_json::from_str(&value)
+            .map(Value::Json)
+            .map_err(|error| {
+                LixError::unknown(format!(
+                    "invalid JSON value in SQL parameter batch: {error}"
+                ))
+            }),
+        ScalarValue::Utf8(Some(value)) => Ok(Value::Text(value)),
+        ScalarValue::LargeBinary(Some(value)) => Ok(Value::Blob(value.into())),
+        ScalarValue::Boolean(None)
+        | ScalarValue::Int64(None)
+        | ScalarValue::Float64(None)
+        | ScalarValue::Utf8(None)
+        | ScalarValue::LargeBinary(None)
+        | ScalarValue::Null => Ok(Value::Null),
+        value => Err(LixError::unknown(format!(
+            "unsupported Arrow SQL parameter value {value:?}"
+        ))),
+    }
+}
+
+/// Attempts the one currently certified physical parameter-batch route.
+///
+/// `None` means the logical statements are not independent and must retain
+/// public `executeBatch`'s sequential execution semantics.
+pub(crate) async fn execute_write_logical_plan_parameter_batch(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    plan: SqlLogicalPlan,
+    parameter_batch: &RecordBatch,
+) -> Result<Option<Vec<SqlWriteResult>>, LixError> {
+    let SqlLogicalPlan::Write(write_plan) = plan else {
+        return Ok(None);
+    };
+    validate_write_parameter_count(&write_plan.plan, parameter_batch.num_columns())?;
+    super::bound_public_write::try_execute_entity_update_parameter_batch(
+        ctx,
+        &write_plan.plan,
+        parameter_batch,
+    )
+    .await
+    .map_err(normalize_bound_public_write_error)
 }
 
 #[cfg(test)]

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -48,15 +48,15 @@ pub(crate) use exec::{
     SqlLogicalPlan, create_write_logical_plan_from_template,
     create_write_plan_template_from_parsed, execute_read_statement_from_parsed,
     execute_read_statement_in_session_from_parsed, execute_transaction_read_statement_from_parsed,
-    execute_write_logical_plan_result_with_metadata, prepare_read_session,
-    prepare_read_session_at_head,
+    execute_write_logical_plan_parameter_batch, execute_write_logical_plan_result_with_metadata,
+    parameter_record_batch, prepare_read_session, prepare_read_session_at_head,
 };
 #[cfg(test)]
 pub(crate) use exec::{
     WriteExecutorMode, WriteExecutorPath, create_write_logical_plan, execute_write_logical_plan,
     execute_write_logical_plan_with_mode, execute_write_logical_plan_with_mode_and_trace,
     execute_write_logical_plan_with_mode_and_trace_result,
-    execute_write_logical_plan_with_mode_result,
+    execute_write_logical_plan_with_mode_result, take_entity_update_parameter_batch_executions,
 };
 pub(crate) use file_view::{
     SessionFileViewKey, SessionFileViewMutation, SessionFileViews, SessionPluginFileView,


### PR DESCRIPTION
## What changed

- Keep the public `executeBatch` API unchanged.
- Recognize homogeneous runs of the same bound entity `UPDATE` internally.
- Transpose row-oriented parameters into an Arrow `RecordBatch`.
- Prepare the write plan once, scan all distinct primary keys once, evaluate every row, and stage one physical replacement batch.
- Preserve the sequential path for duplicate identities, primary-key assignments, inter-row constraints, mixed parameter columns, `RETURNING`, conflict handling, active-commit-dependent expressions, and unsupported surfaces.
- Preserve per-statement `rowsAffected`, atomic rollback, and `statementIndex` on row-local failures.

This removes 9,999 repeated plan/scan/stage boundaries from the representative 10,000-statement bound update workload. Arrow is only the columnar parameter carrier; the optimization is set-at-a-time execution.

## Why

After #866 moved native entrypoints to mimalloc, bound 10k `UPDATE` remained roughly 269 ms while direct Lix batch update was about 86 ms and raw SQLite was about 10 ms. Profiles pointed at repeated per-statement SQL/write execution rather than another allocator or storage-read issue.

## Performance evidence

All CRUD numbers use RocksDB, the representative 10k fixture, CPU 2 pinning, and setup-excluded measurements. The bound-update A/B uses the exact same public `executeBatch` benchmark harness in both binaries; only the engine lowering differs.

| Gate | `origin/main` | candidate | delta |
| --- | ---: | ---: | ---: |
| bound `executeBatch` UPDATE, median of 11 balanced pairs | 296.9 ms | 182.0 ms | **-38.7%** |
| direct transaction INSERT, 7-sample median | 64.7 ms | 67.0 ms | +3.6% |
| direct transaction UPDATE, 7-sample median | 76.6 ms | 80.9 ms | +5.5% |
| direct transaction DELETE, 7-sample median | 77.2 ms | 74.1 ms | -4.0% |
| historical diff, median of 9 alternating run p50s | 4.799 ms | 4.697 ms | -2.1% |
| committed merge, median of 7 alternating run p50s | 2.505 ms | 2.387 ms | -4.7% |

Every one of the 11 bound-update pairs improved, by approximately 33–45%. Direct CRUD, diff, and merge remain inside the 10% no-regression gate.

## Correctness boundary

The fast path is certified only when batching is observationally equivalent to sequential execution:

- identical SQL and default per-statement metadata
- base entity `UPDATE` on the active branch
- exactly one distinct primary-key identity per statement
- no primary-key assignment
- no inter-row unique or foreign-key constraints
- no `RETURNING`, conflict route, or active-branch-commit dependency

Everything else returns to the existing statement-by-statement executor before staging any write.

## Validation

- `cargo test -p lix_engine --features all-simulations`
  - 1,371 unit tests passed
  - 758 integration simulations passed
  - 3 doctests passed
- `cargo check -p lix_engine_benchmarks --all-features`
- `cargo fmt --all --check`
- `git diff --check`
- focused tests cover one physical lowering, duplicate-identity fallback, inter-row-constraint fallback, atomic error rollback, and `statementIndex` preservation
