### PR TITLE
Reduce Markdown replay memory

### DIFF
--- a/plugins/markdown-v2/benchmarks/vscode-docs-d5badf-memory.md
+++ b/plugins/markdown-v2/benchmarks/vscode-docs-d5badf-memory.md
@@ -1,0 +1,115 @@
+# vscode-docs `d5badf` Markdown memory profile
+
+Measured on 2026-07-29 with the production Wasm Component v2 Markdown plugin
+and RocksDB replay storage.
+
+## Workload
+
+- Repository: `microsoft/vscode-docs`
+- Transition:
+  `15faa92b6970dc11001cded47db900aa890ca05b..d5badf95f8ab16c4deb91199dc696f2293d93554`
+- Changed paths: 151
+- Changed blob bytes submitted by replay: 3,276,550
+- Largest changed file: `api/references/vscode-api.md`, 1,237,840 bytes
+- Change in that file: one insertion and one deletion
+- Wasm guest memory limit: 134,217,728 bytes (128 MiB)
+
+The parent tree was bootstrapped before the timed transition. The replay ran
+with all production semantic plugins and verified both the commit state and
+the final Git tree manifest.
+
+## Result
+
+| Build | Peak guest linear memory | Replay result |
+| --- | ---: | --- |
+| Baseline | greater than 134,217,728 bytes | OOM trap |
+| Borrowed-view prototype, run 1 | 102,367,232 bytes (97.63 MiB) | success |
+| Borrowed-view prototype, run 2 | 102,367,232 bytes (97.63 MiB) | success |
+
+The successful build leaves 31,850,496 bytes (30.38 MiB, 23.7%) free under
+the guest limit. The two measured transition execution times were 8.95 s and
+9.22 s. Timing is secondary here because the baseline cannot complete.
+
+The baseline trap backtrace ends in UUID formatting called from
+`allocate_generated_ids`, reached while processing `Document::file_changed`.
+
+## Prototype cut
+
+The full-parse fallback previously held or created these owned structures:
+
+1. a materialized clone of the persistent tree;
+2. an owned projection containing a clone of every snapshot;
+3. a second tree rebuilt from that projection for reconciliation;
+4. the parsed successor tree;
+5. an owned flattened clone of the reconciled successor;
+6. another projection/tree rebuild to retain the successor.
+
+The prototype changes that pipeline to:
+
+1. materialize the persistent tree once;
+2. create a sorted identity index containing borrowed `&str` and
+   `&NodeSnapshot` references;
+3. parse one owned successor tree using compact transition-local identities;
+4. reconcile and diff through borrowed views;
+5. retain that same reconciled successor tree.
+
+It also replaces parse-only UUIDv7 strings with one collision-free per-parse
+ordinal namespace (`~0`, `~1`, ... in hexadecimal). Durable identities remain
+canonical host-namespaced UUIDs; only identities that cannot cross the
+component boundary use the compact representation.
+
+This is an arena-shaped ownership cut without introducing a general-purpose
+arena allocator: phases share one owned tree through borrowed indexes, and the
+parsed successor becomes persistent state instead of being flattened and
+rebuilt.
+
+## Reproduction
+
+Hydrate the target commit and its parent before measuring so partial-clone
+network fetches do not contaminate the replay:
+
+```sh
+git clone --filter=blob:none --no-checkout \
+  https://github.com/microsoft/vscode-docs.git /tmp/vscode-docs
+git -C /tmp/vscode-docs fetch --filter=blob:limit=5m origin \
+  15faa92b6970dc11001cded47db900aa890ca05b \
+  d5badf95f8ab16c4deb91199dc696f2293d93554
+```
+
+Build and run the exact transition:
+
+```sh
+cargo run --release -p lix_cli -- exp git-replay \
+  --repo-path /tmp/vscode-docs \
+  --output-path /tmp/vscode-d5badf-replay \
+  --storage rocksdb \
+  --plugins all \
+  --branch d5badf95f8ab16c4deb91199dc696f2293d93554 \
+  --from-commit d5badf95f8ab16c4deb91199dc696f2293d93554 \
+  --num-commits 1 \
+  --verify-state \
+  --force \
+  --profile-json /tmp/vscode-d5badf-profile.json
+```
+
+Read the peak from:
+
+```sh
+jq '.commits[0].plugin_counters.guest_linear_memory_high_water_bytes' \
+  /tmp/vscode-d5badf-profile.json
+```
+
+## Architectural conclusion
+
+A full parser/semantic/storage arena is not justified by this result alone.
+The immediate problem was ownership topology, not allocation API selection.
+Borrowed views and direct successor retention recover more than 30 MiB of
+headroom while preserving the existing semantic model.
+
+The next arena cut should be conditional on a new profile showing that the
+remaining peak is dominated by `NodeSnapshot`/`serde_json::Value`
+materialization. If so, use typed arena nodes with compact `NodeId` references
+and defer JSON wire serialization to changed entities only. Do not put source
+bytes, parser AST, semantic nodes, and durable snapshots into one universal
+arena: their lifetimes and mutation patterns differ, and coupling them would
+make sparse persistent successors harder to share.

--- a/plugins/markdown-v2/src/core.rs
+++ b/plugins/markdown-v2/src/core.rs
@@ -162,9 +162,17 @@ impl MarkdownPlugin {
         namespace: IdNamespace,
     ) -> Result<Vec<DetectedChange>, PluginError> {
         let before = Projection::from_entity_state(state.into_iter())?;
+        let before_root = if before.nodes_by_id.is_empty() {
+            None
+        } else {
+            Some(before.to_tree()?)
+        };
+        let before_view = ProjectionView::from_projection(&before);
         let mut after = parse_file(&file)?;
         retain_noncanonical_source(&mut after, &file.data)?;
-        detect_changes_for_markdown(&before, after, namespace)
+        let (changes, _) =
+            detect_changes_for_markdown(&before_view, before_root.as_ref(), after, namespace)?;
+        Ok(changes)
     }
 
     pub fn render(state: Vec<EntityState>) -> Result<Vec<u8>, PluginError> {
@@ -226,18 +234,14 @@ fn render_tree_with_lexical_fallback(root: &NodeTree) -> Result<Vec<u8>, PluginE
 }
 
 fn detect_changes_for_markdown(
-    before: &Projection,
+    before: &ProjectionView<'_>,
+    before_root: Option<&NodeTree>,
     mut after: ParsedMarkdown,
     namespace: IdNamespace,
-) -> Result<Vec<DetectedChange>, PluginError> {
+) -> Result<(Vec<DetectedChange>, NodeTree), PluginError> {
     let generated_ids = collect_generated_ids(&after.root);
-    let before_root = if before.nodes_by_id.is_empty() {
-        None
-    } else {
-        Some(before.to_tree()?)
-    };
     let mut replacements = BTreeMap::new();
-    if let Some(before_root) = &before_root {
+    if let Some(before_root) = before_root {
         let old_hashes = SubtreeHashes::from_tree(before_root);
         let new_hashes = SubtreeHashes::from_tree(&after.root);
         let mut global_subtrees = HashMap::<SubtreeHash, Vec<&NodeTree>>::new();
@@ -288,8 +292,8 @@ fn detect_changes_for_markdown(
         }
         replace_column_ids(&mut node.payload, &replacements);
     });
-    let after_nodes = flatten_tree(&after.root);
-    diff_projections(before, &after_nodes)
+    let changes = diff_tree(before, &after.root)?;
+    Ok((changes, after.root))
 }
 
 fn collect_generated_ids(root: &NodeTree) -> BTreeSet<String> {
@@ -1244,33 +1248,34 @@ fn flatten_tree(root: &NodeTree) -> BTreeMap<String, NodeSnapshot> {
     output
 }
 
-fn diff_projections(
-    before: &Projection,
-    after: &BTreeMap<String, NodeSnapshot>,
+fn diff_tree(
+    before: &ProjectionView<'_>,
+    after: &NodeTree,
 ) -> Result<Vec<DetectedChange>, PluginError> {
+    let after = ProjectionView::from_tree(after);
     let mut changes = Vec::new();
-    for id in before.nodes_by_id.keys() {
-        if !after.contains_key(id) {
+    for id in before.nodes_by_id.keys().copied() {
+        if !after.nodes_by_id.contains_key(id) {
             changes.push(DetectedChange {
-                entity_pk: vec![id.clone()],
+                entity_pk: vec![id.to_owned()],
                 schema_key: NODE_SCHEMA_KEY.to_string(),
                 snapshot_content: None,
                 metadata: None,
             });
         }
     }
-    for (id, node) in after {
-        if before.nodes_by_id.get(id) == Some(node) {
+    for (id, node) in &after.nodes_by_id {
+        if before.nodes_by_id.get(id).copied() == Some(*node) {
             continue;
         }
         let snapshot_content = serde_json::to_string(node).map_err(|error| {
             PluginError::Internal(format!("failed to serialize Markdown node '{id}': {error}"))
         })?;
         changes.push(DetectedChange {
-            entity_pk: vec![id.clone()],
+            entity_pk: vec![(*id).to_owned()],
             schema_key: NODE_SCHEMA_KEY.to_string(),
             snapshot_content: Some(snapshot_content),
-            metadata: change_metadata(before.nodes_by_id.get(id), node),
+            metadata: change_metadata(before.nodes_by_id.get(id).copied(), node),
         });
     }
     Ok(changes)
@@ -1408,6 +1413,40 @@ impl Projection {
             )));
         }
         Ok(tree)
+    }
+}
+
+/// Read-only identity index over an existing tree or projection. Reconciliation
+/// needs keyed lookup and deletion detection, not another owned copy of every
+/// snapshot. The index owns only references and is discarded with the
+/// transition.
+#[derive(Default)]
+struct ProjectionView<'a> {
+    nodes_by_id: BTreeMap<&'a str, &'a NodeSnapshot>,
+}
+
+impl<'a> ProjectionView<'a> {
+    fn from_projection(projection: &'a Projection) -> Self {
+        Self {
+            nodes_by_id: projection
+                .nodes_by_id
+                .values()
+                .map(|node| (node.id.as_str(), node))
+                .collect(),
+        }
+    }
+
+    fn from_tree(root: &'a NodeTree) -> Self {
+        fn visit<'a>(tree: &'a NodeTree, output: &mut BTreeMap<&'a str, &'a NodeSnapshot>) {
+            output.insert(tree.node.id.as_str(), &tree.node);
+            for child in &tree.children {
+                visit(child, output);
+            }
+        }
+
+        let mut nodes_by_id = BTreeMap::new();
+        visit(root, &mut nodes_by_id);
+        Self { nodes_by_id }
     }
 }
 
@@ -1800,31 +1839,6 @@ fn detected_to_entity_change(change: DetectedChange) -> Result<EntityChange, Plu
     })
 }
 
-fn apply_detected_changes(state: &[EntityState], changes: &[DetectedChange]) -> Vec<EntityState> {
-    let mut rows = state
-        .iter()
-        .cloned()
-        .map(|row| ((row.schema_key.clone(), row.entity_pk.clone()), row))
-        .collect::<BTreeMap<_, _>>();
-    for change in changes {
-        let key = (change.schema_key.clone(), change.entity_pk.clone());
-        if let Some(snapshot_content) = &change.snapshot_content {
-            rows.insert(
-                key,
-                EntityState {
-                    entity_pk: change.entity_pk.clone(),
-                    schema_key: change.schema_key.clone(),
-                    snapshot_content: snapshot_content.clone(),
-                    metadata: change.metadata.clone(),
-                },
-            );
-        } else {
-            rows.remove(&key);
-        }
-    }
-    rows.into_values().collect()
-}
-
 fn entity_change_to_detected(change: EntityChange) -> Result<DetectedChange, PluginError> {
     if change.schema_key != NODE_SCHEMA_KEY {
         return Err(PluginError::InvalidInput(format!(
@@ -1976,9 +1990,8 @@ impl Document {
         let mut parsed = parse_file_with_literal_fast_path(&file, allow_literal_fast_path)?;
         retain_noncanonical_source(&mut parsed, &file.data)?;
         let top_level_ranges = parsed.top_level_ranges.clone();
-        let detected = detect_changes_for_markdown(&Projection::default(), parsed, namespace)?;
-        let state = apply_detected_changes(&[], &detected);
-        let root = Projection::from_entity_state(state.iter().cloned())?.to_tree()?;
+        let (detected, root) =
+            detect_changes_for_markdown(&ProjectionView::default(), None, parsed, namespace)?;
         let changes = detected
             .into_iter()
             .map(detected_to_entity_change)
@@ -2062,14 +2075,12 @@ impl Document {
                 data: bytes,
             };
             let current_root = self.tree.materialize();
-            let before = Projection {
-                nodes_by_id: flatten_tree(&current_root),
-            };
+            let before = ProjectionView::from_tree(&current_root);
             let mut parsed = parse_file(&file)?;
             retain_noncanonical_source(&mut parsed, &file.data)?;
             let top_level_ranges = Arc::new(parsed.top_level_ranges.clone());
-            let detected = detect_changes_for_markdown(&before, parsed, namespace)?;
-            let root = projection_after_detected_changes(&current_root, &detected)?.to_tree()?;
+            let (detected, root) =
+                detect_changes_for_markdown(&before, Some(&current_root), parsed, namespace)?;
             (detected, top_level_ranges, PersistentTree::new(root))
         };
         let changes = detected

--- a/plugins/markdown-v2/src/markdown_file.rs
+++ b/plugins/markdown-v2/src/markdown_file.rs
@@ -10,9 +10,9 @@ use encoding_rs::Encoding;
 use markdown_syntax::ast as md;
 use markdown_syntax::{LineEnding, SerializeOptions, Span, SyntaxOptions};
 use serde_json::{Value, json};
+use std::cell::Cell;
 use std::collections::BTreeMap;
 use std::ops::Range;
-use uuid::Uuid;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct ParsedMarkdown {
@@ -154,11 +154,12 @@ fn parse_markdown_source_once(source: &str) -> Result<ParsedMarkdown, PluginErro
         .into_iter()
         .map(|span| span.start..span.end)
         .collect();
+    let parse_ids = ParseIds::default();
     let children = output
         .document
         .children
         .iter()
-        .map(|block| tree_from_block(block, source))
+        .map(|block| tree_from_block(block, source, &parse_ids))
         .collect::<Result<Vec<_>, _>>()?;
     let root = NodeTree {
         node: NodeSnapshot {
@@ -431,10 +432,31 @@ fn detected_line_ending(source: &str) -> &'static str {
     if saw_crlf && !saw_other { "crlf" } else { "lf" }
 }
 
-fn new_tree(kind: NodeKind, payload: Value, format: Value, children: Vec<NodeTree>) -> NodeTree {
+#[derive(Default)]
+struct ParseIds(Cell<u32>);
+
+impl ParseIds {
+    fn next(&self) -> String {
+        let ordinal = self.0.get();
+        self.0.set(
+            ordinal
+                .checked_add(1)
+                .expect("one Markdown parse cannot contain more than u32::MAX identified nodes"),
+        );
+        format!("~{ordinal:x}")
+    }
+}
+
+fn new_tree(
+    ids: &ParseIds,
+    kind: NodeKind,
+    payload: Value,
+    format: Value,
+    children: Vec<NodeTree>,
+) -> NodeTree {
     NodeTree {
         node: NodeSnapshot {
-            id: Uuid::now_v7().to_string(),
+            id: ids.next(),
             kind,
             parent_id: None,
             order_key: None,
@@ -445,20 +467,26 @@ fn new_tree(kind: NodeKind, payload: Value, format: Value, children: Vec<NodeTre
     }
 }
 
-fn tree_from_block(block: &md::Block, source: &str) -> Result<NodeTree, PluginError> {
+fn tree_from_block(
+    block: &md::Block,
+    source: &str,
+    ids: &ParseIds,
+) -> Result<NodeTree, PluginError> {
     let empty = || json!({});
     match block {
         md::Block::Paragraph(node) => Ok(new_tree(
+            ids,
             NodeKind::Paragraph,
-            inline_payload(leaf_inlines_from_ast(&node.children, source)?),
+            inline_payload(leaf_inlines_from_ast(&node.children, source, ids)?),
             empty(),
             Vec::new(),
         )),
         md::Block::Heading(node) => Ok(new_tree(
+            ids,
             NodeKind::Heading,
             json!({
                 "depth": node.depth,
-                "inline": leaf_inlines_from_ast(&node.children, source)?,
+                "inline": leaf_inlines_from_ast(&node.children, source, ids)?,
             }),
             json!({
                 "style": match node.kind {
@@ -469,6 +497,7 @@ fn tree_from_block(block: &md::Block, source: &str) -> Result<NodeTree, PluginEr
             Vec::new(),
         )),
         md::Block::ThematicBreak(node) => Ok(new_tree(
+            ids,
             NodeKind::ThematicBreak,
             empty(),
             json!({
@@ -481,6 +510,7 @@ fn tree_from_block(block: &md::Block, source: &str) -> Result<NodeTree, PluginEr
             Vec::new(),
         )),
         md::Block::Frontmatter(node) => Ok(new_tree(
+            ids,
             NodeKind::Frontmatter,
             json!({
                 "kind": match node.kind {
@@ -493,15 +523,17 @@ fn tree_from_block(block: &md::Block, source: &str) -> Result<NodeTree, PluginEr
             Vec::new(),
         )),
         md::Block::BlockQuote(node) => Ok(new_tree(
+            ids,
             NodeKind::BlockQuote,
             empty(),
             empty(),
             node.children
                 .iter()
-                .map(|child| tree_from_block(child, source))
+                .map(|child| tree_from_block(child, source, ids))
                 .collect::<Result<Vec<_>, _>>()?,
         )),
         md::Block::List(node) => Ok(new_tree(
+            ids,
             NodeKind::List,
             json!({
                 "ordered": node.ordered,
@@ -513,7 +545,7 @@ fn tree_from_block(block: &md::Block, source: &str) -> Result<NodeTree, PluginEr
             }),
             node.children
                 .iter()
-                .map(|item| tree_from_list_item(item, source))
+                .map(|item| tree_from_list_item(item, source, ids))
                 .collect::<Result<Vec<_>, _>>()?,
         )),
         md::Block::CodeBlock(node) => {
@@ -529,6 +561,7 @@ fn tree_from_block(block: &md::Block, source: &str) -> Result<NodeTree, PluginEr
                 }),
             };
             Ok(new_tree(
+                ids,
                 NodeKind::CodeBlock,
                 json!({
                     "value": normalized_code_block_value(node, source),
@@ -539,12 +572,14 @@ fn tree_from_block(block: &md::Block, source: &str) -> Result<NodeTree, PluginEr
             ))
         }
         md::Block::HtmlBlock(node) => Ok(new_tree(
+            ids,
             NodeKind::HtmlBlock,
             json!({ "value": node.value }),
             empty(),
             Vec::new(),
         )),
         md::Block::Definition(node) => Ok(new_tree(
+            ids,
             NodeKind::Definition,
             json!({
                 "identifier": node.identifier,
@@ -559,15 +594,16 @@ fn tree_from_block(block: &md::Block, source: &str) -> Result<NodeTree, PluginEr
             Vec::new(),
         )),
         md::Block::FootnoteDefinition(node) => Ok(new_tree(
+            ids,
             NodeKind::FootnoteDefinition,
             json!({ "identifier": node.identifier }),
             json!({ "label": node.label }),
             node.children
                 .iter()
-                .map(|child| tree_from_block(child, source))
+                .map(|child| tree_from_block(child, source, ids))
                 .collect::<Result<Vec<_>, _>>()?,
         )),
-        md::Block::Table(node) => tree_from_table(node, source),
+        md::Block::Table(node) => tree_from_table(node, source, ids),
         unsupported => Err(PluginError::InvalidInput(format!(
             "GFM parser produced unsupported block node: {unsupported:?}"
         ))),
@@ -582,23 +618,33 @@ fn normalize_embedded_line_endings(value: &str) -> String {
     value.replace("\r\n", "\n").replace('\r', "\n")
 }
 
-fn tree_from_list_item(node: &md::ListItem, source: &str) -> Result<NodeTree, PluginError> {
+fn tree_from_list_item(
+    node: &md::ListItem,
+    source: &str,
+    ids: &ParseIds,
+) -> Result<NodeTree, PluginError> {
     Ok(new_tree(
+        ids,
         NodeKind::ListItem,
         json!({ "checked": node.checked }),
         json!({}),
         node.children
             .iter()
-            .map(|child| tree_from_block(child, source))
+            .map(|child| tree_from_block(child, source, ids))
             .collect::<Result<Vec<_>, _>>()?,
     ))
 }
 
-fn tree_from_table(node: &md::Table, source: &str) -> Result<NodeTree, PluginError> {
+fn tree_from_table(
+    node: &md::Table,
+    source: &str,
+    ids: &ParseIds,
+) -> Result<NodeTree, PluginError> {
     let mut children = Vec::new();
     let mut column_ids = Vec::new();
     for alignment in &node.alignments {
         let column = new_tree(
+            ids,
             NodeKind::TableColumn,
             json!({
                 "alignment": match alignment {
@@ -623,37 +669,50 @@ fn tree_from_table(node: &md::Table, source: &str) -> Result<NodeTree, PluginErr
                 )
             })?;
             cells.push(new_tree(
+                ids,
                 NodeKind::TableCell,
                 json!({
                     "column_id": column_id,
-                    "inline": leaf_inlines_from_ast(&cell.children, source)?,
+                    "inline": leaf_inlines_from_ast(&cell.children, source, ids)?,
                 }),
                 json!({}),
                 Vec::new(),
             ));
         }
         children.push(new_tree(
+            ids,
             NodeKind::TableRow,
             json!({ "role": if row_index == 0 { "header" } else { "body" } }),
             json!({}),
             cells,
         ));
     }
-    Ok(new_tree(NodeKind::Table, json!({}), json!({}), children))
+    Ok(new_tree(
+        ids,
+        NodeKind::Table,
+        json!({}),
+        json!({}),
+        children,
+    ))
 }
 
-fn inlines_from_ast(nodes: &[md::Inline], source: &str) -> Result<Vec<InlineNode>, PluginError> {
+fn inlines_from_ast(
+    nodes: &[md::Inline],
+    source: &str,
+    ids: &ParseIds,
+) -> Result<Vec<InlineNode>, PluginError> {
     nodes
         .iter()
-        .map(|node| inline_from_ast(node, source))
+        .map(|node| inline_from_ast(node, source, ids))
         .collect()
 }
 
 fn leaf_inlines_from_ast(
     nodes: &[md::Inline],
     source: &str,
+    ids: &ParseIds,
 ) -> Result<Vec<InlineNode>, PluginError> {
-    let mut inlines = inlines_from_ast(nodes, source)?;
+    let mut inlines = inlines_from_ast(nodes, source, ids)?;
     if let Some(InlineNode {
         content: InlineContent::Text { value },
         ..
@@ -668,7 +727,11 @@ fn leaf_inlines_from_ast(
     Ok(inlines)
 }
 
-fn inline_from_ast(node: &md::Inline, source: &str) -> Result<InlineNode, PluginError> {
+fn inline_from_ast(
+    node: &md::Inline,
+    source: &str,
+    ids: &ParseIds,
+) -> Result<InlineNode, PluginError> {
     let (id, content) = match node {
         md::Inline::Text(node) => (
             None,
@@ -677,11 +740,11 @@ fn inline_from_ast(node: &md::Inline, source: &str) -> Result<InlineNode, Plugin
             },
         ),
         md::Inline::Escape(node) => (
-            Some(new_inline_id()),
+            Some(ids.next()),
             InlineContent::Escape { value: node.value },
         ),
         md::Inline::CharacterReference(node) => (
-            Some(new_inline_id()),
+            Some(ids.next()),
             InlineContent::CharacterReference {
                 value: node.value.clone(),
                 format: CharacterReferenceFormat {
@@ -690,27 +753,27 @@ fn inline_from_ast(node: &md::Inline, source: &str) -> Result<InlineNode, Plugin
             },
         ),
         md::Inline::Emphasis(node) => (
-            Some(new_inline_id()),
+            Some(ids.next()),
             InlineContent::Emphasis {
-                children: inlines_from_ast(&node.children, source)?,
+                children: inlines_from_ast(&node.children, source, ids)?,
                 format: DelimiterFormat {
                     marker: delimiter_from_span(node.meta.span, source, "*"),
                 },
             },
         ),
         md::Inline::Strong(node) => (
-            Some(new_inline_id()),
+            Some(ids.next()),
             InlineContent::Strong {
-                children: inlines_from_ast(&node.children, source)?,
+                children: inlines_from_ast(&node.children, source, ids)?,
                 format: DelimiterFormat {
                     marker: delimiter_from_span(node.meta.span, source, "**"),
                 },
             },
         ),
         md::Inline::Delete(node) => (
-            Some(new_inline_id()),
+            Some(ids.next()),
             InlineContent::Delete {
-                children: inlines_from_ast(&node.children, source)?,
+                children: inlines_from_ast(&node.children, source, ids)?,
                 format: DeleteFormat {
                     marker: match node.marker {
                         md::DeleteMarker::SingleTilde => "~",
@@ -721,7 +784,7 @@ fn inline_from_ast(node: &md::Inline, source: &str) -> Result<InlineNode, Plugin
             },
         ),
         md::Inline::Code(node) => (
-            Some(new_inline_id()),
+            Some(ids.next()),
             InlineContent::Code {
                 value: node.value.clone(),
                 format: InlineCodeFormat {
@@ -731,11 +794,11 @@ fn inline_from_ast(node: &md::Inline, source: &str) -> Result<InlineNode, Plugin
             },
         ),
         md::Inline::Link(node) => (
-            Some(new_inline_id()),
+            Some(ids.next()),
             InlineContent::Link {
                 destination: node.destination.clone(),
                 title: node.title.clone(),
-                children: inlines_from_ast(&node.children, source)?,
+                children: inlines_from_ast(&node.children, source, ids)?,
                 format: ResourceFormat {
                     destination: link_destination_name(node.destination_kind).to_string(),
                     title: node.title_kind.map(link_title_name).map(str::to_string),
@@ -743,11 +806,11 @@ fn inline_from_ast(node: &md::Inline, source: &str) -> Result<InlineNode, Plugin
             },
         ),
         md::Inline::Image(node) => (
-            Some(new_inline_id()),
+            Some(ids.next()),
             InlineContent::Image {
                 destination: node.destination.clone(),
                 title: node.title.clone(),
-                alt: inlines_from_ast(&node.alt, source)?,
+                alt: inlines_from_ast(&node.alt, source, ids)?,
                 format: ResourceFormat {
                     destination: link_destination_name(node.destination_kind).to_string(),
                     title: node.title_kind.map(link_title_name).map(str::to_string),
@@ -755,10 +818,10 @@ fn inline_from_ast(node: &md::Inline, source: &str) -> Result<InlineNode, Plugin
             },
         ),
         md::Inline::LinkReference(node) => (
-            Some(new_inline_id()),
+            Some(ids.next()),
             InlineContent::LinkReference {
                 identifier: node.identifier.clone(),
-                children: inlines_from_ast(&node.children, source)?,
+                children: inlines_from_ast(&node.children, source, ids)?,
                 format: ReferenceFormat {
                     label: node.label.clone(),
                     kind: reference_kind_name(node.kind).to_string(),
@@ -766,10 +829,10 @@ fn inline_from_ast(node: &md::Inline, source: &str) -> Result<InlineNode, Plugin
             },
         ),
         md::Inline::ImageReference(node) => (
-            Some(new_inline_id()),
+            Some(ids.next()),
             InlineContent::ImageReference {
                 identifier: node.identifier.clone(),
-                alt: inlines_from_ast(&node.alt, source)?,
+                alt: inlines_from_ast(&node.alt, source, ids)?,
                 format: ReferenceFormat {
                     label: node.label.clone(),
                     kind: reference_kind_name(node.kind).to_string(),
@@ -777,7 +840,7 @@ fn inline_from_ast(node: &md::Inline, source: &str) -> Result<InlineNode, Plugin
             },
         ),
         md::Inline::Autolink(node) => (
-            Some(new_inline_id()),
+            Some(ids.next()),
             InlineContent::Autolink {
                 destination: node.destination.clone(),
                 format: match &node.kind {
@@ -793,14 +856,14 @@ fn inline_from_ast(node: &md::Inline, source: &str) -> Result<InlineNode, Plugin
             },
         ),
         md::Inline::Html(node) => (
-            Some(new_inline_id()),
+            Some(ids.next()),
             InlineContent::Html {
                 value: node.value.clone(),
             },
         ),
         md::Inline::SoftBreak(_) => (None, InlineContent::SoftBreak),
         md::Inline::LineBreak(node) => (
-            Some(new_inline_id()),
+            Some(ids.next()),
             InlineContent::LineBreak {
                 format: LineBreakFormat {
                     kind: match node.kind {
@@ -812,7 +875,7 @@ fn inline_from_ast(node: &md::Inline, source: &str) -> Result<InlineNode, Plugin
             },
         ),
         md::Inline::FootnoteReference(node) => (
-            Some(new_inline_id()),
+            Some(ids.next()),
             InlineContent::FootnoteReference {
                 identifier: node.identifier.clone(),
                 format: FootnoteReferenceFormat {
@@ -827,10 +890,6 @@ fn inline_from_ast(node: &md::Inline, source: &str) -> Result<InlineNode, Plugin
         }
     };
     Ok(InlineNode { id, content })
-}
-
-fn new_inline_id() -> String {
-    Uuid::now_v7().to_string()
 }
 
 fn delimiter_from_span(span: Option<Span>, source: &str, fallback: &str) -> String {

--- a/plugins/markdown-v2/src/tests.rs
+++ b/plugins/markdown-v2/src/tests.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use base64::Engine as _;
 use serde_json::Value;
+use std::collections::BTreeSet;
 
 fn assert_number_free(value: &Value) {
     match value {
@@ -367,7 +368,7 @@ fn incremental_paragraph_edit_preserves_unrelated_entities_after_cold_reopen() {
     let initial_ids = initial_records
         .iter()
         .map(|record| record.entity_pk.clone())
-        .collect::<std::collections::BTreeSet<_>>();
+        .collect::<BTreeSet<_>>();
     let (document, _) = Document::open_entities(initial_records, None).unwrap();
     let offset = source
         .windows(b"Bravo".len())
@@ -550,4 +551,54 @@ fn literal_prose_fast_path_rejects_markdown_syntax_and_noncanonical_layout() {
             "{name} must use the existing canonical-render fallback"
         );
     }
+}
+
+#[test]
+fn parser_uses_compact_transition_local_identities() {
+    fn collect_value_ids(value: &Value, output: &mut Vec<String>) {
+        match value {
+            Value::Object(object) => {
+                if let Some(Value::String(id)) = object.get("id") {
+                    output.push(id.clone());
+                }
+                for child in object.values() {
+                    collect_value_ids(child, output);
+                }
+            }
+            Value::Array(array) => {
+                for child in array {
+                    collect_value_ids(child, output);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn collect_tree_ids(tree: &crate::model::NodeTree, output: &mut Vec<String>) {
+        if tree.node.kind != crate::model::NodeKind::Document {
+            output.push(tree.node.id.clone());
+        }
+        collect_value_ids(&tree.node.payload, output);
+        for child in &tree.children {
+            collect_tree_ids(child, output);
+        }
+    }
+
+    let parsed = parse_markdown_source(
+        "# Heading with *emphasis* and [a link](https://example.com)\n\n- list item\n",
+    )
+    .expect("syntax-rich Markdown should parse");
+    let mut ids = Vec::new();
+    collect_tree_ids(&parsed.root, &mut ids);
+
+    assert!(
+        ids.len() >= 5,
+        "fixture should allocate structural and inline ids"
+    );
+    assert!(ids.iter().all(|id| id.starts_with('~') && id.len() <= 9));
+    assert_eq!(
+        ids.iter().collect::<BTreeSet<_>>().len(),
+        ids.len(),
+        "parse-local identities must share one collision-free namespace"
+    );
 }


### PR DESCRIPTION
## What changed

- reconcile full Markdown parses against borrowed views of persistent state
- retain the reconciled successor tree directly instead of flattening and rebuilding it
- replace parse-only UUIDv7 strings with compact transition-local ordinal IDs
- add coverage for the compact ID namespace and a reproducible `vscode-docs` memory report

## Why

Replaying `microsoft/vscode-docs` commit `d5badf95f8ab16c4deb91199dc696f2293d93554`
OOMed the Markdown Wasm guest on the 1.24 MB `vscode-api.md` transition.
The parser was not the problem by itself: the full-parse fallback held several
owned representations of the same semantic tree, while temporary nodes also
paid for UUID allocation and formatting.

The new pipeline shares persistent nodes through borrowed indexes and turns the
reconciled parse tree directly into the next persistent tree.

## Impact

On the exact failing transition:

| Build | Peak Wasm guest memory | Result |
| --- | ---: | --- |
| `main` | greater than 128 MiB | OOM |
| this PR | 102,367,232 bytes (97.63 MiB) | success |

The result was reproduced twice on the prototype and again against the latest
`origin/main`, leaving 30.38 MiB of guest-memory headroom. All 151 changed paths,
the replayed commit state, and the final Git tree manifest verified.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p plugin_markdown_incremental_v2`
- `cargo clippy -p plugin_markdown_incremental_v2 --all-targets -- -D warnings`
- exact one-commit `vscode-docs` replay with all production plugins and RocksDB
- repeated on latest `origin/main` at `bc89b8ddd`
