### PR TITLE
perf(engine): index pending tombstone identities

### DIFF
--- a/packages/engine/src/transaction/validation.rs
+++ b/packages/engine/src/transaction/validation.rs
@@ -24,7 +24,9 @@ use crate::common::format_json_pointer;
 #[cfg(test)]
 use crate::common::parse_json_pointer;
 use crate::common::{json_pointer_get, validate_row_metadata};
-use crate::domain::{Domain, DomainFileScope, DomainRowIdentity};
+use crate::domain::{
+    Domain, DomainFileScope, DomainRowIdentity, committed_row_ref_is_exact_branch_scoped,
+};
 use crate::entity_pk::{EntityPk, EntityPkError, canonical_json_text};
 use crate::live_state::{
     LiveStateFilter, LiveStateProjection, LiveStateReader, LiveStateScanRequest,
@@ -2070,12 +2072,15 @@ impl PendingConstraintIndexes {
     }
 
     fn tombstones_identity(&self, row: MaterializedLiveStateRowRef<'_>) -> bool {
-        if self.tombstone_identities.is_empty() {
-            return false;
-        }
-        self.tombstone_identities
-            .iter()
-            .any(|identity| identity.matches_live_row_ref(row))
+        !self.tombstone_identities.is_empty()
+            && committed_row_ref_is_exact_branch_scoped(row, row.branch_id())
+            && self
+                .tombstone_identities
+                .contains(&DomainRowIdentity::in_domain(
+                    Domain::for_live_row_ref(row),
+                    row.schema_key().to_string(),
+                    row.entity_pk().clone(),
+                ))
     }
 
     fn replaces_committed_identity(&self, row: MaterializedLiveStateRowRef<'_>) -> bool {
@@ -6709,6 +6714,31 @@ mod tests {
                 EntityPk::single("target-1"),
             ))
         );
+    }
+
+    #[test]
+    fn pending_indexes_match_tombstones_by_exact_committed_identity() {
+        let mut indexes = PendingConstraintIndexes::default();
+        let branch_id = "01920000-0000-7000-8000-0000000000a1";
+        let mut deleted = fk_child_row("child-1", "parent-1", branch_id);
+        deleted.snapshot = None;
+        indexes.remember_tombstone(PreparedValidationRow::State(deleted.borrowed()));
+
+        let committed =
+            MaterializedLiveStateRow::from(fk_child_row("child-1", "parent-1", branch_id));
+        let mut other_file = committed.clone();
+        other_file.file_id = Some("01920000-0000-7000-8000-0000000000b1".into());
+        let mut malformed_projection = committed.clone();
+        malformed_projection.global = true;
+        let batch = MaterializedLiveStateBatch::from_rows(vec![
+            committed,
+            other_file,
+            malformed_projection,
+        ]);
+
+        assert!(indexes.tombstones_identity(batch.row(0)));
+        assert!(!indexes.tombstones_identity(batch.row(1)));
+        assert!(!indexes.tombstones_identity(batch.row(2)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- replace a linear scan over all pending tombstones for every committed validation row with an exact `HashSet` identity lookup
- retain the committed-row branch/global projection guard from the previous predicate
- add regression coverage for matching identities, different file scopes, and malformed global projections

## Root cause

Eager plugin materialization can stage thousands of semantic tombstones in one transaction. Constraint validation checked each scanned committed row by iterating the entire pending tombstone set and comparing domain, schema, and entity key. This made large semantic commits quadratic.

A `perf` profile of OpenClaw commit `20e41c5a10c1e4133628d6677a784d6b0020c9c6` attributed 30.2% of cycles to `memcmp`, 10.0% to `DomainRowIdentity::matches_live_row_ref`, and 4.0% directly to `PendingConstraintIndexes::tombstones_identity`.

## Impact

Exact-parent replay with the Markdown, CSV, and text WASM plugins enabled improved:

- `20e41c5…`: 32.91s → 7.45s (4.42× faster)
- `3ed06c…`: 187.58s → 32.13s (5.84× faster)

The post-fix profile reduced `memcmp` from 30.2% to 6.6% and removed the linear tombstone predicate from the hot symbols. Eager semantic materialization and WASM execution remain unchanged. The replay still produced 1,268 fully materialized semantic rows and 1,101 durable semantic changes for `20e41c5…`.

## Validation

- `cargo fmt --check`
- `cargo test -p lix_engine transaction::validation --lib` (115 passed)
- isolated exact-parent OpenClaw replay on RocksDB
- pre/post `perf record` + flat reports