### PR TITLE
Prevent warm text-plugin OOM on large minified files

### DIFF
--- a/.changenotes/bound-text-snapshot-allocation.md
+++ b/.changenotes/bound-text-snapshot-allocation.md
@@ -1,0 +1,8 @@
+---
+type: patch
+---
+
+The Git text WASM plugin now writes base64 content directly into its final JSON
+snapshot buffer, avoiding a duplicate large allocation for minified files.
+WASM Stores retain a bounded 128 MiB ceiling so warm updates of large minified
+documents can materialize their successor without exhausting linear memory.

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -87,8 +87,8 @@ impl EngineOptions {
     /// The Store limit bounds the active working set, not the number of plugin
     /// documents an atomic transaction may open. Transactions retire completed
     /// Stores and reuse their slots while preserving atomic commit.
-    /// Defaults are 64 MiB and sixteen Stores, bounding guest linear memory to
-    /// 1 GiB before host-side document state. Cached actors, active
+    /// Defaults are 128 MiB and sixteen Stores, bounding guest linear memory to
+    /// 2 GiB before host-side document state. Cached actors, active
     /// existing-document transaction leases, pending publications, cold-open
     /// candidates, and upgrade preflight Stores consume the same
     /// workspace-wide budget. Completed publications may retire their Stores

--- a/packages/engine/src/plugin/component.rs
+++ b/packages/engine/src/plugin/component.rs
@@ -15,9 +15,9 @@ use super::{
 /// for normal operations. The cold-file budget may extend up to this ceiling,
 /// but no guest call can exceed it.
 const MAX_PLUGIN_EXECUTION_TIMEOUT_MS: u64 = 60_000;
-/// Preserve enough headroom for recursive plugins while favoring a wider file
-/// working set over the prior 128 MiB per-actor ceiling.
-pub(crate) const DEFAULT_PLUGIN_V2_MEMORY_BYTES: u64 = 64 * 1024 * 1024;
+/// Preserve enough headroom for recursive plugins and large minified text
+/// snapshots. The live-Store working set remains independently bounded.
+pub(crate) const DEFAULT_PLUGIN_V2_MEMORY_BYTES: u64 = 128 * 1024 * 1024;
 
 fn plugin_v2_wasm_limits(max_memory_bytes: u64) -> Result<WasmLimits, LixError> {
     if max_memory_bytes == 0 {
@@ -269,11 +269,11 @@ mod tests {
         assert_eq!(WasmLimits::default().max_memory_bytes, 64 * 1024 * 1024);
         assert_eq!(
             default_plugin_v2_wasm_limits().max_memory_bytes,
-            64 * 1024 * 1024
+            128 * 1024 * 1024
         );
         assert_eq!(
             DEFAULT_PLUGIN_V2_MEMORY_BYTES * DEFAULT_MAX_LIVE_PLUGIN_STORES as u64,
-            1024 * 1024 * 1024
+            2 * 1024 * 1024 * 1024
         );
         assert_eq!(
             default_plugin_v2_wasm_limits().timeout_ms,

--- a/plugins/text-v2/src/core.rs
+++ b/plugins/text-v2/src/core.rs
@@ -7,7 +7,7 @@ use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use lix_order_key::OrderKey;
 use lix_plugin_api_v2 as lix;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 pub(crate) const LINE_SCHEMA_KEY: &str = "git_text_line_v2";
 const GIT_TEXT_SCAN_BYTES: usize = 8_000;
@@ -93,7 +93,7 @@ impl Iterator for AllUpserts {
 
 impl ExactSizeIterator for AllUpserts {}
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct LineSnapshot {
     id: String,
@@ -550,12 +550,36 @@ impl Line {
     }
 
     pub(crate) fn snapshot_bytes(&self) -> Result<Vec<u8>, String> {
-        serde_json::to_vec(&LineSnapshot {
-            id: self.id.clone(),
-            order_key: self.order_key.to_snapshot_string(),
-            content_base64: URL_SAFE_NO_PAD.encode(self.bytes.as_slice()),
-        })
-        .map_err(|error| format!("failed to serialize line snapshot: {error}"))
+        let id = serde_json::to_vec(&self.id)
+            .map_err(|error| format!("failed to serialize line ID: {error}"))?;
+        let order_key = serde_json::to_vec(&self.order_key.to_snapshot_string())
+            .map_err(|error| format!("failed to serialize line order key: {error}"))?;
+        let content_len = base64::encoded_len(self.bytes.len(), false)
+            .ok_or_else(|| "base64 line snapshot length overflow".to_owned())?;
+        let prefix_len = b"{\"id\":".len()
+            + id.len()
+            + b",\"order_key\":".len()
+            + order_key.len()
+            + b",\"content_base64\":\"".len();
+        let capacity = prefix_len
+            .checked_add(content_len)
+            .and_then(|length| length.checked_add(b"\"}".len()))
+            .ok_or_else(|| "line snapshot length overflow".to_owned())?;
+
+        let mut snapshot = Vec::with_capacity(capacity);
+        snapshot.extend_from_slice(b"{\"id\":");
+        snapshot.extend_from_slice(&id);
+        snapshot.extend_from_slice(b",\"order_key\":");
+        snapshot.extend_from_slice(&order_key);
+        snapshot.extend_from_slice(b",\"content_base64\":\"");
+        let content_start = snapshot.len();
+        snapshot.resize(content_start + content_len, 0);
+        let written = URL_SAFE_NO_PAD
+            .encode_slice(self.bytes.as_slice(), &mut snapshot[content_start..])
+            .map_err(|error| format!("failed to base64-encode line snapshot: {error}"))?;
+        snapshot.truncate(content_start + written);
+        snapshot.extend_from_slice(b"\"}");
+        Ok(snapshot)
     }
 
     fn from_snapshot(snapshot: &[u8]) -> Result<Self, String> {


### PR DESCRIPTION
## Summary

- encode Git-text base64 content directly into the final JSON snapshot buffer instead of allocating an intermediate large `String`
- set the bounded WASM Store ceiling to 128 MiB while retaining the independent 16-Store working-set bound
- keep eager semantic materialization and WASM isolation unchanged

## Reproduction and evidence

A continuous OpenClaw replay failed deterministically at commit `4ff5004d7cba35331bc138eacee70169ada0cabe` while updating the 5,516,029-byte minified `webchat.bundle.js`. The text component aborted in `Document::file_changed` under the former 64 MiB ceiling.

After this change:

- RocksDB replay passes the first 700 commits continuously
- the formerly failing commit completes in 663 ms
- its measured guest linear-memory high-water mark is 72,417,280 bytes, proving the former 64 MiB ceiling was insufficient
- it eagerly persists 17 durable semantic changes
- process peak RSS for the 700-commit replay is 3.34 GB

## Validation

- `cargo test -p plugin_git_text_v2` (9 passed)
- `cargo test -p lix_engine plugin_memory_policy_is_explicit --lib`
- continuous 700-commit OpenClaw replay with RocksDB and all bundled plugins

Stacked on #933.