### PR TITLE
perf(engine): stream validated packed change scans

### DIFF
--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -181,6 +181,11 @@ pub(crate) struct CommitDeltaInventory {
     pub(crate) commits: BTreeMap<CommitId, CommitDeltaInventoryEntry>,
 }
 
+struct CommitDeltaPlane {
+    manifests: BTreeMap<CommitId, CommitDeltaManifest>,
+    segments: BTreeMap<CommitId, BTreeMap<usize, Bytes>>,
+}
+
 // Version the root metadata independently of storage backends. Version 3 is a
 // hard cut for derived commit rows, prefix-friendly keys, and compact tree
 // nodes. Reject older roots before their differently ordered state can be
@@ -1071,16 +1076,43 @@ pub(crate) async fn scan_commit_delta_values(
 pub(crate) async fn scan_change_records_from_commit_deltas(
     store: &(impl StorageAdapterRead + ?Sized),
 ) -> Result<Vec<crate::changelog::ChangeRecord>, LixError> {
-    let mut records = BTreeMap::<crate::changelog::ChangeId, crate::changelog::ChangeRecord>::new();
-    let inventory = scan_commit_delta_inventory(store).await?;
-    for entry in inventory.commits.into_values() {
-        for member in entry.members {
-            records
-                .entry(member.change.change_id)
-                .or_insert(member.change);
+    let CommitDeltaPlane {
+        manifests,
+        mut segments,
+    } = scan_commit_delta_plane(store).await?;
+    let mut records =
+        BTreeMap::<crate::changelog::ChangeId, (CommitId, crate::changelog::ChangeRecord)>::new();
+    for (commit_id, manifest) in manifests {
+        let physical_segments = segments.remove(&commit_id).unwrap_or_default();
+        if let Some(inline_segment) = manifest.inline_segment() {
+            if !physical_segments.is_empty() {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "tracked_state inline commit_delta for commit '{commit_id}' has external segments"
+                    ),
+                ));
+            }
+            collect_validated_commit_delta_change_records(
+                inline_segment,
+                None,
+                commit_id,
+                &mut records,
+            )?;
+        } else {
+            validate_physical_commit_delta_segments(commit_id, &manifest, &physical_segments)?;
+            for (segment_index, bounds) in manifest.segments.iter().enumerate() {
+                collect_validated_commit_delta_change_records(
+                    &physical_segments[&segment_index],
+                    Some(bounds),
+                    commit_id,
+                    &mut records,
+                )?;
+            }
         }
     }
-    Ok(records.into_values().collect())
+    debug_assert!(segments.is_empty());
+    Ok(records.into_values().map(|(_, change)| change).collect())
 }
 
 /// Inventories the complete packed commit-delta plane in one manifest scan and
@@ -1090,6 +1122,68 @@ pub(crate) async fn scan_change_records_from_commit_deltas(
 pub(crate) async fn scan_commit_delta_inventory(
     store: &(impl StorageAdapterRead + ?Sized),
 ) -> Result<CommitDeltaInventory, LixError> {
+    let CommitDeltaPlane {
+        manifests,
+        mut segments,
+    } = scan_commit_delta_plane(store).await?;
+    let mut inventory = CommitDeltaInventory::default();
+    let mut authoritative_changes =
+        BTreeMap::<crate::changelog::ChangeId, crate::changelog::ChangeRecord>::new();
+    for (commit_id, manifest) in manifests {
+        let physical_segments = segments.remove(&commit_id).unwrap_or_default();
+        let segment_count = manifest.segments.len();
+        let mut members = Vec::new();
+        if let Some(inline_segment) = manifest.inline_segment() {
+            if !physical_segments.is_empty() {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "tracked_state inline commit_delta for commit '{commit_id}' has external segments"
+                    ),
+                ));
+            }
+            collect_strict_commit_delta_members(inline_segment, None, commit_id, &mut members)?;
+        } else {
+            validate_physical_commit_delta_segments(commit_id, &manifest, &physical_segments)?;
+            for (segment_index, bounds) in manifest.segments.iter().enumerate() {
+                collect_strict_commit_delta_members(
+                    &physical_segments[&segment_index],
+                    Some(bounds),
+                    commit_id,
+                    &mut members,
+                )?;
+            }
+        }
+        validate_commit_delta_member_order_and_ids(commit_id, &members)?;
+        for member in &members {
+            if let Some(existing) =
+                authoritative_changes.insert(member.change.change_id, member.change.clone())
+                && existing != member.change
+            {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "tracked_state change '{}' has conflicting authoritative packed payloads",
+                        member.change.change_id
+                    ),
+                ));
+            }
+        }
+        inventory.commits.insert(
+            commit_id,
+            CommitDeltaInventoryEntry {
+                members,
+                segment_count,
+            },
+        );
+    }
+    debug_assert!(segments.is_empty());
+    Ok(inventory)
+}
+
+async fn scan_commit_delta_plane(
+    store: &(impl StorageAdapterRead + ?Sized),
+) -> Result<CommitDeltaPlane, LixError> {
     let manifest_rows = scan_full_space(store, TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE).await?;
     let segment_rows = scan_full_space(store, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE).await?;
 
@@ -1155,71 +1249,38 @@ pub(crate) async fn scan_commit_delta_inventory(
         ));
     }
 
-    let mut inventory = CommitDeltaInventory::default();
-    let mut authoritative_changes =
-        BTreeMap::<crate::changelog::ChangeId, crate::changelog::ChangeRecord>::new();
-    for (commit_id, manifest) in manifests {
-        let physical_segments = segments.remove(&commit_id).unwrap_or_default();
-        let segment_count = manifest.segments.len();
-        let mut members = Vec::new();
-        if let Some(inline_segment) = manifest.inline_segment() {
-            if !physical_segments.is_empty() {
-                return Err(LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!(
-                        "tracked_state inline commit_delta for commit '{commit_id}' has external segments"
-                    ),
-                ));
-            }
-            collect_strict_commit_delta_members(inline_segment, None, commit_id, &mut members)?;
-        } else {
-            if physical_segments.len() != manifest.segments.len() {
-                return Err(LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!(
-                        "tracked_state commit_delta for commit '{commit_id}' has {} physical segments but its manifest declares {}",
-                        physical_segments.len(),
-                        manifest.segments.len(),
-                    ),
-                ));
-            }
-            for (segment_index, bounds) in manifest.segments.iter().enumerate() {
-                let bytes = physical_segments.get(&segment_index).ok_or_else(|| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        format!(
-                            "tracked_state commit_delta for commit '{commit_id}' is missing segment {segment_index}"
-                        ),
-                    )
-                })?;
-                collect_strict_commit_delta_members(bytes, Some(bounds), commit_id, &mut members)?;
-            }
-        }
-        validate_commit_delta_member_order_and_ids(commit_id, &members)?;
-        for member in &members {
-            if let Some(existing) =
-                authoritative_changes.insert(member.change.change_id, member.change.clone())
-                && existing != member.change
-            {
-                return Err(LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!(
-                        "tracked_state change '{}' has conflicting authoritative packed payloads",
-                        member.change.change_id
-                    ),
-                ));
-            }
-        }
-        inventory.commits.insert(
-            commit_id,
-            CommitDeltaInventoryEntry {
-                members,
-                segment_count,
-            },
-        );
+    Ok(CommitDeltaPlane {
+        manifests,
+        segments,
+    })
+}
+
+fn validate_physical_commit_delta_segments(
+    commit_id: CommitId,
+    manifest: &CommitDeltaManifest,
+    physical_segments: &BTreeMap<usize, Bytes>,
+) -> Result<(), LixError> {
+    if physical_segments.len() != manifest.segments.len() {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "tracked_state commit_delta for commit '{commit_id}' has {} physical segments but its manifest declares {}",
+                physical_segments.len(),
+                manifest.segments.len(),
+            ),
+        ));
     }
-    debug_assert!(segments.is_empty());
-    Ok(inventory)
+    if let Some(segment_index) =
+        (0..manifest.segments.len()).find(|index| !physical_segments.contains_key(index))
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "tracked_state commit_delta for commit '{commit_id}' is missing segment {segment_index}"
+            ),
+        ));
+    }
+    Ok(())
 }
 
 pub(crate) fn stage_delete_commit_delta_inventory_entry(
@@ -1337,6 +1398,61 @@ fn collect_strict_commit_delta_members(
         members.push(CommitDeltaMember { key, value, change });
     }
     Ok(())
+}
+
+fn collect_validated_commit_delta_change_records(
+    bytes: &[u8],
+    expected_bounds: Option<&CommitDeltaSegmentBounds>,
+    expected_commit_id: CommitId,
+    records: &mut BTreeMap<crate::changelog::ChangeId, (CommitId, crate::changelog::ChangeRecord)>,
+) -> Result<(), LixError> {
+    let (leaf, payloads) = decode_commit_delta_with_payloads(bytes, expected_bounds)?;
+    visit_commit_delta_leaf(
+        &leaf,
+        expected_commit_id,
+        |entry_index, encoded_key, value| {
+            let payload = payloads.decode(entry_index)?;
+            let key = decode_key(encoded_key)?;
+            let change = crate::changelog::ChangeRecord {
+                format_version: 2,
+                change_id: value.change_id,
+                schema_key: key.schema_key,
+                entity_pk: key.entity_pk,
+                file_id: key.file_id,
+                snapshot: payload.snapshot,
+                metadata: payload.metadata,
+                created_at: value.updated_at,
+                origin_key: payload.origin_key,
+            };
+            match records.entry(change.change_id) {
+                std::collections::btree_map::Entry::Vacant(entry) => {
+                    entry.insert((expected_commit_id, change));
+                }
+                std::collections::btree_map::Entry::Occupied(entry)
+                    if entry.get().0 == expected_commit_id =>
+                {
+                    return Err(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!(
+                            "tracked_state commit_delta for commit '{expected_commit_id}' contains duplicate change id '{}'",
+                            change.change_id
+                        ),
+                    ));
+                }
+                std::collections::btree_map::Entry::Occupied(entry) if entry.get().1 != change => {
+                    return Err(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!(
+                            "tracked_state change '{}' has conflicting authoritative packed payloads",
+                            change.change_id
+                        ),
+                    ));
+                }
+                std::collections::btree_map::Entry::Occupied(_) => {}
+            }
+            Ok(())
+        },
+    )
 }
 
 fn validate_commit_delta_member_order_and_ids(
@@ -2124,9 +2240,9 @@ mod tests {
         encode_commit_delta_segment_with_payloads, encode_commit_root, key,
         load_commit_delta_change_ids, load_commit_delta_change_records,
         load_commit_delta_members_with_payloads, load_commit_delta_values_encoded,
-        load_owned_commit_delta_entries, scan_commit_delta_inventory, scan_commit_delta_members,
-        scan_commit_delta_values, stage_commit_deltas, stage_delete_commit_delta_inventory_entry,
-        value,
+        load_owned_commit_delta_entries, scan_change_records_from_commit_deltas,
+        scan_commit_delta_inventory, scan_commit_delta_members, scan_commit_delta_values,
+        stage_commit_deltas, stage_delete_commit_delta_inventory_entry, value,
     };
 
     #[derive(Clone)]
@@ -2318,6 +2434,10 @@ mod tests {
             .await
             .expect_err("global authority must reject duplicate change ids");
         assert!(error.to_string().contains("contains duplicate change id"));
+        let error = scan_change_records_from_commit_deltas(&read)
+            .await
+            .expect_err("streaming authority must reject duplicate change ids");
+        assert!(error.to_string().contains("contains duplicate change id"));
     }
 
     #[tokio::test]
@@ -2371,6 +2491,10 @@ mod tests {
             .await
             .expect_err("orphan segments must fail inventory");
         assert!(error.to_string().contains("found orphan segments"));
+        let error = scan_change_records_from_commit_deltas(&read)
+            .await
+            .expect_err("orphan segments must fail streaming scan");
+        assert!(error.to_string().contains("found orphan segments"));
 
         let storage = StorageAdapter::new(Memory::new());
         let commit_id = CommitId::for_test_label("noncontiguous-segments");
@@ -2417,6 +2541,10 @@ mod tests {
             .await
             .expect_err("noncontiguous physical suffixes must fail inventory");
         assert!(error.to_string().contains("missing segment 1"));
+        let error = scan_change_records_from_commit_deltas(&read)
+            .await
+            .expect_err("noncontiguous physical suffixes must fail streaming scan");
+        assert!(error.to_string().contains("missing segment 1"));
     }
 
     #[tokio::test]
@@ -2462,6 +2590,11 @@ mod tests {
                 .len(),
             2
         );
+        let changes = scan_change_records_from_commit_deltas(&read)
+            .await
+            .expect("streaming scan should deduplicate identical shared authority");
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].change_id, fixture.change_id);
         drop(read);
 
         let conflicting_commit = CommitId::for_test_label("shared-authority-conflict");
@@ -2485,6 +2618,14 @@ mod tests {
         let error = scan_commit_delta_inventory(&read)
             .await
             .expect_err("conflicting payloads for one change id must fail");
+        assert!(
+            error
+                .to_string()
+                .contains("conflicting authoritative packed payloads")
+        );
+        let error = scan_change_records_from_commit_deltas(&read)
+            .await
+            .expect_err("streaming scan must reject conflicting packed payloads");
         assert!(
             error
                 .to_string()


### PR DESCRIPTION
## Summary

- split packed-history enumeration from the retained GC inventory representation
- validate manifests, exact segment inventory, segment bounds/order, owner commit IDs, duplicate change IDs, payload cardinality, and conflicting authority while collecting each public change once
- keep GC on `CommitDeltaInventory`, because GC genuinely needs retained ownership members
- share the physical manifest/segment topology validation between both consumers

This removes the SQL scan's per-commit `CommitDeltaMember` vectors, repository-wide duplicate-ID `BTreeSet`s, cloned authoritative-change map, and final flattening pass.

## Correctness

The streaming path is exercised directly by the existing corruption fixtures and rejects:

- duplicate change IDs within a commit
- orphan segments
- missing/non-contiguous physical segments
- conflicting authoritative payloads across commits

Identical authority shared across commits is deduplicated to one public change.

Validation:

- `cargo test -p lix_engine --lib`: **1536 passed, 6 ignored**
- `cargo clippy -p lix_engine --lib -- -D warnings`: **pass**
- `cargo clippy -p lix_engine --lib --tests -- -D warnings`: blocked by the pre-existing main warning that `StorageWriteSet::apply` is dead code in test builds

## Performance

Compared exact main `8e787dc7e` with candidate `177e87e1d` using independently built release binaries, the identical committed `lix_change_scale` harness, byte-identical packed fixtures, two warmups, three repetitions, and balanced order `main → candidate → candidate → main`.

Numbers are the mean of the two epoch p50s.

### 1M changes

| Backend | Query | Main | Candidate | Improvement |
|---|---|---:|---:|---:|
| RocksDB | `COUNT(*)` | 1674 ms | 930 ms | **44.4%** |
| RocksDB | identity enumeration | 2097 ms | 1561 ms | **25.5%** |
| RocksDB | payload enumeration | 2663 ms | 2074 ms | **22.1%** |
| RocksDB | packed identity lookup | 1759 ms | 1078 ms | **38.7%** |
| RocksDB | packed payload lookup | 1914 ms | 1441 ms | **24.7%** |
| RocksDB | standalone lookup | 1894 ms | 1380 ms | **27.1%** |
| RocksDB | missing lookup | 1926 ms | 1481 ms | **23.1%** |
| SlateDB | `COUNT(*)` | 1704 ms | 1031 ms | **39.5%** |
| SlateDB | identity enumeration | 2242 ms | 1694 ms | **24.4%** |
| SlateDB | payload enumeration | 2751 ms | 2120 ms | **23.0%** |
| SlateDB | packed identity lookup | 1957 ms | 1316 ms | **32.7%** |
| SlateDB | packed payload lookup | 2057 ms | 1459 ms | **29.1%** |
| SlateDB | standalone lookup | 2146 ms | 1381 ms | **35.7%** |
| SlateDB | missing lookup | 2126 ms | 1484 ms | **30.2%** |

At 100k, all 14 backend/query combinations improve by **25.6%–39.4%**. Across the complete 100k/1M matrix, the minimum gain is **22.1%**.

## Profile confirmation

A 1M RocksDB `perf` capture shows the removed main-path buckets are gone:

- `Bytes::shared_drop`: 4.67% on main
- duplicate-ID `BTreeSet::insert`: 2.90% on main
- `collect_strict_commit_delta_members`: 1.95% on main

The candidate performs validation and result construction in one `collect_validated_commit_delta_change_records` pass. Storage format and footprint are unchanged.