### PR TITLE
refactor(live-state): require batch readers

### DIFF
--- a/packages/engine/src/catalog/context.rs
+++ b/packages/engine/src/catalog/context.rs
@@ -777,41 +777,42 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for RowsLiveStateReader {
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &crate::live_state::LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        ) -> Result<crate::live_state::MaterializedLiveStateExactBatch, LixError> {
+            crate::live_state::load_exact_batch_via_scan_for_test(self, request).await
         }
 
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        ) -> Result<MaterializedLiveStateBatch, LixError> {
             self.scan_count.fetch_add(1, Ordering::Relaxed);
-            Ok(self
-                .rows
-                .iter()
-                .filter(|row| {
-                    request.filter.schema_keys.is_empty()
-                        || request.filter.schema_keys.contains(&row.schema_key)
-                })
-                .filter(|row| {
-                    request.filter.branch_ids.is_empty()
-                        || request
+            Ok(MaterializedLiveStateBatch::from_rows(
+                self.rows
+                    .iter()
+                    .filter(|row| {
+                        request.filter.schema_keys.is_empty()
+                            || request.filter.schema_keys.contains(&row.schema_key)
+                    })
+                    .filter(|row| {
+                        request.filter.branch_ids.is_empty()
+                            || request
+                                .filter
+                                .branch_ids
+                                .iter()
+                                .any(|branch_id| branch_id.as_str() == row.branch_id.as_ref())
+                    })
+                    .filter(|row| {
+                        request
                             .filter
-                            .branch_ids
-                            .iter()
-                            .any(|branch_id| branch_id.as_str() == row.branch_id.as_ref())
-                })
-                .filter(|row| {
-                    request
-                        .filter
-                        .untracked
-                        .is_none_or(|untracked| row.untracked == untracked)
-                })
-                .cloned()
-                .collect())
+                            .untracked
+                            .is_none_or(|untracked| row.untracked == untracked)
+                    })
+                    .cloned()
+                    .collect(),
+            ))
         }
 
         async fn load_row(

--- a/packages/engine/src/filesystem/path_index.rs
+++ b/packages/engine/src/filesystem/path_index.rs
@@ -1444,17 +1444,17 @@ mod tests {
             Ok(self.rows.clone())
         }
 
-        async fn scan_rows(
-            &self,
-            _request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-            panic!("production path-index construction must not lower its batch to owned rows")
-        }
-
         async fn load_row(
             &self,
             _request: &crate::live_state::LiveStateRowRequest,
         ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
+            unreachable!("path-index construction only scans live state")
+        }
+
+        async fn load_exact_batch(
+            &self,
+            _request: &crate::live_state::LiveStateExactBatchRequest,
+        ) -> Result<crate::live_state::MaterializedLiveStateExactBatch, LixError> {
             unreachable!("path-index construction only scans live state")
         }
     }

--- a/packages/engine/src/filesystem/visibility.rs
+++ b/packages/engine/src/filesystem/visibility.rs
@@ -415,36 +415,37 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for RecordingLiveStateReader {
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &crate::live_state::LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        ) -> Result<crate::live_state::MaterializedLiveStateExactBatch, LixError> {
+            crate::live_state::load_exact_batch_via_scan_for_test(self, request).await
         }
 
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        ) -> Result<MaterializedLiveStateBatch, LixError> {
             *self
                 .last_request
                 .lock()
                 .expect("recorded request lock should not be poisoned") = Some(request.clone());
-            Ok(self
-                .rows
-                .iter()
-                .filter(|row| {
-                    (request.filter.schema_keys.is_empty()
-                        || request.filter.schema_keys.contains(&row.schema_key))
-                        && (request.filter.branch_ids.is_empty()
-                            || request
-                                .filter
-                                .branch_ids
-                                .iter()
-                                .any(|branch_id| branch_id.as_str() == row.branch_id.as_ref()))
-                })
-                .cloned()
-                .collect())
+            Ok(MaterializedLiveStateBatch::from_rows(
+                self.rows
+                    .iter()
+                    .filter(|row| {
+                        (request.filter.schema_keys.is_empty()
+                            || request.filter.schema_keys.contains(&row.schema_key))
+                            && (request.filter.branch_ids.is_empty()
+                                || request
+                                    .filter
+                                    .branch_ids
+                                    .iter()
+                                    .any(|branch_id| branch_id.as_str() == row.branch_id.as_ref()))
+                    })
+                    .cloned()
+                    .collect(),
+            ))
         }
 
         async fn load_row(
@@ -461,32 +462,33 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for RowsLiveStateReader {
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &crate::live_state::LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        ) -> Result<crate::live_state::MaterializedLiveStateExactBatch, LixError> {
+            crate::live_state::load_exact_batch_via_scan_for_test(self, request).await
         }
 
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-            Ok(self
-                .rows
-                .iter()
-                .filter(|row| {
-                    (request.filter.schema_keys.is_empty()
-                        || request.filter.schema_keys.contains(&row.schema_key))
-                        && (request.filter.branch_ids.is_empty()
-                            || request
-                                .filter
-                                .branch_ids
-                                .iter()
-                                .any(|branch_id| branch_id.as_str() == row.branch_id.as_ref()))
-                })
-                .cloned()
-                .collect())
+        ) -> Result<MaterializedLiveStateBatch, LixError> {
+            Ok(MaterializedLiveStateBatch::from_rows(
+                self.rows
+                    .iter()
+                    .filter(|row| {
+                        (request.filter.schema_keys.is_empty()
+                            || request.filter.schema_keys.contains(&row.schema_key))
+                            && (request.filter.branch_ids.is_empty()
+                                || request
+                                    .filter
+                                    .branch_ids
+                                    .iter()
+                                    .any(|branch_id| branch_id.as_str() == row.branch_id.as_ref()))
+                    })
+                    .cloned()
+                    .collect(),
+            ))
         }
 
         async fn load_row(

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -551,16 +551,6 @@ where
         MaterializedLiveStateExactBatch::new(builder.finish(), slots)
     }
 
-    #[cfg(test)]
-    pub(crate) async fn scan_tracked_rows(
-        &self,
-        request: &LiveStateScanRequest,
-    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-        self.scan_tracked_batch(request)
-            .await
-            .map(MaterializedLiveStateBatch::into_rows)
-    }
-
     pub(crate) async fn scan_tracked_batch(
         &self,
         request: &LiveStateScanRequest,
@@ -687,14 +677,6 @@ where
         Self::scan_batch(self, request).await
     }
 
-    #[cfg(test)]
-    async fn scan_rows(
-        &self,
-        request: &LiveStateScanRequest,
-    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-        Self::scan_rows(self, request).await
-    }
-
     async fn load_row(
         &self,
         request: &LiveStateRowRequest,
@@ -707,14 +689,6 @@ where
         request: &LiveStateExactBatchRequest,
     ) -> Result<MaterializedLiveStateExactBatch, LixError> {
         Self::load_exact_batch(self, request).await
-    }
-
-    #[cfg(test)]
-    async fn scan_tracked_rows(
-        &self,
-        request: &LiveStateScanRequest,
-    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-        Self::scan_tracked_rows(self, request).await
     }
 
     async fn scan_tracked_batch(

--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -9,7 +9,7 @@ pub(crate) use context::{LiveStateContext, LiveStateStoreReader};
 #[allow(unused_imports)]
 pub(crate) use reader::LiveStateReader;
 #[cfg(test)]
-pub(crate) use reader::load_exact_rows_via_scan_for_test;
+pub(crate) use reader::load_exact_batch_via_scan_for_test;
 #[cfg(test)]
 pub(crate) use tracked_head::TrackedHeadDeltaRef;
 #[allow(unused_imports)]

--- a/packages/engine/src/live_state/reader.rs
+++ b/packages/engine/src/live_state/reader.rs
@@ -1,6 +1,8 @@
 use async_trait::async_trait;
 
 use crate::LixError;
+#[cfg(test)]
+use crate::live_state::MaterializedLiveStateBatchBuilder;
 use crate::live_state::{LiveStateExactBatchRequest, LiveStateRowRequest, LiveStateScanRequest};
 use crate::live_state::{
     MaterializedLiveStateBatch, MaterializedLiveStateExactBatch, MaterializedLiveStateRow,
@@ -15,23 +17,10 @@ use crate::live_state::{
 pub(crate) trait LiveStateReader: Send + Sync {
     /// Columnar scan lane used by live-state composition and SQL providers.
     ///
-    /// Production readers must enter the shared batch pipeline directly.
-    #[cfg(not(test))]
     async fn scan_batch(
         &self,
         request: &LiveStateScanRequest,
     ) -> Result<MaterializedLiveStateBatch, LixError>;
-
-    /// Test-only bridge for small row-oriented reader fakes.
-    #[cfg(test)]
-    async fn scan_batch(
-        &self,
-        request: &LiveStateScanRequest,
-    ) -> Result<MaterializedLiveStateBatch, LixError> {
-        self.scan_rows(request)
-            .await
-            .map(MaterializedLiveStateBatch::from_rows)
-    }
 
     /// Scans committed rows for constraint validation into one shared owner.
     ///
@@ -50,16 +39,6 @@ pub(crate) trait LiveStateReader: Send + Sync {
         }
     }
 
-    #[cfg(test)]
-    async fn scan_rows(
-        &self,
-        request: &LiveStateScanRequest,
-    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-        self.scan_batch(request)
-            .await
-            .map(MaterializedLiveStateBatch::into_rows)
-    }
-
     /// Scans the immutable tracked head selected by the current branch ref.
     ///
     /// Normal SQL reads use [`Self::scan_batch`] and therefore see exactly one
@@ -67,19 +46,8 @@ pub(crate) trait LiveStateReader: Send + Sync {
     /// durability view when a tracked commit must not depend on untracked
     /// live state. Readers that wrap canonical current scans must override
     /// this method instead of relying on the fallback below.
-    #[cfg(test)]
-    async fn scan_tracked_rows(
-        &self,
-        request: &LiveStateScanRequest,
-    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-        let mut request = request.clone();
-        request.filter.untracked = Some(false);
-        self.scan_rows(&request).await
-    }
-
-    /// Production default keeps the explicit tracked filter in the batch
+    /// The default keeps the explicit tracked filter in the batch
     /// lane. Readers with a distinct immutable tracked source override this.
-    #[cfg(not(test))]
     async fn scan_tracked_batch(
         &self,
         request: &LiveStateScanRequest,
@@ -87,18 +55,6 @@ pub(crate) trait LiveStateReader: Send + Sync {
         let mut request = request.clone();
         request.filter.untracked = Some(false);
         self.scan_batch(&request).await
-    }
-
-    /// Test-only bridge for fakes that model canonical and tracked rows
-    /// independently through the legacy row helper.
-    #[cfg(test)]
-    async fn scan_tracked_batch(
-        &self,
-        request: &LiveStateScanRequest,
-    ) -> Result<MaterializedLiveStateBatch, LixError> {
-        self.scan_tracked_rows(request)
-            .await
-            .map(MaterializedLiveStateBatch::from_rows)
     }
 
     #[allow(dead_code)]
@@ -109,59 +65,40 @@ pub(crate) trait LiveStateReader: Send + Sync {
 
     /// Loads concrete visible identities while preserving request alignment.
     ///
-    /// Production readers must provide the correlated batch path directly.
+    /// Readers must provide the correlated batch path directly.
     /// There is no scan-based default because silently lowering this operation
     /// to one scan per row would reintroduce the amplification this API exists
     /// to prevent.
-    #[cfg(not(test))]
     async fn load_exact_batch(
         &self,
         request: &LiveStateExactBatchRequest,
     ) -> Result<MaterializedLiveStateExactBatch, LixError>;
-
-    /// Test-only bridge for small row-oriented reader fakes.
-    #[cfg(test)]
-    async fn load_exact_batch(
-        &self,
-        request: &LiveStateExactBatchRequest,
-    ) -> Result<MaterializedLiveStateExactBatch, LixError> {
-        self.load_exact_rows(request)
-            .await
-            .map(MaterializedLiveStateExactBatch::from_rows)
-    }
-
-    /// Explicit terminal DTO bridge for scalar consumers.
-    ///
-    /// Bulk production callers should retain the exact batch owner and borrow
-    /// row views instead of materializing one owned structure per result.
-    #[cfg(test)]
-    async fn load_exact_rows(
-        &self,
-        request: &LiveStateExactBatchRequest,
-    ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-        self.load_exact_batch(request)
-            .await
-            .map(MaterializedLiveStateExactBatch::into_rows)
-    }
 }
 
 #[cfg(test)]
-pub(crate) async fn load_exact_rows_via_scan_for_test<R>(
+pub(crate) async fn load_exact_batch_via_scan_for_test<R>(
     reader: &R,
     request: &LiveStateExactBatchRequest,
-) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError>
+) -> Result<MaterializedLiveStateExactBatch, LixError>
 where
     R: LiveStateReader + ?Sized,
 {
-    let mut rows = Vec::with_capacity(request.rows.len());
+    let mut rows = MaterializedLiveStateBatchBuilder::with_capacity(request.rows.len());
+    let mut slots = Vec::with_capacity(request.rows.len());
     for row in &request.rows {
-        rows.push(
-            reader
-                .scan_rows(&request.row_scan_request(row))
-                .await?
-                .into_iter()
-                .next(),
+        let scanned = reader.scan_batch(&request.row_scan_request(row)).await?;
+        slots.push(
+            scanned
+                .get(0)
+                .map(|row| u32::try_from(rows.push_ref(row, None)))
+                .transpose()
+                .map_err(|_| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "test exact live-state result exceeds u32 rows",
+                    )
+                })?,
         );
     }
-    Ok(rows)
+    MaterializedLiveStateExactBatch::new(rows.finish(), slots)
 }

--- a/packages/engine/src/live_state/visibility.rs
+++ b/packages/engine/src/live_state/visibility.rs
@@ -1495,26 +1495,26 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for ExistingGlobalOnlyReader {
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        ) -> Result<MaterializedLiveStateExactBatch, LixError> {
+            crate::live_state::load_exact_batch_via_scan_for_test(self, request).await
         }
 
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        ) -> Result<MaterializedLiveStateBatch, LixError> {
             if request
                 .filter
                 .branch_ids
                 .iter()
                 .any(|branch_id| branch_id == GLOBAL_BRANCH_ID)
             {
-                Ok(self.rows.clone())
+                Ok(self.rows.clone().into())
             } else {
-                Ok(Vec::new())
+                Ok(Vec::new().into())
             }
         }
 
@@ -1532,23 +1532,24 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for FilteringReader {
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        ) -> Result<MaterializedLiveStateExactBatch, LixError> {
+            crate::live_state::load_exact_batch_via_scan_for_test(self, request).await
         }
 
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-            Ok(self
-                .rows
-                .iter()
-                .filter(|row| matches_scan_request(row, request))
-                .cloned()
-                .collect())
+        ) -> Result<MaterializedLiveStateBatch, LixError> {
+            Ok(MaterializedLiveStateBatch::from_rows(
+                self.rows
+                    .iter()
+                    .filter(|row| matches_scan_request(row, request))
+                    .cloned()
+                    .collect(),
+            ))
         }
 
         async fn load_row(

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -1598,7 +1598,7 @@ fn datafusion_filters_from_predicate(
     params: &[Value],
 ) -> Result<Vec<Expr>, LixError> {
     match predicate {
-        BoundPredicate::True => Ok(Vec::new()),
+        BoundPredicate::True => Ok(Vec::new().into()),
         BoundPredicate::False => Ok(vec![Expr::Literal(ScalarValue::Boolean(Some(false)), None)]),
         BoundPredicate::And(predicates) => {
             let mut filters = Vec::new();
@@ -1612,7 +1612,7 @@ fn datafusion_filters_from_predicate(
         BoundPredicate::Or(predicates) => {
             let mut iter = predicates.iter();
             let Some(first) = iter.next() else {
-                return Ok(Vec::new());
+                return Ok(Vec::new().into());
             };
             let mut expr = datafusion_single_filter_from_predicate(session, schema, first, params)?;
             for predicate in iter {
@@ -2782,7 +2782,7 @@ mod tests {
             &mut self,
             _head_commit_id: &CommitId,
         ) -> Result<Vec<ReachableCommitGraphCommit>, LixError> {
-            Ok(Vec::new())
+            Ok(Vec::new().into())
         }
 
         async fn change_history_from_commit(
@@ -2790,24 +2790,24 @@ mod tests {
             _start_commit_id: &CommitId,
             _request: &CommitGraphChangeHistoryRequest,
         ) -> Result<Vec<CommitGraphChangeHistoryEntry>, LixError> {
-            Ok(Vec::new())
+            Ok(Vec::new().into())
         }
     }
 
     #[async_trait]
     impl LiveStateReader for DummyLiveStateReader {
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &crate::live_state::LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        ) -> Result<crate::live_state::MaterializedLiveStateExactBatch, LixError> {
+            crate::live_state::load_exact_batch_via_scan_for_test(self, request).await
         }
 
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             _request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-            Ok(vec![])
+        ) -> Result<crate::live_state::MaterializedLiveStateBatch, LixError> {
+            Ok(vec![].into())
         }
 
         async fn load_row(
@@ -2865,18 +2865,18 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for RowsLiveStateReader {
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &crate::live_state::LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        ) -> Result<crate::live_state::MaterializedLiveStateExactBatch, LixError> {
+            crate::live_state::load_exact_batch_via_scan_for_test(self, request).await
         }
 
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-            Ok(filter_live_state_rows(&self.rows, request))
+        ) -> Result<crate::live_state::MaterializedLiveStateBatch, LixError> {
+            Ok(filter_live_state_rows(&self.rows, request).into())
         }
 
         async fn load_row(
@@ -2889,22 +2889,22 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for CapturingRowsLiveStateReader {
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &crate::live_state::LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        ) -> Result<crate::live_state::MaterializedLiveStateExactBatch, LixError> {
+            crate::live_state::load_exact_batch_via_scan_for_test(self, request).await
         }
 
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        ) -> Result<crate::live_state::MaterializedLiveStateBatch, LixError> {
             self.requests
                 .lock()
                 .expect("captured live-state requests lock")
                 .push(request.clone());
-            Ok(filter_live_state_rows(&self.rows, request))
+            Ok(filter_live_state_rows(&self.rows, request).into())
         }
 
         async fn load_row(
@@ -2917,19 +2917,19 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for CountingRowsLiveStateReader {
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &crate::live_state::LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        ) -> Result<crate::live_state::MaterializedLiveStateExactBatch, LixError> {
+            crate::live_state::load_exact_batch_via_scan_for_test(self, request).await
         }
 
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        ) -> Result<crate::live_state::MaterializedLiveStateBatch, LixError> {
             self.scans.fetch_add(1, Ordering::SeqCst);
-            Ok(filter_live_state_rows(&self.rows, request))
+            Ok(filter_live_state_rows(&self.rows, request).into())
         }
 
         async fn load_row(

--- a/packages/engine/src/sql2/providers/branch.rs
+++ b/packages/engine/src/sql2/providers/branch.rs
@@ -483,7 +483,7 @@ async fn load_branch_rows_scoped(
 ) -> Result<Vec<BranchRow>, LixError> {
     let entity_pks = match descriptor_scope {
         BranchDescriptorScope::All => Vec::new(),
-        BranchDescriptorScope::Ids(ids) if ids.is_empty() => return Ok(Vec::new()),
+        BranchDescriptorScope::Ids(ids) if ids.is_empty() => return Ok(Vec::new().into()),
         BranchDescriptorScope::Ids(ids) => ids
             .into_iter()
             .map(|id| {
@@ -1005,18 +1005,18 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for RowsLiveStateReader {
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &crate::live_state::LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        ) -> Result<crate::live_state::MaterializedLiveStateExactBatch, LixError> {
+            crate::live_state::load_exact_batch_via_scan_for_test(self, request).await
         }
 
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             _request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-            Ok(self.rows.clone())
+        ) -> Result<crate::live_state::MaterializedLiveStateBatch, LixError> {
+            Ok(self.rows.clone().into())
         }
 
         async fn load_row(
@@ -1042,17 +1042,17 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for RoutingLiveStateReader {
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &crate::live_state::LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        ) -> Result<crate::live_state::MaterializedLiveStateExactBatch, LixError> {
+            crate::live_state::load_exact_batch_via_scan_for_test(self, request).await
         }
 
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        ) -> Result<crate::live_state::MaterializedLiveStateBatch, LixError> {
             self.requests.lock().unwrap().push(request.clone());
             Ok(self
                 .rows
@@ -1062,7 +1062,8 @@ mod tests {
                         || request.filter.entity_pks.contains(&row.entity_pk)
                 })
                 .cloned()
-                .collect())
+                .collect::<Vec<_>>()
+                .into())
         }
 
         async fn load_row(

--- a/packages/engine/src/sql2/providers/directory.rs
+++ b/packages/engine/src/sql2/providers/directory.rs
@@ -2188,17 +2188,17 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for RejectingLiveStateReader {
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &crate::live_state::LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        ) -> Result<crate::live_state::MaterializedLiveStateExactBatch, LixError> {
+            crate::live_state::load_exact_batch_via_scan_for_test(self, request).await
         }
 
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             _request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        ) -> Result<MaterializedLiveStateBatch, LixError> {
             self.scan_count.fetch_add(1, Ordering::SeqCst);
             Err(LixError::unknown(
                 "directory parent-id scan should not read live state",

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -1829,18 +1829,18 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for EmptyLiveStateReader {
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &crate::live_state::LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        ) -> Result<crate::live_state::MaterializedLiveStateExactBatch, LixError> {
+            crate::live_state::load_exact_batch_via_scan_for_test(self, request).await
         }
 
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             _request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-            Ok(vec![])
+        ) -> Result<MaterializedLiveStateBatch, LixError> {
+            Ok(vec![].into())
         }
 
         async fn load_row(
@@ -1858,7 +1858,7 @@ mod tests {
         }
 
         async fn scan_heads(&self) -> Result<Vec<BranchHead>, LixError> {
-            Ok(Vec::new())
+            Ok(Vec::new().into())
         }
     }
 
@@ -1881,7 +1881,7 @@ mod tests {
         }
 
         fn list_visible_schemas(&self) -> Result<Vec<serde_json::Value>, LixError> {
-            Ok(Vec::new())
+            Ok(Vec::new().into())
         }
 
         async fn load_bytes_many(

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -8497,7 +8497,7 @@ mod tests {
         }
 
         fn list_visible_schemas(&self) -> Result<Vec<JsonValue>, LixError> {
-            Ok(Vec::new())
+            Ok(Vec::new().into())
         }
 
         async fn load_bytes_many(
@@ -8602,7 +8602,7 @@ mod tests {
         }
 
         fn list_visible_schemas(&self) -> Result<Vec<JsonValue>, LixError> {
-            Ok(Vec::new())
+            Ok(Vec::new().into())
         }
 
         async fn load_bytes_many(
@@ -8700,15 +8700,15 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for RecordingLiveStateReader {
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        ) -> Result<MaterializedLiveStateBatch, LixError> {
             self.scan_requests
                 .lock()
                 .expect("live-state request mutex should not be poisoned")
                 .push(request.clone());
-            Ok(self.rows.clone())
+            Ok(self.rows.clone().into())
         }
 
         async fn load_row(
@@ -8718,10 +8718,10 @@ mod tests {
             Ok(None)
         }
 
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+        ) -> Result<crate::live_state::MaterializedLiveStateExactBatch, LixError> {
             let mut recorded = LiveStateScanRequest {
                 filter: LiveStateFilter {
                     branch_ids: request
@@ -8770,59 +8770,62 @@ mod tests {
                 .expect("live-state request mutex should not be poisoned")
                 .push(recorded);
 
-            Ok(request
-                .rows
-                .iter()
-                .map(|requested| {
-                    let exact_match = |row: &&MaterializedLiveStateRow| {
-                        row.schema_key == requested.schema_key
-                            && row.entity_pk == requested.entity_pk
-                            && row.file_id == requested.file_id
-                            && request
-                                .untracked
-                                .is_none_or(|untracked| row.untracked == untracked)
-                    };
-                    let mut row = self
+            Ok(
+                crate::live_state::MaterializedLiveStateExactBatch::from_rows(
+                    request
                         .rows
                         .iter()
-                        .filter(exact_match)
-                        .find(|row| row.branch_id.as_ref() == requested.branch_id.as_str())
-                        .or_else(|| {
-                            self.rows
+                        .map(|requested| {
+                            let exact_match = |row: &&MaterializedLiveStateRow| {
+                                row.schema_key == requested.schema_key
+                                    && row.entity_pk == requested.entity_pk
+                                    && row.file_id == requested.file_id
+                                    && request
+                                        .untracked
+                                        .is_none_or(|untracked| row.untracked == untracked)
+                            };
+                            let mut row = self
+                                .rows
                                 .iter()
                                 .filter(exact_match)
-                                .find(|row| row.branch_id.as_ref() == crate::GLOBAL_BRANCH_ID)
-                        })?
-                        .clone();
-                    if row.branch_id.as_ref() == crate::GLOBAL_BRANCH_ID
-                        && requested.branch_id != crate::GLOBAL_BRANCH_ID
-                    {
-                        row.branch_id = requested.branch_id.clone().into();
-                        row.global = true;
-                    }
-                    if row.deleted && !request.include_tombstones {
-                        None
-                    } else {
-                        Some(row)
-                    }
-                })
-                .collect())
+                                .find(|row| row.branch_id.as_ref() == requested.branch_id.as_str())
+                                .or_else(|| {
+                                    self.rows.iter().filter(exact_match).find(|row| {
+                                        row.branch_id.as_ref() == crate::GLOBAL_BRANCH_ID
+                                    })
+                                })?
+                                .clone();
+                            if row.branch_id.as_ref() == crate::GLOBAL_BRANCH_ID
+                                && requested.branch_id != crate::GLOBAL_BRANCH_ID
+                            {
+                                row.branch_id = requested.branch_id.clone().into();
+                                row.global = true;
+                            }
+                            if row.deleted && !request.include_tombstones {
+                                None
+                            } else {
+                                Some(row)
+                            }
+                        })
+                        .collect(),
+                ),
+            )
         }
     }
 
     #[async_trait]
     impl LiveStateReader for RejectingLiveStateReader {
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        ) -> Result<crate::live_state::MaterializedLiveStateExactBatch, LixError> {
+            crate::live_state::load_exact_batch_via_scan_for_test(self, request).await
         }
 
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             _request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        ) -> Result<MaterializedLiveStateBatch, LixError> {
             self.scan_count.fetch_add(1, Ordering::SeqCst);
             Err(LixError::unknown(
                 "descriptor-only scan should not read live state",
@@ -8867,24 +8870,24 @@ mod tests {
         }
 
         async fn scan_heads(&self) -> Result<Vec<BranchHead>, LixError> {
-            Ok(Vec::new())
+            Ok(Vec::new().into())
         }
     }
 
     #[async_trait]
     impl LiveStateReader for RowsLiveStateReader {
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        ) -> Result<crate::live_state::MaterializedLiveStateExactBatch, LixError> {
+            crate::live_state::load_exact_batch_via_scan_for_test(self, request).await
         }
 
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             _request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-            Ok(self.rows.clone())
+        ) -> Result<MaterializedLiveStateBatch, LixError> {
+            Ok(self.rows.clone().into())
         }
 
         async fn load_row(

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -1127,18 +1127,18 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for EmptyLiveStateReader {
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &crate::live_state::LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        ) -> Result<crate::live_state::MaterializedLiveStateExactBatch, LixError> {
+            crate::live_state::load_exact_batch_via_scan_for_test(self, request).await
         }
 
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             _request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-            Ok(Vec::new())
+        ) -> Result<crate::live_state::MaterializedLiveStateBatch, LixError> {
+            Ok(Vec::new().into())
         }
 
         async fn load_row(
@@ -1161,7 +1161,7 @@ mod tests {
         }
 
         async fn scan_heads(&self) -> Result<Vec<BranchHead>, LixError> {
-            Ok(Vec::new())
+            Ok(Vec::new().into())
         }
     }
 
@@ -1180,7 +1180,7 @@ mod tests {
             &mut self,
             _head_commit_id: &CommitId,
         ) -> Result<Vec<ReachableCommitGraphCommit>, LixError> {
-            Ok(Vec::new())
+            Ok(Vec::new().into())
         }
 
         async fn change_history_from_commit(
@@ -1188,7 +1188,7 @@ mod tests {
             _start_commit_id: &CommitId,
             _request: &CommitGraphChangeHistoryRequest,
         ) -> Result<Vec<CommitGraphChangeHistoryEntry>, LixError> {
-            Ok(Vec::new())
+            Ok(Vec::new().into())
         }
     }
 }

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -4720,16 +4720,6 @@ where
         Ok(rows.get(0).map(MaterializedLiveStateRowRef::to_owned))
     }
 
-    #[cfg(test)]
-    async fn load_exact_rows(
-        &self,
-        request: &LiveStateExactBatchRequest,
-    ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-        Ok(overlay_load_exact_batch(&self.base, &self.staged, request)
-            .await?
-            .into_rows())
-    }
-
     async fn load_exact_batch(
         &self,
         request: &LiveStateExactBatchRequest,

--- a/packages/engine/src/transaction/schema_resolver.rs
+++ b/packages/engine/src/transaction/schema_resolver.rs
@@ -172,31 +172,33 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for SplitCurrentAndTrackedReader {
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        ) -> Result<MaterializedLiveStateExactBatch, LixError> {
+            crate::live_state::load_exact_batch_via_scan_for_test(self, request).await
         }
 
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        ) -> Result<MaterializedLiveStateBatch, LixError> {
             Ok(row_matches(&self.canonical, request)
                 .then(|| self.canonical.clone())
                 .into_iter()
-                .collect())
+                .collect::<Vec<_>>()
+                .into())
         }
 
-        async fn scan_tracked_rows(
+        async fn scan_tracked_batch(
             &self,
             request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        ) -> Result<MaterializedLiveStateBatch, LixError> {
             Ok(row_matches(&self.tracked, request)
                 .then(|| self.tracked.clone())
                 .into_iter()
-                .collect())
+                .collect::<Vec<_>>()
+                .into())
         }
 
         async fn load_row(

--- a/packages/engine/src/transaction/validation.rs
+++ b/packages/engine/src/transaction/validation.rs
@@ -3405,10 +3405,10 @@ mod tests {
                 .expect("constraint batch should be consumed once"))
         }
 
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             _request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        ) -> Result<MaterializedLiveStateBatch, LixError> {
             panic!("constraint validation must not project the shared batch into owned rows")
         }
 
@@ -3419,11 +3419,14 @@ mod tests {
             Ok(None)
         }
 
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &crate::live_state::LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-            Ok(vec![None; request.rows.len()])
+        ) -> Result<crate::live_state::MaterializedLiveStateExactBatch, LixError> {
+            crate::live_state::MaterializedLiveStateExactBatch::new(
+                MaterializedLiveStateBatch::default(),
+                vec![None; request.rows.len()],
+            )
         }
     }
 
@@ -3579,21 +3582,22 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for EmptyLiveStateReader {
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &crate::live_state::LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        ) -> Result<crate::live_state::MaterializedLiveStateExactBatch, LixError> {
+            crate::live_state::load_exact_batch_via_scan_for_test(self, request).await
         }
 
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        ) -> Result<MaterializedLiveStateBatch, LixError> {
             Ok(test_file_descriptor_rows()
                 .into_iter()
                 .filter(|row| live_state_row_matches_scan(row, request))
-                .collect())
+                .collect::<Vec<_>>()
+                .into())
         }
 
         async fn load_row(
@@ -3768,24 +3772,25 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for StaticLiveStateReader {
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &crate::live_state::LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        ) -> Result<crate::live_state::MaterializedLiveStateExactBatch, LixError> {
+            crate::live_state::load_exact_batch_via_scan_for_test(self, request).await
         }
 
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        ) -> Result<MaterializedLiveStateBatch, LixError> {
             Ok(self
                 .rows
                 .iter()
                 .cloned()
                 .chain(test_file_descriptor_rows())
                 .filter(|row| live_state_row_matches_scan(row, request))
-                .collect())
+                .collect::<Vec<_>>()
+                .into())
         }
 
         async fn load_row(
@@ -3812,17 +3817,17 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for OverlayingStaticLiveStateReader {
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &crate::live_state::LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        ) -> Result<crate::live_state::MaterializedLiveStateExactBatch, LixError> {
+            crate::live_state::load_exact_batch_via_scan_for_test(self, request).await
         }
 
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        ) -> Result<MaterializedLiveStateBatch, LixError> {
             let rows = self
                 .rows
                 .iter()
@@ -3831,7 +3836,7 @@ mod tests {
                 .filter(|row| live_state_row_matches_scan(row, request))
                 .collect::<Vec<_>>();
             if request.filter.untracked.is_some() {
-                return Ok(rows);
+                return Ok(rows.into());
             }
             let tracked_rows = rows
                 .iter()
@@ -3842,18 +3847,15 @@ mod tests {
                 .into_iter()
                 .filter(|row| row.untracked)
                 .collect::<Vec<_>>();
-            Ok(overlay_untracked_rows_for_test(
-                tracked_rows,
-                untracked_rows,
-            ))
+            Ok(overlay_untracked_rows_for_test(tracked_rows, untracked_rows).into())
         }
 
         async fn load_row(
             &self,
             request: &LiveStateRowRequest,
         ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            Ok(self
-                .scan_rows(&LiveStateScanRequest {
+            let rows = self
+                .scan_batch(&LiveStateScanRequest {
                     filter: LiveStateFilter {
                         schema_keys: vec![request.schema_key.clone()],
                         entity_pks: vec![request.entity_pk.clone()],
@@ -3863,9 +3865,8 @@ mod tests {
                     },
                     ..Default::default()
                 })
-                .await?
-                .into_iter()
-                .next())
+                .await?;
+            Ok(rows.get(0).map(MaterializedLiveStateRowRef::to_owned))
         }
     }
 
@@ -3887,18 +3888,18 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for StrictEmptyLiveStateReader {
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &crate::live_state::LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        ) -> Result<crate::live_state::MaterializedLiveStateExactBatch, LixError> {
+            crate::live_state::load_exact_batch_via_scan_for_test(self, request).await
         }
 
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             _request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-            Ok(Vec::new())
+        ) -> Result<MaterializedLiveStateBatch, LixError> {
+            Ok(Vec::new().into())
         }
 
         async fn load_row(
@@ -3915,23 +3916,24 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for StrictStaticLiveStateReader {
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &crate::live_state::LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        ) -> Result<crate::live_state::MaterializedLiveStateExactBatch, LixError> {
+            crate::live_state::load_exact_batch_via_scan_for_test(self, request).await
         }
 
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        ) -> Result<MaterializedLiveStateBatch, LixError> {
             Ok(self
                 .rows
                 .iter()
                 .filter(|row| live_state_row_matches_scan(row, request))
                 .cloned()
-                .collect())
+                .collect::<Vec<_>>()
+                .into())
         }
 
         async fn load_row(
@@ -3953,17 +3955,17 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for CountingStaticLiveStateReader {
-        async fn load_exact_rows(
+        async fn load_exact_batch(
             &self,
             request: &crate::live_state::LiveStateExactBatchRequest,
-        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        ) -> Result<crate::live_state::MaterializedLiveStateExactBatch, LixError> {
+            crate::live_state::load_exact_batch_via_scan_for_test(self, request).await
         }
 
-        async fn scan_rows(
+        async fn scan_batch(
             &self,
             request: &LiveStateScanRequest,
-        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        ) -> Result<MaterializedLiveStateBatch, LixError> {
             self.scan_count.fetch_add(1, Ordering::Relaxed);
             Ok(self
                 .rows
@@ -3971,7 +3973,8 @@ mod tests {
                 .cloned()
                 .chain(test_file_descriptor_rows())
                 .filter(|row| live_state_row_matches_scan(row, request))
-                .collect())
+                .collect::<Vec<_>>()
+                .into())
         }
 
         async fn load_row(


### PR DESCRIPTION
## Summary

- make `LiveStateReader` expose one batch-only contract in test and production builds
- remove the test-only `scan_rows`, `scan_tracked_rows`, and `load_exact_rows` trait methods
- migrate every reader fake to `scan_batch`, `scan_tracked_batch`, and `load_exact_batch`
- replace the row-returning exact-scan test helper with a batch-building helper
- remove dead row-forwarding methods from production reader implementations

## Why

The shared-batch refactor left tests compiling against a separate legacy row contract. That hid whether fakes conformed to the production API and kept row lowering available throughout the engine test surface. This is a hard cut: every implementation now satisfies the same batch API.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/root/lix-pr889-target cargo check --locked -p lix_engine --tests`