### PR TITLE
Scale plugin imports by live working set, not document count

### DIFF
--- a/.changenotes/scale-plugin-imports-by-working-set.md
+++ b/.changenotes/scale-plugin-imports-by-working-set.md
@@ -1,0 +1,8 @@
+---
+type: minor
+---
+
+Plugin-backed atomic imports now scale independently of document count. The
+engine automatically reuses its bounded live-Store working set for fresh
+documents while retaining existing-document leases through commit, so callers
+no longer need a special single-writer ingestion API or actor-retention policy.

--- a/.changenotes/scale-plugin-imports-by-working-set.md
+++ b/.changenotes/scale-plugin-imports-by-working-set.md
@@ -3,6 +3,7 @@ type: minor
 ---
 
 Plugin-backed atomic imports now scale independently of document count. The
-engine automatically reuses its bounded live-Store working set for fresh
-documents while retaining existing-document leases through commit, so callers
-no longer need a special single-writer ingestion API or actor-retention policy.
+engine automatically reuses its bounded live-Store working set for fresh and
+existing documents while preserving actively contested same-file leases, so
+callers no longer need a special single-writer ingestion API or
+actor-retention policy.

--- a/.changenotes/scale-plugin-imports-by-working-set.md
+++ b/.changenotes/scale-plugin-imports-by-working-set.md
@@ -6,4 +6,5 @@ Plugin-backed atomic imports now scale independently of document count. The
 engine automatically reuses its bounded live-Store working set for fresh and
 existing documents while preserving actively contested same-file leases, so
 callers no longer need a special single-writer ingestion API or
-actor-retention policy.
+actor-retention policy. Retained session observations also recover from benign
+working-set eviction when their exact durable semantic root is unchanged.

--- a/packages/cli/src/commands/exp/git_replay.rs
+++ b/packages/cli/src/commands/exp/git_replay.rs
@@ -2748,7 +2748,7 @@ mod tests {
 
     #[test]
     fn rocksdb_replay_bounds_text_actor_lifecycle_across_hundred_commits() {
-        const TEXT_FILES: usize = 5;
+        const TEXT_FILES: usize = 17;
 
         let fixture = unique_temp_dir();
         let repo = fixture.join("repo");
@@ -2767,18 +2767,19 @@ mod tests {
             expected_final.push(bytes);
         }
         git_ok(&repo, &["add", "-A"]);
-        git_ok(&repo, &["commit", "-qm", "root five text files"]);
+        git_ok(&repo, &["commit", "-qm", "root text working set"]);
 
         // This one atomic replay batch updates every file that was just
         // imported. It exercises the cold-open Existing path as well as the
-        // five New actors in the root commit.
+        // New actors in the root commit, and deliberately exceeds the default
+        // 16-Store working set.
         for (index, bytes) in expected_final.iter_mut().enumerate() {
             *bytes = format!("second-{index}\n").into_bytes();
             fs::write(repo.join(format!("bulk-{index:02}.txt")), bytes)
                 .expect("second text fixture should write");
         }
         git_ok(&repo, &["add", "-A"]);
-        git_ok(&repo, &["commit", "-qm", "update five text files"]);
+        git_ok(&repo, &["commit", "-qm", "update broad text working set"]);
 
         for revision in 2..100 {
             let index = revision % TEXT_FILES;
@@ -2801,7 +2802,7 @@ mod tests {
             force: false,
             profile_json: Some(profile.clone()),
         })
-        .expect("100-commit replay with five semantic files should complete");
+        .expect("100-commit replay beyond the Store working set should complete");
 
         let profile_json: serde_json::Value =
             serde_json::from_slice(&fs::read(&profile).expect("replay profile should be written"))
@@ -2834,7 +2835,7 @@ mod tests {
             profile_json
                 .get("changed_paths_total")
                 .and_then(serde_json::Value::as_u64),
-            Some(108)
+            Some((TEXT_FILES * 2 + 98) as u64)
         );
         let commits = profile_json
             .get("commits")
@@ -2858,7 +2859,7 @@ mod tests {
                 .get("statement_count")
                 .and_then(serde_json::Value::as_u64),
             Some(2),
-            "five inserts and the replay marker must share one atomic batch"
+            "bulk inserts and the replay marker must share one atomic batch"
         );
         assert_eq!(
             commits[1]
@@ -2871,7 +2872,7 @@ mod tests {
                 .get("statement_count")
                 .and_then(serde_json::Value::as_u64),
             Some(TEXT_FILES as u64 + 1),
-            "five updates and the replay marker must share one atomic batch"
+            "bulk updates and the replay marker must share one atomic batch"
         );
 
         let storage = RocksDB::open(&output).expect("replay RocksDB should reopen");

--- a/packages/cli/src/commands/exp/git_replay.rs
+++ b/packages/cli/src/commands/exp/git_replay.rs
@@ -17,10 +17,6 @@ use zip::write::SimpleFileOptions;
 
 const PROGRESS_EVERY: usize = 10;
 const DEFAULT_INSERT_BATCH_ROWS: usize = 100;
-// The replay opens Lix with the default 16-Store v2 actor bound. Batches
-// that fit can populate the bounded cache; broader imports retire candidates
-// as they go so one transaction never exhausts admission.
-const RETAINED_PLUGIN_ACTOR_BATCH_LIMIT: usize = 16;
 // Four SHA-256 `<oid>\n` requests are 260 bytes, below POSIX `PIPE_BUF`.
 // Keeping each flush below that floor lets the caller enqueue a small request
 // window before draining responses without depending on a platform's larger
@@ -315,12 +311,7 @@ pub fn run(args: ExpGitReplayArgs) -> Result<(), CliError> {
             marker_only += 1;
         }
         let execute_started = Instant::now();
-        execute_statements_as_transaction(
-            &lix,
-            &statements,
-            commit_sha,
-            inserts.saturating_add(updates) <= RETAINED_PLUGIN_ACTOR_BATCH_LIMIT,
-        )?;
+        execute_statements_as_transaction(&lix, &statements, commit_sha)?;
         let execute_ms = duration_to_ms(execute_started.elapsed());
         phase_totals.execute_ms += execute_ms;
         applied += 1;
@@ -464,7 +455,6 @@ fn execute_statements_as_transaction(
     lix: &RocksLix,
     statements: &[SqlStatement],
     commit_sha: &str,
-    retain_plugin_actors: bool,
 ) -> Result<(), CliError> {
     let batch = statements
         .iter()
@@ -474,11 +464,7 @@ fn execute_statements_as_transaction(
         })
         .collect::<Vec<_>>();
 
-    db::block_on(lix.execute_batch_for_single_writer_ingest(
-        &batch,
-        retain_plugin_actors,
-    ))
-    .map_err(|error| {
+    db::block_on(lix.execute_batch(&batch)).map_err(|error| {
         let sql_preview = batch
             .first()
             .map(|statement| statement.sql.chars().take(160).collect::<String>())
@@ -670,7 +656,7 @@ fn seed_parent_tree(
     let prepared = prepare_commit_changes(state, &changes, &blob_by_oid)?;
     let statements = build_replay_commit_statements(&prepared, DEFAULT_INSERT_BATCH_ROWS);
     if !statements.is_empty() {
-        execute_statements_as_transaction(lix, &statements, parent_commit, false)?;
+        execute_statements_as_transaction(lix, &statements, parent_commit)?;
     }
     if verify_state {
         apply_prepared_to_expected_state(expected_state_by_id, &prepared);

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -13,7 +13,7 @@ use crate::live_state::LiveStateRowRequest;
 use crate::observe_coordinator::ObserveCoordinator;
 use crate::observe_invalidation::ObserveInvalidation;
 use crate::plugin::{
-    DEFAULT_MAX_LIVE_PLUGIN_FILE_ACTORS, DEFAULT_PLUGIN_V2_MEMORY_BYTES, PluginRuntimeHost,
+    DEFAULT_MAX_LIVE_PLUGIN_STORES, DEFAULT_PLUGIN_V2_MEMORY_BYTES, PluginRuntimeHost,
 };
 use crate::session::SessionContext;
 use crate::sql2::SqlPlanningCache;
@@ -52,7 +52,7 @@ pub struct EngineOptions {
     wasm_runtime: Option<Arc<dyn WasmRuntime>>,
     telemetry: Option<Arc<dyn TelemetrySink>>,
     plugin_v2_max_memory_bytes: u64,
-    plugin_v2_max_live_file_actors: usize,
+    plugin_v2_max_live_stores: usize,
 }
 
 impl Default for EngineOptions {
@@ -61,7 +61,7 @@ impl Default for EngineOptions {
             wasm_runtime: None,
             telemetry: None,
             plugin_v2_max_memory_bytes: DEFAULT_PLUGIN_V2_MEMORY_BYTES,
-            plugin_v2_max_live_file_actors: DEFAULT_MAX_LIVE_PLUGIN_FILE_ACTORS,
+            plugin_v2_max_live_stores: DEFAULT_MAX_LIVE_PLUGIN_STORES,
         }
     }
 }
@@ -81,19 +81,23 @@ impl EngineOptions {
         self
     }
 
-    /// Sets the per-actor Wasm linear-memory ceiling and the hard maximum
-    /// number of live v2 plugin Stores for this engine. Defaults are 64 MiB
-    /// and sixteen Stores, bounding guest linear memory to 1 GiB before
-    /// host-side document state. Cached actors, active transaction leases,
-    /// pending publications, cold-open candidates, and upgrade preflight
-    /// Stores all consume the same workspace-wide admission budget.
+    /// Sets the per-Store Wasm linear-memory ceiling and the hard maximum
+    /// number of simultaneously live v2 plugin Stores for this engine.
+    ///
+    /// The Store limit bounds the active working set, not the number of plugin
+    /// documents an atomic transaction may open. Fresh-document imports retire
+    /// completed Stores and reuse their slots while preserving atomic commit.
+    /// Defaults are 64 MiB and sixteen Stores, bounding guest linear memory to
+    /// 1 GiB before host-side document state. Cached actors, existing-document
+    /// transaction leases, pending publications, cold-open candidates, and
+    /// upgrade preflight Stores consume the same workspace-wide budget.
     pub fn with_plugin_v2_resource_limits(
         mut self,
         max_memory_bytes: u64,
-        max_live_file_actors: usize,
+        max_live_stores: usize,
     ) -> Self {
         self.plugin_v2_max_memory_bytes = max_memory_bytes;
-        self.plugin_v2_max_live_file_actors = max_live_file_actors;
+        self.plugin_v2_max_live_stores = max_live_stores;
         self
     }
 }
@@ -148,7 +152,7 @@ where
         let plugin_host = PluginRuntimeHost::new_with_v2_limits(
             wasm_runtime,
             options.plugin_v2_max_memory_bytes,
-            options.plugin_v2_max_live_file_actors,
+            options.plugin_v2_max_live_stores,
         )?;
 
         let tracked_state = Arc::new(TrackedStateContext::new());

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -85,12 +85,14 @@ impl EngineOptions {
     /// number of simultaneously live v2 plugin Stores for this engine.
     ///
     /// The Store limit bounds the active working set, not the number of plugin
-    /// documents an atomic transaction may open. Fresh-document imports retire
-    /// completed Stores and reuse their slots while preserving atomic commit.
+    /// documents an atomic transaction may open. Transactions retire completed
+    /// Stores and reuse their slots while preserving atomic commit.
     /// Defaults are 64 MiB and sixteen Stores, bounding guest linear memory to
-    /// 1 GiB before host-side document state. Cached actors, existing-document
-    /// transaction leases, pending publications, cold-open candidates, and
-    /// upgrade preflight Stores consume the same workspace-wide budget.
+    /// 1 GiB before host-side document state. Cached actors, active
+    /// existing-document transaction leases, pending publications, cold-open
+    /// candidates, and upgrade preflight Stores consume the same
+    /// workspace-wide budget. Completed publications may retire their Stores
+    /// under pressure and cold-open again after commit.
     pub fn with_plugin_v2_resource_limits(
         mut self,
         max_memory_bytes: u64,

--- a/packages/engine/src/plugin/actor.rs
+++ b/packages/engine/src/plugin/actor.rs
@@ -18,7 +18,7 @@ use super::incremental::FileBytesSha256;
 use crate::wasm::{WasmComponentV2Actor, WasmDocumentHandle};
 use crate::{Blob, LixError};
 
-pub(crate) const DEFAULT_MAX_LIVE_PLUGIN_FILE_ACTORS: usize = 16;
+pub(crate) const DEFAULT_MAX_LIVE_PLUGIN_STORES: usize = 16;
 // One predecessor is enough for the required two-reader serialization while
 // keeping each file actor's retained working set bounded.
 pub(crate) const DEFAULT_MAX_PLUGIN_FILE_HISTORY: usize = 1;
@@ -161,7 +161,7 @@ struct PluginActorExpectedStale {
 
 impl Default for PluginActorCache {
     fn default() -> Self {
-        Self::new(DEFAULT_MAX_LIVE_PLUGIN_FILE_ACTORS)
+        Self::new(DEFAULT_MAX_LIVE_PLUGIN_STORES)
             .expect("the default plugin actor capacity is nonzero")
     }
 }
@@ -702,7 +702,7 @@ fn plugin_store_resource_limit(capacity: NonZeroUsize) -> LixError {
         ),
     )
     .with_hint(
-        "commit or split transactions retaining plugin actors, or raise EngineOptions::with_plugin_v2_resource_limits",
+        "finish transactions holding existing-document plugin leases, or raise EngineOptions::with_plugin_v2_resource_limits",
     )
 }
 

--- a/packages/engine/src/plugin/component.rs
+++ b/packages/engine/src/plugin/component.rs
@@ -6,7 +6,7 @@ use crate::common::LixError;
 use crate::wasm::{WasmComponentV2Factory, WasmLimits, WasmRuntime, WasmTransitionCounters};
 
 use super::{
-    CompiledPluginCatalog, DEFAULT_MAX_LIVE_PLUGIN_FILE_ACTORS, InstalledPlugin, PluginActorCache,
+    CompiledPluginCatalog, DEFAULT_MAX_LIVE_PLUGIN_STORES, InstalledPlugin, PluginActorCache,
     PluginCatalogCache, PluginRegistry,
 };
 
@@ -72,7 +72,7 @@ impl PluginRuntimeHost {
         Self::new_with_v2_limits(
             wasm_runtime,
             DEFAULT_PLUGIN_V2_MEMORY_BYTES,
-            DEFAULT_MAX_LIVE_PLUGIN_FILE_ACTORS,
+            DEFAULT_MAX_LIVE_PLUGIN_STORES,
         )
         .expect("default plugin resource limits are valid")
     }
@@ -80,13 +80,13 @@ impl PluginRuntimeHost {
     pub(crate) fn new_with_v2_limits(
         wasm_runtime: Arc<dyn WasmRuntime>,
         max_memory_bytes: u64,
-        max_live_file_actors: usize,
+        max_live_stores: usize,
     ) -> Result<Self, LixError> {
         Ok(Self {
             wasm_runtime,
             plugin_v2_factory_cache: Arc::new(Mutex::new(BTreeMap::new())),
             plugin_v2_wasm_limits: plugin_v2_wasm_limits(max_memory_bytes)?,
-            plugin_actor_cache: PluginActorCache::new(max_live_file_actors)?,
+            plugin_actor_cache: PluginActorCache::new(max_live_stores)?,
             plugin_v2_transition_counters: Arc::new(Mutex::new(WasmTransitionCounters::default())),
             plugin_catalog_cache: Arc::new(Mutex::new(PluginCatalogCache::default())),
             plugin_registry_read_cache: Arc::new(Mutex::new(PluginRegistryReadCache::default())),
@@ -268,7 +268,7 @@ mod tests {
             64 * 1024 * 1024
         );
         assert_eq!(
-            DEFAULT_PLUGIN_V2_MEMORY_BYTES * DEFAULT_MAX_LIVE_PLUGIN_FILE_ACTORS as u64,
+            DEFAULT_PLUGIN_V2_MEMORY_BYTES * DEFAULT_MAX_LIVE_PLUGIN_STORES as u64,
             1024 * 1024 * 1024
         );
         assert_eq!(

--- a/packages/engine/src/plugin/mod.rs
+++ b/packages/engine/src/plugin/mod.rs
@@ -16,8 +16,8 @@ mod registry;
 mod storage;
 
 pub(crate) use actor::{
-    DEFAULT_MAX_LIVE_PLUGIN_FILE_ACTORS, PluginActorCache, PluginActorColdInstall,
-    PluginActorColdOpen, PluginActorKey, PluginActorLease, PluginActorStore, PluginObservation,
+    DEFAULT_MAX_LIVE_PLUGIN_STORES, PluginActorCache, PluginActorColdInstall, PluginActorColdOpen,
+    PluginActorKey, PluginActorLease, PluginActorStore, PluginActorStorePermit, PluginObservation,
 };
 pub(crate) use archive::{ParsedPluginArchive, parse_plugin_archive_for_install};
 pub(crate) use component::{DEFAULT_PLUGIN_V2_MEMORY_BYTES, PluginRuntimeHost};

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -1146,41 +1146,6 @@ where
         .await
     }
 
-    /// Executes one atomic import batch whose caller serializes every writer
-    /// that could transition the same plugin-owned files.
-    ///
-    /// The caller may retain actors when the batch fits the configured live
-    /// Store bound, or retire them for a broad one-shot import. Retained actors
-    /// remain bounded cache candidates but are not session acknowledgements
-    /// across batches. Do not use this for concurrent mutation workloads:
-    /// ordinary execution retains acknowledged actor leases through commit to
-    /// compose concurrent semantic transitions.
-    #[doc(hidden)]
-    pub async fn execute_batch_for_single_writer_ingest(
-        &self,
-        statements: &[ExecuteBatchStatement],
-        retain_plugin_actors: bool,
-    ) -> Result<Vec<ExecuteResult>, LixError> {
-        let result = self
-            .execute_batch_with_options_and_metadata_inner(
-                statements,
-                ExecuteOptions::default(),
-                vec![ExecuteStatementMetadata::default(); statements.len()],
-                None,
-                false,
-                retain_plugin_actors,
-            )
-            .await;
-        // A serialized importer submits authoritative successor bytes rather
-        // than edits based on a session acknowledgement. Keep any bounded
-        // private actors as reusable cold-open candidates, but never expose
-        // their observations as acknowledgement authority across batches:
-        // normal cache eviction would otherwise turn a later import into a
-        // stale-observation error instead of a safe cold open.
-        self.file_views.clear();
-        result
-    }
-
     #[doc(hidden)]
     pub async fn execute_batch_with_options_and_metadata(
         &self,
@@ -1194,7 +1159,6 @@ where
             statement_metadata,
             None,
             false,
-            true,
         )
         .await
     }
@@ -1206,7 +1170,6 @@ where
         statement_metadata: Vec<ExecuteStatementMetadata>,
         idempotency: Option<ExecuteIdempotency>,
         require_idempotency_for_writes: bool,
-        retain_plugin_actor_publications: bool,
     ) -> Result<Vec<ExecuteResult>, LixError> {
         let telemetry = start_batch(
             self.telemetry.as_ref(),
@@ -1219,7 +1182,6 @@ where
             statement_metadata,
             idempotency,
             require_idempotency_for_writes,
-            retain_plugin_actor_publications,
         );
         let result = match telemetry.as_ref() {
             Some(telemetry) => telemetry.instrument(operation).await,
@@ -1248,7 +1210,6 @@ where
             statement_metadata,
             idempotency,
             true,
-            true,
         )
         .await
     }
@@ -1260,7 +1221,6 @@ where
         statement_metadata: Vec<ExecuteStatementMetadata>,
         idempotency: Option<ExecuteIdempotency>,
         require_idempotency_for_writes: bool,
-        retain_plugin_actor_publications: bool,
     ) -> Result<Vec<ExecuteResult>, LixError> {
         self.ensure_open()?;
         if statements.is_empty() {
@@ -1310,7 +1270,6 @@ where
                             options,
                             statement_metadata,
                             None,
-                            retain_plugin_actor_publications,
                         )
                         .await;
                 }
@@ -1328,7 +1287,6 @@ where
                             options,
                             statement_metadata,
                             None,
-                            retain_plugin_actor_publications,
                         )
                         .await;
                 };
@@ -1344,7 +1302,6 @@ where
                         options,
                         statement_metadata,
                         Some(idempotency.clone()),
-                        retain_plugin_actor_publications,
                     )
                     .await;
                 match result {
@@ -1383,12 +1340,10 @@ where
         options: ExecuteOptions,
         statement_metadata: Vec<ExecuteStatementMetadata>,
         idempotency: Option<ExecuteIdempotency>,
-        retain_plugin_actor_publications: bool,
     ) -> Result<Vec<ExecuteResult>, LixError> {
         let telemetry_sink = self.telemetry.clone();
         self.with_write_transaction(move |transaction| {
             Box::pin(async move {
-                transaction.set_retain_plugin_actor_publications(retain_plugin_actor_publications);
                 if let Some(results) = try_execute_transaction_parameter_batch(
                     transaction,
                     &statements,
@@ -3397,46 +3352,6 @@ mod tests {
             sql: sql.to_string(),
             params: Vec::new(),
         }
-    }
-
-    #[tokio::test]
-    async fn single_writer_ingest_never_carries_acknowledgement_authority_across_batches() {
-        let session = open_session().await;
-        let view_key = sql2::SessionFileViewKey::new("branch", "file");
-        session.file_views.remember_plugin_file_view(
-            view_key.clone(),
-            sql2::SessionPluginFileView {
-                path: "/file.txt".to_string(),
-                plugin_key: "plugin".to_string(),
-                plugin_generation: "generation".to_string(),
-                owner_change_id: "owner".to_string(),
-                observation: None,
-            },
-        );
-        assert!(
-            session
-                .file_views
-                .has_plugin_file_at_path("branch", "/file.txt")
-        );
-
-        session
-            .execute_batch_for_single_writer_ingest(
-                &[batch_statement(
-                    "INSERT INTO lix_key_value (key, value) \
-                     VALUES ('single-writer-ingest', lix_json('{}'))",
-                )],
-                true,
-            )
-            .await
-            .expect("serialized ingest should commit");
-
-        assert!(
-            session
-                .file_views
-                .plugin_file_view(&view_key, "plugin", "generation", "owner")
-                .is_none(),
-            "serialized ingestion may cache actors but must clear session acknowledgement authority"
-        );
     }
 
     #[test]

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -56,11 +56,12 @@ use crate::live_state::{
 use crate::plugin::{
     ArcByteSource, BoundCreateContext, CompiledPluginCatalog, FileBytesSha256, PLUGIN_OWNER_KEY,
     PLUGIN_REGISTRY_KEY, PluginActorCache, PluginActorColdInstall, PluginActorColdOpen,
-    PluginActorKey, PluginActorLease, PluginActorStore, PluginArchiveInstallPlan,
-    PluginContentType, PluginFileOwner, PluginMaterialization, PluginObservation, PluginRegistry,
-    PluginRegistryEntry, PluginRegistryEntryInput, PluginRuntimeHost, V2SchemaAllowlist,
-    ValidatedConflictTransition, ValidatedSameLengthOutputSplice, VecEntityChangeSource,
-    VecEntityConflictSource, VecEntitySource, build_file_update_splices, canonicalize_v2_snapshot,
+    PluginActorKey, PluginActorLease, PluginActorStore, PluginActorStorePermit,
+    PluginArchiveInstallPlan, PluginContentType, PluginFileOwner, PluginMaterialization,
+    PluginObservation, PluginRegistry, PluginRegistryEntry, PluginRegistryEntryInput,
+    PluginRuntimeHost, V2SchemaAllowlist, ValidatedConflictTransition,
+    ValidatedSameLengthOutputSplice, VecEntityChangeSource, VecEntityConflictSource,
+    VecEntitySource, build_file_update_splices, canonicalize_v2_snapshot,
     drain_conflict_transition_resolutions, drain_entity_transition_edits,
     drain_file_transition_changes, host_entity_change_with_lazy_snapshot,
     host_entity_with_lazy_snapshot, inferred_media_type_for_path, is_plugin_storage_path,
@@ -335,7 +336,6 @@ pub(crate) struct Transaction<StorageImpl: Storage = Memory> {
     origin_key: Option<SharedStr>,
     idempotency_receipt: Option<(crate::storage_adapter::StorageKey, Vec<u8>)>,
     session_file_views: SessionFileViews,
-    retain_plugin_actor_publications: bool,
     pending_file_view_mutations: BTreeMap<SessionFileViewKey, SessionFileViewMutation>,
     pending_plugin_actor_publications: Vec<PendingPluginActorPublication>,
     plugin_generation_read_guard: Option<tokio::sync::OwnedRwLockReadGuard<()>>,
@@ -586,7 +586,6 @@ where
                 origin_key: None,
                 idempotency_receipt: None,
                 session_file_views,
-                retain_plugin_actor_publications: true,
                 pending_file_view_mutations: BTreeMap::new(),
                 pending_plugin_actor_publications: Vec::new(),
                 plugin_generation_read_guard: None,
@@ -817,12 +816,32 @@ where
         self.trust_filesystem_planner = true;
     }
 
-    /// Bulk import only needs the durable rows produced by a plugin, not a
-    /// warm private Wasm document for every imported file. Retaining those
-    /// documents through one atomic commit can exceed the engine-wide actor
-    /// bound before the transaction is allowed to publish them.
-    pub(crate) fn set_retain_plugin_actor_publications(&mut self, retain: bool) {
-        self.retain_plugin_actor_publications = retain;
+    /// Admits a Store for a file that has no durable plugin actor yet.
+    ///
+    /// Fresh documents are independent until this transaction commits. When
+    /// their pending Stores fill the working set, retire the oldest fresh
+    /// candidate after its durable rows and materialization have been staged,
+    /// then reuse that admission slot. Existing-file leases are never retired
+    /// here: they serialize semantic successors through the commit boundary.
+    async fn admit_fresh_plugin_store(
+        &mut self,
+        current_publications: &mut Vec<PendingPluginActorPublication>,
+    ) -> Result<PluginActorStorePermit, LixError> {
+        loop {
+            match self.plugin_host.actor_cache().admit_store() {
+                Ok(permit) => return Ok(permit),
+                Err(error) if error.code == LixError::CODE_PLUGIN_RESOURCE_LIMIT => {
+                    if retire_oldest_fresh_actor(current_publications).await
+                        || retire_oldest_fresh_actor(&mut self.pending_plugin_actor_publications)
+                            .await
+                    {
+                        continue;
+                    }
+                    return Err(error);
+                }
+                Err(error) => return Err(error),
+            }
+        }
     }
 
     /// Rolls back the storage transaction.
@@ -3412,7 +3431,9 @@ where
                     create_rows,
                 )
             } else {
-                let store_permit = self.plugin_host.actor_cache().admit_store()?;
+                let store_permit = self
+                    .admit_fresh_plugin_store(&mut reconciliation.actor_publications)
+                    .await?;
                 let mut actor = factory
                     .instantiate_actor()
                     .instrument(tracing::debug_span!(
@@ -3530,11 +3551,6 @@ where
             reconciliation
                 .materialization_versions
                 .insert(file_key.clone(), materialization_version);
-            let publication = if self.retain_plugin_actor_publications {
-                publication
-            } else {
-                publication.into_uncached().await
-            };
             reconciliation.actor_publications.push(publication);
             reconciled_file_keys.insert(file_key);
         }
@@ -3847,11 +3863,6 @@ where
                 .as_mut()
                 .expect("semantic groups promote the reconciled row batch");
             rows.put_prepared_batch_at(&group.row_indices, prepared)?;
-            let publication = if self.retain_plugin_actor_publications {
-                publication
-            } else {
-                publication.into_uncached().await
-            };
             reconciliation.actor_publications.push(publication);
             reconciled_file_keys.insert(file_key);
         }
@@ -6088,6 +6099,18 @@ impl PendingPluginActorPublication {
             }
         }
     }
+}
+
+async fn retire_oldest_fresh_actor(publications: &mut Vec<PendingPluginActorPublication>) -> bool {
+    let Some(index) = publications
+        .iter()
+        .position(|publication| matches!(publication, PendingPluginActorPublication::New { .. }))
+    else {
+        return false;
+    };
+    let publication = publications.remove(index).into_uncached().await;
+    publications.insert(index, publication);
+    true
 }
 
 /// Builds the file write for an accepted semantic renderer transition.

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -819,10 +819,9 @@ where
     /// Admits a Store for a file that has no durable plugin actor yet.
     ///
     /// Fresh documents are independent until this transaction commits. When
-    /// their pending Stores fill the working set, retire the oldest fresh
+    /// their pending Stores fill the working set, retire the oldest completed
     /// candidate after its durable rows and materialization have been staged,
-    /// then reuse that admission slot. Existing-file leases are never retired
-    /// here: they serialize semantic successors through the commit boundary.
+    /// then reuse that admission slot.
     async fn admit_fresh_plugin_store(
         &mut self,
         current_publications: &mut Vec<PendingPluginActorPublication>,
@@ -831,9 +830,11 @@ where
             match self.plugin_host.actor_cache().admit_store() {
                 Ok(permit) => return Ok(permit),
                 Err(error) if error.code == LixError::CODE_PLUGIN_RESOURCE_LIMIT => {
-                    if retire_oldest_fresh_actor(current_publications).await
-                        || retire_oldest_fresh_actor(&mut self.pending_plugin_actor_publications)
-                            .await
+                    if retire_oldest_completed_actor(current_publications).await
+                        || retire_oldest_completed_actor(
+                            &mut self.pending_plugin_actor_publications,
+                        )
+                        .await
                     {
                         continue;
                     }
@@ -1156,6 +1157,7 @@ where
         plugin: &PluginRegistryEntry,
         descriptor: WasmFileDescriptor,
         factory: Arc<dyn WasmComponentV2Factory>,
+        current_publications: &mut Vec<PendingPluginActorPublication>,
     ) -> Result<PluginObservation, LixError> {
         let cache = self.plugin_host.actor_cache();
         let _cold_open_guard = cache.cold_open_guard().await;
@@ -1229,7 +1231,23 @@ where
             PluginActorColdOpen::Ready(observation) => return Ok(observation),
             PluginActorColdOpen::Build(cold_install) => cold_install,
         };
-        let store_permit = cache.admit_cold_store(&mut cold_install)?;
+        let store_permit = loop {
+            match cache.admit_cold_store(&mut cold_install) {
+                Ok(permit) => break permit,
+                Err(error) if error.code == LixError::CODE_PLUGIN_RESOURCE_LIMIT => {
+                    if retire_oldest_completed_actor(current_publications).await
+                        || retire_oldest_completed_actor(
+                            &mut self.pending_plugin_actor_publications,
+                        )
+                        .await
+                    {
+                        continue;
+                    }
+                    return Err(error);
+                }
+                Err(error) => return Err(error),
+            }
+        };
         let rows = overlay_scan_batch(
             &base,
             &staged,
@@ -3154,6 +3172,7 @@ where
                                 selected,
                                 descriptor.clone(),
                                 Arc::clone(&factory),
+                                &mut reconciliation.actor_publications,
                             )
                             .await?
                         }
@@ -3177,6 +3196,7 @@ where
                             selected,
                             descriptor.clone(),
                             Arc::clone(&factory),
+                            &mut reconciliation.actor_publications,
                         )
                         .await?
                     }
@@ -3716,6 +3736,7 @@ where
                                 &group.plugin,
                                 descriptor.clone(),
                                 factory,
+                                &mut reconciliation.actor_publications,
                             )
                             .instrument(tracing::debug_span!(
                                 target: "lix_perf",
@@ -5988,8 +6009,8 @@ enum PendingPluginActorPublication {
         semantic_root: Arc<str>,
         view: PendingPluginActorView,
     },
-    /// The plugin transition has already produced its durable rows, but bulk
-    /// ingestion deliberately does not keep its private Wasm Store alive.
+    /// The plugin transition has already produced its durable rows, but the
+    /// bounded working set does not keep its private Wasm Store alive.
     /// Keeping this marker preserves the normal one-transition-per-file
     /// validation and gives the session a non-authoritative file view after
     /// commit, forcing a cold open before any later edit.
@@ -6101,11 +6122,21 @@ impl PendingPluginActorPublication {
     }
 }
 
-async fn retire_oldest_fresh_actor(publications: &mut Vec<PendingPluginActorPublication>) -> bool {
-    let Some(index) = publications
-        .iter()
-        .position(|publication| matches!(publication, PendingPluginActorPublication::New { .. }))
-    else {
+/// Releases the oldest completed Store retained only for post-commit cache
+/// publication. Existing-file successors keep their durable staged rows but
+/// become uncached. Dropping their leases makes the predecessor slot evictable
+/// only when no concurrent transition references it; an active or waiting
+/// same-file lease therefore still preserves serialization.
+async fn retire_oldest_completed_actor(
+    publications: &mut Vec<PendingPluginActorPublication>,
+) -> bool {
+    let Some(index) = publications.iter().position(|publication| {
+        matches!(
+            publication,
+            PendingPluginActorPublication::Existing { .. }
+                | PendingPluginActorPublication::New { .. }
+        )
+    }) else {
         return false;
     };
     let publication = publications.remove(index).into_uncached().await;

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -1424,6 +1424,55 @@ where
             .await
     }
 
+    /// Leases an acknowledged actor, cold-opening only when cache eviction is
+    /// the sole reason the observation no longer resolves.
+    ///
+    /// The durable semantic root must still exactly match the root delivered
+    /// with the observation. A concurrent committed transition therefore
+    /// remains stale and cannot be mistaken for benign working-set eviction.
+    async fn lease_or_reopen_observed_v2_actor(
+        &mut self,
+        observation: &PluginObservation,
+        actor_key: &PluginActorKey,
+        plugin: &PluginRegistryEntry,
+        descriptor: WasmFileDescriptor,
+        factory: Arc<dyn WasmComponentV2Factory>,
+        current_publications: &mut Vec<PendingPluginActorPublication>,
+    ) -> Result<PluginActorLease, LixError> {
+        let cache = self.plugin_host.actor_cache();
+        match cache.lease_for_transition(observation).await {
+            Ok(lease) => return Ok(lease),
+            Err(error) if error.code == LixError::CODE_PLUGIN_OBSERVATION_STALE => {
+                let file_key = PluginFileWriteKey {
+                    branch_id: actor_key.branch_id.clone(),
+                    global: false,
+                    untracked: false,
+                    file_id: actor_key.file_id.clone(),
+                };
+                let Some(visible_materialization) =
+                    self.visible_v2_materialization(&file_key).await?
+                else {
+                    return Err(error);
+                };
+                if visible_materialization.semantic_root != observation.semantic_root() {
+                    return Err(error);
+                }
+            }
+            Err(error) => return Err(error),
+        }
+
+        let reopened = self
+            .cold_open_v2_semantic_actor(
+                actor_key,
+                plugin,
+                descriptor,
+                factory,
+                current_publications,
+            )
+            .await?;
+        cache.lease_for_transition(&reopened).await
+    }
+
     async fn load_visible_exact_live_state_batch(
         &mut self,
         request: &LiveStateExactBatchRequest,
@@ -3210,13 +3259,20 @@ where
                 }
                 let before_descriptor = v2_file_descriptor_from_actor_key(observation.key());
                 let after_descriptor = descriptor.clone();
-                let cache = self.plugin_host.actor_cache();
-                // Acquire serialization first, then read the root again.
-                // A second local session may have committed while this
-                // request waited for the actor; reading before the lease
-                // would mistake that valid serialization for an external
-                // stale-cache race.
-                let mut lease = cache.lease_for_transition(&observation).await?;
+                // Acquire serialization first, reopening a benignly evicted
+                // observation only while its exact durable root is unchanged.
+                // Then read the root again: a second local session may have
+                // committed while this request waited for the actor.
+                let mut lease = self
+                    .lease_or_reopen_observed_v2_actor(
+                        &observation,
+                        &actor_key,
+                        selected,
+                        descriptor.clone(),
+                        Arc::clone(&factory),
+                        &mut reconciliation.actor_publications,
+                    )
+                    .await?;
                 let visible_materialization = self
                     .visible_v2_materialization(&file_key)
                     .await?

--- a/packages/rs-sdk-tests/PLUGIN_DOCUMENT_SCALE.md
+++ b/packages/rs-sdk-tests/PLUGIN_DOCUMENT_SCALE.md
@@ -1,0 +1,70 @@
+# Plugin document-scale profile
+
+This profile guards the invariant that an atomic plugin-backed import is
+bounded by the configured live-Store working set, not by its document count.
+The executable conformance fixture is
+`tests/plugin_document_scale.rs`.
+
+## Reproduce
+
+Build the release fixture once, then time the executable directly so Cargo and
+compilation are outside the measurement:
+
+```sh
+CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 \
+  cargo test --release -p lix_sdk_tests \
+  --test plugin_document_scale --no-run
+
+PLUGIN_DOCUMENT_SCALE_BIN="$(find target/release/deps -maxdepth 1 \
+  -type f -executable -name 'plugin_document_scale-*' -print -quit)"
+
+/usr/bin/time -v "$PLUGIN_DOCUMENT_SCALE_BIN" \
+  --exact atomic_markdown_import_scales_to_1184_documents \
+  --nocapture --test-threads=1
+
+perf stat -x, \
+  -e task-clock,cycles,instructions,branches,branch-misses,cache-misses \
+  "$PLUGIN_DOCUMENT_SCALE_BIN" \
+  --exact atomic_markdown_import_scales_to_1184_documents \
+  --nocapture --test-threads=1
+```
+
+The fixture installs the production Markdown component before timing, then
+executes one public `execute_batch` statement containing 1,184 fresh Markdown
+documents. It verifies the committed file count, semantic rows, and exact bytes
+from the first and last files. CSV, Git-text, and Excalidraw run the same
+capacity-plus-one conformance check.
+
+## Results
+
+Measured on Linux x86-64 with Rust nightly 1.97.0 and the release profile.
+Seven warm-cache runs used fresh processes and the same 30,932-byte logical
+fixture:
+
+| Metric | Result |
+| --- | ---: |
+| Documents | 1,184 |
+| Atomic import p50 | 578.739 ms |
+| Atomic import p95 | 608.904 ms |
+| p50 per document | 0.489 ms |
+| Warm whole-process wall time | 690 ms |
+| Warm peak RSS | 149,064 KiB |
+| Swaps | 0 |
+
+A profiled warm run completed the measured import in 585.505 ms with these
+counters:
+
+| Counter | Result |
+| --- | ---: |
+| task-clock | 785.07 ms |
+| cycles | 2,357,089,796 |
+| instructions | 4,584,533,807 |
+| branches | 839,994,658 |
+| branch misses | 14,814,239 |
+| cache misses | 41,726,648 |
+
+The exact `origin/main` baseline (`f860b30ea`) rejects the capacity-plus-one
+fixture before commit with `LIX_ERROR_PLUGIN_RESOURCE_LIMIT`: its 16 live
+Stores are held by the first 16 fresh documents. The candidate keeps that same
+16-Store resource ceiling, retires completed fresh-document Stores as pressure
+requires, and retains the most recent bounded working set for reuse.

--- a/packages/rs-sdk-tests/PLUGIN_DOCUMENT_SCALE.md
+++ b/packages/rs-sdk-tests/PLUGIN_DOCUMENT_SCALE.md
@@ -44,27 +44,28 @@ fixture:
 | Metric | Result |
 | --- | ---: |
 | Documents | 1,184 |
-| Atomic import p50 | 578.739 ms |
-| Atomic import p95 | 608.904 ms |
-| p50 per document | 0.489 ms |
-| Warm whole-process wall time | 690 ms |
-| Warm peak RSS | 149,064 KiB |
+| Atomic import p50 | 594.637 ms |
+| Atomic import p95 | 604.307 ms |
+| p50 per document | 0.502 ms |
+| Warm whole-process wall time | 680 ms |
+| Warm peak RSS | 148,848 KiB |
 | Swaps | 0 |
 
-A profiled warm run completed the measured import in 585.505 ms with these
+A profiled warm run completed the measured import in 577.842 ms with these
 counters:
 
 | Counter | Result |
 | --- | ---: |
-| task-clock | 785.07 ms |
-| cycles | 2,357,089,796 |
-| instructions | 4,584,533,807 |
-| branches | 839,994,658 |
-| branch misses | 14,814,239 |
-| cache misses | 41,726,648 |
+| task-clock | 775.27 ms |
+| cycles | 2,349,944,681 |
+| instructions | 4,583,514,106 |
+| branches | 839,576,968 |
+| branch misses | 14,714,570 |
+| cache misses | 41,646,839 |
 
 The exact `origin/main` baseline (`f860b30ea`) rejects the capacity-plus-one
 fixture before commit with `LIX_ERROR_PLUGIN_RESOURCE_LIMIT`: its 16 live
 Stores are held by the first 16 fresh documents. The candidate keeps that same
-16-Store resource ceiling, retires completed fresh-document Stores as pressure
-requires, and retains the most recent bounded working set for reuse.
+16-Store resource ceiling, retires completed fresh- or existing-document Stores
+as pressure requires, preserves actively contested same-file leases, and
+retains the most recent bounded working set for reuse.

--- a/packages/rs-sdk-tests/PLUGIN_DOCUMENT_SCALE.md
+++ b/packages/rs-sdk-tests/PLUGIN_DOCUMENT_SCALE.md
@@ -33,7 +33,9 @@ The fixture installs the production Markdown component before timing, then
 executes one public `execute_batch` statement containing 1,184 fresh Markdown
 documents. It verifies the committed file count, semantic rows, and exact bytes
 from the first and last files. CSV, Git-text, and Excalidraw run the same
-capacity-plus-one conformance check.
+capacity-plus-one conformance check. A sequential Git-text fixture imports 17
+files, then updates them in deterministic path order to prove retained session
+observations survive cache eviction between atomic batches.
 
 ## Results
 

--- a/packages/rs-sdk-tests/tests/plugin_document_scale.rs
+++ b/packages/rs-sdk-tests/tests/plugin_document_scale.rs
@@ -1,0 +1,283 @@
+use std::fs;
+use std::io::{Cursor, Write};
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use lix_sdk::{ExecuteBatchStatement, Lix, OpenLixOptions, Storage, Value, open_lix};
+
+const MARKDOWN_PLUGIN_KEY: &str = "plugin_markdown_incremental_v2";
+
+#[tokio::test]
+async fn atomic_markdown_import_scales_to_1184_documents() {
+    assert_format_scales(
+        MARKDOWN_PLUGIN_KEY,
+        build_markdown_v2_plugin_archive(),
+        "md",
+        (0..1_184)
+            .map(|index| format!("# Document {index}\n\nBody {index}.\n").into_bytes())
+            .collect(),
+        "markdown_node_v2",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn atomic_plugin_import_scaling_is_format_independent() {
+    assert_format_scales(
+        "plugin_csv_v2",
+        build_csv_v2_plugin_archive(),
+        "csv",
+        (0..17)
+            .map(|index| format!("name,value\nrow-{index},{index}\n").into_bytes())
+            .collect(),
+        "csv_v2_row",
+    )
+    .await;
+    assert_format_scales(
+        "plugin_git_text_v2",
+        build_git_text_v2_plugin_archive(),
+        "txt",
+        (0..17)
+            .map(|index| format!("line {index}\nsecond line {index}\n").into_bytes())
+            .collect(),
+        "git_text_line_v2",
+    )
+    .await;
+    assert_format_scales(
+        "plugin_excalidraw_v2",
+        build_excalidraw_v2_plugin_archive(),
+        "excalidraw",
+        (0..17)
+            .map(|index| {
+                format!(
+                    r#"{{"type":"excalidraw","version":2,"source":"https://excalidraw.com","elements":[{{"id":"shape-{index}","type":"rectangle","x":{index},"y":2,"width":3,"height":4,"isDeleted":false}}],"appState":{{}},"files":{{}}}}"#
+                )
+                .into_bytes()
+            })
+            .collect(),
+        "excalidraw_element",
+    )
+    .await;
+}
+
+async fn assert_format_scales(
+    plugin_key: &str,
+    archive: Vec<u8>,
+    extension: &str,
+    documents: Vec<Vec<u8>>,
+    semantic_table: &str,
+) -> Duration {
+    let lix = open_lix(OpenLixOptions::default())
+        .await
+        .expect("document-scale workspace should open");
+    install_plugin(&lix, plugin_key, &archive).await;
+
+    let expected_count = documents.len();
+    let first = documents.first().cloned().unwrap();
+    let last = documents.last().cloned().unwrap();
+    let input_bytes = documents.iter().map(Vec::len).sum::<usize>();
+    let statement = file_insert_statement(extension, documents);
+    let started = Instant::now();
+    let results = lix
+        .execute_batch(&[statement])
+        .await
+        .expect("an atomic import must not be bounded by the live actor working set");
+    let elapsed = started.elapsed();
+    eprintln!(
+        "plugin_document_scale format={extension} documents={expected_count} input_bytes={input_bytes} elapsed_ms={:.3} per_document_us={:.3}",
+        elapsed.as_secs_f64() * 1_000.0,
+        elapsed.as_secs_f64() * 1_000_000.0 / expected_count as f64,
+    );
+    assert_eq!(results[0].rows_affected(), expected_count as u64);
+
+    let files = lix
+        .execute(
+            "SELECT COUNT(*) AS count FROM lix_file WHERE path LIKE '/scale-document-%'",
+            &[],
+        )
+        .await
+        .expect("imported documents should query");
+    assert_eq!(
+        files.rows()[0].get::<i64>("count").unwrap(),
+        expected_count as i64
+    );
+    let semantic_rows = lix
+        .execute(
+            &format!("SELECT COUNT(*) AS count FROM {semantic_table}"),
+            &[],
+        )
+        .await
+        .expect("semantic rows should query");
+    assert!(
+        semantic_rows.rows()[0].get::<i64>("count").unwrap() >= expected_count as i64,
+        "{plugin_key} should materialize semantic state for every document"
+    );
+    assert_eq!(
+        read_file(&lix, &format!("/scale-document-0000.{extension}")).await,
+        first
+    );
+    assert_eq!(
+        read_file(
+            &lix,
+            &format!("/scale-document-{:04}.{extension}", expected_count - 1)
+        )
+        .await,
+        last
+    );
+
+    lix.close()
+        .await
+        .expect("document-scale workspace should close");
+    elapsed
+}
+
+fn file_insert_statement(
+    extension: &str,
+    documents: impl IntoIterator<Item = Vec<u8>>,
+) -> ExecuteBatchStatement {
+    let mut sql = String::from("INSERT INTO lix_file (path, data) VALUES ");
+    let mut params = Vec::new();
+    for (index, document) in documents.into_iter().enumerate() {
+        if index > 0 {
+            sql.push(',');
+        }
+        let path_parameter = params.len() + 1;
+        let data_parameter = params.len() + 2;
+        sql.push_str(&format!("(${path_parameter}, ${data_parameter})"));
+        params.push(Value::Text(format!(
+            "/scale-document-{index:04}.{extension}"
+        )));
+        params.push(Value::Blob(document.into()));
+    }
+    ExecuteBatchStatement { sql, params }
+}
+
+async fn read_file<StorageImpl>(lix: &Lix<StorageImpl>, path: &str) -> Vec<u8>
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    lix.execute(
+        "SELECT data FROM lix_file WHERE path = $1",
+        &[Value::Text(path.to_owned())],
+    )
+    .await
+    .expect("imported file should read")
+    .rows()[0]
+        .get::<Vec<u8>>("data")
+        .expect("imported file data should be bytes")
+}
+
+async fn install_plugin<StorageImpl>(lix: &Lix<StorageImpl>, key: &str, archive: &[u8])
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    lix.execute(
+        "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+        &[
+            Value::Text(format!("/.lix/plugins/{key}.lixplugin")),
+            Value::Blob(archive.to_vec().into()),
+        ],
+    )
+    .await
+    .expect("reference plugin should install");
+}
+
+fn build_markdown_v2_plugin_archive() -> Vec<u8> {
+    build_plugin_archive(
+        Path::new(env!(
+            "CARGO_CDYLIB_FILE_PLUGIN_MARKDOWN_INCREMENTAL_V2_plugin_markdown_incremental_v2"
+        )),
+        include_str!("../../../plugins/markdown-v2/manifest.json"),
+        &[(
+            "schema/markdown_node_v2.json",
+            include_str!("../../../plugins/markdown-v2/schema/markdown_node_v2.json"),
+        )],
+    )
+}
+
+fn build_csv_v2_plugin_archive() -> Vec<u8> {
+    build_plugin_archive(
+        Path::new(env!("CARGO_CDYLIB_FILE_PLUGIN_CSV_V2_plugin_csv_v2")),
+        include_str!("../../../plugins/csv-v2/manifest.json"),
+        &[
+            (
+                "schema/csv_v2_table.json",
+                include_str!("../../../plugins/csv-v2/schema/csv_v2_table.json"),
+            ),
+            (
+                "schema/csv_v2_row.json",
+                include_str!("../../../plugins/csv-v2/schema/csv_v2_row.json"),
+            ),
+        ],
+    )
+}
+
+fn build_git_text_v2_plugin_archive() -> Vec<u8> {
+    build_plugin_archive(
+        Path::new(env!(
+            "CARGO_CDYLIB_FILE_PLUGIN_GIT_TEXT_V2_plugin_git_text_v2"
+        )),
+        include_str!("../../../plugins/text-v2/manifest.json"),
+        &[(
+            "schema/git_text_line_v2.json",
+            include_str!("../../../plugins/text-v2/schema/git_text_line_v2.json"),
+        )],
+    )
+}
+
+fn build_excalidraw_v2_plugin_archive() -> Vec<u8> {
+    build_plugin_archive(
+        Path::new(env!(
+            "CARGO_CDYLIB_FILE_PLUGIN_EXCALIDRAW_V2_plugin_excalidraw_v2"
+        )),
+        include_str!("../../../plugins/excalidraw-v2/manifest.json"),
+        &[
+            (
+                "schema/excalidraw_scene.json",
+                include_str!("../../../plugins/excalidraw-v2/schema/excalidraw_scene.json"),
+            ),
+            (
+                "schema/excalidraw_element.json",
+                include_str!("../../../plugins/excalidraw-v2/schema/excalidraw_element.json"),
+            ),
+            (
+                "schema/excalidraw_file.json",
+                include_str!("../../../plugins/excalidraw-v2/schema/excalidraw_file.json"),
+            ),
+        ],
+    )
+}
+
+fn build_plugin_archive(wasm_path: &Path, manifest: &str, schemas: &[(&str, &str)]) -> Vec<u8> {
+    let wasm = fs::read(wasm_path).unwrap_or_else(|error| {
+        panic!(
+            "failed to read plugin component at {}: {error}",
+            wasm_path.display()
+        )
+    });
+    let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    writer
+        .start_file("manifest.json", options)
+        .expect("manifest entry should start");
+    writer
+        .write_all(manifest.as_bytes())
+        .expect("manifest should write");
+    for (path, schema) in schemas {
+        writer
+            .start_file(*path, options)
+            .expect("schema entry should start");
+        writer
+            .write_all(schema.as_bytes())
+            .expect("schema should write");
+    }
+    writer
+        .start_file("plugin.wasm", options)
+        .expect("component entry should start");
+    writer.write_all(&wasm).expect("component should write");
+    writer
+        .finish()
+        .expect("plugin archive should finish")
+        .into_inner()
+}

--- a/packages/rs-sdk-tests/tests/plugin_document_scale.rs
+++ b/packages/rs-sdk-tests/tests/plugin_document_scale.rs
@@ -60,6 +60,51 @@ async fn atomic_plugin_import_scaling_is_format_independent() {
     .await;
 }
 
+#[tokio::test]
+async fn sequential_batches_survive_observation_cache_eviction() {
+    const DOCUMENTS: usize = 17;
+
+    let lix = open_lix(OpenLixOptions::default())
+        .await
+        .expect("document-scale workspace should open");
+    install_plugin(
+        &lix,
+        "plugin_git_text_v2",
+        &build_git_text_v2_plugin_archive(),
+    )
+    .await;
+
+    lix.execute_batch(&[file_insert_statement(
+        "txt",
+        (0..DOCUMENTS).map(|index| format!("before {index}\n").into_bytes()),
+    )])
+    .await
+    .expect("the first batch should exceed the Store working set");
+
+    let updates = (0..DOCUMENTS)
+        .map(|index| ExecuteBatchStatement {
+            sql: "UPDATE lix_file SET data = $1 WHERE path = $2".to_string(),
+            params: vec![
+                Value::Blob(format!("after {index}\n").into_bytes().into()),
+                Value::Text(format!("/scale-document-{index:04}.txt")),
+            ],
+        })
+        .collect::<Vec<_>>();
+    lix.execute_batch(&updates)
+        .await
+        .expect("retained observations must survive cache eviction between batches");
+
+    for index in 0..DOCUMENTS {
+        assert_eq!(
+            read_file(&lix, &format!("/scale-document-{index:04}.txt")).await,
+            format!("after {index}\n").into_bytes()
+        );
+    }
+    lix.close()
+        .await
+        .expect("document-scale workspace should close");
+}
+
 async fn assert_format_scales(
     plugin_key: &str,
     archive: Vec<u8>,

--- a/packages/rs-sdk/src/lix.rs
+++ b/packages/rs-sdk/src/lix.rs
@@ -296,17 +296,6 @@ where
             .await
     }
 
-    #[doc(hidden)]
-    pub async fn execute_batch_for_single_writer_ingest(
-        &self,
-        statements: &[ExecuteBatchStatement],
-        retain_plugin_actors: bool,
-    ) -> Result<Vec<ExecuteResult>, LixError> {
-        self.session
-            .execute_batch_for_single_writer_ingest(statements, retain_plugin_actors)
-            .await
-    }
-
     /// Classifies an atomic SQL batch for a caller that owns its transport
     /// lifecycle.
     pub fn execute_batch_disposition(


### PR DESCRIPTION
## Why

An atomic plugin-backed import retained one Wasm Store per completed document transition until commit. The default 16-Store admission ceiling therefore rejected the 17th file (and the reported 1,184-file Markdown import), even though completed publications no longer needed a warm Store for transaction correctness.

## What changed

- Treat the Store ceiling as a live working-set bound rather than a document-count bound.
- Under admission pressure, retire the oldest completed **fresh- or existing-document** Store after its durable rows/materialization are staged, then reuse that permit inside the same atomic transaction.
- Preserve actively contested same-file leases: cache eviction still refuses slots referenced by an active or waiting transition.
- Publish recycled transitions as non-authoritative file views so later edits cold-open from durable state.
- Recover retained session observations from benign cache eviction only while their exact durable semantic root is unchanged; genuinely newer roots remain stale.
- Remove the hidden `execute_batch_for_single_writer_ingest(..., retain_plugin_actors)` compatibility path and its policy boolean.
- Move Git replay to the general public `execute_batch` API.
- Add production-Wasm conformance coverage for Markdown (1,184 files), CSV, text, and Excalidraw, including committed bytes and semantic-row verification.
- Add a deterministic two-batch Git-text fixture that imports 17 files and then updates them in path order, forcing observation-named Store eviction between batches.
- Expand Git replay coverage to a 100-commit repository whose second commit atomically updates 17 existing plugin-owned text files.
- Check in the benchmark/profiling procedure and results.

## Performance

Release profile, Linux x86-64, Rust nightly 1.97.0, seven fresh warm-cache processes, one atomic 1,184-document Markdown statement (30,932 logical input bytes):

| Metric | Result |
| --- | ---: |
| p50 | 594.637 ms |
| p95 | 604.307 ms |
| p50 / document | 0.502 ms |
| whole-process wall | 680 ms |
| peak RSS | 148,848 KiB |
| swaps | 0 |

A profiled run completed the measured import in 577.842 ms with 775.27 ms task-clock, 4.58B instructions, and 41.6M cache misses.

Exact pre-change `origin/main` (`f860b30ea`) fails the capacity-plus-one Markdown fixture with `LIX_ERROR_PLUGIN_RESOURCE_LIMIT`; this branch keeps the same 16-Store resource ceiling and passes 1,184 fresh files plus broad existing-file updates atomically.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --profile test -p lix_engine -p lix_sdk -p lix_cli -p lix_sdk_tests --all-targets --all-features -- -D warnings`
- `cargo test -p lix_engine --features all-simulations`
- `cargo test -p lix_sdk_tests --test plugin_document_scale -- --nocapture --test-threads=1`
- `cargo test -p lix_cli git_replay`
- release fixture: 7-run distribution, `/usr/bin/time`, and `perf stat`

This intentionally removes the unreleased specialized ingestion API; no backward-compatibility shim is retained.