### PR TITLE
Superseded: bound large Markdown reparses

### DIFF
--- a/plugins/markdown-v2/src/core.rs
+++ b/plugins/markdown-v2/src/core.rs
@@ -227,17 +227,25 @@ fn render_tree_with_lexical_fallback(root: &NodeTree) -> Result<Vec<u8>, PluginE
 
 fn detect_changes_for_markdown(
     before: &Projection,
-    mut after: ParsedMarkdown,
+    after: ParsedMarkdown,
     namespace: IdNamespace,
 ) -> Result<Vec<DetectedChange>, PluginError> {
-    let generated_ids = collect_generated_ids(&after.root);
     let before_root = if before.nodes_by_id.is_empty() {
         None
     } else {
         Some(before.to_tree()?)
     };
+    detect_changes_for_markdown_tree(before_root.as_ref(), after, namespace)
+}
+
+fn detect_changes_for_markdown_tree(
+    before_root: Option<&NodeTree>,
+    mut after: ParsedMarkdown,
+    namespace: IdNamespace,
+) -> Result<Vec<DetectedChange>, PluginError> {
+    let generated_ids = collect_generated_ids(&after.root);
     let mut replacements = BTreeMap::new();
-    if let Some(before_root) = &before_root {
+    if let Some(before_root) = before_root {
         let old_hashes = SubtreeHashes::from_tree(before_root);
         let new_hashes = SubtreeHashes::from_tree(&after.root);
         let mut global_subtrees = HashMap::<SubtreeHash, Vec<&NodeTree>>::new();
@@ -289,7 +297,8 @@ fn detect_changes_for_markdown(
         replace_column_ids(&mut node.payload, &replacements);
     });
     let after_nodes = flatten_tree(&after.root);
-    diff_projections(before, &after_nodes)
+    let before_nodes = before_root.map(flatten_tree_refs).unwrap_or_default();
+    diff_tree_nodes(&before_nodes, &after_nodes)
 }
 
 fn collect_generated_ids(root: &NodeTree) -> BTreeSet<String> {
@@ -1244,15 +1253,27 @@ fn flatten_tree(root: &NodeTree) -> BTreeMap<String, NodeSnapshot> {
     output
 }
 
-fn diff_projections(
-    before: &Projection,
+fn flatten_tree_refs(root: &NodeTree) -> BTreeMap<&str, &NodeSnapshot> {
+    fn visit<'a>(tree: &'a NodeTree, output: &mut BTreeMap<&'a str, &'a NodeSnapshot>) {
+        output.insert(tree.node.id.as_str(), &tree.node);
+        for child in &tree.children {
+            visit(child, output);
+        }
+    }
+    let mut output = BTreeMap::new();
+    visit(root, &mut output);
+    output
+}
+
+fn diff_tree_nodes(
+    before: &BTreeMap<&str, &NodeSnapshot>,
     after: &BTreeMap<String, NodeSnapshot>,
 ) -> Result<Vec<DetectedChange>, PluginError> {
     let mut changes = Vec::new();
-    for id in before.nodes_by_id.keys() {
-        if !after.contains_key(id) {
+    for id in before.keys() {
+        if !after.contains_key(*id) {
             changes.push(DetectedChange {
-                entity_pk: vec![id.clone()],
+                entity_pk: vec![(*id).to_owned()],
                 schema_key: NODE_SCHEMA_KEY.to_string(),
                 snapshot_content: None,
                 metadata: None,
@@ -1260,7 +1281,8 @@ fn diff_projections(
         }
     }
     for (id, node) in after {
-        if before.nodes_by_id.get(id) == Some(node) {
+        let previous = before.get(id.as_str()).copied();
+        if previous == Some(node) {
             continue;
         }
         let snapshot_content = serde_json::to_string(node).map_err(|error| {
@@ -1270,7 +1292,7 @@ fn diff_projections(
             entity_pk: vec![id.clone()],
             schema_key: NODE_SCHEMA_KEY.to_string(),
             snapshot_content: Some(snapshot_content),
-            metadata: change_metadata(before.nodes_by_id.get(id), node),
+            metadata: change_metadata(previous, node),
         });
     }
     Ok(changes)
@@ -2062,13 +2084,11 @@ impl Document {
                 data: bytes,
             };
             let current_root = self.tree.materialize();
-            let before = Projection {
-                nodes_by_id: flatten_tree(&current_root),
-            };
             let mut parsed = parse_file(&file)?;
             retain_noncanonical_source(&mut parsed, &file.data)?;
             let top_level_ranges = Arc::new(parsed.top_level_ranges.clone());
-            let detected = detect_changes_for_markdown(&before, parsed, namespace)?;
+            let detected =
+                detect_changes_for_markdown_tree(Some(&current_root), parsed, namespace)?;
             let root = projection_after_detected_changes(&current_root, &detected)?.to_tree()?;
             (detected, top_level_ranges, PersistentTree::new(root))
         };

--- a/plugins/markdown-v2/src/markdown_file.rs
+++ b/plugins/markdown-v2/src/markdown_file.rs
@@ -10,9 +10,13 @@ use encoding_rs::Encoding;
 use markdown_syntax::ast as md;
 use markdown_syntax::{LineEnding, SerializeOptions, Span, SyntaxOptions};
 use serde_json::{Value, json};
+use std::cell::Cell;
 use std::collections::BTreeMap;
 use std::ops::Range;
-use uuid::Uuid;
+
+thread_local! {
+    static PARSE_ID_ORDINAL: Cell<u64> = const { Cell::new(0) };
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct ParsedMarkdown {
@@ -123,6 +127,7 @@ fn fully_escape_orphan_table_delimiters(rendered: Vec<u8>) -> Vec<u8> {
 }
 
 fn parse_markdown_source_once(source: &str) -> Result<ParsedMarkdown, PluginError> {
+    PARSE_ID_ORDINAL.set(0);
     let mut options = SyntaxOptions::gfm();
     options.constructs.frontmatter = true;
     options.parse.preserve_character_escapes = true;
@@ -434,7 +439,7 @@ fn detected_line_ending(source: &str) -> &'static str {
 fn new_tree(kind: NodeKind, payload: Value, format: Value, children: Vec<NodeTree>) -> NodeTree {
     NodeTree {
         node: NodeSnapshot {
-            id: Uuid::now_v7().to_string(),
+            id: new_parse_id(),
             kind,
             parent_id: None,
             order_key: None,
@@ -830,7 +835,19 @@ fn inline_from_ast(node: &md::Inline, source: &str) -> Result<InlineNode, Plugin
 }
 
 fn new_inline_id() -> String {
-    Uuid::now_v7().to_string()
+    new_parse_id()
+}
+
+fn new_parse_id() -> String {
+    PARSE_ID_ORDINAL.with(|ordinal| {
+        let current = ordinal.get();
+        ordinal.set(
+            current
+                .checked_add(1)
+                .expect("one Markdown parse cannot allocate more than u64::MAX temporary IDs"),
+        );
+        format!("~{current:x}")
+    })
 }
 
 fn delimiter_from_span(span: Option<Span>, source: &str, fallback: &str) -> String {


### PR DESCRIPTION
Superseded by #951, which landed on `main` while the full-history replay was running. #951 implements the same root-cause fix with a more robust borrowed projection, directly retained successor tree, compact parse-local IDs, regression coverage, and a 23.7% guest-memory reduction on the fatal `vscode-docs` transition.

This draft is closed to avoid sending a duplicate implementation through review.