### PR TITLE
perf(bench): isolate packed history scaling

### DIFF
--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -135,6 +135,12 @@ harness = false
 required-features = ["storage-benches", "slatedb"]
 
 [[bench]]
+name = "packed_history_scale"
+path = "benches/packed_history_scale.rs"
+harness = false
+required-features = ["storage-benches", "slatedb"]
+
+[[bench]]
 name = "multi_space_point_read"
 path = "benches/multi_space_point_read.rs"
 harness = false

--- a/packages/engine-benchmarks/benches/packed_history_scale.rs
+++ b/packages/engine-benchmarks/benches/packed_history_scale.rs
@@ -1,0 +1,281 @@
+use std::fmt::{self, Display, Formatter};
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use lix_engine::storage::Storage;
+use lix_engine::storage_adapter::StorageAdapter;
+use lix_engine::tracked_state::bench::{
+    BenchLayoutAccounting, packed_history_layout, scan_packed_history, seed_packed_history,
+};
+use lix_rocksdb_storage::RocksDB;
+use lix_slatedb_storage::SlateDB;
+
+const DEFAULT_CHANGES: &[usize] = &[100_000];
+const DEFAULT_COMMIT_WIDTHS: &[usize] = &[1, 10, 100, 10_000];
+const DEFAULT_STORAGE_BATCH_CHANGES: usize = 100_000;
+const DEFAULT_WARMUPS: usize = 1;
+const DEFAULT_SAMPLES: usize = 5;
+
+#[derive(Clone, Copy, Debug)]
+enum Backend {
+    RocksDB,
+    SlateDB,
+}
+
+impl Display for Backend {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RocksDB => formatter.write_str("rocksdb"),
+            Self::SlateDB => formatter.write_str("slatedb"),
+        }
+    }
+}
+
+fn main() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("create packed-history benchmark runtime");
+    runtime.block_on(run());
+}
+
+async fn run() {
+    let changes = env_usizes("LIX_PACKED_HISTORY_CHANGES", DEFAULT_CHANGES);
+    let commit_widths = env_usizes("LIX_PACKED_HISTORY_COMMIT_WIDTHS", DEFAULT_COMMIT_WIDTHS);
+    let storage_batch_changes = env_usize(
+        "LIX_PACKED_HISTORY_STORAGE_BATCH_CHANGES",
+        DEFAULT_STORAGE_BATCH_CHANGES,
+    );
+    let warmups = env_nonnegative_usize("LIX_PACKED_HISTORY_WARMUPS", DEFAULT_WARMUPS);
+    let samples = env_usize("LIX_PACKED_HISTORY_SAMPLES", DEFAULT_SAMPLES).max(1);
+    let flush = env_bool("LIX_PACKED_HISTORY_FLUSH", true);
+    let memtable_flush = env_bool("LIX_PACKED_HISTORY_MEMTABLE_FLUSH", false);
+    let account_layout = env_bool("LIX_PACKED_HISTORY_ACCOUNT_LAYOUT", true);
+
+    for backend in [Backend::RocksDB, Backend::SlateDB] {
+        if !selected("LIX_PACKED_HISTORY_BACKENDS", &backend.to_string()) {
+            continue;
+        }
+        for &change_count in &changes {
+            for &commit_width in &commit_widths {
+                if change_count % commit_width != 0 {
+                    eprintln!(
+                        "skip backend={backend} changes={change_count} commit_width={commit_width}: width does not divide changes"
+                    );
+                    continue;
+                }
+                match backend {
+                    Backend::RocksDB => {
+                        let dir = tempfile::tempdir().expect("create RocksDB benchmark directory");
+                        let path = dir.path().join("rocksdb");
+                        let storage = RocksDB::open(&path).expect("open benchmark RocksDB");
+                        run_case(
+                            backend,
+                            storage.clone(),
+                            &path,
+                            change_count,
+                            commit_width,
+                            storage_batch_changes,
+                            warmups,
+                            samples,
+                            flush,
+                            false,
+                            account_layout,
+                            || async {
+                                storage.flush().expect("flush benchmark RocksDB");
+                            },
+                        )
+                        .await;
+                    }
+                    Backend::SlateDB => {
+                        let dir = tempfile::tempdir().expect("create SlateDB benchmark directory");
+                        let path = dir.path().join("slatedb");
+                        let storage = SlateDB::open(&path).expect("open benchmark SlateDB");
+                        run_case(
+                            backend,
+                            storage.clone(),
+                            &path,
+                            change_count,
+                            commit_width,
+                            storage_batch_changes,
+                            warmups,
+                            samples,
+                            flush,
+                            memtable_flush,
+                            account_layout,
+                            || async {
+                                if memtable_flush {
+                                    storage
+                                        .flush_memtable_for_diagnostics()
+                                        .await
+                                        .expect("flush benchmark SlateDB memtable");
+                                } else {
+                                    storage.flush().await.expect("flush benchmark SlateDB WAL");
+                                }
+                            },
+                        )
+                        .await;
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[expect(clippy::too_many_arguments)]
+async fn run_case<S, Flush, FlushFuture>(
+    backend: Backend,
+    storage: S,
+    storage_path: &Path,
+    changes: usize,
+    commit_width: usize,
+    storage_batch_changes: usize,
+    warmups: usize,
+    samples: usize,
+    flush: bool,
+    memtable_flush: bool,
+    account_layout: bool,
+    flush_storage: Flush,
+) where
+    S: Storage + Clone,
+    Flush: FnOnce() -> FlushFuture,
+    FlushFuture: Future<Output = ()>,
+{
+    let adapter = StorageAdapter::new(storage);
+    let seed_started = Instant::now();
+    let writes = seed_packed_history(&adapter, changes, commit_width, storage_batch_changes).await;
+    let seed_elapsed = seed_started.elapsed();
+    if flush {
+        flush_storage().await;
+    }
+    let backend_bytes = directory_bytes(storage_path);
+
+    for _ in 0..warmups {
+        assert_eq!(scan_packed_history(&adapter).await, changes);
+    }
+    let mut timings = Vec::with_capacity(samples);
+    for _ in 0..samples {
+        let started = Instant::now();
+        assert_eq!(scan_packed_history(&adapter).await, changes);
+        timings.push(started.elapsed());
+    }
+    timings.sort_unstable();
+    // Account after timing so a layout scan cannot pre-warm the measured
+    // storage pages. `warmups=0,samples=1` is therefore the cold profile.
+    let layout = if account_layout {
+        packed_history_layout(&adapter).await
+    } else {
+        Vec::new()
+    };
+    let manifest = find_layout(&layout, "tracked_state.commit_delta_manifest.v2");
+    let segments = find_layout(&layout, "tracked_state.commit_delta_segment.v2");
+
+    println!(
+        "packed_history_scale,backend={backend},changes={changes},commits={},commit_width={commit_width},\
+         storage_batch_changes={storage_batch_changes},flushed={flush},warmups={warmups},samples={samples},\
+         memtable_flushed={memtable_flush},\
+         layout_accounted={account_layout},\
+         seed_ms={},ingest_changes_per_second={:.1},staged_puts={},logical_written_bytes={},\
+         scan_p50_ms={},scan_p95_ms={},scan_p99_ms={},\
+         manifest_keys={},manifest_key_bytes={},manifest_value_bytes={},\
+         segment_keys={},segment_key_bytes={},segment_value_bytes={},backend_bytes={backend_bytes}",
+        writes.commits,
+        seed_elapsed.as_millis(),
+        changes as f64 / seed_elapsed.as_secs_f64(),
+        writes.staged_puts,
+        writes.written_bytes,
+        millis(percentile(&timings, 50)),
+        millis(percentile(&timings, 95)),
+        millis(percentile(&timings, 99)),
+        manifest.rows,
+        manifest.key_bytes,
+        manifest.value_bytes,
+        segments.rows,
+        segments.key_bytes,
+        segments.value_bytes,
+    );
+}
+
+fn find_layout(layout: &[BenchLayoutAccounting], name: &str) -> BenchLayoutAccounting {
+    layout
+        .iter()
+        .find(|space| space.space == name)
+        .copied()
+        .unwrap_or(BenchLayoutAccounting {
+            space_id: 0,
+            space: "missing",
+            rows: 0,
+            key_bytes: 0,
+            value_bytes: 0,
+        })
+}
+
+fn percentile(sorted: &[Duration], percentile: usize) -> Duration {
+    let rank = sorted.len().saturating_mul(percentile).div_ceil(100);
+    sorted[rank.saturating_sub(1).min(sorted.len() - 1)]
+}
+
+fn millis(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
+fn env_nonnegative_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn env_usizes(name: &str, default: &[usize]) -> Vec<usize> {
+    std::env::var(name)
+        .ok()
+        .map(|value| {
+            value
+                .split(',')
+                .filter_map(|value| value.trim().parse().ok())
+                .filter(|value| *value > 0)
+                .collect()
+        })
+        .filter(|values: &Vec<_>| !values.is_empty())
+        .unwrap_or_else(|| default.to_vec())
+}
+
+fn env_bool(name: &str, default: bool) -> bool {
+    std::env::var(name).map_or(default, |value| {
+        matches!(value.as_str(), "1" | "true" | "yes")
+    })
+}
+
+fn selected(variable: &str, candidate: &str) -> bool {
+    std::env::var(variable).map_or(true, |selection| {
+        selection
+            .split(',')
+            .map(str::trim)
+            .any(|value| value == candidate)
+    })
+}
+
+fn directory_bytes(path: &Path) -> u64 {
+    std::fs::read_dir(path).map_or(0, |entries| {
+        entries
+            .filter_map(Result::ok)
+            .map(|entry| {
+                entry.metadata().map_or(0, |metadata| {
+                    if metadata.is_dir() {
+                        directory_bytes(&entry.path())
+                    } else {
+                        metadata.len()
+                    }
+                })
+            })
+            .sum()
+    })
+}

--- a/packages/engine/src/tracked_state/bench_support.rs
+++ b/packages/engine/src/tracked_state/bench_support.rs
@@ -6,8 +6,8 @@ use crate::storage_adapter::{
     StorageWriteSetStats,
 };
 use crate::tracked_state::{
-    TrackedStateContext, TrackedStateDeltaRef, TrackedStateFilter, TrackedStateKey,
-    TrackedStateReadColumns, TrackedStateScanRequest,
+    TrackedStateCommitDeltaRef, TrackedStateContext, TrackedStateDeltaRef, TrackedStateFilter,
+    TrackedStateKey, TrackedStateReadColumns, TrackedStateScanRequest,
 };
 
 #[derive(Clone, Debug)]
@@ -47,6 +47,168 @@ pub struct BenchLayoutAccounting {
     pub rows: u64,
     pub key_bytes: u64,
     pub value_bytes: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct BenchPackedHistoryAccounting {
+    pub changes: usize,
+    pub commits: usize,
+    pub staged_puts: u64,
+    pub written_bytes: u64,
+}
+
+/// Seeds the authoritative packed-history plane without commit headers, roots,
+/// or live-state indexes.
+///
+/// This deliberately isolates the physical packed scan from public commit
+/// facts and live-state work. `storage_batch_changes` controls only how many
+/// logical changes share one backend transaction; it does not change the
+/// commit-delta layout.
+pub async fn seed_packed_history<StorageImpl>(
+    storage: &StorageAdapter<StorageImpl>,
+    changes: usize,
+    commit_width: usize,
+    storage_batch_changes: usize,
+) -> BenchPackedHistoryAccounting
+where
+    StorageImpl: Storage,
+{
+    assert!(changes > 0, "packed-history changes must be positive");
+    assert!(
+        commit_width > 0,
+        "packed-history commit width must be positive"
+    );
+    assert!(
+        changes.is_multiple_of(commit_width),
+        "packed-history changes must divide evenly by commit width"
+    );
+    assert!(
+        storage_batch_changes >= commit_width,
+        "storage batch must hold at least one logical commit"
+    );
+
+    let commits = changes / commit_width;
+    let commits_per_storage_batch = (storage_batch_changes / commit_width).max(1);
+    let mut staged_puts = 0;
+    let mut written_bytes = 0;
+    for commit_batch_start in (0..commits).step_by(commits_per_storage_batch) {
+        let commit_batch_end = (commit_batch_start + commits_per_storage_batch).min(commits);
+        let mut writes = storage.new_write_set();
+        for commit_index in commit_batch_start..commit_batch_end {
+            let owned = (0..commit_width)
+                .map(|row_index| PackedHistoryDelta::new(commit_index, row_index))
+                .collect::<Vec<_>>();
+            let deltas = owned
+                .iter()
+                .map(PackedHistoryDelta::as_commit_ref)
+                .collect::<Vec<_>>();
+            super::storage::stage_commit_deltas(&mut writes, &deltas)
+                .expect("stage packed-history commit delta");
+        }
+        let (_commit, stats) = storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit packed-history storage batch");
+        staged_puts += stats.staged_puts;
+        written_bytes += stats.written_bytes;
+    }
+    BenchPackedHistoryAccounting {
+        changes,
+        commits,
+        staged_puts,
+        written_bytes,
+    }
+}
+
+pub async fn scan_packed_history<StorageImpl>(storage: &StorageAdapter<StorageImpl>) -> usize
+where
+    StorageImpl: Storage,
+{
+    let read = SharedStorageAdapterRead::new(
+        storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("begin packed-history scan"),
+    );
+    super::storage::scan_change_records_from_commit_deltas(&read)
+        .await
+        .expect("scan packed history")
+        .len()
+}
+
+pub async fn packed_history_layout<StorageImpl>(
+    storage: &StorageAdapter<StorageImpl>,
+) -> Vec<BenchLayoutAccounting>
+where
+    StorageImpl: Storage,
+{
+    let read = SharedStorageAdapterRead::new(
+        storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("begin packed-history layout scan"),
+    );
+    crate::storage_bench::layout_accounting(&read)
+        .await
+        .into_iter()
+        .map(|space| BenchLayoutAccounting {
+            space_id: space.space_id,
+            space: space.space,
+            rows: space.rows,
+            key_bytes: space.key_bytes,
+            value_bytes: space.value_bytes,
+        })
+        .collect()
+}
+
+struct PackedHistoryDelta {
+    change_id: ChangeId,
+    commit_id: CommitId,
+    entity_pk: EntityPk,
+    schema_key: String,
+    created_at: crate::common::LixTimestamp,
+    updated_at: crate::common::LixTimestamp,
+}
+
+impl PackedHistoryDelta {
+    fn new(commit_index: usize, row_index: usize) -> Self {
+        Self {
+            change_id: ChangeId::for_test_label(&format!(
+                "packed-history-change-{commit_index}-{row_index}"
+            )),
+            commit_id: CommitId::for_test_label(&format!("packed-history-commit-{commit_index}")),
+            entity_pk: EntityPk::single(format!(
+                "packed-history-entity-{commit_index}-{row_index}"
+            )),
+            schema_key: "packed_history".to_string(),
+            created_at: crate::common::LixTimestamp::expect_parse(
+                "created_at",
+                "2026-07-28T00:00:00.000Z",
+            ),
+            updated_at: crate::common::LixTimestamp::expect_parse(
+                "updated_at",
+                "2026-07-28T00:00:00.000Z",
+            ),
+        }
+    }
+
+    fn as_commit_ref(&self) -> TrackedStateCommitDeltaRef<'_> {
+        TrackedStateCommitDeltaRef {
+            delta: TrackedStateDeltaRef {
+                schema_key: &self.schema_key,
+                file_id: None,
+                entity_pk: &self.entity_pk,
+                change_id: self.change_id,
+                commit_id: self.commit_id,
+                deleted: false,
+                created_at: self.created_at,
+                updated_at: self.updated_at,
+            },
+            snapshot: crate::json_store::JsonSlotRef::None,
+            metadata: crate::json_store::JsonSlotRef::None,
+            origin_key: None,
+        }
+    }
 }
 
 struct BenchWriteOutcome {

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -31,8 +31,9 @@ use object_store::{
     PutOptions, PutPayload, PutResult,
 };
 use slatedb::config::{
-    CompressionCodec, DurabilityLevel, ObjectStoreCacheOptions, ReadOptions as SlateDBReadOptions,
-    ScanOptions as SlateDBScanOptions, Settings, WriteOptions as SlateDBWriteOptions,
+    CompressionCodec, DurabilityLevel, FlushOptions, FlushType, ObjectStoreCacheOptions,
+    ReadOptions as SlateDBReadOptions, ScanOptions as SlateDBScanOptions, Settings,
+    WriteOptions as SlateDBWriteOptions,
 };
 use slatedb::db_cache::moka::{MokaCache, MokaCacheOptions};
 use slatedb::db_cache::{DbCache, SplitCache};
@@ -982,6 +983,27 @@ impl SlateDB {
         self.write_pipeline.wait_for_visible().await?;
         self.worker
             .call(|db| async move { db.flush().await.map_err(slatedb_error) })
+            .await
+    }
+
+    /// Forces the active and immutable memtables into SSTs for storage-layout
+    /// diagnostics.
+    ///
+    /// [`Self::flush`] intentionally follows upstream durability semantics and
+    /// flushes only the WAL while WAL is enabled. Benchmarks must opt into this
+    /// stronger lifecycle boundary when comparing memory-resident and SST
+    /// scan shapes.
+    #[doc(hidden)]
+    pub async fn flush_memtable_for_diagnostics(&self) -> Result<(), StorageError> {
+        self.write_pipeline.wait_for_visible().await?;
+        self.worker
+            .call(|db| async move {
+                db.flush_with_options(FlushOptions {
+                    flush_type: FlushType::MemTable,
+                })
+                .await
+                .map_err(slatedb_error)
+            })
             .await
     }
 }


### PR DESCRIPTION
## Summary

Adds a dedicated packed-history scale benchmark that isolates commit-delta manifests/segments from public commit facts and live-state work.

The benchmark is environment-driven across backend, history size, commit width, storage transaction width, warmup/sample count, WAL flush, and explicit SlateDB memtable flush. It reports ingest throughput, p50/p95/p99 scan latency, logical writes, staged storage objects, manifest/segment keys and bytes, and physical backend bytes. Layout accounting can be disabled for cold/profile runs.

A diagnostic-only SlateDB memtable flush boundary makes WAL/memtable/SST lifecycle comparisons explicit instead of conflating `Db::flush()` durability semantics with an SST flush.

## Reproduction

Current `main`, SlateDB, 1M logical changes, 100K changes per storage transaction:

| commit width | commits / inline manifests | packed scan |
|---:|---:|---:|
| 1 | 1,000,000 | 57.89s |
| 100 | 10,000 | 1.01s |

At 100K history, width 1 is 305.6ms. The 100K→1M width-1 tail therefore grows ~189× for 10× history (log-log slope ~2.28).

A true memtable flush does not explain the cliff: 1M/width-1 remains 55.05s, while width 100 remains 1.03s. This reproduces the engine problem without public commit facts or live-state `COUNT(*)` work and separates it from backend lifecycle policy.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p lix_engine --features all-simulations` (768 passed, 2 ignored; doctests passed)
- SlateDB adapter suite is running separately before the stacked optimization PR.

## Stack

This is the measurement/base PR. The next PR retains SlateDB scan cursors across bounded continuation pages; profiles show the current 1,024-row page loop repeatedly reconstructing range iterators and churning block decompression/cache allocation.