### PR TITLE
fix(markdown): stabilize orphan table delimiters

### DIFF
--- a/plugins/markdown-v2/src/markdown_file.rs
+++ b/plugins/markdown-v2/src/markdown_file.rs
@@ -67,7 +67,7 @@ fn parse_markdown_source_with_literal_fast_path(
     }
     let mut canonical = source.to_string();
     for _ in 0..8 {
-        let rendered = render_tree(&parsed.root)?;
+        let rendered = fully_escape_orphan_table_delimiters(render_tree(&parsed.root)?);
         if rendered == canonical.as_bytes() {
             parsed.canonical_literal_paragraph_layout =
                 source_is_canonical_literal_paragraph_layout;
@@ -85,6 +85,41 @@ fn parse_markdown_source_with_literal_fast_path(
         "Markdown parser/serializer did not reach a stable representation after 8 passes"
             .to_string(),
     ))
+}
+
+fn fully_escape_orphan_table_delimiters(rendered: Vec<u8>) -> Vec<u8> {
+    let mut output = Vec::with_capacity(rendered.len());
+    for line in rendered.split_inclusive(|byte| *byte == b'\n') {
+        let content = line
+            .strip_suffix(b"\n")
+            .unwrap_or(line)
+            .strip_suffix(b"\r")
+            .unwrap_or_else(|| line.strip_suffix(b"\n").unwrap_or(line));
+        let trimmed = content
+            .iter()
+            .copied()
+            .skip_while(|byte| byte.is_ascii_whitespace())
+            .collect::<Vec<_>>();
+        let candidate = trimmed.starts_with(b"|")
+            && trimmed.ends_with(b"|")
+            && trimmed.contains(&b'\\')
+            && trimmed
+                .iter()
+                .all(|byte| matches!(byte, b'|' | b'-' | b':' | b'\\' | b' ' | b'\t'));
+        if !candidate {
+            output.extend_from_slice(line);
+            continue;
+        }
+        let mut previous = None;
+        for byte in line {
+            if *byte == b'-' && previous != Some(b'\\') {
+                output.push(b'\\');
+            }
+            output.push(*byte);
+            previous = Some(*byte);
+        }
+    }
+    output
 }
 
 fn parse_markdown_source_once(source: &str) -> Result<ParsedMarkdown, PluginError> {

--- a/plugins/markdown-v2/src/tests.rs
+++ b/plugins/markdown-v2/src/tests.rs
@@ -200,6 +200,20 @@ fn cold_entity_open_roundtrips_marker_free_complete_gfm_document() {
 }
 
 #[test]
+fn duplicate_adjacent_table_headers_reach_a_stable_representation() {
+    let source = "\
+| Command | Description |
+|---------|-------------|
+| Command | Description |
+|---------|-------------|
+| `clawdis login` | Link WhatsApp Web via QR |
+";
+    let parsed =
+        parse_markdown_source(source).expect("adjacent table-like headers should stabilize");
+    assert!(parsed.canonical_render.is_some());
+}
+
+#[test]
 fn cold_entity_open_reuses_host_verified_materialized_bytes() {
     let source = b"Alpha\n\nBeta\n".to_vec();
     let (_, changes) = Document::open_file(


### PR DESCRIPTION
## What changed

Canonical rendering now recognizes an orphan pipe-table delimiter row once the serializer has begun escaping it and escapes the entire hyphen run in one pass. A regression covers adjacent duplicate table headers followed by a second delimiter-like row.

## Root cause

For an orphan row such as `|---------|-------------|`, the Markdown serializer escaped one additional leading hyphen per parse/render pass. Canonicalization is intentionally bounded at eight passes, so delimiter runs longer than eight never stabilized and returned an internal plugin error.

The normalization is narrow: it only applies to pipe-bounded lines made exclusively from table-delimiter characters and only after the serializer has introduced an escape. Real table delimiter rows remain parsed as table structure and are unaffected.

## Impact

Markdown documents containing duplicated/adjacent table headers no longer fail `file-changed`. This blocked the OpenClaw RocksDB replay after 960 commits at `c35f9c13153157a2d975cf1656f029f2ab4dabab`.

## Validation

- `cargo test -p plugin_markdown_incremental_v2` (full suite; 2 opt-in spec fixtures remain ignored)
- focused adjacent-table-header stabilization regression