### PR TITLE
bench(checkpoint): isolate public-history scaling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3511,6 +3511,7 @@ dependencies = [
  "lix_engine",
  "object_store 0.14.0",
  "slatedb",
+ "slatedb-common",
  "tempfile",
  "tokio",
 ]

--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -146,6 +146,12 @@ harness = false
 required-features = ["storage-benches", "slatedb"]
 
 [[bench]]
+name = "checkpoint_history_scale"
+path = "benches/checkpoint_history_scale.rs"
+harness = false
+required-features = ["storage-benches", "slatedb"]
+
+[[bench]]
 name = "fixed_live_history_scale"
 path = "benches/fixed_live_history_scale.rs"
 harness = false

--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -152,6 +152,12 @@ harness = false
 required-features = ["storage-benches", "slatedb"]
 
 [[bench]]
+name = "repository_gc_scale"
+path = "benches/repository_gc_scale.rs"
+harness = false
+required-features = ["storage-benches", "slatedb"]
+
+[[bench]]
 name = "fixed_live_history_scale"
 path = "benches/fixed_live_history_scale.rs"
 harness = false

--- a/packages/engine-benchmarks/benches/checkpoint_history_scale.rs
+++ b/packages/engine-benchmarks/benches/checkpoint_history_scale.rs
@@ -1,0 +1,614 @@
+use std::fmt::{self, Display, Formatter};
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+#[cfg(not(target_family = "wasm"))]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+use lix_engine::Engine;
+use lix_engine::changelog::bench::{append_ordered_commits, append_with_shape, stage_append_once};
+use lix_engine::storage::Storage;
+use lix_engine::storage_adapter::StorageAdapter;
+use lix_engine::storage_bench::{CheckpointCommitScanBenchMode, scan_checkpoint_commits_for_bench};
+use lix_rocksdb_storage::RocksDB;
+use lix_slatedb_storage::{SlateDB, SlateDBIoCounters, SlateDBIoSnapshot};
+
+const DEFAULT_BATCH_COMMITS: usize = 100_000;
+const DEFAULT_SAMPLES: usize = 5;
+const DEFAULT_WARMUPS: usize = 1;
+
+#[derive(Clone, Copy, Debug)]
+enum IdShape {
+    Ordered,
+    Hashed,
+}
+
+impl IdShape {
+    fn from_env() -> Self {
+        match std::env::var("LIX_CHECKPOINT_HISTORY_ID_SHAPE").as_deref() {
+            Ok("hashed") => Self::Hashed,
+            Ok("ordered") | Err(_) => Self::Ordered,
+            Ok(value) => {
+                panic!("checkpoint-history ID shape must be ordered or hashed, got {value}")
+            }
+        }
+    }
+
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Ordered => "ordered",
+            Self::Hashed => "hashed",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Backend {
+    RocksDB,
+    SlateDB,
+}
+
+impl Backend {
+    fn parse(value: &str) -> Self {
+        match value {
+            "rocksdb" => Self::RocksDB,
+            "slatedb" => Self::SlateDB,
+            _ => panic!("backend must be rocksdb or slatedb, got '{value}'"),
+        }
+    }
+}
+
+impl Display for Backend {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RocksDB => formatter.write_str("rocksdb"),
+            Self::SlateDB => formatter.write_str("slatedb"),
+        }
+    }
+}
+
+fn main() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("create checkpoint-history benchmark runtime");
+    runtime.block_on(run());
+}
+
+async fn run() {
+    let args = std::env::args().collect::<Vec<_>>();
+    let Some(command) = args.get(1).map(String::as_str) else {
+        print_usage();
+        return;
+    };
+    let Some(backend) = args.get(2).map(|value| Backend::parse(value)) else {
+        print_usage();
+        return;
+    };
+    let Some(path) = args.get(3).map(String::as_str) else {
+        print_usage();
+        return;
+    };
+    let history_changes = parse_positive(args.get(4), "history changes");
+    let commit_width = parse_positive(args.get(5), "commit width");
+    assert!(
+        history_changes.is_multiple_of(commit_width),
+        "history changes must divide evenly by commit width"
+    );
+    let expected_commits = history_changes / commit_width;
+    let id_shape = IdShape::from_env();
+    let query_checkpoint_count =
+        env_nonnegative_usize("LIX_CHECKPOINT_HISTORY_QUERY_CHECKPOINTS", 0);
+
+    match command {
+        "setup" | "setup-query" => {
+            let initialize_repository = command == "setup-query";
+            assert!(
+                !Path::new(path).exists(),
+                "refusing to overwrite checkpoint-history fixture {path}"
+            );
+            let batch_commits = args
+                .get(6)
+                .map_or(DEFAULT_BATCH_COMMITS, |value| {
+                    value
+                        .parse::<usize>()
+                        .expect("batch commits must be a positive integer")
+                })
+                .max(1);
+            match backend {
+                Backend::RocksDB => {
+                    let storage = RocksDB::open(path).expect("open checkpoint-history RocksDB");
+                    if initialize_repository {
+                        initialize_query_fixture(storage.clone(), query_checkpoint_count).await;
+                    }
+                    let seed = seed_public_commits(
+                        storage.clone(),
+                        history_changes,
+                        commit_width,
+                        batch_commits,
+                        id_shape,
+                    )
+                    .await;
+                    storage.flush().expect("flush checkpoint-history RocksDB");
+                    print_setup(
+                        backend,
+                        path,
+                        history_changes,
+                        commit_width,
+                        batch_commits,
+                        id_shape,
+                        initialize_repository,
+                        query_checkpoint_count,
+                        seed,
+                        SlateDBIoSnapshot::default(),
+                        false,
+                        0,
+                    );
+                }
+                Backend::SlateDB => {
+                    let counters = SlateDBIoCounters::default();
+                    let storage = SlateDB::open_with_io_counters(path, counters.clone())
+                        .expect("open checkpoint-history SlateDB");
+                    let before = counters.snapshot();
+                    if initialize_repository {
+                        initialize_query_fixture(storage.clone(), query_checkpoint_count).await;
+                    }
+                    let seed = seed_public_commits(
+                        storage.clone(),
+                        history_changes,
+                        commit_width,
+                        batch_commits,
+                        id_shape,
+                    )
+                    .await;
+                    let memtable_flushed = env_bool("LIX_CHECKPOINT_HISTORY_MEMTABLE_FLUSH", false);
+                    if memtable_flushed {
+                        storage
+                            .flush_memtable_for_diagnostics()
+                            .await
+                            .expect("flush checkpoint-history SlateDB memtable");
+                    } else {
+                        storage
+                            .flush()
+                            .await
+                            .expect("flush checkpoint-history SlateDB WAL");
+                    }
+                    let settle_ms = env_nonnegative_u64("LIX_CHECKPOINT_HISTORY_SETTLE_MS", 0);
+                    if settle_ms > 0 {
+                        tokio::time::sleep(Duration::from_millis(settle_ms)).await;
+                    }
+                    print_setup(
+                        backend,
+                        path,
+                        history_changes,
+                        commit_width,
+                        batch_commits,
+                        id_shape,
+                        initialize_repository,
+                        query_checkpoint_count,
+                        seed,
+                        counters.snapshot().saturating_sub(before),
+                        memtable_flushed,
+                        settle_ms,
+                    );
+                }
+            }
+        }
+        "measure" => {
+            let mode = match args.get(6).map(String::as_str).unwrap_or("materialize") {
+                "materialize" => CheckpointCommitScanBenchMode::Materialize,
+                "stream" => CheckpointCommitScanBenchMode::Stream,
+                value => panic!("scan mode must be materialize or stream, got '{value}'"),
+            };
+            let samples = args
+                .get(7)
+                .map_or(DEFAULT_SAMPLES, |value| {
+                    value
+                        .parse::<usize>()
+                        .expect("samples must be a positive integer")
+                })
+                .max(1);
+            let warmups = args.get(8).map_or(DEFAULT_WARMUPS, |value| {
+                value
+                    .parse::<usize>()
+                    .expect("warmups must be a non-negative integer")
+            });
+            match backend {
+                Backend::RocksDB => {
+                    measure(
+                        RocksDB::open(path).expect("open checkpoint-history RocksDB"),
+                        backend,
+                        path,
+                        history_changes,
+                        commit_width,
+                        expected_commits,
+                        mode,
+                        samples,
+                        warmups,
+                        None,
+                    )
+                    .await;
+                }
+                Backend::SlateDB => {
+                    let counters = SlateDBIoCounters::default();
+                    measure(
+                        SlateDB::open_with_io_counters(path, counters.clone())
+                            .expect("open checkpoint-history SlateDB"),
+                        backend,
+                        path,
+                        history_changes,
+                        commit_width,
+                        expected_commits,
+                        mode,
+                        samples,
+                        warmups,
+                        Some(counters),
+                    )
+                    .await;
+                }
+            }
+        }
+        "measure-query" => {
+            let samples = args
+                .get(6)
+                .map_or(DEFAULT_SAMPLES, |value| {
+                    value
+                        .parse::<usize>()
+                        .expect("samples must be a positive integer")
+                })
+                .max(1);
+            let warmups = args.get(7).map_or(DEFAULT_WARMUPS, |value| {
+                value
+                    .parse::<usize>()
+                    .expect("warmups must be a non-negative integer")
+            });
+            match backend {
+                Backend::RocksDB => {
+                    measure_query(
+                        RocksDB::open(path).expect("open checkpoint-query RocksDB"),
+                        backend,
+                        path,
+                        history_changes,
+                        commit_width,
+                        samples,
+                        warmups,
+                        query_checkpoint_count + 1,
+                        None,
+                    )
+                    .await;
+                }
+                Backend::SlateDB => {
+                    let counters = SlateDBIoCounters::default();
+                    measure_query(
+                        SlateDB::open_with_io_counters(path, counters.clone())
+                            .expect("open checkpoint-query SlateDB"),
+                        backend,
+                        path,
+                        history_changes,
+                        commit_width,
+                        samples,
+                        warmups,
+                        query_checkpoint_count + 1,
+                        Some(counters),
+                    )
+                    .await;
+                }
+            }
+        }
+        _ => print_usage(),
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SeedResult {
+    elapsed: Duration,
+    puts: usize,
+    written_bytes: usize,
+}
+
+async fn seed_public_commits<StorageImpl>(
+    storage: StorageImpl,
+    history_changes: usize,
+    commit_width: usize,
+    batch_commits: usize,
+    id_shape: IdShape,
+) -> SeedResult
+where
+    StorageImpl: Storage + Clone + Sync,
+{
+    let commit_count = history_changes / commit_width;
+    let started = Instant::now();
+    let mut puts = 0usize;
+    let mut written_bytes = 0usize;
+    for batch_start in (0..commit_count).step_by(batch_commits) {
+        let count = (commit_count - batch_start).min(batch_commits);
+        let append = match id_shape {
+            IdShape::Ordered => append_ordered_commits(batch_start, count),
+            IdShape::Hashed => append_with_shape(
+                &format!("checkpoint-history-{history_changes}-{commit_width}-{batch_start}"),
+                count,
+                0,
+            ),
+        }
+        .expect("build checkpoint-history commit batch");
+        let stats = stage_append_once(storage.clone(), &append)
+            .await
+            .expect("stage checkpoint-history commit batch");
+        puts = puts.saturating_add(stats.puts);
+        written_bytes = written_bytes.saturating_add(stats.bytes_written);
+    }
+    SeedResult {
+        elapsed: started.elapsed(),
+        puts,
+        written_bytes,
+    }
+}
+
+async fn initialize_query_fixture<StorageImpl>(storage: StorageImpl, additional_checkpoints: usize)
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize checkpoint-query fixture");
+    if additional_checkpoints == 0 {
+        return;
+    }
+    let engine = Engine::new(storage)
+        .await
+        .expect("open checkpoint-query setup engine");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("open checkpoint-query setup session");
+    for _ in 0..additional_checkpoints {
+        session
+            .create_checkpoint()
+            .await
+            .expect("create checkpoint-query fixture checkpoint");
+    }
+}
+
+#[expect(clippy::too_many_arguments)]
+async fn measure<StorageImpl>(
+    storage: StorageImpl,
+    backend: Backend,
+    path: &str,
+    history_changes: usize,
+    commit_width: usize,
+    expected_commits: usize,
+    mode: CheckpointCommitScanBenchMode,
+    samples: usize,
+    warmups: usize,
+    counters: Option<SlateDBIoCounters>,
+) where
+    StorageImpl: Storage,
+{
+    let adapter = StorageAdapter::new(storage);
+    for _ in 0..warmups {
+        let result = scan_checkpoint_commits_for_bench(&adapter, mode)
+            .await
+            .expect("warm checkpoint commit scan");
+        assert_eq!(result.commits, expected_commits);
+    }
+    let io_before = counters
+        .as_ref()
+        .map_or_else(SlateDBIoSnapshot::default, SlateDBIoCounters::snapshot);
+    let mut timings = Vec::with_capacity(samples);
+    let mut pages = 0usize;
+    for _ in 0..samples {
+        let started = Instant::now();
+        let result = scan_checkpoint_commits_for_bench(&adapter, mode)
+            .await
+            .expect("measure checkpoint commit scan");
+        timings.push(started.elapsed());
+        assert_eq!(result.commits, expected_commits);
+        pages = result.pages;
+    }
+    timings.sort_unstable();
+    let io = counters
+        .as_ref()
+        .map_or_else(SlateDBIoSnapshot::default, SlateDBIoCounters::snapshot)
+        .saturating_sub(io_before);
+    println!(
+        "checkpoint_history_scale,phase=measure,backend={backend},mode={},\
+         history_changes={history_changes},commit_width={commit_width},commits={expected_commits},\
+         pages={pages},warmups={warmups},samples={samples},\
+         p50_ms={},p95_ms={},p99_ms={},\
+         read_objects={},read_bytes={},write_objects={},write_bytes={},\
+         list_operations={},listed_objects={},backend_bytes={}",
+        mode_name(mode),
+        millis(percentile(&timings, 50)),
+        millis(percentile(&timings, 95)),
+        millis(percentile(&timings, 99)),
+        io.read_objects,
+        io.read_bytes,
+        io.write_objects,
+        io.write_bytes,
+        io.list_operations,
+        io.listed_objects,
+        directory_bytes(Path::new(path)),
+    );
+}
+
+#[expect(clippy::too_many_arguments)]
+async fn measure_query<StorageImpl>(
+    storage: StorageImpl,
+    backend: Backend,
+    path: &str,
+    history_changes: usize,
+    commit_width: usize,
+    samples: usize,
+    warmups: usize,
+    expected_checkpoints: usize,
+    counters: Option<SlateDBIoCounters>,
+) where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let engine = Engine::new(storage)
+        .await
+        .expect("open checkpoint-query engine");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("open checkpoint-query session");
+    for _ in 0..warmups {
+        let rows = session
+            .execute("SELECT commit_id FROM lix_checkpoint", &[])
+            .await
+            .expect("warm checkpoint query");
+        assert_eq!(rows.len(), expected_checkpoints);
+    }
+    let io_before = counters
+        .as_ref()
+        .map_or_else(SlateDBIoSnapshot::default, SlateDBIoCounters::snapshot);
+    let mut timings = Vec::with_capacity(samples);
+    for _ in 0..samples {
+        let started = Instant::now();
+        let rows = session
+            .execute("SELECT commit_id FROM lix_checkpoint", &[])
+            .await
+            .expect("measure checkpoint query");
+        timings.push(started.elapsed());
+        assert_eq!(rows.len(), expected_checkpoints);
+    }
+    timings.sort_unstable();
+    let io = counters
+        .as_ref()
+        .map_or_else(SlateDBIoSnapshot::default, SlateDBIoCounters::snapshot)
+        .saturating_sub(io_before);
+    println!(
+        "checkpoint_history_scale,phase=measure_query,backend={backend},\
+         history_changes={history_changes},commit_width={commit_width},\
+         requested_checkpoints={expected_checkpoints},\
+         warmups={warmups},samples={samples},\
+         p50_ms={},p95_ms={},p99_ms={},\
+         read_objects={},read_bytes={},write_objects={},write_bytes={},\
+         list_operations={},listed_objects={},backend_bytes={}",
+        millis(percentile(&timings, 50)),
+        millis(percentile(&timings, 95)),
+        millis(percentile(&timings, 99)),
+        io.read_objects,
+        io.read_bytes,
+        io.write_objects,
+        io.write_bytes,
+        io.list_operations,
+        io.listed_objects,
+        directory_bytes(Path::new(path)),
+    );
+}
+
+#[expect(clippy::too_many_arguments)]
+fn print_setup(
+    backend: Backend,
+    path: &str,
+    history_changes: usize,
+    commit_width: usize,
+    batch_commits: usize,
+    id_shape: IdShape,
+    initialized_repository: bool,
+    query_checkpoints: usize,
+    seed: SeedResult,
+    io: SlateDBIoSnapshot,
+    memtable_flushed: bool,
+    settle_ms: u64,
+) {
+    println!(
+        "checkpoint_history_scale,phase=setup,backend={backend},\
+         history_changes={history_changes},commit_width={commit_width},commits={},\
+         batch_commits={batch_commits},id_shape={},initialized_repository={initialized_repository},\
+         query_checkpoints={},seed_ms={},ingest_changes_per_second={:.1},\
+         staged_puts={},logical_written_bytes={},memtable_flushed={memtable_flushed},\
+         settle_ms={settle_ms},read_objects={},read_bytes={},write_objects={},write_bytes={},\
+         list_operations={},listed_objects={},backend_bytes={}",
+        history_changes / commit_width,
+        id_shape.name(),
+        query_checkpoints + usize::from(initialized_repository),
+        seed.elapsed.as_millis(),
+        history_changes as f64 / seed.elapsed.as_secs_f64(),
+        seed.puts,
+        seed.written_bytes,
+        io.read_objects,
+        io.read_bytes,
+        io.write_objects,
+        io.write_bytes,
+        io.list_operations,
+        io.listed_objects,
+        directory_bytes(Path::new(path)),
+    );
+}
+
+fn percentile(sorted: &[Duration], percentile: usize) -> Duration {
+    let rank = sorted.len().saturating_mul(percentile).div_ceil(100);
+    sorted[rank.saturating_sub(1).min(sorted.len() - 1)]
+}
+
+fn millis(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}
+
+const fn mode_name(mode: CheckpointCommitScanBenchMode) -> &'static str {
+    match mode {
+        CheckpointCommitScanBenchMode::Materialize => "materialize",
+        CheckpointCommitScanBenchMode::Stream => "stream",
+    }
+}
+
+fn parse_positive(value: Option<&String>, label: &str) -> usize {
+    value
+        .unwrap_or_else(|| panic!("missing {label}"))
+        .parse::<usize>()
+        .unwrap_or_else(|_| panic!("{label} must be a positive integer"))
+        .max(1)
+}
+
+fn env_bool(name: &str, default: bool) -> bool {
+    std::env::var(name).map_or(default, |value| {
+        matches!(value.as_str(), "1" | "true" | "yes")
+    })
+}
+
+fn env_nonnegative_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn env_nonnegative_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn directory_bytes(path: &Path) -> u64 {
+    std::fs::read_dir(path).map_or(0, |entries| {
+        entries
+            .filter_map(Result::ok)
+            .map(|entry| {
+                entry.metadata().map_or(0, |metadata| {
+                    if metadata.is_dir() {
+                        directory_bytes(&entry.path())
+                    } else {
+                        metadata.len()
+                    }
+                })
+            })
+            .sum()
+    })
+}
+
+fn print_usage() {
+    eprintln!(
+        "usage:\n  checkpoint_history_scale setup <rocksdb|slatedb> <path> \
+         <history-changes> <commit-width> [batch-commits]\n  \
+         checkpoint_history_scale setup-query <rocksdb|slatedb> <path> \
+         <history-changes> <commit-width> [batch-commits]\n  \
+         checkpoint_history_scale measure <rocksdb|slatedb> <path> \
+         <history-changes> <commit-width> <materialize|stream> [samples] [warmups]\n  \
+         checkpoint_history_scale measure-query <rocksdb|slatedb> <path> \
+         <history-changes> <commit-width> [samples] [warmups]"
+    );
+}

--- a/packages/engine-benchmarks/benches/checkpoint_history_scale.rs
+++ b/packages/engine-benchmarks/benches/checkpoint_history_scale.rs
@@ -577,10 +577,15 @@ fn env_nonnegative_u64(name: &str, default: u64) -> u64 {
 }
 
 fn env_nonnegative_usize(name: &str, default: usize) -> usize {
-    std::env::var(name)
-        .ok()
-        .and_then(|value| value.parse().ok())
-        .unwrap_or(default)
+    match std::env::var(name) {
+        Ok(value) => value
+            .parse()
+            .unwrap_or_else(|_| panic!("{name} must be a non-negative integer")),
+        Err(std::env::VarError::NotPresent) => default,
+        Err(std::env::VarError::NotUnicode(_)) => {
+            panic!("{name} must contain valid UTF-8")
+        }
+    }
 }
 
 fn directory_bytes(path: &Path) -> u64 {

--- a/packages/engine-benchmarks/benches/repository_gc_scale.rs
+++ b/packages/engine-benchmarks/benches/repository_gc_scale.rs
@@ -1,0 +1,413 @@
+use std::fmt::{self, Display, Formatter};
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+#[cfg(not(target_family = "wasm"))]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+use lix_engine::Engine;
+use lix_engine::changelog::bench::{append_ordered_commits, stage_append_once};
+use lix_engine::storage::Storage;
+use lix_engine::storage_adapter::StorageAdapter;
+use lix_engine::storage_bench::{RepositoryGcBenchResult, plan_repository_gc_for_bench};
+use lix_rocksdb_storage::RocksDB;
+use lix_slatedb_storage::{SlateDB, SlateDBIoCounters, SlateDBIoSnapshot};
+
+const DEFAULT_BATCH_COMMITS: usize = 100_000;
+const DEFAULT_SAMPLES: usize = 5;
+const DEFAULT_WARMUPS: usize = 1;
+
+#[derive(Clone, Copy, Debug)]
+enum Backend {
+    RocksDB,
+    SlateDB,
+}
+
+impl Backend {
+    fn parse(value: &str) -> Self {
+        match value {
+            "rocksdb" => Self::RocksDB,
+            "slatedb" => Self::SlateDB,
+            _ => panic!("backend must be rocksdb or slatedb, got '{value}'"),
+        }
+    }
+}
+
+impl Display for Backend {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RocksDB => formatter.write_str("rocksdb"),
+            Self::SlateDB => formatter.write_str("slatedb"),
+        }
+    }
+}
+
+fn main() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("create repository-GC benchmark runtime");
+    runtime.block_on(run());
+}
+
+async fn run() {
+    let args = std::env::args().collect::<Vec<_>>();
+    let Some(command) = args.get(1).map(String::as_str) else {
+        print_usage();
+        return;
+    };
+    let Some(backend) = args.get(2).map(|value| Backend::parse(value)) else {
+        print_usage();
+        return;
+    };
+    let Some(path) = args.get(3).map(String::as_str) else {
+        print_usage();
+        return;
+    };
+    let history_changes = parse_positive(args.get(4), "history changes");
+    let commit_width = parse_positive(args.get(5), "commit width");
+    assert!(
+        history_changes.is_multiple_of(commit_width),
+        "history changes must divide evenly by commit width"
+    );
+    let expected_swept_commits = history_changes / commit_width;
+
+    match command {
+        "setup" => {
+            assert!(
+                !Path::new(path).exists(),
+                "refusing to overwrite repository-GC fixture {path}"
+            );
+            let batch_commits = args
+                .get(6)
+                .map_or(DEFAULT_BATCH_COMMITS, |value| {
+                    value
+                        .parse::<usize>()
+                        .expect("batch commits must be a positive integer")
+                })
+                .max(1);
+            match backend {
+                Backend::RocksDB => {
+                    let storage = RocksDB::open(path).expect("open repository-GC RocksDB");
+                    Engine::initialize(storage.clone())
+                        .await
+                        .expect("initialize repository-GC RocksDB fixture");
+                    let seed = seed_unreachable_commits(
+                        storage.clone(),
+                        expected_swept_commits,
+                        batch_commits,
+                    )
+                    .await;
+                    storage.flush().expect("flush repository-GC RocksDB");
+                    print_setup(
+                        backend,
+                        path,
+                        history_changes,
+                        commit_width,
+                        batch_commits,
+                        seed,
+                        SlateDBIoSnapshot::default(),
+                        false,
+                        0,
+                    );
+                }
+                Backend::SlateDB => {
+                    let counters = SlateDBIoCounters::default();
+                    let storage = SlateDB::open_with_io_counters(path, counters.clone())
+                        .expect("open repository-GC SlateDB");
+                    let before = counters.snapshot();
+                    Engine::initialize(storage.clone())
+                        .await
+                        .expect("initialize repository-GC SlateDB fixture");
+                    let seed = seed_unreachable_commits(
+                        storage.clone(),
+                        expected_swept_commits,
+                        batch_commits,
+                    )
+                    .await;
+                    let memtable_flushed = env_bool("LIX_REPOSITORY_GC_MEMTABLE_FLUSH", false);
+                    if memtable_flushed {
+                        storage
+                            .flush_memtable_for_diagnostics()
+                            .await
+                            .expect("flush repository-GC SlateDB memtable");
+                    } else {
+                        storage
+                            .flush()
+                            .await
+                            .expect("flush repository-GC SlateDB WAL");
+                    }
+                    let settle_ms = env_nonnegative_u64("LIX_REPOSITORY_GC_SETTLE_MS", 0);
+                    if settle_ms > 0 {
+                        tokio::time::sleep(Duration::from_millis(settle_ms)).await;
+                    }
+                    print_setup(
+                        backend,
+                        path,
+                        history_changes,
+                        commit_width,
+                        batch_commits,
+                        seed,
+                        counters.snapshot().saturating_sub(before),
+                        memtable_flushed,
+                        settle_ms,
+                    );
+                }
+            }
+        }
+        "measure" => {
+            let samples = args
+                .get(6)
+                .map_or(DEFAULT_SAMPLES, |value| {
+                    value.parse::<usize>().expect("samples must be positive")
+                })
+                .max(1);
+            let warmups = args.get(7).map_or(DEFAULT_WARMUPS, |value| {
+                value
+                    .parse::<usize>()
+                    .expect("warmups must be non-negative")
+            });
+            match backend {
+                Backend::RocksDB => {
+                    measure(
+                        RocksDB::open(path).expect("open repository-GC RocksDB"),
+                        backend,
+                        path,
+                        history_changes,
+                        commit_width,
+                        expected_swept_commits,
+                        samples,
+                        warmups,
+                        None,
+                    )
+                    .await;
+                }
+                Backend::SlateDB => {
+                    let counters = SlateDBIoCounters::default();
+                    measure(
+                        SlateDB::open_with_io_counters(path, counters.clone())
+                            .expect("open repository-GC SlateDB"),
+                        backend,
+                        path,
+                        history_changes,
+                        commit_width,
+                        expected_swept_commits,
+                        samples,
+                        warmups,
+                        Some(counters),
+                    )
+                    .await;
+                }
+            }
+        }
+        _ => print_usage(),
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SeedResult {
+    elapsed: Duration,
+    puts: usize,
+    written_bytes: usize,
+}
+
+async fn seed_unreachable_commits<StorageImpl>(
+    storage: StorageImpl,
+    commit_count: usize,
+    batch_commits: usize,
+) -> SeedResult
+where
+    StorageImpl: Storage + Clone + Sync,
+{
+    let started = Instant::now();
+    let mut puts = 0usize;
+    let mut written_bytes = 0usize;
+    for batch_start in (0..commit_count).step_by(batch_commits) {
+        let count = (commit_count - batch_start).min(batch_commits);
+        let append =
+            append_ordered_commits(batch_start, count).expect("build repository-GC commit batch");
+        let stats = stage_append_once(storage.clone(), &append)
+            .await
+            .expect("stage repository-GC commit batch");
+        puts = puts.saturating_add(stats.puts);
+        written_bytes = written_bytes.saturating_add(stats.bytes_written);
+    }
+    SeedResult {
+        elapsed: started.elapsed(),
+        puts,
+        written_bytes,
+    }
+}
+
+#[expect(clippy::too_many_arguments)]
+async fn measure<StorageImpl>(
+    storage: StorageImpl,
+    backend: Backend,
+    path: &str,
+    history_changes: usize,
+    commit_width: usize,
+    expected_swept_commits: usize,
+    samples: usize,
+    warmups: usize,
+    counters: Option<SlateDBIoCounters>,
+) where
+    StorageImpl: Storage,
+{
+    let adapter = StorageAdapter::new(storage);
+    for _ in 0..warmups {
+        let result = plan_repository_gc_for_bench(&adapter)
+            .await
+            .expect("warm repository-GC plan");
+        assert_eq!(result.swept_commits, expected_swept_commits);
+    }
+    let io_before = counters
+        .as_ref()
+        .map_or_else(SlateDBIoSnapshot::default, SlateDBIoCounters::snapshot);
+    let mut timings = Vec::with_capacity(samples);
+    let mut last = RepositoryGcBenchResult::default();
+    for _ in 0..samples {
+        let started = Instant::now();
+        last = plan_repository_gc_for_bench(&adapter)
+            .await
+            .expect("measure repository-GC plan");
+        timings.push(started.elapsed());
+        assert_eq!(last.swept_commits, expected_swept_commits);
+    }
+    timings.sort_unstable();
+    let io = counters
+        .as_ref()
+        .map_or_else(SlateDBIoSnapshot::default, SlateDBIoCounters::snapshot)
+        .saturating_sub(io_before);
+    println!(
+        "repository_gc_scale,phase=measure,backend={backend},\
+         history_changes={history_changes},commit_width={commit_width},\
+         swept_commits={},live_commits={},swept_standalone_changes={},swept_payloads={},\
+         samples={samples},warmups={warmups},p50_ms={},p95_ms={},p99_ms={},\
+         root_discovery_us={},changelog_us={},tracked_root_stage_us={},gc_total_us={},\
+         staged_puts={},staged_deletes={},staged_written_bytes={},\
+         delete_descriptors={},delete_descriptor_capacity={},\
+         key_inline_bytes={},key_inline_capacity={},\
+         key_shared_buffers={},key_shared_bytes={},key_shared_capacity={},\
+         read_objects={},read_bytes={},write_objects={},write_bytes={},\
+         list_operations={},listed_objects={},backend_bytes={}",
+        last.swept_commits,
+        last.live_commits,
+        last.swept_standalone_changes,
+        last.swept_payloads,
+        millis(percentile(&timings, 50)),
+        millis(percentile(&timings, 95)),
+        millis(percentile(&timings, 99)),
+        last.root_discovery_us,
+        last.changelog_us,
+        last.tracked_root_stage_us,
+        last.total_us,
+        last.staged_puts,
+        last.staged_deletes,
+        last.staged_written_bytes,
+        last.delete_descriptors,
+        last.delete_descriptor_capacity,
+        last.key_inline_bytes,
+        last.key_inline_capacity,
+        last.key_shared_buffers,
+        last.key_shared_bytes,
+        last.key_shared_capacity,
+        io.read_objects,
+        io.read_bytes,
+        io.write_objects,
+        io.write_bytes,
+        io.list_operations,
+        io.listed_objects,
+        directory_bytes(Path::new(path)),
+    );
+}
+
+#[expect(clippy::too_many_arguments)]
+fn print_setup(
+    backend: Backend,
+    path: &str,
+    history_changes: usize,
+    commit_width: usize,
+    batch_commits: usize,
+    seed: SeedResult,
+    io: SlateDBIoSnapshot,
+    memtable_flushed: bool,
+    settle_ms: u64,
+) {
+    println!(
+        "repository_gc_scale,phase=setup,backend={backend},history_changes={history_changes},\
+         commit_width={commit_width},commits={},batch_commits={batch_commits},\
+         seed_ms={},ingest_changes_per_second={:.1},staged_puts={},logical_written_bytes={},\
+         memtable_flushed={memtable_flushed},settle_ms={settle_ms},\
+         read_objects={},read_bytes={},write_objects={},write_bytes={},\
+         list_operations={},listed_objects={},backend_bytes={}",
+        history_changes / commit_width,
+        seed.elapsed.as_millis(),
+        history_changes as f64 / seed.elapsed.as_secs_f64(),
+        seed.puts,
+        seed.written_bytes,
+        io.read_objects,
+        io.read_bytes,
+        io.write_objects,
+        io.write_bytes,
+        io.list_operations,
+        io.listed_objects,
+        directory_bytes(Path::new(path)),
+    );
+}
+
+fn percentile(sorted: &[Duration], percentile: usize) -> Duration {
+    let rank = sorted.len().saturating_mul(percentile).div_ceil(100);
+    sorted[rank.saturating_sub(1).min(sorted.len() - 1)]
+}
+
+fn millis(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}
+
+fn parse_positive(value: Option<&String>, label: &str) -> usize {
+    value
+        .unwrap_or_else(|| panic!("missing {label}"))
+        .parse::<usize>()
+        .unwrap_or_else(|_| panic!("{label} must be positive"))
+        .max(1)
+}
+
+fn env_bool(name: &str, default: bool) -> bool {
+    std::env::var(name).map_or(default, |value| {
+        matches!(value.as_str(), "1" | "true" | "yes")
+    })
+}
+
+fn env_nonnegative_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn directory_bytes(path: &Path) -> u64 {
+    std::fs::read_dir(path).map_or(0, |entries| {
+        entries
+            .filter_map(Result::ok)
+            .map(|entry| {
+                entry.metadata().map_or(0, |metadata| {
+                    if metadata.is_dir() {
+                        directory_bytes(&entry.path())
+                    } else {
+                        metadata.len()
+                    }
+                })
+            })
+            .sum()
+    })
+}
+
+fn print_usage() {
+    eprintln!(
+        "usage:\n  repository_gc_scale setup <rocksdb|slatedb> <path> \
+         <history-changes> <commit-width> [batch-commits]\n  \
+         repository_gc_scale measure <rocksdb|slatedb> <path> \
+         <history-changes> <commit-width> [samples] [warmups]"
+    );
+}

--- a/packages/engine-benchmarks/benches/repository_gc_scale.rs
+++ b/packages/engine-benchmarks/benches/repository_gc_scale.rs
@@ -320,6 +320,7 @@ async fn measure<StorageImpl>(
         io.listed_objects,
         directory_bytes(Path::new(path)),
     );
+    print_io_categories("measure", backend, history_changes, commit_width, io);
 }
 
 #[expect(clippy::too_many_arguments)]
@@ -353,6 +354,61 @@ fn print_setup(
         io.list_operations,
         io.listed_objects,
         directory_bytes(Path::new(path)),
+    );
+    print_io_categories("setup", backend, history_changes, commit_width, io);
+}
+
+fn print_io_categories(
+    phase: &str,
+    backend: Backend,
+    history_changes: usize,
+    commit_width: usize,
+    io: SlateDBIoSnapshot,
+) {
+    println!(
+        "repository_gc_scale_io,phase={phase},backend={backend},\
+         history_changes={history_changes},commit_width={commit_width},\
+         wal_read_objects={},wal_read_bytes={},wal_write_objects={},wal_write_bytes={},\
+         compacted_read_objects={},compacted_read_bytes={},\
+         compacted_write_objects={},compacted_write_bytes={},\
+         manifest_read_objects={},manifest_read_bytes={},\
+         manifest_write_objects={},manifest_write_bytes={},\
+         compactions_read_objects={},compactions_read_bytes={},\
+         compactions_write_objects={},compactions_write_bytes={},\
+         other_read_objects={},other_read_bytes={},\
+         other_write_objects={},other_write_bytes={},\
+         main_read_requests={},main_write_requests={},\
+         reader_read_requests={},reader_write_requests={},\
+         compactor_read_requests={},compactor_write_requests={},\
+         gc_read_requests={},gc_write_requests={}",
+        io.wal.read_objects,
+        io.wal.read_bytes,
+        io.wal.write_objects,
+        io.wal.write_bytes,
+        io.compacted.read_objects,
+        io.compacted.read_bytes,
+        io.compacted.write_objects,
+        io.compacted.write_bytes,
+        io.manifest.read_objects,
+        io.manifest.read_bytes,
+        io.manifest.write_objects,
+        io.manifest.write_bytes,
+        io.compactions.read_objects,
+        io.compactions.read_bytes,
+        io.compactions.write_objects,
+        io.compactions.write_bytes,
+        io.other.read_objects,
+        io.other.read_bytes,
+        io.other.write_objects,
+        io.other.write_bytes,
+        io.main.read_requests,
+        io.main.write_requests,
+        io.reader.read_requests,
+        io.reader.write_requests,
+        io.compactor.read_requests,
+        io.compactor.write_requests,
+        io.gc.read_requests,
+        io.gc.write_requests,
     );
 }
 

--- a/packages/engine-benchmarks/benches/repository_gc_scale.rs
+++ b/packages/engine-benchmarks/benches/repository_gc_scale.rs
@@ -265,16 +265,31 @@ async fn measure<StorageImpl>(
         .as_ref()
         .map_or_else(SlateDBIoSnapshot::default, SlateDBIoCounters::snapshot);
     let mut timings = Vec::with_capacity(samples);
-    let mut last = RepositoryGcBenchResult::default();
+    let mut results = Vec::with_capacity(samples);
     for _ in 0..samples {
         let started = Instant::now();
-        last = plan_repository_gc_for_bench(&adapter)
+        let result = plan_repository_gc_for_bench(&adapter)
             .await
             .expect("measure repository-GC plan");
         timings.push(started.elapsed());
-        assert_eq!(last.swept_commits, expected_swept_commits);
+        assert_eq!(result.swept_commits, expected_swept_commits);
+        results.push(result);
     }
     timings.sort_unstable();
+    let last = *results.last().expect("repository-GC samples are positive");
+    let phase_percentiles = |select: fn(&RepositoryGcBenchResult) -> u64| {
+        let mut values = results.iter().map(select).collect::<Vec<_>>();
+        values.sort_unstable();
+        (
+            percentile_u64(&values, 50),
+            percentile_u64(&values, 95),
+            percentile_u64(&values, 99),
+        )
+    };
+    let root_discovery = phase_percentiles(|result| result.root_discovery_us);
+    let changelog = phase_percentiles(|result| result.changelog_us);
+    let tracked_root_stage = phase_percentiles(|result| result.tracked_root_stage_us);
+    let gc_total = phase_percentiles(|result| result.total_us);
     let io = counters
         .as_ref()
         .map_or_else(SlateDBIoSnapshot::default, SlateDBIoCounters::snapshot)
@@ -284,7 +299,10 @@ async fn measure<StorageImpl>(
          history_changes={history_changes},commit_width={commit_width},\
          swept_commits={},live_commits={},swept_standalone_changes={},swept_payloads={},\
          samples={samples},warmups={warmups},p50_ms={},p95_ms={},p99_ms={},\
-         root_discovery_us={},changelog_us={},tracked_root_stage_us={},gc_total_us={},\
+         root_discovery_p50_us={},root_discovery_p95_us={},root_discovery_p99_us={},\
+         changelog_p50_us={},changelog_p95_us={},changelog_p99_us={},\
+         tracked_root_stage_p50_us={},tracked_root_stage_p95_us={},tracked_root_stage_p99_us={},\
+         gc_total_p50_us={},gc_total_p95_us={},gc_total_p99_us={},\
          staged_puts={},staged_deletes={},staged_written_bytes={},\
          delete_descriptors={},delete_descriptor_capacity={},\
          key_inline_bytes={},key_inline_capacity={},\
@@ -298,10 +316,18 @@ async fn measure<StorageImpl>(
         millis(percentile(&timings, 50)),
         millis(percentile(&timings, 95)),
         millis(percentile(&timings, 99)),
-        last.root_discovery_us,
-        last.changelog_us,
-        last.tracked_root_stage_us,
-        last.total_us,
+        root_discovery.0,
+        root_discovery.1,
+        root_discovery.2,
+        changelog.0,
+        changelog.1,
+        changelog.2,
+        tracked_root_stage.0,
+        tracked_root_stage.1,
+        tracked_root_stage.2,
+        gc_total.0,
+        gc_total.1,
+        gc_total.2,
         last.staged_puts,
         last.staged_deletes,
         last.staged_written_bytes,
@@ -357,6 +383,11 @@ fn print_setup(
 }
 
 fn percentile(sorted: &[Duration], percentile: usize) -> Duration {
+    let rank = sorted.len().saturating_mul(percentile).div_ceil(100);
+    sorted[rank.saturating_sub(1).min(sorted.len() - 1)]
+}
+
+fn percentile_u64(sorted: &[u64], percentile: usize) -> u64 {
     let rank = sorted.len().saturating_mul(percentile).div_ceil(100);
     sorted[rank.saturating_sub(1).min(sorted.len() - 1)]
 }

--- a/packages/engine/src/changelog/bench_support.rs
+++ b/packages/engine/src/changelog/bench_support.rs
@@ -216,6 +216,34 @@ pub fn append_with_shape(
     direct_append_with_shape(name, commit_count, change_count)
 }
 
+/// Builds commit-only public facts with production-shaped monotonic UUIDv7
+/// keys. This avoids turning benchmark label hashing into random-LSM ingest.
+pub fn append_ordered_commits(
+    first_commit_index: usize,
+    commit_count: usize,
+) -> Result<BenchAppend, LixError> {
+    let mut append = ChangelogAppend::default();
+    append.commits.reserve(commit_count);
+    for offset in 0..commit_count {
+        let commit_index = first_commit_index
+            .checked_add(offset)
+            .ok_or_else(|| LixError::unknown("ordered benchmark commit index overflow"))?;
+        append.commits.push(CommitRecord {
+            format_version: 1,
+            commit_id: CommitId::new(ordered_bench_uuid(commit_index, 0)),
+            parent_commit_ids: Vec::new(),
+            tracked_state_rootless: false,
+            change_id: ChangeId::new(ordered_bench_uuid(commit_index, 1)),
+            author_account_ids: Vec::new(),
+            created_at: crate::common::LixTimestamp::expect_parse(
+                "created_at",
+                "2026-05-20T00:00:00Z",
+            ),
+        });
+    }
+    Ok(BenchAppend { append })
+}
+
 pub fn append_1c_with_commit_change_id(
     name: &str,
     commit_change_id: &str,
@@ -576,6 +604,21 @@ fn direct_append_with_shape(
     Ok(BenchAppend { append })
 }
 
+fn ordered_bench_uuid(index: usize, discriminator: u8) -> uuid::Uuid {
+    let timestamp = 0x0192_0000_0000u64
+        .checked_add(u64::try_from(index).expect("benchmark commit index fits u64"))
+        .expect("benchmark timestamp does not overflow");
+    let mut bytes = [0u8; 16];
+    bytes[..6].copy_from_slice(&timestamp.to_be_bytes()[2..]);
+    bytes[6] = 0x70;
+    bytes[7] = 0;
+    let suffix = (u64::try_from(index).expect("benchmark commit index fits u64") << 1)
+        | u64::from(discriminator);
+    bytes[8..].copy_from_slice(&suffix.to_be_bytes());
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    uuid::Uuid::from_bytes(bytes)
+}
+
 impl BenchCorpus {
     fn from_append_batches(append_batches: Vec<BenchAppend>) -> Self {
         let commit_ids = append_batches
@@ -718,5 +761,26 @@ impl std::ops::AddAssign for BenchWriteStats {
         self.puts += rhs.puts;
         self.deletes += rhs.deletes;
         self.bytes_written += rhs.bytes_written;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::append_ordered_commits;
+
+    #[test]
+    fn ordered_commit_fixture_uses_monotonic_distinct_v7_ids() {
+        let append = append_ordered_commits(100, 3).expect("build ordered commits");
+        let commits = &append.append.commits;
+
+        assert_eq!(commits.len(), 3);
+        assert!(commits.windows(2).all(|pair| {
+            pair[0].commit_id < pair[1].commit_id && pair[0].change_id < pair[1].change_id
+        }));
+        assert!(commits.iter().all(|commit| {
+            commit.commit_id.as_uuid().get_version_num() == 7
+                && commit.change_id.as_uuid().get_version_num() == 7
+                && commit.commit_id.as_uuid() != commit.change_id.as_uuid()
+        }));
     }
 }

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -13,8 +13,8 @@ use bytes::Bytes;
 use crate::branch::BranchHeadControlContext;
 use crate::changelog::{
     CHANGE_SPACE, COMMIT_CHANGE_ID_SPACE, COMMIT_SPACE, ChangeId, ChangeRecord, ChangeScanRequest,
-    ChangelogContext, ChangelogReader, CommitId, CommitRecord, CommitScanRequest, GcLiveSet,
-    GcPlan, GcRepairSet, GcRoot, GcSweepSet, change_key, commit_change_id_key, commit_key,
+    ChangelogContext, ChangelogReader, CommitId, CommitScanRequest, GcLiveSet, GcPlan, GcRepairSet,
+    GcRoot, GcSweepSet, change_key, commit_change_id_key, commit_key,
 };
 use crate::json_store::{
     JsonRef, JsonSlot, JsonStoreContext, JsonStoreWriter, UntrackedJsonReclaimCandidate,
@@ -521,7 +521,7 @@ where
     if let Some(commit_id) = packed
         .commits
         .keys()
-        .find(|commit_id| !commits.contains_key(commit_id))
+        .find(|commit_id| !commits.contains(commit_id))
     {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
@@ -558,13 +558,13 @@ where
         if !live_commits.insert(commit_id) {
             continue;
         }
-        let commit = commits.get(&commit_id).ok_or_else(|| {
+        let commit = commits.get(commit_id).ok_or_else(|| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 format!("garbage-collection root references missing commit '{commit_id}'"),
             )
         })?;
-        pending.extend(commit.parent_commit_ids.iter().copied());
+        pending.extend(commits.parent_commit_ids(commit).iter().copied());
     }
 
     let standalone_root_ids = roots
@@ -609,20 +609,11 @@ where
         }
     }
 
-    let sweep_commits = commits
-        .keys()
-        .filter(|commit_id| !live_commits.contains(commit_id))
-        .copied()
-        .collect::<Vec<_>>();
-    let sweep_commit_change_ids = sweep_commits
+    let (sweep_commits, sweep_commit_change_ids): (Vec<CommitId>, Vec<ChangeId>) = commits
         .iter()
-        .map(|commit_id| {
-            commits
-                .get(commit_id)
-                .expect("sweep commit came from commit inventory")
-                .change_id
-        })
-        .collect::<Vec<_>>();
+        .filter(|commit| !live_commits.contains(&commit.commit_id))
+        .map(|commit| (commit.commit_id, commit.change_id))
+        .unzip();
     let sweep_changes = standalone_changes
         .keys()
         .filter(|change_id| !standalone_root_ids.contains(change_id))
@@ -736,12 +727,47 @@ where
     })
 }
 
-async fn scan_all_gc_commits<S>(store: S) -> Result<BTreeMap<CommitId, CommitRecord>, LixError>
+#[derive(Clone, Copy, Debug)]
+struct GcCommitInventoryEntry {
+    commit_id: CommitId,
+    change_id: ChangeId,
+    parent_start: usize,
+    parent_len: usize,
+}
+
+#[derive(Debug, Default)]
+struct GcCommitInventory {
+    entries: Vec<GcCommitInventoryEntry>,
+    parent_commit_ids: Vec<CommitId>,
+}
+
+impl GcCommitInventory {
+    fn contains(&self, commit_id: &CommitId) -> bool {
+        self.get(*commit_id).is_some()
+    }
+
+    fn get(&self, commit_id: CommitId) -> Option<&GcCommitInventoryEntry> {
+        self.entries
+            .binary_search_by_key(&commit_id, |entry| entry.commit_id)
+            .ok()
+            .map(|index| &self.entries[index])
+    }
+
+    fn parent_commit_ids(&self, entry: &GcCommitInventoryEntry) -> &[CommitId] {
+        &self.parent_commit_ids[entry.parent_start..entry.parent_start + entry.parent_len]
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &GcCommitInventoryEntry> {
+        self.entries.iter()
+    }
+}
+
+async fn scan_all_gc_commits<S>(store: S) -> Result<GcCommitInventory, LixError>
 where
     S: StorageAdapterRead,
 {
     let mut reader = ChangelogContext::new().reader(store);
-    let mut commits = BTreeMap::new();
+    let mut commits = GcCommitInventory::default();
     let mut start_after = None::<String>;
     loop {
         let batch = reader
@@ -751,15 +777,30 @@ where
             })
             .await?;
         for commit in batch.entries {
-            if commits.insert(commit.commit_id, commit.clone()).is_some() {
+            if commits
+                .entries
+                .last()
+                .is_some_and(|previous| previous.commit_id >= commit.commit_id)
+            {
                 return Err(LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
                     format!(
-                        "garbage collection found duplicate commit '{}'",
+                        "garbage collection found duplicate or out-of-order commit '{}'",
                         commit.commit_id
                     ),
                 ));
             }
+            let parent_start = commits.parent_commit_ids.len();
+            let parent_len = commit.parent_commit_ids.len();
+            commits
+                .parent_commit_ids
+                .extend(commit.parent_commit_ids.into_iter());
+            commits.entries.push(GcCommitInventoryEntry {
+                commit_id: commit.commit_id,
+                change_id: commit.change_id,
+                parent_start,
+                parent_len,
+            });
         }
         let Some(next) = batch.next_start_after else {
             break;

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -422,9 +422,10 @@ where
     // content-addressed maintenance work, but delta rows have no shared
     // ownership and must be reclaimed in the same logical GC pass.
     let phase_started = Instant::now();
-    for commit_id in &sweep_tracked_commit_roots {
-        crate::tracked_state::stage_delete_commit_root(writes, *commit_id);
-    }
+    crate::tracked_state::stage_delete_commit_roots(
+        writes,
+        sweep_tracked_commit_roots.iter().copied(),
+    );
     // Old serving generations are derived data. Removing them in the same
     // atomic sweep as their untracked payload-root withdrawal prevents stale
     // branch generations from accumulating indefinitely.
@@ -689,29 +690,27 @@ where
         .collect::<Vec<_>>();
     crate::tracked_state::stage_change_locators(writes, &relocated_locators);
 
+    writes.delete_batch(
+        COMMIT_SPACE,
+        sweep_commits.iter().map(|commit_id| commit_key(*commit_id)),
+    );
     for commit_id in &sweep_commits {
-        writes.delete(
-            COMMIT_SPACE,
-            StorageKey(Bytes::from(commit_key(*commit_id))),
-        );
         if let Some(entry) = packed.commits.get(commit_id) {
             crate::tracked_state::stage_delete_commit_delta_inventory_entry(
                 writes, *commit_id, entry,
             )?;
         }
     }
-    for change_id in &sweep_commit_change_ids {
-        writes.delete(
-            COMMIT_CHANGE_ID_SPACE,
-            StorageKey(Bytes::from(commit_change_id_key(*change_id))),
-        );
-    }
-    for change_id in &sweep_changes {
-        writes.delete(
-            CHANGE_SPACE,
-            StorageKey(Bytes::from(change_key(*change_id))),
-        );
-    }
+    writes.delete_batch(
+        COMMIT_CHANGE_ID_SPACE,
+        sweep_commit_change_ids
+            .iter()
+            .map(|change_id| commit_change_id_key(*change_id)),
+    );
+    writes.delete_batch(
+        CHANGE_SPACE,
+        sweep_changes.iter().map(|change_id| change_key(*change_id)),
+    );
     JsonStoreContext::new()
         .writer()
         .stage_delete_refs(writes, sweep_json_payloads.iter().copied());

--- a/packages/engine/src/sql2/providers/checkpoint.rs
+++ b/packages/engine/src/sql2/providers/checkpoint.rs
@@ -10,7 +10,7 @@ use tokio::sync::Mutex;
 
 use crate::LixError;
 use crate::branch::{BranchHead, BranchRefReader};
-use crate::checkpoint::{checkpoint_history_for_branch, scan_checkpoint_commit_records};
+use crate::checkpoint::checkpoint_history_for_branch;
 use crate::commit_graph::CommitGraphReader;
 use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::sql2::history_route::{HistoryRoute, parse_history_filter};
@@ -21,13 +21,6 @@ use crate::tracked_state::TrackedStateContext;
 use super::columns::{Col, ColumnTable, ColumnTableError};
 use super::file::{FileIdConstraint, exact_string_column_constraint_from_filters};
 use super::spec::{PlannedScan, TableSpec, projected_schema, register_spec_table, row_source};
-
-// Keep small UI pages page-bounded on the point-walk path. At and above this
-// boundary, a paged scan avoids enough serial remote LSM reads to outweigh
-// materializing the retained record map. The cutoff is a conservative
-// cross-backend tradeoff; the scale harness covers LIMIT 20, 128, and full
-// history on both SlateDB and RocksDB.
-const CHECKPOINT_HISTORY_RECORD_SCAN_LIMIT: usize = 64;
 
 pub(super) async fn register_checkpoint_provider<S>(
     session: &datafusion::prelude::SessionContext,
@@ -151,23 +144,6 @@ where
                         } else {
                             None
                         };
-                    let record_scan_limit = depth_scan_limit.or(provider_limit);
-                    // An unbounded history (including COUNT(*)) would otherwise
-                    // point-read one commit record per checkpoint. Scan the
-                    // immutable commit records once and reuse the map for all
-                    // selected branch heads. Small UI pages retain the
-                    // page-bounded point-walk path.
-                    let checkpoint_records = if record_scan_limit
-                        .is_none_or(|limit| limit >= CHECKPOINT_HISTORY_RECORD_SCAN_LIMIT)
-                    {
-                        Some(
-                            scan_checkpoint_commit_records(store.clone())
-                                .await
-                                .map_err(lix_error_to_datafusion_error)?,
-                        )
-                    } else {
-                        None
-                    };
                     let mut reader = commit_graph.lock().await;
                     let mut tracked = TrackedStateContext::new().reader(store);
                     let mut rows = Vec::new();
@@ -184,7 +160,10 @@ where
                             &head.commit_id,
                             &head.branch_id,
                             head_scan_limit,
-                            checkpoint_records.as_ref(),
+                            // Checkpoint commits directly parent the previous
+                            // checkpoint. Follow that sparse chain instead of
+                            // retaining every unrelated public commit fact.
+                            None,
                         )
                         .await
                         .map_err(lix_error_to_datafusion_error)?

--- a/packages/engine/src/storage_adapter/write_set.rs
+++ b/packages/engine/src/storage_adapter/write_set.rs
@@ -382,6 +382,37 @@ impl StorageWriteSet {
             .stage_delete(key.0);
     }
 
+    /// Stages delete keys in one contiguous retained buffer.
+    ///
+    /// Large maintenance sweeps should use this path instead of retaining one
+    /// separately allocated [`Bytes`] buffer per key.
+    pub fn delete_batch<S, I, K>(&mut self, space: S, keys: I)
+    where
+        S: IntoStorageSpace,
+        I: IntoIterator<Item = K>,
+        K: IntoStorageKey,
+    {
+        let mut key_bytes = Vec::new();
+        let mut deletes = Vec::new();
+        for key in keys {
+            let key = key.into_storage_key();
+            let start = key_bytes.len();
+            key_bytes.extend_from_slice(&key.0);
+            deletes.push(BufferRange::new(start, key_bytes.len() - start));
+        }
+        if deletes.is_empty() {
+            return;
+        }
+        let batch = EncodedMutationBatch::try_new(
+            Bytes::from(key_bytes),
+            Bytes::new(),
+            Vec::new(),
+            deletes,
+        )
+        .expect("delete ranges originate in the supplied encoded key buffer");
+        self.stage_encoded_batch(space.into_storage_space(), batch);
+    }
+
     /// Reserves capacity for a storage space's grouped puts and deletes.
     ///
     /// This is most useful with canonical construction, where domain stores can
@@ -1157,6 +1188,32 @@ mod tests {
                 .map(|key| key.0.as_ptr() as usize)
                 .collect::<Vec<_>>(),
             delete_key_pointers
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_batch_retains_one_contiguous_key_buffer() {
+        let mut writes = StorageWriteSet::new();
+        writes.delete_batch(space(), [key("c"), key("a"), key("b")]);
+
+        let arenas = writes.arena_stats();
+        assert_eq!(arenas.delete_descriptors, 3);
+        assert_eq!(arenas.key_shared_buffers, 1);
+        assert_eq!(arenas.key_shared_bytes, 3);
+
+        let mut backend = CapturingStorageWrite::default();
+        writes
+            .lower_into(&mut backend)
+            .await
+            .expect("lower contiguous delete batch");
+        let (_, deletes) = backend.deletes.pop().expect("one delete batch");
+        assert_eq!(
+            deletes.into_iter().map(|key| key.0).collect::<Vec<_>>(),
+            [
+                Bytes::from_static(b"a"),
+                Bytes::from_static(b"b"),
+                Bytes::from_static(b"c")
+            ]
         );
     }
 

--- a/packages/engine/src/storage_adapter/write_set.rs
+++ b/packages/engine/src/storage_adapter/write_set.rs
@@ -98,8 +98,32 @@ struct MutationArena {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct ArenaRange {
-    buffer_index: usize,
-    range: BufferRange,
+    buffer_index: u32,
+    offset: u32,
+    length: u32,
+}
+
+impl ArenaRange {
+    fn new(buffer_index: usize, range: BufferRange) -> Self {
+        Self {
+            buffer_index: u32::try_from(buffer_index)
+                .expect("mutation arena buffer count fits u32"),
+            offset: u32::try_from(range.offset()).expect("mutation arena offset fits u32"),
+            length: u32::try_from(range.len()).expect("mutation arena range length fits u32"),
+        }
+    }
+
+    fn buffer_index(self) -> usize {
+        self.buffer_index as usize
+    }
+
+    fn offset(self) -> usize {
+        self.offset as usize
+    }
+
+    fn len(self) -> usize {
+        self.length as usize
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -785,21 +809,17 @@ impl StorageWriteGroup {
         let key_buffer_index = self.key_arena.import(key_bytes);
         let value_buffer_index = (!puts.is_empty()).then(|| self.value_arena.import(value_bytes));
         self.puts.extend(puts.into_iter().map(|put| StagedPut {
-            key: ArenaRange {
-                buffer_index: key_buffer_index,
-                range: put.key,
-            },
-            value: ArenaRange {
-                buffer_index:
-                    value_buffer_index.expect("an encoded put batch must retain its value buffer"),
-                range: put.value,
-            },
+            key: ArenaRange::new(key_buffer_index, put.key),
+            value: ArenaRange::new(
+                value_buffer_index.expect("an encoded put batch must retain its value buffer"),
+                put.value,
+            ),
         }));
-        self.deletes
-            .extend(deletes.into_iter().map(|range| ArenaRange {
-                buffer_index: key_buffer_index,
-                range,
-            }));
+        self.deletes.extend(
+            deletes
+                .into_iter()
+                .map(|range| ArenaRange::new(key_buffer_index, range)),
+        );
     }
 
     fn key_bytes(&self, range: ArenaRange) -> &[u8] {
@@ -902,10 +922,7 @@ impl MutationArena {
     fn stage_bytes(&mut self, bytes: Bytes) -> ArenaRange {
         let length = bytes.len();
         let buffer_index = self.import(bytes);
-        ArenaRange {
-            buffer_index,
-            range: BufferRange::new(0, length),
-        }
+        ArenaRange::new(buffer_index, BufferRange::new(0, length))
     }
 
     fn import(&mut self, bytes: Bytes) -> usize {
@@ -917,9 +934,9 @@ impl MutationArena {
     fn bytes(&self, range: ArenaRange) -> &[u8] {
         slice_bytes(
             self.shared
-                .get(range.buffer_index)
+                .get(range.buffer_index())
                 .expect("staged mutation references a retained shared buffer"),
-            range.range,
+            range,
         )
     }
 
@@ -938,10 +955,10 @@ impl MutationArena {
 
 impl ArenaRemap {
     fn remap(&self, range: ArenaRange) -> ArenaRange {
-        ArenaRange {
-            buffer_index: self.shared_buffer_base + range.buffer_index,
-            range: range.range,
-        }
+        ArenaRange::new(
+            self.shared_buffer_base + range.buffer_index(),
+            BufferRange::new(range.offset(), range.len()),
+        )
     }
 }
 
@@ -949,9 +966,8 @@ impl FrozenMutationArena {
     fn slice(&self, range: ArenaRange) -> Bytes {
         let bytes = self
             .shared
-            .get(range.buffer_index)
+            .get(range.buffer_index())
             .expect("lowered mutation references a retained shared buffer");
-        let range = range.range;
         if range.offset() == 0 && range.len() == bytes.len() {
             return bytes.clone();
         }
@@ -959,7 +975,7 @@ impl FrozenMutationArena {
     }
 }
 
-fn slice_bytes(bytes: &[u8], range: BufferRange) -> &[u8] {
+fn slice_bytes(bytes: &[u8], range: ArenaRange) -> &[u8] {
     &bytes[range.offset()..range.offset() + range.len()]
 }
 
@@ -1193,6 +1209,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_batch_retains_one_contiguous_key_buffer() {
+        assert_eq!(size_of::<super::ArenaRange>(), 12);
         let mut writes = StorageWriteSet::new();
         writes.delete_batch(space(), [key("c"), key("a"), key("b")]);
 

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -497,6 +497,8 @@ mod tests {
         // Each unreachable commit removes its changelog record, exact-ID
         // locator, and derived tracked-root record.
         assert_eq!(first.staged_deletes, 30);
+        assert_eq!(first.key_shared_buffers, 3);
+        assert_eq!(first.key_shared_bytes, 30 * 16);
         assert_eq!(second.swept_commits, first.swept_commits);
         assert_eq!(second.staged_deletes, first.staged_deletes);
     }

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -39,6 +39,78 @@ pub struct TrackedHistoricalDiffBenchResult {
     pub right_has_durable_root: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CheckpointCommitScanBenchMode {
+    Materialize,
+    Stream,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CheckpointCommitScanBenchResult {
+    pub commits: usize,
+    pub pages: usize,
+}
+
+/// Scans public commit facts through the two checkpoint-history strategies.
+///
+/// `Materialize` is the current production path for unbounded checkpoint
+/// history. `Stream` is a bounded-memory baseline over the same storage rows,
+/// page size, codec, and read snapshot.
+#[inline(never)]
+pub async fn scan_checkpoint_commits_for_bench<StorageImpl>(
+    storage: &StorageAdapter<StorageImpl>,
+    mode: CheckpointCommitScanBenchMode,
+) -> Result<CheckpointCommitScanBenchResult, crate::LixError>
+where
+    StorageImpl: Storage,
+{
+    const PAGE_SIZE: usize = 1_024;
+
+    let read = storage.begin_read(ReadOptions::default()).await?;
+    match mode {
+        CheckpointCommitScanBenchMode::Materialize => {
+            let records = crate::checkpoint::scan_checkpoint_commit_records(read).await?;
+            Ok(CheckpointCommitScanBenchResult {
+                commits: records.len(),
+                pages: records.len().div_ceil(PAGE_SIZE),
+            })
+        }
+        CheckpointCommitScanBenchMode::Stream => {
+            let mut reader = crate::changelog::ChangelogContext::new().reader(read);
+            let mut commits = 0usize;
+            let mut pages = 0usize;
+            let mut start_after = None::<String>;
+            loop {
+                let batch = crate::changelog::ChangelogReader::scan_commits(
+                    &mut reader,
+                    crate::changelog::CommitScanRequest {
+                        start_after: start_after.as_deref(),
+                        limit: Some(PAGE_SIZE),
+                    },
+                )
+                .await?;
+                commits = commits.checked_add(batch.entries.len()).ok_or_else(|| {
+                    crate::LixError::new(
+                        crate::LixError::CODE_INTERNAL_ERROR,
+                        "checkpoint benchmark commit count overflow",
+                    )
+                })?;
+                pages = pages.checked_add(1).ok_or_else(|| {
+                    crate::LixError::new(
+                        crate::LixError::CODE_INTERNAL_ERROR,
+                        "checkpoint benchmark page count overflow",
+                    )
+                })?;
+                let Some(next) = batch.next_start_after else {
+                    break;
+                };
+                start_after = Some(next.to_string());
+            }
+            Ok(CheckpointCommitScanBenchResult { commits, pages })
+        }
+    }
+}
+
 /// Diffs two tracked commits through the production historical reader.
 ///
 /// This is compiled only with `storage-benches`; it intentionally provides a
@@ -303,5 +375,35 @@ where
             resume_after.is_some(),
             "storage scan reported more rows without a resume key"
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CheckpointCommitScanBenchMode, scan_checkpoint_commits_for_bench};
+    use crate::changelog::bench::{append_ordered_commits, stage_append_once};
+    use crate::storage_adapter::{Memory, StorageAdapter};
+
+    #[tokio::test]
+    async fn checkpoint_commit_scan_baseline_matches_materialized_records_across_pages() {
+        let storage = Memory::new();
+        let append = append_ordered_commits(0, 1_025).expect("build commit fixture");
+        stage_append_once(storage.clone(), &append)
+            .await
+            .expect("stage commit fixture");
+        let adapter = StorageAdapter::new(storage);
+
+        let materialized =
+            scan_checkpoint_commits_for_bench(&adapter, CheckpointCommitScanBenchMode::Materialize)
+                .await
+                .expect("materialize checkpoint commit records");
+        let streamed =
+            scan_checkpoint_commits_for_bench(&adapter, CheckpointCommitScanBenchMode::Stream)
+                .await
+                .expect("stream checkpoint commit records");
+
+        assert_eq!(materialized.commits, 1_025);
+        assert_eq!(materialized.pages, 2);
+        assert_eq!(streamed, materialized);
     }
 }

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -51,6 +51,69 @@ pub struct CheckpointCommitScanBenchResult {
     pub pages: usize,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RepositoryGcBenchResult {
+    pub live_commits: usize,
+    pub swept_commits: usize,
+    pub swept_standalone_changes: usize,
+    pub swept_payloads: usize,
+    pub staged_puts: u64,
+    pub staged_deletes: u64,
+    pub staged_written_bytes: u64,
+    pub delete_descriptors: usize,
+    pub delete_descriptor_capacity: usize,
+    pub key_inline_bytes: usize,
+    pub key_inline_capacity: usize,
+    pub key_shared_buffers: usize,
+    pub key_shared_bytes: usize,
+    pub key_shared_capacity: usize,
+    pub root_discovery_us: u64,
+    pub changelog_us: u64,
+    pub tracked_root_stage_us: u64,
+    pub total_us: u64,
+}
+
+/// Plans production repository GC without committing its staged sweep.
+///
+/// The returned arena sizes expose the planner's retained mutation footprint;
+/// dropping this function's local write set leaves the fixture unchanged for
+/// repeatable measurements.
+#[inline(never)]
+pub async fn plan_repository_gc_for_bench<StorageImpl>(
+    storage: &StorageAdapter<StorageImpl>,
+) -> Result<RepositoryGcBenchResult, crate::LixError>
+where
+    StorageImpl: Storage,
+{
+    let read = crate::storage_adapter::SharedStorageAdapterRead::new(
+        storage.begin_read(ReadOptions::default()).await?,
+    );
+    let mut writes = storage.new_write_set();
+    let plan = crate::gc::stage_repository_gc(read, &mut writes).await?;
+    let stats = writes.stats();
+    let arena = writes.arena_stats();
+    Ok(RepositoryGcBenchResult {
+        live_commits: plan.changelog.live.commits.len(),
+        swept_commits: plan.changelog.sweep.commits.len(),
+        swept_standalone_changes: plan.changelog.sweep.changes.len(),
+        swept_payloads: plan.changelog.sweep.json_payloads.len(),
+        staged_puts: stats.staged_puts,
+        staged_deletes: stats.staged_deletes,
+        staged_written_bytes: stats.written_bytes,
+        delete_descriptors: arena.delete_descriptors,
+        delete_descriptor_capacity: arena.delete_descriptor_capacity,
+        key_inline_bytes: arena.key_inline_bytes,
+        key_inline_capacity: arena.key_inline_capacity,
+        key_shared_buffers: arena.key_shared_buffers,
+        key_shared_bytes: arena.key_shared_bytes,
+        key_shared_capacity: arena.key_shared_capacity,
+        root_discovery_us: plan.profile.root_discovery_us,
+        changelog_us: plan.profile.changelog_us,
+        tracked_root_stage_us: plan.profile.tracked_root_stage_us,
+        total_us: plan.profile.total_us,
+    })
+}
+
 /// Scans public commit facts through the two checkpoint-history strategies.
 ///
 /// `Materialize` is the current production path for unbounded checkpoint
@@ -380,7 +443,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{CheckpointCommitScanBenchMode, scan_checkpoint_commits_for_bench};
+    use super::{
+        CheckpointCommitScanBenchMode, plan_repository_gc_for_bench,
+        scan_checkpoint_commits_for_bench,
+    };
+    use crate::Engine;
     use crate::changelog::bench::{append_ordered_commits, stage_append_once};
     use crate::storage_adapter::{Memory, StorageAdapter};
 
@@ -405,5 +472,32 @@ mod tests {
         assert_eq!(materialized.commits, 1_025);
         assert_eq!(materialized.pages, 2);
         assert_eq!(streamed, materialized);
+    }
+
+    #[tokio::test]
+    async fn repository_gc_benchmark_plans_unreachable_commits_without_mutating() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("initialize engine");
+        let append = append_ordered_commits(100, 10).expect("build unreachable commit fixture");
+        stage_append_once(storage.clone(), &append)
+            .await
+            .expect("stage unreachable commit fixture");
+        let adapter = StorageAdapter::new(storage);
+
+        let first = plan_repository_gc_for_bench(&adapter)
+            .await
+            .expect("plan repository gc");
+        let second = plan_repository_gc_for_bench(&adapter)
+            .await
+            .expect("repeat repository gc plan");
+
+        assert_eq!(first.swept_commits, 10);
+        // Each unreachable commit removes its changelog record, exact-ID
+        // locator, and derived tracked-root record.
+        assert_eq!(first.staged_deletes, 30);
+        assert_eq!(second.swept_commits, first.swept_commits);
+        assert_eq!(second.staged_deletes, first.staged_deletes);
     }
 }

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -34,7 +34,7 @@ pub(crate) use storage::{
     load_commit_delta_members_with_payloads, scan_change_records_from_commit_deltas,
     scan_commit_delta_inventory, stage_change_locators, stage_commit_deltas,
     stage_delete_change_locators, stage_delete_commit_delta_inventory_entry,
-    stage_delete_commit_root,
+    stage_delete_commit_roots,
 };
 #[cfg(feature = "storage-benches")]
 pub(crate) use storage::{

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -555,10 +555,13 @@ pub(crate) fn stage_commit_root(
     Ok(())
 }
 
-pub(crate) fn stage_delete_commit_root(writes: &mut StorageWriteSet, commit_id: CommitId) {
-    writes.delete(
+pub(crate) fn stage_delete_commit_roots(
+    writes: &mut StorageWriteSet,
+    commit_ids: impl IntoIterator<Item = CommitId>,
+) {
+    writes.delete_batch(
         TRACKED_STATE_COMMIT_ROOT_SPACE,
-        key(commit_root_key(commit_id)),
+        commit_ids.into_iter().map(commit_root_key),
     );
 }
 
@@ -752,12 +755,12 @@ pub(crate) fn stage_delete_change_locators(
     writes: &mut StorageWriteSet,
     change_ids: impl IntoIterator<Item = crate::changelog::ChangeId>,
 ) {
-    for change_id in change_ids {
-        writes.delete(
-            TRACKED_STATE_CHANGE_LOCATOR_SPACE,
-            key(change_id.as_uuid().as_bytes().to_vec()),
-        );
-    }
+    writes.delete_batch(
+        TRACKED_STATE_CHANGE_LOCATOR_SPACE,
+        change_ids
+            .into_iter()
+            .map(|change_id| change_id.as_uuid().as_bytes().to_vec()),
+    );
 }
 
 pub(crate) async fn load_change_record_by_id(

--- a/packages/slatedb-storage/Cargo.toml
+++ b/packages/slatedb-storage/Cargo.toml
@@ -25,5 +25,6 @@ blake3 = "1"
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 object_store = { version = "0.14", default-features = false, features = ["fs"] }
 slatedb = { version = "0.14.1", default-features = false, features = ["lz4", "moka"] }
+slatedb-common = "0.14.1"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }

--- a/packages/slatedb-storage/src/lib.rs
+++ b/packages/slatedb-storage/src/lib.rs
@@ -3,6 +3,7 @@
 mod slatedb;
 
 pub use slatedb::{
-    SlateDB, SlateDBCacheOptions, SlateDBFactory, SlateDBFixture, SlateDBIoCounters,
-    SlateDBIoSnapshot, SlateDBObjectStoreOptions, SlateDBRead, SlateDBWrite,
+    SlateDB, SlateDBCacheOptions, SlateDBFactory, SlateDBFixture, SlateDBIoCategorySnapshot,
+    SlateDBIoComponentSnapshot, SlateDBIoCounters, SlateDBIoSnapshot, SlateDBObjectStoreOptions,
+    SlateDBRead, SlateDBWrite,
 };

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -59,7 +59,10 @@ const SNAPSHOT_POINT_CACHE_BYTES: usize = 16 * 1024 * 1024;
 const SNAPSHOT_POINT_CACHE_ENTRIES: usize = 4096;
 const SNAPSHOT_POINT_CACHE_MAX_VALUE_BYTES: usize = 64 * 1024;
 const DEFAULT_BLOCK_CACHE_BYTES: u64 = 16 * 1024 * 1024;
-const DEFAULT_METADATA_CACHE_BYTES: u64 = 4 * 1024 * 1024;
+// Keep indexes and Bloom filters resident across batched point validation.
+// A tiny metadata cache repeatedly fetched multi-megabyte filters once the
+// repository crossed the first large-SST boundary.
+const DEFAULT_METADATA_CACHE_BYTES: u64 = 64 * 1024 * 1024;
 const SCAN_BATCH_ROWS: usize = 1024;
 const SCAN_READ_AHEAD_BYTES: usize = 2 * 1024 * 1024;
 const SCAN_MAX_FETCH_TASKS: usize = 16;

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -6,7 +6,7 @@
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::fmt;
 use std::future::Future;
-use std::ops::Bound;
+use std::ops::{Bound, Range};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, mpsc};
@@ -15,6 +15,7 @@ use std::time::{Duration, SystemTime};
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use futures_util::FutureExt;
 use futures_util::stream::{self, BoxStream, StreamExt, TryStreamExt};
 use lix_engine::storage::{
     CommitResult, CoreProjection, GetManyRequest, GetManyResult, Key, KeyRange, Precondition,
@@ -39,6 +40,7 @@ use slatedb::db_cache::moka::{MokaCache, MokaCacheOptions};
 use slatedb::db_cache::{DbCache, SplitCache};
 use slatedb::prefix_extractor::{PrefixExtractor, PrefixTarget};
 use slatedb::{CloseReason, Db, DbIterator, DbSnapshot, DbStatus, KeyValue, WriteBatch};
+use slatedb_common::metrics::{DefaultMetricsRecorder, MetricValue};
 use tempfile::TempDir;
 use tokio::runtime::{Builder, Handle, Runtime};
 use tokio::sync::{Mutex as AsyncMutex, Notify, OwnedMutexGuard, oneshot};
@@ -120,9 +122,25 @@ pub struct SlateDBCacheOptions {
     pub metadata_cache_bytes: u64,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone)]
 pub struct SlateDBIoCounters {
     inner: Arc<SlateDBIoCounterValues>,
+    metrics: Arc<DefaultMetricsRecorder>,
+}
+
+impl fmt::Debug for SlateDBIoCounters {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_struct("SlateDBIoCounters").finish()
+    }
+}
+
+impl Default for SlateDBIoCounters {
+    fn default() -> Self {
+        Self {
+            inner: Arc::default(),
+            metrics: Arc::new(DefaultMetricsRecorder::new()),
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -135,6 +153,19 @@ struct SlateDBIoCounterValues {
     listed_objects: AtomicU64,
     deleted_objects: AtomicU64,
     copied_objects: AtomicU64,
+    wal: SlateDBIoCategoryCounters,
+    compacted: SlateDBIoCategoryCounters,
+    manifest: SlateDBIoCategoryCounters,
+    compactions: SlateDBIoCategoryCounters,
+    other: SlateDBIoCategoryCounters,
+}
+
+#[derive(Debug, Default)]
+struct SlateDBIoCategoryCounters {
+    read_objects: AtomicU64,
+    read_bytes: AtomicU64,
+    write_objects: AtomicU64,
+    write_bytes: AtomicU64,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -147,10 +178,34 @@ pub struct SlateDBIoSnapshot {
     pub listed_objects: u64,
     pub deleted_objects: u64,
     pub copied_objects: u64,
+    pub wal: SlateDBIoCategorySnapshot,
+    pub compacted: SlateDBIoCategorySnapshot,
+    pub manifest: SlateDBIoCategorySnapshot,
+    pub compactions: SlateDBIoCategorySnapshot,
+    pub other: SlateDBIoCategorySnapshot,
+    pub main: SlateDBIoComponentSnapshot,
+    pub reader: SlateDBIoComponentSnapshot,
+    pub compactor: SlateDBIoComponentSnapshot,
+    pub gc: SlateDBIoComponentSnapshot,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SlateDBIoCategorySnapshot {
+    pub read_objects: u64,
+    pub read_bytes: u64,
+    pub write_objects: u64,
+    pub write_bytes: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SlateDBIoComponentSnapshot {
+    pub read_requests: u64,
+    pub write_requests: u64,
 }
 
 impl SlateDBIoCounters {
     pub fn snapshot(&self) -> SlateDBIoSnapshot {
+        let metrics = self.metrics.snapshot();
         SlateDBIoSnapshot {
             read_objects: self.inner.read_objects.load(Ordering::Relaxed),
             read_bytes: self.inner.read_bytes.load(Ordering::Relaxed),
@@ -160,6 +215,70 @@ impl SlateDBIoCounters {
             listed_objects: self.inner.listed_objects.load(Ordering::Relaxed),
             deleted_objects: self.inner.deleted_objects.load(Ordering::Relaxed),
             copied_objects: self.inner.copied_objects.load(Ordering::Relaxed),
+            wal: self.inner.wal.snapshot(),
+            compacted: self.inner.compacted.snapshot(),
+            manifest: self.inner.manifest.snapshot(),
+            compactions: self.inner.compactions.snapshot(),
+            other: self.inner.other.snapshot(),
+            main: component_snapshot(&metrics, "db"),
+            reader: component_snapshot(&metrics, "reader"),
+            compactor: component_snapshot(&metrics, "compactor"),
+            gc: component_snapshot(&metrics, "gc"),
+        }
+    }
+}
+
+fn component_snapshot(
+    metrics: &slatedb_common::metrics::Metrics,
+    component: &str,
+) -> SlateDBIoComponentSnapshot {
+    let mut snapshot = SlateDBIoComponentSnapshot::default();
+    for metric in metrics.by_name("slatedb.object_store.request_count") {
+        let label = |name: &str| {
+            metric
+                .labels
+                .iter()
+                .find_map(|(key, value)| (key == name).then_some(value.as_str()))
+        };
+        if label("component") != Some(component) {
+            continue;
+        }
+        let MetricValue::Counter(value) = metric.value else {
+            continue;
+        };
+        match label("op") {
+            Some("get") => snapshot.read_requests = snapshot.read_requests.saturating_add(value),
+            Some("put") => snapshot.write_requests = snapshot.write_requests.saturating_add(value),
+            _ => {}
+        }
+    }
+    snapshot
+}
+
+impl SlateDBIoCounterValues {
+    fn category(&self, location: &ObjectPath) -> &SlateDBIoCategoryCounters {
+        let path = location.as_ref();
+        if path.split('/').any(|part| part == "wal") {
+            &self.wal
+        } else if path.split('/').any(|part| part == "compacted") {
+            &self.compacted
+        } else if path.split('/').any(|part| part == "manifest") {
+            &self.manifest
+        } else if path.split('/').any(|part| part == "compactions") {
+            &self.compactions
+        } else {
+            &self.other
+        }
+    }
+}
+
+impl SlateDBIoCategoryCounters {
+    fn snapshot(&self) -> SlateDBIoCategorySnapshot {
+        SlateDBIoCategorySnapshot {
+            read_objects: self.read_objects.load(Ordering::Relaxed),
+            read_bytes: self.read_bytes.load(Ordering::Relaxed),
+            write_objects: self.write_objects.load(Ordering::Relaxed),
+            write_bytes: self.write_bytes.load(Ordering::Relaxed),
         }
     }
 }
@@ -175,6 +294,35 @@ impl SlateDBIoSnapshot {
             listed_objects: self.listed_objects.saturating_sub(earlier.listed_objects),
             deleted_objects: self.deleted_objects.saturating_sub(earlier.deleted_objects),
             copied_objects: self.copied_objects.saturating_sub(earlier.copied_objects),
+            wal: self.wal.saturating_sub(earlier.wal),
+            compacted: self.compacted.saturating_sub(earlier.compacted),
+            manifest: self.manifest.saturating_sub(earlier.manifest),
+            compactions: self.compactions.saturating_sub(earlier.compactions),
+            other: self.other.saturating_sub(earlier.other),
+            main: self.main.saturating_sub(earlier.main),
+            reader: self.reader.saturating_sub(earlier.reader),
+            compactor: self.compactor.saturating_sub(earlier.compactor),
+            gc: self.gc.saturating_sub(earlier.gc),
+        }
+    }
+}
+
+impl SlateDBIoCategorySnapshot {
+    fn saturating_sub(self, earlier: Self) -> Self {
+        Self {
+            read_objects: self.read_objects.saturating_sub(earlier.read_objects),
+            read_bytes: self.read_bytes.saturating_sub(earlier.read_bytes),
+            write_objects: self.write_objects.saturating_sub(earlier.write_objects),
+            write_bytes: self.write_bytes.saturating_sub(earlier.write_bytes),
+        }
+    }
+}
+
+impl SlateDBIoComponentSnapshot {
+    fn saturating_sub(self, earlier: Self) -> Self {
+        Self {
+            read_requests: self.read_requests.saturating_sub(earlier.read_requests),
+            write_requests: self.write_requests.saturating_sub(earlier.write_requests),
         }
     }
 }
@@ -199,6 +347,52 @@ struct CountingObjectStore {
     counters: SlateDBIoCounters,
 }
 
+#[derive(Debug)]
+struct CountingMultipartUpload {
+    inner: Box<dyn MultipartUpload>,
+    counters: SlateDBIoCounters,
+    location: ObjectPath,
+    uploaded_bytes: Arc<AtomicU64>,
+}
+
+#[async_trait]
+impl MultipartUpload for CountingMultipartUpload {
+    fn put_part(&mut self, payload: PutPayload) -> object_store::UploadPart {
+        let bytes = payload.content_length() as u64;
+        let uploaded_bytes = Arc::clone(&self.uploaded_bytes);
+        self.inner
+            .put_part(payload)
+            .map(move |result| {
+                if result.is_ok() {
+                    uploaded_bytes.fetch_add(bytes, Ordering::Relaxed);
+                }
+                result
+            })
+            .boxed()
+    }
+
+    async fn complete(&mut self) -> object_store::Result<PutResult> {
+        let result = self.inner.complete().await?;
+        let bytes = self.uploaded_bytes.load(Ordering::Relaxed);
+        let category = self.counters.inner.category(&self.location);
+        self.counters
+            .inner
+            .write_objects
+            .fetch_add(1, Ordering::Relaxed);
+        self.counters
+            .inner
+            .write_bytes
+            .fetch_add(bytes, Ordering::Relaxed);
+        category.write_objects.fetch_add(1, Ordering::Relaxed);
+        category.write_bytes.fetch_add(bytes, Ordering::Relaxed);
+        Ok(result)
+    }
+
+    async fn abort(&mut self) -> object_store::Result<()> {
+        self.inner.abort().await
+    }
+}
+
 impl fmt::Display for CountingObjectStore {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(formatter, "counting {}", self.inner)
@@ -215,6 +409,7 @@ impl ObjectStore for CountingObjectStore {
     ) -> object_store::Result<PutResult> {
         let bytes = payload.content_length() as u64;
         let result = self.inner.put_opts(location, payload, options).await?;
+        let category = self.counters.inner.category(location);
         self.counters
             .inner
             .write_objects
@@ -223,6 +418,8 @@ impl ObjectStore for CountingObjectStore {
             .inner
             .write_bytes
             .fetch_add(bytes, Ordering::Relaxed);
+        category.write_objects.fetch_add(1, Ordering::Relaxed);
+        category.write_bytes.fetch_add(bytes, Ordering::Relaxed);
         Ok(result)
     }
 
@@ -231,7 +428,13 @@ impl ObjectStore for CountingObjectStore {
         location: &ObjectPath,
         options: PutMultipartOptions,
     ) -> object_store::Result<Box<dyn MultipartUpload>> {
-        self.inner.put_multipart_opts(location, options).await
+        let inner = self.inner.put_multipart_opts(location, options).await?;
+        Ok(Box::new(CountingMultipartUpload {
+            inner,
+            counters: self.counters.clone(),
+            location: location.clone(),
+            uploaded_bytes: Arc::new(AtomicU64::new(0)),
+        }))
     }
 
     async fn get_opts(
@@ -240,12 +443,15 @@ impl ObjectStore for CountingObjectStore {
         options: ObjectStoreGetOptions,
     ) -> object_store::Result<GetResult> {
         let mut result = self.inner.get_opts(location, options).await?;
+        let category = self.counters.inner.category(location);
         self.counters
             .inner
             .read_objects
             .fetch_add(1, Ordering::Relaxed);
+        category.read_objects.fetch_add(1, Ordering::Relaxed);
         if let GetResultPayload::Stream(payload) = result.payload {
             let counters = self.counters.clone();
+            let location = location.clone();
             result.payload = GetResultPayload::Stream(
                 payload
                     .map(move |item| {
@@ -254,12 +460,38 @@ impl ObjectStore for CountingObjectStore {
                                 .inner
                                 .read_bytes
                                 .fetch_add(bytes.len() as u64, Ordering::Relaxed);
+                            counters
+                                .inner
+                                .category(&location)
+                                .read_bytes
+                                .fetch_add(bytes.len() as u64, Ordering::Relaxed);
                         }
                         item
                     })
                     .boxed(),
             );
         }
+        Ok(result)
+    }
+
+    async fn get_ranges(
+        &self,
+        location: &ObjectPath,
+        ranges: &[Range<u64>],
+    ) -> object_store::Result<Vec<Bytes>> {
+        let result = self.inner.get_ranges(location, ranges).await?;
+        let bytes = result.iter().map(|bytes| bytes.len() as u64).sum::<u64>();
+        let category = self.counters.inner.category(location);
+        self.counters
+            .inner
+            .read_objects
+            .fetch_add(1, Ordering::Relaxed);
+        self.counters
+            .inner
+            .read_bytes
+            .fetch_add(bytes, Ordering::Relaxed);
+        category.read_objects.fetch_add(1, Ordering::Relaxed);
+        category.read_bytes.fetch_add(bytes, Ordering::Relaxed);
         Ok(result)
     }
 
@@ -434,6 +666,22 @@ impl ObjectStore for DirectLocalReads {
             attributes: Attributes::default(),
             extensions: Extensions::default(),
         })
+    }
+
+    async fn get_ranges(
+        &self,
+        location: &ObjectPath,
+        ranges: &[Range<u64>],
+    ) -> object_store::Result<Vec<Bytes>> {
+        let mut result = Vec::with_capacity(ranges.len());
+        for range in ranges {
+            let options = ObjectStoreGetOptions {
+                range: Some(object_store::GetRange::Bounded(range.clone())),
+                ..ObjectStoreGetOptions::default()
+            };
+            result.push(self.get_opts(location, options).await?.bytes().await?);
+        }
+        Ok(result)
     }
 
     fn delete_stream(
@@ -1245,6 +1493,9 @@ impl SlateDB {
             inner: LocalFileSystem::new_with_prefix(&path).map_err(object_store_error)?,
             files: Mutex::new(DirectLocalFileCache::default()),
         });
+        let metrics = counters
+            .as_ref()
+            .map(|counters| Arc::clone(&counters.metrics));
         if let Some(counters) = counters {
             object_store = Arc::new(CountingObjectStore {
                 inner: object_store,
@@ -1256,6 +1507,7 @@ impl SlateDB {
             object_store,
             SlateDBObjectStoreOptions::default(),
             true,
+            metrics,
         )
         .map(|mut storage| {
             storage.path = path;
@@ -1268,7 +1520,7 @@ impl SlateDB {
         object_store: Arc<dyn ObjectStore>,
         options: SlateDBObjectStoreOptions,
     ) -> Result<Self, StorageError> {
-        Self::open_object_store_with_read_dispatch(db_path, object_store, options, false)
+        Self::open_object_store_with_read_dispatch(db_path, object_store, options, false, None)
     }
 
     /// Opens SlateDB with a private current-thread read-dispatch choice.
@@ -1282,6 +1534,7 @@ impl SlateDB {
         object_store: Arc<dyn ObjectStore>,
         options: SlateDBObjectStoreOptions,
         read_on_caller_current_thread: bool,
+        metrics: Option<Arc<DefaultMetricsRecorder>>,
     ) -> Result<Self, StorageError> {
         validate_object_store_options(&options)?;
         let db_path = db_path.into();
@@ -1291,6 +1544,7 @@ impl SlateDB {
                 object_store,
                 options,
                 read_on_caller_current_thread,
+                metrics,
             )?,
             path: PathBuf::from(db_path),
             write_gate: WriteGate::new(),
@@ -2324,6 +2578,7 @@ impl SlateDBWorker {
         object_store: Arc<dyn ObjectStore>,
         options: SlateDBObjectStoreOptions,
         read_on_caller_current_thread: bool,
+        metrics: Option<Arc<DefaultMetricsRecorder>>,
     ) -> Result<Self, StorageError> {
         let in_flight = InFlightTracker::default();
         let reclamation = InFlightTracker::default();
@@ -2337,6 +2592,7 @@ impl SlateDBWorker {
                     db_path,
                     object_store,
                     options,
+                    metrics,
                     shutdown_rx,
                     opened_tx,
                     manager_in_flight,
@@ -2535,6 +2791,7 @@ fn run_slatedb_manager(
     db_path: String,
     object_store: Arc<dyn ObjectStore>,
     options: SlateDBObjectStoreOptions,
+    metrics: Option<Arc<DefaultMetricsRecorder>>,
     shutdown: mpsc::Receiver<()>,
     opened: mpsc::Sender<Result<(Handle, Arc<Db>), StorageError>>,
     in_flight: InFlightTracker,
@@ -2553,7 +2810,7 @@ fn run_slatedb_manager(
         }
     };
 
-    let db = match open_slatedb(&runtime, db_path, object_store, options) {
+    let db = match open_slatedb(&runtime, db_path, object_store, options, metrics) {
         Ok(db) => db,
         Err(error) => {
             let _ = opened.send(Err(error));
@@ -2579,11 +2836,15 @@ fn open_slatedb(
     db_path: String,
     object_store: Arc<dyn ObjectStore>,
     options: SlateDBObjectStoreOptions,
+    metrics: Option<Arc<DefaultMetricsRecorder>>,
 ) -> Result<Db, StorageError> {
     runtime.block_on(async move {
         let physical_db_path = join_db_path(&db_path, SEGMENTED_FORMAT_PATH);
         let mut builder = Db::builder(physical_db_path, object_store)
             .with_segment_extractor(Arc::new(StorageSpacePrefixExtractor));
+        if let Some(metrics) = metrics {
+            builder = builder.with_metrics_recorder(metrics);
+        }
         let mut settings = slatedb_settings();
         if let Some(cache) = options.cache {
             settings.object_store_cache_options = ObjectStoreCacheOptions {
@@ -3260,27 +3521,76 @@ mod tests {
             .await
             .expect("read counted object");
         assert_eq!(bytes, Bytes::from_static(b"payload"));
+        let ranges = store
+            .get_ranges(&path, &[0..2, 5..7])
+            .await
+            .expect("read counted object ranges");
+        assert_eq!(
+            ranges,
+            vec![Bytes::from_static(b"pa"), Bytes::from_static(b"ad")]
+        );
+        let multipart_path = ObjectPath::from("multipart.sst");
+        let mut multipart = store
+            .put_multipart_opts(&multipart_path, PutMultipartOptions::default())
+            .await
+            .expect("open counted multipart object");
+        multipart
+            .put_part(PutPayload::from_static(b"multi"))
+            .await
+            .expect("write counted multipart part");
+        multipart
+            .put_part(PutPayload::from_static(b"part"))
+            .await
+            .expect("write second counted multipart part");
+        multipart
+            .complete()
+            .await
+            .expect("complete counted multipart object");
         let listed = store
             .list(None)
             .try_collect::<Vec<_>>()
             .await
             .expect("list counted object");
-        assert_eq!(listed.len(), 1);
+        assert_eq!(listed.len(), 2);
         store.delete(&path).await.expect("delete counted object");
 
         assert_eq!(
             counters.snapshot(),
             SlateDBIoSnapshot {
-                read_objects: 1,
-                read_bytes: 7,
-                write_objects: 1,
-                write_bytes: 7,
+                read_objects: 2,
+                read_bytes: 11,
+                write_objects: 2,
+                write_bytes: 16,
                 list_operations: 1,
-                listed_objects: 1,
+                listed_objects: 2,
                 deleted_objects: 1,
                 copied_objects: 0,
+                other: SlateDBIoCategorySnapshot {
+                    read_objects: 2,
+                    read_bytes: 11,
+                    write_objects: 2,
+                    write_bytes: 16,
+                },
+                ..SlateDBIoSnapshot::default()
             }
         );
+    }
+
+    #[test]
+    fn diagnostic_object_store_counters_classify_slatedb_paths() {
+        let counters = SlateDBIoCounterValues::default();
+        for (path, expected) in [
+            ("db/wal/1.sst", &counters.wal),
+            ("db/compacted/1.sst", &counters.compacted),
+            ("db/manifest/1.manifest", &counters.manifest),
+            ("db/compactions/1.compactions", &counters.compactions),
+            ("db/other/file", &counters.other),
+        ] {
+            assert!(std::ptr::eq(
+                counters.category(&ObjectPath::from(path)),
+                expected
+            ));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a two-phase checkpoint-history scale harness that separates public commit facts from packed deltas, live-state work, and query result size.

- setup/measure modes for RocksDB and SlateDB persistent fixtures
- production materialization vs bounded page-stream baseline
- end-to-end `lix_checkpoint` query mode with a fixed requested checkpoint set
- p50/p95/p99, ingest throughput, physical bytes, peak-RSS-compatible process phases, and Slate object I/O accounting
- ordered production-shaped UUIDv7 commit facts by default
- explicit `hashed` ID mode to diagnose random-key compaction confounds
- configurable 128+ checkpoint fixtures covering the former provider routing boundary

## Profiler evidence

At 10M public commit facts:

| Backend | Scan | p99 / latency | Peak RSS |
| --- | --- | ---: | ---: |
| RocksDB | page stream | 5.03 s | 109 MiB |
| RocksDB | materialized map | 8.77 s | 1.61 GiB |
| SlateDB | page stream | 14.02 s | 150 MiB |
| SlateDB | materialized map | 17.71 s | 1.67 GiB |

The page stream remains near-linear (100k→10M slope about 1.0–1.07) while removing the history-sized decoded-record map.

The end-to-end one-checkpoint query before the follow-up production cut grows with unrelated public facts:

- RocksDB p99: 42.8 ms at 100k → 606 ms at 1M (14.2×)
- SlateDB p99: 132 ms → 1.49 s (11.3×)

The harness also proved a fixture confound: hash-derived UUIDv8 keys caused a 10M Slate setup to exceed 10 minutes and 1.37 TB process read traffic. Ordered UUIDv7 keys complete in 2:56; at 1M they reduce physical storage from 172 MiB to 89 MiB and setup object reads from 12.3 MiB to 44 KiB.

## Validation

- `cargo fmt --all`
- engine and benchmark `cargo check` with storage benches, RocksDB, and SlateDB
- ordered UUIDv7 fixture test
- materialized/stream equivalence test across the 1,024-record page boundary
- 100k, 1M, and 10M profiles on both backends

## Stack

- depends on #936
- follow-up production cut is intentionally separate