### PR TITLE
Batch canonical SQL inserts

### DIFF
--- a/packages/engine/src/catalog/snapshot.rs
+++ b/packages/engine/src/catalog/snapshot.rs
@@ -2137,6 +2137,10 @@ enum DefaultValuePlan {
 }
 
 impl DefaultPlan {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.properties.is_empty()
+    }
+
     pub(crate) fn from_schema(schema: &JsonValue) -> Self {
         let Some(properties) = schema.get("properties").and_then(JsonValue::as_object) else {
             return Self::default();

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -3994,6 +3994,148 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn entity_insert_values_use_one_certified_canonical_batch() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "x-lix-key": "certified_insert_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": { "type": "string" }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .expect("schema registration should succeed");
+
+        sql2::take_certified_entity_insert_batch_executions();
+        session
+            .execute(
+                "INSERT INTO certified_insert_probe (value, id) VALUES \
+                 ('value-a', 'a'), ('value-b', 'b')",
+                &[],
+            )
+            .await
+            .expect("certified insert batch should commit");
+
+        assert_eq!(sql2::take_certified_entity_insert_batch_executions(), 1);
+        let rows = session
+            .execute(
+                "SELECT id, value FROM certified_insert_probe ORDER BY id",
+                &[],
+            )
+            .await
+            .expect("certified rows should be readable");
+        assert_eq!(rows.rows()[0].get::<String>("value").unwrap(), "value-a");
+        assert_eq!(rows.rows()[1].get::<String>("value").unwrap(), "value-b");
+    }
+
+    #[tokio::test]
+    async fn conflict_insert_filters_rows_before_snapshot_validation() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "x-lix-key": "conflict_validation_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": { "type": "string", "minLength": 3 }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .expect("schema registration should succeed");
+        session
+            .execute(
+                "INSERT INTO conflict_validation_probe (id, value) VALUES ('a', 'valid')",
+                &[],
+            )
+            .await
+            .expect("seed row should commit");
+
+        sql2::take_certified_entity_insert_batch_executions();
+        session
+            .execute(
+                "INSERT INTO conflict_validation_probe (id, value) VALUES ('a', 'x') \
+                 ON CONFLICT (id) DO NOTHING",
+                &[],
+            )
+            .await
+            .expect("conflicting invalid payload should be discarded before validation");
+
+        assert_eq!(sql2::take_certified_entity_insert_batch_executions(), 0);
+        let rows = session
+            .execute(
+                "SELECT value FROM conflict_validation_probe WHERE id = 'a'",
+                &[],
+            )
+            .await
+            .expect("seed row should remain readable");
+        assert_eq!(rows.rows()[0].get::<String>("value").unwrap(), "valid");
+    }
+
+    #[tokio::test]
+    async fn certified_insert_compares_explicit_uuid_keys_by_external_value() {
+        const UUID: &str = "550e8400-e29b-41d4-a716-446655440000";
+
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "x-lix-key": "explicit_uuid_key_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string", "format": "uuid" },
+                "value": { "type": "string" }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .expect("schema registration should succeed");
+
+        sql2::take_certified_entity_insert_batch_executions();
+        session
+            .execute(
+                "INSERT INTO explicit_uuid_key_probe (id, value, lixcol_entity_pk) \
+                 VALUES ($1, 'value', lix_json($2))",
+                &[
+                    Value::Text(UUID.to_string()),
+                    Value::Text(format!("[\"{UUID}\"]")),
+                ],
+            )
+            .await
+            .expect("matching typed and external UUID keys should commit");
+
+        assert_eq!(sql2::take_certified_entity_insert_batch_executions(), 1);
+        let rows = session
+            .execute(
+                "SELECT value FROM explicit_uuid_key_probe WHERE id = $1",
+                &[Value::Text(UUID.to_string())],
+            )
+            .await
+            .expect("inserted UUID row should be readable");
+        assert_eq!(rows.rows()[0].get::<String>("value").unwrap(), "value");
+    }
+
+    #[tokio::test]
     async fn execute_batch_certifies_complete_path_value_replacements() {
         let session = open_session().await;
         let schema = serde_json::json!({

--- a/packages/engine/src/sql2/context.rs
+++ b/packages/engine/src/sql2/context.rs
@@ -124,6 +124,9 @@ pub(crate) trait SqlWriteExecutionContext: Send {
             &self.list_visible_schemas()?,
         )?))
     }
+    fn schema_catalog_snapshot(&self) -> Option<Arc<crate::catalog::CatalogSnapshot>> {
+        None
+    }
     fn plugin_host(&self) -> PluginRuntimeHost {
         PluginRuntimeHost::new(Arc::new(UnsupportedWasmRuntime))
     }

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use datafusion::arrow::datatypes::DataType;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::ScalarValue;
@@ -28,6 +29,7 @@ use crate::sql2::value_contract::{json_bigint_value, json_double_value};
 use crate::transaction::types::{
     RawWriteBatch, RawWriteRowRef, TransactionJson, TransactionWrite, TransactionWriteMode,
 };
+use crate::wasm::{WasmCanonicalJson, WasmEntityKey};
 use crate::{LixError, NullableKeyFilter, Value, parse_row_metadata_value};
 
 use super::SqlWriteResult;
@@ -37,6 +39,8 @@ std::thread_local! {
     static ENTITY_UPDATE_PARAMETER_BATCH_EXECUTIONS: std::cell::Cell<usize> =
         const { std::cell::Cell::new(0) };
     static CERTIFIED_REPLACEMENT_PARAMETER_BATCH_EXECUTIONS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+    static CERTIFIED_ENTITY_INSERT_BATCH_EXECUTIONS: std::cell::Cell<usize> =
         const { std::cell::Cell::new(0) };
 }
 
@@ -48,6 +52,11 @@ pub(crate) fn take_entity_update_parameter_batch_executions() -> usize {
 #[cfg(test)]
 pub(crate) fn take_certified_replacement_parameter_batch_executions() -> usize {
     CERTIFIED_REPLACEMENT_PARAMETER_BATCH_EXECUTIONS.with(|executions| executions.replace(0))
+}
+
+#[cfg(test)]
+pub(crate) fn take_certified_entity_insert_batch_executions() -> usize {
+    CERTIFIED_ENTITY_INSERT_BATCH_EXECUTIONS.with(|executions| executions.replace(0))
 }
 
 #[cfg(test)]
@@ -1231,6 +1240,17 @@ fn entity_insert_batch(
         ));
     };
     let layout = InsertRowLayout::from_values(spec, values)?;
+    if let Some(rows) = certified_entity_insert_batch(
+        ctx,
+        plan,
+        spec,
+        &layout,
+        values,
+        params,
+        active_branch_commit_id,
+    )? {
+        return Ok(rows);
+    }
     let mut write_rows = RawWriteBatch::with_capacity(values.rows.len());
     for row in &values.rows {
         append_entity_insert_row(
@@ -2098,6 +2118,337 @@ impl InsertRowLayout {
             columns,
         })
     }
+}
+
+struct CertifiedInsertRow {
+    file_id: Option<SharedStr>,
+    metadata: Option<TransactionJson>,
+    global: bool,
+    untracked: bool,
+    branch_id: SharedStr,
+}
+
+fn certified_entity_insert_batch(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    plan: &LogicalWritePlan,
+    spec: &EntitySurfaceSpec,
+    layout: &InsertRowLayout,
+    values: &BoundInsertValues,
+    params: &[Value],
+    active_branch_commit_id: Option<&CommitId>,
+) -> Result<Option<RawWriteBatch>, LixError> {
+    if plan.bound.conflict.is_some() {
+        return Ok(None);
+    }
+    if layout.columns.iter().any(|target| {
+        matches!(
+            target,
+            InsertColumnTarget::FileId
+                | InsertColumnTarget::Visible {
+                    column_type: EntityColumnType::Json
+                        | EntityColumnType::Integer
+                        | EntityColumnType::Number,
+                    ..
+                }
+        )
+    }) {
+        return Ok(None);
+    }
+    let Some(schema_catalog) = ctx.schema_catalog_snapshot() else {
+        return Ok(None);
+    };
+    let Some((_, schema_plan)) = schema_catalog.plan_for_key(&layout.schema_key) else {
+        return Ok(None);
+    };
+    if !schema_plan.accepts_v2_canonical_certificate() || !spec.defaults.is_empty() {
+        return Ok(None);
+    }
+    if spec.columns.iter().any(|column| {
+        column.insert_required
+            && !layout.columns.iter().any(|target| {
+                matches!(
+                    target,
+                    InsertColumnTarget::Visible { name, .. } if name == &column.name
+                )
+            })
+    }) {
+        return Ok(None);
+    }
+
+    let mut visible_indices = layout
+        .columns
+        .iter()
+        .enumerate()
+        .filter_map(|(index, target)| match target {
+            InsertColumnTarget::Visible { name, .. } => Some((index, name.as_str())),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    visible_indices.sort_unstable_by_key(|(_, name)| *name);
+    let primary_key_indices = spec
+        .primary_key_paths
+        .iter()
+        .map(|path| {
+            let [name] = path.as_slice() else {
+                return None;
+            };
+            layout
+                .columns
+                .iter()
+                .position(|target| matches!(target, InsertColumnTarget::Visible { name: candidate, .. } if candidate == name))
+        })
+        .collect::<Option<Vec<_>>>();
+    let Some(primary_key_indices) = primary_key_indices else {
+        return Ok(None);
+    };
+
+    let estimated_row_bytes = visible_indices
+        .iter()
+        .map(|(_, name)| name.len().saturating_add(35))
+        .sum::<usize>()
+        .saturating_add(2);
+    let estimated_batch_bytes = values
+        .rows
+        .len()
+        .checked_mul(estimated_row_bytes)
+        .ok_or_else(|| LixError::unknown("certified INSERT batch size overflowed"))?;
+    let mut normalized = Vec::with_capacity(estimated_batch_bytes);
+    let mut offsets = Vec::with_capacity(values.rows.len());
+    let mut entity_pks = Vec::with_capacity(values.rows.len());
+    let mut row_parts = Vec::with_capacity(values.rows.len());
+    let mut row_values = (0..layout.columns.len())
+        .map(|_| None)
+        .collect::<Vec<Option<JsonValue>>>();
+    let context = EntityEvalContext::insert(&JsonValue::Null, &layout.visible_columns);
+
+    for row in &values.rows {
+        if row.len() != layout.columns.len() {
+            return Err(LixError::new(
+                LixError::CODE_UNSUPPORTED_SQL,
+                "entity INSERT rows must have a consistent column layout",
+            ));
+        }
+
+        let mut explicit_entity_pk = None;
+        let mut file_id = None;
+        let mut metadata = None;
+        let mut global = None;
+        let mut untracked = None;
+        let mut explicit_branch_id = None;
+        for (index, (expr, target)) in row.iter().zip(layout.columns.iter()).enumerate() {
+            if let InsertColumnTarget::Visible { column_type, .. } = target {
+                reject_direct_blob_json_value(expr, *column_type, params)?;
+            }
+            let eval_value = eval_expr_value(expr, &context, ctx, params, active_branch_commit_id)?;
+            if matches!(
+                target,
+                InsertColumnTarget::Global | InsertColumnTarget::Untracked
+            ) && entity_eval_value_is_null(&eval_value)
+            {
+                let column_name = match target {
+                    InsertColumnTarget::Global => "lixcol_global",
+                    InsertColumnTarget::Untracked => "lixcol_untracked",
+                    _ => unreachable!("matched defaulted boolean system column"),
+                };
+                return Err(LixError::new(
+                    LixError::CODE_TYPE_MISMATCH,
+                    format!(
+                        "INSERT into {} column '{column_name}' may be omitted to use its default, but explicit NULL is not allowed",
+                        layout.schema_key
+                    ),
+                ));
+            }
+            if matches!(target, InsertColumnTarget::Metadata) {
+                metadata = optional_metadata_from_eval_value(
+                    eval_value,
+                    "lixcol_metadata",
+                    &layout.schema_key,
+                )?;
+                continue;
+            }
+            if let InsertColumnTarget::Visible {
+                name,
+                column_type,
+                read_nullable,
+            } = target
+            {
+                if !read_nullable && entity_eval_value_is_null(&eval_value) {
+                    return Err(LixError::new(
+                        LixError::CODE_SCHEMA_VALIDATION,
+                        format!(
+                            "INSERT into {} column '{name}' does not allow explicit NULL",
+                            layout.schema_key
+                        ),
+                    ));
+                }
+                row_values[index] = Some(entity_json_value(
+                    expr,
+                    eval_value,
+                    *column_type,
+                    &layout.schema_key,
+                    name,
+                )?);
+                continue;
+            }
+            let value = eval_value.into_json();
+            match target {
+                InsertColumnTarget::Visible { .. } => unreachable!("visible columns handled above"),
+                InsertColumnTarget::EntityPk => {
+                    explicit_entity_pk = Some(entity_pk_from_value(&value, "lixcol_entity_pk")?);
+                }
+                InsertColumnTarget::FileId => {
+                    file_id = text_value(value, "lixcol_file_id")?;
+                }
+                InsertColumnTarget::Metadata => {
+                    unreachable!("metadata handled before JSON value coercion")
+                }
+                InsertColumnTarget::Global => {
+                    global = bool_value(value, "lixcol_global")?;
+                }
+                InsertColumnTarget::Untracked => {
+                    untracked = bool_value(value, "lixcol_untracked")?;
+                }
+                InsertColumnTarget::BranchId => {
+                    explicit_branch_id = text_value(value, "lixcol_branch_id")?;
+                }
+            }
+        }
+
+        let primary_key_values = primary_key_indices
+            .iter()
+            .map(|index| {
+                row_values[*index].as_ref().ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_SCHEMA_VALIDATION,
+                        format!(
+                            "INSERT failed to derive entity primary key for schema '{}': missing primary-key value",
+                            layout.schema_key
+                        ),
+                    )
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let derived_entity_pk = EntityPk::from_json_values(
+            &primary_key_values
+                .iter()
+                .map(|value| (*value).clone())
+                .collect::<Vec<_>>(),
+            &spec.primary_key_component_types,
+        )
+        .map_err(|error| {
+            LixError::new(
+                LixError::CODE_SCHEMA_VALIDATION,
+                format!(
+                    "INSERT failed to derive entity primary key for schema '{}': {error}",
+                    layout.schema_key
+                ),
+            )
+        })?;
+        if explicit_entity_pk.as_ref().is_some_and(|explicit| {
+            explicit.clone().into_parts() != derived_entity_pk.clone().into_parts()
+        }) {
+            return Err(LixError::new(
+                LixError::CODE_SCHEMA_VALIDATION,
+                format!(
+                    "INSERT into {} has lixcol_entity_pk that does not match its public primary-key columns",
+                    layout.schema_key
+                ),
+            ));
+        }
+
+        let start = normalized.len();
+        normalized.push(b'{');
+        for (field_index, (value_index, name)) in visible_indices.iter().enumerate() {
+            if field_index != 0 {
+                normalized.push(b',');
+            }
+            serde_json::to_writer(&mut normalized, name).map_err(|error| {
+                LixError::unknown(format!(
+                    "certified INSERT key serialization failed: {error}"
+                ))
+            })?;
+            normalized.push(b':');
+            serde_json::to_writer(
+                &mut normalized,
+                row_values[*value_index]
+                    .as_ref()
+                    .expect("visible INSERT value was evaluated"),
+            )
+            .map_err(|error| {
+                LixError::unknown(format!(
+                    "certified INSERT value serialization failed: {error}"
+                ))
+            })?;
+        }
+        normalized.push(b'}');
+        let key = WasmEntityKey::from_owned_parts(
+            layout.schema_key.clone(),
+            derived_entity_pk.clone().into_parts(),
+        );
+        let certified = schema_plan
+            .certify_or_normalize_v2_plugin_row(&normalized[start..], &key)?
+            .ok_or_else(|| {
+                LixError::unknown("eligible certified INSERT row declined its schema certificate")
+            })?;
+        if let Some(canonical) = certified.normalized {
+            normalized.truncate(start);
+            normalized.extend_from_slice(&canonical);
+        }
+        let end = normalized.len();
+        offsets.push((start, end));
+        entity_pks.push(certified.entity_pk);
+        let global = global.unwrap_or(false);
+        row_parts.push(CertifiedInsertRow {
+            file_id: file_id.map(Into::into),
+            metadata,
+            global,
+            untracked: untracked.unwrap_or(false),
+            branch_id: entity_row_branch_id(plan, explicit_branch_id, global)?.into(),
+        });
+        for value in &mut row_values {
+            *value = None;
+        }
+    }
+
+    let normalized = Bytes::from(normalized);
+    let normalized_rows = offsets
+        .into_iter()
+        .map(|(start, end)| {
+            SharedStr::from_utf8(normalized.slice(start..end))
+                .map_err(|_| LixError::unknown("certified INSERT row is not UTF-8"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let row_count = normalized_rows.len();
+    let snapshots = WasmCanonicalJson::from_certified_batch_parts(
+        normalized_rows,
+        entity_pks.clone(),
+        vec![schema_plan.shared_fingerprint()],
+        vec![0; row_count],
+        row_count,
+    )?;
+    let mut rows = RawWriteBatch::with_capacity(row_count);
+    for ((entity_pk, snapshot), row) in entity_pks.into_iter().zip(snapshots).zip(row_parts) {
+        rows.push_parts(
+            Some(entity_pk),
+            layout.schema_key.as_str().into(),
+            row.file_id,
+            Some(TransactionJson::from_canonical_batch(snapshot)),
+            row.metadata,
+            None,
+            None,
+            None,
+            row.global,
+            None,
+            None,
+            row.untracked,
+            row.branch_id,
+        );
+    }
+    #[cfg(test)]
+    CERTIFIED_ENTITY_INSERT_BATCH_EXECUTIONS.with(|executions| {
+        executions.set(executions.get().saturating_add(1));
+    });
+    Ok(Some(rows))
 }
 
 fn append_entity_insert_row(

--- a/packages/engine/src/sql2/exec/mod.rs
+++ b/packages/engine/src/sql2/exec/mod.rs
@@ -56,6 +56,7 @@ pub(crate) enum SqlLogicalPlan {
 
 #[cfg(test)]
 pub(crate) use bound_public_write::{
+    take_certified_entity_insert_batch_executions,
     take_certified_replacement_parameter_batch_executions,
     take_entity_update_parameter_batch_executions,
 };

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -56,7 +56,7 @@ pub(crate) use exec::{
     WriteExecutorMode, WriteExecutorPath, create_write_logical_plan, execute_write_logical_plan,
     execute_write_logical_plan_with_mode, execute_write_logical_plan_with_mode_and_trace,
     execute_write_logical_plan_with_mode_and_trace_result,
-    execute_write_logical_plan_with_mode_result,
+    execute_write_logical_plan_with_mode_result, take_certified_entity_insert_batch_executions,
     take_certified_replacement_parameter_batch_executions,
     take_entity_update_parameter_batch_executions,
 };

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -5092,6 +5092,10 @@ where
         self.sql_public_catalog()
     }
 
+    fn schema_catalog_snapshot(&self) -> Option<Arc<CatalogSnapshot>> {
+        Some(Arc::clone(&self.sql_schema_snapshot))
+    }
+
     fn plugin_host(&self) -> PluginRuntimeHost {
         self.plugin_host.clone()
     }

--- a/packages/engine/src/wasm/component_v2.rs
+++ b/packages/engine/src/wasm/component_v2.rs
@@ -6,7 +6,7 @@
 //! cursor, output-table, and transition handles created by that instance.
 
 use std::fmt;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -343,6 +343,7 @@ enum WasmCanonicalJsonStorage {
         offsets: Box<[WasmCanonicalJsonOffset]>,
     },
     CertifiedRows {
+        decoded_values: OnceLock<Box<[OnceLock<JsonValue>]>>,
         entity_pks: Box<[EntityPk]>,
         schema_fingerprints: Box<[Arc<SchemaPlanFingerprint>]>,
         schema_fingerprint_indices: Box<[u32]>,
@@ -540,6 +541,7 @@ impl WasmCanonicalJson {
 
         Self::from_validated_batch(WasmCanonicalJsonBatch {
             storage: WasmCanonicalJsonStorage::CertifiedRows {
+                decoded_values: OnceLock::new(),
                 entity_pks: entity_pks.into_boxed_slice(),
                 schema_fingerprints: schema_fingerprints.into_boxed_slice(),
                 schema_fingerprint_indices: schema_fingerprint_indices.into_boxed_slice(),
@@ -570,9 +572,17 @@ impl WasmCanonicalJson {
             WasmCanonicalJsonStorage::Arena { values, .. } => values[self.row_index()]
                 .as_ref()
                 .expect("certified canonical JSON rows do not own decoded values"),
-            WasmCanonicalJsonStorage::CertifiedRows { .. } => {
-                panic!("certified canonical JSON rows do not own decoded values")
-            }
+            WasmCanonicalJsonStorage::CertifiedRows {
+                decoded_values,
+                normalized,
+                ..
+            } => decoded_values
+                .get_or_init(|| (0..normalized.len()).map(|_| OnceLock::new()).collect())
+                [self.row_index()]
+            .get_or_init(|| {
+                serde_json::from_str(normalized[self.row_index()].as_str())
+                    .expect("certified canonical JSON must parse")
+            }),
         }
     }
 
@@ -660,7 +670,10 @@ impl WasmCanonicalJson {
             WasmCanonicalJsonStorage::Arena { values, .. } => {
                 values.iter().filter(|value| value.is_some()).count()
             }
-            WasmCanonicalJsonStorage::CertifiedRows { .. } => 0,
+            WasmCanonicalJsonStorage::CertifiedRows { decoded_values, .. } => decoded_values
+                .get()
+                .map(|values| values.iter().filter(|value| value.get().is_some()).count())
+                .unwrap_or(0),
         }
     }
 


### PR DESCRIPTION
## Summary

- lower eligible homogeneous SQL INSERT VALUES batches directly into one shared canonical JSON byte arena
- reuse the transaction catalog snapshot and one schema fingerprint across the batch
- retain a batch-level lazy DOM fallback for conflict and lifecycle consumers while keeping the happy path decode-free
- leave numeric, JSON, defaulted, and file-scoped shapes on the existing path for a focused first cut

## Performance

Compared with the exact parent of this change in release mode on the same host:

- direct no-file JSON insert: 687.49 ms → 520.99 ms p50 (24.2% faster in the adjacent run; 14.8% faster versus the earlier contemporary parent run)
- allocation count: 1,787,802 → 1,549,623 (13.3% lower)
- allocated bytes: 600.74 MB → 596.96 MB (0.6% lower)
- plugin and file-scoped allocation profiles are unchanged; adjacent-run timings improved 6.0% and 12.4%, respectively
- CSV remains on the existing file-scoped path and passes the 10 MiB scorecard

The direct lane adds one large shared arena per INSERT batch in place of row-owned JSON maps and strings.

## Validation

- `cargo test -p lix_engine --features all-simulations --lib` (1,563 passed, 6 ignored)
- focused certified SQL insert route/round-trip test after rebasing onto current main
- `cargo clippy -p lix_engine --features all-simulations --all-targets -- -D warnings` after rebasing
- 10 MiB JSON RocksDB import parity benchmark, 7 samples
- 10 MiB CSV RocksDB import parity benchmark, 5 paired samples

Originally stacked on #887; rebased onto `main` after #887 merged.