### PR TITLE
Hard cut history SQL to table-valued functions

### DIFF
--- a/.changenotes/history-table-functions.md
+++ b/.changenotes/history-table-functions.md
@@ -1,0 +1,10 @@
+---
+type: minor
+---
+
+History relations are now table-valued functions with explicit commit arguments.
+
+Use `example_history()` for history from the active head or
+`example_history($commit)` for an explicit head. The former
+`lixcol_as_of_commit_id` result column and predicate-based anchor API have been
+removed.

--- a/docs/history.md
+++ b/docs/history.md
@@ -12,7 +12,8 @@ the question:
 | `<schema>_history`, `lix_file_history`, `lix_directory_history` | Which logical revisions are reachable from a commit? |
 | `lix_change` | Which retained changes exist anywhere in this workspace? |
 
-Typed history is schema-specific and commit-reachability scoped.
+Typed history is exposed through table-valued functions. It is schema-specific
+and commit-reachability scoped.
 `lix_change` is heterogeneous and workspace-wide. A change on an unmerged
 sibling branch can therefore appear in `lix_change` without appearing in
 history read from the active branch.
@@ -21,9 +22,10 @@ For the full surface grid, see [SQL Surfaces](./surfaces.md).
 
 ## Typed entity history
 
-A registered application schema such as `acme_task` has three typed relations:
+A registered application schema such as `acme_task` has two typed relations
+and one history function:
 `acme_task` for the active branch, `acme_task_by_branch` for explicit branch
-scope, and `acme_task_history` for branch-reachable history.
+scope, and `acme_task_history()` for branch-reachable history.
 
 History starts at the active branch head pinned for the statement or coherent
 read batch, so the common query needs no anchor predicate:
@@ -36,7 +38,7 @@ SELECT
   lixcol_observed_commit_id,
   lixcol_commit_created_at,
   lixcol_is_deleted
-FROM acme_task_history
+FROM acme_task_history()
 WHERE id = $1
 ORDER BY lixcol_depth;
 ```
@@ -56,14 +58,19 @@ Entity history adds these system columns:
 | `lixcol_origin_key` | Optional origin key attached to the source change. |
 | `lixcol_observed_commit_id` | The commit where this state was observed. |
 | `lixcol_commit_created_at` | When that commit was created. It never falls back to the change timestamp. |
-| `lixcol_as_of_commit_id` | The commit anchoring the history walk. |
 | `lixcol_depth` | `0` is the revision at the anchor; higher values walk back through reachable history. |
 | `lixcol_is_deleted` | `true` when the revision is a tombstone. |
 
-For time travel, use exact equality or a non-empty `IN` predicate on
-`lixcol_as_of_commit_id`. Ranges, `LIKE`, `NOT IN`, expressions around the
-anchor, and mixed `OR` conditions are rejected instead of silently using the
-pinned head.
+The anchor belongs to the relation, not to each result row. Call the function
+without an argument to use the pinned active head, or pass a commit id for
+time travel:
+
+```sql
+SELECT id, title, lixcol_depth
+FROM acme_task_history($1)
+WHERE id = $2
+ORDER BY lixcol_depth;
+```
 
 To inspect another branch, resolve its `commit_id` and bind it:
 
@@ -76,11 +83,10 @@ const commitId = branch.rows[0].value("commit_id").asText();
 
 const history = await lix.execute(
   `SELECT id, title, lixcol_depth
-     FROM acme_task_history
-    WHERE id = $1
-      AND lixcol_as_of_commit_id = $2
+     FROM acme_task_history($1)
+    WHERE id = $2
     ORDER BY lixcol_depth`,
-  ["t1", commitId],
+  [commitId, "t1"],
 );
 ```
 
@@ -89,7 +95,7 @@ order does not change the identity encoded by the schema:
 
 ```sql
 SELECT project_id, issue_number, title, lixcol_depth
-FROM acme_issue_history
+FROM acme_issue_history()
 WHERE project_id = 'launch'
   AND issue_number = '7'
 ORDER BY lixcol_depth;
@@ -104,7 +110,7 @@ Use a stable ID to follow an object across renames:
 
 ```sql
 SELECT path, name, lixcol_depth, lixcol_observed_commit_id
-FROM lix_file_history
+FROM lix_file_history()
 WHERE id = $1
 ORDER BY lixcol_depth;
 ```

--- a/docs/history.md
+++ b/docs/history.md
@@ -106,6 +106,16 @@ ORDER BY lixcol_depth;
 `lix_file_history` and `lix_directory_history` expose logical filesystem
 history. Their storage descriptors are not public SQL relations.
 
+Both follow the same active-head and explicit-anchor convention:
+
+```sql
+lix_file_history()
+lix_file_history($as_of)
+
+lix_directory_history()
+lix_directory_history($as_of)
+```
+
 Use a stable ID to follow an object across renames:
 
 ```sql

--- a/docs/lix-for-ai-agents.md
+++ b/docs/lix-for-ai-agents.md
@@ -47,7 +47,7 @@ agent did. Query the typed history relation for each application schema:
 ```sql
 SELECT id, title, status, lixcol_depth,
        lixcol_observed_commit_id, lixcol_is_deleted
-FROM acme_task_history
+FROM acme_task_history()
 ORDER BY lixcol_depth, id;
 ```
 

--- a/docs/sql-functions.md
+++ b/docs/sql-functions.md
@@ -30,22 +30,21 @@ Returns the active branch id of the current SQL session. Branch-pinned clients t
 
 Returns the commit id at the tip of the **currently active** branch, as resolved when the SQL statement was planned.
 
-History surfaces (`<schema>_history`, `lix_file_history`, and
-`lix_directory_history`) use that same pinned active-branch head by default.
-No anchor predicate is needed for the common case:
+History table functions (`<schema>_history`, `lix_file_history`, and
+`lix_directory_history`) use that same pinned active-branch head when called
+without an argument:
 
 ```sql
 -- Walk one entity's history from the active branch's tip
 SELECT lixcol_depth, lixcol_observed_commit_id, title
-FROM acme_task_history
+FROM acme_task_history()
 WHERE id = 't1'
 ORDER BY lixcol_depth;
 ```
 
-For time travel, override the default with exact equality or a non-empty `IN`
-predicate on `lixcol_as_of_commit_id`. Other anchor predicates are rejected
-instead of falling back to the active head. For an arbitrary branch, resolve
-the commit id with one query and pass it as a parameter:
+For time travel, pass a commit id as the function argument. For an arbitrary
+branch, resolve the commit id with one query and bind it into the history
+function:
 
 ```ts
 const { rows } = await lix.execute(
@@ -56,9 +55,8 @@ const commitId = rows[0].value("commit_id").asText();
 
 await lix.execute(
   `SELECT lixcol_depth, title
-     FROM acme_task_history
-    WHERE lixcol_as_of_commit_id = $1
-      AND id = $2
+     FROM acme_task_history($1)
+    WHERE id = $2
     ORDER BY lixcol_depth`,
   [commitId, "t1"],
 );

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -8,9 +8,9 @@ Lix exposes logical application data through typed SQL relations:
 
 | Data | Active branch | Cross-branch | Branch-reachable history |
 | :-- | :-- | :-- | :-- |
-| Registered application entity `X` | `<schema>` | `<schema>_by_branch` | `<schema>_history` |
-| Files | `lix_file` | `lix_file_by_branch` | `lix_file_history` |
-| Directories | `lix_directory` | `lix_directory_by_branch` | `lix_directory_history` |
+| Registered application entity `X` | `<schema>` | `<schema>_by_branch` | `<schema>_history()` |
+| Files | `lix_file` | `lix_file_by_branch` | `lix_file_history()` |
+| Directories | `lix_directory` | `lix_directory_by_branch` | `lix_directory_history()` |
 | Working changes | `lix_working_change` | `lix_working_change_by_branch` | — |
 | File working changes | `lix_file_working_change` | `lix_file_working_change_by_branch` | — |
 | Directory working changes | `lix_directory_working_change` | `lix_directory_working_change_by_branch` | — |
@@ -30,6 +30,11 @@ The SQL engine is backed by DataFusion. Query
 `information_schema.columns` for the executable public contract instead of
 inferring types from Arrow or JSON Schema names. Lix reports the canonical SQL
 types `TEXT`, `BYTEA`, `BIGINT`, `DOUBLE PRECISION`, and `BOOLEAN`.
+
+History functions are discoverable through
+`information_schema.table_functions`, which reports their argument signature
+and result columns. They do not appear in `information_schema.tables` or
+`information_schema.columns`.
 
 JSON-backed columns remain SQL `TEXT` and are marked with
 `lix_value_kind = 'JSON'`. `is_nullable` describes values returned by reads;
@@ -73,7 +78,8 @@ Registering an application schema with `x-lix-key: "acme_task"` produces:
 | :-- | :-- |
 | `acme_task` | Read and mutate tasks on the active branch. |
 | `acme_task_by_branch` | Read or mutate tasks with an explicit `lixcol_branch_id`. |
-| `acme_task_history` | Read task revisions reachable from a commit. |
+| `acme_task_history()` | Read task revisions reachable from the active head. |
+| `acme_task_history($commit)` | Read task revisions reachable from an explicit commit. |
 
 User properties become ordinary typed columns:
 
@@ -89,20 +95,19 @@ implicitly to the active branch, while `_by_branch` adds
 
 History starts at the active branch head pinned for the statement or coherent
 read batch. It adds `lixcol_entity_pk`, `lixcol_observed_commit_id`,
-`lixcol_commit_created_at`, `lixcol_as_of_commit_id`, `lixcol_depth`, and
-`lixcol_is_deleted`, together with singular change provenance such as
-`lixcol_change_id`, `lixcol_change_created_at`, and `lixcol_origin_key`.
+`lixcol_commit_created_at`, `lixcol_depth`, and `lixcol_is_deleted`, together
+with singular change provenance such as `lixcol_change_id`,
+`lixcol_change_created_at`, and `lixcol_origin_key`.
 
 ```sql
 SELECT lixcol_depth, lixcol_observed_commit_id, title, done
-FROM acme_task_history
+FROM acme_task_history()
 WHERE id = 't1'
 ORDER BY lixcol_depth;
 ```
 
-Add exact `lixcol_as_of_commit_id = ...` or a non-empty
-`lixcol_as_of_commit_id IN (...)` only for time travel. Other anchor predicates
-are rejected instead of silently using the pinned head.
+Pass a commit id to the function for time travel. The anchor is not exposed as
+a result column.
 
 Typed history preserves every declared primary-key root on deletion rows,
 including nested JSON roots. For a composite key, constrain every public key
@@ -111,14 +116,14 @@ column for an exact entity lookup; Lix encodes identity in the schema's
 
 ```sql
 SELECT lixcol_depth, value, lixcol_is_deleted
-FROM localized_message_history
+FROM localized_message_history()
 WHERE key = 'welcome'
   AND locale = 'en'
 ORDER BY lixcol_depth;
 ```
 
-There are no bare history aliases. Every public history surface uses the
-`lixcol_` prefix and the `lixcol_as_of_commit_id` spelling.
+There are no bare history table aliases. Every public history read calls its
+table-valued function with zero or one commit-id argument.
 
 ## Schema discovery and interoperability
 
@@ -178,7 +183,7 @@ FROM lix_file
 WHERE path = '/orders.xlsx';
 
 SELECT lixcol_depth, lixcol_observed_commit_id, data, lixcol_source_changes
-FROM lix_file_history
+FROM lix_file_history()
 WHERE path = '/orders.xlsx'
 ORDER BY lixcol_depth;
 ```

--- a/docs/what-is-lix.md
+++ b/docs/what-is-lix.md
@@ -64,7 +64,7 @@ activity:
 ```sql
 -- Which revisions of this task are reachable from the active branch?
 SELECT id, title, lixcol_depth, lixcol_is_deleted
-FROM acme_task_history
+FROM acme_task_history()
 WHERE id = 't1'
 ORDER BY lixcol_depth;
 ```

--- a/packages/cli/src/cli/sql.rs
+++ b/packages/cli/src/cli/sql.rs
@@ -13,7 +13,7 @@ pub enum SqlSubcommand {
 Examples:
   lix sql execute \"INSERT INTO lix_file (path, data) VALUES ('/hello.md', CAST('# Hello' AS BYTEA))\"
   lix sql execute \"SELECT path, CAST(data AS TEXT) FROM lix_file\"
-  lix sql execute \"SELECT path, lixcol_depth FROM lix_file_history\"")]
+  lix sql execute \"SELECT path, lixcol_depth FROM lix_file_history()\"")]
     Execute(SqlExecuteArgs),
 }
 

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -4729,8 +4729,8 @@ mod tests {
                 &[],
             ),
             (
-                "SELECT DISTINCT lixcol_as_of_commit_id \
-                 FROM lix_key_value_history \
+                "SELECT lixcol_depth \
+                 FROM lix_key_value_history() \
                  WHERE key = 'batch-read'",
                 &[],
             ),
@@ -4757,9 +4757,9 @@ mod tests {
         );
         assert_eq!(
             batch.results[2].rows()[0]
-                .get::<String>("lixcol_as_of_commit_id")
+                .get::<i64>("lixcol_depth")
                 .unwrap(),
-            batch.active_branch_commit_id
+            0
         );
     }
 
@@ -4842,7 +4842,7 @@ mod tests {
         );
 
         session
-            .execute("SELECT COUNT(*) AS rows FROM lix_key_value_history", &[])
+            .execute("SELECT COUNT(*) AS rows FROM lix_key_value_history()", &[])
             .await
             .expect("fixed history surface should execute");
         assert_eq!(

--- a/packages/engine/src/sql2/bind/table.rs
+++ b/packages/engine/src/sql2/bind/table.rs
@@ -351,7 +351,7 @@ mod tests {
         let catalog = catalog();
         let table = bind_public_table(
             &catalog,
-            &table_name("SELECT * FROM test_state_schema_history"),
+            &table_name("SELECT * FROM test_state_schema_history()"),
         )
         .expect("entity history surface should bind");
 

--- a/packages/engine/src/sql2/catalog/registry.rs
+++ b/packages/engine/src/sql2/catalog/registry.rs
@@ -1,16 +1,13 @@
 use std::collections::BTreeMap;
-#[cfg(test)]
 use std::sync::Arc;
 use std::sync::OnceLock;
 
-#[cfg(test)]
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use serde_json::Value as JsonValue;
 
 use crate::LixError;
 
 use super::{PublicColumn, PublicSurfaceContract, PublicSurfaceKind, SurfaceCapabilities};
-#[cfg(test)]
 use crate::sql2::catalog::entity_surface_schema;
 use crate::sql2::catalog::{
     EntitySurfaceShape, EntitySurfaceSpec, derive_entity_surface_spec_from_schema,
@@ -25,7 +22,6 @@ use crate::sql2::history_route::{
 };
 #[cfg(test)]
 use crate::sql2::providers::filesystem_working_change_schema;
-#[cfg(test)]
 use crate::sql2::result_metadata::json_field;
 
 #[derive(Clone, Debug, Default)]
@@ -140,6 +136,19 @@ impl PublicCatalog {
                 entity_surface_schema(self.entity_spec(schema_key)?, EntitySurfaceShape::History)
             }
         })
+    }
+
+    pub(crate) fn history_surface_schema(&self, table_name: &str) -> Option<SchemaRef> {
+        let surface = self.surface(table_name)?;
+        match &surface.kind {
+            PublicSurfaceKind::FileHistory => Some(history_filesystem_schema(true)),
+            PublicSurfaceKind::DirectoryHistory => Some(history_filesystem_schema(false)),
+            PublicSurfaceKind::EntityHistory { schema_key } => Some(entity_surface_schema(
+                self.entity_spec(schema_key)?,
+                EntitySurfaceShape::History,
+            )),
+            _ => None,
+        }
     }
 
     pub(crate) fn require_surface(
@@ -458,7 +467,6 @@ fn filesystem_schema(by_branch: bool, include_data: bool) -> SchemaRef {
     Arc::new(Schema::new(fields))
 }
 
-#[cfg(test)]
 fn history_filesystem_schema(include_data: bool) -> SchemaRef {
     let mut fields = if include_data {
         vec![
@@ -629,7 +637,7 @@ fn entity_system_columns(
 }
 
 fn entity_history_system_columns() -> Vec<PublicColumn> {
-    public_columns([
+    history_columns([
         (HISTORY_COL_ENTITY_PK, false),
         (HISTORY_COL_SCHEMA_KEY, false),
         (HISTORY_COL_FILE_ID, true),
@@ -647,7 +655,7 @@ fn entity_history_system_columns() -> Vec<PublicColumn> {
 }
 
 fn file_history_columns() -> Vec<PublicColumn> {
-    public_columns([
+    history_columns([
         ("id", false),
         ("path", true),
         ("directory_id", true),
@@ -664,7 +672,7 @@ fn file_history_columns() -> Vec<PublicColumn> {
 }
 
 fn directory_history_columns() -> Vec<PublicColumn> {
-    public_columns([
+    history_columns([
         ("id", false),
         ("path", true),
         ("parent_id", true),
@@ -677,6 +685,19 @@ fn directory_history_columns() -> Vec<PublicColumn> {
         (HISTORY_COL_DEPTH, false),
         (HISTORY_COL_IS_DELETED, false),
     ])
+}
+
+fn history_columns<const N: usize>(columns: [(&str, bool); N]) -> Vec<PublicColumn> {
+    columns
+        .into_iter()
+        .map(|(name, nullable)| {
+            if name == HISTORY_COL_AS_OF_COMMIT_ID {
+                PublicColumn::hidden(name, nullable)
+            } else {
+                PublicColumn::public_read_only(name, nullable)
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -19,9 +19,14 @@ use datafusion::logical_expr::registry::FunctionRegistry;
 use datafusion::logical_expr::{Expr, ExprSchemable, LogicalPlan, LogicalPlanBuilder, Operator};
 use datafusion::prelude::SessionContext;
 use datafusion::sql::parser::Statement as DataFusionStatement;
+use datafusion::sql::sqlparser::ast::{
+    Expr as SqlExpr, FunctionArg, FunctionArgExpr, TableFactor, Value as SqlValue, Visit, VisitMut,
+    Visitor, VisitorMut,
+};
 use serde_json::json;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::marker::PhantomData;
+use std::ops::ControlFlow;
 
 use crate::branch::BranchHead;
 use crate::functions::FunctionContext;
@@ -59,6 +64,7 @@ pub(crate) struct DataFusionLogicalPlan {
     pub(super) plan: LogicalPlan,
     pub(super) notices: Vec<LixNotice>,
     pub(super) json_predicate_params: BTreeSet<usize>,
+    pub(super) expected_parameter_count: usize,
 }
 
 pub(crate) struct SessionReadSqlResult {
@@ -135,16 +141,21 @@ pub(crate) async fn execute_read_statement_in_session_from_parsed(
     statement: DataFusionStatement,
     params: &[Value],
 ) -> Result<SqlQueryResult, LixError> {
-    let plan = create_logical_plan_in_session_from_parsed(session, sql, statement).await?;
+    let plan = create_logical_plan_in_session_from_parsed(session, sql, statement, params).await?;
     execute_logical_plan(plan, params).await
 }
 
 async fn create_logical_plan_in_session_from_parsed(
     session: &ReadSqlSession<'_>,
     sql: &str,
-    statement: DataFusionStatement,
+    mut statement: DataFusionStatement,
+    params: &[Value],
 ) -> Result<SqlLogicalPlan, LixError> {
     crate::sql2::bind_read_statement(sql, &statement)?;
+    let parameter_names = statement_parameter_names(&statement)?;
+    let expected_parameter_count = expected_positional_parameter_count(&parameter_names)?;
+    validate_parameter_count_values(expected_parameter_count, &parameter_names, params.len())?;
+    bind_table_function_parameters(&mut statement, params)?;
     let plan = create_logical_plan_from_statement(&session.session, statement).await?;
     validate_supported_logical_plan(&plan)?;
     validate_json_predicates_in_logical_plan(&plan)?;
@@ -156,6 +167,7 @@ async fn create_logical_plan_in_session_from_parsed(
         plan,
         notices: Vec::new(),
         json_predicate_params,
+        expected_parameter_count,
     }))
 }
 
@@ -174,9 +186,10 @@ pub(crate) async fn execute_transaction_read_statement_from_parsed(
     }
     // Same fence as session reads, with the transaction overlay available
     // during planning/execution but not returned to the caller.
-    let plan =
-        create_transaction_read_logical_plan_from_parsed(read_ctx, write_ctx, sql, statement)
-            .await?;
+    let plan = create_transaction_read_logical_plan_from_parsed(
+        read_ctx, write_ctx, sql, statement, params,
+    )
+    .await?;
     execute_logical_plan(plan, params).await
 }
 
@@ -184,9 +197,14 @@ async fn create_transaction_read_logical_plan_from_parsed(
     read_ctx: &impl SqlExecutionContext,
     write_ctx: &mut dyn SqlWriteExecutionContext,
     sql: &str,
-    statement: DataFusionStatement,
+    mut statement: DataFusionStatement,
+    params: &[Value],
 ) -> Result<SqlLogicalPlan, LixError> {
     crate::sql2::bind_read_statement(sql, &statement)?;
+    let parameter_names = statement_parameter_names(&statement)?;
+    let expected_parameter_count = expected_positional_parameter_count(&parameter_names)?;
+    validate_parameter_count_values(expected_parameter_count, &parameter_names, params.len())?;
+    bind_table_function_parameters(&mut statement, params)?;
     let session = build_transaction_read_session(read_ctx, write_ctx, &statement).await?;
     let plan = create_logical_plan_from_statement(&session, statement).await?;
     validate_supported_logical_plan(&plan)?;
@@ -199,6 +217,7 @@ async fn create_transaction_read_logical_plan_from_parsed(
         plan,
         notices: Vec::new(),
         json_predicate_params,
+        expected_parameter_count,
     }))
 }
 
@@ -890,8 +909,9 @@ async fn execute_logical_plan(
         plan,
         notices,
         json_predicate_params,
+        expected_parameter_count,
     } = plan;
-    validate_parameter_count(&plan, params.len())?;
+    debug_assert_eq!(expected_parameter_count, params.len());
     validate_json_predicate_params(&json_predicate_params, params)?;
 
     let mut dataframe = session
@@ -1953,6 +1973,14 @@ fn validate_parameter_count(plan: &LogicalPlan, param_count: usize) -> Result<()
         .get_parameter_names()
         .map_err(datafusion_error_to_lix_error)?;
     let expected_count = expected_positional_parameter_count(&parameter_names)?;
+    validate_parameter_count_values(expected_count, &parameter_names, param_count)
+}
+
+fn validate_parameter_count_values(
+    expected_count: usize,
+    parameter_names: &HashSet<String>,
+    param_count: usize,
+) -> Result<(), LixError> {
     if param_count == expected_count {
         return Ok(());
     }
@@ -1969,6 +1997,128 @@ fn validate_parameter_count(plan: &LogicalPlan, param_count: usize) -> Result<()
         "provided_param_count": param_count,
         "placeholders": sorted_parameter_names(&parameter_names),
     })))
+}
+
+fn statement_parameter_names(statement: &DataFusionStatement) -> Result<HashSet<String>, LixError> {
+    struct ParameterVisitor {
+        names: HashSet<String>,
+    }
+
+    impl Visitor for ParameterVisitor {
+        type Break = ();
+
+        fn pre_visit_expr(&mut self, expression: &SqlExpr) -> ControlFlow<Self::Break> {
+            if let SqlExpr::Value(value) = expression
+                && let SqlValue::Placeholder(name) = &value.value
+            {
+                self.names.insert(name.clone());
+            }
+            ControlFlow::Continue(())
+        }
+    }
+
+    fn visit(
+        statement: &DataFusionStatement,
+        visitor: &mut ParameterVisitor,
+    ) -> Result<(), LixError> {
+        match statement {
+            DataFusionStatement::Statement(statement) => {
+                let _ = statement.visit(visitor);
+                Ok(())
+            }
+            DataFusionStatement::Explain(explain) => visit(explain.statement.as_ref(), visitor),
+            _ => Err(LixError::new(
+                LixError::CODE_UNSUPPORTED_SQL,
+                "SQL statement is not supported by Lix SQL",
+            )),
+        }
+    }
+
+    let mut visitor = ParameterVisitor {
+        names: HashSet::new(),
+    };
+    visit(statement, &mut visitor)?;
+    Ok(visitor.names)
+}
+
+fn bind_table_function_parameters(
+    statement: &mut DataFusionStatement,
+    params: &[Value],
+) -> Result<(), LixError> {
+    struct TableFunctionParameterBinder<'a> {
+        params: &'a [Value],
+    }
+
+    impl VisitorMut for TableFunctionParameterBinder<'_> {
+        type Break = Box<LixError>;
+
+        fn pre_visit_table_factor(
+            &mut self,
+            table_factor: &mut TableFactor,
+        ) -> ControlFlow<Self::Break> {
+            let TableFactor::Table {
+                args: Some(arguments),
+                ..
+            } = table_factor
+            else {
+                return ControlFlow::Continue(());
+            };
+            for argument in &mut arguments.args {
+                let FunctionArg::Unnamed(FunctionArgExpr::Expr(expression)) = argument else {
+                    continue;
+                };
+                let SqlExpr::Value(value) = expression else {
+                    continue;
+                };
+                let SqlValue::Placeholder(name) = &value.value else {
+                    continue;
+                };
+                let Some(index) = name
+                    .strip_prefix('$')
+                    .and_then(|raw| raw.parse::<usize>().ok())
+                    .and_then(|index| index.checked_sub(1))
+                else {
+                    return ControlFlow::Break(Box::new(LixError::new(
+                        LixError::CODE_PARSE_ERROR,
+                        format!("unsupported SQL parameter placeholder '{name}'"),
+                    )));
+                };
+                let Some(param) = self.params.get(index) else {
+                    return ControlFlow::Break(Box::new(LixError::new(
+                        LixError::CODE_INVALID_PARAM,
+                        format!("missing SQL parameter ${}", index + 1),
+                    )));
+                };
+                let Value::Text(text) = param else {
+                    return ControlFlow::Break(Box::new(LixError::new(
+                        LixError::CODE_TYPE_MISMATCH,
+                        "history table function as_of argument must be text",
+                    )));
+                };
+                *expression = SqlExpr::value(SqlValue::SingleQuotedString(text.clone()));
+            }
+            ControlFlow::Continue(())
+        }
+    }
+
+    fn visit(
+        statement: &mut DataFusionStatement,
+        visitor: &mut TableFunctionParameterBinder<'_>,
+    ) -> Result<(), LixError> {
+        let result = match statement {
+            DataFusionStatement::Statement(statement) => statement.visit(visitor),
+            DataFusionStatement::Explain(explain) => {
+                return visit(explain.statement.as_mut(), visitor);
+            }
+            _ => return Ok(()),
+        };
+        match result {
+            ControlFlow::Continue(()) => Ok(()),
+            ControlFlow::Break(error) => Err(*error),
+        }
+    }
+
+    visit(statement, &mut TableFunctionParameterBinder { params })
 }
 
 fn expected_positional_parameter_count(
@@ -3595,10 +3745,9 @@ mod tests {
         let result = session
             .execute(
                 &format!(
-                    "SELECT value, count, lixcol_entity_pk, lixcol_as_of_commit_id, lixcol_depth \
-	             FROM test_state_schema_history \
-	             WHERE lixcol_as_of_commit_id = '{head_commit_id}' \
-	               AND lixcol_entity_pk = lix_json('[\"entity-history\"]')"
+                    "SELECT value, count, lixcol_entity_pk, lixcol_depth \
+	             FROM test_state_schema_history('{head_commit_id}') \
+	             WHERE lixcol_entity_pk = lix_json('[\"entity-history\"]')"
                 ),
                 &[],
             )
@@ -3608,20 +3757,13 @@ mod tests {
 
         assert_eq!(
             columns,
-            vec![
-                "value",
-                "count",
-                "lixcol_entity_pk",
-                "lixcol_as_of_commit_id",
-                "lixcol_depth",
-            ]
+            vec!["value", "count", "lixcol_entity_pk", "lixcol_depth",]
         );
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0][0], Value::Text("A".to_string()));
         assert_eq!(rows[0][1], Value::Integer(7));
         assert_eq!(rows[0][2], Value::Json(json!(["entity-history"])));
-        assert_eq!(rows[0][3], Value::Text(head_commit_id));
-        assert!(matches!(rows[0][4], Value::Integer(_)));
+        assert!(matches!(rows[0][3], Value::Integer(_)));
     }
 
     #[tokio::test]
@@ -3632,9 +3774,9 @@ mod tests {
         let result = session
             .execute(
                 &format!(
-                    "SELECT id, parent_id, name, path, lixcol_as_of_commit_id, lixcol_depth \
-             FROM lix_directory_history \
-             WHERE id = '01920000-0000-7000-8000-0000000000d3' AND lixcol_as_of_commit_id = '{head_commit_id}'"
+                    "SELECT id, parent_id, name, path, lixcol_depth \
+             FROM lix_directory_history('{head_commit_id}') \
+             WHERE id = '01920000-0000-7000-8000-0000000000d3'"
                 ),
                 &[],
             )
@@ -3648,14 +3790,7 @@ mod tests {
 
         assert_eq!(
             columns,
-            vec![
-                "id",
-                "parent_id",
-                "name",
-                "path",
-                "lixcol_as_of_commit_id",
-                "lixcol_depth",
-            ]
+            vec!["id", "parent_id", "name", "path", "lixcol_depth",]
         );
         assert_eq!(rows.len(), 1);
         assert_eq!(
@@ -3665,16 +3800,14 @@ mod tests {
         assert_eq!(rows[0][1], Value::Null);
         assert_eq!(rows[0][2], Value::Text("docs".to_string()));
         assert_eq!(rows[0][3], Value::Text("/docs/".to_string()));
-        assert_eq!(rows[0][4], Value::Text(head_commit_id.clone()));
-        assert!(matches!(rows[0][5], Value::Integer(_)));
+        assert!(matches!(rows[0][4], Value::Integer(_)));
 
         let name_filtered_result = session
             .execute(
                 &format!(
                     "SELECT id \
-             FROM lix_directory_history \
-             WHERE name = 'docs' \
-               AND lixcol_as_of_commit_id = '{head_commit_id}'"
+             FROM lix_directory_history('{head_commit_id}') \
+             WHERE name = 'docs'"
                 ),
                 &[],
             )
@@ -3694,10 +3827,9 @@ mod tests {
         let result = session
             .execute(
                 &format!(
-                    "SELECT id, path, data, lixcol_as_of_commit_id, lixcol_depth \
-             FROM lix_file_history \
+                    "SELECT id, path, data, lixcol_depth \
+             FROM lix_file_history('{head_commit_id}') \
              WHERE id = '01920000-0000-7000-8000-0000000000a2' \
-               AND lixcol_as_of_commit_id = '{head_commit_id}' \
                AND data IS NOT NULL \
              ORDER BY lixcol_depth",
                 ),
@@ -3711,16 +3843,7 @@ mod tests {
         );
         let (columns, rows) = rows_from_execute_result(result);
 
-        assert_eq!(
-            columns,
-            vec![
-                "id",
-                "path",
-                "data",
-                "lixcol_as_of_commit_id",
-                "lixcol_depth",
-            ]
-        );
+        assert_eq!(columns, vec!["id", "path", "data", "lixcol_depth",]);
         assert_eq!(rows.len(), 1);
         assert_eq!(
             rows[0][0],
@@ -3728,16 +3851,14 @@ mod tests {
         );
         assert_eq!(rows[0][1], Value::Text("/docs/readme.md".to_string()));
         assert_eq!(rows[0][2], Value::Blob(b"hello".to_vec().into()));
-        assert_eq!(rows[0][3], Value::Text(head_commit_id.clone()));
-        assert!(matches!(rows[0][4], Value::Integer(_)));
+        assert!(matches!(rows[0][3], Value::Integer(_)));
 
         let path_filtered_result = session
             .execute(
                 &format!(
                     "SELECT id \
-             FROM lix_file_history \
-             WHERE path = '/docs/readme.md' \
-               AND lixcol_as_of_commit_id = '{head_commit_id}'"
+             FROM lix_file_history('{head_commit_id}') \
+             WHERE path = '/docs/readme.md'"
                 ),
                 &[],
             )

--- a/packages/engine/src/sql2/information_schema.rs
+++ b/packages/engine/src/sql2/information_schema.rs
@@ -15,10 +15,12 @@ use datafusion::prelude::SessionContext;
 
 use crate::LixError;
 
+use super::catalog::PublicSurfaceKind;
 use super::catalog::{PublicCatalog, PublicColumnInsertPolicy};
 use super::result_metadata::field_is_json;
 
 const LIX_VALUE_KIND_JSON: &str = "JSON";
+const TABLE_FUNCTIONS: &str = "table_functions";
 
 /// Installs Lix's SQL-level column contract while retaining DataFusion's other
 /// standard information-schema views.
@@ -118,9 +120,15 @@ impl LixInformationSchemaProvider {
                 }
             }
 
-            for table_name in INFORMATION_SCHEMA_TABLES {
-                let table_schema = if *table_name == "columns" {
+            for table_name in INFORMATION_SCHEMA_TABLES
+                .iter()
+                .copied()
+                .chain(std::iter::once(TABLE_FUNCTIONS))
+            {
+                let table_schema = if table_name == "columns" {
                     Arc::clone(&schema)
+                } else if table_name == TABLE_FUNCTIONS {
+                    table_functions_schema()
                 } else {
                     delegate
                         .table(table_name)
@@ -145,6 +153,71 @@ impl LixInformationSchemaProvider {
         let batch = rows.finish(Arc::clone(&schema))?;
         Ok(Arc::new(MemTable::try_new(schema, vec![vec![batch]])?))
     }
+
+    fn table_functions_table(&self) -> Result<Arc<dyn TableProvider>> {
+        let schema = table_functions_schema();
+        let mut function_catalog = Vec::new();
+        let mut function_schema = Vec::new();
+        let mut function_name = Vec::new();
+        let mut argument_signature = Vec::new();
+        let mut result_column = Vec::new();
+        let mut ordinal_position = Vec::new();
+        let mut is_nullable = Vec::new();
+        let mut data_type = Vec::new();
+        let mut lix_value_kind = Vec::new();
+
+        for surface in self.public_catalog.surfaces().filter(|surface| {
+            matches!(
+                surface.kind,
+                PublicSurfaceKind::EntityHistory { .. }
+                    | PublicSurfaceKind::FileHistory
+                    | PublicSurfaceKind::DirectoryHistory
+            )
+        }) {
+            let provider_schema = self
+                .public_catalog
+                .history_surface_schema(&surface.name)
+                .ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "history function '{}' is missing its result schema",
+                        surface.name
+                    ))
+                })?;
+            for (position, column) in surface
+                .columns
+                .iter()
+                .filter(|column| column.is_public())
+                .enumerate()
+            {
+                let field = provider_schema.field_with_name(&column.name)?;
+                function_catalog.push(self.public_catalog_name.clone());
+                function_schema.push(self.public_schema_name.clone());
+                function_name.push(surface.name.clone());
+                argument_signature.push("() | (as_of TEXT)".to_string());
+                result_column.push(column.name.clone());
+                ordinal_position.push((position + 1) as u64);
+                is_nullable.push(if column.read_nullable { "YES" } else { "NO" }.to_string());
+                data_type.push(public_sql_type(field.data_type()));
+                lix_value_kind.push(field_is_json(field).then(|| LIX_VALUE_KIND_JSON.to_string()));
+            }
+        }
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(function_catalog)),
+                Arc::new(StringArray::from(function_schema)),
+                Arc::new(StringArray::from(function_name)),
+                Arc::new(StringArray::from(argument_signature)),
+                Arc::new(StringArray::from(result_column)),
+                Arc::new(UInt64Array::from(ordinal_position)),
+                Arc::new(StringArray::from(is_nullable)),
+                Arc::new(StringArray::from(data_type)),
+                Arc::new(StringArray::from(lix_value_kind)),
+            ],
+        )?;
+        Ok(Arc::new(MemTable::try_new(schema, vec![vec![batch]])?))
+    }
 }
 
 #[async_trait]
@@ -157,12 +230,16 @@ impl SchemaProvider for LixInformationSchemaProvider {
         INFORMATION_SCHEMA_TABLES
             .iter()
             .map(|name| (*name).to_string())
+            .chain(std::iter::once(TABLE_FUNCTIONS.to_string()))
             .collect()
     }
 
     async fn table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>> {
         if name.eq_ignore_ascii_case("columns") {
             return self.columns_table().await.map(Some);
+        }
+        if name.eq_ignore_ascii_case(TABLE_FUNCTIONS) {
+            return self.table_functions_table().map(Some);
         }
         let catalog_list = self.catalog_list.upgrade().ok_or_else(|| {
             DataFusionError::Execution("SQL catalog closed while reading information_schema".into())
@@ -176,7 +253,22 @@ impl SchemaProvider for LixInformationSchemaProvider {
         INFORMATION_SCHEMA_TABLES
             .iter()
             .any(|candidate| candidate.eq_ignore_ascii_case(name))
+            || name.eq_ignore_ascii_case(TABLE_FUNCTIONS)
     }
+}
+
+fn table_functions_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("function_catalog", DataType::Utf8, false),
+        Field::new("function_schema", DataType::Utf8, false),
+        Field::new("function_name", DataType::Utf8, false),
+        Field::new("argument_signature", DataType::Utf8, false),
+        Field::new("result_column", DataType::Utf8, false),
+        Field::new("ordinal_position", DataType::UInt64, false),
+        Field::new("is_nullable", DataType::Utf8, false),
+        Field::new("data_type", DataType::Utf8, false),
+        Field::new("lix_value_kind", DataType::Utf8, true),
+    ]))
 }
 
 fn columns_schema() -> SchemaRef {

--- a/packages/engine/src/sql2/providers/history_table_function.rs
+++ b/packages/engine/src/sql2/providers/history_table_function.rs
@@ -1,0 +1,167 @@
+use std::any::Any;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::arrow::datatypes::{Schema, SchemaRef};
+use datafusion::catalog::{Session, TableProvider};
+use datafusion::common::{DataFusionError, Result, ScalarValue};
+use datafusion::datasource::TableType;
+use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, col, lit};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::prelude::SessionContext;
+
+use crate::LixError;
+
+/// Registers a history relation as a table-valued function.
+///
+/// The wrapped provider retains its internal anchor column for commit-graph
+/// routing, while callers only see the row-shaped history columns.
+pub(super) fn register_history_table_function(
+    session: &SessionContext,
+    name: &str,
+    provider: Arc<dyn TableProvider>,
+    anchor_column: &'static str,
+) -> Result<(), LixError> {
+    let anchor_index = provider.schema().index_of(anchor_column).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("history provider is missing its anchor column: {error}"),
+        )
+    })?;
+    session.register_udtf(
+        name,
+        Arc::new(HistoryTableFunction {
+            name: name.to_string(),
+            provider,
+            anchor_column,
+            anchor_index,
+        }),
+    );
+    Ok(())
+}
+
+struct HistoryTableFunction {
+    name: String,
+    provider: Arc<dyn TableProvider>,
+    anchor_column: &'static str,
+    anchor_index: usize,
+}
+
+impl std::fmt::Debug for HistoryTableFunction {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("HistoryTableFunction")
+            .field("name", &self.name)
+            .finish_non_exhaustive()
+    }
+}
+
+impl datafusion::catalog::TableFunctionImpl for HistoryTableFunction {
+    fn call(&self, args: &[Expr]) -> Result<Arc<dyn TableProvider>> {
+        let anchor = match args {
+            [] => None,
+            [Expr::Literal(ScalarValue::Utf8(Some(value)), _)]
+            | [Expr::Literal(ScalarValue::LargeUtf8(Some(value)), _)]
+            | [Expr::Literal(ScalarValue::Utf8View(Some(value)), _)] => Some(value.clone()),
+            [_] => {
+                return Err(DataFusionError::Plan(format!(
+                    "{}(as_of) requires a non-null text commit ID",
+                    self.name
+                )));
+            }
+            _ => {
+                return Err(DataFusionError::Plan(format!(
+                    "{} expects zero or one argument",
+                    self.name
+                )));
+            }
+        };
+        Ok(Arc::new(HistoryFunctionProvider {
+            inner: Arc::clone(&self.provider),
+            schema: public_history_schema(&self.provider.schema(), self.anchor_index),
+            anchor,
+            anchor_column: self.anchor_column,
+            anchor_index: self.anchor_index,
+        }))
+    }
+}
+
+struct HistoryFunctionProvider {
+    inner: Arc<dyn TableProvider>,
+    schema: SchemaRef,
+    anchor: Option<String>,
+    anchor_column: &'static str,
+    anchor_index: usize,
+}
+
+impl std::fmt::Debug for HistoryFunctionProvider {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("HistoryFunctionProvider")
+            .field("anchor", &self.anchor)
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl TableProvider for HistoryFunctionProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::View
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> Result<Vec<TableProviderFilterPushDown>> {
+        self.inner.supports_filters_pushdown(filters)
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let projection = projection
+            .cloned()
+            .unwrap_or_else(|| (0..self.schema.fields().len()).collect());
+        let inner_projection = projection
+            .into_iter()
+            .map(|index| {
+                if index < self.anchor_index {
+                    index
+                } else {
+                    index + 1
+                }
+            })
+            .collect::<Vec<_>>();
+        let mut inner_filters = filters.to_vec();
+        if let Some(anchor) = &self.anchor {
+            inner_filters.push(col(self.anchor_column).eq(lit(anchor.clone())));
+        }
+        self.inner
+            .scan(state, Some(&inner_projection), &inner_filters, limit)
+            .await
+    }
+}
+
+fn public_history_schema(schema: &SchemaRef, anchor_index: usize) -> SchemaRef {
+    Arc::new(Schema::new(
+        schema
+            .fields()
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| *index != anchor_index)
+            .map(|(_, field)| field.as_ref().clone())
+            .collect::<Vec<_>>(),
+    ))
+}

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -21,6 +21,7 @@ mod file;
 mod file_history;
 mod filesystem_history_path;
 mod filesystem_working_change;
+mod history_table_function;
 mod history_util;
 mod spec;
 mod upsert;
@@ -693,7 +694,9 @@ mod tests {
     use crate::json_store::JsonStoreContext;
     use crate::live_state::{LiveStateReader, LiveStateScanRequest};
     use crate::sql2::HistoryQuerySource;
-    use crate::sql2::catalog::{PublicCatalog, derive_entity_surface_spec_from_schema};
+    use crate::sql2::catalog::{
+        PublicCatalog, PublicSurfaceKind, derive_entity_surface_spec_from_schema,
+    };
     use crate::storage_adapter::{
         Memory, MemoryRead, SharedStorageAdapterRead, StorageAdapter, StorageReadOptions,
     };
@@ -1066,10 +1069,26 @@ mod tests {
         catalog: &PublicCatalog,
         surface_name: &str,
     ) {
-        let provider = session
-            .table_provider(surface_name)
-            .await
-            .unwrap_or_else(|error| panic!("{surface_name} provider should load: {error}"));
+        let surface = catalog
+            .surface(surface_name)
+            .unwrap_or_else(|| panic!("{surface_name} should be in catalog"));
+        let provider = if matches!(
+            surface.kind,
+            PublicSurfaceKind::EntityHistory { .. }
+                | PublicSurfaceKind::FileHistory
+                | PublicSurfaceKind::DirectoryHistory
+        ) {
+            session
+                .table_function(surface_name)
+                .unwrap_or_else(|error| panic!("{surface_name} function should load: {error}"))
+                .create_table_provider(&[])
+                .unwrap_or_else(|error| panic!("{surface_name} function should bind: {error}"))
+        } else {
+            session
+                .table_provider(surface_name)
+                .await
+                .unwrap_or_else(|error| panic!("{surface_name} provider should load: {error}"))
+        };
         assert_surface_schema_matches_provider_schema(catalog, surface_name, provider.schema());
     }
 
@@ -1081,14 +1100,25 @@ mod tests {
         let surface = catalog
             .surface(surface_name)
             .unwrap_or_else(|| panic!("{surface_name} should be in catalog"));
+        let history_surface = matches!(
+            surface.kind,
+            PublicSurfaceKind::EntityHistory { .. }
+                | PublicSurfaceKind::FileHistory
+                | PublicSurfaceKind::DirectoryHistory
+        );
         let catalog_column_names = surface
             .columns
             .iter()
+            .filter(|column| !history_surface || column.is_public())
             .map(|column| column.name.as_str())
             .collect::<Vec<_>>();
         let provider_field_names = provider_schema
             .fields()
             .iter()
+            .filter(|field| {
+                !history_surface
+                    || field.name() != crate::sql2::history_route::HISTORY_COL_AS_OF_COMMIT_ID
+            })
             .map(|field| field.name().as_str())
             .collect::<Vec<_>>();
         assert_eq!(
@@ -1096,14 +1126,16 @@ mod tests {
             "{surface_name} column order"
         );
 
-        let catalog_schema = catalog
-            .surface_schema(surface_name)
-            .unwrap_or_else(|| panic!("{surface_name} should be in catalog"));
-        assert_eq!(
-            catalog_schema.fields(),
-            provider_schema.fields(),
-            "{surface_name}"
-        );
+        if !history_surface {
+            let catalog_schema = catalog
+                .surface_schema(surface_name)
+                .unwrap_or_else(|| panic!("{surface_name} should be in catalog"));
+            assert_eq!(
+                catalog_schema.fields(),
+                provider_schema.fields(),
+                "{surface_name}"
+            );
+        }
     }
 
     async fn empty_history_query_source()

--- a/packages/engine/src/sql2/providers/spec.rs
+++ b/packages/engine/src/sql2/providers/spec.rs
@@ -320,11 +320,17 @@ pub(super) fn register_spec_table(
     spec: Arc<dyn TableSpec>,
     write_access: WriteAccess,
 ) -> Result<(), LixError> {
-    session
-        .register_table(
+    let provider = Arc::new(SpecTableProvider::new(spec, write_access));
+    if let Some(anchor_column) = provider.history_anchor_column() {
+        return super::history_table_function::register_history_table_function(
+            session,
             surface_name,
-            Arc::new(SpecTableProvider::new(spec, write_access)),
-        )
+            provider,
+            anchor_column,
+        );
+    }
+    session
+        .register_table(surface_name, provider)
         .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
     Ok(())
 }

--- a/packages/engine/tests/integration/branching.rs
+++ b/packages/engine/tests/integration/branching.rs
@@ -1092,9 +1092,8 @@ simulation_test!(
         let history = main
             .execute(
                 "SELECT value \
-	             FROM lix_key_value_history \
-	             WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id() \
-	               AND key = 'merge-select-change' \
+	             FROM lix_key_value_history() \
+	               WHERE key = 'merge-select-change' \
 	             ORDER BY lixcol_depth",
                 &[],
             )

--- a/packages/engine/tests/integration/sql/entity_history.rs
+++ b/packages/engine/tests/integration/sql/entity_history.rs
@@ -62,10 +62,9 @@ simulation_test!(
         let result = session
             .execute(
                 &format!(
-                    "SELECT id, count, active, meta, lixcol_entity_pk, lixcol_observed_commit_id, lixcol_as_of_commit_id, lixcol_is_deleted, lixcol_depth \
-                     FROM engine_history_schema_history \
-                     WHERE lixcol_as_of_commit_id = '{second_commit_id}' \
-                       AND lixcol_entity_pk = lix_json('[\"history-entity\"]') \
+                    "SELECT id, count, active, meta, lixcol_entity_pk, lixcol_observed_commit_id, lixcol_is_deleted, lixcol_depth \
+                     FROM engine_history_schema_history('{second_commit_id}') \
+                     WHERE lixcol_entity_pk = lix_json('[\"history-entity\"]') \
                      ORDER BY lixcol_depth"
                 ),
                 &[],
@@ -83,7 +82,6 @@ simulation_test!(
                     Value::Json(json!({"source": "update"})),
                     Value::Json(json!(["history-entity"])),
                     Value::Text(second_commit_id.clone()),
-                    Value::Text(second_commit_id.clone()),
                     Value::Boolean(false),
                     Value::Integer(0),
                 ],
@@ -94,7 +92,6 @@ simulation_test!(
                     Value::Json(json!({"source": "insert"})),
                     Value::Json(json!(["history-entity"])),
                     Value::Text(first_commit_id),
-                    Value::Text(second_commit_id),
                     Value::Boolean(false),
                     Value::Integer(1),
                 ],
@@ -135,16 +132,10 @@ simulation_test!(entity_history_defaults_to_active_head, |sim| async move {
         )
         .await
         .expect("entity insert should succeed");
-    let active_head = engine
-        .load_branch_head_commit_id(sim.main_branch_id())
-        .await
-        .expect("active head should load")
-        .expect("active head should exist");
-
     let result = session
         .execute(
-            "SELECT id, lixcol_as_of_commit_id, lixcol_depth \
-                 FROM engine_history_error_schema_history \
+            "SELECT id, lixcol_depth \
+                 FROM engine_history_error_schema_history() \
                  WHERE id = 'history-default'",
             &[],
         )
@@ -155,7 +146,6 @@ simulation_test!(entity_history_defaults_to_active_head, |sim| async move {
         result,
         vec![vec![
             Value::Text("history-default".to_string()),
-            Value::Text(active_head),
             Value::Integer(0),
         ]],
     );
@@ -191,7 +181,7 @@ simulation_test!(
                 .execute(
                     &format!(
                         "SELECT id \
-                         FROM engine_history_bare_error_schema_history \
+                         FROM engine_history_bare_error_schema_history() \
                          WHERE {retired} = lix_active_branch_commit_id()"
                     ),
                     &[],

--- a/packages/engine/tests/integration/sql/history_conformance.rs
+++ b/packages/engine/tests/integration/sql/history_conformance.rs
@@ -4,7 +4,7 @@ use serde_json::json;
 use super::select_rows;
 
 simulation_test!(
-    history_surfaces_are_introspected_as_views,
+    history_functions_are_not_exposed_as_static_tables,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
@@ -41,58 +41,12 @@ simulation_test!(
         )
         .await;
 
-        let expected = [
-            "engine_history_table_type_history",
-            "lix_directory_history",
-            "lix_file_history",
-        ]
-        .into_iter()
-        .map(|table| {
-            vec![
-                Value::Text(table.to_string()),
-                Value::Text("VIEW".to_string()),
-            ]
-        })
-        .collect::<Vec<_>>();
-
-        assert_eq!(rows, expected);
-
-        let provenance_columns = select_rows(
-            &session,
-            "SELECT table_name, column_name \
-             FROM information_schema.columns \
-             WHERE table_name IN ('lix_file_history', 'lix_directory_history') \
-               AND column_name IN (\
-                 'lixcol_source_changes',\
-                 'lixcol_schema_key',\
-                 'lixcol_file_id',\
-                 'lixcol_snapshot_content',\
-                 'lixcol_change_id',\
-                 'lixcol_origin_key',\
-                 'lixcol_metadata'\
-               ) \
-             ORDER BY table_name, column_name",
-        )
-        .await;
-        assert_eq!(
-            provenance_columns,
-            vec![
-                vec![
-                    Value::Text("lix_directory_history".to_string()),
-                    Value::Text("lixcol_source_changes".to_string()),
-                ],
-                vec![
-                    Value::Text("lix_file_history".to_string()),
-                    Value::Text("lixcol_source_changes".to_string()),
-                ],
-            ],
-            "composed histories expose aggregate provenance without singular aliases"
-        );
+        assert!(rows.is_empty());
     }
 );
 
 simulation_test!(
-    history_view_schemas_expose_tombstone_contract,
+    history_function_results_hide_the_anchor_column,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
@@ -116,63 +70,31 @@ simulation_test!(
             .await
             .expect("registered schema insert should succeed");
 
-        let rows = select_rows(
-            &session,
-            "SELECT table_name, column_name, is_nullable \
-             FROM information_schema.columns \
-             WHERE table_name IN (\
-               'lix_file_history',\
-               'lix_directory_history',\
-               'engine_history_contract_schema_history'\
-             ) \
-               AND (\
-                 column_name IN ('path', 'directory_id', 'parent_id', 'name', 'data', 'id', 'count', 'active', 'meta') \
-                 OR column_name IN ('lixcol_snapshot_content', 'lixcol_is_deleted', 'lixcol_source_changes')\
-               ) \
-             ORDER BY table_name, column_name",
-        )
-        .await;
-
-        let expected = vec![
-            ("engine_history_contract_schema_history", "active", "YES"),
-            ("engine_history_contract_schema_history", "count", "YES"),
-            ("engine_history_contract_schema_history", "id", "NO"),
-            (
-                "engine_history_contract_schema_history",
-                "lixcol_is_deleted",
-                "NO",
-            ),
-            (
-                "engine_history_contract_schema_history",
-                "lixcol_snapshot_content",
-                "YES",
-            ),
-            ("engine_history_contract_schema_history", "meta", "YES"),
-            ("lix_directory_history", "id", "NO"),
-            ("lix_directory_history", "lixcol_is_deleted", "NO"),
-            ("lix_directory_history", "lixcol_source_changes", "NO"),
-            ("lix_directory_history", "name", "YES"),
-            ("lix_directory_history", "parent_id", "YES"),
-            ("lix_directory_history", "path", "YES"),
-            ("lix_file_history", "data", "YES"),
-            ("lix_file_history", "directory_id", "YES"),
-            ("lix_file_history", "id", "NO"),
-            ("lix_file_history", "lixcol_is_deleted", "NO"),
-            ("lix_file_history", "lixcol_source_changes", "NO"),
-            ("lix_file_history", "name", "YES"),
-            ("lix_file_history", "path", "YES"),
-        ]
-        .into_iter()
-        .map(|(table, column, nullable)| {
-            vec![
-                Value::Text(table.to_string()),
-                Value::Text(column.to_string()),
-                Value::Text(nullable.to_string()),
-            ]
-        })
-        .collect::<Vec<_>>();
-
-        assert_eq!(rows, expected);
+        for sql in [
+            "SELECT * FROM lix_file_history() LIMIT 0",
+            "SELECT * FROM lix_directory_history() LIMIT 0",
+            "SELECT * FROM engine_history_contract_schema_history() LIMIT 0",
+        ] {
+            let result = session.execute(sql, &[]).await.expect("history function");
+            assert!(
+                !result
+                    .columns()
+                    .iter()
+                    .any(|column| column == "lixcol_as_of_commit_id")
+            );
+            assert!(
+                result
+                    .columns()
+                    .iter()
+                    .any(|column| column == "lixcol_depth")
+            );
+            assert!(
+                result
+                    .columns()
+                    .iter()
+                    .any(|column| column == "lixcol_is_deleted")
+            );
+        }
     }
 );
 
@@ -229,9 +151,8 @@ simulation_test!(typed_entity_history_exposes_tombstones, |sim| async move {
     let typed_rows = select_rows(
         &session,
         "SELECT id, value, lixcol_entity_pk, lixcol_snapshot_content, lixcol_depth \
-             FROM engine_history_conformance_history \
-             WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id() \
-               AND lixcol_entity_pk = lix_json('[\"history-conformance-entity\"]') \
+             FROM engine_history_conformance_history() \
+               WHERE lixcol_entity_pk = lix_json('[\"history-conformance-entity\"]') \
              ORDER BY lixcol_depth",
     )
     .await;
@@ -279,9 +200,8 @@ simulation_test!(
         let rows = select_rows(
             &session,
             "SELECT key, value, lixcol_entity_pk, lixcol_snapshot_content, lixcol_depth \
-             FROM lix_key_value_history \
-             WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id() \
-               AND key = 'history-pk-backfill' \
+             FROM lix_key_value_history() \
+               WHERE key = 'history-pk-backfill' \
              ORDER BY lixcol_depth",
         )
         .await;
@@ -357,9 +277,8 @@ simulation_test!(
         let rows = select_rows(
             &session,
             "SELECT namespace, id, value, lixcol_snapshot_content, lixcol_depth \
-             FROM engine_history_composite_pk_history \
-             WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id() \
-               AND namespace = 'messages' \
+             FROM engine_history_composite_pk_history() \
+               WHERE namespace = 'messages' \
                AND id = '7' \
              ORDER BY lixcol_depth",
         )
@@ -437,9 +356,8 @@ simulation_test!(
         let rows = select_rows(
             &session,
             "SELECT identity, value, lixcol_snapshot_content, lixcol_depth \
-             FROM engine_history_nested_pk_history \
-             WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id() \
-               AND lix_json_get_text(identity, 'tenant') = 'acme' \
+             FROM engine_history_nested_pk_history() \
+               WHERE lix_json_get_text(identity, 'tenant') = 'acme' \
                AND lix_json_get_text(identity, 'id') = '7' \
              ORDER BY lixcol_depth",
         )
@@ -478,9 +396,9 @@ simulation_test!(
         let nullability = select_rows(
             &session,
             "SELECT is_nullable \
-             FROM information_schema.columns \
-             WHERE table_name = 'engine_history_nested_pk_history' \
-               AND column_name = 'identity'",
+             FROM information_schema.table_functions \
+             WHERE function_name = 'engine_history_nested_pk_history' \
+               AND result_column = 'identity'",
         )
         .await;
         assert_eq!(nullability, vec![vec![Value::Text("NO".to_string())]]);
@@ -525,9 +443,8 @@ simulation_test!(
         let file_rows = select_rows(
             &session,
             "SELECT id, path, name, data, lixcol_entity_pk, lixcol_is_deleted, lixcol_depth \
-             FROM lix_file_history \
-             WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id() \
-               AND id = '68697374-6f72-892d-836f-6e666f726d00' \
+             FROM lix_file_history() \
+               WHERE id = '68697374-6f72-892d-836f-6e666f726d00' \
                AND lixcol_depth = 0",
         )
         .await;
@@ -585,9 +502,8 @@ simulation_test!(
         let directory_rows = select_rows(
             &session,
             "SELECT id, path, parent_id, name, lixcol_entity_pk, lixcol_is_deleted, lixcol_depth \
-             FROM lix_directory_history \
-             WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id() \
-               AND id = '68697374-6f72-892d-836f-6e666f726d00' \
+             FROM lix_directory_history() \
+               WHERE id = '68697374-6f72-892d-836f-6e666f726d00' \
                AND lixcol_depth = 0",
         )
         .await;
@@ -607,7 +523,7 @@ simulation_test!(
 );
 
 simulation_test!(
-    typed_history_routes_exact_anchor_from_join_predicate,
+    typed_history_function_anchor_composes_with_joins,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
@@ -641,11 +557,10 @@ simulation_test!(
         let result = session
             .execute(
                 &format!(
-                    "SELECT h.lixcol_as_of_commit_id \
-                     FROM lix_key_value_history AS h \
+                    "SELECT h.lixcol_snapshot_content \
+                     FROM lix_key_value_history('{first_commit_id}') AS h \
                      JOIN lix_key_value AS active \
                        ON h.key = active.key \
-                      AND h.lixcol_as_of_commit_id = '{first_commit_id}' \
                      WHERE h.key = 'history-join-anchor'"
                 ),
                 &[],
@@ -657,20 +572,21 @@ simulation_test!(
                 .rows()
                 .iter()
                 .map(|row| row
-                    .get::<Value>("lixcol_as_of_commit_id")
-                    .expect("lixcol_as_of_commit_id"))
+                    .get::<Value>("lixcol_snapshot_content")
+                    .expect("lixcol_snapshot_content"))
                 .collect::<Vec<_>>(),
-            vec![Value::Text(first_commit_id.clone())]
+            vec![Value::Json(
+                json!({"key": "history-join-anchor", "value": "one"})
+            )]
         );
 
         let nullable_side = session
             .execute(
                 &format!(
-                    "SELECT h.lixcol_as_of_commit_id, h.lixcol_snapshot_content \
+                    "SELECT h.lixcol_snapshot_content \
                      FROM lix_branch AS b \
-                     LEFT JOIN lix_key_value_history AS h \
-                       ON h.lixcol_as_of_commit_id = '{first_commit_id}' \
-                      AND h.key = 'history-join-anchor' \
+                     LEFT JOIN lix_key_value_history('{first_commit_id}') AS h \
+                       ON h.key = 'history-join-anchor' \
                      WHERE b.id = 'ffffffff-ffff-7fff-bfff-ffffffffffff'"
                 ),
                 &[],
@@ -683,20 +599,18 @@ simulation_test!(
                 .iter()
                 .map(|row| row.values().to_vec())
                 .collect::<Vec<_>>(),
-            vec![vec![
-                Value::Text(first_commit_id.clone()),
-                Value::Json(json!({"key": "history-join-anchor", "value": "one"})),
-            ]]
+            vec![vec![Value::Json(
+                json!({"key": "history-join-anchor", "value": "one"})
+            ),]]
         );
 
         let right_nullable_side = session
             .execute(
                 &format!(
-                    "SELECT h.lixcol_as_of_commit_id, h.lixcol_snapshot_content \
-                     FROM lix_key_value_history AS h \
+                    "SELECT h.lixcol_snapshot_content \
+                     FROM lix_key_value_history('{first_commit_id}') AS h \
                      RIGHT JOIN lix_branch AS b \
-                       ON h.lixcol_as_of_commit_id = '{first_commit_id}' \
-                      AND h.key = 'history-join-anchor' \
+                       ON h.key = 'history-join-anchor' \
                      WHERE b.id = 'ffffffff-ffff-7fff-bfff-ffffffffffff'"
                 ),
                 &[],
@@ -709,19 +623,18 @@ simulation_test!(
                 .iter()
                 .map(|row| row.values().to_vec())
                 .collect::<Vec<_>>(),
-            vec![vec![
-                Value::Text(first_commit_id.clone()),
-                Value::Json(json!({"key": "history-join-anchor", "value": "one"})),
-            ]]
+            vec![vec![Value::Json(
+                json!({"key": "history-join-anchor", "value": "one"})
+            ),]]
         );
 
         let semi_join = session
             .execute(
                 &format!(
-                    "SELECT h.lixcol_as_of_commit_id, h.lixcol_snapshot_content \
-                     FROM lix_key_value_history AS h \
+                    "SELECT h.lixcol_snapshot_content \
+                     FROM lix_key_value_history('{first_commit_id}') AS h \
                      LEFT SEMI JOIN lix_branch AS b \
-                       ON h.lixcol_as_of_commit_id = '{first_commit_id}' \
+                       ON true \
                      WHERE h.key = 'history-join-anchor'"
                 ),
                 &[],
@@ -734,22 +647,20 @@ simulation_test!(
                 .iter()
                 .map(|row| row.values().to_vec())
                 .collect::<Vec<_>>(),
-            vec![vec![
-                Value::Text(first_commit_id.clone()),
-                Value::Json(json!({"key": "history-join-anchor", "value": "one"})),
-            ]]
+            vec![vec![Value::Json(
+                json!({"key": "history-join-anchor", "value": "one"})
+            ),]]
         );
 
         let projected = session
             .execute(
                 &format!(
-                    "SELECT projected.anchor AS lixcol_as_of_commit_id \
+                    "SELECT projected.snapshot \
                      FROM (\
-                       SELECT key, lixcol_as_of_commit_id AS anchor \
-                       FROM lix_key_value_history\
+                       SELECT key, lixcol_snapshot_content AS snapshot \
+                       FROM lix_key_value_history('{first_commit_id}')\
                      ) AS projected \
-                     WHERE projected.anchor = '{first_commit_id}' \
-                       AND projected.key = 'history-join-anchor'"
+                     WHERE projected.key = 'history-join-anchor'"
                 ),
                 &[],
             )
@@ -759,17 +670,17 @@ simulation_test!(
             projected
                 .rows()
                 .iter()
-                .map(|row| row
-                    .get::<Value>("lixcol_as_of_commit_id")
-                    .expect("lixcol_as_of_commit_id"))
+                .map(|row| row.get::<Value>("snapshot").expect("snapshot"))
                 .collect::<Vec<_>>(),
-            vec![Value::Text(first_commit_id)]
+            vec![Value::Json(
+                json!({"key": "history-join-anchor", "value": "one"})
+            )]
         );
     }
 );
 
 simulation_test!(
-    history_surfaces_reject_unrouteable_anchor_predicates,
+    history_surfaces_require_function_anchors,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
@@ -781,36 +692,15 @@ simulation_test!(
         );
 
         for sql in [
-            "SELECT key FROM lix_key_value_history WHERE lixcol_as_of_commit_id > 'cid_invalid'",
-            "SELECT key FROM lix_key_value_history WHERE lixcol_as_of_commit_id NOT IN ('cid_invalid')",
-            "SELECT key FROM lix_key_value_history WHERE lixcol_as_of_commit_id = 'cid_invalid' OR key = 'other'",
-            "SELECT h.key FROM lix_key_value_history AS h JOIN lix_branch AS b ON h.lixcol_as_of_commit_id = b.commit_id",
-            "SELECT h.key FROM lix_key_value_history AS h JOIN lix_branch AS b ON h.lixcol_as_of_commit_id > b.commit_id",
-            "SELECT h.key FROM lix_key_value_history AS h LEFT JOIN lix_branch AS b ON h.lixcol_as_of_commit_id = 'cid_invalid'",
-            "SELECT h.key FROM lix_branch AS b RIGHT JOIN lix_key_value_history AS h ON h.lixcol_as_of_commit_id = 'cid_invalid'",
-            "SELECT h.key FROM lix_key_value_history AS h FULL JOIN lix_branch AS b ON h.lixcol_as_of_commit_id = 'cid_invalid'",
-            "SELECT h.key FROM lix_key_value_history AS h LEFT ANTI JOIN lix_branch AS b ON h.lixcol_as_of_commit_id = 'cid_invalid'",
-            "SELECT h.key FROM lix_branch AS b RIGHT ANTI JOIN lix_key_value_history AS h ON h.lixcol_as_of_commit_id = 'cid_invalid'",
-            "SELECT projected.key FROM (SELECT key, lixcol_as_of_commit_id AS anchor FROM lix_key_value_history) AS projected WHERE projected.anchor > 'cid_invalid'",
-            "SELECT limited.key FROM (SELECT key, lixcol_as_of_commit_id AS anchor FROM lix_key_value_history LIMIT 1) AS limited WHERE limited.anchor = 'cid_invalid'",
-            "SELECT id FROM lix_file_history WHERE lixcol_as_of_commit_id LIKE 'cid_%'",
-            "SELECT id FROM lix_directory_history WHERE lixcol_as_of_commit_id IS NULL",
+            "SELECT key FROM lix_key_value_history",
+            "SELECT lixcol_as_of_commit_id FROM lix_key_value_history()",
+            "SELECT key FROM lix_key_value_history('one', 'two')",
+            "SELECT key FROM lix_key_value_history(42)",
         ] {
-            let error = session
+            session
                 .execute(sql, &[])
                 .await
-                .expect_err("unrouteable history anchors must not fall back to the active head");
-            assert_eq!(error.code, lix_engine::LixError::CODE_UNSUPPORTED_SQL);
-            assert!(
-                error.to_string().contains("only supports exact equality"),
-                "unexpected error: {error}"
-            );
-            assert!(
-                error
-                    .hint()
-                    .is_some_and(|hint| hint.contains("pinned active branch head")),
-                "unexpected hint: {error:?}"
-            );
+                .expect_err("invalid history function usage must fail");
         }
     }
 );
@@ -839,7 +729,7 @@ simulation_test!(
             .execute(
                 "SELECT ordinary.lixcol_as_of_commit_id \
                  FROM (SELECT 'ordinary' AS lixcol_as_of_commit_id) AS ordinary \
-                 CROSS JOIN lix_key_value_history AS history \
+                 CROSS JOIN lix_key_value_history() AS history \
                  WHERE ordinary.lixcol_as_of_commit_id > 'a' \
                    AND history.key = 'collision' \
                  LIMIT 1",
@@ -900,12 +790,14 @@ simulation_test!(
         let in_rows = select_rows(
             &session,
             &format!(
-                "SELECT lixcol_as_of_commit_id, lixcol_depth, lixcol_snapshot_content \
-                 FROM lix_key_value_history \
-                 WHERE lixcol_as_of_commit_id IN ('{first_commit_id}', '{second_commit_id}') \
-                   AND key = 'history-multi-start' \
-                   AND lixcol_depth = 0 \
-                 ORDER BY lixcol_as_of_commit_id"
+                "SELECT '{first_commit_id}' AS anchor, lixcol_depth, lixcol_snapshot_content \
+                 FROM lix_key_value_history('{first_commit_id}') \
+                 WHERE key = 'history-multi-start' AND lixcol_depth = 0 \
+                 UNION ALL \
+                 SELECT '{second_commit_id}' AS anchor, lixcol_depth, lixcol_snapshot_content \
+                 FROM lix_key_value_history('{second_commit_id}') \
+                 WHERE key = 'history-multi-start' AND lixcol_depth = 0 \
+                 ORDER BY anchor"
             ),
         )
         .await;
@@ -923,19 +815,20 @@ simulation_test!(
                     Value::Json(json!({"key": "history-multi-start", "value": "two"})),
                 ],
             ],
-            "IN should allow multiple explicit history anchors"
+            "multiple history function calls can be unioned"
         );
 
         let or_rows = select_rows(
             &session,
             &format!(
-                "SELECT lixcol_as_of_commit_id \
-                 FROM lix_key_value_history \
-                 WHERE (lixcol_as_of_commit_id = '{first_commit_id}' \
-                        OR lixcol_as_of_commit_id = '{second_commit_id}') \
-                   AND key = 'history-multi-start' \
-                   AND lixcol_depth = 0 \
-                 ORDER BY lixcol_as_of_commit_id"
+                "SELECT '{first_commit_id}' AS anchor \
+                 FROM lix_key_value_history('{first_commit_id}') \
+                 WHERE key = 'history-multi-start' AND lixcol_depth = 0 \
+                 UNION ALL \
+                 SELECT '{second_commit_id}' AS anchor \
+                 FROM lix_key_value_history('{second_commit_id}') \
+                 WHERE key = 'history-multi-start' AND lixcol_depth = 0 \
+                 ORDER BY anchor"
             ),
         )
         .await;
@@ -945,7 +838,7 @@ simulation_test!(
                 vec![Value::Text(first_commit_id)],
                 vec![Value::Text(second_commit_id)],
             ],
-            "OR should also allow multiple explicit history anchors"
+            "union preserves both explicit anchors"
         );
     }
 );
@@ -986,9 +879,8 @@ simulation_test!(
             &session,
             &format!(
                 "SELECT key \
-                 FROM lix_key_value_history \
-                 WHERE lixcol_as_of_commit_id = '{head_commit_id}' \
-                   AND key IN ('history-and-a', 'history-and-b') \
+                 FROM lix_key_value_history('{head_commit_id}') \
+                   WHERE key IN ('history-and-a', 'history-and-b') \
                    AND key = 'history-and-a'"
             ),
         )
@@ -1003,9 +895,8 @@ simulation_test!(
             &session,
             &format!(
                 "SELECT key \
-                 FROM lix_key_value_history \
-                 WHERE lixcol_as_of_commit_id = '{head_commit_id}' \
-                   AND key = 'history-and-a' \
+                 FROM lix_key_value_history('{head_commit_id}') \
+                   WHERE key = 'history-and-a' \
                    AND key = 'history-and-b'"
             ),
         )

--- a/packages/engine/tests/integration/sql/information_schema.rs
+++ b/packages/engine/tests/integration/sql/information_schema.rs
@@ -375,11 +375,11 @@ simulation_test!(
 
         let history_contract = session
             .execute(
-                "SELECT column_name, is_nullable, lix_insert_policy \
-                 FROM information_schema.columns \
-                 WHERE table_name = 'engine_column_contract_history' \
-                   AND column_name IN ('id', 'title') \
-                 ORDER BY column_name",
+                "SELECT result_column, is_nullable \
+                 FROM information_schema.table_functions \
+                 WHERE function_name = 'engine_column_contract_history' \
+                   AND result_column IN ('id', 'title') \
+                 ORDER BY result_column",
                 &[],
             )
             .await
@@ -387,15 +387,10 @@ simulation_test!(
         assert_rows_eq(
             history_contract,
             vec![
-                vec![
-                    Value::Text("id".to_string()),
-                    Value::Text("NO".to_string()),
-                    Value::Text("READ_ONLY".to_string()),
-                ],
+                vec![Value::Text("id".to_string()), Value::Text("NO".to_string())],
                 vec![
                     Value::Text("title".to_string()),
                     Value::Text("YES".to_string()),
-                    Value::Text("READ_ONLY".to_string()),
                 ],
             ],
         );
@@ -1407,9 +1402,8 @@ simulation_test!(
         assert_rows_eq(
             session
                 .execute(
-                    "SELECT count FROM engine_bigint_contract_history \
-                     WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id() \
-                       AND lixcol_entity_pk = lix_json('[\"integral-real\"]')",
+                    "SELECT count FROM engine_bigint_contract_history() \
+                       WHERE lixcol_entity_pk = lix_json('[\"integral-real\"]')",
                     &[],
                 )
                 .await

--- a/packages/engine/tests/integration/sql/lix_directory_history.rs
+++ b/packages/engine/tests/integration/sql/lix_directory_history.rs
@@ -50,10 +50,9 @@ simulation_test!(
         let result = session
             .execute(
                 &format!(
-                    "SELECT id, path, parent_id, name, lixcol_as_of_commit_id, lixcol_depth \
-                     FROM lix_directory_history \
-                     WHERE lixcol_as_of_commit_id = '{second_commit_id}' \
-                       AND id IN ('68697374-6f72-892d-8469-722d646f6300', '68697374-6f72-892d-8469-722d67756900') \
+                    "SELECT id, path, parent_id, name, lixcol_depth \
+                     FROM lix_directory_history('{second_commit_id}') \
+                       WHERE id IN ('68697374-6f72-892d-8469-722d646f6300', '68697374-6f72-892d-8469-722d67756900') \
                      ORDER BY lixcol_depth, id"
                 ),
                 &[],
@@ -69,7 +68,6 @@ simulation_test!(
                     Value::Text("/docs/guides/".to_string()),
                     Value::Text("68697374-6f72-892d-8469-722d646f6300".to_string()),
                     Value::Text("guides".to_string()),
-                    Value::Text(second_commit_id.clone()),
                     Value::Integer(0),
                 ],
                 vec![
@@ -77,7 +75,6 @@ simulation_test!(
                     Value::Text("/docs/".to_string()),
                     Value::Null,
                     Value::Text("docs".to_string()),
-                    Value::Text(second_commit_id.clone()),
                     Value::Integer(1),
                 ],
             ],
@@ -87,9 +84,8 @@ simulation_test!(
             .execute(
                 &format!(
                     "SELECT lixcol_source_changes \
-                     FROM lix_directory_history \
-                     WHERE lixcol_as_of_commit_id = '{second_commit_id}' \
-                       AND id = '68697374-6f72-892d-8469-722d67756900' \
+                     FROM lix_directory_history('{second_commit_id}') \
+                       WHERE id = '68697374-6f72-892d-8469-722d67756900' \
                        AND lixcol_depth = 0"
                 ),
                 &[],
@@ -156,16 +152,10 @@ simulation_test!(
             )
             .await
             .expect("directory insert should succeed");
-        let active_head = engine
-            .load_branch_head_commit_id(sim.main_branch_id())
-            .await
-            .expect("active head should load")
-            .expect("active head should exist");
-
         let result = session
             .execute(
-                "SELECT id, lixcol_as_of_commit_id, lixcol_depth \
-                 FROM lix_directory_history \
+                "SELECT id, lixcol_depth \
+                 FROM lix_directory_history() \
                  WHERE id = '68697374-6f72-892d-8465-6661756c7401'",
                 &[],
             )
@@ -176,7 +166,6 @@ simulation_test!(
             result,
             vec![vec![
                 Value::Text("68697374-6f72-892d-8465-6661756c7401".to_string()),
-                Value::Text(active_head),
                 Value::Integer(0),
             ]],
         );
@@ -252,9 +241,8 @@ simulation_test!(
             .execute(
                 &format!(
                     "SELECT path, lixcol_observed_commit_id, lixcol_depth \
-                     FROM lix_directory_history \
-                     WHERE lixcol_as_of_commit_id = '{merge_commit_id}' \
-                       AND id = '6469616d-6f6e-842d-8469-720000000000' \
+                     FROM lix_directory_history('{merge_commit_id}') \
+                       WHERE id = '6469616d-6f6e-842d-8469-720000000000' \
                        AND lixcol_depth = 1 \
                      ORDER BY lixcol_observed_commit_id"
                 ),
@@ -338,10 +326,9 @@ simulation_test!(
         let result = session
             .execute(
                 &format!(
-					"SELECT id, path, name, lixcol_is_deleted, lixcol_source_changes, lixcol_as_of_commit_id, lixcol_depth \
-	                 FROM lix_directory_history \
-	                 WHERE lixcol_as_of_commit_id = '{delete_commit_id}' \
-	                   AND lixcol_entity_pk IN (lix_json('[\"01940000-0000-7000-8000-000000000001\"]'), lix_json('[\"01940000-0000-7000-8000-000000000002\"]')) \
+					"SELECT id, path, name, lixcol_is_deleted, lixcol_source_changes, lixcol_depth \
+	                 FROM lix_directory_history('{delete_commit_id}') \
+	                   WHERE lixcol_entity_pk IN (lix_json('[\"01940000-0000-7000-8000-000000000001\"]'), lix_json('[\"01940000-0000-7000-8000-000000000002\"]')) \
 	                   AND lixcol_depth = 0 \
 	                 ORDER BY lixcol_entity_pk"
 				),
@@ -389,8 +376,7 @@ simulation_test!(
                 })
                 .collect::<BTreeSet<_>>();
             assert_eq!(actual_source_ids, expected_source_ids);
-            assert_eq!(row.values()[5], Value::Text(delete_commit_id.clone()));
-            assert_eq!(row.values()[6], Value::Integer(0));
+            assert_eq!(row.values()[5], Value::Integer(0));
         }
     }
 );

--- a/packages/engine/tests/integration/sql/lix_file.rs
+++ b/packages/engine/tests/integration/sql/lix_file.rs
@@ -2600,9 +2600,8 @@ async fn file_descriptor_event_count(
     let result = session
         .execute(
             &format!(
-                "SELECT lixcol_source_changes FROM lix_file_history \
-                 WHERE lixcol_as_of_commit_id = '{commit_id}' \
-                   AND lixcol_depth = 0 \
+                "SELECT lixcol_source_changes FROM lix_file_history('{commit_id}') \
+                   WHERE lixcol_depth = 0 \
                    AND id = '{file_id}'"
             ),
             &[],

--- a/packages/engine/tests/integration/sql/lix_file_history.rs
+++ b/packages/engine/tests/integration/sql/lix_file_history.rs
@@ -187,9 +187,8 @@ async fn lix_file_history_point_lookup_does_not_rescan_unrelated_observed_state(
         .execute(
             &format!(
                 "SELECT id, path \
-                 FROM lix_file_history \
-                 WHERE lixcol_as_of_commit_id = '{commit_id}' \
-                   AND lixcol_depth = 0 \
+                 FROM lix_file_history('{commit_id}') \
+                   WHERE lixcol_depth = 0 \
                    AND id = '3faa577b-02e3-7c30-8b7d-30a9698cba93'"
             ),
             &[],
@@ -289,9 +288,8 @@ async fn lix_file_history_ancestor_point_lookup_keeps_parent_evidence_bounded() 
         .execute(
             &format!(
                 "SELECT path, lixcol_source_changes \
-                 FROM lix_file_history \
-                 WHERE lixcol_as_of_commit_id = '{commit_id}' \
-                   AND lixcol_depth = 0 \
+                 FROM lix_file_history('{commit_id}') \
+                   WHERE lixcol_depth = 0 \
                    AND id = '626f756e-6465-842d-8669-6c6500000000'"
             ),
             &[],
@@ -379,9 +377,8 @@ simulation_test!(
             .execute(
                 &format!(
                     "SELECT path, lixcol_source_changes \
-                     FROM lix_file_history \
-                     WHERE lixcol_as_of_commit_id = '{rename_commit_id}' \
-                       AND lixcol_depth = 0 \
+                     FROM lix_file_history('{rename_commit_id}') \
+                       WHERE lixcol_depth = 0 \
                        AND id = '70726f6a-6563-8469-8f6e-2d66696c6500'"
                 ),
                 &[],
@@ -409,9 +406,8 @@ simulation_test!(
             .execute(
                 &format!(
                     "SELECT path, lixcol_source_changes \
-                     FROM lix_directory_history \
-                     WHERE lixcol_as_of_commit_id = '{rename_commit_id}' \
-                       AND lixcol_depth = 0 \
+                     FROM lix_directory_history('{rename_commit_id}') \
+                       WHERE lixcol_depth = 0 \
                        AND id = 'f6105c07-3ce2-7baf-884d-30da343db297'"
                 ),
                 &[],
@@ -442,9 +438,8 @@ simulation_test!(
         let moved = session
             .execute(
                 &format!(
-                    "SELECT path FROM lix_file_history \
-                     WHERE lixcol_as_of_commit_id = '{move_commit_id}' \
-                       AND lixcol_depth = 0 \
+                    "SELECT path FROM lix_file_history('{move_commit_id}') \
+                       WHERE lixcol_depth = 0 \
                        AND id = '70726f6a-6563-8469-8f6e-2d66696c6500'"
                 ),
                 &[],
@@ -529,9 +524,8 @@ simulation_test!(
             .execute(
                 &format!(
                     "SELECT path, lixcol_source_changes \
-                     FROM lix_file_history \
-                     WHERE lixcol_as_of_commit_id = '{commit_id}' \
-                       AND lixcol_depth = 0 \
+                     FROM lix_file_history('{commit_id}') \
+                       WHERE lixcol_depth = 0 \
                        AND id = '67726f75-7065-842d-8669-6c6500000000'"
                 ),
                 &[],
@@ -568,9 +562,8 @@ simulation_test!(
             .execute(
                 &format!(
                     "SELECT path, lixcol_source_changes \
-                     FROM lix_directory_history \
-                     WHERE lixcol_as_of_commit_id = '{commit_id}' \
-                       AND lixcol_depth = 0 \
+                     FROM lix_directory_history('{commit_id}') \
+                       WHERE lixcol_depth = 0 \
                        AND id = '46d97a70-d3ec-7d27-8b28-8c62f72869dd'"
                 ),
                 &[],
@@ -666,9 +659,8 @@ simulation_test!(
             .execute(
                 &format!(
                     "SELECT path, lixcol_observed_commit_id \
-                     FROM lix_file_history \
-                     WHERE lixcol_as_of_commit_id = '{merge_commit_id}' \
-                       AND lixcol_depth = 1 \
+                     FROM lix_file_history('{merge_commit_id}') \
+                       WHERE lixcol_depth = 1 \
                        AND id = '616e6365-7374-8f72-8d73-69626c696e00' \
                      ORDER BY lixcol_observed_commit_id"
                 ),
@@ -744,9 +736,8 @@ simulation_test!(
             .execute(
                 &format!(
                     "SELECT path, lixcol_source_changes \
-                     FROM lix_file_history \
-                     WHERE lixcol_as_of_commit_id = '{delete_commit_id}' \
-                       AND lixcol_depth = 0 \
+                     FROM lix_file_history('{delete_commit_id}') \
+                       WHERE lixcol_depth = 0 \
                        AND id = '72657374-6f72-852d-8669-6c6500000000'"
                 ),
                 &[],
@@ -810,9 +801,8 @@ simulation_test!(
             .execute(
                 &format!(
                     "SELECT path, data, lixcol_source_changes \
-                     FROM lix_file_history \
-                     WHERE lixcol_as_of_commit_id = '{restore_commit_id}' \
-                       AND lixcol_depth = 0 \
+                     FROM lix_file_history('{restore_commit_id}') \
+                       WHERE lixcol_depth = 0 \
                        AND id = '72657374-6f72-852d-8669-6c6500000000'"
                 ),
                 &[],
@@ -896,10 +886,9 @@ simulation_test!(
 
         let result = session
             .execute(
-                "SELECT id, path, name, data, lixcol_as_of_commit_id, lixcol_depth \
-                 FROM lix_file_history \
-                 WHERE lixcol_as_of_commit_id = $1 \
-                   AND id = $2 \
+                "SELECT id, path, name, data, lixcol_depth \
+                 FROM lix_file_history($1) \
+                   WHERE id = $2 \
                    AND path LIKE $3 \
                  ORDER BY lixcol_depth",
                 &[
@@ -923,7 +912,6 @@ simulation_test!(
                     Value::Text("/docs/readme-renamed.md".to_string()),
                     Value::Text("readme-renamed.md".to_string()),
                     Value::Blob(b"hello".to_vec().into()),
-                    Value::Text(second_commit_id.clone()),
                     Value::Integer(0),
                 ],
                 vec![
@@ -931,7 +919,6 @@ simulation_test!(
                     Value::Text("/docs/guides/readme.md".to_string()),
                     Value::Text("readme.md".to_string()),
                     Value::Blob(b"hello".to_vec().into()),
-                    Value::Text(second_commit_id.clone()),
                     Value::Integer(1),
                 ],
             ],
@@ -940,9 +927,8 @@ simulation_test!(
         let old_path_result = session
             .execute(
                 "SELECT id, path, lixcol_depth \
-                 FROM lix_file_history \
-                 WHERE lixcol_as_of_commit_id = $1 \
-                   AND path = '/docs/guides/readme.md' \
+                 FROM lix_file_history($1) \
+                   WHERE path = '/docs/guides/readme.md' \
                  ORDER BY lixcol_depth",
                 &[Value::Text(second_commit_id.clone())],
             )
@@ -961,9 +947,8 @@ simulation_test!(
             .execute(
                 &format!(
                     "SELECT lixcol_source_changes \
-                     FROM lix_file_history \
-                     WHERE lixcol_as_of_commit_id = '{second_commit_id}' \
-                       AND id = '68697374-6f72-892d-8669-6c6500000000' \
+                     FROM lix_file_history('{second_commit_id}') \
+                       WHERE id = '68697374-6f72-892d-8669-6c6500000000' \
                        AND lixcol_depth = 0"
                 ),
                 &[],
@@ -990,9 +975,8 @@ simulation_test!(
             .execute(
                 &format!(
                     "SELECT id \
-                     FROM lix_file_history \
-                     WHERE lixcol_as_of_commit_id = '{first_commit_id}' \
-                       AND path LIKE '/missing/%'"
+                     FROM lix_file_history('{first_commit_id}') \
+                       WHERE path LIKE '/missing/%'"
                 ),
                 &[],
             )
@@ -1031,9 +1015,8 @@ simulation_test!(
             .execute(
                 &format!(
                     "SELECT path, data \
-                     FROM lix_file_history \
-                     WHERE lixcol_as_of_commit_id = '{commit_id}' \
-                       AND path = '/empty-history.txt' \
+                     FROM lix_file_history('{commit_id}') \
+                       WHERE path = '/empty-history.txt' \
                        AND lixcol_depth = 0"
                 ),
                 &[],
@@ -1122,9 +1105,8 @@ simulation_test!(
             .execute(
                 &format!(
                     "SELECT path, lixcol_observed_commit_id, lixcol_depth, lixcol_source_changes \
-                     FROM lix_file_history \
-                     WHERE lixcol_as_of_commit_id = '{merge_commit_id}' \
-                       AND id = '6469616d-6f6e-842d-8669-6c6500000000' \
+                     FROM lix_file_history('{merge_commit_id}') \
+                       WHERE id = '6469616d-6f6e-842d-8669-6c6500000000' \
                        AND lixcol_depth = 1 \
                      ORDER BY lixcol_observed_commit_id"
                 ),
@@ -1215,12 +1197,10 @@ simulation_test!(
         let result = session
             .execute(
                 "SELECT file.id, file.path, directory.id \
-                 FROM lix_file_history AS file \
-                 JOIN lix_directory_history AS directory \
+                 FROM lix_file_history() AS file \
+                 JOIN lix_directory_history() AS directory \
                    ON file.directory_id = directory.id \
-                 WHERE file.lixcol_as_of_commit_id = lix_active_branch_commit_id() \
-                   AND directory.lixcol_as_of_commit_id = lix_active_branch_commit_id() \
-                   AND file.path = '/joined/old.txt'",
+                 WHERE file.path = '/joined/old.txt'",
                 &[],
             )
             .await
@@ -1269,9 +1249,8 @@ simulation_test!(lix_file_history_reads_bound_id_in_list, |sim| async move {
     let result = session
         .execute(
             "SELECT id, path, data \
-                 FROM lix_file_history \
-                 WHERE lixcol_as_of_commit_id = $1 \
-                   AND id IN ($2, $3) \
+                 FROM lix_file_history($1) \
+                   WHERE id IN ($2, $3) \
                  ORDER BY id",
             &[
                 Value::Text(commit_id),
@@ -1337,8 +1316,7 @@ simulation_test!(
             .execute(
                 &format!(
                     "SELECT id, path, lixcol_depth \
-                     FROM lix_file_history \
-                     WHERE lixcol_as_of_commit_id = '{commit_id}' \
+                     FROM lix_file_history('{commit_id}') \
                      ORDER BY lixcol_depth \
                      LIMIT 1"
                 ),
@@ -1390,9 +1368,8 @@ simulation_test!(
             .execute(
                 &format!(
                     "SELECT id, path, data \
-                     FROM lix_file_history \
-                     WHERE lixcol_as_of_commit_id = '{commit_id}' \
-                       AND path LIKE '/target/%' \
+                     FROM lix_file_history('{commit_id}') \
+                       WHERE path LIKE '/target/%' \
                      LIMIT 1"
                 ),
                 &[],
@@ -1429,16 +1406,10 @@ simulation_test!(lix_file_history_defaults_to_active_head, |sim| async move {
         )
         .await
         .expect("file insert should succeed");
-    let active_head = engine
-        .load_branch_head_commit_id(sim.main_branch_id())
-        .await
-        .expect("active head should load")
-        .expect("active head should exist");
-
     let result = session
         .execute(
-            "SELECT id, lixcol_as_of_commit_id, lixcol_depth \
-                 FROM lix_file_history \
+            "SELECT id, lixcol_depth \
+                 FROM lix_file_history() \
                  WHERE id = '68697374-6f72-892d-8465-6661756c7401'",
             &[],
         )
@@ -1449,7 +1420,6 @@ simulation_test!(lix_file_history_defaults_to_active_head, |sim| async move {
         result,
         vec![vec![
             Value::Text("68697374-6f72-892d-8465-6661756c7401".to_string()),
-            Value::Text(active_head),
             Value::Integer(0),
         ]],
     );
@@ -1493,9 +1463,8 @@ simulation_test!(
             .execute(
                 &format!(
                     "SELECT path, data, lixcol_depth \
-                     FROM lix_file_history \
-                     WHERE lixcol_as_of_commit_id = '{commit_id}' \
-                       AND id = '6f726469-6e61-8279-8d68-6973746f7200' \
+                     FROM lix_file_history('{commit_id}') \
+                       WHERE id = '6f726469-6e61-8279-8d68-6973746f7200' \
                      ORDER BY lixcol_depth"
                 ),
                 &[],
@@ -1552,9 +1521,8 @@ simulation_test!(
             .execute(
                 &format!(
                     "SELECT id, path, data, lixcol_source_changes \
-                     FROM lix_file_history \
-                     WHERE lixcol_as_of_commit_id = '{commit_id}' \
-                       AND id = '68697374-6f72-892d-8669-6c652d626c00' \
+                     FROM lix_file_history('{commit_id}') \
+                       WHERE id = '68697374-6f72-892d-8669-6c652d626c00' \
                      ORDER BY lixcol_depth"
                 ),
                 &[],
@@ -1641,8 +1609,7 @@ simulation_test!(
                 .execute(
                     &format!(
                         "SELECT {retired} \
-                         FROM lix_file_history \
-                         WHERE lixcol_as_of_commit_id = '{commit_id}'"
+                         FROM lix_file_history('{commit_id}')"
                     ),
                     &[],
                 )

--- a/packages/engine/tests/integration/sql/lix_registered_schema.rs
+++ b/packages/engine/tests/integration/sql/lix_registered_schema.rs
@@ -349,10 +349,8 @@ simulation_test!(
         for surface_name in [
             "lix_key_value",
             "lix_key_value_by_branch",
-            "lix_key_value_history",
             "lix_registered_schema",
             "lix_registered_schema_by_branch",
-            "lix_registered_schema_history",
             "lix_checkpoint",
             "lix_checkpoint_by_branch",
             "lix_working_change",
@@ -367,6 +365,24 @@ simulation_test!(
                 "{surface_name} should remain public"
             );
         }
+        let history_functions = session
+            .execute(
+                "SELECT function_name \
+                 FROM information_schema.table_functions \
+                 WHERE function_name IN ('lix_key_value_history', 'lix_registered_schema_history') \
+                 GROUP BY function_name \
+                 ORDER BY function_name",
+                &[],
+            )
+            .await
+            .expect("history function metadata should load");
+        assert_rows_eq(
+            history_functions,
+            vec![
+                vec![Value::Text("lix_key_value_history".to_string())],
+                vec![Value::Text("lix_registered_schema_history".to_string())],
+            ],
+        );
         for surface_name in [
             "lix_state",
             "lix_state_by_branch",
@@ -548,10 +564,9 @@ simulation_test!(
         let result = session
             .execute(
                 &format!(
-                    "SELECT value, lixcol_entity_pk, lixcol_observed_commit_id, lixcol_as_of_commit_id, lixcol_depth \
-                     FROM lix_registered_schema_history \
-                     WHERE lixcol_as_of_commit_id = '{second_commit_id}' \
-                       AND lixcol_entity_pk = lix_json('[\"engine_schema_update_history\"]') \
+                    "SELECT value, lixcol_entity_pk, lixcol_observed_commit_id, lixcol_depth \
+                     FROM lix_registered_schema_history('{second_commit_id}') \
+                       WHERE lixcol_entity_pk = lix_json('[\"engine_schema_update_history\"]') \
                      ORDER BY lixcol_depth"
                 ),
                 &[],
@@ -566,14 +581,12 @@ simulation_test!(
                     Value::Json(amended_schema),
                     Value::Json(json!(["engine_schema_update_history"])),
                     Value::Text(second_commit_id.clone()),
-                    Value::Text(second_commit_id.clone()),
                     Value::Integer(0),
                 ],
                 vec![
                     Value::Json(initial_schema),
                     Value::Json(json!(["engine_schema_update_history"])),
                     Value::Text(first_commit_id),
-                    Value::Text(second_commit_id),
                     Value::Integer(1),
                 ],
             ],

--- a/packages/engine/tests/integration/sql/metadata.rs
+++ b/packages/engine/tests/integration/sql/metadata.rs
@@ -574,9 +574,8 @@ simulation_test!(
                 .execute(
                     &format!(
                         "SELECT lixcol_metadata \
-                         FROM lix_key_value_history \
-                         WHERE lixcol_as_of_commit_id = '{commit_id}' \
-                           AND key = 'metadata-valid-object'"
+                         FROM lix_key_value_history('{commit_id}') \
+                           WHERE key = 'metadata-valid-object'"
                     ),
                     &[],
                 )

--- a/packages/engine/tests/integration/sql/untracked_current_state.rs
+++ b/packages/engine/tests/integration/sql/untracked_current_state.rs
@@ -304,9 +304,8 @@ simulation_test!(
         let tracked_history = session
             .execute(
                 &format!(
-                    "SELECT lixcol_change_id FROM lix_key_value_history \
-                     WHERE lixcol_as_of_commit_id = '{mixed_head}' \
-                       AND key = 'untracked-current-tx-tracked' \
+                    "SELECT lixcol_change_id FROM lix_key_value_history('{mixed_head}') \
+                       WHERE key = 'untracked-current-tx-tracked' \
                        AND lixcol_depth = 0"
                 ),
                 &[],
@@ -317,9 +316,8 @@ simulation_test!(
         let untracked_history = session
             .execute(
                 &format!(
-                    "SELECT lixcol_change_id FROM lix_key_value_history \
-                     WHERE lixcol_as_of_commit_id = '{mixed_head}' \
-                       AND key = 'untracked-current-tx-untracked'"
+                    "SELECT lixcol_change_id FROM lix_key_value_history('{mixed_head}') \
+                       WHERE key = 'untracked-current-tx-untracked'"
                 ),
                 &[],
             )

--- a/packages/engine/tests/integration/transaction.rs
+++ b/packages/engine/tests/integration/transaction.rs
@@ -521,11 +521,7 @@ async fn transaction_read_can_query_history_surfaces() {
         .await
         .expect("transaction should begin");
     let result = tx
-        .execute(
-            "SELECT key FROM lix_key_value_history \
-             WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id()",
-            &[],
-        )
+        .execute("SELECT key FROM lix_key_value_history()", &[])
         .await
         .expect("transaction read should register history surfaces");
 

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -1237,7 +1237,7 @@ test("beginTransaction preserves handle after failed statement", async () => {
 			"SELECT id FROM lix_file_history('one', 'two')",
 		),
 	).rejects.toMatchObject({
-		code: "LIX_UNSUPPORTED_SQL",
+		code: "LIX_PARSE_ERROR",
 	});
 	await tx.rollback();
 
@@ -1268,7 +1268,7 @@ test("beginTransaction can continue after failed statement", async () => {
 			"SELECT id FROM lix_file_history('one', 'two')",
 		),
 	).rejects.toMatchObject({
-		code: "LIX_UNSUPPORTED_SQL",
+		code: "LIX_PARSE_ERROR",
 	});
 	await tx.execute(
 		"INSERT INTO crm_task (id, title, done, meta) VALUES ($1, $2, $3, lix_json($4))",
@@ -1406,7 +1406,7 @@ test("engine errors cross the native boundary", async () => {
 	} catch (error) {
 		expect(error).toMatchObject({
 			name: "LixError",
-			code: "LIX_UNSUPPORTED_SQL",
+			code: "LIX_PARSE_ERROR",
 		});
 	}
 

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -421,7 +421,7 @@ test("execute originKey is exposed on change and history surfaces without metada
 	expect(get(inserted, "lixcol_metadata")).toEqual(metadata);
 	const fileHistorySources = get(
 		await lix.execute(
-			"SELECT lixcol_source_changes FROM lix_file_history WHERE id = $1 AND lixcol_as_of_commit_id = $2 AND lixcol_depth = 0",
+			"SELECT lixcol_source_changes FROM lix_file_history($2) WHERE id = $1 AND lixcol_depth = 0",
 			[fileId, insertedHeadCommitId],
 		),
 		"lixcol_source_changes",
@@ -450,7 +450,7 @@ test("execute originKey is exposed on change and history surfaces without metada
 	expect(get(txStamped, "origin_key")).toBe("tx-origin");
 	const txFileHistorySources = get(
 		await lix.execute(
-			"SELECT lixcol_source_changes FROM lix_file_history WHERE id = $1 AND lixcol_as_of_commit_id = $2 AND lixcol_depth = 0",
+			"SELECT lixcol_source_changes FROM lix_file_history($2) WHERE id = $1 AND lixcol_depth = 0",
 			[fileId, txHeadCommitId],
 		),
 		"lixcol_source_changes",
@@ -1234,7 +1234,7 @@ test("beginTransaction preserves handle after failed statement", async () => {
 	);
 	await expect(
 		tx.execute(
-			"SELECT id FROM lix_file_history WHERE lixcol_as_of_commit_id > 'cid_invalid'",
+			"SELECT id FROM lix_file_history('one', 'two')",
 		),
 	).rejects.toMatchObject({
 		code: "LIX_UNSUPPORTED_SQL",
@@ -1265,7 +1265,7 @@ test("beginTransaction can continue after failed statement", async () => {
 	);
 	await expect(
 		tx.execute(
-			"SELECT id FROM lix_file_history WHERE lixcol_as_of_commit_id > 'cid_invalid'",
+			"SELECT id FROM lix_file_history('one', 'two')",
 		),
 	).rejects.toMatchObject({
 		code: "LIX_UNSUPPORTED_SQL",
@@ -1400,7 +1400,7 @@ test("engine errors cross the native boundary", async () => {
 
 	try {
 		await lix.execute(
-			"SELECT id FROM lix_file_history WHERE lixcol_as_of_commit_id > 'cid_invalid'",
+			"SELECT id FROM lix_file_history('one', 'two')",
 		);
 		throw new Error("expected history query to fail");
 	} catch (error) {
@@ -1408,7 +1408,6 @@ test("engine errors cross the native boundary", async () => {
 			name: "LixError",
 			code: "LIX_UNSUPPORTED_SQL",
 		});
-		expect((error as { hint?: string }).hint).toContain("pinned active branch head");
 	}
 
 	await lix.close();
@@ -1834,9 +1833,8 @@ test("lix_directory_history snapshot_content preserves JSON null after binary fi
 
 	const result = await lix.execute(
 		"SELECT lixcol_source_changes \
-		 FROM lix_directory_history \
+		 FROM lix_directory_history() \
 		 WHERE id = $1 \
-		   AND lixcol_as_of_commit_id = lix_active_branch_commit_id() \
 		 ORDER BY lixcol_depth \
 		 LIMIT 1",
 		["01920000-0000-7000-8000-000000000431"],

--- a/packages/js-sdk/tests/memory-storage-contract.ts
+++ b/packages/js-sdk/tests/memory-storage-contract.ts
@@ -70,7 +70,7 @@ export function registerMemoryStorageContract({
 					),
 				).rejects.toMatchObject({
 					name: "LixError",
-					code: "LIX_UNSUPPORTED_SQL",
+					code: "LIX_PARSE_ERROR",
 				});
 			} finally {
 				await lix.close();
@@ -187,7 +187,7 @@ export function registerMemoryStorageContract({
 					]),
 				).rejects.toMatchObject({
 					name: "LixError",
-					code: "LIX_UNSUPPORTED_SQL",
+					code: "LIX_PARSE_ERROR",
 					details: { statementIndex: 1 },
 				});
 				const rolledBack = await lix.execute(

--- a/packages/js-sdk/tests/memory-storage-contract.ts
+++ b/packages/js-sdk/tests/memory-storage-contract.ts
@@ -66,12 +66,11 @@ export function registerMemoryStorageContract({
 				});
 				await expect(
 					lix.execute(
-						"SELECT id FROM lix_file_history WHERE lixcol_as_of_commit_id > 'cid_invalid'",
+						"SELECT id FROM lix_file_history('one', 'two')",
 					),
 				).rejects.toMatchObject({
 					name: "LixError",
 					code: "LIX_UNSUPPORTED_SQL",
-					hint: expect.stringContaining("pinned active branch head"),
 				});
 			} finally {
 				await lix.close();
@@ -179,7 +178,7 @@ export function registerMemoryStorageContract({
 							params: ["batch-rolled-back", "before failure"],
 						},
 						{
-							sql: "SELECT id FROM lix_file_history WHERE lixcol_as_of_commit_id > 'cid_invalid'",
+							sql: "SELECT id FROM lix_file_history('one', 'two')",
 						},
 						{
 							sql: "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",

--- a/packages/rs-sdk-tests/tests/e2e.rs
+++ b/packages/rs-sdk-tests/tests/e2e.rs
@@ -228,8 +228,8 @@ async fn v2_file_history_reads_durable_materialized_bytes_without_plugin_executi
     let result = history_lix
         .execute(
             "SELECT data, lixcol_depth \
-             FROM lix_file_history \
-             WHERE lixcol_as_of_commit_id = $1 AND id = $2 \
+             FROM lix_file_history($1) \
+             WHERE id = $2 \
              ORDER BY lixcol_depth \
              LIMIT 2",
             &[Value::Text(head), Value::Text(file_id)],

--- a/packages/rs-sdk-tests/tests/git_text_plugin.rs
+++ b/packages/rs-sdk-tests/tests/git_text_plugin.rs
@@ -543,8 +543,8 @@ async fn assert_history_file<StorageImpl>(
 {
     let result = lix
         .execute(
-            "SELECT data FROM lix_file_history \
-             WHERE lixcol_as_of_commit_id = $1 AND id = $2 \
+            "SELECT data FROM lix_file_history($1) \
+             WHERE id = $2 \
              ORDER BY lixcol_depth",
             &[
                 Value::Text(as_of_commit_id.to_owned()),

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -628,8 +628,7 @@ async fn execute_batch_is_atomic_and_returns_ordered_results() {
                 ],
             },
             ExecuteBatchStatement {
-                sql: "SELECT id FROM lix_file_history WHERE lixcol_as_of_commit_id > 'cid_invalid'"
-                    .to_string(),
+                sql: "SELECT id FROM lix_file_history('one', 'two')".to_string(),
                 params: Vec::new(),
             },
         ])

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -634,7 +634,7 @@ async fn execute_batch_is_atomic_and_returns_ordered_results() {
         ])
         .await
         .expect_err("middle batch statement should fail");
-    assert_eq!(error.code, LixError::CODE_UNSUPPORTED_SQL);
+    assert_eq!(error.code, LixError::CODE_PARSE_ERROR);
     assert!(
         error
             .details


### PR DESCRIPTION
## What

- replace static `*_history` relations with table-valued functions
- use `history()` for the pinned active head and `history($commit)` for an explicit anchor
- migrate filesystem history explicitly to `lix_file_history()` / `lix_file_history($as_of)` and `lix_directory_history()` / `lix_directory_history($as_of)`
- remove `lixcol_as_of_commit_id` from public history rows
- expose function signatures and result columns through `information_schema.table_functions`
- migrate engine, CLI, SDK tests, examples, and history documentation to the new API

## Why

The commit anchor defines the history relation; it is not a predicate on individual history rows. Making it a function argument leaves `WHERE` for actual row selection and aligns history with other parameterized relations.

## Compatibility

This is an intentional hard cut. Bare `*_history` table reads and `lixcol_as_of_commit_id` predicates no longer work. Use:

```sql
SELECT * FROM task_history();
SELECT * FROM task_history($commit) WHERE id = $task_id;
```

## Validation

- `cargo check -p lix_engine`
- `cargo test -p lix_engine --lib` (1,540 passed; 6 ignored)
- `cargo test -p lix_engine --test integration` (417 passed; 2 ignored)
- `cargo test -p lix_engine --features all-simulations` (1,540 library, 768 integration, and 3 doctests passed)
- focused metadata and history-function integration tests after the final metadata self-contract update
- `cargo fmt --all`
- `git diff --check`