### PR TITLE
perf(engine): accelerate root file listings

### DIFF
--- a/packages/engine-benchmarks/tests/exact_file_read_benchmark.rs
+++ b/packages/engine-benchmarks/tests/exact_file_read_benchmark.rs
@@ -213,6 +213,74 @@ where
             percentile(&samples, 95).as_nanos(),
         );
     }
+
+    let root_listing_sql = "SELECT id, path, name, lixcol_metadata, lixcol_updated_at \
+         FROM lix_file WHERE directory_id IS NULL ORDER BY name";
+    for _ in 0..WARMUPS {
+        black_box(
+            session
+                .execute(root_listing_sql, &[])
+                .await
+                .expect("warm root listing"),
+        );
+    }
+    let mut samples = Vec::with_capacity(ROUNDS);
+    for _ in 0..ROUNDS {
+        let started = Instant::now();
+        let result = session
+            .execute(root_listing_sql, &[])
+            .await
+            .expect("execute root listing");
+        black_box(&result);
+        samples.push(started.elapsed());
+    }
+    samples.sort_unstable();
+    let mean_ns = samples.iter().map(Duration::as_nanos).sum::<u128>()
+        / u128::try_from(samples.len()).expect("sample count fits u128");
+    println!(
+        "exact_file_read backend={backend} files={file_count} shape=root_listing rounds={ROUNDS} p50_ns={} p95_ns={} mean_ns={mean_ns}",
+        percentile(&samples, 50).as_nanos(),
+        percentile(&samples, 95).as_nanos(),
+    );
+
+    let root_directory_sql = "SELECT id, path, name, lixcol_updated_at \
+         FROM lix_directory WHERE parent_id IS NULL ORDER BY name";
+    for _ in 0..WARMUPS {
+        black_box(
+            session
+                .execute(root_directory_sql, &[])
+                .await
+                .expect("warm root directories"),
+        );
+        black_box(
+            session
+                .execute(root_listing_sql, &[])
+                .await
+                .expect("warm root files"),
+        );
+    }
+    let mut samples = Vec::with_capacity(ROUNDS);
+    for _ in 0..ROUNDS {
+        let started = Instant::now();
+        let directories = session
+            .execute(root_directory_sql, &[])
+            .await
+            .expect("execute root directories");
+        let files = session
+            .execute(root_listing_sql, &[])
+            .await
+            .expect("execute root files");
+        black_box((&directories, &files));
+        samples.push(started.elapsed());
+    }
+    samples.sort_unstable();
+    let mean_ns = samples.iter().map(Duration::as_nanos).sum::<u128>()
+        / u128::try_from(samples.len()).expect("sample count fits u128");
+    println!(
+        "exact_file_read backend={backend} files={file_count} shape=root_directory_listing rounds={ROUNDS} p50_ns={} p95_ns={} mean_ns={mean_ns}",
+        percentile(&samples, 50).as_nanos(),
+        percentile(&samples, 95).as_nanos(),
+    );
 }
 
 fn file_count_from_env() -> usize {

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -1789,42 +1789,63 @@ where
         let file_view_collector = acknowledge_file_views.then(sql2::SessionFileViews::default);
         let active_branch_id = self.active_branch_id_from_reader(&read_store).await?;
         if let Some(exact_lix_file_read) = exact_lix_file_read {
-            let live_state: Arc<dyn crate::live_state::LiveStateReader> =
-                Arc::new(self.live_state.reader(read_store.clone()));
-            let filesystem_path_index: Arc<dyn crate::filesystem::FilesystemPathIndexReader> =
-                Arc::new(self.live_state.reader(read_store.clone()));
-            let branch_ref: Arc<dyn BranchRefReader> =
-                Arc::new(self.branch_ctx.ref_reader(read_store.clone()));
-            let blob_reader: Arc<dyn crate::binary_cas::BlobDataReader> =
-                Arc::new(self.binary_cas.reader(read_store));
             let query = match exact_lix_file_read {
-                ExactLixFileRead::Point(selector, column) => {
-                    sql2::execute_exact_lix_file_read(
+                ExactLixFileRead::RootListing => {
+                    let filesystem_path_index: Arc<
+                        dyn crate::filesystem::FilesystemPathIndexReader,
+                    > = Arc::new(self.live_state.reader(read_store.clone()));
+                    let branch_ref: Arc<dyn BranchRefReader> =
+                        Arc::new(self.branch_ctx.ref_reader(read_store));
+                    sql2::execute_exact_lix_file_root_listing(
                         &active_branch_id,
-                        live_state,
                         filesystem_path_index,
                         branch_ref,
-                        blob_reader,
-                        self.plugin_host.clone(),
-                        file_view_collector.clone(),
-                        &selector,
-                        column,
                     )
                     .await?
                 }
-                ExactLixFileRead::PathDataBatch(paths) => {
-                    sql2::execute_exact_lix_file_batch_read(
-                        &active_branch_id,
-                        live_state,
-                        filesystem_path_index,
-                        branch_ref,
-                        blob_reader,
-                        self.plugin_host.clone(),
-                        file_view_collector.clone(),
-                        None,
-                        &paths,
-                    )
-                    .await?
+                exact_lix_file_read => {
+                    let live_state: Arc<dyn crate::live_state::LiveStateReader> =
+                        Arc::new(self.live_state.reader(read_store.clone()));
+                    let filesystem_path_index: Arc<
+                        dyn crate::filesystem::FilesystemPathIndexReader,
+                    > = Arc::new(self.live_state.reader(read_store.clone()));
+                    let branch_ref: Arc<dyn BranchRefReader> =
+                        Arc::new(self.branch_ctx.ref_reader(read_store.clone()));
+                    let blob_reader: Arc<dyn crate::binary_cas::BlobDataReader> =
+                        Arc::new(self.binary_cas.reader(read_store));
+                    match exact_lix_file_read {
+                        ExactLixFileRead::Point(selector, column) => {
+                            sql2::execute_exact_lix_file_read(
+                                &active_branch_id,
+                                live_state,
+                                filesystem_path_index,
+                                branch_ref,
+                                blob_reader,
+                                self.plugin_host.clone(),
+                                file_view_collector.clone(),
+                                &selector,
+                                column,
+                            )
+                            .await?
+                        }
+                        ExactLixFileRead::PathDataBatch(paths) => {
+                            sql2::execute_exact_lix_file_batch_read(
+                                &active_branch_id,
+                                live_state,
+                                filesystem_path_index,
+                                branch_ref,
+                                blob_reader,
+                                self.plugin_host.clone(),
+                                file_view_collector.clone(),
+                                None,
+                                &paths,
+                            )
+                            .await?
+                        }
+                        ExactLixFileRead::RootListing => {
+                            unreachable!("root listing handled before file data readers")
+                        }
+                    }
                 }
             };
             let file_view_mutations = file_view_collector
@@ -2746,6 +2767,7 @@ impl Visitor for ColumnReferenceVisitor<'_> {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ExactLixFileRead {
+    RootListing,
     Point(sql2::ExactLixFileReadSelector, sql2::ExactLixFileReadColumn),
     PathDataBatch(BTreeSet<String>),
 }
@@ -2754,6 +2776,9 @@ fn exact_lix_file_read_route(
     statement: &DataFusionStatement,
     params: &[Value],
 ) -> Option<ExactLixFileRead> {
+    if exact_lix_file_root_listing(statement, params) {
+        return Some(ExactLixFileRead::RootListing);
+    }
     if let Some((selector, column)) = exact_lix_file_point_read(statement, params) {
         return Some(ExactLixFileRead::Point(selector, column));
     }
@@ -2763,6 +2788,61 @@ fn exact_lix_file_read_route(
         return None;
     }
     exact_path_data_batch(point_read.select, params).map(ExactLixFileRead::PathDataBatch)
+}
+
+fn exact_lix_file_root_listing(statement: &DataFusionStatement, params: &[Value]) -> bool {
+    if !params.is_empty() {
+        return false;
+    }
+    let Some(simple) = simple_single_table_select(statement) else {
+        return false;
+    };
+    if simple.table_name != "lix_file"
+        || !simple.unqualified_unquoted_table
+        || simple.alias.is_some()
+        || simple.query.limit_clause.is_some()
+        || simple.query.fetch.is_some()
+    {
+        return false;
+    }
+    let expected = ["id", "path", "name", "lixcol_metadata", "lixcol_updated_at"];
+    if simple.select.projection.len() != expected.len()
+        || !simple
+            .select
+            .projection
+            .iter()
+            .zip(expected)
+            .all(|(item, expected)| {
+                let SelectItem::UnnamedExpr(expression) = item else {
+                    return false;
+                };
+                exact_point_column(expression).as_deref() == Some(expected)
+            })
+    {
+        return false;
+    }
+    let Some(Expr::IsNull(directory_id)) = simple.select.selection.as_ref() else {
+        return false;
+    };
+    if exact_point_column(directory_id).as_deref() != Some("directory_id") {
+        return false;
+    }
+    let Some(order_by) = &simple.query.order_by else {
+        return false;
+    };
+    if order_by.interpolate.is_some() {
+        return false;
+    }
+    let OrderByKind::Expressions(expressions) = &order_by.kind else {
+        return false;
+    };
+    let [order] = expressions.as_slice() else {
+        return false;
+    };
+    order.with_fill.is_none()
+        && order.options.asc != Some(false)
+        && order.options.nulls_first.is_none()
+        && exact_point_column(&order.expr).as_deref() == Some("name")
 }
 
 fn exact_lix_file_point_read(
@@ -3318,6 +3398,16 @@ mod tests {
 
     #[test]
     fn exact_lix_file_read_recognizes_only_the_narrow_shapes() {
+        let root_listing = sql2::parse_statement(
+            "SELECT id, path, name, lixcol_metadata, lixcol_updated_at \
+             FROM lix_file WHERE directory_id IS NULL ORDER BY name",
+        )
+        .unwrap();
+        assert_eq!(
+            exact_lix_file_read_route(&root_listing, &[]),
+            Some(ExactLixFileRead::RootListing)
+        );
+
         let data_by_id = sql2::parse_statement("SELECT data FROM lix_file WHERE id = $1").unwrap();
         assert_eq!(
             exact_lix_file_read_route(&data_by_id, &[Value::Text("file-a".to_string())]),
@@ -3356,6 +3446,31 @@ mod tests {
         );
 
         for (sql, params) in [
+            (
+                "SELECT id, path, name, lixcol_metadata, lixcol_updated_at \
+                 FROM lix_file AS file WHERE directory_id IS NULL ORDER BY name",
+                vec![],
+            ),
+            (
+                "SELECT id, path, name, lixcol_metadata, lixcol_updated_at \
+                 FROM lix_file WHERE directory_id IS NULL ORDER BY path",
+                vec![],
+            ),
+            (
+                "SELECT id, path, name, lixcol_metadata, lixcol_updated_at \
+                 FROM lix_file WHERE directory_id IS NULL ORDER BY name DESC",
+                vec![],
+            ),
+            (
+                "SELECT id, path, name, lixcol_metadata, lixcol_updated_at \
+                 FROM lix_file WHERE directory_id IS NULL ORDER BY name LIMIT 1",
+                vec![],
+            ),
+            (
+                "SELECT id, path, name, lixcol_metadata, lixcol_updated_at \
+                 FROM lix_file WHERE directory_id IS NULL ORDER BY name",
+                vec![Value::Text("unused".to_string())],
+            ),
             (
                 "SELECT data, path FROM lix_file WHERE path IN ($1, $2)",
                 vec![
@@ -3443,6 +3558,61 @@ mod tests {
                 "unexpected fast-path match for {sql}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn exact_root_file_listing_matches_the_relational_path() {
+        let session = open_session().await;
+        session
+            .execute(
+                "INSERT INTO lix_directory (id, path) VALUES ('nested-dir', '/nested/')",
+                &[],
+            )
+            .await
+            .unwrap();
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, data, lixcol_metadata) VALUES \
+                 ('root-b', '/b.txt', $1, lix_json('{\"rank\":2}')), \
+                 ('nested', '/nested/a.txt', $2, NULL), \
+                 ('root-a', '/a.txt', $3, NULL)",
+                &[
+                    Value::Blob(b"bravo".to_vec().into()),
+                    Value::Blob(b"nested".to_vec().into()),
+                    Value::Blob(b"alpha".to_vec().into()),
+                ],
+            )
+            .await
+            .unwrap();
+
+        let exact = session
+            .execute(
+                "SELECT id, path, name, lixcol_metadata, lixcol_updated_at \
+                 FROM lix_file WHERE directory_id IS NULL ORDER BY name",
+                &[],
+            )
+            .await
+            .unwrap();
+        let relational = session
+            .execute(
+                "SELECT file.id AS id, file.path AS path, file.name AS name, \
+                        file.lixcol_metadata AS lixcol_metadata, \
+                        file.lixcol_updated_at AS lixcol_updated_at \
+                 FROM lix_file AS file \
+                 WHERE file.directory_id IS NULL ORDER BY file.name",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(exact, relational);
+        assert_eq!(exact.rows().len(), 2);
+        assert_eq!(exact.rows()[0].get::<String>("id").unwrap(), "root-a");
+        assert_eq!(exact.rows()[1].get::<String>("id").unwrap(), "root-b");
+        assert_eq!(
+            exact.rows()[1].value("lixcol_metadata").unwrap(),
+            &Value::Json(serde_json::json!({"rank": 2}))
+        );
     }
 
     #[test]

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -70,6 +70,6 @@ pub(crate) use planning_cache::SqlPlanningCache;
 pub(crate) use providers::{
     ExactLixFileReadColumn, ExactLixFileReadSelector, FastLixFilePathWriteConflict,
     execute_exact_lix_file_batch_read, execute_exact_lix_file_read,
-    execute_fast_lix_file_path_writes,
+    execute_exact_lix_file_root_listing, execute_fast_lix_file_path_writes,
 };
 pub use script::{SqlScriptPlan, SqlScriptStatement, parse_sql_script};

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -624,6 +624,66 @@ pub(crate) async fn execute_exact_lix_file_read(
     )
 }
 
+/// Executes the exact root-file listing used by the filesystem API directly
+/// from the shared path index. The recognized SQL shape has no joins,
+/// grouping, computed values, or residual predicates, so constructing a
+/// DataFusion catalog, logical plan, physical plan and Arrow batch adds no
+/// semantics.
+pub(crate) async fn execute_exact_lix_file_root_listing(
+    active_branch_id: &str,
+    filesystem_path_index: Arc<dyn FilesystemPathIndexReader>,
+    branch_ref: Arc<dyn BranchRefReader>,
+) -> Result<SqlQueryResult, LixError> {
+    let branch_binding = BranchBinding::active(active_branch_id);
+    let branch_ids = resolve_provider_branch_ids(
+        branch_ref.as_ref(),
+        &branch_binding,
+        vec![active_branch_id.to_string()],
+    )
+    .await?;
+    let index = filesystem_path_index
+        .path_index(&FilesystemPathIndexRequest::new(branch_ids))
+        .await?;
+    let matches = indexed_file_matches(index, &FilePathPredicate::All);
+    let mut entries = matches
+        .entries()
+        .filter(|entry| entry.parent_id.is_none())
+        .collect::<Vec<_>>();
+    entries.sort_unstable_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then_with(|| left.path.cmp(&right.path))
+            .then_with(|| left.key.cmp(&right.key))
+    });
+    let rows = entries
+        .into_iter()
+        .map(|entry| {
+            let metadata = entry
+                .metadata()
+                .map(|metadata| parse_row_metadata_value(metadata, "lix_file"))
+                .transpose()?;
+            Ok(vec![
+                Value::Text(entry.id().to_string()),
+                Value::Text(entry.path.clone()),
+                Value::Text(entry.name.clone()),
+                metadata.map_or(Value::Null, Value::Json),
+                Value::Text(entry.updated_at().to_string()),
+            ])
+        })
+        .collect::<Result<Vec<_>, LixError>>()?;
+    Ok(SqlQueryResult {
+        columns: vec![
+            "id".to_string(),
+            "path".to_string(),
+            "name".to_string(),
+            "lixcol_metadata".to_string(),
+            "lixcol_updated_at".to_string(),
+        ],
+        rows,
+        notices: Vec::new(),
+    })
+}
+
 /// Executes Lixray's exact active-branch file batch without constructing a
 /// DataFusion catalog, plan, or Arrow result batch. Keep this separate from
 /// the established point-read path so unrelated file queries remain

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -38,8 +38,9 @@ use datafusion::logical_expr::TableSource;
 pub(crate) use file::{
     ExactLixFileReadColumn, ExactLixFileReadSelector, FastLixFilePathWriteConflict,
     execute_exact_lix_file_batch_read, execute_exact_lix_file_read,
-    execute_fast_lix_file_data_update_by_id, execute_fast_lix_file_data_update_by_id_with_metadata,
-    execute_fast_lix_file_id_path_writes, execute_fast_lix_file_path_writes,
+    execute_exact_lix_file_root_listing, execute_fast_lix_file_data_update_by_id,
+    execute_fast_lix_file_data_update_by_id_with_metadata, execute_fast_lix_file_id_path_writes,
+    execute_fast_lix_file_path_writes,
 };
 #[cfg(test)]
 pub(crate) use filesystem_working_change::filesystem_working_change_schema;

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -438,6 +438,7 @@ struct WritePipelineState {
     draining: bool,
     visible: VecDeque<Arc<PublishedWrite>>,
     active_views: BTreeMap<(u64, u64), usize>,
+    newest_snapshot_sequence: u64,
     next_publication_id: u64,
     terminal_error: Option<StorageError>,
     latest_snapshot: Option<Arc<DbSnapshot>>,
@@ -557,6 +558,7 @@ impl WritePipeline {
                     .tail
                     .as_ref()
                     .is_none_or(|tail| tail.done.load(Ordering::Acquire))
+                && snapshot_covers_persisted_publications(&state, snapshot.seq())
         };
         if cacheable {
             self.install_snapshot(Arc::clone(&snapshot));
@@ -585,6 +587,7 @@ impl WritePipeline {
             .state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.newest_snapshot_sequence = state.newest_snapshot_sequence.max(snapshot_sequence);
         cleanup_publications(&mut state, snapshot_sequence);
         let publication_id = state.next_publication_id;
         *state
@@ -654,7 +657,8 @@ impl Drop for PublicationView {
         if remove {
             state.active_views.remove(&key);
         }
-        cleanup_publications(&mut state, u64::MAX);
+        let newest_snapshot_sequence = state.newest_snapshot_sequence;
+        cleanup_publications(&mut state, newest_snapshot_sequence);
     }
 }
 
@@ -682,6 +686,16 @@ fn cleanup_publications(state: &mut WritePipelineState, newest_snapshot_sequence
     }) {
         state.visible.pop_front();
     }
+}
+
+fn snapshot_covers_persisted_publications(
+    state: &WritePipelineState,
+    snapshot_sequence: u64,
+) -> bool {
+    state.visible.iter().all(|write| {
+        let persisted = write.persisted_sequence.load(Ordering::Acquire);
+        persisted != PENDING_WRITE_SEQUENCE && persisted <= snapshot_sequence
+    })
 }
 
 impl SnapshotPointCache {
@@ -3407,6 +3421,52 @@ mod tests {
             "publication is reclaimed after its last dependent view"
         );
         drop(newer);
+    }
+
+    #[test]
+    fn dropping_unrelated_view_does_not_reclaim_publication_a_stale_fetch_needs() {
+        let pipeline = WritePipeline::new();
+        let unrelated = pipeline.capture(1);
+        let key = Key(Bytes::from_static(b"stale-fetch"));
+        let value = Bytes::from_static(b"published");
+        let published = Arc::new(PublishedWrite {
+            publication_id: 1,
+            overlay: Arc::new(BTreeMap::from([(key.clone(), Some(value.clone()))])),
+            persisted_sequence: AtomicU64::new(2),
+        });
+        {
+            let mut state = pipeline.state.lock().expect("lock publication state");
+            state.next_publication_id = 1;
+            state.visible.push_back(published);
+        }
+
+        // Model a snapshot fetch that started at sequence 1 before the
+        // publication persisted. Dropping an older unrelated view in the gap
+        // must not discard the overlay before that fetch captures its view.
+        drop(unrelated);
+        let stale_fetch = pipeline.capture(1);
+
+        assert_eq!(
+            pipeline.point_value(
+                stale_fetch.snapshot_sequence,
+                stale_fetch.publication_id,
+                &key,
+            ),
+            Some(Some(value))
+        );
+    }
+
+    #[test]
+    fn stale_snapshot_is_not_cacheable_after_publication_persists() {
+        let mut state = WritePipelineState::default();
+        state.visible.push_back(Arc::new(PublishedWrite {
+            publication_id: 1,
+            overlay: Arc::new(BTreeMap::new()),
+            persisted_sequence: AtomicU64::new(2),
+        }));
+
+        assert!(!snapshot_covers_persisted_publications(&state, 1));
+        assert!(snapshot_covers_persisted_publications(&state, 2));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- recognize the exact no-plugin root `lix_file` listing shape and return it directly from the shared filesystem path index, skipping DataFusion catalog/planning/Arrow work
- preserve all other SQL shapes on the existing relational path with a deliberately strict recognizer
- fix a SlateDB snapshot/publication race found while profiling the real file-write benchmark
- extend the public API benchmark to measure both the file query and the complete directory-plus-file listing on Memory, RocksDB, and SlateDB

## Why

The warmed root listing spent most of its time allocating and planning two DataFusion queries even though the shared filesystem path index already held every projected value. The direct route benefits every adapter rather than specializing for SlateDB.

The write benchmark also exposed a correctness race: a read could fetch a stale SlateDB snapshot immediately before a publication persisted, while an unrelated view drop reclaimed that publication before the stale fetch captured it. The fix retains publications through the newest actually observed snapshot and refuses to cache snapshots that do not cover all persisted publications.

## Performance

Measured from separate release binaries against latest `origin/main` `564a5c8d9`, 100-file corpus, 30 warmups, 300 samples per backend. Values below are the average p50 from two process runs.

| Public API operation | Backend | main | PR | Improvement |
|---|---:|---:|---:|---:|
| complete root listing (directories + files) | RocksDB | 1.240 ms | 603 µs | 51.4% faster |
| complete root listing (directories + files) | SlateDB | 1.215 ms | 592 µs | 51.3% faster |
| root file query | RocksDB | 647 µs | 27.0 µs | 95.8% faster |
| root file query | SlateDB | 656 µs | 24.9 µs | 96.2% faster |

The previously conflicting SlateDB single-overwrite and 10-file batch-overwrite Criterion workloads both completed warmup and sampling without a transaction conflict.

## Correctness and validation

- strict route/fallback recognition tests
- direct-result equivalence test covering root/nested files, order, JSON metadata, null metadata, and timestamps
- deterministic publication reclamation race regression test
- stale snapshot cache regression test
- `cargo fmt --all -- --check`
- `cargo test --profile test --workspace --all-features --no-run`
- `cargo test --profile test --workspace --all-features`
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`

No storage contract change is required for this cut.