### PR TITLE
perf(slatedb): compress SST data with Zstd

### DIFF
--- a/.changenotes/compress-slatedb-sst-files.md
+++ b/.changenotes/compress-slatedb-sst-files.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Reduced SlateDB storage and read I/O by compressing newly written SST data with Zstandard.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "flatbuffers",
- "lz4_flex 0.13.0",
+ "lz4_flex",
 ]
 
 [[package]]
@@ -3569,15 +3569,6 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
-dependencies = [
- "twox-hash",
-]
-
-[[package]]
-name = "lz4_flex"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
@@ -4933,7 +4924,6 @@ dependencies = [
  "futures",
  "log",
  "lru",
- "lz4_flex 0.11.6",
  "moka",
  "object_store 0.14.0",
  "ouroboros",
@@ -4954,6 +4944,7 @@ dependencies = [
  "url",
  "uuid",
  "walkdir",
+ "zstd",
 ]
 
 [[package]]

--- a/packages/slatedb-storage/Cargo.toml
+++ b/packages/slatedb-storage/Cargo.toml
@@ -24,7 +24,7 @@ bytes = "1"
 blake3 = "1"
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 object_store = { version = "0.14", default-features = false, features = ["fs"] }
-slatedb = { version = "0.14.1", default-features = false, features = ["lz4", "moka"] }
+slatedb = { version = "0.14.1", default-features = false, features = ["moka", "zstd"] }
 slatedb-common = "0.14.1"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -2898,7 +2898,7 @@ fn join_db_path(db_path: &str, child: &str) -> String {
 
 fn slatedb_settings() -> Settings {
     let mut settings = Settings {
-        compression_codec: Some(CompressionCodec::Lz4),
+        compression_codec: Some(CompressionCodec::Zstd),
         ..Settings::default()
     };
     settings
@@ -3619,10 +3619,10 @@ mod tests {
     }
 
     #[test]
-    fn uses_lz4_compression_by_default() {
+    fn uses_zstd_compression_by_default() {
         assert_eq!(
             slatedb_settings().compression_codec,
-            Some(CompressionCodec::Lz4)
+            Some(CompressionCodec::Zstd)
         );
     }
 
@@ -3911,31 +3911,31 @@ mod tests {
     #[test]
     fn fresh_storage_uses_versioned_segmented_format() {
         let store = Arc::new(InMemory::new());
-        let db_path = "test-lz4-physical-format";
+        let db_path = "test-zstd-physical-format";
         let space = SpaceId(7);
         let storage = SlateDB::open_object_store_with_options(
             db_path,
             store.clone(),
             SlateDBObjectStoreOptions::default(),
         )
-        .expect("open fresh LZ4 storage");
+        .expect("open fresh Zstd storage");
 
         let mut write =
-            block_on(storage.begin_write(WriteOptions::default())).expect("begin LZ4 write");
+            block_on(storage.begin_write(WriteOptions::default())).expect("begin Zstd write");
         block_on(write.put_many(
             space,
             PutBatch {
                 entries: vec![PutEntry {
-                    key: Key(Bytes::from_static(b"lz4-key")),
+                    key: Key(Bytes::from_static(b"zstd-key")),
                     value: StoredValue {
-                        bytes: Bytes::from_static(b"lz4-value"),
+                        bytes: Bytes::from_static(b"zstd-value"),
                     },
                 }],
             },
         ))
-        .expect("stage LZ4 row");
-        block_on(write.commit()).expect("commit LZ4 row");
-        block_on(storage.flush()).expect("flush LZ4 row");
+        .expect("stage Zstd row");
+        block_on(write.commit()).expect("commit Zstd row");
+        block_on(storage.flush()).expect("flush Zstd row");
         block_on(storage.worker.call(move |db| async move {
             db.flush_with_options(FlushOptions {
                 flush_type: FlushType::MemTable,
@@ -3958,12 +3958,12 @@ mod tests {
                     .segments()
                     .iter()
                     .flat_map(|segment| segment.l0())
-                    .any(|view| view.sst.info.compression_codec == Some(CompressionCodec::Lz4)),
-                "new physical SST must record the LZ4 codec"
+                    .any(|view| view.sst.info.compression_codec == Some(CompressionCodec::Zstd)),
+                "new physical SST must record the Zstd codec"
             );
             Ok(())
         }))
-        .expect("flush and inspect LZ4 SST");
+        .expect("flush and inspect Zstd SST");
         drop(storage);
 
         let physical_prefix = format!("{db_path}/{SEGMENTED_FORMAT_PATH}/");
@@ -3973,7 +3973,7 @@ mod tests {
             while let Some(object) = objects.next().await {
                 paths.push(
                     object
-                        .expect("list fresh LZ4 storage object")
+                        .expect("list fresh Zstd storage object")
                         .location
                         .to_string(),
                 );


### PR DESCRIPTION
## What changed

- switch newly written SlateDB SSTs from LZ4 to Zstd
- remove SlateDB's LZ4 feature and enable only Zstd (plus the existing Moka cache)
- assert both the configured default and persisted SST codec

## Why

On the identical 3,000-commit OpenClaw all-plugin replay, Zstd reduced the database from 1.383 GB to 1.102 GB (20.3%), reduced compacted SST reads from 529 MB to 396 MB (25.1%), improved replay time by 2.7%, and lowered peak RSS by 7.4%.

The paired query suite remained effectively flat at 26.0 s versus 25.7 s. Bulk semantic commits regressed only 0.3–7.5%, while a compaction-heavy stall at position 2,586 fell from 40.9 s to 2.79 s.

## Compatibility

This intentionally removes LZ4 codec support. Existing LZ4 SlateDB artifacts are not expected to reopen with this build; the change targets newly created databases.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p lix_slatedb_storage uses_zstd_compression_by_default`
- `cargo test -p lix_slatedb_storage fresh_storage_uses_versioned_segmented_format`
- paired 3,000-commit OpenClaw replay and query/I/O comparison