### PR TITLE
feat(engine): hard-cut SQL diff command API

### DIFF
--- a/docs/checkpoints.md
+++ b/docs/checkpoints.md
@@ -43,7 +43,7 @@ async fn main() -> Result<(), LixError> {
 
     let working = lix
         .execute(
-            "SELECT entity_pk, schema_key, change_kind
+            "SELECT entity_pk, schema_key, diff_type
              FROM lix_working_diff",
             &[],
         )
@@ -52,8 +52,8 @@ async fn main() -> Result<(), LixError> {
     for row in working.rows() {
         let entity_pk = row.get::<serde_json::Value>("entity_pk")?;
         let schema_key = row.get::<String>("schema_key")?;
-        let change_kind = row.get::<String>("change_kind")?;
-        println!("{change_kind} {schema_key} {entity_pk}");
+        let diff_type = row.get::<String>("diff_type")?;
+        println!("{diff_type} {schema_key} {entity_pk}");
     }
 
     let checkpoint = lix.create_checkpoint().await?;
@@ -101,7 +101,7 @@ Checkpointing has eight read-only SQL surfaces:
 
 | Surface | Scope | Columns |
 | :-- | :-- | :-- |
-| `lix_working_diff` | Active branch | `diff_id`, `entity_pk`, `schema_key`, `file_id`, `change_kind`, `before_change_id`, `after_change_id` |
+| `lix_working_diff` | Active branch | `diff_id`, `entity_pk`, `schema_key`, `file_id`, `diff_type`, `before_change_id`, `after_change_id` |
 | `lix_working_diff_by_branch` | All branches | The same columns plus `lixcol_branch_id` |
 | `lix_file_working_change` | Active branch | `id`, `path`, `previous_path`, `change_kind` |
 | `lix_file_working_change_by_branch` | All branches | The same columns plus `lixcol_branch_id` |
@@ -114,7 +114,7 @@ Use the unqualified surfaces for the common active-branch workflow. Use their
 `_by_branch` counterparts to inspect multiple branches in one query;
 `lixcol_branch_id` identifies the branch represented by each row.
 
-`change_kind` is `added`, `modified`, or `removed`. Working changes compare the
+`diff_type` is `added`, `modified`, or `removed`. Working changes compare the
 current branch head with that branch's newest checkpoint. Creating a checkpoint
 makes the current head the new baseline, so `lix_working_diff` is empty until
 another tracked change is committed.

--- a/docs/diff-commands.md
+++ b/docs/diff-commands.md
@@ -8,7 +8,7 @@ Lix represents a diff as rows. `lix_working_diff` compares the active branch
 head with its latest checkpoint. `lix_diff` compares any two commits:
 
 ```sql
-SELECT diff_id, entity_pk, schema_key, file_id, change_kind,
+SELECT diff_id, entity_pk, schema_key, file_id, diff_type,
        before_change_id, after_change_id
 FROM lix_diff($1, $2);
 ```
@@ -48,9 +48,21 @@ WHERE file_id <> $1;
 ```
 
 The source is a normal SQL query, so filters, joins, ordering, and limits stay
-inside the database. `INSERT ... VALUES` is intentionally rejected: a client
-must select diff rows rather than copy opaque IDs out and send them back.
-Selecting zero rows is an error.
+inside the database. Applications may also retain a selection and submit it
+through DataFusion's `VALUES` relation:
+
+```sql
+INSERT INTO lix_revert (diff_id)
+SELECT diff_id
+FROM VALUES ($1), ($2), ($3) AS selected(diff_id);
+```
+
+Direct `INSERT ... VALUES` remains intentionally rejected. Every command must
+use `INSERT ... SELECT`; the query may read a Lix relation, a `VALUES`
+relation, a CTE, or another valid query.
+
+An empty selection is a successful zero-row operation. It does not create a
+commit and does not require a preflight query.
 
 Each statement is atomic. Revert and apply use strict compare-and-set
 semantics: every selected entity must still be on the side from which the
@@ -60,6 +72,20 @@ changing the branch.
 A partial checkpoint commits the selected state as a checkpoint and preserves
 the unselected working state in a child commit. Both commits and the branch-head
 move publish atomically. Checkpoint naming is not part of this API.
+
+Every command supports `RETURNING commit_id`:
+
+```sql
+INSERT INTO lix_apply (diff_id)
+SELECT diff_id
+FROM lix_diff($1, $2)
+WHERE file_id = $3
+RETURNING commit_id;
+```
+
+For a non-empty selection, the affected-row count and returned-row count equal
+the number of consumed diffs. Every returned row contains the same
+engine-created commit ID. An empty selection returns zero rows.
 
 These command names describe state transformations. They are not a session
 undo/redo stack.

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -2371,11 +2371,11 @@ async fn execute_prepared_transaction_write<StorageImpl>(
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
-    if let Some((command, query_sql)) = sql2::diff_command_query(&plan) {
-        let count = transaction
+    if let Some((command, query_sql, returning)) = sql2::diff_command_query(&plan) {
+        let outcome = transaction
             .execute_diff_command_query_owned(command, query_sql, params.to_vec())
             .await?;
-        return Ok(sql2::SqlWriteResult::affected(count));
+        return sql2::SqlWriteResult::diff_command(outcome, returning.as_ref());
     }
     sql2::execute_write_logical_plan_result_with_metadata(transaction, plan, params, metadata).await
 }

--- a/packages/engine/src/sql2/bind/statement.rs
+++ b/packages/engine/src/sql2/bind/statement.rs
@@ -108,6 +108,7 @@ pub(super) fn bind_insert_bound(
         insert.source.as_deref(),
         &mut params,
     )?;
+    let returning = bind_insert_returning(&table, insert.returning.as_ref(), &mut params)?;
     let conflict = bind_insert_conflict(insert.on.as_ref(), &table, &mut params)?;
     if conflict.is_some() {
         if !matches!(
@@ -139,7 +140,7 @@ pub(super) fn bind_insert_bound(
         predicate: BoundPredicate::True,
         assignments: Vec::new(),
         conflict,
-        returning: None,
+        returning,
         params: params.into_map(),
         branch_scope,
     })
@@ -274,6 +275,50 @@ fn bind_delete_returning(
     Ok(Some(BoundReturning { items }))
 }
 
+fn bind_insert_returning(
+    table: &BoundTable,
+    returning: Option<&Vec<SelectItem>>,
+    params: &mut ParamBinder,
+) -> Result<Option<BoundReturning>, LixError> {
+    let Some(returning) = returning else {
+        return Ok(None);
+    };
+    if !matches!(
+        table.surface.kind,
+        PublicSurfaceKind::Revert | PublicSurfaceKind::Apply | PublicSurfaceKind::CreateCheckpoint
+    ) {
+        return Err(super::error::unsupported(
+            "INSERT RETURNING is only supported for diff command sinks",
+        ));
+    }
+
+    let mut items = Vec::with_capacity(returning.len());
+    for item in returning {
+        let (sql_expr, output_name) = match item {
+            SelectItem::UnnamedExpr(expr) => (expr, "commit_id".to_string()),
+            SelectItem::ExprWithAlias { expr, alias } => (expr, normalize_identifier(alias)),
+            SelectItem::Wildcard(_) | SelectItem::QualifiedWildcard(_, _) => {
+                return Err(super::error::unsupported(
+                    "diff command INSERT RETURNING only supports commit_id",
+                ));
+            }
+        };
+        let expr = bind_expr(table, sql_expr, params)?;
+        if !matches!(&expr, BoundExpr::Column(column) if column.name == "commit_id") {
+            return Err(super::error::unsupported(
+                "diff command INSERT RETURNING only supports commit_id",
+            ));
+        }
+        items.push(BoundReturningItem { expr, output_name });
+    }
+    if items.is_empty() {
+        return Err(super::error::unsupported(
+            "diff command INSERT RETURNING requires commit_id",
+        ));
+    }
+    Ok(Some(BoundReturning { items }))
+}
+
 fn reject_returning_wildcard_options(options: &WildcardAdditionalOptions) -> Result<(), LixError> {
     if options.opt_ilike.is_some()
         || options.opt_exclude.is_some()
@@ -318,11 +363,6 @@ fn reject_unsupported_insert_clauses(insert: &Insert) -> Result<(), LixError> {
     if insert.partitioned.is_some() || !insert.after_columns.is_empty() {
         return Err(super::error::unsupported(
             "partitioned INSERT is not supported",
-        ));
-    }
-    if insert.returning.is_some() {
-        return Err(super::error::unsupported(
-            "INSERT RETURNING is not supported",
         ));
     }
     if insert.replace_into {
@@ -2193,6 +2233,41 @@ mod tests {
                 output_name,
             }] if param.index == 2 && output_name == "marker"
         ));
+    }
+
+    #[test]
+    fn bind_statement_allows_only_commit_id_for_diff_command_insert_returning() {
+        let bound = bind_statement(
+            &parse_statement(
+                "INSERT INTO lix_revert (diff_id) \
+                 SELECT diff_id FROM lix_working_diff \
+                 RETURNING commit_id AS created_commit_id",
+            ),
+            &[],
+            "branch1",
+        )
+        .expect("diff command RETURNING commit_id should bind");
+        assert!(matches!(
+            bound
+                .returning
+                .expect("RETURNING should be bound")
+                .items
+                .as_slice(),
+            [BoundReturningItem {
+                expr: BoundExpr::Column(column),
+                output_name,
+            }] if column.name == "commit_id" && output_name == "created_commit_id"
+        ));
+
+        for sql in [
+            "INSERT INTO lix_revert (diff_id) SELECT diff_id FROM lix_working_diff RETURNING diff_id",
+            "INSERT INTO lix_revert (diff_id) SELECT diff_id FROM lix_working_diff RETURNING *",
+            "INSERT INTO lix_file (path) VALUES ('readme.md') RETURNING id",
+        ] {
+            let error = bind_statement(&parse_statement(sql), &[], "branch1")
+                .expect_err("unsupported INSERT RETURNING shape should fail");
+            assert_eq!(error.code, LixError::CODE_UNSUPPORTED_SQL, "{sql}");
+        }
     }
 
     #[test]

--- a/packages/engine/src/sql2/catalog/registry.rs
+++ b/packages/engine/src/sql2/catalog/registry.rs
@@ -251,7 +251,7 @@ impl PublicCatalog {
                 ("entity_pk", false),
                 ("schema_key", false),
                 ("file_id", true),
-                ("change_kind", false),
+                ("diff_type", false),
                 ("before_change_id", true),
                 ("after_change_id", true),
             ]),
@@ -265,7 +265,7 @@ impl PublicCatalog {
                 ("entity_pk", false),
                 ("schema_key", false),
                 ("file_id", true),
-                ("change_kind", false),
+                ("diff_type", false),
                 ("before_change_id", true),
                 ("after_change_id", true),
                 ("lixcol_branch_id", false),
@@ -280,7 +280,10 @@ impl PublicCatalog {
             self.insert(surface(
                 name,
                 kind,
-                vec![PublicColumn::public_insert_only("diff_id", false)],
+                vec![
+                    PublicColumn::public_insert_only("diff_id", false),
+                    PublicColumn::public_read_only("commit_id", false),
+                ],
                 SurfaceCapabilities {
                     insert: true,
                     update: false,
@@ -447,7 +450,7 @@ fn working_change_schema(by_branch: bool) -> SchemaRef {
         json_field("entity_pk", false),
         Field::new("schema_key", DataType::Utf8, false),
         Field::new("file_id", DataType::Utf8, true),
-        Field::new("change_kind", DataType::Utf8, false),
+        Field::new("diff_type", DataType::Utf8, false),
         Field::new("before_change_id", DataType::Utf8, true),
         Field::new("after_change_id", DataType::Utf8, true),
     ];

--- a/packages/engine/src/sql2/context.rs
+++ b/packages/engine/src/sql2/context.rs
@@ -35,6 +35,12 @@ pub(crate) enum DiffCommand {
     CreateCheckpoint,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct DiffCommandOutcome {
+    pub(crate) rows_affected: u64,
+    pub(crate) commit_id: Option<String>,
+}
+
 pub(crate) type SqlChangelogQuerySource<S> = ChangelogQuerySource<S>;
 pub(crate) type SqlHistoryQuerySource<S> = HistoryQuerySource<S>;
 
@@ -174,11 +180,15 @@ pub(crate) trait SqlWriteExecutionContext: Send {
         &mut self,
         _command: DiffCommand,
         _diff_ids: Vec<String>,
-    ) -> Result<u64, LixError> {
+    ) -> Result<DiffCommandOutcome, LixError> {
         Err(LixError::new(
             LixError::CODE_UNSUPPORTED_SQL,
             "diff commands are not supported by this write context",
         ))
+    }
+
+    fn staged_commit_id(&self, _branch_id: &str) -> Result<Option<String>, LixError> {
+        Ok(None)
     }
 }
 
@@ -349,7 +359,7 @@ impl SqlWriteContext {
         &self,
         command: DiffCommand,
         diff_ids: Vec<String>,
-    ) -> Result<u64, LixError> {
+    ) -> Result<DiffCommandOutcome, LixError> {
         let _guard = self.gate.lock().await;
         unsafe {
             self.ptr

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -957,12 +957,16 @@ pub(crate) async fn execute_datafusion_write_logical_plan(
         .map_err(datafusion_error_to_lix_error)?;
     let table_schema = table.schema();
     let state = session.state();
-    let returning = datafusion_delete_returning(
-        &session,
-        table_schema.as_ref(),
-        plan.bound.returning.as_ref(),
-        params,
-    )?;
+    let returning = if plan.bound.op == BoundWriteOp::Delete {
+        datafusion_delete_returning(
+            &session,
+            table_schema.as_ref(),
+            plan.bound.returning.as_ref(),
+            params,
+        )?
+    } else {
+        None
+    };
 
     let exec = match plan.bound.op {
         BoundWriteOp::Insert => {
@@ -1057,6 +1061,17 @@ pub(crate) async fn execute_datafusion_write_logical_plan(
     let result =
         query_result_from_batches(&[Field::new("count", DataType::UInt64, false)], &batches)?;
     let rows_affected = affected_rows_from_query_result(result)?;
+    if matches!(plan.bound.target, BoundWriteTarget::DiffCommand(_)) {
+        let outcome = crate::sql2::DiffCommandOutcome {
+            rows_affected,
+            commit_id: if rows_affected == 0 {
+                None
+            } else {
+                ctx.staged_commit_id(ctx.active_branch_id())?
+            },
+        };
+        return SqlWriteResult::diff_command(outcome, plan.bound.returning.as_ref());
+    }
     match returning {
         Some(returning) => {
             let batch = returning
@@ -2671,6 +2686,21 @@ mod tests {
                 .push(CapturedStageWrite { rows });
             Ok(TransactionWriteOutcome { count })
         }
+
+        async fn execute_diff_command(
+            &mut self,
+            _command: crate::sql2::DiffCommand,
+            diff_ids: Vec<String>,
+        ) -> Result<crate::sql2::DiffCommandOutcome, LixError> {
+            Ok(crate::sql2::DiffCommandOutcome {
+                rows_affected: diff_ids.len() as u64,
+                commit_id: (!diff_ids.is_empty()).then(|| "commit-diff-command".to_string()),
+            })
+        }
+
+        fn staged_commit_id(&self, _branch_id: &str) -> Result<Option<String>, LixError> {
+            Ok(Some("commit-diff-command".to_string()))
+        }
     }
 
     #[async_trait]
@@ -2897,6 +2927,47 @@ mod tests {
                 .deltas
                 .len(),
             1
+        );
+    }
+
+    #[tokio::test]
+    async fn diff_command_returning_executes_through_datafusion() {
+        let mut ctx = DummySqlWriteExecutionContext {
+            active_branch_id: "01920000-0000-7000-8000-0000000000a1",
+            blob_reader: Arc::new(StaticBlobReader { bytes: Vec::new() }),
+            live_state: Arc::new(CapturingRowsLiveStateReader {
+                rows: Vec::new(),
+                requests: Arc::new(Mutex::new(Vec::new())),
+            }),
+            staged_writes: Arc::new(Mutex::new(CapturingStagedWrites::default())),
+            schema_definitions: Vec::new(),
+        };
+        let plan = create_write_logical_plan(
+            &mut ctx,
+            "INSERT INTO lix_revert (diff_id) \
+             SELECT diff_id FROM VALUES ('d1.test') AS selected(diff_id) \
+             RETURNING commit_id",
+        )
+        .await
+        .expect("diff command RETURNING should plan");
+        let (result, path) = crate::sql2::execute_write_logical_plan_with_mode_and_trace_result(
+            &mut ctx,
+            plan,
+            &[],
+            WriteExecutorMode::ForceDataFusion,
+        )
+        .await
+        .expect("diff command RETURNING should execute through DataFusion");
+
+        assert_eq!(path, WriteExecutorPath::DataFusion);
+        assert_eq!(result.rows_affected, 1);
+        assert_eq!(
+            result.returning,
+            Some(crate::SqlQueryResult {
+                columns: vec!["commit_id".to_string()],
+                rows: vec![vec![Value::Text("commit-diff-command".to_string())]],
+                notices: Vec::new(),
+            })
         );
     }
 

--- a/packages/engine/src/sql2/exec/mod.rs
+++ b/packages/engine/src/sql2/exec/mod.rs
@@ -28,6 +28,45 @@ impl SqlWriteResult {
             returning: Some(returning),
         }
     }
+
+    pub(crate) fn diff_command(
+        outcome: crate::sql2::DiffCommandOutcome,
+        returning: Option<&crate::sql2::bind::write::BoundReturning>,
+    ) -> Result<Self, crate::LixError> {
+        let Some(returning) = returning else {
+            return Ok(Self::affected(outcome.rows_affected));
+        };
+        let rows = match outcome.commit_id {
+            Some(commit_id) => (0..outcome.rows_affected)
+                .map(|_| {
+                    returning
+                        .items
+                        .iter()
+                        .map(|_| crate::Value::Text(commit_id.clone()))
+                        .collect()
+                })
+                .collect(),
+            None if outcome.rows_affected == 0 => Vec::new(),
+            None => {
+                return Err(crate::LixError::new(
+                    crate::LixError::CODE_INTERNAL_ERROR,
+                    "diff command staged rows without a commit ID",
+                ));
+            }
+        };
+        Ok(Self::returning(
+            outcome.rows_affected,
+            SqlQueryResult {
+                columns: returning
+                    .items
+                    .iter()
+                    .map(|item| item.output_name.clone())
+                    .collect(),
+                rows,
+                notices: Vec::new(),
+            },
+        ))
+    }
 }
 
 pub(crate) use datafusion::{

--- a/packages/engine/src/sql2/exec/write.rs
+++ b/packages/engine/src/sql2/exec/write.rs
@@ -40,7 +40,11 @@ pub(crate) struct WriteLogicalPlan {
 
 pub(crate) fn diff_command_query(
     plan: &SqlLogicalPlan,
-) -> Option<(crate::sql2::DiffCommand, String)> {
+) -> Option<(
+    crate::sql2::DiffCommand,
+    String,
+    Option<crate::sql2::bind::write::BoundReturning>,
+)> {
     let SqlLogicalPlan::Write(write) = plan else {
         return None;
     };
@@ -51,7 +55,11 @@ pub(crate) fn diff_command_query(
     else {
         return None;
     };
-    Some((command, query.query.to_string()))
+    Some((
+        command,
+        query.query.to_string(),
+        write.plan.bound.returning.clone(),
+    ))
 }
 
 #[cfg(test)]

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -37,9 +37,10 @@ pub(crate) use bind::{
 };
 pub(crate) use catalog::PublicCatalog;
 pub(crate) use context::{
-    ChangelogQuerySource, DiffCommand, HistoryQuerySource, SqlChangelogQuerySource,
-    SqlExecutionContext, SqlHistoryQuerySource, SqlWriteContext, SqlWriteExecutionContext,
-    WriteAccess, WriteContextBranchRefReader, WriteContextLiveStateReader,
+    ChangelogQuerySource, DiffCommand, DiffCommandOutcome, HistoryQuerySource,
+    SqlChangelogQuerySource, SqlExecutionContext, SqlHistoryQuerySource, SqlWriteContext,
+    SqlWriteExecutionContext, WriteAccess, WriteContextBranchRefReader,
+    WriteContextLiveStateReader,
 };
 pub(crate) use entity_batch::{CurrentEntitySnapshotReader, EntitySnapshotReader};
 pub(crate) use exec::{SessionReadSqlResult, SqlWriteResult};

--- a/packages/engine/src/sql2/providers/diff.rs
+++ b/packages/engine/src/sql2/providers/diff.rs
@@ -169,7 +169,7 @@ where
                             entity_pk: entry.identity.entity_pk().as_json_array_text(),
                             schema_key: entry.identity.schema_key().to_owned(),
                             file_id: entry.identity.file_id().map(str::to_owned),
-                            change_kind: match entry.kind {
+                            diff_type: match entry.kind {
                                 TrackedStateDiffKind::Added => "added",
                                 TrackedStateDiffKind::Modified => "modified",
                                 TrackedStateDiffKind::Removed => "removed",
@@ -242,7 +242,7 @@ fn diff_schema() -> SchemaRef {
         json_field("entity_pk", false),
         Field::new("schema_key", DataType::Utf8, false),
         Field::new("file_id", DataType::Utf8, true),
-        Field::new("change_kind", DataType::Utf8, false),
+        Field::new("diff_type", DataType::Utf8, false),
         Field::new("before_change_id", DataType::Utf8, true),
         Field::new("after_change_id", DataType::Utf8, true),
     ]))
@@ -253,7 +253,7 @@ struct DiffSqlRow {
     entity_pk: Result<String, LixError>,
     schema_key: String,
     file_id: Option<String>,
-    change_kind: &'static str,
+    diff_type: &'static str,
     before_change_id: Option<String>,
     after_change_id: Option<String>,
 }
@@ -270,7 +270,7 @@ static DIFF_COLS: ColumnTable<DiffSqlRow> = ColumnTable {
         ),
         ("schema_key", Col::Utf8(|row| Some(&row.schema_key))),
         ("file_id", Col::Utf8(|row| row.file_id.as_deref())),
-        ("change_kind", Col::Utf8(|row| Some(row.change_kind))),
+        ("diff_type", Col::Utf8(|row| Some(row.diff_type))),
         (
             "before_change_id",
             Col::Utf8(|row| row.before_change_id.as_deref()),

--- a/packages/engine/src/sql2/providers/diff_command.rs
+++ b/packages/engine/src/sql2/providers/diff_command.rs
@@ -77,13 +77,12 @@ impl TableSpec for DiffCommandSpec {
             Box::pin(async move {
                 let diff_ids = diff_ids_from_batches(&batches)?;
                 if diff_ids.is_empty() {
-                    return Err(DataFusionError::Execution(
-                        "diff command selection is empty".to_string(),
-                    ));
+                    return Ok(0);
                 }
                 write_ctx
                     .execute_diff_command(command, diff_ids)
                     .await
+                    .map(|outcome| outcome.rows_affected)
                     .map_err(lix_error_to_datafusion_error)
             })
         })))
@@ -91,11 +90,10 @@ impl TableSpec for DiffCommandSpec {
 }
 
 fn command_schema() -> SchemaRef {
-    Arc::new(Schema::new(vec![Field::new(
-        "diff_id",
-        DataType::Utf8,
-        false,
-    )]))
+    Arc::new(Schema::new(vec![
+        Field::new("diff_id", DataType::Utf8, false),
+        Field::new("commit_id", DataType::Utf8, false),
+    ]))
 }
 
 fn diff_ids_from_batches(batches: &[RecordBatch]) -> Result<Vec<String>> {

--- a/packages/engine/src/sql2/providers/working_change.rs
+++ b/packages/engine/src/sql2/providers/working_change.rs
@@ -207,7 +207,7 @@ where
                                 entity_pk: entry.identity.entity_pk().as_json_array_text(),
                                 schema_key: entry.identity.schema_key().to_owned(),
                                 file_id: entry.identity.file_id().map(str::to_owned),
-                                change_kind: match entry.kind {
+                                diff_type: match entry.kind {
                                     TrackedStateDiffKind::Added => "added",
                                     TrackedStateDiffKind::Modified => "modified",
                                     TrackedStateDiffKind::Removed => "removed",
@@ -298,7 +298,7 @@ pub(super) fn working_change_schema(by_branch: bool) -> SchemaRef {
         json_field("entity_pk", false),
         Field::new("schema_key", DataType::Utf8, false),
         Field::new("file_id", DataType::Utf8, true),
-        Field::new("change_kind", DataType::Utf8, false),
+        Field::new("diff_type", DataType::Utf8, false),
         Field::new("before_change_id", DataType::Utf8, true),
         Field::new("after_change_id", DataType::Utf8, true),
     ];
@@ -313,7 +313,7 @@ struct WorkingChangeSqlRow {
     entity_pk: Result<String, LixError>,
     schema_key: String,
     file_id: Option<String>,
-    change_kind: &'static str,
+    diff_type: &'static str,
     before_change_id: Option<String>,
     after_change_id: Option<String>,
     branch_id: String,
@@ -331,7 +331,7 @@ static WORKING_CHANGE_COLS: ColumnTable<WorkingChangeSqlRow> = ColumnTable {
         ),
         ("schema_key", Col::Utf8(|row| Some(&row.schema_key))),
         ("file_id", Col::Utf8(|row| row.file_id.as_deref())),
-        ("change_kind", Col::Utf8(|row| Some(row.change_kind))),
+        ("diff_type", Col::Utf8(|row| Some(row.diff_type))),
         (
             "before_change_id",
             Col::Utf8(|row| row.before_change_id.as_deref()),

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -4961,11 +4961,13 @@ where
         &mut self,
         command: DiffCommand,
         diff_ids: Vec<String>,
-    ) -> Result<u64, LixError> {
+    ) -> Result<crate::sql2::DiffCommandOutcome, LixError> {
         let selections = diff_ids
             .iter()
             .map(|diff_id| {
-                crate::tracked_state::decode_diff_id(diff_id).map(|sides| (diff_id.as_str(), sides))
+                crate::tracked_state::decode_diff_id(diff_id)
+                    .map(|sides| (diff_id.as_str(), sides))
+                    .map_err(|_| stale_or_unknown_diff_id())
             })
             .collect::<Result<Vec<_>, _>>()?;
         let change_ids = selections
@@ -5076,17 +5078,7 @@ where
                 None => current.as_ref().is_none_or(|row| row.deleted),
             };
             if !current_matches {
-                let actual = current
-                    .as_ref()
-                    .and_then(|row| row.change_id)
-                    .map_or_else(|| "absent".to_string(), |id| id.to_string());
-                let expected = expected.map_or_else(|| "absent".to_string(), |id| id.to_string());
-                return Err(LixError::new(
-                    LixError::CODE_CONSTRAINT_VIOLATION,
-                    format!(
-                        "stale diff_id '{diff_id}': current change is {actual}, expected {expected}"
-                    ),
-                ));
+                return Err(stale_or_unknown_diff_id());
             }
             if let Some(target) = target {
                 required_diff_change(&records, target, diff_id)?;
@@ -5153,13 +5145,19 @@ where
             })
             .await?;
         }
-        Ok(diff_ids.len() as u64)
+        Ok(crate::sql2::DiffCommandOutcome {
+            rows_affected: diff_ids.len() as u64,
+            commit_id: self
+                .staged_writes
+                .commit_id_for_branch(&branch_id)?
+                .map(|commit_id| commit_id.to_string()),
+        })
     }
 
     async fn execute_checkpoint_selection(
         &mut self,
         diff_ids: Vec<String>,
-    ) -> Result<u64, LixError> {
+    ) -> Result<crate::sql2::DiffCommandOutcome, LixError> {
         let branch_id = self.active_branch_id.clone();
         let (previous_recovery, mut gc_state) =
             self.checkpoint_publication_state(&branch_id).await?;
@@ -5233,11 +5231,7 @@ where
         let selected = selected.finish();
         let unselected = unselected.finish();
         if matched != requested {
-            let unknown = requested.difference(&matched).next().expect("sets differ");
-            return Err(LixError::new(
-                LixError::CODE_CONSTRAINT_VIOLATION,
-                format!("checkpoint selection contains stale or unknown diff_id '{unknown}'"),
-            ));
+            return Err(stale_or_unknown_diff_id());
         }
         let interval_has_commits = head_commit_id != previous_checkpoint_commit_id;
         gc_state.checkpoint_sequence =
@@ -5260,7 +5254,7 @@ where
             })
             .await?;
             self.stage_checkpoint_commit(
-                branch_id,
+                branch_id.clone(),
                 previous_checkpoint_commit_id,
                 head_commit_id,
                 interval_has_commits,
@@ -5285,7 +5279,7 @@ where
             self.staged_writes
                 .add_checkpoint_publication(CheckpointPublication {
                     recovery_ref: CheckpointRecoveryRef {
-                        branch_id,
+                        branch_id: branch_id.clone(),
                         recovered_head_commit_id: head_commit_id,
                         checkpoint_commit_id,
                         interval_has_commits,
@@ -5293,7 +5287,13 @@ where
                     gc_state,
                 })?;
         }
-        Ok(diff_ids.len() as u64)
+        Ok(crate::sql2::DiffCommandOutcome {
+            rows_affected: diff_ids.len() as u64,
+            commit_id: self
+                .staged_writes
+                .commit_id_for_branch(&branch_id)?
+                .map(|commit_id| commit_id.to_string()),
+        })
     }
 
     pub(crate) async fn execute_diff_command_query_owned(
@@ -5301,7 +5301,7 @@ where
         command: DiffCommand,
         query_sql: String,
         params: Vec<Value>,
-    ) -> Result<u64, LixError> {
+    ) -> Result<crate::sql2::DiffCommandOutcome, LixError> {
         let statement = crate::sql2::parse_statement(&query_sql)?;
         let result = self
             .execute_read_sql_statement(query_sql, statement, params)
@@ -5326,10 +5326,10 @@ where
             diff_ids.push(diff_id.clone());
         }
         if diff_ids.is_empty() {
-            return Err(LixError::new(
-                LixError::CODE_CONSTRAINT_VIOLATION,
-                "diff command selection is empty",
-            ));
+            return Ok(crate::sql2::DiffCommandOutcome {
+                rows_affected: 0,
+                commit_id: None,
+            });
         }
         self.execute_diff_command(command, diff_ids).await
     }
@@ -5338,14 +5338,16 @@ where
 fn required_diff_change<'a>(
     records: &'a HashMap<ChangeId, ChangeRecord>,
     change_id: ChangeId,
-    diff_id: &str,
+    _diff_id: &str,
 ) -> Result<&'a ChangeRecord, LixError> {
-    records.get(&change_id).ok_or_else(|| {
-        LixError::new(
-            LixError::CODE_CONSTRAINT_VIOLATION,
-            format!("diff_id '{diff_id}' references missing change '{change_id}'"),
-        )
-    })
+    records.get(&change_id).ok_or_else(stale_or_unknown_diff_id)
+}
+
+fn stale_or_unknown_diff_id() -> LixError {
+    LixError::new(
+        LixError::CODE_CONSTRAINT_VIOLATION,
+        "stale or unknown diff_id; re-evaluate the source diff and retry",
+    )
 }
 
 fn diff_record_identity(record: &ChangeRecord) -> (String, EntityPk, Option<String>) {
@@ -6026,13 +6028,19 @@ where
         &mut self,
         command: DiffCommand,
         diff_ids: Vec<String>,
-    ) -> Result<u64, LixError> {
+    ) -> Result<crate::sql2::DiffCommandOutcome, LixError> {
         match command {
             DiffCommand::Revert | DiffCommand::Apply => {
                 self.execute_apply_or_revert(command, diff_ids).await
             }
             DiffCommand::CreateCheckpoint => self.execute_checkpoint_selection(diff_ids).await,
         }
+    }
+
+    fn staged_commit_id(&self, branch_id: &str) -> Result<Option<String>, LixError> {
+        self.staged_writes
+            .commit_id_for_branch(branch_id)
+            .map(|commit_id| commit_id.map(|commit_id| commit_id.to_string()))
     }
 }
 

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -5245,7 +5245,7 @@ where
             gc_state.add_collectible_interval(previous_recovery.interval_has_commits);
         }
 
-        if unselected.is_empty() {
+        let checkpoint_commit_id = if unselected.is_empty() {
             let mut marker_rows = RawWriteBatch::with_capacity(1);
             marker_rows.push(checkpoint_marker_stage_row(&branch_id));
             self.stage_write(TransactionWrite::Rows {
@@ -5260,7 +5260,7 @@ where
                 interval_has_commits,
                 gc_state,
                 selected,
-            )?;
+            )?
         } else {
             let checkpoint_commit_id = self.staged_writes.stage_intermediate_commit(
                 branch_id.clone(),
@@ -5286,13 +5286,11 @@ where
                     },
                     gc_state,
                 })?;
-        }
+            checkpoint_commit_id.to_string()
+        };
         Ok(crate::sql2::DiffCommandOutcome {
             rows_affected: diff_ids.len() as u64,
-            commit_id: self
-                .staged_writes
-                .commit_id_for_branch(&branch_id)?
-                .map(|commit_id| commit_id.to_string()),
+            commit_id: Some(checkpoint_commit_id),
         })
     }
 

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -1055,6 +1055,23 @@ impl TransactionWriteBuffer {
         Ok(())
     }
 
+    pub(crate) fn commit_id_for_branch(
+        &self,
+        branch_id: &str,
+    ) -> Result<Option<CommitId>, LixError> {
+        Ok(self
+            .commit_change_refs_by_branch
+            .lock()
+            .map_err(|_| {
+                LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    "failed to acquire transaction staged commit change refs lock",
+                )
+            })?
+            .get(branch_id)
+            .map(|change_refs| change_refs.commit_id))
+    }
+
     /// Overrides the normal branch-head first parent for a staged commit.
     ///
     /// Checkpoint compaction uses the previous checkpoint as the new commit's

--- a/packages/engine/tests/integration/branching.rs
+++ b/packages/engine/tests/integration/branching.rs
@@ -859,7 +859,7 @@ simulation_test!(
         assert_key_value(&main, "main-merge-target", Some("\"main\"")).await;
         let working_changes = main
             .execute(
-                "SELECT entity_pk, change_kind \
+                "SELECT entity_pk, diff_type \
                  FROM lix_working_diff \
                  WHERE schema_key = 'lix_key_value' \
                  ORDER BY entity_pk",

--- a/packages/engine/tests/integration/sql/checkpoint.rs
+++ b/packages/engine/tests/integration/sql/checkpoint.rs
@@ -65,7 +65,7 @@ simulation_test!(
         assert_eq!(
             select_rows(
                 &session,
-                "SELECT entity_pk, schema_key, change_kind \
+                "SELECT entity_pk, schema_key, diff_type \
                  FROM lix_working_diff ORDER BY schema_key, entity_pk",
             )
             .await,
@@ -78,7 +78,7 @@ simulation_test!(
         assert_eq!(
             select_rows(
                 &session,
-                "SELECT entity_pk, schema_key, change_kind \
+                "SELECT entity_pk, schema_key, diff_type \
                  FROM lix_working_diff \
                  WHERE schema_key = 'lix_key_value' \
                    AND entity_pk = lix_json('[\"checkpoint-key\"]')",
@@ -211,7 +211,7 @@ simulation_test!(
              VALUES ('fake', '2026-01-01T00:00:00Z', 0)",
             "UPDATE lix_checkpoint SET created_at = 'fake'",
             "DELETE FROM lix_working_diff",
-            "UPDATE lix_working_diff_by_branch SET change_kind = 'fake'",
+            "UPDATE lix_working_diff_by_branch SET diff_type = 'fake'",
             "DELETE FROM lix_file_working_change",
             "UPDATE lix_directory_working_change_by_branch SET change_kind = 'fake'",
         ] {
@@ -265,7 +265,7 @@ simulation_test!(
         assert_eq!(
             select_rows(
                 &session,
-                "SELECT entity_pk, change_kind \
+                "SELECT entity_pk, diff_type \
                  FROM lix_working_diff \
                  WHERE schema_key = 'lix_key_value' \
                  ORDER BY entity_pk",
@@ -286,7 +286,7 @@ simulation_test!(
         assert_eq!(
             select_rows(
                 &session,
-                "SELECT change_kind \
+                "SELECT diff_type \
                  FROM lix_working_diff \
                  WHERE schema_key = 'lix_key_value' \
                    AND entity_pk = lix_json('[\"working-removed\"]')",

--- a/packages/engine/tests/integration/sql/diff_commands.rs
+++ b/packages/engine/tests/integration/sql/diff_commands.rs
@@ -38,12 +38,13 @@ simulation_test!(
 
         let working = select_rows(
             &session,
-            "SELECT diff_id, entity_pk FROM lix_working_diff \
+            "SELECT diff_id, entity_pk, diff_type FROM lix_working_diff \
          WHERE schema_key = 'lix_key_value' ORDER BY entity_pk",
         )
         .await;
         assert_eq!(working.len(), 2);
         assert!(matches!(&working[0][0], Value::Text(id) if id.starts_with("d1.")));
+        assert_eq!(working[0][2], Value::Text("added".to_string()));
 
         let values_error = session
             .execute(
@@ -54,17 +55,24 @@ simulation_test!(
             .expect_err("command sinks must reject VALUES");
         assert_eq!(values_error.code, LixError::CODE_UNSUPPORTED_SQL);
 
-        session
+        let selected_diff_id = working[0][0].clone();
+        let reverted = session
             .execute(
                 "INSERT INTO lix_revert (diff_id) \
-             SELECT diff_id FROM lix_working_diff \
-             WHERE schema_key = 'lix_key_value' \
-             ORDER BY entity_pk \
-             LIMIT 1",
-                &[],
+                 SELECT diff_id \
+                 FROM VALUES ($1) AS selected(diff_id) \
+                 RETURNING commit_id",
+                &[selected_diff_id],
             )
             .await
             .expect("selected revert should succeed");
+        assert_eq!(reverted.rows_affected(), 1);
+        assert_eq!(reverted.columns(), &["commit_id"]);
+        assert_eq!(reverted.len(), 1);
+        assert!(matches!(
+            reverted.get(&reverted.rows()[0], "commit_id"),
+            Some(Value::Text(commit_id)) if !commit_id.is_empty()
+        ));
         assert_eq!(
             select_rows(
                 &session,
@@ -88,12 +96,13 @@ simulation_test!(
         assert_eq!(historical_rows[0][1], Value::Null);
         assert!(matches!(historical_rows[0][2], Value::Text(_)));
 
-        session
+        let applied = session
             .execute(
                 "INSERT INTO lix_apply (diff_id) \
                  SELECT diff_id FROM lix_diff($1, $2) \
                  WHERE schema_key = 'lix_key_value' \
-                   AND entity_pk = lix_json('[\"a\"]')",
+                   AND entity_pk = lix_json('[\"a\"]') \
+                 RETURNING commit_id",
                 &[
                     Value::Text(baseline.clone()),
                     Value::Text(original_head.to_string()),
@@ -101,6 +110,9 @@ simulation_test!(
             )
             .await
             .expect("selected historical apply should succeed");
+        assert_eq!(applied.rows_affected(), 1);
+        assert_eq!(applied.columns(), &["commit_id"]);
+        assert_eq!(applied.len(), 1);
 
         let stale = session
             .execute(
@@ -116,13 +128,18 @@ simulation_test!(
             .await
             .expect_err("strict apply must reject a moved head");
         assert_eq!(stale.code, LixError::CODE_CONSTRAINT_VIOLATION);
+        assert_eq!(
+            stale.message,
+            "stale or unknown diff_id; re-evaluate the source diff and retry"
+        );
 
-        session
+        let checkpointed = session
             .execute(
                 "INSERT INTO lix_create_checkpoint (diff_id) \
              SELECT diff_id FROM lix_working_diff \
              WHERE schema_key = $1 \
-               AND entity_pk = lix_json($2)",
+               AND entity_pk = lix_json($2) \
+             RETURNING commit_id",
                 &[
                     Value::Text("lix_key_value".to_string()),
                     Value::Text("[\"a\"]".to_string()),
@@ -130,6 +147,9 @@ simulation_test!(
             )
             .await
             .expect("partial checkpoint should succeed");
+        assert_eq!(checkpointed.rows_affected(), 1);
+        assert_eq!(checkpointed.columns(), &["commit_id"]);
+        assert_eq!(checkpointed.len(), 1);
 
         assert_eq!(
             select_rows(
@@ -151,5 +171,29 @@ simulation_test!(
                 vec![Value::Text("b".to_string()), Value::Json(json!("two"))],
             ]
         );
+
+        let head_before_empty = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("head before empty selection should load")
+            .expect("head before empty selection should exist");
+        let empty = session
+            .execute(
+                "INSERT INTO lix_revert (diff_id) \
+                 SELECT diff_id FROM lix_working_diff WHERE 1 = 0 \
+                 RETURNING commit_id",
+                &[],
+            )
+            .await
+            .expect("empty diff selection should be a successful no-op");
+        assert_eq!(empty.rows_affected(), 0);
+        assert_eq!(empty.columns(), &["commit_id"]);
+        assert!(empty.is_empty());
+        let head_after_empty = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("head after empty selection should load")
+            .expect("head after empty selection should exist");
+        assert_eq!(head_after_empty, head_before_empty);
     }
 );

--- a/packages/engine/tests/integration/sql/diff_commands.rs
+++ b/packages/engine/tests/integration/sql/diff_commands.rs
@@ -150,6 +150,24 @@ simulation_test!(
         assert_eq!(checkpointed.rows_affected(), 1);
         assert_eq!(checkpointed.columns(), &["commit_id"]);
         assert_eq!(checkpointed.len(), 1);
+        let checkpoint_commit_id = match checkpointed.get(&checkpointed.rows()[0], "commit_id") {
+            Some(Value::Text(commit_id)) => commit_id.clone(),
+            value => panic!("checkpoint RETURNING should contain a commit ID, got {value:?}"),
+        };
+        let checkpoint_row = session
+            .execute(
+                "SELECT commit_id FROM lix_checkpoint WHERE commit_id = $1",
+                &[Value::Text(checkpoint_commit_id.clone())],
+            )
+            .await
+            .expect("returned checkpoint commit should be queryable");
+        assert_eq!(checkpoint_row.len(), 1);
+        let child_head = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("partial checkpoint child head should load")
+            .expect("partial checkpoint child head should exist");
+        assert_ne!(child_head.to_string(), checkpoint_commit_id);
 
         assert_eq!(
             select_rows(


### PR DESCRIPTION
## Summary

Follow-up to #920 that makes the SQL diff-command API match the final hard-cut contract, without compatibility aliases or legacy behavior.

- renames the entity-level diff discriminator from `change_kind` to `diff_type` on `lix_diff`, `lix_working_diff`, and `lix_working_diff_by_branch`
- accepts retained `diff_id` selections through a DataFusion `VALUES` relation while continuing to reject direct `INSERT … VALUES`
- makes empty selections successful zero-row operations that create no commit
- adds `RETURNING commit_id` to all three command sinks, with one identical engine-created commit ID per consumed diff
- normalizes malformed, unknown, and stale CAS failures to the documented retry error
- updates command execution in both the optimized path and the generic DataFusion path

## Compatibility

This is intentionally a hard cut. There is no `change_kind` alias on entity-level diff relations and no backward shim for the prior empty-selection behavior.

## Validation

- `cargo test -p lix_engine --features all-simulations`
  - 1,553 unit tests passed; 6 ignored
  - 782 integration simulations passed; 2 ignored
  - 3 doctests passed
- focused forced-DataFusion `RETURNING commit_id` coverage
- `git diff --check`
