### PR TITLE
perf(binary): inline content through 64 KiB

### DIFF
--- a/.changenotes/guard-inline-binary-content.md
+++ b/.changenotes/guard-inline-binary-content.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Improved 32–64 KiB binary file reads and repeat writes on RocksDB and SlateDB.
+
+Lix now stores this common size band in one inline manifest and uses a key-only manifest probe to avoid repeated payload rewrites.

--- a/.changenotes/inline-binary-content-128k.md
+++ b/.changenotes/inline-binary-content-128k.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Improved 64–128 KiB binary file reads and reduced their storage rows on RocksDB and SlateDB.
+
+Lix now includes this size band in its manifest-probed inline layout.

--- a/packages/engine-benchmarks/benches/small_blob_cas.rs
+++ b/packages/engine-benchmarks/benches/small_blob_cas.rs
@@ -18,7 +18,7 @@ use lix_slatedb_storage::SlateDB;
 use tempfile::TempDir;
 
 const BACKENDS: &[Backend] = &[Backend::Rocks, Backend::Slate];
-const SIZES: &[usize] = &[4 << 10, 32 << 10];
+const SIZES: &[usize] = &[4 << 10, 32 << 10, 64 << 10];
 const OPERATIONS: &[Operation] = &[
     Operation::UniqueWrite,
     Operation::DedupeWrite,

--- a/packages/engine-benchmarks/benches/small_blob_cas.rs
+++ b/packages/engine-benchmarks/benches/small_blob_cas.rs
@@ -18,7 +18,7 @@ use lix_slatedb_storage::SlateDB;
 use tempfile::TempDir;
 
 const BACKENDS: &[Backend] = &[Backend::Rocks, Backend::Slate];
-const SIZES: &[usize] = &[4 << 10, 32 << 10, 64 << 10, 128 << 10];
+const SIZES: &[usize] = &[4 << 10, 32 << 10, 64 << 10, 128 << 10, 256 << 10];
 const OPERATIONS: &[Operation] = &[
     Operation::UniqueWrite,
     Operation::DedupeWrite,

--- a/packages/engine-benchmarks/benches/small_blob_cas.rs
+++ b/packages/engine-benchmarks/benches/small_blob_cas.rs
@@ -18,7 +18,7 @@ use lix_slatedb_storage::SlateDB;
 use tempfile::TempDir;
 
 const BACKENDS: &[Backend] = &[Backend::Rocks, Backend::Slate];
-const SIZES: &[usize] = &[4 << 10, 32 << 10, 64 << 10];
+const SIZES: &[usize] = &[4 << 10, 32 << 10, 64 << 10, 128 << 10];
 const OPERATIONS: &[Operation] = &[
     Operation::UniqueWrite,
     Operation::DedupeWrite,

--- a/packages/engine-benchmarks/benches/small_blob_cas_results.md
+++ b/packages/engine-benchmarks/benches/small_blob_cas_results.md
@@ -157,3 +157,25 @@ The exact-case binaries had SHA-256
 `3e2d86c24a18491b352bbcd77d8a0c6417ab0d9fd881efe8a209d52799500866`
 (candidate). The combined raw-result SHA-256 is
 `e78b2dcd263addb7cff669f43779c9c24a86828d4b407ce3e0ab82e2862bc174`.
+
+### Rejected 256 KiB extension
+
+The same seven-pair protocol tested extending inline manifests through
+256 KiB. This is rejected because it moves the larger value into the manifest
+space and materially regresses RocksDB:
+
+| Backend | Operation | 128 KiB limit p50 | 256 KiB limit p50 | Change |
+| ------- | --------- | ---------------: | ----------------: | -----: |
+| RocksDB | New-content write | 412,075 ns | 413,457 ns | 0.3% slower |
+| RocksDB | Repeat write | 39,174 ns | 48,827 ns | **24.6% slower** |
+| RocksDB | Hot read | 10,473 ns | 12,798 ns | **22.2% slower** |
+| SlateDB | New-content write | 204,020 ns | 203,700 ns | 0.2% faster |
+| SlateDB | Repeat write | 52,703 ns | 43,640 ns | **17.2% faster** |
+| SlateDB | Hot read | 8,581 ns | 8,151 ns | 5.0% faster |
+
+The exact-case binaries had SHA-256
+`1ead339d48e6f3e351e88376eebdfc58031c4fd6bbf673c4d0719d6c7e65b949`
+(baseline) and
+`7224531462d84fd4d87d0928719ca3bf5caab195c1ab36e3eaa8950117a9a3f1`
+(candidate). The combined raw-result SHA-256 is
+`add3c863a4e22fb4494a9eb4f327230939d388e2870ad1c9452c3ee542f0e39e`.

--- a/packages/engine-benchmarks/benches/small_blob_cas_results.md
+++ b/packages/engine-benchmarks/benches/small_blob_cas_results.md
@@ -124,3 +124,36 @@ The exact-case binaries had SHA-256
 `eb0cbbd5d2f1a6acf11589c73175fb8a326f0a0a6eb31353dc4e0bd2097da8e4`
 (candidate). The combined raw-result SHA-256 is
 `86f828358d38bff5f4a82d3a0bd956d079b2162efa9e7e2823db4d24e88594e3`.
+
+## Inline manifests through 128 KiB
+
+Date: 2026-07-29
+
+OpenClaw has another 23,049 unique blobs (2,088,120,165 logical bytes) above
+64 KiB and at or below 128 KiB. Extending the manifest-probed inline layout to
+this band again replaces one manifest, payload, and presence row with one
+manifest row.
+
+Seven counterbalanced baseline/candidate process pairs used fresh temporary
+databases per exact case, 300 warmups, and 3,000 timed samples. The values are
+the median per-run p50:
+
+| Backend | Operation | 64 KiB limit p50 | 128 KiB limit p50 | Change |
+| ------- | --------- | ---------------: | ----------------: | -----: |
+| RocksDB | New-content write | 226,571 ns | 231,737 ns | 2.3% slower |
+| RocksDB | Repeat write | 22,230 ns | 24,293 ns | 9.3% slower |
+| RocksDB | Hot read | 5,938 ns | 4,917 ns | **17.2% faster** |
+| SlateDB | New-content write | 111,402 ns | 106,846 ns | 4.1% faster |
+| SlateDB | Repeat write | 35,839 ns | 21,460 ns | **40.1% faster** |
+| SlateDB | Hot read | 6,970 ns | 6,249 ns | **10.3% faster** |
+
+The logical shape drops from three rows and 96 key bytes to one row and 32 key
+bytes per unique blob in this band. Encoded value bytes remain nearly flat
+(131,119 to 131,084 bytes for the measured high-entropy 128 KiB payload).
+
+The exact-case binaries had SHA-256
+`29725d7f58f0ce28830e958bd0186756b8d5ff28e08a3cafbd057e7f79786ccf`
+(baseline) and
+`3e2d86c24a18491b352bbcd77d8a0c6417ab0d9fd881efe8a209d52799500866`
+(candidate). The combined raw-result SHA-256 is
+`e78b2dcd263addb7cff669f43779c9c24a86828d4b407ce3e0ab82e2862bc174`.

--- a/packages/engine-benchmarks/benches/small_blob_cas_results.md
+++ b/packages/engine-benchmarks/benches/small_blob_cas_results.md
@@ -85,3 +85,42 @@ rewrites the whole value. This change is justified only when new or changed
 file content plus reads represent the dominant path. If repeat writes of
 identical content are common, do not treat this optimization as a net win
 without a representative workload measurement.
+
+## Manifest-probed inline values through 64 KiB
+
+Date: 2026-07-29
+
+OpenClaw's complete `main` object set contains 455,883 unique blobs. Of those,
+43,444 blobs (9.5%, 1,991,214,838 logical bytes) fall above 32 KiB and at or
+below 64 KiB. The previous layout stored each of these as a manifest, an empty
+presence row, and a payload row.
+
+The extended layout stores that band as one inline manifest. Reads finish from
+the manifest point read, while repeat writes use a key-only manifest probe and
+stage no value. Payloads through 32 KiB retain the original unguarded one-row
+layout.
+
+Seven counterbalanced baseline/candidate process pairs used fresh temporary
+databases per exact case, 300 warmups, and 3,000 timed samples. The values are
+the median per-run p50:
+
+| Backend | Operation | Baseline p50 | Inline p50 | Change |
+| ------- | --------- | -----------: | ---------: | -----: |
+| RocksDB | New-content write | 139,402 ns | 135,556 ns | 2.8% faster |
+| RocksDB | Repeat write | 13,459 ns | 13,169 ns | 2.2% faster |
+| RocksDB | Hot read | 4,276 ns | 3,685 ns | **13.8% faster** |
+| SlateDB | New-content write | 72,400 ns | 66,161 ns | 8.6% faster |
+| SlateDB | Repeat write | 28,418 ns | 12,636 ns | **55.5% faster** |
+| SlateDB | Hot read | 5,208 ns | 4,636 ns | **11.0% faster** |
+
+The logical shape drops from three rows and 96 key bytes to one row and 32 key
+bytes per unique blob in the extended band, both 66.7% reductions. Encoded
+value bytes remain nearly flat (65,583 to 65,548 bytes for the measured
+high-entropy 64 KiB payload).
+
+The exact-case binaries had SHA-256
+`335b84b9ef6ae399b999613ef49f095684f313411f761b877a9a696f4422e815`
+(baseline) and
+`eb0cbbd5d2f1a6acf11589c73175fb8a326f0a0a6eb31353dc4e0bd2097da8e4`
+(candidate). The combined raw-result SHA-256 is
+`86f828358d38bff5f4a82d3a0bd956d079b2162efa9e7e2823db4d24e88594e3`.

--- a/packages/engine-benchmarks/benches/small_blob_cas_results.md
+++ b/packages/engine-benchmarks/benches/small_blob_cas_results.md
@@ -179,3 +179,32 @@ The exact-case binaries had SHA-256
 `7224531462d84fd4d87d0928719ca3bf5caab195c1ab36e3eaa8950117a9a3f1`
 (candidate). The combined raw-result SHA-256 is
 `add3c863a4e22fb4494a9eb4f327230939d388e2870ad1c9452c3ee542f0e39e`.
+
+### OpenClaw end-to-end check
+
+The storage-neutral Git replay profiler from PR #925 replayed OpenClaw commit
+`c5c50a2141f2cdd805ae9b70a14a2e66dabac9b6` with all text, CSV, and Markdown
+plugins enabled. This commit changes 3,423 paths and eagerly persists 559,701
+semantic changes. Three counterbalanced pairs compared #925 alone with #925
+plus the 64 KiB and 128 KiB layout changes:
+
+| Backend | Metric | Baseline median | Layout stack median | Change |
+| ------- | ------ | --------------: | ------------------: | -----: |
+| RocksDB | Timed replay | 17,830.306 ms | 17,919.724 ms | 0.5% slower |
+| RocksDB | Parent bootstrap | 1,488.259 ms | 1,416.860 ms | 4.8% faster |
+| RocksDB | Final flush | 1,720.548 ms | 1,729.472 ms | 0.5% slower |
+| SlateDB | Timed replay | 17,618.113 ms | 17,823.678 ms | 1.2% slower |
+| SlateDB | Parent bootstrap | 1,388.375 ms | 1,387.330 ms | 0.1% faster |
+| SlateDB | Final flush | 4,410.714 ms | 4,576.873 ms | 3.8% slower |
+
+Final physical size was effectively flat: RocksDB changed from 136,500,209 to
+136,503,305 bytes and SlateDB from 341,107,956 to 341,168,511 bytes. This
+confirms that plugin reconciliation and validation, rather than binary CAS
+layout, dominate this pathological commit.
+
+The exact replay binaries had SHA-256
+`9b99f9ac44bd4e3c06913fadc375d5bba1d6c65039d7d9f01ceb0635e210f19b`
+(baseline) and
+`eb4df3645df61d65213e706034efebe39db92b04f68df00f688f24910da2ffca`
+(layout stack). The ordered profile-hash manifest SHA-256 is
+`23f3b0551cc4b729895871e7b6c5976ee27402182614ab4222807ecb5145473c`.

--- a/packages/engine/src/binary_cas/chunking.rs
+++ b/packages/engine/src/binary_cas/chunking.rs
@@ -1,4 +1,8 @@
-pub(super) const INLINE_BINARY_CAS_MAX_BYTES: usize = 32 * 1024;
+// Values through 32 KiB are a one-row write with no existence probe. The
+// 32–64 KiB band stays inline for one-phase reads, but probes the manifest key
+// before staging so repeat-content writes do not rewrite the large value.
+pub(super) const UNGUARDED_INLINE_BINARY_CAS_MAX_BYTES: usize = 32 * 1024;
+pub(super) const INLINE_BINARY_CAS_MAX_BYTES: usize = 64 * 1024;
 pub(super) const SINGLE_CHUNK_FAST_PATH_MAX_BYTES: usize = 64 * 1024;
 pub(super) const MAX_BINARY_CAS_CHUNK_BYTES: usize = 4096 * 1024;
 const FASTCDC_WRITE_MAX_CHUNK_BYTES: usize = 1024 * 1024;

--- a/packages/engine/src/binary_cas/chunking.rs
+++ b/packages/engine/src/binary_cas/chunking.rs
@@ -1,8 +1,8 @@
 // Values through 32 KiB are a one-row write with no existence probe. The
-// 32–64 KiB band stays inline for one-phase reads, but probes the manifest key
+// 32–128 KiB band stays inline for one-phase reads, but probes the manifest key
 // before staging so repeat-content writes do not rewrite the large value.
 pub(super) const UNGUARDED_INLINE_BINARY_CAS_MAX_BYTES: usize = 32 * 1024;
-pub(super) const INLINE_BINARY_CAS_MAX_BYTES: usize = 64 * 1024;
+pub(super) const INLINE_BINARY_CAS_MAX_BYTES: usize = 128 * 1024;
 pub(super) const SINGLE_CHUNK_FAST_PATH_MAX_BYTES: usize = 64 * 1024;
 pub(super) const MAX_BINARY_CAS_CHUNK_BYTES: usize = 4096 * 1024;
 const FASTCDC_WRITE_MAX_CHUNK_BYTES: usize = 1024 * 1024;

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -2,7 +2,8 @@
 
 use crate::LixError;
 use crate::binary_cas::chunking::{
-    INLINE_BINARY_CAS_MAX_BYTES, MAX_BINARY_CAS_CHUNK_BYTES, fastcdc_chunk_ranges_with_chunking,
+    INLINE_BINARY_CAS_MAX_BYTES, MAX_BINARY_CAS_CHUNK_BYTES, UNGUARDED_INLINE_BINARY_CAS_MAX_BYTES,
+    fastcdc_chunk_ranges_with_chunking,
 };
 use crate::binary_cas::codec::{
     BinaryCasManifest, BinaryChunkCodec, decode_binary_cas_chunk, decode_binary_cas_manifest,
@@ -975,6 +976,11 @@ fn stage_prepared_blob_write(
             );
         }
         BlobLayout::Inline => {
+            if bytes.len() > UNGUARDED_INLINE_BINARY_CAS_MAX_BYTES
+                && !should_stage_chunk(plan.blob_hash)?
+            {
+                return Ok(());
+            }
             let encoded = encode_chunk_payload(plan.blob_hash, bytes)?;
             writes.put(
                 BINARY_CAS_MANIFEST_SPACE,
@@ -1040,7 +1046,17 @@ async fn missing_chunk_hashes(
 ) -> Result<HashSet<BlobHash>, LixError> {
     let mut candidates = Vec::<(BlobHash, StorageKey)>::new();
     match &plan.layout {
-        BlobLayout::Empty | BlobLayout::Inline => {}
+        BlobLayout::Empty => {}
+        BlobLayout::Inline
+            if plan.receipt.size_bytes
+                > u64::try_from(UNGUARDED_INLINE_BINARY_CAS_MAX_BYTES)
+                    .expect("inline CAS threshold fits u64") =>
+        {
+            let exists =
+                manifest_keys_exist(store, vec![key(manifest_key(plan.blob_hash))]).await?;
+            return Ok((!exists[0]).then_some(plan.blob_hash).into_iter().collect());
+        }
+        BlobLayout::Inline => {}
         BlobLayout::SingleChunk { chunk_hash } => {
             collect_chunk_lookup_candidate(*chunk_hash, transaction_chunk_keys, &mut candidates);
         }
@@ -1110,6 +1126,34 @@ async fn chunk_keys_exist(
 ) -> Result<Vec<bool>, LixError> {
     let started = Instant::now();
     let result = PointReadPlan::from_unique_keys(BINARY_CAS_CHUNK_PRESENCE_SPACE, keys)
+        .materialize(
+            store,
+            StorageGetOptions {
+                projection: StorageCoreProjection::KeyOnly,
+            },
+        )
+        .await?;
+    let exists = result
+        .value
+        .into_iter()
+        .map(|value| value.is_some())
+        .collect::<Vec<_>>();
+    let hit_count = exists.iter().filter(|&&exists| exists).count() as u64;
+    let miss_count = exists.len() as u64 - hit_count;
+    crate::binary_cas::metrics::record_binary_cas_chunk_lookup_batch(
+        hit_count,
+        miss_count,
+        started.elapsed(),
+    );
+    Ok(exists)
+}
+
+async fn manifest_keys_exist(
+    store: &(impl StorageAdapterRead + ?Sized),
+    keys: Vec<StorageKey>,
+) -> Result<Vec<bool>, LixError> {
+    let started = Instant::now();
+    let result = PointReadPlan::from_unique_keys(BINARY_CAS_MANIFEST_SPACE, keys)
         .materialize(
             store,
             StorageGetOptions {
@@ -1255,6 +1299,7 @@ mod tests {
         active_manifest_scans: AtomicUsize,
         max_active_manifest_scans: AtomicUsize,
         manifest_scan_calls: AtomicUsize,
+        manifest_get_many_calls: AtomicUsize,
         chunk_get_many_calls: AtomicUsize,
         presence_get_many_calls: AtomicUsize,
         chunk_keys_requested: AtomicUsize,
@@ -1271,6 +1316,7 @@ mod tests {
                 active_manifest_scans: AtomicUsize::new(0),
                 max_active_manifest_scans: AtomicUsize::new(0),
                 manifest_scan_calls: AtomicUsize::new(0),
+                manifest_get_many_calls: AtomicUsize::new(0),
                 chunk_get_many_calls: AtomicUsize::new(0),
                 presence_get_many_calls: AtomicUsize::new(0),
                 chunk_keys_requested: AtomicUsize::new(0),
@@ -1297,6 +1343,9 @@ mod tests {
             requests: &[crate::storage_adapter::StorageGetManyRequest<'_>],
         ) -> Result<StorageGetManyResult, StorageError> {
             for request in requests {
+                if request.space == BINARY_CAS_MANIFEST_SPACE.id {
+                    self.manifest_get_many_calls.fetch_add(1, Ordering::Relaxed);
+                }
                 if request.space == BINARY_CAS_CHUNK_SPACE.id {
                     self.chunk_get_many_calls.fetch_add(1, Ordering::Relaxed);
                     self.chunk_keys_requested
@@ -1841,7 +1890,7 @@ mod tests {
     }
 
     #[test]
-    fn inline_layout_stops_at_the_32kib_boundary() {
+    fn inline_layout_stops_at_the_64kib_boundary() {
         let at_boundary = vec![b'a'; INLINE_BINARY_CAS_MAX_BYTES];
         let above_boundary = vec![b'a'; INLINE_BINARY_CAS_MAX_BYTES + 1];
 
@@ -1972,7 +2021,7 @@ mod tests {
     #[tokio::test]
     async fn public_kv_api_keeps_high_entropy_inline_blob_raw() {
         let storage = StorageAdapter::new(Memory::new());
-        let data = deterministic_high_entropy_bytes(32 * 1024);
+        let data = deterministic_high_entropy_bytes(INLINE_BINARY_CAS_MAX_BYTES);
         let blob_hash = BlobHash::from_content(&data);
 
         {
@@ -2083,6 +2132,85 @@ mod tests {
             counted.chunk_get_many_calls.load(Ordering::Relaxed),
             0,
             "inline blob reads must finish from the manifest point read"
+        );
+    }
+
+    #[tokio::test]
+    async fn extended_inline_writer_uses_manifest_probe_to_skip_repeat_payload_writes() {
+        let storage = StorageAdapter::new(Memory::new());
+        let data = deterministic_high_entropy_bytes(INLINE_BINARY_CAS_MAX_BYTES);
+        let payload = BlobPayload::from_bytes(data.clone());
+        let blob_hash = payload.hash().expect("payload should have a hash");
+
+        {
+            let mut writes = storage.new_write_set();
+            stage_test_payload(&storage, &mut writes, &payload).await;
+            assert_eq!(
+                writes.stats().staged_puts,
+                1,
+                "extended inline content stores only its manifest"
+            );
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .expect("extended inline blob write should commit");
+        }
+
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        assert_eq!(
+            get_one(
+                &store,
+                BINARY_CAS_CHUNK_PRESENCE_SPACE,
+                chunk_key(blob_hash),
+            )
+            .await
+            .expect("chunk presence lookup should succeed"),
+            None,
+            "inline content must not occupy the chunk presence namespace"
+        );
+
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let counted = DelayedManifestScanRead::new(store, Duration::ZERO);
+        let mut writes = storage.new_write_set();
+        let mut writer =
+            BinaryCasContext::new().writer_skipping_existing_chunks(&counted, &mut writes);
+        writer
+            .stage_payload(&payload)
+            .await
+            .expect("repeat extended inline blob write should stage");
+
+        assert_eq!(
+            writes.stats().staged_puts,
+            0,
+            "an existing extended inline payload should not be rewritten"
+        );
+        assert_eq!(
+            counted.manifest_get_many_calls.load(Ordering::Relaxed),
+            1,
+            "extended inline dedupe should use one key-only manifest lookup"
+        );
+        assert_eq!(
+            counted.presence_get_many_calls.load(Ordering::Relaxed),
+            0,
+            "extended inline content must not probe chunk presence"
+        );
+        assert_eq!(
+            load_bytes_many(&counted, &[blob_hash])
+                .await
+                .expect("extended inline blob should load")
+                .into_vec(),
+            vec![Some(data)]
+        );
+        assert_eq!(
+            counted.chunk_get_many_calls.load(Ordering::Relaxed),
+            0,
+            "extended inline reads must finish from the manifest point read"
         );
     }
 

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -1152,7 +1152,6 @@ async fn manifest_keys_exist(
     store: &(impl StorageAdapterRead + ?Sized),
     keys: Vec<StorageKey>,
 ) -> Result<Vec<bool>, LixError> {
-    let started = Instant::now();
     let result = PointReadPlan::from_unique_keys(BINARY_CAS_MANIFEST_SPACE, keys)
         .materialize(
             store,
@@ -1166,13 +1165,6 @@ async fn manifest_keys_exist(
         .into_iter()
         .map(|value| value.is_some())
         .collect::<Vec<_>>();
-    let hit_count = exists.iter().filter(|&&exists| exists).count() as u64;
-    let miss_count = exists.len() as u64 - hit_count;
-    crate::binary_cas::metrics::record_binary_cas_chunk_lookup_batch(
-        hit_count,
-        miss_count,
-        started.elapsed(),
-    );
     Ok(exists)
 }
 

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -1890,7 +1890,7 @@ mod tests {
     }
 
     #[test]
-    fn inline_layout_stops_at_the_64kib_boundary() {
+    fn inline_layout_stops_at_the_128kib_boundary() {
         let at_boundary = vec![b'a'; INLINE_BINARY_CAS_MAX_BYTES];
         let above_boundary = vec![b'a'; INLINE_BINARY_CAS_MAX_BYTES + 1];
 


### PR DESCRIPTION
## What

- inline binary CAS values through 64 KiB in the manifest row
- keep <=32 KiB writes probe-free; use a key-only manifest existence probe for the 32-64 KiB band
- extend the cross-adapter small-blob benchmark and record reproducible results

## Why

The complete OpenClaw main object set has 43,444 unique blobs in the 32-64 KiB band (9.5% of 455,883 blobs; 1.99 GB logical). The old single-chunk shape costs a manifest, payload, and presence row plus two read phases.

The new shape uses one row and one read phase. Rows and key bytes fall 66.7% (3 to 1 rows, 96 to 32 key bytes) while encoded value bytes remain nearly flat.

Seven counterbalanced process pairs, each with fresh databases, 300 warmups, and 3,000 samples per case:

| Backend | Operation | Baseline p50 | Candidate p50 | Change |
| --- | --- | ---: | ---: | ---: |
| RocksDB | unique write | 139,402 ns | 135,556 ns | 2.8% faster |
| RocksDB | repeat write | 13,459 ns | 13,169 ns | 2.2% faster |
| RocksDB | hot read | 4,276 ns | 3,685 ns | **13.8% faster** |
| SlateDB | unique write | 72,400 ns | 66,161 ns | 8.6% faster |
| SlateDB | repeat write | 28,418 ns | 12,636 ns | **55.5% faster** |
| SlateDB | hot read | 5,208 ns | 4,636 ns | **11.0% faster** |

Exact executable and raw-result SHA-256 values are recorded in the benchmark result document.

## Checks

- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- `cargo test --profile test --workspace --all-features --no-run`
- `cargo test --profile test --workspace --all-features`
- 7-pair RocksDB/SlateDB 64 KiB exact-case A/B benchmark