### PR TITLE
fix(markdown): retain localized successor subtrees

### DIFF
--- a/.changenotes/markdown-localized-successor-tree.md
+++ b/.changenotes/markdown-localized-successor-tree.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Fixed sequential localized Markdown edits to reconcile against the latest persistent subtree.

--- a/plugins/markdown-v2/src/core.rs
+++ b/plugins/markdown-v2/src/core.rs
@@ -1643,9 +1643,10 @@ impl PersistentBytes {
 
     fn range(&self, range: Range<usize>) -> Result<Vec<u8>, PluginError> {
         if !(range.start..=self.len).contains(&range.end) {
-            return Err(PluginError::InvalidInput(
-                "Markdown byte range is out of bounds".to_owned(),
-            ));
+            return Err(PluginError::InvalidInput(format!(
+                "Markdown byte range {}..{} is out of bounds for {} bytes",
+                range.start, range.end, self.len
+            )));
         }
         let mut output = Vec::with_capacity(range.end - range.start);
         let mut logical_start = 0usize;
@@ -1672,9 +1673,10 @@ impl PersistentBytes {
         output: &mut Vec<BytePiece>,
     ) -> Result<(), PluginError> {
         if !(range.start..=self.len).contains(&range.end) {
-            return Err(PluginError::InvalidInput(
-                "Markdown byte range is out of bounds".to_owned(),
-            ));
+            return Err(PluginError::InvalidInput(format!(
+                "Markdown byte range {}..{} is out of bounds for {} bytes",
+                range.start, range.end, self.len
+            )));
         }
         let mut logical_start = 0usize;
         for piece in self.pieces.iter() {
@@ -2206,6 +2208,9 @@ impl Document {
         let Some(range) = self.top_level_ranges.get(block_index) else {
             return Ok(None);
         };
+        if range.end > self.bytes.len {
+            return Ok(None);
+        }
         let new: NodeSnapshot = serde_json::from_str(snapshot_content).map_err(|error| {
             PluginError::InvalidInput(format!(
                 "invalid Markdown paragraph snapshot for incremental rendering: {error}"
@@ -2299,6 +2304,9 @@ impl Document {
         else {
             return Ok(None);
         };
+        if range.end > bytes.len {
+            return Ok(None);
+        }
 
         if self
             .tree
@@ -2328,12 +2336,11 @@ impl Document {
             return Ok(None);
         }
 
-        let mut old = self.tree.base.children[block_index].clone();
-        old.node.clone_from(
-            self.tree
-                .top_level_node(block_index)
-                .expect("validated top-level paragraph exists"),
-        );
+        let old = self
+            .tree
+            .top_level_tree(block_index)
+            .expect("validated top-level paragraph exists")
+            .clone();
         let mut new = replacement.root.children.remove(0);
         let generated_ids = collect_generated_ids(&new);
         let generated_node_id = new.node.id.clone();
@@ -2420,6 +2427,9 @@ impl Document {
             .end
             .checked_add_signed(delta)
             .ok_or_else(|| PluginError::Internal("Markdown block range shift overflow".into()))?;
+        if successor_end > bytes.len {
+            return Ok(None);
+        }
         let fragment_bytes = bytes.range(range.start..successor_end)?;
         let fragment = std::str::from_utf8(&fragment_bytes).map_err(|error| {
             PluginError::InvalidInput(format!(

--- a/plugins/markdown-v2/src/tests.rs
+++ b/plugins/markdown-v2/src/tests.rs
@@ -356,6 +356,102 @@ fn localized_text_edit_emits_one_sparse_complete_entity_upsert() {
 }
 
 #[test]
+fn sequential_localized_edits_read_the_latest_overridden_subtree() {
+    let before = b"Alpha words here\n\nUntouched\n".to_vec();
+    let (document, _) = Document::open_file(
+        before.clone(),
+        Some("sequential.md"),
+        IdNamespace::from_halves(1, 2),
+    )
+    .unwrap();
+    let words = before
+        .windows(b"words".len())
+        .position(|window| window == b"words")
+        .unwrap();
+    let (first, _) = document
+        .file_changed(
+            &[InputSplice {
+                offset: u64::try_from(words).unwrap(),
+                delete_len: u64::try_from("words".len()).unwrap(),
+                insert: b"localized",
+            }],
+            IdNamespace::from_halves(3, 4),
+        )
+        .unwrap();
+    let first_bytes = first.accepted_bytes();
+    let alpha = first_bytes
+        .windows(b"Alpha".len())
+        .position(|window| window == b"Alpha")
+        .unwrap();
+    let (second, changes) = first
+        .file_changed(
+            &[InputSplice {
+                offset: u64::try_from(alpha).unwrap(),
+                delete_len: 1,
+                insert: b"O",
+            }],
+            IdNamespace::from_halves(5, 6),
+        )
+        .unwrap();
+
+    assert_eq!(
+        second.accepted_bytes(),
+        b"Olpha localized here\n\nUntouched\n"
+    );
+    assert_eq!(changes.len(), 1, "{changes:#?}");
+    let snapshot = changes[0]
+        .snapshot
+        .as_deref()
+        .expect("paragraph remains live");
+    assert_eq!(
+        plain_text_from_snapshot(snapshot),
+        "Olpha localized here",
+        "the second edit must reconcile against the first edit's subtree"
+    );
+}
+
+#[test]
+fn localized_edit_falls_back_when_parser_range_exceeds_source_bytes() {
+    let before = b"```json5\n{}\n```\n\nDuring dev.\n\n## Notes\n\n- Monitor uses polling.\n- Stop with `Ctrl+C`.\n".to_vec();
+    let parsed = parse_markdown_source(std::str::from_utf8(&before).unwrap()).unwrap();
+    assert!(
+        parsed
+            .top_level_ranges
+            .iter()
+            .any(|range| range.end > before.len()),
+        "fixture must retain the parser's virtual final newline: {:?} for {} bytes",
+        parsed.top_level_ranges,
+        before.len()
+    );
+    let (document, _) = Document::open_file(
+        before.clone(),
+        Some("virtual-newline.md"),
+        IdNamespace::from_halves(1, 2),
+    )
+    .unwrap();
+    let offset = before
+        .windows(b"polling".len())
+        .position(|window| window == b"polling")
+        .unwrap();
+    let (after, changes) = document
+        .file_changed(
+            &[InputSplice {
+                offset: u64::try_from(offset).unwrap(),
+                delete_len: 1,
+                insert: b"P",
+            }],
+            IdNamespace::from_halves(3, 4),
+        )
+        .expect("an unsafe localized range must fall back to a full parse");
+
+    assert_eq!(
+        after.accepted_bytes(),
+        b"```json5\n{}\n```\n\nDuring dev.\n\n## Notes\n\n- Monitor uses Polling.\n- Stop with `Ctrl+C`.\n"
+    );
+    assert!(!changes.is_empty());
+}
+
+#[test]
 fn localized_frontmatter_edit_reuses_noncanonical_document_tree() {
     let before =
         b"---\nDateApproved: 6/10/2020\n---\n\n\n# Title\n\nA large untouched suffix.\n".to_vec();


### PR DESCRIPTION
## What changed

- Reconcile a second localized Markdown edit against the latest overridden top-level subtree instead of the immutable base tree.
- Treat parser ranges that exceed the accepted source byte rope as an unsafe optimization case and fall back to a full parse.
- Include exact byte-range diagnostics if an actually invalid range reaches the byte rope.
- Add regressions for sequential localized edits and parser virtual-final-newline ranges.

## Root cause

The localized edit optimization merged in #966 stores persistent top-level tree overrides. A later paragraph edit still cloned `base.children[block_index]`, so its semantic tree could lag the accepted byte rope. Separately, Markdown parser ranges can include a virtual final newline for noncanonical source; localized paths treated that optimization cache miss as invalid user input.

On a long-lived all-plugin OpenClaw replay, current main failed at Git commit `dd55a804302e47d5cecc3f2415dbcccc7249b38b` with `Markdown byte range is out of bounds`. Replaying that commit from a fresh parent passed, confirming the persistent-state dependency.

## Validation

- `cargo test -p plugin_markdown_incremental_v2 --lib`: 21 passed.
- `cargo clippy -p plugin_markdown_incremental_v2 --all-targets --all-features -- -D warnings`.
- Replayed the first 180 OpenClaw commits with all bundled WASM plugins in one long-lived process; the former commit-174 failure now passes and all 180 commits complete.
- Retained the passing replay database/profile and the failing main artifacts for comparison.