### PR TITLE
perf: scan dense hot-state identities

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -65,6 +65,34 @@ fn profile_row_count(max_rows: usize) -> usize {
     row_count
 }
 
+fn profile_bound_update_row_count(max_rows: usize) -> usize {
+    let Some(value) = std::env::var_os("LIX_TRACKED_STATE_CRUD_PROFILE_BOUND_UPDATE_ROW_COUNT")
+    else {
+        return max_rows;
+    };
+    let value = value.to_string_lossy();
+    let row_count = value.parse::<usize>().unwrap_or_else(|_| {
+        panic!(
+            "LIX_TRACKED_STATE_CRUD_PROFILE_BOUND_UPDATE_ROW_COUNT must be an integer between 1 and {max_rows}, got '{value}'"
+        )
+    });
+    assert!(
+        (1..=max_rows).contains(&row_count),
+        "LIX_TRACKED_STATE_CRUD_PROFILE_BOUND_UPDATE_ROW_COUNT must be between 1 and {max_rows}, got {row_count}"
+    );
+    row_count
+}
+
+fn profile_bound_update_spread() -> bool {
+    match std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_BOUND_UPDATE_DISTRIBUTION").as_deref() {
+        Ok("spread") => true,
+        Ok("prefix") | Err(_) => false,
+        Ok(other) => panic!(
+            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_BOUND_UPDATE_DISTRIBUTION '{other}'; expected prefix or spread"
+        ),
+    }
+}
+
 /// Reproducible, setup-excluded latency samples for one production transaction
 /// operation. Criterion's CodSpeed-compatible harness intentionally delegates
 /// timing to the runner, while this opt-in mode is useful for local profiling
@@ -390,6 +418,8 @@ fn profile_hot_sql_session_bound_updates(
 ) {
     let repeats_u32 =
         u32::try_from(repeats).expect("LIX_TRACKED_STATE_CRUD_PROFILE_HOT_REPEATS must fit in u32");
+    let bound_update_row_count = profile_bound_update_row_count(rows.len());
+    let spread = profile_bound_update_spread();
     let fixture = runtime.block_on(sql_session::seeded_fixture_with_read_many_pk_count(
         profile,
         rows,
@@ -398,7 +428,13 @@ fn profile_hot_sql_session_bound_updates(
     let start = Instant::now();
     let mut row_count = 0;
     for _ in 0..repeats {
-        row_count += runtime.block_on(fixture.update_all_bound());
+        row_count += if spread {
+            runtime.block_on(fixture.update_spread_bound_rows(bound_update_row_count))
+        } else if bound_update_row_count == rows.len() {
+            runtime.block_on(fixture.update_all_bound())
+        } else {
+            runtime.block_on(fixture.update_bound_rows(bound_update_row_count))
+        };
     }
     let elapsed = start.elapsed();
     println!(
@@ -669,6 +705,8 @@ fn profile_sql_session_bound_updates(
     sample_count: usize,
     profile: StorageProfile,
 ) {
+    let bound_update_row_count = profile_bound_update_row_count(rows.len());
+    let spread = profile_bound_update_spread();
     let mut samples = Vec::with_capacity(sample_count);
     for _ in 0..sample_count {
         let fixture = runtime.block_on(sql_session::seeded_fixture_with_read_many_pk_count(
@@ -677,7 +715,13 @@ fn profile_sql_session_bound_updates(
             read_many_pk_count,
         ));
         let start = Instant::now();
-        let result = runtime.block_on(fixture.update_all_bound());
+        let result = if spread {
+            runtime.block_on(fixture.update_spread_bound_rows(bound_update_row_count))
+        } else if bound_update_row_count == rows.len() {
+            runtime.block_on(fixture.update_all_bound())
+        } else {
+            runtime.block_on(fixture.update_bound_rows(bound_update_row_count))
+        };
         samples.push(start.elapsed());
         black_box(result);
     }

--- a/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
@@ -184,6 +184,20 @@ impl SqlFixture {
         }
     }
 
+    pub(crate) async fn update_bound_rows(&self, row_count: usize) -> usize {
+        match self {
+            Self::SQLite(fixture) => fixture.update_bound_rows(row_count).await,
+            Self::RocksDB(fixture) => fixture.update_bound_rows(row_count).await,
+        }
+    }
+
+    pub(crate) async fn update_spread_bound_rows(&self, row_count: usize) -> usize {
+        match self {
+            Self::SQLite(fixture) => fixture.update_spread_bound_rows(row_count).await,
+            Self::RocksDB(fixture) => fixture.update_spread_bound_rows(row_count).await,
+        }
+    }
+
     pub(crate) async fn update_one_by_pk(&self) -> usize {
         match self {
             Self::SQLite(fixture) => fixture.update_one_by_pk().await,
@@ -273,18 +287,55 @@ where
         affected as usize
     }
 
-    #[expect(clippy::cast_possible_truncation)]
     async fn update_all_bound(&self) -> usize {
+        self.update_bound_rows(self.row_count).await
+    }
+
+    #[expect(clippy::cast_possible_truncation)]
+    async fn update_bound_rows(&self, row_count: usize) -> usize {
+        assert!(
+            (1..=self.row_count).contains(&row_count),
+            "bound update row count must be between 1 and {}, got {row_count}",
+            self.row_count
+        );
         let results = self
             .session
-            .execute_batch(&self.bound_update_all_batch)
+            .execute_batch(&self.bound_update_all_batch[..row_count])
             .await
             .expect("execute tracked-state CRUD bound update batch");
         let affected = results
             .iter()
             .map(ExecuteResult::rows_affected)
             .sum::<u64>();
-        assert_eq!(affected as usize, self.row_count);
+        assert_eq!(affected as usize, row_count);
+        affected as usize
+    }
+
+    #[expect(clippy::cast_possible_truncation)]
+    async fn update_spread_bound_rows(&self, row_count: usize) -> usize {
+        assert!(
+            (1..=self.row_count).contains(&row_count),
+            "bound update row count must be between 1 and {}, got {row_count}",
+            self.row_count
+        );
+        let last = self.row_count - 1;
+        let batch = if row_count == 1 {
+            vec![self.bound_update_all_batch[0].clone()]
+        } else {
+            (0..row_count)
+                .map(|index| self.bound_update_all_batch[index * last / (row_count - 1)].clone())
+                .collect::<Vec<_>>()
+        };
+        let results = self
+            .session
+            .execute_batch(&batch)
+            .await
+            .expect("execute spread tracked-state CRUD bound update batch");
+        let affected = results
+            .iter()
+            .map(ExecuteResult::rows_affected)
+            .sum::<u64>();
+        assert_eq!(affected as usize, row_count);
         affected as usize
     }
 

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -23,6 +23,8 @@ pub(crate) const HOT_FILE_SPACE: StorageSpace =
 /// Reserved for the row-level first-before working-diff index.
 pub(crate) const HOT_DIFF_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_001d), HOT_DIFF_NAMESPACE);
+const HOT_DENSE_SCAN_MIN_IDENTITIES: usize = 64;
+const HOT_DENSE_SCAN_MAX_OVERREAD: usize = 2;
 
 /// Direct reader for one published hot generation.
 pub(crate) struct HotStateStoreReader<S> {
@@ -1610,6 +1612,11 @@ async fn hot_scan_entries(
             || !hot_schema_has_file_members(store, branch_id, generation, &filter.schema_keys)
                 .await?;
         if may_use_null_point_batch {
+            if limit.is_none()
+                && let Some(entries) = hot_scan_dense_identity_range(store, &identities).await?
+            {
+                return Ok(entries);
+            }
             let values = hot_load_identity_bytes(store, &identities).await?;
             return Ok(identities
                 .into_iter()
@@ -1676,6 +1683,80 @@ async fn hot_scan_entries(
         }
     }
     Ok(rows)
+}
+
+async fn hot_scan_dense_identity_range(
+    store: &(impl StorageAdapterRead + ?Sized),
+    identities: &[HeadIdentity],
+) -> Result<Option<Vec<(HeadRowIdentity, Bytes)>>, LixError> {
+    if identities.len() < HOT_DENSE_SCAN_MIN_IDENTITIES
+        || identities
+            .windows(2)
+            .any(|pair| pair[0].schema_key != pair[1].schema_key)
+    {
+        return Ok(None);
+    }
+
+    let requested_keys = identities
+        .iter()
+        .map(encode_hot_row_key)
+        .collect::<Vec<_>>();
+    let Some(first_key) = requested_keys.first() else {
+        return Ok(Some(Vec::new()));
+    };
+    let Some(last_key) = requested_keys.last() else {
+        return Ok(Some(Vec::new()));
+    };
+    let plan = ScanPlan::range(
+        HOT_ROW_SPACE,
+        crate::storage_adapter::StorageKeyRange {
+            lower: std::ops::Bound::Included(StorageKey(Bytes::copy_from_slice(first_key))),
+            upper: std::ops::Bound::Included(StorageKey(Bytes::copy_from_slice(last_key))),
+        },
+    );
+    let scan_budget = identities.len().saturating_mul(HOT_DENSE_SCAN_MAX_OVERREAD);
+    let mut scanned = 0;
+    let mut requested_index = 0;
+    let mut resume_after = None;
+    let mut rows = Vec::with_capacity(identities.len());
+    loop {
+        let remaining_budget = scan_budget.saturating_sub(scanned);
+        if remaining_budget == 0 {
+            return Ok(None);
+        }
+        let page = plan
+            .collect(
+                store,
+                StorageScanOptions {
+                    resume_after: resume_after.clone(),
+                    limit_rows: remaining_budget.min(StorageScanOptions::default().limit_rows),
+                    ..StorageScanOptions::default()
+                },
+            )
+            .await?;
+        resume_after = page.value.entries.last().map(|entry| entry.key.clone());
+        scanned += page.value.entries.len();
+        for entry in page.value.entries {
+            while requested_index < requested_keys.len()
+                && requested_keys[requested_index].as_slice() < entry.key.0.as_ref()
+            {
+                requested_index += 1;
+            }
+            if requested_index < requested_keys.len()
+                && requested_keys[requested_index].as_slice() == entry.key.0.as_ref()
+            {
+                rows.push((
+                    identities[requested_index].clone().into_row_identity(),
+                    full_value_bytes(entry.value)?,
+                ));
+                requested_index += 1;
+            }
+        }
+        if requested_index == requested_keys.len() || !page.value.has_more || resume_after.is_none()
+        {
+            return Ok(Some(rows));
+        }
+    }
 }
 
 fn hot_file_scan_prefixes(
@@ -2237,6 +2318,98 @@ mod tests {
             entity_pk: EntityPk::single(entity),
             file_id: None,
         }
+    }
+
+    #[tokio::test]
+    async fn dense_identity_range_scan_returns_requested_rows() {
+        let storage = StorageAdapter::new(Memory::new());
+        let generation = CommitId::for_test_label("dense-range-generation");
+        let all_identities = (0..HOT_DENSE_SCAN_MIN_IDENTITIES * 2)
+            .map(|index| diff_identity("branch", generation, &format!("{index:04}")))
+            .collect::<Vec<_>>();
+        let requested = all_identities
+            .iter()
+            .step_by(2)
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut writes = StorageWriteSet::new();
+        for identity in &all_identities {
+            writes.put(
+                HOT_ROW_SPACE,
+                StorageKey(Bytes::from(encode_hot_row_key(identity))),
+                StorageValue {
+                    bytes: Bytes::from_static(b"row"),
+                },
+            );
+        }
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit dense-range fixture");
+        let read = crate::storage_adapter::SharedStorageAdapterRead::new(
+            storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("open dense-range read"),
+        );
+
+        let rows = hot_scan_dense_identity_range(&read, &requested)
+            .await
+            .expect("scan dense identity range")
+            .expect("dense range should stay on the scan path");
+
+        assert_eq!(
+            rows.into_iter()
+                .map(|(identity, _)| identity.entity_pk)
+                .collect::<Vec<_>>(),
+            requested
+                .into_iter()
+                .map(|identity| identity.entity_pk)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn sparse_identity_range_scan_returns_to_point_reads() {
+        let storage = StorageAdapter::new(Memory::new());
+        let generation = CommitId::for_test_label("sparse-range-generation");
+        let all_identities = (0..HOT_DENSE_SCAN_MIN_IDENTITIES * 4)
+            .map(|index| diff_identity("branch", generation, &format!("{index:04}")))
+            .collect::<Vec<_>>();
+        let requested = all_identities
+            .iter()
+            .step_by(4)
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut writes = StorageWriteSet::new();
+        for identity in &all_identities {
+            writes.put(
+                HOT_ROW_SPACE,
+                StorageKey(Bytes::from(encode_hot_row_key(identity))),
+                StorageValue {
+                    bytes: Bytes::from_static(b"row"),
+                },
+            );
+        }
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit sparse-range fixture");
+        let read = crate::storage_adapter::SharedStorageAdapterRead::new(
+            storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("open sparse-range read"),
+        );
+
+        let rows = hot_scan_dense_identity_range(&read, &requested)
+            .await
+            .expect("probe sparse identity range");
+
+        assert!(
+            rows.is_none(),
+            "sparse ranges must return to the exact point-read path"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Stacked on #870.

Replace the RocksDB point-read path for dense, single-schema exact-identity batches with an ordered key-range scan and a linear merge against the requested identities.

The strategy is deliberately adaptive:

- fewer than 64 identities keep the existing point-read path
- cross-schema batches keep point reads
- a range scan may read at most 2x the requested identity count
- if the range is too sparse, execution falls back to point reads
- SQL/public batch APIs and the storage adapter contract stay unchanged

The profiling harness now supports bounded prefix and spread distributions so dense wins and sparse fallback costs can be measured independently.

## Why

`perf` on the #870 head attributed 12.82% inclusive CPU to synchronous RocksDB `MultiGet`; preparing/sorting the point keys alone was 2.76%. Dense 10,000-row bound updates already identify an ordered region, so 10,000 point probes are unnecessary.

## Performance

10k homogeneous bound UPDATE, RocksDB, setup excluded, 15 order-balanced pairs; each observation is the median of 5 independent fixtures:

| version | median |
| --- | ---: |
| #870 baseline | 184.108 ms |
| dense range scan | 166.809 ms |

Paired median improvement: **11.26%**; candidate won 13/15 pairs.

Sparse/small safety (paired medians, 7 pairs × 3 fixtures):

| requested identities | distribution | candidate vs baseline |
| ---: | --- | ---: |
| 32 | prefix | +3.47% faster |
| 64 | prefix | +1.13% faster |
| 64 | spread | +0.99% faster |
| 1,000 | spread | +1.73% faster |

Direct 10k transaction CRUD remained neutral-to-better:

| operation | paired result |
| --- | ---: |
| insert | 1.64% slower (noise) |
| update | 3.85% faster |
| delete | 0.16% faster |

Existing no-regression gates remained below the 10% threshold:

- historical diff: 4.017 ms → 4.020 ms (+0.07%)
- merge commit: 2.378 ms → 2.451 ms (+3.07%)

A separate experiment raised the global storage scan-page ceiling from 1,024 to 16,384 rows. Isolated A/B measured **2.78% slower**, so that storage API/contract change was removed. `get_many` also remains because sparse and small batches prove it is still the correct access path.

## Validation

- `cargo test -p lix_engine --features all-simulations` (1,382 unit, 758 integration, 3 doctests)
- dense interleaved-row filtering test
- sparse overread-budget fallback test
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
