### PR TITLE
Fix empty lix_file_working_change results

### DIFF
--- a/packages/engine/src/sql2/providers/filesystem_working_change.rs
+++ b/packages/engine/src/sql2/providers/filesystem_working_change.rs
@@ -343,7 +343,10 @@ where
     let file_entity_pks = if load_all_files {
         Vec::new()
     } else {
-        selected_file_ids.iter().map(EntityPk::single).collect()
+        selected_file_ids
+            .iter()
+            .map(|file_id| filesystem_descriptor_entity_pk(file_id, "file"))
+            .collect::<Result<Vec<_>, _>>()?
     };
     let files = if !load_all_files && selected_file_ids.is_empty() {
         Vec::new()
@@ -425,7 +428,9 @@ where
             tracked,
             commit_id,
             DIRECTORY_DESCRIPTOR_SCHEMA_KEY,
-            ids.into_iter().map(EntityPk::single).collect(),
+            ids.iter()
+                .map(|directory_id| filesystem_descriptor_entity_pk(directory_id, "directory"))
+                .collect::<Result<Vec<_>, _>>()?,
         )
         .await?;
         pending.extend(
@@ -437,6 +442,15 @@ where
         directories.extend(loaded);
     }
     Ok(directories)
+}
+
+fn filesystem_descriptor_entity_pk(id: &str, kind: &str) -> Result<EntityPk, LixError> {
+    EntityPk::uuid_from_canonical(id).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("validated {kind} ID is not a canonical UUID: {error}"),
+        )
+    })
 }
 
 async fn scan_descriptors<S, T>(

--- a/packages/engine/tests/integration/sql/checkpoint.rs
+++ b/packages/engine/tests/integration/sql/checkpoint.rs
@@ -299,6 +299,139 @@ simulation_test!(
 );
 
 simulation_test!(
+    file_working_change_reports_root_file_changes_without_directory_changes,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("workspace session should open"),
+            &engine,
+        );
+        let file_id = "01950000-0000-7000-8000-000000000099";
+        let nested_file_id = "01950000-0000-7000-8000-000000000100";
+
+        session
+            .execute(
+                &format!(
+                    "INSERT INTO lix_file (id, path, data) \
+                     VALUES ('{file_id}', '/a.md', X'6F6C64')"
+                ),
+                &[],
+            )
+            .await
+            .expect("root file insert should succeed");
+
+        assert_eq!(
+            select_rows(
+                &session,
+                "SELECT id, path, previous_path, change_kind \
+                 FROM lix_file_working_change",
+            )
+            .await,
+            vec![vec![
+                Value::Text(file_id.to_string()),
+                Value::Text("/a.md".to_string()),
+                Value::Null,
+                Value::Text("added".to_string()),
+            ]],
+            "a root file add must not require an unrelated directory change",
+        );
+
+        session
+            .execute(
+                &format!(
+                    "INSERT INTO lix_file (id, path, data) \
+                     VALUES ('{nested_file_id}', '/existing/b.md', X'6F6C64')"
+                ),
+                &[],
+            )
+            .await
+            .expect("nested baseline file insert should succeed");
+        session
+            .create_checkpoint()
+            .await
+            .expect("baseline checkpoint should succeed");
+        for changed_file_id in [file_id, nested_file_id] {
+            session
+                .execute(
+                    &format!("UPDATE lix_file SET data = X'6E6577' WHERE id = '{changed_file_id}'"),
+                    &[],
+                )
+                .await
+                .expect("file data update should succeed");
+        }
+
+        assert_eq!(
+            select_rows(
+                &session,
+                "SELECT id, path, previous_path, change_kind \
+                 FROM lix_file_working_change ORDER BY id",
+            )
+            .await,
+            vec![
+                vec![
+                    Value::Text(file_id.to_string()),
+                    Value::Text("/a.md".to_string()),
+                    Value::Text("/a.md".to_string()),
+                    Value::Text("modified".to_string()),
+                ],
+                vec![
+                    Value::Text(nested_file_id.to_string()),
+                    Value::Text("/existing/b.md".to_string()),
+                    Value::Text("/existing/b.md".to_string()),
+                    Value::Text("modified".to_string()),
+                ],
+            ],
+            "data-only file changes must resolve targeted file and ancestor descriptors",
+        );
+
+        session
+            .create_checkpoint()
+            .await
+            .expect("second baseline checkpoint should succeed");
+        session
+            .execute(&format!("DELETE FROM lix_file WHERE id = '{file_id}'"), &[])
+            .await
+            .expect("root file delete should succeed");
+        session
+            .execute(
+                &format!(
+                    "UPDATE lix_file SET path = '/existing/c.md' WHERE id = '{nested_file_id}'"
+                ),
+                &[],
+            )
+            .await
+            .expect("nested file rename should succeed");
+
+        assert_eq!(
+            select_rows(
+                &session,
+                "SELECT id, path, previous_path, change_kind \
+                 FROM lix_file_working_change ORDER BY id",
+            )
+            .await,
+            vec![
+                vec![
+                    Value::Text(file_id.to_string()),
+                    Value::Null,
+                    Value::Text("/a.md".to_string()),
+                    Value::Text("removed".to_string()),
+                ],
+                vec![
+                    Value::Text(nested_file_id.to_string()),
+                    Value::Text("/existing/c.md".to_string()),
+                    Value::Text("/existing/b.md".to_string()),
+                    Value::Text("modified".to_string()),
+                ],
+            ],
+            "descriptor-only removes and renames must use typed targeted keys",
+        );
+    }
+);
+
+simulation_test!(
     filesystem_working_change_surfaces_compose_paths_and_directory_moves,
     |sim| async move {
         let engine = sim.boot_engine().await;


### PR DESCRIPTION
## Summary

- construct targeted file and directory descriptor keys with their declared UUID primary-key type
- keep the narrow snapshot-loading path instead of falling back to a broad scan
- add regression coverage for root-level additions, data-only updates, files under existing directories, renames, and removals

## Root cause

`lix_file_working_change` collected changed filesystem IDs as strings and rebuilt targeted descriptor keys with `EntityPk::single`. Filesystem descriptor primary keys are typed UUIDs, so those string-typed keys did not match tracked-state rows. When a directory descriptor changed, the provider switched to an unfiltered scan, masking the mismatch and making all file changes appear again. Ancestor-directory lookups had the same typed-key bug.

## Impact

The surface now reports file working changes regardless of whether the working range also contains a directory descriptor change. This allows consumers to query `lix_file_working_change` directly for root files and data-only edits.

## Validation

- `cargo test -p lix_engine --features all-simulations`
- `cargo fmt --check`
- `git diff --check`

The full engine suite passed in both base and tracked-state-rebuild simulations.