### PR TITLE
avoid allocating schema keys during catalog lookup

### DIFF
--- a/packages/engine/src/catalog/snapshot.rs
+++ b/packages/engine/src/catalog/snapshot.rs
@@ -260,10 +260,7 @@ impl CatalogSnapshot {
     }
 
     pub(crate) fn plan_for_key(&self, schema_key: &str) -> Option<(SchemaPlanId, &SchemaPlan)> {
-        let key = SchemaCatalogKey {
-            schema_key: schema_key.to_string(),
-        };
-        let plan_id = *self.by_key.get(&key)?;
+        let plan_id = *self.by_key.get(schema_key)?;
         let plan = self.plan(plan_id)?;
         Some((plan_id, plan))
     }
@@ -2290,6 +2287,12 @@ impl StateForeignKeyPlan {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct SchemaCatalogKey {
     pub(crate) schema_key: String,
+}
+
+impl std::borrow::Borrow<str> for SchemaCatalogKey {
+    fn borrow(&self) -> &str {
+        &self.schema_key
+    }
 }
 
 impl SchemaCatalogKey {


### PR DESCRIPTION
## What changed

Use `BTreeMap`'s borrowed-key lookup for `CatalogSnapshot::plan_for_key` instead of allocating a temporary `String`-backed `SchemaCatalogKey` on every lookup.

## Why

Schema-plan lookup is a per-row hot path during plugin and transaction validation. A heaptrack profile of a 39,871-entity JSON import showed one temporary catalog-key allocation per validation lookup. In the matched v2 benchmark, this cut the host allocation count from 525,293 to 445,548 while leaving validation behavior unchanged.

## Validation

- `cargo test -p lix_engine catalog::snapshot::tests --lib`
- 18 catalog snapshot tests passed
