### PR TITLE
Retain SlateDB metadata across point batches

### DIFF
--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -59,7 +59,10 @@ const SNAPSHOT_POINT_CACHE_BYTES: usize = 16 * 1024 * 1024;
 const SNAPSHOT_POINT_CACHE_ENTRIES: usize = 4096;
 const SNAPSHOT_POINT_CACHE_MAX_VALUE_BYTES: usize = 64 * 1024;
 const DEFAULT_BLOCK_CACHE_BYTES: u64 = 16 * 1024 * 1024;
-const DEFAULT_METADATA_CACHE_BYTES: u64 = 4 * 1024 * 1024;
+// Keep indexes and Bloom filters resident across batched point validation.
+// A tiny metadata cache repeatedly fetched multi-megabyte filters once the
+// repository crossed the first large-SST boundary.
+const DEFAULT_METADATA_CACHE_BYTES: u64 = 64 * 1024 * 1024;
 const SCAN_BATCH_ROWS: usize = 1024;
 const SCAN_READ_AHEAD_BYTES: usize = 2 * 1024 * 1024;
 const SCAN_MAX_FETCH_TASKS: usize = 16;


### PR DESCRIPTION
## What changed

Raise Lix's default SlateDB metadata cache from 4 MiB to 64 MiB while leaving the 16 MiB data-block cache unchanged.

## Root cause

At the 10M one-row-commit boundary, SlateDB creates large compacted SSTs whose Bloom filters no longer fit in Lix's 4 MiB metadata cache. Each append batch validates new commit IDs and derived change IDs with exact point reads. Filter eviction made those fixed-work point checks repeatedly fetch multi-megabyte filter sections.

Caller-attributed storage accounting in the parent PR disproved the initial compactor hypothesis: foreground DB reads dominated, averaging about 1.85 MiB per request, while compactor request volume was small. Lix's 4 MiB limit was also far below SlateDB's 128 MiB upstream metadata-cache default.

## Before / after

SlateDB, 10M changes, one-row commits, forced memtable flush, 5 s settle, on `hetzner-ccx33`:

| metric | 4 MiB | 64 MiB | change |
|---|---:|---:|---:|
| compacted bytes read during setup | 121.05 GB | 0.732 GB | 165× lower |
| foreground read requests | 65,439 | 1,906 | 34× lower |
| ingest time | 252.9 s | 194.9 s | 1.30× faster |
| ingest throughput | 39.5k changes/s | 51.3k changes/s | +30% |
| setup peak RSS | 809 MiB | 840 MiB | +31 MiB |
| physical storage | 1.633 GB | 1.629 GB | unchanged |

The subsequent 10M GC scan remained about 19.4 s p99 with ~2.0 GiB peak RSS, confirming this cut targets point-validation/filter thrash rather than hiding history-scan work.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo check -p lix_engine_benchmarks --bench repository_gc_scale --features storage-benches,slatedb,rocksdb`
- `cargo test -p lix_slatedb_storage diagnostic_object_store_counters --lib`
- before/after 10M width-one SlateDB setup and three-sample GC measure on `hetzner-ccx33`; fixtures removed after each run