### PR TITLE
bench(storage): stream layout accounting

### DIFF
--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -381,23 +381,58 @@ async fn scan_layout_space<R>(
 where
     R: StorageAdapterRead,
 {
-    let entries = scan_layout_entries(read, space).await;
-
-    StorageLayoutAccounting {
+    let plan = ScanPlan::prefix(
+        space,
+        StoragePrefix {
+            bytes: Bytes::new(),
+        },
+    );
+    let mut accounting = StorageLayoutAccounting {
         space_id: space.id.0,
         space: space.name,
-        rows: entries.len() as u64,
-        key_bytes: entries
-            .iter()
-            .map(|entry| entry.key.0.len() as u64 + 4)
-            .sum(),
-        value_bytes: entries
-            .iter()
-            .map(|entry| match &entry.value {
-                StorageProjectedValue::KeyOnly => 0,
-                StorageProjectedValue::FullValue(value) => value.len() as u64,
-            })
-            .sum(),
+        rows: 0,
+        key_bytes: 0,
+        value_bytes: 0,
+    };
+    let mut resume_after = None;
+    loop {
+        let result = plan
+            .collect(
+                read,
+                StorageScanOptions {
+                    projection: StorageCoreProjection::FullValue,
+                    resume_after,
+                    ..StorageScanOptions::default()
+                },
+            )
+            .await
+            .expect("scan complete storage bench layout space");
+        let has_more = result.value.has_more;
+        resume_after = result.value.entries.last().map(|entry| entry.key.clone());
+        for entry in result.value.entries {
+            accounting.rows = accounting
+                .rows
+                .checked_add(1)
+                .expect("storage layout row count should not overflow");
+            accounting.key_bytes = accounting
+                .key_bytes
+                .checked_add(entry.key.0.len() as u64 + 4)
+                .expect("storage layout key bytes should not overflow");
+            accounting.value_bytes = accounting
+                .value_bytes
+                .checked_add(match entry.value {
+                    StorageProjectedValue::KeyOnly => 0,
+                    StorageProjectedValue::FullValue(value) => value.len() as u64,
+                })
+                .expect("storage layout value bytes should not overflow");
+        }
+        if !has_more {
+            return accounting;
+        }
+        assert!(
+            resume_after.is_some(),
+            "storage scan reported more rows without a resume key"
+        );
     }
 }
 
@@ -472,6 +507,43 @@ mod tests {
         assert_eq!(materialized.commits, 1_025);
         assert_eq!(materialized.pages, 2);
         assert_eq!(streamed, materialized);
+    }
+
+    #[tokio::test]
+    async fn streamed_layout_accounting_matches_full_space_inventory() {
+        let storage = Memory::new();
+        let append = append_ordered_commits(0, 1_025).expect("build commit fixture");
+        stage_append_once(storage.clone(), &append)
+            .await
+            .expect("stage commit fixture");
+        let adapter = StorageAdapter::new(storage);
+        let read = adapter
+            .begin_read(crate::ReadOptions::default())
+            .await
+            .expect("begin layout accounting read");
+
+        let inventory = super::space_inventory(&read, crate::changelog::COMMIT_SPACE.name).await;
+        let accounting = super::layout_accounting(&read)
+            .await
+            .into_iter()
+            .find(|space| space.space == crate::changelog::COMMIT_SPACE.name)
+            .expect("commit space is accounted");
+
+        assert_eq!(accounting.rows, inventory.len() as u64);
+        assert_eq!(
+            accounting.key_bytes,
+            inventory
+                .iter()
+                .map(|(key, _)| key.len() as u64 + 4)
+                .sum::<u64>()
+        );
+        assert_eq!(
+            accounting.value_bytes,
+            inventory
+                .iter()
+                .map(|(_, value)| value.len() as u64)
+                .sum::<u64>()
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

- Accumulate storage layout row/key/value totals one scan page at a time.
- Keep `space_inventory` materialized for byte-for-byte equivalence tests.
- Add an equivalence test proving streamed totals match the full inventory across a 1,025-row, multi-page commit fixture.

## Root cause

`layout_accounting()` reused `scan_layout_entries()`, which appended every key and full value in a storage space to one `Vec`. The 10M-change packed-history benchmark therefore materialized roughly 1.3 GiB of manifest values plus millions of entry objects *after* the timed scan. That contaminated peak RSS and made a diagnostic operation violate the benchmark's bounded-memory requirement.

## Measured impact

SlateDB, 10M changes, one-row commits, forced memtable flush, 5s settle, ext4-backed `TMPDIR`:

| implementation | peak RSS | manifest rows | locator rows |
| --- | ---: | ---: | ---: |
| materialized accounting | 5,073,108 KiB | 10,000,000 | 10,000,000 |
| streamed accounting | 3,658,864 KiB | 10,000,000 | 10,000,000 |

Peak RSS falls 27.9% while all physical layout counts remain exact. The retained memory is now bounded by one storage scan page rather than total history.

This run also corrected an environment confound discovered during profiling: `/tmp` on the benchmark host is a 16 GiB tmpfs. These comparison runs set `TMPDIR=/root/profile-results/tmp` on ext4; tmpfs/OOM results are excluded.

Binary SHA-256:

- before: `735c0c835816ebbbac728f95309fc79ec0e19eb193767486c23e845ae13ae702`
- after: `c08b9e64a0ed859613dbe6424e0b7077226ebc5e7c75a4fd2e53245ecc6874c9`

## Validation

- `cargo test -p lix_engine --features storage-benches storage_bench::tests --lib`
- `cargo clippy -p lix_engine --features storage-benches --lib -- -D warnings`
- `cargo check -p lix_engine_benchmarks --bench packed_history_scale --features storage-benches,slatedb,rocksdb`
- 10M SlateDB packed-history run with exact before/after layout-count comparison
