### PR TITLE
perf: certify normalized replacement batches

### DIFF
--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -3689,6 +3689,87 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_batch_certifies_complete_path_value_replacements() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "x-lix-key": "certified_replacement_probe",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" },
+                "value": {
+                    "type": [
+                        "object", "array", "string", "number", "integer", "boolean", "null"
+                    ]
+                }
+            },
+            "required": ["path", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+        session
+            .execute(
+                "INSERT INTO certified_replacement_probe (path, value) VALUES \
+                 ('/a', lix_json('\"old-a\"')), ('/b', lix_json('\"old-b\"'))",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sql2::take_certified_replacement_parameter_batch_executions();
+        let sql = "UPDATE certified_replacement_probe SET value = lix_json($1) WHERE path = $2";
+        let results = session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("null".to_string()),
+                        Value::Text("/a".to_string()),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text(r#"{"nested":[1,true,"x"]}"#.to_string()),
+                        Value::Text("/b".to_string()),
+                    ],
+                },
+            ])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            sql2::take_certified_replacement_parameter_batch_executions(),
+            1
+        );
+        assert_eq!(
+            results
+                .iter()
+                .map(ExecuteResult::rows_affected)
+                .collect::<Vec<_>>(),
+            vec![1, 1]
+        );
+        let rows = session
+            .execute(
+                "SELECT path, value FROM certified_replacement_probe ORDER BY path",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(rows.rows()[0].value("value").unwrap(), &Value::Null);
+        assert_eq!(
+            rows.rows()[1].get::<serde_json::Value>("value").unwrap(),
+            serde_json::json!({"nested": [1, true, "x"]})
+        );
+    }
+
+    #[tokio::test]
     async fn execute_batch_keeps_repeated_entity_identity_sequential() {
         let session = open_session().await;
         let schema = serde_json::json!({

--- a/packages/engine/src/sql2/catalog/entity_surface.rs
+++ b/packages/engine/src/sql2/catalog/entity_surface.rs
@@ -50,6 +50,9 @@ pub(crate) struct EntitySurfaceSpec {
     /// only when every row is independent. JSON Schema validation is row-local;
     /// uniqueness and foreign-key declarations are the inter-row exceptions.
     pub(crate) has_inter_row_constraints: bool,
+    /// This exact schema shape proves that replacing `value` while preserving
+    /// the already-valid string `path` produces complete valid row content.
+    pub(crate) certifies_path_value_replacement: bool,
 }
 
 impl EntitySurfaceSpec {
@@ -133,6 +136,7 @@ pub(crate) fn derive_entity_surface_spec_from_schema(
         .collect::<Result<Vec<_>, LixError>>()?;
     columns.sort_by(|left, right| left.name.cmp(&right.name));
 
+    let certifies_path_value_replacement = certifies_path_value_replacement(schema);
     Ok(EntitySurfaceSpec {
         schema_key: schema_key.to_string(),
         primary_key_paths,
@@ -146,7 +150,117 @@ pub(crate) fn derive_entity_surface_spec_from_schema(
                     .is_some_and(|values| !values.is_empty())
             },
         ),
+        certifies_path_value_replacement,
     })
+}
+
+fn certifies_path_value_replacement(schema: &JsonValue) -> bool {
+    let Some(object) = schema.as_object() else {
+        return false;
+    };
+    let allowed_schema_keys = [
+        "$id",
+        "$schema",
+        "$comment",
+        "title",
+        "description",
+        "type",
+        "properties",
+        "required",
+        "additionalProperties",
+        "x-lix-key",
+        "x-lix-primary-key",
+    ];
+    if object
+        .keys()
+        .any(|key| !allowed_schema_keys.contains(&key.as_str()))
+        || object.get("type").and_then(JsonValue::as_str) != Some("object")
+        || object.get("additionalProperties") != Some(&JsonValue::Bool(false))
+    {
+        return false;
+    }
+    let Some(properties) = object.get("properties").and_then(JsonValue::as_object) else {
+        return false;
+    };
+    if properties.len() != 2
+        || !properties.contains_key("path")
+        || !properties
+            .get("path")
+            .is_some_and(schema_accepts_string_identity)
+        || !properties
+            .get("value")
+            .is_some_and(schema_accepts_every_json_value)
+    {
+        return false;
+    }
+    let required = object
+        .get("required")
+        .and_then(JsonValue::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(JsonValue::as_str)
+        .collect::<BTreeSet<_>>();
+    required == BTreeSet::from(["path", "value"])
+        && object
+            .get("x-lix-primary-key")
+            .and_then(JsonValue::as_array)
+            .is_some_and(|paths| paths.as_slice() == [JsonValue::String("/path".to_string())])
+}
+
+fn schema_accepts_string_identity(schema: &JsonValue) -> bool {
+    schema
+        .as_object()
+        .and_then(|schema| schema.get("type"))
+        .and_then(JsonValue::as_str)
+        == Some("string")
+}
+
+fn schema_accepts_every_json_value(schema: &JsonValue) -> bool {
+    if schema == &JsonValue::Bool(true) {
+        return true;
+    }
+    let Some(schema) = schema.as_object() else {
+        return false;
+    };
+    let annotations = ["$comment", "title", "description", "default", "examples"];
+    if schema.is_empty() || schema.keys().all(|key| annotations.contains(&key.as_str())) {
+        return true;
+    }
+    let validation_keys = schema
+        .keys()
+        .filter(|key| !annotations.contains(&key.as_str()))
+        .collect::<Vec<_>>();
+    if validation_keys.len() == 1 && validation_keys[0].as_str() == "type" {
+        let Some(types) = schema.get("type").and_then(JsonValue::as_array) else {
+            return false;
+        };
+        let accepted = types
+            .iter()
+            .filter_map(JsonValue::as_str)
+            .collect::<BTreeSet<_>>();
+        return accepted
+            == BTreeSet::from([
+                "array", "boolean", "integer", "null", "number", "object", "string",
+            ]);
+    }
+    if validation_keys.len() != 1 || validation_keys[0].as_str() != "anyOf" {
+        return false;
+    }
+    let Some(branches) = schema.get("anyOf").and_then(JsonValue::as_array) else {
+        return false;
+    };
+    let accepted = branches
+        .iter()
+        .filter_map(|branch| {
+            let branch = branch.as_object()?;
+            branch
+                .keys()
+                .all(|key| key == "type" || annotations.contains(&key.as_str()))
+                .then(|| branch.get("type")?.as_str())
+                .flatten()
+        })
+        .collect::<BTreeSet<_>>();
+    accepted == BTreeSet::from(["array", "boolean", "null", "number", "object", "string"])
 }
 
 pub(crate) fn schema_exposed_as_entity_surface(schema_key: &str) -> bool {
@@ -396,6 +510,63 @@ mod tests {
     use super::{
         EntitySurfaceShape, derive_entity_surface_spec_from_schema, entity_surface_schema,
     };
+
+    fn path_value_schema(value_schema: serde_json::Value) -> serde_json::Value {
+        json!({
+            "x-lix-key": "arbitrary_name",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" },
+                "value": value_schema
+            },
+            "required": ["path", "value"],
+            "additionalProperties": false
+        })
+    }
+
+    #[test]
+    fn certifies_complete_path_value_rows_when_value_accepts_all_json() {
+        let spec = derive_entity_surface_spec_from_schema(&path_value_schema(json!({
+            "anyOf": [
+                { "type": "object" },
+                { "type": "array" },
+                { "type": "string" },
+                { "type": "number" },
+                { "type": "boolean" },
+                { "type": "null" }
+            ]
+        })))
+        .expect("schema should derive");
+
+        assert!(spec.certifies_path_value_replacement);
+    }
+
+    #[test]
+    fn does_not_certify_path_value_rows_with_value_constraints() {
+        let spec = derive_entity_surface_spec_from_schema(&path_value_schema(json!({
+            "type": "object"
+        })))
+        .expect("schema should derive");
+        assert!(!spec.certifies_path_value_replacement);
+
+        let mut schema = path_value_schema(json!({
+            "anyOf": [
+                { "type": "object" },
+                { "type": "array" },
+                { "type": "string" },
+                { "type": "number" },
+                { "type": "boolean" },
+                { "type": "null" }
+            ]
+        }));
+        schema
+            .as_object_mut()
+            .expect("object schema")
+            .insert("minProperties".to_string(), json!(3));
+        let spec = derive_entity_surface_spec_from_schema(&schema).expect("schema should derive");
+        assert!(!spec.certifies_path_value_replacement);
+    }
 
     #[test]
     fn history_identity_roots_are_non_null_even_for_nested_keys() {

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -6,7 +6,9 @@ use serde_json::Value as JsonValue;
 use crate::changelog::CommitId;
 use crate::common::{ExecuteStatementMetadata, RequestBlobSpliceProvenance, validate_row_metadata};
 use crate::entity_pk::EntityPk;
-use crate::live_state::{LiveStateFilter, LiveStateRowFilter, LiveStateScanRequest};
+use crate::live_state::{
+    LiveStateFilter, LiveStateProjection, LiveStateRowFilter, LiveStateScanRequest,
+};
 use crate::sql2::SqlWriteExecutionContext;
 use crate::sql2::bind::expr::{BoundCastType, BoundExpr, BoundLiteral};
 use crate::sql2::bind::write::{
@@ -31,11 +33,18 @@ use super::SqlWriteResult;
 std::thread_local! {
     static ENTITY_UPDATE_PARAMETER_BATCH_EXECUTIONS: std::cell::Cell<usize> =
         const { std::cell::Cell::new(0) };
+    static CERTIFIED_REPLACEMENT_PARAMETER_BATCH_EXECUTIONS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
 }
 
 #[cfg(test)]
 pub(crate) fn take_entity_update_parameter_batch_executions() -> usize {
     ENTITY_UPDATE_PARAMETER_BATCH_EXECUTIONS.with(|executions| executions.replace(0))
+}
+
+#[cfg(test)]
+pub(crate) fn take_certified_replacement_parameter_batch_executions() -> usize {
+    CERTIFIED_REPLACEMENT_PARAMETER_BATCH_EXECUTIONS.with(|executions| executions.replace(0))
 }
 
 #[cfg(test)]
@@ -96,6 +105,7 @@ pub(crate) async fn try_execute_entity_update_parameter_batch(
 
     let direct_primary_key_param =
         bound_single_text_primary_key_param(&spec, &plan.bound.predicate);
+    let direct_replacement = direct_path_value_replacement(&spec, plan, direct_primary_key_param);
     let mut parameter_rows = Vec::with_capacity(parameter_batch.num_rows());
     let mut entity_pks = Vec::with_capacity(parameter_batch.num_rows());
     let mut unique_entity_pks = std::collections::BTreeSet::new();
@@ -127,9 +137,24 @@ pub(crate) async fn try_execute_entity_update_parameter_batch(
         entity_pks.push(entity_pk);
     }
 
-    let candidates =
-        scan_entity_candidates_for_pks(ctx, plan, &spec, unique_entity_pks.into_iter().collect())
-            .await?;
+    let candidates = scan_entity_candidates_for_pks(
+        ctx,
+        plan,
+        &spec,
+        unique_entity_pks.into_iter().collect(),
+        direct_replacement.is_some(),
+    )
+    .await?;
+    if direct_replacement.is_some()
+        && candidates
+            .iter()
+            .any(|candidate| candidate.untracked || candidate.file_id.is_some())
+    {
+        // Retention and plugin-owned file rows retain the canonical semantic
+        // preparation path. This certificate is only for ordinary tracked
+        // entity replacements.
+        return Ok(None);
+    }
     let mut candidates_by_pk = std::collections::BTreeMap::<EntityPk, Vec<_>>::new();
     for candidate in candidates {
         candidates_by_pk
@@ -144,10 +169,17 @@ pub(crate) async fn try_execute_entity_update_parameter_batch(
     {
         let mut affected = 0;
         for candidate in candidates_by_pk.remove(&entity_pk).unwrap_or_default() {
-            if let Some(write_row) =
-                entity_update_row(ctx, plan, &spec, &candidate, params, None)
-                    .map_err(|error| with_parameter_batch_statement_index(error, row_index))?
-            {
+            let write_row = direct_replacement
+                .as_ref()
+                .map_or_else(
+                    || entity_update_row(ctx, plan, &spec, &candidate, params, None),
+                    |replacement| {
+                        direct_path_value_replacement_row(&spec, &candidate, params, replacement)
+                            .map(Some)
+                    },
+                )
+                .map_err(|error| with_parameter_batch_statement_index(error, row_index))?;
+            if let Some(write_row) = write_row {
                 write_rows.push(write_row);
                 affected += 1;
             }
@@ -156,15 +188,123 @@ pub(crate) async fn try_execute_entity_update_parameter_batch(
     }
     stage_rows(ctx, TransactionWriteMode::Replace, write_rows).await?;
     #[cfg(test)]
-    ENTITY_UPDATE_PARAMETER_BATCH_EXECUTIONS.with(|executions| {
-        executions.set(executions.get() + 1);
-    });
+    {
+        ENTITY_UPDATE_PARAMETER_BATCH_EXECUTIONS.with(|executions| {
+            executions.set(executions.get() + 1);
+        });
+        if direct_replacement.is_some() {
+            CERTIFIED_REPLACEMENT_PARAMETER_BATCH_EXECUTIONS.with(|executions| {
+                executions.set(executions.get() + 1);
+            });
+        }
+    }
     Ok(Some(
         affected_by_statement
             .into_iter()
             .map(SqlWriteResult::affected)
             .collect(),
     ))
+}
+
+struct DirectPathValueReplacement {
+    value_param_index: usize,
+}
+
+fn direct_path_value_replacement(
+    spec: &EntitySurfaceSpec,
+    plan: &LogicalWritePlan,
+    primary_key_param_index: Option<usize>,
+) -> Option<DirectPathValueReplacement> {
+    if !spec.certifies_path_value_replacement
+        || primary_key_param_index.is_none()
+        || spec.columns.len() != 2
+        || plan.bound.assignments.len() != 1
+    {
+        return None;
+    }
+    let assignment = &plan.bound.assignments[0];
+    if assignment.column.name != "value"
+        || spec
+            .visible_column("value")
+            .is_none_or(|column| column.column_type != EntityColumnType::Json)
+    {
+        return None;
+    }
+    let BoundExpr::Function { name, args } = &assignment.value else {
+        return None;
+    };
+    let [BoundExpr::Param(param)] = args.as_slice() else {
+        return None;
+    };
+    (name == "lix_json").then(|| DirectPathValueReplacement {
+        value_param_index: param.index.saturating_sub(1),
+    })
+}
+
+fn direct_path_value_replacement_row(
+    spec: &EntitySurfaceSpec,
+    candidate: &crate::live_state::MaterializedLiveStateRow,
+    params: &[Value],
+    replacement: &DirectPathValueReplacement,
+) -> Result<TransactionWriteRow, LixError> {
+    let value = match params.get(replacement.value_param_index) {
+        Some(Value::Null) => JsonValue::Null,
+        Some(Value::Text(raw)) => serde_json::from_str(raw).map_err(|error| {
+            LixError::new(
+                LixError::CODE_TYPE_MISMATCH,
+                format!("lix_json argument is not valid JSON: {error}"),
+            )
+        })?,
+        Some(_) => {
+            return Err(LixError::new(
+                LixError::CODE_TYPE_MISMATCH,
+                "lix_json expects a text argument",
+            ));
+        }
+        None => {
+            return Err(LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                format!(
+                    "missing SQL parameter ${}",
+                    replacement.value_param_index + 1
+                ),
+            ));
+        }
+    };
+    let value = serde_json::to_string(&value).map_err(|error| {
+        LixError::new(
+            LixError::CODE_UNKNOWN,
+            format!("certified replacement value failed to serialize: {error}"),
+        )
+    })?;
+    let path = serde_json::to_string(candidate.entity_pk.as_single_string()?).map_err(|error| {
+        LixError::new(
+            LixError::CODE_UNKNOWN,
+            format!("certified replacement identity failed to serialize: {error}"),
+        )
+    })?;
+    let normalized = format!(r#"{{"path":{path},"value":{value}}}"#);
+    Ok(TransactionWriteRow {
+        entity_pk: Some(candidate.entity_pk.clone()),
+        schema_key: spec.schema_key.clone(),
+        file_id: candidate.file_id.clone(),
+        snapshot: Some(TransactionJson::from_certified_normalized_row_content(
+            normalized.into(),
+        )),
+        metadata: inherited_metadata(candidate, spec)?,
+        origin: None,
+        created_at: None,
+        updated_at: None,
+        global: candidate.global,
+        change_id: None,
+        commit_id: None,
+        untracked: candidate.untracked,
+        branch_id: if candidate.global {
+            crate::GLOBAL_BRANCH_ID.to_string()
+        } else {
+            candidate.branch_id.to_string()
+        },
+    })
 }
 
 fn bound_single_text_primary_key_param(
@@ -1515,6 +1655,7 @@ async fn scan_entity_candidates_for_pks(
     plan: &LogicalWritePlan,
     spec: &EntitySurfaceSpec,
     entity_pks: Vec<EntityPk>,
+    metadata_only: bool,
 ) -> Result<Vec<crate::live_state::MaterializedLiveStateRow>, LixError> {
     ctx.scan_live_state(&LiveStateScanRequest {
         filter: LiveStateFilter {
@@ -1523,6 +1664,13 @@ async fn scan_entity_candidates_for_pks(
             branch_ids: scan_branch_ids(&plan.bound.branch_scope)?,
             include_tombstones: false,
             ..LiveStateFilter::default()
+        },
+        projection: if metadata_only {
+            LiveStateProjection {
+                columns: vec!["metadata".to_string()],
+            }
+        } else {
+            LiveStateProjection::default()
         },
         ..LiveStateScanRequest::default()
     })

--- a/packages/engine/src/sql2/exec/mod.rs
+++ b/packages/engine/src/sql2/exec/mod.rs
@@ -55,4 +55,7 @@ pub(crate) enum SqlLogicalPlan {
 }
 
 #[cfg(test)]
-pub(crate) use bound_public_write::take_entity_update_parameter_batch_executions;
+pub(crate) use bound_public_write::{
+    take_certified_replacement_parameter_batch_executions,
+    take_entity_update_parameter_batch_executions,
+};

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -56,7 +56,9 @@ pub(crate) use exec::{
     WriteExecutorMode, WriteExecutorPath, create_write_logical_plan, execute_write_logical_plan,
     execute_write_logical_plan_with_mode, execute_write_logical_plan_with_mode_and_trace,
     execute_write_logical_plan_with_mode_and_trace_result,
-    execute_write_logical_plan_with_mode_result, take_entity_update_parameter_batch_executions,
+    execute_write_logical_plan_with_mode_result,
+    take_certified_replacement_parameter_batch_executions,
+    take_entity_update_parameter_batch_executions,
 };
 pub(crate) use file_view::{
     SessionFileViewKey, SessionFileViewMutation, SessionFileViews, SessionPluginFileView,

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -2203,7 +2203,7 @@ fn explicit_branch_head_targets(
             .as_ref()
             .map(|snapshot| {
                 let commit_id = snapshot
-                    .value
+                    .value()
                     .get("commit_id")
                     .and_then(serde_json::Value::as_str)
                     .ok_or_else(|| {

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -5032,7 +5032,7 @@ fn v2_host_changes_from_prepared_rows(
                     let format_only = row
                         .metadata
                         .as_ref()
-                        .and_then(|metadata| metadata.value.get("impact"))
+                        .and_then(|metadata| metadata.value().get("impact"))
                         .and_then(JsonValue::as_str)
                         .is_some_and(|impact| impact == "format");
                     let effect = if format_only {

--- a/packages/engine/src/transaction/normalization.rs
+++ b/packages/engine/src/transaction/normalization.rs
@@ -61,6 +61,29 @@ pub(crate) fn normalize_transaction_write_row(
         ));
     };
 
+    if row
+        .snapshot
+        .as_ref()
+        .is_some_and(TransactionJson::row_content_certified)
+    {
+        if row.entity_pk.is_none() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "certified replacement row is missing its proven entity identity",
+            ));
+        }
+        let snapshot = row.snapshot.take();
+        return Ok(NormalizedTransactionWriteRow {
+            row,
+            snapshot,
+            schema_plan_id,
+            facts: PreparedRowFacts {
+                row_content_validated: true,
+                requires_transaction_validation: false,
+            },
+        });
+    }
+
     let normalized_snapshot = if let Some(snapshot) = row.snapshot.take() {
         let (mut snapshot, normalized) = snapshot_object_from_transaction_json(snapshot, &row)?;
         let defaults_changed = apply_defaults(&mut snapshot, schema_plan, &row, functions)?;
@@ -203,7 +226,7 @@ fn snapshot_object_from_transaction_json(
     snapshot: TransactionJson,
     row: &TransactionWriteRow,
 ) -> Result<(JsonMap<String, JsonValue>, Arc<str>), LixError> {
-    let (snapshot, normalized) = snapshot.into_parts();
+    let (snapshot, normalized) = snapshot.into_materialized_parts();
     let snapshot = match Arc::try_unwrap(snapshot) {
         Ok(snapshot) => snapshot,
         Err(snapshot) => snapshot.as_ref().clone(),

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -30,8 +30,8 @@ use crate::live_state::{
     MaterializedLiveStateRow,
 };
 use crate::transaction::types::{
-    LogicalPrimaryKey, PreparedTransactionWrite, StagedCommitChangeRef, TransactionFileData,
-    TransactionWriteMode, TransactionWriteOperation, TransactionWriteOrigin,
+    LogicalPrimaryKey, PreparedTransactionWrite, StageJson, StagedCommitChangeRef,
+    TransactionFileData, TransactionWriteMode, TransactionWriteOperation, TransactionWriteOrigin,
     TransactionWriteOutcome,
 };
 use crate::transaction::types::{PreparedStateRow, StagedCommitChangeRefs};
@@ -234,19 +234,13 @@ impl<'a> PreparedValidationRow<'a> {
 
     pub(crate) fn snapshot_json(self) -> Option<&'a serde_json::Value> {
         match self {
-            Self::State(row) => row
-                .snapshot
-                .as_ref()
-                .map(|snapshot| snapshot.value.as_ref()),
+            Self::State(row) => row.snapshot.as_ref().map(StageJson::value),
         }
     }
 
     pub(crate) fn metadata_json(self) -> Option<&'a serde_json::Value> {
         match self {
-            Self::State(row) => row
-                .metadata
-                .as_ref()
-                .map(|metadata| metadata.value.as_ref()),
+            Self::State(row) => row.metadata.as_ref().map(StageJson::value),
         }
     }
 
@@ -2315,7 +2309,7 @@ mod tests {
             drained.state_rows[0]
                 .snapshot
                 .as_ref()
-                .map(crate::transaction::types::StageJson::materialize)
+                .map(StageJson::materialize)
                 .as_deref(),
             Some("{\"key\":\"alternating-key\",\"value\":\"tracked-final\"}")
         );

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -1,4 +1,9 @@
-use std::{collections::BTreeSet, fmt, ops::Deref, sync::Arc};
+use std::{
+    collections::BTreeSet,
+    fmt,
+    ops::Deref,
+    sync::{Arc, OnceLock},
+};
 
 use crate::LixError;
 use crate::binary_cas::{BlobHash, BlobPayload, BlobSameLengthSplice};
@@ -13,7 +18,7 @@ use serde_json::Value as JsonValue;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TransactionJson {
-    value: Arc<JsonValue>,
+    value: Option<Arc<JsonValue>>,
     normalized: Arc<str>,
 }
 
@@ -27,10 +32,7 @@ impl TransactionJson {
                 )
             })?
             .into();
-        Ok(Self {
-            value: Arc::new(value),
-            normalized,
-        })
+        Ok(Self::from_parts(Arc::new(value), normalized))
     }
 
     pub(crate) fn from_value_unchecked(value: JsonValue) -> Self {
@@ -44,19 +46,53 @@ impl TransactionJson {
     }
 
     pub(crate) fn from_parts(value: Arc<JsonValue>, normalized: Arc<str>) -> Self {
-        Self { value, normalized }
+        Self {
+            value: Some(value),
+            normalized,
+        }
+    }
+
+    /// Constructs canonical row content whose schema semantics and identity
+    /// were proven by a typed lowerer.
+    ///
+    /// The decoded JSON stays lazy because ordinary staging and durable
+    /// placement only consume canonical bytes. Callers may issue this
+    /// certificate only for complete replacement rows whose unchanged
+    /// identity and row-local schema constraints were already established.
+    pub(crate) fn from_certified_normalized_row_content(normalized: Arc<str>) -> Self {
+        Self {
+            value: None,
+            normalized,
+        }
+    }
+
+    pub(crate) fn row_content_certified(&self) -> bool {
+        self.value.is_none()
     }
 
     pub(crate) fn value(&self) -> &JsonValue {
-        self.value.as_ref()
+        self.value
+            .as_ref()
+            .expect("certified row content must be prepared before decoded JSON is requested")
+            .as_ref()
     }
 
     pub(crate) fn normalized(&self) -> &str {
         self.normalized.as_ref()
     }
 
-    pub(crate) fn into_parts(self) -> (Arc<JsonValue>, Arc<str>) {
-        (self.value, self.normalized)
+    pub(crate) fn into_parts(self) -> (OnceLock<Arc<JsonValue>>, Arc<str>) {
+        (
+            self.value.map_or_else(OnceLock::new, OnceLock::from),
+            self.normalized,
+        )
+    }
+
+    pub(crate) fn into_materialized_parts(self) -> (Arc<JsonValue>, Arc<str>) {
+        let value = self
+            .value
+            .expect("certified row content must bypass semantic normalization");
+        (value, self.normalized)
     }
 }
 
@@ -91,7 +127,7 @@ impl Serialize for TransactionJson {
     where
         S: Serializer,
     {
-        self.value.serialize(serializer)
+        self.value().serialize(serializer)
     }
 }
 
@@ -387,12 +423,23 @@ pub(crate) struct TransactionWriteOutcome {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct StageJson {
-    pub(crate) value: Arc<serde_json::Value>,
+    value: OnceLock<Arc<serde_json::Value>>,
     pub(crate) normalized: Arc<str>,
     pub(crate) json_ref: JsonRef,
 }
 
 impl StageJson {
+    pub(crate) fn value(&self) -> &serde_json::Value {
+        self.value
+            .get_or_init(|| {
+                Arc::new(
+                    serde_json::from_str(&self.normalized)
+                        .expect("prepared normalized JSON must remain valid JSON"),
+                )
+            })
+            .as_ref()
+    }
+
     pub(crate) fn materialize(&self) -> String {
         self.normalized.as_ref().to_string()
     }
@@ -610,6 +657,21 @@ impl StagedCommitChangeRefs {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn certified_normalized_content_can_materialize_from_the_prepared_boundary() {
+        let transaction_json = TransactionJson::from_certified_normalized_row_content(
+            r#"{"path":"/a","value":{"nested":true}}"#.into(),
+        );
+        assert!(transaction_json.row_content_certified());
+
+        let staged = stage_json_from_value(transaction_json, "certified test row")
+            .expect("certified JSON should prepare");
+        assert_eq!(
+            staged.value(),
+            &serde_json::json!({"path": "/a", "value": {"nested": true}})
+        );
+    }
 
     #[test]
     fn verified_same_length_splice_requires_the_visible_blob_base() {


### PR DESCRIPTION
## Summary

Stacked on #876.

- derive a narrow certificate for complete `{ path, value }` schemas whose `value` accepts every JSON type and whose identity is the already-valid string `path`
- lower homogeneous bound `UPDATE ... SET value = lix_json($n) WHERE path = $m` batches directly into canonical replacement bytes
- project only identity/system fields plus metadata from live state, avoiding predecessor snapshot hydration and full replacement-object construction
- keep decoded JSON lazy after the certified normalization boundary
- retain the canonical path for inserts, untracked rows, file-owned rows, checkpoints/lifecycle work, constrained schemas, repeated identities, and non-SQL callers

No public SQL API or storage-adapter API changes.

## Profile evidence

10,000 distinct bound updates, RocksDB, 15 order-balanced parent/candidate pairs, each process reporting the median of 5 independently seeded fixtures:

| build | median |
| --- | ---: |
| #876 parent | 134.803 ms |
| candidate | 110.907 ms |

- independent median: **17.73% faster**
- paired median: **17.89% faster**
- candidate wins: **14/15**
- raw SQLite median: 13.289 ms
- current Lix/SQLite ratio: about **8.35x** (still above the 2x project goal)

The profile attributed the removable ownership cluster to predecessor JSON deserialization, BTree object construction/cloning/insertion/drop, normalization, and allocation. Earlier storage experiments did not clear 10%, so this PR does not widen the storage adapter.

## Regression controls

| workload | parent | candidate | delta |
| --- | ---: | ---: | ---: |
| transaction insert 10k | 63.363 ms | 64.587 ms | +1.93% |
| transaction update 10k | 79.611 ms | 79.699 ms | +0.11% |
| transaction delete 10k | 79.632 ms | 79.614 ms | -0.02% |
| populated working diff | 0.531 ms | 0.517 ms | -2.64% |
| merge preview | 0.134 ms | 0.139 ms | +3.73% |
| merge commit | 0.518 ms | 0.516 ms | -0.39% |

Diff and merge figures are medians from 9 order-balanced pairs. CRUD controls use 9 pairs except insert, which uses 15.

## Rejected alternative

Materializing the complete replacement DOM at the prepared-row boundary restored the old shared layout but measured about 137 ms for the target workload and did not clear the 10% gate. The accepted representation restores the original `TransactionJson` size and keeps laziness only on `StageJson`, where mixed-transaction validation can materialize certified content if required.

## Correctness

- schema proof accepts both JSON Schema `anyOf` and `type: [...]` forms for every JSON value type
- schemas with value constraints or unsupported top-level constraints remain ineligible
- certified execution test proves the fast lane ran and round-trips JSON null plus nested JSON
- prepared-boundary test proves certified content remains materializable for mixed validation

## Validation

- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p lix_engine --features all-simulations`
  - 1,397 unit tests
  - 760 integration simulations (2 ignored)
  - 3 doctests
