### PR TITLE
perf(slatedb): retain large-history point filters

### DIFF
--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -38,6 +38,7 @@ use slatedb::config::{
 };
 use slatedb::db_cache::moka::{MokaCache, MokaCacheOptions};
 use slatedb::db_cache::{DbCache, SplitCache};
+use slatedb::filter_policy::BloomFilterPolicy;
 use slatedb::prefix_extractor::{PrefixExtractor, PrefixTarget};
 use slatedb::{CloseReason, Db, DbIterator, DbSnapshot, DbStatus, KeyValue, WriteBatch};
 use slatedb_common::metrics::{DefaultMetricsRecorder, MetricValue};
@@ -64,6 +65,10 @@ const DEFAULT_BLOCK_CACHE_BYTES: u64 = 16 * 1024 * 1024;
 // these multi-megabyte filters and turned 1,001 five-key probes into 353 MiB
 // of repeated compacted-object reads.
 const DEFAULT_METADATA_CACHE_BYTES: u64 = 256 * 1024 * 1024;
+// Large repositories probe several identity spaces for new absent IDs on
+// every append. Sixteen bits keeps aggregate false positives bounded across
+// the L0 and sorted-run fan-out without changing the filter encoding.
+const FILTER_BITS_PER_KEY: u32 = 16;
 const MAX_UNFLUSHED_BYTES: usize = 128 * 1024 * 1024;
 const SCAN_BATCH_ROWS: usize = 1024;
 const SCAN_READ_AHEAD_BYTES: usize = 2 * 1024 * 1024;
@@ -2848,7 +2853,8 @@ fn open_slatedb(
     runtime.block_on(async move {
         let physical_db_path = join_db_path(&db_path, SEGMENTED_FORMAT_PATH);
         let mut builder = Db::builder(physical_db_path, object_store)
-            .with_segment_extractor(Arc::new(StorageSpacePrefixExtractor));
+            .with_segment_extractor(Arc::new(StorageSpacePrefixExtractor))
+            .with_filter_policies(vec![Arc::new(BloomFilterPolicy::new(FILTER_BITS_PER_KEY))]);
         if let Some(metrics) = metrics {
             builder = builder.with_metrics_recorder(metrics);
         }
@@ -3625,6 +3631,15 @@ mod tests {
         let settings = slatedb_settings();
         assert_eq!(settings.max_unflushed_bytes, MAX_UNFLUSHED_BYTES);
         assert_eq!(settings.max_unflushed_bytes, settings.l0_sst_size_bytes * 2);
+    }
+
+    #[test]
+    fn strengthens_point_filters_for_large_history() {
+        assert_eq!(FILTER_BITS_PER_KEY, 16);
+        assert_eq!(
+            BloomFilterPolicy::new(FILTER_BITS_PER_KEY).bits_per_key(),
+            FILTER_BITS_PER_KEY
+        );
     }
 
     #[test]

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -59,10 +59,11 @@ const SNAPSHOT_POINT_CACHE_BYTES: usize = 16 * 1024 * 1024;
 const SNAPSHOT_POINT_CACHE_ENTRIES: usize = 4096;
 const SNAPSHOT_POINT_CACHE_MAX_VALUE_BYTES: usize = 64 * 1024;
 const DEFAULT_BLOCK_CACHE_BYTES: u64 = 16 * 1024 * 1024;
-// Keep indexes and Bloom filters resident across batched point validation.
-// A tiny metadata cache repeatedly fetched multi-megabyte filters once the
-// repository crossed the first large-SST boundary.
-const DEFAULT_METADATA_CACHE_BYTES: u64 = 64 * 1024 * 1024;
+// Keep the commit, change, and reverse change-ID indexes' Bloom filters
+// resident across batched point validation. At 10M commits, 64 MiB thrashed
+// these multi-megabyte filters and turned 1,001 five-key probes into 353 MiB
+// of repeated compacted-object reads.
+const DEFAULT_METADATA_CACHE_BYTES: u64 = 256 * 1024 * 1024;
 const MAX_UNFLUSHED_BYTES: usize = 128 * 1024 * 1024;
 const SCAN_BATCH_ROWS: usize = 1024;
 const SCAN_READ_AHEAD_BYTES: usize = 2 * 1024 * 1024;


### PR DESCRIPTION
## Summary

- raise the bounded SlateDB metadata cache from 64 MiB to 256 MiB so large identity-index Bloom filters remain resident
- strengthen SlateDB Bloom filters from 10 to 16 bits/key to bound aggregate false positives across L0 and sorted runs
- keep the same filter encoding and propagate one policy through writes, reads, and compaction

## Profiler evidence

After controlling memtable/compaction state, 10M exact change-ID rejection still took p99 1,057 us. Across 1,001 operations it fetched 311 compacted objects / 353 MB, versus 31 objects / 1.22 MB at 1M. The ~1.1 MB fetches identified metadata-cache thrash; after the cache cut, the remaining 75 small reads identified Bloom false positives.

## Before / after (SlateDB, 10M, memtable-flushed + 60s settle)

| | p50 | p95 | p99 | objects read | bytes read | peak RSS | elapsed |
|---|---:|---:|---:|---:|---:|---:|---:|
| 64 MiB / 10-bit | 48 us | 498 us | 1,057 us | 311 | 353 MB | 1,364,132 KiB | 12:44 |
| 256 MiB / 10-bit | 55 us | 118 us | 254 us | 75 | 3.26 MB | 1,373,072 KiB | 12:30 |
| 256 MiB / 16-bit | 41 us | 63 us | 81 us | 5 | 4.82 MB | 1,501,352 KiB | 11:40 |

The matching 100k settled p99 is 41 us, so 100k -> 10M is 1.98x and meets the <=2x fixed-state criterion.

Normal visible 10M (no diagnostic flush/settle) improves from p99 710 us to 78 us with only 2 object reads / 4.8 KB across 1,001 operations.

## Tradeoffs

- cache capacity is lazy: the 256 MiB cache-only run added ~9 MiB peak RSS; combined with stronger filters, worst measured 10M peak rose 10.1% versus baseline
- 16-bit filters increased filesystem output by 1.37% at 10M, preserving the packed layout storage advantage
- 10M end-to-end ingest + lifecycle time improved rather than regressed (12:44 -> 11:40)
- RocksDB code and storage behavior are unchanged

## Validation

- `cargo test -p lix_slatedb_storage` (40 unit + 8 integration/conformance tests passed)
- `cargo clippy -p lix_engine_benchmarks --bench changelog_history_append --features storage-benches,slatedb,rocksdb -- -D warnings`
- release SlateDB 100k/1M/10M visible and settled runs, 1,001 samples
- release RocksDB 100k/1M control runs

## Final-code packed-layout audit

Rebuilt `packed_history_scale` at PR head `0401c51c8` and reran SlateDB 10M unique inserts with all commit widths (5 scan samples, 1,001 exact samples, memtable flush + 15s settle):

| width | scan p99 | exact p99 | physical storage | storage amp |
|---:|---:|---:|---:|---:|
| 1 | 24.918 s | 1.83 us | 1.672 GB | 1.086 |
| 10 | 10.523 s | 4.09 us | 489 MB | 0.788 |
| 100 | 9.551 s | 14.6 us | 597 MB | 1.113 |
| 10,000 | 12.857 s | 28.9 us | 712 MB | 1.268 |

The former 67.8 s versus ~0.82 s one-row cliff is absent: current max/min scan p99 spread is 2.6x, all exact reads remain microsecond-scale, and the packed storage advantage is preserved. Result: `/root/profile-results/final-pr959-packed-slate-10m-widths-20260729.txt` on `hetzner-ccx33`.