### PR TITLE
feat(sdk): expose plugin v2 resource limits

### DIFF
--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -366,7 +366,8 @@ impl LocalFilesystem {
         let layout = prepare_filesystem_layout(&options.root, options.lix_dir.as_deref())?;
         let storage = open_filesystem_rocksdb(&layout)?;
         let engine =
-            crate::lix::open_or_initialize_engine(storage.clone(), wasm_runtime, None).await?;
+            crate::lix::open_or_initialize_engine(storage.clone(), wasm_runtime, None, None)
+                .await?;
         let inner =
             FilesystemSync::open_with_engine(storage, engine, layout, options.sync_all_files)
                 .await?;
@@ -2563,7 +2564,7 @@ mod tests {
         path_filter: FilesystemPathFilter,
     ) -> FilesystemState<RocksDBFilesystem> {
         let storage = open_filesystem_rocksdb(&layout).unwrap();
-        let engine = crate::lix::open_or_initialize_engine(storage.clone(), None, None)
+        let engine = crate::lix::open_or_initialize_engine(storage.clone(), None, None, None)
             .await
             .unwrap();
         FilesystemState {

--- a/packages/rs-sdk/src/lib.rs
+++ b/packages/rs-sdk/src/lib.rs
@@ -19,7 +19,8 @@ pub use client_state::ClientState;
 #[cfg(all(not(target_family = "wasm"), feature = "local_filesystem"))]
 pub use filesystem::{LocalFilesystem, LocalFilesystemOpenOptions};
 pub use lix::{
-    Lix, LixTransaction, OpenLixOptions, open_lix, open_lix_with_storage, open_lix_with_telemetry,
+    Lix, LixTransaction, OpenLixOptions, open_lix, open_lix_with_storage,
+    open_lix_with_storage_and_plugin_v2_resource_limits, open_lix_with_telemetry,
 };
 pub use lix_engine::telemetry::{
     CallbackTelemetrySink, CompletedTelemetrySpan, TelemetryAttribute, TelemetrySink,

--- a/packages/rs-sdk/src/lix.rs
+++ b/packages/rs-sdk/src/lix.rs
@@ -88,7 +88,7 @@ where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
     let engine =
-        open_or_initialize_engine(options.storage, options.wasm_runtime, telemetry).await?;
+        open_or_initialize_engine(options.storage, options.wasm_runtime, telemetry, None).await?;
     let session = engine.open_workspace_session().await?;
     Ok(Lix { engine, session })
 }
@@ -100,6 +100,27 @@ where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
     open_lix(OpenLixOptions::new(storage)).await
+}
+
+/// Opens a workspace with explicit per-Store memory and live-Store limits for
+/// Component API v2 plugins.
+pub async fn open_lix_with_storage_and_plugin_v2_resource_limits<StorageImpl>(
+    storage: StorageImpl,
+    max_memory_bytes: u64,
+    max_live_stores: usize,
+) -> Result<Lix<StorageImpl>, LixError>
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let engine = open_or_initialize_engine(
+        storage,
+        None,
+        None,
+        Some((max_memory_bytes, max_live_stores)),
+    )
+    .await?;
+    let session = engine.open_workspace_session().await?;
+    Ok(Lix { engine, session })
 }
 
 impl<StorageImpl> Lix<StorageImpl>
@@ -477,15 +498,23 @@ pub(crate) async fn open_or_initialize_engine<StorageImpl>(
     storage: StorageImpl,
     wasm_runtime: Option<Arc<dyn WasmRuntime>>,
     telemetry: Option<Arc<dyn TelemetrySink>>,
+    plugin_v2_resource_limits: Option<(u64, usize)>,
 ) -> Result<Engine<StorageImpl>, LixError>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
-    match new_engine(storage.clone(), wasm_runtime.clone(), telemetry.clone()).await {
+    match new_engine(
+        storage.clone(),
+        wasm_runtime.clone(),
+        telemetry.clone(),
+        plugin_v2_resource_limits,
+    )
+    .await
+    {
         Ok(engine) => Ok(engine),
         Err(error) if error.code == "LIX_ERROR_NOT_INITIALIZED" => {
             Engine::initialize(storage.clone()).await?;
-            new_engine(storage, wasm_runtime, telemetry).await
+            new_engine(storage, wasm_runtime, telemetry, plugin_v2_resource_limits).await
         }
         Err(error) => Err(error),
     }
@@ -495,6 +524,7 @@ async fn new_engine<StorageImpl>(
     storage: StorageImpl,
     wasm_runtime: Option<Arc<dyn WasmRuntime>>,
     telemetry: Option<Arc<dyn TelemetrySink>>,
+    plugin_v2_resource_limits: Option<(u64, usize)>,
 ) -> Result<Engine<StorageImpl>, LixError>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
@@ -510,6 +540,9 @@ where
     }
     if let Some(telemetry) = telemetry {
         options = options.with_telemetry(telemetry);
+    }
+    if let Some((max_memory_bytes, max_live_stores)) = plugin_v2_resource_limits {
+        options = options.with_plugin_v2_resource_limits(max_memory_bytes, max_live_stores);
     }
     Engine::new_with_options(storage, options).await
 }


### PR DESCRIPTION
## What changed

Adds `open_lix_with_storage_and_plugin_v2_resource_limits`, an SDK opening path that configures the existing engine-level per-Store memory ceiling and maximum live v2 Store count without requiring callers to construct an `Engine` directly.

The normal `open_lix` and filesystem paths retain their existing defaults.

## Why

The OpenClaw replay contains a 195k-entity generated text document. Even after streaming changes and sharing unchanged line state, its accepted and successor semantic documents must coexist during a warm transition and exceed the default 64 MiB per-Store ceiling. Raising the per-document limit while lowering the live Store count preserves the same aggregate guest-memory envelope.

The SDK previously exposed custom WASM runtimes but not the engine's existing v2 resource-limit controls, so storage-backed applications could not make that tradeoff.

## Validation

- `cargo check -p lix_sdk --all-features`
- OpenClaw warm bundle edit succeeds with 128 MiB per Store / 8 live Stores (1.62 s, parent bootstrap excluded)
- default open paths remain unchanged