### PR TITLE
perf(history): add exact packed change lookup

### DIFF
--- a/packages/engine-benchmarks/benches/packed_history_scale.rs
+++ b/packages/engine-benchmarks/benches/packed_history_scale.rs
@@ -5,7 +5,8 @@ use std::time::{Duration, Instant};
 use lix_engine::storage::Storage;
 use lix_engine::storage_adapter::StorageAdapter;
 use lix_engine::tracked_state::bench::{
-    BenchLayoutAccounting, packed_history_layout, scan_packed_history, seed_packed_history,
+    BenchLayoutAccounting, load_packed_change, packed_history_layout, scan_packed_history,
+    seed_packed_history,
 };
 use lix_rocksdb_storage::RocksDB;
 use lix_slatedb_storage::SlateDB;
@@ -15,6 +16,7 @@ const DEFAULT_COMMIT_WIDTHS: &[usize] = &[1, 10, 100, 10_000];
 const DEFAULT_STORAGE_BATCH_CHANGES: usize = 100_000;
 const DEFAULT_WARMUPS: usize = 1;
 const DEFAULT_SAMPLES: usize = 5;
+const DEFAULT_EXACT_SAMPLES: usize = 1_001;
 
 #[derive(Clone, Copy, Debug)]
 enum Backend {
@@ -48,6 +50,7 @@ async fn run() {
     );
     let warmups = env_nonnegative_usize("LIX_PACKED_HISTORY_WARMUPS", DEFAULT_WARMUPS);
     let samples = env_usize("LIX_PACKED_HISTORY_SAMPLES", DEFAULT_SAMPLES).max(1);
+    let exact_samples = env_usize("LIX_PACKED_HISTORY_EXACT_SAMPLES", DEFAULT_EXACT_SAMPLES).max(1);
     let flush = env_bool("LIX_PACKED_HISTORY_FLUSH", true);
     let memtable_flush = env_bool("LIX_PACKED_HISTORY_MEMTABLE_FLUSH", false);
     let account_layout = env_bool("LIX_PACKED_HISTORY_ACCOUNT_LAYOUT", true);
@@ -78,6 +81,7 @@ async fn run() {
                             storage_batch_changes,
                             warmups,
                             samples,
+                            exact_samples,
                             flush,
                             false,
                             account_layout,
@@ -100,6 +104,7 @@ async fn run() {
                             storage_batch_changes,
                             warmups,
                             samples,
+                            exact_samples,
                             flush,
                             memtable_flush,
                             account_layout,
@@ -132,6 +137,7 @@ async fn run_case<S, Flush, FlushFuture>(
     storage_batch_changes: usize,
     warmups: usize,
     samples: usize,
+    exact_samples: usize,
     flush: bool,
     memtable_flush: bool,
     account_layout: bool,
@@ -142,6 +148,8 @@ async fn run_case<S, Flush, FlushFuture>(
     FlushFuture: Future<Output = ()>,
 {
     let adapter = StorageAdapter::new(storage);
+    let id_shape =
+        std::env::var("LIX_PACKED_HISTORY_ID_SHAPE").unwrap_or_else(|_| "deterministic".into());
     let seed_started = Instant::now();
     let writes = seed_packed_history(&adapter, changes, commit_width, storage_batch_changes).await;
     let seed_elapsed = seed_started.elapsed();
@@ -160,6 +168,18 @@ async fn run_case<S, Flush, FlushFuture>(
         timings.push(started.elapsed());
     }
     timings.sort_unstable();
+    let exact_commit_index = changes / commit_width / 2;
+    let exact_row_index = commit_width / 2;
+    for _ in 0..warmups {
+        assert!(load_packed_change(&adapter, exact_commit_index, exact_row_index).await);
+    }
+    let mut exact_timings = Vec::with_capacity(exact_samples);
+    for _ in 0..exact_samples {
+        let started = Instant::now();
+        assert!(load_packed_change(&adapter, exact_commit_index, exact_row_index).await);
+        exact_timings.push(started.elapsed());
+    }
+    exact_timings.sort_unstable();
     // Account after timing so a layout scan cannot pre-warm the measured
     // storage pages. `warmups=0,samples=1` is therefore the cold profile.
     let layout = if account_layout {
@@ -169,16 +189,19 @@ async fn run_case<S, Flush, FlushFuture>(
     };
     let manifest = find_layout(&layout, "tracked_state.commit_delta_manifest.v2");
     let segments = find_layout(&layout, "tracked_state.commit_delta_segment.v2");
+    let locators = find_layout(&layout, "tracked_state.change_locator.v1");
 
     println!(
-        "packed_history_scale,backend={backend},changes={changes},commits={},commit_width={commit_width},\
+        "packed_history_scale,backend={backend},id_shape={id_shape},changes={changes},commits={},commit_width={commit_width},\
          storage_batch_changes={storage_batch_changes},flushed={flush},warmups={warmups},samples={samples},\
          memtable_flushed={memtable_flush},\
          layout_accounted={account_layout},\
-         seed_ms={},ingest_changes_per_second={:.1},staged_puts={},logical_written_bytes={},\
+         exact_samples={exact_samples},seed_ms={},ingest_changes_per_second={:.1},staged_puts={},logical_written_bytes={},\
          scan_p50_ms={},scan_p95_ms={},scan_p99_ms={},\
+         exact_p50_ms={},exact_p95_ms={},exact_p99_ms={},\
          manifest_keys={},manifest_key_bytes={},manifest_value_bytes={},\
-         segment_keys={},segment_key_bytes={},segment_value_bytes={},backend_bytes={backend_bytes}",
+         segment_keys={},segment_key_bytes={},segment_value_bytes={},\
+         locator_keys={},locator_key_bytes={},locator_value_bytes={},backend_bytes={backend_bytes}",
         writes.commits,
         seed_elapsed.as_millis(),
         changes as f64 / seed_elapsed.as_secs_f64(),
@@ -187,12 +210,18 @@ async fn run_case<S, Flush, FlushFuture>(
         millis(percentile(&timings, 50)),
         millis(percentile(&timings, 95)),
         millis(percentile(&timings, 99)),
+        millis(percentile(&exact_timings, 50)),
+        millis(percentile(&exact_timings, 95)),
+        millis(percentile(&exact_timings, 99)),
         manifest.rows,
         manifest.key_bytes,
         manifest.value_bytes,
         segments.rows,
         segments.key_bytes,
         segments.value_bytes,
+        locators.rows,
+        locators.key_bytes,
+        locators.value_bytes,
     );
 }
 

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -650,6 +650,45 @@ where
         .map(JsonRef::from_hash_bytes)
         .collect::<Vec<_>>();
 
+    let dead_packed_change_ids = sweep_commits
+        .iter()
+        .filter_map(|commit_id| packed.commits.get(commit_id))
+        .flat_map(|entry| entry.members.iter().map(|member| member.value.change_id))
+        .collect::<BTreeSet<_>>();
+    crate::tracked_state::stage_delete_change_locators(
+        writes,
+        dead_packed_change_ids.difference(&live_change_ids).copied(),
+    );
+    let relocated_locators = live_commits
+        .iter()
+        .filter_map(|commit_id| {
+            packed
+                .commits
+                .get(commit_id)
+                .map(|entry| (*commit_id, entry))
+        })
+        .flat_map(|(commit_id, entry)| {
+            let dead_packed_change_ids = &dead_packed_change_ids;
+            entry.members.iter().filter_map(move |member| {
+                dead_packed_change_ids
+                    .contains(&member.value.change_id)
+                    .then_some(crate::tracked_state::CommitDeltaChangeLocator {
+                        change_id: member.value.change_id,
+                        commit_id,
+                        segment_index: member.segment_index,
+                        ordinal: u8::try_from(member.ordinal)
+                            .expect("commit-delta segment row count fits u8"),
+                    })
+            })
+        })
+        .fold(BTreeMap::new(), |mut locators, locator| {
+            locators.entry(locator.change_id).or_insert(locator);
+            locators
+        })
+        .into_values()
+        .collect::<Vec<_>>();
+    crate::tracked_state::stage_change_locators(writes, &relocated_locators);
+
     for commit_id in &sweep_commits {
         writes.delete(
             COMMIT_SPACE,
@@ -800,7 +839,8 @@ mod tests {
     };
     use crate::tracked_state::{
         TrackedStateCommitDeltaRef, TrackedStateContext, TrackedStateDeltaRef,
-        scan_commit_delta_inventory, stage_commit_deltas,
+        load_change_record_by_id, scan_commit_delta_inventory, stage_change_locators,
+        stage_commit_deltas,
     };
     use crate::{Engine, GLOBAL_BRANCH_ID, Value};
     use bytes::Bytes;
@@ -1135,11 +1175,7 @@ mod tests {
             "live-member",
             JsonSlot::Ref(shared_ref),
         );
-        let dead_shared_member = packed_change(
-            "authority-gc-dead-shared-member",
-            "dead-shared-member",
-            JsonSlot::Ref(shared_ref),
-        );
+        let dead_shared_member = live_member.clone();
         let dead_only_member = packed_change(
             "authority-gc-dead-only-member",
             "dead-only-member",
@@ -1205,7 +1241,11 @@ mod tests {
         stage_commit_deltas(&mut writes, &live_deltas).expect("live packed member should stage");
         let dead_members = vec![dead_shared_member.clone(), dead_only_member.clone()];
         let dead_deltas = commit_delta_refs(dead_commit, &dead_members);
-        stage_commit_deltas(&mut writes, &dead_deltas).expect("dead packed members should stage");
+        let dead_locators = stage_commit_deltas(&mut writes, &dead_deltas)
+            .expect("dead packed members should stage");
+        // Point the shared change at the owner about to be collected. GC must
+        // relocate it to the surviving physical copy, not delete the index.
+        stage_change_locators(&mut writes, &dead_locators);
         storage_adapter
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
@@ -1265,6 +1305,18 @@ mod tests {
             .expect("standalone facts should load");
         assert!(changes.entries[0].is_some());
         assert!(changes.entries[1].is_none());
+        assert!(
+            load_change_record_by_id(&read, live_member.change_id)
+                .await
+                .expect("relocated live locator should load")
+                .is_some()
+        );
+        assert!(
+            load_change_record_by_id(&read, dead_only_member.change_id)
+                .await
+                .expect("dead locator lookup should succeed")
+                .is_none()
+        );
         let inventory = scan_commit_delta_inventory(&read)
             .await
             .expect("post-GC packed inventory should scan");

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -45,7 +45,7 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"packed-commit-authority.v18";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"indexed-packed-history.v19";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately
@@ -89,7 +89,7 @@ pub(crate) async fn repository_protocol_status(
 pub(crate) fn unsupported_repository_protocol_error() -> LixError {
     LixError::new(
         "LIX_ERROR_UNSUPPORTED_STORAGE_FORMAT",
-        "repository uses an unsupported live-state hot-index storage protocol; recreate the repository",
+        "repository uses an unsupported storage protocol; recreate the repository",
     )
 }
 
@@ -360,7 +360,8 @@ where
                 origin_key: change.origin_key.as_deref(),
             })
             .collect::<Vec<_>>();
-        crate::tracked_state::stage_commit_deltas(&mut writes, &commit_deltas)?;
+        let locators = crate::tracked_state::stage_commit_deltas(&mut writes, &commit_deltas)?;
+        crate::tracked_state::stage_change_locators(&mut writes, &locators);
         tracked_state
             .writer(&read, &mut writes)
             .stage_commit_root(&receipt.initial_commit_id, None, root_deltas)

--- a/packages/engine/src/sql2/providers/change.rs
+++ b/packages/engine/src/sql2/providers/change.rs
@@ -2,13 +2,14 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-use datafusion::common::{DataFusionError, Result};
+use datafusion::common::{DataFusionError, Result, ScalarValue};
 use datafusion::execution::context::ExecutionProps;
-use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
+use datafusion::logical_expr::{Expr, Operator, TableProviderFilterPushDown};
 
 use crate::LixError;
 use crate::changelog::{
-    ChangeId, ChangeRecord, ChangeScanRequest, ChangelogContext, ChangelogReader, CommitScanRequest,
+    COMMIT_CHANGE_ID_SPACE, ChangeId, ChangeLoadRequest, ChangeRecord, ChangeScanRequest,
+    ChangelogContext, ChangelogReader, CommitId, CommitLoadRequest, CommitScanRequest,
 };
 use crate::serialize_row_metadata;
 
@@ -20,7 +21,10 @@ use crate::sql2::change_materialization::{
 };
 use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::sql2::result_metadata::json_field;
-use crate::storage_adapter::StorageAdapterRead;
+use crate::storage_adapter::{
+    PointReadPlan, StorageAdapterRead, StorageGetOptions, StorageKey, StorageProjectedValue,
+};
+use bytes::Bytes;
 
 use super::columns::{Col, ColumnTable, ColumnTableError};
 use super::spec::{PlannedScan, TableSpec, projected_schema, register_spec_table, row_source};
@@ -66,11 +70,11 @@ where
     }
 
     fn filter_pushdown(&self, filter: &Expr) -> TableProviderFilterPushDown {
-        let _ = filter;
-        // Packed changes are identity-ordered inside commit-owned segments.
-        // Until the layout has a measured change-id index, no `lix_change`
-        // predicate is a bounded point read.
-        TableProviderFilterPushDown::Unsupported
+        if exact_change_id_filter(filter).is_some() {
+            TableProviderFilterPushDown::Exact
+        } else {
+            TableProviderFilterPushDown::Unsupported
+        }
     }
 
     async fn plan_scan(
@@ -81,6 +85,7 @@ where
         _props: &ExecutionProps,
     ) -> Result<PlannedScan> {
         let pushed_limit = if filters.is_empty() { limit } else { None };
+        let route = change_scan_route(filters);
         let schema = projected_schema(&lix_change_schema(), projection);
         let payload_projection = change_payload_projection(schema.as_ref(), filters);
         Ok(PlannedScan {
@@ -91,7 +96,7 @@ where
                 move |(query_source, schema)| async move {
                     let mut json_reader = query_source.json_reader;
                     let canonical_changes =
-                        scan_changelog_changes(query_source.store, pushed_limit)
+                        scan_changelog_changes(query_source.store, pushed_limit, route)
                             .await
                             .map_err(lix_error_to_datafusion_error)?;
                     let mut changes = Vec::with_capacity(canonical_changes.len());
@@ -145,10 +150,20 @@ fn change_payload_projection(schema: &Schema, filters: &[Expr]) -> ChangePayload
 async fn scan_changelog_changes<S>(
     store: S,
     limit: Option<usize>,
+    route: ChangeScanRoute,
 ) -> Result<Vec<LixChangeRow>, LixError>
 where
     S: StorageAdapterRead + Clone + Send + Sync + 'static,
 {
+    match route {
+        ChangeScanRoute::Empty => return Ok(Vec::new()),
+        ChangeScanRoute::Exact(change_id) => {
+            return load_exact_change(store, change_id)
+                .await
+                .map(|change| change.into_iter().collect());
+        }
+        ChangeScanRoute::All => {}
+    }
     let packed_changes =
         crate::tracked_state::scan_change_records_from_commit_deltas(&store).await?;
     let mut reader = ChangelogContext::new().reader(store);
@@ -193,6 +208,120 @@ where
         changes.truncate(limit);
     }
     Ok(changes)
+}
+
+#[derive(Clone, Copy)]
+enum ChangeScanRoute {
+    All,
+    Exact(ChangeId),
+    Empty,
+}
+
+fn change_scan_route(filters: &[Expr]) -> ChangeScanRoute {
+    let mut exact = None;
+    for filter in filters {
+        let Some(candidate) = exact_change_id_filter(filter) else {
+            continue;
+        };
+        let Some(candidate) = candidate else {
+            return ChangeScanRoute::Empty;
+        };
+        if exact.is_some_and(|current| current != candidate) {
+            return ChangeScanRoute::Empty;
+        }
+        exact = Some(candidate);
+    }
+    exact.map_or(ChangeScanRoute::All, ChangeScanRoute::Exact)
+}
+
+fn exact_change_id_filter(filter: &Expr) -> Option<Option<ChangeId>> {
+    let Expr::BinaryExpr(binary) = filter else {
+        return None;
+    };
+    if binary.op != Operator::Eq {
+        return None;
+    }
+    let literal = match (binary.left.as_ref(), binary.right.as_ref()) {
+        (Expr::Column(column), literal) | (literal, Expr::Column(column))
+            if column.name == "id" =>
+        {
+            literal
+        }
+        _ => return None,
+    };
+    let Expr::Literal(
+        ScalarValue::Utf8(Some(value))
+        | ScalarValue::Utf8View(Some(value))
+        | ScalarValue::LargeUtf8(Some(value)),
+        _,
+    ) = literal
+    else {
+        return None;
+    };
+    Some(ChangeId::parse(value).ok())
+}
+
+async fn load_exact_change<S>(
+    store: S,
+    change_id: ChangeId,
+) -> Result<Option<LixChangeRow>, LixError>
+where
+    S: StorageAdapterRead + Clone + Send + Sync + 'static,
+{
+    if let Some(change) = crate::tracked_state::load_change_record_by_id(&store, change_id).await? {
+        return Ok(Some(LixChangeRow::Direct(change)));
+    }
+
+    let mut reader = ChangelogContext::new().reader(store.clone());
+    if let Some(change) = reader
+        .load_changes(ChangeLoadRequest {
+            change_ids: std::slice::from_ref(&change_id),
+        })
+        .await?
+        .entries
+        .into_iter()
+        .next()
+        .flatten()
+    {
+        return Ok(Some(LixChangeRow::Direct(change)));
+    }
+
+    let index_key = StorageKey(Bytes::copy_from_slice(change_id.as_uuid().as_bytes()));
+    let indexed_commit =
+        PointReadPlan::new(COMMIT_CHANGE_ID_SPACE, std::slice::from_ref(&index_key))
+            .materialize(&store, StorageGetOptions::default())
+            .await?
+            .value
+            .into_iter()
+            .next()
+            .flatten();
+    let Some(StorageProjectedValue::FullValue(commit_id)) = indexed_commit else {
+        return Ok(None);
+    };
+    let commit_id = CommitId::new(uuid::Uuid::from_slice(&commit_id).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("changelog commit change-id index has invalid commit id: {error}"),
+        )
+    })?);
+    let commit = reader
+        .load_commits(CommitLoadRequest {
+            commit_ids: std::slice::from_ref(&commit_id),
+        })
+        .await?
+        .entries
+        .into_iter()
+        .next()
+        .flatten()
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("changelog commit change-id index references missing commit '{commit_id}'"),
+            )
+        })?;
+    Ok(Some(LixChangeRow::DerivedCommit(
+        commit_record_canonical_change(&commit),
+    )))
 }
 
 enum LixChangeRow {
@@ -284,9 +413,9 @@ fn change_batch_error(error: ColumnTableError) -> DataFusionError {
 #[cfg(test)]
 mod tests {
     use datafusion::arrow::datatypes::Schema;
-    use datafusion::logical_expr::{Expr, col};
+    use datafusion::logical_expr::{Expr, col, lit};
 
-    use super::{change_payload_projection, lix_change_schema};
+    use super::{ChangeScanRoute, change_payload_projection, change_scan_route, lix_change_schema};
 
     #[test]
     fn identity_projection_skips_json_payloads() {
@@ -315,5 +444,20 @@ mod tests {
 
         assert!(!projection.snapshot_content);
         assert!(projection.metadata);
+    }
+
+    #[test]
+    fn exact_change_id_route_accepts_uuid_and_rejects_impossible_literals() {
+        let id = crate::changelog::ChangeId::for_test_label("exact-change-route");
+        let route = change_scan_route(&[col("id").eq(lit(id.to_string()))]);
+        assert!(matches!(route, ChangeScanRoute::Exact(actual) if actual == id));
+        assert!(matches!(
+            change_scan_route(&[col("id").eq(lit("not-a-uuid"))]),
+            ChangeScanRoute::Empty
+        ));
+        assert!(matches!(
+            change_scan_route(&[col("schema_key").eq(lit("example"))]),
+            ChangeScanRoute::All
+        ));
     }
 }

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -228,6 +228,7 @@ fn native_storage_spaces() -> &'static [crate::storage_adapter::StorageSpace] {
         crate::tracked_state::TRACKED_STATE_COMMIT_ROOT_SPACE,
         crate::tracked_state::TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
         crate::tracked_state::TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
+        crate::tracked_state::TRACKED_STATE_CHANGE_LOCATOR_SPACE,
         crate::binary_cas::kv::BINARY_CAS_MANIFEST_SPACE,
         crate::binary_cas::kv::BINARY_CAS_MANIFEST_CHUNK_SPACE,
         crate::binary_cas::kv::BINARY_CAS_CHUNK_PRESENCE_SPACE,

--- a/packages/engine/src/test_support.rs
+++ b/packages/engine/src/test_support.rs
@@ -431,9 +431,19 @@ fn stage_test_commit_deltas_by_owner(
         let owner = delta.delta.commit_id;
         by_owner.entry(owner).or_default().push(*delta);
     }
+    let mut canonical_locators = BTreeMap::new();
     for owner_deltas in by_owner.values() {
-        crate::tracked_state::stage_commit_deltas(writes, owner_deltas)?;
+        let locators = crate::tracked_state::stage_commit_deltas(writes, owner_deltas)?;
+        for locator in locators {
+            canonical_locators
+                .entry(locator.change_id)
+                .or_insert(locator);
+        }
     }
+    crate::tracked_state::stage_change_locators(
+        writes,
+        &canonical_locators.into_values().collect::<Vec<_>>(),
+    );
     Ok(())
 }
 

--- a/packages/engine/src/tracked_state/bench_support.rs
+++ b/packages/engine/src/tracked_state/bench_support.rs
@@ -102,8 +102,9 @@ where
                 .iter()
                 .map(PackedHistoryDelta::as_commit_ref)
                 .collect::<Vec<_>>();
-            super::storage::stage_commit_deltas(&mut writes, &deltas)
+            let locators = super::storage::stage_commit_deltas(&mut writes, &deltas)
                 .expect("stage packed-history commit delta");
+            super::storage::stage_change_locators(&mut writes, &locators);
         }
         let (_commit, stats) = storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -134,6 +135,29 @@ where
         .await
         .expect("scan packed history")
         .len()
+}
+
+pub async fn load_packed_change<StorageImpl>(
+    storage: &StorageAdapter<StorageImpl>,
+    commit_index: usize,
+    row_index: usize,
+) -> bool
+where
+    StorageImpl: Storage,
+{
+    let read = SharedStorageAdapterRead::new(
+        storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("begin packed-history exact read"),
+    );
+    super::storage::load_change_record_by_id(
+        &read,
+        packed_history_change_id(commit_index, row_index),
+    )
+    .await
+    .expect("load packed-history change by id")
+    .is_some()
 }
 
 pub async fn packed_history_layout<StorageImpl>(
@@ -173,10 +197,8 @@ struct PackedHistoryDelta {
 impl PackedHistoryDelta {
     fn new(commit_index: usize, row_index: usize) -> Self {
         Self {
-            change_id: ChangeId::for_test_label(&format!(
-                "packed-history-change-{commit_index}-{row_index}"
-            )),
-            commit_id: CommitId::for_test_label(&format!("packed-history-commit-{commit_index}")),
+            change_id: packed_history_change_id(commit_index, row_index),
+            commit_id: CommitId::new(packed_history_uuid(commit_index, 0, 0x43)),
             entity_pk: EntityPk::single(format!(
                 "packed-history-entity-{commit_index}-{row_index}"
             )),
@@ -209,6 +231,45 @@ impl PackedHistoryDelta {
             origin_key: None,
         }
     }
+}
+
+fn packed_history_change_id(commit_index: usize, row_index: usize) -> ChangeId {
+    ChangeId::new(packed_history_uuid(commit_index, row_index, 0x68))
+}
+
+fn packed_history_uuid(commit_index: usize, ordinal: usize, discriminator: u8) -> uuid::Uuid {
+    let timestamp = 0x0192_0000_0000u64
+        .checked_add(u64::try_from(commit_index).expect("benchmark commit index fits u64"))
+        .expect("benchmark timestamp does not overflow");
+    static DETERMINISTIC_IDS: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    let deterministic = *DETERMINISTIC_IDS.get_or_init(|| {
+        std::env::var("LIX_PACKED_HISTORY_ID_SHAPE").map_or(true, |shape| shape != "system")
+    });
+    let mut bytes = [0u8; 16];
+    bytes[..6].copy_from_slice(&timestamp.to_be_bytes()[2..]);
+    if deterministic {
+        bytes[6] = 0x70;
+        bytes[7] = 0;
+    } else {
+        bytes[6] = 0x70 | u8::try_from((ordinal >> 8) & 0x0f).expect("ordinal nibble fits u8");
+        bytes[7] = u8::try_from(ordinal & 0xff).expect("ordinal byte fits u8");
+    }
+    let mixed = if deterministic {
+        (u64::try_from(commit_index).expect("commit index fits u64") << 20)
+            | (u64::try_from(ordinal).expect("ordinal fits u64") << 1)
+            | u64::from(discriminator == 0x68)
+    } else {
+        let mut mixed = (u64::try_from(commit_index).expect("commit index fits u64") << 16)
+            ^ u64::try_from(ordinal).expect("ordinal fits u64")
+            ^ u64::from(discriminator);
+        mixed = mixed.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        mixed = (mixed ^ (mixed >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        mixed = (mixed ^ (mixed >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        mixed ^ (mixed >> 31)
+    };
+    bytes[8..].copy_from_slice(&mixed.to_be_bytes());
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    uuid::Uuid::from_bytes(bytes)
 }
 
 struct BenchWriteOutcome {

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -27,15 +27,18 @@ pub(crate) use row_materialization::{
 };
 #[cfg(test)]
 pub(crate) use storage::load_commit_delta_change_ids;
+pub(crate) use storage::{
+    CommitDeltaChangeLocator, load_change_record_by_id, load_commit_delta_change_records,
+    load_commit_delta_members_with_payloads, scan_change_records_from_commit_deltas,
+    scan_commit_delta_inventory, stage_change_locators, stage_commit_deltas,
+    stage_delete_change_locators, stage_delete_commit_delta_inventory_entry,
+    stage_delete_commit_root,
+};
 #[cfg(feature = "storage-benches")]
 pub(crate) use storage::{
-    TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
-    TRACKED_STATE_COMMIT_ROOT_SPACE, TRACKED_STATE_TREE_CHUNK_SPACE,
-};
-pub(crate) use storage::{
-    load_commit_delta_change_records, load_commit_delta_members_with_payloads,
-    scan_change_records_from_commit_deltas, scan_commit_delta_inventory, stage_commit_deltas,
-    stage_delete_commit_delta_inventory_entry, stage_delete_commit_root,
+    TRACKED_STATE_CHANGE_LOCATOR_SPACE, TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
+    TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, TRACKED_STATE_COMMIT_ROOT_SPACE,
+    TRACKED_STATE_TREE_CHUNK_SPACE,
 };
 pub(crate) use types::{
     MaterializedTrackedStateRow, TrackedStateCommitDeltaRef, TrackedStateDeltaRef,

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -2557,12 +2557,13 @@ mod tests {
     };
 
     use super::{
-        COMMIT_DELTA_FORMAT_MAGIC, COMMIT_DELTA_SEGMENT_MAX_ROWS, CommitDeltaManifest,
-        CommitDeltaPayloadRef, DecodedCommitDeltaBatch, TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
-        TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, TRACKED_STATE_COMMIT_ROOT_MAGIC,
-        TRACKED_STATE_COMMIT_ROOT_SPACE, TRACKED_STATE_TREE_CHUNK_SPACE, TrackedStateChunkOverlay,
-        commit_delta_manifest_key, decode_commit_delta_manifest, decode_commit_delta_with_payloads,
-        decode_commit_root, encode_commit_delta_manifest, encode_commit_delta_segment,
+        COMMIT_DELTA_FORMAT_MAGIC, COMMIT_DELTA_SEGMENT_MAX_ROWS, CommitDeltaChangeLocator,
+        CommitDeltaManifest, CommitDeltaPayloadRef, DecodedCommitDeltaBatch,
+        TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
+        TRACKED_STATE_COMMIT_ROOT_MAGIC, TRACKED_STATE_COMMIT_ROOT_SPACE,
+        TRACKED_STATE_TREE_CHUNK_SPACE, TrackedStateChunkOverlay, commit_delta_manifest_key,
+        decode_commit_delta_manifest, decode_commit_delta_with_payloads, decode_commit_root,
+        encode_commit_delta_manifest, encode_commit_delta_segment,
         encode_commit_delta_segment_with_payloads, encode_commit_root, key,
         load_change_record_by_id, load_commit_delta_change_ids, load_commit_delta_change_records,
         load_commit_delta_members_with_payloads, load_commit_delta_values_encoded,
@@ -2731,7 +2732,7 @@ mod tests {
     #[test]
     fn change_locator_codec_compacts_sequential_ids_and_round_trips_fallback_ids() {
         let sequential = CommitDeltaChangeLocator {
-            change_id: crate::changelog::ChangeId::new(uuid::Uuid::from_u128(
+            change_id: ChangeId::new(uuid::Uuid::from_u128(
                 0x0192_0000_0000_7000_8000_0000_0000_0101,
             )),
             commit_id: CommitId::new(uuid::Uuid::from_u128(
@@ -2748,7 +2749,7 @@ mod tests {
         );
 
         let fallback = CommitDeltaChangeLocator {
-            change_id: crate::changelog::ChangeId::new(uuid::Uuid::from_u128(u128::MAX)),
+            change_id: ChangeId::new(uuid::Uuid::from_u128(u128::MAX)),
             commit_id: CommitId::new(uuid::Uuid::from_u128(1)),
             segment_index: u32::MAX,
             ordinal: 127,

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -34,6 +34,7 @@ pub(crate) const TRACKED_STATE_COMMIT_DELTA_MANIFEST_NAMESPACE: &str =
     "tracked_state.commit_delta_manifest.v2";
 pub(crate) const TRACKED_STATE_COMMIT_DELTA_SEGMENT_NAMESPACE: &str =
     "tracked_state.commit_delta_segment.v2";
+pub(crate) const TRACKED_STATE_CHANGE_LOCATOR_NAMESPACE: &str = "tracked_state.change_locator.v1";
 pub(crate) const TRACKED_STATE_TREE_CHUNK_SPACE: StorageSpace = StorageSpace::new(
     StorageSpaceId(0x0004_0001),
     TRACKED_STATE_TREE_CHUNK_NAMESPACE,
@@ -54,6 +55,10 @@ pub(crate) const TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE: StorageSpace = Stora
 pub(crate) const TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE: StorageSpace = StorageSpace::new(
     StorageSpaceId(0x0004_001a),
     TRACKED_STATE_COMMIT_DELTA_SEGMENT_NAMESPACE,
+);
+pub(crate) const TRACKED_STATE_CHANGE_LOCATOR_SPACE: StorageSpace = StorageSpace::new(
+    StorageSpaceId(0x0004_001b),
+    TRACKED_STATE_CHANGE_LOCATOR_NAMESPACE,
 );
 
 const COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 128;
@@ -163,11 +168,21 @@ pub(crate) struct LoadedCommitDeltaEntry {
     pub(crate) change_record: crate::changelog::ChangeRecord,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct CommitDeltaChangeLocator {
+    pub(crate) change_id: crate::changelog::ChangeId,
+    pub(crate) commit_id: CommitId,
+    pub(crate) segment_index: u32,
+    pub(crate) ordinal: u8,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CommitDeltaMember {
     pub(crate) key: TrackedStateKey,
     pub(crate) value: TrackedStateIndexValue,
     pub(crate) change: crate::changelog::ChangeRecord,
+    pub(crate) segment_index: u32,
+    pub(crate) ordinal: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -546,9 +561,9 @@ pub(crate) fn stage_delete_commit_root(writes: &mut StorageWriteSet, commit_id: 
 pub(crate) fn stage_commit_deltas(
     writes: &mut StorageWriteSet,
     deltas: &[TrackedStateCommitDeltaRef<'_>],
-) -> Result<(), LixError> {
+) -> Result<Vec<CommitDeltaChangeLocator>, LixError> {
     let Some(&commit_id) = deltas.first().map(|delta| &delta.delta.commit_id) else {
-        return Ok(());
+        return Ok(Vec::new());
     };
     let mut entries = TrackedStateMutationBatchBuilder::with_row_capacity(deltas.len());
     let mut payloads = Vec::with_capacity(deltas.len());
@@ -640,13 +655,14 @@ pub(crate) fn stage_commit_deltas(
                 segments: Vec::new(),
             })?),
         );
-        return Ok(());
+        return commit_delta_change_locators(commit_id, 0, &entries);
     }
     writes.reserve_space(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, segment_count, 0);
     let mut manifest = CommitDeltaManifest {
         inline_segment: Vec::new(),
         segments: Vec::with_capacity(segment_count),
     };
+    let mut locators = Vec::with_capacity(entries.len());
     for (segment_index, (range, encoded)) in encoded_segments.into_iter().enumerate() {
         let segment_entries = &entries[range];
         let first_key = segment_entries
@@ -668,13 +684,314 @@ pub(crate) fn stage_commit_deltas(
             key(commit_delta_segment_key(commit_id, segment_index)?),
             value(encoded),
         );
+        locators.extend(commit_delta_change_locators(
+            commit_id,
+            segment_index,
+            segment_entries,
+        )?);
     }
     writes.put(
         TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
         key(commit_delta_manifest_key(commit_id)),
         value(encode_commit_delta_manifest(&manifest)?),
     );
-    Ok(())
+    Ok(locators)
+}
+
+fn commit_delta_change_locators(
+    commit_id: CommitId,
+    segment_index: usize,
+    entries: &[EncodedLeafEntry],
+) -> Result<Vec<CommitDeltaChangeLocator>, LixError> {
+    let segment_index = u32::try_from(segment_index).map_err(|_| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit_delta locator segment index exceeds u32",
+        )
+    })?;
+    entries
+        .iter()
+        .enumerate()
+        .map(|(ordinal, entry)| {
+            let ordinal = u8::try_from(ordinal).expect("commit-delta segment row count fits u8");
+            let change_id = decode_value(&entry.value)?.change_id;
+            Ok(CommitDeltaChangeLocator {
+                change_id,
+                commit_id,
+                segment_index,
+                ordinal,
+            })
+        })
+        .collect()
+}
+
+pub(crate) fn stage_change_locators(
+    writes: &mut StorageWriteSet,
+    locators: &[CommitDeltaChangeLocator],
+) {
+    writes.reserve_space(TRACKED_STATE_CHANGE_LOCATOR_SPACE, locators.len(), 0);
+    for locator in locators {
+        let encoded = encode_change_locator(*locator);
+        writes.put(
+            TRACKED_STATE_CHANGE_LOCATOR_SPACE,
+            key(locator.change_id.as_uuid().as_bytes().to_vec()),
+            value(encoded),
+        );
+    }
+}
+
+pub(crate) fn stage_delete_change_locators(
+    writes: &mut StorageWriteSet,
+    change_ids: impl IntoIterator<Item = crate::changelog::ChangeId>,
+) {
+    for change_id in change_ids {
+        writes.delete(
+            TRACKED_STATE_CHANGE_LOCATOR_SPACE,
+            key(change_id.as_uuid().as_bytes().to_vec()),
+        );
+    }
+}
+
+pub(crate) async fn load_change_record_by_id(
+    store: &(impl StorageAdapterRead + ?Sized),
+    change_id: crate::changelog::ChangeId,
+) -> Result<Option<crate::changelog::ChangeRecord>, LixError> {
+    let locator_key = StorageKey(Bytes::copy_from_slice(change_id.as_uuid().as_bytes()));
+    let locator = PointReadPlan::new(
+        TRACKED_STATE_CHANGE_LOCATOR_SPACE,
+        std::slice::from_ref(&locator_key),
+    )
+    .materialize(store, StorageGetOptions::default())
+    .await?
+    .value
+    .into_iter()
+    .next()
+    .flatten()
+    .and_then(full_value_bytes);
+    let Some(locator) = locator else {
+        return Ok(None);
+    };
+    let locator = decode_change_locator(change_id, &locator)?;
+    let Some(manifest) = load_commit_delta_manifest(store, locator.commit_id).await? else {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "tracked_state change locator for '{change_id}' references missing commit '{}'",
+                locator.commit_id
+            ),
+        ));
+    };
+    let (segment, bounds) = if let Some(inline) = manifest.inline_segment() {
+        if locator.segment_index != 0 {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "tracked_state change locator for '{change_id}' references segment {} of an inline commit",
+                    locator.segment_index
+                ),
+            ));
+        }
+        (Bytes::copy_from_slice(inline), None)
+    } else {
+        let segment_index = usize::try_from(locator.segment_index).expect("u32 fits usize");
+        let bounds = manifest.segments.get(segment_index).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "tracked_state change locator for '{change_id}' references missing segment {}",
+                    locator.segment_index
+                ),
+            )
+        })?;
+        let segment_key = StorageKey(Bytes::from(commit_delta_segment_key(
+            locator.commit_id,
+            segment_index,
+        )?));
+        let segment = PointReadPlan::new(
+            TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
+            std::slice::from_ref(&segment_key),
+        )
+        .materialize(store, StorageGetOptions::default())
+        .await?
+        .value
+        .into_iter()
+        .next()
+        .flatten()
+        .and_then(full_value_bytes)
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "tracked_state change locator for '{change_id}' references absent segment {}",
+                    locator.segment_index
+                ),
+            )
+        })?;
+        (segment, Some(bounds))
+    };
+    let (leaf, payloads) = decode_commit_delta_with_payloads(&segment, bounds)?;
+    let ordinal = usize::from(locator.ordinal);
+    let entry = leaf.entry(ordinal)?.ok_or_else(|| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "tracked_state change locator for '{change_id}' references absent ordinal {}",
+                locator.ordinal
+            ),
+        )
+    })?;
+    let value = decode_value(entry.value)?;
+    if value.change_id != change_id || value.commit_id != locator.commit_id {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("tracked_state change locator for '{change_id}' points to the wrong row"),
+        ));
+    }
+    let key = decode_key(entry.key)?;
+    let payload = payloads.decode(ordinal)?;
+    Ok(Some(crate::changelog::ChangeRecord {
+        format_version: 2,
+        change_id,
+        schema_key: key.schema_key,
+        entity_pk: key.entity_pk,
+        file_id: key.file_id,
+        snapshot: payload.snapshot,
+        metadata: payload.metadata,
+        created_at: value.updated_at,
+        origin_key: payload.origin_key,
+    }))
+}
+
+fn decode_change_locator(
+    change_id: crate::changelog::ChangeId,
+    bytes: &[u8],
+) -> Result<CommitDeltaChangeLocator, LixError> {
+    let mut cursor = 0usize;
+    let encoding = *bytes.get(cursor).ok_or_else(|| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("tracked_state change locator for '{change_id}' is truncated"),
+        )
+    })?;
+    cursor += 1;
+    let commit_id = match encoding {
+        0 => {
+            let encoded_delta = decode_locator_varint(bytes, &mut cursor)
+                .ok_or_else(|| invalid_change_locator(change_id, "has an invalid commit delta"))?;
+            let delta = ((encoded_delta >> 1) as i64) ^ -((encoded_delta & 1) as i64);
+            let change = change_id.as_uuid().as_u128();
+            let commit = if delta >= 0 {
+                change.checked_add(delta as u128)
+            } else {
+                change.checked_sub(u128::from(delta.unsigned_abs()))
+            }
+            .ok_or_else(|| invalid_change_locator(change_id, "commit delta overflows"))?;
+            uuid::Uuid::from_u128(commit)
+        }
+        1 => {
+            let common_prefix = usize::from(*bytes.get(cursor).ok_or_else(|| {
+                invalid_change_locator(change_id, "is missing its commit prefix length")
+            })?);
+            cursor += 1;
+            if common_prefix > 16 || bytes.len() - cursor < 16 - common_prefix {
+                return Err(invalid_change_locator(
+                    change_id,
+                    "has an invalid commit id",
+                ));
+            }
+            let suffix_end = cursor + 16 - common_prefix;
+            let mut commit_id = *change_id.as_uuid().as_bytes();
+            commit_id[common_prefix..].copy_from_slice(&bytes[cursor..suffix_end]);
+            cursor = suffix_end;
+            uuid::Uuid::from_bytes(commit_id)
+        }
+        _ => {
+            return Err(invalid_change_locator(
+                change_id,
+                "has an unsupported encoding",
+            ));
+        }
+    };
+    let packed_ordinal = decode_locator_varint(bytes, &mut cursor)
+        .filter(|_| cursor == bytes.len())
+        .ok_or_else(|| invalid_change_locator(change_id, "has an invalid ordinal"))?;
+    let segment_index = u32::try_from(packed_ordinal / COMMIT_DELTA_SEGMENT_MAX_ROWS as u64)
+        .map_err(|_| invalid_change_locator(change_id, "has an invalid segment"))?;
+    let ordinal = u8::try_from(packed_ordinal % COMMIT_DELTA_SEGMENT_MAX_ROWS as u64)
+        .expect("segment remainder fits u8");
+    Ok(CommitDeltaChangeLocator {
+        change_id,
+        commit_id: CommitId::new(commit_id),
+        segment_index,
+        ordinal,
+    })
+}
+
+fn encode_change_locator(locator: CommitDeltaChangeLocator) -> Vec<u8> {
+    let packed_ordinal = u64::from(locator.segment_index)
+        * u64::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS).expect("segment row limit fits u64")
+        + u64::from(locator.ordinal);
+    let change_uuid = locator.change_id.as_uuid();
+    let commit_uuid = locator.commit_id.as_uuid();
+    let numeric_delta = if commit_uuid.as_u128() >= change_uuid.as_u128() {
+        i128::try_from(commit_uuid.as_u128() - change_uuid.as_u128()).ok()
+    } else {
+        i128::try_from(change_uuid.as_u128() - commit_uuid.as_u128())
+            .ok()
+            .map(|delta| -delta)
+    };
+    if let Some(delta) = numeric_delta.and_then(|delta| i64::try_from(delta).ok()) {
+        let mut encoded = Vec::with_capacity(12);
+        encoded.push(0);
+        let zigzag = ((delta << 1) ^ (delta >> 63)) as u64;
+        encode_locator_varint(zigzag, &mut encoded);
+        encode_locator_varint(packed_ordinal, &mut encoded);
+        return encoded;
+    }
+    let change_id = change_uuid.as_bytes();
+    let commit_id = commit_uuid.as_bytes();
+    let common_prefix = change_id
+        .iter()
+        .zip(commit_id)
+        .position(|(change, commit)| change != commit)
+        .unwrap_or(16);
+    let mut encoded = Vec::with_capacity(19);
+    encoded.push(1);
+    encoded.push(u8::try_from(common_prefix).expect("UUID prefix length fits u8"));
+    encoded.extend_from_slice(&commit_id[common_prefix..]);
+    encode_locator_varint(packed_ordinal, &mut encoded);
+    encoded
+}
+
+fn invalid_change_locator(change_id: crate::changelog::ChangeId, reason: &str) -> LixError {
+    LixError::new(
+        LixError::CODE_INTERNAL_ERROR,
+        format!("tracked_state change locator for '{change_id}' {reason}"),
+    )
+}
+
+fn encode_locator_varint(mut value: u64, encoded: &mut Vec<u8>) {
+    while value >= 0x80 {
+        encoded.push((value as u8 & 0x7f) | 0x80);
+        value >>= 7;
+    }
+    encoded.push(value as u8);
+}
+
+fn decode_locator_varint(bytes: &[u8], cursor: &mut usize) -> Option<u64> {
+    let mut value = 0u64;
+    for shift in (0..=63).step_by(7) {
+        let byte = *bytes.get(*cursor)?;
+        *cursor += 1;
+        if shift == 63 && byte > 1 {
+            return None;
+        }
+        value |= u64::from(byte & 0x7f) << shift;
+        if byte & 0x80 == 0 {
+            return Some(value);
+        }
+    }
+    None
 }
 
 /// Loads commit deltas by encoded key for first-parent batch replay.
@@ -800,7 +1117,7 @@ pub(crate) async fn load_commit_delta_members_with_payloads(
     };
     let mut members = Vec::new();
     if let Some(inline_segment) = manifest.inline_segment() {
-        collect_strict_commit_delta_members(inline_segment, None, commit_id, &mut members)?;
+        collect_strict_commit_delta_members(inline_segment, None, commit_id, 0, &mut members)?;
     } else {
         let segment_keys = (0..manifest.segments.len())
             .map(|segment_index| {
@@ -824,6 +1141,7 @@ pub(crate) async fn load_commit_delta_members_with_payloads(
                 &bytes,
                 Some(&manifest.segments[segment_index]),
                 commit_id,
+                u32::try_from(segment_index).expect("segment index fits u32"),
                 &mut members,
             )?;
         }
@@ -1142,7 +1460,7 @@ pub(crate) async fn scan_commit_delta_inventory(
                     ),
                 ));
             }
-            collect_strict_commit_delta_members(inline_segment, None, commit_id, &mut members)?;
+            collect_strict_commit_delta_members(inline_segment, None, commit_id, 0, &mut members)?;
         } else {
             validate_physical_commit_delta_segments(commit_id, &manifest, &physical_segments)?;
             for (segment_index, bounds) in manifest.segments.iter().enumerate() {
@@ -1150,6 +1468,7 @@ pub(crate) async fn scan_commit_delta_inventory(
                     &physical_segments[&segment_index],
                     Some(bounds),
                     commit_id,
+                    u32::try_from(segment_index).expect("segment index fits u32"),
                     &mut members,
                 )?;
             }
@@ -1361,6 +1680,7 @@ fn collect_strict_commit_delta_members(
     bytes: &[u8],
     expected_bounds: Option<&CommitDeltaSegmentBounds>,
     expected_commit_id: CommitId,
+    segment_index: u32,
     members: &mut Vec<CommitDeltaMember>,
 ) -> Result<(), LixError> {
     let (leaf, payloads) = decode_commit_delta_with_payloads(bytes, expected_bounds)?;
@@ -1395,7 +1715,13 @@ fn collect_strict_commit_delta_members(
             created_at: value.updated_at,
             origin_key: payload.origin_key,
         };
-        members.push(CommitDeltaMember { key, value, change });
+        members.push(CommitDeltaMember {
+            key,
+            value,
+            change,
+            segment_index,
+            ordinal: u32::try_from(entry_index).expect("segment ordinal fits u32"),
+        });
     }
     Ok(())
 }
@@ -2238,11 +2564,12 @@ mod tests {
         commit_delta_manifest_key, decode_commit_delta_manifest, decode_commit_delta_with_payloads,
         decode_commit_root, encode_commit_delta_manifest, encode_commit_delta_segment,
         encode_commit_delta_segment_with_payloads, encode_commit_root, key,
-        load_commit_delta_change_ids, load_commit_delta_change_records,
+        load_change_record_by_id, load_commit_delta_change_ids, load_commit_delta_change_records,
         load_commit_delta_members_with_payloads, load_commit_delta_values_encoded,
         load_owned_commit_delta_entries, scan_change_records_from_commit_deltas,
         scan_commit_delta_inventory, scan_commit_delta_members, scan_commit_delta_values,
-        stage_commit_deltas, stage_delete_commit_delta_inventory_entry, value,
+        stage_change_locators, stage_commit_deltas, stage_delete_commit_delta_inventory_entry,
+        value,
     };
 
     #[derive(Clone)]
@@ -2350,6 +2677,87 @@ mod tests {
             metadata,
             origin_key,
         }
+    }
+
+    #[tokio::test]
+    async fn change_locator_loads_inline_and_segmented_records_by_id() {
+        for (label, fixtures) in [
+            (
+                "inline",
+                packed_commit_delta_fixtures()
+                    .into_iter()
+                    .take(3)
+                    .collect::<Vec<_>>(),
+            ),
+            ("segmented", packed_commit_delta_fixtures()),
+        ] {
+            let storage = StorageAdapter::new(Memory::new());
+            let commit_id = CommitId::for_test_label(&format!("{label}-locator-commit"));
+            let deltas = commit_delta_refs(commit_id, &fixtures);
+            let mut writes = storage.new_write_set();
+            let locators =
+                stage_commit_deltas(&mut writes, &deltas).expect("locator delta should stage");
+            stage_change_locators(&mut writes, &locators);
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .expect("locator delta should commit");
+            let read = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("locator read should open");
+            let expected = &fixtures[fixtures.len() / 2];
+            let loaded = load_change_record_by_id(&read, expected.change_id)
+                .await
+                .expect("exact locator read should succeed")
+                .expect("exact locator should find the change");
+            assert_eq!(loaded.change_id, expected.change_id);
+            assert_eq!(loaded.schema_key, expected.schema_key);
+            assert_eq!(loaded.entity_pk, expected.entity_pk);
+            assert_eq!(loaded.file_id, expected.file_id);
+            assert_eq!(loaded.created_at, expected.updated_at);
+            assert!(
+                load_change_record_by_id(
+                    &read,
+                    ChangeId::for_test_label(&format!("{label}-missing-change"))
+                )
+                .await
+                .expect("missing exact locator read should succeed")
+                .is_none()
+            );
+        }
+    }
+
+    #[test]
+    fn change_locator_codec_compacts_sequential_ids_and_round_trips_fallback_ids() {
+        let sequential = CommitDeltaChangeLocator {
+            change_id: crate::changelog::ChangeId::new(uuid::Uuid::from_u128(
+                0x0192_0000_0000_7000_8000_0000_0000_0101,
+            )),
+            commit_id: CommitId::new(uuid::Uuid::from_u128(
+                0x0192_0000_0000_7000_8000_0000_0000_0100,
+            )),
+            segment_index: 2,
+            ordinal: 7,
+        };
+        let encoded = super::encode_change_locator(sequential);
+        assert_eq!(encoded.len(), 4);
+        assert_eq!(
+            super::decode_change_locator(sequential.change_id, &encoded).expect("decode locator"),
+            sequential
+        );
+
+        let fallback = CommitDeltaChangeLocator {
+            change_id: crate::changelog::ChangeId::new(uuid::Uuid::from_u128(u128::MAX)),
+            commit_id: CommitId::new(uuid::Uuid::from_u128(1)),
+            segment_index: u32::MAX,
+            ordinal: 127,
+        };
+        let encoded = super::encode_change_locator(fallback);
+        assert_eq!(
+            super::decode_change_locator(fallback.change_id, &encoded).expect("decode locator"),
+            fallback
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -57,7 +57,7 @@ pub(crate) const TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE: StorageSpace = Storag
     TRACKED_STATE_COMMIT_DELTA_SEGMENT_NAMESPACE,
 );
 pub(crate) const TRACKED_STATE_CHANGE_LOCATOR_SPACE: StorageSpace = StorageSpace::new(
-    StorageSpaceId(0x0004_001b),
+    StorageSpaceId(0x0004_0021),
     TRACKED_STATE_CHANGE_LOCATOR_NAMESPACE,
 );
 
@@ -2559,11 +2559,11 @@ mod tests {
     use super::{
         COMMIT_DELTA_FORMAT_MAGIC, COMMIT_DELTA_SEGMENT_MAX_ROWS, CommitDeltaChangeLocator,
         CommitDeltaManifest, CommitDeltaPayloadRef, DecodedCommitDeltaBatch,
-        TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
-        TRACKED_STATE_COMMIT_ROOT_MAGIC, TRACKED_STATE_COMMIT_ROOT_SPACE,
-        TRACKED_STATE_TREE_CHUNK_SPACE, TrackedStateChunkOverlay, commit_delta_manifest_key,
-        decode_commit_delta_manifest, decode_commit_delta_with_payloads, decode_commit_root,
-        encode_commit_delta_manifest, encode_commit_delta_segment,
+        TRACKED_STATE_CHANGE_LOCATOR_SPACE, TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
+        TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, TRACKED_STATE_COMMIT_ROOT_MAGIC,
+        TRACKED_STATE_COMMIT_ROOT_SPACE, TRACKED_STATE_TREE_CHUNK_SPACE, TrackedStateChunkOverlay,
+        commit_delta_manifest_key, decode_commit_delta_manifest, decode_commit_delta_with_payloads,
+        decode_commit_root, encode_commit_delta_manifest, encode_commit_delta_segment,
         encode_commit_delta_segment_with_payloads, encode_commit_root, key,
         load_change_record_by_id, load_commit_delta_change_ids, load_commit_delta_change_records,
         load_commit_delta_members_with_payloads, load_commit_delta_values_encoded,
@@ -4041,6 +4041,7 @@ mod tests {
             TRACKED_STATE_COMMIT_ROOT_SPACE,
             TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
             TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
+            TRACKED_STATE_CHANGE_LOCATOR_SPACE,
             BINARY_CAS_MANIFEST_SPACE,
             BINARY_CAS_MANIFEST_CHUNK_SPACE,
             BINARY_CAS_CHUNK_PRESENCE_SPACE,

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -30,7 +30,7 @@ use crate::tracked_state::{
     MaterializedTrackedStateRow, TrackedStateCommitDeltaRef, TrackedStateContext,
     TrackedStateDeltaRef, TrackedStateFilter, TrackedStateKey, TrackedStateKeyRef,
     TrackedStateReadColumns, TrackedStateRootMutationRef, TrackedStateScanRequest, encode_key_ref,
-    load_commit_delta_change_records, stage_commit_deltas,
+    load_commit_delta_change_records, stage_change_locators, stage_commit_deltas,
 };
 use crate::transaction::staging::{PreparedInsertSelection, PreparedWriteSet};
 #[cfg(test)]
@@ -922,7 +922,16 @@ fn stage_tracked_commit_delta_index(
                 record,
             )?);
         }
-        stage_commit_deltas(writes, &deltas)?;
+        let locators = stage_commit_deltas(writes, &deltas)?;
+        let authored_change_ids = state_row_indices
+            .iter()
+            .filter_map(|&row_index| state_rows.row(row_index).change_id)
+            .collect::<std::collections::HashSet<_>>();
+        let authored_locators = locators
+            .into_iter()
+            .filter(|locator| authored_change_ids.contains(&locator.change_id))
+            .collect::<Vec<_>>();
+        stage_change_locators(writes, &authored_locators);
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

- add an immutable `change_id -> packed commit/segment/row` locator and route exact `lix_change.id = ...` predicates through point reads
- encode locators in 3–6 bytes on Lix's deterministic UUIDv7 happy path (with a correct system-UUID fallback)
- maintain locator correctness through authored commits, initialization, checkpoint/merge copies, and authority GC relocation/deletion
- hard-cut the repository protocol to `indexed-packed-history.v19`
- extend the isolated packed-history benchmark with exact p50/p95/p99 and locator layout accounting

## Why

Exact packed change lookup previously required scanning all history. The locator makes it O(1) backend point reads and also gives the next bounded-streaming change a canonical-copy discriminator.

## Results

SlateDB, deterministic UUID shape, width 1 exact p99:

| history | p99 |
| ---: | ---: |
| 100k | 1.56 µs |
| 1M | 2.23 µs |
| 10M | 1.55 µs |

That is <2x across 100k→10M. RocksDB at 100k width 1 is 3.62 µs p99.

At 100k, locator values average 3.0 B at widths 1/10, 3.68 B at width 100, and 5.57 B at width 10k. Total physical storage on SlateDB is 1.30–2.31 MiB for widths 10–10k; RocksDB is 1.10–1.49 MiB for widths 100–10k. The system-random UUID fallback is measured separately and remains correct, but is intentionally not the optimized layout.

## Validation

- `cargo check -p lix_engine --features storage-benches`
- 26 tracked-state storage tests
- exact locator inline + segmented test
- GC deletion/relocation test
- exact SQL route test
- remote RocksDB and SlateDB benchmark runs at 100k, 1M, and 10M

Stacked on #912.