### PR TITLE
perf(engine): index pending identity targets

### DIFF
--- a/packages/engine/src/transaction/validation.rs
+++ b/packages/engine/src/transaction/validation.rs
@@ -1926,7 +1926,7 @@ fn validate_primary_key_identity(
 #[derive(Default)]
 struct PendingConstraintIndexes {
     unique_values: BTreeMap<PendingUniqueKey, EntityPk>,
-    identity_targets: Vec<PendingIdentityTarget>,
+    identity_targets: HashSet<DomainRowIdentity>,
     fk_targets: BTreeMap<PendingForeignKeyTargetKey, Vec<PendingForeignKeyTarget>>,
     fk_references: BTreeMap<PendingForeignKeyReferenceTarget, Vec<PendingForeignKeyReference>>,
     tombstones: Vec<PendingTombstone>,
@@ -1953,9 +1953,7 @@ impl PendingConstraintIndexes {
     }
 
     fn remember_identity_target(&mut self, row: PreparedValidationRow<'_>) {
-        self.identity_targets.push(PendingIdentityTarget {
-            identity: row.domain_row_identity(),
-        });
+        self.identity_targets.insert(row.domain_row_identity());
     }
 
     fn remember_primary_key_target(
@@ -2082,14 +2080,15 @@ impl PendingConstraintIndexes {
 
     fn replaces_committed_identity(&self, row: MaterializedLiveStateRowRef<'_>) -> bool {
         self.identity_targets
-            .iter()
-            .any(|target| target.identity.matches_live_row_ref(row))
+            .contains(&DomainRowIdentity::in_domain(
+                Domain::for_live_row_ref(row),
+                row.schema_key().to_string(),
+                row.entity_pk().clone(),
+            ))
     }
 
     fn has_identity_target(&self, identity: &DomainRowIdentity) -> bool {
-        self.identity_targets
-            .iter()
-            .any(|target| target.identity == *identity)
+        self.identity_targets.contains(identity)
     }
 
     fn has_reachable_identity_target(&self, identity: &DomainRowIdentity) -> bool {
@@ -2196,11 +2195,6 @@ impl PendingConstraintIndexes {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PendingTombstone {
-    identity: DomainRowIdentity,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct PendingIdentityTarget {
     identity: DomainRowIdentity,
 }
 


### PR DESCRIPTION
## What changed

- store pending transaction identity targets in a `HashSet<DomainRowIdentity>`
- replace linear identity scans in state-surface foreign-key validation with indexed membership checks
- preserve committed-row replacement checks by reconstructing the exact domain identity before lookup

## Root cause

OpenClaw commit `c5c50a2141` adds 3,420 files and produces roughly 615,000 Git-text line entities. Each state-surface foreign-key check previously searched the full pending identity vector. The resulting O(rows²) comparisons consumed 37.3% of sampled CPU in `memcmp`, with `Domain::contains_canonical_ref` and identity matching immediately behind it.

## Impact

Exact RocksDB replay of `c5c50a2141` on the same host:

| Metric | `main` | this PR | Change |
|---|---:|---:|---:|
| Lix transaction | 55.619 s | 26.613 s | **2.09× faster / -52.2%** |
| Total replay phase | 55.707 s | 26.912 s | **2.07× faster / -51.7%** |

Peak RSS remains approximately 2.7 GiB; this PR addresses the CPU algorithmic regression, not the independent eager semantic-materialization/storage amplification.

For diagnosis, disabling only Git-text selection while leaving all format plugins installed reduces the same commit to 2.394 s and 473 MiB RSS. That establishes eager parsing and persistence of vendored dependency files as the next major bottleneck.

## Validation

- `cargo fmt --check`
- `cargo test -p lix_engine --features all-simulations` (2,304 passed, 9 ignored across unit/integration/doc tests)
- exact OpenClaw RocksDB replay from parent `9c32e630a0` through `c5c50a2141`
