### PR TITLE
perf: reuse homogeneous bound batch plans

### DIFF
--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -427,7 +427,55 @@ pub struct ExecuteBatchStatement {
 
 enum ExecuteBatchExecution {
     ReadOnly(Vec<datafusion::sql::parser::Statement>),
-    Transaction(Vec<datafusion::sql::parser::Statement>),
+    Transaction(TransactionBatchStatements),
+}
+
+enum TransactionBatchStatements {
+    Shared {
+        statement: datafusion::sql::parser::Statement,
+        len: usize,
+    },
+    Distinct(Vec<datafusion::sql::parser::Statement>),
+}
+
+impl TransactionBatchStatements {
+    fn len(&self) -> usize {
+        match self {
+            Self::Shared { len, .. } => *len,
+            Self::Distinct(statements) => statements.len(),
+        }
+    }
+
+    fn first(&self) -> Option<&datafusion::sql::parser::Statement> {
+        match self {
+            Self::Shared { statement, len } => (*len > 0).then_some(statement),
+            Self::Distinct(statements) => statements.first(),
+        }
+    }
+
+    fn contains_write(&self) -> Result<bool, LixError> {
+        match self {
+            Self::Shared { statement, .. } => {
+                Ok(sql2::bind_statement_route(statement)? == sql2::BoundStatementRoute::Write)
+            }
+            Self::Distinct(statements) => {
+                statements
+                    .iter()
+                    .try_fold(false, |contains_write, statement| {
+                        Ok(contains_write
+                            || sql2::bind_statement_route(statement)?
+                                == sql2::BoundStatementRoute::Write)
+                    })
+            }
+        }
+    }
+
+    fn into_vec(self) -> Vec<datafusion::sql::parser::Statement> {
+        match self {
+            Self::Shared { statement, len } => vec![statement; len],
+            Self::Distinct(statements) => statements,
+        }
+    }
 }
 
 enum IdempotencyReceiptResolution {
@@ -1253,14 +1301,7 @@ where
                 self.execute_read_only_batch(&statements, parsed).await
             }
             ExecuteBatchExecution::Transaction(parsed) => {
-                let contains_write =
-                    parsed.iter().try_fold(false, |contains_write, statement| {
-                        Ok::<_, LixError>(
-                            contains_write
-                                || sql2::bind_statement_route(statement)?
-                                    == sql2::BoundStatementRoute::Write,
-                        )
-                    })?;
+                let contains_write = parsed.contains_write()?;
                 if !contains_write {
                     return self
                         .execute_transaction_batch(
@@ -1338,7 +1379,7 @@ where
     async fn execute_transaction_batch(
         &self,
         statements: Vec<ExecuteBatchStatement>,
-        parsed: Vec<DataFusionStatement>,
+        parsed: TransactionBatchStatements,
         options: ExecuteOptions,
         statement_metadata: Vec<ExecuteStatementMetadata>,
         idempotency: Option<ExecuteIdempotency>,
@@ -1365,6 +1406,7 @@ where
                     return Ok(results);
                 }
                 let mut results = Vec::with_capacity(statements.len());
+                let parsed = parsed.into_vec();
                 for (statement_index, ((statement, parsed), metadata)) in statements
                     .iter()
                     .zip(parsed)
@@ -2187,7 +2229,7 @@ where
 async fn try_execute_transaction_parameter_batch<StorageImpl>(
     transaction: &mut crate::transaction::Transaction<StorageImpl>,
     statements: &[ExecuteBatchStatement],
-    parsed: &[DataFusionStatement],
+    parsed: &TransactionBatchStatements,
     options: &ExecuteOptions,
     statement_metadata: &[ExecuteStatementMetadata],
     telemetry_sink: Option<&Arc<dyn crate::telemetry::TelemetrySink>>,
@@ -2207,7 +2249,11 @@ where
         || statement_metadata
             .iter()
             .any(|metadata| metadata != &ExecuteStatementMetadata::default())
-        || sql2::bind_statement_route(&parsed[0])? != sql2::BoundStatementRoute::Write
+        || sql2::bind_statement_route(
+            parsed
+                .first()
+                .expect("non-empty transaction batch has a parsed statement"),
+        )? != sql2::BoundStatementRoute::Write
     {
         return Ok(None);
     }
@@ -2222,7 +2268,12 @@ where
 
     let previous_origin_key = transaction.replace_origin_key(options.origin_key.clone());
     let execution = async {
-        let plan = transaction.prepare_sql_write_logical_plan(&first_statement.sql, &parsed[0])?;
+        let plan = transaction.prepare_sql_write_logical_plan(
+            &first_statement.sql,
+            parsed
+                .first()
+                .expect("non-empty transaction batch has a parsed statement"),
+        )?;
         sql2::execute_write_logical_plan_parameter_batch(transaction, plan, &parameter_batch).await
     }
     .await;
@@ -3003,6 +3054,32 @@ fn classify_execute_batch(
     // switching execution modes between statements would break atomicity, and
     // any possible durable mutation keeps the whole batch transactional so
     // later reads retain read-after-write visibility.
+    if let Some(first) = statements.first()
+        && statements
+            .iter()
+            .skip(1)
+            .all(|statement| statement.sql == first.sql)
+    {
+        let parsed = planning_cache
+            .parse_statement(&first.sql)
+            .map_err(|error| with_batch_statement_index(error, 0))?;
+        let disposition =
+            execution_disposition(&parsed).map_err(|error| with_batch_statement_index(error, 0))?;
+        return if disposition == ExecutionDisposition::Durable {
+            Ok(ExecuteBatchExecution::Transaction(
+                TransactionBatchStatements::Shared {
+                    statement: parsed,
+                    len: statements.len(),
+                },
+            ))
+        } else {
+            Ok(ExecuteBatchExecution::ReadOnly(vec![
+                parsed;
+                statements.len()
+            ]))
+        };
+    }
+
     let mut parsed = Vec::with_capacity(statements.len());
     let mut is_read_only = true;
     for (statement_index, statement) in statements.iter().enumerate() {
@@ -3019,7 +3096,9 @@ fn classify_execute_batch(
     if is_read_only {
         Ok(ExecuteBatchExecution::ReadOnly(parsed))
     } else {
-        Ok(ExecuteBatchExecution::Transaction(parsed))
+        Ok(ExecuteBatchExecution::Transaction(
+            TransactionBatchStatements::Distinct(parsed),
+        ))
     }
 }
 
@@ -3440,6 +3519,21 @@ mod tests {
             classify_execute_batch(&[batch_statement("SELECT lix_uuid_v7()")], &cache).unwrap(),
             ExecuteBatchExecution::Transaction(_)
         ));
+    }
+
+    #[test]
+    fn execute_batch_reuses_one_parsed_statement_for_homogeneous_writes() {
+        let cache = sql2::SqlPlanningCache::default();
+        let statements = [
+            batch_statement("UPDATE lix_file SET path = '/a' WHERE id = 'a'"),
+            batch_statement("UPDATE lix_file SET path = '/a' WHERE id = 'a'"),
+        ];
+        let ExecuteBatchExecution::Transaction(TransactionBatchStatements::Shared { len, .. }) =
+            classify_execute_batch(&statements, &cache).unwrap()
+        else {
+            panic!("homogeneous durable statements should share one parsed statement");
+        };
+        assert_eq!(len, statements.len());
     }
 
     #[tokio::test]

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -94,21 +94,30 @@ pub(crate) async fn try_execute_entity_update_parameter_batch(
     }
     validate_bound_write_supported(plan, &spec)?;
 
+    let direct_primary_key_param =
+        bound_single_text_primary_key_param(&spec, &plan.bound.predicate);
     let mut parameter_rows = Vec::with_capacity(parameter_batch.num_rows());
     let mut entity_pks = Vec::with_capacity(parameter_batch.num_rows());
     let mut unique_entity_pks = std::collections::BTreeSet::new();
     for row_index in 0..parameter_batch.num_rows() {
         let params = super::write::parameter_row(parameter_batch, row_index)
             .map_err(|error| with_parameter_batch_statement_index(error, row_index))?;
-        let Some(mut row_entity_pks) =
-            bound_entity_pks_from_primary_key_predicate(&spec, &plan.bound.predicate, &params)
-        else {
-            return Ok(None);
+        let entity_pk = if let Some(param_index) = direct_primary_key_param {
+            let Some(Value::Text(value)) = params.get(param_index) else {
+                return Ok(None);
+            };
+            EntityPk::single(value.clone())
+        } else {
+            let Some(mut row_entity_pks) =
+                bound_entity_pks_from_primary_key_predicate(&spec, &plan.bound.predicate, &params)
+            else {
+                return Ok(None);
+            };
+            if row_entity_pks.len() != 1 {
+                return Ok(None);
+            }
+            row_entity_pks.pop().expect("one point-update identity")
         };
-        if row_entity_pks.len() != 1 {
-            return Ok(None);
-        }
-        let entity_pk = row_entity_pks.pop().expect("one point-update identity");
         if !unique_entity_pks.insert(entity_pk.clone()) {
             // Repeated identities observe earlier staged writes and are not
             // independent statements.
@@ -156,6 +165,32 @@ pub(crate) async fn try_execute_entity_update_parameter_batch(
             .map(SqlWriteResult::affected)
             .collect(),
     ))
+}
+
+fn bound_single_text_primary_key_param(
+    spec: &EntitySurfaceSpec,
+    predicate: &BoundPredicate,
+) -> Option<usize> {
+    let [path] = spec.primary_key_paths.as_slice() else {
+        return None;
+    };
+    let [primary_key_column] = path.as_slice() else {
+        return None;
+    };
+    spec.visible_column(primary_key_column)
+        .filter(|column| column.column_type == EntityColumnType::String)?;
+    let BoundPredicate::Eq(left, right) = predicate else {
+        return None;
+    };
+    match (left, right) {
+        (BoundExpr::Column(column), BoundExpr::Param(param))
+        | (BoundExpr::Param(param), BoundExpr::Column(column))
+            if column.name == *primary_key_column =>
+        {
+            param.index.checked_sub(1)
+        }
+        _ => None,
+    }
 }
 
 fn with_parameter_batch_statement_index(mut error: LixError, statement_index: usize) -> LixError {
@@ -3437,6 +3472,43 @@ fn entity_action(op: &BoundWriteOp) -> &'static str {
 mod primary_key_route_tests {
     use super::*;
     use crate::sql2::bind::expr::{BoundColumnRef, BoundParamRef};
+
+    #[test]
+    fn compiles_single_text_primary_key_parameter_once() {
+        let spec = crate::sql2::catalog::derive_entity_surface_spec_from_schema(
+            &serde_json::json!({
+                "x-lix-key": "entity",
+                "x-lix-primary-key": ["/id"],
+                "type": "object",
+                "required": ["id", "value"],
+                "properties": {
+                    "id": { "type": "string" },
+                    "value": {
+                        "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+                    }
+                },
+                "additionalProperties": false
+            }),
+        )
+        .expect("entity surface schema should compile");
+        assert_eq!(
+            bound_single_text_primary_key_param(
+                &spec,
+                &equals(column("id"), BoundExpr::Param(BoundParamRef { index: 2 }),),
+            ),
+            Some(1)
+        );
+        assert_eq!(
+            bound_single_text_primary_key_param(
+                &spec,
+                &equals(
+                    column("value"),
+                    BoundExpr::Param(BoundParamRef { index: 2 }),
+                ),
+            ),
+            None
+        );
+    }
 
     #[test]
     fn routes_literal_and_parameter_primary_keys() {


### PR DESCRIPTION
## Summary

- parse and classify homogeneous `executeBatch` SQL once, retaining one shared parsed statement through the vectorized route
- expand the parsed statement only if the vectorized route declines and execution falls back to the existing sequential path
- compile the common single-string-primary-key parameter mapping once per bound UPDATE plan instead of rebuilding the generic predicate constraint machinery for every parameter row
- keep the public `executeBatch` API, telemetry, error indexing, repeated-identity fallback, parameterless fallback, and inter-row-constraint fallback unchanged

## Why

After #870 vectorized homogeneous bound UPDATE execution and #872 replaced dense point reads with an ordered range scan, profiling showed the remaining batch front end still repeated general work 10,000 times:

- SQL classification was about 9–10 ms per operation
- primary-key identity extraction was about 6.5–7 ms per operation

Those are properties of one homogeneous program, not of each row. This change represents that fact directly with one shared parsed statement and one compiled key-parameter mapping.

## Accepted benchmark

10,000-row bound UPDATE, RocksDB, setup excluded. 15 order-balanced pairs; each observation is the median of five independent fixtures.

| metric | parent | candidate | result |
|---|---:|---:|---:|
| independent median | 161.708 ms | 143.039 ms | 13.05% faster |
| paired median | — | — | 12.54% faster |
| pair wins | — | — | 15 / 15 |

Using the previously measured raw SQLite prepared UPDATE median of 13.650 ms, this moves the bound Lix workload from about 12.4× SQLite to about 10.5×. More work remains to reach the 2× goal.

## Regression benches

| workload | parent median | candidate median | result |
|---|---:|---:|---:|
| transaction insert 10k | 66.388 ms | 65.172 ms | flat / 1.8% faster |
| transaction update 10k | 79.478 ms | 78.118 ms | flat / 1.7% faster |
| transaction delete 10k | 76.631 ms | 71.109 ms | no regression |
| populated working diff | 0.547 ms | 0.487 ms | no regression |
| merge preview | 1.133 ms | 1.135 ms | flat |
| merge commit | 4.271 ms | 4.339 ms | flat / 1.6% noise |

## Rejected profiler-guided cuts

These experiments were removed because they did not clear the >10% policy:

| experiment | paired median result |
|---|---:|
| bypass Arrow parameter materialization | 0.96% faster |
| reconstruct complete replacement without predecessor snapshot | 4.5% faster |
| omit all direct changelog change-record writes | 4.3% faster |
| remove row-local validation entirely | 0.36% slower / flat |
| bypass certified transaction normalization | 2.3% slower / flat |

The storage adapter already lowers each storage space as one batch. Removing 10,001 direct change-record writes remained below the bar, and the remaining predecessor MultiGet is about 1.2% of CPU after #872, so this PR does not introduce a storage API cut without evidence.

## Validation

- `cargo test -p lix_engine --features all-simulations`
  - 1,393 unit tests passed
  - 760 integration simulations passed (2 ignored)
  - 3 doctests passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- focused homogeneous batch, telemetry, error-index, repeated-identity, parameterless, inter-row-constraint, and direct primary-key compiler tests passed

The branch is rebased on current `origin/main` (`32304a178`, merge of #872).