### PR TITLE
bench(storage): account packed-history object I/O

### DIFF
--- a/packages/engine-benchmarks/benches/changelog_history_append.rs
+++ b/packages/engine-benchmarks/benches/changelog_history_append.rs
@@ -20,6 +20,7 @@ const OPERATIONS: &[Operation] = &[Operation::UniqueAppend, Operation::Duplicate
 const DEFAULT_HISTORY_COMMITS: &[usize] = &[1_000, 5_000];
 const DEFAULT_WARMUPS: usize = 5;
 const DEFAULT_SAMPLES: usize = 31;
+const DEFAULT_SEED_BATCH_COMMITS: usize = 100_000;
 
 #[derive(Clone, Copy, Debug)]
 enum Backend {
@@ -63,6 +64,11 @@ async fn run() {
     let histories = env_usizes("LIX_CHANGELOG_HISTORY_COMMITS", DEFAULT_HISTORY_COMMITS);
     let warmups = env_usize("LIX_CHANGELOG_HISTORY_WARMUPS", DEFAULT_WARMUPS);
     let samples = env_usize("LIX_CHANGELOG_HISTORY_SAMPLES", DEFAULT_SAMPLES).max(1);
+    let seed_batch_commits = env_usize(
+        "LIX_CHANGELOG_HISTORY_SEED_BATCH_COMMITS",
+        DEFAULT_SEED_BATCH_COMMITS,
+    )
+    .max(1);
 
     for &backend in BACKENDS {
         if !selected("LIX_CHANGELOG_HISTORY_BACKENDS", &backend.to_string()) {
@@ -73,7 +79,15 @@ async fn run() {
                 if !selected("LIX_CHANGELOG_HISTORY_OPERATIONS", &operation.to_string()) {
                     continue;
                 }
-                run_case(backend, history_commits, operation, warmups, samples).await;
+                run_case(
+                    backend,
+                    history_commits,
+                    operation,
+                    warmups,
+                    samples,
+                    seed_batch_commits,
+                )
+                .await;
             }
         }
     }
@@ -85,8 +99,9 @@ async fn run_case(
     operation: Operation,
     warmups: usize,
     samples: usize,
+    seed_batch_commits: usize,
 ) {
-    let mut fixture = Fixture::new(backend, history_commits).await;
+    let mut fixture = Fixture::new(backend, history_commits, seed_batch_commits).await;
     for _ in 0..warmups {
         let append = fixture.prepare(operation);
         black_box(fixture.execute(operation, append).await);
@@ -112,10 +127,11 @@ async fn run_case(
     let sample_count = u64::try_from(samples).expect("benchmark sample count should fit in u64");
 
     println!(
-        "changelog_history_append,backend={backend},operation={operation},history_commits={history_commits},warmups={warmups},samples={samples},\
-         stage_p50_us={},stage_p95_us={},stage_mean_us={},\
-         commit_p50_us={},commit_p95_us={},commit_mean_us={},\
-         total_p50_us={},total_p95_us={},total_mean_us={},\
+        "changelog_history_append,backend={backend},operation={operation},history_commits={history_commits},\
+         seed_batch_commits={seed_batch_commits},warmups={warmups},samples={samples},\
+         stage_p50_us={},stage_p95_us={},stage_p99_us={},stage_mean_us={},\
+         commit_p50_us={},commit_p95_us={},commit_p99_us={},commit_mean_us={},\
+         total_p50_us={},total_p95_us={},total_p99_us={},total_mean_us={},\
          get_many_calls_per_op={},get_many_keys_per_op={},\
          scan_calls_per_op={},scan_rows_per_op={},scan_value_bytes_per_op={},\
          put_batches_per_op={},puts_per_op={},write_bytes_per_op={},\
@@ -123,12 +139,15 @@ async fn run_case(
          commit_change_id_index_key_bytes={},commit_change_id_index_value_bytes={}",
         micros(percentile(&stage_timings, 50, 100)),
         micros(percentile(&stage_timings, 95, 100)),
+        micros(percentile(&stage_timings, 99, 100)),
         micros(mean(&stage_timings)),
         micros(percentile(&commit_timings, 50, 100)),
         micros(percentile(&commit_timings, 95, 100)),
+        micros(percentile(&commit_timings, 99, 100)),
         micros(mean(&commit_timings)),
         micros(percentile(&total_timings, 50, 100)),
         micros(percentile(&total_timings, 95, 100)),
+        micros(percentile(&total_timings, 99, 100)),
         micros(mean(&total_timings)),
         io.get_many_calls / sample_count,
         io.get_many_keys / sample_count,
@@ -362,34 +381,53 @@ impl<S> BackendFixture<S>
 where
     S: Storage + Clone,
 {
-    async fn create(storage: S, temp_dir: TempDir, history_commits: usize) -> Self {
+    async fn create(
+        storage: S,
+        temp_dir: TempDir,
+        history_commits: usize,
+        seed_batch_commits: usize,
+    ) -> Self {
         let (storage, stats) = CountingStorage::new(storage);
         let history_name = "changelog-history";
-        let history =
-            changelog_bench::append_with_shape(history_name, history_commits, history_commits)
-                .expect("build changelog history append");
-        let store = changelog_bench::prepare_store(storage, &history)
+        let first_batch_name = format!("{history_name}-batch-0");
+        let first_batch_commits = history_commits.min(seed_batch_commits);
+        let first_batch = changelog_bench::append_with_shape(
+            &first_batch_name,
+            first_batch_commits,
+            first_batch_commits,
+        )
+        .expect("build first changelog history seed batch");
+        let store = changelog_bench::prepare_store(storage, &first_batch)
             .await
-            .expect("seed changelog history append");
-        let seed_layout = changelog_bench::layout_accounting(&store)
-            .await
-            .expect("measure changelog history layout")
-            .into_iter()
-            .find(|space| space.space == "changelog.commit_change_id")
-            .unwrap_or(StorageLayoutAccounting {
-                space_id: 0x0006_0004,
-                space: "changelog.commit_change_id",
-                rows: 0,
-                key_bytes: 0,
-                value_bytes: 0,
-            });
+            .expect("seed first changelog history batch");
+        drop(first_batch);
+        let mut seeded_commits = first_batch_commits;
+        let mut batch_index = 1usize;
+        while seeded_commits < history_commits {
+            let batch_commits = (history_commits - seeded_commits).min(seed_batch_commits);
+            let batch = changelog_bench::append_with_shape(
+                &format!("{history_name}-batch-{batch_index}"),
+                batch_commits,
+                batch_commits,
+            )
+            .expect("build changelog history seed batch");
+            changelog_bench::stage_append_to_store(&store, &batch)
+                .await
+                .expect("seed changelog history batch");
+            seeded_commits += batch_commits;
+            batch_index += 1;
+        }
+        let seed_layout =
+            changelog_bench::layout_space_accounting(&store, "changelog.commit_change_id")
+                .await
+                .expect("measure changelog change-ID layout");
         *stats.lock().expect("io stats mutex") = IoStats::default();
         Self {
             store,
             _temp_dir: temp_dir,
             stats,
             seed_layout,
-            history_commit_change_id: format!("{history_name}-commit-0:commit"),
+            history_commit_change_id: format!("{first_batch_name}-commit-0:commit"),
             version: 0,
         }
     }
@@ -453,7 +491,7 @@ enum Fixture {
 }
 
 impl Fixture {
-    async fn new(backend: Backend, history_commits: usize) -> Self {
+    async fn new(backend: Backend, history_commits: usize, seed_batch_commits: usize) -> Self {
         let temp_dir = tempfile::tempdir().expect("create changelog history benchmark directory");
         let database_path = temp_dir.path().join("database");
         match backend {
@@ -462,6 +500,7 @@ impl Fixture {
                     RocksDB::open(&database_path).expect("open benchmark RocksDB"),
                     temp_dir,
                     history_commits,
+                    seed_batch_commits,
                 )
                 .await,
             ),
@@ -470,6 +509,7 @@ impl Fixture {
                     SlateDB::open(&database_path).expect("open benchmark SlateDB"),
                     temp_dir,
                     history_commits,
+                    seed_batch_commits,
                 )
                 .await,
             ),

--- a/packages/engine-benchmarks/benches/packed_history_scale.rs
+++ b/packages/engine-benchmarks/benches/packed_history_scale.rs
@@ -10,7 +10,7 @@ use lix_engine::tracked_state::bench::{
     seed_packed_history_with_options,
 };
 use lix_rocksdb_storage::RocksDB;
-use lix_slatedb_storage::SlateDB;
+use lix_slatedb_storage::{SlateDB, SlateDBIoCounters, SlateDBIoSnapshot};
 
 const DEFAULT_CHANGES: &[usize] = &[100_000];
 const DEFAULT_COMMIT_WIDTHS: &[usize] = &[1, 10, 100, 10_000];
@@ -132,6 +132,7 @@ async fn run() {
                                     settle_ms,
                                     account_layout,
                                     skip_seed,
+                                    None,
                                     || async {
                                         storage.flush().expect("flush benchmark RocksDB");
                                     },
@@ -141,11 +142,14 @@ async fn run() {
                             Backend::SlateDB => {
                                 let dir = tempfile::tempdir()
                                     .expect("create SlateDB benchmark directory");
+                                let io_counters = SlateDBIoCounters::default();
                                 let path = persistent_root.as_ref().map_or_else(
                                     || dir.path().join("slatedb"),
                                     |root| root.join("slatedb"),
                                 );
-                                let storage = SlateDB::open(&path).expect("open benchmark SlateDB");
+                                let storage =
+                                    SlateDB::open_with_io_counters(&path, io_counters.clone())
+                                        .expect("open benchmark SlateDB");
                                 run_case(
                                     backend,
                                     storage.clone(),
@@ -165,6 +169,7 @@ async fn run() {
                                     settle_ms,
                                     account_layout,
                                     skip_seed,
+                                    Some(&io_counters),
                                     || async {
                                         if memtable_flush {
                                             storage
@@ -209,6 +214,7 @@ async fn run_case<S, Flush, FlushFuture>(
     settle_ms: u64,
     account_layout: bool,
     skip_seed: bool,
+    io_counters: Option<&SlateDBIoCounters>,
     flush_storage: Flush,
 ) where
     S: Storage + Clone,
@@ -218,6 +224,8 @@ async fn run_case<S, Flush, FlushFuture>(
     let adapter = StorageAdapter::new(storage);
     let id_shape =
         std::env::var("LIX_PACKED_HISTORY_ID_SHAPE").unwrap_or_else(|_| "deterministic".into());
+    let seed_io_before =
+        io_counters.map_or_else(SlateDBIoSnapshot::default, SlateDBIoCounters::snapshot);
     let seed_started = Instant::now();
     let shared_large_payload = matches!(payload, BenchPackedHistoryPayload::SharedLarge)
         .then(|| format!(r#"{{"payload":"{}"}}"#, "x".repeat(large_payload_bytes)));
@@ -241,14 +249,20 @@ async fn run_case<S, Flush, FlushFuture>(
         )
     };
     let seed_elapsed = seed_started.elapsed();
+    let seed_io_after =
+        io_counters.map_or_else(SlateDBIoSnapshot::default, SlateDBIoCounters::snapshot);
     if flush {
         flush_storage().await;
     }
     if settle_ms > 0 {
         tokio::time::sleep(Duration::from_millis(settle_ms)).await;
     }
+    let lifecycle_io_after =
+        io_counters.map_or_else(SlateDBIoSnapshot::default, SlateDBIoCounters::snapshot);
     let backend_bytes = directory_bytes(storage_path);
+    let backend_objects = directory_objects(storage_path);
 
+    let scan_io_before = lifecycle_io_after;
     for _ in 0..warmups {
         assert_eq!(scan_packed_history(&adapter).await, changes);
     }
@@ -259,6 +273,8 @@ async fn run_case<S, Flush, FlushFuture>(
         timings.push(started.elapsed());
     }
     timings.sort_unstable();
+    let scan_io_after =
+        io_counters.map_or_else(SlateDBIoSnapshot::default, SlateDBIoCounters::snapshot);
     let exact_commit_index = changes / commit_width / 2;
     let exact_row_index = commit_width / 2;
     for _ in 0..warmups {
@@ -271,6 +287,8 @@ async fn run_case<S, Flush, FlushFuture>(
         exact_timings.push(started.elapsed());
     }
     exact_timings.sort_unstable();
+    let exact_io_after =
+        io_counters.map_or_else(SlateDBIoSnapshot::default, SlateDBIoCounters::snapshot);
     // Account after timing so a layout scan cannot pre-warm the measured
     // storage pages. `warmups=0,samples=1` is therefore the cold profile.
     let layout = if account_layout {
@@ -278,6 +296,20 @@ async fn run_case<S, Flush, FlushFuture>(
     } else {
         Vec::new()
     };
+    let layout_io_after =
+        io_counters.map_or_else(SlateDBIoSnapshot::default, SlateDBIoCounters::snapshot);
+    let seed_io = seed_io_after.saturating_sub(seed_io_before);
+    let lifecycle_io = lifecycle_io_after.saturating_sub(seed_io_after);
+    let scan_io = scan_io_after.saturating_sub(scan_io_before);
+    let exact_io = exact_io_after.saturating_sub(scan_io_after);
+    let layout_io = layout_io_after.saturating_sub(exact_io_after);
+    let logical_written_bytes = writes.map_or(0, |writes| writes.written_bytes);
+    let write_amplification = ratio(
+        seed_io.write_bytes.saturating_add(lifecycle_io.write_bytes),
+        logical_written_bytes,
+    );
+    let lifecycle_write_amplification = ratio(lifecycle_io.write_bytes, logical_written_bytes);
+    let storage_amplification = ratio(backend_bytes, logical_written_bytes);
     let manifest = find_layout(&layout, "tracked_state.commit_delta_manifest.v2");
     let segments = find_layout(&layout, "tracked_state.commit_delta_segment.v2");
     let locators = find_layout(&layout, "tracked_state.change_locator.v1");
@@ -297,14 +329,20 @@ async fn run_case<S, Flush, FlushFuture>(
          segment_keys={},segment_key_bytes={},segment_value_bytes={},\
          locator_keys={},locator_key_bytes={},locator_value_bytes={},\
          json_payload_keys={},json_payload_key_bytes={},json_payload_value_bytes={},\
-         backend_bytes={backend_bytes}",
+         backend_bytes={backend_bytes},backend_objects={},storage_amplification={storage_amplification:.3},\
+         seed_object_reads={},seed_object_read_bytes={},seed_object_writes={},seed_object_write_bytes={},\
+         lifecycle_object_reads={},lifecycle_object_read_bytes={},lifecycle_object_writes={},lifecycle_object_write_bytes={},\
+         write_amplification={write_amplification:.3},lifecycle_write_amplification={lifecycle_write_amplification:.3},\
+         scan_object_reads={},scan_object_read_bytes={},scan_object_writes={},scan_object_write_bytes={},\
+         exact_object_reads={},exact_object_read_bytes={},exact_object_writes={},exact_object_write_bytes={},\
+         layout_object_reads={},layout_object_read_bytes={},layout_object_writes={},layout_object_write_bytes={}",
         shape_name(shape),
         payload_name(payload),
         writes.map_or_else(|| changes / commit_width, |writes| writes.commits),
         seed_elapsed.as_millis(),
         changes as f64 / seed_elapsed.as_secs_f64(),
         writes.map_or(0, |writes| writes.staged_puts),
-        writes.map_or(0, |writes| writes.written_bytes),
+        logical_written_bytes,
         millis(percentile(&timings, 50)),
         millis(percentile(&timings, 95)),
         millis(percentile(&timings, 99)),
@@ -323,6 +361,27 @@ async fn run_case<S, Flush, FlushFuture>(
         json_payloads.rows,
         json_payloads.key_bytes,
         json_payloads.value_bytes,
+        backend_objects,
+        seed_io.read_objects,
+        seed_io.read_bytes,
+        seed_io.write_objects,
+        seed_io.write_bytes,
+        lifecycle_io.read_objects,
+        lifecycle_io.read_bytes,
+        lifecycle_io.write_objects,
+        lifecycle_io.write_bytes,
+        scan_io.read_objects,
+        scan_io.read_bytes,
+        scan_io.write_objects,
+        scan_io.write_bytes,
+        exact_io.read_objects,
+        exact_io.read_bytes,
+        exact_io.write_objects,
+        exact_io.write_bytes,
+        layout_io.read_objects,
+        layout_io.read_bytes,
+        layout_io.write_objects,
+        layout_io.write_bytes,
     );
 }
 
@@ -347,6 +406,14 @@ fn percentile(sorted: &[Duration], percentile: usize) -> Duration {
 
 fn millis(duration: Duration) -> f64 {
     duration.as_secs_f64() * 1_000.0
+}
+
+fn ratio(numerator: u64, denominator: u64) -> f64 {
+    if denominator == 0 {
+        f64::NAN
+    } else {
+        numerator as f64 / denominator as f64
+    }
 }
 
 fn shape_name(shape: BenchPackedHistoryShape) -> &'static str {
@@ -469,4 +536,28 @@ fn directory_bytes(path: &Path) -> u64 {
             })
             .sum()
     })
+}
+
+fn directory_objects(path: &Path) -> u64 {
+    std::fs::read_dir(path).map_or(0, |entries| {
+        entries
+            .filter_map(Result::ok)
+            .map(|entry| {
+                if entry.metadata().is_ok_and(|metadata| metadata.is_dir()) {
+                    directory_objects(&entry.path())
+                } else {
+                    1
+                }
+            })
+            .sum()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn amplification_is_unavailable_without_a_logical_baseline() {
+        assert!(super::ratio(1, 0).is_nan());
+        assert_eq!(super::ratio(3, 2), 1.5);
+    }
 }

--- a/packages/engine/src/changelog/bench_support.rs
+++ b/packages/engine/src/changelog/bench_support.rs
@@ -428,6 +428,20 @@ where
     Ok(crate::storage_bench::layout_accounting(&read).await)
 }
 
+pub async fn layout_space_accounting<StorageImpl>(
+    store: &BenchStore<StorageImpl>,
+    space_name: &str,
+) -> Result<crate::storage_bench::StorageLayoutAccounting, LixError>
+where
+    StorageImpl: BenchStorage + Sync,
+{
+    let read = store
+        .storage
+        .begin_read(StorageReadOptions::default())
+        .await?;
+    Ok(crate::storage_bench::layout_space_accounting(&read, space_name).await)
+}
+
 pub async fn stage_corpus_once<StorageImpl>(
     storage: StorageImpl,
     corpus: &BenchCorpus,

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -322,6 +322,19 @@ where
     accounting
 }
 
+/// Streams accounting for one named storage space without touching unrelated
+/// spaces. Use this when a benchmark reports a single layout component.
+pub async fn layout_space_accounting<R>(read: &R, space_name: &str) -> StorageLayoutAccounting
+where
+    R: StorageAdapterRead,
+{
+    let space = *native_storage_spaces()
+        .iter()
+        .find(|space| space.name == space_name)
+        .expect("space name should exist");
+    scan_layout_space(read, space).await
+}
+
 /// Per-row (key, value bytes) inventory of one space.
 ///
 /// Equivalence tests compare these inventories byte-for-byte, so the scan
@@ -528,6 +541,8 @@ mod tests {
             .into_iter()
             .find(|space| space.space == crate::changelog::COMMIT_SPACE.name)
             .expect("commit space is accounted");
+        let targeted =
+            super::layout_space_accounting(&read, crate::changelog::COMMIT_SPACE.name).await;
 
         assert_eq!(accounting.rows, inventory.len() as u64);
         assert_eq!(
@@ -544,6 +559,9 @@ mod tests {
                 .map(|(_, value)| value.len() as u64)
                 .sum::<u64>()
         );
+        assert_eq!(targeted.rows, accounting.rows);
+        assert_eq!(targeted.key_bytes, accounting.key_bytes);
+        assert_eq!(targeted.value_bytes, accounting.value_bytes);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- attach SlateDB object-store counters to the packed-history scaling benchmark
- split object reads, read bytes, writes, and write bytes across seed, lifecycle, scan, exact-read, and layout phases
- report physical object count plus storage, total-write, and lifecycle-write amplification
- keep RocksDB output comparable with physical size/object accounting and zero object-store counters

## Why

The benchmark previously reported logical writes and physical bytes but could not distinguish ingest, flush/compaction, scan, exact lookup, or benchmark-accounting I/O. That made lifecycle confounds and write amplification impossible to prove directly.

## Validation

- `cargo check -p lix_engine_benchmarks --bench packed_history_scale --features storage-benches,slatedb,rocksdb`
- `cargo clippy -p lix_engine_benchmarks --bench packed_history_scale --features storage-benches,slatedb,rocksdb -- -D warnings`
- release smoke run at 100k changes on RocksDB and flushed SlateDB

The SlateDB smoke run attributed 8.73 MB of lifecycle writes (0.575x logical), 1.51 MB of scan reads, 1 KiB across 101 exact reads, and 1.16 MB to layout accounting. This confirms phase separation and exposes benchmark-induced reads independently from engine scans.