### PR TITLE
perf(git-text): stream large document transitions

### DIFF
--- a/plugins/text-v2/src/bindings.rs
+++ b/plugins/text-v2/src/bindings.rs
@@ -21,11 +21,11 @@ impl lix::FormatPlugin for GitTextPlugin {
         .map_err(lix::Error::invalid_input)?;
         Ok((
             document,
-            lix::try_changes(
-                changes
-                    .into_iter()
-                    .map(move |change| creates.keyless(change)),
-            ),
+            lix::try_changes(changes.into_iter().map(move |change| {
+                change
+                    .map_err(lix::Error::invalid_input)
+                    .and_then(|change| creates.keyless(change))
+            })),
         ))
     }
 
@@ -38,11 +38,13 @@ impl lix::FormatPlugin for GitTextPlugin {
         // that the renderer agrees. A missing checkpoint instead means the
         // host needs one insertion relative to an empty file.
         let has_accepted = input.accepted.is_some();
-        let mut records = Vec::new();
-        while let Some(record) = input.entities.next()? {
-            records.push(record);
-        }
-        let document = Document::open_entities(records).map_err(lix::Error::invalid_input)?;
+        let records = std::iter::from_fn(|| match input.entities.next() {
+            Ok(Some(record)) => Some(Ok(record)),
+            Ok(None) => None,
+            Err(error) => Some(Err(format!("{error:?}"))),
+        });
+        let document =
+            Document::open_entities_fallible(records).map_err(lix::Error::invalid_input)?;
         let edits = restore_edits(has_accepted, document.bytes());
         Ok((document, lix::edits(edits.into_iter())))
     }

--- a/plugins/text-v2/src/core.rs
+++ b/plugins/text-v2/src/core.rs
@@ -36,6 +36,28 @@ pub(crate) struct Line {
     bytes: Arc<Vec<u8>>,
 }
 
+pub(crate) struct AllUpserts {
+    document: Document,
+    index: usize,
+}
+
+impl Iterator for AllUpserts {
+    type Item = Result<lix::EntityChange, String>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let line = self.document.lines().get(self.index)?;
+        self.index += 1;
+        Some(line.upsert_change())
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.document.lines().len().saturating_sub(self.index);
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for AllUpserts {}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct LineSnapshot {
@@ -48,7 +70,7 @@ impl Document {
     pub(crate) fn open_file(
         bytes: Vec<u8>,
         mut id_for_ordinal: impl FnMut(u64) -> String,
-    ) -> Result<(Self, Vec<lix::EntityChange>), String> {
+    ) -> Result<(Self, AllUpserts), String> {
         validate_git_text(&bytes)?;
         let chunks = split_lines(&bytes);
         let order_keys = OrderKey::evenly_between(None, None, chunks.len())?;
@@ -70,15 +92,26 @@ impl Document {
             bytes: Arc::new(bytes),
             lines,
         }));
-        let changes = document.all_upserts()?;
+        let changes = AllUpserts {
+            document: document.clone(),
+            index: 0,
+        };
         Ok((document, changes))
     }
 
+    #[cfg(test)]
     pub(crate) fn open_entities(
         records: impl IntoIterator<Item = lix::EntityRecord>,
     ) -> Result<Self, String> {
+        Self::open_entities_fallible(records.into_iter().map(Ok))
+    }
+
+    pub(crate) fn open_entities_fallible(
+        records: impl IntoIterator<Item = Result<lix::EntityRecord, String>>,
+    ) -> Result<Self, String> {
         let mut lines = Vec::new();
         for record in records {
+            let record = record?;
             validate_entity_key(&record.schema_key, &record.entity_pk)?;
             let line = Line::from_snapshot(&record.snapshot)?;
             if record.entity_pk[0] != line.id {
@@ -101,20 +134,56 @@ impl Document {
         validate_git_text(&bytes)?;
         let chunks = split_lines(&bytes);
 
-        // Exact byte matches preserve their entity identity even across a
-        // reorder. Remaining old/new positions are paired in order, which
-        // preserves an edited line's ID without inventing a parser-specific
-        // identity rule for arbitrary text.
+        // Preserve the overwhelmingly common unchanged prefix and suffix
+        // without indexing the complete document. Generated bundles can have
+        // hundreds of thousands of lines with a localized edit; putting every
+        // line into the reorder matcher needlessly exhausts the guest heap.
+        let prefix_len = self
+            .lines()
+            .iter()
+            .zip(&chunks)
+            .take_while(|(old, new)| old.bytes.as_slice() == new.as_slice())
+            .count();
+        let suffix_len = self.lines()[prefix_len..]
+            .iter()
+            .rev()
+            .zip(chunks[prefix_len..].iter().rev())
+            .take_while(|(old, new)| old.bytes.as_slice() == new.as_slice())
+            .count();
+
+        let mut old_for_new = vec![None; chunks.len()];
+        let mut old_used = vec![false; self.lines().len()];
+        for index in 0..prefix_len {
+            old_for_new[index] = Some(index);
+            old_used[index] = true;
+        }
+        for offset in 0..suffix_len {
+            let old_index = self.lines().len() - suffix_len + offset;
+            let new_index = chunks.len() - suffix_len + offset;
+            old_for_new[new_index] = Some(old_index);
+            old_used[old_index] = true;
+        }
+
+        // Exact byte matches in the changed middle preserve their entity
+        // identity even across a reorder. Remaining old/new positions are
+        // paired in order, preserving an edited line's ID without inventing a
+        // parser-specific identity rule for arbitrary text.
         let mut exact = BTreeMap::<&[u8], VecDeque<usize>>::new();
-        for (old_index, line) in self.lines().iter().enumerate() {
+        for (old_index, line) in self.lines()[prefix_len..self.lines().len() - suffix_len]
+            .iter()
+            .enumerate()
+            .map(|(index, line)| (prefix_len + index, line))
+        {
             exact
                 .entry(line.bytes.as_slice())
                 .or_default()
                 .push_back(old_index);
         }
-        let mut old_for_new = vec![None; chunks.len()];
-        let mut old_used = vec![false; self.lines().len()];
-        for (new_index, bytes) in chunks.iter().enumerate() {
+        for (new_index, bytes) in chunks[prefix_len..chunks.len() - suffix_len]
+            .iter()
+            .enumerate()
+            .map(|(index, bytes)| (prefix_len + index, bytes))
+        {
             let Some(candidates) = exact.get_mut(bytes.as_slice()) else {
                 continue;
             };
@@ -262,13 +331,6 @@ impl Document {
             bytes: Arc::new(bytes),
             lines,
         })))
-    }
-
-    fn all_upserts(&self) -> Result<Vec<lix::EntityChange>, String> {
-        self.lines()
-            .iter()
-            .map(Line::upsert_change)
-            .collect::<Result<Vec<_>, _>>()
     }
 
     fn changes_to(&self, after: &Self) -> Result<Vec<lix::EntityChange>, String> {

--- a/plugins/text-v2/src/tests.rs
+++ b/plugins/text-v2/src/tests.rs
@@ -6,8 +6,15 @@ use serde_json::{Value, json};
 use crate::core::{Document, InputSplice, LINE_SCHEMA_KEY, Line};
 
 fn open(bytes: &[u8]) -> (Document, Vec<lix::EntityChange>) {
-    Document::open_file(bytes.to_vec(), |ordinal| format!("line-{ordinal}"))
-        .expect("Git text document should open")
+    let (document, changes) =
+        Document::open_file(bytes.to_vec(), |ordinal| format!("line-{ordinal}"))
+            .expect("Git text document should open");
+    (
+        document,
+        changes
+            .collect::<Result<Vec<_>, _>>()
+            .expect("Git text changes should serialize"),
+    )
 }
 
 fn ids(document: &Document) -> Vec<String> {
@@ -244,6 +251,9 @@ fn git_nul_window_rejects_early_nul_and_allows_nul_after_eight_kib() {
     let (document, changes) =
         Document::open_file(source.clone(), |ordinal| format!("line-{ordinal}"))
             .expect("a NUL after Git's scan window remains text");
+    let changes = changes
+        .collect::<Result<Vec<_>, _>>()
+        .expect("late-NUL changes should serialize");
     assert_eq!(document.bytes(), source);
     let reopened = Document::open_entities(records(&changes)).expect("late-NUL row should reopen");
     assert_eq!(reopened.bytes(), source);


### PR DESCRIPTION
## What changed

- emits initial Git-text entity upserts lazily instead of materializing a file-sized `Vec<EntityChange>`
- consumes cold-open entity records as a stream instead of buffering a second file-sized record vector
- preserves unchanged line prefixes/suffixes before building the reorder index, bounding localized warm-edit reconciliation by the changed middle

## Why

The OpenClaw first-parent replay reaches generated JavaScript bundles with roughly 195,000 lines. Under the default 64 MiB v2 guest limit, Git-text aborted while building the initial `Vec<EntityChange>`, and then while buffering cold-open records. The lazy paths allow the previously fatal 5.5 MiB/195,542-line initial import to complete without raising the guest limit.

A later warm edit still exposes a deeper layout issue: `split_lines` owns one allocation per line while the predecessor document is live. That follow-up should move line bytes to shared backing storage plus ranges; this draft intentionally keeps that remaining blocker visible.

## Validation

- `cargo test -p plugin_git_text_v2`
- replay of OpenClaw commit `98651c2a141793360c9690c82061b1a2028f48f2` succeeds under the default 64 MiB guest limit (4.27 s, parent bootstrap excluded)
- 650-commit RocksDB prefix replay succeeds with Git-text, Markdown, and Excalidraw installed