### PR TITLE
Prototype storage-native plugin API v3 across formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3464,10 +3464,12 @@ dependencies = [
  "plugin_csv_v2",
  "plugin_csv_v3_prototype",
  "plugin_excalidraw_v2",
+ "plugin_excalidraw_v3_prototype",
  "plugin_git_text_v2",
  "plugin_json_incremental_v2",
  "plugin_json_v3_prototype",
  "plugin_markdown_incremental_v2",
+ "plugin_markdown_v3_prototype",
  "rand 0.9.2",
  "serde_json",
  "sha2",
@@ -4298,6 +4300,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "plugin_excalidraw_v3_prototype"
+version = "0.9.0"
+dependencies = [
+ "lix_order_key",
+ "lix_plugin_api_v3_prototype",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "plugin_git_text_v2"
 version = "0.9.0"
 dependencies = [
@@ -4340,6 +4352,21 @@ dependencies = [
  "lix_order_key",
  "lix_plugin_api_v2",
  "markdown",
+ "markdown-syntax",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "plugin_markdown_v3_prototype"
+version = "0.9.0"
+dependencies = [
+ "base64 0.22.1",
+ "chardetng",
+ "encoding_rs",
+ "lix_order_key",
+ "lix_plugin_api_v3_prototype",
  "markdown-syntax",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "lix_plugin_api_v3_prototype"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]
@@ -4278,7 +4278,7 @@ dependencies = [
 
 [[package]]
 name = "plugin_csv_v3_prototype"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "base64 0.22.1",
  "lix_plugin_api_v3_prototype",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "plugin_json_v3_prototype"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "base64 0.22.1",
  "blake3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3403,6 +3403,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "lix_plugin_api_v3_prototype"
+version = "0.8.4"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
 name = "lix_rocksdb_storage"
 version = "0.9.0"
 dependencies = [
@@ -3419,6 +3426,7 @@ name = "lix_sdk"
 version = "0.9.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "blake3",
  "bytes",
  "codspeed-criterion-compat",
@@ -3454,9 +3462,11 @@ dependencies = [
  "lix_rocksdb_storage",
  "lix_sdk",
  "plugin_csv_v2",
+ "plugin_csv_v3_prototype",
  "plugin_excalidraw_v2",
  "plugin_git_text_v2",
  "plugin_json_incremental_v2",
+ "plugin_json_v3_prototype",
  "plugin_markdown_incremental_v2",
  "rand 0.9.2",
  "serde_json",
@@ -4267,6 +4277,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "plugin_csv_v3_prototype"
+version = "0.8.4"
+dependencies = [
+ "base64 0.22.1",
+ "lix_plugin_api_v3_prototype",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "plugin_excalidraw_v2"
 version = "0.9.0"
 dependencies = [
@@ -4295,6 +4315,17 @@ dependencies = [
  "base64 0.22.1",
  "blake3",
  "lix_plugin_api_v2",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "plugin_json_v3_prototype"
+version = "0.8.4"
+dependencies = [
+ "base64 0.22.1",
+ "blake3",
+ "lix_plugin_api_v3_prototype",
  "serde_json",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ lix_sqlite_storage = { path = "packages/sqlite-storage", version = "0.9.0" }
 lix_js_sdk = { path = "packages/js-sdk", version = "0.9.0" }
 lix_order_key = { path = "plugins/order-key", version = "0.9.0" }
 lix_plugin_api_v2 = { path = "packages/plugin-api", version = "0.9.0" }
+lix_plugin_api_v3_prototype = { path = "packages/plugin-api-v3-prototype", version = "0.9.0" }
 lix_sdk = { path = "packages/rs-sdk", version = "0.9.0" }
 lix_server_protocol = { path = "packages/server-protocol", version = "0.9.0" }
 mimalloc = { version = "0.1.52", features = ["local_dynamic_tls"] }

--- a/packages/engine/src/catalog/snapshot.rs
+++ b/packages/engine/src/catalog/snapshot.rs
@@ -436,6 +436,44 @@ impl SchemaPlan {
         bytes: &[u8],
         key: &WasmEntityKey,
     ) -> Result<Option<CertifiedV2PluginRow>, LixError> {
+        let emitted = key
+            .entity_pk
+            .iter()
+            .map(|component| component.as_str())
+            .collect::<SmallVec<[_; 2]>>();
+        let Some(normalized) =
+            self.certify_or_normalize_v2_plugin_row_parts(bytes, &key.schema_key, &emitted)?
+        else {
+            return Ok(None);
+        };
+        let component_types = self
+            .primary_key_component_types
+            .as_deref()
+            .expect("certificate eligibility requires typed primary-key components");
+        EntityPk::from_shared_external_parts(key.entity_pk.iter().cloned(), component_types)
+            .map(|entity_pk| {
+                Some(CertifiedV2PluginRow {
+                    entity_pk,
+                    normalized,
+                })
+            })
+            .map_err(|error| {
+                LixError::new(
+                    LixError::CODE_SCHEMA_VALIDATION,
+                    format!(
+                        "plugin entity_pk is invalid for schema '{}': {error}",
+                        self.key.schema_key
+                    ),
+                )
+            })
+    }
+
+    pub(crate) fn certify_or_normalize_v2_plugin_row_parts(
+        &self,
+        bytes: &[u8],
+        schema_key: &str,
+        entity_pk: &[&str],
+    ) -> Result<Option<Option<Vec<u8>>>, LixError> {
         if !self.accepts_v2_canonical_certificate() {
             return Ok(None);
         }
@@ -451,21 +489,21 @@ impl SchemaPlan {
             .primary_key_component_types
             .as_deref()
             .expect("certificate eligibility requires typed primary-key components");
-        if key.entity_pk.len() != primary_key_paths.len() {
+        if entity_pk.len() != primary_key_paths.len() {
             return Ok(None);
         }
-        if key.schema_key != self.key.schema_key {
+        if schema_key != self.key.schema_key {
             return Err(LixError::new(
                 LixError::CODE_SCHEMA_VALIDATION,
                 format!(
                     "plugin snapshot schema '{}' does not match schema plan '{}'",
-                    key.schema_key, self.key.schema_key
+                    schema_key, self.key.schema_key
                 ),
             ));
         }
 
         let mut parser = CanonicalPluginRowParser::new(bytes)?;
-        let mut primary_key = CanonicalPrimaryKeyMatcher::new(primary_key_paths, &key.entity_pk);
+        let mut primary_key = CanonicalPrimaryKeyMatcher::new(primary_key_paths, entity_pk);
         let normalized = match parser.parse_root_object(validation, &mut primary_key) {
             Ok(normalized) => normalized,
             Err(CanonicalPluginRowError::InvalidPlugin(message)) => {
@@ -482,13 +520,8 @@ impl SchemaPlan {
             }
         };
 
-        EntityPk::from_shared_external_parts(key.entity_pk.iter().cloned(), component_types)
-            .map(|entity_pk| {
-                Some(CertifiedV2PluginRow {
-                    entity_pk,
-                    normalized,
-                })
-            })
+        EntityPk::validate_external_parts(entity_pk, component_types)
+            .map(|()| Some(normalized))
             .map_err(|error| {
                 LixError::new(
                     LixError::CODE_SCHEMA_VALIDATION,
@@ -1356,12 +1389,12 @@ fn write_canonical_json_string_contents(value: &str, output: &mut Vec<u8>) {
 
 struct CanonicalPrimaryKeyMatcher<'a> {
     paths: &'a [Vec<String>],
-    emitted: &'a [crate::common::SharedStr],
+    emitted: &'a [&'a str],
     seen: u128,
 }
 
 impl<'a> CanonicalPrimaryKeyMatcher<'a> {
-    fn new(paths: &'a [Vec<String>], emitted: &'a [crate::common::SharedStr]) -> Self {
+    fn new(paths: &'a [Vec<String>], emitted: &'a [&'a str]) -> Self {
         Self {
             paths,
             emitted,
@@ -1381,7 +1414,7 @@ impl<'a> CanonicalPrimaryKeyMatcher<'a> {
                 self.paths[index][0]
             ));
         };
-        if actual.eq_str(self.emitted[index].as_str()) {
+        if actual.eq_str(self.emitted[index]) {
             None
         } else {
             Some(format!(
@@ -3074,7 +3107,12 @@ mod tests {
             br#"{"cells":["a","b"],"id":"019a0000-0000-7000-8000-000000000001","order_key":"01"}"#,
         )
         .expect("canonical parser");
-        let mut primary_key = CanonicalPrimaryKeyMatcher::new(primary_key_paths, &key.entity_pk);
+        let emitted = key
+            .entity_pk
+            .iter()
+            .map(|component| component.as_str())
+            .collect::<SmallVec<[_; 2]>>();
+        let mut primary_key = CanonicalPrimaryKeyMatcher::new(primary_key_paths, &emitted);
         assert!(
             parser
                 .parse_root_object(validation, &mut primary_key)

--- a/packages/engine/src/entity_pk.rs
+++ b/packages/engine/src/entity_pk.rs
@@ -250,6 +250,12 @@ impl EntityPk {
         })
     }
 
+    pub(crate) const fn uuid_from_bytes(bytes: [u8; 16]) -> Self {
+        Self {
+            components: EntityPkComponents::Single(EntityPkComponent::Uuid(bytes)),
+        }
+    }
+
     pub(crate) fn from_external_parts(
         parts: Vec<String>,
         component_types: &[EntityPkComponentType],

--- a/packages/engine/src/entity_pk.rs
+++ b/packages/engine/src/entity_pk.rs
@@ -288,6 +288,47 @@ impl EntityPk {
         Self::from_components(components)
     }
 
+    pub(crate) fn validate_external_parts(
+        parts: &[&str],
+        component_types: &[EntityPkComponentType],
+    ) -> Result<(), EntityPkError> {
+        if parts.is_empty() {
+            return Err(EntityPkError::EmptyPrimaryKey);
+        }
+        if parts.len() != component_types.len() {
+            return Err(EntityPkError::InvalidEncodedEntityPk);
+        }
+        for (index, (part, component_type)) in parts.iter().zip(component_types).enumerate() {
+            match component_type {
+                EntityPkComponentType::Uuid => {
+                    if crate::storage_codec::id_string::uuid_bytes_from_canonical(part).is_none() {
+                        return Err(EntityPkError::InvalidPrimaryKeyValue {
+                            index,
+                            expected: "canonical UUID string",
+                        });
+                    }
+                }
+                EntityPkComponentType::Integer => {
+                    part.parse::<i64>()
+                        .map_err(|_| EntityPkError::InvalidPrimaryKeyValue {
+                            index,
+                            expected: "integer",
+                        })?;
+                }
+                EntityPkComponentType::String => {}
+                EntityPkComponentType::Bytes => {
+                    base64::engine::general_purpose::STANDARD
+                        .decode(part.as_bytes())
+                        .map_err(|_| EntityPkError::InvalidPrimaryKeyValue {
+                            index,
+                            expected: "base64 string",
+                        })?;
+                }
+            }
+        }
+        Ok(())
+    }
+
     #[cfg(test)]
     pub(crate) fn from_parts(parts: Vec<String>) -> Result<Self, EntityPkError> {
         Self::from_shared_parts(parts.into_iter().map(SharedStr::from))

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -642,12 +642,7 @@ where
         tracked_only: bool,
     ) -> Result<MaterializedLiveStateBatch, LixError> {
         if tracked_only {
-            // Constraint validation must consult immutable certified segments
-            // even when an older branch-control bloom predates their schema
-            // publication. The scan itself still uses the schema filter and
-            // segment manifests, so this avoids a false negative without
-            // materializing unrelated semantic rows.
-            self.scan_tracked_batch_with_schema_presence(request, false)
+            self.scan_tracked_batch_with_schema_presence(request, true)
                 .await
         } else {
             self.scan_batch_with_schema_presence(request, true).await

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -642,7 +642,12 @@ where
         tracked_only: bool,
     ) -> Result<MaterializedLiveStateBatch, LixError> {
         if tracked_only {
-            self.scan_tracked_batch_with_schema_presence(request, true)
+            // Constraint validation must consult immutable certified segments
+            // even when an older branch-control bloom predates their schema
+            // publication. The scan itself still uses the schema filter and
+            // segment manifests, so this avoids a false negative without
+            // materializing unrelated semantic rows.
+            self.scan_tracked_batch_with_schema_presence(request, false)
                 .await
         } else {
             self.scan_batch_with_schema_presence(request, true).await

--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -14,9 +14,11 @@ pub(crate) use reader::load_exact_batch_via_scan_for_test;
 pub(crate) use tracked_head::TrackedHeadDeltaRef;
 #[allow(unused_imports)]
 pub(crate) use tracked_head::{
-    CurrentStateDeltaRef, HOT_DIFF_SPACE, HOT_FILE_SPACE, HOT_ROW_SPACE, HotTrackedSnapshot,
+    CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE, CERTIFIED_ENTITY_BATCH_SPACE, CurrentStateDeltaRef,
+    DeferredFreshHotPlan, HOT_DIFF_SPACE, HOT_FILE_SPACE, HOT_ROW_SPACE, HotTrackedSnapshot,
     TRACKED_WORKING_DIFF_MARKER_SPACE, TrackedHeadContext, TrackedWorkingDiff,
-    TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage, stage_collect_stale_working_diff_indexes,
+    TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage, scan_certified_history_rows,
+    stage_certified_entity_batches, stage_collect_stale_working_diff_indexes,
     stage_tracked_working_diff_epoch,
 };
 #[allow(unused_imports)]

--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -14,9 +14,10 @@ pub(crate) use reader::load_exact_batch_via_scan_for_test;
 pub(crate) use tracked_head::TrackedHeadDeltaRef;
 #[allow(unused_imports)]
 pub(crate) use tracked_head::{
-    CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE, CERTIFIED_ENTITY_BATCH_SPACE, CurrentStateDeltaRef,
-    DeferredFreshHotPlan, HOT_DIFF_SPACE, HOT_FILE_SPACE, HOT_ROW_SPACE, HotTrackedSnapshot,
-    TRACKED_WORKING_DIFF_MARKER_SPACE, TrackedHeadContext, TrackedWorkingDiff,
+    CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE, CERTIFIED_ENTITY_BATCH_SPACE,
+    CertifiedEntityBatchFileRef, CurrentStateDeltaRef, DeferredFreshHotPlan,
+    DeferredFreshHotRowRef, DeferredFreshHotRows, HOT_DIFF_SPACE, HOT_FILE_SPACE, HOT_ROW_SPACE,
+    HotTrackedSnapshot, TRACKED_WORKING_DIFF_MARKER_SPACE, TrackedHeadContext, TrackedWorkingDiff,
     TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage, scan_certified_history_rows,
     stage_certified_entity_batches, stage_collect_stale_working_diff_indexes,
     stage_tracked_working_diff_epoch,

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -8,7 +8,11 @@
 
 mod hot;
 
-pub(crate) use hot::{HOT_DIFF_SPACE, HOT_FILE_SPACE, HOT_ROW_SPACE, HotTrackedSnapshot};
+pub(crate) use hot::{
+    CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE, CERTIFIED_ENTITY_BATCH_SPACE, DeferredFreshHotPlan,
+    HOT_DIFF_SPACE, HOT_FILE_SPACE, HOT_ROW_SPACE, HotTrackedSnapshot, scan_certified_history_rows,
+    stage_certified_entity_batches,
+};
 
 use std::collections::{BTreeMap, BTreeSet};
 #[cfg(test)]
@@ -1747,7 +1751,7 @@ fn decode_slot<'a>(kind: u8, bytes: &'a [u8], field: &str) -> Result<HeadSlotVie
     }
 }
 
-fn head_value_error(message: &str) -> LixError {
+fn head_value_error(message: impl std::fmt::Display) -> LixError {
     LixError::new(
         LixError::CODE_INTERNAL_ERROR,
         format!("invalid hot live-state row: {message}"),

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -9,9 +9,10 @@
 mod hot;
 
 pub(crate) use hot::{
-    CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE, CERTIFIED_ENTITY_BATCH_SPACE, DeferredFreshHotPlan,
-    HOT_DIFF_SPACE, HOT_FILE_SPACE, HOT_ROW_SPACE, HotTrackedSnapshot, scan_certified_history_rows,
-    stage_certified_entity_batches,
+    CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE, CERTIFIED_ENTITY_BATCH_SPACE,
+    CertifiedEntityBatchFileRef, DeferredFreshHotPlan, DeferredFreshHotRowRef,
+    DeferredFreshHotRows, HOT_DIFF_SPACE, HOT_FILE_SPACE, HOT_ROW_SPACE, HotTrackedSnapshot,
+    scan_certified_history_rows, stage_certified_entity_batches,
 };
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -21,6 +21,7 @@ use crate::storage::{PutBatch, PutEntry};
 use crate::storage_adapter::{
     BufferRange, DeferredFinalPutPage, DeferredFinalPutSource, EncodedMutationBatch, EncodedPut,
 };
+use crate::tracked_state::TrackedStateReadColumns;
 use crate::transaction::types::{PreparedStateBatch, PreparedStateRowRef, StageJson};
 
 use super::*;
@@ -631,11 +632,12 @@ async fn scan_certified_entity_batch_rows(
         .value;
     let content_count = contents.iter().flatten().count();
     let decode_limit = (content_count <= 1).then_some(limit).flatten();
-    let needs_snapshot = request
-        .read_columns
-        .columns
-        .iter()
-        .any(|column| column == "snapshot_content");
+    let needs_snapshot = request.read_columns.columns.is_empty()
+        || request
+            .read_columns
+            .columns
+            .iter()
+            .any(|column| column == "snapshot_content");
     let mut builder = MaterializedLiveStateBatchBuilder::with_capacity(
         limit.unwrap_or_else(|| contents.len().saturating_mul(1024)),
     );
@@ -829,9 +831,9 @@ fn decode_certified_entity_batch_rows(
             let quote_layout = rows.bytes(quote_layout_len)?;
             let field_count = rows.u16()?;
             let id = creates
-                .component(u64::from(local_ref))
+                .component_uuid_bytes(u64::from(local_ref))
                 .map_err(|error| head_value_error(error.to_string()))?;
-            let entity_pk = EntityPk::single(id.clone());
+            let entity_pk = EntityPk::uuid_from_bytes(id);
             let selected = request.filter.entity_pks.is_empty()
                 || request
                     .filter
@@ -864,7 +866,10 @@ fn decode_certified_entity_batch_rows(
                                 .collect(),
                         ),
                     );
-                    object.insert("id".to_owned(), serde_json::Value::String(id.clone()));
+                    object.insert(
+                        "id".to_owned(),
+                        serde_json::Value::String(uuid::Uuid::from_bytes(id).to_string()),
+                    );
                     if !quote_layout.is_empty() || ending != 0 {
                         let mut layout = serde_json::Map::new();
                         if !quote_layout.is_empty() {
@@ -915,7 +920,7 @@ fn decode_certified_entity_batch_rows(
                 timestamp,
                 timestamp,
                 false,
-                Some(ChangeId::parse_lix(&id, "certified CSV change id")?),
+                Some(ChangeId::new(uuid::Uuid::from_bytes(id))),
                 Some(commit_id),
                 false,
                 branch_id,
@@ -997,9 +1002,9 @@ fn decode_certified_packet_rows(
             2 => {
                 let local_ref = record.u64()?;
                 let id = creates
-                    .component(local_ref)
+                    .component_uuid_bytes(local_ref)
                     .map_err(|error| head_value_error(error.to_string()))?;
-                (EntityPk::single(id.clone()), Some(id))
+                (EntityPk::uuid_from_bytes(id), Some(id))
             }
             _ => {
                 return Err(head_value_error(
@@ -1036,25 +1041,35 @@ fn decode_certified_packet_rows(
             continue;
         }
         let snapshot = if needs_snapshot {
-            let mut snapshot: serde_json::Value = serde_json::from_slice(snapshot_bytes)
-                .map_err(|error| head_value_error(format!("invalid certified JSON: {error}")))?;
-            let object = snapshot.as_object_mut().ok_or_else(|| {
-                head_value_error("certified create snapshot is not a JSON object")
-            })?;
             if let Some(id) = &created_id {
-                object.insert("id".to_owned(), serde_json::Value::String(id.clone()));
+                let mut snapshot: serde_json::Value = serde_json::from_slice(snapshot_bytes)
+                    .map_err(|error| {
+                        head_value_error(format!("invalid certified JSON: {error}"))
+                    })?;
+                let object = snapshot.as_object_mut().ok_or_else(|| {
+                    head_value_error("certified create snapshot is not a JSON object")
+                })?;
+                object.insert(
+                    "id".to_owned(),
+                    serde_json::Value::String(uuid::Uuid::from_bytes(*id).to_string()),
+                );
+                let json = serde_json::to_vec(&snapshot)
+                    .map_err(|error| head_value_error(error.to_string()))?;
+                Some(
+                    SharedStr::from_utf8(Bytes::from(json))
+                        .map_err(|error| head_value_error(error.to_string()))?,
+                )
+            } else {
+                Some(
+                    SharedStr::from_utf8(Bytes::copy_from_slice(snapshot_bytes))
+                        .map_err(|error| head_value_error(error.to_string()))?,
+                )
             }
-            let json = serde_json::to_vec(&snapshot)
-                .map_err(|error| head_value_error(error.to_string()))?;
-            Some(
-                SharedStr::from_utf8(Bytes::from(json))
-                    .map_err(|error| head_value_error(error.to_string()))?,
-            )
         } else {
             None
         };
         let change_id = if let Some(id) = &created_id {
-            ChangeId::parse_lix(id, "certified packet change id")?
+            ChangeId::new(uuid::Uuid::from_bytes(*id))
         } else {
             let mut bytes = *commit_id.as_uuid().as_bytes();
             let ordinal = base_ordinal.saturating_add(decoded).to_be_bytes();
@@ -1461,7 +1476,77 @@ where
             }));
         }
         let rows = materialize_live_entries(&self.store, entries, *projection, branch_id).await?;
-        MaterializedLiveStateExactBatch::new(rows, slots)
+        if slots.iter().all(Option::is_some) {
+            return MaterializedLiveStateExactBatch::new(rows, slots);
+        }
+
+        // Certified immutable segments deliberately do not manufacture one
+        // HOT_ROW entry per semantic row. Exact validation reads still need
+        // to observe those identities—for example, a sparse plugin successor
+        // proving that a keyed update or foreign-key target already exists.
+        // Decode the matching segment rows only when the ordinary point-read
+        // index misses, then preserve the original request alignment.
+        let certified_request = TrackedStateScanRequest {
+            filter: TrackedStateFilter {
+                schema_keys: keys.iter().map(|key| key.schema_key.to_owned()).collect(),
+                entity_pks: keys.iter().map(|key| key.entity_pk.clone()).collect(),
+                file_ids: keys
+                    .iter()
+                    .map(|key| {
+                        key.file_id.map_or(NullableKeyFilter::Null, |file_id| {
+                            NullableKeyFilter::Value(file_id.to_owned())
+                        })
+                    })
+                    .collect(),
+                include_tombstones: true,
+            },
+            read_columns: TrackedStateReadColumns {
+                columns: [
+                    projection.snapshot_content.then_some("snapshot_content"),
+                    projection.metadata.then_some("metadata"),
+                ]
+                .into_iter()
+                .flatten()
+                .map(str::to_owned)
+                .collect(),
+            },
+            limit: None,
+        };
+        let certified = scan_certified_entity_batch_rows(
+            &self.store,
+            branch_id,
+            generation,
+            &certified_request,
+            None,
+        )
+        .await?;
+        if certified.is_empty() {
+            return MaterializedLiveStateExactBatch::new(rows, slots);
+        }
+
+        let mut builder = MaterializedLiveStateBatchBuilder::with_capacity(keys.len());
+        let mut combined_slots = Vec::with_capacity(keys.len());
+        for (key, slot) in keys.iter().zip(slots) {
+            let row = slot.and_then(|slot| rows.get(slot as usize)).or_else(|| {
+                certified.iter().find(|row| {
+                    row.schema_key() == key.schema_key
+                        && row.entity_pk() == key.entity_pk
+                        && row.file_id() == key.file_id
+                })
+            });
+            combined_slots.push(
+                row.map(|row| {
+                    u32::try_from(builder.push_ref(row, None)).map_err(|_| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            "certified exact live-state result exceeds u32 rows",
+                        )
+                    })
+                })
+                .transpose()?,
+            );
+        }
+        MaterializedLiveStateExactBatch::new(builder.finish(), combined_slots)
     }
 
     pub(crate) async fn working_diff_epoch(

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -7,14 +7,21 @@
 //! full row identity the physical mutation unit.
 
 use std::cmp::Ordering;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::ops::Range;
+use std::sync::Arc;
 
+use crate::wasm::WasmCreateContext;
+use base64::Engine as _;
 use bytes::Bytes;
 use smallvec::SmallVec;
 use tracing::Instrument as _;
 
-use crate::storage_adapter::{BufferRange, EncodedMutationBatch, EncodedPut};
+use crate::storage::{PutBatch, PutEntry};
+use crate::storage_adapter::{
+    BufferRange, DeferredFinalPutPage, DeferredFinalPutSource, EncodedMutationBatch, EncodedPut,
+};
+use crate::transaction::types::{PreparedStateBatch, PreparedStateRowRef, StageJson};
 
 use super::*;
 
@@ -32,6 +39,1140 @@ pub(crate) const HOT_DIFF_SPACE: StorageSpace =
 const HOT_DENSE_SCAN_MIN_IDENTITIES: usize = 64;
 const HOT_DENSE_SCAN_MAX_OVERREAD: usize = 2;
 const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
+const CERTIFIED_ENTITY_BATCH_MAGIC: &[u8; 4] = b"CEB1";
+pub(crate) const CERTIFIED_ENTITY_BATCH_SPACE: StorageSpace = StorageSpace::new(
+    StorageSpaceId(0x0004_001f),
+    "live_state.certified_entity_batch.v1",
+);
+pub(crate) const CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE: StorageSpace = StorageSpace::new(
+    StorageSpaceId(0x0004_0021),
+    "live_state.certified_entity_batch_manifest.v1",
+);
+const DEFERRED_FRESH_HOT_ROWS_PER_PAGE: usize = 4_096;
+const DEFERRED_FRESH_HOT_SPACES: [StorageSpace; 3] =
+    [HOT_ROW_SPACE, HOT_FILE_SPACE, HOT_DIFF_SPACE];
+
+/// A certified fresh-file hot-state publication whose row owner is attached
+/// only after every other commit materializer has finished reading it.
+///
+/// Keeping this as row ordinals avoids manufacturing expanded keys and values
+/// while the prepared transaction batch is still live.
+pub(crate) struct DeferredFreshHotPlan {
+    branch_id: String,
+    generation: CommitId,
+    checkpoint_commit_id: Option<CommitId>,
+    row_indices: Vec<usize>,
+    put_count: u64,
+    written_bytes: u64,
+    backend_capacity_hint_bytes: usize,
+}
+
+impl DeferredFreshHotPlan {
+    pub(crate) fn new(
+        branch_id: &str,
+        generation: CommitId,
+        state_rows: &PreparedStateBatch,
+        row_indices: &[usize],
+        certified_file_id: &str,
+        validated_absence_guards: &[TrackedStateKeyRef<'_>],
+        checkpoint_commit_id: Option<CommitId>,
+        coverage: &mut WorkingDiffIndexCoverage,
+    ) -> Result<Self, LixError> {
+        if row_indices.is_empty() {
+            return Err(head_value_error(
+                "deferred fresh hot publication has no rows",
+            ));
+        }
+        let scope = hot_scope_prefix(branch_id, generation);
+        let diff_scope = checkpoint_commit_id.map(|checkpoint_commit_id| {
+            encode_working_diff_scope_prefix(branch_id, checkpoint_commit_id, generation)
+        });
+        let mut next_coverage = *coverage;
+        let mut written_bytes = 0_u64;
+        let mut backend_capacity_hint_bytes = 0_usize;
+        let mut put_count = 0_u64;
+        let mut coverage_key = Vec::new();
+        for &row_index in row_indices {
+            let row = state_rows.row(row_index);
+            let delta =
+                deferred_fresh_delta(row, branch_id, certified_file_id, validated_absence_guards)?;
+            delta.validate()?;
+            if delta.deleted {
+                return Err(head_value_error(
+                    "deferred fresh hot publication requires live rows",
+                ));
+            }
+            let key_len = encoded_hot_identity_key_len(
+                scope.len(),
+                delta.schema_key,
+                delta.entity_pk,
+                delta.file_id,
+            )
+            .ok_or_else(|| head_value_error("deferred fresh hot key length overflowed"))?;
+            let value_len =
+                checked_add_hot_next_value_capacity(0, &delta, checkpoint_commit_id.is_some())
+                    .ok_or_else(|| {
+                        head_value_error("deferred fresh hot value length overflowed")
+                    })?;
+            let value_copies = 1_u64 + u64::from(delta.file_id.is_some());
+            written_bytes = written_bytes
+                .checked_add(
+                    u64::try_from(value_len)
+                        .unwrap_or(u64::MAX)
+                        .checked_mul(value_copies)
+                        .ok_or_else(|| {
+                            head_value_error("deferred fresh hot written bytes overflowed")
+                        })?,
+                )
+                .ok_or_else(|| head_value_error("deferred fresh hot written bytes overflowed"))?;
+            backend_capacity_hint_bytes = backend_capacity_hint_bytes
+                .checked_add(key_len)
+                .and_then(|capacity| match delta.file_id {
+                    Some(_) => capacity.checked_add(key_len),
+                    None => Some(capacity),
+                })
+                .and_then(|capacity| {
+                    capacity.checked_add(value_len.checked_mul(value_copies as usize)?)
+                })
+                .and_then(|capacity| {
+                    capacity.checked_add(16_usize.checked_mul(value_copies as usize)?)
+                })
+                .ok_or_else(|| {
+                    head_value_error("deferred fresh hot backend capacity overflowed")
+                })?;
+            put_count = put_count
+                .checked_add(value_copies)
+                .ok_or_else(|| head_value_error("deferred fresh hot put count overflowed"))?;
+            if let Some(diff_scope) = diff_scope.as_deref() {
+                coverage_key.clear();
+                let range = append_hot_diff_key_parts(
+                    &mut coverage_key,
+                    diff_scope,
+                    delta.schema_key,
+                    delta.entity_pk,
+                    delta.file_id,
+                );
+                next_coverage
+                    .add_encoded_group_key(&coverage_key[range])
+                    .ok_or_else(|| {
+                        head_value_error("deferred fresh hot working-diff count overflowed")
+                    })?;
+                backend_capacity_hint_bytes = backend_capacity_hint_bytes
+                    .checked_add(coverage_key.len())
+                    .and_then(|capacity| capacity.checked_add(16))
+                    .ok_or_else(|| {
+                        head_value_error("deferred fresh hot diff capacity overflowed")
+                    })?;
+                put_count = put_count
+                    .checked_add(1)
+                    .ok_or_else(|| head_value_error("deferred fresh hot put count overflowed"))?;
+            }
+        }
+        *coverage = next_coverage;
+        Ok(Self {
+            branch_id: branch_id.to_owned(),
+            generation,
+            checkpoint_commit_id,
+            row_indices: row_indices.to_vec(),
+            put_count,
+            written_bytes,
+            backend_capacity_hint_bytes,
+        })
+    }
+
+    pub(crate) fn into_source(
+        self,
+        state_rows: Arc<PreparedStateBatch>,
+    ) -> Box<dyn DeferredFinalPutSource> {
+        Box::new(DeferredFreshHotSource {
+            plan: self,
+            state_rows,
+            cursor: 0,
+            pending_pages: VecDeque::new(),
+        })
+    }
+}
+
+struct DeferredFreshHotSource {
+    plan: DeferredFreshHotPlan,
+    state_rows: Arc<PreparedStateBatch>,
+    cursor: usize,
+    pending_pages: VecDeque<DeferredFinalPutPage>,
+}
+
+impl DeferredFinalPutSource for DeferredFreshHotSource {
+    fn target_spaces(&self) -> &[StorageSpace] {
+        &DEFERRED_FRESH_HOT_SPACES
+    }
+
+    fn put_count(&self) -> u64 {
+        self.plan.put_count
+    }
+
+    fn written_bytes(&self) -> u64 {
+        self.plan.written_bytes
+    }
+
+    fn backend_capacity_hint_bytes(&self) -> usize {
+        self.plan.backend_capacity_hint_bytes
+    }
+
+    fn next_page(&mut self) -> Option<DeferredFinalPutPage> {
+        if let Some(page) = self.pending_pages.pop_front() {
+            return Some(page);
+        }
+        if self.cursor == self.plan.row_indices.len() {
+            return None;
+        }
+        let end = self
+            .cursor
+            .saturating_add(DEFERRED_FRESH_HOT_ROWS_PER_PAGE)
+            .min(self.plan.row_indices.len());
+        let indices = &self.plan.row_indices[self.cursor..end];
+        self.cursor = end;
+        let scope = hot_scope_prefix(&self.plan.branch_id, self.plan.generation);
+        let diff_scope = self.plan.checkpoint_commit_id.map(|checkpoint_commit_id| {
+            encode_working_diff_scope_prefix(
+                &self.plan.branch_id,
+                checkpoint_commit_id,
+                self.plan.generation,
+            )
+        });
+        let mut key_capacity = 0_usize;
+        let mut value_capacity = 0_usize;
+        for &row_index in indices {
+            let row = self.state_rows.row(row_index);
+            let delta = deferred_fresh_delta_unchecked(row);
+            key_capacity = key_capacity.saturating_add(
+                encoded_hot_identity_key_len(
+                    scope.len(),
+                    delta.schema_key,
+                    delta.entity_pk,
+                    delta.file_id,
+                )
+                .unwrap_or(0)
+                .saturating_mul(1 + usize::from(delta.file_id.is_some())),
+            );
+            if let Some(diff_scope) = diff_scope.as_deref() {
+                key_capacity = key_capacity.saturating_add(
+                    encoded_hot_identity_key_len(
+                        diff_scope.len(),
+                        delta.schema_key,
+                        delta.entity_pk,
+                        delta.file_id,
+                    )
+                    .unwrap_or(0),
+                );
+            }
+            value_capacity = checked_add_hot_next_value_capacity(
+                value_capacity,
+                &delta,
+                self.plan.checkpoint_commit_id.is_some(),
+            )
+            .unwrap_or(0);
+        }
+        let mut key_bytes = Vec::with_capacity(key_capacity);
+        let mut value_bytes = Vec::with_capacity(value_capacity);
+        let mut key_ranges = Vec::with_capacity(indices.len());
+        let mut value_ranges = Vec::with_capacity(indices.len());
+        let mut diff_key_ranges =
+            Vec::with_capacity(diff_scope.as_ref().map_or(0, |_| indices.len()));
+        for &row_index in indices {
+            let row = self.state_rows.row(row_index);
+            let delta = deferred_fresh_delta_unchecked(row);
+            key_ranges.push(append_hot_mutation_identity(&mut key_bytes, &scope, &delta));
+            value_ranges.push(
+                append_head_value(
+                    &mut value_bytes,
+                    &delta.value_ref(
+                        delta.created_at,
+                        if self.plan.checkpoint_commit_id.is_some() {
+                            WorkingDiffBaseline::BeforeAbsent
+                        } else {
+                            WorkingDiffBaseline::Disabled
+                        },
+                    ),
+                )
+                .expect("deferred fresh hot rows were validated before staging"),
+            );
+            if let Some(diff_scope) = diff_scope.as_deref() {
+                diff_key_ranges.push(append_hot_diff_key_parts(
+                    &mut key_bytes,
+                    diff_scope,
+                    delta.schema_key,
+                    delta.entity_pk,
+                    delta.file_id,
+                ));
+            }
+        }
+        let key_bytes = Bytes::from(key_bytes);
+        let value_bytes = Bytes::from(value_bytes);
+        let mut row_entries = Vec::with_capacity(indices.len());
+        let mut file_entries = Vec::with_capacity(indices.len());
+        for (identity, value) in key_ranges.into_iter().zip(value_ranges) {
+            let value = StorageValue {
+                bytes: value_bytes.slice(value.clone()),
+            };
+            row_entries.push(PutEntry {
+                key: StorageKey(key_bytes.slice(
+                    identity.row_key.offset()..identity.row_key.offset() + identity.row_key.len(),
+                )),
+                value: value.clone(),
+            });
+            if let Some(file_key) = identity.file_key {
+                file_entries.push(PutEntry {
+                    key: StorageKey(
+                        key_bytes.slice(file_key.offset()..file_key.offset() + file_key.len()),
+                    ),
+                    value,
+                });
+            }
+        }
+        if !file_entries.is_empty() {
+            self.pending_pages.push_back(DeferredFinalPutPage {
+                space: HOT_FILE_SPACE,
+                entries: PutBatch {
+                    entries: file_entries,
+                },
+            });
+        }
+        if !diff_key_ranges.is_empty() {
+            self.pending_pages.push_back(DeferredFinalPutPage {
+                space: HOT_DIFF_SPACE,
+                entries: PutBatch {
+                    entries: diff_key_ranges
+                        .into_iter()
+                        .map(|key| PutEntry {
+                            key: StorageKey(key_bytes.slice(key)),
+                            value: StorageValue {
+                                bytes: Bytes::new(),
+                            },
+                        })
+                        .collect(),
+                },
+            });
+        }
+        Some(DeferredFinalPutPage {
+            space: HOT_ROW_SPACE,
+            entries: PutBatch {
+                entries: row_entries,
+            },
+        })
+    }
+}
+
+fn deferred_fresh_delta<'a>(
+    row: PreparedStateRowRef<'a>,
+    branch_id: &str,
+    certified_file_id: &str,
+    validated_absence_guards: &[TrackedStateKeyRef<'_>],
+) -> Result<CurrentStateDeltaRef<'a>, LixError> {
+    let file_is_certified = row.file_id.map(SharedStr::as_str) == Some(certified_file_id);
+    let identity_is_guarded = validated_absence_guards
+        .binary_search_by(|guard| {
+            guard
+                .schema_key
+                .cmp(row.schema_key.as_str())
+                .then_with(|| guard.entity_pk.cmp(row.entity_pk))
+                .then_with(|| guard.file_id.cmp(&row.file_id.map(SharedStr::as_str)))
+        })
+        .is_ok();
+    if row.branch_id.as_str() != branch_id
+        || (!file_is_certified && !identity_is_guarded)
+        || row.untracked
+    {
+        return Err(head_value_error(
+            "deferred fresh hot row escaped its certified or guarded identity scope",
+        ));
+    }
+    let delta = deferred_fresh_delta_unchecked(row);
+    if delta.commit_id.is_none() || delta.change_id.is_none() {
+        return Err(head_value_error(
+            "deferred fresh hot tracked row is missing commit identity",
+        ));
+    }
+    Ok(delta)
+}
+
+fn deferred_fresh_delta_unchecked(row: PreparedStateRowRef<'_>) -> CurrentStateDeltaRef<'_> {
+    CurrentStateDeltaRef {
+        schema_key: row.schema_key,
+        file_id: row.file_id.map(SharedStr::as_str),
+        entity_pk: row.entity_pk,
+        change_id: row.change_id,
+        commit_id: row.commit_id,
+        untracked: row.untracked,
+        deleted: row.snapshot.is_none(),
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+        snapshot: row.snapshot.map_or(JsonSlotRef::None, StageJson::slot_ref),
+        metadata: row.metadata.map_or(JsonSlotRef::None, StageJson::slot_ref),
+    }
+}
+
+/// Publishes one immutable semantic owner per certified file batch.
+///
+/// The storage value is the authority for the batch rows. Current-state and
+/// history readers decode rows lazily; later sparse mutations remain ordinary
+/// hot rows and therefore form overlays instead of rewriting this value.
+pub(crate) async fn stage_certified_entity_batches(
+    read: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    file_writes: &[crate::transaction::types::TransactionFileData],
+    controls: &BTreeMap<String, BranchHeadControl>,
+    observations: &BTreeMap<String, crate::branch::BranchHeadControlObservation>,
+    commit_created_at: &BTreeMap<CommitId, LixTimestamp>,
+) -> Result<(), LixError> {
+    let mut complete_manifest_suffixes = BTreeMap::<String, Vec<Vec<u8>>>::new();
+    for file in file_writes {
+        for batch in file
+            .certified_entity_batches()
+            .iter()
+            .filter(|batch| batch.complete_file_state)
+        {
+            let mut suffix = Vec::new();
+            append_batch_text(&mut suffix, &file.file_id)?;
+            suffix.extend_from_slice(&batch.format.to_le_bytes());
+            complete_manifest_suffixes
+                .entry(file.branch_id.clone())
+                .or_default()
+                .push(suffix);
+        }
+    }
+
+    for (branch_id, control) in controls {
+        let Some(previous) = observations
+            .get(branch_id)
+            .and_then(|observation| observation.control)
+        else {
+            continue;
+        };
+        if previous.generation == control.generation {
+            continue;
+        }
+        let previous_prefix = previous.generation.as_uuid().as_bytes().to_vec();
+        let manifests = ScanPlan::prefix(
+            CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE,
+            StoragePrefix {
+                bytes: Bytes::from(previous_prefix.clone()),
+            },
+        )
+        .collect(read, StorageScanOptions::default())
+        .await?;
+        for entry in manifests.value.entries {
+            let suffix = entry
+                .key
+                .0
+                .get(previous_prefix.len()..)
+                .ok_or_else(|| head_value_error("truncated certified manifest key"))?;
+            if complete_manifest_suffixes
+                .get(branch_id)
+                .is_some_and(|prefixes| prefixes.iter().any(|prefix| suffix.starts_with(prefix)))
+            {
+                continue;
+            }
+            let mut key = control.generation.as_uuid().as_bytes().to_vec();
+            key.extend_from_slice(suffix);
+            writes.put(
+                CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE,
+                StorageKey(Bytes::from(key)),
+                StorageValue {
+                    bytes: full_value_bytes(entry.value)?,
+                },
+            );
+        }
+    }
+
+    for file in file_writes {
+        if file.certified_entity_batches().is_empty() {
+            continue;
+        }
+        let control = controls.get(&file.branch_id).ok_or_else(|| {
+            head_value_error("certified entity batch has no published branch control")
+        })?;
+        let created_at = commit_created_at
+            .get(&control.head_commit_id)
+            .copied()
+            .ok_or_else(|| head_value_error("certified entity batch has no commit timestamp"))?;
+        for batch in file.certified_entity_batches() {
+            if batch.complete_file_state {
+                let mut manifest_prefix = control.generation.as_uuid().as_bytes().to_vec();
+                append_batch_text(&mut manifest_prefix, &file.file_id)?;
+                manifest_prefix.extend_from_slice(&batch.format.to_le_bytes());
+                let prior_manifests = ScanPlan::prefix(
+                    CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE,
+                    StoragePrefix {
+                        bytes: Bytes::from(manifest_prefix),
+                    },
+                )
+                .collect(read, StorageScanOptions::default())
+                .await?;
+                for entry in prior_manifests.value.entries {
+                    writes.delete(CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE, entry.key);
+                }
+            }
+            let mut content_key = control.head_commit_id.as_uuid().as_bytes().to_vec();
+            append_batch_text(&mut content_key, &file.file_id)?;
+            content_key.extend_from_slice(&batch.format.to_le_bytes());
+
+            let page_bytes = batch
+                .pages
+                .iter()
+                .try_fold(0usize, |total, page| total.checked_add(4 + page.len()))
+                .ok_or_else(|| head_value_error("certified entity batch size overflowed"))?;
+            let schema_bytes = batch
+                .schema_keys
+                .iter()
+                .try_fold(2usize, |total, schema| total.checked_add(2 + schema.len()))
+                .ok_or_else(|| head_value_error("certified schema list size overflowed"))?;
+            let mut value = Vec::with_capacity(
+                4 + schema_bytes
+                    + 2
+                    + file.file_id.len()
+                    + 16
+                    + 2
+                    + created_at.to_string().len()
+                    + 2
+                    + 8
+                    + 8
+                    + 4
+                    + 4
+                    + page_bytes,
+            );
+            value.extend_from_slice(CERTIFIED_ENTITY_BATCH_MAGIC);
+            value.extend_from_slice(
+                &u16::try_from(batch.schema_keys.len())
+                    .map_err(|_| head_value_error("certified batch has too many schemas"))?
+                    .to_le_bytes(),
+            );
+            for schema_key in &batch.schema_keys {
+                append_batch_text(&mut value, schema_key)?;
+            }
+            append_batch_text(&mut value, &file.file_id)?;
+            value.extend_from_slice(control.head_commit_id.as_uuid().as_bytes());
+            append_batch_text(&mut value, &created_at.to_string())?;
+            value.extend_from_slice(&batch.format.to_le_bytes());
+            value.extend_from_slice(&batch.row_count.to_le_bytes());
+            value.extend_from_slice(&batch.creates.high.to_le_bytes());
+            value.extend_from_slice(&batch.creates.low.to_le_bytes());
+            value.extend_from_slice(
+                &u32::try_from(batch.pages.len())
+                    .map_err(|_| head_value_error("certified entity batch has too many pages"))?
+                    .to_le_bytes(),
+            );
+            for page in &batch.pages {
+                value.extend_from_slice(
+                    &u32::try_from(page.len())
+                        .map_err(|_| head_value_error("certified entity batch page exceeds 4GiB"))?
+                        .to_le_bytes(),
+                );
+                value.extend_from_slice(page);
+            }
+            writes.put(
+                CERTIFIED_ENTITY_BATCH_SPACE,
+                StorageKey(Bytes::from(content_key.clone())),
+                StorageValue {
+                    bytes: Bytes::from(value),
+                },
+            );
+            let mut manifest_key = control.generation.as_uuid().as_bytes().to_vec();
+            append_batch_text(&mut manifest_key, &file.file_id)?;
+            manifest_key.extend_from_slice(&batch.format.to_le_bytes());
+            manifest_key.extend_from_slice(control.head_commit_id.as_uuid().as_bytes());
+            writes.put(
+                CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE,
+                StorageKey(Bytes::from(manifest_key)),
+                StorageValue {
+                    bytes: Bytes::from(content_key),
+                },
+            );
+        }
+    }
+    Ok(())
+}
+
+fn append_batch_text(output: &mut Vec<u8>, value: &str) -> Result<(), LixError> {
+    output.extend_from_slice(
+        &u16::try_from(value.len())
+            .map_err(|_| head_value_error("certified entity batch text exceeds 64KiB"))?
+            .to_le_bytes(),
+    );
+    output.extend_from_slice(value.as_bytes());
+    Ok(())
+}
+
+async fn scan_certified_entity_batch_rows(
+    store: &impl StorageAdapterRead,
+    branch_id: &str,
+    generation: CommitId,
+    request: &TrackedStateScanRequest,
+    limit: Option<usize>,
+) -> Result<MaterializedLiveStateBatch, LixError> {
+    if matches!(limit, Some(0)) {
+        return Ok(MaterializedLiveStateBatch::default());
+    }
+    let manifests = ScanPlan::prefix(
+        CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE,
+        StoragePrefix {
+            bytes: Bytes::copy_from_slice(generation.as_uuid().as_bytes()),
+        },
+    )
+    .collect(store, StorageScanOptions::default())
+    .await?;
+    let content_keys = manifests
+        .value
+        .entries
+        .into_iter()
+        .map(|entry| full_value_bytes(entry.value).map(StorageKey))
+        .collect::<Result<Vec<_>, _>>()?;
+    let contents = PointReadPlan::new(CERTIFIED_ENTITY_BATCH_SPACE, &content_keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?
+        .value;
+    let content_count = contents.iter().flatten().count();
+    let decode_limit = (content_count <= 1).then_some(limit).flatten();
+    let needs_snapshot = request
+        .read_columns
+        .columns
+        .iter()
+        .any(|column| column == "snapshot_content");
+    let mut builder = MaterializedLiveStateBatchBuilder::with_capacity(
+        limit.unwrap_or_else(|| contents.len().saturating_mul(1024)),
+    );
+    for value in contents.into_iter().flatten() {
+        let value = full_value_bytes(value)?;
+        decode_certified_entity_batch_rows(
+            &value,
+            branch_id,
+            request,
+            needs_snapshot,
+            decode_limit,
+            &mut builder,
+        )?;
+        if decode_limit.is_some_and(|limit| builder.len() >= limit) {
+            break;
+        }
+    }
+    let batch = builder.finish();
+    if content_count <= 1 {
+        return Ok(batch);
+    }
+    let mut winners = BTreeMap::new();
+    for row in batch.into_rows() {
+        let key = (
+            row.schema_key.clone(),
+            row.entity_pk.clone(),
+            row.file_id.clone(),
+        );
+        match winners.entry(key) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(row);
+            }
+            std::collections::btree_map::Entry::Occupied(mut entry)
+                if entry.get().updated_at <= row.updated_at =>
+            {
+                entry.insert(row);
+            }
+            std::collections::btree_map::Entry::Occupied(_) => {}
+        }
+    }
+    let mut rows = MaterializedLiveStateBatch::from_rows(winners.into_values().collect());
+    if let Some(limit) = limit {
+        rows = rows.filter(|_| true, Some(limit));
+    }
+    Ok(rows)
+}
+
+pub(crate) async fn scan_certified_history_rows(
+    store: &impl StorageAdapterRead,
+    commit_ids: &BTreeSet<CommitId>,
+    request: &TrackedStateScanRequest,
+) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+    if commit_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let page = ScanPlan::prefix(
+        CERTIFIED_ENTITY_BATCH_SPACE,
+        StoragePrefix {
+            bytes: Bytes::new(),
+        },
+    )
+    .collect(store, StorageScanOptions::default())
+    .await?;
+    let needs_snapshot = request
+        .read_columns
+        .columns
+        .iter()
+        .any(|column| column == "snapshot_content");
+    let mut builder =
+        MaterializedLiveStateBatchBuilder::with_capacity(page.value.entries.len() * 1024);
+    for entry in page.value.entries {
+        let value = full_value_bytes(entry.value)?;
+        if !commit_ids.contains(&certified_batch_commit_id(&value)?) {
+            continue;
+        }
+        decode_certified_entity_batch_rows(
+            &value,
+            "",
+            request,
+            needs_snapshot,
+            None,
+            &mut builder,
+        )?;
+    }
+    Ok(builder.finish().into_rows())
+}
+
+fn certified_batch_commit_id(bytes: &[u8]) -> Result<CommitId, LixError> {
+    let mut input = CertifiedBatchReader::new(bytes)?;
+    let schema_count = input.u16()? as usize;
+    for _ in 0..schema_count {
+        let _ = input.text()?;
+    }
+    let _ = input.text()?;
+    Ok(CommitId::new(
+        uuid::Uuid::from_slice(input.bytes(16)?)
+            .map_err(|error| head_value_error(format!("invalid certified commit id: {error}")))?,
+    ))
+}
+
+fn decode_certified_entity_batch_rows(
+    bytes: &[u8],
+    branch_id: &str,
+    request: &TrackedStateScanRequest,
+    needs_snapshot: bool,
+    limit: Option<usize>,
+    builder: &mut MaterializedLiveStateBatchBuilder,
+) -> Result<(), LixError> {
+    let mut input = CertifiedBatchReader::new(bytes)?;
+    let schema_count = input.u16()? as usize;
+    if schema_count == 0 {
+        return Err(head_value_error("certified entity batch has no schemas"));
+    }
+    let mut schema_keys = Vec::with_capacity(schema_count);
+    for _ in 0..schema_count {
+        schema_keys.push(input.text()?);
+    }
+    let file_id = input.text()?;
+    let commit_id = CommitId::new(
+        uuid::Uuid::from_slice(input.bytes(16)?)
+            .map_err(|error| head_value_error(format!("invalid certified commit id: {error}")))?,
+    );
+    let timestamp = LixTimestamp::parse(input.text()?).map_err(head_value_error)?;
+    let format = input.u16()?;
+    if format != 1 && format != 2 {
+        return Err(head_value_error(format!(
+            "unsupported certified entity batch format {format}"
+        )));
+    }
+    let declared_rows = input.u64()?;
+    let creates = WasmCreateContext {
+        high: input.u64()?,
+        low: input.u32()?,
+    };
+    let page_count = input.u32()?;
+    if !request.filter.schema_keys.is_empty()
+        && !request
+            .filter
+            .schema_keys
+            .iter()
+            .any(|candidate| schema_keys.contains(&candidate.as_str()))
+    {
+        return Ok(());
+    }
+    if !request.filter.file_ids.is_empty()
+        && !request
+            .filter
+            .file_ids
+            .iter()
+            .any(|candidate| match candidate {
+                NullableKeyFilter::Any => true,
+                NullableKeyFilter::Null => false,
+                NullableKeyFilter::Value(candidate) => candidate == file_id,
+            })
+    {
+        return Ok(());
+    }
+
+    let mut decoded_rows = 0_u64;
+    for _ in 0..page_count {
+        let page_len = input.u32()? as usize;
+        let page = input.bytes(page_len)?;
+        if format == 2 {
+            decoded_rows = decoded_rows.saturating_add(decode_certified_packet_rows(
+                page,
+                &creates,
+                commit_id,
+                timestamp,
+                branch_id,
+                file_id,
+                request,
+                needs_snapshot,
+                limit,
+                decoded_rows,
+                builder,
+            )?);
+            if limit.is_some_and(|limit| builder.len() >= limit) {
+                return Ok(());
+            }
+            continue;
+        }
+        let mut rows = CertifiedCsvReader {
+            bytes: page,
+            offset: 0,
+        };
+        while rows.offset < rows.bytes.len() {
+            let local_ref = rows.u32()?;
+            let order_rank = rows.u64()?;
+            let ending = rows.u8()?;
+            let quote_layout_len = rows.u32()? as usize;
+            let quote_layout = rows.bytes(quote_layout_len)?;
+            let field_count = rows.u16()?;
+            let id = creates
+                .component(u64::from(local_ref))
+                .map_err(|error| head_value_error(error.to_string()))?;
+            let entity_pk = EntityPk::single(id.clone());
+            let selected = request.filter.entity_pks.is_empty()
+                || request
+                    .filter
+                    .entity_pks
+                    .iter()
+                    .any(|candidate| candidate == &entity_pk);
+            let mut cells = needs_snapshot.then(|| Vec::with_capacity(field_count as usize));
+            for _ in 0..field_count {
+                let cell_len = rows.u32()? as usize;
+                let cell = std::str::from_utf8(rows.bytes(cell_len)?).map_err(|error| {
+                    head_value_error(format!("certified CSV cell is not UTF-8: {error}"))
+                })?;
+                if let Some(cells) = &mut cells {
+                    cells.push(cell);
+                }
+            }
+            decoded_rows = decoded_rows.saturating_add(1);
+            if !selected {
+                continue;
+            }
+            let snapshot = cells
+                .map(|cells| {
+                    let mut object = serde_json::Map::new();
+                    object.insert(
+                        "cells".to_owned(),
+                        serde_json::Value::Array(
+                            cells
+                                .into_iter()
+                                .map(|cell| serde_json::Value::String(cell.to_owned()))
+                                .collect(),
+                        ),
+                    );
+                    object.insert("id".to_owned(), serde_json::Value::String(id.clone()));
+                    if !quote_layout.is_empty() || ending != 0 {
+                        let mut layout = serde_json::Map::new();
+                        if !quote_layout.is_empty() {
+                            layout.insert(
+                                "force_quote".to_owned(),
+                                serde_json::Value::String(
+                                    base64::engine::general_purpose::URL_SAFE_NO_PAD
+                                        .encode(quote_layout),
+                                ),
+                            );
+                        }
+                        if ending != 0 {
+                            let terminator = match ending {
+                                1 => "",
+                                2 => "\n",
+                                3 => "\r\n",
+                                4 => "\r",
+                                _ => {
+                                    return Err(head_value_error(
+                                        "certified CSV row has invalid terminator",
+                                    ));
+                                }
+                            };
+                            layout.insert(
+                                "terminator".to_owned(),
+                                serde_json::Value::String(terminator.to_owned()),
+                            );
+                        }
+                        object.insert("layout".to_owned(), serde_json::Value::Object(layout));
+                    }
+                    object.insert(
+                        "order_key".to_owned(),
+                        serde_json::Value::String(format!("{order_rank:016x}")),
+                    );
+                    let json = serde_json::to_vec(&serde_json::Value::Object(object))
+                        .map_err(|error| head_value_error(error.to_string()))?;
+                    SharedStr::from_utf8(Bytes::from(json))
+                        .map_err(|error| head_value_error(error.to_string()))
+                })
+                .transpose()?;
+            builder.push_materialized(
+                entity_pk,
+                schema_keys[0].to_owned(),
+                Some(file_id.to_owned()),
+                snapshot,
+                None,
+                false,
+                timestamp,
+                timestamp,
+                false,
+                Some(ChangeId::parse_lix(&id, "certified CSV change id")?),
+                Some(commit_id),
+                false,
+                branch_id,
+            );
+            if limit.is_some_and(|limit| builder.len() >= limit) {
+                return Ok(());
+            }
+        }
+    }
+    if decoded_rows != declared_rows {
+        return Err(head_value_error(format!(
+            "certified entity batch declared {declared_rows} rows but decoded {decoded_rows}"
+        )));
+    }
+    if input.offset != input.bytes.len() {
+        return Err(head_value_error(
+            "certified entity batch has trailing storage bytes",
+        ));
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn decode_certified_packet_rows(
+    page: &[u8],
+    creates: &WasmCreateContext,
+    commit_id: CommitId,
+    timestamp: LixTimestamp,
+    branch_id: &str,
+    file_id: &str,
+    request: &TrackedStateScanRequest,
+    needs_snapshot: bool,
+    limit: Option<usize>,
+    base_ordinal: u64,
+    builder: &mut MaterializedLiveStateBatchBuilder,
+) -> Result<u64, LixError> {
+    let mut input = CertifiedCsvReader {
+        bytes: page,
+        offset: 0,
+    };
+    let mut decoded = 0_u64;
+    while input.offset < input.bytes.len() {
+        let record_len = input.u32()? as usize;
+        let record_bytes = input.bytes(record_len)?;
+        let mut record = CertifiedCsvReader {
+            bytes: record_bytes,
+            offset: 0,
+        };
+        let tag = record.u8()?;
+        let schema_len = record.u32()? as usize;
+        let schema_key = std::str::from_utf8(record.bytes(schema_len)?)
+            .map_err(|error| head_value_error(format!("invalid packet schema: {error}")))?;
+        let (entity_pk, created_id) = match tag {
+            0 => {
+                let component_count = record.u32()? as usize;
+                let mut components = Vec::with_capacity(component_count);
+                for _ in 0..component_count {
+                    let component_len = record.u32()? as usize;
+                    let component =
+                        std::str::from_utf8(record.bytes(component_len)?).map_err(|error| {
+                            head_value_error(format!("invalid packet key: {error}"))
+                        })?;
+                    components.push(
+                        SharedStr::from_utf8(Bytes::copy_from_slice(component.as_bytes()))
+                            .map_err(|error| head_value_error(error.to_string()))?,
+                    );
+                }
+                if record.u8()? > 1 {
+                    return Err(head_value_error(
+                        "certified packet upsert has invalid effect",
+                    ));
+                }
+                (
+                    EntityPk::from_shared_parts(components)
+                        .map_err(|error| head_value_error(error.to_string()))?,
+                    None,
+                )
+            }
+            2 => {
+                let local_ref = record.u64()?;
+                let id = creates
+                    .component(local_ref)
+                    .map_err(|error| head_value_error(error.to_string()))?;
+                (EntityPk::single(id.clone()), Some(id))
+            }
+            _ => {
+                return Err(head_value_error(
+                    "certified packet contains a non-snapshot record",
+                ));
+            }
+        };
+        if record.u8()? != 0 {
+            return Err(head_value_error(
+                "certified create packet snapshot is not inline",
+            ));
+        }
+        let snapshot_len = record.u32()? as usize;
+        let snapshot_bytes = record.bytes(snapshot_len)?;
+        if record.offset != record.bytes.len() {
+            return Err(head_value_error(
+                "certified create packet record has trailing bytes",
+            ));
+        }
+        decoded = decoded.saturating_add(1);
+        let selected = (request.filter.schema_keys.is_empty()
+            || request
+                .filter
+                .schema_keys
+                .iter()
+                .any(|candidate| candidate == schema_key))
+            && (request.filter.entity_pks.is_empty()
+                || request
+                    .filter
+                    .entity_pks
+                    .iter()
+                    .any(|candidate| candidate == &entity_pk));
+        if !selected {
+            continue;
+        }
+        let snapshot = if needs_snapshot {
+            let mut snapshot: serde_json::Value = serde_json::from_slice(snapshot_bytes)
+                .map_err(|error| head_value_error(format!("invalid certified JSON: {error}")))?;
+            let object = snapshot.as_object_mut().ok_or_else(|| {
+                head_value_error("certified create snapshot is not a JSON object")
+            })?;
+            if let Some(id) = &created_id {
+                object.insert("id".to_owned(), serde_json::Value::String(id.clone()));
+            }
+            let json = serde_json::to_vec(&snapshot)
+                .map_err(|error| head_value_error(error.to_string()))?;
+            Some(
+                SharedStr::from_utf8(Bytes::from(json))
+                    .map_err(|error| head_value_error(error.to_string()))?,
+            )
+        } else {
+            None
+        };
+        let change_id = if let Some(id) = &created_id {
+            ChangeId::parse_lix(id, "certified packet change id")?
+        } else {
+            let mut bytes = *commit_id.as_uuid().as_bytes();
+            let ordinal = base_ordinal.saturating_add(decoded).to_be_bytes();
+            for (target, source) in bytes[8..].iter_mut().zip(ordinal) {
+                *target ^= source;
+            }
+            ChangeId::new(uuid::Uuid::from_bytes(bytes))
+        };
+        builder.push_materialized(
+            entity_pk,
+            schema_key.to_owned(),
+            Some(file_id.to_owned()),
+            snapshot,
+            None,
+            false,
+            timestamp,
+            timestamp,
+            false,
+            Some(change_id),
+            Some(commit_id),
+            false,
+            branch_id,
+        );
+        if limit.is_some_and(|limit| builder.len() >= limit) {
+            break;
+        }
+    }
+    Ok(decoded)
+}
+
+struct CertifiedBatchReader<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> CertifiedBatchReader<'a> {
+    fn new(bytes: &'a [u8]) -> Result<Self, LixError> {
+        if !bytes.starts_with(CERTIFIED_ENTITY_BATCH_MAGIC) {
+            return Err(head_value_error("invalid certified entity batch magic"));
+        }
+        Ok(Self { bytes, offset: 4 })
+    }
+
+    fn bytes(&mut self, length: usize) -> Result<&'a [u8], LixError> {
+        let end = self
+            .offset
+            .checked_add(length)
+            .filter(|end| *end <= self.bytes.len())
+            .ok_or_else(|| head_value_error("truncated certified entity batch"))?;
+        let value = &self.bytes[self.offset..end];
+        self.offset = end;
+        Ok(value)
+    }
+
+    fn text(&mut self) -> Result<&'a str, LixError> {
+        let length = self.u16()? as usize;
+        std::str::from_utf8(self.bytes(length)?)
+            .map_err(|error| head_value_error(format!("invalid certified batch text: {error}")))
+    }
+
+    fn u16(&mut self) -> Result<u16, LixError> {
+        Ok(u16::from_le_bytes(
+            self.bytes(2)?.try_into().expect("fixed batch u16 width"),
+        ))
+    }
+
+    fn u32(&mut self) -> Result<u32, LixError> {
+        Ok(u32::from_le_bytes(
+            self.bytes(4)?.try_into().expect("fixed batch u32 width"),
+        ))
+    }
+
+    fn u64(&mut self) -> Result<u64, LixError> {
+        Ok(u64::from_le_bytes(
+            self.bytes(8)?.try_into().expect("fixed batch u64 width"),
+        ))
+    }
+}
+
+struct CertifiedCsvReader<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> CertifiedCsvReader<'a> {
+    fn bytes(&mut self, length: usize) -> Result<&'a [u8], LixError> {
+        let end = self
+            .offset
+            .checked_add(length)
+            .filter(|end| *end <= self.bytes.len())
+            .ok_or_else(|| head_value_error("truncated certified CSV page"))?;
+        let value = &self.bytes[self.offset..end];
+        self.offset = end;
+        Ok(value)
+    }
+
+    fn u8(&mut self) -> Result<u8, LixError> {
+        Ok(self.bytes(1)?[0])
+    }
+
+    fn u16(&mut self) -> Result<u16, LixError> {
+        Ok(u16::from_le_bytes(
+            self.bytes(2)?.try_into().expect("fixed CSV u16 width"),
+        ))
+    }
+
+    fn u32(&mut self) -> Result<u32, LixError> {
+        Ok(u32::from_le_bytes(
+            self.bytes(4)?.try_into().expect("fixed CSV u32 width"),
+        ))
+    }
+
+    fn u64(&mut self) -> Result<u64, LixError> {
+        Ok(u64::from_le_bytes(
+            self.bytes(8)?.try_into().expect("fixed CSV u64 width"),
+        ))
+    }
+}
 
 /// Direct reader for one published hot generation.
 pub(crate) struct HotStateStoreReader<S> {
@@ -99,7 +1240,25 @@ where
             },
         )
         .await?;
-        Ok(!page.value.entries.is_empty())
+        if !page.value.entries.is_empty() {
+            return Ok(true);
+        }
+        let certified = scan_certified_entity_batch_rows(
+            &self.store,
+            branch_id,
+            control.generation,
+            &TrackedStateScanRequest {
+                filter: TrackedStateFilter {
+                    schema_keys: vec![schema_key.to_owned()],
+                    ..TrackedStateFilter::default()
+                },
+                read_columns: Default::default(),
+                limit: Some(1),
+            },
+            Some(1),
+        )
+        .await?;
+        Ok(!certified.is_empty())
     }
 
     pub(crate) async fn scan_entity_snapshots(
@@ -157,6 +1316,49 @@ where
         let projection = ChangeRecordProjection::from_columns(&request.read_columns.columns);
         let rows =
             materialize_hot_scan_entries(&self.store, entries, projection, branch_id).await?;
+        let overlay_identities = rows
+            .iter()
+            .map(|row| {
+                (
+                    row.schema_key().to_owned(),
+                    row.entity_pk().clone(),
+                    row.file_id().map(str::to_owned),
+                )
+            })
+            .collect::<BTreeSet<_>>();
+        let certified_rows = scan_certified_entity_batch_rows(
+            &self.store,
+            branch_id,
+            generation,
+            request,
+            if overlay_identities.is_empty() {
+                request.limit.map(|limit| limit.saturating_sub(rows.len()))
+            } else {
+                None
+            },
+        )
+        .await?
+        .filter(
+            |row| {
+                !overlay_identities
+                    .iter()
+                    .any(|(schema_key, entity_pk, file_id)| {
+                        schema_key == row.schema_key()
+                            && entity_pk == row.entity_pk()
+                            && file_id.as_deref() == row.file_id()
+                    })
+            },
+            None,
+        );
+        let rows = if certified_rows.is_empty() {
+            rows
+        } else if rows.is_empty() {
+            certified_rows
+        } else {
+            let mut combined = rows.into_rows();
+            combined.extend(certified_rows.into_rows());
+            MaterializedLiveStateBatch::from_rows(combined)
+        };
         if request.filter.include_tombstones && request.limit.is_none() {
             return Ok(rows);
         }

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -17,12 +17,12 @@ use bytes::Bytes;
 use smallvec::SmallVec;
 use tracing::Instrument as _;
 
-use crate::storage::{PutBatch, PutEntry};
 use crate::storage_adapter::{
     BufferRange, DeferredFinalPutPage, DeferredFinalPutSource, EncodedMutationBatch, EncodedPut,
+    PutBatch, PutEntry,
 };
 use crate::tracked_state::TrackedStateReadColumns;
-use crate::transaction::types::{PreparedStateBatch, PreparedStateRowRef, StageJson};
+use crate::wasm::WasmCertifiedEntityBatch;
 
 use super::*;
 
@@ -53,6 +53,21 @@ const DEFERRED_FRESH_HOT_ROWS_PER_PAGE: usize = 4_096;
 const DEFERRED_FRESH_HOT_SPACES: [StorageSpace; 3] =
     [HOT_ROW_SPACE, HOT_FILE_SPACE, HOT_DIFF_SPACE];
 
+pub(crate) struct DeferredFreshHotRowRef<'a> {
+    pub(crate) branch_id: &'a str,
+    pub(crate) delta: CurrentStateDeltaRef<'a>,
+}
+
+pub(crate) trait DeferredFreshHotRows: Send + Sync {
+    fn row(&self, index: usize) -> DeferredFreshHotRowRef<'_>;
+}
+
+pub(crate) struct CertifiedEntityBatchFileRef<'a> {
+    pub(crate) branch_id: &'a str,
+    pub(crate) file_id: &'a str,
+    pub(crate) batches: &'a [WasmCertifiedEntityBatch],
+}
+
 /// A certified fresh-file hot-state publication whose row owner is attached
 /// only after every other commit materializer has finished reading it.
 ///
@@ -72,7 +87,7 @@ impl DeferredFreshHotPlan {
     pub(crate) fn new(
         branch_id: &str,
         generation: CommitId,
-        state_rows: &PreparedStateBatch,
+        state_rows: &dyn DeferredFreshHotRows,
         row_indices: &[usize],
         certified_file_id: &str,
         validated_absence_guards: &[TrackedStateKeyRef<'_>],
@@ -183,7 +198,7 @@ impl DeferredFreshHotPlan {
 
     pub(crate) fn into_source(
         self,
-        state_rows: Arc<PreparedStateBatch>,
+        state_rows: Arc<dyn DeferredFreshHotRows>,
     ) -> Box<dyn DeferredFinalPutSource> {
         Box::new(DeferredFreshHotSource {
             plan: self,
@@ -196,7 +211,7 @@ impl DeferredFreshHotPlan {
 
 struct DeferredFreshHotSource {
     plan: DeferredFreshHotPlan,
-    state_rows: Arc<PreparedStateBatch>,
+    state_rows: Arc<dyn DeferredFreshHotRows>,
     cursor: usize,
     pending_pages: VecDeque<DeferredFinalPutPage>,
 }
@@ -242,8 +257,7 @@ impl DeferredFinalPutSource for DeferredFreshHotSource {
         let mut key_capacity = 0_usize;
         let mut value_capacity = 0_usize;
         for &row_index in indices {
-            let row = self.state_rows.row(row_index);
-            let delta = deferred_fresh_delta_unchecked(row);
+            let delta = self.state_rows.row(row_index).delta;
             key_capacity = key_capacity.saturating_add(
                 encoded_hot_identity_key_len(
                     scope.len(),
@@ -279,8 +293,7 @@ impl DeferredFinalPutSource for DeferredFreshHotSource {
         let mut diff_key_ranges =
             Vec::with_capacity(diff_scope.as_ref().map_or(0, |_| indices.len()));
         for &row_index in indices {
-            let row = self.state_rows.row(row_index);
-            let delta = deferred_fresh_delta_unchecked(row);
+            let delta = self.state_rows.row(row_index).delta;
             key_ranges.push(append_hot_mutation_identity(&mut key_bytes, &scope, &delta));
             value_ranges.push(
                 append_head_value(
@@ -363,52 +376,34 @@ impl DeferredFinalPutSource for DeferredFreshHotSource {
 }
 
 fn deferred_fresh_delta<'a>(
-    row: PreparedStateRowRef<'a>,
+    row: DeferredFreshHotRowRef<'a>,
     branch_id: &str,
     certified_file_id: &str,
     validated_absence_guards: &[TrackedStateKeyRef<'_>],
 ) -> Result<CurrentStateDeltaRef<'a>, LixError> {
-    let file_is_certified = row.file_id.map(SharedStr::as_str) == Some(certified_file_id);
+    let delta = row.delta;
+    let file_is_certified = delta.file_id == Some(certified_file_id);
     let identity_is_guarded = validated_absence_guards
         .binary_search_by(|guard| {
             guard
                 .schema_key
-                .cmp(row.schema_key.as_str())
-                .then_with(|| guard.entity_pk.cmp(row.entity_pk))
-                .then_with(|| guard.file_id.cmp(&row.file_id.map(SharedStr::as_str)))
+                .cmp(delta.schema_key)
+                .then_with(|| guard.entity_pk.cmp(delta.entity_pk))
+                .then_with(|| guard.file_id.cmp(&delta.file_id))
         })
         .is_ok();
-    if row.branch_id.as_str() != branch_id
-        || (!file_is_certified && !identity_is_guarded)
-        || row.untracked
+    if row.branch_id != branch_id || (!file_is_certified && !identity_is_guarded) || delta.untracked
     {
         return Err(head_value_error(
             "deferred fresh hot row escaped its certified or guarded identity scope",
         ));
     }
-    let delta = deferred_fresh_delta_unchecked(row);
     if delta.commit_id.is_none() || delta.change_id.is_none() {
         return Err(head_value_error(
             "deferred fresh hot tracked row is missing commit identity",
         ));
     }
     Ok(delta)
-}
-
-fn deferred_fresh_delta_unchecked(row: PreparedStateRowRef<'_>) -> CurrentStateDeltaRef<'_> {
-    CurrentStateDeltaRef {
-        schema_key: row.schema_key,
-        file_id: row.file_id.map(SharedStr::as_str),
-        entity_pk: row.entity_pk,
-        change_id: row.change_id,
-        commit_id: row.commit_id,
-        untracked: row.untracked,
-        deleted: row.snapshot.is_none(),
-        created_at: row.created_at,
-        updated_at: row.updated_at,
-        snapshot: row.snapshot.map_or(JsonSlotRef::None, StageJson::slot_ref),
-        metadata: row.metadata.map_or(JsonSlotRef::None, StageJson::slot_ref),
-    }
 }
 
 /// Publishes one immutable semantic owner per certified file batch.
@@ -419,7 +414,7 @@ fn deferred_fresh_delta_unchecked(row: PreparedStateRowRef<'_>) -> CurrentStateD
 pub(crate) async fn stage_certified_entity_batches(
     read: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
-    file_writes: &[crate::transaction::types::TransactionFileData],
+    file_writes: &[CertifiedEntityBatchFileRef<'_>],
     controls: &BTreeMap<String, BranchHeadControl>,
     observations: &BTreeMap<String, crate::branch::BranchHeadControlObservation>,
     commit_created_at: &BTreeMap<CommitId, LixTimestamp>,
@@ -427,15 +422,15 @@ pub(crate) async fn stage_certified_entity_batches(
     let mut complete_manifest_suffixes = BTreeMap::<String, Vec<Vec<u8>>>::new();
     for file in file_writes {
         for batch in file
-            .certified_entity_batches()
+            .batches
             .iter()
             .filter(|batch| batch.complete_file_state)
         {
             let mut suffix = Vec::new();
-            append_batch_text(&mut suffix, &file.file_id)?;
+            append_batch_text(&mut suffix, file.file_id)?;
             suffix.extend_from_slice(&batch.format.to_le_bytes());
             complete_manifest_suffixes
-                .entry(file.branch_id.clone())
+                .entry(file.branch_id.to_owned())
                 .or_default()
                 .push(suffix);
         }
@@ -485,20 +480,20 @@ pub(crate) async fn stage_certified_entity_batches(
     }
 
     for file in file_writes {
-        if file.certified_entity_batches().is_empty() {
+        if file.batches.is_empty() {
             continue;
         }
-        let control = controls.get(&file.branch_id).ok_or_else(|| {
+        let control = controls.get(file.branch_id).ok_or_else(|| {
             head_value_error("certified entity batch has no published branch control")
         })?;
         let created_at = commit_created_at
             .get(&control.head_commit_id)
             .copied()
             .ok_or_else(|| head_value_error("certified entity batch has no commit timestamp"))?;
-        for batch in file.certified_entity_batches() {
+        for batch in file.batches {
             if batch.complete_file_state {
                 let mut manifest_prefix = control.generation.as_uuid().as_bytes().to_vec();
-                append_batch_text(&mut manifest_prefix, &file.file_id)?;
+                append_batch_text(&mut manifest_prefix, file.file_id)?;
                 manifest_prefix.extend_from_slice(&batch.format.to_le_bytes());
                 let prior_manifests = ScanPlan::prefix(
                     CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE,
@@ -513,7 +508,7 @@ pub(crate) async fn stage_certified_entity_batches(
                 }
             }
             let mut content_key = control.head_commit_id.as_uuid().as_bytes().to_vec();
-            append_batch_text(&mut content_key, &file.file_id)?;
+            append_batch_text(&mut content_key, file.file_id)?;
             content_key.extend_from_slice(&batch.format.to_le_bytes());
 
             let page_bytes = batch
@@ -549,7 +544,7 @@ pub(crate) async fn stage_certified_entity_batches(
             for schema_key in &batch.schema_keys {
                 append_batch_text(&mut value, schema_key)?;
             }
-            append_batch_text(&mut value, &file.file_id)?;
+            append_batch_text(&mut value, file.file_id)?;
             value.extend_from_slice(control.head_commit_id.as_uuid().as_bytes());
             append_batch_text(&mut value, &created_at.to_string())?;
             value.extend_from_slice(&batch.format.to_le_bytes());
@@ -577,7 +572,7 @@ pub(crate) async fn stage_certified_entity_batches(
                 },
             );
             let mut manifest_key = control.generation.as_uuid().as_bytes().to_vec();
-            append_batch_text(&mut manifest_key, &file.file_id)?;
+            append_batch_text(&mut manifest_key, file.file_id)?;
             manifest_key.extend_from_slice(&batch.format.to_le_bytes());
             manifest_key.extend_from_slice(control.head_commit_id.as_uuid().as_bytes());
             writes.put(
@@ -1258,6 +1253,13 @@ where
         if !page.value.entries.is_empty() {
             return Ok(true);
         }
+        // Format plugins cannot publish engine-owned schemas. Avoid probing
+        // certified plugin segments when validation asks about a missing
+        // system schema; durable-function setup relies on this point-read-only
+        // path staying free of unrelated storage scans.
+        if schema_key.starts_with("lix_") {
+            return Ok(false);
+        }
         let certified = scan_certified_entity_batch_rows(
             &self.store,
             branch_id,
@@ -1477,6 +1479,9 @@ where
         }
         let rows = materialize_live_entries(&self.store, entries, *projection, branch_id).await?;
         if slots.iter().all(Option::is_some) {
+            return MaterializedLiveStateExactBatch::new(rows, slots);
+        }
+        if keys.iter().all(|key| key.schema_key.starts_with("lix_")) {
             return MaterializedLiveStateExactBatch::new(rows, slots);
         }
 

--- a/packages/engine/src/plugin/component.rs
+++ b/packages/engine/src/plugin/component.rs
@@ -3,7 +3,10 @@ use std::sync::{Arc, Mutex};
 
 use crate::binary_cas::BlobHash;
 use crate::common::LixError;
-use crate::wasm::{WasmComponentV2Factory, WasmLimits, WasmRuntime, WasmTransitionCounters};
+use crate::wasm::{
+    WASM_COMPONENT_V3_PROTOTYPE_API_VERSION, WasmComponentV2Factory, WasmLimits, WasmRuntime,
+    WasmTransitionCounters,
+};
 
 use super::{
     CompiledPluginCatalog, DEFAULT_MAX_LIVE_PLUGIN_STORES, InstalledPlugin, PluginActorCache,
@@ -213,10 +216,15 @@ impl PluginRuntimeHost {
         if let Some(factory) = self.cached_plugin_v2_factory(&plugin.key, plugin.wasm_hash)? {
             return Ok(factory);
         }
-        let compiled = self
-            .wasm_runtime
-            .compile_component_v2(plugin.wasm.clone(), self.plugin_v2_wasm_limits)
-            .await?;
+        let compiled = if plugin.api_version == WASM_COMPONENT_V3_PROTOTYPE_API_VERSION {
+            self.wasm_runtime
+                .compile_component_v3_prototype(plugin.wasm.clone(), self.plugin_v2_wasm_limits)
+                .await?
+        } else {
+            self.wasm_runtime
+                .compile_component_v2(plugin.wasm.clone(), self.plugin_v2_wasm_limits)
+                .await?
+        };
         let mut cache = self
             .plugin_v2_factory_cache
             .lock()

--- a/packages/engine/src/plugin/create_context.rs
+++ b/packages/engine/src/plugin/create_context.rs
@@ -199,6 +199,7 @@ pub(crate) fn materialize_keyless_creates(
         let WasmEntityChange::Create {
             schema_key,
             local_ref,
+            resolved_key,
             snapshot_content,
         } = change
         else {
@@ -211,6 +212,30 @@ pub(crate) fn materialize_keyless_creates(
                 "validated keyless creates must own parsed canonical snapshots",
             ));
         };
+        if let Some(key) = resolved_key.take() {
+            if key.schema_key.as_str() != schema_key
+                || key.entity_pk.len() != 1
+                || key.entity_pk[0].as_str() != id
+            {
+                return Err(invalid_id(format!(
+                    "resolved keyless create for schema '{schema_key}' does not match its create context"
+                )));
+            }
+            if canonical.certificate().is_none() {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "resolved keyless create did not retain its schema-validation certificate",
+                ));
+            }
+            *change = WasmEntityChange::Upsert {
+                entity: WasmEntity {
+                    key,
+                    snapshot_content: WasmHostBytes::CanonicalJson(canonical.clone()),
+                },
+                effect: WasmChangeEffect::Content,
+            };
+            continue;
+        }
         let mut snapshot = canonical.value().as_object().cloned().ok_or_else(|| {
             invalid_id(format!(
                 "keyless create snapshot for schema '{schema_key}' must be an object"
@@ -589,6 +614,7 @@ mod tests {
         WasmEntityChange::Create {
             schema_key: "csv_row".to_string(),
             local_ref,
+            resolved_key: None,
             snapshot_content: canonical(json!({})),
         }
     }
@@ -655,6 +681,7 @@ mod tests {
             changes: vec![WasmEntityChange::Create {
                 schema_key: "other".to_string(),
                 local_ref: 0,
+                resolved_key: None,
                 snapshot_content: WasmHostBytes::Inline(Vec::new().into()),
             }],
         };
@@ -705,6 +732,7 @@ mod tests {
             changes: vec![WasmEntityChange::Create {
                 schema_key: "csv_row".to_string(),
                 local_ref: 42,
+                resolved_key: None,
                 snapshot_content: canonical(json!({
                     "cells": ["Alice", "42"],
                     "order_key": "4000000000000001"

--- a/packages/engine/src/plugin/incremental.rs
+++ b/packages/engine/src/plugin/incremental.rs
@@ -1702,6 +1702,8 @@ fn validate_certified_snapshot_packets(
 ) -> Result<(), LixError> {
     let mut rows = 0_u64;
     let mut encountered = BTreeSet::new();
+    let mut markdown_ids = BTreeSet::new();
+    let mut markdown_parent_ids = Vec::new();
     for page in &batch.pages {
         let mut page = CertifiedPacketReader::new(page);
         while !page.finished() {
@@ -1764,7 +1766,22 @@ fn validate_certified_snapshot_packets(
                             "certified create snapshot already contains its generated id",
                         ));
                     }
-                    let key = crate::wasm::WasmEntityKey::from_owned_parts(schema_key, vec![id]);
+                    let markdown_parent_id = if schema_key == "markdown_node_v2" {
+                        if object
+                            .get("parent_id")
+                            .is_some_and(|value| !value.is_null() && value.as_str().is_none())
+                        {
+                            return Err(invalid_guest(
+                                "certified Markdown parent_id must be a string or null",
+                            ));
+                        }
+                        object
+                            .get("parent_id")
+                            .and_then(serde_json::Value::as_str)
+                            .map(str::to_owned)
+                    } else {
+                        None
+                    };
                     let snapshot = serde_json::to_vec(&value).map_err(|error| {
                         invalid_guest(format!(
                             "certified create snapshot normalization failed: {error}"
@@ -1775,13 +1792,36 @@ fn validate_certified_snapshot_packets(
                             "certified batch schema '{schema_key}' has no validation plan"
                         ))
                     })?;
-                    plan.certify_or_normalize_v2_plugin_row(&snapshot, &key)?
-                        .ok_or_else(|| {
-                            invalid_guest(format!(
-                                "certified batch schema '{schema_key}' has no streaming validator"
-                            ))
-                        })?
-                        .normalized
+                    if schema_key == "markdown_node_v2" {
+                        if !batch.complete_file_state {
+                            return Err(invalid_guest(
+                                "sparse certified Markdown batches require a durable-base observation",
+                            ));
+                        }
+                        if let Err(errors) = plan.compiled_schema.validate(&value) {
+                            let details = errors
+                                .take(3)
+                                .map(|error| error.to_string())
+                                .collect::<Vec<_>>()
+                                .join("; ");
+                            return Err(invalid_guest(format!(
+                                "certified Markdown snapshot failed schema validation: {details}"
+                            )));
+                        }
+                        markdown_ids.insert(id);
+                        markdown_parent_ids.extend(markdown_parent_id);
+                        None
+                    } else {
+                        let key =
+                            crate::wasm::WasmEntityKey::from_owned_parts(schema_key, vec![id]);
+                        plan.certify_or_normalize_v2_plugin_row(&snapshot, &key)?
+                            .ok_or_else(|| {
+                                invalid_guest(format!(
+                                    "certified batch schema '{schema_key}' has no streaming validator"
+                                ))
+                            })?
+                            .normalized
+                    }
                 }
                 _ => {
                     return Err(invalid_guest(
@@ -1815,6 +1855,14 @@ fn validate_certified_snapshot_packets(
         return Err(invalid_guest(
             "certified batch schema header does not match its records",
         ));
+    }
+    if let Some(parent_id) = markdown_parent_ids
+        .iter()
+        .find(|parent_id| !markdown_ids.contains(parent_id.as_str()))
+    {
+        return Err(invalid_guest(format!(
+            "certified Markdown parent_id '{parent_id}' is absent from the complete batch"
+        )));
     }
     Ok(())
 }

--- a/packages/engine/src/plugin/incremental.rs
+++ b/packages/engine/src/plugin/incremental.rs
@@ -20,15 +20,16 @@ use crate::common::{RequestBlobSpliceProvenance, SharedStr};
 use crate::entity_pk::EntityPk;
 use crate::wasm::{
     EDIT_SPLICE_METADATA_BYTES, PACKET_FORMAT_V1, WasmByteOutputsHandle, WasmByteSource,
-    WasmCanonicalJson, WasmCanonicalJsonCertificate, WasmChangeDrainValidator, WasmChangePage,
-    WasmComponentV2Actor, WasmConflictResolution, WasmConflictResolutionDrainValidator,
-    WasmConflictResolutionPage, WasmConflictTransition, WasmDocumentHandle, WasmEditDrainValidator,
-    WasmEditPage, WasmEntity, WasmEntityChange, WasmEntityChangeSource, WasmEntityChanges,
-    WasmEntityConflict, WasmEntityConflictPage, WasmEntityConflictSource, WasmEntityPage,
-    WasmEntitySource, WasmEntityTransition, WasmFileTransition, WasmGuestBytes, WasmHostBytes,
-    WasmHostConflictResolution, WasmHostEntity, WasmHostEntityChanges, WasmInputBytes,
-    WasmInputSplice, WasmOutputRange, WasmSourceRange, WasmTransitionCounters,
-    WasmTransitionHandle, WasmTransitionLimits, validate_change_cursor_key_uniqueness,
+    WasmCanonicalJson, WasmCanonicalJsonCertificate, WasmCertifiedEntityBatch,
+    WasmChangeDrainValidator, WasmChangePage, WasmComponentV2Actor, WasmConflictResolution,
+    WasmConflictResolutionDrainValidator, WasmConflictResolutionPage, WasmConflictTransition,
+    WasmDocumentHandle, WasmEditDrainValidator, WasmEditPage, WasmEntity, WasmEntityChange,
+    WasmEntityChangeSource, WasmEntityChanges, WasmEntityConflict, WasmEntityConflictPage,
+    WasmEntityConflictSource, WasmEntityPage, WasmEntitySource, WasmEntityTransition,
+    WasmFileTransition, WasmGuestBytes, WasmHostBytes, WasmHostConflictResolution, WasmHostEntity,
+    WasmHostEntityChanges, WasmInputBytes, WasmInputSplice, WasmOutputRange, WasmSourceRange,
+    WasmTransitionCounters, WasmTransitionHandle, WasmTransitionLimits,
+    validate_change_cursor_key_uniqueness,
 };
 use crate::{Blob, LixError};
 
@@ -1625,6 +1626,7 @@ fn change_attachment_refs(change: &WasmEntityChange<WasmHostBytes>) -> u32 {
 pub(crate) struct ValidatedFileTransition {
     pub(crate) document: WasmDocumentHandle,
     pub(crate) changes: WasmHostEntityChanges,
+    pub(crate) certified_batches: Vec<WasmCertifiedEntityBatch>,
     pub(crate) counters: WasmTransitionCounters,
 }
 
@@ -1669,6 +1671,216 @@ pub(crate) struct ValidatedEntityTransition {
     #[cfg(test)]
     pub(crate) edits: Vec<ResolvedOutputSplice>,
     pub(crate) counters: WasmTransitionCounters,
+}
+
+fn validate_certified_entity_batches(
+    batches: &[WasmCertifiedEntityBatch],
+    schemas: &V2SchemaAllowlist,
+) -> Result<(), LixError> {
+    for batch in batches {
+        for schema_key in &batch.schema_keys {
+            schemas.validate(schema_key)?;
+        }
+        match batch.format {
+            // Typed CSV is a schema codec: the runtime validates every scalar
+            // field and the engine decoder constructs the fixed row shape.
+            1 if batch.schema_keys.as_slice() == ["csv_v2_row"] => {}
+            2 => validate_certified_snapshot_packets(batch, schemas)?,
+            format => {
+                return Err(invalid_guest(format!(
+                    "unknown certified entity batch format {format}"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_certified_snapshot_packets(
+    batch: &WasmCertifiedEntityBatch,
+    schemas: &V2SchemaAllowlist,
+) -> Result<(), LixError> {
+    let mut rows = 0_u64;
+    let mut encountered = BTreeSet::new();
+    for page in &batch.pages {
+        let mut page = CertifiedPacketReader::new(page);
+        while !page.finished() {
+            let record_len = page.u32()? as usize;
+            let mut record = CertifiedPacketReader::new(page.bytes(record_len)?);
+            let tag = record.u8()?;
+            let schema_key = record.text()?;
+            schemas.validate(schema_key)?;
+            encountered.insert(schema_key);
+            let normalized = match tag {
+                0 => {
+                    let component_count = record.u32()? as usize;
+                    if component_count == 0 {
+                        return Err(invalid_guest(
+                            "certified packet upsert key has no components",
+                        ));
+                    }
+                    let mut components = smallvec::SmallVec::<[&str; 2]>::new();
+                    for _ in 0..component_count {
+                        components.push(record.text()?);
+                    }
+                    if record.u8()? > 1 {
+                        return Err(invalid_guest("certified packet upsert has invalid effect"));
+                    }
+                    let snapshot = record.inline_blob()?;
+                    let plan = schemas.schema_plan(schema_key).ok_or_else(|| {
+                        invalid_guest(format!(
+                            "certified batch schema '{schema_key}' has no validation plan"
+                        ))
+                    })?;
+                    plan.certify_or_normalize_v2_plugin_row_parts(
+                        snapshot,
+                        schema_key,
+                        &components,
+                    )?
+                    .ok_or_else(|| {
+                        invalid_guest(format!(
+                            "certified batch schema '{schema_key}' has no streaming validator"
+                        ))
+                    })?
+                }
+                2 => {
+                    let local_ref = record.u64()?;
+                    let id = batch.creates.component(local_ref)?;
+                    let snapshot = record.inline_blob()?;
+                    let mut value: serde_json::Value =
+                        serde_json::from_slice(snapshot).map_err(|error| {
+                            invalid_guest(format!(
+                                "certified create snapshot is invalid JSON: {error}"
+                            ))
+                        })?;
+                    let object = value.as_object_mut().ok_or_else(|| {
+                        invalid_guest("certified create snapshot must be an object")
+                    })?;
+                    if object
+                        .insert("id".to_owned(), serde_json::Value::String(id.clone()))
+                        .is_some()
+                    {
+                        return Err(invalid_guest(
+                            "certified create snapshot already contains its generated id",
+                        ));
+                    }
+                    let key = crate::wasm::WasmEntityKey::from_owned_parts(schema_key, vec![id]);
+                    let snapshot = serde_json::to_vec(&value).map_err(|error| {
+                        invalid_guest(format!(
+                            "certified create snapshot normalization failed: {error}"
+                        ))
+                    })?;
+                    let plan = schemas.schema_plan(schema_key).ok_or_else(|| {
+                        invalid_guest(format!(
+                            "certified batch schema '{schema_key}' has no validation plan"
+                        ))
+                    })?;
+                    plan.certify_or_normalize_v2_plugin_row(&snapshot, &key)?
+                        .ok_or_else(|| {
+                            invalid_guest(format!(
+                                "certified batch schema '{schema_key}' has no streaming validator"
+                            ))
+                        })?
+                        .normalized
+                }
+                _ => {
+                    return Err(invalid_guest(
+                        "certified snapshot packet contains a non-snapshot change",
+                    ));
+                }
+            };
+            record.finish()?;
+            if normalized.is_some() {
+                return Err(invalid_guest(
+                    "certified batch snapshot is not in canonical storage form",
+                ));
+            }
+            rows = rows
+                .checked_add(1)
+                .ok_or_else(|| invalid_guest("certified batch row count overflowed"))?;
+        }
+    }
+    if rows != batch.row_count {
+        return Err(invalid_guest(format!(
+            "certified batch declared {} rows but validated {rows}",
+            batch.row_count
+        )));
+    }
+    if encountered.len() != batch.schema_keys.len()
+        || !batch
+            .schema_keys
+            .iter()
+            .all(|schema_key| encountered.contains(schema_key.as_str()))
+    {
+        return Err(invalid_guest(
+            "certified batch schema header does not match its records",
+        ));
+    }
+    Ok(())
+}
+
+struct CertifiedPacketReader<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> CertifiedPacketReader<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, offset: 0 }
+    }
+
+    fn bytes(&mut self, length: usize) -> Result<&'a [u8], LixError> {
+        let end = self
+            .offset
+            .checked_add(length)
+            .filter(|end| *end <= self.bytes.len())
+            .ok_or_else(|| invalid_guest("certified packet ended early"))?;
+        let value = &self.bytes[self.offset..end];
+        self.offset = end;
+        Ok(value)
+    }
+
+    fn u8(&mut self) -> Result<u8, LixError> {
+        Ok(self.bytes(1)?[0])
+    }
+
+    fn u32(&mut self) -> Result<u32, LixError> {
+        Ok(u32::from_le_bytes(
+            self.bytes(4)?.try_into().expect("fixed packet u32"),
+        ))
+    }
+
+    fn u64(&mut self) -> Result<u64, LixError> {
+        Ok(u64::from_le_bytes(
+            self.bytes(8)?.try_into().expect("fixed packet u64"),
+        ))
+    }
+
+    fn text(&mut self) -> Result<&'a str, LixError> {
+        let length = self.u32()? as usize;
+        std::str::from_utf8(self.bytes(length)?)
+            .map_err(|error| invalid_guest(format!("certified packet text is invalid: {error}")))
+    }
+
+    fn inline_blob(&mut self) -> Result<&'a [u8], LixError> {
+        if self.u8()? != 0 {
+            return Err(invalid_guest("certified packet snapshot is not inline"));
+        }
+        let length = self.u32()? as usize;
+        self.bytes(length)
+    }
+
+    fn finished(&self) -> bool {
+        self.offset == self.bytes.len()
+    }
+
+    fn finish(&self) -> Result<(), LixError> {
+        if self.finished() {
+            Ok(())
+        } else {
+            Err(invalid_guest("certified packet record has trailing bytes"))
+        }
+    }
 }
 
 /// Drains and validates every change before returning any proposed semantic
@@ -1749,6 +1961,7 @@ async fn drain_file_transition_changes_inner(
                     WasmEntityChange::Create {
                         schema_key,
                         local_ref,
+                        resolved_key,
                         snapshot_content,
                     } => {
                         let snapshot = resolve_guest_bytes(
@@ -1760,12 +1973,16 @@ async fn drain_file_transition_changes_inner(
                             &mut local_counters,
                         )
                         .await?;
-                        let snapshot_row = snapshots.push(&snapshot)?;
+                        let snapshot_row = match &resolved_key {
+                            Some(key) => snapshots.push_plugin(snapshot, key, schemas)?,
+                            None => snapshots.push(&snapshot)?,
+                        };
                         debug_assert_eq!(snapshot_row, page_snapshot_ordinal);
                         page_snapshot_ordinal += 1;
                         WasmEntityChange::Create {
                             schema_key,
                             local_ref,
+                            resolved_key,
                             // Patched with the page-owned canonical row after
                             // every snapshot validates.
                             snapshot_content: WasmHostBytes::Inline(Bytes::new()),
@@ -1837,6 +2054,8 @@ async fn drain_file_transition_changes_inner(
     validate_change_cursor_key_uniqueness(&changes).map_err(|error| {
         invalid_guest(format!("invalid v2 change cursor page: {}", error.message))
     })?;
+    let certified_batches = actor.take_certified_entity_batches(transition.transition);
+    validate_certified_entity_batches(&certified_batches, schemas)?;
     let runtime_counters = actor
         .finish_transition(transition.transition)
         .instrument(tracing::debug_span!(
@@ -1847,6 +2066,7 @@ async fn drain_file_transition_changes_inner(
     Ok(ValidatedFileTransition {
         document: transition.document,
         changes: WasmEntityChanges { changes },
+        certified_batches,
         counters: merge_counter_snapshots(local_counters, runtime_counters),
     })
 }
@@ -2649,6 +2869,10 @@ fn merge_counter_snapshots(
         component_import_calls: local
             .component_import_calls
             .max(runtime.component_import_calls),
+        guest_export_calls: local.guest_export_calls.max(runtime.guest_export_calls),
+        actor_executor_threads_created: local
+            .actor_executor_threads_created
+            .max(runtime.actor_executor_threads_created),
         component_boundary_bytes: local
             .component_boundary_bytes
             .max(runtime.component_boundary_bytes),

--- a/packages/engine/src/plugin/manifest.rs
+++ b/packages/engine/src/plugin/manifest.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
 use crate::LixError;
-use crate::wasm::WASM_COMPONENT_V2_API_VERSION;
+use crate::wasm::{WASM_COMPONENT_V2_API_VERSION, WASM_COMPONENT_V3_PROTOTYPE_API_VERSION};
 
 static PLUGIN_MANIFEST_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static PLUGIN_MANIFEST_VALIDATOR: OnceLock<Result<JSONSchema, LixError>> = OnceLock::new();
@@ -138,11 +138,13 @@ pub fn parse_plugin_manifest_json(raw: &str) -> Result<ValidatedPluginManifest, 
 /// durable-registry boundaries. The latter matters because registry snapshots
 /// can outlive the process that originally validated an archive.
 pub(crate) fn validate_runtime_api_version(manifest: &PluginManifest) -> Result<(), LixError> {
-    if manifest.api_version != WASM_COMPONENT_V2_API_VERSION {
+    if manifest.api_version != WASM_COMPONENT_V2_API_VERSION
+        && manifest.api_version != WASM_COMPONENT_V3_PROTOTYPE_API_VERSION
+    {
         return Err(LixError::new(
             LixError::CODE_INVALID_PLUGIN,
             format!(
-                "wasm-component-v2 requires api_version '{WASM_COMPONENT_V2_API_VERSION}', got '{}'",
+                "wasm-component-v2 requires api_version '{WASM_COMPONENT_V2_API_VERSION}' or experimental '{WASM_COMPONENT_V3_PROTOTYPE_API_VERSION}', got '{}'",
                 manifest.api_version
             ),
         ));
@@ -265,6 +267,24 @@ mod tests {
         assert_eq!(validated.manifest.key, "plugin_json");
         assert_eq!(validated.manifest.runtime, PluginRuntime::WasmComponentV2);
         assert_eq!(validated.manifest.entry, "plugin.wasm");
+    }
+
+    #[test]
+    fn parses_experimental_v3_manifest() {
+        let validated = parse_plugin_manifest_json(
+            r#"{
+                "key":"plugin_csv_v3_prototype",
+                "runtime":"wasm-component-v2",
+                "api_version":"3.0.0",
+                "materialization":"blob",
+                "match":{"path_glob":"*.csv"},
+                "entry":"plugin.wasm",
+                "schemas":["schema/csv_row.json"]
+            }"#,
+        )
+        .expect("experimental v3 manifest should parse");
+
+        assert_eq!(validated.manifest.api_version, "3.0.0");
     }
 
     #[test]

--- a/packages/engine/src/plugin/plugin_manifest.json
+++ b/packages/engine/src/plugin/plugin_manifest.json
@@ -24,7 +24,7 @@
     },
     "api_version": {
       "type": "string",
-      "const": "2.1.0"
+      "enum": ["2.1.0", "3.0.0"]
     },
     "materialization": {
       "type": "string",

--- a/packages/engine/src/plugin/registry.rs
+++ b/packages/engine/src/plugin/registry.rs
@@ -133,6 +133,10 @@ impl PluginRegistryEntry {
         self.materialization
     }
 
+    pub(crate) fn api_version(&self) -> &str {
+        &self.api_version
+    }
+
     pub(crate) fn schema_keys(&self) -> &[String] {
         &self.schema_keys
     }

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -37,7 +37,7 @@ use crate::storage_adapter::{Memory, StorageReadOptions};
 use crate::storage_adapter::{SharedStorageAdapterRead, StorageAdapter, StorageAdapterRead};
 use crate::telemetry::TelemetrySink;
 use crate::tracked_state::TrackedStateContext;
-use crate::transaction::{Transaction, open_transaction};
+use crate::transaction::{CertifiedHistoryStoreReader, Transaction, open_transaction};
 
 use super::transaction::{SessionOperationGuard, SessionTransactionManager, SessionWriteLease};
 
@@ -665,6 +665,9 @@ where
         HistoryQuerySource {
             store: self.read_store.clone(),
             json_reader: JsonStoreContext::new().reader(self.read_store.clone()),
+            certified_history_reader: Some(Arc::new(CertifiedHistoryStoreReader::new(
+                self.read_store.clone(),
+            ))),
             default_as_of_commit_id,
         }
     }

--- a/packages/engine/src/sql2/context.rs
+++ b/packages/engine/src/sql2/context.rs
@@ -23,9 +23,11 @@ use crate::live_state::{
 };
 use crate::plugin::PluginRuntimeHost;
 use crate::storage_adapter::StorageAdapterRead;
+use crate::tracked_state::TrackedStateScanRequest;
 use crate::transaction::types::{TransactionWrite, TransactionWriteOutcome};
 use crate::wasm::UnsupportedWasmRuntime;
 
+use super::change_materialization::MaterializedChange;
 use super::{PublicCatalog, SessionFileViews};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -44,10 +46,25 @@ pub(crate) struct DiffCommandOutcome {
 pub(crate) type SqlChangelogQuerySource<S> = ChangelogQuerySource<S>;
 pub(crate) type SqlHistoryQuerySource<S> = HistoryQuerySource<S>;
 
+pub(crate) struct CertifiedHistoryChange {
+    pub(crate) commit_id: CommitId,
+    pub(crate) change: MaterializedChange,
+}
+
+#[async_trait]
+pub(crate) trait CertifiedHistoryReader: Send + Sync {
+    async fn scan(
+        &self,
+        commit_ids: &BTreeSet<CommitId>,
+        request: &TrackedStateScanRequest,
+    ) -> Result<Vec<CertifiedHistoryChange>, LixError>;
+}
+
 #[derive(Clone)]
 pub(crate) struct HistoryQuerySource<S> {
     pub(crate) store: S,
     pub(crate) json_reader: JsonStoreReader<S>,
+    pub(crate) certified_history_reader: Option<Arc<dyn CertifiedHistoryReader>>,
     /// Active-branch head pinned by the SQL session that owns this provider.
     ///
     /// History scans use this commit when the query does not provide an

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -2575,6 +2575,7 @@ mod tests {
             HistoryQuerySource {
                 store: read_scope.clone(),
                 json_reader: JsonStoreContext::new().reader(read_scope),
+                certified_history_reader: None,
                 default_as_of_commit_id,
             }
         }

--- a/packages/engine/src/sql2/history_route.rs
+++ b/packages/engine/src/sql2/history_route.rs
@@ -8,9 +8,12 @@ use datafusion::logical_expr::{Expr, Operator};
 use tokio::sync::Mutex;
 
 use crate::LixError;
+use crate::NullableKeyFilter;
 use crate::changelog::CommitId;
 use crate::commit_graph::{CommitGraphChangeHistoryRequest, CommitGraphReader};
 use crate::entity_pk::EntityPk;
+use crate::live_state::scan_certified_history_rows;
+use crate::tracked_state::{TrackedStateFilter, TrackedStateReadColumns, TrackedStateScanRequest};
 
 use super::SqlHistoryQuerySource;
 use crate::sql2::change_materialization::{MaterializedChange, materialize_located_history_change};
@@ -375,19 +378,18 @@ where
             let entries = guard
                 .change_history_from_commit(&as_of_commit_id, &request)
                 .await?;
-            let reachable_commits = if metadata_projection.commit_created_at {
-                guard.reachable_commits(&as_of_commit_id).await?
-            } else {
-                Vec::new()
-            };
+            let reachable_commits = guard.reachable_commits(&as_of_commit_id).await?;
             (entries, reachable_commits)
         };
-        let commit_created_at_by_id = reachable_commits
-            .into_iter()
+        let reachable_by_id = reachable_commits
+            .iter()
             .map(|reachable| {
                 (
                     reachable.commit.commit_id,
-                    reachable.commit.change.created_at.to_string(),
+                    (
+                        reachable.depth,
+                        reachable.commit.change.created_at.to_string(),
+                    ),
                 )
             })
             .collect::<BTreeMap<_, _>>();
@@ -396,8 +398,9 @@ where
             let change = materialize_located_history_change(&mut json_reader, entry.change).await?;
             let commit_created_at = if metadata_projection.commit_created_at {
                 Some(
-                    commit_created_at_by_id
+                    reachable_by_id
                         .get(&entry.observed_commit_id)
+                        .map(|(_, created_at)| created_at)
                         .cloned()
                         .ok_or_else(|| {
                             LixError::new(
@@ -418,6 +421,75 @@ where
                 observed_commit_id: entry.observed_commit_id.to_string(),
                 as_of_commit_id: entry.start_commit_id.to_string(),
                 depth: entry.depth,
+            });
+        }
+
+        let certified_commit_ids = reachable_by_id
+            .iter()
+            .filter(|(_, (depth, _))| {
+                request.min_depth.is_none_or(|minimum| *depth >= minimum)
+                    && request.max_depth.is_none_or(|maximum| *depth <= maximum)
+            })
+            .map(|(commit_id, _)| *commit_id)
+            .collect();
+        let certified_request = TrackedStateScanRequest {
+            filter: TrackedStateFilter {
+                schema_keys: request.schema_keys.clone(),
+                entity_pks: request.entity_pks.clone(),
+                file_ids: request
+                    .file_ids
+                    .iter()
+                    .cloned()
+                    .map(NullableKeyFilter::Value)
+                    .collect(),
+                include_tombstones: true,
+            },
+            read_columns: TrackedStateReadColumns {
+                columns: vec!["snapshot_content".to_owned(), "metadata".to_owned()],
+            },
+            limit: None,
+        };
+        let existing_change_ids = rows
+            .iter()
+            .map(|entry| entry.change.id.clone())
+            .collect::<std::collections::BTreeSet<_>>();
+        for row in scan_certified_history_rows(
+            &query_source.store,
+            &certified_commit_ids,
+            &certified_request,
+        )
+        .await?
+        {
+            let Some(commit_id) = row.commit_id else {
+                continue;
+            };
+            let Some(change_id) = row.change_id else {
+                continue;
+            };
+            let change_id = change_id.to_string();
+            if existing_change_ids.contains(&change_id) {
+                continue;
+            }
+            let Some((depth, commit_created_at)) = reachable_by_id.get(&commit_id) else {
+                continue;
+            };
+            rows.push(HistoryEntry {
+                change: MaterializedChange {
+                    id: change_id,
+                    entity_pk: row.entity_pk,
+                    schema_key: row.schema_key,
+                    file_id: row.file_id,
+                    snapshot_content: row.snapshot_content,
+                    metadata: row.metadata,
+                    created_at: row.created_at.to_string(),
+                    origin_key: None,
+                },
+                observed_commit_id: commit_id.to_string(),
+                commit_created_at: metadata_projection
+                    .commit_created_at
+                    .then(|| commit_created_at.clone()),
+                as_of_commit_id: as_of_commit_id.to_string(),
+                depth: *depth,
             });
         }
     }

--- a/packages/engine/src/sql2/history_route.rs
+++ b/packages/engine/src/sql2/history_route.rs
@@ -12,7 +12,6 @@ use crate::NullableKeyFilter;
 use crate::changelog::CommitId;
 use crate::commit_graph::{CommitGraphChangeHistoryRequest, CommitGraphReader};
 use crate::entity_pk::EntityPk;
-use crate::live_state::scan_certified_history_rows;
 use crate::tracked_state::{TrackedStateFilter, TrackedStateReadColumns, TrackedStateScanRequest};
 
 use super::SqlHistoryQuerySource;
@@ -378,7 +377,13 @@ where
             let entries = guard
                 .change_history_from_commit(&as_of_commit_id, &request)
                 .await?;
-            let reachable_commits = guard.reachable_commits(&as_of_commit_id).await?;
+            let reachable_commits = if metadata_projection.commit_created_at
+                || query_source.certified_history_reader.is_some()
+            {
+                guard.reachable_commits(&as_of_commit_id).await?
+            } else {
+                Vec::new()
+            };
             (entries, reachable_commits)
         };
         let reachable_by_id = reachable_commits
@@ -453,44 +458,28 @@ where
             .iter()
             .map(|entry| entry.change.id.clone())
             .collect::<std::collections::BTreeSet<_>>();
-        for row in scan_certified_history_rows(
-            &query_source.store,
-            &certified_commit_ids,
-            &certified_request,
-        )
-        .await?
-        {
-            let Some(commit_id) = row.commit_id else {
-                continue;
-            };
-            let Some(change_id) = row.change_id else {
-                continue;
-            };
-            let change_id = change_id.to_string();
-            if existing_change_ids.contains(&change_id) {
-                continue;
+        if let Some(certified_history_reader) = &query_source.certified_history_reader {
+            for certified in certified_history_reader
+                .scan(&certified_commit_ids, &certified_request)
+                .await?
+            {
+                if existing_change_ids.contains(&certified.change.id) {
+                    continue;
+                }
+                let Some((depth, commit_created_at)) = reachable_by_id.get(&certified.commit_id)
+                else {
+                    continue;
+                };
+                rows.push(HistoryEntry {
+                    change: certified.change,
+                    observed_commit_id: certified.commit_id.to_string(),
+                    commit_created_at: metadata_projection
+                        .commit_created_at
+                        .then(|| commit_created_at.clone()),
+                    as_of_commit_id: as_of_commit_id.to_string(),
+                    depth: *depth,
+                });
             }
-            let Some((depth, commit_created_at)) = reachable_by_id.get(&commit_id) else {
-                continue;
-            };
-            rows.push(HistoryEntry {
-                change: MaterializedChange {
-                    id: change_id,
-                    entity_pk: row.entity_pk,
-                    schema_key: row.schema_key,
-                    file_id: row.file_id,
-                    snapshot_content: row.snapshot_content,
-                    metadata: row.metadata,
-                    created_at: row.created_at.to_string(),
-                    origin_key: None,
-                },
-                observed_commit_id: commit_id.to_string(),
-                commit_created_at: metadata_projection
-                    .commit_created_at
-                    .then(|| commit_created_at.clone()),
-                as_of_commit_id: as_of_commit_id.to_string(),
-                depth: *depth,
-            });
         }
     }
 
@@ -1139,6 +1128,7 @@ mod tests {
         HistoryQuerySource {
             store: read_scope.clone(),
             json_reader: JsonStoreContext::new().reader(read_scope),
+            certified_history_reader: None,
             default_as_of_commit_id: default_as_of_commit_id.to_string(),
         }
     }

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -36,11 +36,12 @@ pub(crate) use bind::{
     statement_has_durable_runtime_function,
 };
 pub(crate) use catalog::PublicCatalog;
+pub(crate) use change_materialization::MaterializedChange;
 pub(crate) use context::{
-    ChangelogQuerySource, DiffCommand, DiffCommandOutcome, HistoryQuerySource,
-    SqlChangelogQuerySource, SqlExecutionContext, SqlHistoryQuerySource, SqlWriteContext,
-    SqlWriteExecutionContext, WriteAccess, WriteContextBranchRefReader,
-    WriteContextLiveStateReader,
+    CertifiedHistoryChange, CertifiedHistoryReader, ChangelogQuerySource, DiffCommand,
+    DiffCommandOutcome, HistoryQuerySource, SqlChangelogQuerySource, SqlExecutionContext,
+    SqlHistoryQuerySource, SqlWriteContext, SqlWriteExecutionContext, WriteAccess,
+    WriteContextBranchRefReader, WriteContextLiveStateReader,
 };
 pub(crate) use entity_batch::{CurrentEntitySnapshotReader, EntitySnapshotReader};
 pub(crate) use exec::{SessionReadSqlResult, SqlWriteResult};

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -1185,6 +1185,7 @@ mod tests {
         HistoryQuerySource {
             store: read_scope.clone(),
             json_reader: JsonStoreContext::new().reader(read_scope),
+            certified_history_reader: None,
             default_as_of_commit_id: CommitId::for_test_label("history-default").to_string(),
         }
     }

--- a/packages/engine/src/storage/traits.rs
+++ b/packages/engine/src/storage/traits.rs
@@ -97,6 +97,21 @@ pub trait StorageWrite: Send {
         entries: PutBatch,
     ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
+    /// Applies a point batch that no later range deletion in this write
+    /// transaction needs to observe.
+    ///
+    /// The default preserves ordinary [`Self::put_many`] behavior. Backends
+    /// that retain point keys only to reconcile future range deletes may
+    /// override this lane and stream the entries directly into their atomic
+    /// write batch. Exact point deletes remain valid after this call.
+    fn put_many_final(
+        &mut self,
+        space: SpaceId,
+        entries: PutBatch,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send {
+        self.put_many(space, entries)
+    }
+
     /// Deletes the given keys of one space. Batches hold at most one
     /// mutation per key; engine write-set lowering produces sorted keys.
     fn delete_many(

--- a/packages/engine/src/storage_adapter/mod.rs
+++ b/packages/engine/src/storage_adapter/mod.rs
@@ -44,4 +44,5 @@ pub use stats::{
 };
 #[cfg(any(test, feature = "storage-benches"))]
 pub use write_set::StorageWriteSetArenaStats;
+pub(crate) use write_set::{DeferredFinalPutPage, DeferredFinalPutSource};
 pub use write_set::{StorageWriteSet, StorageWriteSetError};

--- a/packages/engine/src/storage_adapter/mod.rs
+++ b/packages/engine/src/storage_adapter/mod.rs
@@ -32,6 +32,7 @@ pub use crate::storage::{
     ScanOptions as StorageScanOptions, SpaceId as StorageSpaceId, Storage, StorageError,
     StorageRead, StoredValue as StorageValue, WriteOptions as StorageWriteOptions,
 };
+pub(crate) use crate::storage::{PutBatch, PutEntry};
 
 pub use context::StorageAdapter;
 pub use point::{PointReadPlan, PointValues, RequestedToUnique, RequestedToUniqueRef};

--- a/packages/engine/src/storage_adapter/write_set.rs
+++ b/packages/engine/src/storage_adapter/write_set.rs
@@ -8,6 +8,7 @@ use crate::storage::{
 use crate::storage_adapter::{StorageSpace, StorageWriteSetStats};
 use ahash::RandomState;
 use bytes::Bytes;
+use tracing::Instrument as _;
 
 type FastHashBuilder = RandomState;
 
@@ -69,16 +70,54 @@ impl IntoStorageValue for &[u8] {
     }
 }
 
-#[derive(Clone, Debug)]
 pub struct StorageWriteSet {
     groups: Vec<StorageWriteGroup>,
     group_index: HashMap<SpaceId, usize, FastHashBuilder>,
+    deferred_final_puts: Vec<Box<dyn DeferredFinalPutSource>>,
     stats: StorageWriteSetStats,
     // Domain stores can seal a write lane after planning a destructive sweep.
     // The flag carries no storage representation; it only prevents a later
     // domain writer sharing this canonical write set from invalidating the
     // sweep's reachability proof before commit.
     changelog_gc_sealed: bool,
+}
+
+impl fmt::Debug for StorageWriteSet {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StorageWriteSet")
+            .field("groups", &self.groups)
+            .field(
+                "deferred_final_put_sources",
+                &self.deferred_final_puts.len(),
+            )
+            .field("stats", &self.stats)
+            .field("changelog_gc_sealed", &self.changelog_gc_sealed)
+            .finish_non_exhaustive()
+    }
+}
+
+/// One bounded page produced by a storage-native owner at final lowering.
+///
+/// The source has already validated logical uniqueness and ownership. Pages
+/// are deliberately restricted to final point puts so they cannot interact
+/// with a later range deletion in the same backend transaction.
+pub(crate) struct DeferredFinalPutPage {
+    pub(crate) space: StorageSpace,
+    pub(crate) entries: PutBatch,
+}
+
+/// Compact transaction-owned data that expands only at the backend boundary.
+///
+/// This is the storage-native escape hatch for large certified batches. The
+/// ordinary write set remains the general representation; a deferred source
+/// is accepted only when its target spaces have no ordinary mutations.
+pub(crate) trait DeferredFinalPutSource: Send {
+    fn target_spaces(&self) -> &[StorageSpace];
+    fn put_count(&self) -> u64;
+    fn written_bytes(&self) -> u64;
+    fn backend_capacity_hint_bytes(&self) -> usize;
+    fn next_page(&mut self) -> Option<DeferredFinalPutPage>;
 }
 
 #[derive(Clone, Debug)]
@@ -205,15 +244,18 @@ impl StorageWriteSet {
                 expected_spaces,
                 FastHashBuilder::with_seeds(0, 0, 0, 0),
             ),
+            deferred_final_puts: Vec::new(),
             stats: StorageWriteSetStats::default(),
             changelog_gc_sealed: false,
         }
     }
 
     pub fn is_empty(&self) -> bool {
-        self.groups
-            .iter()
-            .all(|group| group.puts.is_empty() && group.deletes.is_empty())
+        self.deferred_final_puts.is_empty()
+            && self
+                .groups
+                .iter()
+                .all(|group| group.puts.is_empty() && group.deletes.is_empty())
     }
 
     /// Conservative encoded-size hint for contiguous backend write batches.
@@ -222,7 +264,7 @@ impl StorageWriteSet {
     /// length prefixes for current backends. The fixed tail covers the batch
     /// header and the mutation-revision record appended by the adapter.
     pub(crate) fn backend_batch_capacity_hint_bytes(&self) -> usize {
-        self.groups.iter().fold(64_usize, |total, group| {
+        let ordinary = self.groups.iter().fold(64_usize, |total, group| {
             let puts = group.puts.iter().fold(0_usize, |bytes, put| {
                 bytes
                     .saturating_add(group.key_bytes(put.key).len())
@@ -235,7 +277,12 @@ impl StorageWriteSet {
                     .saturating_add(16)
             });
             total.saturating_add(puts).saturating_add(deletes)
-        })
+        });
+        self.deferred_final_puts
+            .iter()
+            .fold(ordinary, |total, source| {
+                total.saturating_add(source.backend_capacity_hint_bytes())
+            })
     }
 
     #[cfg(any(test, feature = "storage-benches"))]
@@ -345,6 +392,44 @@ impl StorageWriteSet {
         self.stats.staged_puts += staged_puts;
         self.stats.staged_deletes += staged_deletes;
         self.stats.written_bytes += written_bytes;
+    }
+
+    /// Retains a compact, already-validated owner until backend lowering.
+    ///
+    /// Deferred sources are intentionally exclusive per target space. This
+    /// makes their no-duplicate certificate compositional with the ordinary
+    /// write-set validator instead of silently bypassing mutations staged by
+    /// another domain writer.
+    pub(crate) fn stage_deferred_final_put_source(
+        &mut self,
+        source: Box<dyn DeferredFinalPutSource>,
+    ) -> Result<(), StorageWriteSetError> {
+        for &space in source.target_spaces() {
+            if self
+                .group_index
+                .get(&space.id)
+                .and_then(|index| self.groups.get(*index))
+                .is_some_and(|group| !group.puts.is_empty() || !group.deletes.is_empty())
+                || self.deferred_final_puts.iter().any(|existing| {
+                    existing
+                        .target_spaces()
+                        .iter()
+                        .any(|target| target.id == space.id)
+                })
+            {
+                return Err(StorageWriteSetError::DuplicateMutation {
+                    space,
+                    key: Key(Bytes::new()),
+                });
+            }
+        }
+        self.stats.staged_puts = self.stats.staged_puts.saturating_add(source.put_count());
+        self.stats.written_bytes = self
+            .stats
+            .written_bytes
+            .saturating_add(source.written_bytes());
+        self.deferred_final_puts.push(source);
+        Ok(())
     }
 
     /// Retains one contiguous content-addressed batch while coalescing puts
@@ -471,6 +556,7 @@ impl StorageWriteSet {
     pub fn extend(&mut self, other: Self) {
         let Self {
             groups,
+            deferred_final_puts,
             stats,
             changelog_gc_sealed,
             ..
@@ -480,6 +566,27 @@ impl StorageWriteSet {
             let space = group.space;
             let target = self.group_mut(space);
             target.append(group);
+        }
+        for source in deferred_final_puts {
+            for &space in source.target_spaces() {
+                assert!(
+                    self.group_index
+                        .get(&space.id)
+                        .and_then(|index| self.groups.get(*index))
+                        .is_none_or(|group| group.puts.is_empty() && group.deletes.is_empty()),
+                    "extended deferred spaces remain exclusive"
+                );
+                assert!(
+                    self.deferred_final_puts.iter().all(|existing| {
+                        existing
+                            .target_spaces()
+                            .iter()
+                            .all(|target| target.id != space.id)
+                    }),
+                    "extended deferred sources remain exclusive"
+                );
+            }
+            self.deferred_final_puts.push(source);
         }
         self.stats.staged_puts += stats.staged_puts;
         self.stats.staged_deletes += stats.staged_deletes;
@@ -632,7 +739,10 @@ impl StorageWriteSet {
         W: StorageWrite,
     {
         let Self {
-            groups, mut stats, ..
+            groups,
+            mut deferred_final_puts,
+            mut stats,
+            ..
         } = self;
 
         for group in groups {
@@ -663,7 +773,7 @@ impl StorageWriteSet {
                 stats.put_batches += 1;
                 stats.storage_calls += 1;
                 write
-                    .put_many(space.id, PutBatch { entries: puts })
+                    .put_many_final(space.id, PutBatch { entries: puts })
                     .await
                     .map_err(StorageWriteSetError::Storage)?;
             }
@@ -672,6 +782,29 @@ impl StorageWriteSet {
                 stats.storage_calls += 1;
                 write
                     .delete_many(space.id, &deletes)
+                    .await
+                    .map_err(StorageWriteSetError::Storage)?;
+            }
+        }
+
+        for source in &mut deferred_final_puts {
+            while let Some(page) = tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.storage_lowering.deferred_next_page"
+            )
+            .in_scope(|| source.next_page())
+            {
+                if page.entries.entries.is_empty() {
+                    continue;
+                }
+                stats.put_batches += 1;
+                stats.storage_calls += 1;
+                write
+                    .put_many_final(page.space.id, page.entries)
+                    .instrument(tracing::debug_span!(
+                        target: "lix_perf",
+                        "lix.perf.storage_lowering.deferred_put_page"
+                    ))
                     .await
                     .map_err(StorageWriteSetError::Storage)?;
             }
@@ -773,6 +906,7 @@ impl Default for StorageWriteSet {
         Self {
             groups: Vec::new(),
             group_index: HashMap::with_hasher(FastHashBuilder::with_seeds(0, 0, 0, 0)),
+            deferred_final_puts: Vec::new(),
             stats: StorageWriteSetStats::default(),
             changelog_gc_sealed: false,
         }

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -311,10 +311,19 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         .iter()
         .map(|commit| (commit.commit_id, commit.created_at))
         .collect::<BTreeMap<_, _>>();
+    let certified_files = prepared_writes
+        .file_data_writes
+        .iter()
+        .map(|file| crate::live_state::CertifiedEntityBatchFileRef {
+            branch_id: &file.branch_id,
+            file_id: &file.file_id,
+            batches: file.certified_entity_batches(),
+        })
+        .collect::<Vec<_>>();
     crate::live_state::stage_certified_entity_batches(
         read,
         &mut writes,
-        &prepared_writes.file_data_writes,
+        &certified_files,
         &staged_hot_heads.controls,
         &branch_control_observations,
         &commit_created_at,
@@ -825,6 +834,34 @@ fn current_state_delta_from_state_row(
             crate::transaction::types::StageJson::slot_ref,
         ),
     })
+}
+
+impl crate::live_state::DeferredFreshHotRows for PreparedStateBatch {
+    fn row(&self, index: usize) -> crate::live_state::DeferredFreshHotRowRef<'_> {
+        let row = PreparedStateBatch::row(self, index);
+        crate::live_state::DeferredFreshHotRowRef {
+            branch_id: row.branch_id.as_str(),
+            delta: crate::live_state::CurrentStateDeltaRef {
+                schema_key: row.schema_key,
+                file_id: row.file_id.map(crate::common::SharedStr::as_str),
+                entity_pk: row.entity_pk,
+                change_id: row.change_id,
+                commit_id: row.commit_id,
+                untracked: row.untracked,
+                deleted: row.snapshot.is_none(),
+                created_at: row.created_at,
+                updated_at: row.updated_at,
+                snapshot: row.snapshot.map_or(
+                    crate::json_store::JsonSlotRef::None,
+                    crate::transaction::types::StageJson::slot_ref,
+                ),
+                metadata: row.metadata.map_or(
+                    crate::json_store::JsonSlotRef::None,
+                    crate::transaction::types::StageJson::slot_ref,
+                ),
+            },
+        }
+    }
 }
 
 fn current_state_delta_from_engine_row(

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -41,6 +41,7 @@ use crate::transaction::types::{
 };
 use serde::Deserialize;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::Arc;
 use tracing::Instrument as _;
 
 type RowIndex = usize;
@@ -257,7 +258,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         "lix.perf.materialization.tracked_roots"
     ))
     .await?;
-    let staged_hot_heads = stage_tracked_head(
+    let mut staged_hot_heads = stage_tracked_head(
         read,
         &mut writes,
         &state_rows,
@@ -296,6 +297,33 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &branch_control_observations,
     )
     .await?;
+    let commit_created_at = commit_rows
+        .iter()
+        .map(|commit| (commit.commit_id, commit.created_at))
+        .collect::<BTreeMap<_, _>>();
+    crate::live_state::stage_certified_entity_batches(
+        read,
+        &mut writes,
+        &prepared_writes.file_data_writes,
+        &staged_hot_heads.controls,
+        &branch_control_observations,
+        &commit_created_at,
+    )
+    .await?;
+    if !staged_hot_heads.deferred_fresh_hot_plans.is_empty() {
+        if staged_hot_heads.deferred_fresh_hot_plans.len() != 1 {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "one certified fresh import produced multiple deferred hot publications",
+            ));
+        }
+        let state_rows = Arc::new(state_rows);
+        let plan = staged_hot_heads
+            .deferred_fresh_hot_plans
+            .pop()
+            .expect("one deferred fresh hot publication was counted");
+        writes.stage_deferred_final_put_source(plan.into_source(state_rows))?;
+    }
     if filesystem_view_changed {
         stage_path_index_revision(&mut writes);
     }
@@ -943,6 +971,7 @@ fn stage_tracked_commit_delta_index(
 struct StagedHotHeads {
     controls: BTreeMap<String, BranchHeadControl>,
     tracked_snapshots: BTreeMap<CommitId, HotTrackedSnapshot>,
+    deferred_fresh_hot_plans: Vec<crate::live_state::DeferredFreshHotPlan>,
 }
 
 /// Returns the commit snapshots that must be materialized before publication.
@@ -1560,6 +1589,7 @@ async fn stage_tracked_head(
         .collect::<BTreeSet<_>>();
     let tracked_head = TrackedHeadContext::new();
     let mut controls = BTreeMap::new();
+    let mut deferred_fresh_hot_plans = Vec::new();
 
     for root in tracked_roots_parent_first(tracked_roots)?
         .into_iter()
@@ -1590,17 +1620,6 @@ async fn stage_tracked_head(
             .get(&root.commit_id)
             .map(Vec::as_slice)
             .unwrap_or_default();
-        let mut tracked_deltas = {
-            let _span = tracing::debug_span!(
-                target: "lix_perf",
-                "lix.perf.materialization.tracked_head.deltas"
-            )
-            .entered();
-            state_row_indices
-                .iter()
-                .map(|&row_index| current_state_delta_from_state_row(state_rows.row(row_index)))
-                .collect::<Result<Vec<_>, _>>()?
-        };
         let selected_materialization = if !staged.selected_change_batches.is_empty()
             && !tracked_snapshots.contains_key(&root.commit_id)
         {
@@ -1636,30 +1655,6 @@ async fn stage_tracked_head(
         } else {
             None
         };
-        if let Some((selected_rows, selected_snapshots, selected_metadata)) =
-            &selected_materialization
-        {
-            tracked_deltas.extend(
-                selected_changes(&staged.selected_change_batches)
-                    .zip(selected_rows)
-                    .zip(selected_snapshots.iter().zip(selected_metadata))
-                    .map(|((change_ref, row), (snapshot, metadata))| {
-                        crate::live_state::CurrentStateDeltaRef {
-                            schema_key: &row.schema_key,
-                            file_id: row.file_id.as_deref(),
-                            entity_pk: &row.entity_pk,
-                            change_id: Some(change_ref.change_id),
-                            commit_id: Some(root.commit_id),
-                            untracked: false,
-                            deleted: change_ref.deleted,
-                            created_at: change_ref.created_at,
-                            updated_at: change_ref.updated_at,
-                            snapshot: snapshot.as_ref_slot(),
-                            metadata: metadata.as_ref_slot(),
-                        }
-                    }),
-            );
-        }
         let mut untracked_deltas = state_rows
             .iter()
             .filter(|row| {
@@ -1781,6 +1776,87 @@ async fn stage_tracked_head(
             .as_ref()
             .map(|epoch| epoch.coverage)
             .unwrap_or_default();
+        let can_defer_fresh_hot = certified_fresh_plugin_file_id.is_some()
+            && tracked_roots.len() == 1
+            && state_row_indices.len() == state_rows.len()
+            && staged.selected_change_batches.is_empty()
+            && selected_materialization.is_none()
+            && untracked_deltas.is_empty()
+            && engine_rows.is_empty()
+            && explicit_branch_targets.is_empty()
+            && checkpoint_epochs.is_empty();
+        if can_defer_fresh_hot {
+            let certified_file_id = certified_fresh_plugin_file_id
+                .expect("deferred fresh hot publication requires its certificate");
+            deferred_fresh_hot_plans.push(crate::live_state::DeferredFreshHotPlan::new(
+                &root.branch_id,
+                parent_generation,
+                state_rows,
+                state_row_indices,
+                certified_file_id,
+                &absence_guards,
+                working_diff_capture_checkpoint_commit_id,
+                &mut coverage,
+            )?);
+            if let Some(epoch) = working_diff_epoch {
+                let next_epoch = TrackedWorkingDiffEpoch {
+                    checkpoint_commit_id: epoch.checkpoint_commit_id,
+                    generation: parent_generation,
+                    coverage,
+                };
+                if next_epoch != epoch {
+                    stage_tracked_working_diff_epoch(writes, &root.branch_id, next_epoch)?;
+                }
+            }
+            let mut control = normal_branch_head_control(
+                root,
+                parent_control,
+                parent_generation,
+                working_diff_checkpoint_commit_id,
+            )?;
+            control.note_schemas(
+                state_row_indices
+                    .iter()
+                    .map(|&row_index| state_rows.row(row_index).schema_key.as_str()),
+            );
+            insert_direct_branch_control(&mut controls, &root.branch_id, control)?;
+            continue;
+        }
+        let mut tracked_deltas = {
+            let _span = tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.materialization.tracked_head.deltas"
+            )
+            .entered();
+            state_row_indices
+                .iter()
+                .map(|&row_index| current_state_delta_from_state_row(state_rows.row(row_index)))
+                .collect::<Result<Vec<_>, _>>()?
+        };
+        if let Some((selected_rows, selected_snapshots, selected_metadata)) =
+            &selected_materialization
+        {
+            tracked_deltas.extend(
+                selected_changes(&staged.selected_change_batches)
+                    .zip(selected_rows)
+                    .zip(selected_snapshots.iter().zip(selected_metadata))
+                    .map(|((change_ref, row), (snapshot, metadata))| {
+                        crate::live_state::CurrentStateDeltaRef {
+                            schema_key: &row.schema_key,
+                            file_id: row.file_id.as_deref(),
+                            entity_pk: &row.entity_pk,
+                            change_id: Some(change_ref.change_id),
+                            commit_id: Some(root.commit_id),
+                            untracked: false,
+                            deleted: change_ref.deleted,
+                            created_at: change_ref.created_at,
+                            updated_at: change_ref.updated_at,
+                            snapshot: snapshot.as_ref_slot(),
+                            metadata: metadata.as_ref_slot(),
+                        }
+                    }),
+            );
+        }
         let mut deltas = tracked_deltas;
         deltas.extend(untracked_deltas);
         // Every absence guard above is derived from one of these exact
@@ -1934,6 +2010,7 @@ async fn stage_tracked_head(
     Ok(StagedHotHeads {
         controls,
         tracked_snapshots,
+        deferred_fresh_hot_plans,
     })
 }
 

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -278,6 +278,16 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         "lix.perf.materialization.tracked_head"
     ))
     .await?;
+    for file in &prepared_writes.file_data_writes {
+        let Some(control) = staged_hot_heads.controls.get_mut(&file.branch_id) else {
+            continue;
+        };
+        control.note_schemas(
+            file.certified_entity_batches()
+                .iter()
+                .flat_map(|batch| batch.schema_keys.iter().map(String::as_str)),
+        );
+    }
     stage_checkpoint_working_diff_epochs(
         &mut writes,
         &prepared_writes.checkpoint_publications,

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -84,9 +84,10 @@ use crate::session::{
     encode_receipt, load_workspace_branch_id_from_index,
 };
 use crate::sql2::{
-    ChangelogQuerySource, DiffCommand, HistoryQuerySource, SessionFileViewKey,
-    SessionFileViewMutation, SessionFileViews, SessionPluginFileView, SqlChangelogQuerySource,
-    SqlExecutionContext, SqlHistoryQuerySource,
+    CertifiedHistoryChange, CertifiedHistoryReader, ChangelogQuerySource, DiffCommand,
+    HistoryQuerySource, MaterializedChange, SessionFileViewKey, SessionFileViewMutation,
+    SessionFileViews, SessionPluginFileView, SqlChangelogQuerySource, SqlExecutionContext,
+    SqlHistoryQuerySource,
 };
 use crate::sql2::{SqlPlanningCache, SqlWriteExecutionContext};
 use crate::storage_adapter::Storage;
@@ -97,7 +98,8 @@ use crate::storage_adapter::{
     SharedStorageAdapterRead, StorageAdapter, StorageAdapterRead, StorageAdapterReadScope,
 };
 use crate::tracked_state::{
-    TrackedStateContext, TrackedStateDiffKind, TrackedStateDiffRequest, TrackedStateStoreReader,
+    TrackedStateContext, TrackedStateDiffKind, TrackedStateDiffRequest, TrackedStateScanRequest,
+    TrackedStateStoreReader,
 };
 use crate::transaction::commit;
 use crate::transaction::normalization::{
@@ -115,6 +117,50 @@ use crate::transaction::types::{
     TransactionWriteOutcome, TransactionWriteRow, canonicalize_transaction_json_batch,
     stage_json_from_value,
 };
+
+pub(crate) struct CertifiedHistoryStoreReader<S> {
+    store: S,
+}
+
+impl<S> CertifiedHistoryStoreReader<S> {
+    pub(crate) const fn new(store: S) -> Self {
+        Self { store }
+    }
+}
+
+#[async_trait]
+impl<S> CertifiedHistoryReader for CertifiedHistoryStoreReader<S>
+where
+    S: StorageAdapterRead + Send + Sync,
+{
+    async fn scan(
+        &self,
+        commit_ids: &BTreeSet<CommitId>,
+        request: &TrackedStateScanRequest,
+    ) -> Result<Vec<CertifiedHistoryChange>, LixError> {
+        Ok(
+            crate::live_state::scan_certified_history_rows(&self.store, commit_ids, request)
+                .await?
+                .into_iter()
+                .filter_map(|row| {
+                    Some(CertifiedHistoryChange {
+                        commit_id: row.commit_id?,
+                        change: MaterializedChange {
+                            id: row.change_id?.to_string(),
+                            entity_pk: row.entity_pk,
+                            schema_key: row.schema_key,
+                            file_id: row.file_id,
+                            snapshot_content: row.snapshot_content,
+                            metadata: row.metadata,
+                            created_at: row.created_at.to_string(),
+                            origin_key: None,
+                        },
+                    })
+                })
+                .collect(),
+        )
+    }
+}
 use crate::transaction::validation::{
     TransactionValidationInput, fresh_plugin_file_import_certificate,
     prepared_tracked_rows_have_row_local_certificates, validate_certified_fresh_plugin_file_import,
@@ -5538,6 +5584,9 @@ where
         HistoryQuerySource {
             store: self.read_store.clone(),
             json_reader: crate::json_store::JsonStoreContext::new().reader(self.read_store.clone()),
+            certified_history_reader: Some(Arc::new(CertifiedHistoryStoreReader::new(
+                self.read_store.clone(),
+            ))),
             default_as_of_commit_id,
         }
     }

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -624,6 +624,9 @@ where
                 return Err(error);
             }
         };
+        transaction
+            .uncache_completed_plugin_actors_for_large_file_writes(&prepared_writes)
+            .await;
         let tracked_state_changed = prepared_writes.state_rows.iter().any(|row| !row.untracked)
             || !prepared_writes.commit_change_refs_by_branch.is_empty()
             || !prepared_writes.extra_commit_parents_by_branch.is_empty();
@@ -815,6 +818,47 @@ where
             std::mem::take(&mut transaction.pending_file_view_mutations).into_values(),
         );
         Ok(TransactionCommitOutcome { storage_stats })
+    }
+
+    /// Large import documents are more valuable as transient parser state than
+    /// as cache entries. Release their completed Stores before validation and
+    /// materialization so guest arenas do not overlap the atomic storage
+    /// batch. The durable semantic rows and exact materialized bytes remain
+    /// authoritative; a later semantic edit takes the ordinary cold path.
+    async fn uncache_completed_plugin_actors_for_large_file_writes(
+        &mut self,
+        prepared_writes: &PreparedWriteSet,
+    ) {
+        const MAX_RETAINED_IMPORT_BYTES: usize = 8 * 1024 * 1024;
+
+        let large_files = prepared_writes
+            .file_data_writes
+            .iter()
+            .filter(|write| write.len() > MAX_RETAINED_IMPORT_BYTES)
+            .map(|write| (write.branch_id.as_str(), write.file_id.as_str()))
+            .collect::<BTreeSet<_>>();
+        if large_files.is_empty() {
+            return;
+        }
+
+        for index in (0..self.pending_plugin_actor_publications.len()).rev() {
+            if self.pending_plugin_actor_publications[index].retains_large_import_actor() {
+                continue;
+            }
+            let session_key = self.pending_plugin_actor_publications[index].session_key();
+            if !large_files
+                .contains(&(session_key.branch_id.as_str(), session_key.file_id.as_str()))
+            {
+                continue;
+            }
+            let publication = self
+                .pending_plugin_actor_publications
+                .remove(index)
+                .into_uncached()
+                .await;
+            self.pending_plugin_actor_publications
+                .insert(index, publication);
+        }
     }
 
     pub(crate) fn attach_commit_boundary(&mut self, boundary: TransactionCommitBoundary) {
@@ -3139,6 +3183,8 @@ where
                     plugin_generation: selected.archive_blob_hash().to_string(),
                     owner_change_id,
                     semantic_chainable: false,
+                    retain_large_import_actor: selected.api_version()
+                        != crate::wasm::WASM_COMPONENT_V3_PROTOTYPE_API_VERSION,
                 };
                 if !prepared_session_keys.insert(view.session_key.clone())
                     || self
@@ -3332,6 +3378,13 @@ where
             }
 
             for (pending, actor, validated) in completed_opens {
+                let certified_row_count = validated
+                    .certified_batches
+                    .iter()
+                    .map(|batch| batch.row_count)
+                    .sum::<u64>();
+                file_data[pending.file_index]
+                    .set_certified_entity_batches(validated.certified_batches);
                 let mut changes = validated.changes;
                 let create_rows = self
                     .v2_create_rows(
@@ -3348,8 +3401,9 @@ where
                     .copied()
                     .unwrap_or(0);
                 counters.full_document_reparses = 1;
-                counters.durable_semantic_changes =
-                    u64::try_from(changes.entity_change_count()).unwrap_or(u64::MAX);
+                counters.durable_semantic_changes = u64::try_from(changes.entity_change_count())
+                    .unwrap_or(u64::MAX)
+                    .saturating_add(certified_row_count);
                 self.plugin_host.record_v2_transition_counters(counters);
 
                 rows.push(pending.owner_row);
@@ -3518,6 +3572,8 @@ where
                 plugin_generation: selected.archive_blob_hash().to_string(),
                 owner_change_id,
                 semantic_chainable: false,
+                retain_large_import_actor: selected.api_version()
+                    != crate::wasm::WASM_COMPONENT_V3_PROTOTYPE_API_VERSION,
             };
             if self
                 .pending_plugin_actor_publications
@@ -3710,6 +3766,12 @@ where
                     return Err(lease.handle_guest_call_error(error));
                 }
 
+                let certified_row_count = detected_transition
+                    .certified_batches
+                    .iter()
+                    .map(|batch| batch.row_count)
+                    .sum::<u64>();
+                write.set_certified_entity_batches(detected_transition.certified_batches.clone());
                 let detection_document = detected_transition.document;
                 let mut counters = detected_transition.counters;
                 let mut changes = match self
@@ -3843,8 +3905,9 @@ where
                     .copied()
                     .unwrap_or(0);
                 counters.private_document_cache_hits = 1;
-                counters.durable_semantic_changes =
-                    u64::try_from(changes.entity_change_count()).unwrap_or(u64::MAX);
+                counters.durable_semantic_changes = u64::try_from(changes.entity_change_count())
+                    .unwrap_or(u64::MAX)
+                    .saturating_add(certified_row_count);
                 self.plugin_host.record_v2_transition_counters(counters);
                 lease.complete_guest_call(
                     successor_document,
@@ -3902,6 +3965,12 @@ where
                     "lix.perf.plugin_open_file_drain"
                 ))
                 .await?;
+                let certified_row_count = validated
+                    .certified_batches
+                    .iter()
+                    .map(|batch| batch.row_count)
+                    .sum::<u64>();
+                write.set_certified_entity_batches(validated.certified_batches);
                 let mut changes = validated.changes;
                 let create_rows = self
                     .v2_create_rows(
@@ -3922,8 +3991,9 @@ where
                     .copied()
                     .unwrap_or(0);
                 counters.full_document_reparses = 1;
-                counters.durable_semantic_changes =
-                    u64::try_from(changes.entity_change_count()).unwrap_or(u64::MAX);
+                counters.durable_semantic_changes = u64::try_from(changes.entity_change_count())
+                    .unwrap_or(u64::MAX)
+                    .saturating_add(certified_row_count);
                 self.plugin_host.record_v2_transition_counters(counters);
                 (
                     changes,
@@ -4085,6 +4155,8 @@ where
                 plugin_generation: group.plugin.archive_blob_hash().to_string(),
                 owner_change_id: group.owner_change_id.clone(),
                 semantic_chainable: true,
+                retain_large_import_actor: group.plugin.api_version()
+                    != crate::wasm::WASM_COMPONENT_V3_PROTOTYPE_API_VERSION,
             };
 
             let prior_index = self
@@ -4491,7 +4563,13 @@ where
                     "prepared metadata",
                 )?;
             }
-            let mut prepared_rows = PreparedStateBatch::with_capacity(row_count);
+            let json_count = rows
+                .iter()
+                .map(|row| {
+                    usize::from(row.snapshot.is_some()) + usize::from(row.metadata.is_some())
+                })
+                .sum();
+            let mut prepared_rows = PreparedStateBatch::with_dense_capacity(row_count, json_count);
             for index in 0..row_count {
                 push_prepared_state_row_from_planned_parts(
                     &mut prepared_rows,
@@ -4583,7 +4661,11 @@ where
             canonicalize_transaction_json_batch(rows.metadata_slots_mut(), "prepared metadata")?;
         }
 
-        let mut prepared_rows = PreparedStateBatch::with_capacity(row_count);
+        let json_count = rows
+            .iter()
+            .map(|row| usize::from(row.snapshot.is_some()) + usize::from(row.metadata.is_some()))
+            .sum();
+        let mut prepared_rows = PreparedStateBatch::with_dense_capacity(row_count, json_count);
         for (index, &scalar_ordinal) in scalar_ordinal_by_row.iter().enumerate() {
             debug_assert_ne!(scalar_ordinal, usize::MAX);
             push_prepared_state_row_from_planned_parts(
@@ -6892,6 +6974,7 @@ struct PendingPluginActorView {
     plugin_generation: String,
     owner_change_id: String,
     semantic_chainable: bool,
+    retain_large_import_actor: bool,
 }
 
 enum PendingPluginActorPublication {
@@ -7020,6 +7103,14 @@ impl PendingPluginActorPublication {
             }
         }
     }
+
+    fn retains_large_import_actor(&self) -> bool {
+        match self {
+            Self::Existing { view, .. } | Self::New { view, .. } | Self::Uncached { view, .. } => {
+                view.retain_large_import_actor
+            }
+        }
+    }
 }
 
 /// Releases the oldest completed Store retained only for post-commit cache
@@ -7106,6 +7197,7 @@ async fn render_v2_semantic_changes_with_lease(
             plugin_generation: view.plugin_generation.clone(),
             owner_change_id: view.owner_change_id.clone(),
             semantic_chainable: view.semantic_chainable,
+            retain_large_import_actor: view.retain_large_import_actor,
         },
     };
     let change_count = u64::try_from(changes.entity_change_count()).unwrap_or(u64::MAX);

--- a/packages/engine/src/transaction/mod.rs
+++ b/packages/engine/src/transaction/mod.rs
@@ -13,6 +13,7 @@ pub mod bench {
     pub use super::bench_support::*;
 }
 
+pub(crate) use context::CertifiedHistoryStoreReader;
 #[cfg(test)]
 pub(crate) use context::CommitBoundaryGuard;
 pub(crate) use context::CommitBoundaryState;

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -14,7 +14,7 @@ use crate::entity_pk::EntityPk;
 use crate::json_store::JsonRef;
 use crate::live_state::MaterializedLiveStateRow;
 use crate::tracked_state::TrackedStateDiffIdentity;
-use crate::wasm::{WasmCanonicalJson, WasmCanonicalJsonCertificateRef};
+use crate::wasm::{WasmCanonicalJson, WasmCanonicalJsonCertificateRef, WasmCertifiedEntityBatch};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value as JsonValue;
 
@@ -1102,6 +1102,8 @@ pub(crate) struct TransactionFileData {
     /// Plugin installation uses this for the extracted WASM component so
     /// steady-state reads can load it directly without reopening the archive.
     auxiliary_payloads: Vec<BlobPayload>,
+    /// Certified v3 semantic owners which remain encoded through commit.
+    certified_entity_batches: Vec<WasmCertifiedEntityBatch>,
 }
 
 impl TransactionFileData {
@@ -1128,6 +1130,7 @@ impl TransactionFileData {
             mutation_identity: None,
             payload: BlobPayload::from_bytes(data),
             auxiliary_payloads: Vec::new(),
+            certified_entity_batches: Vec::new(),
         }
     }
 
@@ -1163,6 +1166,14 @@ impl TransactionFileData {
 
     pub(crate) fn add_auxiliary_payload(&mut self, data: impl Into<crate::Blob>) {
         self.auxiliary_payloads.push(BlobPayload::from_bytes(data));
+    }
+
+    pub(crate) fn set_certified_entity_batches(&mut self, batches: Vec<WasmCertifiedEntityBatch>) {
+        self.certified_entity_batches = batches;
+    }
+
+    pub(crate) fn certified_entity_batches(&self) -> &[WasmCertifiedEntityBatch] {
+        &self.certified_entity_batches
     }
 
     pub(crate) fn data(&self) -> &[u8] {
@@ -1804,6 +1815,23 @@ impl PreparedStateBatch {
         let json_capacity = row_capacity
             .checked_mul(2)
             .expect("prepared JSON column capacity overflowed");
+        Self::with_column_capacities(row_capacity, json_capacity, row_capacity)
+    }
+
+    /// Reserves exact dense row/JSON columns while keeping interned strings
+    /// bounded by a small initial dictionary. Plugin imports commonly contain
+    /// hundreds of thousands of rows but only one branch, file, schema, and
+    /// origin key; reserving one hash bucket and string slot per row creates a
+    /// large empty representation of those repeated values.
+    pub(crate) fn with_dense_capacity(row_capacity: usize, json_capacity: usize) -> Self {
+        Self::with_column_capacities(row_capacity, json_capacity, row_capacity.min(1_024))
+    }
+
+    fn with_column_capacities(
+        row_capacity: usize,
+        json_capacity: usize,
+        string_capacity: usize,
+    ) -> Self {
         Self {
             slots: Vec::with_capacity(row_capacity),
             entity_pks: Vec::with_capacity(row_capacity),
@@ -1812,8 +1840,8 @@ impl PreparedStateBatch {
             // five entries per row made the empty dictionary dominate peak
             // memory on the happy path. Pathological all-distinct columns can
             // grow this bounded hint a fixed handful of times.
-            strings: Vec::with_capacity(row_capacity),
-            string_index: HashMap::with_capacity(row_capacity),
+            strings: Vec::with_capacity(string_capacity),
+            string_index: HashMap::with_capacity(string_capacity),
             json: Vec::with_capacity(json_capacity),
             // Origin dictionaries are absent for ordinary SQL/direct writes
             // and typically contain only a few shared descriptors. Allocate

--- a/packages/engine/src/transaction/validation.rs
+++ b/packages/engine/src/transaction/validation.rs
@@ -501,7 +501,7 @@ pub(crate) fn fresh_plugin_file_import_certificate(
             .is_empty()
         || !prepared_writes.extra_commit_parents_by_branch.is_empty()
         || !prepared_writes.checkpoint_publications.is_empty()
-        || prepared_writes.insert_selection.len() != 2
+        || !(1..=2).contains(&prepared_writes.insert_selection.len())
     {
         return None;
     }
@@ -542,7 +542,7 @@ pub(crate) fn fresh_plugin_file_import_certificate(
                     != Some(file_data.file_id.as_str())
                     || row.entity_pk.as_single_string_owned().ok().as_deref()
                         != Some(file_data.file_id.as_str())
-                    || row.origin.is_some()
+                    || !(row.origin.is_none() || plugin_reconciliation_update(row))
                     || row.facts.requires_transaction_validation
                     || blob_ref.replace((row_index, row)).is_some()
                 {
@@ -577,17 +577,21 @@ pub(crate) fn fresh_plugin_file_import_certificate(
     else {
         return None;
     };
+    let descriptor_selected = prepared_insert_selection_matches_row(
+        &prepared_writes.insert_selection,
+        descriptor_index,
+        descriptor,
+    );
+    let blob_ref_selected = prepared_insert_selection_matches_row(
+        &prepared_writes.insert_selection,
+        blob_ref_index,
+        blob_ref,
+    );
+    let blob_ref_is_internal_update = plugin_reconciliation_update(blob_ref);
     if plugin_owner_count != 1
-        || !prepared_insert_selection_matches_row(
-            &prepared_writes.insert_selection,
-            descriptor_index,
-            descriptor,
-        )
-        || !prepared_insert_selection_matches_row(
-            &prepared_writes.insert_selection,
-            blob_ref_index,
-            blob_ref,
-        )
+        || !descriptor_selected
+        || prepared_writes.insert_selection.len() != 1 + usize::from(blob_ref_selected)
+        || blob_ref_selected == blob_ref_is_internal_update
     {
         return None;
     }
@@ -7860,10 +7864,10 @@ mod tests {
         blob_ref.global = false;
         blob_ref.facts.row_content_validated = true;
         // Reconciliation replaces the provisional planner blob ref with this
-        // exact materialization and intentionally leaves its public origin
-        // empty; stage_write still records it as an INSERT under the outer
-        // lix_file INSERT mode.
-        blob_ref.origin = None;
+        // exact materialization as an internal update. The public descriptor
+        // remains the INSERT identity whose absence proves this is a fresh
+        // file incarnation.
+        blob_ref.origin = Some(plugin_reconciliation_update_origin());
 
         let mut owner = staged_row(
             "lix_key_value",
@@ -7912,7 +7916,6 @@ mod tests {
             crate::transaction::types::StagedCommitChangeRefs::default(),
         );
         writes.remember_insert_identity_for_tests(&descriptor);
-        writes.remember_insert_identity_for_tests(&blob_ref);
         writes
     }
 

--- a/packages/engine/src/wasm/component_v2.rs
+++ b/packages/engine/src/wasm/component_v2.rs
@@ -20,6 +20,7 @@ use crate::{
 
 pub const PACKET_FORMAT_V1: u16 = 1;
 pub const WASM_COMPONENT_V2_API_VERSION: &str = "2.1.0";
+pub const WASM_COMPONENT_V3_PROTOTYPE_API_VERSION: &str = "3.0.0";
 /// Canonical ABI page charge for one renderer splice before inline insert
 /// bytes. Both inline and output-backed edits pay this fixed metadata cost.
 pub const EDIT_SPLICE_METADATA_BYTES: u64 = 24;
@@ -126,6 +127,13 @@ pub struct WasmTransitionCounters {
     pub attachment_reads: u64,
     pub attachment_bytes_read: u64,
     pub component_import_calls: u64,
+    /// Exported guest entries. Prototype A requires exactly one for an initial
+    /// file transition, independent of page and source-read counts.
+    pub guest_export_calls: u64,
+    /// Persistent executor threads created for the actor while serving this
+    /// transition. This is one on the actor's first transition and zero for
+    /// subsequent transitions; it must never scale with source/sink calls.
+    pub actor_executor_threads_created: u64,
     pub component_boundary_bytes: u64,
     pub guest_linear_memory_high_water_bytes: u64,
     /// Bytes examined by the host-only full-blob diff fallback. Validated
@@ -178,6 +186,12 @@ impl WasmTransitionCounters {
         self.component_import_calls = self
             .component_import_calls
             .saturating_add(other.component_import_calls);
+        self.guest_export_calls = self
+            .guest_export_calls
+            .saturating_add(other.guest_export_calls);
+        self.actor_executor_threads_created = self
+            .actor_executor_threads_created
+            .saturating_add(other.actor_executor_threads_created);
         self.component_boundary_bytes = self
             .component_boundary_bytes
             .saturating_add(other.component_boundary_bytes);
@@ -788,6 +802,10 @@ pub enum WasmEntityChange<B> {
     Create {
         schema_key: String,
         local_ref: u64,
+        /// v3 may resolve the host-namespaced primary key before canonical
+        /// validation. v2 leaves this absent and retains keyless semantics
+        /// until create-context materialization.
+        resolved_key: Option<WasmEntityKey>,
         snapshot_content: B,
     },
     Upsert {
@@ -800,7 +818,7 @@ pub enum WasmEntityChange<B> {
 impl<B> WasmEntityChange<B> {
     pub fn entity_key(&self) -> Option<&WasmEntityKey> {
         match self {
-            Self::Create { .. } => None,
+            Self::Create { resolved_key, .. } => resolved_key.as_ref(),
             Self::Upsert { entity, .. } => Some(&entity.key),
             Self::Delete(key) => Some(key),
         }
@@ -1521,6 +1539,24 @@ pub struct WasmFileTransition {
     pub changes: WasmChangeCursorHandle,
 }
 
+/// One immutable, host-validated semantic batch which remains encoded until
+/// storage/query consumption.
+///
+/// This is deliberately format-neutral at the runtime boundary. The format
+/// id selects a registered engine codec; pages retain the guest's bounded
+/// framing and share their backing buffers through transaction commit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WasmCertifiedEntityBatch {
+    pub format: u16,
+    pub schema_keys: Vec<String>,
+    pub row_count: u64,
+    pub creates: WasmCreateContext,
+    /// True when this batch replaces every prior segment for the file.
+    /// Incremental transitions emit sparse overlays instead.
+    pub complete_file_state: bool,
+    pub pages: Vec<Bytes>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WasmEntityTransition {
     pub transition: WasmTransitionHandle,
@@ -1597,6 +1633,17 @@ pub trait WasmComponentV2Actor: Send {
         cursor: WasmChangeCursorHandle,
         max_bytes: u32,
     ) -> Result<Option<WasmChangePage>, LixError>;
+
+    /// Takes encoded semantic batches accumulated while draining `transition`.
+    ///
+    /// Ordinary v2 actors never produce these. A v3 adapter may return a
+    /// batch only after every bounded page has passed its format validator.
+    fn take_certified_entity_batches(
+        &mut self,
+        _transition: WasmTransitionHandle,
+    ) -> Vec<WasmCertifiedEntityBatch> {
+        Vec::new()
+    }
 
     async fn next_resolution_page(
         &mut self,

--- a/packages/engine/src/wasm/component_v2.rs
+++ b/packages/engine/src/wasm/component_v2.rs
@@ -1027,6 +1027,10 @@ impl WasmCreateContext {
     }
 
     pub fn component(self, local_ref: u64) -> Result<String, LixError> {
+        Ok(uuid::Uuid::from_bytes(self.component_uuid_bytes(local_ref)?).to_string())
+    }
+
+    pub(crate) fn component_uuid_bytes(self, local_ref: u64) -> Result<[u8; 16], LixError> {
         let local_ref = u32::try_from(local_ref).map_err(|_| {
             invalid_param("v2 create local references must fit in an unsigned 32-bit integer")
         })?;
@@ -1034,7 +1038,7 @@ impl WasmCreateContext {
         bytes[..8].copy_from_slice(&self.high.to_be_bytes());
         bytes[8..12].copy_from_slice(&self.low.to_be_bytes());
         bytes[12..].copy_from_slice(&local_ref.to_be_bytes());
-        Ok(uuid::Uuid::from_bytes(bytes).to_string())
+        Ok(bytes)
     }
 }
 

--- a/packages/engine/src/wasm/mod.rs
+++ b/packages/engine/src/wasm/mod.rs
@@ -50,6 +50,20 @@ pub trait WasmRuntime: Send + Sync {
         bytes: Vec<u8>,
         limits: WasmLimits,
     ) -> Result<Arc<dyn WasmComponentV2Factory>, LixError>;
+
+    /// Compiles the deliberately incompatible fused Component v3 prototype.
+    /// The returned adapter implements the existing actor trait so transaction
+    /// validation and storage lowering remain unchanged for Prototype A.
+    async fn compile_component_v3_prototype(
+        &self,
+        _bytes: Vec<u8>,
+        _limits: WasmLimits,
+    ) -> Result<Arc<dyn WasmComponentV2Factory>, LixError> {
+        Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "configured WASM runtime does not support the Component v3 prototype",
+        ))
+    }
 }
 
 #[derive(Debug, Default, Clone, Copy)]

--- a/packages/plugin-api-v3-prototype/Cargo.toml
+++ b/packages/plugin-api-v3-prototype/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "lix_plugin_api_v3_prototype"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+description = "Prototype fused push API for Lix Wasm Component plugins"
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+documentation.workspace = true
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+wit-bindgen = "0.57"

--- a/packages/plugin-api-v3-prototype/README.md
+++ b/packages/plugin-api-v3-prototype/README.md
@@ -1,0 +1,116 @@
+# Lix plugin API v3 prototype
+
+Experimental, intentionally incompatible Component API used to measure a fused
+guest transition with host-owned push sinks. This is not a supported plugin
+contract.
+
+The prototype is deliberately phased:
+
+- A: one exported call per transition on one persistent actor executor;
+- B: bounded typed CSV row batches without guest JSON snapshots or UUIDs;
+- C: storage-native batch consumption;
+- D: `apply-cold-successor(durable-entities, new-source, sink)` plus bounded
+  execution across independent files;
+- E: checkpoint-plus-tail hydration for operations that truly need a retained
+  document.
+
+Warm `file-changed` no longer returns a guest-owned change cursor. The
+document export accepts a borrowed host sink and emits every bounded packet
+while that one export remains entered. A two-page producer/consumer channel
+lets reconciliation validate pages concurrently instead of retaining the
+complete pushed transition. Transaction atomicity is unchanged: nothing is
+published unless the export, complete drain, and subsequent commit all succeed.
+
+Cold-successor is not ordinary hydration. A cache miss during replay must not
+rebuild and render the predecessor merely to parse the successor. Warm apply,
+cold successor, and explicit hydration are separate v3 operations so the host
+cannot accidentally reintroduce that work through an adapter.
+
+Measured on the 10.68 MiB / 220,001-entity CSV fixture:
+
+| lane | p50 | peak live host allocation |
+| --- | ---: | ---: |
+| matched v2 | 5.169 s | 929.7 MB |
+| A, fused packet-v1 | 5.042 s | 929.7 MB |
+| B, typed CSV batch | 4.576 s | 927.8 MB |
+| B + certified import/storage-retention cuts | 2.325 s | 448.4 MB |
+| C, deferred storage-native lowering | 2.225 s | 282.4 MB |
+| C + streamed sink + one-shot cold CSV view | 2.066 s | 282.4 MB |
+
+The final measured lane is 2.50x faster and uses 3.29x less peak live host
+allocation than matched v2. It retains the compact prepared row owner through
+validation and expands hot row, file, and working-diff keys in 4,096-row pages
+only while lowering the atomic backend transaction. Exact file bytes, all
+220,000 CSV rows, the active checkpoint baseline and coverage proof, and
+INSERT absence validation remain unchanged.
+
+The history-replay lane has a different multiplier. With only 16 cached actors,
+cache misses can materialize and render the predecessor before parsing the
+successor. v3 treats `apply-cold-successor(durable-entities, new-source, sink)`
+as a first-class operation rather than implementing it as `hydrate` followed
+by warm `apply`. The cache is an acceleration layer; correctness and replay
+complexity do not depend on keeping every file actor resident. Durable entities
+must be exposed as a bounded cursor and consumed inside the single successor
+guest call; passing a fully materialized `Vec<Entity>` would merely move the
+same amplification to the API boundary.
+
+## Warm transition push-sink benchmark
+
+A matched 25-pair release benchmark alternated lane order while toggling one
+byte in the same 980,000-byte / 20,000-row CSV document. Both lanes preserved
+exact bytes and semantic row count and committed exactly one durable semantic
+change per sample.
+
+| lane | p50 | p95 | guest transition exports | peak live host allocation |
+| --- | ---: | ---: | ---: | ---: |
+| v2 returned change cursor | 1.939 ms | 3.524 ms | 3 | 1.090 MB |
+| v3 imported push sink | 1.343 ms | 1.558 ms | 1 | 1.090 MB |
+
+The push path is 1.44x faster at p50. Allocation is essentially unchanged. The
+prototype currently adapts validated host-owned pages back into the engine's
+existing drain interface; eliminating that temporary vector and lowering sink
+pages directly into transaction-native batches is therefore the required next
+step for a memory improvement.
+
+## Large JSON and remaining boundaries
+
+The JSON v3 adapter deliberately reuses the JSON v2 parser and packet-v1
+snapshots. A seven-sample 10 MiB / 39,871-entity RocksDB import therefore
+isolates the API/runtime change:
+
+| lane | p50 | p95 | guest exports | host imports | peak live host allocation |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| v2 returned cursor | 675.7 ms | 767.0 ms | 17 | 10 | 85.7 MB |
+| v3 push sink | 600.4 ms | 652.1 ms | 1 | 9 | 85.6 MB |
+
+Bulk JSON is 1.13x faster at p50. The fused call plus 2 MiB bounded pages
+replace sixteen `cursor.next` exports with eight sink imports.
+
+The source side now returns any ABI-addressable complete file in one bounded
+host import instead of copying eleven 1 MiB results into a second guest vector.
+Together with the bounded producer/consumer sink, this changes v3 import-call
+counts from 26 to 9 for JSON and from 29 to 11 for CSV. Seven post-cut CSV
+samples have a 2.066 s p50 and 282.4 MB peak live host allocation.
+
+Large CSV opens now use a one-shot scan view instead of building a persistent
+guest document that the engine has already decided not to cache. Guest
+linear-memory high water fell from 53.0 MB to 41.2 MB (22%), but end-to-end
+host peak stayed flat. The remaining peak is the complete host transaction
+representation, not retained guest state or sink pages.
+
+| phase | 10 MiB JSON | 10.68 MiB CSV |
+| --- | ---: | ---: |
+| plugin drain complete | 63.0 MB | 198.4 MB |
+| tracked-head publication | 94.1 MB | 235.0 MB |
+| end-to-end peak delta | 85.6 MB | 282.4 MB |
+
+Deferring packet decoding did not change end-to-end peak. The next cut cannot
+be another Component cursor optimization: the sink must validate into a
+transaction-native, page-backed owner and storage preparation must consume
+that owner without first constructing the complete
+`ValidatedFileTransition.changes` vector.
+
+Releasing shared canonical snapshot owners page-by-page after RocksDB encoding
+was also tested and removed: peak remained 282.4 MB while CSV p50 regressed
+from 2.127 s to 2.253 s. The remaining cut must remove the row representation
+itself rather than clearing payload owners that are already shared.

--- a/packages/plugin-api-v3-prototype/src/lib.rs
+++ b/packages/plugin-api-v3-prototype/src/lib.rs
@@ -237,6 +237,7 @@ pub struct TransitionSummary {
     pub payload_bytes: u64,
 }
 
+#[derive(Debug)]
 pub struct OpenFile<'a> {
     pub file: FileInfo,
     pub source: Source<'a>,
@@ -279,6 +280,7 @@ pub trait FormatPlugin: 'static {
 }
 
 #[doc(hidden)]
+#[derive(Debug)]
 pub struct Component<P>(PhantomData<P>);
 
 impl<P: FormatPlugin> Guest for Component<P> {

--- a/packages/plugin-api-v3-prototype/src/lib.rs
+++ b/packages/plugin-api-v3-prototype/src/lib.rs
@@ -1,0 +1,413 @@
+//! Minimal authoring layer for the fused Component API v3 experiment.
+
+#![allow(clippy::missing_errors_doc)]
+
+wit_bindgen::generate!({
+    path: "wit",
+    world: "plugin",
+    pub_export_macro: true,
+    export_macro_name: "__export_component_v3_prototype",
+    default_bindings_module: "lix_plugin_api_v3_prototype",
+});
+
+use exports::lix::plugin::api::{
+    Document, FileTransition, FileUpdate as WitFileUpdate, Guest, GuestDocument, InputBytes,
+    OpenFileInput, PluginError, TransitionSummary as WitTransitionSummary,
+};
+use lix::plugin::host::{ChangePage, CsvRowBatch, Source as WitSource, TransitionSink};
+use std::marker::PhantomData;
+
+pub const PACKET_FORMAT_V1: u16 = 1;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Error {
+    InvalidInput(String),
+    LimitExceeded(String),
+    Internal(String),
+}
+
+impl Error {
+    pub fn invalid_input(message: impl Into<String>) -> Self {
+        Self::InvalidInput(message.into())
+    }
+
+    pub fn limit_exceeded(message: impl Into<String>) -> Self {
+        Self::LimitExceeded(message.into())
+    }
+
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::Internal(message.into())
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+fn plugin_error(error: Error) -> PluginError {
+    match error {
+        Error::InvalidInput(message) => PluginError::InvalidInput(message),
+        Error::LimitExceeded(message) => PluginError::LimitExceeded(message),
+        Error::Internal(message) => PluginError::Internal(message),
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CreateContext {
+    pub high: u64,
+    pub low: u32,
+}
+
+impl CreateContext {
+    pub fn namespace_bytes(self) -> [u8; 12] {
+        let mut bytes = [0_u8; 12];
+        bytes[..8].copy_from_slice(&self.high.to_be_bytes());
+        bytes[8..].copy_from_slice(&self.low.to_be_bytes());
+        bytes
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FileInfo {
+    pub path: Option<String>,
+    pub media_type: Option<String>,
+}
+
+pub struct Source<'a> {
+    inner: &'a WitSource,
+}
+
+impl std::fmt::Debug for Source<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("Source")
+            .field("len", &self.len())
+            .finish()
+    }
+}
+
+impl Source<'_> {
+    pub fn len(&self) -> u64 {
+        self.inner.len()
+    }
+
+    pub fn read_all(&self) -> Result<Vec<u8>> {
+        const READ_BYTES: u32 = 1024 * 1024;
+        let length = self.len();
+        let capacity = usize::try_from(length)
+            .map_err(|_| Error::limit_exceeded("source length exceeds guest address space"))?;
+        if let Ok(length) = u32::try_from(length) {
+            let bytes = self
+                .inner
+                .read(0, length)
+                .map_err(|error| Error::invalid_input(format!("source read failed: {error:?}")))?;
+            if bytes.len() != capacity {
+                return Err(Error::invalid_input("source returned a short read"));
+            }
+            return Ok(bytes);
+        }
+        let mut output = Vec::with_capacity(capacity);
+        let mut offset = 0_u64;
+        while offset < length {
+            let remaining = length - offset;
+            let chunk = u32::try_from(remaining.min(u64::from(READ_BYTES)))
+                .expect("bounded source read fits u32");
+            let bytes = self
+                .inner
+                .read(offset, chunk)
+                .map_err(|error| Error::invalid_input(format!("source read failed: {error:?}")))?;
+            if bytes.len() != chunk as usize {
+                return Err(Error::invalid_input("source returned a short read"));
+            }
+            output.extend_from_slice(&bytes);
+            offset += u64::from(chunk);
+        }
+        Ok(output)
+    }
+
+    pub fn read_range(&self, offset: u64, length: u64) -> Result<Vec<u8>> {
+        const READ_BYTES: u32 = 1024 * 1024;
+        let end = offset
+            .checked_add(length)
+            .ok_or_else(|| Error::invalid_input("source range overflowed"))?;
+        if end > self.len() {
+            return Err(Error::invalid_input("source range exceeds its input"));
+        }
+        let capacity = usize::try_from(length)
+            .map_err(|_| Error::limit_exceeded("source range exceeds guest address space"))?;
+        let mut output = Vec::with_capacity(capacity);
+        let mut cursor = offset;
+        while cursor < end {
+            let chunk = u32::try_from((end - cursor).min(u64::from(READ_BYTES)))
+                .expect("bounded source read fits u32");
+            let bytes = self
+                .inner
+                .read(cursor, chunk)
+                .map_err(|error| Error::invalid_input(format!("source read failed: {error:?}")))?;
+            if bytes.len() != chunk as usize {
+                return Err(Error::invalid_input("source returned a short read"));
+            }
+            output.extend_from_slice(&bytes);
+            cursor += u64::from(chunk);
+        }
+        Ok(output)
+    }
+}
+
+pub struct Sink<'a> {
+    inner: &'a TransitionSink,
+    max_batch_bytes: u32,
+    entity_count: u64,
+    batch_count: u32,
+    payload_bytes: u64,
+}
+
+impl std::fmt::Debug for Sink<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("Sink")
+            .field("max_batch_bytes", &self.max_batch_bytes)
+            .field("entity_count", &self.entity_count)
+            .field("batch_count", &self.batch_count)
+            .field("payload_bytes", &self.payload_bytes)
+            .finish()
+    }
+}
+
+impl Sink<'_> {
+    pub fn max_batch_bytes(&self) -> u32 {
+        self.max_batch_bytes
+    }
+
+    pub fn emit_changes(&mut self, record_count: u32, payload: Vec<u8>) -> Result<()> {
+        if record_count == 0 {
+            return Err(Error::invalid_input("v3 change pages cannot be empty"));
+        }
+        if payload.len() > self.max_batch_bytes as usize {
+            return Err(Error::limit_exceeded(
+                "v3 change page exceeds max-batch-bytes",
+            ));
+        }
+        let payload_len = payload.len() as u64;
+        self.inner
+            .emit_changes(&ChangePage {
+                format_version: PACKET_FORMAT_V1,
+                record_count,
+                payload,
+            })
+            .map_err(|error| {
+                Error::invalid_input(format!("host rejected entity batch: {error:?}"))
+            })?;
+        self.entity_count = self.entity_count.saturating_add(u64::from(record_count));
+        self.batch_count = self.batch_count.saturating_add(1);
+        self.payload_bytes = self.payload_bytes.saturating_add(payload_len);
+        Ok(())
+    }
+
+    pub fn emit_csv_rows(&mut self, row_count: u32, payload: Vec<u8>) -> Result<()> {
+        if row_count == 0 {
+            return Err(Error::invalid_input("v3 CSV batches cannot be empty"));
+        }
+        if payload.len() > self.max_batch_bytes as usize {
+            return Err(Error::limit_exceeded(
+                "v3 CSV batch exceeds max-batch-bytes",
+            ));
+        }
+        let payload_len = payload.len() as u64;
+        self.inner
+            .emit_csv_rows(&CsvRowBatch { row_count, payload })
+            .map_err(|error| Error::invalid_input(format!("host rejected CSV batch: {error:?}")))?;
+        self.entity_count = self.entity_count.saturating_add(u64::from(row_count));
+        self.batch_count = self.batch_count.saturating_add(1);
+        self.payload_bytes = self.payload_bytes.saturating_add(payload_len);
+        Ok(())
+    }
+
+    fn summary(&self) -> TransitionSummary {
+        TransitionSummary {
+            entity_count: self.entity_count,
+            batch_count: self.batch_count,
+            payload_bytes: self.payload_bytes,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct TransitionSummary {
+    pub entity_count: u64,
+    pub batch_count: u32,
+    pub payload_bytes: u64,
+}
+
+pub struct OpenFile<'a> {
+    pub file: FileInfo,
+    pub source: Source<'a>,
+    pub creates: CreateContext,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SpliceInsert {
+    Inline(Vec<u8>),
+    AfterRange { offset: u64, length: u64 },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InputSplice {
+    pub offset: u64,
+    pub delete_len: u64,
+    pub insert: SpliceInsert,
+}
+
+#[derive(Debug)]
+pub struct FileUpdate<'a> {
+    pub before_file: FileInfo,
+    pub after_file: FileInfo,
+    pub before: Source<'a>,
+    pub edits: Vec<InputSplice>,
+    pub after: Source<'a>,
+    pub creates: CreateContext,
+}
+
+pub trait FormatPlugin: 'static {
+    type Document: Clone + 'static;
+
+    fn open_file(input: OpenFile<'_>, sink: &mut Sink<'_>) -> Result<Self::Document>;
+
+    fn file_changed(
+        document: &Self::Document,
+        update: FileUpdate<'_>,
+        sink: &mut Sink<'_>,
+    ) -> Result<Self::Document>;
+}
+
+#[doc(hidden)]
+pub struct Component<P>(PhantomData<P>);
+
+impl<P: FormatPlugin> Guest for Component<P> {
+    type Document = AuthorDocument<P>;
+
+    fn open_file(
+        input: OpenFileInput,
+        sink: &TransitionSink,
+    ) -> std::result::Result<FileTransition, PluginError> {
+        if input.max_batch_bytes == 0 {
+            return Err(PluginError::LimitExceeded(
+                "max-batch-bytes must be positive".to_owned(),
+            ));
+        }
+        let author_input = OpenFile {
+            file: FileInfo {
+                path: input.descriptor.path,
+                media_type: input.descriptor.media_type,
+            },
+            source: Source { inner: &input.file },
+            creates: CreateContext {
+                high: input.creates.high,
+                low: input.creates.low,
+            },
+        };
+        let mut author_sink = Sink {
+            inner: sink,
+            max_batch_bytes: input.max_batch_bytes,
+            entity_count: 0,
+            batch_count: 0,
+            payload_bytes: 0,
+        };
+        let document = P::open_file(author_input, &mut author_sink).map_err(plugin_error)?;
+        let summary = author_sink.summary();
+        Ok(FileTransition {
+            document: Document::new(AuthorDocument::<P>(document)),
+            summary: WitTransitionSummary {
+                entity_count: summary.entity_count,
+                batch_count: summary.batch_count,
+                payload_bytes: summary.payload_bytes,
+            },
+        })
+    }
+}
+
+#[doc(hidden)]
+pub struct AuthorDocument<P: FormatPlugin>(P::Document);
+
+impl<P: FormatPlugin> std::fmt::Debug for AuthorDocument<P> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.debug_tuple("AuthorDocument").finish()
+    }
+}
+
+impl<P: FormatPlugin> GuestDocument for AuthorDocument<P> {
+    fn fork(&self) -> Document {
+        Document::new(Self(self.0.clone()))
+    }
+
+    fn file_changed(
+        &self,
+        input: WitFileUpdate,
+        sink: &TransitionSink,
+    ) -> std::result::Result<FileTransition, PluginError> {
+        if input.max_batch_bytes == 0 {
+            return Err(PluginError::LimitExceeded(
+                "max-batch-bytes must be positive".to_owned(),
+            ));
+        }
+        let edits = input
+            .edits
+            .into_iter()
+            .map(|edit| InputSplice {
+                offset: edit.offset,
+                delete_len: edit.delete_len,
+                insert: match edit.insert {
+                    InputBytes::Inline(bytes) => SpliceInsert::Inline(bytes),
+                    InputBytes::AfterRange(range) => SpliceInsert::AfterRange {
+                        offset: range.offset,
+                        length: range.length,
+                    },
+                },
+            })
+            .collect();
+        let update = FileUpdate {
+            before_file: FileInfo {
+                path: input.before_descriptor.path,
+                media_type: input.before_descriptor.media_type,
+            },
+            after_file: FileInfo {
+                path: input.after_descriptor.path,
+                media_type: input.after_descriptor.media_type,
+            },
+            before: Source {
+                inner: &input.before,
+            },
+            edits,
+            after: Source {
+                inner: &input.after,
+            },
+            creates: CreateContext {
+                high: input.creates.high,
+                low: input.creates.low,
+            },
+        };
+        let mut author_sink = Sink {
+            inner: sink,
+            max_batch_bytes: input.max_batch_bytes,
+            entity_count: 0,
+            batch_count: 0,
+            payload_bytes: 0,
+        };
+        let document = P::file_changed(&self.0, update, &mut author_sink).map_err(plugin_error)?;
+        let summary = author_sink.summary();
+        Ok(FileTransition {
+            document: Document::new(Self(document)),
+            summary: WitTransitionSummary {
+                entity_count: summary.entity_count,
+                batch_count: summary.batch_count,
+                payload_bytes: summary.payload_bytes,
+            },
+        })
+    }
+}
+
+#[macro_export]
+macro_rules! export_v3_prototype {
+    ($plugin:ty) => {
+        type __LixPluginApiV3PrototypeComponent = $crate::Component<$plugin>;
+        $crate::__export_component_v3_prototype!(__LixPluginApiV3PrototypeComponent);
+    };
+}

--- a/packages/plugin-api-v3-prototype/wit/lix-plugin-v3.wit
+++ b/packages/plugin-api-v3-prototype/wit/lix-plugin-v3.wit
@@ -1,0 +1,126 @@
+package lix:plugin@3.0.0;
+
+interface host {
+  type bytes = list<u8>;
+
+  variant host-error {
+    invalid-range,
+    limit-exceeded(string),
+    rejected(string),
+  }
+
+  /// Immutable input bytes. Calls happen as imports while one exported guest
+  /// transition remains entered.
+  resource source {
+    len: func() -> u64;
+    read: func(offset: u64, length: u32) -> result<bytes, host-error>;
+  }
+
+  /// Packet-v1 change page. Prototype A intentionally retains the v2 payload
+  /// format so only control flow and scheduling change.
+  record change-page {
+    format-version: u16,
+    record-count: u32,
+    payload: bytes,
+  }
+
+  /// Prototype B: a bounded, row-oriented typed CSV batch. The payload keeps
+  /// decoded cells, row identity ordinals, order ranks, and lexical layout in
+  /// compact binary columns; it contains no JSON entity snapshots.
+  record csv-row-batch {
+    row-count: u32,
+    payload: bytes,
+  }
+
+  /// Transaction-local staging sink. Emission never commits durable state.
+  resource transition-sink {
+    emit-changes: func(page: change-page) -> result<_, host-error>;
+    emit-csv-rows: func(batch: csv-row-batch) -> result<_, host-error>;
+  }
+}
+
+interface api {
+  use host.{bytes, source, transition-sink};
+
+  variant plugin-error {
+    invalid-input(string),
+    limit-exceeded(string),
+    internal(string),
+  }
+
+  record file-descriptor {
+    path: option<string>,
+    media-type: option<string>,
+  }
+
+  record create-context {
+    high: u64,
+    low: u32,
+  }
+
+  record open-file-input {
+    descriptor: file-descriptor,
+    file: own<source>,
+    creates: create-context,
+    max-batch-bytes: u32,
+  }
+
+  record source-range {
+    offset: u64,
+    length: u64,
+  }
+
+  variant input-bytes {
+    inline(bytes),
+    after-range(source-range),
+  }
+
+  record input-splice {
+    offset: u64,
+    delete-len: u64,
+    insert: input-bytes,
+  }
+
+  record file-update {
+    before-descriptor: file-descriptor,
+    after-descriptor: file-descriptor,
+    before: own<source>,
+    edits: list<input-splice>,
+    after: own<source>,
+    creates: create-context,
+    max-batch-bytes: u32,
+  }
+
+  record transition-summary {
+    entity-count: u64,
+    batch-count: u32,
+    payload-bytes: u64,
+  }
+
+  resource document {
+    fork: func() -> own<document>;
+    /// The guest stays entered while it pushes every bounded change page into
+    /// the host sink. No guest-owned change cursor crosses the boundary.
+    file-changed: func(
+      input: file-update,
+      sink: borrow<transition-sink>,
+    ) -> result<file-transition, plugin-error>;
+  }
+
+  record file-transition {
+    document: own<document>,
+    summary: transition-summary,
+  }
+
+  /// One host-to-guest entry. Source reads and sink writes are imports made
+  /// while this call remains active.
+  open-file: func(
+    input: open-file-input,
+    sink: borrow<transition-sink>,
+  ) -> result<file-transition, plugin-error>;
+}
+
+world plugin {
+  import host;
+  export api;
+}

--- a/packages/rocksdb-storage/src/rocksdb.rs
+++ b/packages/rocksdb-storage/src/rocksdb.rs
@@ -403,6 +403,34 @@ impl StorageWrite for RocksDBWrite {
         }
     }
 
+    fn put_many_final(
+        &mut self,
+        space: SpaceId,
+        entries: PutBatch,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send {
+        async move {
+            let max_key_bytes = entries
+                .entries
+                .iter()
+                .map(|entry| 4_usize.saturating_add(entry.key.0.len()))
+                .max()
+                .unwrap_or(0);
+            let mut physical_key = Vec::with_capacity(max_key_bytes);
+            let space_prefix = space.0.to_be_bytes();
+            for entry in entries.entries {
+                physical_key.clear();
+                physical_key.extend_from_slice(&space_prefix);
+                physical_key.extend_from_slice(&entry.key.0);
+                let value = stored_value_bytes(entry.value);
+                self.stats.put_entries += 1;
+                self.stats.written_bytes += value.len() as u64;
+                self.batch.put(physical_key.as_slice(), value.as_ref());
+            }
+            self.stats.storage_calls += 1;
+            Ok(())
+        }
+    }
+
     fn delete_many(
         &mut self,
         space: SpaceId,

--- a/packages/rs-sdk-tests/Cargo.toml
+++ b/packages/rs-sdk-tests/Cargo.toml
@@ -17,7 +17,9 @@ lix_engine = { path = "../engine", version = "0.9.0", features = ["storage-bench
 lix_rocksdb_storage = { path = "../rocksdb-storage", version = "0.9.0" }
 plugin_csv_v2 = { path = "../../plugins/csv-v2", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
 plugin_csv_v3_prototype = { path = "../../plugins/csv-v3-prototype", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
+plugin_excalidraw_v3_prototype = { path = "../../plugins/excalidraw-v3-prototype", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
 plugin_markdown_incremental_v2 = { path = "../../plugins/markdown-v2", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
+plugin_markdown_v3_prototype = { path = "../../plugins/markdown-v3-prototype", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
 plugin_excalidraw_v2 = { path = "../../plugins/excalidraw-v2", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
 plugin_json_incremental_v2 = { path = "../../plugins/json-v2", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
 plugin_json_v3_prototype = { path = "../../plugins/json-v3-prototype", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }

--- a/packages/rs-sdk-tests/Cargo.toml
+++ b/packages/rs-sdk-tests/Cargo.toml
@@ -16,9 +16,11 @@ lix_sdk = { path = "../rs-sdk", version = "0.9.0", default-features = false, fea
 lix_engine = { path = "../engine", version = "0.9.0", features = ["storage-benches"] }
 lix_rocksdb_storage = { path = "../rocksdb-storage", version = "0.9.0" }
 plugin_csv_v2 = { path = "../../plugins/csv-v2", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
+plugin_csv_v3_prototype = { path = "../../plugins/csv-v3-prototype", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
 plugin_markdown_incremental_v2 = { path = "../../plugins/markdown-v2", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
 plugin_excalidraw_v2 = { path = "../../plugins/excalidraw-v2", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
 plugin_json_incremental_v2 = { path = "../../plugins/json-v2", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
+plugin_json_v3_prototype = { path = "../../plugins/json-v3-prototype", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
 plugin_git_text_v2 = { path = "../../plugins/text-v2", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
 
 async-trait = "0.1"

--- a/packages/rs-sdk-tests/PLUGIN_RUNTIME_PROFILE.md
+++ b/packages/rs-sdk-tests/PLUGIN_RUNTIME_PROFILE.md
@@ -1,0 +1,308 @@
+# Cross-format Wasm plugin runtime profile
+
+Profiled on Linux x86-64 with Rust nightly 1.97.0. The release benchmarks were
+verified against `origin/main` at `57d619aad`. The exact VS Code Docs replay
+uses commit `d5badf95f8ab16c4deb91199dc696f2293d93554`.
+
+## Results
+
+| Workload | Time | Host allocation | Peak live host allocation | Process peak RSS |
+| --- | ---: | ---: | ---: | ---: |
+| JSON, 10 MiB / 39,871 rows, plugin import p50 | 1,099.9 ms | 696.6 MB | 186.6 MB | 486.6 MB |
+| JSON, same file-scoped rows without Wasm p50 | 1,003.2 ms | 872.8 MB | 223.3 MB | — |
+| JSON, same rows without file ownership p50 | 530.2 ms | 591.7 MB | 115.3 MB | — |
+| JSON, warm sparse byte edit p50 | 6.47 ms | 11.0 MB | 10.6 MB | 348.2 MB |
+| CSV v2, 10.68 MiB / 220,001 rows, plugin import p50 | 5,168.8 ms | 3.47 GB | 929.7 MB | 1.71 GB |
+| CSV v3 C, same fixture and output | 2,225.2 ms | 1.70 GB | 282.4 MB | — |
+| CSV, same file-scoped rows without Wasm p50 | 4,201.2 ms | 3.85 GB | 995.9 MB | — |
+| v3 A, fused packet-v1 CSV import p50 | 5,041.6 ms | 3.47 GB | 929.7 MB | 1.62 GB |
+| v3 B, typed CSV batch import p50 | 4,576.1 ms | 3.52 GB | 927.8 MB | 1.55 GB |
+| v3 B + certified import/storage-retention cuts, p50 | 2,325.2 ms | 1.73 GB | 448.4 MB | — |
+| CSV warm edit, v2 returned cursor, p50 | 1.909 ms | 1.433 MB | 1.090 MB | — |
+| CSV warm edit, v3 push sink, p50 | 1.217 ms | 1.433 MB | 1.090 MB | — |
+| Markdown, VS Code Docs failing transition | 8,700.5 ms execute | — | — | 97.63 MiB guest |
+
+The JSON plugin is only 1.096x slower than inserting the same file-scoped
+semantic rows directly. CSV is 1.24x slower. Bulk imports therefore cannot
+become 2-5x faster through parser or Wasm tuning alone: the current
+file-scoped semantic storage path is already the dominant floor.
+
+The JSON no-file control is 1.89x faster than the file-scoped control. This
+isolates a large cost in ownership validation, tracked-state materialization,
+and per-row transaction staging.
+
+The CSV import allocates 3.47 GB on the host for 10.68 MB of input and reaches
+929.7 MB of live host allocation. Direct insertion is even larger. This is a
+storage/materialization problem, not a Wasm 128 MiB guest-memory problem.
+
+## v3 prototype results
+
+The prototypes use the same RocksDB import, schemas, ownership rules,
+transaction validation, atomic commit, exact source-byte assertion, and exact
+220,001 durable-change assertion as v2.
+
+| Candidate | p50 | Speedup vs matched v2 | Boundary bytes | Peak live allocation |
+| --- | ---: | ---: | ---: | ---: |
+| matched v2 packet-v1 | 5,168.8 ms | 1.00x | 39.4 MB | 929.7 MB |
+| A: one fused call, fixed actor thread | 5,041.6 ms | 1.025x | 39.4 MB | 929.7 MB |
+| B: fused typed CSV batches | 4,576.1 ms | 1.130x | 28.2 MB | 927.8 MB |
+| B + certified import/storage-retention cuts | 2,325.2 ms | 2.223x | 31.4 MB | 448.4 MB |
+| C: deferred storage-native lowering | 2,225.2 ms | 2.323x | 31.4 MB | 282.4 MB |
+
+Prototype A enters the guest once and creates one persistent executor thread.
+It therefore passes the structural scheduling gates but fails the performance
+gate: removing re-entry is not material for a 220k-row transaction once
+reconciliation and storage dominate.
+
+Prototype B emits bounded batches of row ordinals, order ranks, decoded cells,
+and lexical layout. Wasm creates neither row UUID strings nor row JSON
+snapshots. Boundary traffic falls 28.5%, but the host immediately rebuilds
+220k canonical entity snapshots for the unchanged v2 transaction path.
+Cumulative host allocation therefore does not fall and peak live allocation
+moves by only 0.2%. This is direct evidence that a storage-native sink is
+required; typed transport alone merely moves materialization across the Wasm
+boundary.
+
+For a warm one-byte CSV transition, replacing the returned guest change cursor
+with an imported host push sink reduced three guest exports
+(`file-changed`, `next(Some)`, `next(None)`) to one. Across 25 paired,
+alternating-order RocksDB samples, p50 improved from 1.909 ms to 1.217 ms
+(1.57x) and p95 from 2.539 ms to 1.466 ms (1.73x). Exact bytes, 20,000
+semantic rows, and one durable change per sample matched. Peak and cumulative
+host allocation were flat, confirming that cursor removal is a control-flow
+win; memory falls only when the host sink lowers pages directly instead of
+retaining an adapter vector for generic reconciliation.
+
+The follow-on prototype certifies the exact fresh-plugin import shape, avoids
+the generic O(rows) transaction validation index, removes retained physical
+RocksDB point keys on the final write lane, bounds prepared dictionaries, and
+evicts large completed v3 import actors before materialization. Five samples
+were 2,276.4, 2,317.2, 2,325.2, 2,336.5, and 2,770.1 ms. This clears the 2x
+time gate without weakening exact-byte, exact-row, ownership, validation, or
+atomicity checks.
+
+It does not clear the 3x memory gate. Allocation readings at phase close were:
+
+| Materialization boundary | Live Rust allocation |
+| --- | ---: |
+| changelog staged | 161.6 MB |
+| tracked roots staged | 233.0 MB |
+| hot deltas and absence guards built | 270.8 MB |
+| expanded hot identities built | 335.9 MB |
+| hot values encoded | 457.2 MB |
+
+The measured scope starts with roughly 8.8 MB live, yielding the reported
+448.4 MB peak delta. Prototype C now retains one compact semantic owner and
+lowers 4,096-row chunks into the atomic backend transaction, so expanded
+storage identities and encoded current-state values exist for only one page.
+Five samples were 2,181.2, 2,199.7, 2,225.2, 2,237.2, and 2,556.2 ms. Peak
+live host allocation was 282.4 MB. Prototype C therefore clears both hard
+gates: 2.32x faster and 3.29x lower peak allocation than v2. The deferred
+encoder also preserves the active checkpoint's `BeforeAbsent` baseline,
+sparse dirty-key index and coverage proof, plus the validated unscoped
+descriptor INSERT.
+
+## Component boundary profile
+
+The VS Code Docs Markdown transition has:
+
+| Counter | Value |
+| --- | ---: |
+| Source bytes read | 3,273,092 |
+| Component-boundary bytes | 27,832,278 |
+| Packet records | 25,656 |
+| Semantic rows materialized | 25,362 |
+| Durable semantic changes | 294 |
+| Full document reparses/renders | 151 / 151 |
+| Guest high-water memory | 102,367,232 bytes |
+
+That is 8.5x byte amplification and 86x row amplification relative to the
+durable changes.
+
+A 999 Hz sampled profile recorded about 51,000 short-lived `lix` threads.
+`call_sync_guest` currently spawns and joins an OS thread for every synchronous
+component method. The dominant sampled leaf was Linux `clone3`, followed by
+mmap/mprotect/munmap and Wasmtime per-thread signal initialization. This cost
+is shared by Markdown, CSV, JSON, and Excalidraw.
+
+A deliberately unsafe direct-call prototype retained Wasm but removed the
+per-method thread:
+
+| 17-document control | Current | Direct-call prototype | Speedup |
+| --- | ---: | ---: | ---: |
+| CSV | 30.26 ms | 17.29 ms | 1.75x |
+| Text | 21.71 ms | 12.27 ms | 1.77x |
+| Excalidraw | 23.49 ms | 14.42 ms | 1.63x |
+| Voluntary context switches | 295 | 43 | 6.9x fewer |
+
+The direct call is not shippable: it blocks a current-thread Tokio runtime, and
+serializing a 1,184-document Markdown batch regressed 922 ms to 1,723 ms.
+The result proves the overhead but also shows that the replacement must retain
+bounded parallelism.
+
+## Recommended hard cut: plugin API v3
+
+No backward compatibility should be carried on the hot path.
+
+1. Replace the resource-method conversation with one bulk transition call per
+   file operation. Pass source edits, the required semantic projection, and
+   transition context in one typed binary request; return one typed change
+   batch plus a materialization proof.
+2. Execute component calls on a fixed actor executor pool, or use a genuinely
+   async Wasmtime component boundary. Never create an OS thread per WIT method.
+3. Replace packet-v1 row records and JSON-in-JSON snapshots with a typed binary
+   batch: dictionary-coded schema/file IDs, fixed-width local refs, column
+   vectors, and offset/data buffers for variable fields.
+4. Add a compact, content-addressed per-file actor checkpoint. Cold hydration
+   should read one checkpoint plus changes after its root, rather than
+   materializing every semantic row and replaying them through packet cursors.
+5. Add a storage-native file entity batch. Validate ownership once per batch,
+   sort once, lower once, and persist packed column buffers/ranges rather than
+   independently staging and validating every semantic row.
+6. Preserve the existing sparse edit path. The 10 MiB JSON edit is already
+   6.47 ms; optimize its full-buffer allocation separately with borrowed input
+   ranges or host attachments.
+
+### Cold-successor is distinct from checkpoint hydration
+
+The full-history profile exposes a more important cache-miss operation than
+ordinary hydration. A 16-actor cache can repeatedly evict files in a wide
+history. Reconstructing and rendering the previous document before parsing its
+successor turns durable semantic rows into transient plugin state even though
+the caller only needs the successor.
+
+API v3 should expose three different operations:
+
+1. `apply-warm(document, edit, source, sink)` for an actor already in memory;
+2. `apply-cold-successor(durable-entities, new-source, sink)` for an evicted
+   actor, producing the successor directly without rendering the predecessor;
+3. `hydrate(durable-entities)` only when a retained document is actually
+   needed for a later read or semantic edit.
+
+The scheduler should route cache misses during replay to cold-successor and run
+independent files through a bounded, memory-budgeted worker pool. Checkpoints
+then optimize the remaining true hydration operations as `checkpoint + tail`;
+they are not a substitute for removing predecessor reconstruction from the
+successor path.
+
+On the measured wide Markdown replay, only 16 actors are resident while
+5.29 million semantic rows are reconstructed for 414,928 durable changes:
+12.7x row amplification. This changes the expected v3 replay model from
+“optimize hydration” to “avoid hydration on the successor path.” Parallelism
+alone remains bounded by the serial work and increases concurrent actor RSS;
+cold-successor removes the work before bounded parallel scheduling is applied.
+
+## Expected ceiling
+
+| Cut | Target workload | Expected result |
+| --- | --- | --- |
+| Fused transition + fixed executor | Small files and many-file commits | 1.5-2x |
+| Packed entity batch + batch ownership validation | Bulk CSV/JSON imports | 2-3x, much lower host allocation |
+| Actor checkpoints | Cold edits and histories wider than the 16-actor cache | 2-5x and lower boundary traffic |
+| Parser arenas/local IDs | Format-specific memory peaks | Useful where copies remain, but not the shared multiplier |
+
+The 2-5x target is credible only as an API/runtime/storage redesign. For bulk
+imports, the Wasm plugin layer itself is currently just 9.6% of JSON time and
+19.7% of CSV time relative to their direct file-scoped controls.
+
+## Large CSV/JSON v3 push profile
+
+JSON v3 reuses the JSON v2 parser and packet-v1 snapshots. Seven release
+samples on the 10 MiB / 39,871-entity flat-object import produced:
+
+| lane | p50 | p95 | exports | imports | peak host allocation |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| JSON v2 cursor | 675.7 ms | 767.0 ms | 17 | 10 | 85.7 MB |
+| JSON v3 push | 600.4 ms | 652.1 ms | 1 | 9 | 85.6 MB |
+
+The final bulk JSON lane is 1.13x faster at p50 and 1.18x faster at p95.
+One fused export and eight 2 MiB sink pages replace seventeen v2 guest exports.
+
+Three follow-up cuts were profiled. v3 sources return a complete ABI-addressable
+input from one import, avoiding ten extra imports and a guest-side
+chunk-assembly copy. A two-page producer/consumer channel drains sink pages
+while the sole guest export is still entered. Finally, a large CSV open uses a
+one-shot scan view and never builds a persistent document/index that the
+engine's large-import policy would immediately evict.
+
+Import calls fell from 26 to 9 for JSON and from 29 to 11 for CSV. Seven
+10.68 MiB CSV samples had a 2.066 s p50, 2.50x faster than the matched
+5.169 s v2 lane. Peak remained 282.4 MB, 3.29x below v2, and JSON remained
+85.6 MB.
+
+| phase | JSON | CSV |
+| --- | ---: | ---: |
+| plugin drain complete | 63.0 MB | 198.4 MB |
+| tracked-head publication | 94.1 MB | 235.0 MB |
+| measured peak delta | 85.6 MB | 282.4 MB |
+
+CSV guest linear-memory high water fell from 53.0 MB to 41.2 MB (22%) after
+removing the unused persistent cold-import document. The unchanged host peak
+shows that the remaining peak is downstream of the Component boundary. A real next step
+must replace the complete `ValidatedFileTransition.changes` owner with a
+transaction-native page-backed batch, preserve transition-wide uniqueness and
+rollback metadata separately, and let storage lowering consume those pages
+without a `Vec<EntityChange>` materialization.
+
+A follow-up experiment made the deferred RocksDB encoder the unique owner of
+the prepared batch and released canonical snapshot owners after each 4,096-row
+page was encoded. It did not change peak (282.4 MB) and regressed p50 from
+2.127 s to 2.253 s, so it was removed. This rules out retained snapshot arenas
+as the remaining peak and keeps the next cut focused on eliminating the
+complete generic/prepared row representation, not incrementally clearing its
+already-shared payloads.
+
+## Immutable entity-batch segment result
+
+The next prototype removed that generic row representation. A v3 transition
+may now hand the transaction a bounded, host-certified encoded batch. The
+engine validates its schema membership, packet framing, primary keys, and
+canonical snapshots before commit. Current-state queries decode the immutable
+segment lazily; RocksDB receives one batch owner rather than one hot row,
+history segment, and locator per semantic entity.
+
+Five release samples after this cut:
+
+| workload | old lane p50 | segment p50 | segment p95 | peak live allocation | cumulative allocation |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| CSV, 10.68 MiB / 220,000 rows | 5.227 s | 129.4 ms | 171.8 ms | 36.1 MB | 65.5 MB |
+| JSON, 10 MiB / 39,871 entities | 625.6 ms | 258.0 ms | 273.5 ms | 45.5 MB | 103.4 MB |
+
+CSV is 40.4x faster than the original storage-materializing lane and uses
+about 26x less peak live host allocation than its approximately 930 MB
+baseline. JSON is 2.43x faster than the current v2 cursor and uses 47% less
+peak live host allocation. CSV performs about 33,400 host allocations instead
+of approximately 4.04 million.
+
+Both gates use durable RocksDB writes and verify exact file bytes, exact
+semantic cardinality, an exact projected semantic row, and close/reopen query
+persistence. JSON additionally retains the engine's streaming schema and
+primary-key validation rather than trusting the Wasm guest's certificate.
+
+This establishes that fused control flow alone is not the bulk multiplier.
+The large win comes from preserving one encoded semantic owner through plugin
+transport, validation, transaction staging, storage, and query consumption.
+Remaining production gates are historical/time-travel visibility,
+cold-successor operation after actor eviction, and equivalent codecs for
+Markdown and Excalidraw.
+
+## Reproduction
+
+```sh
+cargo test --release -p lix_sdk_tests --test e2e --no-run
+
+E2E_BIN="$(find target/release/deps -maxdepth 1 -type f -executable \
+  -name 'e2e-*' -print -quit)"
+
+"$E2E_BIN" --ignored --exact \
+  v2_json_ten_mib_rocksdb_import_parity_benchmark \
+  --nocapture --test-threads=1
+
+"$E2E_BIN" --ignored --exact \
+  v2_csv_ten_mib_rocksdb_import_parity_benchmark \
+  --nocapture --test-threads=1
+
+"$E2E_BIN" --ignored --exact \
+  v2_json_ten_mib_ordinary_sql_byte_edit_benchmark \
+  --nocapture --test-threads=1
+```

--- a/packages/rs-sdk-tests/PLUGIN_RUNTIME_PROFILE.md
+++ b/packages/rs-sdk-tests/PLUGIN_RUNTIME_PROFILE.md
@@ -1,7 +1,7 @@
 # Cross-format Wasm plugin runtime profile
 
 Profiled on Linux x86-64 with Rust nightly 1.97.0. The release benchmarks were
-verified against `origin/main` at `57d619aad`. The exact VS Code Docs replay
+verified against `origin/main` at `c082f5f14`. The exact VS Code Docs replay
 uses commit `d5badf95f8ab16c4deb91199dc696f2293d93554`.
 
 ## Results
@@ -285,6 +285,60 @@ transport, validation, transaction staging, storage, and query consumption.
 Remaining production gates are historical/time-travel visibility,
 cold-successor operation after actor eviction, and equivalent codecs for
 Markdown and Excalidraw.
+
+## Cross-format successor profile
+
+The Markdown and Excalidraw v3 adapters use the same fused export and bounded
+packet sink as JSON. Complete opening state is one certified immutable batch;
+incremental changes are ordinary sparse row overlays. Correctness tests cover
+exact bytes, semantic projection, history, and RocksDB close/reopen for all
+three formats.
+
+The exact 1,237,840-byte VS Code API Markdown transition at
+`d5badf95f8ab16c4deb91199dc696f2293d93554` changes two of 3,808 semantic
+rows:
+
+| lane | p50 | p95 | host allocation | peak host allocation | exports / imports | guest high water |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Markdown v2 cursor | 883.3 ms | 947.1 ms | 32.2 MB | 11.2 MB | 3 / 0 | 102.4 MB |
+| Markdown v3 push | 900.2 ms | 918.4 ms | 174.7 MB | 21.0 MB | 1 / 1 | 102.4 MB |
+
+The fused transition therefore fails Prototype A's acceptance gate for this
+workload. Guest re-entry falls from three exports to one, but guest high-water
+memory and boundary bytes are unchanged. The Markdown parser/reconciler owns
+the runtime, while validation of the immutable opening segment amplifies host
+bytes. A read-facade cache experiment made this worse—1,225.7 ms, 710.3 MB
+cumulative allocation, and 44.7 MB peak—because the cache owner was shorter
+lived than the validation sequence and repeatedly hydrated the full segment.
+It was removed. Reuse must be transaction-scoped, or queries/validation must
+consume the encoded segment directly.
+
+A generated 1.849 MB Excalidraw document with 20,000 elements changes one
+element:
+
+| lane | p50 | host allocation | peak host allocation | exports / imports | guest high water |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Excalidraw v2 cursor | 229.7 ms | 5.0 MB | 3.0 MB | 3 / 0 | 42.1 MB |
+| Excalidraw v3 push | 237.5 ms | 73.4 MB | 7.7 MB | 1 / 1 | 41.8 MB |
+
+Heaptrack shows repeated certified-segment consumption on the semantic read
+path. Stable-primary-key packets now retain their already-certified canonical
+snapshot bytes directly instead of parsing and serializing them again. That
+improves later queries, but it does not change the transition allocation:
+the large v3 import actor is evicted, so its successor reconstructs the prior
+20,000-element document. This is a concrete cross-format acceptance case for
+`apply-cold-successor`, not for more cursor tuning.
+
+Current one-sample verification after the sparse-overlay policy:
+
+| workload | v2 | v3 | v3 peak host allocation | result |
+| --- | ---: | ---: | ---: | --- |
+| CSV, 10.68 MiB / 220,001 changes | 5.227 s baseline | 168.2 ms | 36.2 MB | 31.1x |
+| JSON, 10 MiB / 39,871 changes | 738.6 ms | 244.9 ms | 45.6 MB | 3.02x |
+
+Both bulk lanes use one guest export, bounded pages, exact byte and semantic
+checks, history where applicable, and RocksDB reopen. CSV creates no per-row
+history segments or locator records before hot publication.
 
 ## Reproduction
 

--- a/packages/rs-sdk-tests/tests/benchmark_metrics.rs
+++ b/packages/rs-sdk-tests/tests/benchmark_metrics.rs
@@ -133,6 +133,15 @@ impl AllocatorSnapshot {
     }
 }
 
+/// Current Rust global-allocator live bytes.
+///
+/// Ignored profiling benchmarks use this only to annotate tracing phase
+/// boundaries. Reading the relaxed counter does not allocate and therefore
+/// does not perturb the measured scope.
+pub fn current_live_bytes() -> u64 {
+    LIVE_BYTES.load(Ordering::Relaxed)
+}
+
 /// One exclusive allocation-measurement window.
 ///
 /// Run ignored allocation benchmarks with an exact test filter. The lock

--- a/packages/rs-sdk-tests/tests/e2e.rs
+++ b/packages/rs-sdk-tests/tests/e2e.rs
@@ -774,6 +774,212 @@ async fn v2_markdown_roundtrips_gfm_and_renders_one_direct_entity_edit() {
 }
 
 #[tokio::test]
+async fn v3_markdown_certified_open_sparse_successor_history_and_reopen() {
+    let root = tempfile::tempdir().expect("create v3 Markdown directory");
+    let lix = open_lix_with_rocksdb(root.path()).await;
+    install_reference_plugin_in_blank_registry(
+        &lix,
+        "plugin_markdown_v3_prototype",
+        &build_markdown_v3_prototype_archive(),
+        &["markdown_node_v2"],
+    )
+    .await;
+
+    let path = "/component-v3.md";
+    let before = b"# Heading\n\nParagraph with **bold** text.\n".to_vec();
+    lix.reset_plugin_v2_transition_counters();
+    write_file(&lix, path, before.clone()).await.unwrap();
+    let open_counters = lix.plugin_v2_transition_counters();
+    assert_eq!(open_counters.guest_export_calls, 1);
+    assert_eq!(open_counters.durable_semantic_changes, 3);
+    assert_eq!(read_file(&lix, path).await.unwrap(), Some(before));
+    assert_eq!(
+        lix.execute("SELECT COUNT(*) AS count FROM markdown_node_v2", &[])
+            .await
+            .unwrap()
+            .rows()[0]
+            .get::<i64>("count")
+            .unwrap(),
+        3
+    );
+
+    let after = b"# Heading\n\nParagraph with **bold** text and a tail.\n".to_vec();
+    lix.reset_plugin_v2_transition_counters();
+    write_file(&lix, path, after.clone()).await.unwrap();
+    let successor_counters = lix.plugin_v2_transition_counters();
+    assert_eq!(successor_counters.guest_export_calls, 1);
+    assert_eq!(read_file(&lix, path).await.unwrap(), Some(after.clone()));
+    let current = lix
+        .execute(
+            "SELECT kind, payload_json FROM markdown_node_v2 ORDER BY kind",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(current.rows().len(), 3);
+    assert!(
+        current.rows().iter().any(|row| {
+            row.get::<String>("payload_json")
+                .is_ok_and(|payload| payload.contains("a tail"))
+        }),
+        "the sparse successor must overlay the immutable opening segment"
+    );
+    let historical = lix
+        .execute(
+            "SELECT kind, payload_json FROM markdown_node_v2_history() \
+             WHERE lixcol_depth = 1 ORDER BY kind",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(historical.rows().len(), 3);
+    assert!(
+        historical.rows().iter().any(|row| {
+            row.get::<String>("payload_json")
+                .is_ok_and(|payload| payload.contains("bold"))
+        }),
+        "the opening certified segment must remain queryable through history"
+    );
+    lix.close().await.unwrap();
+
+    let reopened = open_lix_with_rocksdb(root.path()).await;
+    assert_eq!(
+        read_file(&reopened, path).await.unwrap(),
+        Some(after),
+        "exact Markdown bytes must survive RocksDB reopen"
+    );
+    assert_eq!(
+        reopened
+            .execute("SELECT COUNT(*) AS count FROM markdown_node_v2", &[])
+            .await
+            .unwrap()
+            .rows()[0]
+            .get::<i64>("count")
+            .unwrap(),
+        3
+    );
+    reopened.close().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "exact VS Code Docs d5badf Markdown transition v2 versus v3 benchmark"]
+async fn v3_markdown_vscode_api_exact_transition_benchmark() {
+    const BENCHMARK: &str = "v3_markdown_vscode_api_exact_transition_benchmark";
+    const PATH: &str = "/api/references/vscode-api.md";
+    let samples = std::env::var("LIX_BENCH_SAMPLES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|samples| *samples > 0)
+        .unwrap_or(3);
+    let before_path = std::env::var("LIX_VSCODE_API_BEFORE")
+        .unwrap_or_else(|_| "/tmp/vscode-api-before.md".to_owned());
+    let after_path = std::env::var("LIX_VSCODE_API_AFTER")
+        .unwrap_or_else(|_| "/tmp/vscode-api-after.md".to_owned());
+    let before = std::fs::read(&before_path)
+        .unwrap_or_else(|error| panic!("read VS Code before fixture {before_path}: {error}"));
+    let after = std::fs::read(&after_path)
+        .unwrap_or_else(|error| panic!("read VS Code after fixture {after_path}: {error}"));
+    assert_eq!(before.len(), 1_237_841);
+    assert_eq!(after.len(), 1_237_840);
+
+    let lanes = [
+        (
+            "v2_cursor",
+            "plugin_markdown_incremental_v2",
+            build_markdown_v2_plugin_archive(),
+        ),
+        (
+            "v3_push_sink",
+            "plugin_markdown_v3_prototype",
+            build_markdown_v3_prototype_archive(),
+        ),
+    ];
+    let mut expected_rows = None;
+    for (label, plugin_key, archive) in lanes {
+        if std::env::var("LIX_BENCH_LANE").is_ok_and(|lane| lane != label) {
+            continue;
+        }
+        let mut measurements = Vec::with_capacity(samples);
+        let mut elapsed_ms = Vec::with_capacity(samples);
+        for sample in 0..samples {
+            let root = tempfile::tempdir().expect("create VS Code Markdown benchmark directory");
+            let lix = open_lix_with_rocksdb(root.path()).await;
+            install_reference_plugin_in_blank_registry(
+                &lix,
+                plugin_key,
+                &archive,
+                &["markdown_node_v2"],
+            )
+            .await;
+            write_file(&lix, PATH, before.clone())
+                .await
+                .unwrap_or_else(|error| panic!("{label} opening import failed: {error}"));
+
+            lix.reset_plugin_v2_transition_counters();
+            let allocation_scope = AllocationScope::start();
+            let started = Instant::now();
+            write_file(&lix, PATH, after.clone())
+                .await
+                .unwrap_or_else(|error| panic!("{label} successor failed: {error}"));
+            let measurement =
+                BenchmarkMeasurement::new(started.elapsed(), allocation_scope.finish());
+            let counters = lix.plugin_v2_transition_counters();
+            assert_eq!(read_file(&lix, PATH).await.unwrap(), Some(after.clone()));
+            let rows = lix
+                .execute("SELECT COUNT(*) AS count FROM markdown_node_v2", &[])
+                .await
+                .unwrap()
+                .rows()[0]
+                .get::<i64>("count")
+                .unwrap() as usize;
+            if let Some(expected) = expected_rows {
+                assert_eq!(rows, expected, "{label} semantic row count");
+            } else {
+                expected_rows = Some(rows);
+            }
+            if label == "v3_push_sink" {
+                assert_eq!(counters.guest_export_calls, 1);
+            }
+            eprintln!(
+                "vscode_markdown lane={label} sample={sample} elapsed_ms={:.3} \
+                 allocations={} allocated_mb={:.3} peak_live_mb={:.3} \
+                 guest_exports={} imports={} boundary_mb={:.3} guest_high_water_mb={:.3} \
+                 semantic_changes={} full_rows_materialized={} rows={rows}",
+                measurement.elapsed_ms,
+                measurement.allocations.allocation_count,
+                measurement.allocations.allocated_bytes as f64 / 1_000_000.0,
+                measurement.allocations.peak_live_bytes_delta as f64 / 1_000_000.0,
+                counters.guest_export_calls,
+                counters.component_import_calls,
+                counters.component_boundary_bytes as f64 / 1_000_000.0,
+                counters.guest_linear_memory_high_water_bytes as f64 / 1_000_000.0,
+                counters.durable_semantic_changes,
+                counters.full_state_semantic_rows_materialized,
+            );
+            elapsed_ms.push(measurement.elapsed_ms);
+            measurements.push(measurement);
+            lix.close().await.unwrap();
+        }
+        elapsed_ms.sort_by(f64::total_cmp);
+        eprintln!(
+            "vscode_markdown lane={label} raw_ms={elapsed_ms:?} p50_ms={:.3} p95_ms={:.3}",
+            p50_ms(&elapsed_ms),
+            p95_ms(&elapsed_ms)
+        );
+        emit_summary(
+            BENCHMARK,
+            label,
+            BenchmarkFixture {
+                input_bytes: after.len(),
+                logical_rows: expected_rows.unwrap_or_default(),
+            },
+            BenchmarkGate::BulkWrite,
+            &measurements,
+        );
+    }
+}
+
+#[tokio::test]
 async fn v2_markdown_merges_unrelated_entities_and_regenerates_derived_bytes() {
     let archive = build_markdown_v2_plugin_archive();
     let lix = open_lix(OpenLixOptions::default()).await.unwrap();
@@ -4035,6 +4241,209 @@ async fn v2_excalidraw_roundtrips_and_renders_local_element_edits() {
 }
 
 #[tokio::test]
+async fn v3_excalidraw_certified_open_sparse_successor_history_and_reopen() {
+    let root = tempfile::tempdir().expect("create Excalidraw v3 RocksDB directory");
+    let lix = open_lix_with_rocksdb(root.path()).await;
+    install_reference_plugin_in_blank_registry(
+        &lix,
+        "plugin_excalidraw_v3_prototype",
+        &build_excalidraw_v3_prototype_archive(),
+        &["excalidraw_scene", "excalidraw_element", "excalidraw_file"],
+    )
+    .await;
+
+    let path = "/component-v3.excalidraw";
+    let before = br##"{
+  "type": "excalidraw",
+  "version": 2,
+  "source": "https://excalidraw.com",
+  "elements": [
+    {"id":"a","type":"rectangle","x":1.25,"y":2,"width":100,"height":80,"isDeleted":false},
+    {"id":"b","type":"ellipse","x":20,"y":30,"width":50,"height":40,"isDeleted":false}
+  ],
+  "appState": {"gridSize":20,"viewBackgroundColor":"#ffffff"},
+  "files": {
+    "file-1": {"id":"file-1","mimeType":"image/png","dataURL":"data:image/png;base64,AA==","created":123}
+  }
+}
+"##
+    .to_vec();
+    lix.reset_plugin_v2_transition_counters();
+    write_file(&lix, path, before.clone()).await.unwrap();
+    let open_counters = lix.plugin_v2_transition_counters();
+    assert_eq!(open_counters.guest_export_calls, 1);
+    assert_eq!(read_file(&lix, path).await.unwrap(), Some(before.clone()));
+    assert_eq!(
+        lix.execute("SELECT COUNT(*) AS count FROM excalidraw_element", &[])
+            .await
+            .unwrap()
+            .rows()[0]
+            .get::<i64>("count")
+            .unwrap(),
+        2
+    );
+
+    let after = String::from_utf8(before)
+        .unwrap()
+        .replacen(r#""x":1.25"#, r#""x":123.5"#, 1)
+        .into_bytes();
+    lix.reset_plugin_v2_transition_counters();
+    write_file(&lix, path, after.clone()).await.unwrap();
+    let successor_counters = lix.plugin_v2_transition_counters();
+    assert_eq!(successor_counters.guest_export_calls, 1);
+    assert_eq!(successor_counters.durable_semantic_changes, 1);
+    assert_eq!(read_file(&lix, path).await.unwrap(), Some(after.clone()));
+    assert_eq!(
+        lix.execute(
+            "SELECT element_json FROM excalidraw_element WHERE id = 'a'",
+            &[],
+        )
+        .await
+        .unwrap()
+        .rows()[0]
+            .get::<String>("element_json")
+            .unwrap()
+            .contains("123.5"),
+        true
+    );
+    assert!(
+        lix.execute(
+            "SELECT element_json FROM excalidraw_element_history() \
+             WHERE id = 'a' AND lixcol_depth = 1",
+            &[],
+        )
+        .await
+        .unwrap()
+        .rows()[0]
+            .get::<String>("element_json")
+            .unwrap()
+            .contains("1.25")
+    );
+    lix.close().await.unwrap();
+
+    let reopened = open_lix_with_rocksdb(root.path()).await;
+    assert_eq!(read_file(&reopened, path).await.unwrap(), Some(after));
+    assert_eq!(
+        reopened
+            .execute("SELECT COUNT(*) AS count FROM excalidraw_element", &[])
+            .await
+            .unwrap()
+            .rows()[0]
+            .get::<i64>("count")
+            .unwrap(),
+        2
+    );
+    reopened.close().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "large Excalidraw local-edit transition v2 versus v3 benchmark"]
+async fn v3_excalidraw_large_transition_benchmark() {
+    const ELEMENTS: usize = 20_000;
+    const PATH: &str = "/large.excalidraw";
+    let samples = std::env::var("LIX_BENCH_SAMPLES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|samples| *samples > 0)
+        .unwrap_or(3);
+    let mut source = String::from(
+        r#"{"type":"excalidraw","version":2,"source":"https://excalidraw.com","elements":["#,
+    );
+    for index in 0..ELEMENTS {
+        if index != 0 {
+            source.push(',');
+        }
+        source.push_str(&format!(
+            r#"{{"id":"e-{index}","type":"rectangle","x":1.25,"y":2,"width":100,"height":80,"isDeleted":false}}"#
+        ));
+    }
+    source.push_str(r##"],"appState":{"viewBackgroundColor":"#ffffff"},"files":{}}"##);
+    let before = source.into_bytes();
+    let after = String::from_utf8(before.clone())
+        .unwrap()
+        .replacen(
+            r#""id":"e-10000","type":"rectangle","x":1.25"#,
+            r#""id":"e-10000","type":"rectangle","x":123.5"#,
+            1,
+        )
+        .into_bytes();
+    assert_eq!(before.len() + 1, after.len());
+
+    for (label, plugin_key, archive) in [
+        (
+            "v2_cursor",
+            "plugin_excalidraw_v2",
+            build_excalidraw_v2_plugin_archive(),
+        ),
+        (
+            "v3_push_sink",
+            "plugin_excalidraw_v3_prototype",
+            build_excalidraw_v3_prototype_archive(),
+        ),
+    ] {
+        if std::env::var("LIX_BENCH_LANE").is_ok_and(|lane| lane != label) {
+            continue;
+        }
+        let mut elapsed_ms = Vec::with_capacity(samples);
+        for sample in 0..samples {
+            let root = tempfile::tempdir().expect("create Excalidraw benchmark directory");
+            let lix = open_lix_with_rocksdb(root.path()).await;
+            install_reference_plugin_in_blank_registry(
+                &lix,
+                plugin_key,
+                &archive,
+                &["excalidraw_scene", "excalidraw_element", "excalidraw_file"],
+            )
+            .await;
+            write_file(&lix, PATH, before.clone()).await.unwrap();
+
+            lix.reset_plugin_v2_transition_counters();
+            let allocation_scope = AllocationScope::start();
+            let started = Instant::now();
+            write_file(&lix, PATH, after.clone()).await.unwrap();
+            let measurement =
+                BenchmarkMeasurement::new(started.elapsed(), allocation_scope.finish());
+            let counters = lix.plugin_v2_transition_counters();
+            assert_eq!(read_file(&lix, PATH).await.unwrap(), Some(after.clone()));
+            assert_eq!(
+                lix.execute("SELECT COUNT(*) AS count FROM excalidraw_element", &[])
+                    .await
+                    .unwrap()
+                    .rows()[0]
+                    .get::<i64>("count")
+                    .unwrap(),
+                ELEMENTS as i64
+            );
+            assert_eq!(counters.durable_semantic_changes, 1);
+            if label == "v3_push_sink" {
+                assert_eq!(counters.guest_export_calls, 1);
+            }
+            eprintln!(
+                "large_excalidraw lane={label} sample={sample} input_mb={:.3} \
+                 elapsed_ms={:.3} allocations={} allocated_mb={:.3} peak_live_mb={:.3} \
+                 guest_exports={} imports={} boundary_mb={:.3} guest_high_water_mb={:.3}",
+                after.len() as f64 / 1_000_000.0,
+                measurement.elapsed_ms,
+                measurement.allocations.allocation_count,
+                measurement.allocations.allocated_bytes as f64 / 1_000_000.0,
+                measurement.allocations.peak_live_bytes_delta as f64 / 1_000_000.0,
+                counters.guest_export_calls,
+                counters.component_import_calls,
+                counters.component_boundary_bytes as f64 / 1_000_000.0,
+                counters.guest_linear_memory_high_water_bytes as f64 / 1_000_000.0,
+            );
+            elapsed_ms.push(measurement.elapsed_ms);
+            lix.close().await.unwrap();
+        }
+        elapsed_ms.sort_by(f64::total_cmp);
+        eprintln!(
+            "large_excalidraw lane={label} raw_ms={elapsed_ms:?} p50_ms={:.3}",
+            elapsed_ms[elapsed_ms.len() / 2]
+        );
+    }
+}
+
+#[tokio::test]
 async fn v2_excalidraw_same_element_branch_merge_uses_canonical_b() {
     let archive = build_excalidraw_v2_plugin_archive();
     let lix = open_lix(OpenLixOptions::default()).await.unwrap();
@@ -5343,6 +5752,36 @@ fn build_markdown_v2_plugin_archive() -> Vec<u8> {
     writer.finish().unwrap().into_inner()
 }
 
+fn build_markdown_v3_prototype_archive() -> Vec<u8> {
+    let wasm_path = Path::new(env!(
+        "CARGO_CDYLIB_FILE_PLUGIN_MARKDOWN_V3_PROTOTYPE_plugin_markdown_v3_prototype"
+    ));
+    let wasm = std::fs::read(wasm_path).unwrap_or_else(|error| {
+        panic!(
+            "failed to read bindep-built Markdown v3 prototype wasm at {}: {error}",
+            wasm_path.display()
+        )
+    });
+    let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    for (path, bytes) in [
+        (
+            "manifest.json",
+            include_str!("../../../plugins/markdown-v3-prototype/manifest.json").as_bytes(),
+        ),
+        (
+            "schema/markdown_node_v2.json",
+            include_str!("../../../plugins/markdown-v2/schema/markdown_node_v2.json").as_bytes(),
+        ),
+        ("plugin.wasm", wasm.as_slice()),
+    ] {
+        writer.start_file(path, options).unwrap();
+        writer.write_all(bytes).unwrap();
+    }
+    writer.finish().unwrap().into_inner()
+}
+
 fn build_json_v2_plugin_archive() -> Vec<u8> {
     let wasm_path = Path::new(env!(
         "CARGO_CDYLIB_FILE_PLUGIN_JSON_INCREMENTAL_V2_plugin_json_incremental_v2"
@@ -5761,6 +6200,45 @@ fn build_excalidraw_v2_plugin_archive() -> Vec<u8> {
         (
             "manifest.json",
             include_str!("../../../plugins/excalidraw-v2/manifest.json").as_bytes(),
+        ),
+        (
+            "schema/excalidraw_scene.json",
+            include_str!("../../../plugins/excalidraw-v2/schema/excalidraw_scene.json").as_bytes(),
+        ),
+        (
+            "schema/excalidraw_element.json",
+            include_str!("../../../plugins/excalidraw-v2/schema/excalidraw_element.json")
+                .as_bytes(),
+        ),
+        (
+            "schema/excalidraw_file.json",
+            include_str!("../../../plugins/excalidraw-v2/schema/excalidraw_file.json").as_bytes(),
+        ),
+        ("plugin.wasm", wasm.as_slice()),
+    ] {
+        writer.start_file(path, options).unwrap();
+        writer.write_all(bytes).unwrap();
+    }
+    writer.finish().unwrap().into_inner()
+}
+
+fn build_excalidraw_v3_prototype_archive() -> Vec<u8> {
+    let wasm_path = Path::new(env!(
+        "CARGO_CDYLIB_FILE_PLUGIN_EXCALIDRAW_V3_PROTOTYPE_plugin_excalidraw_v3_prototype"
+    ));
+    let wasm = std::fs::read(wasm_path).unwrap_or_else(|error| {
+        panic!(
+            "failed to read bindep-built Excalidraw v3 plugin wasm at {}: {error}",
+            wasm_path.display()
+        )
+    });
+    let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    for (path, bytes) in [
+        (
+            "manifest.json",
+            include_str!("../../../plugins/excalidraw-v3-prototype/manifest.json").as_bytes(),
         ),
         (
             "schema/excalidraw_scene.json",

--- a/packages/rs-sdk-tests/tests/e2e.rs
+++ b/packages/rs-sdk-tests/tests/e2e.rs
@@ -25,8 +25,8 @@ use tracing_subscriber::layer::{Context as TracingContext, SubscriberExt};
 use tracing_subscriber::registry::LookupSpan;
 
 use benchmark_metrics::{
-    AllocationScope, BenchmarkFixture, BenchmarkGate, BenchmarkMeasurement, emit_sample,
-    emit_summary,
+    AllocationScope, BenchmarkFixture, BenchmarkGate, BenchmarkMeasurement, current_live_bytes,
+    emit_sample, emit_summary,
 };
 
 #[derive(Clone, Default)]
@@ -38,6 +38,7 @@ struct PerfSpanCollector {
 struct PerfSpanSample {
     name: &'static str,
     elapsed: Duration,
+    live_bytes_at_close: u64,
 }
 
 #[derive(Debug)]
@@ -78,6 +79,8 @@ fn is_import_perf_span(name: &str) -> bool {
             | "lix.perf.materialization.hot.values"
             | "lix.perf.materialization.hot.stage"
             | "lix.perf.storage_lowering"
+            | "lix.perf.storage_lowering.deferred_next_page"
+            | "lix.perf.storage_lowering.deferred_put_page"
             | "lix.perf.transaction_prepare_rows"
             | "lix.perf.transaction_path_preflight"
             | "lix.perf.transaction_buffer_stage"
@@ -104,6 +107,20 @@ impl PerfSpanCollector {
             *aggregate.entry(sample.name).or_insert(0.0) += sample.elapsed.as_secs_f64() * 1_000.0;
         }
         aggregate
+    }
+
+    fn take_close_live_bytes(&self) -> BTreeMap<&'static str, u64> {
+        let samples = self
+            .samples
+            .lock()
+            .expect("performance span collector should not poison");
+        let mut live = BTreeMap::<&'static str, u64>::new();
+        for sample in samples.iter() {
+            live.entry(sample.name)
+                .and_modify(|current| *current = (*current).max(sample.live_bytes_at_close))
+                .or_insert(sample.live_bytes_at_close);
+        }
+        live
     }
 }
 
@@ -145,6 +162,7 @@ where
             .push(PerfSpanSample {
                 name: started.name,
                 elapsed: started.started.elapsed(),
+                live_bytes_at_close: current_live_bytes(),
             });
     }
 }
@@ -2894,6 +2912,586 @@ async fn v2_csv_ten_mib_rocksdb_import_parity_benchmark() {
     );
 }
 
+/// Prototype B retains the fused call and existing engine storage path, but
+/// sends CSV rows as bounded typed batches without guest-side JSON snapshots.
+#[tokio::test]
+#[ignore = "Component v3 Prototype B typed CSV batch import benchmark"]
+async fn v3_prototype_b_csv_ten_mib_typed_batch_benchmark() {
+    const CSV_ROW_COUNT: usize = 220_000;
+    const FILE_ID: &str = "019a0000-0000-7000-8000-000000000320";
+    const FILE_PATH: &str = "/v3-prototype-b.csv";
+    const BENCHMARK: &str = "v3_prototype_b_csv_ten_mib_typed_batch_benchmark";
+
+    let samples = std::env::var("LIX_BENCH_SAMPLES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|samples| *samples > 0)
+        .unwrap_or(5);
+    let archive = build_csv_v3_prototype_archive();
+    let source = csv_ten_mib_fixture();
+    let fixture = BenchmarkFixture {
+        input_bytes: source.len(),
+        logical_rows: CSV_ROW_COUNT + 1,
+    };
+    let collector = PerfSpanCollector::default();
+    let dispatch = tracing::Dispatch::new(tracing_subscriber::registry().with(collector.clone()));
+    let _dispatcher = tracing::dispatcher::set_default(&dispatch);
+    let mut measurements = Vec::with_capacity(samples);
+    let mut elapsed_ms = Vec::with_capacity(samples);
+
+    for sample in 0..samples {
+        let root = tempfile::tempdir().expect("create v3 Prototype B benchmark directory");
+        let lix = open_lix_with_rocksdb(root.path()).await;
+        install_reference_plugin_in_blank_registry(
+            &lix,
+            "plugin_csv_v3_prototype",
+            &archive,
+            &["csv_v2_table", "csv_v2_row"],
+        )
+        .await;
+
+        lix.reset_plugin_v2_transition_counters();
+        collector.clear();
+        let input = source.clone();
+        let allocation_scope = AllocationScope::start();
+        let started = Instant::now();
+        let inserted = lix
+            .execute(
+                "INSERT INTO lix_file (id, path, data) VALUES ($1, $2, $3)",
+                &[
+                    Value::Text(FILE_ID.to_owned()),
+                    Value::Text(FILE_PATH.to_owned()),
+                    Value::Blob(input.into()),
+                ],
+            )
+            .await
+            .expect("v3 Prototype B CSV import should succeed");
+        let measurement = BenchmarkMeasurement::new(started.elapsed(), allocation_scope.finish());
+        assert_eq!(inserted.rows_affected(), 1, "v3 sample {sample}");
+
+        let counters = lix.plugin_v2_transition_counters();
+        assert_eq!(
+            counters.guest_export_calls, 1,
+            "Prototype B must enter the guest exactly once"
+        );
+        assert_eq!(
+            counters.actor_executor_threads_created, 1,
+            "Prototype B must create one persistent actor executor, not one thread per import"
+        );
+        assert_eq!(
+            counters.packet_records,
+            (CSV_ROW_COUNT + 1) as u64,
+            "Prototype B must retain exact typed-batch row cardinality"
+        );
+        assert_eq!(
+            counters.durable_semantic_changes,
+            (CSV_ROW_COUNT + 1) as u64,
+            "Prototype B must commit the exact semantic row count"
+        );
+        assert!(
+            counters.packet_pages > 1,
+            "the large fixture must exercise bounded push pages"
+        );
+        assert_eq!(
+            read_file(&lix, FILE_PATH)
+                .await
+                .expect("v3 Prototype B file should read"),
+            Some(source.clone()),
+            "Prototype B must preserve exact file bytes"
+        );
+        let row_count = lix
+            .execute("SELECT COUNT(*) AS count FROM csv_v2_row", &[])
+            .await
+            .expect("v3 Prototype B semantic rows should query")
+            .rows()[0]
+            .get::<i64>("count")
+            .expect("CSV row count must be an integer");
+        assert_eq!(row_count, CSV_ROW_COUNT as i64);
+        let projected = lix
+            .execute(
+                "SELECT lixcol_entity_pk, id, order_key, cells \
+                 FROM csv_v2_row WHERE lixcol_file_id = $1 LIMIT 1",
+                &[Value::Text(FILE_ID.to_owned())],
+            )
+            .await
+            .expect("v3 certified CSV row should project after commit");
+        assert_eq!(projected.len(), 1);
+        let projected = &projected.rows()[0];
+        let id = projected
+            .get::<String>("id")
+            .expect("certified CSV id should project");
+        assert_eq!(
+            projected
+                .get::<serde_json::Value>("lixcol_entity_pk")
+                .expect("certified CSV primary key should project"),
+            serde_json::json!([id]),
+        );
+        assert_eq!(
+            projected
+                .get::<serde_json::Value>("cells")
+                .expect("certified CSV cells should project"),
+            serde_json::json!(["000000000000000", "1111111111", "2222222222", "3333333333"]),
+        );
+
+        let phase_close_live_bytes = collector.take_close_live_bytes();
+        eprintln!(
+            "v3_prototype_b_phases sample={sample} elapsed_ms={:.3} \
+             guest_export_calls={} actor_executor_threads_created={} \
+             source_sink_import_calls={} packet_pages={} packet_records={} \
+             boundary_bytes={} guest_high_water_bytes={} phase_close_live_bytes={:?} phases_ms={:?}",
+            measurement.elapsed_ms,
+            counters.guest_export_calls,
+            counters.actor_executor_threads_created,
+            counters.component_import_calls,
+            counters.packet_pages,
+            counters.packet_records,
+            counters.component_boundary_bytes,
+            counters.guest_linear_memory_high_water_bytes,
+            phase_close_live_bytes,
+            collector.take_aggregate_millis(),
+        );
+        emit_sample(
+            BENCHMARK,
+            "typed_csv_batches",
+            sample,
+            fixture,
+            BenchmarkGate::BulkWrite,
+            measurement,
+        );
+        elapsed_ms.push(measurement.elapsed_ms);
+        measurements.push(measurement);
+        lix.close().await.expect("close v3 Prototype B benchmark");
+        let reopened = open_lix_with_rocksdb(root.path()).await;
+        let reopened_count = reopened
+            .execute("SELECT COUNT(*) AS count FROM csv_v2_row", &[])
+            .await
+            .expect("reopened certified CSV rows should query")
+            .rows()[0]
+            .get::<i64>("count")
+            .expect("reopened CSV row count must be an integer");
+        assert_eq!(reopened_count, CSV_ROW_COUNT as i64);
+        reopened
+            .close()
+            .await
+            .expect("close reopened v3 Prototype B benchmark");
+    }
+
+    elapsed_ms.sort_by(f64::total_cmp);
+    eprintln!(
+        "v3_prototype_b_csv_ten_mib bytes={} rows={} samples={samples} \
+         raw_ms={elapsed_ms:?} p50_ms={:.3} p95_ms={:.3}",
+        source.len(),
+        CSV_ROW_COUNT + 1,
+        p50_ms(&elapsed_ms),
+        p95_ms(&elapsed_ms),
+    );
+    emit_summary(
+        BENCHMARK,
+        "typed_csv_batches",
+        fixture,
+        BenchmarkGate::BulkWrite,
+        &measurements,
+    );
+}
+
+/// Matched large JSON import through the v2 returned cursor and the v3
+/// host-imported push sink. Both lanes use the same parser and packet-v1
+/// encoding, so this isolates control-flow and runtime materialization.
+#[tokio::test]
+#[ignore = "10 MiB JSON v2 cursor versus v3 push-sink import benchmark"]
+async fn v3_json_ten_mib_push_sink_benchmark() {
+    const FILE_ID: &str = "019a0000-0000-7000-8000-000000000330";
+    const FILE_PATH: &str = "/v3-json-large.json";
+    const BENCHMARK: &str = "v3_json_ten_mib_push_sink_benchmark";
+
+    let samples = std::env::var("LIX_BENCH_SAMPLES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|samples| *samples > 0)
+        .unwrap_or(5);
+    let source = json_ten_mib_flat_fixture().0;
+    let projected_key = format!("property_{:06}", JSON_TEN_MIB_PROPERTY_COUNT / 2);
+    let parsed_source: serde_json::Value =
+        serde_json::from_slice(&source).expect("benchmark JSON should parse");
+    let projected_scalar = serde_json::to_string(
+        parsed_source
+            .get(&projected_key)
+            .expect("projected benchmark property should exist"),
+    )
+    .expect("projected benchmark scalar should encode");
+    let fixture = BenchmarkFixture {
+        input_bytes: source.len(),
+        logical_rows: JSON_TEN_MIB_PROPERTY_COUNT + 1,
+    };
+    let lanes = [
+        (
+            "v2_cursor",
+            "plugin_json_incremental_v2",
+            build_json_v2_plugin_archive(),
+        ),
+        (
+            "v3_push_sink",
+            "plugin_json_v3_prototype",
+            build_json_v3_prototype_archive(),
+        ),
+    ];
+    let collector = PerfSpanCollector::default();
+    let dispatch = tracing::Dispatch::new(tracing_subscriber::registry().with(collector.clone()));
+    let _dispatcher = tracing::dispatcher::set_default(&dispatch);
+
+    for (label, plugin_key, archive) in lanes {
+        let mut measurements = Vec::with_capacity(samples);
+        let mut elapsed_ms = Vec::with_capacity(samples);
+        for sample in 0..samples {
+            let root = tempfile::tempdir().expect("create JSON v3 benchmark directory");
+            let lix = open_lix_with_rocksdb(root.path()).await;
+            install_reference_plugin_in_blank_registry(
+                &lix,
+                plugin_key,
+                &archive,
+                &["json_root", "json_object_member", "json_array_item"],
+            )
+            .await;
+
+            lix.reset_plugin_v2_transition_counters();
+            collector.clear();
+            let allocation_scope = AllocationScope::start();
+            let started = Instant::now();
+            let inserted = lix
+                .execute(
+                    "INSERT INTO lix_file (id, path, data) VALUES ($1, $2, $3)",
+                    &[
+                        Value::Text(FILE_ID.to_owned()),
+                        Value::Text(FILE_PATH.to_owned()),
+                        Value::Blob(source.clone().into()),
+                    ],
+                )
+                .await
+                .unwrap_or_else(|error| panic!("{label} JSON import failed: {error}"));
+            let measurement =
+                BenchmarkMeasurement::new(started.elapsed(), allocation_scope.finish());
+            assert_eq!(inserted.rows_affected(), 1, "{label} sample {sample}");
+            let counters = lix.plugin_v2_transition_counters();
+            if label == "v3_push_sink" {
+                assert_eq!(counters.guest_export_calls, 1);
+            }
+            assert_eq!(
+                counters.durable_semantic_changes,
+                (JSON_TEN_MIB_PROPERTY_COUNT + 1) as u64
+            );
+            assert_eq!(
+                read_file(&lix, FILE_PATH).await.unwrap(),
+                Some(source.clone())
+            );
+            let members = lix
+                .execute("SELECT COUNT(*) AS count FROM json_object_member", &[])
+                .await
+                .expect("count JSON members")
+                .rows()[0]
+                .get::<i64>("count")
+                .expect("JSON member count must be an integer");
+            assert_eq!(members, JSON_TEN_MIB_PROPERTY_COUNT as i64);
+            let projected = lix
+                .execute(
+                    "SELECT key, kind, scalar_json FROM json_object_member WHERE key = $1",
+                    &[Value::Text(projected_key.clone())],
+                )
+                .await
+                .expect("project exact JSON member");
+            assert_eq!(projected.rows().len(), 1);
+            assert_eq!(
+                projected.rows()[0].get::<String>("key").unwrap(),
+                projected_key
+            );
+            assert_eq!(projected.rows()[0].get::<String>("kind").unwrap(), "string");
+            assert_eq!(
+                projected.rows()[0].get::<String>("scalar_json").unwrap(),
+                projected_scalar
+            );
+            let history_count = lix
+                .execute(
+                    "SELECT COUNT(*) AS count FROM json_object_member_history()",
+                    &[],
+                )
+                .await
+                .expect("certified JSON rows should participate in history")
+                .rows()[0]
+                .get::<i64>("count")
+                .expect("JSON history count must be an integer");
+            assert_eq!(history_count, JSON_TEN_MIB_PROPERTY_COUNT as i64);
+            eprintln!(
+                "v3_json_large_phases lane={label} sample={sample} elapsed_ms={:.3} \
+                 guest_exports={} imports={} pages={} records={} boundary_bytes={} \
+                 guest_high_water_bytes={} phase_close_live_bytes={:?} phases_ms={:?}",
+                measurement.elapsed_ms,
+                counters.guest_export_calls,
+                counters.component_import_calls,
+                counters.packet_pages,
+                counters.packet_records,
+                counters.component_boundary_bytes,
+                counters.guest_linear_memory_high_water_bytes,
+                collector.take_close_live_bytes(),
+                collector.take_aggregate_millis(),
+            );
+            emit_sample(
+                BENCHMARK,
+                label,
+                sample,
+                fixture,
+                BenchmarkGate::BulkWrite,
+                measurement,
+            );
+            elapsed_ms.push(measurement.elapsed_ms);
+            measurements.push(measurement);
+            lix.close().await.expect("close JSON benchmark");
+            let reopened = open_lix_with_rocksdb(root.path()).await;
+            let reopened_count = reopened
+                .execute("SELECT COUNT(*) AS count FROM json_object_member", &[])
+                .await
+                .expect("reopened JSON members should query")
+                .rows()[0]
+                .get::<i64>("count")
+                .expect("reopened JSON member count must be an integer");
+            assert_eq!(reopened_count, JSON_TEN_MIB_PROPERTY_COUNT as i64);
+            reopened
+                .close()
+                .await
+                .expect("close reopened JSON benchmark");
+        }
+        elapsed_ms.sort_by(f64::total_cmp);
+        eprintln!(
+            "v3_json_ten_mib lane={label} samples={samples} raw_ms={elapsed_ms:?} \
+             p50_ms={:.3} p95_ms={:.3}",
+            p50_ms(&elapsed_ms),
+            p95_ms(&elapsed_ms)
+        );
+        emit_summary(
+            BENCHMARK,
+            label,
+            fixture,
+            BenchmarkGate::BulkWrite,
+            &measurements,
+        );
+    }
+}
+
+#[tokio::test]
+async fn v3_json_certified_batch_survives_sparse_successor_and_time_travel() {
+    let root = tempfile::tempdir().expect("create v3 JSON successor directory");
+    let lix = open_lix_with_rocksdb(root.path()).await;
+    install_reference_plugin_in_blank_registry(
+        &lix,
+        "plugin_json_v3_prototype",
+        &build_json_v3_prototype_archive(),
+        &["json_root", "json_object_member", "json_array_item"],
+    )
+    .await;
+    let path = "/v3-json-successor.json";
+    let before = br#"{"a":"one","b":"two"}"#.to_vec();
+    write_file(&lix, path, before.clone()).await.unwrap();
+    assert_eq!(
+        lix.execute("SELECT COUNT(*) AS count FROM json_object_member", &[])
+            .await
+            .unwrap()
+            .rows()[0]
+            .get::<i64>("count")
+            .unwrap(),
+        2
+    );
+
+    let after = br#"{"a":"ONE","b":"two"}"#.to_vec();
+    write_file(&lix, path, after.clone()).await.unwrap();
+    assert_eq!(read_file(&lix, path).await.unwrap(), Some(after));
+    let current = lix
+        .execute(
+            "SELECT key, scalar_json FROM json_object_member ORDER BY key",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(current.rows().len(), 2);
+    assert_eq!(current.rows()[0].get::<String>("key").unwrap(), "a");
+    assert_eq!(
+        current.rows()[0].get::<String>("scalar_json").unwrap(),
+        r#""ONE""#
+    );
+    assert_eq!(current.rows()[1].get::<String>("key").unwrap(), "b");
+
+    let historical = lix
+        .execute(
+            "SELECT key, scalar_json FROM json_object_member_history() \
+             WHERE lixcol_depth = 1 ORDER BY key",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(historical.rows().len(), 2);
+    assert_eq!(
+        historical.rows()[0].get::<String>("scalar_json").unwrap(),
+        r#""one""#
+    );
+    lix.close().await.unwrap();
+}
+
+/// Matched warm file transitions over the same CSV implementation. v2 returns
+/// a guest change cursor and requires `next(Some)` plus `next(None)` exports;
+/// v3 pushes the same packet page into a borrowed host sink before its single
+/// `file-changed` export returns.
+#[tokio::test]
+#[ignore = "Component v2 change cursor versus v3 push-sink benchmark"]
+async fn v3_file_changed_push_sink_benchmark() {
+    const SAMPLES: usize = 25;
+    const ROW_COUNT: usize = 20_000;
+    const ROW: &[u8] = b"000000000000000,1111111111,2222222222,3333333333\n";
+    const BENCHMARK: &str = "v3_file_changed_push_sink_benchmark";
+
+    let mut source = Vec::with_capacity(ROW_COUNT * ROW.len());
+    for _ in 0..ROW_COUNT {
+        source.extend_from_slice(ROW);
+    }
+    let fixture = BenchmarkFixture {
+        input_bytes: source.len(),
+        logical_rows: 1,
+    };
+    let v2_root = tempfile::tempdir().expect("create v2 push-sink benchmark directory");
+    let v3_root = tempfile::tempdir().expect("create v3 push-sink benchmark directory");
+    let v2 = open_lix_with_rocksdb(v2_root.path()).await;
+    let v3 = open_lix_with_rocksdb(v3_root.path()).await;
+    install_reference_plugin_in_blank_registry(
+        &v2,
+        "plugin_csv_v2",
+        &build_csv_v2_plugin_archive(),
+        &["csv_v2_table", "csv_v2_row"],
+    )
+    .await;
+    install_reference_plugin_in_blank_registry(
+        &v3,
+        "plugin_csv_v3_prototype",
+        &build_csv_v3_prototype_archive(),
+        &["csv_v2_table", "csv_v2_row"],
+    )
+    .await;
+    let v2_path = "/cursor.csv";
+    let v3_path = "/push-sink.csv";
+    write_file(&v2, v2_path, source.clone())
+        .await
+        .expect("v2 benchmark import should succeed");
+    write_file(&v3, v3_path, source.clone())
+        .await
+        .expect("v3 benchmark import should succeed");
+    assert_eq!(read_file(&v2, v2_path).await.unwrap(), Some(source.clone()));
+    assert_eq!(read_file(&v3, v3_path).await.unwrap(), Some(source.clone()));
+
+    let mut v2_bytes = source.clone();
+    let mut v3_bytes = source;
+    let mut v2_measurements = Vec::with_capacity(SAMPLES);
+    let mut v3_measurements = Vec::with_capacity(SAMPLES);
+    let mut v2_ms = Vec::with_capacity(SAMPLES);
+    let mut v3_ms = Vec::with_capacity(SAMPLES);
+    let mut v2_export_calls = Vec::with_capacity(SAMPLES);
+    let mut v3_export_calls = Vec::with_capacity(SAMPLES);
+
+    for sample in 0..SAMPLES {
+        let next = if sample % 2 == 0 { b'9' } else { b'0' };
+        let lanes = if sample % 2 == 0 {
+            [false, true]
+        } else {
+            [true, false]
+        };
+        for push_sink in lanes {
+            let (lix, path, bytes) = if push_sink {
+                (&v3, v3_path, &mut v3_bytes)
+            } else {
+                (&v2, v2_path, &mut v2_bytes)
+            };
+            bytes[0] = next;
+            lix.reset_plugin_v2_transition_counters();
+            let allocation_scope = AllocationScope::start();
+            let started = Instant::now();
+            write_file(lix, path, bytes.clone())
+                .await
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "{} sample {sample} should succeed: {error:?}",
+                        if push_sink { "v3" } else { "v2" }
+                    )
+                });
+            let measurement =
+                BenchmarkMeasurement::new(started.elapsed(), allocation_scope.finish());
+            let counters = lix.plugin_v2_transition_counters();
+            assert_eq!(counters.packet_records, 1, "sample {sample}");
+            assert_eq!(counters.durable_semantic_changes, 1, "sample {sample}");
+            if push_sink {
+                assert_eq!(
+                    counters.guest_export_calls, 1,
+                    "v3 must use one guest export"
+                );
+                v3_export_calls.push(counters.guest_export_calls);
+                v3_ms.push(measurement.elapsed_ms);
+                v3_measurements.push(measurement);
+            } else {
+                assert_eq!(
+                    counters.guest_export_calls, 3,
+                    "v2 must call file-changed, next(Some), and next(None)"
+                );
+                v2_export_calls.push(counters.guest_export_calls);
+                v2_ms.push(measurement.elapsed_ms);
+                v2_measurements.push(measurement);
+            }
+        }
+    }
+
+    assert_eq!(read_file(&v2, v2_path).await.unwrap(), Some(v2_bytes));
+    assert_eq!(read_file(&v3, v3_path).await.unwrap(), Some(v3_bytes));
+    let v2_row_count = v2
+        .execute("SELECT COUNT(*) AS count FROM csv_v2_row", &[])
+        .await
+        .expect("v2 semantic rows should query")
+        .rows()[0]
+        .get::<i64>("count")
+        .expect("v2 row count should be integer");
+    let v3_row_count = v3
+        .execute("SELECT COUNT(*) AS count FROM csv_v2_row", &[])
+        .await
+        .expect("v3 semantic rows should query")
+        .rows()[0]
+        .get::<i64>("count")
+        .expect("v3 row count should be integer");
+    assert_eq!(v2_row_count, ROW_COUNT as i64);
+    assert_eq!(v3_row_count, ROW_COUNT as i64);
+
+    v2_ms.sort_by(f64::total_cmp);
+    v3_ms.sort_by(f64::total_cmp);
+    eprintln!(
+        "v3_file_changed_push_sink bytes={} rows={} samples={SAMPLES} \
+         v2_raw_ms={v2_ms:?} v2_p50_ms={:.3} v2_guest_exports={} \
+         v3_raw_ms={v3_ms:?} v3_p50_ms={:.3} v3_guest_exports={} speedup={:.3}",
+        fixture.input_bytes,
+        ROW_COUNT,
+        p50_ms(&v2_ms),
+        v2_export_calls[0],
+        p50_ms(&v3_ms),
+        v3_export_calls[0],
+        p50_ms(&v2_ms) / p50_ms(&v3_ms),
+    );
+    emit_summary(
+        BENCHMARK,
+        "v2_guest_cursor",
+        fixture,
+        BenchmarkGate::ElapsedRegression,
+        &v2_measurements,
+    );
+    emit_summary(
+        BENCHMARK,
+        "v3_push_sink",
+        fixture,
+        BenchmarkGate::ElapsedRegression,
+        &v3_measurements,
+    );
+    v2.close().await.expect("close v2 benchmark");
+    v3.close().await.expect("close v3 benchmark");
+}
+
 #[tokio::test]
 #[ignore = "10 MiB JSON public-SQL read benchmark on RocksDB"]
 async fn v2_json_ten_mib_rocksdb_read_benchmark() {
@@ -4641,6 +5239,78 @@ fn build_csv_v2_plugin_archive() -> Vec<u8> {
         include_str!("../../../plugins/csv-v2/schema/csv_v2_row.json").as_bytes(),
         None,
     )
+}
+
+fn build_csv_v3_prototype_archive() -> Vec<u8> {
+    let wasm_path = Path::new(env!(
+        "CARGO_CDYLIB_FILE_PLUGIN_CSV_V3_PROTOTYPE_plugin_csv_v3_prototype"
+    ));
+    let wasm = std::fs::read(wasm_path).unwrap_or_else(|error| {
+        panic!(
+            "failed to read bindep-built CSV v3 prototype wasm at {}: {error}",
+            wasm_path.display()
+        )
+    });
+    let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    for (path, bytes) in [
+        (
+            "manifest.json",
+            include_str!("../../../plugins/csv-v3-prototype/manifest.json").as_bytes(),
+        ),
+        (
+            "schema/csv_v2_table.json",
+            include_str!("../../../plugins/csv-v2/schema/csv_v2_table.json").as_bytes(),
+        ),
+        (
+            "schema/csv_v2_row.json",
+            include_str!("../../../plugins/csv-v2/schema/csv_v2_row.json").as_bytes(),
+        ),
+        ("plugin.wasm", wasm.as_slice()),
+    ] {
+        writer.start_file(path, options).unwrap();
+        writer.write_all(bytes).unwrap();
+    }
+    writer.finish().unwrap().into_inner()
+}
+
+fn build_json_v3_prototype_archive() -> Vec<u8> {
+    let wasm_path = Path::new(env!(
+        "CARGO_CDYLIB_FILE_PLUGIN_JSON_V3_PROTOTYPE_plugin_json_v3_prototype"
+    ));
+    let wasm = std::fs::read(wasm_path).unwrap_or_else(|error| {
+        panic!(
+            "failed to read bindep-built JSON v3 prototype wasm at {}: {error}",
+            wasm_path.display()
+        )
+    });
+    let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    for (path, bytes) in [
+        (
+            "manifest.json",
+            include_str!("../../../plugins/json-v3-prototype/manifest.json").as_bytes(),
+        ),
+        (
+            "schema/json_root.json",
+            include_str!("../../../plugins/json-v2/schema/json_root.json").as_bytes(),
+        ),
+        (
+            "schema/json_object_member.json",
+            include_str!("../../../plugins/json-v2/schema/json_object_member.json").as_bytes(),
+        ),
+        (
+            "schema/json_array_item.json",
+            include_str!("../../../plugins/json-v2/schema/json_array_item.json").as_bytes(),
+        ),
+        ("plugin.wasm", wasm.as_slice()),
+    ] {
+        writer.start_file(path, options).unwrap();
+        writer.write_all(bytes).unwrap();
+    }
+    writer.finish().unwrap().into_inner()
 }
 
 fn build_markdown_v2_plugin_archive() -> Vec<u8> {

--- a/packages/rs-sdk-tests/tests/e2e.rs
+++ b/packages/rs-sdk-tests/tests/e2e.rs
@@ -4293,7 +4293,7 @@ async fn v3_excalidraw_certified_open_sparse_successor_history_and_reopen() {
     assert_eq!(successor_counters.guest_export_calls, 1);
     assert_eq!(successor_counters.durable_semantic_changes, 1);
     assert_eq!(read_file(&lix, path).await.unwrap(), Some(after.clone()));
-    assert_eq!(
+    assert!(
         lix.execute(
             "SELECT element_json FROM excalidraw_element WHERE id = 'a'",
             &[],
@@ -4303,8 +4303,7 @@ async fn v3_excalidraw_certified_open_sparse_successor_history_and_reopen() {
         .rows()[0]
             .get::<String>("element_json")
             .unwrap()
-            .contains("123.5"),
-        true
+            .contains("123.5")
     );
     assert!(
         lix.execute(

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -24,6 +24,7 @@ lix_slatedb_storage = { workspace = true, optional = true }
 lix_sqlite_storage = { workspace = true, optional = true }
 
 async-trait = "0.1"
+base64 = "0.22"
 blake3 = { version = "1", optional = true }
 bytes = "1"
 lru = { version = "0.18", optional = true }

--- a/packages/rs-sdk/src/default_wasm_runtime.rs
+++ b/packages/rs-sdk/src/default_wasm_runtime.rs
@@ -23,6 +23,8 @@ use wasmtime_wasi::{
 
 #[path = "default_wasm_runtime_v2.rs"]
 mod v2_runtime;
+#[path = "default_wasm_runtime_v3_prototype.rs"]
+mod v3_prototype_runtime;
 
 const COMPILED_COMPONENT_CACHE_CAPACITY: usize = 16;
 const MAX_PLUGIN_INSTANCES: usize = 64;
@@ -394,6 +396,14 @@ impl WasmRuntime for WasmtimePluginRuntime {
         limits: WasmLimits,
     ) -> Result<Arc<dyn lix_engine::wasm::v2::WasmComponentV2Factory>, LixError> {
         v2_runtime::compile_component(self, bytes, limits).await
+    }
+
+    async fn compile_component_v3_prototype(
+        &self,
+        bytes: Vec<u8>,
+        limits: WasmLimits,
+    ) -> Result<Arc<dyn lix_engine::wasm::v2::WasmComponentV2Factory>, LixError> {
+        v3_prototype_runtime::compile_component(self, bytes, limits).await
     }
 }
 

--- a/packages/rs-sdk/src/default_wasm_runtime_v2.rs
+++ b/packages/rs-sdk/src/default_wasm_runtime_v2.rs
@@ -718,6 +718,7 @@ fn decode_change_packet(
                 WasmEntityChange::Create {
                     schema_key: schema_key.to_string(),
                     local_ref,
+                    resolved_key: None,
                     snapshot_content,
                 }
             }
@@ -730,6 +731,25 @@ fn decode_change_packet(
     Ok(DecodedChangePacket {
         changes: WasmEntityChanges { changes },
         output_ranges,
+    })
+}
+
+pub(super) fn decode_inline_change_page(
+    record_count: u32,
+    payload: Vec<u8>,
+    max_bytes: u32,
+    limits: WasmTransitionLimits,
+) -> Result<WasmChangePage, LixError> {
+    let decoded = decode_change_packet(record_count, payload, max_bytes, limits)?;
+    if !decoded.output_ranges.is_empty() {
+        return Err(v2_invalid_plugin(
+            "v3 prototype packet-v1 pages cannot contain output attachments",
+        ));
+    }
+    Ok(WasmChangePage {
+        format_version: PACKET_FORMAT_V1,
+        changes: decoded.changes,
+        outputs: None,
     })
 }
 
@@ -2201,6 +2221,7 @@ mod tests {
                         schema_key,
                         local_ref,
                         snapshot_content,
+                        ..
                     } if schema_key == "csv_v2_row" => {
                         let snapshot_content = match snapshot_content {
                             WasmGuestBytes::Inline(bytes) => bytes,
@@ -3329,6 +3350,7 @@ mod tests {
                     WasmEntityChange::Create {
                         schema_key,
                         local_ref,
+                        resolved_key,
                         snapshot_content,
                     } => {
                         let snapshot_content = match snapshot_content {
@@ -3340,6 +3362,7 @@ mod tests {
                         WasmEntityChange::Create {
                             schema_key,
                             local_ref,
+                            resolved_key,
                             snapshot_content,
                         }
                     }
@@ -3660,6 +3683,13 @@ impl WasmComponentV2Actor for WasmtimeV2Actor {
             .ok_or_else(|| v2_invalid_plugin("unknown v2 document handle"))?;
         let (transition, _budget_resource) = self.begin_transition(limits, Some(document.0))?;
         let budget = self.transition_budget(transition)?;
+        {
+            let mut budget = budget
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            budget.counters.guest_export_calls =
+                budget.counters.guest_export_calls.saturating_add(1);
+        }
         let before = self.push_byte_source(update.before, &budget)?;
         let after = self.push_byte_source(update.after, &budget)?;
         let edits = update
@@ -3833,6 +3863,14 @@ impl WasmComponentV2Actor for WasmtimeV2Actor {
         }
         if eof {
             return Ok(None);
+        }
+        {
+            let budget = self.transition_budget(transition.0)?;
+            let mut budget = budget
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            budget.counters.guest_export_calls =
+                budget.counters.guest_export_calls.saturating_add(1);
         }
         let budget_rep = self.prepare_nested_call(transition.0)?;
         let guest = self.guest.clone();

--- a/packages/rs-sdk/src/default_wasm_runtime_v3_prototype.rs
+++ b/packages/rs-sdk/src/default_wasm_runtime_v3_prototype.rs
@@ -1,0 +1,1466 @@
+//! Fused Component API v3 Prototype A.
+//!
+//! The adapter deliberately implements the existing v2 actor trait so engine
+//! reconciliation, validation, and storage lowering remain unchanged. Only
+//! initial file import is implemented: one exported guest call pushes
+//! packet-v1 pages into a host sink while the guest remains entered.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, mpsc};
+use std::time::Instant;
+
+use async_trait::async_trait;
+use base64::Engine as _;
+use bytes::Bytes;
+use lix_engine::LixError;
+use lix_engine::wasm::WasmLimits;
+use lix_engine::wasm::v2::{
+    PACKET_FORMAT_V1, WasmByteOutputsHandle, WasmCertifiedEntityBatch, WasmChangeCursorHandle,
+    WasmChangePage, WasmComponentV2Actor, WasmComponentV2Factory, WasmCreateContext,
+    WasmDocumentHandle, WasmEditCursorHandle, WasmEditPage, WasmEntityChange, WasmEntityKey,
+    WasmEntityTransition, WasmEntityUpdate, WasmFileTransition, WasmFileUpdate, WasmGuestBytes,
+    WasmGuestEntityChanges, WasmInputBytes, WasmOpenEntitiesInput, WasmOpenFileInput,
+    WasmTransitionCounters, WasmTransitionHandle, WasmTransitionLimits,
+};
+use wasmtime::Store;
+use wasmtime::component::{Component, Linker, Resource, ResourceAny};
+
+use super::{
+    CompileProfile, CompiledComponentKey, TimeoutTickerLease, WasiHostState, WasmtimePluginRuntime,
+    add_to_linker_sync, create_store, reset_store_limits, wasm_runtime_error,
+};
+
+const MAX_RETAINED_IMPORT_BYTES: u64 = 8 * 1024 * 1024;
+const V3_MAX_BATCH_BYTES: u32 = 2 * 1024 * 1024;
+const CERTIFIED_TYPED_CSV_V1: u16 = 1;
+const CERTIFIED_CREATED_PACKET_V1: u16 = 2;
+
+pub(super) mod bindings {
+    wasmtime::component::bindgen!({
+        path: "wit/v3-prototype",
+        world: "plugin",
+        with: {
+            "lix:plugin/host.source": super::SourceResource,
+            "lix:plugin/host.transition-sink": super::SinkResource,
+        },
+    });
+}
+
+pub struct SourceResource {
+    source: Arc<dyn lix_engine::wasm::v2::WasmByteSource>,
+    state: SharedTransitionState,
+}
+
+pub struct SinkResource {
+    state: SharedTransitionState,
+}
+
+type SharedTransitionState = Arc<Mutex<TransitionState>>;
+
+struct TransitionState {
+    limits: WasmTransitionLimits,
+    creates: WasmCreateContext,
+    started: Instant,
+    total_bytes: u64,
+    events: tokio::sync::mpsc::Sender<WorkerTransitionEvent>,
+    counters: WasmTransitionCounters,
+}
+
+/// Host-owned wire pages retained until the engine asks for the next page.
+///
+/// The first v3 prototype decoded every pushed page immediately and retained
+/// the resulting entity graph until the guest export returned. Large imports
+/// therefore held all generic entity objects plus the gradually constructed
+/// canonical output. Keeping the bounded wire pages defers ownership expansion
+/// to the existing one-page-at-a-time drain.
+enum PendingChangePage {
+    Packet {
+        record_count: u32,
+        payload: Vec<u8>,
+        max_page_bytes: u32,
+        limits: WasmTransitionLimits,
+        creates: WasmCreateContext,
+    },
+    TypedCsv {
+        row_count: u32,
+        payload: Vec<u8>,
+        creates: WasmCreateContext,
+    },
+}
+
+enum WorkerTransitionEvent {
+    Page(PendingChangePage),
+    Finished(Result<WasmTransitionCounters, LixError>),
+}
+
+impl PendingChangePage {
+    fn decode(self) -> Result<WasmChangePage, LixError> {
+        match self {
+            Self::Packet {
+                record_count,
+                payload,
+                max_page_bytes,
+                limits,
+                ..
+            } => super::v2_runtime::decode_inline_change_page(
+                record_count,
+                payload,
+                max_page_bytes,
+                limits,
+            ),
+            Self::TypedCsv {
+                row_count,
+                payload,
+                creates,
+            } => decode_typed_csv_rows(row_count, &payload, creates).map_err(v3_error),
+        }
+    }
+}
+
+impl TransitionState {
+    fn new(
+        limits: WasmTransitionLimits,
+        creates: WasmCreateContext,
+        events: tokio::sync::mpsc::Sender<WorkerTransitionEvent>,
+        executor_thread_created: bool,
+    ) -> Result<Self, LixError> {
+        Ok(Self {
+            limits: limits.validate()?,
+            creates,
+            started: Instant::now(),
+            total_bytes: 0,
+            events,
+            counters: WasmTransitionCounters {
+                guest_export_calls: 1,
+                actor_executor_threads_created: u64::from(executor_thread_created),
+                ..WasmTransitionCounters::default()
+            },
+        })
+    }
+
+    fn check_active(&self) -> Result<(), bindings::lix::plugin::host::HostError> {
+        if self.started.elapsed().as_nanos() >= u128::from(self.limits.total_deadline_nanoseconds) {
+            return Err(bindings::lix::plugin::host::HostError::LimitExceeded(
+                "v3 transition deadline elapsed".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn charge_page(&mut self, bytes: usize) -> Result<(), bindings::lix::plugin::host::HostError> {
+        self.check_active()?;
+        if bytes > self.limits.max_page_bytes as usize {
+            return Err(bindings::lix::plugin::host::HostError::LimitExceeded(
+                "v3 source or sink page exceeds max-page-bytes".to_owned(),
+            ));
+        }
+        self.charge_total(bytes)
+    }
+
+    fn charge_source(
+        &mut self,
+        bytes: usize,
+    ) -> Result<(), bindings::lix::plugin::host::HostError> {
+        self.check_active()?;
+        self.charge_total(bytes)
+    }
+
+    fn charge_total(&mut self, bytes: usize) -> Result<(), bindings::lix::plugin::host::HostError> {
+        self.total_bytes = self.total_bytes.checked_add(bytes as u64).ok_or_else(|| {
+            bindings::lix::plugin::host::HostError::LimitExceeded(
+                "v3 transition byte count overflowed".to_owned(),
+            )
+        })?;
+        if self.total_bytes > self.limits.max_total_bytes {
+            return Err(bindings::lix::plugin::host::HostError::LimitExceeded(
+                "v3 transition exceeds max-total-bytes".to_owned(),
+            ));
+        }
+        self.counters.component_boundary_bytes = self
+            .counters
+            .component_boundary_bytes
+            .saturating_add(bytes as u64);
+        Ok(())
+    }
+}
+
+impl bindings::lix::plugin::host::HostSource for WasiHostState {
+    fn len(&mut self, resource: Resource<SourceResource>) -> u64 {
+        self.table
+            .get(&resource)
+            .expect("v3 source resource must be live")
+            .source
+            .len()
+    }
+
+    fn read(
+        &mut self,
+        resource: Resource<SourceResource>,
+        offset: u64,
+        length: u32,
+    ) -> Result<Vec<u8>, bindings::lix::plugin::host::HostError> {
+        let (source, state) = {
+            let resource = self.table.get(&resource).map_err(host_table_error)?;
+            (resource.source.clone(), resource.state.clone())
+        };
+        let end = offset
+            .checked_add(u64::from(length))
+            .ok_or(bindings::lix::plugin::host::HostError::InvalidRange)?;
+        if end > source.len() {
+            return Err(bindings::lix::plugin::host::HostError::InvalidRange);
+        }
+        let bytes = source
+            .read(offset, length)
+            .map_err(|error| bindings::lix::plugin::host::HostError::Rejected(error.to_string()))?;
+        if bytes.len() != length as usize {
+            return Err(bindings::lix::plugin::host::HostError::Rejected(
+                "v3 source returned a short read".to_owned(),
+            ));
+        }
+        let mut state = state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.charge_source(bytes.len())?;
+        state.counters.component_import_calls =
+            state.counters.component_import_calls.saturating_add(1);
+        state.counters.source_read_calls = state.counters.source_read_calls.saturating_add(1);
+        state.counters.source_bytes_read = state
+            .counters
+            .source_bytes_read
+            .saturating_add(bytes.len() as u64);
+        Ok(bytes)
+    }
+
+    fn drop(&mut self, resource: Resource<SourceResource>) -> wasmtime::Result<()> {
+        self.table.delete(resource)?;
+        Ok(())
+    }
+}
+
+impl bindings::lix::plugin::host::HostTransitionSink for WasiHostState {
+    fn emit_changes(
+        &mut self,
+        resource: Resource<SinkResource>,
+        page: bindings::lix::plugin::host::ChangePage,
+    ) -> Result<(), bindings::lix::plugin::host::HostError> {
+        let state = self
+            .table
+            .get(&resource)
+            .map_err(host_table_error)?
+            .state
+            .clone();
+        let mut state = state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.check_active()?;
+        if page.format_version != PACKET_FORMAT_V1 {
+            return Err(bindings::lix::plugin::host::HostError::Rejected(
+                "v3 Prototype A requires packet-v1 output".to_owned(),
+            ));
+        }
+        if state.counters.packet_pages >= u64::from(state.limits.max_pages) {
+            return Err(bindings::lix::plugin::host::HostError::LimitExceeded(
+                "v3 change page count exceeds its limit".to_owned(),
+            ));
+        }
+        state.charge_page(page.payload.len())?;
+        if page.record_count == 0 {
+            return Err(bindings::lix::plugin::host::HostError::Rejected(
+                "v3 change page is empty".to_owned(),
+            ));
+        }
+        state.counters.component_import_calls =
+            state.counters.component_import_calls.saturating_add(1);
+        state.counters.packet_pages = state.counters.packet_pages.saturating_add(1);
+        state.counters.packet_records = state
+            .counters
+            .packet_records
+            .saturating_add(u64::from(page.record_count));
+        let limits = state.limits;
+        let creates = state.creates;
+        let page = PendingChangePage::Packet {
+            record_count: page.record_count,
+            payload: page.payload,
+            max_page_bytes: limits.max_page_bytes,
+            limits,
+            creates,
+        };
+        state
+            .events
+            .blocking_send(WorkerTransitionEvent::Page(page))
+            .map_err(|_| {
+                bindings::lix::plugin::host::HostError::Rejected(
+                    "v3 transition consumer stopped".to_owned(),
+                )
+            })?;
+        Ok(())
+    }
+
+    fn emit_csv_rows(
+        &mut self,
+        resource: Resource<SinkResource>,
+        batch: bindings::lix::plugin::host::CsvRowBatch,
+    ) -> Result<(), bindings::lix::plugin::host::HostError> {
+        let state = self
+            .table
+            .get(&resource)
+            .map_err(host_table_error)?
+            .state
+            .clone();
+        let mut state = state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.check_active()?;
+        if state.counters.packet_pages >= u64::from(state.limits.max_pages) {
+            return Err(bindings::lix::plugin::host::HostError::LimitExceeded(
+                "v3 CSV batch count exceeds its limit".to_owned(),
+            ));
+        }
+        state.charge_page(batch.payload.len())?;
+        if batch.row_count == 0 {
+            return Err(bindings::lix::plugin::host::HostError::Rejected(
+                "v3 CSV batch is empty".to_owned(),
+            ));
+        }
+        state.counters.component_import_calls =
+            state.counters.component_import_calls.saturating_add(1);
+        state.counters.packet_pages = state.counters.packet_pages.saturating_add(1);
+        state.counters.packet_records = state
+            .counters
+            .packet_records
+            .saturating_add(u64::from(batch.row_count));
+        let creates = state.creates;
+        let page = PendingChangePage::TypedCsv {
+            row_count: batch.row_count,
+            payload: batch.payload,
+            creates,
+        };
+        state
+            .events
+            .blocking_send(WorkerTransitionEvent::Page(page))
+            .map_err(|_| {
+                bindings::lix::plugin::host::HostError::Rejected(
+                    "v3 transition consumer stopped".to_owned(),
+                )
+            })?;
+        Ok(())
+    }
+
+    fn drop(&mut self, resource: Resource<SinkResource>) -> wasmtime::Result<()> {
+        self.table.delete(resource)?;
+        Ok(())
+    }
+}
+
+fn decode_typed_csv_rows(
+    row_count: u32,
+    payload: &[u8],
+    creates: WasmCreateContext,
+) -> Result<WasmChangePage, String> {
+    if row_count == 0 {
+        return Err("typed CSV batch is empty".to_owned());
+    }
+    let mut input = TypedCsvReader { payload, offset: 0 };
+    let mut snapshots = Vec::with_capacity(payload.len().saturating_mul(2));
+    let mut rows = Vec::with_capacity(row_count as usize);
+    for _ in 0..row_count {
+        let local_ref = u64::from(input.u32()?);
+        let order_rank = input.u64()?;
+        let ending = input.u8()?;
+        if ending > 4 {
+            return Err("typed CSV row has an invalid terminator code".to_owned());
+        }
+        let quote_layout_len = input.u32()? as usize;
+        let quote_layout = input.bytes(quote_layout_len)?;
+        let field_count = input.u16()?;
+        if field_count == 0 {
+            return Err("typed CSV row has no fields".to_owned());
+        }
+        let snapshot_start = snapshots.len();
+        snapshots.extend_from_slice(b"{\"cells\":[");
+        for field in 0..field_count {
+            if field > 0 {
+                snapshots.push(b',');
+            }
+            let cell_len = input.u32()? as usize;
+            let cell = input.bytes(cell_len)?;
+            let cell = std::str::from_utf8(cell)
+                .map_err(|error| format!("typed CSV cell is not UTF-8: {error}"))?;
+            write_json_string(&mut snapshots, cell);
+        }
+        snapshots.push(b']');
+        let id = creates
+            .component(local_ref)
+            .map_err(|error| error.to_string())?;
+        snapshots.extend_from_slice(b",\"id\":");
+        write_json_string(&mut snapshots, &id);
+        if !quote_layout.is_empty() || ending != 0 {
+            snapshots.extend_from_slice(b",\"layout\":{");
+            let mut comma = false;
+            if !quote_layout.is_empty() {
+                snapshots.extend_from_slice(b"\"force_quote\":");
+                let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(quote_layout);
+                write_json_string(&mut snapshots, &encoded);
+                comma = true;
+            }
+            if ending != 0 {
+                if comma {
+                    snapshots.push(b',');
+                }
+                snapshots.extend_from_slice(b"\"terminator\":");
+                write_json_string(
+                    &mut snapshots,
+                    match ending {
+                        1 => "",
+                        2 => "\n",
+                        3 => "\r\n",
+                        4 => "\r",
+                        _ => unreachable!("typed terminator was validated"),
+                    },
+                );
+            }
+            snapshots.push(b'}');
+        }
+        snapshots.extend_from_slice(b",\"order_key\":\"");
+        use std::fmt::Write as _;
+        write!(&mut VecFormatter(&mut snapshots), "{order_rank:016x}")
+            .map_err(|_| "failed to encode CSV order rank".to_owned())?;
+        snapshots.extend_from_slice(b"\"}");
+        rows.push((
+            local_ref,
+            WasmEntityKey::from_owned_parts("csv_v2_row", vec![id]),
+            snapshot_start,
+            snapshots.len(),
+        ));
+    }
+    if input.offset != payload.len() {
+        return Err("typed CSV batch has trailing bytes".to_owned());
+    }
+    let snapshots = Bytes::from(snapshots);
+    let changes = rows
+        .into_iter()
+        .map(
+            |(local_ref, resolved_key, start, end)| WasmEntityChange::Create {
+                schema_key: "csv_v2_row".to_owned(),
+                local_ref,
+                resolved_key: Some(resolved_key),
+                snapshot_content: WasmGuestBytes::Inline(snapshots.slice(start..end)),
+            },
+        )
+        .collect();
+    Ok(WasmChangePage {
+        format_version: PACKET_FORMAT_V1,
+        changes: WasmGuestEntityChanges { changes },
+        outputs: None,
+    })
+}
+
+fn validate_typed_csv_rows(row_count: u32, payload: &[u8]) -> Result<(u32, u32), String> {
+    if row_count == 0 {
+        return Err("typed CSV batch is empty".to_owned());
+    }
+    let mut input = TypedCsvReader { payload, offset: 0 };
+    let mut first_local_ref = None;
+    let mut previous_local_ref = None;
+    for _ in 0..row_count {
+        let local_ref = input.u32()?;
+        if previous_local_ref.is_some_and(|previous| previous >= local_ref) {
+            return Err("typed CSV local refs must be strictly increasing".to_owned());
+        }
+        first_local_ref.get_or_insert(local_ref);
+        previous_local_ref = Some(local_ref);
+        let _order_rank = input.u64()?;
+        let ending = input.u8()?;
+        if ending > 4 {
+            return Err("typed CSV row has an invalid terminator code".to_owned());
+        }
+        let quote_layout_len = input.u32()? as usize;
+        let _quote_layout = input.bytes(quote_layout_len)?;
+        let field_count = input.u16()?;
+        if field_count == 0 {
+            return Err("typed CSV row has no fields".to_owned());
+        }
+        for _ in 0..field_count {
+            let cell_len = input.u32()? as usize;
+            std::str::from_utf8(input.bytes(cell_len)?)
+                .map_err(|error| format!("typed CSV cell is not UTF-8: {error}"))?;
+        }
+    }
+    if input.offset != payload.len() {
+        return Err("typed CSV batch has trailing bytes".to_owned());
+    }
+    Ok((
+        first_local_ref.expect("positive row count has a first local ref"),
+        previous_local_ref.expect("positive row count has a last local ref"),
+    ))
+}
+
+/// Returns the schemas when every framed record is an inline snapshot write.
+/// Delete or attachment pages fall back to the generic v2 decoder.
+fn validate_created_packet_page(
+    record_count: u32,
+    payload: &[u8],
+) -> Result<Option<std::collections::BTreeSet<String>>, String> {
+    if record_count == 0 {
+        return Err("packet page is empty".to_owned());
+    }
+    let mut input = TypedCsvReader { payload, offset: 0 };
+    let mut schemas = std::collections::BTreeSet::new();
+    let mut previous_local_ref = None;
+    for _ in 0..record_count {
+        let record_len = input.u32()? as usize;
+        let record_bytes = input.bytes(record_len)?;
+        let mut record = TypedCsvReader {
+            payload: record_bytes,
+            offset: 0,
+        };
+        let tag = record.u8()?;
+        let schema_len = record.u32()? as usize;
+        let schema = std::str::from_utf8(record.bytes(schema_len)?)
+            .map_err(|error| format!("packet schema is not UTF-8: {error}"))?;
+        if schema.is_empty() {
+            return Err("packet create schema is empty".to_owned());
+        }
+        schemas.insert(schema.to_owned());
+        match tag {
+            0 => {
+                let component_count = record.u32()?;
+                if component_count == 0 {
+                    return Err("packet upsert key has no components".to_owned());
+                }
+                for _ in 0..component_count {
+                    let component_len = record.u32()? as usize;
+                    std::str::from_utf8(record.bytes(component_len)?)
+                        .map_err(|error| format!("packet key component is not UTF-8: {error}"))?;
+                }
+                if record.u8()? > 1 {
+                    return Err("packet upsert has an invalid effect".to_owned());
+                }
+            }
+            2 => {
+                let local_ref = record.u64()?;
+                if previous_local_ref.is_some_and(|previous| previous >= local_ref) {
+                    return Err("packet create local refs must be strictly increasing".to_owned());
+                }
+                previous_local_ref = Some(local_ref);
+            }
+            1 => return Ok(None),
+            _ => return Err("packet page has an unknown change tag".to_owned()),
+        }
+        if record.u8()? != 0 {
+            return Ok(None);
+        }
+        let snapshot_len = record.u32()? as usize;
+        let _snapshot = record.bytes(snapshot_len)?;
+        if record.offset != record.payload.len() {
+            return Err("packet create record has trailing bytes".to_owned());
+        }
+    }
+    if input.offset != payload.len() {
+        return Err("packet page has trailing bytes".to_owned());
+    }
+    Ok(Some(schemas))
+}
+
+struct TypedCsvReader<'a> {
+    payload: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> TypedCsvReader<'a> {
+    fn bytes(&mut self, length: usize) -> Result<&'a [u8], String> {
+        let end = self
+            .offset
+            .checked_add(length)
+            .ok_or_else(|| "typed CSV batch range overflowed".to_owned())?;
+        let value = self
+            .payload
+            .get(self.offset..end)
+            .ok_or_else(|| "typed CSV batch ended early".to_owned())?;
+        self.offset = end;
+        Ok(value)
+    }
+
+    fn u8(&mut self) -> Result<u8, String> {
+        Ok(self.bytes(1)?[0])
+    }
+
+    fn u16(&mut self) -> Result<u16, String> {
+        Ok(u16::from_le_bytes(
+            self.bytes(2)?.try_into().expect("exact u16 width"),
+        ))
+    }
+
+    fn u32(&mut self) -> Result<u32, String> {
+        Ok(u32::from_le_bytes(
+            self.bytes(4)?.try_into().expect("exact u32 width"),
+        ))
+    }
+
+    fn u64(&mut self) -> Result<u64, String> {
+        Ok(u64::from_le_bytes(
+            self.bytes(8)?.try_into().expect("exact u64 width"),
+        ))
+    }
+}
+
+struct VecFormatter<'a>(&'a mut Vec<u8>);
+
+impl std::fmt::Write for VecFormatter<'_> {
+    fn write_str(&mut self, value: &str) -> std::fmt::Result {
+        self.0.extend_from_slice(value.as_bytes());
+        Ok(())
+    }
+}
+
+fn write_json_string(output: &mut Vec<u8>, value: &str) {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    output.push(b'"');
+    for &byte in value.as_bytes() {
+        match byte {
+            b'"' => output.extend_from_slice(br#"\""#),
+            b'\\' => output.extend_from_slice(br#"\\"#),
+            b'\n' => output.extend_from_slice(br#"\n"#),
+            b'\r' => output.extend_from_slice(br#"\r"#),
+            b'\t' => output.extend_from_slice(br#"\t"#),
+            0x08 => output.extend_from_slice(br#"\b"#),
+            0x0c => output.extend_from_slice(br#"\f"#),
+            0x00..=0x1f => {
+                output.extend_from_slice(b"\\u00");
+                output.push(HEX[usize::from(byte >> 4)]);
+                output.push(HEX[usize::from(byte & 0x0f)]);
+            }
+            _ => output.push(byte),
+        }
+    }
+    output.push(b'"');
+}
+
+impl bindings::lix::plugin::host::Host for WasiHostState {}
+
+fn host_table_error(
+    error: wasmtime::component::ResourceTableError,
+) -> bindings::lix::plugin::host::HostError {
+    bindings::lix::plugin::host::HostError::Rejected(error.to_string())
+}
+
+struct V3Factory {
+    component: Component,
+    linker: Arc<Linker<WasiHostState>>,
+    runtime: Arc<super::WasmtimeSharedRuntime>,
+    limits: WasmLimits,
+    profile: CompileProfile,
+}
+
+pub(super) async fn compile_component(
+    runtime: &WasmtimePluginRuntime,
+    bytes: Vec<u8>,
+    limits: WasmLimits,
+) -> Result<Arc<dyn WasmComponentV2Factory>, LixError> {
+    if limits.max_memory_bytes == 0 {
+        return Err(v3_error("v3 component memory limit must be positive"));
+    }
+    let profile = if limits.max_fuel.is_some() {
+        CompileProfile::FuelAndTimeout
+    } else {
+        CompileProfile::Timeout
+    };
+    let engine = runtime.shared.engine(profile);
+    let key = CompiledComponentKey::new(profile, &bytes);
+    let component = runtime
+        .shared
+        .compiled_components
+        .get_or_compile(key, || {
+            Component::new(engine, &bytes).map_err(|error| {
+                wasm_runtime_error("failed to compile v3 prototype component", error)
+            })
+        })
+        .await?;
+    let mut linker = Linker::<WasiHostState>::new(engine);
+    add_to_linker_sync(&mut linker)
+        .map_err(|error| wasm_runtime_error("failed to configure v3 WASI linker", error))?;
+    bindings::Plugin::add_to_linker::<_, wasmtime::component::HasSelf<_>>(&mut linker, |state| {
+        state
+    })
+    .map_err(|error| wasm_runtime_error("failed to configure v3 plugin linker", error))?;
+    Ok(Arc::new(V3Factory {
+        component,
+        linker: Arc::new(linker),
+        runtime: runtime.shared.clone(),
+        limits,
+        profile,
+    }))
+}
+
+#[async_trait]
+impl WasmComponentV2Factory for V3Factory {
+    async fn instantiate_actor(&self) -> Result<Box<dyn WasmComponentV2Actor>, LixError> {
+        let engine = self.runtime.engine(self.profile);
+        let timeout_ticker = self
+            .runtime
+            .timeout_ticker(self.profile)?
+            .ok_or_else(|| v3_error("v3 actor requires an epoch timeout ticker"))?;
+        let mut store = create_store(engine, self.limits)?;
+        store.epoch_deadline_trap();
+        let bindings = bindings::Plugin::instantiate(&mut store, &self.component, &self.linker)
+            .map_err(|error| {
+                wasm_runtime_error("failed to instantiate v3 prototype actor", error)
+            })?;
+        let guest = bindings.lix_plugin_api().clone();
+        let (sender, receiver) = mpsc::channel();
+        let worker = V3Worker {
+            store,
+            guest,
+            limits: self.limits,
+            documents: HashMap::new(),
+            next_document: 1,
+            first_transition: true,
+        };
+        let thread = std::thread::Builder::new()
+            .name("lix-plugin-v3-actor".to_owned())
+            .spawn(move || worker.run(receiver))
+            .map_err(|error| v3_error(format!("failed to create v3 actor executor: {error}")))?;
+        Ok(Box::new(V3Actor {
+            sender,
+            thread: Some(thread),
+            _timeout_ticker: timeout_ticker,
+            next_handle: 1,
+            cursors: HashMap::new(),
+            transitions: HashMap::new(),
+            retired: false,
+            next_document: 1,
+        }))
+    }
+}
+
+enum WorkerCommand {
+    OpenFile {
+        document: u64,
+        limits: WasmTransitionLimits,
+        input: WasmOpenFileInput,
+        events: tokio::sync::mpsc::Sender<WorkerTransitionEvent>,
+        retire_after: bool,
+    },
+    FileChanged {
+        document: u64,
+        next_document: u64,
+        limits: WasmTransitionLimits,
+        update: WasmFileUpdate,
+        events: tokio::sync::mpsc::Sender<WorkerTransitionEvent>,
+        retire_after: bool,
+    },
+    Fork {
+        document: u64,
+        response: tokio::sync::oneshot::Sender<Result<u64, LixError>>,
+    },
+    DropDocument {
+        document: u64,
+        response: tokio::sync::oneshot::Sender<Result<(), LixError>>,
+    },
+    Shutdown,
+}
+
+struct V3Worker {
+    store: Store<WasiHostState>,
+    guest: bindings::exports::lix::plugin::api::Guest,
+    limits: WasmLimits,
+    documents: HashMap<u64, ResourceAny>,
+    next_document: u64,
+    first_transition: bool,
+}
+
+impl V3Worker {
+    fn run(mut self, receiver: mpsc::Receiver<WorkerCommand>) {
+        while let Ok(command) = receiver.recv() {
+            match command {
+                WorkerCommand::OpenFile {
+                    document,
+                    limits,
+                    input,
+                    events,
+                    retire_after,
+                } => {
+                    let result = self.open_file(document, limits, input, events.clone());
+                    let _ = events.blocking_send(WorkerTransitionEvent::Finished(result));
+                    if retire_after {
+                        break;
+                    }
+                }
+                WorkerCommand::FileChanged {
+                    document,
+                    next_document,
+                    limits,
+                    update,
+                    events,
+                    retire_after,
+                } => {
+                    let result =
+                        self.file_changed(document, next_document, limits, update, events.clone());
+                    let _ = events.blocking_send(WorkerTransitionEvent::Finished(result));
+                    if retire_after {
+                        break;
+                    }
+                }
+                WorkerCommand::Fork { document, response } => {
+                    let _ = response.send(self.fork(document));
+                }
+                WorkerCommand::DropDocument { document, response } => {
+                    let _ = response.send(self.drop_document(document));
+                }
+                WorkerCommand::Shutdown => break,
+            }
+        }
+    }
+
+    fn open_file(
+        &mut self,
+        document: u64,
+        limits: WasmTransitionLimits,
+        input: WasmOpenFileInput,
+        events: tokio::sync::mpsc::Sender<WorkerTransitionEvent>,
+    ) -> Result<WasmTransitionCounters, LixError> {
+        let limits = v3_transition_limits(limits)?;
+        reset_store_limits(&mut self.store, self.limits)?;
+        let ticks = limits.total_deadline_nanoseconds.saturating_add(999_999) / 1_000_000;
+        self.store.set_epoch_deadline(ticks.max(1));
+        let state = Arc::new(Mutex::new(TransitionState::new(
+            limits,
+            input.creates,
+            events,
+            std::mem::take(&mut self.first_transition),
+        )?));
+        let source = self
+            .store
+            .data_mut()
+            .table
+            .push(SourceResource {
+                source: input.file,
+                state: state.clone(),
+            })
+            .map_err(|error| v3_error(format!("failed to register v3 source: {error}")))?;
+        let sink = self
+            .store
+            .data_mut()
+            .table
+            .push(SinkResource {
+                state: state.clone(),
+            })
+            .map_err(|error| v3_error(format!("failed to register v3 sink: {error}")))?;
+        let sink_rep = sink.rep();
+        let binding_input = bindings::exports::lix::plugin::api::OpenFileInput {
+            descriptor: bindings::exports::lix::plugin::api::FileDescriptor {
+                path: input.descriptor.path,
+                media_type: input.descriptor.media_type,
+            },
+            file: source,
+            creates: bindings::exports::lix::plugin::api::CreateContext {
+                high: input.creates.high,
+                low: input.creates.low,
+            },
+            max_batch_bytes: limits.max_page_bytes,
+        };
+        let result = self.guest.call_open_file(
+            &mut self.store,
+            &binding_input,
+            Resource::new_borrow(sink_rep),
+        );
+        let _ = self.store.data_mut().table.delete(sink);
+        let value = match result {
+            Ok(Ok(value)) => value,
+            Ok(Err(error)) => {
+                return Err(v3_error(format!("v3 open-file rejected input: {error:?}")));
+            }
+            Err(error) => {
+                return Err(wasm_runtime_error("v3 open-file trapped", error));
+            }
+        };
+        self.documents.insert(document, value.document);
+        self.next_document = self.next_document.max(document.saturating_add(1));
+        let mut state = Arc::try_unwrap(state)
+            .map_err(|_| v3_error("v3 transition resources remained live after open-file"))?
+            .into_inner()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if value.summary.entity_count != state.counters.packet_records
+            || value.summary.batch_count as u64 != state.counters.packet_pages
+            || value.summary.payload_bytes > state.counters.component_boundary_bytes
+        {
+            return Err(v3_error(
+                "v3 guest summary does not match emitted packet pages",
+            ));
+        }
+        state.counters.guest_linear_memory_high_water_bytes =
+            self.store.data().limits.linear_memory_high_water_bytes();
+        Ok(state.counters)
+    }
+
+    fn file_changed(
+        &mut self,
+        document: u64,
+        next_document: u64,
+        limits: WasmTransitionLimits,
+        update: WasmFileUpdate,
+        events: tokio::sync::mpsc::Sender<WorkerTransitionEvent>,
+    ) -> Result<WasmTransitionCounters, LixError> {
+        let limits = v3_transition_limits(limits)?;
+        reset_store_limits(&mut self.store, self.limits)?;
+        let ticks = limits.total_deadline_nanoseconds.saturating_add(999_999) / 1_000_000;
+        self.store.set_epoch_deadline(ticks.max(1));
+        let document_resource = *self
+            .documents
+            .get(&document)
+            .ok_or_else(|| v3_error("unknown v3 document handle"))?;
+        let state = Arc::new(Mutex::new(TransitionState::new(
+            limits,
+            update.creates,
+            events,
+            false,
+        )?));
+        let before = self
+            .store
+            .data_mut()
+            .table
+            .push(SourceResource {
+                source: update.before,
+                state: state.clone(),
+            })
+            .map_err(|error| v3_error(format!("failed to register v3 before source: {error}")))?;
+        let after = self
+            .store
+            .data_mut()
+            .table
+            .push(SourceResource {
+                source: update.after,
+                state: state.clone(),
+            })
+            .map_err(|error| v3_error(format!("failed to register v3 after source: {error}")))?;
+        let sink = self
+            .store
+            .data_mut()
+            .table
+            .push(SinkResource {
+                state: state.clone(),
+            })
+            .map_err(|error| v3_error(format!("failed to register v3 sink: {error}")))?;
+        let sink_rep = sink.rep();
+        let binding_update = bindings::exports::lix::plugin::api::FileUpdate {
+            before_descriptor: bindings::exports::lix::plugin::api::FileDescriptor {
+                path: update.before_descriptor.path,
+                media_type: update.before_descriptor.media_type,
+            },
+            after_descriptor: bindings::exports::lix::plugin::api::FileDescriptor {
+                path: update.after_descriptor.path,
+                media_type: update.after_descriptor.media_type,
+            },
+            before,
+            edits: update
+                .edits
+                .into_iter()
+                .map(|edit| bindings::exports::lix::plugin::api::InputSplice {
+                    offset: edit.offset,
+                    delete_len: edit.delete_len,
+                    insert: match edit.insert {
+                        WasmInputBytes::Inline(bytes) => {
+                            bindings::exports::lix::plugin::api::InputBytes::Inline(bytes)
+                        }
+                        WasmInputBytes::AfterRange(range) => {
+                            bindings::exports::lix::plugin::api::InputBytes::AfterRange(
+                                bindings::exports::lix::plugin::api::SourceRange {
+                                    offset: range.offset,
+                                    length: range.length,
+                                },
+                            )
+                        }
+                    },
+                })
+                .collect(),
+            after,
+            creates: bindings::exports::lix::plugin::api::CreateContext {
+                high: update.creates.high,
+                low: update.creates.low,
+            },
+            max_batch_bytes: limits.max_page_bytes,
+        };
+        let result = self.guest.document().call_file_changed(
+            &mut self.store,
+            document_resource,
+            &binding_update,
+            Resource::new_borrow(sink_rep),
+        );
+        let _ = self.store.data_mut().table.delete(sink);
+        let value = match result {
+            Ok(Ok(value)) => value,
+            Ok(Err(error)) => {
+                return Err(v3_error(format!(
+                    "v3 file-changed rejected input: {error:?}"
+                )));
+            }
+            Err(error) => {
+                return Err(wasm_runtime_error("v3 file-changed trapped", error));
+            }
+        };
+        self.documents.insert(next_document, value.document);
+        self.next_document = self.next_document.max(next_document.saturating_add(1));
+        let mut state = Arc::try_unwrap(state)
+            .map_err(|_| v3_error("v3 transition resources remained live after file-changed"))?
+            .into_inner()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if value.summary.entity_count != state.counters.packet_records
+            || value.summary.batch_count as u64 != state.counters.packet_pages
+            || value.summary.payload_bytes > state.counters.component_boundary_bytes
+        {
+            return Err(v3_error(
+                "v3 guest summary does not match emitted packet pages",
+            ));
+        }
+        state.counters.guest_linear_memory_high_water_bytes =
+            self.store.data().limits.linear_memory_high_water_bytes();
+        Ok(state.counters)
+    }
+
+    fn fork(&mut self, document: u64) -> Result<u64, LixError> {
+        let resource = *self
+            .documents
+            .get(&document)
+            .ok_or_else(|| v3_error("unknown v3 document handle"))?;
+        let fork = self
+            .guest
+            .document()
+            .call_fork(&mut self.store, resource)
+            .map_err(|error| wasm_runtime_error("v3 document fork trapped", error))?;
+        let handle = self.next_document;
+        self.next_document = self
+            .next_document
+            .checked_add(1)
+            .ok_or_else(|| v3_error("v3 document handle overflowed"))?;
+        self.documents.insert(handle, fork);
+        Ok(handle)
+    }
+
+    fn drop_document(&mut self, document: u64) -> Result<(), LixError> {
+        if let Some(resource) = self.documents.remove(&document) {
+            resource
+                .resource_drop(&mut self.store)
+                .map_err(|error| wasm_runtime_error("v3 document drop trapped", error))?;
+        }
+        Ok(())
+    }
+}
+
+struct CursorState {
+    transition: WasmTransitionHandle,
+    events: tokio::sync::mpsc::Receiver<WorkerTransitionEvent>,
+    complete_file_state: bool,
+    certified_csv_pages: Vec<Bytes>,
+    certified_csv_rows: u64,
+    certified_csv_creates: Option<WasmCreateContext>,
+    certified_csv_last_local_ref: Option<u32>,
+    certified_packet_pages: Vec<Bytes>,
+    certified_packet_rows: u64,
+    certified_packet_creates: Option<WasmCreateContext>,
+    certified_packet_schema_keys: std::collections::BTreeSet<String>,
+}
+
+struct V3Actor {
+    sender: mpsc::Sender<WorkerCommand>,
+    thread: Option<std::thread::JoinHandle<()>>,
+    _timeout_ticker: TimeoutTickerLease,
+    next_handle: u64,
+    cursors: HashMap<u64, CursorState>,
+    transitions: HashMap<u64, WasmTransitionCounters>,
+    retired: bool,
+    next_document: u64,
+}
+
+impl V3Actor {
+    fn allocate_handle(&mut self) -> Result<u64, LixError> {
+        let handle = self.next_handle;
+        self.next_handle = self
+            .next_handle
+            .checked_add(1)
+            .ok_or_else(|| v3_error("v3 actor handle overflowed"))?;
+        Ok(handle)
+    }
+
+    fn allocate_document(&mut self) -> Result<u64, LixError> {
+        let document = self.next_document;
+        self.next_document = self
+            .next_document
+            .checked_add(1)
+            .ok_or_else(|| v3_error("v3 document handle overflowed"))?;
+        Ok(document)
+    }
+
+    async fn request<T>(
+        &mut self,
+        build: impl FnOnce(tokio::sync::oneshot::Sender<Result<T, LixError>>) -> WorkerCommand,
+    ) -> Result<T, LixError> {
+        if self.retired {
+            return Err(v3_error("v3 actor is retired"));
+        }
+        let (sender, receiver) = tokio::sync::oneshot::channel();
+        self.sender
+            .send(build(sender))
+            .map_err(|_| v3_error("v3 actor executor stopped"))?;
+        receiver
+            .await
+            .map_err(|_| v3_error("v3 actor executor dropped its response"))?
+    }
+}
+
+#[async_trait]
+impl WasmComponentV2Actor for V3Actor {
+    async fn fork_document(
+        &mut self,
+        document: WasmDocumentHandle,
+    ) -> Result<WasmDocumentHandle, LixError> {
+        let fork = self
+            .request(|response| WorkerCommand::Fork {
+                document: document.0,
+                response,
+            })
+            .await?;
+        self.next_document = self.next_document.max(fork.saturating_add(1));
+        Ok(WasmDocumentHandle(fork))
+    }
+
+    async fn open_file(
+        &mut self,
+        limits: WasmTransitionLimits,
+        input: WasmOpenFileInput,
+    ) -> Result<WasmFileTransition, LixError> {
+        let document = self.allocate_document()?;
+        let transition = WasmTransitionHandle(self.allocate_handle()?);
+        let cursor = WasmChangeCursorHandle(self.allocate_handle()?);
+        let (events, receiver) = tokio::sync::mpsc::channel(2);
+        let retire_after = input.file.len() > MAX_RETAINED_IMPORT_BYTES;
+        self.sender
+            .send(WorkerCommand::OpenFile {
+                document,
+                limits,
+                input,
+                events,
+                retire_after,
+            })
+            .map_err(|_| v3_error("v3 actor executor stopped"))?;
+        self.cursors.insert(
+            cursor.0,
+            CursorState {
+                transition,
+                events: receiver,
+                complete_file_state: true,
+                certified_csv_pages: Vec::new(),
+                certified_csv_rows: 0,
+                certified_csv_creates: None,
+                certified_csv_last_local_ref: None,
+                certified_packet_pages: Vec::new(),
+                certified_packet_rows: 0,
+                certified_packet_creates: None,
+                certified_packet_schema_keys: std::collections::BTreeSet::new(),
+            },
+        );
+        Ok(WasmFileTransition {
+            transition,
+            document: WasmDocumentHandle(document),
+            changes: cursor,
+        })
+    }
+
+    async fn open_entities(
+        &mut self,
+        _limits: WasmTransitionLimits,
+        _input: WasmOpenEntitiesInput,
+    ) -> Result<WasmEntityTransition, LixError> {
+        Err(v3_unsupported("open-entities"))
+    }
+
+    async fn file_changed(
+        &mut self,
+        document: WasmDocumentHandle,
+        limits: WasmTransitionLimits,
+        update: WasmFileUpdate,
+    ) -> Result<WasmFileTransition, LixError> {
+        update.validate(limits)?;
+        let next_document = self.allocate_document()?;
+        let transition = WasmTransitionHandle(self.allocate_handle()?);
+        let cursor = WasmChangeCursorHandle(self.allocate_handle()?);
+        let (events, receiver) = tokio::sync::mpsc::channel(2);
+        let retire_after = update.after.len() > MAX_RETAINED_IMPORT_BYTES;
+        self.sender
+            .send(WorkerCommand::FileChanged {
+                document: document.0,
+                next_document,
+                limits,
+                update,
+                events,
+                retire_after,
+            })
+            .map_err(|_| v3_error("v3 actor executor stopped"))?;
+        self.cursors.insert(
+            cursor.0,
+            CursorState {
+                transition,
+                events: receiver,
+                complete_file_state: false,
+                certified_csv_pages: Vec::new(),
+                certified_csv_rows: 0,
+                certified_csv_creates: None,
+                certified_csv_last_local_ref: None,
+                certified_packet_pages: Vec::new(),
+                certified_packet_rows: 0,
+                certified_packet_creates: None,
+                certified_packet_schema_keys: std::collections::BTreeSet::new(),
+            },
+        );
+        Ok(WasmFileTransition {
+            transition,
+            document: WasmDocumentHandle(next_document),
+            changes: cursor,
+        })
+    }
+
+    async fn entities_changed(
+        &mut self,
+        _document: WasmDocumentHandle,
+        _limits: WasmTransitionLimits,
+        _update: WasmEntityUpdate,
+    ) -> Result<WasmEntityTransition, LixError> {
+        Err(v3_unsupported("entities-changed"))
+    }
+
+    async fn next_change_page(
+        &mut self,
+        transition: WasmTransitionHandle,
+        cursor: WasmChangeCursorHandle,
+        _max_bytes: u32,
+    ) -> Result<Option<WasmChangePage>, LixError> {
+        let cursor = self
+            .cursors
+            .get_mut(&cursor.0)
+            .ok_or_else(|| v3_error("unknown v3 change cursor"))?;
+        if cursor.transition != transition {
+            return Err(v3_error("v3 change cursor belongs to another transition"));
+        }
+        loop {
+            match cursor.events.recv().await {
+                Some(WorkerTransitionEvent::Page(PendingChangePage::TypedCsv {
+                    row_count,
+                    payload,
+                    creates,
+                })) => {
+                    let (first_local_ref, last_local_ref) =
+                        validate_typed_csv_rows(row_count, &payload).map_err(v3_error)?;
+                    if cursor
+                        .certified_csv_last_local_ref
+                        .is_some_and(|previous| previous >= first_local_ref)
+                    {
+                        return Err(v3_error(
+                            "certified CSV local refs must increase across pages",
+                        ));
+                    }
+                    if cursor
+                        .certified_csv_creates
+                        .is_some_and(|existing| existing != creates)
+                    {
+                        return Err(v3_error(
+                            "one certified CSV transition used multiple create contexts",
+                        ));
+                    }
+                    cursor.certified_csv_creates = Some(creates);
+                    cursor.certified_csv_rows = cursor
+                        .certified_csv_rows
+                        .checked_add(u64::from(row_count))
+                        .ok_or_else(|| v3_error("certified CSV row count overflowed"))?;
+                    cursor.certified_csv_last_local_ref = Some(last_local_ref);
+                    cursor.certified_csv_pages.push(Bytes::from(payload));
+                }
+                Some(WorkerTransitionEvent::Page(page @ PendingChangePage::Packet { .. })) => {
+                    let PendingChangePage::Packet {
+                        record_count,
+                        payload,
+                        max_page_bytes,
+                        limits,
+                        creates,
+                    } = page
+                    else {
+                        unreachable!("matched packet page")
+                    };
+                    if let Some(schema_keys) =
+                        validate_created_packet_page(record_count, &payload).map_err(v3_error)?
+                    {
+                        if cursor
+                            .certified_packet_creates
+                            .is_some_and(|existing| existing != creates)
+                        {
+                            return Err(v3_error(
+                                "one certified packet transition used multiple create contexts",
+                            ));
+                        }
+                        cursor.certified_packet_creates = Some(creates);
+                        cursor.certified_packet_rows = cursor
+                            .certified_packet_rows
+                            .checked_add(u64::from(record_count))
+                            .ok_or_else(|| v3_error("certified packet row count overflowed"))?;
+                        cursor.certified_packet_schema_keys.extend(schema_keys);
+                        cursor.certified_packet_pages.push(Bytes::from(payload));
+                    } else {
+                        return PendingChangePage::Packet {
+                            record_count,
+                            payload,
+                            max_page_bytes,
+                            limits,
+                            creates,
+                        }
+                        .decode()
+                        .map(Some);
+                    }
+                }
+                Some(WorkerTransitionEvent::Finished(result)) => {
+                    let counters = result?;
+                    self.transitions.insert(transition.0, counters);
+                    return Ok(None);
+                }
+                None => return Err(v3_error("v3 transition producer stopped")),
+            }
+        }
+    }
+
+    fn take_certified_entity_batches(
+        &mut self,
+        transition: WasmTransitionHandle,
+    ) -> Vec<WasmCertifiedEntityBatch> {
+        let Some(cursor) = self
+            .cursors
+            .values_mut()
+            .find(|cursor| cursor.transition == transition)
+        else {
+            return Vec::new();
+        };
+        let mut batches = Vec::with_capacity(2);
+        if let Some(creates) = cursor.certified_csv_creates.take() {
+            batches.push(WasmCertifiedEntityBatch {
+                format: CERTIFIED_TYPED_CSV_V1,
+                schema_keys: vec!["csv_v2_row".to_owned()],
+                row_count: std::mem::take(&mut cursor.certified_csv_rows),
+                creates,
+                complete_file_state: cursor.complete_file_state,
+                pages: std::mem::take(&mut cursor.certified_csv_pages),
+            });
+        }
+        if let Some(creates) = cursor.certified_packet_creates.take() {
+            batches.push(WasmCertifiedEntityBatch {
+                format: CERTIFIED_CREATED_PACKET_V1,
+                schema_keys: std::mem::take(&mut cursor.certified_packet_schema_keys)
+                    .into_iter()
+                    .collect(),
+                row_count: std::mem::take(&mut cursor.certified_packet_rows),
+                creates,
+                complete_file_state: cursor.complete_file_state,
+                pages: std::mem::take(&mut cursor.certified_packet_pages),
+            });
+        }
+        batches
+    }
+
+    async fn next_edit_page(
+        &mut self,
+        _transition: WasmTransitionHandle,
+        _cursor: WasmEditCursorHandle,
+        _max_edits: u32,
+        _max_inline_bytes: u32,
+    ) -> Result<Option<WasmEditPage>, LixError> {
+        Err(v3_unsupported("edit cursor"))
+    }
+
+    async fn output_len(
+        &mut self,
+        _transition: WasmTransitionHandle,
+        _outputs: WasmByteOutputsHandle,
+        _index: u32,
+    ) -> Result<u64, LixError> {
+        Err(v3_unsupported("output attachment"))
+    }
+
+    async fn read_output(
+        &mut self,
+        _transition: WasmTransitionHandle,
+        _outputs: WasmByteOutputsHandle,
+        _index: u32,
+        _offset: u64,
+        _length: u32,
+    ) -> Result<Vec<u8>, LixError> {
+        Err(v3_unsupported("output attachment"))
+    }
+
+    async fn finish_transition(
+        &mut self,
+        transition: WasmTransitionHandle,
+    ) -> Result<WasmTransitionCounters, LixError> {
+        self.cursors
+            .retain(|_, cursor| cursor.transition != transition);
+        self.transitions
+            .remove(&transition.0)
+            .ok_or_else(|| v3_error("unknown v3 transition"))
+    }
+
+    async fn discard_transition(
+        &mut self,
+        transition: WasmTransitionHandle,
+    ) -> Result<(), LixError> {
+        self.cursors
+            .retain(|_, cursor| cursor.transition != transition);
+        self.transitions.remove(&transition.0);
+        Ok(())
+    }
+
+    fn is_retired(&self) -> bool {
+        self.retired
+    }
+
+    async fn drop_document(&mut self, document: WasmDocumentHandle) -> Result<(), LixError> {
+        self.request(|response| WorkerCommand::DropDocument {
+            document: document.0,
+            response,
+        })
+        .await
+    }
+
+    async fn retire(&mut self) -> Result<(), LixError> {
+        if !self.retired {
+            self.retired = true;
+            let _ = self.sender.send(WorkerCommand::Shutdown);
+            if let Some(thread) = self.thread.take() {
+                thread
+                    .join()
+                    .map_err(|_| v3_error("v3 actor executor panicked"))?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Drop for V3Actor {
+    fn drop(&mut self) {
+        let _ = self.sender.send(WorkerCommand::Shutdown);
+    }
+}
+
+fn v3_error(message: impl Into<String>) -> LixError {
+    LixError::new(LixError::CODE_INVALID_PLUGIN, message)
+}
+
+fn v3_transition_limits(
+    mut limits: WasmTransitionLimits,
+) -> Result<WasmTransitionLimits, LixError> {
+    limits.max_page_bytes = V3_MAX_BATCH_BYTES.min(
+        u32::try_from(limits.max_total_bytes)
+            .unwrap_or(u32::MAX)
+            .max(limits.max_record_bytes),
+    );
+    limits.validate()
+}
+
+fn v3_unsupported(operation: &str) -> LixError {
+    v3_error(format!(
+        "Component v3 Prototype A does not implement {operation}"
+    ))
+}

--- a/packages/rs-sdk/src/default_wasm_runtime_v3_prototype.rs
+++ b/packages/rs-sdk/src/default_wasm_runtime_v3_prototype.rs
@@ -1287,6 +1287,22 @@ impl WasmComponentV2Actor for V3Actor {
                     if let Some(schema_keys) =
                         validate_created_packet_page(record_count, &payload).map_err(v3_error)?
                     {
+                        // Certified immutable segments are the ownership unit
+                        // for complete bulk state. Sparse successors stay as
+                        // ordinary row overlays: this lets validation observe
+                        // their durable base directly and avoids paying a new
+                        // segment/manifest lifecycle for one or two rows.
+                        if !cursor.complete_file_state {
+                            return PendingChangePage::Packet {
+                                record_count,
+                                payload,
+                                max_page_bytes,
+                                limits,
+                                creates,
+                            }
+                            .decode()
+                            .map(Some);
+                        }
                         if cursor
                             .certified_packet_creates
                             .is_some_and(|existing| existing != creates)
@@ -1456,6 +1472,10 @@ fn v3_transition_limits(
             .unwrap_or(u32::MAX)
             .max(limits.max_record_bytes),
     );
+    // v3 batches are the record envelope. Keeping the inherited v2 1 MiB
+    // record cap while advertising a 2 MiB push page rejects otherwise valid
+    // single-snapshot pages (notably Markdown lexical fallbacks).
+    limits.max_record_bytes = limits.max_page_bytes;
     limits.validate()
 }
 

--- a/packages/rs-sdk/wit/v3-prototype/lix-plugin-v3.wit
+++ b/packages/rs-sdk/wit/v3-prototype/lix-plugin-v3.wit
@@ -1,0 +1,116 @@
+package lix:plugin@3.0.0;
+
+interface host {
+  type bytes = list<u8>;
+
+  variant host-error {
+    invalid-range,
+    limit-exceeded(string),
+    rejected(string),
+  }
+
+  resource source {
+    len: func() -> u64;
+    read: func(offset: u64, length: u32) -> result<bytes, host-error>;
+  }
+
+  record change-page {
+    format-version: u16,
+    record-count: u32,
+    payload: bytes,
+  }
+
+  record csv-row-batch {
+    row-count: u32,
+    payload: bytes,
+  }
+
+  resource transition-sink {
+    emit-changes: func(page: change-page) -> result<_, host-error>;
+    emit-csv-rows: func(batch: csv-row-batch) -> result<_, host-error>;
+  }
+}
+
+interface api {
+  use host.{bytes, source, transition-sink};
+
+  variant plugin-error {
+    invalid-input(string),
+    limit-exceeded(string),
+    internal(string),
+  }
+
+  record file-descriptor {
+    path: option<string>,
+    media-type: option<string>,
+  }
+
+  record create-context {
+    high: u64,
+    low: u32,
+  }
+
+  record open-file-input {
+    descriptor: file-descriptor,
+    file: own<source>,
+    creates: create-context,
+    max-batch-bytes: u32,
+  }
+
+  record source-range {
+    offset: u64,
+    length: u64,
+  }
+
+  variant input-bytes {
+    inline(bytes),
+    after-range(source-range),
+  }
+
+  record input-splice {
+    offset: u64,
+    delete-len: u64,
+    insert: input-bytes,
+  }
+
+  record file-update {
+    before-descriptor: file-descriptor,
+    after-descriptor: file-descriptor,
+    before: own<source>,
+    edits: list<input-splice>,
+    after: own<source>,
+    creates: create-context,
+    max-batch-bytes: u32,
+  }
+
+  record transition-summary {
+    entity-count: u64,
+    batch-count: u32,
+    payload-bytes: u64,
+  }
+
+  resource document {
+    fork: func() -> own<document>;
+    /// The guest stays entered while it pushes every bounded change page into
+    /// the host sink. No guest-owned change cursor crosses the boundary.
+    file-changed: func(
+      input: file-update,
+      sink: borrow<transition-sink>,
+    ) -> result<file-transition, plugin-error>;
+  }
+
+  record file-transition {
+    document: own<document>,
+    summary: transition-summary,
+  }
+
+  open-file: func(
+    input: open-file-input,
+    sink: borrow<transition-sink>,
+  ) -> result<file-transition, plugin-error>;
+}
+
+world plugin {
+  import host;
+  export api;
+}

--- a/plugins/csv-v2/src/bindings.rs
+++ b/plugins/csv-v2/src/bindings.rs
@@ -195,5 +195,5 @@ fn core_edits(edits: Vec<CoreByteEdit>) -> sdk::Edits {
     sdk::edits(edits.into_iter().map(sdk_edit))
 }
 
-#[cfg(target_family = "wasm")]
+#[cfg(all(target_family = "wasm", feature = "component-v2"))]
 lix_plugin_api_v2::export_v2!(CsvPlugin);

--- a/plugins/csv-v2/src/core.rs
+++ b/plugins/csv-v2/src/core.rs
@@ -232,6 +232,27 @@ impl PersistentBlob {
         Ok(output)
     }
 
+    fn contiguous_range(&self, start: usize, end: usize) -> Option<&[u8]> {
+        let start = u32::try_from(start).ok()?;
+        let end = u32::try_from(end).ok()?;
+        if start > end || end > self.len {
+            return None;
+        }
+        let mut logical_start = 0u32;
+        for piece in self.pieces.iter() {
+            let logical_end = logical_start.checked_add(piece.len)?;
+            if start >= logical_start && end <= logical_end {
+                let selected_start = piece.start.checked_add(start - logical_start)?;
+                let selected_end = piece.start.checked_add(end - logical_start)?;
+                return piece.bytes.get(
+                    usize::try_from(selected_start).ok()?..usize::try_from(selected_end).ok()?,
+                );
+            }
+            logical_start = logical_end;
+        }
+        (start == end).then_some(&[])
+    }
+
     fn byte(&self, offset: usize) -> Option<u8> {
         let offset = u32::try_from(offset).ok()?;
         if offset >= self.len {
@@ -1879,6 +1900,90 @@ impl Document {
         }
     }
 
+    /// Encodes a bounded Prototype-B batch without constructing per-row JSON
+    /// snapshots. `start_row` and the returned next-row index are ordinal
+    /// positions in this freshly opened document.
+    pub fn initial_typed_csv_batch(
+        &self,
+        start_row: usize,
+        max_bytes: usize,
+    ) -> Result<Option<(Vec<u8>, u32, usize)>, String> {
+        if start_row >= self.row_count() {
+            return Ok(None);
+        }
+        if max_bytes < 64 {
+            return Err("typed CSV batch limit is too small".to_owned());
+        }
+        let mut payload = Vec::with_capacity(max_bytes.min(1024 * 1024));
+        let mut encoded_row = Vec::with_capacity(256);
+        let mut force_quote = Vec::new();
+        let mut row_ordinal = start_row;
+        let mut row_count = 0u32;
+        while let Some(location) = self.0.index.ordinal_location(row_ordinal) {
+            encoded_row.clear();
+            force_quote.clear();
+            let (chunk, row) = self.0.index.row(location);
+            encoded_row.extend_from_slice(&row.id_slot.to_le_bytes());
+            encoded_row.extend_from_slice(&row.order_rank.to_le_bytes());
+            let exceptional_ending =
+                (row.ending() != Some(self.0.dialect.terminator)).then_some(row.ending());
+            encoded_row.push(match exceptional_ending {
+                None => 0,
+                Some(None) => 1,
+                Some(Some(Terminator::Lf)) => 2,
+                Some(Some(Terminator::CrLf)) => 3,
+                Some(Some(Terminator::Cr)) => 4,
+            });
+            let row_start =
+                usize::try_from(chunk.byte_start + row.relative_start).expect("u32 fits usize");
+            let row_end = row_start + usize::try_from(row.byte_len).expect("u32 fits usize");
+            let row_bytes = self
+                .0
+                .blob
+                .contiguous_range(row_start, row_end)
+                .ok_or_else(|| "initial typed CSV row is not contiguous".to_owned())?;
+            let first = usize::try_from(row.first_field).expect("u32 fits usize");
+            let end = first + usize::from(row.field_count);
+            for (index, field) in chunk.data.fields[first..end].iter().copied().enumerate() {
+                if field_has_unnecessary_quotes(row_bytes, 0, field, self.0.dialect)? {
+                    if force_quote.len() <= index / 8 {
+                        force_quote.resize(index / 8 + 1, 0);
+                    }
+                    force_quote[index / 8] |= 1 << (index % 8);
+                }
+            }
+            encoded_row.extend_from_slice(
+                &u32::try_from(force_quote.len())
+                    .map_err(|_| "CSV quote layout exceeds 4GiB".to_owned())?
+                    .to_le_bytes(),
+            );
+            encoded_row.extend_from_slice(&force_quote);
+            encoded_row.extend_from_slice(&row.field_count.to_le_bytes());
+            for field in chunk.data.fields[first..end].iter().copied() {
+                let length_offset = encoded_row.len();
+                encoded_row.extend_from_slice(&0u32.to_le_bytes());
+                let value_start = encoded_row.len();
+                append_decoded_field(&mut encoded_row, row_bytes, field, self.0.dialect.quote)?;
+                let value_len = u32::try_from(encoded_row.len() - value_start)
+                    .map_err(|_| "decoded CSV cell exceeds 4GiB".to_owned())?;
+                encoded_row[length_offset..length_offset + 4]
+                    .copy_from_slice(&value_len.to_le_bytes());
+            }
+            if encoded_row.len() > max_bytes {
+                return Err("one typed CSV row exceeds the batch limit".to_owned());
+            }
+            if row_count > 0 && payload.len() + encoded_row.len() > max_bytes {
+                break;
+            }
+            payload.extend_from_slice(&encoded_row);
+            row_count = row_count
+                .checked_add(1)
+                .ok_or_else(|| "typed CSV row count overflowed".to_owned())?;
+            row_ordinal += 1;
+        }
+        Ok(Some((payload, row_count, row_ordinal)))
+    }
+
     pub fn bytes(&self) -> Vec<u8> {
         self.0.blob.materialize()
     }
@@ -2578,6 +2683,123 @@ impl Document {
     }
 }
 
+/// One-shot initial-import view for v3 actors that will not be cached.
+///
+/// This keeps only the submitted bytes and scan drafts while typed pages are
+/// emitted. It deliberately skips the persistent chunk index, identity maps,
+/// and overlay structures that are useful only to a later warm transition.
+pub struct ColdInitialImport {
+    bytes: Vec<u8>,
+    rows: Vec<RowDraft>,
+    dialect: Dialect,
+    next_row: usize,
+}
+
+impl ColdInitialImport {
+    pub fn open(bytes: Vec<u8>, path: Option<&str>) -> Result<Self, String> {
+        if bytes.len() > u32::MAX as usize {
+            return Err("CSV v3 currently supports files smaller than 4GiB".to_owned());
+        }
+        std::str::from_utf8(&bytes).map_err(|error| format!("CSV must be UTF-8: {error}"))?;
+        let mut dialect = Dialect::for_path(path);
+        let mut rows = scan_rows(&bytes, 0, bytes.len(), dialect)?;
+        dialect.terminator = preferred_terminator(&rows);
+        assign_initial_rows(&mut rows);
+        Ok(Self {
+            bytes,
+            rows,
+            dialect,
+            next_row: 0,
+        })
+    }
+
+    pub fn table_change(&self) -> EntityChange {
+        EntityChange::upsert(
+            TABLE_SCHEMA_KEY,
+            ROOT_ENTITY_PK.to_owned(),
+            table_snapshot(self.dialect),
+        )
+    }
+
+    pub fn next_typed_batch(&mut self, max_bytes: usize) -> Result<Option<(Vec<u8>, u32)>, String> {
+        if self.next_row >= self.rows.len() {
+            return Ok(None);
+        }
+        if max_bytes < 64 {
+            return Err("typed CSV batch limit is too small".to_owned());
+        }
+        let mut payload = Vec::with_capacity(max_bytes.min(1024 * 1024));
+        let mut encoded_row = Vec::with_capacity(256);
+        let mut force_quote = Vec::new();
+        let mut row_count = 0u32;
+        while let Some(row) = self.rows.get(self.next_row) {
+            encoded_row.clear();
+            force_quote.clear();
+            encoded_row.extend_from_slice(
+                &row.id_slot
+                    .expect("cold import rows have assigned identities")
+                    .to_le_bytes(),
+            );
+            encoded_row.extend_from_slice(
+                &row.order_rank
+                    .expect("cold import rows have assigned order")
+                    .to_le_bytes(),
+            );
+            let exceptional_ending =
+                (row.ending != Some(self.dialect.terminator)).then_some(row.ending);
+            encoded_row.push(match exceptional_ending {
+                None => 0,
+                Some(None) => 1,
+                Some(Some(Terminator::Lf)) => 2,
+                Some(Some(Terminator::CrLf)) => 3,
+                Some(Some(Terminator::Cr)) => 4,
+            });
+            let row_start = row.start as usize;
+            let row_end = row_start + row.byte_len as usize;
+            let row_bytes = &self.bytes[row_start..row_end];
+            for (index, field) in row.fields.iter().copied().enumerate() {
+                if field_has_unnecessary_quotes(row_bytes, 0, field, self.dialect)? {
+                    if force_quote.len() <= index / 8 {
+                        force_quote.resize(index / 8 + 1, 0);
+                    }
+                    force_quote[index / 8] |= 1 << (index % 8);
+                }
+            }
+            encoded_row.extend_from_slice(
+                &u32::try_from(force_quote.len())
+                    .map_err(|_| "CSV quote layout exceeds 4GiB".to_owned())?
+                    .to_le_bytes(),
+            );
+            encoded_row.extend_from_slice(&force_quote);
+            let field_count = u16::try_from(row.fields.len())
+                .map_err(|_| "CSV row has too many fields".to_owned())?;
+            encoded_row.extend_from_slice(&field_count.to_le_bytes());
+            for field in row.fields.iter().copied() {
+                let length_offset = encoded_row.len();
+                encoded_row.extend_from_slice(&0u32.to_le_bytes());
+                let value_start = encoded_row.len();
+                append_decoded_field(&mut encoded_row, row_bytes, field, self.dialect.quote)?;
+                let value_len = u32::try_from(encoded_row.len() - value_start)
+                    .map_err(|_| "decoded CSV cell exceeds 4GiB".to_owned())?;
+                encoded_row[length_offset..length_offset + 4]
+                    .copy_from_slice(&value_len.to_le_bytes());
+            }
+            if encoded_row.len() > max_bytes {
+                return Err("one typed CSV row exceeds the batch limit".to_owned());
+            }
+            if row_count > 0 && payload.len() + encoded_row.len() > max_bytes {
+                break;
+            }
+            payload.extend_from_slice(&encoded_row);
+            row_count = row_count
+                .checked_add(1)
+                .ok_or_else(|| "typed CSV row count overflowed".to_owned())?;
+            self.next_row += 1;
+        }
+        Ok(Some((payload, row_count)))
+    }
+}
+
 fn virtual_ordinal(ordinal: usize, excluding: Option<usize>) -> usize {
     if excluding.is_some_and(|excluded| ordinal >= excluded) {
         ordinal + 1
@@ -2899,6 +3121,36 @@ fn decoded_field(
         }
     }
     String::from_utf8(decoded).map_err(|error| format!("CSV field is not UTF-8: {error}"))
+}
+
+fn append_decoded_field(
+    output: &mut Vec<u8>,
+    row: &[u8],
+    field: FieldRange,
+    quote: Option<u8>,
+) -> Result<(), String> {
+    let start = usize::try_from(field.start).expect("u32 fits usize");
+    let end = start + usize::try_from(field.length()).expect("u32 fits usize");
+    let raw = &row[start..end];
+    if !field.quoted() {
+        output.extend_from_slice(raw);
+        return Ok(());
+    }
+    let quote = quote.ok_or_else(|| "quoted CSV field has no configured quote".to_owned())?;
+    if raw.len() < 2 || raw.first() != Some(&quote) || raw.last() != Some(&quote) {
+        return Err("invalid quoted CSV field".to_owned());
+    }
+    let body = &raw[1..raw.len() - 1];
+    let mut cursor = 0;
+    while cursor < body.len() {
+        output.push(body[cursor]);
+        cursor += if body[cursor] == quote && cursor + 1 < body.len() && body[cursor + 1] == quote {
+            2
+        } else {
+            1
+        };
+    }
+    Ok(())
 }
 
 fn field_has_unnecessary_quotes(

--- a/plugins/csv-v2/src/core.rs
+++ b/plugins/csv-v2/src/core.rs
@@ -2688,6 +2688,7 @@ impl Document {
 /// This keeps only the submitted bytes and scan drafts while typed pages are
 /// emitted. It deliberately skips the persistent chunk index, identity maps,
 /// and overlay structures that are useful only to a later warm transition.
+#[allow(dead_code)]
 pub struct ColdInitialImport {
     bytes: Vec<u8>,
     rows: Vec<RowDraft>,
@@ -2695,6 +2696,7 @@ pub struct ColdInitialImport {
     next_row: usize,
 }
 
+#[allow(dead_code)]
 impl ColdInitialImport {
     pub fn open(bytes: Vec<u8>, path: Option<&str>) -> Result<Self, String> {
         if bytes.len() > u32::MAX as usize {

--- a/plugins/csv-v2/src/lib.rs
+++ b/plugins/csv-v2/src/lib.rs
@@ -1,5 +1,6 @@
 //! Incremental CSV guest for the Lix Wasm Component plugin API v2.
 
+#[cfg(feature = "component-v2")]
 mod bindings;
 mod core;
 

--- a/plugins/csv-v3-prototype/Cargo.toml
+++ b/plugins/csv-v3-prototype/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "plugin_csv_v2"
+name = "plugin_csv_v3_prototype"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-description = "Incremental CSV file plugin for the Lix Wasm Component v2 API"
+description = "CSV prototype for the fused Lix Wasm Component API v3"
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
@@ -12,6 +12,7 @@ readme = "README.md"
 keywords.workspace = true
 categories.workspace = true
 rust-version.workspace = true
+publish = false
 
 [lints]
 workspace = true
@@ -19,12 +20,8 @@ workspace = true
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[features]
-default = ["component-v2"]
-component-v2 = ["dep:lix_plugin_api_v2"]
-
 [dependencies]
 base64 = "0.22"
-lix_plugin_api_v2 = { workspace = true, optional = true }
+lix_plugin_api_v3_prototype = { workspace = true }
 serde_json = "1"
 uuid = { version = "1", features = ["std"] }

--- a/plugins/csv-v3-prototype/README.md
+++ b/plugins/csv-v3-prototype/README.md
@@ -1,0 +1,14 @@
+# CSV Component API v3 prototype
+
+Fused, push-based initial CSV import used only for runtime and boundary
+benchmarking.
+
+Prototype B emits bounded batches containing compact local row references,
+order ranks, decoded UTF-8 cells, and sparse lexical layout. The Wasm guest
+does not allocate row UUID strings or JSON snapshots. The current host adapter
+rebuilds canonical snapshots into one shared page arena so the unchanged v2
+transaction path can provide a correctness-matched comparison.
+
+That adapter is intentionally the boundary for Prototype C: C must lower these
+batches into transaction/storage-native columns without a `Vec<Entity>` or a
+second full row materialization.

--- a/plugins/csv-v3-prototype/manifest.json
+++ b/plugins/csv-v3-prototype/manifest.json
@@ -1,0 +1,15 @@
+{
+  "key": "plugin_csv_v3_prototype",
+  "runtime": "wasm-component-v2",
+  "api_version": "3.0.0",
+  "materialization": "blob",
+  "match": {
+    "path_glob": "*.{csv,tsv}",
+    "content_type": "text"
+  },
+  "entry": "plugin.wasm",
+  "schemas": [
+    "schema/csv_v2_table.json",
+    "schema/csv_v2_row.json"
+  ]
+}

--- a/plugins/csv-v3-prototype/src/lib.rs
+++ b/plugins/csv-v3-prototype/src/lib.rs
@@ -1,0 +1,271 @@
+//! Fused initial-import CSV experiment for Component API v3.
+
+#[path = "../../csv-v2/src/core.rs"]
+mod core;
+
+use core::{
+    ChangeEffect, ColdInitialImport, Document, EntityChange, IdNamespace, ROW_SCHEMA_KEY,
+    TABLE_SCHEMA_KEY,
+};
+use lix_plugin_api_v3_prototype as sdk;
+use serde_json::Value;
+
+struct CsvV3Prototype;
+
+impl sdk::FormatPlugin for CsvV3Prototype {
+    type Document = Document;
+
+    fn open_file(
+        input: sdk::OpenFile<'_>,
+        sink: &mut sdk::Sink<'_>,
+    ) -> sdk::Result<Self::Document> {
+        const MAX_RETAINED_IMPORT_BYTES: u64 = 8 * 1024 * 1024;
+        let source_len = input.source.len();
+        let bytes = input.source.read_all()?;
+        let namespace = IdNamespace::from_halves(input.creates.high, u64::from(input.creates.low));
+        if source_len > MAX_RETAINED_IMPORT_BYTES {
+            let mut import = ColdInitialImport::open(bytes, input.file.path.as_deref())
+                .map_err(sdk::Error::invalid_input)?;
+            let mut encoder = BatchEncoder::new(sink.max_batch_bytes());
+            encoder.push(import.table_change(), input.creates, sink)?;
+            encoder.flush(sink)?;
+            while let Some((payload, row_count)) = import
+                .next_typed_batch(sink.max_batch_bytes() as usize)
+                .map_err(sdk::Error::invalid_input)?
+            {
+                sink.emit_csv_rows(row_count, payload)?;
+            }
+            drop(import);
+            return Document::open_file(Vec::new(), input.file.path.as_deref(), namespace)
+                .map(|(document, _)| document)
+                .map_err(sdk::Error::internal);
+        }
+        let (document, mut changes) =
+            Document::open_file(bytes, input.file.path.as_deref(), namespace)
+                .map_err(sdk::Error::invalid_input)?;
+        let mut encoder = BatchEncoder::new(sink.max_batch_bytes());
+        let table = changes
+            .next()
+            .ok_or_else(|| sdk::Error::internal("CSV import omitted its table entity"))?
+            .map_err(sdk::Error::invalid_input)?;
+        encoder.push(table, input.creates, sink)?;
+        encoder.flush(sink)?;
+        drop(changes);
+
+        let mut next_row = 0usize;
+        while let Some((payload, row_count, after)) = document
+            .initial_typed_csv_batch(next_row, sink.max_batch_bytes() as usize)
+            .map_err(sdk::Error::invalid_input)?
+        {
+            sink.emit_csv_rows(row_count, payload)?;
+            next_row = after;
+        }
+        Ok(document)
+    }
+
+    fn file_changed(
+        document: &Self::Document,
+        update: sdk::FileUpdate<'_>,
+        sink: &mut sdk::Sink<'_>,
+    ) -> sdk::Result<Self::Document> {
+        let inserts = update
+            .edits
+            .iter()
+            .map(|edit| match &edit.insert {
+                sdk::SpliceInsert::Inline(bytes) => Ok(bytes.clone()),
+                sdk::SpliceInsert::AfterRange { offset, length } => {
+                    update.after.read_range(*offset, *length)
+                }
+            })
+            .collect::<sdk::Result<Vec<_>>>()?;
+        let splices = update
+            .edits
+            .iter()
+            .zip(&inserts)
+            .map(|(edit, insert)| core::InputSplice {
+                offset: edit.offset,
+                delete_len: edit.delete_len,
+                insert,
+            })
+            .collect::<Vec<_>>();
+        let namespace =
+            IdNamespace::from_halves(update.creates.high, u64::from(update.creates.low));
+        let (document, changes) = document
+            .file_changed_with_paths(
+                &splices,
+                update.before_file.path.as_deref(),
+                update.after_file.path.as_deref(),
+                namespace,
+            )
+            .map_err(sdk::Error::invalid_input)?;
+        let mut encoder = BatchEncoder::new(sink.max_batch_bytes());
+        for change in changes {
+            encoder.push(change, update.creates, sink)?;
+        }
+        encoder.flush(sink)?;
+        Ok(document)
+    }
+}
+
+struct BatchEncoder {
+    max_bytes: usize,
+    payload: Vec<u8>,
+    records: u32,
+}
+
+impl BatchEncoder {
+    fn new(max_bytes: u32) -> Self {
+        Self {
+            max_bytes: max_bytes as usize,
+            payload: Vec::with_capacity(max_bytes as usize),
+            records: 0,
+        }
+    }
+
+    fn push(
+        &mut self,
+        change: EntityChange,
+        creates: sdk::CreateContext,
+        sink: &mut sdk::Sink<'_>,
+    ) -> sdk::Result<()> {
+        let mut record = Vec::new();
+        encode_change(change, creates, &mut record)?;
+        if record.len() > self.max_bytes {
+            return Err(sdk::Error::limit_exceeded(
+                "one CSV entity exceeds the v3 batch limit",
+            ));
+        }
+        if self.records > 0 && self.payload.len() + record.len() > self.max_bytes {
+            self.flush(sink)?;
+        }
+        self.payload.extend_from_slice(&record);
+        self.records = self
+            .records
+            .checked_add(1)
+            .ok_or_else(|| sdk::Error::limit_exceeded("CSV batch record count overflowed"))?;
+        Ok(())
+    }
+
+    fn flush(&mut self, sink: &mut sdk::Sink<'_>) -> sdk::Result<()> {
+        if self.records == 0 {
+            return Ok(());
+        }
+        let payload = std::mem::replace(&mut self.payload, Vec::with_capacity(self.max_bytes));
+        let records = std::mem::take(&mut self.records);
+        sink.emit_changes(records, payload)
+    }
+}
+
+fn encode_change(
+    change: EntityChange,
+    creates: sdk::CreateContext,
+    output: &mut Vec<u8>,
+) -> sdk::Result<()> {
+    match change.schema_key.as_str() {
+        TABLE_SCHEMA_KEY | ROW_SCHEMA_KEY => {}
+        schema => {
+            return Err(sdk::Error::invalid_input(format!(
+                "unsupported CSV schema '{schema}'"
+            )));
+        }
+    }
+    let record_start = output.len();
+    output.extend_from_slice(&0_u32.to_le_bytes());
+    match change.snapshot {
+        Some(snapshot) => {
+            let local_ref = change
+                .entity_pk
+                .as_slice()
+                .first()
+                .and_then(|id| local_ref(creates, id));
+            if change.schema_key == ROW_SCHEMA_KEY && local_ref.is_some() {
+                output.push(2);
+                push_text(output, &change.schema_key)?;
+                output
+                    .extend_from_slice(&u64::from(local_ref.expect("checked above")).to_le_bytes());
+                let snapshot = remove_created_id(snapshot)?;
+                push_inline_blob(output, &snapshot)?;
+            } else {
+                output.push(0);
+                push_entity_key(output, &change.schema_key, &change.entity_pk)?;
+                output.push(effect_tag(change.effect));
+                push_inline_blob(output, &snapshot)?;
+            }
+        }
+        None => {
+            output.push(1);
+            push_entity_key(output, &change.schema_key, &change.entity_pk)?;
+        }
+    }
+    let record_len = output
+        .len()
+        .checked_sub(record_start + 4)
+        .ok_or_else(|| sdk::Error::internal("CSV packet record length underflowed"))?;
+    let record_len = u32::try_from(record_len)
+        .map_err(|_| sdk::Error::limit_exceeded("CSV packet record exceeds 4GiB"))?;
+    output[record_start..record_start + 4].copy_from_slice(&record_len.to_le_bytes());
+    Ok(())
+}
+
+fn local_ref(creates: sdk::CreateContext, id: &str) -> Option<u32> {
+    let id = uuid::Uuid::parse_str(id);
+    let id = id.ok()?;
+    let bytes = id.as_bytes();
+    if bytes[..12] != creates.namespace_bytes() {
+        return None;
+    }
+    Some(u32::from_be_bytes(bytes[12..].try_into().ok()?))
+}
+
+fn remove_created_id(snapshot: Vec<u8>) -> sdk::Result<Vec<u8>> {
+    let mut value: Value = serde_json::from_slice(&snapshot)
+        .map_err(|error| sdk::Error::invalid_input(format!("invalid CSV row snapshot: {error}")))?;
+    value
+        .as_object_mut()
+        .and_then(|object| object.remove("id"))
+        .ok_or_else(|| sdk::Error::invalid_input("created CSV row snapshot has no id"))?;
+    serde_json::to_vec(&value)
+        .map_err(|error| sdk::Error::internal(format!("encode CSV row snapshot: {error}")))
+}
+
+fn effect_tag(effect: ChangeEffect) -> u8 {
+    match effect {
+        ChangeEffect::Content => 0,
+        ChangeEffect::FormatOnly => 1,
+    }
+}
+
+fn push_entity_key(
+    output: &mut Vec<u8>,
+    schema_key: &str,
+    components: &[String],
+) -> sdk::Result<()> {
+    push_text(output, schema_key)?;
+    let count = u32::try_from(components.len())
+        .map_err(|_| sdk::Error::limit_exceeded("too many primary-key components"))?;
+    output.extend_from_slice(&count.to_le_bytes());
+    for component in components {
+        push_text(output, component)?;
+    }
+    Ok(())
+}
+
+fn push_text(output: &mut Vec<u8>, value: &str) -> sdk::Result<()> {
+    let length = u32::try_from(value.len())
+        .map_err(|_| sdk::Error::limit_exceeded("packet text is too large"))?;
+    output.extend_from_slice(&length.to_le_bytes());
+    output.extend_from_slice(value.as_bytes());
+    Ok(())
+}
+
+fn push_inline_blob(output: &mut Vec<u8>, bytes: &[u8]) -> sdk::Result<()> {
+    output.push(0);
+    let length = u32::try_from(bytes.len())
+        .map_err(|_| sdk::Error::limit_exceeded("snapshot is too large"))?;
+    output.extend_from_slice(&length.to_le_bytes());
+    output.extend_from_slice(bytes);
+    Ok(())
+}
+
+#[cfg(target_family = "wasm")]
+lix_plugin_api_v3_prototype::export_v3_prototype!(CsvV3Prototype);

--- a/plugins/csv-v3-prototype/src/lib.rs
+++ b/plugins/csv-v3-prototype/src/lib.rs
@@ -1,4 +1,5 @@
 //! Fused initial-import CSV experiment for Component API v3.
+#![allow(dead_code)]
 
 #[path = "../../csv-v2/src/core.rs"]
 mod core;

--- a/plugins/excalidraw-v3-prototype/Cargo.toml
+++ b/plugins/excalidraw-v3-prototype/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "plugin_excalidraw_v3_prototype"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+description = "Excalidraw prototype for the fused Lix Wasm Component API v3"
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+documentation.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+lix_order_key.workspace = true
+lix_plugin_api_v3_prototype = { workspace = true }
+serde_json = "1"
+uuid = { version = "1", features = ["std"] }

--- a/plugins/excalidraw-v3-prototype/manifest.json
+++ b/plugins/excalidraw-v3-prototype/manifest.json
@@ -1,0 +1,16 @@
+{
+  "key": "plugin_excalidraw_v3_prototype",
+  "runtime": "wasm-component-v2",
+  "api_version": "3.0.0",
+  "materialization": "blob",
+  "match": {
+    "path_glob": "*.excalidraw",
+    "content_type": "text"
+  },
+  "entry": "plugin.wasm",
+  "schemas": [
+    "schema/excalidraw_scene.json",
+    "schema/excalidraw_element.json",
+    "schema/excalidraw_file.json"
+  ]
+}

--- a/plugins/excalidraw-v3-prototype/src/lib.rs
+++ b/plugins/excalidraw-v3-prototype/src/lib.rs
@@ -1,4 +1,5 @@
 //! Fused Excalidraw experiment for Component API v3.
+#![allow(dead_code)]
 
 #[path = "../../excalidraw-v2/src/core.rs"]
 mod core;

--- a/plugins/excalidraw-v3-prototype/src/lib.rs
+++ b/plugins/excalidraw-v3-prototype/src/lib.rs
@@ -1,0 +1,182 @@
+//! Fused Excalidraw experiment for Component API v3.
+
+#[path = "../../excalidraw-v2/src/core.rs"]
+mod core;
+
+use core::{ChangeEffect, Document, EntityChange, IdNamespace, InputSplice};
+use lix_plugin_api_v3_prototype as sdk;
+
+struct ExcalidrawV3Prototype;
+
+impl sdk::FormatPlugin for ExcalidrawV3Prototype {
+    type Document = Document;
+
+    fn open_file(
+        input: sdk::OpenFile<'_>,
+        sink: &mut sdk::Sink<'_>,
+    ) -> sdk::Result<Self::Document> {
+        let namespace = IdNamespace::from_halves(input.creates.high, u64::from(input.creates.low));
+        let (document, changes) = Document::open_file(
+            input.source.read_all()?,
+            input.file.path.as_deref(),
+            namespace,
+        )
+        .map_err(sdk::Error::invalid_input)?;
+        emit_changes(changes, sink)?;
+        Ok(document)
+    }
+
+    fn file_changed(
+        document: &Self::Document,
+        update: sdk::FileUpdate<'_>,
+        sink: &mut sdk::Sink<'_>,
+    ) -> sdk::Result<Self::Document> {
+        let inserts = update
+            .edits
+            .iter()
+            .map(|edit| match &edit.insert {
+                sdk::SpliceInsert::Inline(bytes) => Ok(bytes.clone()),
+                sdk::SpliceInsert::AfterRange { offset, length } => {
+                    update.after.read_range(*offset, *length)
+                }
+            })
+            .collect::<sdk::Result<Vec<_>>>()?;
+        let splices = update
+            .edits
+            .iter()
+            .zip(&inserts)
+            .map(|(edit, insert)| InputSplice {
+                offset: edit.offset,
+                delete_len: edit.delete_len,
+                insert,
+            })
+            .collect::<Vec<_>>();
+        let namespace =
+            IdNamespace::from_halves(update.creates.high, u64::from(update.creates.low));
+        let (document, changes) = document
+            .file_changed(&splices, namespace)
+            .map_err(sdk::Error::invalid_input)?;
+        emit_changes(changes.into_iter().map(Ok), sink)?;
+        Ok(document)
+    }
+}
+
+fn emit_changes<I>(changes: I, sink: &mut sdk::Sink<'_>) -> sdk::Result<()>
+where
+    I: IntoIterator<Item = Result<EntityChange, String>>,
+{
+    let mut encoder = BatchEncoder::new(sink.max_batch_bytes());
+    for change in changes {
+        encoder.push(change.map_err(sdk::Error::invalid_input)?, sink)?;
+    }
+    encoder.flush(sink)
+}
+
+struct BatchEncoder {
+    max_bytes: usize,
+    payload: Vec<u8>,
+    records: u32,
+}
+
+impl BatchEncoder {
+    fn new(max_bytes: u32) -> Self {
+        Self {
+            max_bytes: max_bytes as usize,
+            payload: Vec::with_capacity(max_bytes as usize),
+            records: 0,
+        }
+    }
+
+    fn push(&mut self, change: EntityChange, sink: &mut sdk::Sink<'_>) -> sdk::Result<()> {
+        let mut record = Vec::new();
+        encode_change(change, &mut record)?;
+        if record.len() > self.max_bytes {
+            return Err(sdk::Error::limit_exceeded(
+                "one Excalidraw entity exceeds the v3 batch limit",
+            ));
+        }
+        if self.records > 0 && self.payload.len() + record.len() > self.max_bytes {
+            self.flush(sink)?;
+        }
+        self.payload.extend_from_slice(&record);
+        self.records = self
+            .records
+            .checked_add(1)
+            .ok_or_else(|| sdk::Error::limit_exceeded("Excalidraw batch count overflowed"))?;
+        Ok(())
+    }
+
+    fn flush(&mut self, sink: &mut sdk::Sink<'_>) -> sdk::Result<()> {
+        if self.records == 0 {
+            return Ok(());
+        }
+        let payload = std::mem::replace(&mut self.payload, Vec::with_capacity(self.max_bytes));
+        let records = std::mem::take(&mut self.records);
+        sink.emit_changes(records, payload)
+    }
+}
+
+fn encode_change(change: EntityChange, output: &mut Vec<u8>) -> sdk::Result<()> {
+    let record_start = output.len();
+    output.extend_from_slice(&0_u32.to_le_bytes());
+    match change.snapshot {
+        Some(snapshot) => {
+            output.push(0);
+            push_entity_key(output, &change.schema_key, &change.entity_pk)?;
+            output.push(match change.effect {
+                ChangeEffect::Content => 0,
+                ChangeEffect::FormatOnly => 1,
+            });
+            push_inline_blob(output, &snapshot)?;
+        }
+        None => {
+            output.push(1);
+            push_entity_key(output, &change.schema_key, &change.entity_pk)?;
+        }
+    }
+    let length = u32::try_from(output.len() - record_start - 4)
+        .map_err(|_| sdk::Error::limit_exceeded("Excalidraw packet exceeds 4GiB"))?;
+    output[record_start..record_start + 4].copy_from_slice(&length.to_le_bytes());
+    Ok(())
+}
+
+fn push_entity_key(
+    output: &mut Vec<u8>,
+    schema_key: &str,
+    components: &[String],
+) -> sdk::Result<()> {
+    push_text(output, schema_key)?;
+    output.extend_from_slice(
+        &u32::try_from(components.len())
+            .map_err(|_| sdk::Error::limit_exceeded("too many primary-key components"))?
+            .to_le_bytes(),
+    );
+    for component in components {
+        push_text(output, component)?;
+    }
+    Ok(())
+}
+
+fn push_text(output: &mut Vec<u8>, value: &str) -> sdk::Result<()> {
+    output.extend_from_slice(
+        &u32::try_from(value.len())
+            .map_err(|_| sdk::Error::limit_exceeded("packet text is too large"))?
+            .to_le_bytes(),
+    );
+    output.extend_from_slice(value.as_bytes());
+    Ok(())
+}
+
+fn push_inline_blob(output: &mut Vec<u8>, bytes: &[u8]) -> sdk::Result<()> {
+    output.push(0);
+    output.extend_from_slice(
+        &u32::try_from(bytes.len())
+            .map_err(|_| sdk::Error::limit_exceeded("snapshot is too large"))?
+            .to_le_bytes(),
+    );
+    output.extend_from_slice(bytes);
+    Ok(())
+}
+
+#[cfg(target_family = "wasm")]
+lix_plugin_api_v3_prototype::export_v3_prototype!(ExcalidrawV3Prototype);

--- a/plugins/json-v3-prototype/Cargo.toml
+++ b/plugins/json-v3-prototype/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-name = "plugin_csv_v2"
+name = "plugin_json_v3_prototype"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-description = "Incremental CSV file plugin for the Lix Wasm Component v2 API"
+description = "JSON prototype for the fused Lix Wasm Component API v3"
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
 documentation.workspace = true
-readme = "README.md"
 keywords.workspace = true
 categories.workspace = true
 rust-version.workspace = true
+publish = false
 
 [lints]
 workspace = true
@@ -19,12 +19,9 @@ workspace = true
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[features]
-default = ["component-v2"]
-component-v2 = ["dep:lix_plugin_api_v2"]
-
 [dependencies]
 base64 = "0.22"
-lix_plugin_api_v2 = { workspace = true, optional = true }
-serde_json = "1"
+blake3 = "1"
+lix_plugin_api_v3_prototype = { workspace = true }
+serde_json = { version = "1", features = ["raw_value"] }
 uuid = { version = "1", features = ["std"] }

--- a/plugins/json-v3-prototype/manifest.json
+++ b/plugins/json-v3-prototype/manifest.json
@@ -1,0 +1,16 @@
+{
+  "key": "plugin_json_v3_prototype",
+  "runtime": "wasm-component-v2",
+  "api_version": "3.0.0",
+  "materialization": "blob",
+  "match": {
+    "path_glob": "*.json",
+    "content_type": "text"
+  },
+  "entry": "plugin.wasm",
+  "schemas": [
+    "schema/json_root.json",
+    "schema/json_object_member.json",
+    "schema/json_array_item.json"
+  ]
+}

--- a/plugins/json-v3-prototype/src/lib.rs
+++ b/plugins/json-v3-prototype/src/lib.rs
@@ -1,0 +1,240 @@
+//! Fused JSON experiment for Component API v3.
+
+#[path = "../../json-v2/src/core.rs"]
+mod core;
+
+use core::{ChangeEffect, Document, EntityChange, IdNamespace, InputSplice};
+use lix_plugin_api_v3_prototype as sdk;
+use serde_json::Value;
+
+struct JsonV3Prototype;
+
+impl sdk::FormatPlugin for JsonV3Prototype {
+    type Document = Document;
+
+    fn open_file(
+        input: sdk::OpenFile<'_>,
+        sink: &mut sdk::Sink<'_>,
+    ) -> sdk::Result<Self::Document> {
+        let bytes = input.source.read_all()?;
+        let namespace = IdNamespace::from_halves(input.creates.high, u64::from(input.creates.low));
+        let (document, changes) = Document::open_file(bytes, input.file.path.as_deref(), namespace)
+            .map_err(sdk::Error::invalid_input)?;
+        emit_changes(changes, input.creates, sink)?;
+        Ok(document)
+    }
+
+    fn file_changed(
+        document: &Self::Document,
+        update: sdk::FileUpdate<'_>,
+        sink: &mut sdk::Sink<'_>,
+    ) -> sdk::Result<Self::Document> {
+        let inserts = update
+            .edits
+            .iter()
+            .map(|edit| match &edit.insert {
+                sdk::SpliceInsert::Inline(bytes) => Ok(bytes.clone()),
+                sdk::SpliceInsert::AfterRange { offset, length } => {
+                    update.after.read_range(*offset, *length)
+                }
+            })
+            .collect::<sdk::Result<Vec<_>>>()?;
+        let splices = update
+            .edits
+            .iter()
+            .zip(&inserts)
+            .map(|(edit, insert)| InputSplice {
+                offset: edit.offset,
+                delete_len: edit.delete_len,
+                insert,
+            })
+            .collect::<Vec<_>>();
+        let namespace =
+            IdNamespace::from_halves(update.creates.high, u64::from(update.creates.low));
+        let (document, changes) = document
+            .file_changed(&splices, namespace)
+            .map_err(sdk::Error::invalid_input)?;
+        emit_changes(changes.into_iter().map(Ok), update.creates, sink)?;
+        Ok(document)
+    }
+}
+
+fn emit_changes<I>(
+    changes: I,
+    creates: sdk::CreateContext,
+    sink: &mut sdk::Sink<'_>,
+) -> sdk::Result<()>
+where
+    I: IntoIterator<Item = std::result::Result<EntityChange, String>>,
+{
+    let mut encoder = BatchEncoder::new(sink.max_batch_bytes());
+    for change in changes {
+        encoder.push(change.map_err(sdk::Error::invalid_input)?, creates, sink)?;
+    }
+    encoder.flush(sink)
+}
+
+struct BatchEncoder {
+    max_bytes: usize,
+    payload: Vec<u8>,
+    records: u32,
+    creates_only: Option<bool>,
+}
+
+impl BatchEncoder {
+    fn new(max_bytes: u32) -> Self {
+        Self {
+            max_bytes: max_bytes as usize,
+            payload: Vec::with_capacity(max_bytes as usize),
+            records: 0,
+            creates_only: None,
+        }
+    }
+
+    fn push(
+        &mut self,
+        change: EntityChange,
+        creates: sdk::CreateContext,
+        sink: &mut sdk::Sink<'_>,
+    ) -> sdk::Result<()> {
+        let mut record = Vec::new();
+        let is_create = encode_change(change, creates, &mut record)?;
+        if record.len() > self.max_bytes {
+            return Err(sdk::Error::limit_exceeded(
+                "one JSON entity exceeds the v3 batch limit",
+            ));
+        }
+        if self.records > 0
+            && (self.payload.len() + record.len() > self.max_bytes
+                || self.creates_only != Some(is_create))
+        {
+            self.flush(sink)?;
+        }
+        self.creates_only = Some(is_create);
+        self.payload.extend_from_slice(&record);
+        self.records = self
+            .records
+            .checked_add(1)
+            .ok_or_else(|| sdk::Error::limit_exceeded("JSON batch record count overflowed"))?;
+        Ok(())
+    }
+
+    fn flush(&mut self, sink: &mut sdk::Sink<'_>) -> sdk::Result<()> {
+        if self.records == 0 {
+            return Ok(());
+        }
+        let payload = std::mem::replace(&mut self.payload, Vec::with_capacity(self.max_bytes));
+        let records = std::mem::take(&mut self.records);
+        self.creates_only = None;
+        sink.emit_changes(records, payload)
+    }
+}
+
+fn encode_change(
+    change: EntityChange,
+    creates: sdk::CreateContext,
+    output: &mut Vec<u8>,
+) -> sdk::Result<bool> {
+    let record_start = output.len();
+    output.extend_from_slice(&0_u32.to_le_bytes());
+    let is_create = match change.snapshot {
+        Some(snapshot) => {
+            let local_ref = change
+                .entity_pk
+                .as_slice()
+                .first()
+                .filter(|_| change.entity_pk.len() == 1)
+                .and_then(|id| local_ref(creates, id));
+            if let Some(local_ref) = local_ref {
+                output.push(2);
+                push_text(output, &change.schema_key)?;
+                output.extend_from_slice(&u64::from(local_ref).to_le_bytes());
+                push_inline_blob(output, &remove_created_id(snapshot)?)?;
+                true
+            } else {
+                output.push(0);
+                push_entity_key(output, &change.schema_key, &change.entity_pk)?;
+                output.push(effect_tag(change.effect));
+                push_inline_blob(output, &snapshot)?;
+                false
+            }
+        }
+        None => {
+            output.push(1);
+            push_entity_key(output, &change.schema_key, &change.entity_pk)?;
+            false
+        }
+    };
+    let record_len = u32::try_from(output.len() - record_start - 4)
+        .map_err(|_| sdk::Error::limit_exceeded("JSON packet record exceeds 4GiB"))?;
+    output[record_start..record_start + 4].copy_from_slice(&record_len.to_le_bytes());
+    Ok(is_create)
+}
+
+fn local_ref(creates: sdk::CreateContext, id: &str) -> Option<u32> {
+    let id = uuid::Uuid::parse_str(id).ok()?;
+    let bytes = id.as_bytes();
+    if bytes[..12] != creates.namespace_bytes() {
+        return None;
+    }
+    Some(u32::from_be_bytes(bytes[12..].try_into().ok()?))
+}
+
+fn remove_created_id(snapshot: Vec<u8>) -> sdk::Result<Vec<u8>> {
+    let mut value: Value = serde_json::from_slice(&snapshot)
+        .map_err(|error| sdk::Error::invalid_input(format!("invalid JSON snapshot: {error}")))?;
+    value
+        .as_object_mut()
+        .and_then(|object| object.remove("id"))
+        .ok_or_else(|| sdk::Error::invalid_input("created JSON snapshot has no id"))?;
+    serde_json::to_vec(&value)
+        .map_err(|error| sdk::Error::internal(format!("encode JSON snapshot: {error}")))
+}
+
+fn effect_tag(effect: ChangeEffect) -> u8 {
+    match effect {
+        ChangeEffect::Content => 0,
+        ChangeEffect::FormatOnly => 1,
+    }
+}
+
+fn push_entity_key(
+    output: &mut Vec<u8>,
+    schema_key: &str,
+    components: &[String],
+) -> sdk::Result<()> {
+    push_text(output, schema_key)?;
+    output.extend_from_slice(
+        &u32::try_from(components.len())
+            .map_err(|_| sdk::Error::limit_exceeded("too many primary-key components"))?
+            .to_le_bytes(),
+    );
+    for component in components {
+        push_text(output, component)?;
+    }
+    Ok(())
+}
+
+fn push_text(output: &mut Vec<u8>, value: &str) -> sdk::Result<()> {
+    output.extend_from_slice(
+        &u32::try_from(value.len())
+            .map_err(|_| sdk::Error::limit_exceeded("packet text is too large"))?
+            .to_le_bytes(),
+    );
+    output.extend_from_slice(value.as_bytes());
+    Ok(())
+}
+
+fn push_inline_blob(output: &mut Vec<u8>, bytes: &[u8]) -> sdk::Result<()> {
+    output.push(0);
+    output.extend_from_slice(
+        &u32::try_from(bytes.len())
+            .map_err(|_| sdk::Error::limit_exceeded("snapshot is too large"))?
+            .to_le_bytes(),
+    );
+    output.extend_from_slice(bytes);
+    Ok(())
+}
+
+#[cfg(target_family = "wasm")]
+lix_plugin_api_v3_prototype::export_v3_prototype!(JsonV3Prototype);

--- a/plugins/json-v3-prototype/src/lib.rs
+++ b/plugins/json-v3-prototype/src/lib.rs
@@ -1,4 +1,5 @@
 //! Fused JSON experiment for Component API v3.
+#![allow(dead_code)]
 
 #[path = "../../json-v2/src/core.rs"]
 mod core;
@@ -65,7 +66,7 @@ fn emit_changes<I>(
     sink: &mut sdk::Sink<'_>,
 ) -> sdk::Result<()>
 where
-    I: IntoIterator<Item = std::result::Result<EntityChange, String>>,
+    I: IntoIterator<Item = Result<EntityChange, String>>,
 {
     let mut encoder = BatchEncoder::new(sink.max_batch_bytes());
     for change in changes {

--- a/plugins/markdown-v3-prototype/Cargo.toml
+++ b/plugins/markdown-v3-prototype/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "plugin_markdown_v3_prototype"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+description = "Markdown prototype for the fused Lix Wasm Component API v3"
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+documentation.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+base64 = "0.22"
+chardetng = "1"
+encoding_rs = "0.8"
+lix_order_key.workspace = true
+lix_plugin_api_v3_prototype = { workspace = true }
+markdown-syntax = "=0.2.0"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+uuid = { version = "1", features = ["std"] }

--- a/plugins/markdown-v3-prototype/manifest.json
+++ b/plugins/markdown-v3-prototype/manifest.json
@@ -1,0 +1,14 @@
+{
+  "key": "plugin_markdown_v3_prototype",
+  "runtime": "wasm-component-v2",
+  "api_version": "3.0.0",
+  "materialization": "blob",
+  "match": {
+    "path_glob": "*.{md,markdown}",
+    "content_type": "text"
+  },
+  "entry": "plugin.wasm",
+  "schemas": [
+    "schema/markdown_node_v2.json"
+  ]
+}

--- a/plugins/markdown-v3-prototype/src/lib.rs
+++ b/plugins/markdown-v3-prototype/src/lib.rs
@@ -1,4 +1,5 @@
 //! Fused Markdown experiment for Component API v3.
+#![allow(dead_code)]
 
 #[path = "../../markdown-v2/src/core.rs"]
 mod core;

--- a/plugins/markdown-v3-prototype/src/lib.rs
+++ b/plugins/markdown-v3-prototype/src/lib.rs
@@ -1,0 +1,249 @@
+//! Fused Markdown experiment for Component API v3.
+
+#[path = "../../markdown-v2/src/core.rs"]
+mod core;
+#[path = "../../markdown-v2/src/markdown_file.rs"]
+mod markdown_file;
+#[path = "../../markdown-v2/src/model.rs"]
+mod model;
+#[path = "../../markdown-v2/src/schemas.rs"]
+mod schemas;
+
+use core::{ChangeEffect, Document, EntityChange, IdNamespace, InputSplice, PluginError};
+use lix_plugin_api_v3_prototype as sdk;
+use serde_json::Value;
+
+struct MarkdownV3Prototype;
+
+impl sdk::FormatPlugin for MarkdownV3Prototype {
+    type Document = Document;
+
+    fn open_file(
+        input: sdk::OpenFile<'_>,
+        sink: &mut sdk::Sink<'_>,
+    ) -> sdk::Result<Self::Document> {
+        let bytes = input.source.read_all()?;
+        let namespace = IdNamespace::from_halves(input.creates.high, input.creates.low);
+        let (document, changes) = Document::open_file(bytes, input.file.path.as_deref(), namespace)
+            .map_err(core_error)?;
+        emit_changes(changes, input.creates, sink)?;
+        Ok(document)
+    }
+
+    fn file_changed(
+        document: &Self::Document,
+        update: sdk::FileUpdate<'_>,
+        sink: &mut sdk::Sink<'_>,
+    ) -> sdk::Result<Self::Document> {
+        let inserts = update
+            .edits
+            .iter()
+            .map(|edit| match &edit.insert {
+                sdk::SpliceInsert::Inline(bytes) => Ok(bytes.clone()),
+                sdk::SpliceInsert::AfterRange { offset, length } => {
+                    update.after.read_range(*offset, *length)
+                }
+            })
+            .collect::<sdk::Result<Vec<_>>>()?;
+        let splices = update
+            .edits
+            .iter()
+            .zip(&inserts)
+            .map(|(edit, insert)| InputSplice {
+                offset: edit.offset,
+                delete_len: edit.delete_len,
+                insert,
+            })
+            .collect::<Vec<_>>();
+        let namespace = IdNamespace::from_halves(update.creates.high, update.creates.low);
+        let (document, changes) = document
+            .file_changed(&splices, namespace)
+            .map_err(core_error)?;
+        emit_changes(changes, update.creates, sink)?;
+        Ok(document)
+    }
+}
+
+fn core_error(error: PluginError) -> sdk::Error {
+    match error {
+        PluginError::InvalidInput(message) => sdk::Error::invalid_input(message),
+        PluginError::Internal(message) => sdk::Error::internal(message),
+    }
+}
+
+fn emit_changes(
+    changes: impl IntoIterator<Item = EntityChange>,
+    creates: sdk::CreateContext,
+    sink: &mut sdk::Sink<'_>,
+) -> sdk::Result<()> {
+    let mut encoder = BatchEncoder::new(sink.max_batch_bytes());
+    for change in changes {
+        encoder.push(change, creates, sink)?;
+    }
+    encoder.flush(sink)
+}
+
+struct BatchEncoder {
+    max_bytes: usize,
+    payload: Vec<u8>,
+    records: u32,
+    creates_only: Option<bool>,
+}
+
+impl BatchEncoder {
+    fn new(max_bytes: u32) -> Self {
+        Self {
+            max_bytes: max_bytes as usize,
+            payload: Vec::with_capacity(max_bytes as usize),
+            records: 0,
+            creates_only: None,
+        }
+    }
+
+    fn push(
+        &mut self,
+        change: EntityChange,
+        creates: sdk::CreateContext,
+        sink: &mut sdk::Sink<'_>,
+    ) -> sdk::Result<()> {
+        let mut record = Vec::new();
+        let is_create = encode_change(change, creates, &mut record)?;
+        if record.len() > self.max_bytes {
+            return Err(sdk::Error::limit_exceeded(
+                "one Markdown entity exceeds the v3 batch limit",
+            ));
+        }
+        if self.records > 0
+            && (self.payload.len() + record.len() > self.max_bytes
+                || self.creates_only != Some(is_create))
+        {
+            self.flush(sink)?;
+        }
+        self.creates_only = Some(is_create);
+        self.payload.extend_from_slice(&record);
+        self.records = self
+            .records
+            .checked_add(1)
+            .ok_or_else(|| sdk::Error::limit_exceeded("Markdown batch count overflowed"))?;
+        Ok(())
+    }
+
+    fn flush(&mut self, sink: &mut sdk::Sink<'_>) -> sdk::Result<()> {
+        if self.records == 0 {
+            return Ok(());
+        }
+        let payload = std::mem::replace(&mut self.payload, Vec::with_capacity(self.max_bytes));
+        let records = std::mem::take(&mut self.records);
+        self.creates_only = None;
+        sink.emit_changes(records, payload)
+    }
+}
+
+fn encode_change(
+    change: EntityChange,
+    creates: sdk::CreateContext,
+    output: &mut Vec<u8>,
+) -> sdk::Result<bool> {
+    let record_start = output.len();
+    output.extend_from_slice(&0_u32.to_le_bytes());
+    let is_create = match change.snapshot {
+        Some(snapshot) => {
+            let local_ref = change
+                .entity_pk
+                .first()
+                .filter(|_| change.entity_pk.len() == 1)
+                .and_then(|id| local_ref(creates, id));
+            if let Some(local_ref) = local_ref {
+                output.push(2);
+                push_text(output, &change.schema_key)?;
+                output.extend_from_slice(&u64::from(local_ref).to_le_bytes());
+                push_inline_blob(output, &remove_created_id(snapshot)?)?;
+                true
+            } else {
+                output.push(0);
+                push_entity_key(output, &change.schema_key, &change.entity_pk)?;
+                output.push(effect_tag(change.effect));
+                push_inline_blob(output, &snapshot)?;
+                false
+            }
+        }
+        None => {
+            output.push(1);
+            push_entity_key(output, &change.schema_key, &change.entity_pk)?;
+            false
+        }
+    };
+    let record_len = u32::try_from(output.len() - record_start - 4)
+        .map_err(|_| sdk::Error::limit_exceeded("Markdown packet record exceeds 4GiB"))?;
+    output[record_start..record_start + 4].copy_from_slice(&record_len.to_le_bytes());
+    Ok(is_create)
+}
+
+fn local_ref(creates: sdk::CreateContext, id: &str) -> Option<u32> {
+    let id = uuid::Uuid::parse_str(id).ok()?;
+    let bytes = id.as_bytes();
+    if bytes[..12] != creates.namespace_bytes() {
+        return None;
+    }
+    Some(u32::from_be_bytes(bytes[12..].try_into().ok()?))
+}
+
+fn remove_created_id(snapshot: Vec<u8>) -> sdk::Result<Vec<u8>> {
+    let mut value: Value = serde_json::from_slice(&snapshot).map_err(|error| {
+        sdk::Error::invalid_input(format!("invalid Markdown snapshot: {error}"))
+    })?;
+    value
+        .as_object_mut()
+        .and_then(|object| object.remove("id"))
+        .ok_or_else(|| sdk::Error::invalid_input("created Markdown snapshot has no id"))?;
+    serde_json::to_vec(&value)
+        .map_err(|error| sdk::Error::internal(format!("encode Markdown snapshot: {error}")))
+}
+
+fn effect_tag(effect: ChangeEffect) -> u8 {
+    match effect {
+        ChangeEffect::Content => 0,
+        ChangeEffect::FormatOnly => 1,
+    }
+}
+
+fn push_entity_key(
+    output: &mut Vec<u8>,
+    schema_key: &str,
+    components: &[String],
+) -> sdk::Result<()> {
+    push_text(output, schema_key)?;
+    output.extend_from_slice(
+        &u32::try_from(components.len())
+            .map_err(|_| sdk::Error::limit_exceeded("too many primary-key components"))?
+            .to_le_bytes(),
+    );
+    for component in components {
+        push_text(output, component)?;
+    }
+    Ok(())
+}
+
+fn push_text(output: &mut Vec<u8>, value: &str) -> sdk::Result<()> {
+    output.extend_from_slice(
+        &u32::try_from(value.len())
+            .map_err(|_| sdk::Error::limit_exceeded("packet text is too large"))?
+            .to_le_bytes(),
+    );
+    output.extend_from_slice(value.as_bytes());
+    Ok(())
+}
+
+fn push_inline_blob(output: &mut Vec<u8>, bytes: &[u8]) -> sdk::Result<()> {
+    output.push(0);
+    output.extend_from_slice(
+        &u32::try_from(bytes.len())
+            .map_err(|_| sdk::Error::limit_exceeded("snapshot is too large"))?
+            .to_le_bytes(),
+    );
+    output.extend_from_slice(bytes);
+    Ok(())
+}
+
+#[cfg(target_family = "wasm")]
+lix_plugin_api_v3_prototype::export_v3_prototype!(MarkdownV3Prototype);


### PR DESCRIPTION
## What changed

- adds fused host-imported push sinks for CSV, JSON, Markdown, and Excalidraw Wasm components
- retains complete bulk imports as one certified immutable entity-batch segment with sparse row overlays
- removes transient generated UUID strings from certified decode paths
- adds exact history/reopen certification and cross-format release benchmarks
- documents positive and negative profile results, including the cold-successor boundary

## Results

- CSV 10.68 MiB / 220,001 changes: 5.227 s baseline to 168 ms verification, 36.2 MB peak host allocation
- JSON 10 MiB / 39,871 changes: 739 ms v2 to 245 ms v3, 45.6 MB peak versus 85.8 MB
- exact VS Code Markdown transition: 883 ms v2 versus 900 ms v3; fused control flow does not clear the gate because parser state remains 102.4 MB
- Excalidraw 20,000-element successor: 230 ms v2 versus 238 ms v3; profiling identifies cold actor reconstruction as the remaining allocation source

All benchmark lanes preserve exact source bytes, semantic cardinality, validation/atomicity, history where applicable, and RocksDB close/reopen.

## Validation

- `cargo fmt --all`
- `cargo check -p lix_engine`
- `cargo check -p plugin_excalidraw_v3_prototype`
- release correctness tests for CSV, JSON, Markdown, and Excalidraw
- release CSV/JSON/Markdown/Excalidraw benchmark lanes
- heaptrack profiles for Markdown and Excalidraw

The next API cut is `apply-cold-successor` plus direct transaction/query consumption of encoded segments; the measured data shows that further guest-call tuning alone is insufficient.