### PR TITLE
perf(history): stream canonical packed changes with bounded memory

### DIFF
--- a/packages/engine-benchmarks/benches/packed_history_scale.rs
+++ b/packages/engine-benchmarks/benches/packed_history_scale.rs
@@ -1,5 +1,5 @@
 use std::fmt::{self, Display, Formatter};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use lix_engine::storage::Storage;
@@ -54,6 +54,20 @@ async fn run() {
     let flush = env_bool("LIX_PACKED_HISTORY_FLUSH", true);
     let memtable_flush = env_bool("LIX_PACKED_HISTORY_MEMTABLE_FLUSH", false);
     let account_layout = env_bool("LIX_PACKED_HISTORY_ACCOUNT_LAYOUT", true);
+    let skip_seed = env_bool("LIX_PACKED_HISTORY_SKIP_SEED", false);
+    let persistent_root = std::env::var_os("LIX_PACKED_HISTORY_STORAGE_PATH").map(PathBuf::from);
+    if persistent_root.is_some() {
+        assert_eq!(
+            changes.len(),
+            1,
+            "persistent storage requires one history size"
+        );
+        assert_eq!(
+            commit_widths.len(),
+            1,
+            "persistent storage requires one commit width"
+        );
+    }
 
     for backend in [Backend::RocksDB, Backend::SlateDB] {
         if !selected("LIX_PACKED_HISTORY_BACKENDS", &backend.to_string()) {
@@ -70,7 +84,10 @@ async fn run() {
                 match backend {
                     Backend::RocksDB => {
                         let dir = tempfile::tempdir().expect("create RocksDB benchmark directory");
-                        let path = dir.path().join("rocksdb");
+                        let path = persistent_root.as_ref().map_or_else(
+                            || dir.path().join("rocksdb"),
+                            |root| root.join("rocksdb"),
+                        );
                         let storage = RocksDB::open(&path).expect("open benchmark RocksDB");
                         run_case(
                             backend,
@@ -85,6 +102,7 @@ async fn run() {
                             flush,
                             false,
                             account_layout,
+                            skip_seed,
                             || async {
                                 storage.flush().expect("flush benchmark RocksDB");
                             },
@@ -93,7 +111,10 @@ async fn run() {
                     }
                     Backend::SlateDB => {
                         let dir = tempfile::tempdir().expect("create SlateDB benchmark directory");
-                        let path = dir.path().join("slatedb");
+                        let path = persistent_root.as_ref().map_or_else(
+                            || dir.path().join("slatedb"),
+                            |root| root.join("slatedb"),
+                        );
                         let storage = SlateDB::open(&path).expect("open benchmark SlateDB");
                         run_case(
                             backend,
@@ -108,6 +129,7 @@ async fn run() {
                             flush,
                             memtable_flush,
                             account_layout,
+                            skip_seed,
                             || async {
                                 if memtable_flush {
                                     storage
@@ -141,6 +163,7 @@ async fn run_case<S, Flush, FlushFuture>(
     flush: bool,
     memtable_flush: bool,
     account_layout: bool,
+    skip_seed: bool,
     flush_storage: Flush,
 ) where
     S: Storage + Clone,
@@ -151,7 +174,11 @@ async fn run_case<S, Flush, FlushFuture>(
     let id_shape =
         std::env::var("LIX_PACKED_HISTORY_ID_SHAPE").unwrap_or_else(|_| "deterministic".into());
     let seed_started = Instant::now();
-    let writes = seed_packed_history(&adapter, changes, commit_width, storage_batch_changes).await;
+    let writes = if skip_seed {
+        None
+    } else {
+        Some(seed_packed_history(&adapter, changes, commit_width, storage_batch_changes).await)
+    };
     let seed_elapsed = seed_started.elapsed();
     if flush {
         flush_storage().await;
@@ -194,7 +221,7 @@ async fn run_case<S, Flush, FlushFuture>(
     println!(
         "packed_history_scale,backend={backend},id_shape={id_shape},changes={changes},commits={},commit_width={commit_width},\
          storage_batch_changes={storage_batch_changes},flushed={flush},warmups={warmups},samples={samples},\
-         memtable_flushed={memtable_flush},\
+         memtable_flushed={memtable_flush},skip_seed={skip_seed},\
          layout_accounted={account_layout},\
          exact_samples={exact_samples},seed_ms={},ingest_changes_per_second={:.1},staged_puts={},logical_written_bytes={},\
          scan_p50_ms={},scan_p95_ms={},scan_p99_ms={},\
@@ -202,11 +229,11 @@ async fn run_case<S, Flush, FlushFuture>(
          manifest_keys={},manifest_key_bytes={},manifest_value_bytes={},\
          segment_keys={},segment_key_bytes={},segment_value_bytes={},\
          locator_keys={},locator_key_bytes={},locator_value_bytes={},backend_bytes={backend_bytes}",
-        writes.commits,
+        writes.map_or_else(|| changes / commit_width, |writes| writes.commits),
         seed_elapsed.as_millis(),
         changes as f64 / seed_elapsed.as_secs_f64(),
-        writes.staged_puts,
-        writes.written_bytes,
+        writes.map_or(0, |writes| writes.staged_puts),
+        writes.map_or(0, |writes| writes.written_bytes),
         millis(percentile(&timings, 50)),
         millis(percentile(&timings, 95)),
         millis(percentile(&timings, 99)),

--- a/packages/engine/src/commit_graph/context.rs
+++ b/packages/engine/src/commit_graph/context.rs
@@ -1104,6 +1104,7 @@ mod tests {
                     snapshot: change.snapshot.as_ref_slot(),
                     metadata: change.metadata.as_ref_slot(),
                     origin_key: change.origin_key.as_deref(),
+                    authored: true,
                 })
                 .collect::<Vec<_>>();
             stage_commit_deltas(&mut writes, &deltas).expect("packed commit members should stage");

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -839,8 +839,8 @@ mod tests {
     };
     use crate::tracked_state::{
         TrackedStateCommitDeltaRef, TrackedStateContext, TrackedStateDeltaRef,
-        load_change_record_by_id, scan_commit_delta_inventory, stage_change_locators,
-        stage_commit_deltas,
+        load_change_record_by_id, scan_change_records_from_commit_deltas,
+        scan_commit_delta_inventory, stage_change_locators, stage_commit_deltas,
     };
     use crate::{Engine, GLOBAL_BRANCH_ID, Value};
     use bytes::Bytes;
@@ -1237,7 +1237,10 @@ mod tests {
             .await
             .expect("authority GC changelog fixture should stage");
         drop(writer);
-        let live_deltas = commit_delta_refs(live_parent, std::slice::from_ref(&live_member));
+        let mut live_deltas = commit_delta_refs(live_parent, std::slice::from_ref(&live_member));
+        // The surviving copy is a merge/checkpoint selection. Once the
+        // original owner dies, GC promotes it through locator relocation.
+        live_deltas[0].authored = false;
         stage_commit_deltas(&mut writes, &live_deltas).expect("live packed member should stage");
         let dead_members = vec![dead_shared_member.clone(), dead_only_member.clone()];
         let dead_deltas = commit_delta_refs(dead_commit, &dead_members);
@@ -1316,6 +1319,19 @@ mod tests {
                 .await
                 .expect("dead locator lookup should succeed")
                 .is_none()
+        );
+        let canonical_changes = scan_change_records_from_commit_deltas(&read)
+            .await
+            .expect("post-GC packed changes should stream");
+        assert!(
+            canonical_changes
+                .iter()
+                .any(|change| change.change_id == live_member.change_id)
+        );
+        assert!(
+            canonical_changes
+                .iter()
+                .all(|change| change.change_id != dead_only_member.change_id)
         );
         let inventory = scan_commit_delta_inventory(&read)
             .await
@@ -1538,6 +1554,7 @@ mod tests {
                 snapshot: change.snapshot.as_ref_slot(),
                 metadata: change.metadata.as_ref_slot(),
                 origin_key: change.origin_key.as_deref(),
+                authored: true,
             })
             .collect()
     }

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -358,6 +358,7 @@ where
                 snapshot: change.snapshot.as_ref_slot(),
                 metadata: change.metadata.as_ref_slot(),
                 origin_key: change.origin_key.as_deref(),
+                authored: true,
             })
             .collect::<Vec<_>>();
         let locators = crate::tracked_state::stage_commit_deltas(&mut writes, &commit_deltas)?;

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -2325,6 +2325,7 @@ mod tests {
                     snapshot: change.snapshot.as_ref_slot(),
                     metadata: change.metadata.as_ref_slot(),
                     origin_key: change.origin_key.as_deref(),
+                    authored: true,
                 })
                 .collect::<Vec<_>>();
             stage_commit_deltas(writes, &commit_deltas)?;

--- a/packages/engine/src/test_support.rs
+++ b/packages/engine/src/test_support.rs
@@ -257,6 +257,7 @@ pub(crate) async fn stage_tracked_root_from_materialized(
                 snapshot: change.snapshot.as_ref_slot(),
                 metadata: change.metadata.as_ref_slot(),
                 origin_key: change.origin_key.as_deref(),
+                authored: true,
             }
         })
         .collect::<Vec<_>>();
@@ -334,6 +335,7 @@ pub(crate) async fn stage_rootless_tracked_commit_from_materialized(
                 snapshot: change.snapshot.as_ref_slot(),
                 metadata: change.metadata.as_ref_slot(),
                 origin_key: change.origin_key.as_deref(),
+                authored: true,
             }
         })
         .collect::<Vec<_>>();
@@ -407,6 +409,7 @@ pub(crate) async fn stage_tracked_root_from_materialized_with_parents(
                 snapshot: change.snapshot.as_ref_slot(),
                 metadata: change.metadata.as_ref_slot(),
                 origin_key: change.origin_key.as_deref(),
+                authored: true,
             }
         })
         .collect::<Vec<_>>();

--- a/packages/engine/src/tracked_state/bench_support.rs
+++ b/packages/engine/src/tracked_state/bench_support.rs
@@ -131,10 +131,14 @@ where
             .await
             .expect("begin packed-history scan"),
     );
-    super::storage::scan_change_records_from_commit_deltas(&read)
-        .await
-        .expect("scan packed history")
-        .len()
+    let mut count = 0usize;
+    super::storage::visit_change_records_from_commit_deltas(&read, |_| {
+        count += 1;
+        Ok(())
+    })
+    .await
+    .expect("scan packed history");
+    count
 }
 
 pub async fn load_packed_change<StorageImpl>(
@@ -229,6 +233,7 @@ impl PackedHistoryDelta {
             snapshot: crate::json_store::JsonSlotRef::None,
             metadata: crate::json_store::JsonSlotRef::None,
             origin_key: None,
+            authored: true,
         }
     }
 }

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -75,6 +75,7 @@ struct CommitDeltaPayloadRef<'a> {
     metadata: crate::json_store::JsonSlotRef<'a>,
     #[musli(with = storage_codec::option)]
     origin_key: Option<&'a str>,
+    authored: bool,
 }
 
 #[derive(Debug, musli::Decode)]
@@ -86,6 +87,7 @@ struct CommitDeltaPayload {
     metadata: crate::json_store::JsonSlot,
     #[musli(with = storage_codec::option)]
     origin_key: Option<String>,
+    authored: bool,
 }
 
 /// Borrowed fixed-width directory over independently encoded payload records.
@@ -183,6 +185,7 @@ pub(crate) struct CommitDeltaMember {
     pub(crate) change: crate::changelog::ChangeRecord,
     pub(crate) segment_index: u32,
     pub(crate) ordinal: u32,
+    pub(crate) authored: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -592,6 +595,7 @@ pub(crate) fn stage_commit_deltas(
             snapshot: delta.snapshot,
             metadata: delta.metadata,
             origin_key: delta.origin_key,
+            authored: delta.authored,
         });
     }
     let mutations = entries
@@ -756,6 +760,18 @@ pub(crate) async fn load_change_record_by_id(
     store: &(impl StorageAdapterRead + ?Sized),
     change_id: crate::changelog::ChangeId,
 ) -> Result<Option<crate::changelog::ChangeRecord>, LixError> {
+    let Some(locator) = load_change_locator_by_id(store, change_id).await? else {
+        return Ok(None);
+    };
+    load_change_record_at_locator(store, locator)
+        .await
+        .map(Some)
+}
+
+async fn load_change_locator_by_id(
+    store: &(impl StorageAdapterRead + ?Sized),
+    change_id: crate::changelog::ChangeId,
+) -> Result<Option<CommitDeltaChangeLocator>, LixError> {
     let locator_key = StorageKey(Bytes::copy_from_slice(change_id.as_uuid().as_bytes()));
     let locator = PointReadPlan::new(
         TRACKED_STATE_CHANGE_LOCATOR_SPACE,
@@ -771,7 +787,14 @@ pub(crate) async fn load_change_record_by_id(
     let Some(locator) = locator else {
         return Ok(None);
     };
-    let locator = decode_change_locator(change_id, &locator)?;
+    decode_change_locator(change_id, &locator).map(Some)
+}
+
+async fn load_change_record_at_locator(
+    store: &(impl StorageAdapterRead + ?Sized),
+    locator: CommitDeltaChangeLocator,
+) -> Result<crate::changelog::ChangeRecord, LixError> {
+    let change_id = locator.change_id;
     let Some(manifest) = load_commit_delta_manifest(store, locator.commit_id).await? else {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
@@ -849,7 +872,7 @@ pub(crate) async fn load_change_record_by_id(
     }
     let key = decode_key(entry.key)?;
     let payload = payloads.decode(ordinal)?;
-    Ok(Some(crate::changelog::ChangeRecord {
+    Ok(crate::changelog::ChangeRecord {
         format_version: 2,
         change_id,
         schema_key: key.schema_key,
@@ -859,7 +882,7 @@ pub(crate) async fn load_change_record_by_id(
         metadata: payload.metadata,
         created_at: value.updated_at,
         origin_key: payload.origin_key,
-    }))
+    })
 }
 
 fn decode_change_locator(
@@ -1115,6 +1138,14 @@ pub(crate) async fn load_commit_delta_members_with_payloads(
     let Some(manifest) = load_commit_delta_manifest(store, commit_id).await? else {
         return Ok(Vec::new());
     };
+    load_commit_delta_members_from_manifest(store, commit_id, &manifest).await
+}
+
+async fn load_commit_delta_members_from_manifest(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+    manifest: &CommitDeltaManifest,
+) -> Result<Vec<CommitDeltaMember>, LixError> {
     let mut members = Vec::new();
     if let Some(inline_segment) = manifest.inline_segment() {
         collect_strict_commit_delta_members(inline_segment, None, commit_id, 0, &mut members)?;
@@ -1394,43 +1425,191 @@ pub(crate) async fn scan_commit_delta_values(
 pub(crate) async fn scan_change_records_from_commit_deltas(
     store: &(impl StorageAdapterRead + ?Sized),
 ) -> Result<Vec<crate::changelog::ChangeRecord>, LixError> {
-    let CommitDeltaPlane {
-        manifests,
-        mut segments,
-    } = scan_commit_delta_plane(store).await?;
-    let mut records =
-        BTreeMap::<crate::changelog::ChangeId, (CommitId, crate::changelog::ChangeRecord)>::new();
-    for (commit_id, manifest) in manifests {
-        let physical_segments = segments.remove(&commit_id).unwrap_or_default();
-        if let Some(inline_segment) = manifest.inline_segment() {
-            if !physical_segments.is_empty() {
+    let mut records = Vec::new();
+    visit_change_records_from_commit_deltas(store, |record| {
+        records.push(record);
+        Ok(())
+    })
+    .await?;
+    records.sort_unstable_by_key(|record| record.change_id);
+    Ok(records)
+}
+
+/// Visits canonical packed changes while retaining memory proportional to one
+/// storage page plus one logical commit, never total repository history.
+///
+/// Merge/checkpoint selections carry an explicit non-authored marker. Those
+/// uncommon duplicates validate against the immutable locator before being
+/// skipped; authored rows require no secondary read.
+pub(crate) async fn visit_change_records_from_commit_deltas(
+    store: &(impl StorageAdapterRead + ?Sized),
+    mut visit: impl FnMut(crate::changelog::ChangeRecord) -> Result<(), LixError>,
+) -> Result<usize, LixError> {
+    let plan = ScanPlan::range(
+        TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
+        StorageKeyRange {
+            lower: Bound::Unbounded,
+            upper: Bound::Unbounded,
+        },
+    );
+    let mut resume_after = None;
+    let mut emitted = 0usize;
+    loop {
+        let page = plan
+            .collect(
+                store,
+                StorageScanOptions {
+                    projection: StorageCoreProjection::FullValue,
+                    limit_rows: crate::storage_adapter::MAX_SCAN_PAGE_ROWS,
+                    resume_after,
+                },
+            )
+            .await?;
+        for entry in &page.value.entries {
+            if entry.key.0.len() != 16 {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state commit_delta manifest key is not a 16-byte commit id",
+                ));
+            }
+            let StorageProjectedValue::FullValue(bytes) = &entry.value else {
+                unreachable!("full commit-delta scan returned a key-only row");
+            };
+            let commit_id = commit_id_from_delta_key(&entry.key)?;
+            let manifest = decode_commit_delta_manifest(bytes)?;
+            let members =
+                load_commit_delta_members_from_manifest(store, commit_id, &manifest).await?;
+            for member in members {
+                if member.authored {
+                    visit(member.change)?;
+                    emitted += 1;
+                } else {
+                    let locator = load_change_locator_by_id(store, member.change.change_id)
+                        .await?
+                        .ok_or_else(|| {
+                            invalid_change_locator(
+                                member.change.change_id,
+                                "does not resolve to a canonical record",
+                            )
+                        })?;
+                    if locator.commit_id == member.value.commit_id
+                        && locator.segment_index == member.segment_index
+                        && u32::from(locator.ordinal) == member.ordinal
+                    {
+                        visit(member.change)?;
+                        emitted += 1;
+                        continue;
+                    }
+                    let canonical = load_change_record_at_locator(store, locator).await?;
+                    if canonical != member.change {
+                        return Err(LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            format!(
+                                "tracked_state change '{}' has conflicting authoritative packed payloads",
+                                member.change.change_id
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+        if !page.value.has_more {
+            break;
+        }
+        resume_after = page.value.entries.last().map(|entry| entry.key.clone());
+    }
+    validate_no_orphan_commit_delta_segments(store).await?;
+    Ok(emitted)
+}
+
+async fn validate_no_orphan_commit_delta_segments(
+    store: &(impl StorageAdapterRead + ?Sized),
+) -> Result<(), LixError> {
+    let plan = ScanPlan::range(
+        TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
+        StorageKeyRange {
+            lower: Bound::Unbounded,
+            upper: Bound::Unbounded,
+        },
+    );
+    let mut resume_after = None;
+    loop {
+        let page = plan
+            .collect(
+                store,
+                StorageScanOptions {
+                    projection: StorageCoreProjection::KeyOnly,
+                    limit_rows: crate::storage_adapter::MAX_SCAN_PAGE_ROWS,
+                    resume_after,
+                },
+            )
+            .await?;
+        if page.value.entries.is_empty() {
+            break;
+        }
+        let mut commit_ids = Vec::new();
+        for entry in &page.value.entries {
+            if entry.key.0.len() != 20 {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state commit_delta segment key is not commit-id plus u32 suffix",
+                ));
+            }
+            let commit_id = commit_id_from_delta_key(&entry.key)?;
+            if commit_ids.last() != Some(&commit_id) {
+                commit_ids.push(commit_id);
+            }
+        }
+        let manifest_keys = commit_ids
+            .iter()
+            .map(|commit_id| StorageKey(Bytes::from(commit_delta_manifest_key(*commit_id))))
+            .collect::<Vec<_>>();
+        let manifests =
+            PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE, &manifest_keys)
+                .materialize(store, StorageGetOptions::default())
+                .await?;
+        let manifests = commit_ids
+            .into_iter()
+            .zip(manifests.value)
+            .map(|(commit_id, value)| {
+                value
+                    .and_then(full_value_bytes)
+                    .map(|bytes| decode_commit_delta_manifest(&bytes))
+                    .transpose()
+                    .map(|manifest| (commit_id, manifest))
+            })
+            .collect::<Result<BTreeMap<_, _>, LixError>>()?;
+        for entry in &page.value.entries {
+            let commit_id = commit_id_from_delta_key(&entry.key)?;
+            let segment_index = usize::try_from(u32::from_be_bytes(
+                entry.key.0[16..20]
+                    .try_into()
+                    .expect("segment suffix length checked"),
+            ))
+            .expect("u32 fits usize");
+            let Some(Some(manifest)) = manifests.get(&commit_id) else {
                 return Err(LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
                     format!(
-                        "tracked_state inline commit_delta for commit '{commit_id}' has external segments"
+                        "tracked_state commit_delta inventory found orphan segments for commit '{commit_id}'"
+                    ),
+                ));
+            };
+            if manifest.inline_segment().is_some() || segment_index >= manifest.segments.len() {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "tracked_state commit_delta for commit '{commit_id}' has an undeclared segment {segment_index}"
                     ),
                 ));
             }
-            collect_validated_commit_delta_change_records(
-                inline_segment,
-                None,
-                commit_id,
-                &mut records,
-            )?;
-        } else {
-            validate_physical_commit_delta_segments(commit_id, &manifest, &physical_segments)?;
-            for (segment_index, bounds) in manifest.segments.iter().enumerate() {
-                collect_validated_commit_delta_change_records(
-                    &physical_segments[&segment_index],
-                    Some(bounds),
-                    commit_id,
-                    &mut records,
-                )?;
-            }
         }
+        if !page.value.has_more {
+            break;
+        }
+        resume_after = page.value.entries.last().map(|entry| entry.key.clone());
     }
-    debug_assert!(segments.is_empty());
-    Ok(records.into_values().map(|(_, change)| change).collect())
+    Ok(())
 }
 
 /// Inventories the complete packed commit-delta plane in one manifest scan and
@@ -1721,64 +1900,10 @@ fn collect_strict_commit_delta_members(
             change,
             segment_index,
             ordinal: u32::try_from(entry_index).expect("segment ordinal fits u32"),
+            authored: payload.authored,
         });
     }
     Ok(())
-}
-
-fn collect_validated_commit_delta_change_records(
-    bytes: &[u8],
-    expected_bounds: Option<&CommitDeltaSegmentBounds>,
-    expected_commit_id: CommitId,
-    records: &mut BTreeMap<crate::changelog::ChangeId, (CommitId, crate::changelog::ChangeRecord)>,
-) -> Result<(), LixError> {
-    let (leaf, payloads) = decode_commit_delta_with_payloads(bytes, expected_bounds)?;
-    visit_commit_delta_leaf(
-        &leaf,
-        expected_commit_id,
-        |entry_index, encoded_key, value| {
-            let payload = payloads.decode(entry_index)?;
-            let key = decode_key(encoded_key)?;
-            let change = crate::changelog::ChangeRecord {
-                format_version: 2,
-                change_id: value.change_id,
-                schema_key: key.schema_key,
-                entity_pk: key.entity_pk,
-                file_id: key.file_id,
-                snapshot: payload.snapshot,
-                metadata: payload.metadata,
-                created_at: value.updated_at,
-                origin_key: payload.origin_key,
-            };
-            match records.entry(change.change_id) {
-                std::collections::btree_map::Entry::Vacant(entry) => {
-                    entry.insert((expected_commit_id, change));
-                }
-                std::collections::btree_map::Entry::Occupied(entry)
-                    if entry.get().0 == expected_commit_id =>
-                {
-                    return Err(LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        format!(
-                            "tracked_state commit_delta for commit '{expected_commit_id}' contains duplicate change id '{}'",
-                            change.change_id
-                        ),
-                    ));
-                }
-                std::collections::btree_map::Entry::Occupied(entry) if entry.get().1 != change => {
-                    return Err(LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        format!(
-                            "tracked_state change '{}' has conflicting authoritative packed payloads",
-                            change.change_id
-                        ),
-                    ));
-                }
-                std::collections::btree_map::Entry::Occupied(_) => {}
-            }
-            Ok(())
-        },
-    )
 }
 
 fn validate_commit_delta_member_order_and_ids(
@@ -1967,6 +2092,7 @@ fn encode_commit_delta_segment(entries: &[EncodedLeafEntry]) -> Vec<u8> {
             snapshot: crate::json_store::JsonSlotRef::None,
             metadata: crate::json_store::JsonSlotRef::None,
             origin_key: None,
+            authored: true,
         };
         entries.len()
     ];
@@ -2677,6 +2803,7 @@ mod tests {
             snapshot,
             metadata,
             origin_key,
+            authored: true,
         }
     }
 
@@ -2879,6 +3006,7 @@ mod tests {
                 snapshot: crate::json_store::JsonSlotRef::None,
                 metadata: crate::json_store::JsonSlotRef::None,
                 origin_key: None,
+                authored: true,
             }],
         );
         let mut writes = orphan_storage.new_write_set();
@@ -2973,15 +3101,18 @@ mod tests {
             crate::json_store::JsonSlotRef::None,
             None,
         );
-        let second = commit_delta_ref(
+        let mut second = commit_delta_ref(
             second_commit,
             &fixture,
             crate::json_store::JsonSlotRef::Inline(shared_snapshot),
             crate::json_store::JsonSlotRef::None,
             None,
         );
+        second.authored = false;
         let mut writes = storage.new_write_set();
-        stage_commit_deltas(&mut writes, &[first]).expect("first owner should stage");
+        let locators =
+            stage_commit_deltas(&mut writes, &[first]).expect("first owner should stage");
+        stage_change_locators(&mut writes, &locators);
         stage_commit_deltas(&mut writes, &[second]).expect("second owner should stage");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -3007,13 +3138,14 @@ mod tests {
         drop(read);
 
         let conflicting_commit = CommitId::for_test_label("shared-authority-conflict");
-        let conflicting = commit_delta_ref(
+        let mut conflicting = commit_delta_ref(
             conflicting_commit,
             &fixture,
             crate::json_store::JsonSlotRef::Inline(r#"{"shared":false}"#),
             crate::json_store::JsonSlotRef::None,
             None,
         );
+        conflicting.authored = false;
         let mut writes = storage.new_write_set();
         stage_commit_deltas(&mut writes, &[conflicting]).expect("conflicting owner should stage");
         storage
@@ -3289,16 +3421,19 @@ mod tests {
                 snapshot: crate::json_store::JsonSlotRef::Inline(snapshots[0]),
                 metadata: crate::json_store::JsonSlotRef::None,
                 origin_key: Some("first"),
+                authored: true,
             },
             CommitDeltaPayloadRef {
                 snapshot: crate::json_store::JsonSlotRef::Inline(snapshots[1]),
                 metadata: crate::json_store::JsonSlotRef::None,
                 origin_key: None,
+                authored: true,
             },
             CommitDeltaPayloadRef {
                 snapshot: crate::json_store::JsonSlotRef::Inline(snapshots[2]),
                 metadata: crate::json_store::JsonSlotRef::None,
                 origin_key: Some("last"),
+                authored: true,
             },
         ];
         let mut encoded = encode_commit_delta_segment_with_payloads(&entries, &payloads);
@@ -3383,11 +3518,13 @@ mod tests {
                 snapshot: crate::json_store::JsonSlotRef::None,
                 metadata: crate::json_store::JsonSlotRef::None,
                 origin_key: None,
+                authored: true,
             },
             CommitDeltaPayloadRef {
                 snapshot: crate::json_store::JsonSlotRef::Inline(r#"{"second":true}"#),
                 metadata: crate::json_store::JsonSlotRef::None,
                 origin_key: None,
+                authored: true,
             },
         ];
         let mut encoded = encode_commit_delta_segment_with_payloads(&entries, &payloads);
@@ -3533,6 +3670,7 @@ mod tests {
                 snapshot: crate::json_store::JsonSlotRef::Inline(r#"{"ok":true}"#),
                 metadata: crate::json_store::JsonSlotRef::None,
                 origin_key: None,
+                authored: true,
             }],
         );
 

--- a/packages/engine/src/tracked_state/types.rs
+++ b/packages/engine/src/tracked_state/types.rs
@@ -60,6 +60,7 @@ pub(crate) struct TrackedStateCommitDeltaRef<'a> {
     pub(crate) snapshot: crate::json_store::JsonSlotRef<'a>,
     pub(crate) metadata: crate::json_store::JsonSlotRef<'a>,
     pub(crate) origin_key: Option<&'a str>,
+    pub(crate) authored: bool,
 }
 
 /// One ordered tracked-root mutation with its insert-collision contract.

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -698,6 +698,7 @@ fn tracked_commit_delta_from_state_row(
             crate::transaction::types::StageJson::slot_ref,
         ),
         origin_key: row.origin_key.map(crate::common::SharedStr::as_str),
+        authored: true,
     })
 }
 
@@ -742,6 +743,7 @@ fn tracked_commit_delta_from_selected_change_ref<'a>(
         snapshot: record.snapshot.as_ref_slot(),
         metadata: record.metadata.as_ref_slot(),
         origin_key: record.origin_key.as_deref(),
+        authored: false,
     })
 }
 


### PR DESCRIPTION
## Summary

- replace full manifest/segment materialization and global `BTreeMap<ChangeId, ...>` dedup with a page-at-a-time packed-history visitor
- mark packed payloads as authored vs merge/checkpoint selections; authored rows stream with no secondary read, while uncommon selected copies validate through the exact locator
- preserve corruption checks for missing, noncontiguous, extra, and orphan segments with bounded second-pass validation
- preserve GC correctness when a selected physical copy becomes canonical after the authored owner is collected
- add persistent-store / skip-seed benchmark mode so scan RSS is measured independently from ingest and backend cache state

## Why

After the Slate iterator fix, the 10M scan had a near-linear slope but still materialized all history and peaked around 12 GiB RSS. A first bounded prototype checked the locator for every row and regressed 1M scans to 23 s; this PR does not use that design. The authored bit keeps the common path sequential.

## Scan-only results

Fresh process, persisted width-1 store:

| backend | history | scan | peak RSS | exact p99 |
| --- | ---: | ---: | ---: | ---: |
| SlateDB | 100k | 206 ms | 57.5 MiB | 2.05 µs |
| SlateDB | 1M | 1.97 s | 148.7 MiB | 1.54 µs |
| SlateDB | 10M | 19.93 s | 201.3 MiB | 1.48 µs |
| RocksDB | 100k | 127 ms | 31.8 MiB | 3.94 µs |
| RocksDB | 10M | 11.76 s | 89.2 MiB | 6.32 µs |

Log-log 100k→10M scan slopes are ~0.99 on SlateDB and ~0.98 on RocksDB. RSS growth is bounded by backend caches rather than retained history; Slate's 10M scan-only RSS is ~58x below the prior same-process 12 GiB peak.

At 1M in the normal same-process benchmark, SlateDB width 1 is 2.47 s and width 100 is 0.99 s, slightly faster than the pre-streaming 3.03 s / 1.25 s measurements.

## Validation

- `cargo check -p lix_engine --features storage-benches`
- all 1,545 engine library tests: 1,539 passed, 6 ignored
- all 26 tracked-state storage tests
- GC relocation plus post-GC canonical enumeration
- RocksDB and SlateDB scan-only persisted-store runs through 10M

Stacked on #913.