### PR TITLE
perf(storage): compact mutation ranges

### DIFF
--- a/packages/engine/src/storage_adapter/write_set.rs
+++ b/packages/engine/src/storage_adapter/write_set.rs
@@ -98,8 +98,32 @@ struct MutationArena {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct ArenaRange {
-    buffer_index: usize,
-    range: BufferRange,
+    buffer_index: u32,
+    offset: u32,
+    length: u32,
+}
+
+impl ArenaRange {
+    fn new(buffer_index: usize, range: BufferRange) -> Self {
+        Self {
+            buffer_index: u32::try_from(buffer_index)
+                .expect("mutation arena buffer count fits u32"),
+            offset: u32::try_from(range.offset()).expect("mutation arena offset fits u32"),
+            length: u32::try_from(range.len()).expect("mutation arena range length fits u32"),
+        }
+    }
+
+    fn buffer_index(self) -> usize {
+        self.buffer_index as usize
+    }
+
+    fn offset(self) -> usize {
+        self.offset as usize
+    }
+
+    fn len(self) -> usize {
+        self.length as usize
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -785,21 +809,17 @@ impl StorageWriteGroup {
         let key_buffer_index = self.key_arena.import(key_bytes);
         let value_buffer_index = (!puts.is_empty()).then(|| self.value_arena.import(value_bytes));
         self.puts.extend(puts.into_iter().map(|put| StagedPut {
-            key: ArenaRange {
-                buffer_index: key_buffer_index,
-                range: put.key,
-            },
-            value: ArenaRange {
-                buffer_index:
-                    value_buffer_index.expect("an encoded put batch must retain its value buffer"),
-                range: put.value,
-            },
+            key: ArenaRange::new(key_buffer_index, put.key),
+            value: ArenaRange::new(
+                value_buffer_index.expect("an encoded put batch must retain its value buffer"),
+                put.value,
+            ),
         }));
-        self.deletes
-            .extend(deletes.into_iter().map(|range| ArenaRange {
-                buffer_index: key_buffer_index,
-                range,
-            }));
+        self.deletes.extend(
+            deletes
+                .into_iter()
+                .map(|range| ArenaRange::new(key_buffer_index, range)),
+        );
     }
 
     fn key_bytes(&self, range: ArenaRange) -> &[u8] {
@@ -902,10 +922,7 @@ impl MutationArena {
     fn stage_bytes(&mut self, bytes: Bytes) -> ArenaRange {
         let length = bytes.len();
         let buffer_index = self.import(bytes);
-        ArenaRange {
-            buffer_index,
-            range: BufferRange::new(0, length),
-        }
+        ArenaRange::new(buffer_index, BufferRange::new(0, length))
     }
 
     fn import(&mut self, bytes: Bytes) -> usize {
@@ -917,9 +934,9 @@ impl MutationArena {
     fn bytes(&self, range: ArenaRange) -> &[u8] {
         slice_bytes(
             self.shared
-                .get(range.buffer_index)
+                .get(range.buffer_index())
                 .expect("staged mutation references a retained shared buffer"),
-            range.range,
+            range,
         )
     }
 
@@ -938,10 +955,10 @@ impl MutationArena {
 
 impl ArenaRemap {
     fn remap(&self, range: ArenaRange) -> ArenaRange {
-        ArenaRange {
-            buffer_index: self.shared_buffer_base + range.buffer_index,
-            range: range.range,
-        }
+        ArenaRange::new(
+            self.shared_buffer_base + range.buffer_index(),
+            BufferRange::new(range.offset(), range.len()),
+        )
     }
 }
 
@@ -949,9 +966,8 @@ impl FrozenMutationArena {
     fn slice(&self, range: ArenaRange) -> Bytes {
         let bytes = self
             .shared
-            .get(range.buffer_index)
+            .get(range.buffer_index())
             .expect("lowered mutation references a retained shared buffer");
-        let range = range.range;
         if range.offset() == 0 && range.len() == bytes.len() {
             return bytes.clone();
         }
@@ -959,7 +975,7 @@ impl FrozenMutationArena {
     }
 }
 
-fn slice_bytes(bytes: &[u8], range: BufferRange) -> &[u8] {
+fn slice_bytes(bytes: &[u8], range: ArenaRange) -> &[u8] {
     &bytes[range.offset()..range.offset() + range.len()]
 }
 
@@ -1193,6 +1209,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_batch_retains_one_contiguous_key_buffer() {
+        assert_eq!(size_of::<super::ArenaRange>(), 12);
         let mut writes = StorageWriteSet::new();
         writes.delete_batch(space(), [key("c"), key("a"), key("b")]);
 


### PR DESCRIPTION
## What changed

- compacts the internal retained mutation range from three machine-word fields (24 bytes on 64-bit) to three checked `u32` fields (12 bytes)
- keeps conversion back to `usize` at arena access/lowering boundaries
- retains all existing sorting, duplicate validation, write-set extension/remapping, zero-copy slicing, and backend batch behavior
- adds an explicit size assertion to prevent the descriptor from silently growing again

This is an in-memory representation hard cut only. It does not change durable formats or public storage keys. A single retained buffer/range and total buffer index must fit `u32`; constructors fail immediately if a write set exceeds that bound. The profiled 10M GC case uses 160 MB per key buffer, well inside the limit.

## Root cause

After delete-key batching and compact commit inventory, the 10M one-row-commit GC plan still retained 30M delete descriptors. At 24 bytes each, descriptors alone accounted for roughly 720 MB and drove enough memory traffic for RocksDB's 1M→10M p99 slope to reach about 1.26.

## Before / after

Immediate baseline is the compact GC inventory PR. Flushed fixtures, 3 cold samples on `hetzner-ccx33`:

| backend | history | metric | before | after | change |
|---|---:|---|---:|---:|---:|
| RocksDB | 1M | peak RSS | 319 MiB | 265 MiB | -17% |
| SlateDB | 1M | peak RSS | 367 MiB | 303 MiB | -17% |
| RocksDB | 1M | p99 | 605.3 ms | 606.2 ms | flat |
| SlateDB | 1M | p99 | 1524.1 ms | 1522.8 ms | flat |
| RocksDB | 10M | peak RSS | 2.40 GiB | 2.13 GiB | -11% |
| RocksDB | 10M | p99 | 11.02 s | 9.18 s | -17% |

RocksDB's 1M→10M p99 log-log slope falls from approximately 1.26 to 1.18, inside the 1.1–1.2 historical-scan target. The after run still plans all 30M deletes and retains the same 480 MB of logical key bytes, so no work was skipped.

The prior SlateDB 10M endpoint already had a ~1.14 slope; this cut was verified on SlateDB at 1M and affects the backend-independent write-set representation identically. Its 10M fixture also exposed a separate lifecycle confound: setup performed 56.4 GB of object reads for 600 MB logical ingest, and background compaction was still writing during the nominally read-only measure after a 5 s settle. That compaction policy issue is intentionally not mixed into this representation PR.

## Validation

- `cargo test -j 1 -p lix_engine --features storage-benches storage_adapter::write_set::tests --lib` (11 tests)
- `cargo test -j 1 -p lix_engine --features storage-benches gc --lib` (15 tests)
- `cargo clippy -j 1 -p lix_engine --features storage-benches -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- release profiles at 1M on both backends and 10M on RocksDB

Stacked on the compact GC inventory PR.