### PR TITLE
refactor(live-state): remove row reader entrypoints

### DIFF
--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -153,16 +153,6 @@ where
         ))
     }
 
-    #[cfg(test)]
-    pub(crate) async fn scan_rows(
-        &self,
-        request: &LiveStateScanRequest,
-    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-        self.scan_batch(request)
-            .await
-            .map(MaterializedLiveStateBatch::into_rows)
-    }
-
     pub(crate) async fn scan_batch(
         &self,
         request: &LiveStateScanRequest,
@@ -340,17 +330,6 @@ where
             })
             .await?;
         Ok(rows.get(0).map(MaterializedLiveStateRowRef::to_owned))
-    }
-
-    /// Loads exact visible identities without lowering correlated row keys to
-    /// independent scan dimensions.
-    pub(crate) async fn load_exact_rows(
-        &self,
-        request: &LiveStateExactBatchRequest,
-    ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
-        self.load_exact_batch(request)
-            .await
-            .map(MaterializedLiveStateExactBatch::into_rows)
     }
 
     pub(crate) async fn load_exact_batch(
@@ -1421,8 +1400,9 @@ mod tests {
                     .await
                     .expect("open normal scan read"),
             )
-            .scan_rows(request)
+            .scan_batch(request)
             .await
+            .map(MaterializedLiveStateBatch::into_rows)
     }
 
     async fn scan_direct_entity_snapshots_for_test(
@@ -2537,7 +2517,7 @@ mod tests {
                     .await
                     .expect("read should reopen"),
             )
-            .load_exact_rows(&LiveStateExactBatchRequest {
+            .load_exact_batch(&LiveStateExactBatchRequest {
                 rows: vec![
                     selected.clone(),
                     selected,
@@ -2554,7 +2534,8 @@ mod tests {
                 ..Default::default()
             })
             .await
-            .expect("exact batch should load");
+            .expect("exact batch should load")
+            .into_rows();
 
         assert_eq!(rows.len(), 3);
         assert_eq!(rows[0], rows[1]);
@@ -3238,7 +3219,7 @@ mod tests {
                 .expect("read should reopen"),
         );
         let loaded = reader
-            .load_exact_rows(&LiveStateExactBatchRequest {
+            .load_exact_batch(&LiveStateExactBatchRequest {
                 rows: vec![
                     exact("fallback", "fallback"),
                     exact("overridden", "overridden"),
@@ -3254,7 +3235,8 @@ mod tests {
                 ..Default::default()
             })
             .await
-            .expect("exact tracked batch should load");
+            .expect("exact tracked batch should load")
+            .into_rows();
 
         let fallback = loaded[0].as_ref().expect("global fallback should load");
         assert!(fallback.global);
@@ -3285,13 +3267,14 @@ mod tests {
         assert_eq!(loaded[6], None);
 
         let tombstone = reader
-            .load_exact_rows(&LiveStateExactBatchRequest {
+            .load_exact_batch(&LiveStateExactBatchRequest {
                 rows: vec![exact("hidden", "hidden")],
                 include_tombstones: true,
                 ..Default::default()
             })
             .await
             .expect("exact tombstone read should load")
+            .into_rows()
             .pop()
             .flatten()
             .expect("tombstone should be returned when requested");
@@ -3518,7 +3501,7 @@ mod tests {
                     .await
                     .expect("read should open"),
             )
-            .scan_rows(&LiveStateScanRequest {
+            .scan_batch(&LiveStateScanRequest {
                 filter: LiveStateFilter {
                     schema_keys: vec!["lix_key_value".to_string()],
                     entity_pks: vec![crate::entity_pk::EntityPk::single("selected-tab")],
@@ -3530,6 +3513,7 @@ mod tests {
                 ..LiveStateScanRequest::default()
             })
             .await
+            .map(MaterializedLiveStateBatch::into_rows)
     }
 
     async fn scan_tracked_root(

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -51,9 +51,9 @@ pub(crate) async fn load_workspace_branch_id_from_index(
     branch_ctx: &BranchContext,
     reader: &(impl StorageAdapterRead + ?Sized),
 ) -> Result<String, LixError> {
-    let mut rows = live_state
+    let rows = live_state
         .reader(reader)
-        .load_exact_rows(&LiveStateExactBatchRequest {
+        .load_exact_batch(&LiveStateExactBatchRequest {
             rows: vec![LiveStateExactRowRequest {
                 schema_key: "lix_key_value".to_string(),
                 branch_id: GLOBAL_BRANCH_ID.to_string(),
@@ -67,18 +67,21 @@ pub(crate) async fn load_workspace_branch_id_from_index(
             include_tombstones: false,
         })
         .await?;
-    let row = rows.pop().flatten().ok_or_else(|| {
+    let row = rows.row(0).ok_or_else(|| {
         LixError::new(
             "LIX_ERROR_UNKNOWN",
             "workspace branch selector is missing lix_key_value:lix_workspace_branch_id",
         )
     })?;
-    let snapshot_content = row.snapshot_content.as_deref().ok_or_else(|| {
-        LixError::new(
-            "LIX_ERROR_UNKNOWN",
-            "workspace branch selector is missing snapshot_content",
-        )
-    })?;
+    let snapshot_content = row
+        .snapshot_content()
+        .map(|value| value.as_ref())
+        .ok_or_else(|| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "workspace branch selector is missing snapshot_content",
+            )
+        })?;
     let snapshot = serde_json::from_str::<JsonValue>(snapshot_content).map_err(|error| {
         LixError::new(
             "LIX_ERROR_UNKNOWN",

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -3411,7 +3411,7 @@ mod tests {
                     .await
                     .expect("read should open"),
             )
-            .scan_rows(&crate::live_state::LiveStateScanRequest {
+            .scan_batch(&crate::live_state::LiveStateScanRequest {
                 filter: crate::live_state::LiveStateFilter {
                     schema_keys: vec!["lix_commit".to_string()],
                     branch_ids: vec![GLOBAL_BRANCH_ID.to_string()],
@@ -3420,7 +3420,8 @@ mod tests {
                 ..Default::default()
             })
             .await
-            .expect("derived commit rows should scan");
+            .expect("derived commit rows should scan")
+            .into_rows();
         assert!(
             derived_commit_rows
                 .iter()
@@ -4383,7 +4384,7 @@ mod tests {
                     .expect("counted scan read should open"),
                 counts: Arc::clone(&counts),
             }))
-            .scan_rows(&crate::live_state::LiveStateScanRequest {
+            .scan_batch(&crate::live_state::LiveStateScanRequest {
                 filter: crate::live_state::LiveStateFilter {
                     branch_ids: vec![GLOBAL_BRANCH_ID.to_string()],
                     schema_keys: vec!["test_schema".to_string()],
@@ -4393,7 +4394,8 @@ mod tests {
                 ..Default::default()
             })
             .await
-            .expect("tracked scan should succeed");
+            .expect("tracked scan should succeed")
+            .into_rows();
         assert_eq!(scanned.len(), 1);
         assert_eq!(scanned[0].change_id, Some(change_id("tracked-head-change")));
         assert!(
@@ -4456,7 +4458,7 @@ mod tests {
                     .expect("counted exact batch read should open"),
                 counts: Arc::clone(&counts),
             }))
-            .load_exact_rows(&LiveStateExactBatchRequest {
+            .load_exact_batch(&LiveStateExactBatchRequest {
                 rows: vec![LiveStateExactRowRequest {
                     schema_key: "test_schema".to_string(),
                     branch_id: GLOBAL_BRANCH_ID.to_string(),
@@ -4468,7 +4470,8 @@ mod tests {
                 include_tombstones: false,
             })
             .await
-            .expect("exact tracked batch should succeed");
+            .expect("exact tracked batch should succeed")
+            .into_rows();
         assert!(matches!(
             exact_rows.as_slice(),
             [Some(row)] if row.change_id == Some(change_id("tracked-head-change"))
@@ -4833,7 +4836,7 @@ mod tests {
                     .expect("counted branch scan read should open"),
                 counts: Arc::clone(&counts),
             }))
-            .scan_rows(&crate::live_state::LiveStateScanRequest {
+            .scan_batch(&crate::live_state::LiveStateScanRequest {
                 filter: crate::live_state::LiveStateFilter {
                     branch_ids: vec!["01920000-0000-7000-8000-0000000000a1".to_string()],
                     schema_keys: vec!["test_schema".to_string()],
@@ -4843,7 +4846,8 @@ mod tests {
                 ..Default::default()
             })
             .await
-            .expect("branch tracked scan should succeed");
+            .expect("branch tracked scan should succeed")
+            .into_rows();
         assert_eq!(
             scanned.len(),
             2,
@@ -4925,7 +4929,7 @@ mod tests {
                     .expect("counted tombstone scan read should open"),
                 counts: Arc::clone(&counts),
             }))
-            .scan_rows(&crate::live_state::LiveStateScanRequest {
+            .scan_batch(&crate::live_state::LiveStateScanRequest {
                 filter: crate::live_state::LiveStateFilter {
                     branch_ids: vec!["01920000-0000-7000-8000-0000000000a1".to_string()],
                     schema_keys: vec!["test_schema".to_string()],
@@ -4935,7 +4939,8 @@ mod tests {
                 ..Default::default()
             })
             .await
-            .expect("branch tombstone scan should succeed");
+            .expect("branch tombstone scan should succeed")
+            .into_rows();
         assert_eq!(
             scanned.len(),
             1,


### PR DESCRIPTION
## Summary

- remove `LiveStateStoreReader::scan_rows` and `load_exact_rows`
- migrate engine tests to consume batches and lower only at assertion boundaries
- keep the production workspace selector lookup borrowed from its exact batch
- remove every remaining call to the deleted live-state row entrypoints

## Why

After the batch-only trait cut, two inherent row APIs still allowed callers to bypass the shared owner. They had direct batch replacements, including the production workspace-selector point read, so retaining them served no compatibility requirement.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/root/lix-pr889-target cargo check --locked -p lix_engine --tests`