### PR TITLE
bench(changelog): avoid observer-induced index scan

### DIFF
--- a/packages/engine-benchmarks/benches/changelog_history_append.rs
+++ b/packages/engine-benchmarks/benches/changelog_history_append.rs
@@ -10,7 +10,6 @@ use lix_engine::storage::{
     ReadOptions, ScanChunk, ScanOptions, SpaceId, StorageError, StorageRead, StorageWrite,
     WriteOptions,
 };
-use lix_engine::storage_bench::StorageLayoutAccounting;
 use lix_rocksdb_storage::RocksDB;
 use lix_slatedb_storage::SlateDB;
 use tempfile::TempDir;
@@ -123,7 +122,7 @@ async fn run_case(
     stage_timings.sort_unstable();
     commit_timings.sort_unstable();
     total_timings.sort_unstable();
-    let layout = fixture.seed_layout();
+    let expected_seed_index_mapping_rows = fixture.expected_seed_index_mapping_rows();
     let sample_count = u64::try_from(samples).expect("benchmark sample count should fit in u64");
 
     println!(
@@ -135,8 +134,7 @@ async fn run_case(
          get_many_calls_per_op={},get_many_keys_per_op={},\
          scan_calls_per_op={},scan_rows_per_op={},scan_value_bytes_per_op={},\
          put_batches_per_op={},puts_per_op={},write_bytes_per_op={},\
-         commit_change_id_index_rows={},commit_change_id_index_mapping_rows={},\
-         commit_change_id_index_key_bytes={},commit_change_id_index_value_bytes={}",
+         expected_seed_commit_change_id_index_mapping_rows={}",
         micros(percentile(&stage_timings, 50, 100)),
         micros(percentile(&stage_timings, 95, 100)),
         micros(percentile(&stage_timings, 99, 100)),
@@ -157,10 +155,7 @@ async fn run_case(
         io.put_batches / sample_count,
         io.puts / sample_count,
         io.write_bytes / sample_count,
-        layout.rows,
-        layout.rows.saturating_sub(1),
-        layout.key_bytes,
-        layout.value_bytes,
+        expected_seed_index_mapping_rows,
     );
 }
 
@@ -372,7 +367,7 @@ where
     store: changelog_bench::BenchStore<CountingStorage<S>>,
     _temp_dir: TempDir,
     stats: Arc<Mutex<IoStats>>,
-    seed_layout: StorageLayoutAccounting,
+    seed_index_mapping_rows: u64,
     history_commit_change_id: String,
     version: u64,
 }
@@ -417,16 +412,14 @@ where
             seeded_commits += batch_commits;
             batch_index += 1;
         }
-        let seed_layout =
-            changelog_bench::layout_space_accounting(&store, "changelog.commit_change_id")
-                .await
-                .expect("measure changelog change-ID layout");
         *stats.lock().expect("io stats mutex") = IoStats::default();
         Self {
             store,
             _temp_dir: temp_dir,
             stats,
-            seed_layout,
+            seed_index_mapping_rows: history_commits
+                .try_into()
+                .expect("history commit count should fit in u64"),
             history_commit_change_id: format!("{first_batch_name}-commit-0:commit"),
             version: 0,
         }
@@ -480,8 +473,8 @@ where
         *self.stats.lock().expect("io stats mutex")
     }
 
-    fn seed_layout(&self) -> StorageLayoutAccounting {
-        self.seed_layout
+    fn expected_seed_index_mapping_rows(&self) -> u64 {
+        self.seed_index_mapping_rows
     }
 }
 
@@ -548,10 +541,10 @@ impl Fixture {
         }
     }
 
-    fn seed_layout(&self) -> StorageLayoutAccounting {
+    fn expected_seed_index_mapping_rows(&self) -> u64 {
         match self {
-            Self::Rocks(fixture) => fixture.seed_layout(),
-            Self::Slate(fixture) => fixture.seed_layout(),
+            Self::Rocks(fixture) => fixture.expected_seed_index_mapping_rows(),
+            Self::Slate(fixture) => fixture.expected_seed_index_mapping_rows(),
         }
     }
 }

--- a/packages/engine/src/changelog/bench_support.rs
+++ b/packages/engine/src/changelog/bench_support.rs
@@ -428,20 +428,6 @@ where
     Ok(crate::storage_bench::layout_accounting(&read).await)
 }
 
-pub async fn layout_space_accounting<StorageImpl>(
-    store: &BenchStore<StorageImpl>,
-    space_name: &str,
-) -> Result<crate::storage_bench::StorageLayoutAccounting, LixError>
-where
-    StorageImpl: BenchStorage + Sync,
-{
-    let read = store
-        .storage
-        .begin_read(StorageReadOptions::default())
-        .await?;
-    Ok(crate::storage_bench::layout_space_accounting(&read, space_name).await)
-}
-
 pub async fn stage_corpus_once<StorageImpl>(
     storage: StorageImpl,
     corpus: &BenchCorpus,

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -322,19 +322,6 @@ where
     accounting
 }
 
-/// Streams accounting for one named storage space without touching unrelated
-/// spaces. Use this when a benchmark reports a single layout component.
-pub async fn layout_space_accounting<R>(read: &R, space_name: &str) -> StorageLayoutAccounting
-where
-    R: StorageAdapterRead,
-{
-    let space = *native_storage_spaces()
-        .iter()
-        .find(|space| space.name == space_name)
-        .expect("space name should exist");
-    scan_layout_space(read, space).await
-}
-
 /// Per-row (key, value bytes) inventory of one space.
 ///
 /// Equivalence tests compare these inventories byte-for-byte, so the scan
@@ -541,9 +528,6 @@ mod tests {
             .into_iter()
             .find(|space| space.space == crate::changelog::COMMIT_SPACE.name)
             .expect("commit space is accounted");
-        let targeted =
-            super::layout_space_accounting(&read, crate::changelog::COMMIT_SPACE.name).await;
-
         assert_eq!(accounting.rows, inventory.len() as u64);
         assert_eq!(
             accounting.key_bytes,
@@ -559,9 +543,6 @@ mod tests {
                 .map(|(_, value)| value.len() as u64)
                 .sum::<u64>()
         );
-        assert_eq!(targeted.rows, accounting.rows);
-        assert_eq!(targeted.key_bytes, accounting.key_bytes);
-        assert_eq!(targeted.value_bytes, accounting.value_bytes);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- stop enumerating the entire change-ID index after seeding the exact-ID benchmark
- report the fixture-known seed mapping cardinality explicitly instead
- remove the one-space layout helper that made the benchmark observer part of the workload

## Profiler evidence

The merged 10M SlateDB run completed the intended lookup with one five-key `get_many` and zero scans, but benchmark-only layout accounting drove roughly 360 GB of logical reads from a ~3.2 GB fixture. It stretched the run to 26:02 despite bounded 1.27 GiB peak RSS. This is observer-induced I/O, not exact change-ID lookup work.

After the cut, the same 10M case completed in 11:31 at 1.14 GiB peak RSS. At a comparable point in the run, logical reads were 3.78 GB instead of 275 GB. The timed lookup tail was essentially unchanged (p99 736 us before, 710 us after), proving the remaining tail is backend/lifecycle behavior rather than accounting.

The cut preserves physical/object I/O accounting in the dedicated packed-history benchmark and avoids mixing intentional history enumeration into the exact-ID latency benchmark.

## Results

SlateDB 10M release run after the cut:

- 11:31 end-to-end, 1.14 GiB peak RSS
- p50/p95/p99: 42/470/710 us
- one five-key `get_many` per operation, zero scans
- expected seed mappings: 10,000,000

SlateDB 200k release smoke after the cut:

- 4.71 s end-to-end, 570 MiB peak RSS
- p50/p95/p99: 17/22/41 us
- one five-key `get_many` per operation, zero scans
- expected seed mappings: 200,000

## Validation

- `cargo fmt --check`
- `cargo test -p lix_engine --features storage-benches storage_bench::tests --lib` (3 passed)
- `cargo check -p lix_engine_benchmarks --bench changelog_history_append --features storage-benches,slatedb,rocksdb`
- `cargo clippy -p lix_engine_benchmarks --bench changelog_history_append --features storage-benches,slatedb,rocksdb -- -D warnings`
- SlateDB 200k and 10M release runs