### PR TITLE
refactor(filesystem): remove row-owned test adapters

### DIFF
--- a/packages/engine/src/filesystem/path_index.rs
+++ b/packages/engine/src/filesystem/path_index.rs
@@ -300,11 +300,6 @@ impl Default for FilesystemPathIndex {
 }
 
 impl FilesystemPathIndex {
-    #[cfg(test)]
-    pub(crate) fn from_live_rows(rows: Vec<MaterializedLiveStateRow>) -> Result<Self, LixError> {
-        Self::from_live_batch(&MaterializedLiveStateBatch::from_rows(rows))
-    }
-
     pub(crate) fn from_live_batch(rows: &MaterializedLiveStateBatch) -> Result<Self, LixError> {
         let mut directory_rows = BTreeMap::<FilesystemDescriptorKey, DirectoryRecord>::new();
         let mut file_rows = Vec::<(FilesystemDescriptorKey, FileRecord)>::new();
@@ -1427,6 +1422,12 @@ mod tests {
     use crate::entity_pk::EntityPk;
     use crate::live_state::MaterializedLiveStateBatchBuilder;
 
+    fn path_index_from_rows(
+        rows: Vec<MaterializedLiveStateRow>,
+    ) -> Result<FilesystemPathIndex, LixError> {
+        FilesystemPathIndex::from_live_batch(&MaterializedLiveStateBatch::from_rows(rows))
+    }
+
     #[derive(Clone)]
     struct BatchOnlyLiveStateReader {
         rows: MaterializedLiveStateBatch,
@@ -1535,7 +1536,7 @@ mod tests {
 
     #[test]
     fn exact_range_and_order_preserve_path_buckets() {
-        let index = FilesystemPathIndex::from_live_rows(vec![
+        let index = path_index_from_rows(vec![
             directory_row(
                 "01920000-0000-7000-8000-0000000000d3",
                 None,
@@ -1598,7 +1599,7 @@ mod tests {
 
     #[test]
     fn exact_file_id_entries_keep_every_file_lane_and_exclude_directories() {
-        let index = FilesystemPathIndex::from_live_rows(vec![
+        let index = path_index_from_rows(vec![
             directory_row(
                 "shared",
                 None,
@@ -1700,7 +1701,7 @@ mod tests {
             &request,
             Some(&[1]),
             Arc::new(
-                FilesystemPathIndex::from_live_rows(vec![file_row(
+                path_index_from_rows(vec![file_row(
                     "01920000-0000-7000-8000-0000000000a2",
                     None,
                     "before.md",
@@ -1735,7 +1736,7 @@ mod tests {
     #[test]
     fn blob_refs_build_and_advance_with_their_file_entry() {
         let request = FilesystemPathIndexRequest::new(vec!["branch-a".to_string()]);
-        let prior = FilesystemPathIndex::from_live_rows(vec![
+        let prior = path_index_from_rows(vec![
             file_row("file-a", None, "a.md", "branch-a", false),
             blob_row("file-a", "hash-before", "branch-a"),
         ])
@@ -1786,7 +1787,7 @@ mod tests {
         let request = FilesystemPathIndexRequest::new(vec!["branch-a".to_string()]);
         let mut projected_blob = blob_row("global-file", "hash-before", "branch-a");
         projected_blob.global = true;
-        let prior = FilesystemPathIndex::from_live_rows(vec![
+        let prior = path_index_from_rows(vec![
             file_row("global-file", None, "global.md", "branch-a", true),
             projected_blob,
         ])
@@ -1814,7 +1815,7 @@ mod tests {
     fn global_descriptor_delta_updates_only_unshadowed_branch_entries() {
         let request =
             FilesystemPathIndexRequest::new(vec!["branch-a".to_string(), "branch-b".to_string()]);
-        let prior = FilesystemPathIndex::from_live_rows(vec![
+        let prior = path_index_from_rows(vec![
             file_row("global-file", None, "local.md", "branch-a", false),
             file_row("global-file", None, "global.md", "branch-b", true),
         ])
@@ -1842,7 +1843,7 @@ mod tests {
         let request = FilesystemPathIndexRequest::new(vec![
             "01920000-0000-7000-8000-0000000000a1".to_string(),
         ]);
-        let prior = FilesystemPathIndex::from_live_rows(vec![file_row(
+        let prior = path_index_from_rows(vec![file_row(
             "01920000-0000-7000-8000-0000000000a2",
             None,
             "before.md",
@@ -1884,7 +1885,7 @@ mod tests {
             "01920000-0000-7000-8000-0000000000a1".to_string(),
             "01920000-0000-7000-8000-0000000000b1".to_string(),
         ]);
-        let prior = FilesystemPathIndex::from_live_rows(vec![
+        let prior = path_index_from_rows(vec![
             file_row(
                 "shared",
                 None,
@@ -1926,7 +1927,7 @@ mod tests {
         let request = FilesystemPathIndexRequest::new(vec![
             "01920000-0000-7000-8000-0000000000a1".to_string(),
         ]);
-        let prior = FilesystemPathIndex::from_live_rows(vec![
+        let prior = path_index_from_rows(vec![
             directory_row(
                 "docs",
                 None,
@@ -1984,7 +1985,7 @@ mod tests {
         let request = FilesystemPathIndexRequest::new(vec![
             "01920000-0000-7000-8000-0000000000a1".to_string(),
         ]);
-        let prior = FilesystemPathIndex::from_live_rows(vec![
+        let prior = path_index_from_rows(vec![
             directory_row(
                 "docs",
                 None,

--- a/packages/engine/src/filesystem/visibility.rs
+++ b/packages/engine/src/filesystem/visibility.rs
@@ -4,8 +4,6 @@ use std::sync::Arc;
 use serde::Deserialize;
 
 use crate::LixError;
-#[cfg(test)]
-use crate::live_state::MaterializedLiveStateRow;
 use crate::live_state::{
     LiveStateFilter, LiveStateReader, LiveStateScanRequest, MaterializedLiveStateBatch,
 };
@@ -53,13 +51,6 @@ impl VisibleFilesystem {
             })
             .await?;
         Self::from_live_batch(&rows)
-    }
-
-    /// Builds filesystem lookup indexes from rows that are already known to be
-    /// transaction-visible.
-    #[cfg(test)]
-    pub(crate) fn from_live_rows(rows: Vec<MaterializedLiveStateRow>) -> Result<Self, LixError> {
-        Self::from_live_batch(&MaterializedLiveStateBatch::from_rows(rows))
     }
 
     pub(crate) fn from_live_batch(rows: &MaterializedLiveStateBatch) -> Result<Self, LixError> {
@@ -182,13 +173,21 @@ mod tests {
     use crate::changelog::{ChangeId, CommitId};
     use crate::common::LixTimestamp;
     use crate::filesystem::{FilesystemDescriptorKey, FilesystemRowContext};
-    use crate::live_state::MaterializedLiveStateRow;
-    use crate::live_state::{LiveStateReader, LiveStateRowRequest, LiveStateScanRequest};
+    use crate::live_state::{
+        LiveStateReader, LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateBatch,
+        MaterializedLiveStateRow,
+    };
 
     use super::{
         BLOB_REF_SCHEMA_KEY, DERIVED_FILE_REF_SCHEMA_KEY, DIRECTORY_DESCRIPTOR_SCHEMA_KEY,
         FILE_DESCRIPTOR_SCHEMA_KEY, VisibleFilesystem,
     };
+
+    fn visible_filesystem_from_rows(
+        rows: Vec<MaterializedLiveStateRow>,
+    ) -> Result<VisibleFilesystem, LixError> {
+        VisibleFilesystem::from_live_batch(&MaterializedLiveStateBatch::from_rows(rows))
+    }
 
     #[tokio::test]
     async fn load_uses_expected_scan_filter() {
@@ -335,7 +334,7 @@ mod tests {
 
     #[test]
     fn from_live_rows_ignores_tombstones_unrelated_schemas_and_indexes_root_files() {
-        let filesystem = VisibleFilesystem::from_live_rows(vec![
+        let filesystem = visible_filesystem_from_rows(vec![
             live_row(
                 "dir-tombstone",
                 DIRECTORY_DESCRIPTOR_SCHEMA_KEY,
@@ -388,7 +387,7 @@ mod tests {
 
     #[test]
     fn from_live_rows_rejects_invalid_filesystem_json() {
-        let error = VisibleFilesystem::from_live_rows(vec![live_row(
+        let error = visible_filesystem_from_rows(vec![live_row(
             "dir-invalid",
             DIRECTORY_DESCRIPTOR_SCHEMA_KEY,
             None,

--- a/packages/engine/src/sql2/providers/directory.rs
+++ b/packages/engine/src/sql2/providers/directory.rs
@@ -2150,6 +2150,18 @@ mod tests {
         FilesystemDescriptorKey, VisibleFilesystem, directory_path_resolvers_from_state_rows,
     };
 
+    fn path_index_from_rows(
+        rows: Vec<MaterializedLiveStateRow>,
+    ) -> Result<FilesystemPathIndex, LixError> {
+        FilesystemPathIndex::from_live_batch(&MaterializedLiveStateBatch::from_rows(rows))
+    }
+
+    fn visible_filesystem_from_rows(
+        rows: Vec<MaterializedLiveStateRow>,
+    ) -> Result<VisibleFilesystem, LixError> {
+        VisibleFilesystem::from_live_batch(&MaterializedLiveStateBatch::from_rows(rows))
+    }
+
     fn test_id_generator(ids: &'static [&'static str]) -> impl FnMut() -> String {
         let mut ids = ids.iter();
         move || ids.next().expect("test id should exist").to_string()
@@ -2646,7 +2658,7 @@ mod tests {
         let live_state_scans = Arc::new(AtomicUsize::new(0));
         let path_index_requests = Arc::new(AtomicUsize::new(0));
         let index = Arc::new(
-            FilesystemPathIndex::from_live_rows(vec![
+            path_index_from_rows(vec![
                 live_row(
                     "01920000-0000-7000-8000-0000000000d3",
                     "01920000-0000-7000-8000-0000000000a1",
@@ -2720,7 +2732,7 @@ mod tests {
         let live_state_scans = Arc::new(AtomicUsize::new(0));
         let path_index_requests = Arc::new(AtomicUsize::new(0));
         let index = Arc::new(
-            FilesystemPathIndex::from_live_rows(vec![
+            path_index_from_rows(vec![
                 live_row(
                     "01920000-0000-7000-8000-0000000000d3",
                     "01920000-0000-7000-8000-0000000000a1",
@@ -2889,7 +2901,7 @@ mod tests {
 
     #[test]
     fn recursive_directory_delete_deletes_nested_dirs_files_and_blob_refs() {
-        let visible_filesystem = VisibleFilesystem::from_live_rows(filesystem_rows())
+        let visible_filesystem = visible_filesystem_from_rows(filesystem_rows())
             .expect("visible filesystem should build");
         let mut visible_filesystems = BTreeMap::new();
         visible_filesystems.insert(
@@ -2946,7 +2958,7 @@ mod tests {
 
     #[test]
     fn recursive_directory_delete_dedupes_overlapping_parent_and_child() {
-        let visible_filesystem = VisibleFilesystem::from_live_rows(filesystem_rows())
+        let visible_filesystem = visible_filesystem_from_rows(filesystem_rows())
             .expect("visible filesystem should build");
         let mut visible_filesystems = BTreeMap::new();
         visible_filesystems.insert(
@@ -3059,7 +3071,7 @@ mod tests {
     #[tokio::test]
     async fn directory_path_insert_uses_indexed_resolver_without_live_state_fallback() {
         let index = Arc::new(
-            FilesystemPathIndex::from_live_rows(vec![live_row(
+            path_index_from_rows(vec![live_row(
                 "01920000-0000-7000-8000-0000000000d3",
                 "01920000-0000-7000-8000-0000000000a1",
                 "{\"id\":\"01920000-0000-7000-8000-0000000000d3\",\"parent_id\":null,\"name\":\"docs\"}",
@@ -3163,7 +3175,7 @@ mod tests {
             "{\"id\":\"01920000-0000-7000-8000-000000000383\",\"parent_id\":null,\"name\":\"other\"}",
         );
         let index = Arc::new(
-            FilesystemPathIndex::from_live_rows(vec![tracked, untracked, global, other])
+            path_index_from_rows(vec![tracked, untracked, global, other])
                 .expect("filesystem path index should build"),
         );
         let filesystem_path_index: Arc<dyn FilesystemPathIndexReader> =
@@ -3299,7 +3311,7 @@ mod tests {
         let filesystem_path_index: Arc<dyn FilesystemPathIndexReader> =
             Arc::new(StaticFilesystemPathIndexReader {
                 index: Arc::new(
-                    FilesystemPathIndex::from_live_rows(vec![indexed])
+                    path_index_from_rows(vec![indexed])
                         .expect("filesystem path index should build"),
                 ),
                 request_count: Arc::new(AtomicUsize::new(0)),

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -6857,6 +6857,12 @@ mod tests {
             .expect("fixture ID should be a canonical UUID")
     }
 
+    fn path_index_from_rows(
+        rows: Vec<MaterializedLiveStateRow>,
+    ) -> Result<FilesystemPathIndex, LixError> {
+        FilesystemPathIndex::from_live_batch(&MaterializedLiveStateBatch::from_rows(rows))
+    }
+
     fn test_functions() -> FunctionProviderHandle {
         FunctionProviderHandle::system()
     }
@@ -6944,8 +6950,7 @@ mod tests {
         match operation.as_str() {
             "lookup" => {
                 let index = Arc::new(
-                    FilesystemPathIndex::from_live_rows(rows)
-                        .expect("benchmark path index should build"),
+                    path_index_from_rows(rows).expect("benchmark path index should build"),
                 );
                 heap_bytes = index.estimated_heap_bytes();
                 let target_ids = BTreeSet::from([target_id]);
@@ -6967,8 +6972,8 @@ mod tests {
                 for iteration in 0..warmups.saturating_add(rounds) {
                     let input = rows.clone();
                     let started = Instant::now();
-                    let index = FilesystemPathIndex::from_live_rows(input)
-                        .expect("benchmark path index should build");
+                    let index =
+                        path_index_from_rows(input).expect("benchmark path index should build");
                     let elapsed = started.elapsed();
                     heap_bytes = index.estimated_heap_bytes();
                     assert_eq!(
@@ -7026,7 +7031,7 @@ mod tests {
     #[test]
     fn indexed_file_id_matches_restores_path_order_and_applies_path_predicate() {
         let index = Arc::new(
-            FilesystemPathIndex::from_live_rows(vec![
+            path_index_from_rows(vec![
                 live_file_row(
                     "01920000-0000-7000-8000-000000000532",
                     "01920000-0000-7000-8000-0000000000b1",
@@ -7426,7 +7431,7 @@ mod tests {
         );
         file.metadata = Some(r#"{"source":"index"}"#.into());
         let index = Arc::new(
-            FilesystemPathIndex::from_live_rows(vec![
+            path_index_from_rows(vec![
                 live_directory_row(
                     "01920000-0000-7000-8000-0000000000d3",
                     "01920000-0000-7000-8000-0000000000b1",
@@ -7514,7 +7519,7 @@ mod tests {
         let live_state_scans = Arc::new(AtomicUsize::new(0));
         let path_index_requests = Arc::new(AtomicUsize::new(0));
         let index = Arc::new(
-            FilesystemPathIndex::from_live_rows(vec![
+            path_index_from_rows(vec![
                 live_file_row(
                     "01920000-0000-7000-8000-0000000000c2",
                     "01920000-0000-7000-8000-0000000000b1",
@@ -7602,7 +7607,7 @@ mod tests {
         target.file_id = Some("remote-01920000-0000-7000-8000-000000000522".to_string());
         target.untracked = true;
         let index = Arc::new(
-            FilesystemPathIndex::from_live_rows(vec![
+            path_index_from_rows(vec![
                 live_file_row(
                     "01920000-0000-7000-8000-000000000482",
                     "01920000-0000-7000-8000-0000000000a1",
@@ -7700,7 +7705,7 @@ mod tests {
         let live_state_requests = Arc::new(Mutex::new(Vec::new()));
         let path_index_requests = Arc::new(AtomicUsize::new(0));
         let index = Arc::new(
-            FilesystemPathIndex::from_live_rows(vec![
+            path_index_from_rows(vec![
                 live_file_row(
                     "01920000-0000-7000-8000-0000000000d2",
                     "01920000-0000-7000-8000-0000000000b1",
@@ -7775,7 +7780,7 @@ mod tests {
         );
         selected_blob.change_id = Some(selected_change_id);
         let index = Arc::new(
-            FilesystemPathIndex::from_live_rows(vec![
+            path_index_from_rows(vec![
                 live_directory_row(
                     "01920000-0000-7000-8000-0000000000d3",
                     "01920000-0000-7000-8000-0000000000b1",
@@ -7923,7 +7928,7 @@ mod tests {
         let live_state_requests = Arc::new(Mutex::new(Vec::new()));
         let path_index_requests = Arc::new(AtomicUsize::new(0));
         let index = Arc::new(
-            FilesystemPathIndex::from_live_rows(vec![
+            path_index_from_rows(vec![
                 live_directory_row(
                     "01920000-0000-7000-8000-0000000000d3",
                     "01920000-0000-7000-8000-0000000000b1",
@@ -8118,10 +8123,8 @@ mod tests {
             untracked_blob.clone(),
             misplaced_blob.clone(),
         ]);
-        let index = Arc::new(
-            FilesystemPathIndex::from_live_rows(index_rows)
-                .expect("filesystem path index should build"),
-        );
+        let index =
+            Arc::new(path_index_from_rows(index_rows).expect("filesystem path index should build"));
         let matches =
             super::indexed_file_matches(Arc::clone(&index), &super::FilePathPredicate::All);
         let live_state_requests = Arc::new(Mutex::new(Vec::new()));
@@ -8217,7 +8220,7 @@ mod tests {
         let live_state_requests = Arc::new(Mutex::new(Vec::new()));
         let path_index_requests = Arc::new(AtomicUsize::new(0));
         let index = Arc::new(
-            FilesystemPathIndex::from_live_rows(vec![
+            path_index_from_rows(vec![
                 live_directory_row(
                     "01920000-0000-7000-8000-0000000000d3",
                     "01920000-0000-7000-8000-0000000000b1",
@@ -8564,9 +8567,7 @@ mod tests {
             _request: &FilesystemPathIndexRequest,
         ) -> Result<Arc<FilesystemPathIndex>, LixError> {
             self.path_index_count += 1;
-            Ok(Arc::new(FilesystemPathIndex::from_live_rows(
-                self.rows.clone(),
-            )?))
+            Ok(Arc::new(path_index_from_rows(self.rows.clone())?))
         }
 
         async fn load_branch_head(
@@ -9561,7 +9562,7 @@ mod tests {
         let data = b"indexed contents";
         let blob_hash = BlobHash::from_content(data);
         let index = Arc::new(
-            FilesystemPathIndex::from_live_rows(vec![
+            path_index_from_rows(vec![
                 live_file_row(
                     file_id,
                     branch_id,
@@ -11493,7 +11494,7 @@ mod tests {
         let path_index_requests = Arc::new(AtomicUsize::new(0));
         let scan_requests = Arc::new(Mutex::new(Vec::new()));
         let index = Arc::new(
-            FilesystemPathIndex::from_live_rows(vec![
+            path_index_from_rows(vec![
                 live_directory_row(
                     "01920000-0000-7000-8000-0000000000d3",
                     "01920000-0000-7000-8000-0000000000b1",


### PR DESCRIPTION
## Summary

- remove the row-owned `FilesystemPathIndex::from_live_rows` constructor
- remove the row-owned `VisibleFilesystem::from_live_rows` constructor
- adapt tests explicitly through `MaterializedLiveStateBatch`
- keep the filesystem index and visibility APIs batch-only

## Why

The shared-batch refactor in #884 made `MaterializedLiveStateBatch` the ownership boundary. Keeping row-vector convenience constructors, even behind `cfg(test)`, preserves the superseded API shape and makes it easy for row-owned paths to return. This is a clean cut: the constructors no longer exist.

## Stack

1. **This PR** → `main`
2. `refactor(filesystem): keep plugin materialization writes batched` → this branch

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- GitHub Cargo Clippy, Cargo Test, changelog, and JS SDK checks
