### PR TITLE
refactor(live-state): remove scalar reader contract

### DIFF
--- a/packages/engine/src/catalog/context.rs
+++ b/packages/engine/src/catalog/context.rs
@@ -385,7 +385,7 @@ mod tests {
     use crate::GLOBAL_BRANCH_ID;
     use crate::changelog::ChangeId;
     use crate::common::LixTimestamp;
-    use crate::live_state::{LiveStateRowRequest, MaterializedLiveStateRow};
+    use crate::live_state::MaterializedLiveStateRow;
 
     #[tokio::test]
     async fn compiled_catalog_for_domain_hits_cache_without_decoding() {
@@ -813,22 +813,6 @@ mod tests {
                     .cloned()
                     .collect(),
             ))
-        }
-
-        async fn load_row(
-            &self,
-            request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            let request_branch_id = request.branch_id.as_str();
-            Ok(self
-                .rows
-                .iter()
-                .find(|row| {
-                    row.schema_key == request.schema_key
-                        && row.branch_id.as_ref() == request_branch_id
-                        && row.entity_pk == request.entity_pk
-                })
-                .cloned())
         }
     }
 

--- a/packages/engine/src/filesystem/path_index.rs
+++ b/packages/engine/src/filesystem/path_index.rs
@@ -1444,13 +1444,6 @@ mod tests {
             Ok(self.rows.clone())
         }
 
-        async fn load_row(
-            &self,
-            _request: &crate::live_state::LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            unreachable!("path-index construction only scans live state")
-        }
-
         async fn load_exact_batch(
             &self,
             _request: &crate::live_state::LiveStateExactBatchRequest,

--- a/packages/engine/src/filesystem/visibility.rs
+++ b/packages/engine/src/filesystem/visibility.rs
@@ -174,8 +174,7 @@ mod tests {
     use crate::common::LixTimestamp;
     use crate::filesystem::{FilesystemDescriptorKey, FilesystemRowContext};
     use crate::live_state::{
-        LiveStateReader, LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateBatch,
-        MaterializedLiveStateRow,
+        LiveStateReader, LiveStateScanRequest, MaterializedLiveStateBatch, MaterializedLiveStateRow,
     };
 
     use super::{
@@ -447,13 +446,6 @@ mod tests {
                     .collect(),
             ))
         }
-
-        async fn load_row(
-            &self,
-            _request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            Ok(None)
-        }
     }
 
     struct RowsLiveStateReader {
@@ -489,13 +481,6 @@ mod tests {
                     .cloned()
                     .collect(),
             ))
-        }
-
-        async fn load_row(
-            &self,
-            _request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            Ok(None)
         }
     }
 

--- a/packages/engine/src/functions/context.rs
+++ b/packages/engine/src/functions/context.rs
@@ -5,8 +5,6 @@ use crate::functions::{
     DeterministicFunctionProvider, DeterministicSequence, FunctionProvider, FunctionProviderHandle,
     SystemFunctionProvider, state,
 };
-#[cfg(test)]
-use crate::live_state::LiveStateReader;
 use crate::storage_adapter::{StorageAdapterRead, StoragePrecondition, StorageWriteSet};
 
 /// Execution-scoped runtime function context.
@@ -285,18 +283,17 @@ mod tests {
         // Deterministic mode must stamp the bookkeeping row from the
         // persisted sequence, never from the system clock; the persisted
         // sequence was empty, so next_sequence is 0 -> epoch.
-        let row = LiveStateReader::load_row(
-            &live_state.reader(&read),
-            &crate::live_state::LiveStateRowRequest {
+        let row = live_state
+            .reader(&read)
+            .load_row(&crate::live_state::LiveStateRowRequest {
                 schema_key: "lix_key_value".to_string(),
                 branch_id: GLOBAL_BRANCH_ID.to_string(),
                 entity_pk: EntityPk::single(DETERMINISTIC_SEQUENCE_KEY),
                 file_id: crate::NullableKeyFilter::Null,
-            },
-        )
-        .await
-        .expect("sequence row should load")
-        .expect("sequence row should exist");
+            })
+            .await
+            .expect("sequence row should load")
+            .expect("sequence row should exist");
         assert_eq!(
             row.created_at.to_string(),
             "1970-01-01T00:00:00.000Z",

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -656,13 +656,6 @@ where
         Self::scan_batch(self, request).await
     }
 
-    async fn load_row(
-        &self,
-        request: &LiveStateRowRequest,
-    ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-        Self::load_row(self, request).await
-    }
-
     async fn load_exact_batch(
         &self,
         request: &LiveStateExactBatchRequest,

--- a/packages/engine/src/live_state/reader.rs
+++ b/packages/engine/src/live_state/reader.rs
@@ -3,10 +3,8 @@ use async_trait::async_trait;
 use crate::LixError;
 #[cfg(test)]
 use crate::live_state::MaterializedLiveStateBatchBuilder;
-use crate::live_state::{LiveStateExactBatchRequest, LiveStateRowRequest, LiveStateScanRequest};
-use crate::live_state::{
-    MaterializedLiveStateBatch, MaterializedLiveStateExactBatch, MaterializedLiveStateRow,
-};
+use crate::live_state::{LiveStateExactBatchRequest, LiveStateScanRequest};
+use crate::live_state::{MaterializedLiveStateBatch, MaterializedLiveStateExactBatch};
 
 /// Minimal engine read model for transaction planning and SQL providers.
 ///
@@ -56,12 +54,6 @@ pub(crate) trait LiveStateReader: Send + Sync {
         request.filter.untracked = Some(false);
         self.scan_batch(&request).await
     }
-
-    #[allow(dead_code)]
-    async fn load_row(
-        &self,
-        request: &LiveStateRowRequest,
-    ) -> Result<Option<MaterializedLiveStateRow>, LixError>;
 
     /// Loads concrete visible identities while preserving request alignment.
     ///

--- a/packages/engine/src/live_state/visibility.rs
+++ b/packages/engine/src/live_state/visibility.rs
@@ -429,7 +429,7 @@ mod tests {
     use crate::changelog::{ChangeId, CommitId};
     use crate::common::LixTimestamp;
     use crate::entity_pk::EntityPk;
-    use crate::live_state::LiveStateRowRequest;
+
     use async_trait::async_trait;
 
     fn test_timestamp() -> LixTimestamp {
@@ -1274,13 +1274,6 @@ mod tests {
                 Ok(Vec::new().into())
             }
         }
-
-        async fn load_row(
-            &self,
-            _request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            Ok(None)
-        }
     }
 
     struct FilteringReader {
@@ -1307,13 +1300,6 @@ mod tests {
                     .cloned()
                     .collect(),
             ))
-        }
-
-        async fn load_row(
-            &self,
-            _request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            Ok(None)
         }
     }
 }

--- a/packages/engine/src/sql2/context.rs
+++ b/packages/engine/src/sql2/context.rs
@@ -18,9 +18,8 @@ use crate::filesystem::{
 use crate::functions::FunctionProviderHandle;
 use crate::json_store::JsonStoreReader;
 use crate::live_state::{
-    LiveStateExactBatchRequest, LiveStateFilter, LiveStateProjection, LiveStateReader,
-    LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateBatch,
-    MaterializedLiveStateExactBatch, MaterializedLiveStateRow,
+    LiveStateExactBatchRequest, LiveStateReader, LiveStateScanRequest, MaterializedLiveStateBatch,
+    MaterializedLiveStateExactBatch,
 };
 use crate::plugin::PluginRuntimeHost;
 use crate::storage_adapter::StorageAdapterRead;
@@ -392,29 +391,6 @@ impl LiveStateReader for WriteContextLiveStateReader {
         request: &LiveStateScanRequest,
     ) -> Result<MaterializedLiveStateBatch, LixError> {
         self.ctx.scan_live_state_batch(request).await
-    }
-
-    async fn load_row(
-        &self,
-        request: &LiveStateRowRequest,
-    ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-        let rows = self
-            .ctx
-            .scan_live_state_batch(&LiveStateScanRequest {
-                filter: LiveStateFilter {
-                    schema_keys: vec![request.schema_key.clone()],
-                    entity_pks: vec![request.entity_pk.clone()],
-                    branch_ids: vec![request.branch_id.clone()],
-                    file_ids: vec![request.file_id.clone()],
-                    ..LiveStateFilter::default()
-                },
-                projection: LiveStateProjection::default(),
-                limit: Some(1),
-            })
-            .await?;
-        Ok(rows
-            .get(0)
-            .map(crate::live_state::MaterializedLiveStateRowRef::to_owned))
     }
 
     async fn load_exact_batch(

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -2208,9 +2208,7 @@ mod tests {
     use crate::common::LixTimestamp;
     use crate::functions::FunctionProviderHandle;
     use crate::json_store::JsonStoreContext;
-    use crate::live_state::{
-        LiveStateReader, LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow,
-    };
+    use crate::live_state::{LiveStateReader, LiveStateScanRequest, MaterializedLiveStateRow};
     use crate::sql2::{
         ChangelogQuerySource, EntitySnapshotReader, HistoryQuerySource, SqlChangelogQuerySource,
         SqlHistoryQuerySource,
@@ -2809,13 +2807,6 @@ mod tests {
         ) -> Result<crate::live_state::MaterializedLiveStateBatch, LixError> {
             Ok(vec![].into())
         }
-
-        async fn load_row(
-            &self,
-            _request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            Ok(None)
-        }
     }
 
     fn filter_live_state_rows(
@@ -2878,13 +2869,6 @@ mod tests {
         ) -> Result<crate::live_state::MaterializedLiveStateBatch, LixError> {
             Ok(filter_live_state_rows(&self.rows, request).into())
         }
-
-        async fn load_row(
-            &self,
-            _request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            Ok(None)
-        }
     }
 
     #[async_trait]
@@ -2906,13 +2890,6 @@ mod tests {
                 .push(request.clone());
             Ok(filter_live_state_rows(&self.rows, request).into())
         }
-
-        async fn load_row(
-            &self,
-            _request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            Ok(None)
-        }
     }
 
     #[async_trait]
@@ -2930,13 +2907,6 @@ mod tests {
         ) -> Result<crate::live_state::MaterializedLiveStateBatch, LixError> {
             self.scans.fetch_add(1, Ordering::SeqCst);
             Ok(filter_live_state_rows(&self.rows, request).into())
-        }
-
-        async fn load_row(
-            &self,
-            _request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            Ok(None)
         }
     }
 

--- a/packages/engine/src/sql2/providers/branch.rs
+++ b/packages/engine/src/sql2/providers/branch.rs
@@ -996,7 +996,7 @@ mod tests {
 
     use super::*;
     use crate::common::LixTimestamp;
-    use crate::live_state::{LiveStateRowRequest, MaterializedLiveStateRow};
+    use crate::live_state::MaterializedLiveStateRow;
     use datafusion::common::Column;
 
     struct RowsLiveStateReader {
@@ -1017,13 +1017,6 @@ mod tests {
             _request: &LiveStateScanRequest,
         ) -> Result<crate::live_state::MaterializedLiveStateBatch, LixError> {
             Ok(self.rows.clone().into())
-        }
-
-        async fn load_row(
-            &self,
-            _request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            Ok(None)
         }
     }
 
@@ -1064,13 +1057,6 @@ mod tests {
                 .cloned()
                 .collect::<Vec<_>>()
                 .into())
-        }
-
-        async fn load_row(
-            &self,
-            _request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            Ok(None)
         }
     }
 

--- a/packages/engine/src/sql2/providers/directory.rs
+++ b/packages/engine/src/sql2/providers/directory.rs
@@ -2129,8 +2129,7 @@ mod tests {
     };
     use crate::functions::FunctionProviderHandle;
     use crate::live_state::{
-        LiveStateReader, LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateBatch,
-        MaterializedLiveStateRow,
+        LiveStateReader, LiveStateScanRequest, MaterializedLiveStateBatch, MaterializedLiveStateRow,
     };
     use crate::sql2::{SqlWriteContext, SqlWriteExecutionContext};
     use crate::transaction::types::{
@@ -2202,15 +2201,6 @@ mod tests {
             self.scan_count.fetch_add(1, Ordering::SeqCst);
             Err(LixError::unknown(
                 "directory parent-id scan should not read live state",
-            ))
-        }
-
-        async fn load_row(
-            &self,
-            _request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            Err(LixError::unknown(
-                "directory parent-id scan should not load live-state rows",
             ))
         }
     }

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -1814,8 +1814,7 @@ mod tests {
     use crate::common::LixTimestamp;
     use crate::live_state::{
         LiveStateFilter, LiveStateProjection, LiveStateReader, LiveStateRowFilter,
-        LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateBatch,
-        MaterializedLiveStateRow,
+        LiveStateScanRequest, MaterializedLiveStateBatch, MaterializedLiveStateRow,
     };
     use crate::sql2::WriteAccess;
     use crate::sql2::catalog::{
@@ -1841,13 +1840,6 @@ mod tests {
             _request: &LiveStateScanRequest,
         ) -> Result<MaterializedLiveStateBatch, LixError> {
             Ok(vec![].into())
-        }
-
-        async fn load_row(
-            &self,
-            _request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            Ok(None)
         }
     }
 

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -6822,9 +6822,8 @@ mod tests {
     };
     use crate::functions::FunctionProviderHandle;
     use crate::live_state::{
-        LiveStateExactBatchRequest, LiveStateFilter, LiveStateReader, LiveStateRowRequest,
-        LiveStateScanRequest, MaterializedLiveStateBatch, MaterializedLiveStateBatchBuilder,
-        MaterializedLiveStateRow,
+        LiveStateExactBatchRequest, LiveStateFilter, LiveStateReader, LiveStateScanRequest,
+        MaterializedLiveStateBatch, MaterializedLiveStateBatchBuilder, MaterializedLiveStateRow,
     };
     use crate::plugin::{
         PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY, PluginContentType, PluginFileOwner, PluginRegistry,
@@ -8711,13 +8710,6 @@ mod tests {
             Ok(self.rows.clone().into())
         }
 
-        async fn load_row(
-            &self,
-            _request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            Ok(None)
-        }
-
         async fn load_exact_batch(
             &self,
             request: &LiveStateExactBatchRequest,
@@ -8831,15 +8823,6 @@ mod tests {
                 "descriptor-only scan should not read live state",
             ))
         }
-
-        async fn load_row(
-            &self,
-            _request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            Err(LixError::unknown(
-                "descriptor-only scan should not load live-state rows",
-            ))
-        }
     }
 
     struct StaticFilesystemPathIndexReader {
@@ -8888,13 +8871,6 @@ mod tests {
             _request: &LiveStateScanRequest,
         ) -> Result<MaterializedLiveStateBatch, LixError> {
             Ok(self.rows.clone().into())
-        }
-
-        async fn load_row(
-            &self,
-            _request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            Ok(None)
         }
     }
 

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -691,9 +691,7 @@ mod tests {
         CommitGraphReader, ReachableCommitGraphCommit,
     };
     use crate::json_store::JsonStoreContext;
-    use crate::live_state::{
-        LiveStateReader, LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow,
-    };
+    use crate::live_state::{LiveStateReader, LiveStateScanRequest};
     use crate::sql2::HistoryQuerySource;
     use crate::sql2::catalog::{PublicCatalog, derive_entity_surface_spec_from_schema};
     use crate::storage_adapter::{
@@ -1139,13 +1137,6 @@ mod tests {
             _request: &LiveStateScanRequest,
         ) -> Result<crate::live_state::MaterializedLiveStateBatch, LixError> {
             Ok(Vec::new().into())
-        }
-
-        async fn load_row(
-            &self,
-            _request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            Ok(None)
         }
     }
 

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -44,9 +44,11 @@ use crate::gc::{
     CheckpointGcState, CheckpointPublication, CheckpointRecoveryRef, load_checkpoint_gc_state,
     load_recovery_ref,
 };
+#[cfg(test)]
+use crate::live_state::LiveStateRowRequest;
 use crate::live_state::{
     LiveStateContext, LiveStateExactBatchRequest, LiveStateExactRowRequest, LiveStateFilter,
-    LiveStateProjection, LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateBatch,
+    LiveStateProjection, LiveStateScanRequest, MaterializedLiveStateBatch,
     MaterializedLiveStateBatchBuilder, MaterializedLiveStateExactBatch, MaterializedLiveStateRow,
     MaterializedLiveStateRowRef, StagedLiveStateRows, TrackedHeadContext, TrackedWorkingDiff,
     overlay_load_exact_batch, overlay_scan_batch,
@@ -4679,26 +4681,6 @@ where
         request: &LiveStateScanRequest,
     ) -> Result<MaterializedLiveStateBatch, LixError> {
         overlay_scan_batch(&self.base, &self.staged, request).await
-    }
-
-    async fn load_row(
-        &self,
-        request: &LiveStateRowRequest,
-    ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-        let rows = self
-            .scan_batch(&LiveStateScanRequest {
-                filter: LiveStateFilter {
-                    schema_keys: vec![request.schema_key.clone()],
-                    entity_pks: vec![request.entity_pk.clone()],
-                    branch_ids: vec![request.branch_id.clone()],
-                    file_ids: vec![request.file_id.clone()],
-                    ..Default::default()
-                },
-                limit: Some(1),
-                ..Default::default()
-            })
-            .await?;
-        Ok(rows.get(0).map(MaterializedLiveStateRowRef::to_owned))
     }
 
     async fn load_exact_batch(

--- a/packages/engine/src/transaction/schema_resolver.rs
+++ b/packages/engine/src/transaction/schema_resolver.rs
@@ -7,9 +7,9 @@ use crate::LixError;
 use crate::catalog::{CatalogContext, CatalogSnapshot, TransactionCatalog};
 use crate::domain::Domain;
 use crate::live_state::{
-    LiveStateExactBatchRequest, LiveStateReader, LiveStateRowRequest, LiveStateScanRequest,
-    MaterializedLiveStateBatch, MaterializedLiveStateExactBatch, MaterializedLiveStateRow,
-    StagedLiveStateRows, overlay_load_exact_batch, overlay_scan_batch, overlay_scan_tracked_batch,
+    LiveStateExactBatchRequest, LiveStateReader, LiveStateScanRequest, MaterializedLiveStateBatch,
+    MaterializedLiveStateExactBatch, StagedLiveStateRows, overlay_load_exact_batch,
+    overlay_scan_batch, overlay_scan_tracked_batch,
 };
 use crate::transaction::staging::PreparedStateRowOverlay;
 
@@ -128,28 +128,6 @@ where
         overlay_scan_tracked_batch(self.base, self.staged, request).await
     }
 
-    async fn load_row(
-        &self,
-        request: &LiveStateRowRequest,
-    ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-        let rows = self
-            .scan_batch(&LiveStateScanRequest {
-                filter: crate::live_state::LiveStateFilter {
-                    schema_keys: vec![request.schema_key.clone()],
-                    entity_pks: vec![request.entity_pk.clone()],
-                    branch_ids: vec![request.branch_id.clone()],
-                    file_ids: vec![request.file_id.clone()],
-                    ..Default::default()
-                },
-                limit: Some(1),
-                ..Default::default()
-            })
-            .await?;
-        Ok(rows
-            .get(0)
-            .map(crate::live_state::MaterializedLiveStateRowRef::to_owned))
-    }
-
     async fn load_exact_batch(
         &self,
         request: &LiveStateExactBatchRequest,
@@ -163,7 +141,7 @@ mod tests {
     use super::*;
     use crate::common::LixTimestamp;
     use crate::entity_pk::EntityPk;
-    use crate::live_state::LiveStateFilter;
+    use crate::live_state::{LiveStateFilter, MaterializedLiveStateRow};
 
     struct SplitCurrentAndTrackedReader {
         canonical: MaterializedLiveStateRow,
@@ -199,13 +177,6 @@ mod tests {
                 .into_iter()
                 .collect::<Vec<_>>()
                 .into())
-        }
-
-        async fn load_row(
-            &self,
-            _request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            Ok(Some(self.canonical.clone()))
         }
     }
 

--- a/packages/engine/src/transaction/validation.rs
+++ b/packages/engine/src/transaction/validation.rs
@@ -3370,8 +3370,7 @@ mod tests {
     use super::*;
     use crate::common::SharedStr;
     use crate::live_state::{
-        LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateBatchBuilder,
-        MaterializedLiveStateRow,
+        LiveStateScanRequest, MaterializedLiveStateBatchBuilder, MaterializedLiveStateRow,
     };
     use crate::schema::{schema_key_from_definition, seed_schema_definition};
     use crate::transaction::types::{
@@ -3410,13 +3409,6 @@ mod tests {
             _request: &LiveStateScanRequest,
         ) -> Result<MaterializedLiveStateBatch, LixError> {
             panic!("constraint validation must not project the shared batch into owned rows")
-        }
-
-        async fn load_row(
-            &self,
-            _request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            Ok(None)
         }
 
         async fn load_exact_batch(
@@ -3598,15 +3590,6 @@ mod tests {
                 .filter(|row| live_state_row_matches_scan(row, request))
                 .collect::<Vec<_>>()
                 .into())
-        }
-
-        async fn load_row(
-            &self,
-            request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            Ok(test_file_descriptor_rows()
-                .into_iter()
-                .find(|row| live_state_row_matches_load(row, request)))
         }
     }
 
@@ -3792,23 +3775,6 @@ mod tests {
                 .collect::<Vec<_>>()
                 .into())
         }
-
-        async fn load_row(
-            &self,
-            request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            Ok(self
-                .rows
-                .iter()
-                .cloned()
-                .chain(test_file_descriptor_rows())
-                .find(|row| {
-                    row.schema_key == request.schema_key
-                        && row.branch_id.as_ref() == request.branch_id
-                        && row.entity_pk == request.entity_pk
-                        && request.file_id.matches(row.file_id.as_ref())
-                }))
-        }
     }
 
     struct OverlayingStaticLiveStateReader {
@@ -3849,25 +3815,6 @@ mod tests {
                 .collect::<Vec<_>>();
             Ok(overlay_untracked_rows_for_test(tracked_rows, untracked_rows).into())
         }
-
-        async fn load_row(
-            &self,
-            request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            let rows = self
-                .scan_batch(&LiveStateScanRequest {
-                    filter: LiveStateFilter {
-                        schema_keys: vec![request.schema_key.clone()],
-                        entity_pks: vec![request.entity_pk.clone()],
-                        branch_ids: vec![request.branch_id.clone()],
-                        file_ids: vec![request.file_id.clone()],
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                })
-                .await?;
-            Ok(rows.get(0).map(MaterializedLiveStateRowRef::to_owned))
-        }
     }
 
     fn overlay_untracked_rows_for_test(
@@ -3901,13 +3848,6 @@ mod tests {
         ) -> Result<MaterializedLiveStateBatch, LixError> {
             Ok(Vec::new().into())
         }
-
-        async fn load_row(
-            &self,
-            _request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            Ok(None)
-        }
     }
 
     struct StrictStaticLiveStateReader {
@@ -3934,17 +3874,6 @@ mod tests {
                 .cloned()
                 .collect::<Vec<_>>()
                 .into())
-        }
-
-        async fn load_row(
-            &self,
-            request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            Ok(self
-                .rows
-                .iter()
-                .find(|row| live_state_row_matches_load(row, request))
-                .cloned())
         }
     }
 
@@ -3975,18 +3904,6 @@ mod tests {
                 .filter(|row| live_state_row_matches_scan(row, request))
                 .collect::<Vec<_>>()
                 .into())
-        }
-
-        async fn load_row(
-            &self,
-            request: &LiveStateRowRequest,
-        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-            Ok(self
-                .rows
-                .iter()
-                .cloned()
-                .chain(test_file_descriptor_rows())
-                .find(|row| live_state_row_matches_load(row, request)))
         }
     }
 
@@ -7316,16 +7233,6 @@ mod tests {
                     .file_ids
                     .iter()
                     .any(|filter| filter.matches(row.file_id.as_ref())))
-    }
-
-    fn live_state_row_matches_load(
-        row: &MaterializedLiveStateRow,
-        request: &LiveStateRowRequest,
-    ) -> bool {
-        row.schema_key == request.schema_key
-            && row.branch_id.as_ref() == request.branch_id
-            && row.entity_pk == request.entity_pk
-            && request.file_id.matches(row.file_id.as_ref())
     }
 
     fn test_file_descriptor_rows() -> Vec<MaterializedLiveStateRow> {


### PR DESCRIPTION
## Summary
- remove the unused scalar `load_row` method from `LiveStateReader`
- delete the required boilerplate from every production and test reader implementation
- remove the dead test row matcher exposed by that contract

The concrete live-state store retains its narrow scalar helper for initialization and explicit scalar assertions; the shared reader contract is batch-only.

## Validation
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/root/lix-pr889-target cargo check --locked -p lix_engine --tests`

Stacked on #897.