### PR TITLE
perf(engine): index staged file scans

### DIFF
--- a/.changenotes/index-staged-file-scans.md
+++ b/.changenotes/index-staged-file-scans.md
@@ -1,0 +1,6 @@
+---
+type: patch
+---
+
+File-constrained semantic plugin reads now use the transaction overlay's
+candidate index instead of scanning every staged row.

--- a/.changenotes/parallel-fresh-plugin-materialization.md
+++ b/.changenotes/parallel-fresh-plugin-materialization.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Fresh independent WASM plugin documents now open and drain concurrently within
+the bounded live-Store working set. Create-reservation preflights use aligned
+batch reads, while semantic rows are still eagerly validated and persisted.

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -36,7 +36,7 @@ comfy-table = "7.1"
 base64 = "0.22"
 bytes = "1"
 sha2 = "0.10"
-tokio = { version = "1", features = ["rt"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
 zip = { version = "8", default-features = false }
 uuid = { version = "1", features = ["v5", "std"] }
 

--- a/packages/cli/src/db/mod.rs
+++ b/packages/cli/src/db/mod.rs
@@ -160,7 +160,7 @@ fn validate_lix_file_path(path: &Path) -> Result<(), CliError> {
 }
 
 pub fn block_on<F: Future>(future: F) -> F::Output {
-    tokio::runtime::Builder::new_current_thread()
+    tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .expect("tokio runtime should initialize")

--- a/packages/engine/src/plugin/actor.rs
+++ b/packages/engine/src/plugin/actor.rs
@@ -186,6 +186,10 @@ impl PluginActorCache {
         })
     }
 
+    pub(crate) fn capacity(&self) -> usize {
+        self.capacity.get()
+    }
+
     /// Serializes cold actor construction. The gate is workspace-wide rather
     /// than per-key because cold opens are uncommon and may otherwise retain
     /// multiple full semantic snapshots plus Wasm Stores concurrently.

--- a/packages/engine/src/plugin/component.rs
+++ b/packages/engine/src/plugin/component.rs
@@ -177,6 +177,10 @@ impl PluginRuntimeHost {
         self.plugin_actor_cache.clone()
     }
 
+    pub(crate) fn max_live_plugin_stores(&self) -> usize {
+        self.plugin_actor_cache.capacity()
+    }
+
     /// Aggregates validated guest work and host-owned lifecycle facts.
     /// Poison recovery is deliberate: diagnostics must not fail a transaction.
     pub(crate) fn record_v2_transition_counters(&self, counters: WasmTransitionCounters) {

--- a/packages/engine/src/plugin/mod.rs
+++ b/packages/engine/src/plugin/mod.rs
@@ -28,8 +28,8 @@ pub(crate) use create_context::{
 };
 pub(crate) use incremental::{
     ArcByteSource, FileBytesSha256, V2SchemaAllowlist, ValidatedConflictTransition,
-    ValidatedSameLengthOutputSplice, VecEntityChangeSource, VecEntityConflictSource,
-    VecEntitySource, build_file_update_splices, canonicalize_v2_snapshot,
+    ValidatedFileTransition, ValidatedSameLengthOutputSplice, VecEntityChangeSource,
+    VecEntityConflictSource, VecEntitySource, build_file_update_splices, canonicalize_v2_snapshot,
     drain_conflict_transition_resolutions, drain_entity_transition_edits,
     drain_file_transition_changes, host_entity_change_with_lazy_snapshot,
     host_entity_with_lazy_snapshot, transport_splice_preserves_git_text,

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -61,14 +61,14 @@ use crate::live_state::{
     overlay_load_exact_batch, overlay_scan_batch,
 };
 use crate::plugin::{
-    ArcByteSource, BoundCreateContext, CompiledPluginCatalog, FileBytesSha256, PLUGIN_OWNER_KEY,
-    PLUGIN_REGISTRY_KEY, PluginActorCache, PluginActorColdInstall, PluginActorColdOpen,
-    PluginActorKey, PluginActorLease, PluginActorStore, PluginActorStorePermit,
-    PluginArchiveInstallPlan, PluginContentType, PluginFileOwner, PluginMaterialization,
-    PluginObservation, PluginRegistry, PluginRegistryEntry, PluginRegistryEntryInput,
-    PluginRuntimeHost, V2SchemaAllowlist, ValidatedConflictTransition,
-    ValidatedSameLengthOutputSplice, VecEntityChangeSource, VecEntityConflictSource,
-    VecEntitySource, build_file_update_splices, canonicalize_v2_snapshot,
+    ArcByteSource, BoundCreateContext, CompiledPluginCatalog, DEFAULT_MAX_LIVE_PLUGIN_STORES,
+    FileBytesSha256, PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY, PluginActorCache,
+    PluginActorColdInstall, PluginActorColdOpen, PluginActorKey, PluginActorLease,
+    PluginActorStore, PluginActorStorePermit, PluginArchiveInstallPlan, PluginContentType,
+    PluginFileOwner, PluginMaterialization, PluginObservation, PluginRegistry, PluginRegistryEntry,
+    PluginRegistryEntryInput, PluginRuntimeHost, V2SchemaAllowlist, ValidatedConflictTransition,
+    ValidatedFileTransition, ValidatedSameLengthOutputSplice, VecEntityChangeSource,
+    VecEntityConflictSource, VecEntitySource, build_file_update_splices, canonicalize_v2_snapshot,
     drain_conflict_transition_resolutions, drain_entity_transition_edits,
     drain_file_transition_changes, host_entity_change_with_lazy_snapshot,
     host_entity_with_lazy_snapshot, inferred_media_type_for_path, is_plugin_storage_path,
@@ -1626,28 +1626,46 @@ where
         bound: BoundCreateContext,
         file_key: &PluginFileWriteKey,
     ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-        let reservation_key = bound.reservation_key();
+        self.preflight_v2_creates(&[(bound, file_key.clone())])
+            .await
+            .map(|mut rows| rows.pop().expect("one preflight produces one result"))
+    }
+
+    async fn preflight_v2_creates(
+        &mut self,
+        requests: &[(BoundCreateContext, PluginFileWriteKey)],
+    ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+        if requests.is_empty() {
+            return Ok(Vec::new());
+        }
         let loaded = self
             .load_visible_exact_live_state_batch(&LiveStateExactBatchRequest {
-                rows: vec![LiveStateExactRowRequest {
-                    schema_key: KEY_VALUE_SCHEMA_KEY.to_string(),
-                    branch_id: file_key.branch_id.clone(),
-                    entity_pk: EntityPk::single(reservation_key),
-                    file_id: Some(file_key.file_id.clone()),
-                }],
+                rows: requests
+                    .iter()
+                    .map(|(bound, file_key)| LiveStateExactRowRequest {
+                        schema_key: KEY_VALUE_SCHEMA_KEY.to_string(),
+                        branch_id: file_key.branch_id.clone(),
+                        entity_pk: EntityPk::single(bound.reservation_key()),
+                        file_id: Some(file_key.file_id.clone()),
+                    })
+                    .collect(),
                 projection: plugin_state_live_state_projection(),
                 untracked: Some(false),
                 include_tombstones: false,
             })
             .await?;
-        let existing = loaded.row(0).map(MaterializedLiveStateRowRef::to_owned);
-        validate_create_reservation(
-            existing.as_ref(),
-            bound,
-            &file_key.file_id,
-            &file_key.branch_id,
-        )?;
-        Ok(existing)
+        let mut existing_rows = Vec::with_capacity(requests.len());
+        for (index, (bound, file_key)) in requests.iter().enumerate() {
+            let existing = loaded.row(index).map(MaterializedLiveStateRowRef::to_owned);
+            validate_create_reservation(
+                existing.as_ref(),
+                *bound,
+                &file_key.file_id,
+                &file_key.branch_id,
+            )?;
+            existing_rows.push(existing);
+        }
+        Ok(existing_rows)
     }
 
     async fn v2_id_reservation_tombstones(
@@ -3060,6 +3078,329 @@ where
         }
 
         let mut reconciled_file_keys = BTreeSet::<PluginFileWriteKey>::new();
+        let fresh_file_indices = file_data
+            .iter()
+            .enumerate()
+            .filter_map(|(index, write)| {
+                let path = write.path.as_deref()?;
+                if write.global
+                    || write.untracked
+                    || is_plugin_storage_path(path)
+                    || !active_branch_ids.contains(&write.branch_id)
+                {
+                    return None;
+                }
+                let file_key = PluginFileWriteKey::from(write);
+                (owners.get(&file_key).is_none() && selected_plugins.contains_key(&file_key))
+                    .then_some(index)
+            })
+            .collect::<Vec<_>>();
+
+        for file_indices in fresh_file_indices.chunks(DEFAULT_MAX_LIVE_PLUGIN_STORES) {
+            let mut prepared_opens = Vec::with_capacity(file_indices.len());
+            for &file_index in file_indices {
+                let write = &file_data[file_index];
+                let path = write
+                    .path
+                    .as_deref()
+                    .expect("fresh plugin candidate has a path")
+                    .to_string();
+                let file_key = PluginFileWriteKey::from(write);
+                let selected = selected_plugins
+                    .get(&file_key)
+                    .expect("fresh plugin candidate has a selection")
+                    .clone();
+                let installed_key = PluginBranchEntryKey {
+                    branch_id: write.branch_id.clone(),
+                    plugin_key: selected.key().to_string(),
+                };
+                let factory = component_v2_factories
+                    .get(&installed_key)
+                    .expect("selected v2 plugin should have a compiled factory")
+                    .clone();
+                let desired_owner =
+                    PluginFileOwner::from_registry_entry(write.file_id.clone(), &selected)?;
+                let owner_change_id = self.functions.call_uuid_v7().to_string();
+                let mut owner_row = desired_owner.write_row(&write.branch_id)?;
+                owner_row.change_id = Some(owner_change_id.clone());
+                let actor_key = PluginActorKey {
+                    branch_id: write.branch_id.clone(),
+                    file_id: write.file_id.clone(),
+                    path,
+                    owner_change_id: owner_change_id.clone(),
+                    plugin_key: selected.key().to_string(),
+                    plugin_generation: selected.archive_blob_hash().to_string(),
+                };
+                let view = PendingPluginActorView {
+                    session_key: SessionFileViewKey::new(&write.branch_id, &write.file_id),
+                    plugin_key: selected.key().to_string(),
+                    plugin_generation: selected.archive_blob_hash().to_string(),
+                    owner_change_id,
+                    semantic_chainable: false,
+                };
+                if self
+                    .pending_plugin_actor_publications
+                    .iter()
+                    .chain(reconciliation.actor_publications.iter())
+                    .any(|publication| publication.session_key() == &view.session_key)
+                {
+                    return Err(LixError::new(
+                        LixError::CODE_CONSTRAINT_VIOLATION,
+                        format!(
+                            "one transaction cannot transition v2 plugin file '{}' more than once",
+                            write.file_id
+                        ),
+                    )
+                    .with_hint("combine the byte edits into one file update"));
+                }
+
+                let descriptor = v2_file_descriptor(write, &selected);
+                let schemas = V2SchemaAllowlist::from_catalog(
+                    selected.schema_keys(),
+                    Arc::clone(&self.sql_schema_snapshot),
+                )?;
+                let mutation_identity = write.mutation_identity().unwrap_or_else(|| {
+                    local_mutation_identity(self.functions.call_uuid_v7().into_bytes())
+                });
+                let create_context = BoundCreateContext::bind(mutation_identity, &actor_key)?;
+                let materialization_version = self.functions.call_uuid_v7().to_string();
+                let submitted_bytes = write.payload().shared_bytes();
+                let cold_limits = WasmTransitionLimits::for_cold_file_bytes(
+                    u64::try_from(submitted_bytes.len()).unwrap_or(u64::MAX),
+                );
+                prepared_opens.push(PreparedFreshPluginOpen {
+                    file_index,
+                    file_key,
+                    selected,
+                    owner_row,
+                    actor_key,
+                    view,
+                    materialization_version,
+                    submitted_bytes,
+                    create_context,
+                    existing_create_reservation: None,
+                    factory,
+                    descriptor,
+                    schemas,
+                    cold_limits,
+                });
+            }
+
+            let preflight_requests = prepared_opens
+                .iter()
+                .map(|prepared| (prepared.create_context, prepared.file_key.clone()))
+                .collect::<Vec<_>>();
+            let existing_rows = match self.preflight_v2_creates(&preflight_requests).await {
+                Ok(existing_rows) => existing_rows,
+                Err(error) => {
+                    discard_plugin_actor_publications(std::mem::take(
+                        &mut reconciliation.actor_publications,
+                    ))
+                    .await;
+                    return Err(error);
+                }
+            };
+            for (prepared, existing) in prepared_opens.iter_mut().zip(existing_rows) {
+                prepared.existing_create_reservation = existing;
+            }
+
+            let mut store_permits = Vec::with_capacity(prepared_opens.len());
+            for _ in 0..prepared_opens.len() {
+                match self
+                    .admit_fresh_plugin_store(&mut reconciliation.actor_publications)
+                    .await
+                {
+                    Ok(permit) => store_permits.push(permit),
+                    Err(error) => {
+                        discard_plugin_actor_publications(std::mem::take(
+                            &mut reconciliation.actor_publications,
+                        ))
+                        .await;
+                        return Err(error);
+                    }
+                }
+            }
+
+            let pending_opens = prepared_opens
+                .into_iter()
+                .zip(store_permits)
+                .map(|(prepared, store_permit)| {
+                    let PreparedFreshPluginOpen {
+                        file_index,
+                        file_key,
+                        selected,
+                        owner_row,
+                        actor_key,
+                        view,
+                        materialization_version,
+                        submitted_bytes,
+                        create_context,
+                        existing_create_reservation,
+                        factory,
+                        descriptor,
+                        schemas,
+                        cold_limits,
+                    } = prepared;
+                    let source_bytes = submitted_bytes.clone();
+                    let creates = create_context.creates();
+                    let task = tokio::spawn(async move {
+                        let mut actor = factory
+                            .instantiate_actor()
+                            .instrument(tracing::debug_span!(
+                                target: "lix_perf",
+                                "lix.perf.plugin_actor_instantiate"
+                            ))
+                            .await?;
+                        let transition = actor
+                            .open_file(
+                                cold_limits,
+                                WasmOpenFileInput {
+                                    descriptor,
+                                    file: Arc::new(ArcByteSource::new(source_bytes)),
+                                    creates,
+                                },
+                            )
+                            .instrument(tracing::debug_span!(
+                                target: "lix_perf",
+                                "lix.perf.plugin_open_file"
+                            ))
+                            .await?;
+                        let validated = drain_file_transition_changes(
+                            actor.as_mut(),
+                            transition,
+                            &schemas,
+                            cold_limits,
+                        )
+                        .instrument(tracing::debug_span!(
+                            target: "lix_perf",
+                            "lix.perf.plugin_open_file_drain"
+                        ))
+                        .await?;
+                        Ok((actor, validated))
+                    });
+                    PendingFreshPluginOpen {
+                        file_index,
+                        file_key,
+                        selected,
+                        owner_row,
+                        actor_key,
+                        view,
+                        materialization_version,
+                        submitted_bytes,
+                        create_context,
+                        existing_create_reservation,
+                        store_permit,
+                        task: Some(task),
+                    }
+                })
+                .collect::<Vec<_>>();
+
+            let mut completed_opens = Vec::with_capacity(pending_opens.len());
+            let mut first_error = None;
+            for mut pending in pending_opens {
+                let result = pending
+                    .task
+                    .take()
+                    .expect("fresh plugin worker task is present")
+                    .await;
+                match result {
+                    Ok(Ok((actor, validated))) => {
+                        completed_opens.push((pending, actor, validated));
+                    }
+                    Ok(Err(error)) => {
+                        first_error.get_or_insert(error);
+                    }
+                    Err(error) => {
+                        first_error.get_or_insert_with(|| {
+                            LixError::new(
+                                LixError::CODE_INTERNAL_ERROR,
+                                format!("fresh plugin worker failed: {error}"),
+                            )
+                        });
+                    }
+                }
+            }
+            if let Some(error) = first_error {
+                discard_plugin_actor_publications(std::mem::take(
+                    &mut reconciliation.actor_publications,
+                ))
+                .await;
+                return Err(error);
+            }
+
+            for (pending, actor, validated) in completed_opens {
+                let mut changes = validated.changes;
+                let create_rows = self
+                    .v2_create_rows(
+                        &pending.selected,
+                        &mut changes,
+                        pending.create_context,
+                        &pending.file_key,
+                        pending.existing_create_reservation.as_ref(),
+                    )
+                    .await?;
+                let mut counters = validated.counters;
+                counters.host_content_classification_bytes = content_classification_bytes
+                    .get(&pending.file_key)
+                    .copied()
+                    .unwrap_or(0);
+                counters.full_document_reparses = 1;
+                counters.durable_semantic_changes =
+                    u64::try_from(changes.entity_change_count()).unwrap_or(u64::MAX);
+                self.plugin_host.record_v2_transition_counters(counters);
+
+                rows.push(pending.owner_row);
+                rows.append(create_rows);
+                let write = &mut file_data[pending.file_index];
+                let context = FilesystemRowContext {
+                    branch_id: write.branch_id.clone(),
+                    global: false,
+                    untracked: false,
+                    file_id: None,
+                    metadata: None,
+                };
+                append_plugin_change_rows_from_v2(
+                    rows,
+                    &pending.selected,
+                    changes,
+                    &write.file_id,
+                    &context,
+                )?;
+                match pending.selected.materialization() {
+                    PluginMaterialization::Blob => {
+                        reconciliation
+                            .materialized_file_keys
+                            .insert(pending.file_key.clone());
+                    }
+                    PluginMaterialization::Derived => {
+                        reconciliation.derived_materializations.insert(
+                            pending.file_key.clone(),
+                            DerivedMaterializationProof::from_bytes(
+                                &pending.submitted_bytes,
+                                pending.actor_key.path.clone(),
+                            ),
+                        );
+                    }
+                }
+                reconciliation.materialization_versions.insert(
+                    pending.file_key.clone(),
+                    pending.materialization_version.clone(),
+                );
+                reconciliation
+                    .actor_publications
+                    .push(PendingPluginActorPublication::New {
+                        cache: self.plugin_host.actor_cache(),
+                        key: pending.actor_key,
+                        store: PluginActorStore::new(actor, pending.store_permit),
+                        document: validated.document,
+                        bytes: pending.submitted_bytes,
+                        semantic_root: Arc::from(pending.materialization_version),
+                        view: pending.view,
+                    });
+                reconciled_file_keys.insert(pending.file_key);
+            }
+        }
+
         for write in file_data.iter_mut() {
             let Some(path) = write.path.as_deref() else {
                 continue;
@@ -3072,6 +3413,9 @@ where
                 continue;
             }
             let file_key = PluginFileWriteKey::from(&*write);
+            if reconciled_file_keys.contains(&file_key) {
+                continue;
+            }
             let owner = owners.get(&file_key);
             let selected = selected_plugins.get(&file_key);
             let context = FilesystemRowContext {
@@ -6482,6 +6826,42 @@ struct PluginWriteReconciliation {
     file_view_mutations: BTreeMap<SessionFileViewKey, SessionFileViewMutation>,
     actor_publications: Vec<PendingPluginActorPublication>,
     reconciled_rows: Option<ReconciledRowBatch>,
+}
+
+struct PreparedFreshPluginOpen {
+    file_index: usize,
+    file_key: PluginFileWriteKey,
+    selected: PluginRegistryEntry,
+    owner_row: TransactionWriteRow,
+    actor_key: PluginActorKey,
+    view: PendingPluginActorView,
+    materialization_version: String,
+    submitted_bytes: crate::Blob,
+    create_context: BoundCreateContext,
+    existing_create_reservation: Option<MaterializedLiveStateRow>,
+    factory: Arc<dyn WasmComponentV2Factory>,
+    descriptor: WasmFileDescriptor,
+    schemas: V2SchemaAllowlist,
+    cold_limits: WasmTransitionLimits,
+}
+
+struct PendingFreshPluginOpen {
+    file_index: usize,
+    file_key: PluginFileWriteKey,
+    selected: PluginRegistryEntry,
+    owner_row: TransactionWriteRow,
+    actor_key: PluginActorKey,
+    view: PendingPluginActorView,
+    materialization_version: String,
+    submitted_bytes: crate::Blob,
+    create_context: BoundCreateContext,
+    existing_create_reservation: Option<MaterializedLiveStateRow>,
+    store_permit: PluginActorStorePermit,
+    task: Option<
+        tokio::task::JoinHandle<
+            Result<(Box<dyn WasmComponentV2Actor>, ValidatedFileTransition), LixError>,
+        >,
+    >,
 }
 
 impl PluginWriteReconciliation {

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -61,14 +61,14 @@ use crate::live_state::{
     overlay_load_exact_batch, overlay_scan_batch,
 };
 use crate::plugin::{
-    ArcByteSource, BoundCreateContext, CompiledPluginCatalog, DEFAULT_MAX_LIVE_PLUGIN_STORES,
-    FileBytesSha256, PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY, PluginActorCache,
-    PluginActorColdInstall, PluginActorColdOpen, PluginActorKey, PluginActorLease,
-    PluginActorStore, PluginActorStorePermit, PluginArchiveInstallPlan, PluginContentType,
-    PluginFileOwner, PluginMaterialization, PluginObservation, PluginRegistry, PluginRegistryEntry,
-    PluginRegistryEntryInput, PluginRuntimeHost, V2SchemaAllowlist, ValidatedConflictTransition,
-    ValidatedFileTransition, ValidatedSameLengthOutputSplice, VecEntityChangeSource,
-    VecEntityConflictSource, VecEntitySource, build_file_update_splices, canonicalize_v2_snapshot,
+    ArcByteSource, BoundCreateContext, CompiledPluginCatalog, FileBytesSha256, PLUGIN_OWNER_KEY,
+    PLUGIN_REGISTRY_KEY, PluginActorCache, PluginActorColdInstall, PluginActorColdOpen,
+    PluginActorKey, PluginActorLease, PluginActorStore, PluginActorStorePermit,
+    PluginArchiveInstallPlan, PluginContentType, PluginFileOwner, PluginMaterialization,
+    PluginObservation, PluginRegistry, PluginRegistryEntry, PluginRegistryEntryInput,
+    PluginRuntimeHost, V2SchemaAllowlist, ValidatedConflictTransition, ValidatedFileTransition,
+    ValidatedSameLengthOutputSplice, VecEntityChangeSource, VecEntityConflictSource,
+    VecEntitySource, build_file_update_splices, canonicalize_v2_snapshot,
     drain_conflict_transition_resolutions, drain_entity_transition_edits,
     drain_file_transition_changes, host_entity_change_with_lazy_snapshot,
     host_entity_with_lazy_snapshot, inferred_media_type_for_path, is_plugin_storage_path,
@@ -3091,13 +3091,15 @@ where
                     return None;
                 }
                 let file_key = PluginFileWriteKey::from(write);
-                (owners.get(&file_key).is_none() && selected_plugins.contains_key(&file_key))
+                (!owners.contains_key(&file_key) && selected_plugins.contains_key(&file_key))
                     .then_some(index)
             })
             .collect::<Vec<_>>();
 
-        for file_indices in fresh_file_indices.chunks(DEFAULT_MAX_LIVE_PLUGIN_STORES) {
+        let fresh_parallelism = self.plugin_host.max_live_plugin_stores();
+        for file_indices in fresh_file_indices.chunks(fresh_parallelism) {
             let mut prepared_opens = Vec::with_capacity(file_indices.len());
+            let mut prepared_session_keys = BTreeSet::new();
             for &file_index in file_indices {
                 let write = &file_data[file_index];
                 let path = write
@@ -3138,11 +3140,12 @@ where
                     owner_change_id,
                     semantic_chainable: false,
                 };
-                if self
-                    .pending_plugin_actor_publications
-                    .iter()
-                    .chain(reconciliation.actor_publications.iter())
-                    .any(|publication| publication.session_key() == &view.session_key)
+                if !prepared_session_keys.insert(view.session_key.clone())
+                    || self
+                        .pending_plugin_actor_publications
+                        .iter()
+                        .chain(reconciliation.actor_publications.iter())
+                        .any(|publication| publication.session_key() == &view.session_key)
                 {
                     return Err(LixError::new(
                         LixError::CODE_CONSTRAINT_VIOLATION,

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -72,13 +72,20 @@ pub(crate) enum RowSlot {
     State(usize),
 }
 
-/// Narrows exact entity scans over an indexed transaction overlay without
-/// changing the journal's identity/coalescing semantics. A file id, branch,
-/// and durability remain post-filter checks because one logical entity can
-/// legitimately have multiple such physical rows while it is staged.
+#[derive(Default)]
+struct StagedScanFileCandidates {
+    slots_by_value: HashMap<SharedStr, SmallVec<[RowSlot; 1]>>,
+    null_slots: SmallVec<[RowSlot; 1]>,
+}
+
+/// Narrows entity- or file-constrained scans over an indexed transaction
+/// overlay without changing the journal's identity/coalescing semantics.
+/// Branch and durability remain post-filter checks because one indexed
+/// candidate can legitimately have multiple such physical rows while staged.
 #[derive(Default)]
 struct StagedScanCandidateIndex {
     slots_by_schema_and_entity: HashMap<SharedStr, HashMap<EntityPk, SmallVec<[RowSlot; 1]>>>,
+    slots_by_schema_and_file: HashMap<SharedStr, StagedScanFileCandidates>,
 }
 
 impl StagedScanCandidateIndex {
@@ -89,39 +96,109 @@ impl StagedScanCandidateIndex {
             .entry(row.entity_pk.clone())
             .or_default()
             .push(slot);
+
+        let by_file = self
+            .slots_by_schema_and_file
+            .entry(row.schema_key.clone())
+            .or_default();
+        if let Some(file_id) = row.file_id {
+            by_file
+                .slots_by_value
+                .entry(file_id.clone())
+                .or_default()
+                .push(slot);
+        } else {
+            by_file.null_slots.push(slot);
+        }
     }
 
     /// Returns a strict superset of the staged rows a scan can observe when
-    /// both identity dimensions are constrained. The remaining scan filters
-    /// are deliberately applied by the established matcher afterwards.
+    /// schema plus either entity or file identity are constrained. The
+    /// remaining scan filters are deliberately applied by the established
+    /// matcher afterwards.
     fn slots_for_filter<'a>(
         &'a self,
         filter: &crate::live_state::LiveStateFilter,
     ) -> Option<Cow<'a, [RowSlot]>> {
-        if filter.schema_keys.is_empty() || filter.entity_pks.is_empty() {
+        if filter.schema_keys.is_empty() {
             return None;
         }
 
-        if let ([schema_key], [entity_pk]) =
-            (filter.schema_keys.as_slice(), filter.entity_pks.as_slice())
+        if !filter.entity_pks.is_empty() {
+            if let ([schema_key], [entity_pk]) =
+                (filter.schema_keys.as_slice(), filter.entity_pks.as_slice())
+            {
+                let slots = self
+                    .slots_by_schema_and_entity
+                    .get(schema_key.as_str())
+                    .and_then(|by_entity| by_entity.get(entity_pk))
+                    .map(SmallVec::as_slice)
+                    .unwrap_or(&[]);
+                return Some(Cow::Borrowed(slots));
+            }
+
+            let mut slots = Vec::new();
+            for schema_key in &filter.schema_keys {
+                let Some(by_entity) = self.slots_by_schema_and_entity.get(schema_key.as_str())
+                else {
+                    continue;
+                };
+                for entity_pk in &filter.entity_pks {
+                    if let Some(candidate_slots) = by_entity.get(entity_pk) {
+                        slots.extend(candidate_slots.iter().copied());
+                    }
+                }
+            }
+            slots.sort_unstable();
+            slots.dedup();
+            return Some(Cow::Owned(slots));
+        }
+
+        if filter.file_ids.is_empty()
+            || filter
+                .file_ids
+                .iter()
+                .any(|file_id| matches!(file_id, NullableKeyFilter::Any))
+        {
+            return None;
+        }
+
+        if let ([schema_key], [file_id]) =
+            (filter.schema_keys.as_slice(), filter.file_ids.as_slice())
         {
             let slots = self
-                .slots_by_schema_and_entity
+                .slots_by_schema_and_file
                 .get(schema_key.as_str())
-                .and_then(|by_entity| by_entity.get(entity_pk))
-                .map(SmallVec::as_slice)
+                .map(|by_file| match file_id {
+                    NullableKeyFilter::Null => by_file.null_slots.as_slice(),
+                    NullableKeyFilter::Value(file_id) => by_file
+                        .slots_by_value
+                        .get(file_id.as_str())
+                        .map(SmallVec::as_slice)
+                        .unwrap_or(&[]),
+                    NullableKeyFilter::Any => unreachable!("handled above"),
+                })
                 .unwrap_or(&[]);
             return Some(Cow::Borrowed(slots));
         }
 
         let mut slots = Vec::new();
         for schema_key in &filter.schema_keys {
-            let Some(by_entity) = self.slots_by_schema_and_entity.get(schema_key.as_str()) else {
+            let Some(by_file) = self.slots_by_schema_and_file.get(schema_key.as_str()) else {
                 continue;
             };
-            for entity_pk in &filter.entity_pks {
-                if let Some(candidate_slots) = by_entity.get(entity_pk) {
-                    slots.extend(candidate_slots.iter().copied());
+            for file_id in &filter.file_ids {
+                match file_id {
+                    NullableKeyFilter::Null => {
+                        slots.extend(by_file.null_slots.iter().copied());
+                    }
+                    NullableKeyFilter::Value(file_id) => {
+                        if let Some(candidate_slots) = by_file.slots_by_value.get(file_id.as_str())
+                        {
+                            slots.extend(candidate_slots.iter().copied());
+                        }
+                    }
+                    NullableKeyFilter::Any => unreachable!("handled above"),
                 }
             }
         }
@@ -3452,6 +3529,58 @@ mod tests {
         }));
     }
 
+    #[tokio::test]
+    async fn staging_overlay_file_scan_uses_file_candidates_before_final_matching() {
+        let staged_writes = test_staged_writes();
+        staged_writes
+            .stage_write(PreparedTransactionWrite::Rows {
+                mode: TransactionWriteMode::Replace,
+                rows: prepared_rows![
+                    state_row("global", "selected").with_file_id("selected-file"),
+                    state_row("active", "selected")
+                        .with_file_id("selected-file")
+                        .with_branch("01920000-0000-7000-8000-0000000000a1"),
+                    state_row("other-file", "ignored")
+                        .with_file_id("01920000-0000-7000-8000-0000000000a2"),
+                    state_row("other-schema", "ignored")
+                        .with_schema("other_schema")
+                        .with_file_id("selected-file"),
+                ],
+            })
+            .expect("rows should stage");
+
+        let overlay = staged_writes
+            .staging_overlay()
+            .expect("overlay should build from staged rows");
+        let rows = overlay
+            .scan_parts(&LiveStateScanRequest {
+                filter: LiveStateFilter {
+                    schema_keys: vec!["lix_key_value".to_string()],
+                    branch_ids: vec!["01920000-0000-7000-8000-0000000000a1".to_string()],
+                    file_ids: vec![NullableKeyFilter::Value("selected-file".to_string())],
+                    include_tombstones: true,
+                    ..LiveStateFilter::default()
+                },
+                ..LiveStateScanRequest::default()
+            })
+            .expect("file scan should succeed")
+            .rows;
+
+        assert_eq!(
+            rows.len(),
+            2,
+            "active and global fallback both remain candidates"
+        );
+        assert!(rows.iter().all(|row| {
+            row.schema_key == "lix_key_value"
+                && row.file_id.as_deref() == Some("selected-file")
+                && matches!(
+                    row.branch_id.as_ref(),
+                    "01920000-0000-7000-8000-0000000000a1" | GLOBAL_BRANCH_ID
+                )
+        }));
+    }
+
     #[test]
     fn keyed_staged_scan_deduplicates_multi_key_candidates_by_slot_order() {
         let mut index = StagedScanCandidateIndex::default();
@@ -3475,6 +3604,66 @@ mod tests {
     }
 
     #[test]
+    fn file_staged_scan_deduplicates_multi_key_candidates_by_slot_order() {
+        let mut index = StagedScanCandidateIndex::default();
+        index.insert(
+            state_row("first", "one")
+                .with_file_id("selected")
+                .borrowed(),
+            RowSlot::State(4),
+        );
+        index.insert(
+            state_row("second", "two").with_file_id("other").borrowed(),
+            RowSlot::State(9),
+        );
+
+        let filter = LiveStateFilter {
+            schema_keys: vec!["lix_key_value".to_string(), "lix_key_value".to_string()],
+            file_ids: vec![
+                NullableKeyFilter::Value("other".to_string()),
+                NullableKeyFilter::Value("selected".to_string()),
+                NullableKeyFilter::Value("selected".to_string()),
+            ],
+            ..LiveStateFilter::default()
+        };
+        let Some(Cow::Owned(slots)) = index.slots_for_filter(&filter) else {
+            panic!("multi-key file filter should use the candidate index");
+        };
+
+        assert_eq!(slots, vec![RowSlot::State(4), RowSlot::State(9)]);
+    }
+
+    #[test]
+    fn file_staged_scan_indexes_null_and_declines_any_filter() {
+        let mut index = StagedScanCandidateIndex::default();
+        index.insert(state_row("null", "one").borrowed(), RowSlot::State(4));
+        index.insert(
+            state_row("file", "two").with_file_id("selected").borrowed(),
+            RowSlot::State(9),
+        );
+
+        let null_filter = LiveStateFilter {
+            schema_keys: vec!["lix_key_value".to_string()],
+            file_ids: vec![NullableKeyFilter::Null],
+            ..LiveStateFilter::default()
+        };
+        let Some(Cow::Borrowed(null_slots)) = index.slots_for_filter(&null_filter) else {
+            panic!("single null file filter should borrow indexed candidates");
+        };
+        assert_eq!(null_slots, &[RowSlot::State(4)]);
+
+        let any_filter = LiveStateFilter {
+            schema_keys: vec!["lix_key_value".to_string()],
+            file_ids: vec![NullableKeyFilter::Any],
+            ..LiveStateFilter::default()
+        };
+        assert!(
+            index.slots_for_filter(&any_filter).is_none(),
+            "an Any file filter must retain the complete staged scan"
+        );
+    }
+
+    #[test]
     fn keyed_staged_scan_keeps_the_common_single_slot_inline() {
         let row = state_row("single", "value");
         let mut index = StagedScanCandidateIndex::default();
@@ -3489,6 +3678,17 @@ mod tests {
         assert!(
             !slots.spilled(),
             "one exact-read candidate must not allocate a row-local slot buffer"
+        );
+
+        let file_slots = index
+            .slots_by_schema_and_file
+            .get(row.schema_key.as_str())
+            .and_then(|by_file| by_file.null_slots.first().map(|_| &by_file.null_slots))
+            .expect("indexed null file should retain its candidate slot");
+        assert_eq!(file_slots.as_slice(), &[RowSlot::State(7)]);
+        assert!(
+            !file_slots.spilled(),
+            "one file candidate must not allocate a row-local slot buffer"
         );
     }
 


### PR DESCRIPTION
## Summary

- index staged transaction rows by schema and nullable file ID in addition to entity identity
- use the file index for exact schema+file scans while retaining the existing matcher for branch, durability, and visibility semantics
- preserve full-scan behavior for `NullableKeyFilter::Any`
- cover value/null candidates, duplicate filters, stable slot order, inline single-slot storage, and global-branch fallback

This is stacked on #925.

## Profile evidence

OpenClaw's 3,423-path c5 replay exposed schema+file plugin reads that otherwise walk the complete growing staged overlay. The flat profile attributed 6.29% self time to staged overlay batching plus matcher/index helpers. This change removes that unbounded scan shape.

The full c5 replay remains ~24.4s after this change, so this PR intentionally does not claim to close the overall plugin gap; span profiling identifies cold WASM drain/open and a separate batch-validation fast-path miss as the dominant remaining costs.

## Validation

- `cargo fmt --all`
- `cargo test -p lix_engine staged_scan --lib`
- `cargo test -p lix_engine staging_overlay_file_scan_uses_file_candidates_before_final_matching --lib`
- release OpenClaw c5 replay with eager plugins