### PR TITLE
perf(gc): compact commit inventory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3511,6 +3511,7 @@ dependencies = [
  "lix_engine",
  "object_store 0.14.0",
  "slatedb",
+ "slatedb-common",
  "tempfile",
  "tokio",
 ]

--- a/packages/engine-benchmarks/benches/repository_gc_scale.rs
+++ b/packages/engine-benchmarks/benches/repository_gc_scale.rs
@@ -320,6 +320,7 @@ async fn measure<StorageImpl>(
         io.listed_objects,
         directory_bytes(Path::new(path)),
     );
+    print_io_categories("measure", backend, history_changes, commit_width, io);
 }
 
 #[expect(clippy::too_many_arguments)]
@@ -353,6 +354,61 @@ fn print_setup(
         io.list_operations,
         io.listed_objects,
         directory_bytes(Path::new(path)),
+    );
+    print_io_categories("setup", backend, history_changes, commit_width, io);
+}
+
+fn print_io_categories(
+    phase: &str,
+    backend: Backend,
+    history_changes: usize,
+    commit_width: usize,
+    io: SlateDBIoSnapshot,
+) {
+    println!(
+        "repository_gc_scale_io,phase={phase},backend={backend},\
+         history_changes={history_changes},commit_width={commit_width},\
+         wal_read_objects={},wal_read_bytes={},wal_write_objects={},wal_write_bytes={},\
+         compacted_read_objects={},compacted_read_bytes={},\
+         compacted_write_objects={},compacted_write_bytes={},\
+         manifest_read_objects={},manifest_read_bytes={},\
+         manifest_write_objects={},manifest_write_bytes={},\
+         compactions_read_objects={},compactions_read_bytes={},\
+         compactions_write_objects={},compactions_write_bytes={},\
+         other_read_objects={},other_read_bytes={},\
+         other_write_objects={},other_write_bytes={},\
+         main_read_requests={},main_write_requests={},\
+         reader_read_requests={},reader_write_requests={},\
+         compactor_read_requests={},compactor_write_requests={},\
+         gc_read_requests={},gc_write_requests={}",
+        io.wal.read_objects,
+        io.wal.read_bytes,
+        io.wal.write_objects,
+        io.wal.write_bytes,
+        io.compacted.read_objects,
+        io.compacted.read_bytes,
+        io.compacted.write_objects,
+        io.compacted.write_bytes,
+        io.manifest.read_objects,
+        io.manifest.read_bytes,
+        io.manifest.write_objects,
+        io.manifest.write_bytes,
+        io.compactions.read_objects,
+        io.compactions.read_bytes,
+        io.compactions.write_objects,
+        io.compactions.write_bytes,
+        io.other.read_objects,
+        io.other.read_bytes,
+        io.other.write_objects,
+        io.other.write_bytes,
+        io.main.read_requests,
+        io.main.write_requests,
+        io.reader.read_requests,
+        io.reader.write_requests,
+        io.compactor.read_requests,
+        io.compactor.write_requests,
+        io.gc.read_requests,
+        io.gc.write_requests,
     );
 }
 

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -13,8 +13,8 @@ use bytes::Bytes;
 use crate::branch::BranchHeadControlContext;
 use crate::changelog::{
     CHANGE_SPACE, COMMIT_CHANGE_ID_SPACE, COMMIT_SPACE, ChangeId, ChangeRecord, ChangeScanRequest,
-    ChangelogContext, ChangelogReader, CommitId, CommitRecord, CommitScanRequest, GcLiveSet,
-    GcPlan, GcRepairSet, GcRoot, GcSweepSet, change_key, commit_change_id_key, commit_key,
+    ChangelogContext, ChangelogReader, CommitId, CommitScanRequest, GcLiveSet, GcPlan, GcRepairSet,
+    GcRoot, GcSweepSet, change_key, commit_change_id_key, commit_key,
 };
 use crate::json_store::{
     JsonRef, JsonSlot, JsonStoreContext, JsonStoreWriter, UntrackedJsonReclaimCandidate,
@@ -521,7 +521,7 @@ where
     if let Some(commit_id) = packed
         .commits
         .keys()
-        .find(|commit_id| !commits.contains_key(commit_id))
+        .find(|commit_id| !commits.contains(commit_id))
     {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
@@ -558,13 +558,13 @@ where
         if !live_commits.insert(commit_id) {
             continue;
         }
-        let commit = commits.get(&commit_id).ok_or_else(|| {
+        let commit = commits.get(commit_id).ok_or_else(|| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 format!("garbage-collection root references missing commit '{commit_id}'"),
             )
         })?;
-        pending.extend(commit.parent_commit_ids.iter().copied());
+        pending.extend(commits.parent_commit_ids(commit).iter().copied());
     }
 
     let standalone_root_ids = roots
@@ -609,20 +609,11 @@ where
         }
     }
 
-    let sweep_commits = commits
-        .keys()
-        .filter(|commit_id| !live_commits.contains(commit_id))
-        .copied()
-        .collect::<Vec<_>>();
-    let sweep_commit_change_ids = sweep_commits
+    let (sweep_commits, sweep_commit_change_ids): (Vec<CommitId>, Vec<ChangeId>) = commits
         .iter()
-        .map(|commit_id| {
-            commits
-                .get(commit_id)
-                .expect("sweep commit came from commit inventory")
-                .change_id
-        })
-        .collect::<Vec<_>>();
+        .filter(|commit| !live_commits.contains(&commit.commit_id))
+        .map(|commit| (commit.commit_id, commit.change_id))
+        .unzip();
     let sweep_changes = standalone_changes
         .keys()
         .filter(|change_id| !standalone_root_ids.contains(change_id))
@@ -736,12 +727,47 @@ where
     })
 }
 
-async fn scan_all_gc_commits<S>(store: S) -> Result<BTreeMap<CommitId, CommitRecord>, LixError>
+#[derive(Clone, Copy, Debug)]
+struct GcCommitInventoryEntry {
+    commit_id: CommitId,
+    change_id: ChangeId,
+    parent_start: usize,
+    parent_len: usize,
+}
+
+#[derive(Debug, Default)]
+struct GcCommitInventory {
+    entries: Vec<GcCommitInventoryEntry>,
+    parent_commit_ids: Vec<CommitId>,
+}
+
+impl GcCommitInventory {
+    fn contains(&self, commit_id: &CommitId) -> bool {
+        self.get(*commit_id).is_some()
+    }
+
+    fn get(&self, commit_id: CommitId) -> Option<&GcCommitInventoryEntry> {
+        self.entries
+            .binary_search_by_key(&commit_id, |entry| entry.commit_id)
+            .ok()
+            .map(|index| &self.entries[index])
+    }
+
+    fn parent_commit_ids(&self, entry: &GcCommitInventoryEntry) -> &[CommitId] {
+        &self.parent_commit_ids[entry.parent_start..entry.parent_start + entry.parent_len]
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &GcCommitInventoryEntry> {
+        self.entries.iter()
+    }
+}
+
+async fn scan_all_gc_commits<S>(store: S) -> Result<GcCommitInventory, LixError>
 where
     S: StorageAdapterRead,
 {
     let mut reader = ChangelogContext::new().reader(store);
-    let mut commits = BTreeMap::new();
+    let mut commits = GcCommitInventory::default();
     let mut start_after = None::<String>;
     loop {
         let batch = reader
@@ -751,15 +777,30 @@ where
             })
             .await?;
         for commit in batch.entries {
-            if commits.insert(commit.commit_id, commit.clone()).is_some() {
+            if commits
+                .entries
+                .last()
+                .is_some_and(|previous| previous.commit_id >= commit.commit_id)
+            {
                 return Err(LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
                     format!(
-                        "garbage collection found duplicate commit '{}'",
+                        "garbage collection found duplicate or out-of-order commit '{}'",
                         commit.commit_id
                     ),
                 ));
             }
+            let parent_start = commits.parent_commit_ids.len();
+            let parent_len = commit.parent_commit_ids.len();
+            commits
+                .parent_commit_ids
+                .extend(commit.parent_commit_ids.into_iter());
+            commits.entries.push(GcCommitInventoryEntry {
+                commit_id: commit.commit_id,
+                change_id: commit.change_id,
+                parent_start,
+                parent_len,
+            });
         }
         let Some(next) = batch.next_start_after else {
             break;

--- a/packages/engine/src/storage_adapter/write_set.rs
+++ b/packages/engine/src/storage_adapter/write_set.rs
@@ -98,8 +98,32 @@ struct MutationArena {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct ArenaRange {
-    buffer_index: usize,
-    range: BufferRange,
+    buffer_index: u32,
+    offset: u32,
+    length: u32,
+}
+
+impl ArenaRange {
+    fn new(buffer_index: usize, range: BufferRange) -> Self {
+        Self {
+            buffer_index: u32::try_from(buffer_index)
+                .expect("mutation arena buffer count fits u32"),
+            offset: u32::try_from(range.offset()).expect("mutation arena offset fits u32"),
+            length: u32::try_from(range.len()).expect("mutation arena range length fits u32"),
+        }
+    }
+
+    fn buffer_index(self) -> usize {
+        self.buffer_index as usize
+    }
+
+    fn offset(self) -> usize {
+        self.offset as usize
+    }
+
+    fn len(self) -> usize {
+        self.length as usize
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -785,21 +809,17 @@ impl StorageWriteGroup {
         let key_buffer_index = self.key_arena.import(key_bytes);
         let value_buffer_index = (!puts.is_empty()).then(|| self.value_arena.import(value_bytes));
         self.puts.extend(puts.into_iter().map(|put| StagedPut {
-            key: ArenaRange {
-                buffer_index: key_buffer_index,
-                range: put.key,
-            },
-            value: ArenaRange {
-                buffer_index:
-                    value_buffer_index.expect("an encoded put batch must retain its value buffer"),
-                range: put.value,
-            },
+            key: ArenaRange::new(key_buffer_index, put.key),
+            value: ArenaRange::new(
+                value_buffer_index.expect("an encoded put batch must retain its value buffer"),
+                put.value,
+            ),
         }));
-        self.deletes
-            .extend(deletes.into_iter().map(|range| ArenaRange {
-                buffer_index: key_buffer_index,
-                range,
-            }));
+        self.deletes.extend(
+            deletes
+                .into_iter()
+                .map(|range| ArenaRange::new(key_buffer_index, range)),
+        );
     }
 
     fn key_bytes(&self, range: ArenaRange) -> &[u8] {
@@ -902,10 +922,7 @@ impl MutationArena {
     fn stage_bytes(&mut self, bytes: Bytes) -> ArenaRange {
         let length = bytes.len();
         let buffer_index = self.import(bytes);
-        ArenaRange {
-            buffer_index,
-            range: BufferRange::new(0, length),
-        }
+        ArenaRange::new(buffer_index, BufferRange::new(0, length))
     }
 
     fn import(&mut self, bytes: Bytes) -> usize {
@@ -917,9 +934,9 @@ impl MutationArena {
     fn bytes(&self, range: ArenaRange) -> &[u8] {
         slice_bytes(
             self.shared
-                .get(range.buffer_index)
+                .get(range.buffer_index())
                 .expect("staged mutation references a retained shared buffer"),
-            range.range,
+            range,
         )
     }
 
@@ -938,10 +955,10 @@ impl MutationArena {
 
 impl ArenaRemap {
     fn remap(&self, range: ArenaRange) -> ArenaRange {
-        ArenaRange {
-            buffer_index: self.shared_buffer_base + range.buffer_index,
-            range: range.range,
-        }
+        ArenaRange::new(
+            self.shared_buffer_base + range.buffer_index(),
+            BufferRange::new(range.offset(), range.len()),
+        )
     }
 }
 
@@ -949,9 +966,8 @@ impl FrozenMutationArena {
     fn slice(&self, range: ArenaRange) -> Bytes {
         let bytes = self
             .shared
-            .get(range.buffer_index)
+            .get(range.buffer_index())
             .expect("lowered mutation references a retained shared buffer");
-        let range = range.range;
         if range.offset() == 0 && range.len() == bytes.len() {
             return bytes.clone();
         }
@@ -959,7 +975,7 @@ impl FrozenMutationArena {
     }
 }
 
-fn slice_bytes(bytes: &[u8], range: BufferRange) -> &[u8] {
+fn slice_bytes(bytes: &[u8], range: ArenaRange) -> &[u8] {
     &bytes[range.offset()..range.offset() + range.len()]
 }
 
@@ -1193,6 +1209,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_batch_retains_one_contiguous_key_buffer() {
+        assert_eq!(size_of::<super::ArenaRange>(), 12);
         let mut writes = StorageWriteSet::new();
         writes.delete_batch(space(), [key("c"), key("a"), key("b")]);
 

--- a/packages/slatedb-storage/Cargo.toml
+++ b/packages/slatedb-storage/Cargo.toml
@@ -25,5 +25,6 @@ blake3 = "1"
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 object_store = { version = "0.14", default-features = false, features = ["fs"] }
 slatedb = { version = "0.14.1", default-features = false, features = ["lz4", "moka"] }
+slatedb-common = "0.14.1"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }

--- a/packages/slatedb-storage/src/lib.rs
+++ b/packages/slatedb-storage/src/lib.rs
@@ -3,6 +3,7 @@
 mod slatedb;
 
 pub use slatedb::{
-    SlateDB, SlateDBCacheOptions, SlateDBFactory, SlateDBFixture, SlateDBIoCounters,
-    SlateDBIoSnapshot, SlateDBObjectStoreOptions, SlateDBRead, SlateDBWrite,
+    SlateDB, SlateDBCacheOptions, SlateDBFactory, SlateDBFixture, SlateDBIoCategorySnapshot,
+    SlateDBIoComponentSnapshot, SlateDBIoCounters, SlateDBIoSnapshot, SlateDBObjectStoreOptions,
+    SlateDBRead, SlateDBWrite,
 };

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -59,7 +59,10 @@ const SNAPSHOT_POINT_CACHE_BYTES: usize = 16 * 1024 * 1024;
 const SNAPSHOT_POINT_CACHE_ENTRIES: usize = 4096;
 const SNAPSHOT_POINT_CACHE_MAX_VALUE_BYTES: usize = 64 * 1024;
 const DEFAULT_BLOCK_CACHE_BYTES: u64 = 16 * 1024 * 1024;
-const DEFAULT_METADATA_CACHE_BYTES: u64 = 4 * 1024 * 1024;
+// Keep indexes and Bloom filters resident across batched point validation.
+// A tiny metadata cache repeatedly fetched multi-megabyte filters once the
+// repository crossed the first large-SST boundary.
+const DEFAULT_METADATA_CACHE_BYTES: u64 = 64 * 1024 * 1024;
 const SCAN_BATCH_ROWS: usize = 1024;
 const SCAN_READ_AHEAD_BYTES: usize = 2 * 1024 * 1024;
 const SCAN_MAX_FETCH_TASKS: usize = 16;

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -6,7 +6,7 @@
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::fmt;
 use std::future::Future;
-use std::ops::Bound;
+use std::ops::{Bound, Range};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, mpsc};
@@ -15,6 +15,7 @@ use std::time::{Duration, SystemTime};
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use futures_util::FutureExt;
 use futures_util::stream::{self, BoxStream, StreamExt, TryStreamExt};
 use lix_engine::storage::{
     CommitResult, CoreProjection, GetManyRequest, GetManyResult, Key, KeyRange, Precondition,
@@ -39,6 +40,7 @@ use slatedb::db_cache::moka::{MokaCache, MokaCacheOptions};
 use slatedb::db_cache::{DbCache, SplitCache};
 use slatedb::prefix_extractor::{PrefixExtractor, PrefixTarget};
 use slatedb::{CloseReason, Db, DbIterator, DbSnapshot, DbStatus, KeyValue, WriteBatch};
+use slatedb_common::metrics::{DefaultMetricsRecorder, MetricValue};
 use tempfile::TempDir;
 use tokio::runtime::{Builder, Handle, Runtime};
 use tokio::sync::{Mutex as AsyncMutex, Notify, OwnedMutexGuard, oneshot};
@@ -120,9 +122,25 @@ pub struct SlateDBCacheOptions {
     pub metadata_cache_bytes: u64,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone)]
 pub struct SlateDBIoCounters {
     inner: Arc<SlateDBIoCounterValues>,
+    metrics: Arc<DefaultMetricsRecorder>,
+}
+
+impl fmt::Debug for SlateDBIoCounters {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_struct("SlateDBIoCounters").finish()
+    }
+}
+
+impl Default for SlateDBIoCounters {
+    fn default() -> Self {
+        Self {
+            inner: Arc::default(),
+            metrics: Arc::new(DefaultMetricsRecorder::new()),
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -135,6 +153,19 @@ struct SlateDBIoCounterValues {
     listed_objects: AtomicU64,
     deleted_objects: AtomicU64,
     copied_objects: AtomicU64,
+    wal: SlateDBIoCategoryCounters,
+    compacted: SlateDBIoCategoryCounters,
+    manifest: SlateDBIoCategoryCounters,
+    compactions: SlateDBIoCategoryCounters,
+    other: SlateDBIoCategoryCounters,
+}
+
+#[derive(Debug, Default)]
+struct SlateDBIoCategoryCounters {
+    read_objects: AtomicU64,
+    read_bytes: AtomicU64,
+    write_objects: AtomicU64,
+    write_bytes: AtomicU64,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -147,10 +178,34 @@ pub struct SlateDBIoSnapshot {
     pub listed_objects: u64,
     pub deleted_objects: u64,
     pub copied_objects: u64,
+    pub wal: SlateDBIoCategorySnapshot,
+    pub compacted: SlateDBIoCategorySnapshot,
+    pub manifest: SlateDBIoCategorySnapshot,
+    pub compactions: SlateDBIoCategorySnapshot,
+    pub other: SlateDBIoCategorySnapshot,
+    pub main: SlateDBIoComponentSnapshot,
+    pub reader: SlateDBIoComponentSnapshot,
+    pub compactor: SlateDBIoComponentSnapshot,
+    pub gc: SlateDBIoComponentSnapshot,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SlateDBIoCategorySnapshot {
+    pub read_objects: u64,
+    pub read_bytes: u64,
+    pub write_objects: u64,
+    pub write_bytes: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SlateDBIoComponentSnapshot {
+    pub read_requests: u64,
+    pub write_requests: u64,
 }
 
 impl SlateDBIoCounters {
     pub fn snapshot(&self) -> SlateDBIoSnapshot {
+        let metrics = self.metrics.snapshot();
         SlateDBIoSnapshot {
             read_objects: self.inner.read_objects.load(Ordering::Relaxed),
             read_bytes: self.inner.read_bytes.load(Ordering::Relaxed),
@@ -160,6 +215,70 @@ impl SlateDBIoCounters {
             listed_objects: self.inner.listed_objects.load(Ordering::Relaxed),
             deleted_objects: self.inner.deleted_objects.load(Ordering::Relaxed),
             copied_objects: self.inner.copied_objects.load(Ordering::Relaxed),
+            wal: self.inner.wal.snapshot(),
+            compacted: self.inner.compacted.snapshot(),
+            manifest: self.inner.manifest.snapshot(),
+            compactions: self.inner.compactions.snapshot(),
+            other: self.inner.other.snapshot(),
+            main: component_snapshot(&metrics, "db"),
+            reader: component_snapshot(&metrics, "reader"),
+            compactor: component_snapshot(&metrics, "compactor"),
+            gc: component_snapshot(&metrics, "gc"),
+        }
+    }
+}
+
+fn component_snapshot(
+    metrics: &slatedb_common::metrics::Metrics,
+    component: &str,
+) -> SlateDBIoComponentSnapshot {
+    let mut snapshot = SlateDBIoComponentSnapshot::default();
+    for metric in metrics.by_name("slatedb.object_store.request_count") {
+        let label = |name: &str| {
+            metric
+                .labels
+                .iter()
+                .find_map(|(key, value)| (key == name).then_some(value.as_str()))
+        };
+        if label("component") != Some(component) {
+            continue;
+        }
+        let MetricValue::Counter(value) = metric.value else {
+            continue;
+        };
+        match label("op") {
+            Some("get") => snapshot.read_requests = snapshot.read_requests.saturating_add(value),
+            Some("put") => snapshot.write_requests = snapshot.write_requests.saturating_add(value),
+            _ => {}
+        }
+    }
+    snapshot
+}
+
+impl SlateDBIoCounterValues {
+    fn category(&self, location: &ObjectPath) -> &SlateDBIoCategoryCounters {
+        let path = location.as_ref();
+        if path.split('/').any(|part| part == "wal") {
+            &self.wal
+        } else if path.split('/').any(|part| part == "compacted") {
+            &self.compacted
+        } else if path.split('/').any(|part| part == "manifest") {
+            &self.manifest
+        } else if path.split('/').any(|part| part == "compactions") {
+            &self.compactions
+        } else {
+            &self.other
+        }
+    }
+}
+
+impl SlateDBIoCategoryCounters {
+    fn snapshot(&self) -> SlateDBIoCategorySnapshot {
+        SlateDBIoCategorySnapshot {
+            read_objects: self.read_objects.load(Ordering::Relaxed),
+            read_bytes: self.read_bytes.load(Ordering::Relaxed),
+            write_objects: self.write_objects.load(Ordering::Relaxed),
+            write_bytes: self.write_bytes.load(Ordering::Relaxed),
         }
     }
 }
@@ -175,6 +294,35 @@ impl SlateDBIoSnapshot {
             listed_objects: self.listed_objects.saturating_sub(earlier.listed_objects),
             deleted_objects: self.deleted_objects.saturating_sub(earlier.deleted_objects),
             copied_objects: self.copied_objects.saturating_sub(earlier.copied_objects),
+            wal: self.wal.saturating_sub(earlier.wal),
+            compacted: self.compacted.saturating_sub(earlier.compacted),
+            manifest: self.manifest.saturating_sub(earlier.manifest),
+            compactions: self.compactions.saturating_sub(earlier.compactions),
+            other: self.other.saturating_sub(earlier.other),
+            main: self.main.saturating_sub(earlier.main),
+            reader: self.reader.saturating_sub(earlier.reader),
+            compactor: self.compactor.saturating_sub(earlier.compactor),
+            gc: self.gc.saturating_sub(earlier.gc),
+        }
+    }
+}
+
+impl SlateDBIoCategorySnapshot {
+    fn saturating_sub(self, earlier: Self) -> Self {
+        Self {
+            read_objects: self.read_objects.saturating_sub(earlier.read_objects),
+            read_bytes: self.read_bytes.saturating_sub(earlier.read_bytes),
+            write_objects: self.write_objects.saturating_sub(earlier.write_objects),
+            write_bytes: self.write_bytes.saturating_sub(earlier.write_bytes),
+        }
+    }
+}
+
+impl SlateDBIoComponentSnapshot {
+    fn saturating_sub(self, earlier: Self) -> Self {
+        Self {
+            read_requests: self.read_requests.saturating_sub(earlier.read_requests),
+            write_requests: self.write_requests.saturating_sub(earlier.write_requests),
         }
     }
 }
@@ -199,6 +347,52 @@ struct CountingObjectStore {
     counters: SlateDBIoCounters,
 }
 
+#[derive(Debug)]
+struct CountingMultipartUpload {
+    inner: Box<dyn MultipartUpload>,
+    counters: SlateDBIoCounters,
+    location: ObjectPath,
+    uploaded_bytes: Arc<AtomicU64>,
+}
+
+#[async_trait]
+impl MultipartUpload for CountingMultipartUpload {
+    fn put_part(&mut self, payload: PutPayload) -> object_store::UploadPart {
+        let bytes = payload.content_length() as u64;
+        let uploaded_bytes = Arc::clone(&self.uploaded_bytes);
+        self.inner
+            .put_part(payload)
+            .map(move |result| {
+                if result.is_ok() {
+                    uploaded_bytes.fetch_add(bytes, Ordering::Relaxed);
+                }
+                result
+            })
+            .boxed()
+    }
+
+    async fn complete(&mut self) -> object_store::Result<PutResult> {
+        let result = self.inner.complete().await?;
+        let bytes = self.uploaded_bytes.load(Ordering::Relaxed);
+        let category = self.counters.inner.category(&self.location);
+        self.counters
+            .inner
+            .write_objects
+            .fetch_add(1, Ordering::Relaxed);
+        self.counters
+            .inner
+            .write_bytes
+            .fetch_add(bytes, Ordering::Relaxed);
+        category.write_objects.fetch_add(1, Ordering::Relaxed);
+        category.write_bytes.fetch_add(bytes, Ordering::Relaxed);
+        Ok(result)
+    }
+
+    async fn abort(&mut self) -> object_store::Result<()> {
+        self.inner.abort().await
+    }
+}
+
 impl fmt::Display for CountingObjectStore {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(formatter, "counting {}", self.inner)
@@ -215,6 +409,7 @@ impl ObjectStore for CountingObjectStore {
     ) -> object_store::Result<PutResult> {
         let bytes = payload.content_length() as u64;
         let result = self.inner.put_opts(location, payload, options).await?;
+        let category = self.counters.inner.category(location);
         self.counters
             .inner
             .write_objects
@@ -223,6 +418,8 @@ impl ObjectStore for CountingObjectStore {
             .inner
             .write_bytes
             .fetch_add(bytes, Ordering::Relaxed);
+        category.write_objects.fetch_add(1, Ordering::Relaxed);
+        category.write_bytes.fetch_add(bytes, Ordering::Relaxed);
         Ok(result)
     }
 
@@ -231,7 +428,13 @@ impl ObjectStore for CountingObjectStore {
         location: &ObjectPath,
         options: PutMultipartOptions,
     ) -> object_store::Result<Box<dyn MultipartUpload>> {
-        self.inner.put_multipart_opts(location, options).await
+        let inner = self.inner.put_multipart_opts(location, options).await?;
+        Ok(Box::new(CountingMultipartUpload {
+            inner,
+            counters: self.counters.clone(),
+            location: location.clone(),
+            uploaded_bytes: Arc::new(AtomicU64::new(0)),
+        }))
     }
 
     async fn get_opts(
@@ -240,12 +443,15 @@ impl ObjectStore for CountingObjectStore {
         options: ObjectStoreGetOptions,
     ) -> object_store::Result<GetResult> {
         let mut result = self.inner.get_opts(location, options).await?;
+        let category = self.counters.inner.category(location);
         self.counters
             .inner
             .read_objects
             .fetch_add(1, Ordering::Relaxed);
+        category.read_objects.fetch_add(1, Ordering::Relaxed);
         if let GetResultPayload::Stream(payload) = result.payload {
             let counters = self.counters.clone();
+            let location = location.clone();
             result.payload = GetResultPayload::Stream(
                 payload
                     .map(move |item| {
@@ -254,12 +460,38 @@ impl ObjectStore for CountingObjectStore {
                                 .inner
                                 .read_bytes
                                 .fetch_add(bytes.len() as u64, Ordering::Relaxed);
+                            counters
+                                .inner
+                                .category(&location)
+                                .read_bytes
+                                .fetch_add(bytes.len() as u64, Ordering::Relaxed);
                         }
                         item
                     })
                     .boxed(),
             );
         }
+        Ok(result)
+    }
+
+    async fn get_ranges(
+        &self,
+        location: &ObjectPath,
+        ranges: &[Range<u64>],
+    ) -> object_store::Result<Vec<Bytes>> {
+        let result = self.inner.get_ranges(location, ranges).await?;
+        let bytes = result.iter().map(|bytes| bytes.len() as u64).sum::<u64>();
+        let category = self.counters.inner.category(location);
+        self.counters
+            .inner
+            .read_objects
+            .fetch_add(1, Ordering::Relaxed);
+        self.counters
+            .inner
+            .read_bytes
+            .fetch_add(bytes, Ordering::Relaxed);
+        category.read_objects.fetch_add(1, Ordering::Relaxed);
+        category.read_bytes.fetch_add(bytes, Ordering::Relaxed);
         Ok(result)
     }
 
@@ -434,6 +666,22 @@ impl ObjectStore for DirectLocalReads {
             attributes: Attributes::default(),
             extensions: Extensions::default(),
         })
+    }
+
+    async fn get_ranges(
+        &self,
+        location: &ObjectPath,
+        ranges: &[Range<u64>],
+    ) -> object_store::Result<Vec<Bytes>> {
+        let mut result = Vec::with_capacity(ranges.len());
+        for range in ranges {
+            let options = ObjectStoreGetOptions {
+                range: Some(object_store::GetRange::Bounded(range.clone())),
+                ..ObjectStoreGetOptions::default()
+            };
+            result.push(self.get_opts(location, options).await?.bytes().await?);
+        }
+        Ok(result)
     }
 
     fn delete_stream(
@@ -1245,6 +1493,9 @@ impl SlateDB {
             inner: LocalFileSystem::new_with_prefix(&path).map_err(object_store_error)?,
             files: Mutex::new(DirectLocalFileCache::default()),
         });
+        let metrics = counters
+            .as_ref()
+            .map(|counters| Arc::clone(&counters.metrics));
         if let Some(counters) = counters {
             object_store = Arc::new(CountingObjectStore {
                 inner: object_store,
@@ -1256,6 +1507,7 @@ impl SlateDB {
             object_store,
             SlateDBObjectStoreOptions::default(),
             true,
+            metrics,
         )
         .map(|mut storage| {
             storage.path = path;
@@ -1268,7 +1520,7 @@ impl SlateDB {
         object_store: Arc<dyn ObjectStore>,
         options: SlateDBObjectStoreOptions,
     ) -> Result<Self, StorageError> {
-        Self::open_object_store_with_read_dispatch(db_path, object_store, options, false)
+        Self::open_object_store_with_read_dispatch(db_path, object_store, options, false, None)
     }
 
     /// Opens SlateDB with a private current-thread read-dispatch choice.
@@ -1282,6 +1534,7 @@ impl SlateDB {
         object_store: Arc<dyn ObjectStore>,
         options: SlateDBObjectStoreOptions,
         read_on_caller_current_thread: bool,
+        metrics: Option<Arc<DefaultMetricsRecorder>>,
     ) -> Result<Self, StorageError> {
         validate_object_store_options(&options)?;
         let db_path = db_path.into();
@@ -1291,6 +1544,7 @@ impl SlateDB {
                 object_store,
                 options,
                 read_on_caller_current_thread,
+                metrics,
             )?,
             path: PathBuf::from(db_path),
             write_gate: WriteGate::new(),
@@ -2324,6 +2578,7 @@ impl SlateDBWorker {
         object_store: Arc<dyn ObjectStore>,
         options: SlateDBObjectStoreOptions,
         read_on_caller_current_thread: bool,
+        metrics: Option<Arc<DefaultMetricsRecorder>>,
     ) -> Result<Self, StorageError> {
         let in_flight = InFlightTracker::default();
         let reclamation = InFlightTracker::default();
@@ -2337,6 +2592,7 @@ impl SlateDBWorker {
                     db_path,
                     object_store,
                     options,
+                    metrics,
                     shutdown_rx,
                     opened_tx,
                     manager_in_flight,
@@ -2535,6 +2791,7 @@ fn run_slatedb_manager(
     db_path: String,
     object_store: Arc<dyn ObjectStore>,
     options: SlateDBObjectStoreOptions,
+    metrics: Option<Arc<DefaultMetricsRecorder>>,
     shutdown: mpsc::Receiver<()>,
     opened: mpsc::Sender<Result<(Handle, Arc<Db>), StorageError>>,
     in_flight: InFlightTracker,
@@ -2553,7 +2810,7 @@ fn run_slatedb_manager(
         }
     };
 
-    let db = match open_slatedb(&runtime, db_path, object_store, options) {
+    let db = match open_slatedb(&runtime, db_path, object_store, options, metrics) {
         Ok(db) => db,
         Err(error) => {
             let _ = opened.send(Err(error));
@@ -2579,11 +2836,15 @@ fn open_slatedb(
     db_path: String,
     object_store: Arc<dyn ObjectStore>,
     options: SlateDBObjectStoreOptions,
+    metrics: Option<Arc<DefaultMetricsRecorder>>,
 ) -> Result<Db, StorageError> {
     runtime.block_on(async move {
         let physical_db_path = join_db_path(&db_path, SEGMENTED_FORMAT_PATH);
         let mut builder = Db::builder(physical_db_path, object_store)
             .with_segment_extractor(Arc::new(StorageSpacePrefixExtractor));
+        if let Some(metrics) = metrics {
+            builder = builder.with_metrics_recorder(metrics);
+        }
         let mut settings = slatedb_settings();
         if let Some(cache) = options.cache {
             settings.object_store_cache_options = ObjectStoreCacheOptions {
@@ -3260,27 +3521,76 @@ mod tests {
             .await
             .expect("read counted object");
         assert_eq!(bytes, Bytes::from_static(b"payload"));
+        let ranges = store
+            .get_ranges(&path, &[0..2, 5..7])
+            .await
+            .expect("read counted object ranges");
+        assert_eq!(
+            ranges,
+            vec![Bytes::from_static(b"pa"), Bytes::from_static(b"ad")]
+        );
+        let multipart_path = ObjectPath::from("multipart.sst");
+        let mut multipart = store
+            .put_multipart_opts(&multipart_path, PutMultipartOptions::default())
+            .await
+            .expect("open counted multipart object");
+        multipart
+            .put_part(PutPayload::from_static(b"multi"))
+            .await
+            .expect("write counted multipart part");
+        multipart
+            .put_part(PutPayload::from_static(b"part"))
+            .await
+            .expect("write second counted multipart part");
+        multipart
+            .complete()
+            .await
+            .expect("complete counted multipart object");
         let listed = store
             .list(None)
             .try_collect::<Vec<_>>()
             .await
             .expect("list counted object");
-        assert_eq!(listed.len(), 1);
+        assert_eq!(listed.len(), 2);
         store.delete(&path).await.expect("delete counted object");
 
         assert_eq!(
             counters.snapshot(),
             SlateDBIoSnapshot {
-                read_objects: 1,
-                read_bytes: 7,
-                write_objects: 1,
-                write_bytes: 7,
+                read_objects: 2,
+                read_bytes: 11,
+                write_objects: 2,
+                write_bytes: 16,
                 list_operations: 1,
-                listed_objects: 1,
+                listed_objects: 2,
                 deleted_objects: 1,
                 copied_objects: 0,
+                other: SlateDBIoCategorySnapshot {
+                    read_objects: 2,
+                    read_bytes: 11,
+                    write_objects: 2,
+                    write_bytes: 16,
+                },
+                ..SlateDBIoSnapshot::default()
             }
         );
+    }
+
+    #[test]
+    fn diagnostic_object_store_counters_classify_slatedb_paths() {
+        let counters = SlateDBIoCounterValues::default();
+        for (path, expected) in [
+            ("db/wal/1.sst", &counters.wal),
+            ("db/compacted/1.sst", &counters.compacted),
+            ("db/manifest/1.manifest", &counters.manifest),
+            ("db/compactions/1.compactions", &counters.compactions),
+            ("db/other/file", &counters.other),
+        ] {
+            assert!(std::ptr::eq(
+                counters.category(&ObjectPath::from(path)),
+                expected
+            ));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- replaces GC's `BTreeMap<CommitId, CommitRecord>` with a sorted contiguous commit inventory
- retains only fields GC uses: commit ID, exact commit change ID, and parent ranges
- stores all parent IDs in one shared contiguous arena
- resolves reachability parents with binary search over sorted commit IDs (`O(log history)`)
- rejects duplicate or out-of-order scan rows explicitly
- consumes scanned records instead of cloning full commit records into the inventory

## Root cause

The authority sweep materialized every full `CommitRecord` in a B-tree even though GC never reads author IDs, timestamp, format version, or the rootless flag. That retained per-node tree overhead, two vectors per commit record, and unused fields for the duration of the atomic sweep. In the one-row-commit case this was the largest remaining avoidable allocation after delete-key batching.

This changes only GC's transient in-memory representation. Durable keys, packed layout, reachability semantics, delete set, and backend behavior are unchanged.

## Before / after

Immediate baseline is the batched-delete PR. Smallest-commit shape, flushed/settled fixtures, 3 cold samples on `hetzner-ccx33`:

| backend | history | metric | before | after | change |
|---|---:|---|---:|---:|---:|
| RocksDB | 1M | p99 | 892.0 ms | 605.3 ms | -32% |
| RocksDB | 1M | peak RSS | 447 MiB | 319 MiB | -29% |
| SlateDB | 1M | p99 | 1749.2 ms | 1524.1 ms | -13% |
| SlateDB | 1M | peak RSS | 466 MiB | 367 MiB | -21% |

Across the complete GC stack before both production cuts, 1M peak RSS falls from 475→319 MiB on RocksDB and 546→367 MiB on SlateDB (about one third lower on both).

100k→1M p99 slopes remain near-linear: approximately 0.92 for RocksDB and 1.00 for SlateDB. The sweep still intentionally enumerates history; this PR removes unused materialization without pretending the remaining atomic delete descriptors are bounded memory.

After-profile accounting remains 3M logical deletes, 3 shared key buffers, and 48 MB logical key bytes at 1M, proving the result did not come from skipping work.

## Validation

- `cargo check -p lix_engine --features storage-benches`
- `cargo test -j 1 -p lix_engine --features storage-benches gc --lib` on `hetzner-ccx33` (15 tests)
- `cargo fmt --all -- --check`
- `git diff --check`
- release before/after profiles at 100k and 1M on RocksDB and flushed/settled SlateDB

Stacked on the batched-delete cut and the repository-GC benchmark PR.