### PR TITLE
fix(engine): checkpoint eager derived tombstones

### DIFF
--- a/.changenotes/checkpoint-derived-shared-change-ids.md
+++ b/.changenotes/checkpoint-derived-shared-change-ids.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Fixed checkpoint compaction for eager plugin rows that share a source change ID and for payload-free cascade tombstones.

--- a/packages/engine/src/changelog/materialization.rs
+++ b/packages/engine/src/changelog/materialization.rs
@@ -181,6 +181,27 @@ pub(crate) async fn materialize_known_change_payloads<S>(
 where
     S: StorageAdapterRead + ?Sized,
 {
+    Ok(
+        materialize_known_change_payloads_in_order(store, changes, projection)
+            .await?
+            .into_iter()
+            .collect(),
+    )
+}
+
+/// Hydrates retained change records without collapsing repeated change ids.
+///
+/// Eager plugin materialization can produce multiple semantic identities from
+/// one source change. Lifecycle operations such as checkpoints must preserve
+/// each identity-specific payload even though those rows share a change id.
+pub(crate) async fn materialize_known_change_payloads_in_order<S>(
+    store: &S,
+    changes: impl Iterator<Item = ChangeRecord>,
+    projection: ChangeRecordProjection,
+) -> Result<Vec<(ChangeId, MaterializedChangePayload)>, LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
     let changes = changes.collect::<Vec<_>>();
     if !projection.requires_payload() {
         return Ok(changes
@@ -329,7 +350,9 @@ fn materialized_json_string(
 mod tests {
     use super::*;
     use crate::changelog::test_support::test_change_record;
-    use crate::storage_adapter::RequestedToUniqueRef;
+    use crate::storage_adapter::{
+        Memory, RequestedToUniqueRef, StorageAdapter, StorageReadOptions,
+    };
 
     fn encoded_change(schema_key: &str) -> Bytes {
         let mut record = test_change_record();
@@ -408,6 +431,49 @@ mod tests {
             error
                 .to_string()
                 .contains("returned 1 values for 2 unique ids")
+        );
+    }
+
+    #[tokio::test]
+    async fn ordered_materialization_preserves_repeated_change_ids() {
+        let storage = StorageAdapter::new(Memory::new());
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let first = test_change_record();
+        let mut second = first.clone();
+        second.schema_key = "derived-row".to_owned();
+        second.entity_pk = crate::entity_pk::EntityPk::single("entity-2");
+
+        let payloads = materialize_known_change_payloads_in_order(
+            &read,
+            [first.clone(), second.clone()].into_iter(),
+            ChangeRecordProjection::full(),
+        )
+        .await
+        .expect("repeated source ids should materialize");
+
+        assert_eq!(payloads.len(), 2);
+        assert_eq!(payloads[0].0, first.change_id);
+        assert_eq!(payloads[1].0, first.change_id);
+        assert_eq!(
+            payloads[0]
+                .1
+                .identity
+                .as_ref()
+                .expect("first identity")
+                .schema_key,
+            first.schema_key
+        );
+        assert_eq!(
+            payloads[1]
+                .1
+                .identity
+                .as_ref()
+                .expect("second identity")
+                .schema_key,
+            second.schema_key
         );
     }
 

--- a/packages/engine/src/changelog/mod.rs
+++ b/packages/engine/src/changelog/mod.rs
@@ -21,6 +21,7 @@ pub(crate) use context::{ChangelogContext, ChangelogStoreReader, ChangelogStoreW
 pub(crate) use materialization::{
     ChangeRecordProjection, MaterializedChangeIdentity, MaterializedChangePayload,
     load_change_records, materialize_known_change_payloads,
+    materialize_known_change_payloads_in_order,
 };
 pub(crate) use store::{
     CHANGE_SPACE, COMMIT_CHANGE_ID_SPACE, COMMIT_SPACE, change_key, commit_change_id_key,

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -1136,8 +1136,8 @@ pub(crate) async fn load_commit_delta_change_records(
 ///
 /// A known commit without a manifest is an empty commit. A present manifest is
 /// authoritative: every identity must carry its payload in the same packed
-/// record, and duplicate change ids are corruption even when their identities
-/// differ.
+/// record. Selected cascade tombstones may share their source change id; live
+/// and authored rows remain unique by change id.
 pub(crate) async fn load_commit_delta_members_with_payloads(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
@@ -1194,7 +1194,6 @@ pub(crate) async fn scan_commit_delta_members(
 ) -> Result<Vec<(TrackedStateKey, TrackedStateIndexValue)>, LixError> {
     let batch = scan_commit_delta_values(store, commit_id, &[]).await?;
     let mut members = Vec::with_capacity(batch.len());
-    let mut change_ids = BTreeSet::new();
     for row in batch.iter() {
         let key = row.key_ref();
         let key = TrackedStateKey {
@@ -1211,15 +1210,6 @@ pub(crate) async fn scan_commit_delta_members(
             ));
         }
         let value = row.value().clone();
-        if !change_ids.insert(value.change_id) {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "tracked_state commit_delta for commit '{commit_id}' contains duplicate change id '{}'",
-                    value.change_id
-                ),
-            ));
-        }
         members.push((key, value));
     }
     Ok(members)
@@ -1238,6 +1228,7 @@ pub(crate) async fn load_commit_delta_change_ids(
         .map(|(_, value)| value.change_id)
         .collect::<Vec<_>>();
     change_ids.sort_unstable();
+    change_ids.dedup();
     Ok(change_ids)
 }
 
@@ -1490,6 +1481,10 @@ pub(crate) async fn visit_change_records_from_commit_deltas(
                 if member.authored {
                     visit(member.change)?;
                     emitted += 1;
+                } else if is_payload_free_selected_tombstone(&member) {
+                    // Cascade tombstones preserve identity history but do not
+                    // introduce another public changelog fact.
+                    continue;
                 } else {
                     let locator = load_change_locator_by_id(store, member.change.change_id)
                         .await?
@@ -1661,6 +1656,9 @@ pub(crate) async fn scan_commit_delta_inventory(
         }
         validate_commit_delta_member_order_and_ids(commit_id, &members)?;
         for member in &members {
+            if is_payload_free_selected_tombstone(member) {
+                continue;
+            }
             if let Some(existing) =
                 authoritative_changes.insert(member.change.change_id, member.change.clone())
                 && existing != member.change
@@ -1925,20 +1923,31 @@ fn validate_commit_delta_member_order_and_ids(
             ),
         ));
     }
-    let mut change_ids = BTreeSet::new();
-    if let Some(change_id) = members
-        .iter()
-        .map(|member| member.value.change_id)
-        .find(|change_id| !change_ids.insert(*change_id))
-    {
-        return Err(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!(
-                "tracked_state commit_delta for commit '{commit_id}' contains duplicate change id '{change_id}'"
-            ),
-        ));
+    let mut change_ids = BTreeMap::new();
+    for member in members {
+        if let Some(previous_is_selected_tombstone) = change_ids.insert(
+            member.value.change_id,
+            is_payload_free_selected_tombstone(member),
+        ) && !(previous_is_selected_tombstone && is_payload_free_selected_tombstone(member))
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "tracked_state commit_delta for commit '{commit_id}' contains duplicate change id '{}'",
+                    member.value.change_id
+                ),
+            ));
+        }
     }
     Ok(())
+}
+
+fn is_payload_free_selected_tombstone(member: &CommitDeltaMember) -> bool {
+    !member.authored
+        && member.value.deleted
+        && member.change.snapshot.is_none()
+        && member.change.metadata.is_none()
+        && member.change.origin_key.is_none()
 }
 
 fn encode_commit_delta_manifest(manifest: &CommitDeltaManifest) -> Result<Vec<u8>, LixError> {
@@ -2964,7 +2973,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn commit_local_and_global_authority_reject_duplicate_change_ids() {
+    async fn public_membership_dedupes_ids_but_payload_authority_rejects_conflicts() {
         let storage = StorageAdapter::new(Memory::new());
         let commit_id = CommitId::for_test_label("duplicate-change-id");
         let mut fixtures = packed_commit_delta_fixtures()
@@ -2984,10 +2993,12 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
-        let error = load_commit_delta_change_ids(&read, commit_id)
-            .await
-            .expect_err("commit-local authority must reject duplicate change ids");
-        assert!(error.to_string().contains("contains duplicate change id"));
+        assert_eq!(
+            load_commit_delta_change_ids(&read, commit_id)
+                .await
+                .expect("public commit membership should load"),
+            vec![fixtures[0].change_id]
+        );
         let error = scan_commit_delta_inventory(&read)
             .await
             .expect_err("global authority must reject duplicate change ids");
@@ -2996,6 +3007,50 @@ mod tests {
             .await
             .expect_err("streaming authority must reject duplicate change ids");
         assert!(error.to_string().contains("contains duplicate change id"));
+    }
+
+    #[tokio::test]
+    async fn selected_tombstones_may_share_one_source_change_id() {
+        let storage = StorageAdapter::new(Memory::new());
+        let commit_id = CommitId::for_test_label("duplicate-selected-tombstone");
+        let mut fixtures = packed_commit_delta_fixtures()
+            .into_iter()
+            .take(2)
+            .collect::<Vec<_>>();
+        fixtures[0].deleted = true;
+        fixtures[1].deleted = true;
+        fixtures[1].change_id = fixtures[0].change_id;
+        let mut deltas = commit_delta_refs(commit_id, &fixtures);
+        for delta in &mut deltas {
+            delta.authored = false;
+        }
+        let mut writes = storage.new_write_set();
+        stage_commit_deltas(&mut writes, &deltas).expect("selected tombstones should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("selected tombstones should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        assert_eq!(
+            load_commit_delta_members_with_payloads(&read, commit_id)
+                .await
+                .expect("selected tombstones should remain identity-addressable")
+                .len(),
+            2
+        );
+        assert!(
+            scan_change_records_from_commit_deltas(&read)
+                .await
+                .expect("selected tombstones should not conflict with public authority")
+                .is_empty()
+        );
+        scan_commit_delta_inventory(&read)
+            .await
+            .expect("selected tombstones should be valid inventory members");
     }
 
     #[tokio::test]

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -213,12 +213,8 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         .await?;
 
     let selected_change_records = load_selected_change_records(read, &staged_commits).await?;
-    let selected_change_payloads = crate::changelog::materialize_known_change_payloads(
-        read,
-        selected_change_records.values().cloned(),
-        ChangeRecordProjection::full(),
-    )
-    .await?;
+    let selected_change_payloads =
+        materialize_selected_change_payloads(read, &selected_change_records).await?;
 
     stage_tracked_commit_delta_index(
         &mut writes,
@@ -442,6 +438,23 @@ struct StagedChangelogCommit {
     selected_change_batches: Vec<StagedCommitChangeBatch>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct SelectedChangeKey {
+    source_commit_id: CommitId,
+    identity: TrackedStateKey,
+}
+
+fn selected_change_key(change_ref: StagedCommitChangeRef<'_>) -> SelectedChangeKey {
+    SelectedChangeKey {
+        source_commit_id: change_ref.source_commit_id,
+        identity: TrackedStateKey {
+            schema_key: change_ref.schema_key().to_owned(),
+            file_id: change_ref.file_id().map(str::to_owned),
+            entity_pk: change_ref.entity_pk().clone(),
+        },
+    }
+}
+
 fn selected_changes(
     batches: &[StagedCommitChangeBatch],
 ) -> impl Iterator<Item = StagedCommitChangeRef<'_>> + '_ {
@@ -548,21 +561,15 @@ fn validate_selected_change_refs(
         return Ok(());
     }
 
-    let mut change_ids = BTreeSet::new();
     let mut identities = BTreeSet::new();
     for &row_index in state_row_indices {
         let row = state_rows.row(row_index);
-        let change_id = row.change_id.ok_or_else(|| {
+        row.change_id.ok_or_else(|| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 "tracked staged row is missing change_id before changelog append",
             )
         })?;
-        if !change_ids.insert(change_id) {
-            return Err(LixError::unknown(format!(
-                "commit '{commit_id}' has duplicate change ref '{change_id}'"
-            )));
-        }
         if !identities.insert((
             row.schema_key.as_str(),
             row.file_id.map(crate::common::SharedStr::as_str),
@@ -574,12 +581,6 @@ fn validate_selected_change_refs(
         }
     }
     for change_ref in selected_changes(selected_change_batches) {
-        if !change_ids.insert(change_ref.change_id) {
-            return Err(LixError::unknown(format!(
-                "commit '{commit_id}' has duplicate change ref '{}'",
-                change_ref.change_id
-            )));
-        }
         if !identities.insert((
             change_ref.schema_key(),
             change_ref.file_id(),
@@ -770,12 +771,18 @@ fn tracked_delta_from_selected_change_ref(
 fn tracked_commit_delta_from_selected_change_ref<'a>(
     change_ref: StagedCommitChangeRef<'a>,
     commit_id: CommitId,
-    record: &'a ChangeRecord,
+    record: Option<&'a ChangeRecord>,
 ) -> Result<TrackedStateCommitDeltaRef<'a>, LixError> {
-    if record.change_id != change_ref.change_id {
+    if record.is_some_and(|record| record.change_id != change_ref.change_id) {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
             "selected commit delta payload has the wrong change id",
+        ));
+    }
+    if record.is_none() && !change_ref.deleted {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "live selected commit delta is missing its payload",
         ));
     }
     Ok(TrackedStateCommitDeltaRef {
@@ -789,9 +796,13 @@ fn tracked_commit_delta_from_selected_change_ref<'a>(
             created_at: change_ref.created_at,
             updated_at: change_ref.updated_at,
         },
-        snapshot: record.snapshot.as_ref_slot(),
-        metadata: record.metadata.as_ref_slot(),
-        origin_key: record.origin_key.as_deref(),
+        snapshot: record.map_or(crate::json_store::JsonSlotRef::None, |record| {
+            record.snapshot.as_ref_slot()
+        }),
+        metadata: record.map_or(crate::json_store::JsonSlotRef::None, |record| {
+            record.metadata.as_ref_slot()
+        }),
+        origin_key: record.and_then(|record| record.origin_key.as_deref()),
         authored: false,
     })
 }
@@ -889,12 +900,18 @@ fn current_state_delta_from_engine_row(
 async fn load_selected_change_records(
     read: &(impl StorageAdapterRead + ?Sized),
     staged_commits: &BTreeMap<CommitId, StagedChangelogCommit>,
-) -> Result<HashMap<ChangeId, ChangeRecord>, LixError> {
+) -> Result<HashMap<SelectedChangeKey, ChangeRecord>, LixError> {
     let mut by_source_commit = BTreeMap::<CommitId, Vec<StagedCommitChangeRef<'_>>>::new();
     for change_ref in staged_commits
         .values()
         .flat_map(|staged| selected_changes(&staged.selected_change_batches))
     {
+        // Identity and timestamps fully describe a selected tombstone.
+        // Historical rows may be absent or retain metadata, while checkpoint
+        // HOT tombstones must carry no payload.
+        if change_ref.deleted {
+            continue;
+        }
         by_source_commit
             .entry(change_ref.source_commit_id)
             .or_default()
@@ -913,15 +930,19 @@ async fn load_selected_change_records(
             .collect::<Vec<_>>();
         let loaded = load_commit_delta_change_records(read, source_commit_id, &keys).await?;
         for (change_ref, record) in change_refs.into_iter().zip(loaded) {
-            let record = record.ok_or_else(|| {
-                LixError::new(
+            let Some(record) = record else {
+                return Err(LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
                     format!(
-                        "selected change '{}' has no authoritative payload at source commit '{}'",
-                        change_ref.change_id, source_commit_id
+                        "selected change '{}' for ({:?}, {:?}, {:?}) has no authoritative payload at source commit '{}'",
+                        change_ref.change_id,
+                        change_ref.schema_key(),
+                        change_ref.file_id(),
+                        change_ref.entity_pk(),
+                        source_commit_id
                     ),
-                )
-            })?;
+                ));
+            };
             if record.change_id != change_ref.change_id
                 || record.schema_key != change_ref.schema_key()
                 || record.file_id.as_deref() != change_ref.file_id()
@@ -937,7 +958,8 @@ async fn load_selected_change_records(
                     ),
                 ));
             }
-            if let Some(existing) = records.insert(record.change_id, record.clone())
+            let key = selected_change_key(change_ref);
+            if let Some(existing) = records.insert(key, record.clone())
                 && existing != record
             {
                 return Err(LixError::new(
@@ -953,13 +975,42 @@ async fn load_selected_change_records(
     Ok(records)
 }
 
+async fn materialize_selected_change_payloads(
+    read: &(impl StorageAdapterRead + ?Sized),
+    records: &HashMap<SelectedChangeKey, ChangeRecord>,
+) -> Result<HashMap<SelectedChangeKey, crate::changelog::MaterializedChangePayload>, LixError> {
+    let ordered = records
+        .iter()
+        .map(|(key, record)| (key.clone(), record.clone()))
+        .collect::<Vec<_>>();
+    let payloads = crate::changelog::materialize_known_change_payloads_in_order(
+        read,
+        ordered.iter().map(|(_, record)| record.clone()),
+        ChangeRecordProjection::full(),
+    )
+    .await?;
+    ordered
+        .into_iter()
+        .zip(payloads)
+        .map(|((key, record), (change_id, payload))| {
+            if change_id != record.change_id {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "selected change payload order does not match its source record",
+                ));
+            }
+            Ok((key, payload))
+        })
+        .collect()
+}
+
 fn stage_tracked_commit_delta_index(
     writes: &mut StorageWriteSet,
     state_rows: &PreparedStateBatch,
     tracked_row_indices_by_commit: &BTreeMap<CommitId, Vec<RowIndex>>,
     tracked_roots: &[PendingTrackedRoot],
     staged_commits: &BTreeMap<CommitId, StagedChangelogCommit>,
-    selected_change_records: &HashMap<ChangeId, ChangeRecord>,
+    selected_change_records: &HashMap<SelectedChangeKey, ChangeRecord>,
 ) -> Result<(), LixError> {
     for root in tracked_roots {
         let state_row_indices = tracked_row_indices_by_commit
@@ -984,17 +1035,8 @@ fn stage_tracked_commit_delta_index(
             )?);
         }
         for change_ref in selected_changes(&staged.selected_change_batches) {
-            let record = selected_change_records
-                .get(&change_ref.change_id)
-                .ok_or_else(|| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        format!(
-                            "selected change '{}' lost its authoritative payload before delta staging",
-                            change_ref.change_id
-                        ),
-                    )
-                })?;
+            let key = selected_change_key(change_ref);
+            let record = selected_change_records.get(&key);
             deltas.push(tracked_commit_delta_from_selected_change_ref(
                 change_ref,
                 root.commit_id,
@@ -1120,7 +1162,7 @@ async fn build_lifecycle_tracked_snapshots(
     tracked_row_indices_by_commit: &BTreeMap<CommitId, Vec<RowIndex>>,
     tracked_roots: &[PendingTrackedRoot],
     staged_commits: &BTreeMap<CommitId, StagedChangelogCommit>,
-    selected_payloads: &HashMap<ChangeId, crate::changelog::MaterializedChangePayload>,
+    selected_payloads: &HashMap<SelectedChangeKey, crate::changelog::MaterializedChangePayload>,
     insert_selection: &PreparedInsertSelection,
     required: &BTreeSet<CommitId>,
 ) -> Result<BTreeMap<CommitId, HotTrackedSnapshot>, LixError> {
@@ -1132,7 +1174,7 @@ async fn build_lifecycle_tracked_snapshots(
         .iter()
         .map(|root| (root.commit_id, root))
         .collect::<BTreeMap<_, _>>();
-    let mut prepared_by_change = HashMap::new();
+    let mut prepared_by_identity = HashMap::new();
     for row in state_rows.iter().filter(|row| !row.untracked) {
         let change_id = row.change_id.ok_or_else(|| {
             LixError::new(
@@ -1142,10 +1184,17 @@ async fn build_lifecycle_tracked_snapshots(
         })?;
         let live = MaterializedLiveStateRow::from(row);
         let tracked = MaterializedTrackedStateRow::try_from(&live)?;
-        if prepared_by_change.insert(change_id, tracked).is_some() {
+        let identity = TrackedStateKey {
+            schema_key: tracked.schema_key.clone(),
+            file_id: tracked.file_id.clone(),
+            entity_pk: tracked.entity_pk.clone(),
+        };
+        if prepared_by_identity.insert(identity, tracked).is_some() {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
-                format!("tracked lifecycle snapshot contains duplicate change '{change_id}'"),
+                format!(
+                    "tracked lifecycle snapshot contains duplicate identity for change '{change_id}'"
+                ),
             ));
         }
     }
@@ -1198,8 +1247,9 @@ async fn build_lifecycle_tracked_snapshots(
             )
         })?;
         for change_ref in selected_changes(&staged.selected_change_batches) {
-            let source = prepared_by_change.get(&change_ref.change_id);
-            let payload = selected_payloads.get(&change_ref.change_id);
+            let key = selected_change_key(change_ref);
+            let source = prepared_by_identity.get(&key.identity);
+            let payload = selected_payloads.get(&key);
             let tracked =
                 lifecycle_selected_tracked_row(change_ref, root.commit_id, source, payload)?;
             apply_lifecycle_tracked_snapshot_row(&mut rows, tracked, false)?;
@@ -1460,6 +1510,14 @@ fn lifecycle_selected_tracked_row(
             row.snapshot_content.clone(),
             row.metadata.clone(),
         )
+    } else if change_ref.deleted && payload.is_none() {
+        (
+            change_ref.schema_key().to_owned(),
+            change_ref.entity_pk().clone(),
+            change_ref.file_id().map(str::to_owned),
+            None,
+            None,
+        )
     } else {
         let payload = payload.ok_or_else(|| {
             LixError::new(
@@ -1601,7 +1659,10 @@ async fn stage_tracked_head(
     tracked_row_indices_by_commit: &BTreeMap<CommitId, Vec<RowIndex>>,
     tracked_roots: &[PendingTrackedRoot],
     staged_commits: &BTreeMap<CommitId, StagedChangelogCommit>,
-    selected_change_payloads: &HashMap<ChangeId, crate::changelog::MaterializedChangePayload>,
+    selected_change_payloads: &HashMap<
+        SelectedChangeKey,
+        crate::changelog::MaterializedChangePayload,
+    >,
     insert_selection: &PreparedInsertSelection,
     certified_fresh_plugin_file_id: Option<&str>,
     explicit_branch_targets: &BTreeMap<String, ExplicitBranchHeadTarget>,
@@ -1672,11 +1733,12 @@ async fn stage_tracked_head(
         {
             let selected_rows = selected_changes(&staged.selected_change_batches)
                 .map(|change_ref| {
+                    let key = selected_change_key(change_ref);
                     lifecycle_selected_tracked_row(
                         change_ref,
                         root.commit_id,
                         None,
-                        selected_change_payloads.get(&change_ref.change_id),
+                        selected_change_payloads.get(&key),
                     )
                 })
                 .collect::<Result<Vec<_>, _>>()?;
@@ -3548,14 +3610,13 @@ mod tests {
         assert!(error.message.contains("duplicate change ref key"));
 
         let row = tracked_global_row("normal-change");
-        let error = validate_selected_change_refs(
+        validate_selected_change_refs(
             commit_id("test-uuid-1"),
             &prepared_rows![row],
             &[0],
             &[selected_change_batch("normal-change", "other-entity")],
         )
-        .expect_err("selected ref must not duplicate a normal row change id");
-        assert!(error.message.contains("duplicate change ref '"));
+        .expect("different semantic identities may share one source change id");
     }
 
     #[tokio::test]

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -2505,7 +2505,7 @@ struct StagedCommitChangeColumns {
 #[derive(Debug, Clone)]
 pub(crate) struct StagedCommitChangeBatch {
     columns: Arc<StagedCommitChangeColumns>,
-    /// Present only when duplicate change ids were filtered while combining
+    /// Present only when duplicate identities were filtered while combining
     /// independently supplied batches. The normal merge/checkpoint path views
     /// every row directly and allocates no selection column.
     selection: Option<Arc<[u32]>>,
@@ -2694,16 +2694,21 @@ impl StagedCommitChangeRefs {
             return;
         }
 
-        // Deduplicate only while batches are combined, then drop the index.
+        // Deduplicate logical identities only while batches are combined,
+        // then drop the index. Eager plugin rows may legitimately share one
+        // source change id.
         // Unlike the former BTreeSet retained for the transaction lifetime,
         // this is one temporary contiguous table rather than one allocation
         // per selected mutation.
-        let mut change_ids =
+        let mut identities =
             HashSet::with_capacity(self.selected_change_count().saturating_add(batch.len()));
-        change_ids.extend(self.selected_changes().map(|change| change.change_id));
+        identities.extend(
+            self.selected_changes()
+                .map(|change| (change.schema_key(), change.file_id(), change.entity_pk())),
+        );
         let mut selected: Option<Vec<u32>> = None;
         for (row_index, change) in batch.iter().enumerate() {
-            if change_ids.insert(change.change_id) {
+            if identities.insert((change.schema_key(), change.file_id(), change.entity_pk())) {
                 if let Some(selected) = selected.as_mut() {
                     selected.push(
                         u32::try_from(row_index)
@@ -2822,6 +2827,63 @@ mod tests {
             finalized_clone.selected_change_batches[0]
                 .shares_storage_with(&staged.selected_change_batches[0]),
             "commit finalization clones must be O(1) batch-owner clones"
+        );
+    }
+
+    #[test]
+    fn selected_batches_dedupe_identity_not_source_change_id() {
+        let timestamp = LixTimestamp::from_unix_millis_utc_lossy(0);
+        let source_commit = CommitId::for_test_label("shared-source");
+        let shared_change = ChangeId::for_test_label("shared-change");
+        let identities = TrackedStateDiffIdentity::from_key_batch(
+            ["entity-a", "entity-b"]
+                .into_iter()
+                .map(|entity| TrackedStateKey {
+                    schema_key: "schema".to_string(),
+                    file_id: Some("file".to_string()),
+                    entity_pk: EntityPk::single(entity),
+                })
+                .collect(),
+        )
+        .expect("identity batch should fit");
+
+        let mut first = StagedCommitChangeBatchBuilder::with_capacity(1);
+        first.push(
+            identities[0].clone(),
+            source_commit,
+            shared_change,
+            false,
+            timestamp,
+            timestamp,
+        );
+        let mut second = StagedCommitChangeBatchBuilder::with_capacity(2);
+        second.push(
+            identities[1].clone(),
+            source_commit,
+            shared_change,
+            false,
+            timestamp,
+            timestamp,
+        );
+        second.push(
+            identities[0].clone(),
+            source_commit,
+            ChangeId::for_test_label("duplicate-identity"),
+            false,
+            timestamp,
+            timestamp,
+        );
+
+        let mut staged = StagedCommitChangeRefs::default();
+        staged.add_selected_change_batch(first.finish());
+        staged.add_selected_change_batch(second.finish());
+        assert_eq!(staged.selected_change_count(), 2);
+        assert_eq!(
+            staged
+                .selected_changes()
+                .map(|change| change.change_id)
+                .collect::<Vec<_>>(),
+            vec![shared_change, shared_change]
         );
     }
 


### PR DESCRIPTION
## What changed

- Key checkpoint-selected records by source commit and semantic identity instead of treating `change_id` as a unique row key.
- Preserve repeated source change IDs during payload materialization.
- Represent eager cascade tombstones as identity-addressed, payload-free commit-delta members without weakening authored/public changelog authority.
- Deduplicate selected batches by semantic identity and add focused regression coverage.

## Root cause

One file change can eagerly materialize multiple plugin rows that legitimately share a source `change_id`. Checkpoint code used that ID as a primary key and rejected or collapsed those rows. File-deletion cascades additionally produce selected tombstones whose identity and timestamps are authoritative but whose source commit has no tombstone payload.

This reproduced while replaying OpenClaw with the text, CSV, Markdown, and Excalidraw WASM plugins and checkpointing after every Git commit. Main failed at Git commit 61 (`d0c9bff4ca59d9596675084bc23192886fd4dc6c`) when a coverage tree was deleted.

## Validation

- Rebased on `cb2c418b5` (latest `origin/main` at publication).
- `cargo test -p lix_engine --lib`: 1,557 passed, 6 ignored.
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`.
- Release replay of the first 70 OpenClaw commits with all bundled WASM plugins and a checkpoint after every Git commit completed successfully, crossing the original commit-61 failure.
- Retained replay database and per-commit profile for storage inspection.