### PR TITLE
Optimize localized Markdown block edits

### DIFF
--- a/packages/rs-sdk-tests/PLUGIN_RUNTIME_PROFILE.md
+++ b/packages/rs-sdk-tests/PLUGIN_RUNTIME_PROFILE.md
@@ -301,17 +301,28 @@ rows:
 | lane | p50 | p95 | host allocation | peak host allocation | exports / imports | guest high water |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
 | Markdown v2 cursor | 883.3 ms | 947.1 ms | 32.2 MB | 11.2 MB | 3 / 0 | 102.4 MB |
-| Markdown v3 push | 900.2 ms | 918.4 ms | 174.7 MB | 21.0 MB | 1 / 1 | 102.4 MB |
+| Markdown v3 push, full parse | 912.0 ms | 951.1 ms | 136.2 MB | 21.0 MB | 1 / 1 | 102.4 MB |
+| Markdown v3 push, local subtree | 42.8 ms | 60.8 ms | 136.2 MB | 21.0 MB | 1 / 1 | 56.8 MB |
 
-The fused transition therefore fails Prototype A's acceptance gate for this
-workload. Guest re-entry falls from three exports to one, but guest high-water
-memory and boundary bytes are unchanged. The Markdown parser/reconciler owns
-the runtime, while validation of the immutable opening segment amplifies host
-bytes. A read-facade cache experiment made this worse—1,225.7 ms, 710.3 MB
-cumulative allocation, and 44.7 MB peak—because the cache owner was shorter
-lived than the validation sequence and repeatedly hydrated the full segment.
-It was removed. Reuse must be transaction-scoped, or queries/validation must
-consume the encoded segment directly.
+The fused transition alone therefore failed Prototype A's acceptance gate.
+The exact repository transition changes only `DateApproved` inside the first
+frontmatter block: four source bytes become three while 1,237,730 trailing
+bytes remain identical. The paragraph-only fast path rejected that edit and
+the document's exact-byte lexical fallback, forcing a full parse and stable
+render of the entire file.
+
+The persistent Markdown tree now stores sparse complete top-level subtree
+overrides rather than node-only overrides. A single edit fully contained in
+one block parses and reconciles only that block, retains the untouched base
+tree, shifts later source ranges, and updates the exact-byte fallback directly
+from the piece table. Edits crossing block or line boundaries still take the
+full parser. This makes the measured transition 21.3x faster and reduces guest
+high water by 45.6 MB without changing its two durable semantic changes.
+
+A read-facade cache experiment had made the old full-parse path worse—1,225.7
+ms, 710.3 MB cumulative allocation, and 44.7 MB peak—because the cache owner
+was shorter lived than the validation sequence and repeatedly hydrated the
+full segment. It remains removed.
 
 A generated 1.849 MB Excalidraw document with 20,000 elements changes one
 element:
@@ -319,7 +330,7 @@ element:
 | lane | p50 | host allocation | peak host allocation | exports / imports | guest high water |
 | --- | ---: | ---: | ---: | ---: | ---: |
 | Excalidraw v2 cursor | 229.7 ms | 5.0 MB | 3.0 MB | 3 / 0 | 42.1 MB |
-| Excalidraw v3 push | 237.5 ms | 73.4 MB | 7.7 MB | 1 / 1 | 41.8 MB |
+| Excalidraw v3 push | 217.5 ms | 38.8 MB | 7.7 MB | 1 / 1 | 41.8 MB |
 
 Heaptrack shows repeated certified-segment consumption on the semantic read
 path. Stable-primary-key packets now retain their already-certified canonical
@@ -329,15 +340,19 @@ the large v3 import actor is evicted, so its successor reconstructs the prior
 20,000-element document. This is a concrete cross-format acceptance case for
 `apply-cold-successor`, not for more cursor tuning.
 
-Current one-sample verification after the sparse-overlay policy:
+Current five-sample verification after the sparse-overlay and localized
+Markdown policies:
 
-| workload | v2 | v3 | v3 peak host allocation | result |
-| --- | ---: | ---: | ---: | --- |
-| CSV, 10.68 MiB / 220,001 changes | 5.227 s baseline | 168.2 ms | 36.2 MB | 31.1x |
-| JSON, 10 MiB / 39,871 changes | 738.6 ms | 244.9 ms | 45.6 MB | 3.02x |
+| workload | v3 p50 | v3 p95 | peak host allocation | guest high water |
+| --- | ---: | ---: | ---: | ---: |
+| CSV, 10.68 MiB / 220,001 entities | 127.7 ms | 164.2 ms | 36.1 MB | 41.2 MB |
+| JSON, 10 MiB / 39,871 entities | 237.8 ms | 250.7 ms | 45.5 MB | 29.8 MB |
+| Markdown, 1.24 MiB / 3,808 entities | 42.8 ms | 60.8 ms | 21.0 MB | 56.8 MB |
+| Excalidraw, 1.85 MiB / 20,000 entities | 217.5 ms | 226.1 ms | 7.7 MB | 41.8 MB |
 
-Both bulk lanes use one guest export, bounded pages, exact byte and semantic
-checks, history where applicable, and RocksDB reopen. CSV creates no per-row
+All four lanes remain Wasm components. They use one guest export and bounded
+push pages, preserve exact file bytes and semantic cardinality, and retain the
+format-specific history and RocksDB reopen checks. CSV creates no per-row
 history segments or locator records before hot publication.
 
 ## Reproduction

--- a/plugins/markdown-v2/src/core.rs
+++ b/plugins/markdown-v2/src/core.rs
@@ -1524,40 +1524,65 @@ pub struct Document {
 #[derive(Clone, Debug)]
 struct PersistentTree {
     base: Arc<NodeTree>,
-    top_level_overrides: Arc<BTreeMap<usize, NodeSnapshot>>,
+    root_override: Option<Arc<NodeSnapshot>>,
+    top_level_overrides: Arc<BTreeMap<usize, Arc<NodeTree>>>,
 }
 
 impl PersistentTree {
     fn new(root: NodeTree) -> Self {
         Self {
             base: Arc::new(root),
+            root_override: None,
             top_level_overrides: Arc::new(BTreeMap::new()),
         }
     }
 
     fn root_node(&self) -> &NodeSnapshot {
-        &self.base.node
+        self.root_override.as_deref().unwrap_or(&self.base.node)
     }
 
     fn top_level_node(&self, index: usize) -> Option<&NodeSnapshot> {
-        self.top_level_overrides
-            .get(&index)
-            .or_else(|| self.base.children.get(index).map(|child| &child.node))
+        self.top_level_tree(index).map(|tree| &tree.node)
     }
 
-    fn replace_top_level(&self, index: usize, node: NodeSnapshot) -> Self {
+    fn top_level_tree(&self, index: usize) -> Option<&NodeTree> {
+        self.top_level_overrides
+            .get(&index)
+            .map(Arc::as_ref)
+            .or_else(|| self.base.children.get(index))
+    }
+
+    fn replace_top_level_node(&self, index: usize, node: NodeSnapshot) -> Self {
+        let mut tree = self
+            .top_level_tree(index)
+            .expect("base top-level Markdown tree exists")
+            .clone();
+        tree.node = node;
+        self.replace_top_level_tree(index, tree, None)
+    }
+
+    fn replace_top_level_tree(
+        &self,
+        index: usize,
+        tree: NodeTree,
+        root: Option<NodeSnapshot>,
+    ) -> Self {
         let mut overrides = self.top_level_overrides.as_ref().clone();
-        overrides.insert(index, node);
+        overrides.insert(index, Arc::new(tree));
         Self {
             base: Arc::clone(&self.base),
+            root_override: root.map(Arc::new).or_else(|| self.root_override.clone()),
             top_level_overrides: Arc::new(overrides),
         }
     }
 
     fn materialize(&self) -> NodeTree {
         let mut root = self.base.as_ref().clone();
-        for (&index, node) in self.top_level_overrides.iter() {
-            root.children[index].node.clone_from(node);
+        if let Some(node) = &self.root_override {
+            root.node.clone_from(node);
+        }
+        for (&index, tree) in self.top_level_overrides.iter() {
+            root.children[index].clone_from(tree);
         }
         root
     }
@@ -2068,6 +2093,10 @@ impl Document {
             self.try_paragraph_replacement(splices, &successor_bytes, namespace)?
         {
             incremental
+        } else if let Some(incremental) =
+            self.try_top_level_replacement(splices, &successor_bytes, namespace)?
+        {
+            incremental
         } else {
             let bytes = successor_bytes.materialize();
             let file = File {
@@ -2228,7 +2257,7 @@ impl Document {
             delete_len: u64::try_from(range.end - range.start).expect("usize fits u64"),
             insert: Arc::new(fragment),
         }];
-        let successor_tree = self.tree.replace_top_level(block_index, new);
+        let successor_tree = self.tree.replace_top_level_node(block_index, new);
         Ok(Some((
             bytes,
             Arc::new(top_level_ranges),
@@ -2333,7 +2362,7 @@ impl Document {
                 metadata: change_metadata(Some(&old.node), &new.node),
             }]
         };
-        let successor_tree = self.tree.replace_top_level(block_index, new.node.clone());
+        let successor_tree = self.tree.replace_top_level_tree(block_index, new, None);
         Ok(Some((
             detected,
             Arc::clone(&self.top_level_ranges),
@@ -2341,9 +2370,136 @@ impl Document {
         )))
     }
 
+    /// Reparse one complete top-level block when a single edit is fully
+    /// contained by that block.
+    ///
+    /// The full parser remains the correctness fallback for edits that cross
+    /// block boundaries or alter line structure. A successful local parse is
+    /// accepted only when it produces exactly one block and renders byte-for-
+    /// byte to the successor fragment. Reconciliation then runs over a
+    /// document containing only the changed block, preserving stable subtree
+    /// identities without cloning or parsing unrelated siblings.
+    fn try_top_level_replacement(
+        &self,
+        splices: &[InputSplice<'_>],
+        bytes: &PersistentBytes,
+        namespace: IdNamespace,
+    ) -> Result<Option<(Vec<DetectedChange>, Arc<Vec<Range<usize>>>, PersistentTree)>, PluginError>
+    {
+        let [splice] = splices else {
+            return Ok(None);
+        };
+        let offset = usize::try_from(splice.offset)
+            .map_err(|_| PluginError::InvalidInput("Markdown splice offset is too large".into()))?;
+        let delete_len = usize::try_from(splice.delete_len).map_err(|_| {
+            PluginError::InvalidInput("Markdown splice delete length is too large".into())
+        })?;
+        let delete_end = offset.checked_add(delete_len).ok_or_else(|| {
+            PluginError::InvalidInput("Markdown splice delete range overflowed".into())
+        })?;
+        if splice.insert.contains(&b'\n')
+            || splice.insert.contains(&b'\r')
+            || self
+                .bytes
+                .range(offset..delete_end)?
+                .iter()
+                .any(|byte| matches!(byte, b'\n' | b'\r'))
+        {
+            return Ok(None);
+        }
+        let Some((block_index, range)) =
+            self.top_level_ranges.iter().enumerate().find(|(_, range)| {
+                range.start <= offset && offset < range.end && delete_end <= range.end
+            })
+        else {
+            return Ok(None);
+        };
+        let delta = isize::try_from(splice.insert.len()).expect("usize fits isize")
+            - isize::try_from(delete_len).expect("usize fits isize");
+        let successor_end = range
+            .end
+            .checked_add_signed(delta)
+            .ok_or_else(|| PluginError::Internal("Markdown block range shift overflow".into()))?;
+        let fragment_bytes = bytes.range(range.start..successor_end)?;
+        let fragment = std::str::from_utf8(&fragment_bytes).map_err(|error| {
+            PluginError::InvalidInput(format!(
+                "file.data must be valid UTF-8 for an incremental Markdown edit: {error}"
+            ))
+        })?;
+        let mut replacement = parse_markdown_source(fragment)?;
+        if replacement.root.children.len() != 1
+            || render_tree(&replacement.root)? != fragment.as_bytes()
+        {
+            return Ok(None);
+        }
+
+        let old_block = self
+            .tree
+            .top_level_tree(block_index)
+            .expect("base top-level Markdown tree exists")
+            .clone();
+        if !node_kinds_are_identity_compatible(
+            old_block.node.kind,
+            replacement.root.children[0].node.kind,
+        ) {
+            return Ok(None);
+        }
+        let old_root = NodeTree {
+            node: self.tree.root_node().clone(),
+            children: vec![old_block],
+        };
+        let mut new_root_node = self.tree.root_node().clone();
+        if new_root_node.format.get(LEXICAL_FALLBACK_FIELD).is_some() {
+            let format = new_root_node.format.as_object_mut().ok_or_else(|| {
+                PluginError::Internal("Markdown document format must be an object".into())
+            })?;
+            format.insert(
+                LEXICAL_FALLBACK_FIELD.to_owned(),
+                serde_json::Value::String(
+                    base64::engine::general_purpose::STANDARD.encode(bytes.materialize()),
+                ),
+            );
+        }
+        replacement.root.node.payload = new_root_node.payload;
+        replacement.root.node.format = new_root_node.format;
+        let before = ProjectionView::from_tree(&old_root);
+        let (detected, mut reconciled) =
+            detect_changes_for_markdown(&before, Some(&old_root), replacement, namespace)?;
+        let reconciled_block = reconciled.children.pop().ok_or_else(|| {
+            PluginError::Internal("incremental Markdown parse lost its changed block".into())
+        })?;
+        if !reconciled.children.is_empty() {
+            return Err(PluginError::Internal(
+                "incremental Markdown parse produced multiple changed blocks".into(),
+            ));
+        }
+
+        let mut top_level_ranges = self.top_level_ranges.as_ref().clone();
+        top_level_ranges[block_index].end = successor_end;
+        if delta != 0 {
+            for following in &mut top_level_ranges[block_index + 1..] {
+                following.start = following.start.checked_add_signed(delta).ok_or_else(|| {
+                    PluginError::Internal("Markdown block range shift overflow".into())
+                })?;
+                following.end = following.end.checked_add_signed(delta).ok_or_else(|| {
+                    PluginError::Internal("Markdown block range shift overflow".into())
+                })?;
+            }
+        }
+        let successor_tree =
+            self.tree
+                .replace_top_level_tree(block_index, reconciled_block, Some(reconciled.node));
+        Ok(Some((detected, Arc::new(top_level_ranges), successor_tree)))
+    }
+
     #[cfg(test)]
     pub(crate) fn accepted_bytes(&self) -> Vec<u8> {
         self.bytes.materialize()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn shares_base_tree_with(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.tree.base, &other.tree.base)
     }
 }
 

--- a/plugins/markdown-v2/src/tests.rs
+++ b/plugins/markdown-v2/src/tests.rs
@@ -356,6 +356,65 @@ fn localized_text_edit_emits_one_sparse_complete_entity_upsert() {
 }
 
 #[test]
+fn localized_frontmatter_edit_reuses_noncanonical_document_tree() {
+    let before =
+        b"---\nDateApproved: 6/10/2020\n---\n\n\n# Title\n\nA large untouched suffix.\n".to_vec();
+    let (document, initial) = Document::open_file(
+        before.clone(),
+        Some("frontmatter.md"),
+        IdNamespace::from_halves(1, 2),
+    )
+    .unwrap();
+    let root = initial
+        .iter()
+        .find(|change| {
+            change.snapshot.as_ref().is_some_and(|snapshot| {
+                serde_json::from_slice::<Value>(snapshot)
+                    .is_ok_and(|wire| wire["kind"] == "document")
+            })
+        })
+        .expect("document root must be emitted");
+    assert!(
+        root.snapshot.as_ref().is_some_and(|snapshot| {
+            serde_json::from_slice::<Value>(snapshot).is_ok_and(|wire| {
+                wire["format_json"]
+                    .as_str()
+                    .is_some_and(|format| format.contains("lexical_fallback_base64"))
+            })
+        }),
+        "fixture must exercise exact-byte lexical fallback"
+    );
+    let offset = before
+        .windows(b"6/10".len())
+        .position(|window| window == b"6/10")
+        .unwrap();
+    let (after, changes) = document
+        .file_changed(
+            &[InputSplice {
+                offset: u64::try_from(offset).unwrap(),
+                delete_len: u64::try_from("6/10".len()).unwrap(),
+                insert: b"7/9",
+            }],
+            IdNamespace::from_halves(3, 4),
+        )
+        .unwrap();
+    let expected = String::from_utf8(before)
+        .unwrap()
+        .replacen("6/10", "7/9", 1)
+        .into_bytes();
+    assert_eq!(after.accepted_bytes(), expected);
+    assert!(
+        after.shares_base_tree_with(&document),
+        "localized successor must retain the untouched document tree"
+    );
+    assert_eq!(
+        changes.len(),
+        2,
+        "only frontmatter and the exact-byte root fallback should change"
+    );
+}
+
+#[test]
 fn incremental_paragraph_edit_preserves_unrelated_entities_after_cold_reopen() {
     let source = b"# Title\n\nAlpha paragraph\n\nBravo paragraph\n\nCharlie paragraph\n".to_vec();
     let (_, initial) = Document::open_file(


### PR DESCRIPTION
## What changed

- retain complete top-level Markdown subtrees as sparse persistent-tree overrides
- parse and reconcile only the changed top-level block for safe single-splice edits
- update exact-byte lexical fallback and shifted source ranges without reparsing untouched siblings
- keep the full parser for edits that cross block or line boundaries

## Why

The exact 1.24 MB VS Code API transition changes only four bytes in the first frontmatter block, but the old path parsed and rendered the entire document. That took about 912 ms p50 and drove Wasm guest high-water memory to 102.4 MB.

The localized path retains the immutable base tree and replaces only the changed subtree. The same transition now takes 42.8 ms p50 / 60.8 ms p95, keeps the same two durable semantic changes and exact output bytes, and lowers guest high water to 56.8 MB.

## Cross-format profile

The current five-sample v3 matrix remains below 500 ms at p95:

- CSV, 10.68 MiB / 220,001 entities: 127.7 ms p50, 164.2 ms p95, 36.1 MB peak host allocation
- JSON, 10 MiB / 39,871 entities: 237.8 ms p50, 250.7 ms p95, 45.5 MB peak
- Markdown, 1.24 MiB / 3,808 entities: 42.8 ms p50, 60.8 ms p95, 21.0 MB peak
- Excalidraw, 1.85 MiB / 20,000 entities: 217.5 ms p50, 226.1 ms p95, 7.7 MB peak

All lanes remain Wasm components, use one guest export with bounded pushes, and preserve exact bytes, semantic cardinality, history, and reopen validation.

## Validation

- `cargo test --profile test --workspace --all-features`
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- certified Markdown, JSON, and Excalidraw sparse-successor history/reopen tests in release mode
- five-sample release benchmarks for 10.68 MiB CSV, 10 MiB JSON, VS Code API Markdown, and large Excalidraw