### PR TITLE
fix: file descriptor changes always carry their file_id

### DIFF
--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -594,6 +594,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn predecessor_null_file_descriptor_protocol_is_rejected() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let storage_adapter = StorageAdapter::new(storage.clone());
+        let mut writes = storage_adapter.new_write_set();
+        writes.put(
+            crate::init::REPOSITORY_PROTOCOL_SPACE,
+            crate::init::REPOSITORY_PROTOCOL_KEY,
+            &b"clustered-packed-history.v20"[..],
+        );
+        storage_adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("pre-file-ownership protocol marker should commit");
+
+        let Err(error) = Engine::new(storage).await else {
+            panic!("repositories with null-scoped file descriptors must fail closed");
+        };
+        assert_eq!(error.code, "LIX_ERROR_UNSUPPORTED_STORAGE_FORMAT");
+    }
+
+    #[tokio::test]
     async fn tracked_entity_fast_path_serves_broad_sql_rows() {
         let storage = Memory::new();
         Engine::initialize(storage.clone())

--- a/packages/engine/src/filesystem/path_index.rs
+++ b/packages/engine/src/filesystem/path_index.rs
@@ -367,7 +367,10 @@ impl FilesystemPathIndex {
                                 "invalid lix_file_descriptor snapshot JSON: {error}"
                             ))
                         })?;
-                    let key = FilesystemDescriptorKey::from_live_row_ref(row, snapshot.id.clone());
+                    let key = FilesystemDescriptorKey::from_file_descriptor_live_row_ref(
+                        row,
+                        snapshot.id.clone(),
+                    );
                     file_rows.push((
                         key,
                         FileRecord {
@@ -735,13 +738,22 @@ impl FilesystemPathIndex {
                 !entry.key.global()
                     && entry.key.branch_id() == row.branch_id.as_ref()
                     && entry.key.is_untracked() == row.untracked
-                    && entry.key.file_id() == row.file_id.as_deref()
+                    && entry.key.file_id()
+                        == if kind == FilesystemPathKind::File {
+                            None
+                        } else {
+                            row.file_id.as_deref()
+                        }
             })
         {
             return Ok(());
         }
 
-        let key = FilesystemDescriptorKey::from_live_row(row, descriptor_id);
+        let key = if kind == FilesystemPathKind::File {
+            FilesystemDescriptorKey::from_file_descriptor_live_row(row, descriptor_id)
+        } else {
+            FilesystemDescriptorKey::from_live_row(row, descriptor_id)
+        };
         let identity = FilesystemPathEntryIdentity {
             kind,
             key: key.clone(),

--- a/packages/engine/src/filesystem/planner.rs
+++ b/packages/engine/src/filesystem/planner.rs
@@ -125,6 +125,32 @@ impl FilesystemDescriptorKey {
         }
     }
 
+    pub(crate) fn from_file_descriptor_live_row(
+        row: &MaterializedLiveStateRow,
+        descriptor_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            branch_id: row.branch_id.to_string(),
+            global: row.global,
+            untracked: row.untracked,
+            file_id: None,
+            descriptor_id: descriptor_id.into(),
+        }
+    }
+
+    pub(crate) fn from_file_descriptor_live_row_ref(
+        row: MaterializedLiveStateRowRef<'_>,
+        descriptor_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            branch_id: row.branch_id().to_owned(),
+            global: row.global(),
+            untracked: row.untracked(),
+            file_id: None,
+            descriptor_id: descriptor_id.into(),
+        }
+    }
+
     pub(crate) fn in_same_scope(&self, descriptor_id: &str) -> Self {
         Self {
             branch_id: self.branch_id.clone(),
@@ -284,7 +310,10 @@ impl DirectoryDescriptorWriteIntent {
             self.id,
             DIRECTORY_DESCRIPTOR_SCHEMA_KEY,
             Some(JsonValue::Object(snapshot)),
-            self.context,
+            FilesystemRowContext {
+                file_id: None,
+                ..self.context
+            },
         );
     }
 }
@@ -313,10 +342,13 @@ impl FileDescriptorWriteIntent {
         snapshot.insert("name".to_string(), JsonValue::String(self.name));
         append_partial_state_row(
             rows,
-            self.id,
+            self.id.clone(),
             FILE_DESCRIPTOR_SCHEMA_KEY,
             Some(JsonValue::Object(snapshot)),
-            self.context,
+            FilesystemRowContext {
+                file_id: self.id,
+                ..self.context
+            },
         );
     }
 }
@@ -1434,7 +1466,10 @@ pub(crate) fn plan_file_delete(input: FileDeleteInput) -> FilesystemDeletePlan {
         &mut rows,
         input.file_id.clone(),
         FILE_DESCRIPTOR_SCHEMA_KEY,
-        input.context.clone(),
+        FilesystemRowContext {
+            file_id: Some(input.file_id.clone()),
+            ..input.context.clone()
+        },
     );
 
     if input.has_blob_ref {
@@ -1453,7 +1488,10 @@ pub(crate) fn plan_directory_delete(input: DirectoryDeleteInput) -> FilesystemDe
         &mut rows,
         input.directory_id,
         DIRECTORY_DESCRIPTOR_SCHEMA_KEY,
-        input.context,
+        FilesystemRowContext {
+            file_id: None,
+            ..input.context
+        },
     );
     FilesystemDeletePlan { rows, count: 1 }
 }
@@ -1491,14 +1529,14 @@ pub(crate) fn directory_path_resolvers_from_state_batch(
         } else {
             row.branch_id()
         };
-        let resolver_key = filesystem_storage_scope_key(
-            storage_branch_id,
-            row.global(),
-            row.untracked(),
-            row.file_id(),
-        );
         match row.schema_key() {
             DIRECTORY_DESCRIPTOR_SCHEMA_KEY => {
+                let resolver_key = filesystem_storage_scope_key(
+                    storage_branch_id,
+                    row.global(),
+                    row.untracked(),
+                    None,
+                );
                 let snapshot: DirectoryDescriptorSnapshot = serde_json::from_str(snapshot_content)
                     .map_err(|error| {
                         LixError::new(
@@ -1516,6 +1554,12 @@ pub(crate) fn directory_path_resolvers_from_state_batch(
                 );
             }
             FILE_DESCRIPTOR_SCHEMA_KEY => {
+                let resolver_key = filesystem_storage_scope_key(
+                    storage_branch_id,
+                    row.global(),
+                    row.untracked(),
+                    None,
+                );
                 let snapshot: FileDescriptorSnapshot = serde_json::from_str(snapshot_content)
                     .map_err(|error| {
                         LixError::new(
@@ -2559,7 +2603,7 @@ mod tests {
         );
         assert_eq!(directory_row.global, true);
         assert_eq!(directory_row.untracked, true);
-        assert_eq!(directory_row.file_id.as_deref(), Some("context-file"));
+        assert_eq!(directory_row.file_id, None);
         assert_eq!(directory_row.metadata.as_ref(), Some(&metadata));
 
         let file_row = file_descriptor_write_row(FileDescriptorWriteIntent {
@@ -2579,7 +2623,7 @@ mod tests {
                 .get("id")
                 .is_none()
         );
-        assert_eq!(file_row.file_id.as_deref(), Some("context-file"));
+        assert_eq!(file_row.file_id, None);
         assert_eq!(file_row.metadata.as_ref(), Some(&metadata));
 
         let mut resolver =
@@ -2613,7 +2657,7 @@ mod tests {
         assert_eq!(descriptor.untracked, true);
         assert_eq!(
             descriptor.file_id.map(crate::common::SharedStr::as_str),
-            Some("context-file")
+            Some("01920000-0000-7000-8000-0000000000d2")
         );
         assert_eq!(descriptor.metadata, Some(&metadata));
 
@@ -2765,14 +2809,6 @@ mod tests {
                 None,
                 "{\"id\":\"01920000-0000-7000-8000-000000000413\",\"parent_id\":null,\"name\":\"docs\"}",
             ),
-            live_directory_row_with_scope(
-                "dir-file-scoped",
-                "01920000-0000-7000-8000-0000000000a1",
-                false,
-                false,
-                Some("scope-file".to_string()),
-                "{\"id\":\"dir-file-scoped\",\"parent_id\":null,\"name\":\"docs\"}",
-            ),
         ];
 
         let rows = MaterializedLiveStateBatch::from_rows(rows);
@@ -2798,12 +2834,6 @@ mod tests {
             true,
             None,
         );
-        let file_scoped_key = super::filesystem_storage_scope_key(
-            "01920000-0000-7000-8000-0000000000a1",
-            false,
-            false,
-            Some("scope-file"),
-        );
         let literal_null_file_id_key = super::filesystem_storage_scope_key(
             "01920000-0000-7000-8000-0000000000a1",
             false,
@@ -2814,7 +2844,6 @@ mod tests {
         assert_ne!(branch_a_key, branch_b_key);
         assert_ne!(branch_a_key, global_key);
         assert_ne!(branch_a_key, untracked_key);
-        assert_ne!(branch_a_key, file_scoped_key);
         assert_ne!(branch_a_key, literal_null_file_id_key);
 
         assert_eq!(
@@ -2849,14 +2878,6 @@ mod tests {
                 .unwrap(),
             Some("01920000-0000-7000-8000-000000000413")
         );
-        assert_eq!(
-            resolvers
-                .get(&file_scoped_key)
-                .unwrap()
-                .directory_id("/docs")
-                .unwrap(),
-            Some("dir-file-scoped")
-        );
     }
 
     #[test]
@@ -2879,7 +2900,10 @@ mod tests {
             descriptor.entity_pk,
             Some(&uuid_pk("01920000-0000-7000-8000-0000000000d2"))
         );
-        assert_eq!(descriptor.file_id, None);
+        assert_eq!(
+            descriptor.file_id.map(crate::common::SharedStr::as_str),
+            Some("01920000-0000-7000-8000-0000000000d2")
+        );
         assert_eq!(descriptor.snapshot, None);
 
         let blob_ref = plan

--- a/packages/engine/src/filesystem/read.rs
+++ b/packages/engine/src/filesystem/read.rs
@@ -56,7 +56,13 @@ impl FilesystemIndex {
                                 "invalid lix_file_descriptor snapshot JSON: {error}"
                             ))
                         })?;
-                    file_rows.push((snapshot, scope));
+                    file_rows.push((
+                        snapshot,
+                        RowScope {
+                            file_id: None,
+                            ..scope
+                        },
+                    ));
                 }
                 BLOB_REF_SCHEMA_KEY => {
                     let snapshot: BlobRefSnapshot = serde_json::from_str(snapshot_content)
@@ -397,7 +403,7 @@ mod tests {
     }
 
     #[test]
-    fn from_live_rows_resolves_directories_by_storage_scope() {
+    fn from_live_rows_resolves_directories_by_branch_scope() {
         let index = filesystem_index_from_rows(vec![
             directory_row(
                 "dir-shared",
@@ -407,19 +413,19 @@ mod tests {
                 "dir-shared",
                 DIRECTORY_DESCRIPTOR_SCHEMA_KEY,
                 r#"{"id":"dir-shared","parent_id":null,"name":"scoped"}"#,
-                "01920000-0000-7000-8000-0000000000a1",
+                "01920000-0000-7000-8000-0000000000b1",
                 false,
-                Some("01920000-0000-7000-8000-000000000342".to_string()),
+                None,
             ),
             file_row(
                 "01920000-0000-7000-8000-000000000142",
                 r#"{"id":"01920000-0000-7000-8000-000000000142","directory_id":"dir-shared","name":"root.txt"}"#,
             ),
             live_row_with_scope(
-                "file-scoped",
+                "01920000-0000-7000-8000-000000000342",
                 FILE_DESCRIPTOR_SCHEMA_KEY,
-                r#"{"id":"file-scoped","directory_id":"dir-shared","name":"scoped.txt"}"#,
-                "01920000-0000-7000-8000-0000000000a1",
+                r#"{"id":"01920000-0000-7000-8000-000000000342","directory_id":"dir-shared","name":"scoped.txt"}"#,
+                "01920000-0000-7000-8000-0000000000b1",
                 false,
                 Some("01920000-0000-7000-8000-000000000342".to_string()),
             ),
@@ -451,7 +457,14 @@ mod tests {
     }
 
     fn file_row(entity_pk: &str, snapshot_content: &str) -> MaterializedLiveStateRow {
-        live_row(entity_pk, FILE_DESCRIPTOR_SCHEMA_KEY, snapshot_content)
+        live_row_with_scope(
+            entity_pk,
+            FILE_DESCRIPTOR_SCHEMA_KEY,
+            snapshot_content,
+            "01920000-0000-7000-8000-0000000000a1",
+            false,
+            Some(entity_pk.to_string()),
+        )
     }
 
     fn live_row(

--- a/packages/engine/src/filesystem/visibility.rs
+++ b/packages/engine/src/filesystem/visibility.rs
@@ -84,7 +84,10 @@ impl VisibleFilesystem {
                             format!("invalid lix_file_descriptor snapshot JSON: {error}"),
                         )
                     })?;
-                    let key = FilesystemDescriptorKey::from_live_row_ref(row, snapshot.id.clone());
+                    let key = FilesystemDescriptorKey::from_file_descriptor_live_row_ref(
+                        row,
+                        snapshot.id.clone(),
+                    );
                     visible
                         .files_by_directory_id
                         .entry(snapshot.directory_id.map(|id| key.in_same_scope(&id)))

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -39,13 +39,13 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 
 /// Repository-wide compatibility gate for physical storage protocols.
 ///
-/// V18 makes packed commit deltas the sole tracked commit-membership and
-/// payload authority. Opening an older store must fail closed rather than
-/// mixing the retired changelog ref layout with this physical contract.
+/// V21 makes a file descriptor's `file_id` part of every durable row identity.
+/// Opening an older store must fail closed rather than mixing null-scoped
+/// descriptor identities with file-owned descriptor identities.
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"clustered-packed-history.v20";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"file-descriptor-ownership.v21";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -1486,7 +1486,7 @@ fn apply_complete_file_delete_cascade(
 }
 
 fn file_delete_cascade_id(delta: &CurrentStateDeltaRef<'_>) -> Result<Option<String>, LixError> {
-    if delta.schema_key != FILE_DESCRIPTOR_SCHEMA_KEY || delta.file_id.is_some() || !delta.deleted {
+    if delta.schema_key != FILE_DESCRIPTOR_SCHEMA_KEY || !delta.deleted {
         return Ok(None);
     }
     delta

--- a/packages/engine/src/session/merge/branch.rs
+++ b/packages/engine/src/session/merge/branch.rs
@@ -1035,7 +1035,7 @@ where
         .map(|file_id| {
             Ok(TrackedStateKey {
                 schema_key: FILE_DESCRIPTOR_SCHEMA_KEY.to_owned(),
-                file_id: None,
+                file_id: Some(file_id.clone()),
                 entity_pk: EntityPk::uuid_from_canonical(file_id).map_err(|error| {
                     LixError::new(
                         LixError::CODE_INTERNAL_ERROR,
@@ -1872,7 +1872,7 @@ mod tests {
         MaterializedTrackedStateRow {
             entity_pk: EntityPk::single(file_id),
             schema_key: FILE_DESCRIPTOR_SCHEMA_KEY.to_owned(),
-            file_id: None,
+            file_id: Some(file_id.to_string()),
             snapshot_content: Some(
                 json!({
                     "id": file_id,

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -3190,7 +3190,7 @@ mod tests {
             entity_pk: crate::entity_pk::EntityPk::uuid_from_canonical(entity_pk)
                 .expect("fixture file ID should be a UUID"),
             schema_key: "lix_file_descriptor".to_string(),
-            file_id: None,
+            file_id: Some(entity_pk.to_string()),
             snapshot_content: Some(
                 json!({
                     "id": entity_pk,
@@ -5029,7 +5029,10 @@ mod tests {
             descriptor.metadata.as_deref(),
             Some(r#"{"source":"upload"}"#)
         );
-        assert_eq!(descriptor.file_id, None);
+        assert_eq!(
+            descriptor.file_id.as_deref(),
+            Some("01920000-0000-7000-8000-000000000322")
+        );
         let snapshot: JsonValue = serde_json::from_str(
             descriptor
                 .snapshot_content
@@ -5650,7 +5653,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn execute_sql_file_data_update_by_id_updates_same_path_in_every_matching_scope() {
+    async fn execute_sql_file_data_update_by_id_updates_same_path_in_every_matching_durability_lane()
+     {
         let root = live_file_row(
             "01920000-0000-7000-8000-0000000000d2",
             "01920000-0000-7000-8000-0000000000a1",
@@ -5663,7 +5667,9 @@ mod tests {
             None,
             "shared.md",
         );
-        scoped.file_id = Some("01920000-0000-7000-8000-000000000342".to_string());
+        scoped.untracked = true;
+        scoped.change_id = None;
+        scoped.commit_id = None;
         let rows = vec![root, scoped];
         let (mut fast_ctx, fast_staged, _) = counting_write_context(rows.clone());
         let (mut datafusion_ctx, datafusion_staged, _) = counting_write_context(rows);

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -4188,7 +4188,10 @@ fn prepare_lix_file_rows(
                             format!("invalid lix_file_descriptor snapshot JSON: {error}"),
                         )
                     })?;
-                let key = FilesystemDescriptorKey::from_live_row_ref(row, snapshot.id.clone());
+                let key = FilesystemDescriptorKey::from_file_descriptor_live_row_ref(
+                    row,
+                    snapshot.id.clone(),
+                );
                 file_rows.insert(
                     key.clone(),
                     FileDescriptorRecord {
@@ -4433,7 +4436,7 @@ fn lix_file_record_batch_from_path_selection(
             "lixcol_file_id" => Arc::new(StringArray::from(
                 entries
                     .iter()
-                    .map(|entry| entry.key.file_id())
+                    .map(|entry| Some(entry.id()))
                     .collect::<Vec<_>>(),
             )),
             "lixcol_global" => Arc::new(BooleanArray::from(
@@ -7603,7 +7606,6 @@ mod tests {
             "01920000-0000-7000-8000-0000000000b1",
             r#"{"id":"01920000-0000-7000-8000-000000000522","directory_id":null,"name":"readme.md"}"#,
         );
-        target.file_id = Some("remote-01920000-0000-7000-8000-000000000522".to_string());
         target.untracked = true;
         let index = Arc::new(
             path_index_from_rows(vec![
@@ -7678,7 +7680,7 @@ mod tests {
         assert_eq!(string_value("id"), "01920000-0000-7000-8000-000000000522");
         assert_eq!(
             string_value("lixcol_file_id"),
-            "remote-01920000-0000-7000-8000-000000000522"
+            "01920000-0000-7000-8000-000000000522"
         );
         assert!(!boolean_value("lixcol_global"));
         assert!(boolean_value("lixcol_untracked"));
@@ -8911,7 +8913,7 @@ mod tests {
         MaterializedLiveStateRow {
             entity_pk: typed_entity_pk,
             schema_key: super::FILE_DESCRIPTOR_SCHEMA_KEY.to_string(),
-            file_id: None,
+            file_id: Some(entity_pk.to_string()),
             snapshot_content: Some(snapshot_content.into()),
             metadata: None,
             deleted: false,
@@ -9074,6 +9076,7 @@ mod tests {
                 .to_string(),
         );
         row.schema_key = "lix_key_value".to_string();
+        row.file_id = None;
         row
     }
 
@@ -9703,62 +9706,40 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn file_projection_keeps_same_id_descriptors_in_distinct_file_scopes() {
+    async fn file_projection_sets_descriptor_file_id_to_own_id() {
         let blob_reader = Arc::new(CapturingWriteContext::default()) as Arc<dyn BlobDataReader>;
-        let mut scoped_file = live_file_row(
-            "01920000-0000-7000-8000-0000000000d2",
-            "01920000-0000-7000-8000-0000000000b1",
-            "{\"id\":\"01920000-0000-7000-8000-0000000000d2\",\"directory_id\":null,\"name\":\"scoped.md\"}",
-        );
-        scoped_file.file_id = Some("01920000-0000-7000-8000-000000000342".to_string());
         let batch = super::lix_file_record_batch(
             &super::lix_file_schema(),
             &blob_reader,
             None,
             true,
-            vec![
-                live_file_row(
-                    "01920000-0000-7000-8000-0000000000d2",
-                    "01920000-0000-7000-8000-0000000000b1",
-                    "{\"id\":\"01920000-0000-7000-8000-0000000000d2\",\"directory_id\":null,\"name\":\"root.md\"}",
-                ),
-                scoped_file,
-            ],
+            vec![live_file_row(
+                "01920000-0000-7000-8000-0000000000d2",
+                "01920000-0000-7000-8000-0000000000b1",
+                "{\"id\":\"01920000-0000-7000-8000-0000000000d2\",\"directory_id\":null,\"name\":\"root.md\"}",
+            )],
         )
         .await
-        .expect("same descriptor id in different file scopes should project");
+        .expect("file descriptor should project");
 
-        assert_eq!(batch.num_rows(), 2);
+        assert_eq!(batch.num_rows(), 1);
         let file_id_column = batch
             .column(batch.schema().index_of("lixcol_file_id").unwrap())
             .as_any()
             .downcast_ref::<StringArray>()
             .expect("lixcol_file_id should be string array");
-        let values = (0..batch.num_rows())
-            .map(|index| {
-                if file_id_column.is_null(index) {
-                    None
-                } else {
-                    Some(file_id_column.value(index).to_string())
-                }
-            })
-            .collect::<Vec<_>>();
-        assert!(values.contains(&None));
-        assert!(values.contains(&Some("01920000-0000-7000-8000-000000000342".to_string())));
+        assert_eq!(
+            file_id_column.value(0),
+            "01920000-0000-7000-8000-0000000000d2"
+        );
     }
 
     #[tokio::test]
-    async fn file_projection_reuses_loaded_blob_for_duplicate_blob_ref_keys() {
+    async fn file_projection_matches_blob_ref_by_descriptor_file_id() {
         let data = b"shared data".to_vec();
         let blob_hash = BlobHash::from_content(&data).to_hex();
         let blob_reader =
             Arc::new(StaticBlobReader::from_blobs(vec![data.clone()])) as Arc<dyn BlobDataReader>;
-        let mut scoped_file = live_file_row(
-            "01920000-0000-7000-8000-0000000000d2",
-            "01920000-0000-7000-8000-0000000000b1",
-            "{\"id\":\"01920000-0000-7000-8000-0000000000d2\",\"directory_id\":null,\"name\":\"scoped.md\"}",
-        );
-        scoped_file.file_id = Some("01920000-0000-7000-8000-000000000342".to_string());
         let batch = super::lix_file_record_batch(
             &super::lix_file_schema(),
             &blob_reader,
@@ -9770,7 +9751,6 @@ mod tests {
                     "01920000-0000-7000-8000-0000000000b1",
                     "{\"id\":\"01920000-0000-7000-8000-0000000000d2\",\"directory_id\":null,\"name\":\"root.md\"}",
                 ),
-                scoped_file,
                 live_blob_ref_row(
                     "01920000-0000-7000-8000-0000000000d2",
                     "01920000-0000-7000-8000-0000000000b1",
@@ -9781,14 +9761,14 @@ mod tests {
             ],
         )
         .await
-        .expect("duplicate blob-ref keys should project data for every descriptor");
+        .expect("blob ref should project data for its descriptor");
 
         let data_column = batch
             .column(batch.schema().index_of("data").unwrap())
             .as_any()
             .downcast_ref::<LargeBinaryArray>()
             .expect("data should be large binary array");
-        assert_eq!(batch.num_rows(), 2);
+        assert_eq!(batch.num_rows(), 1);
         for index in 0..batch.num_rows() {
             assert!(!data_column.is_null(index));
             assert_eq!(data_column.value(index), data.as_slice());
@@ -11004,7 +10984,10 @@ mod tests {
             descriptor.entity_pk,
             Some(&uuid_pk("01920000-0000-7000-8000-0000000000d2"))
         );
-        assert_eq!(descriptor.file_id, None);
+        assert_eq!(
+            descriptor.file_id.map(crate::common::SharedStr::as_str),
+            Some("01920000-0000-7000-8000-0000000000d2")
+        );
         assert_eq!(descriptor.snapshot, None);
 
         let blob_ref = staged

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -4048,7 +4048,10 @@ fn file_path_resolver_key(context: &FilesystemRowContext) -> String {
         &context.branch_id,
         context.global,
         context.untracked,
-        context.file_id.as_deref(),
+        // `file_id` is descriptor ownership, not filesystem namespace scope.
+        // Directory resolvers are shared by every file in the same durability
+        // and branch lane.
+        None,
     )
 }
 

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -707,7 +707,7 @@ impl RootlessCascadeIndex {
         key: TrackedStateKeyRef<'_>,
         value: &TrackedStateIndexValue,
     ) -> Result<(), LixError> {
-        if key.schema_key != FILE_DESCRIPTOR_SCHEMA_KEY || key.file_id.is_some() || !value.deleted {
+        if key.schema_key != FILE_DESCRIPTOR_SCHEMA_KEY || !value.deleted {
             return Ok(());
         }
         let start = self.file_id_arena.len();
@@ -1801,7 +1801,7 @@ where
         let mut candidates = winners
             .iter()
             .filter_map(|(identity, change_id)| {
-                if identity.schema_key != FILE_DESCRIPTOR_SCHEMA_KEY || identity.file_id.is_some() {
+                if identity.schema_key != FILE_DESCRIPTOR_SCHEMA_KEY {
                     return None;
                 }
                 let value = row_map.get(identity)?;
@@ -2181,10 +2181,7 @@ where
                         )
                     })?;
                 let key = row.key_ref();
-                if key.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY
-                    && key.file_id.is_none()
-                    && row.value().deleted
-                {
+                if key.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY && row.value().deleted {
                     cascade_capacity += 1;
                 }
             }
@@ -2263,7 +2260,7 @@ where
                     .expect("first-parent interval key/value columns are aligned");
                 let decoded_key = decode_key_shared(encoded_key)?;
                 let key = decoded_key.as_ref();
-                if key.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY && key.file_id.is_none() {
+                if key.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY {
                     overlay.insert_cascade_if_absent(key, value)?;
                 }
             }
@@ -2466,10 +2463,7 @@ where
                         )
                     })?;
                 let key = row.key_ref();
-                if key.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY
-                    && key.file_id.is_none()
-                    && row.value().deleted
-                {
+                if key.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY && row.value().deleted {
                     cascade_capacity = cascade_capacity.saturating_add(1);
                 }
             }
@@ -2599,7 +2593,7 @@ where
             })?;
             descriptor_key_builder.push(TrackedStateKeyRef {
                 schema_key: FILE_DESCRIPTOR_SCHEMA_KEY,
-                file_id: None,
+                file_id: Some(file_id.as_str()),
                 entity_pk: &entity_pk,
             });
         }
@@ -3154,10 +3148,7 @@ where
             )?;
             let mut cascades = BTreeMap::<String, &TrackedStateDeltaRef<'_>>::new();
             for delta in &deltas {
-                if delta.schema_key != FILE_DESCRIPTOR_SCHEMA_KEY
-                    || delta.file_id.is_some()
-                    || !delta.deleted
-                {
+                if delta.schema_key != FILE_DESCRIPTOR_SCHEMA_KEY || !delta.deleted {
                     continue;
                 }
                 let file_id = delta.entity_pk.as_single_string_owned().map_err(|error| {
@@ -3647,7 +3638,7 @@ fn file_descriptor_key_for_file_scoped_key(
         .map(|file_id| {
             Ok(TrackedStateKey {
                 schema_key: FILE_DESCRIPTOR_SCHEMA_KEY.to_string(),
-                file_id: None,
+                file_id: Some(file_id.to_string()),
                 entity_pk: EntityPk::uuid_from_canonical(file_id).map_err(|error| {
                     LixError::new(
                         LixError::CODE_INTERNAL_ERROR,
@@ -3677,7 +3668,7 @@ fn file_delete_cascade_ref(
     key: TrackedStateKeyRef<'_>,
     value: &TrackedStateIndexValue,
 ) -> Result<Option<String>, LixError> {
-    if key.schema_key != FILE_DESCRIPTOR_SCHEMA_KEY || key.file_id.is_some() || !value.deleted {
+    if key.schema_key != FILE_DESCRIPTOR_SCHEMA_KEY || !value.deleted {
         return Ok(None);
     }
     key.entity_pk
@@ -3820,7 +3811,7 @@ fn tracked_state_winner_identity_for_diff_row(
 fn cascade_payload_key(file_id: &str) -> TrackedStateKey {
     TrackedStateKey {
         schema_key: FILE_DESCRIPTOR_SCHEMA_KEY.to_owned(),
-        file_id: None,
+        file_id: Some(file_id.to_string()),
         entity_pk: EntityPk::uuid_from_canonical(file_id)
             .unwrap_or_else(|_| EntityPk::single(file_id)),
     }
@@ -3848,7 +3839,7 @@ fn tracked_state_winner_identity_for_diff_parts(
         TrackedStateRowWinnerKind::FileDeleteCascade => Ok(TrackedStateRowWinner {
             identity: TrackedStateIdentity {
                 schema_key: change.schema_key.clone(),
-                file_id: None,
+                file_id: change.file_id.clone(),
                 entity_pk: change.entity_pk.clone(),
             },
             file_delete_cascade: true,
@@ -3870,11 +3861,7 @@ fn tracked_state_winner_kind_for_diff_parts(
     {
         return Ok(TrackedStateRowWinnerKind::Direct);
     }
-    if change.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY
-        && change.file_id.is_none()
-        && change.snapshot.is_none()
-        && deleted
-    {
+    if change.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY && change.snapshot.is_none() && deleted {
         let cascade_file_id = change.entity_pk.as_single_string_owned().map_err(|error| {
             LixError::unknown(format!(
                 "tracked-state cascade change '{}' has invalid file descriptor identity: {error}",
@@ -4111,7 +4098,7 @@ mod tests {
             .insert_cascade_if_absent(
                 TrackedStateKeyRef {
                     schema_key: FILE_DESCRIPTOR_SCHEMA_KEY,
-                    file_id: None,
+                    file_id: Some(FILE_ID),
                     entity_pk: &descriptor_pk,
                 },
                 &cascade,
@@ -4236,7 +4223,7 @@ mod tests {
             .insert_descriptor(
                 TrackedStateKeyRef {
                     schema_key: FILE_DESCRIPTOR_SCHEMA_KEY,
-                    file_id: None,
+                    file_id: Some(FILE_ID),
                     entity_pk: &descriptor_pk,
                 },
                 &cascade,
@@ -4327,7 +4314,7 @@ mod tests {
                 .insert_descriptor(
                     TrackedStateKeyRef {
                         schema_key: FILE_DESCRIPTOR_SCHEMA_KEY,
-                        file_id: None,
+                        file_id: Some(&file_id),
                         entity_pk: &descriptor_pk,
                     },
                     &cascade_value,
@@ -4829,6 +4816,7 @@ mod tests {
         let mut descriptor =
             tombstone(FILE_ID, "change-cascade-descriptor", "cascade-append-child");
         descriptor.schema_key = FILE_DESCRIPTOR_SCHEMA_KEY.to_string();
+        descriptor.file_id = Some(FILE_ID.to_string());
         let mut tail = row("entity-tail", "change-cascade-tail", "cascade-append-child");
         tail.schema_key = "z_schema".to_string();
         let child_rows = [descriptor, tail];
@@ -6792,6 +6780,7 @@ mod tests {
         descriptor.entity_pk =
             EntityPk::uuid_from_canonical(FILE_ID).expect("fixture file ID is canonical");
         descriptor.schema_key = FILE_DESCRIPTOR_SCHEMA_KEY.to_string();
+        descriptor.file_id = Some(FILE_ID.to_string());
         let mut semantic = row("line-1", "semantic-create", "initial");
         semantic.file_id = Some(FILE_ID.to_string());
         write_root_for_test(
@@ -6869,6 +6858,7 @@ mod tests {
         descriptor.entity_pk =
             EntityPk::uuid_from_canonical(FILE_ID).expect("fixture file ID is canonical");
         descriptor.schema_key = FILE_DESCRIPTOR_SCHEMA_KEY.to_string();
+        descriptor.file_id = Some(FILE_ID.to_string());
         let mut semantic = row("line-1", "semantic-create", "initial");
         semantic.file_id = Some(FILE_ID.to_string());
         write_root_for_test(
@@ -7019,6 +7009,7 @@ mod tests {
         descriptor.entity_pk =
             EntityPk::uuid_from_canonical(FILE_ID).expect("fixture file ID is canonical");
         descriptor.schema_key = FILE_DESCRIPTOR_SCHEMA_KEY.to_string();
+        descriptor.file_id = Some(FILE_ID.to_string());
         let mut semantic = row("line-1", "semantic-create", "initial");
         semantic.file_id = Some(FILE_ID.to_string());
         let mut retired = row("retired-blob", "retired-create", "initial");

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -1443,10 +1443,7 @@ fn apply_lifecycle_tracked_snapshot_row(
     mut next: MaterializedTrackedStateRow,
     require_absence: bool,
 ) -> Result<(), LixError> {
-    if next.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY
-        && next.file_id.is_none()
-        && next.snapshot_content.is_none()
-    {
+    if next.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY && next.snapshot_content.is_none() {
         let file_id = next.entity_pk.as_single_string_owned().map_err(|error| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
@@ -2722,10 +2719,8 @@ async fn stage_tracked_roots(
                 .iter()
                 .filter_map(|&row_index| {
                     let row = state_rows.row(row_index);
-                    (row.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY
-                        && row.file_id.is_none()
-                        && row.snapshot.is_none())
-                    .then_some(row)
+                    (row.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY && row.snapshot.is_none())
+                        .then_some(row)
                 })
                 .map(|row| {
                     let delta = tracked_delta_from_state_row(row)?;
@@ -3181,7 +3176,7 @@ mod tests {
         let descriptor_delete = MaterializedTrackedStateRow {
             entity_pk: EntityPk::single("file-a"),
             schema_key: FILE_DESCRIPTOR_SCHEMA_KEY.to_string(),
-            file_id: None,
+            file_id: Some("file-a".to_string()),
             snapshot_content: None,
             metadata: None,
             deleted: true,
@@ -3252,7 +3247,7 @@ mod tests {
         let mut uncovered_descriptor_insert =
             tracked_branch_row(branch_id, "uncovered-descriptor-insert");
         uncovered_descriptor_insert.schema_key = "lix_file_descriptor".into();
-        uncovered_descriptor_insert.file_id = None;
+        uncovered_descriptor_insert.file_id = Some("certified-file".into());
         uncovered_descriptor_insert.entity_pk = EntityPk::single("certified-file");
 
         let rows = vec![
@@ -3288,18 +3283,11 @@ mod tests {
 
         assert_eq!(
             guards,
-            BTreeSet::from([
-                TrackedStateKey {
-                    schema_key: "lix_file_descriptor".to_string(),
-                    file_id: None,
-                    entity_pk: EntityPk::single("certified-file"),
-                },
-                TrackedStateKey {
-                    schema_key: "uncovered_schema".to_string(),
-                    file_id: Some("other-file".to_string()),
-                    entity_pk: EntityPk::single("uncovered-file"),
-                },
-            ]),
+            BTreeSet::from([TrackedStateKey {
+                schema_key: "uncovered_schema".to_string(),
+                file_id: Some("other-file".to_string()),
+                entity_pk: EntityPk::single("uncovered-file"),
+            }]),
             "only INSERT identities outside the certified file scope still need row-owned guards"
         );
     }
@@ -3328,6 +3316,11 @@ mod tests {
             schema_key: "uncovered_schema".to_string(),
             file_id: Some("other-file".to_string()),
             entity_pk: EntityPk::single("uncovered-file"),
+        }));
+        assert!(guards.contains(&TrackedStateKey {
+            schema_key: "lix_file_descriptor".to_string(),
+            file_id: Some("certified-file".to_string()),
+            entity_pk: EntityPk::single("certified-file"),
         }));
     }
 

--- a/packages/engine/src/transaction/normalization.rs
+++ b/packages/engine/src/transaction/normalization.rs
@@ -17,9 +17,7 @@ use crate::transaction::types::TransactionWriteRow;
 use crate::transaction::types::{PreparedRowFacts, RawWriteBatch, RawWriteRowRef, TransactionJson};
 
 pub(crate) const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
-#[cfg(test)]
 const DIRECTORY_DESCRIPTOR_SCHEMA_KEY: &str = "lix_directory_descriptor";
-#[cfg(test)]
 const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
 
 /// Compact side columns produced while normalizing a row in place.
@@ -115,6 +113,7 @@ pub(crate) fn normalize_raw_write_row_in_place(
                 row_index,
                 Some(TransactionJson::from_certified_shared_normalized_row_content(normalized)),
             );
+            canonicalize_descriptor_file_id(rows, row_index)?;
             return Ok(NormalizedRowFacts {
                 schema_plan_id,
                 facts: PreparedRowFacts {
@@ -136,6 +135,7 @@ pub(crate) fn normalize_raw_write_row_in_place(
                 "certified replacement row is missing its proven entity identity",
             ));
         }
+        canonicalize_descriptor_file_id(rows, row_index)?;
         return Ok(NormalizedRowFacts {
             schema_plan_id,
             facts: PreparedRowFacts {
@@ -216,6 +216,7 @@ pub(crate) fn normalize_raw_write_row_in_place(
     }
 
     rows.set_snapshot(row_index, normalized_snapshot);
+    canonicalize_descriptor_file_id(rows, row_index)?;
     Ok(NormalizedRowFacts {
         schema_plan_id,
         facts: PreparedRowFacts {
@@ -223,6 +224,37 @@ pub(crate) fn normalize_raw_write_row_in_place(
             requires_transaction_validation,
         },
     })
+}
+
+fn canonicalize_descriptor_file_id(
+    rows: &mut RawWriteBatch,
+    row_index: usize,
+) -> Result<(), LixError> {
+    let row = rows.row(row_index);
+    let file_id = match row.schema_key.as_str() {
+        FILE_DESCRIPTOR_SCHEMA_KEY => {
+            let entity_pk = row
+                .entity_pk
+                .expect("normalized row has an entity identity");
+            Some(
+                entity_pk
+                    .as_single_string_owned()
+                    .map_err(|error| {
+                        LixError::new(
+                            LixError::CODE_SCHEMA_VALIDATION,
+                            format!(
+                                "lix_file_descriptor identity must contain its file id: {error}"
+                            ),
+                        )
+                    })?
+                    .into(),
+            )
+        }
+        DIRECTORY_DESCRIPTOR_SCHEMA_KEY => None,
+        _ => return Ok(()),
+    };
+    rows.set_file_id(row_index, file_id);
+    Ok(())
 }
 
 fn validate_normalized_row_content(
@@ -897,6 +929,10 @@ mod tests {
         let file = normalize_test_row(file, &mut catalog, functions()).expect("normalize file");
         let file_snapshot = normalized_snapshot(&file);
         assert_eq!(file_snapshot["name"], "Cafe\u{301}.txt");
+        assert_eq!(
+            file.file_id.as_deref(),
+            Some("01920000-0000-7000-8000-0000000000c1")
+        );
 
         let directory = TransactionWriteRow {
             entity_pk: None,
@@ -906,6 +942,7 @@ mod tests {
                 "parent_id": null,
                 "name": "Cafe\u{301}",
             }))),
+            file_id: Some("must-be-cleared".into()),
             global: false,
             ..base_stage_row()
         };
@@ -913,6 +950,7 @@ mod tests {
             normalize_test_row(directory, &mut catalog, functions()).expect("normalize directory");
         let directory_snapshot = normalized_snapshot(&directory);
         assert_eq!(directory_snapshot["name"], "Cafe\u{301}");
+        assert_eq!(directory.file_id, None);
 
         let bidi = TransactionWriteRow {
             entity_pk: None,

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -648,6 +648,11 @@ impl RawWriteBatch {
         self.slots[index].change_id = ordinal;
     }
 
+    pub(crate) fn set_file_id(&mut self, index: usize, file_id: Option<SharedStr>) {
+        let ordinal = self.intern_optional_string(file_id);
+        self.slots[index].file_id = ordinal;
+    }
+
     /// Retains rows in source order and compacts the aligned mutable columns.
     ///
     /// Dictionaries remain shared until more than half their slots are dead;

--- a/packages/engine/src/transaction/validation.rs
+++ b/packages/engine/src/transaction/validation.rs
@@ -523,7 +523,8 @@ pub(crate) fn fresh_plugin_file_import_certificate(
 
         match row.schema_key.as_str() {
             FILE_DESCRIPTOR_SCHEMA_KEY => {
-                if row.file_id.is_some()
+                if row.file_id.map(crate::common::SharedStr::as_str)
+                    != Some(file_data.file_id.as_str())
                     || row.entity_pk.as_single_string_owned().ok().as_deref()
                         != Some(file_data.file_id.as_str())
                     || !filesystem_planner_validated_insert(&PreparedValidationRow::State(row))
@@ -934,7 +935,7 @@ async fn filesystem_namespace_domain_changed(
         .iter()
         .copied()
         .filter(|row| {
-            row.domain() == *domain
+            prepared_filesystem_row_is_in_domain(*row, domain)
                 && (row.schema_key() == DIRECTORY_DESCRIPTOR_SCHEMA_KEY
                     || row.schema_key() == FILE_DESCRIPTOR_SCHEMA_KEY)
         })
@@ -1045,6 +1046,7 @@ fn staged_filesystem_namespace_domains(
                 || row.schema_key() == FILE_DESCRIPTOR_SCHEMA_KEY
         })
         .map(|row| row.domain())
+        .map(|domain| Domain::any_file(domain.branch_id().to_string(), domain.untracked()))
         .collect()
 }
 
@@ -1084,6 +1086,10 @@ fn committed_filesystem_row_is_in_domain(
         && domain.contains_ref(row)
 }
 
+fn prepared_filesystem_row_is_in_domain(row: PreparedValidationRow<'_>, domain: &Domain) -> bool {
+    row.branch_id() == domain.branch_id() && row.untracked() == domain.untracked()
+}
+
 fn apply_staged_filesystem_namespace_rows(
     staged_rows: &[PreparedValidationRow<'_>],
     domain: &Domain,
@@ -1092,7 +1098,7 @@ fn apply_staged_filesystem_namespace_rows(
     for row in staged_rows {
         if (row.schema_key() != DIRECTORY_DESCRIPTOR_SCHEMA_KEY
             && row.schema_key() != FILE_DESCRIPTOR_SCHEMA_KEY)
-            || row.domain() != *domain
+            || !prepared_filesystem_row_is_in_domain(*row, domain)
         {
             continue;
         }
@@ -1589,7 +1595,7 @@ impl PendingFileDescriptorIndex {
     fn from_rows(staged_rows: &[PreparedValidationRow<'_>]) -> Self {
         let mut index = Self::default();
         for row in staged_rows {
-            if row.schema_key() != FILE_DESCRIPTOR_SCHEMA_KEY || row.file_id().is_some() {
+            if row.schema_key() != FILE_DESCRIPTOR_SCHEMA_KEY {
                 continue;
             }
             if row.entity_pk().as_single_string_owned().is_ok() {
@@ -1612,7 +1618,7 @@ impl PendingFileDescriptorIndex {
         let entity_pk = EntityPk::uuid_from_canonical(file_id).ok()?;
         self.by_identity
             .get(&DomainRowIdentity::in_domain(
-                domain.with_exact_file_scope(None),
+                domain.with_exact_file_scope(Some(file_id.to_string())),
                 FILE_DESCRIPTOR_SCHEMA_KEY,
                 entity_pk,
             ))
@@ -1678,7 +1684,7 @@ impl FileOwnerReferenceValidator {
         domain: &Domain,
         file_id: &str,
     ) -> Result<bool, LixError> {
-        let descriptor_domain = domain.with_exact_file_scope(None);
+        let descriptor_domain = domain.with_exact_file_scope(Some(file_id.to_string()));
         let key = FileOwnerDescriptorKey {
             domain: descriptor_domain.clone(),
             file_id: file_id.to_string(),
@@ -1716,7 +1722,7 @@ async fn committed_file_descriptor_exists_in_domain(
     Ok(row.snapshot_content().is_some()
         && row.schema_key() == FILE_DESCRIPTOR_SCHEMA_KEY
         && row.entity_pk() == &entity_pk
-        && row.file_id().is_none())
+        && row.file_id() == Some(file_id))
 }
 
 fn missing_file_owner_reference_error(
@@ -2045,7 +2051,7 @@ impl PendingConstraintIndexes {
             };
             let target = PendingForeignKeyReferenceTarget::Key(PendingForeignKeyTargetKey {
                 schema_key: foreign_key.referenced_schema.schema_key.clone(),
-                domain: row.domain(),
+                domain: foreign_key_target_domain(row, foreign_key),
                 pointer_group: foreign_key.referenced_properties.clone(),
                 value: local_value,
             });
@@ -2642,7 +2648,7 @@ fn validate_pending_normal_foreign_key(
 ) -> Result<Option<UnresolvedForeignKeyCheck>, LixError> {
     let key = PendingForeignKeyTargetKey {
         schema_key: foreign_key.referenced_schema.schema_key.clone(),
-        domain: row.domain(),
+        domain: foreign_key_target_domain(row, foreign_key),
         pointer_group: foreign_key.referenced_properties.clone(),
         value: local_value,
     };
@@ -2655,6 +2661,19 @@ fn validate_pending_normal_foreign_key(
         source_pointer_group: foreign_key.local_properties.clone(),
         target: UnresolvedForeignKeyTarget::Key(key),
     }))
+}
+
+fn foreign_key_target_domain(
+    row: PreparedValidationRow<'_>,
+    foreign_key: &ForeignKeyPlan,
+) -> Domain {
+    if row.schema_key() == FILE_DESCRIPTOR_SCHEMA_KEY
+        && foreign_key.referenced_schema.schema_key == DIRECTORY_DESCRIPTOR_SCHEMA_KEY
+    {
+        row.domain().with_exact_file_scope(None)
+    } else {
+        row.domain()
+    }
 }
 
 fn validate_pending_state_surface_foreign_key(
@@ -7711,7 +7730,7 @@ mod tests {
         );
         row.entity_pk =
             EntityPk::uuid_from_canonical(file_id).expect("fixture file ID should be a UUID");
-        row.file_id = None;
+        row.file_id = Some(file_id.into());
         row.branch_id = branch_id.into();
         row.global = branch_id == crate::GLOBAL_BRANCH_ID;
         row

--- a/packages/engine/tests/integration/sql/lix_file.rs
+++ b/packages/engine/tests/integration/sql/lix_file.rs
@@ -92,11 +92,11 @@ simulation_test!(
             .commit_id;
         session
             .execute(
-                &format!("UPDATE lix_file SET path = '/notes.md' WHERE id = '{file_id}'"),
+                &format!("UPDATE lix_file SET path = '/notes/readme.md' WHERE id = '{file_id}'"),
                 &[],
             )
             .await
-            .expect("file rename should succeed");
+            .expect("moving a file under an existing directory should succeed");
         let renamed_head = engine
             .load_branch_head_commit_id(sim.main_branch_id())
             .await

--- a/packages/engine/tests/integration/sql/lix_file.rs
+++ b/packages/engine/tests/integration/sql/lix_file.rs
@@ -7,6 +7,171 @@ use serde_json::json;
 use super::assert_rows_eq;
 
 simulation_test!(
+    file_descriptor_changes_always_carry_their_file_id,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        let file_id = "66696c65-2d69-8464-8000-000000000001";
+        let directory_id = "64697265-6374-846f-8000-000000000001";
+
+        session
+            .execute(
+                &format!("INSERT INTO lix_directory (id, path) VALUES ('{directory_id}', '/docs')"),
+                &[],
+            )
+            .await
+            .expect("directory creation should succeed");
+        session
+            .execute(
+                &format!("UPDATE lix_directory SET path = '/notes' WHERE id = '{directory_id}'"),
+                &[],
+            )
+            .await
+            .expect("directory rename should succeed");
+        session
+            .execute(
+                &format!(
+                    "INSERT INTO lix_file (id, path, data) \
+                     VALUES ('{file_id}', '/readme.md', X'68656C6C6F')"
+                ),
+                &[],
+            )
+            .await
+            .expect("file creation should succeed");
+
+        assert_eq!(
+            super::select_rows(
+                &session,
+                &format!(
+                    "SELECT DISTINCT schema_key, file_id \
+                     FROM lix_change \
+                     WHERE file_id = '{file_id}' \
+                       AND schema_key IN ('lix_file_descriptor', 'lix_binary_blob_ref') \
+                     ORDER BY schema_key"
+                ),
+            )
+            .await,
+            vec![
+                vec![
+                    Value::Text("lix_binary_blob_ref".to_string()),
+                    Value::Text(file_id.to_string()),
+                ],
+                vec![
+                    Value::Text("lix_file_descriptor".to_string()),
+                    Value::Text(file_id.to_string()),
+                ],
+            ],
+            "a natural file_id filter must return content and descriptor changes",
+        );
+        assert_eq!(
+            super::select_rows(
+                &session,
+                &format!(
+                    "SELECT file_id \
+                     FROM lix_change \
+                     WHERE schema_key = 'lix_directory_descriptor' \
+                       AND entity_pk = lix_json('[\"{directory_id}\"]') \
+                     ORDER BY created_at"
+                ),
+            )
+            .await,
+            vec![vec![Value::Null], vec![Value::Null]],
+            "directory creation and rename remain namespace-level",
+        );
+
+        let baseline = session
+            .create_checkpoint()
+            .await
+            .expect("baseline checkpoint should succeed")
+            .commit_id;
+        session
+            .execute(
+                &format!("UPDATE lix_file SET path = '/notes.md' WHERE id = '{file_id}'"),
+                &[],
+            )
+            .await
+            .expect("file rename should succeed");
+        let renamed_head = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("renamed head should load")
+            .expect("renamed head should exist")
+            .to_string();
+
+        assert_eq!(
+            super::select_rows(
+                &session,
+                &format!(
+                    "SELECT schema_key, file_id \
+                     FROM lix_working_diff \
+                     WHERE file_id = '{file_id}' \
+                       AND schema_key = 'lix_file_descriptor'"
+                ),
+            )
+            .await,
+            vec![vec![
+                Value::Text("lix_file_descriptor".to_string()),
+                Value::Text(file_id.to_string()),
+            ]],
+            "a pending rename must be visible through a natural working-diff file filter",
+        );
+        assert_eq!(
+            super::select_rows(
+                &session,
+                &format!(
+                    "SELECT schema_key, file_id \
+                     FROM lix_diff('{baseline}', '{renamed_head}') \
+                     WHERE file_id = '{file_id}' \
+                       AND schema_key = 'lix_file_descriptor'"
+                ),
+            )
+            .await,
+            vec![vec![
+                Value::Text("lix_file_descriptor".to_string()),
+                Value::Text(file_id.to_string()),
+            ]],
+            "a pending rename must be visible through a natural historical diff file filter",
+        );
+
+        session
+            .execute(&format!("DELETE FROM lix_file WHERE id = '{file_id}'"), &[])
+            .await
+            .expect("file deletion should succeed");
+        let descriptor_changes = super::select_rows(
+            &session,
+            &format!(
+                "SELECT file_id, snapshot_content \
+                 FROM lix_change \
+                 WHERE file_id = '{file_id}' \
+                   AND schema_key = 'lix_file_descriptor' \
+                 ORDER BY created_at"
+            ),
+        )
+        .await;
+        assert_eq!(descriptor_changes.len(), 3);
+        assert!(
+            descriptor_changes
+                .iter()
+                .all(|row| row[0] == Value::Text(file_id.to_string()))
+        );
+        assert_eq!(
+            descriptor_changes
+                .iter()
+                .filter(|row| row[1] == Value::Null)
+                .count(),
+            1,
+            "exactly the deletion descriptor change is a tombstone",
+        );
+    }
+);
+
+simulation_test!(
     lix_file_update_can_compare_the_read_only_change_id,
     |sim| async move {
         let engine = sim.boot_engine().await;


### PR DESCRIPTION
## Summary

> `file_id` is set on every change that belongs to a file — **including the file's own descriptor changes** (creation, rename/move, deletion). Directory descriptor changes are namespace-level and keep `file_id` NULL.

This makes file ownership canonical when changes are created. File descriptor inserts, updates, moves, and tombstones now store their own file ID, while directory descriptors are explicitly canonicalized to NULL.

## Write-time decision

The rule is enforced during transaction normalization, with filesystem planners also emitting canonical descriptor ownership immediately. `lix_change`, `lix_diff`, `lix_working_diff`, tracked-state/working-diff accelerators, and checkpoint change references therefore inherit the stored value without read-time normalization. There is no per-view `coalesce(file_id, ...)` compensation in the SQL diff relations.

Internal namespace/path resolution deliberately removes the file-ownership dimension when grouping descriptors, preserving the existing branch/global/untracked namespace semantics. `entity_pk` encoding and descriptor schema keys are unchanged.

## Storage compatibility

This is an intentional pre-1.0 hard cut rather than a backfill. The repository protocol advances from `clustered-packed-history.v20` to `file-descriptor-ownership.v21`; repositories using the predecessor format are rejected on open and must be recreated. This prevents old NULL-scoped descriptor identities from being mixed with canonical file-owned descriptor identities.

## Validation

- `cargo test -p lix_engine --no-fail-fast`
- `cargo test -p lix_engine --features all-simulations --no-fail-fast`
- `cargo test -p lix_rocksdb_storage -p lix_sqlite_storage -p lix_slatedb_storage --no-fail-fast`

Coverage includes file create, rename/move, and deletion; directory create/rename remaining NULL; natural `WHERE file_id = ?` queries across `lix_change`, `lix_working_diff`, and `lix_diff`; tracked-state rebuild/cascade behavior; and rejection of the predecessor storage protocol.

## Follow-up

Downstream consumers such as Atelier's `selectFileWorkingChanges` can remove their coalesce workaround in a follow-up. No downstream repositories are changed here.