### PR TITLE
Index schema-constrained staged scans

### DIFF
--- a/.changenotes/bound-text-snapshot-allocation.md
+++ b/.changenotes/bound-text-snapshot-allocation.md
@@ -1,0 +1,8 @@
+---
+type: patch
+---
+
+The Git text WASM plugin now writes base64 content directly into its final JSON
+snapshot buffer, avoiding a duplicate large allocation for minified files.
+WASM Stores retain a bounded 128 MiB ceiling so warm updates of large minified
+documents can materialize their successor without exhausting linear memory.

--- a/.changenotes/index-staged-schema-scans.md
+++ b/.changenotes/index-staged-schema-scans.md
@@ -1,0 +1,6 @@
+---
+type: patch
+---
+
+Schema-constrained semantic plugin reads now use the transaction overlay's
+candidate index instead of scanning unrelated staged rows.

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -87,8 +87,8 @@ impl EngineOptions {
     /// The Store limit bounds the active working set, not the number of plugin
     /// documents an atomic transaction may open. Transactions retire completed
     /// Stores and reuse their slots while preserving atomic commit.
-    /// Defaults are 64 MiB and sixteen Stores, bounding guest linear memory to
-    /// 1 GiB before host-side document state. Cached actors, active
+    /// Defaults are 128 MiB and sixteen Stores, bounding guest linear memory to
+    /// 2 GiB before host-side document state. Cached actors, active
     /// existing-document transaction leases, pending publications, cold-open
     /// candidates, and upgrade preflight Stores consume the same
     /// workspace-wide budget. Completed publications may retire their Stores

--- a/packages/engine/src/plugin/component.rs
+++ b/packages/engine/src/plugin/component.rs
@@ -15,9 +15,9 @@ use super::{
 /// for normal operations. The cold-file budget may extend up to this ceiling,
 /// but no guest call can exceed it.
 const MAX_PLUGIN_EXECUTION_TIMEOUT_MS: u64 = 60_000;
-/// Preserve enough headroom for recursive plugins while favoring a wider file
-/// working set over the prior 128 MiB per-actor ceiling.
-pub(crate) const DEFAULT_PLUGIN_V2_MEMORY_BYTES: u64 = 64 * 1024 * 1024;
+/// Preserve enough headroom for recursive plugins and large minified text
+/// snapshots. The live-Store working set remains independently bounded.
+pub(crate) const DEFAULT_PLUGIN_V2_MEMORY_BYTES: u64 = 128 * 1024 * 1024;
 
 fn plugin_v2_wasm_limits(max_memory_bytes: u64) -> Result<WasmLimits, LixError> {
     if max_memory_bytes == 0 {
@@ -269,11 +269,11 @@ mod tests {
         assert_eq!(WasmLimits::default().max_memory_bytes, 64 * 1024 * 1024);
         assert_eq!(
             default_plugin_v2_wasm_limits().max_memory_bytes,
-            64 * 1024 * 1024
+            128 * 1024 * 1024
         );
         assert_eq!(
             DEFAULT_PLUGIN_V2_MEMORY_BYTES * DEFAULT_MAX_LIVE_PLUGIN_STORES as u64,
-            1024 * 1024 * 1024
+            2 * 1024 * 1024 * 1024
         );
         assert_eq!(
             default_plugin_v2_wasm_limits().timeout_ms,

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -84,12 +84,17 @@ struct StagedScanFileCandidates {
 /// candidate can legitimately have multiple such physical rows while staged.
 #[derive(Default)]
 struct StagedScanCandidateIndex {
+    slots_by_schema: HashMap<SharedStr, SmallVec<[RowSlot; 1]>>,
     slots_by_schema_and_entity: HashMap<SharedStr, HashMap<EntityPk, SmallVec<[RowSlot; 1]>>>,
     slots_by_schema_and_file: HashMap<SharedStr, StagedScanFileCandidates>,
 }
 
 impl StagedScanCandidateIndex {
     fn insert(&mut self, row: PreparedStateRowRef<'_>, slot: RowSlot) {
+        self.slots_by_schema
+            .entry(row.schema_key.clone())
+            .or_default()
+            .push(slot);
         self.slots_by_schema_and_entity
             .entry(row.schema_key.clone())
             .or_default()
@@ -160,7 +165,24 @@ impl StagedScanCandidateIndex {
                 .iter()
                 .any(|file_id| matches!(file_id, NullableKeyFilter::Any))
         {
-            return None;
+            if let [schema_key] = filter.schema_keys.as_slice() {
+                return Some(Cow::Borrowed(
+                    self.slots_by_schema
+                        .get(schema_key.as_str())
+                        .map(SmallVec::as_slice)
+                        .unwrap_or(&[]),
+                ));
+            }
+
+            let mut slots = Vec::new();
+            for schema_key in &filter.schema_keys {
+                if let Some(candidate_slots) = self.slots_by_schema.get(schema_key.as_str()) {
+                    slots.extend(candidate_slots.iter().copied());
+                }
+            }
+            slots.sort_unstable();
+            slots.dedup();
+            return Some(Cow::Owned(slots));
         }
 
         if let ([schema_key], [file_id]) =
@@ -3634,7 +3656,7 @@ mod tests {
     }
 
     #[test]
-    fn file_staged_scan_indexes_null_and_declines_any_filter() {
+    fn file_staged_scan_indexes_null_and_uses_schema_candidates_for_any_filter() {
         let mut index = StagedScanCandidateIndex::default();
         index.insert(state_row("null", "one").borrowed(), RowSlot::State(4));
         index.insert(
@@ -3657,10 +3679,40 @@ mod tests {
             file_ids: vec![NullableKeyFilter::Any],
             ..LiveStateFilter::default()
         };
-        assert!(
-            index.slots_for_filter(&any_filter).is_none(),
-            "an Any file filter must retain the complete staged scan"
+        let Some(Cow::Borrowed(any_slots)) = index.slots_for_filter(&any_filter) else {
+            panic!("an Any file filter should use schema candidates");
+        };
+        assert_eq!(
+            any_slots,
+            &[RowSlot::State(4), RowSlot::State(9)],
+            "the established matcher still applies the Any file predicate"
         );
+    }
+
+    #[test]
+    fn schema_staged_scan_deduplicates_multi_schema_candidates_by_slot_order() {
+        let mut index = StagedScanCandidateIndex::default();
+        index.insert(state_row("first", "one").borrowed(), RowSlot::State(4));
+        index.insert(
+            state_row("second", "two")
+                .with_schema("other_schema")
+                .borrowed(),
+            RowSlot::State(9),
+        );
+
+        let filter = LiveStateFilter {
+            schema_keys: vec![
+                "other_schema".to_string(),
+                "lix_key_value".to_string(),
+                "lix_key_value".to_string(),
+            ],
+            ..LiveStateFilter::default()
+        };
+        let Some(Cow::Owned(slots)) = index.slots_for_filter(&filter) else {
+            panic!("multi-schema filter should use the candidate index");
+        };
+
+        assert_eq!(slots, vec![RowSlot::State(4), RowSlot::State(9)]);
     }
 
     #[test]

--- a/plugins/text-v2/src/core.rs
+++ b/plugins/text-v2/src/core.rs
@@ -7,7 +7,7 @@ use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use lix_order_key::OrderKey;
 use lix_plugin_api_v2 as lix;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 pub(crate) const LINE_SCHEMA_KEY: &str = "git_text_line_v2";
 const GIT_TEXT_SCAN_BYTES: usize = 8_000;
@@ -93,7 +93,7 @@ impl Iterator for AllUpserts {
 
 impl ExactSizeIterator for AllUpserts {}
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct LineSnapshot {
     id: String,
@@ -550,12 +550,36 @@ impl Line {
     }
 
     pub(crate) fn snapshot_bytes(&self) -> Result<Vec<u8>, String> {
-        serde_json::to_vec(&LineSnapshot {
-            id: self.id.clone(),
-            order_key: self.order_key.to_snapshot_string(),
-            content_base64: URL_SAFE_NO_PAD.encode(self.bytes.as_slice()),
-        })
-        .map_err(|error| format!("failed to serialize line snapshot: {error}"))
+        let id = serde_json::to_vec(&self.id)
+            .map_err(|error| format!("failed to serialize line ID: {error}"))?;
+        let order_key = serde_json::to_vec(&self.order_key.to_snapshot_string())
+            .map_err(|error| format!("failed to serialize line order key: {error}"))?;
+        let content_len = base64::encoded_len(self.bytes.len(), false)
+            .ok_or_else(|| "base64 line snapshot length overflow".to_owned())?;
+        let prefix_len = b"{\"id\":".len()
+            + id.len()
+            + b",\"order_key\":".len()
+            + order_key.len()
+            + b",\"content_base64\":\"".len();
+        let capacity = prefix_len
+            .checked_add(content_len)
+            .and_then(|length| length.checked_add(b"\"}".len()))
+            .ok_or_else(|| "line snapshot length overflow".to_owned())?;
+
+        let mut snapshot = Vec::with_capacity(capacity);
+        snapshot.extend_from_slice(b"{\"id\":");
+        snapshot.extend_from_slice(&id);
+        snapshot.extend_from_slice(b",\"order_key\":");
+        snapshot.extend_from_slice(&order_key);
+        snapshot.extend_from_slice(b",\"content_base64\":\"");
+        let content_start = snapshot.len();
+        snapshot.resize(content_start + content_len, 0);
+        let written = URL_SAFE_NO_PAD
+            .encode_slice(self.bytes.as_slice(), &mut snapshot[content_start..])
+            .map_err(|error| format!("failed to base64-encode line snapshot: {error}"))?;
+        snapshot.truncate(content_start + written);
+        snapshot.extend_from_slice(b"\"}");
+        Ok(snapshot)
     }
 
     fn from_snapshot(snapshot: &[u8]) -> Result<Self, String> {


### PR DESCRIPTION
## Summary

- add schema-only candidates to the staged transaction overlay index
- use schema candidates for unconstrained and `file_id = Any` scans instead of falling back to every staged semantic row
- preserve the established matcher as the final predicate
- deduplicate multi-schema candidates in stable slot order

## OpenClaw evidence

On pathological OpenClaw commit `c5c50a2141f2cdd805ae9b70a14a2e66dabac9b6` (559,701 durable semantic changes):

- stacked parallel base execute: 20,760 ms
- this PR execute: 20,200 ms
- incremental improvement: about 2.7%
- cumulative improvement from the 24,369.8 ms profiling baseline: about 17.1%
- peak RSS: 3.14 GB

Semantic counters are identical. The flat profile identified `PreparedStateRowOverlay::staged_batch` as the largest Lix self-time symbol (5.93%), with `memcmp` and `memmove` next.

This remains an incremental fix; it does not claim the final 2x plugin/control target.

## Validation

- `cargo check -p lix_engine`
- `cargo test -p lix_engine staged_scan --lib` (6 passed)
- `cargo test -p lix_engine fresh --lib` (7 passed)
- `cargo test -p lix_cli git_replay` (24 passed)
- exact OpenClaw c5 replay on RocksDB with identical counters

Stacked on #932.