### PR TITLE
refactor(live-state): require staged batch readers

### DIFF
--- a/packages/engine/src/live_state/visibility.rs
+++ b/packages/engine/src/live_state/visibility.rs
@@ -22,70 +22,19 @@ pub(crate) enum VisibilityBranchScope {
 
 pub(crate) trait StagedLiveStateRows {
     /// Returns staged candidates in one shared columnar owner.
-    ///
-    /// Production overlays must implement this batch lane directly. The
-    /// row-oriented fallback exists only for compact test fakes.
-    #[cfg(not(test))]
     fn staged_batch(
         &self,
         request: &LiveStateScanRequest,
     ) -> Result<MaterializedLiveStateBatch, LixError>;
 
-    #[cfg(test)]
-    fn staged_batch(
-        &self,
-        request: &LiveStateScanRequest,
-    ) -> Result<MaterializedLiveStateBatch, LixError> {
-        self.staged_rows(request)
-            .map(MaterializedLiveStateBatch::from_rows)
-    }
-
-    /// Test-only terminal bridge for row-oriented fakes and assertions.
-    #[cfg(test)]
-    fn staged_rows(
-        &self,
-        request: &LiveStateScanRequest,
-    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-        self.staged_batch(request)
-            .map(MaterializedLiveStateBatch::into_rows)
-    }
-
     /// Loads exact staged storage identities in request order.
     ///
     /// This does not apply global fallback: overlay composition needs the
     /// branch and global candidates separately to preserve their precedence.
-    #[cfg(not(test))]
     fn load_exact_batch(
         &self,
         request: &LiveStateExactBatchRequest,
     ) -> Result<MaterializedLiveStateExactBatch, LixError>;
-
-    /// Test-only bridge for small row-oriented staged-state fakes.
-    #[cfg(test)]
-    fn load_exact_rows(
-        &self,
-        request: &LiveStateExactBatchRequest,
-    ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-        request
-            .rows
-            .iter()
-            .map(|row| {
-                Ok(self
-                    .staged_rows(&request.row_scan_request(row))?
-                    .into_iter()
-                    .next())
-            })
-            .collect()
-    }
-
-    #[cfg(test)]
-    fn load_exact_batch(
-        &self,
-        request: &LiveStateExactBatchRequest,
-    ) -> Result<MaterializedLiveStateExactBatch, LixError> {
-        self.load_exact_rows(request)
-            .map(MaterializedLiveStateExactBatch::from_rows)
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -1483,11 +1432,21 @@ mod tests {
     struct EmptyStagedRows;
 
     impl StagedLiveStateRows for EmptyStagedRows {
-        fn staged_rows(
+        fn staged_batch(
             &self,
             _request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-            Ok(Vec::new())
+        ) -> Result<MaterializedLiveStateBatch, LixError> {
+            Ok(MaterializedLiveStateBatch::default())
+        }
+
+        fn load_exact_batch(
+            &self,
+            request: &LiveStateExactBatchRequest,
+        ) -> Result<MaterializedLiveStateExactBatch, LixError> {
+            MaterializedLiveStateExactBatch::new(
+                MaterializedLiveStateBatch::default(),
+                vec![None; request.rows.len()],
+            )
         }
     }
 
@@ -1496,16 +1455,37 @@ mod tests {
     }
 
     impl StagedLiveStateRows for FilteringStagedRows {
-        fn staged_rows(
+        fn staged_batch(
             &self,
             request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-            Ok(self
-                .rows
-                .iter()
-                .filter(|row| matches_scan_request(row, request))
-                .cloned()
-                .collect())
+        ) -> Result<MaterializedLiveStateBatch, LixError> {
+            Ok(MaterializedLiveStateBatch::from_rows(
+                self.rows
+                    .iter()
+                    .filter(|row| matches_scan_request(row, request))
+                    .cloned()
+                    .collect(),
+            ))
+        }
+
+        fn load_exact_batch(
+            &self,
+            request: &LiveStateExactBatchRequest,
+        ) -> Result<MaterializedLiveStateExactBatch, LixError> {
+            Ok(MaterializedLiveStateExactBatch::from_rows(
+                request
+                    .rows
+                    .iter()
+                    .map(|request_row| {
+                        self.rows
+                            .iter()
+                            .find(|row| {
+                                matches_scan_request(row, &request.row_scan_request(request_row))
+                            })
+                            .cloned()
+                    })
+                    .collect(),
+            ))
         }
     }
 

--- a/packages/engine/src/transaction/schema_resolver.rs
+++ b/packages/engine/src/transaction/schema_resolver.rs
@@ -210,16 +210,35 @@ mod tests {
     struct StaticStagedRows(Vec<MaterializedLiveStateRow>);
 
     impl StagedLiveStateRows for StaticStagedRows {
-        fn staged_rows(
+        fn staged_batch(
             &self,
             request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-            Ok(self
-                .0
-                .iter()
-                .filter(|row| row_matches(row, request))
-                .cloned()
-                .collect())
+        ) -> Result<MaterializedLiveStateBatch, LixError> {
+            Ok(MaterializedLiveStateBatch::from_rows(
+                self.0
+                    .iter()
+                    .filter(|row| row_matches(row, request))
+                    .cloned()
+                    .collect(),
+            ))
+        }
+
+        fn load_exact_batch(
+            &self,
+            request: &LiveStateExactBatchRequest,
+        ) -> Result<MaterializedLiveStateExactBatch, LixError> {
+            Ok(MaterializedLiveStateExactBatch::from_rows(
+                request
+                    .rows
+                    .iter()
+                    .map(|request_row| {
+                        self.0
+                            .iter()
+                            .find(|row| row_matches(row, &request.row_scan_request(request_row)))
+                            .cloned()
+                    })
+                    .collect(),
+            ))
         }
     }
 

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -1579,27 +1579,11 @@ impl PreparedStateRowOverlay {
 }
 
 impl crate::live_state::StagedLiveStateRows for PreparedStateRowOverlay {
-    #[cfg(test)]
-    fn staged_rows(
-        &self,
-        request: &LiveStateScanRequest,
-    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-        Ok(self.scan_batch(request)?.into_rows())
-    }
-
     fn staged_batch(
         &self,
         request: &LiveStateScanRequest,
     ) -> Result<MaterializedLiveStateBatch, LixError> {
         self.scan_batch(request)
-    }
-
-    #[cfg(test)]
-    fn load_exact_rows(
-        &self,
-        request: &LiveStateExactBatchRequest,
-    ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-        Ok(self.load_exact_batch(request)?.into_rows())
     }
 
     fn load_exact_batch(
@@ -2536,8 +2520,9 @@ mod tests {
         assert!(batch.row(4).is_none());
         assert!(batch.row(5).is_none());
 
-        let rows = StagedLiveStateRows::load_exact_rows(&overlay, &exact_request)
-            .expect("exact staged rows should load");
+        let rows = StagedLiveStateRows::load_exact_batch(&overlay, &exact_request)
+            .expect("exact staged rows should load")
+            .into_rows();
 
         assert!(rows[0].is_some());
         assert_eq!(rows[0], rows[3]);
@@ -2546,7 +2531,7 @@ mod tests {
         assert_eq!(rows[4], None);
         assert_eq!(rows[5], None, "tombstone should be hidden by default");
 
-        let tombstone = StagedLiveStateRows::load_exact_rows(
+        let tombstone = StagedLiveStateRows::load_exact_batch(
             &overlay,
             &LiveStateExactBatchRequest {
                 rows: vec![exact("deleted", "deleted")],
@@ -2555,6 +2540,7 @@ mod tests {
             },
         )
         .expect("exact staged tombstone should load")
+        .into_rows()
         .pop()
         .flatten()
         .expect("tombstone should be returned");


### PR DESCRIPTION
## Summary

- make `StagedLiveStateRows` expose the same batch-only contract in test and production builds
- remove the test-only `staged_rows` and `load_exact_rows` fallback methods
- migrate staged-state fakes and assertions to batch inputs and outputs
- remove row lowering from `PreparedStateRowOverlay`

## Why

The shared-batch refactor left a second row-oriented trait contract behind `cfg(test)`. That let test fakes bypass the production API and kept legacy row adapters alive. Tests and production now compile against the same hard-cut batch contract.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/root/lix-pr889-target cargo check --locked -p lix_engine --tests`