### PR TITLE
refactor(plugin): validate exact live-state batches

### DIFF
--- a/packages/engine/src/plugin/create_context.rs
+++ b/packages/engine/src/plugin/create_context.rs
@@ -15,7 +15,7 @@ use crate::binary_cas::BlobHash;
 use crate::common::LixTimestamp;
 use crate::common::MutationIdentity;
 use crate::entity_pk::EntityPk;
-use crate::live_state::MaterializedLiveStateRow;
+use crate::live_state::{MaterializedLiveStateExactBatch, MaterializedLiveStateRow};
 use crate::transaction::types::{TransactionJson, TransactionWriteRow};
 use crate::wasm::{
     WasmCanonicalJson, WasmChangeEffect, WasmCreateContext, WasmEntity, WasmEntityChange,
@@ -258,7 +258,7 @@ pub(crate) fn materialize_keyless_creates(
 pub(crate) fn require_existing_id_authorities(
     plugin: &PluginRegistryEntry,
     keys: &[WasmEntityKey],
-    rows: &[Option<MaterializedLiveStateRow>],
+    rows: &MaterializedLiveStateExactBatch,
     file_id: &str,
     branch_id: &str,
 ) -> Result<(), LixError> {
@@ -268,18 +268,18 @@ pub(crate) fn require_existing_id_authorities(
             "create authority lookup returned the wrong cardinality",
         ));
     }
-    for (key, row) in keys.iter().zip(rows) {
-        let valid = row.as_ref().is_some_and(|row| {
-            !row.deleted
-                && row.snapshot_content.is_some()
-                && row.schema_key == key.schema_key
+    for (slot, key) in keys.iter().enumerate() {
+        let valid = rows.row(slot).is_some_and(|row| {
+            !row.deleted()
+                && row.snapshot_content().is_some()
+                && key.schema_key == row.schema_key()
                 && key.entity_pk.len() == 1
                 && EntityPk::uuid_from_canonical(&key.entity_pk[0])
-                    .is_ok_and(|entity_pk| row.entity_pk == entity_pk)
-                && row.file_id.as_deref() == Some(file_id)
-                && row.branch_id.as_ref() == branch_id
-                && !row.global
-                && !row.untracked
+                    .is_ok_and(|entity_pk| row.entity_pk() == &entity_pk)
+                && row.file_id() == Some(file_id)
+                && row.branch_id() == branch_id
+                && !row.global()
+                && !row.untracked()
         });
         if !valid {
             return Err(LixError::new(
@@ -688,7 +688,7 @@ mod tests {
         require_existing_id_authorities(
             &plugin(),
             &[key],
-            &[Some(row)],
+            &MaterializedLiveStateExactBatch::from_rows(vec![Some(row)]),
             "01920000-0000-7000-8000-0000000000a2",
             "main",
         )

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -1445,19 +1445,7 @@ where
                 include_tombstones: false,
             })
             .await?;
-        let accepted = format_only_keys
-            .into_iter()
-            .enumerate()
-            .map(|(slot, key)| {
-                // The format-only comparator is a terminal WASM boundary that
-                // still accepts its historical owned DTO.
-                (
-                    key,
-                    current.row(slot).map(MaterializedLiveStateRowRef::to_owned),
-                )
-            })
-            .collect::<BTreeMap<_, _>>();
-        suppress_v2_format_only_noops_against_rows(changes, &accepted)
+        suppress_v2_format_only_noops_against_batch(changes, &format_only_keys, &current)
     }
 
     /// Materializes keyless creates and returns the one durable mutation
@@ -1504,22 +1492,15 @@ where
             })
             .collect::<Result<Vec<_>, LixError>>()?;
         let loaded = if exact_rows.is_empty() {
-            Vec::new()
+            MaterializedLiveStateExactBatch::default()
         } else {
-            let loaded = self
-                .load_visible_exact_live_state_batch(&LiveStateExactBatchRequest {
-                    rows: exact_rows,
-                    projection: plugin_state_live_state_projection(),
-                    untracked: Some(false),
-                    include_tombstones: false,
-                })
-                .await?;
-            // Namespace validation is the terminal plugin boundary. Retain the
-            // exact owner through the read and scalarize only its aligned
-            // authority slots for the legacy validator.
-            (0..loaded.len())
-                .map(|slot| loaded.row(slot).map(MaterializedLiveStateRowRef::to_owned))
-                .collect()
+            self.load_visible_exact_live_state_batch(&LiveStateExactBatchRequest {
+                rows: exact_rows,
+                projection: plugin_state_live_state_projection(),
+                untracked: Some(false),
+                include_tombstones: false,
+            })
+            .await?
         };
         require_existing_id_authorities(
             plugin,
@@ -5296,10 +5277,22 @@ fn v2_create_context(seed: [u8; 16], actor_key: &PluginActorKey) -> crate::wasm:
         .creates()
 }
 
-fn suppress_v2_format_only_noops_against_rows(
+fn suppress_v2_format_only_noops_against_batch(
     changes: WasmHostEntityChanges,
-    accepted: &BTreeMap<WasmEntityKey, Option<MaterializedLiveStateRow>>,
+    keys: &[WasmEntityKey],
+    accepted: &MaterializedLiveStateExactBatch,
 ) -> Result<WasmHostEntityChanges, LixError> {
+    if keys.len() != accepted.len() {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "format-only lookup returned the wrong cardinality",
+        ));
+    }
+    let accepted = keys
+        .iter()
+        .enumerate()
+        .map(|(slot, key)| (key, accepted.row(slot)))
+        .collect::<BTreeMap<_, _>>();
     let mut effective = Vec::with_capacity(changes.changes.len());
     for change in changes.changes {
         let is_noop = match &change {
@@ -5311,7 +5304,7 @@ fn suppress_v2_format_only_noops_against_rows(
                     effective.push(change);
                     continue;
                 };
-                let Some(base_snapshot) = base.snapshot_content.as_deref() else {
+                let Some(base_snapshot) = base.snapshot_content() else {
                     effective.push(change);
                     continue;
                 };
@@ -5325,7 +5318,7 @@ fn suppress_v2_format_only_noops_against_rows(
                     }
                 };
                 let candidate = canonical.normalized();
-                if candidate == base_snapshot {
+                if candidate == base_snapshot.as_str() {
                     true
                 } else {
                     // New writes retain exact canonical bytes, so equality is
@@ -8019,7 +8012,7 @@ mod tests {
                 WasmEntityChange::Delete(key("deleted")),
             ],
         };
-        let accepted = BTreeMap::from([
+        let accepted = [
             (
                 key("equal"),
                 Some(live("equal", r#"{"text":"\u00e9","id":"equal"}"#)),
@@ -8032,10 +8025,18 @@ mod tests {
                 key("content"),
                 Some(live("content", r#"{"id":"content","text":"same"}"#)),
             ),
-        ]);
+        ];
+        let accepted_keys = accepted
+            .iter()
+            .map(|(key, _)| key.clone())
+            .collect::<Vec<_>>();
+        let accepted = MaterializedLiveStateExactBatch::from_rows(
+            accepted.into_iter().map(|(_, row)| row).collect(),
+        );
 
-        let effective = suppress_v2_format_only_noops_against_rows(changes, &accepted)
-            .expect("number-free normalized snapshots should compare");
+        let effective =
+            suppress_v2_format_only_noops_against_batch(changes, &accepted_keys, &accepted)
+                .expect("number-free normalized snapshots should compare");
         assert_eq!(effective.changes.len(), 3);
         assert_eq!(effective.changes[0].entity_key(), Some(&key("changed")));
         assert_eq!(effective.changes[1].entity_key(), Some(&key("content")));


### PR DESCRIPTION
## Summary
- make create-authority validation consume aligned exact live-state batches
- compare format-only plugin updates against borrowed batch row views
- remove production conversion into legacy owned live-state DTOs

## Validation
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/root/lix-pr889-target cargo check --locked -p lix_engine --tests`
- focused test executable compilation was attempted locally but the constrained runner killed rustc for memory; GitHub CI runs the complete suite

Stacked on #895.