### PR TITLE
perf(storage): cluster packed history keyspaces

### DIFF
--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -45,7 +45,7 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"indexed-packed-history.v19";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"clustered-packed-history.v20";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -56,8 +56,12 @@ pub(crate) const TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE: StorageSpace = Storag
     StorageSpaceId(0x0004_001a),
     TRACKED_STATE_COMMIT_DELTA_SEGMENT_NAMESPACE,
 );
+/// Keep every high-volume packed-history plane below the live-row spaces
+/// (`0x0004_001b..=0x0004_001d`). Backends order the space prefix first, so a
+/// locator above those spaces makes each mixed manifest/locator SST overlap
+/// unrelated live-state point reads.
 pub(crate) const TRACKED_STATE_CHANGE_LOCATOR_SPACE: StorageSpace = StorageSpace::new(
-    StorageSpaceId(0x0004_0021),
+    StorageSpaceId(0x0004_0018),
     TRACKED_STATE_CHANGE_LOCATOR_NAMESPACE,
 );
 
@@ -2804,6 +2808,21 @@ mod tests {
             metadata,
             origin_key,
             authored: true,
+        }
+    }
+
+    #[test]
+    fn packed_history_spaces_do_not_span_the_live_state_key_range() {
+        const FIRST_LIVE_STATE_SPACE: [u8; 4] = 0x0004_001b_u32.to_be_bytes();
+        for space in [
+            TRACKED_STATE_CHANGE_LOCATOR_SPACE,
+            TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
+            TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
+        ] {
+            assert!(
+                space.physical_prefix() < FIRST_LIVE_STATE_SPACE,
+                "{space} would make packed-history SSTs overlap live-state keys"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

- move the high-volume change-locator plane below the live tracked-head spaces
- hard-cut the repository protocol to `clustered-packed-history.v20`
- assert packed-history SST ranges cannot span the live-state key range

## Root cause

Physical keys sort by storage-space prefix. Manifests and segments were at `0x0004_0019..1a`, live rows/files/diffs at `0x0004_001b..1d`, and change locators at `0x0004_0021`. Mixed manifest/locator SSTs therefore overlapped every live-state point key even when the requested working set was fixed.

## Results

RocksDB width-1 fixed-live results from 100k to 10M unrelated history:

- exact read p99: 634 µs → 638 µs (1.01×; previously 3.15×)
- live enumeration p99: 225 µs → 201 µs
- cold exact read: 2.97 ms → 2.61 ms

SlateDB retains a separate global-manifest/active-compaction tail, isolated for the next stack layer.

## Validation

- `cargo test -p lix_engine --lib`: 1540 passed, 6 ignored, 0 failed
- fixed-live 100k/10M width-1 rerun on RocksDB and SlateDB with 101 samples
