### PR TITLE
perf(engine): cascade file-scoped state on delete

### DIFF
--- a/.changenotes/cascade-file-scoped-state-on-delete.md
+++ b/.changenotes/cascade-file-scoped-state-on-delete.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Made file deletion substantially faster by cascading file-scoped state while materializing current state instead of recording a separate historical deletion for every file-owned entity.

--- a/packages/engine/src/domain.rs
+++ b/packages/engine/src/domain.rs
@@ -76,11 +76,6 @@ impl Domain {
         &self.file_scope
     }
 
-    #[expect(clippy::ref_option)]
-    pub(crate) fn is_exact_file(&self, file_id: &Option<String>) -> bool {
-        matches!(&self.file_scope, DomainFileScope::Exact(exact) if exact == file_id)
-    }
-
     pub(crate) fn with_untracked(&self, untracked: bool) -> Self {
         Self {
             branch_id: self.branch_id.clone(),
@@ -161,10 +156,6 @@ impl Domain {
     }
 
     pub(crate) fn branch_descriptor_domains_for_ref_delete(&self) -> Vec<Self> {
-        self.source_domains_that_can_reach()
-    }
-
-    pub(crate) fn file_scoped_row_domains_for_file_descriptor_delete(&self) -> Vec<Self> {
         self.source_domains_that_can_reach()
     }
 

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -3788,6 +3788,192 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn incremental_file_descriptor_delete_cascades_without_resurrection() {
+        let storage = StorageAdapter::new(Memory::new());
+        let branch_id = "branch";
+        let first_head = CommitId::for_test_label("file-cascade-first");
+        let delete_head = CommitId::for_test_label("file-cascade-delete");
+        let recreate_head = CommitId::for_test_label("file-cascade-recreate");
+        let file_pk = EntityPk::single("file-a");
+        let file_row_pk = EntityPk::single("file-row");
+        let unrelated_pk = EntityPk::single("unrelated-row");
+
+        let mut writes = StorageWriteSet::new();
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open initial file-cascade read");
+        TrackedHeadContext::new()
+            .writer(&read, &mut writes)
+            .stage_commit(
+                branch_id,
+                None,
+                first_head,
+                &[
+                    TrackedHeadDeltaRef {
+                        schema_key: "lix_file_descriptor",
+                        file_id: None,
+                        entity_pk: &file_pk,
+                        change_id: ChangeId::for_test_label("file-create"),
+                        commit_id: first_head,
+                        deleted: false,
+                        created_at: ts("2026-01-01T00:00:00Z"),
+                        updated_at: ts("2026-01-01T00:00:00Z"),
+                        snapshot: JsonSlotRef::Inline("{\"name\":\"a\"}"),
+                        metadata: JsonSlotRef::None,
+                    },
+                    TrackedHeadDeltaRef {
+                        schema_key: "semantic",
+                        file_id: Some("file-a"),
+                        entity_pk: &file_row_pk,
+                        change_id: ChangeId::for_test_label("file-row-create"),
+                        commit_id: first_head,
+                        deleted: false,
+                        created_at: ts("2026-01-01T00:00:00Z"),
+                        updated_at: ts("2026-01-01T00:00:00Z"),
+                        snapshot: JsonSlotRef::Inline("{\"value\":1}"),
+                        metadata: JsonSlotRef::None,
+                    },
+                    TrackedHeadDeltaRef {
+                        schema_key: "semantic",
+                        file_id: Some("file-b"),
+                        entity_pk: &unrelated_pk,
+                        change_id: ChangeId::for_test_label("unrelated-create"),
+                        commit_id: first_head,
+                        deleted: false,
+                        created_at: ts("2026-01-01T00:00:00Z"),
+                        updated_at: ts("2026-01-01T00:00:00Z"),
+                        snapshot: JsonSlotRef::Inline("{\"value\":2}"),
+                        metadata: JsonSlotRef::None,
+                    },
+                ],
+                &BTreeSet::new(),
+                None,
+            )
+            .await
+            .expect("stage initial file state");
+        drop(read);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit initial file state");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open file-delete read");
+        let mut writes = StorageWriteSet::new();
+        TrackedHeadContext::new()
+            .writer(&read, &mut writes)
+            .stage_commit(
+                branch_id,
+                Some(first_head),
+                delete_head,
+                &[TrackedHeadDeltaRef {
+                    schema_key: "lix_file_descriptor",
+                    file_id: None,
+                    entity_pk: &file_pk,
+                    change_id: ChangeId::for_test_label("file-delete"),
+                    commit_id: delete_head,
+                    deleted: true,
+                    created_at: ts("2026-01-01T00:00:00Z"),
+                    updated_at: ts("2026-01-02T00:00:00Z"),
+                    snapshot: JsonSlotRef::None,
+                    metadata: JsonSlotRef::None,
+                }],
+                &BTreeSet::new(),
+                None,
+            )
+            .await
+            .expect("stage cascading file delete");
+        drop(read);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit cascading file delete");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open cascade verification read");
+        let mut including_tombstones = TrackedStateScanRequest::default();
+        including_tombstones.filter.include_tombstones = true;
+        let rows = TrackedHeadContext::new()
+            .reader(read)
+            .scan_live_rows_if_current(branch_id, &delete_head.to_string(), &including_tombstones)
+            .await
+            .expect("scan cascaded state")
+            .expect("matching delete head");
+        let cascaded = rows
+            .iter()
+            .find(|row| row.entity_pk == file_row_pk)
+            .expect("file-scoped row remains as a visibility tombstone");
+        assert!(cascaded.deleted);
+        assert_eq!(
+            cascaded.change_id,
+            Some(ChangeId::for_test_label("file-delete"))
+        );
+        assert!(
+            rows.iter()
+                .any(|row| row.entity_pk == unrelated_pk && !row.deleted),
+            "unrelated file state must remain live"
+        );
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open file-recreate read");
+        let mut writes = StorageWriteSet::new();
+        TrackedHeadContext::new()
+            .writer(&read, &mut writes)
+            .stage_commit(
+                branch_id,
+                Some(first_head),
+                recreate_head,
+                &[TrackedHeadDeltaRef {
+                    schema_key: "lix_file_descriptor",
+                    file_id: None,
+                    entity_pk: &file_pk,
+                    change_id: ChangeId::for_test_label("file-recreate"),
+                    commit_id: recreate_head,
+                    deleted: false,
+                    created_at: ts("2026-01-03T00:00:00Z"),
+                    updated_at: ts("2026-01-03T00:00:00Z"),
+                    snapshot: JsonSlotRef::Inline("{\"name\":\"a\"}"),
+                    metadata: JsonSlotRef::None,
+                }],
+                &BTreeSet::new(),
+                None,
+            )
+            .await
+            .expect("stage file recreation");
+        drop(read);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit file recreation");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open recreation verification read");
+        let rows = TrackedHeadContext::new()
+            .reader(read)
+            .scan_live_rows_if_current(
+                branch_id,
+                &recreate_head.to_string(),
+                &TrackedStateScanRequest::default(),
+            )
+            .await
+            .expect("scan recreated state")
+            .expect("matching recreate head");
+        assert!(
+            rows.iter().all(|row| row.entity_pk != file_row_pk),
+            "recreating a file descriptor must not resurrect old scoped state"
+        );
+    }
+
+    #[tokio::test]
     async fn incremental_guarded_insert_resurrects_tombstone_with_first_created_at() {
         let storage = StorageAdapter::new(Memory::new());
         let branch_id = "branch";

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -23,6 +23,7 @@ pub(crate) const HOT_FILE_SPACE: StorageSpace =
 /// Reserved for the row-level first-before working-diff index.
 pub(crate) const HOT_DIFF_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_001d), HOT_DIFF_NAMESPACE);
+const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
 
 /// Direct reader for one published hot generation.
 pub(crate) struct HotStateStoreReader<S> {
@@ -684,6 +685,17 @@ where
         for (identity, value) in identities.iter().zip(next_values) {
             stage_hot_mutation_value(self.writes, identity, value);
         }
+        stage_incremental_file_delete_cascades(
+            self.store,
+            self.writes,
+            branch_id,
+            generation,
+            &sorted,
+            working_diff_capture_checkpoint_commit_id,
+            &mut next_coverage,
+            &mut retired_untracked_json_refs,
+        )
+        .await?;
         JsonStoreWriter::stage_untracked_reclaim_candidates(
             self.writes,
             retired_untracked_json_refs
@@ -793,6 +805,138 @@ where
         Ok(HotTrackedSnapshot {
             rows: final_tracked,
         })
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn stage_incremental_file_delete_cascades(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    branch_id: &str,
+    generation: CommitId,
+    deltas: &[&CurrentStateDeltaRef<'_>],
+    working_diff_capture_checkpoint_commit_id: Option<CommitId>,
+    coverage: &mut WorkingDiffIndexCoverage,
+    retired_untracked_json_refs: &mut BTreeSet<[u8; JSON_REF_BYTES]>,
+) -> Result<(), LixError> {
+    let explicit = deltas
+        .iter()
+        .map(|delta| HeadRowIdentity {
+            schema_key: delta.schema_key.to_string(),
+            entity_pk: delta.entity_pk.clone(),
+            file_id: delta.file_id.map(str::to_string),
+        })
+        .collect::<BTreeSet<_>>();
+    let mut cascades = BTreeMap::<String, &CurrentStateDeltaRef<'_>>::new();
+    for cascade in deltas {
+        let Some(file_id) = file_delete_cascade_id(cascade)? else {
+            continue;
+        };
+        cascades.insert(file_id.to_string(), cascade);
+    }
+    if cascades.is_empty() {
+        return Ok(());
+    }
+    let identities =
+        hot_load_file_scope_identities(store, branch_id, generation, &cascades).await?;
+    let values = hot_load_primary_identity_bytes(store, &identities).await?;
+    for (identity, previous) in identities.into_iter().zip(values) {
+        let row_identity = identity.clone().into_row_identity();
+        if explicit.contains(&row_identity) {
+            continue;
+        }
+        let cascade = cascades
+            .get(
+                identity
+                    .file_id
+                    .as_deref()
+                    .expect("file projection identity requires file id"),
+            )
+            .expect("file scan only returns requested cascade ids");
+        let Some(previous) = previous else {
+            return Err(head_value_error(
+                "hot file projection has no authoritative primary row",
+            ));
+        };
+        let existing = decode_head_value(&previous)?;
+        if (cascade.untracked && !existing.untracked) || existing.deleted {
+            continue;
+        }
+        let encoded = encode_hot_mutation_identity(
+            branch_id,
+            generation,
+            &identity.schema_key,
+            &identity.entity_pk,
+            identity.file_id.as_deref(),
+        );
+        if existing.untracked {
+            collect_hot_untracked_refs(existing, retired_untracked_json_refs);
+            stage_hot_mutation_value(writes, &encoded, None);
+            continue;
+        }
+        let (baseline, newly_dirty) = next_cascade_working_diff_baseline(
+            working_diff_capture_checkpoint_commit_id,
+            existing,
+        )?;
+        if newly_dirty {
+            let checkpoint_commit_id = working_diff_capture_checkpoint_commit_id
+                .expect("new cascade dirty row requires active checkpoint");
+            let key = encode_hot_diff_key_parts(
+                branch_id,
+                checkpoint_commit_id,
+                generation,
+                &identity.schema_key,
+                &identity.entity_pk,
+                identity.file_id.as_deref(),
+            );
+            coverage
+                .add_encoded_group_key(&key)
+                .ok_or_else(|| head_value_error("hot working-diff index count exceeds u64"))?;
+            writes.put(
+                HOT_DIFF_SPACE,
+                StorageKey(Bytes::from(key)),
+                StorageValue {
+                    bytes: Bytes::new(),
+                },
+            );
+        }
+        let value = encode_head_value(&HeadValueRef {
+            change_id: cascade.change_id,
+            commit_id: cascade.commit_id,
+            untracked: false,
+            deleted: true,
+            created_at: existing.created_at,
+            updated_at: cascade.updated_at,
+            snapshot: JsonSlotRef::None,
+            metadata: JsonSlotRef::None,
+            working_diff_baseline: baseline,
+        })?;
+        stage_hot_mutation_value(writes, &encoded, Some(value));
+    }
+    Ok(())
+}
+
+fn next_cascade_working_diff_baseline(
+    active_checkpoint_commit_id: Option<CommitId>,
+    previous: HeadValueView<'_>,
+) -> Result<(WorkingDiffBaseline, bool), LixError> {
+    if active_checkpoint_commit_id.is_none() {
+        return Ok((WorkingDiffBaseline::Disabled, false));
+    }
+    match previous.working_diff_baseline {
+        WorkingDiffBaseline::Clean => {
+            let before = previous
+                .working_diff_version()
+                .ok_or_else(|| head_value_error("tracked cascade member has no version"))?;
+            Ok((WorkingDiffBaseline::BeforePresent(before), true))
+        }
+        WorkingDiffBaseline::BeforeAbsent => Ok((WorkingDiffBaseline::BeforeAbsent, false)),
+        WorkingDiffBaseline::BeforePresent(before) => {
+            Ok((WorkingDiffBaseline::BeforePresent(before), false))
+        }
+        WorkingDiffBaseline::Disabled => Err(head_value_error(
+            "active checkpoint generation contains a cascade member without a baseline",
+        )),
     }
 }
 
@@ -946,6 +1090,7 @@ fn apply_complete_hot_snapshot_delta(
     absence_guards: &BTreeSet<TrackedStateKey>,
     retired_untracked_json_refs: &mut BTreeSet<[u8; JSON_REF_BYTES]>,
 ) -> Result<(), LixError> {
+    apply_complete_file_delete_cascade(rows, delta, retired_untracked_json_refs)?;
     let identity = HeadRowIdentity {
         schema_key: delta.schema_key.to_string(),
         entity_pk: delta.entity_pk.clone(),
@@ -973,6 +1118,67 @@ fn apply_complete_hot_snapshot_delta(
         );
     }
     Ok(())
+}
+
+fn apply_complete_file_delete_cascade(
+    rows: &mut BTreeMap<HeadRowIdentity, Vec<u8>>,
+    delta: &CurrentStateDeltaRef<'_>,
+    retired_untracked_json_refs: &mut BTreeSet<[u8; JSON_REF_BYTES]>,
+) -> Result<(), LixError> {
+    let Some(file_id) = file_delete_cascade_id(delta)? else {
+        return Ok(());
+    };
+    let identities = rows
+        .keys()
+        .filter(|identity| identity.file_id.as_deref() == Some(file_id))
+        .cloned()
+        .collect::<Vec<_>>();
+    for identity in identities {
+        let Some(previous) = rows.get(&identity) else {
+            continue;
+        };
+        let existing = decode_head_value(previous)?;
+        if (delta.untracked && !existing.untracked) || existing.deleted {
+            continue;
+        }
+        if existing.untracked {
+            collect_hot_untracked_refs(existing, retired_untracked_json_refs);
+            rows.remove(&identity);
+            continue;
+        }
+        rows.insert(
+            identity,
+            encode_head_value(&HeadValueRef {
+                change_id: delta.change_id,
+                commit_id: delta.commit_id,
+                untracked: false,
+                deleted: true,
+                created_at: existing.created_at,
+                updated_at: delta.updated_at,
+                snapshot: JsonSlotRef::None,
+                metadata: JsonSlotRef::None,
+                working_diff_baseline: WorkingDiffBaseline::Disabled,
+            })?,
+        );
+    }
+    Ok(())
+}
+
+fn file_delete_cascade_id<'a>(
+    delta: &'a CurrentStateDeltaRef<'_>,
+) -> Result<Option<&'a str>, LixError> {
+    if delta.schema_key != FILE_DESCRIPTOR_SCHEMA_KEY || delta.file_id.is_some() || !delta.deleted {
+        return Ok(None);
+    }
+    delta
+        .entity_pk
+        .as_single_string()
+        .map(Some)
+        .map_err(|error| {
+            head_value_error(&format!(
+                "file descriptor tombstone has invalid identity: {error}"
+            ))
+        })
 }
 
 fn normalize_complete_hot_snapshot_baselines(
@@ -1245,6 +1451,7 @@ fn stage_hot_bootstrap(
     }
     let mut retired_untracked_json_refs = BTreeSet::new();
     for delta in deltas {
+        apply_complete_file_delete_cascade(&mut rows, delta, &mut retired_untracked_json_refs)?;
         let identity = HeadRowIdentity {
             schema_key: delta.schema_key.to_string(),
             entity_pk: delta.entity_pk.clone(),
@@ -1413,6 +1620,57 @@ async fn hot_load_primary_identity_bytes(
         .into_iter()
         .map(|value| value.map(full_value_bytes).transpose())
         .collect()
+}
+
+async fn hot_load_file_scope_identities(
+    store: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    generation: CommitId,
+    cascades: &BTreeMap<String, &CurrentStateDeltaRef<'_>>,
+) -> Result<Vec<HeadIdentity>, LixError> {
+    let scope = hot_scope_prefix(branch_id, generation);
+    let plan = ScanPlan::prefix(
+        HOT_FILE_SPACE,
+        StoragePrefix {
+            bytes: Bytes::from(scope.clone()),
+        },
+    );
+    let mut identities = Vec::new();
+    let mut resume_after = None;
+    loop {
+        let page = plan
+            .collect(
+                store,
+                StorageScanOptions {
+                    projection: StorageCoreProjection::KeyOnly,
+                    resume_after: resume_after.clone(),
+                    ..StorageScanOptions::default()
+                },
+            )
+            .await?;
+        resume_after = page.value.entries.last().map(|entry| entry.key.clone());
+        for entry in page.value.entries {
+            let row = decode_hot_file_key_in_scope(entry.key.0.as_ref(), &scope)?;
+            if !row
+                .file_id
+                .as_ref()
+                .is_some_and(|file_id| cascades.contains_key(file_id))
+            {
+                continue;
+            }
+            identities.push(HeadIdentity {
+                branch_id: branch_id.to_string(),
+                generation,
+                schema_key: row.schema_key,
+                entity_pk: row.entity_pk,
+                file_id: row.file_id,
+            });
+        }
+        if !page.value.has_more || resume_after.is_none() {
+            break;
+        }
+    }
+    Ok(identities)
 }
 
 fn working_diff_baseline_before(

--- a/packages/engine/src/test_support.rs
+++ b/packages/engine/src/test_support.rs
@@ -213,6 +213,7 @@ pub(crate) async fn stage_tracked_root_from_materialized(
         &parent_ids,
         rows,
         &changes,
+        false,
     )
     .await?;
     let deltas = staged
@@ -247,6 +248,60 @@ pub(crate) async fn stage_tracked_root_from_materialized(
 }
 
 #[cfg(test)]
+pub(crate) async fn stage_rootless_tracked_commit_from_materialized(
+    read: &mut (impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    commit_id: &str,
+    parent_commit_id: Option<&str>,
+    rows: &[MaterializedTrackedStateRow],
+) -> Result<(), crate::LixError> {
+    let commit_id_text = test_commit_id(commit_id).to_string();
+    let parent_id_texts = parent_commit_id
+        .map(|parent| vec![test_commit_id(parent).to_string()])
+        .unwrap_or_default();
+    let changes = rows
+        .iter()
+        .map(tracked_change_from_materialized)
+        .collect::<Result<Vec<_>, _>>()?;
+    let staged = stage_test_changelog_commit(
+        read,
+        writes,
+        &commit_id_text,
+        &format!("{commit_id_text}:commit"),
+        &parent_id_texts,
+        rows,
+        &changes,
+        true,
+    )
+    .await?;
+    let deltas = staged
+        .change_commit_ids
+        .iter()
+        .map(|(row_index, change_commit_id)| {
+            let change = &changes[*row_index];
+            let row = &rows[*row_index];
+            TrackedStateDeltaRef {
+                schema_key: &change.schema_key,
+                file_id: change.file_id.as_deref(),
+                entity_pk: &change.entity_pk,
+                change_id: change.change_id,
+                commit_id: *change_commit_id,
+                deleted: change.snapshot.is_none(),
+                created_at: crate::common::LixTimestamp::expect_parse(
+                    "created_at",
+                    &row.created_at,
+                ),
+                updated_at: crate::common::LixTimestamp::expect_parse(
+                    "updated_at",
+                    &row.updated_at,
+                ),
+            }
+        })
+        .collect::<Vec<_>>();
+    crate::tracked_state::stage_commit_deltas(writes, &deltas)
+}
+
+#[cfg(test)]
 pub(crate) async fn stage_tracked_root_from_materialized_with_parents(
     read: &mut (impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
@@ -276,6 +331,7 @@ pub(crate) async fn stage_tracked_root_from_materialized_with_parents(
         &parent_id_texts,
         rows,
         &changes,
+        false,
     )
     .await?;
     let deltas = staged
@@ -335,6 +391,7 @@ pub(crate) async fn stage_empty_changelog_commit(
         &parent_ids,
         &[],
         &[],
+        false,
     )
     .await?;
     Ok(())
@@ -361,6 +418,7 @@ pub(crate) async fn stage_empty_changelog_commit_with_parents(
         &parent_id_texts,
         &[],
         &[],
+        false,
     )
     .await?;
     Ok(())
@@ -374,6 +432,7 @@ async fn stage_test_changelog_commit(
     parent_ids: &[String],
     rows: &[MaterializedTrackedStateRow],
     changes: &[ChangeRecord],
+    tracked_state_rootless: bool,
 ) -> Result<TestStagedChangelogCommit, crate::LixError> {
     let typed_commit_id = test_commit_id(commit_id);
     let typed_parent_ids = parent_ids
@@ -415,7 +474,7 @@ async fn stage_test_changelog_commit(
         format_version: 1,
         commit_id: typed_commit_id,
         parent_commit_ids: typed_parent_ids,
-        tracked_state_rootless: false,
+        tracked_state_rootless,
         change_id: typed_commit_change_id,
         author_account_ids: Vec::new(),
         created_at,

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -46,6 +46,11 @@ struct TrackedStateIdentity {
     entity_pk: EntityPk,
 }
 
+struct TrackedStateRowWinner {
+    identity: TrackedStateIdentity,
+    file_delete_cascade: bool,
+}
+
 /// Factory for tracked-state readers, root writers, and commit-root rebuilders.
 ///
 /// Tracked state is stored as content-addressed roots. Branch refs
@@ -257,19 +262,19 @@ where
         let changes = self.load_and_validate_diff_row_changes(&row_refs).await?;
         let mut validation_cache = DiffCommitRootValidationCache::new();
         for (row, expected_commit_id) in rows {
-            let change_created_at = changes
-                .get(&row.change_id)
-                .map(|change| change.created_at)
-                .ok_or_else(|| {
-                    LixError::unknown(format!(
-                        "tracked-state diff row references missing changelog change '{}'",
-                        row.change_id
-                    ))
-                })?;
+            let change = changes.get(&row.change_id).ok_or_else(|| {
+                LixError::unknown(format!(
+                    "tracked-state diff row references missing changelog change '{}'",
+                    row.change_id
+                ))
+            })?;
+            let winner_identity = tracked_state_winner_identity_for_diff_row(row, change)?;
             self.validate_diff_row_commit_root_membership(
                 row,
                 expected_commit_id,
-                change_created_at,
+                &winner_identity.identity,
+                winner_identity.file_delete_cascade,
+                change.created_at,
                 &mut validation_cache,
             )
             .await?;
@@ -328,10 +333,11 @@ where
         &mut self,
         row: &TrackedStateDiffRow,
         root_commit_id: &str,
+        winner_identity: &TrackedStateIdentity,
+        file_delete_cascade: bool,
         change_created_at: crate::common::LixTimestamp,
         cache: &mut DiffCommitRootValidationCache,
     ) -> Result<(), LixError> {
-        let identity = tracked_state_identity_from_diff_row(row)?;
         let key = TrackedStateKey {
             schema_key: row.schema_key.clone(),
             file_id: row.file_id.clone(),
@@ -353,18 +359,25 @@ where
             }
 
             let winner_change_id = self
-                .load_cached_commit_ref_winner(&current_commit_id, &identity, cache)
+                .load_cached_commit_ref_winner(&current_commit_id, winner_identity, cache)
                 .await?;
             if let Some(winner_change_id) = winner_change_id {
-                if winner_change_id != row.change_id {
+                if winner_change_id == row.change_id {
+                    self.validate_diff_row_created_at(
+                        row,
+                        &key,
+                        &current_commit_id,
+                        change_created_at,
+                    )
+                    .await?;
+                    return Ok(());
+                }
+                if !file_delete_cascade {
                     return Err(LixError::unknown(format!(
                         "tracked-state diff row references changelog change '{}' that is not the first-parent winner for commit '{}' and identity {:?}",
-                        row.change_id, root_commit_id, identity
+                        row.change_id, root_commit_id, winner_identity
                     )));
                 }
-                self.validate_diff_row_created_at(row, &key, &current_commit_id, change_created_at)
-                    .await?;
-                return Ok(());
             }
 
             let metadata = self
@@ -379,7 +392,7 @@ where
             let Some(parent) = metadata.parent_roots.first() else {
                 return Err(LixError::unknown(format!(
                     "tracked-state diff row references changelog change '{}' that is not the first-parent winner for commit '{}' and identity {:?}",
-                    row.change_id, root_commit_id, identity
+                    row.change_id, root_commit_id, winner_identity
                 )));
             };
             let parent_value = self
@@ -388,7 +401,9 @@ where
             if parent_value.as_ref() != Some(&row_value) {
                 return Err(LixError::unknown(format!(
                     "tracked-state commit-root row for commit '{}' does not match parent root '{}' for inherited identity {:?}",
-                    root_commit_id, parent.commit_id, identity
+                    root_commit_id,
+                    parent.commit_id,
+                    tracked_state_identity_from_key(&key)
                 )));
             }
             current_commit_id = parent.commit_id.to_string();
@@ -824,6 +839,7 @@ where
         let winners = self
             .load_cached_commit_ref_winners(commit_id, &mut cache)
             .await?;
+        let file_delete_cascades = self.load_file_delete_cascade_winners(&winners).await?;
         for (identity, change_id) in &winners {
             if !tracked_state_identity_matches_tree_request(identity, request) {
                 continue;
@@ -862,6 +878,16 @@ where
                     identity, parent.commit_id
                 )));
             };
+            if let Some(file_id) = parent_key.file_id.as_ref()
+                && let Some(cascade_change_id) = file_delete_cascades.get(file_id)
+            {
+                if value.deleted && &value.change_id == cascade_change_id {
+                    continue;
+                }
+                return Err(LixError::unknown(format!(
+                    "tracked-state commit-root for commit '{commit_id}' does not apply file descriptor cascade change '{cascade_change_id}' to inherited identity {identity:?}"
+                )));
+            }
             if *value != &parent_value {
                 return Err(LixError::unknown(format!(
                     "tracked-state commit-root for commit '{commit_id}' does not preserve inherited identity {:?} from parent '{}'",
@@ -870,6 +896,48 @@ where
             }
         }
         Ok(())
+    }
+
+    async fn load_file_delete_cascade_winners(
+        &mut self,
+        winners: &HashMap<TrackedStateIdentity, ChangeId>,
+    ) -> Result<HashMap<String, ChangeId>, LixError> {
+        let mut candidates = winners
+            .iter()
+            .filter_map(|(identity, change_id)| {
+                if identity.schema_key != FILE_DESCRIPTOR_SCHEMA_KEY || identity.file_id.is_some() {
+                    return None;
+                }
+                Some((identity.entity_pk.as_single_string_owned(), *change_id))
+            })
+            .collect::<Vec<_>>();
+        if candidates.is_empty() {
+            return Ok(HashMap::new());
+        }
+        candidates.sort_by_key(|(_, change_id)| *change_id);
+        let change_ids = candidates
+            .iter()
+            .map(|(_, change_id)| *change_id)
+            .collect::<Vec<_>>();
+        let mut changelog_reader = ChangelogContext::new().reader(&mut self.store);
+        let changes = changelog_reader
+            .load_changes(ChangeLoadRequest {
+                change_ids: &change_ids,
+            })
+            .await?;
+        let mut cascades = HashMap::new();
+        for ((file_id, change_id), change) in candidates.into_iter().zip(changes.entries) {
+            let file_id = file_id?;
+            let Some(change) = change else {
+                return Err(LixError::unknown(format!(
+                    "file descriptor winner references missing changelog change '{change_id}'"
+                )));
+            };
+            if change.snapshot.is_none() {
+                cascades.insert(file_id, change_id);
+            }
+        }
+        Ok(cascades)
     }
 
     /// Batched payload-slot load for diff's cross-change equality fallback.
@@ -2051,15 +2119,7 @@ fn validate_diff_row_against_changelog(
             row.change_id
         )));
     };
-    if change.schema_key != row.schema_key
-        || change.file_id != row.file_id
-        || change.entity_pk != row.entity_pk
-    {
-        return Err(LixError::unknown(format!(
-            "tracked-state diff row for change '{}' does not match changelog change identity",
-            row.change_id
-        )));
-    }
+    tracked_state_winner_identity_for_diff_row(row, change)?;
     if row.deleted != change.snapshot.is_none() {
         return Err(LixError::unknown(format!(
             "tracked-state diff row for change '{}' deleted flag does not match changelog snapshot",
@@ -2075,14 +2135,49 @@ fn validate_diff_row_against_changelog(
     Ok(())
 }
 
-fn tracked_state_identity_from_diff_row(
+fn tracked_state_winner_identity_for_diff_row(
     row: &TrackedStateDiffRow,
-) -> Result<TrackedStateIdentity, LixError> {
-    Ok(TrackedStateIdentity {
-        schema_key: row.schema_key.clone(),
-        file_id: row.file_id.clone(),
-        entity_pk: row.entity_pk.clone(),
-    })
+    change: &ChangeRecord,
+) -> Result<TrackedStateRowWinner, LixError> {
+    if change.schema_key == row.schema_key
+        && change.file_id == row.file_id
+        && change.entity_pk == row.entity_pk
+    {
+        return Ok(TrackedStateRowWinner {
+            identity: TrackedStateIdentity {
+                schema_key: row.schema_key.clone(),
+                file_id: row.file_id.clone(),
+                entity_pk: row.entity_pk.clone(),
+            },
+            file_delete_cascade: false,
+        });
+    }
+    if change.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY
+        && change.file_id.is_none()
+        && change.snapshot.is_none()
+        && row.deleted
+    {
+        let file_id = change.entity_pk.as_single_string().map_err(|error| {
+            LixError::unknown(format!(
+                "tracked-state cascade change '{}' has invalid file descriptor identity: {error}",
+                row.change_id
+            ))
+        })?;
+        if row.file_id.as_deref() == Some(file_id) {
+            return Ok(TrackedStateRowWinner {
+                identity: TrackedStateIdentity {
+                    schema_key: change.schema_key.clone(),
+                    file_id: None,
+                    entity_pk: change.entity_pk.clone(),
+                },
+                file_delete_cascade: true,
+            });
+        }
+    }
+    Err(LixError::unknown(format!(
+        "tracked-state diff row for change '{}' does not match changelog change identity",
+        row.change_id
+    )))
 }
 
 fn tracked_state_identity_from_key(key: &TrackedStateKey) -> TrackedStateIdentity {
@@ -4249,12 +4344,56 @@ mod tests {
         .await
         .expect("recreate root should write");
 
+        for commit_id in ["delete", "recreate"] {
+            let read = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("rebuild read should open");
+            let mut writes = storage.new_write_set();
+            tracked_state
+                .root_rebuilder(&read, &mut writes)
+                .rebuild_commit_root_at(commit_id)
+                .await
+                .expect("descriptor cascade root should rebuild and pass its staged audit");
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .expect("rebuilt descriptor cascade root should commit");
+        }
+
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
             .expect("verification read should open");
-        let rows = tracked_state
-            .reader(read)
+        let mut reader = tracked_state.reader(read);
+        reader
+            .validate_commit_root_against_changelog("delete")
+            .await
+            .expect("delete root cascade should pass the full changelog audit");
+        reader
+            .validate_commit_root_against_changelog("recreate")
+            .await
+            .expect("inherited cascade should pass the full changelog audit");
+        let diff = reader
+            .diff_commits(
+                "initial",
+                "delete",
+                &TrackedStateDiffRequest {
+                    filter: crate::tracked_state::TrackedStateFilter {
+                        schema_keys: vec!["test_schema".to_string()],
+                        file_ids: vec![NullableKeyFilter::Value("file-a".to_string())],
+                        ..Default::default()
+                    },
+                },
+            )
+            .await
+            .expect("diff should recognize descriptor-driven semantic tombstones");
+        assert_eq!(diff.entries.len(), 1);
+        assert_eq!(
+            diff.entries[0].kind,
+            crate::tracked_state::TrackedStateDiffKind::Removed
+        );
+        let rows = reader
             .scan_rows_at_commit(
                 "recreate",
                 &TrackedStateScanRequest {

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -1038,19 +1038,58 @@ where
         // exactly its value at the descendant endpoint. Retain it here rather
         // than replaying the entire interval a second time to rediscover it.
         let mut latest_after_by_key = BTreeMap::new();
+        let mut latest_cascade_by_file = BTreeMap::new();
         for commit_id in interval {
             // This interval is strictly newer than `ancestor_commit_id`, while
             // the before-image replay below walks the ancestor and its own
             // parents. Caching the descendant rows by `(commit, key)` cannot
             // satisfy that replay, so keep this one-pass diff discovery free
             // of duplicate key/value ownership.
-            for (key, value) in
-                storage::scan_commit_delta_values(&self.store, commit_id, &request.schema_keys)
-                    .await?
-            {
-                if request.matches_key(&key) {
-                    latest_after_by_key.entry(key).or_insert(value);
+            let entries = self
+                .scan_replayed_commit_delta_values(
+                    commit_id,
+                    &schema_keys_with_file_descriptors(&request.schema_keys),
+                )
+                .await?;
+            for (key, value) in &entries {
+                if request.matches_key(key) {
+                    let value = key
+                        .file_id
+                        .as_ref()
+                        .and_then(|file_id| latest_cascade_by_file.get(file_id))
+                        .filter(|_| !value.deleted)
+                        .map_or_else(
+                            || value.clone(),
+                            |cascade| cascade_tombstone(cascade, value),
+                        );
+                    latest_after_by_key.entry(key.clone()).or_insert(value);
                 }
+            }
+            for (key, value) in entries {
+                if let Some(file_id) = file_delete_cascade(&key, &value)? {
+                    latest_cascade_by_file.entry(file_id).or_insert(value);
+                }
+            }
+        }
+        if !latest_cascade_by_file.is_empty() {
+            let mut inherited_request = request.clone();
+            inherited_request.include_tombstones = false;
+            inherited_request.limit = None;
+            for (key, value) in self
+                .index_entries_at_commit(ancestor_commit_id, &inherited_request)
+                .await?
+            {
+                if latest_after_by_key.contains_key(&key) {
+                    continue;
+                }
+                let Some(cascade) = key
+                    .file_id
+                    .as_ref()
+                    .and_then(|file_id| latest_cascade_by_file.get(file_id))
+                else {
+                    continue;
+                };
+                latest_after_by_key.insert(key, cascade_tombstone(cascade, &value));
             }
         }
         let keys = latest_after_by_key.keys().cloned().collect::<Vec<_>>();
@@ -1213,6 +1252,46 @@ where
             BTreeMap::new()
         };
         for plan in plans.iter().rev() {
+            let explicit_keys = plan
+                .deltas
+                .iter()
+                .map(|delta| TrackedStateKey {
+                    schema_key: delta.schema_key.clone(),
+                    file_id: delta.file_id.clone(),
+                    entity_pk: delta.entity_pk.clone(),
+                })
+                .collect::<BTreeSet<_>>();
+            let mut cascades = BTreeMap::new();
+            for delta in &plan.deltas {
+                let key = TrackedStateKey {
+                    schema_key: delta.schema_key.clone(),
+                    file_id: delta.file_id.clone(),
+                    entity_pk: delta.entity_pk.clone(),
+                };
+                let value = TrackedStateIndexValue {
+                    change_id: delta.change_id,
+                    commit_id: delta.commit_id,
+                    deleted: delta.snapshot.is_none(),
+                    created_at: delta.created_at,
+                    updated_at: delta.updated_at,
+                };
+                if let Some(file_id) = file_delete_cascade(&key, &value)? {
+                    cascades.insert(file_id, value);
+                }
+            }
+            for (key, value) in &mut entries {
+                if value.deleted || explicit_keys.contains(key) {
+                    continue;
+                }
+                let Some(cascade) = key
+                    .file_id
+                    .as_ref()
+                    .and_then(|file_id| cascades.get(file_id))
+                else {
+                    continue;
+                };
+                *value = cascade_tombstone(cascade, value);
+            }
             for delta in &plan.deltas {
                 let key = TrackedStateKey {
                     schema_key: delta.schema_key.clone(),
@@ -1283,6 +1362,7 @@ where
         keys: &[TrackedStateKey],
     ) -> Result<Vec<Option<TrackedStateIndexValue>>, LixError> {
         let mut values = vec![None; keys.len()];
+        let mut pending_cascades = vec![None; keys.len()];
         let mut unresolved = (0..keys.len()).collect::<Vec<_>>();
         let mut current_commit_id =
             CommitId::parse_lix(commit_id, "tracked-state point replay commit_id")?;
@@ -1308,7 +1388,12 @@ where
                     .get_many(&self.store, &root_id, &unresolved_keys)
                     .await?;
                 for (index, value) in unresolved.into_iter().zip(baseline) {
-                    values[index] = value;
+                    values[index] = match (&pending_cascades[index], value) {
+                        (Some(cascade), Some(value)) if !value.deleted => {
+                            Some(cascade_tombstone(cascade, &value))
+                        }
+                        (_, value) => value,
+                    };
                 }
                 break;
             }
@@ -1320,11 +1405,40 @@ where
             let deltas = self
                 .load_replayed_commit_delta_values(current_commit_id, &unresolved_keys)
                 .await?;
+            let descriptor_keys = unresolved_keys
+                .iter()
+                .filter_map(file_descriptor_key_for_file_scoped_key)
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>();
+            let descriptor_deltas = self
+                .load_replayed_commit_delta_values(current_commit_id, &descriptor_keys)
+                .await?;
+            let mut cascades = BTreeMap::new();
+            for (key, value) in descriptor_keys.into_iter().zip(descriptor_deltas) {
+                let Some(value) = value else {
+                    continue;
+                };
+                if let Some(file_id) = file_delete_cascade(&key, &value)? {
+                    cascades.insert(file_id, value);
+                }
+            }
             let mut next_unresolved = Vec::new();
             for (index, delta) in unresolved.into_iter().zip(deltas) {
                 if let Some(delta) = delta {
-                    values[index] = Some(delta);
+                    values[index] = match &pending_cascades[index] {
+                        Some(cascade) if !delta.deleted => Some(cascade_tombstone(cascade, &delta)),
+                        _ => Some(delta),
+                    };
                 } else {
+                    if pending_cascades[index].is_none()
+                        && let Some(cascade) = keys[index]
+                            .file_id
+                            .as_ref()
+                            .and_then(|file_id| cascades.get(file_id))
+                    {
+                        pending_cascades[index] = Some(cascade.clone());
+                    }
                     next_unresolved.push(index);
                 }
             }
@@ -1471,10 +1585,37 @@ where
             BTreeMap::new()
         };
         for commit_id in commits.iter().rev() {
-            for (key, delta) in self
-                .scan_replayed_commit_delta_values(*commit_id, &request.schema_keys)
-                .await?
-            {
+            let deltas = self
+                .scan_replayed_commit_delta_values(
+                    *commit_id,
+                    &schema_keys_with_file_descriptors(&request.schema_keys),
+                )
+                .await?;
+            let explicit_keys = deltas
+                .iter()
+                .filter(|(key, _)| request.matches_key(key))
+                .map(|(key, _)| key.clone())
+                .collect::<BTreeSet<_>>();
+            let mut cascades = BTreeMap::new();
+            for (key, value) in &deltas {
+                if let Some(file_id) = file_delete_cascade(key, value)? {
+                    cascades.insert(file_id, value.clone());
+                }
+            }
+            for (key, value) in &mut entries {
+                if value.deleted || explicit_keys.contains(key) {
+                    continue;
+                }
+                let Some(cascade) = key
+                    .file_id
+                    .as_ref()
+                    .and_then(|file_id| cascades.get(file_id))
+                else {
+                    continue;
+                };
+                *value = cascade_tombstone(cascade, value);
+            }
+            for (key, delta) in deltas {
                 if !request.matches_key(&key) {
                     continue;
                 }
@@ -2069,6 +2210,60 @@ fn tree_scan_request_from_tracked(
         // Pushing them into the physical tree can stop on rows that are later
         // hidden, returning too few live rows.
         limit: None,
+    }
+}
+
+fn schema_keys_with_file_descriptors(schema_keys: &[String]) -> Vec<String> {
+    if schema_keys.is_empty()
+        || schema_keys
+            .iter()
+            .any(|schema_key| schema_key == FILE_DESCRIPTOR_SCHEMA_KEY)
+    {
+        return schema_keys.to_vec();
+    }
+    let mut schema_keys = schema_keys.to_vec();
+    schema_keys.push(FILE_DESCRIPTOR_SCHEMA_KEY.to_string());
+    schema_keys
+}
+
+fn file_descriptor_key_for_file_scoped_key(key: &TrackedStateKey) -> Option<TrackedStateKey> {
+    key.file_id.as_ref().map(|file_id| TrackedStateKey {
+        schema_key: FILE_DESCRIPTOR_SCHEMA_KEY.to_string(),
+        file_id: None,
+        entity_pk: EntityPk::single(file_id),
+    })
+}
+
+fn file_delete_cascade(
+    key: &TrackedStateKey,
+    value: &TrackedStateIndexValue,
+) -> Result<Option<String>, LixError> {
+    if key.schema_key != FILE_DESCRIPTOR_SCHEMA_KEY || key.file_id.is_some() || !value.deleted {
+        return Ok(None);
+    }
+    key.entity_pk
+        .as_single_string_owned()
+        .map(Some)
+        .map_err(|error| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "tracked_state commit_delta file descriptor tombstone has invalid identity: {error}"
+                ),
+            )
+        })
+}
+
+fn cascade_tombstone(
+    cascade: &TrackedStateIndexValue,
+    inherited: &TrackedStateIndexValue,
+) -> TrackedStateIndexValue {
+    TrackedStateIndexValue {
+        change_id: cascade.change_id,
+        commit_id: cascade.commit_id,
+        deleted: true,
+        created_at: inherited.created_at,
+        updated_at: cascade.updated_at,
     }
 }
 
@@ -4295,6 +4490,171 @@ mod tests {
             .commit_write_set(writes, StorageWriteOptions::default())
             .await?;
         Ok(())
+    }
+
+    async fn write_rootless_commit_for_test(
+        storage: &StorageAdapter,
+        commit_id: &str,
+        parent_commit_id: &str,
+        rows: &[MaterializedTrackedStateRow],
+    ) {
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("rootless commit read should open");
+        let mut writes = storage.new_write_set();
+        crate::test_support::stage_rootless_tracked_commit_from_materialized(
+            &mut read,
+            &mut writes,
+            commit_id,
+            Some(parent_commit_id),
+            rows,
+        )
+        .await
+        .expect("rootless commit should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("rootless commit should commit");
+    }
+
+    #[tokio::test]
+    async fn rootless_descriptor_cascade_drives_point_scan_diff_and_merge_reads() {
+        let storage = StorageAdapter::new(Memory::new());
+        let tracked_state = TrackedStateContext::new();
+        let mut descriptor = row("file-a", "descriptor-create", "initial");
+        descriptor.schema_key = FILE_DESCRIPTOR_SCHEMA_KEY.to_string();
+        let mut semantic = row("line-1", "semantic-create", "initial");
+        semantic.file_id = Some("file-a".to_string());
+        write_root_for_test(
+            &storage,
+            &tracked_state,
+            "initial",
+            None,
+            &[descriptor.clone(), semantic.clone()],
+        )
+        .await
+        .expect("initial root should write");
+
+        let mut descriptor_delete = descriptor.clone();
+        descriptor_delete.snapshot_content = None;
+        descriptor_delete.deleted = true;
+        descriptor_delete.change_id = ChangeId::for_test_label("descriptor-delete");
+        descriptor_delete.commit_id = CommitId::for_test_label("delete");
+        descriptor_delete.updated_at = "2026-01-02T00:00:00Z".to_string();
+        write_rootless_commit_for_test(
+            &storage,
+            "delete",
+            "initial",
+            std::slice::from_ref(&descriptor_delete),
+        )
+        .await;
+
+        let semantic_key = TrackedStateKey {
+            schema_key: semantic.schema_key.clone(),
+            file_id: semantic.file_id.clone(),
+            entity_pk: semantic.entity_pk.clone(),
+        };
+        let mut reader = tracked_state.reader(
+            storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("rootless read should open"),
+        );
+        let point = reader
+            .load_rows_at_commit("delete", std::slice::from_ref(&semantic_key))
+            .await
+            .expect("rootless cascade point read should succeed")
+            .pop()
+            .flatten()
+            .expect("cascaded semantic row should remain addressable");
+        assert!(point.deleted);
+        assert_eq!(point.change_id, descriptor_delete.change_id);
+        assert_eq!(point.created_at, "2026-01-01T00:00:00.000Z");
+
+        let scan = reader
+            .scan_rows_at_commit(
+                "delete",
+                &TrackedStateScanRequest {
+                    filter: crate::tracked_state::TrackedStateFilter {
+                        schema_keys: vec![semantic.schema_key.clone()],
+                        file_ids: vec![NullableKeyFilter::Value("file-a".to_string())],
+                        include_tombstones: true,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("rootless cascade scan should succeed");
+        assert_eq!(scan.len(), 1);
+        assert!(scan[0].deleted);
+        assert_eq!(scan[0].change_id, descriptor_delete.change_id);
+
+        let diff = reader
+            .diff_commits(
+                "initial",
+                "delete",
+                &TrackedStateDiffRequest {
+                    filter: crate::tracked_state::TrackedStateFilter {
+                        schema_keys: vec![semantic.schema_key.clone()],
+                        file_ids: vec![NullableKeyFilter::Value("file-a".to_string())],
+                        ..Default::default()
+                    },
+                },
+            )
+            .await
+            .expect("rootless cascade diff should succeed");
+        assert_eq!(diff.entries.len(), 1);
+        assert_eq!(
+            diff.entries[0].kind,
+            crate::tracked_state::TrackedStateDiffKind::Removed
+        );
+        drop(reader);
+
+        semantic.change_id = ChangeId::for_test_label("semantic-edit");
+        semantic.commit_id = CommitId::for_test_label("source");
+        semantic.updated_at = "2026-01-02T00:00:00Z".to_string();
+        semantic.snapshot_content = Some(r#"{"value":"source"}"#.to_string());
+        write_rootless_commit_for_test(
+            &storage,
+            "source",
+            "initial",
+            std::slice::from_ref(&semantic),
+        )
+        .await;
+
+        let plan = tracked_state
+            .reader(
+                storage
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .expect("merge read should open"),
+            )
+            .plan_merge(
+                "initial",
+                "delete",
+                "source",
+                &TrackedStateDiffRequest {
+                    filter: crate::tracked_state::TrackedStateFilter {
+                        schema_keys: vec![semantic.schema_key],
+                        file_ids: vec![NullableKeyFilter::Value("file-a".to_string())],
+                        ..Default::default()
+                    },
+                },
+            )
+            .await
+            .expect("rootless delete-vs-edit merge should plan");
+        assert!(plan.picks.is_empty());
+        assert_eq!(merge_conflict_ids(&plan), vec!["line-1"]);
+        assert!(
+            plan.conflicts[0]
+                .target
+                .after
+                .as_ref()
+                .expect("target cascade should have an after row")
+                .deleted
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -17,7 +17,7 @@ use crate::changelog::{
 };
 use crate::entity_pk::EntityPk;
 use crate::storage_adapter::{StorageAdapterRead, StorageWriteSet};
-use crate::tracked_state::codec::{encode_key_ref, encode_value_ref};
+use crate::tracked_state::codec::{encode_key, encode_key_ref, encode_value_ref};
 use crate::tracked_state::diff::{
     TrackedStateDiff, TrackedStateDiffRequest, TrackedStateDiffRow, diff_commits,
 };
@@ -27,14 +27,17 @@ use crate::tracked_state::merge::{self, TrackedStateMergePlan};
 use crate::tracked_state::storage;
 use crate::tracked_state::tree::TrackedStateTree;
 use crate::tracked_state::types::{
-    TrackedStateCommitRoot, TrackedStateCommitRootParent, TrackedStateIndexValue, TrackedStateKey,
-    TrackedStateKeyRef, TrackedStateMutation, TrackedStateRootId, TrackedStateTreeScanRequest,
+    TrackedStateCommitRoot, TrackedStateCommitRootParent, TrackedStateIndexValue,
+    TrackedStateIndexValueRef, TrackedStateKey, TrackedStateKeyRef, TrackedStateMutation,
+    TrackedStateRootId, TrackedStateTreeScanRequest,
 };
 use crate::tracked_state::{
     MaterializedTrackedStateRow, TrackedStateDeltaRef, TrackedStateRootMutationRef,
     TrackedStateScanRequest,
 };
 use crate::{LixError, NullableKeyFilter};
+
+const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct TrackedStateIdentity {
@@ -1634,6 +1637,78 @@ where
                 primary_chunk_puts: 0,
             });
         }
+        let explicit_keys = deltas
+            .iter()
+            .map(|delta| TrackedStateKey {
+                schema_key: delta.schema_key.to_string(),
+                file_id: delta.file_id.map(str::to_string),
+                entity_pk: delta.entity_pk.clone(),
+            })
+            .collect::<BTreeSet<_>>();
+        let mut cascade_mutations = BTreeMap::<Vec<u8>, Vec<u8>>::new();
+        if let Some(base_root) = base_root.as_ref() {
+            let staged_read = storage::TrackedStateStagedRead::new(
+                self.store,
+                self.staged_roots.values(),
+                &self.chunk_overlay,
+            )?;
+            let mut cascades = BTreeMap::<String, &TrackedStateDeltaRef<'_>>::new();
+            for delta in &deltas {
+                if delta.schema_key != FILE_DESCRIPTOR_SCHEMA_KEY
+                    || delta.file_id.is_some()
+                    || !delta.deleted
+                {
+                    continue;
+                }
+                let file_id = delta.entity_pk.as_single_string().map_err(|error| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!("file descriptor tombstone has invalid identity: {error}"),
+                    )
+                })?;
+                cascades.insert(file_id.to_string(), delta);
+            }
+            if !cascades.is_empty() {
+                let rows = self
+                    .tree
+                    .scan(
+                        &staged_read,
+                        base_root,
+                        &TrackedStateTreeScanRequest {
+                            file_ids: cascades
+                                .keys()
+                                .cloned()
+                                .map(NullableKeyFilter::Value)
+                                .collect(),
+                            include_tombstones: false,
+                            ..TrackedStateTreeScanRequest::default()
+                        },
+                    )
+                    .await?;
+                for (key, value) in rows {
+                    if explicit_keys.contains(&key) {
+                        continue;
+                    }
+                    let cascade = cascades
+                        .get(
+                            key.file_id
+                                .as_deref()
+                                .expect("file-filtered tracked row requires file id"),
+                        )
+                        .expect("tracked scan only returns requested cascade ids");
+                    cascade_mutations.insert(
+                        encode_key(&key),
+                        encode_value_ref(TrackedStateIndexValueRef {
+                            change_id: cascade.change_id,
+                            commit_id: cascade.commit_id,
+                            deleted: true,
+                            created_at: value.created_at(),
+                            updated_at: cascade.updated_at,
+                        }),
+                    );
+                }
+            }
+        }
         let parent_values = if let Some(base_root) = base_root.as_ref() {
             let keys = deltas
                 .iter()
@@ -1656,7 +1731,11 @@ where
         } else {
             vec![None; deltas.len()]
         };
-        let mut mutations = Vec::with_capacity(deltas.len());
+        let mut mutations = cascade_mutations
+            .into_iter()
+            .map(|(key, value)| TrackedStateMutation::put_encoded(key, value))
+            .collect::<Vec<_>>();
+        mutations.reserve(deltas.len());
         for (delta, parent_value) in deltas.iter().zip(parent_values.iter()) {
             let key = TrackedStateKey {
                 schema_key: delta.schema_key.to_string(),
@@ -1685,7 +1764,7 @@ where
                 file_id: delta.file_id,
                 entity_pk: delta.entity_pk,
             };
-            let value = crate::tracked_state::types::TrackedStateIndexValueRef {
+            let value = TrackedStateIndexValueRef {
                 change_id: delta.change_id,
                 commit_id: delta.commit_id,
                 deleted: delta.deleted,
@@ -1698,6 +1777,7 @@ where
                 encode_value_ref(value),
             ));
         }
+        let changed_rows = mutations.len();
         let result = self
             .tree
             .apply_mutations_with_overlay(
@@ -1721,7 +1801,7 @@ where
                     }]
                 })
                 .unwrap_or_default(),
-            changed_key_count: u64::try_from(deltas.len()).map_err(|_| {
+            changed_key_count: u64::try_from(changed_rows).map_err(|_| {
                 LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
                     "tracked_state commit_root changed key count exceeds u64",
@@ -1758,7 +1838,7 @@ where
         Ok(TrackedStateWriteReport {
             commit_id: typed_commit_id,
             root_id: result.root_id,
-            changed_rows: deltas.len(),
+            changed_rows,
             primary_chunk_puts: result.chunk_count,
         })
     }
@@ -1772,6 +1852,7 @@ where
         parent_commit_id: Option<&str>,
         mutation_count: usize,
         first_mutation_key: &[u8],
+        file_delete_cascades: &BTreeMap<String, TrackedStateDeltaRef<'a>>,
         mutations: I,
     ) -> Result<Option<TrackedStateWriteReport>, LixError>
     where
@@ -1823,17 +1904,24 @@ where
             return Ok(None);
         }
 
-        let result = self
+        let (result, cascaded_rows) = self
             .tree
             .merge_and_stage_ordered_parent_mutations(
                 self.store,
                 self.writes,
                 &mut self.chunk_overlay,
                 &parent_metadata.root_id,
+                file_delete_cascades,
                 mutations,
                 Some(commit_id),
             )
             .await?;
+        let changed_rows = mutation_count.checked_add(cascaded_rows).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state commit_root changed key count exceeds usize",
+            )
+        })?;
         let metadata = TrackedStateCommitRoot {
             commit_id: typed_commit_id,
             root_id: result.root_id.clone(),
@@ -1841,7 +1929,12 @@ where
                 commit_id: typed_parent_commit_id,
                 root_id: parent_metadata.root_id,
             }],
-            changed_key_count: mutation_count_u64,
+            changed_key_count: u64::try_from(changed_rows).map_err(|_| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state commit_root changed key count exceeds u64",
+                )
+            })?,
             row_count_estimate: u64::try_from(result.row_count).map_err(|_| {
                 LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
@@ -1873,7 +1966,7 @@ where
         Ok(Some(TrackedStateWriteReport {
             commit_id: typed_commit_id,
             root_id: result.root_id,
-            changed_rows: mutation_count,
+            changed_rows,
             primary_chunk_puts: result.chunk_count,
         }))
     }
@@ -2192,6 +2285,7 @@ mod tests {
                     Some(&parent_commit_id),
                     child_rows.len(),
                     &first_child_key,
+                    &BTreeMap::new(),
                     child_rows.iter().map(|row| {
                         Ok(TrackedStateRootMutationRef {
                             delta: delta_from_materialized_row(row),
@@ -2329,6 +2423,7 @@ mod tests {
                 Some(&parent_commit_id),
                 child_rows.len(),
                 &first_child_key,
+                &BTreeMap::new(),
                 child_rows.iter().map(|row| {
                     Ok(TrackedStateRootMutationRef {
                         delta: delta_from_materialized_row(row),
@@ -2378,6 +2473,7 @@ mod tests {
                     Some(&parent_commit_id),
                     child_rows.len(),
                     &first_child_key,
+                    &BTreeMap::new(),
                     child_rows.iter().enumerate().map(|(index, row)| {
                         Ok(TrackedStateRootMutationRef {
                             delta: delta_from_materialized_row(row),
@@ -2429,6 +2525,7 @@ mod tests {
                     Some(&parent_commit_id),
                     child_rows.len(),
                     &first_child_key,
+                    &BTreeMap::new(),
                     child_rows.iter().map(|row| {
                         Ok(TrackedStateRootMutationRef {
                             delta: delta_from_materialized_row(row),
@@ -4105,6 +4202,81 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn file_descriptor_delete_cascade_survives_root_rebuild_and_recreate() {
+        let storage = StorageAdapter::new(Memory::new());
+        let tracked_state = TrackedStateContext::new();
+        let mut descriptor = row("file-a", "descriptor-create", "initial");
+        descriptor.schema_key = FILE_DESCRIPTOR_SCHEMA_KEY.to_string();
+        let mut semantic = row("line-1", "semantic-create", "initial");
+        semantic.file_id = Some("file-a".to_string());
+        write_root_for_test(
+            &storage,
+            &tracked_state,
+            "initial",
+            None,
+            &[descriptor.clone(), semantic],
+        )
+        .await
+        .expect("initial root should write");
+
+        let mut descriptor_delete = descriptor.clone();
+        descriptor_delete.snapshot_content = None;
+        descriptor_delete.deleted = true;
+        descriptor_delete.change_id = ChangeId::for_test_label("descriptor-delete");
+        descriptor_delete.commit_id = CommitId::for_test_label("delete");
+        descriptor_delete.updated_at = "2026-01-02T00:00:00Z".to_string();
+        write_root_for_test(
+            &storage,
+            &tracked_state,
+            "delete",
+            Some("initial"),
+            &[descriptor_delete],
+        )
+        .await
+        .expect("delete root should write");
+
+        descriptor.change_id = ChangeId::for_test_label("descriptor-recreate");
+        descriptor.commit_id = CommitId::for_test_label("recreate");
+        descriptor.updated_at = "2026-01-03T00:00:00Z".to_string();
+        write_root_for_test(
+            &storage,
+            &tracked_state,
+            "recreate",
+            Some("delete"),
+            &[descriptor],
+        )
+        .await
+        .expect("recreate root should write");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("verification read should open");
+        let rows = tracked_state
+            .reader(read)
+            .scan_rows_at_commit(
+                "recreate",
+                &TrackedStateScanRequest {
+                    filter: crate::tracked_state::TrackedStateFilter {
+                        schema_keys: vec!["test_schema".to_string()],
+                        file_ids: vec![NullableKeyFilter::Value("file-a".to_string())],
+                        include_tombstones: true,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("recreated root should scan");
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].deleted);
+        assert_eq!(
+            rows[0].change_id,
+            ChangeId::for_test_label("descriptor-delete")
+        );
+    }
+
     async fn delete_root_chunk_for_test(storage: &StorageAdapter, commit_id: &str) {
         let read = storage
             .begin_read(StorageReadOptions::default())
@@ -4178,7 +4350,7 @@ mod tests {
                     ),
                 };
                 TrackedStateMutation::put_encoded(
-                    crate::tracked_state::codec::encode_key(&key),
+                    encode_key(&key),
                     crate::tracked_state::codec::encode_value(&value),
                 )
             })

--- a/packages/engine/src/tracked_state/tree.rs
+++ b/packages/engine/src/tracked_state/tree.rs
@@ -363,9 +363,10 @@ impl TrackedStateTree {
         writes: &mut StorageWriteSet,
         overlay: &mut storage::TrackedStateChunkOverlay,
         root_id: &TrackedStateRootId,
+        file_delete_cascades: &BTreeMap<String, TrackedStateDeltaRef<'a>>,
         mutations: I,
         commit_id: Option<&str>,
-    ) -> Result<TrackedStateApplyResult, LixError>
+    ) -> Result<(TrackedStateApplyResult, usize), LixError>
     where
         I: IntoIterator<Item = Result<TrackedStateRootMutationRef<'a>, LixError>>,
     {
@@ -373,10 +374,14 @@ impl TrackedStateTree {
         let mut mutations = mutations.into_iter();
         let mut next_mutation = next_root_mutation(&mut mutations)?;
         let mut assembler = OrderedTreeAssembler::new(&self.options);
+        let mut cascaded_rows = 0usize;
 
         let mut next_parent_entry = parent_entries.next(self, store, overlay).await?;
         while let Some(parent_entry) = next_parent_entry.take() {
             let Some(mutation) = next_mutation.take() else {
+                let (parent_entry, cascaded) =
+                    cascade_parent_entry(parent_entry, file_delete_cascades)?;
+                cascaded_rows += usize::from(cascaded);
                 assembler.push(parent_entry)?;
                 next_parent_entry = parent_entries.next(self, store, overlay).await?;
                 continue;
@@ -398,6 +403,9 @@ impl TrackedStateTree {
                     next_parent_entry = parent_entries.next(self, store, overlay).await?;
                 }
                 std::cmp::Ordering::Greater => {
+                    let (parent_entry, cascaded) =
+                        cascade_parent_entry(parent_entry, file_delete_cascades)?;
+                    cascaded_rows += usize::from(cascaded);
                     assembler.push(parent_entry)?;
                     next_mutation = Some(mutation);
                     next_parent_entry = parent_entries.next(self, store, overlay).await?;
@@ -412,8 +420,10 @@ impl TrackedStateTree {
         }
 
         let built = assembler.finish(self)?;
-        self.persist_built_tree(writes, overlay, built, commit_id)
-            .await
+        let result = self
+            .persist_built_tree(writes, overlay, built, commit_id)
+            .await?;
+        Ok((result, cascaded_rows))
     }
 
     /// Returns true when every sorted incoming key is strictly beyond the
@@ -2106,6 +2116,34 @@ impl PendingRootMutation<'_> {
             value: encode_value_ref(value),
         }
     }
+}
+
+fn cascade_parent_entry(
+    mut entry: EncodedLeafEntry,
+    file_delete_cascades: &BTreeMap<String, TrackedStateDeltaRef<'_>>,
+) -> Result<(EncodedLeafEntry, bool), LixError> {
+    if file_delete_cascades.is_empty() {
+        return Ok((entry, false));
+    }
+    let key = decode_key(&entry.key)?;
+    let Some(file_id) = key.file_id.as_deref() else {
+        return Ok((entry, false));
+    };
+    let Some(cascade) = file_delete_cascades.get(file_id) else {
+        return Ok((entry, false));
+    };
+    let parent_value = decode_value(&entry.value)?;
+    if parent_value.deleted() {
+        return Ok((entry, false));
+    }
+    entry.value = encode_value_ref(TrackedStateIndexValueRef {
+        change_id: cascade.change_id,
+        commit_id: cascade.commit_id,
+        deleted: true,
+        created_at: parent_value.created_at(),
+        updated_at: cascade.updated_at,
+    });
+    Ok((entry, true))
 }
 
 fn next_root_mutation<'a, I>(mutations: &mut I) -> Result<Option<PendingRootMutation<'a>>, LixError>

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -1270,6 +1270,33 @@ fn apply_lifecycle_tracked_snapshot_row(
     mut next: MaterializedTrackedStateRow,
     require_absence: bool,
 ) -> Result<(), LixError> {
+    if next.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY
+        && next.file_id.is_none()
+        && next.snapshot_content.is_none()
+    {
+        let file_id = next.entity_pk.as_single_string().map_err(|error| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("file descriptor tombstone has invalid identity: {error}"),
+            )
+        })?;
+        let cascade_keys = rows
+            .iter()
+            .filter(|(key, value)| key.file_id.as_deref() == Some(file_id) && !value.deleted)
+            .map(|(key, _)| key.clone())
+            .collect::<Vec<_>>();
+        for key in cascade_keys {
+            let value = rows
+                .get_mut(&key)
+                .expect("cascade key was selected from this snapshot");
+            value.snapshot_content = None;
+            value.metadata = None;
+            value.deleted = true;
+            value.updated_at.clone_from(&next.updated_at);
+            value.change_id = next.change_id;
+            value.commit_id = next.commit_id;
+        }
+    }
     let key = TrackedStateKey {
         schema_key: next.schema_key.clone(),
         entity_pk: next.entity_pk.clone(),
@@ -2426,6 +2453,26 @@ async fn stage_tracked_roots(
         {
             let commit_id_text = root.commit_id.to_string();
             let parent_commit_id_text = root.parent_commit_id.map(|id| id.to_string());
+            let file_delete_cascades = state_row_indices
+                .iter()
+                .filter_map(|&row_index| {
+                    let row = &state_rows[row_index];
+                    (row.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY
+                        && row.file_id.is_none()
+                        && row.snapshot.is_none())
+                    .then_some(row)
+                })
+                .map(|row| {
+                    let delta = tracked_delta_from_state_row(row)?;
+                    let file_id = row.entity_pk.as_single_string().map_err(|error| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            format!("file descriptor tombstone has invalid identity: {error}"),
+                        )
+                    })?;
+                    Ok((file_id.to_string(), delta))
+                })
+                .collect::<Result<BTreeMap<_, _>, LixError>>()?;
             let first_row = &state_rows[state_row_indices[0]];
             let first_mutation_key = encode_key_ref(TrackedStateKeyRef {
                 schema_key: &first_row.schema_key,
@@ -2438,6 +2485,7 @@ async fn stage_tracked_roots(
                     parent_commit_id_text.as_deref(),
                     state_row_indices.len(),
                     &first_mutation_key,
+                    &file_delete_cascades,
                     state_row_indices.iter().map(|&row_index| {
                         let row = &state_rows[row_index];
                         Ok(TrackedStateRootMutationRef {
@@ -2802,6 +2850,66 @@ mod tests {
 
     fn ts(value: &str) -> LixTimestamp {
         LixTimestamp::expect_parse("timestamp", value)
+    }
+
+    #[test]
+    fn lifecycle_file_delete_cascade_survives_descriptor_recreation() {
+        let semantic_key = TrackedStateKey {
+            schema_key: "semantic".to_string(),
+            entity_pk: EntityPk::single("line-1"),
+            file_id: Some("file-a".to_string()),
+        };
+        let semantic = MaterializedTrackedStateRow {
+            entity_pk: semantic_key.entity_pk.clone(),
+            schema_key: semantic_key.schema_key.clone(),
+            file_id: semantic_key.file_id.clone(),
+            snapshot_content: Some("{\"value\":1}".to_string()),
+            metadata: Some("{\"source\":\"plugin\"}".to_string()),
+            deleted: false,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+            change_id: ChangeId::for_test_label("semantic-create"),
+            commit_id: CommitId::for_test_label("initial"),
+        };
+        let mut rows = BTreeMap::from([(semantic_key.clone(), semantic)]);
+        let descriptor_delete = MaterializedTrackedStateRow {
+            entity_pk: EntityPk::single("file-a"),
+            schema_key: FILE_DESCRIPTOR_SCHEMA_KEY.to_string(),
+            file_id: None,
+            snapshot_content: None,
+            metadata: None,
+            deleted: true,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-02T00:00:00Z".to_string(),
+            change_id: ChangeId::for_test_label("descriptor-delete"),
+            commit_id: CommitId::for_test_label("delete"),
+        };
+        apply_lifecycle_tracked_snapshot_row(&mut rows, descriptor_delete, false)
+            .expect("descriptor delete should cascade");
+
+        let mut descriptor_recreate = rows
+            .values()
+            .find(|row| row.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY)
+            .expect("descriptor tombstone should exist")
+            .clone();
+        descriptor_recreate.snapshot_content = Some("{\"name\":\"a\"}".to_string());
+        descriptor_recreate.deleted = false;
+        descriptor_recreate.updated_at = "2026-01-03T00:00:00Z".to_string();
+        descriptor_recreate.change_id = ChangeId::for_test_label("descriptor-recreate");
+        descriptor_recreate.commit_id = CommitId::for_test_label("recreate");
+        apply_lifecycle_tracked_snapshot_row(&mut rows, descriptor_recreate, false)
+            .expect("descriptor recreation should apply");
+
+        let semantic = rows
+            .get(&semantic_key)
+            .expect("semantic cascade tombstone should remain");
+        assert!(semantic.deleted);
+        assert_eq!(semantic.snapshot_content, None);
+        assert_eq!(semantic.metadata, None);
+        assert_eq!(
+            semantic.change_id,
+            ChangeId::for_test_label("descriptor-delete")
+        );
     }
 
     const DETERMINISTIC_MODE_KEY: &str = "lix_deterministic_mode";

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -2706,6 +2706,12 @@ where
 
         let mut state_groups = BTreeMap::<PluginStateGroupKey, PluginStateGroup>::new();
         for (key, owner) in &owners {
+            // Descriptor deletion cascades file-scoped current state in the
+            // head materializer. Avoid hydrating the full plugin graph only
+            // to persist one historical tombstone per semantic entity.
+            if deleted_file_keys.contains_key(key) {
+                continue;
+            }
             let selected = selected_plugins.get(key);
             let semantic = semantic_groups.get(key).map(|group| &group.plugin);
             // A same-owner v2 write is authorized by an exact document
@@ -3731,43 +3737,23 @@ where
             reconciled_file_keys.insert(file_key);
         }
 
-        for (file_key, metadata) in deleted_file_keys {
+        for (file_key, _metadata) in deleted_file_keys {
             if reconciled_file_keys.contains(&file_key) {
                 continue;
             }
             reconciliation
                 .rows
                 .extend(self.v2_id_reservation_tombstones(&file_key).await?);
-            let Some(owner) = owners.get(&file_key) else {
+            if !owners.contains_key(&file_key) {
                 reconciliation.remove_session_file_view(SessionFileViewKey::new(
                     &file_key.branch_id,
                     &file_key.file_id,
                 ));
                 continue;
-            };
+            }
             reconciliation.remove_session_file_view(SessionFileViewKey::new(
                 &file_key.branch_id,
                 &file_key.file_id,
-            ));
-            let active_state = state_by_file
-                .get(&PluginStateFileKey {
-                    branch_id: file_key.branch_id.clone(),
-                    plugin_key: owner.plugin_key().to_string(),
-                    file_id: file_key.file_id.clone(),
-                })
-                .cloned()
-                .unwrap_or_default();
-            let context = FilesystemRowContext {
-                branch_id: file_key.branch_id.clone(),
-                global: false,
-                untracked: false,
-                file_id: None,
-                metadata,
-            };
-            reconciliation.rows.extend(plugin_state_tombstone_rows(
-                &active_state,
-                &file_key.file_id,
-                &context,
             ));
             reconciliation.rows.push(PluginFileOwner::delete_row(
                 file_key.file_id,

--- a/packages/engine/src/transaction/validation.rs
+++ b/packages/engine/src/transaction/validation.rs
@@ -12,6 +12,7 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 use serde_json::Value as JsonValue;
 use tracing::Instrument as _;
 
+use crate::LixError;
 use crate::branch::{BRANCH_DESCRIPTOR_SCHEMA_KEY, BRANCH_REF_SCHEMA_KEY};
 use crate::catalog::{
     CatalogSnapshot, ForeignKeyPlan, SchemaCatalogKey, SchemaPlan, StateDeleteReferencePlan,
@@ -46,8 +47,6 @@ use crate::transaction::staging::{
 use crate::transaction::types::{
     PreparedStateRow, TransactionWriteOperation, TransactionWriteOrigin,
 };
-use crate::{LixError, NullableKeyFilter};
-
 const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 const DIRECTORY_DESCRIPTOR_SCHEMA_KEY: &str = "lix_directory_descriptor";
 const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
@@ -291,12 +290,6 @@ pub(crate) async fn validate_prepared_writes(
         .instrument(tracing::debug_span!(
             target: "lix_perf",
             "lix.perf.validation.delete_restrictions"
-        ))
-        .await?;
-    validate_file_descriptor_delete_restrictions(&input, &pending_constraints)
-        .instrument(tracing::debug_span!(
-            target: "lix_perf",
-            "lix.perf.validation.file_delete_restrictions"
         ))
         .await?;
     validate_branch_ref_delete_restrictions(&input, &pending_constraints)
@@ -2227,80 +2220,6 @@ struct StateDeleteRestrictionBatchKey {
     source_key: SchemaCatalogKey,
     source_domain: Domain,
     foreign_key: StateDeleteReferencePlan,
-}
-
-async fn validate_file_descriptor_delete_restrictions(
-    input: &TransactionValidationInput<'_>,
-    pending_constraints: &PendingConstraintIndexes,
-) -> Result<(), LixError> {
-    let mut batches = BTreeMap::<Domain, BTreeMap<String, DomainRowIdentity>>::new();
-    for tombstone in &pending_constraints.tombstones {
-        if tombstone.identity.schema_key() != FILE_DESCRIPTOR_SCHEMA_KEY {
-            continue;
-        }
-        if !tombstone.identity.domain().is_exact_file(&None) {
-            continue;
-        }
-        let file_id = tombstone.identity.entity_pk().as_single_string_owned()?;
-        for source_domain in tombstone
-            .identity
-            .domain()
-            .file_scoped_row_domains_for_file_descriptor_delete()
-        {
-            batches
-                .entry(source_domain.with_file_scope(DomainFileScope::Any))
-                .or_default()
-                .insert(file_id.clone(), tombstone.identity.clone());
-        }
-    }
-
-    for (source_domain, targets) in batches {
-        let file_ids = targets
-            .keys()
-            .cloned()
-            .map(NullableKeyFilter::Value)
-            .collect::<Vec<_>>();
-        let request = LiveStateScanRequest {
-            filter: LiveStateFilter {
-                branch_ids: vec![source_domain.branch_id().to_string()],
-                file_ids,
-                untracked: Some(source_domain.untracked()),
-                include_tombstones: false,
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let rows = if source_domain.untracked() {
-            input.live_state.scan_rows(&request).await?
-        } else {
-            input.live_state.scan_tracked_rows(&request).await?
-        };
-        for row in rows {
-            if !source_domain.contains(&row)
-                || pending_constraints.tombstones_identity(&row)
-                || row.snapshot_content.is_none()
-            {
-                continue;
-            }
-            let Some(file_id) = row.file_id.as_ref() else {
-                continue;
-            };
-            let Some(descriptor) = targets.get(file_id) else {
-                continue;
-            };
-            return Err(LixError::new(
-                LixError::CODE_FOREIGN_KEY,
-                format!(
-                    "cannot delete file descriptor '{}' in branch '{}' because committed row '{}' in schema '{}' is still scoped to that file",
-                    file_id,
-                    descriptor.domain().branch_id(),
-                    row.entity_pk.as_json_array_text()?,
-                    row.schema_key,
-                ),
-            ));
-        }
-    }
-    Ok(())
 }
 
 async fn validate_committed_normal_delete_restriction(
@@ -4732,7 +4651,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn validation_rejects_deleting_file_descriptor_referenced_by_committed_row() {
+    async fn validation_allows_file_delete_cascade_over_committed_tracked_rows() {
         let visible_schemas = vec![
             unique_schema(),
             file_descriptor_schema(),
@@ -4748,21 +4667,17 @@ mod tests {
             rows: vec![committed_unique_row("post-1", "hello-world", "first")],
         };
 
-        let error =
-            validate_prepared_writes(TransactionValidationInput::from_visible_schemas_for_tests(
-                &staged_writes,
-                &visible_schemas,
-                &live_state,
-            ))
-            .await
-            .expect_err("file descriptor delete must be blocked by committed file-owned rows");
-
-        assert_eq!(error.code, LixError::CODE_FOREIGN_KEY);
+        validate_prepared_writes(TransactionValidationInput::from_visible_schemas_for_tests(
+            &staged_writes,
+            &visible_schemas,
+            &live_state,
+        ))
+        .await
+        .expect("file descriptor deletion cascades committed file-owned rows");
     }
 
     #[tokio::test]
-    async fn validation_rejects_deleting_tracked_file_descriptor_referenced_by_committed_untracked_row()
-     {
+    async fn validation_allows_file_delete_cascade_over_committed_untracked_rows() {
         let visible_schemas = vec![
             unique_schema(),
             file_descriptor_schema(),
@@ -4784,53 +4699,13 @@ mod tests {
             ],
         };
 
-        let error =
-            validate_prepared_writes(TransactionValidationInput::from_visible_schemas_for_tests(
-                &staged_writes,
-                &visible_schemas,
-                &live_state,
-            ))
-            .await
-            .expect_err("tracked file descriptor delete must be blocked by untracked rows");
-
-        assert_eq!(error.code, LixError::CODE_FOREIGN_KEY);
-    }
-
-    #[tokio::test]
-    async fn file_descriptor_delete_validation_batches_files_by_visibility_domain() {
-        let mut file_a_delete = staged_file_descriptor_row("file-a", "branch-a");
-        file_a_delete.snapshot = None;
-        let mut file_b_delete = staged_file_descriptor_row("file-b", "branch-a");
-        file_b_delete.snapshot = None;
-        let staged_writes = PreparedWriteSet {
-            state_rows: vec![file_a_delete, file_b_delete],
-            ..empty_staged_write_set()
-        };
-        let validation_set = staged_writes.validation_set_for_tests();
-        let catalog = CatalogSnapshot::from_visible_schemas(&[
-            file_descriptor_schema(),
-            directory_descriptor_schema(),
-        ])
-        .expect("catalog should build");
-        let live_state = CountingStaticLiveStateReader {
-            rows: Vec::new(),
-            scan_count: AtomicUsize::new(0),
-        };
-        let input = TransactionValidationInput::new(&validation_set, &catalog, &live_state);
-        let mut pending_constraints = PendingConstraintIndexes::default();
-        for row in validation_set.rows() {
-            pending_constraints.remember_tombstone(row);
-        }
-
-        validate_file_descriptor_delete_restrictions(&input, &pending_constraints)
-            .await
-            .expect("unreferenced file descriptors should be deletable");
-
-        assert_eq!(
-            live_state.scan_count.load(Ordering::Relaxed),
-            2,
-            "tracked and untracked visibility each require one scan, independent of file count"
-        );
+        validate_prepared_writes(TransactionValidationInput::from_visible_schemas_for_tests(
+            &staged_writes,
+            &visible_schemas,
+            &live_state,
+        ))
+        .await
+        .expect("file descriptor deletion cascades untracked file-owned rows");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

File descriptor deletion now has CASCADE semantics for file-scoped plugin state. The changelog records the descriptor deletion once; canonical tracked roots and hot current state synthesize the dependent semantic tombstones while materializing state.

This removes plugin-state hydration and one durable changelog tombstone per file-owned semantic entity. It also removes the old delete restriction and intentionally provides no compatibility shim.

The cascade is covered across:

- incremental hot-head updates (tracked tombstones and physical removal of untracked rows)
- canonical tracked roots, including dense ordered root construction
- lifecycle/merge snapshot materialization
- root rebuild followed by descriptor recreation, preventing semantic-row resurrection

## OpenClaw RocksDB replay

Frozen workload: the first 100 first-parent commits of `openclaw/openclaw` (`f6dd362` through `948ff7f`), replayed with Git-text into RocksDB. Baseline is current `origin/main` (`18e10a7fe`, including Zstd SST compression). Results are medians from 8 alternating baseline/candidate pairs.

| Axis | `main` | this PR | change |
|---|---:|---:|---:|
| replay elapsed | 1,671.8 ms | 1,351.1 ms | **-19.2%** |
| engine execute | 1,614.6 ms | 1,295.9 ms | **-19.7%** |
| RocksDB flush | 103.0 ms | 92.5 ms | **-10.2%** |
| RocksDB bytes | 4,596,829 | 4,056,665 | **-11.7%** |
| peak RSS | 150.8 MiB | 213.3 MiB | +41.4% |

The delete-heavy commit `d0c9bff` falls from 246.9 ms to 74.2 ms (**-69.9%**).

Peak RSS regresses because the hot cascade batches the file-space scan and matching primary reads; the time and durable-storage wins are the intended axes for this PR.

## Correctness and validation

- exact Git-state verification after every replayed commit: **100/100**, plus final tree manifest
- `cargo test -p lix_engine`: **1,369 unit + 412 integration + 3 doc**, zero failures
- `cargo test -p lix_engine --features all-simulations`: **1,369 unit + 758 integration + 3 doc**, zero failures
- `cargo fmt --package lix_engine -- --check`
- `git diff --check`
