### PR TITLE
refactor(live-state): remove row overlay bridges

### DIFF
--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -30,6 +30,6 @@ pub(crate) use types::{
 #[allow(unused_imports)]
 pub(crate) use visibility::{
     StagedLiveStateRows, VisibilityBranchScope, VisibilityRequest, expanded_branch_ids,
-    overlay_load_exact_batch, overlay_load_exact_rows, overlay_scan_batch, overlay_scan_rows,
-    overlay_scan_tracked_batch, resolve_visible_batch, resolve_visible_rows,
+    overlay_load_exact_batch, overlay_scan_batch, overlay_scan_tracked_batch,
+    resolve_visible_batch,
 };

--- a/packages/engine/src/live_state/visibility.rs
+++ b/packages/engine/src/live_state/visibility.rs
@@ -1,9 +1,11 @@
 use crate::GLOBAL_BRANCH_ID;
 use crate::LixError;
+#[cfg(test)]
+use crate::live_state::MaterializedLiveStateRow;
 use crate::live_state::{
     LiveStateExactBatchRequest, LiveStateExactRowRequest, LiveStateReader, LiveStateRowIdentityRef,
     LiveStateScanRequest, MaterializedLiveStateBatch, MaterializedLiveStateBatchBuilder,
-    MaterializedLiveStateExactBatch, MaterializedLiveStateRow, MaterializedLiveStateRowRef,
+    MaterializedLiveStateExactBatch, MaterializedLiveStateRowRef,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -114,21 +116,6 @@ pub(crate) fn expanded_branch_ids(branch_ids: &[String]) -> Vec<String> {
     expanded
 }
 
-/// Explicit terminal bridge for legacy scalar/test consumers.
-#[allow(dead_code)]
-pub(crate) fn resolve_visible_rows(
-    base_rows: Vec<MaterializedLiveStateRow>,
-    staged_rows: Vec<MaterializedLiveStateRow>,
-    request: &VisibilityRequest,
-) -> Vec<MaterializedLiveStateRow> {
-    resolve_visible_batch(
-        MaterializedLiveStateBatch::from_rows(base_rows),
-        MaterializedLiveStateBatch::from_rows(staged_rows),
-        request,
-    )
-    .into_rows()
-}
-
 pub(crate) fn resolve_visible_batch(
     base_rows: MaterializedLiveStateBatch,
     staged_rows: MaterializedLiveStateBatch,
@@ -142,19 +129,6 @@ pub(crate) fn resolve_visible_batch(
         request.include_tombstones,
         request.limit,
     )
-}
-
-/// Explicit terminal bridge for legacy scalar/test consumers.
-#[allow(dead_code)]
-pub(crate) async fn overlay_scan_rows<S>(
-    base: &dyn LiveStateReader,
-    staged: &S,
-    request: &LiveStateScanRequest,
-) -> Result<Vec<MaterializedLiveStateRow>, LixError>
-where
-    S: StagedLiveStateRows + ?Sized,
-{
-    Ok(overlay_scan_batch(base, staged, request).await?.into_rows())
 }
 
 pub(crate) async fn overlay_scan_batch<S>(
@@ -214,21 +188,6 @@ where
 
 /// Overlays staged exact identities without converting correlated row keys to
 /// independent scan filters.
-/// Explicit terminal bridge for legacy scalar/test consumers.
-#[allow(dead_code)]
-pub(crate) async fn overlay_load_exact_rows<S>(
-    base: &dyn LiveStateReader,
-    staged: &S,
-    request: &LiveStateExactBatchRequest,
-) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError>
-where
-    S: StagedLiveStateRows + ?Sized,
-{
-    Ok(overlay_load_exact_batch(base, staged, request)
-        .await?
-        .into_rows())
-}
-
 pub(crate) async fn overlay_load_exact_batch<S>(
     base: &dyn LiveStateReader,
     staged: &S,
@@ -1219,7 +1178,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_visible_rows_maps_branch_scope_and_applies_limit() {
+    fn resolve_visible_batch_maps_branch_scope_and_applies_limit() {
         let request = VisibilityRequest {
             branch_scope: VisibilityBranchScope::BranchIds {
                 branch_ids: vec!["01920000-0000-7000-8000-0000000000a1".to_string()],
@@ -1227,8 +1186,8 @@ mod tests {
             include_tombstones: false,
             limit: Some(1),
         };
-        let rows = resolve_visible_rows(
-            vec![
+        let rows = resolve_visible_batch(
+            MaterializedLiveStateBatch::from_rows(vec![
                 row_at(
                     "01920000-0000-7000-8000-0000000000a1",
                     "a",
@@ -1243,10 +1202,11 @@ mod tests {
                     false,
                     Some("change-b"),
                 ),
-            ],
-            Vec::new(),
+            ]),
+            MaterializedLiveStateBatch::default(),
             &request,
-        );
+        )
+        .into_rows();
 
         assert_eq!(rows.len(), 1);
     }
@@ -1264,7 +1224,7 @@ mod tests {
         };
         let staged = EmptyStagedRows;
 
-        let rows = overlay_scan_rows(
+        let rows = overlay_scan_batch(
             &base,
             &staged,
             &LiveStateScanRequest {
@@ -1276,7 +1236,8 @@ mod tests {
             },
         )
         .await
-        .expect("overlay scan should succeed");
+        .expect("overlay scan should succeed")
+        .into_rows();
 
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].branch_id.as_ref(), "staged-branch");
@@ -1407,9 +1368,10 @@ mod tests {
             ..Default::default()
         };
 
-        let rows = overlay_load_exact_rows(&base, &staged, &request)
+        let rows = overlay_load_exact_batch(&base, &staged, &request)
             .await
-            .expect("exact overlay should resolve");
+            .expect("exact overlay should resolve")
+            .into_rows();
         let value = |index: usize| {
             rows[index]
                 .as_ref()
@@ -1423,7 +1385,7 @@ mod tests {
         assert_eq!(rows[5], None, "base branch tombstone beats staged global");
         assert_eq!(rows[6], None, "staged global tombstone hides base global");
 
-        let tombstone = overlay_load_exact_rows(
+        let tombstone = overlay_load_exact_batch(
             &base,
             &staged,
             &LiveStateExactBatchRequest {
@@ -1434,6 +1396,7 @@ mod tests {
         )
         .await
         .expect("exact tombstone overlay should resolve")
+        .into_rows()
         .pop()
         .flatten()
         .expect("requested tombstone should be returned");

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -44,8 +44,6 @@ use crate::gc::{
     CheckpointGcState, CheckpointPublication, CheckpointRecoveryRef, load_checkpoint_gc_state,
     load_recovery_ref,
 };
-#[cfg(test)]
-use crate::live_state::overlay_load_exact_rows;
 use crate::live_state::{
     LiveStateContext, LiveStateExactBatchRequest, LiveStateExactRowRequest, LiveStateFilter,
     LiveStateProjection, LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateBatch,
@@ -4727,7 +4725,9 @@ where
         &self,
         request: &LiveStateExactBatchRequest,
     ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-        overlay_load_exact_rows(&self.base, &self.staged, request).await
+        Ok(overlay_load_exact_batch(&self.base, &self.staged, request)
+            .await?
+            .into_rows())
     }
 
     async fn load_exact_batch(

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -1471,9 +1471,9 @@ impl PreparedStateRowOverlay {
         &self,
         request: &LiveStateScanRequest,
     ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-        Ok(crate::live_state::resolve_visible_rows(
-            self.scan_parts(request)?.rows,
-            Vec::new(),
+        Ok(crate::live_state::resolve_visible_batch(
+            self.scan_batch(request)?,
+            MaterializedLiveStateBatch::default(),
             &crate::live_state::VisibilityRequest {
                 branch_scope: crate::live_state::VisibilityBranchScope::BranchIds {
                     branch_ids: request.filter.branch_ids.clone(),
@@ -1481,7 +1481,8 @@ impl PreparedStateRowOverlay {
                 include_tombstones: request.filter.include_tombstones,
                 limit: None,
             },
-        ))
+        )
+        .into_rows())
     }
 
     /// Returns staged rows and base-row identities hidden by staged rows in one pass.


### PR DESCRIPTION
## Summary

- remove the legacy row-returning visibility and overlay bridges
- keep production and test callers on the shared batch APIs
- convert to owned rows only at test assertion or trait compatibility boundaries
- remove the associated dead-code suppressions and redundant batch-to-row-to-batch conversion

## Why

PR #884 moved live-state visibility onto shared typed batches, but retained row-owned wrapper functions for legacy and test consumers. The remaining callers can use the batch APIs directly, so keeping the wrappers weakens the clean-cut boundary and requires dead-code allowances.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/root/lix-pr887-target cargo check --locked -p lix_engine --tests`