### PR TITLE
perf(slatedb): bound unflushed write memory

### DIFF
--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -63,6 +63,7 @@ const DEFAULT_BLOCK_CACHE_BYTES: u64 = 16 * 1024 * 1024;
 // A tiny metadata cache repeatedly fetched multi-megabyte filters once the
 // repository crossed the first large-SST boundary.
 const DEFAULT_METADATA_CACHE_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_UNFLUSHED_BYTES: usize = 128 * 1024 * 1024;
 const SCAN_BATCH_ROWS: usize = 1024;
 const SCAN_READ_AHEAD_BYTES: usize = 2 * 1024 * 1024;
 const SCAN_MAX_FETCH_TASKS: usize = 16;
@@ -2898,6 +2899,7 @@ fn slatedb_settings() -> Settings {
         .as_mut()
         .expect("default SlateDB settings enable compaction")
         .commit_compacted_interval = COMPACTOR_COMMIT_INTERVAL;
+    settings.max_unflushed_bytes = MAX_UNFLUSHED_BYTES;
     settings
 }
 
@@ -3615,6 +3617,13 @@ mod tests {
             slatedb_settings().compression_codec,
             Some(CompressionCodec::Lz4)
         );
+    }
+
+    #[test]
+    fn bounds_unflushed_memory_to_two_l0_tables() {
+        let settings = slatedb_settings();
+        assert_eq!(settings.max_unflushed_bytes, MAX_UNFLUSHED_BYTES);
+        assert_eq!(settings.max_unflushed_bytes, settings.l0_sst_size_bytes * 2);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

Set SlateDB's `max_unflushed_bytes` to 128 MiB, or two configured 64 MiB L0 SSTs, instead of inheriting upstream's 1 GiB default. A unit test pins the relationship so an upstream settings change cannot silently invalidate the budget.

This is stacked on #947 so peak-RSS measurements are no longer contaminated by materialized layout accounting.

## Root cause

SlateDB applies write backpressure only after active plus immutable memtables reach `max_unflushed_bytes`. The upstream 1 GiB default permits much larger transient retention once row/object overhead, frozen tables, compaction, and benchmark state are included. At 10M one-row commits, the production path peaked above 3 GiB even after excluding layout accounting.

Profiles first exposed a separate host confound: `/tmp` is a 16 GiB tmpfs. All accepted results below set `TMPDIR=/root/profile-results/tmp` on ext4, and `LIX_PACKED_HISTORY_ACCOUNT_LAYOUT=0` isolates production ingest/scan memory from diagnostic accounting.

## Measured tradeoff

SlateDB, 10M unique changes, one-row commits, 10k-change storage batches, forced memtable flush, 5s settle, one cold full scan:

| unflushed budget | peak RSS | seed | reported ingest | scan | total wall |
| --- | ---: | ---: | ---: | ---: | ---: |
| upstream 1 GiB | 3,083,888 KiB | 62.6s | 159.7k changes/s | 23.29s | 111.5s |
| 256 MiB | 2,127,060 KiB | 76.6s | 130.5k changes/s | 24.20s | 120.5s |
| **128 MiB** | **1,812,172 KiB** | 77.8s | 128.6k changes/s | 23.88s | 122.5s |

The selected 128 MiB budget reduces peak RSS 41.2% versus upstream. End-to-end wall rises 9.8%, while scan latency rises 2.6%. Some compaction work moves into the timed seed phase, so reported ingest throughput falls 19.5% even though the full lifecycle penalty is smaller.

The 256 MiB midpoint is dominated: it retains 17.4% more memory than 128 MiB for only 1.6% lower total wall. This is why the PR uses 128 MiB rather than choosing a cap in advance.

Binary SHA-256:

- upstream baseline: `735c0c835816ebbbac728f95309fc79ec0e19eb193767486c23e845ae13ae702`
- 128 MiB: `1a133705f4e0c4557a5552eb50a529f8b26dc0d976b48ce0d2f2a3d22b408684`
- 256 MiB: `b10b79f5ce0b05e7b230869d94094bba74fd9ee4866bda44bf7458523385c4d0`

## Validation

- all 39 `lix_slatedb_storage` library tests
- `cargo clippy -p lix_engine_benchmarks --bench packed_history_scale --features storage-benches,slatedb,rocksdb -- -D warnings`
- ext4-backed 1M and 10M packed-history controls
- ext4-backed 10M A/B at 1 GiB, 256 MiB, and 128 MiB

RocksDB is unaffected; this changes only SlateDB lifecycle policy and does not alter the packed physical layout.
