### PR TITLE
perf: load minimal replacement owners

### DIFF
--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -12,9 +12,9 @@ use crate::filesystem::{
 };
 use crate::live_state::tracked_head::TrackedHeadContext;
 use crate::live_state::{
-    LiveStateExactBatchRequest, LiveStateReader, LiveStateRowFilter, LiveStateRowIdentity,
-    LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow, VisibilityBranchScope,
-    VisibilityRequest, expanded_branch_ids, resolve_visible_rows,
+    LiveStateExactBatchRequest, LiveStateReader, LiveStateReplacementOwner, LiveStateRowFilter,
+    LiveStateRowIdentity, LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow,
+    VisibilityBranchScope, VisibilityRequest, expanded_branch_ids, resolve_visible_rows,
 };
 use crate::storage_adapter::StorageAdapterRead;
 use crate::tracked_state::{
@@ -150,6 +150,53 @@ where
                 )
                 .await?,
         ))
+    }
+
+    /// Returns the minimal predecessor evidence for a certified full-row
+    /// replacement, or `None` when generic visibility semantics are required.
+    pub(crate) async fn scan_direct_replacement_owners(
+        &self,
+        branch_id: &str,
+        schema_key: &str,
+        entity_pks: &[EntityPk],
+    ) -> Result<Option<Vec<Option<LiveStateReplacementOwner>>>, LixError> {
+        let request = LiveStateScanRequest {
+            filter: crate::live_state::LiveStateFilter {
+                branch_ids: vec![branch_id.to_string()],
+                schema_keys: vec![schema_key.to_string()],
+                entity_pks: entity_pks.to_vec(),
+                include_tombstones: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let scope = scan_scope(&self.store, &request, true).await?;
+        let [requested_branch_id] = scope.projection_branch_ids.as_slice() else {
+            return Ok(None);
+        };
+        if requested_branch_id != branch_id
+            || scope
+                .storage_branch_ids
+                .iter()
+                .any(|candidate| candidate != branch_id && candidate != GLOBAL_BRANCH_ID)
+        {
+            return Ok(None);
+        }
+        let Some(requested_control) = scope.branch_heads.get(branch_id).copied() else {
+            return Ok(None);
+        };
+        let tracked_head = self.tracked_head.reader(&self.store);
+        if branch_id != GLOBAL_BRANCH_ID
+            && let Some(global_control) = scope.branch_heads.get(GLOBAL_BRANCH_ID).copied()
+            && tracked_head
+                .has_schema_rows(GLOBAL_BRANCH_ID, global_control, schema_key)
+                .await?
+        {
+            return Ok(None);
+        }
+        tracked_head
+            .scan_replacement_owners(branch_id, requested_control, schema_key, entity_pks)
+            .await
     }
 
     pub(crate) async fn scan_rows(

--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -22,8 +22,9 @@ pub(crate) use tracked_head::{
 #[allow(unused_imports)]
 pub(crate) use types::{
     Bound, LiveStateExactBatchRequest, LiveStateExactRowRequest, LiveStateFilter,
-    LiveStateProjection, LiveStateRowFilter, LiveStateRowIdentity, LiveStateRowRequest,
-    LiveStateScanRequest, MaterializedLiveStateRow, ScanConstraint, ScanField, ScanOperator,
+    LiveStateProjection, LiveStateReplacementOwner, LiveStateRowFilter, LiveStateRowIdentity,
+    LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow, ScanConstraint, ScanField,
+    ScanOperator,
 };
 #[allow(unused_imports)]
 pub(crate) use visibility::{

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -29,7 +29,7 @@ use crate::json_store::JsonSlot;
 use crate::json_store::{
     JsonLoadRequestRef, JsonReadScopeRef, JsonRef, JsonSlotRef, JsonStoreContext, JsonStoreWriter,
 };
-use crate::live_state::MaterializedLiveStateRow;
+use crate::live_state::{LiveStateReplacementOwner, MaterializedLiveStateRow};
 use crate::storage_adapter::{
     PointReadPlan, ScanPlan, StorageAdapterRead, StorageCoreProjection, StorageGetOptions,
     StorageKey, StoragePrefix, StorageProjectedValue, StorageScanOptions, StorageSpace,

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -106,6 +106,22 @@ where
         .await
     }
 
+    pub(crate) async fn scan_replacement_owners(
+        &self,
+        branch_id: &str,
+        control: BranchHeadControl,
+        schema_key: &str,
+        entity_pks: &[EntityPk],
+    ) -> Result<Option<Vec<Option<LiveStateReplacementOwner>>>, LixError> {
+        self.scan_replacement_owners_for_generation(
+            branch_id,
+            control.generation,
+            schema_key,
+            entity_pks,
+        )
+        .await
+    }
+
     #[cfg(test)]
     pub(crate) async fn scan_live_rows_if_current(
         &self,
@@ -375,6 +391,102 @@ where
             }
         }
         materialize_entity_snapshot_refs(&self.store, snapshots, json_refs, deferred).await
+    }
+
+    async fn scan_replacement_owners_for_generation(
+        &self,
+        branch_id: &str,
+        generation: CommitId,
+        schema_key: &str,
+        entity_pks: &[EntityPk],
+    ) -> Result<Option<Vec<Option<LiveStateReplacementOwner>>>, LixError> {
+        if entity_pks.windows(2).any(|pair| pair[0] >= pair[1]) {
+            return Ok(None);
+        }
+        let entries = hot_scan_entries(
+            &self.store,
+            branch_id,
+            generation,
+            &TrackedStateFilter {
+                schema_keys: vec![schema_key.to_string()],
+                entity_pks: entity_pks.to_vec(),
+                include_tombstones: false,
+                ..TrackedStateFilter::default()
+            },
+            None,
+        )
+        .await?;
+        let mut owners = vec![None; entity_pks.len()];
+        let mut requested_index = 0;
+        let mut json_refs = Vec::new();
+        let mut deferred = Vec::new();
+        for (identity, bytes) in entries {
+            let value = decode_head_value(&bytes)?;
+            if value.deleted {
+                continue;
+            }
+            if value.untracked || identity.file_id.is_some() {
+                return Ok(None);
+            }
+            while requested_index < entity_pks.len()
+                && entity_pks[requested_index] < identity.entity_pk
+            {
+                requested_index += 1;
+            }
+            if requested_index == entity_pks.len() {
+                break;
+            }
+            if entity_pks[requested_index] != identity.entity_pk {
+                continue;
+            }
+            let metadata = match value.metadata {
+                HeadSlotView::None => None,
+                HeadSlotView::Inline(metadata) => Some(metadata.to_string()),
+                HeadSlotView::Ref(json_ref) => {
+                    json_refs.push(json_ref);
+                    deferred.push((requested_index, json_ref));
+                    None
+                }
+            };
+            owners[requested_index] = Some(LiveStateReplacementOwner { metadata });
+            requested_index += 1;
+        }
+        if json_refs.is_empty() {
+            return Ok(Some(owners));
+        }
+        let mut json_values = JsonStoreContext::new()
+            .load_bytes_many(
+                &self.store,
+                JsonLoadRequestRef {
+                    refs: &json_refs,
+                    scope: JsonReadScopeRef::OutOfBand,
+                },
+            )
+            .await?
+            .into_values();
+        for (index, (owner_index, json_ref)) in deferred.into_iter().enumerate() {
+            let bytes = json_values
+                .get_mut(index)
+                .ok_or_else(|| head_value_error("lost replacement metadata value index"))?
+                .take()
+                .ok_or_else(|| {
+                    head_value_error(&format!(
+                        "replacement owner is missing metadata payload '{}'",
+                        json_ref.to_hex()
+                    ))
+                })?;
+            let metadata = String::from_utf8(bytes).map_err(|error| {
+                head_value_error(&format!(
+                    "replacement owner metadata payload is not UTF-8: {error}"
+                ))
+            })?;
+            owners
+                .get_mut(owner_index)
+                .and_then(Option::as_mut)
+                .ok_or_else(|| head_value_error("lost replacement metadata owner index"))?
+                .metadata = Some(metadata);
+        }
+        Ok(Some(owners))
     }
 }
 

--- a/packages/engine/src/live_state/types.rs
+++ b/packages/engine/src/live_state/types.rs
@@ -27,6 +27,17 @@ pub(crate) struct MaterializedLiveStateRow {
     pub(crate) branch_id: Arc<str>,
 }
 
+/// Minimal visible-row evidence needed by a certified full entity replacement.
+///
+/// Identity and target branch are supplied by the caller. A present value
+/// proves that the corresponding live row exists as an ordinary branch-local
+/// tracked member; inherited metadata is the only predecessor payload the
+/// replacement lowerer still needs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LiveStateReplacementOwner {
+    pub(crate) metadata: Option<String>,
+}
+
 impl TryFrom<&MaterializedLiveStateRow> for MaterializedTrackedStateRow {
     type Error = crate::LixError;
 

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -3715,8 +3715,9 @@ mod tests {
             .unwrap();
         session
             .execute(
-                "INSERT INTO certified_replacement_probe (path, value) VALUES \
-                 ('/a', lix_json('\"old-a\"')), ('/b', lix_json('\"old-b\"'))",
+                "INSERT INTO certified_replacement_probe (path, value, lixcol_metadata) VALUES \
+                 ('/a', lix_json('\"old-a\"'), lix_json('{\"owner\":\"a\"}')), \
+                 ('/b', lix_json('\"old-b\"'), NULL)",
                 &[],
             )
             .await
@@ -3740,6 +3741,13 @@ mod tests {
                         Value::Text("/b".to_string()),
                     ],
                 },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text(r#""not-inserted""#.to_string()),
+                        Value::Text("/missing".to_string()),
+                    ],
+                },
             ])
             .await
             .unwrap();
@@ -3753,19 +3761,29 @@ mod tests {
                 .iter()
                 .map(ExecuteResult::rows_affected)
                 .collect::<Vec<_>>(),
-            vec![1, 1]
+            vec![1, 1, 0]
         );
         let rows = session
             .execute(
-                "SELECT path, value FROM certified_replacement_probe ORDER BY path",
+                "SELECT path, value, lixcol_metadata \
+                 FROM certified_replacement_probe ORDER BY path",
                 &[],
             )
             .await
             .unwrap();
+        assert_eq!(rows.len(), 2);
         assert_eq!(rows.rows()[0].value("value").unwrap(), &Value::Null);
+        assert_eq!(
+            rows.rows()[0].value("lixcol_metadata").unwrap(),
+            &Value::Json(serde_json::json!({"owner": "a"}))
+        );
         assert_eq!(
             rows.rows()[1].get::<serde_json::Value>("value").unwrap(),
             serde_json::json!({"nested": [1, true, "x"]})
+        );
+        assert_eq!(
+            rows.rows()[1].value("lixcol_metadata").unwrap(),
+            &Value::Null
         );
     }
 

--- a/packages/engine/src/sql2/context.rs
+++ b/packages/engine/src/sql2/context.rs
@@ -11,6 +11,7 @@ use crate::binary_cas::{BlobBytesBatch, BlobDataReader, BlobHash};
 use crate::branch::{BranchHead, BranchRefReader};
 use crate::changelog::CommitId;
 use crate::commit_graph::CommitGraphReader;
+use crate::entity_pk::EntityPk;
 use crate::filesystem::{
     FilesystemPathIndex, FilesystemPathIndexReader, FilesystemPathIndexRequest,
     UncachedFilesystemPathIndexReader,
@@ -19,7 +20,7 @@ use crate::functions::FunctionProviderHandle;
 use crate::json_store::JsonStoreReader;
 use crate::live_state::{
     LiveStateExactBatchRequest, LiveStateFilter, LiveStateProjection, LiveStateReader,
-    LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow,
+    LiveStateReplacementOwner, LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow,
 };
 use crate::plugin::PluginRuntimeHost;
 use crate::storage_adapter::StorageAdapterRead;
@@ -152,6 +153,14 @@ pub(crate) trait SqlWriteExecutionContext: Send {
             );
         }
         Ok(rows)
+    }
+
+    async fn load_certified_replacement_owners(
+        &mut self,
+        _schema_key: &str,
+        _entity_pks: &[EntityPk],
+    ) -> Result<Option<Vec<Option<LiveStateReplacementOwner>>>, LixError> {
+        Ok(None)
     }
 
     async fn filesystem_path_index(

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -137,6 +137,69 @@ pub(crate) async fn try_execute_entity_update_parameter_batch(
         entity_pks.push(entity_pk);
     }
 
+    if let Some(replacement) = &direct_replacement {
+        let unique_entity_pks = unique_entity_pks.iter().cloned().collect::<Vec<_>>();
+        if let Some(owners) = ctx
+            .load_certified_replacement_owners(&spec.schema_key, &unique_entity_pks)
+            .await?
+        {
+            if owners.len() != unique_entity_pks.len() {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "certified replacement owner read expected {} result slots, got {}",
+                        unique_entity_pks.len(),
+                        owners.len()
+                    ),
+                ));
+            }
+            let mut owners_by_pk = unique_entity_pks
+                .into_iter()
+                .zip(owners)
+                .filter_map(|(entity_pk, owner)| owner.map(|owner| (entity_pk, owner)))
+                .collect::<std::collections::HashMap<_, _>>();
+            let branch_id = ctx.active_branch_id().to_string();
+            let mut affected_by_statement = Vec::with_capacity(entity_pks.len());
+            let mut write_rows = Vec::with_capacity(owners_by_pk.len());
+            for (row_index, (entity_pk, params)) in
+                entity_pks.into_iter().zip(&parameter_rows).enumerate()
+            {
+                let Some(owner) = owners_by_pk.remove(&entity_pk) else {
+                    affected_by_statement.push(0);
+                    continue;
+                };
+                write_rows.push(
+                    direct_path_value_replacement_row_without_candidate(
+                        &spec,
+                        entity_pk,
+                        params,
+                        replacement,
+                        &branch_id,
+                        owner,
+                    )
+                    .map_err(|error| with_parameter_batch_statement_index(error, row_index))?,
+                );
+                affected_by_statement.push(1);
+            }
+            stage_rows(ctx, TransactionWriteMode::Replace, write_rows).await?;
+            #[cfg(test)]
+            {
+                ENTITY_UPDATE_PARAMETER_BATCH_EXECUTIONS.with(|executions| {
+                    executions.set(executions.get() + 1);
+                });
+                CERTIFIED_REPLACEMENT_PARAMETER_BATCH_EXECUTIONS.with(|executions| {
+                    executions.set(executions.get() + 1);
+                });
+            }
+            return Ok(Some(
+                affected_by_statement
+                    .into_iter()
+                    .map(SqlWriteResult::affected)
+                    .collect(),
+            ));
+        }
+    }
+
     let candidates = scan_entity_candidates_for_pks(
         ctx,
         plan,
@@ -210,6 +273,38 @@ struct DirectPathValueReplacement {
     value_param_index: usize,
 }
 
+fn direct_path_value_replacement_row_without_candidate(
+    spec: &EntitySurfaceSpec,
+    entity_pk: EntityPk,
+    params: &[Value],
+    replacement: &DirectPathValueReplacement,
+    branch_id: &str,
+    owner: crate::live_state::LiveStateReplacementOwner,
+) -> Result<TransactionWriteRow, LixError> {
+    let snapshot = normalized_path_value_replacement(&entity_pk, params, replacement)?;
+    Ok(TransactionWriteRow {
+        entity_pk: Some(entity_pk),
+        schema_key: spec.schema_key.clone(),
+        file_id: None,
+        snapshot: Some(snapshot),
+        metadata: owner
+            .metadata
+            .map(|metadata| {
+                let metadata = parse_row_metadata_value(&metadata, &spec.schema_key)?;
+                TransactionJson::from_value(metadata, &format!("{} metadata", spec.schema_key))
+            })
+            .transpose()?,
+        origin: None,
+        created_at: None,
+        updated_at: None,
+        global: false,
+        change_id: None,
+        commit_id: None,
+        untracked: false,
+        branch_id: branch_id.to_string(),
+    })
+}
+
 fn direct_path_value_replacement(
     spec: &EntitySurfaceSpec,
     plan: &LogicalWritePlan,
@@ -247,6 +342,33 @@ fn direct_path_value_replacement_row(
     params: &[Value],
     replacement: &DirectPathValueReplacement,
 ) -> Result<TransactionWriteRow, LixError> {
+    let snapshot = normalized_path_value_replacement(&candidate.entity_pk, params, replacement)?;
+    Ok(TransactionWriteRow {
+        entity_pk: Some(candidate.entity_pk.clone()),
+        schema_key: spec.schema_key.clone(),
+        file_id: candidate.file_id.clone(),
+        snapshot: Some(snapshot),
+        metadata: inherited_metadata(candidate, spec)?,
+        origin: None,
+        created_at: None,
+        updated_at: None,
+        global: candidate.global,
+        change_id: None,
+        commit_id: None,
+        untracked: candidate.untracked,
+        branch_id: if candidate.global {
+            crate::GLOBAL_BRANCH_ID.to_string()
+        } else {
+            candidate.branch_id.to_string()
+        },
+    })
+}
+
+fn normalized_path_value_replacement(
+    entity_pk: &EntityPk,
+    params: &[Value],
+    replacement: &DirectPathValueReplacement,
+) -> Result<TransactionJson, LixError> {
     let value = match params.get(replacement.value_param_index) {
         Some(Value::Null) => JsonValue::Null,
         Some(Value::Text(raw)) => serde_json::from_str(raw).map_err(|error| {
@@ -277,34 +399,16 @@ fn direct_path_value_replacement_row(
             format!("certified replacement value failed to serialize: {error}"),
         )
     })?;
-    let path = serde_json::to_string(candidate.entity_pk.as_single_string()?).map_err(|error| {
+    let path = serde_json::to_string(entity_pk.as_single_string()?).map_err(|error| {
         LixError::new(
             LixError::CODE_UNKNOWN,
             format!("certified replacement identity failed to serialize: {error}"),
         )
     })?;
     let normalized = format!(r#"{{"path":{path},"value":{value}}}"#);
-    Ok(TransactionWriteRow {
-        entity_pk: Some(candidate.entity_pk.clone()),
-        schema_key: spec.schema_key.clone(),
-        file_id: candidate.file_id.clone(),
-        snapshot: Some(TransactionJson::from_certified_normalized_row_content(
-            normalized.into(),
-        )),
-        metadata: inherited_metadata(candidate, spec)?,
-        origin: None,
-        created_at: None,
-        updated_at: None,
-        global: candidate.global,
-        change_id: None,
-        commit_id: None,
-        untracked: candidate.untracked,
-        branch_id: if candidate.global {
-            crate::GLOBAL_BRANCH_ID.to_string()
-        } else {
-            candidate.branch_id.to_string()
-        },
-    })
+    Ok(TransactionJson::from_certified_normalized_row_content(
+        normalized.into(),
+    ))
 }
 
 fn bound_single_text_primary_key_param(

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -4739,6 +4739,25 @@ where
         self.load_visible_exact_live_state_rows(request).await
     }
 
+    async fn load_certified_replacement_owners(
+        &mut self,
+        schema_key: &str,
+        entity_pks: &[EntityPk],
+    ) -> Result<Option<Vec<Option<crate::live_state::LiveStateReplacementOwner>>>, LixError> {
+        if !self.staged_writes.state_rows_are_empty()? {
+            return Ok(None);
+        }
+        let read = SharedStorageAdapterRead::new(
+            self.storage
+                .begin_read(StorageReadOptions::default())
+                .await?,
+        );
+        self.live_state
+            .reader(read)
+            .scan_direct_replacement_owners(&self.active_branch_id, schema_key, entity_pks)
+            .await
+    }
+
     async fn filesystem_path_index(
         &mut self,
         request: &FilesystemPathIndexRequest,

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -424,6 +424,19 @@ impl TransactionWriteBuffer {
         }
     }
 
+    pub(crate) fn state_rows_are_empty(&self) -> Result<bool, LixError> {
+        let rows = self.rows.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_UNKNOWN,
+                "failed to acquire transaction staged writes lock",
+            )
+        })?;
+        Ok(match &*rows {
+            StagedPreparedRows::AppendOnly { rows, .. } => rows.is_empty(),
+            StagedPreparedRows::Indexed { rows, .. } => rows.iter().all(Option::is_none),
+        })
+    }
+
     /// Promotes the compact ordered journal into the existing identity overlay
     /// only when a read or an irregular write needs read-your-writes lookup.
     fn ensure_identity_index(&self, materialize_empty: bool) -> Result<(), LixError> {


### PR DESCRIPTION
## Summary

- hard-cut certified replacement candidate hydration to an aligned minimal ownership projection
- preserve missing-row affected counts and inherited metadata without materializing full live-state rows
- decline staged, global-schema, file-scoped, untracked, and unsupported visibility cases to the canonical path
- leave the storage adapter API unchanged because the profiled point-probe-to-scan experiment did not clear the acceptance bar

## Profile and rejected cut

After #877, `memcmp` was 11.02% of the target profile and about 76% of sampled `memcmp` calls came from RocksDB comparators. Replacing 10,000 point probes with an ordered range scan was therefore tested first. Eleven balanced hot pairs improved only about 2.4%, while `memcmp` remained 10.63%; the iterator performs substantially the same comparator work and adds scan/page overhead. That experiment was reverted.

`memmove` attribution then showed repeated `String` cloning and construction of generic live-state `BTreeMap`s. Certified replacements only need aligned existence plus ownership metadata. Bypassing full generic candidate hydration established an approximately 28% ceiling, so this change introduces the smallest correct projection for that evidence.

## Benchmarks

All target measurements use balanced, fresh-fixture pairs.

| Benchmark | Parent | Candidate | Change |
| --- | ---: | ---: | ---: |
| 10k certified bound UPDATE | 117.71 ms | 98.21 ms | **16.6% faster** |
| Raw SQLite reference | 13.289 ms | — | candidate is 7.39× SQLite |
| SQL-session INSERT | 138.659 ms | 139.814 ms | 0.8% slower |
| Ordinary SQL UPDATE | 406.539 ms | 425.653 ms | 4.7% slower |
| DELETE | 110.735 ms | 114.197 ms | 3.1% slower |
| Transaction UPDATE | 84.131 ms | 84.720 ms | 0.7% slower |
| Diff | 30.128 ms | 30.503 ms | 1.2% slower |
| Merge preview | 121.333 ms | 123.600 ms | 1.9% slower |
| Merge commit | 16.571 ms | 13.469 ms | 18.7% faster |

The target won all 15/15 balanced pairs. In the candidate profile, `memcmp` falls to 7.34%, and the generic visibility `BTreeMap` disappears from the top costs.

## Correctness contract

- owner slots stay aligned with requested identities
- missing rows remain missing and report zero affected rows
- inherited metadata is preserved
- staged rows and visibility shapes not proven equivalent continue through the canonical reader
- checkpoint and lifecycle paths are unchanged

## Validation

- focused certified replacement end-to-end test, including missing rows and metadata preservation
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p lix_engine --features all-simulations`
  - 1,391 unit tests passed, 6 ignored
  - 760 integration tests passed, 2 ignored
  - 3 doctests passed
