### PR TITLE
perf(engine): make checkpoint replay linear and compact

### DIFF
--- a/.changenotes/checkpoint-reuse-hot-generation.md
+++ b/.changenotes/checkpoint-reuse-hot-generation.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Checkpoint publication now rewrites only interval changes instead of copying the complete HOT state.

--- a/.changenotes/checkpoint-rootless-history.md
+++ b/.changenotes/checkpoint-rootless-history.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Checkpoint commits now retain compact absolute deltas instead of rewriting a full immutable history root.
+Git replay can checkpoint at a configured commit interval and records checkpoint latency in its profile.
+Repository GC checkpoints now double their sweep interval so cumulative maintenance stays linear in history.

--- a/packages/cli/src/cli/exp.rs
+++ b/packages/cli/src/cli/exp.rs
@@ -73,6 +73,10 @@ pub struct ExpGitReplayArgs {
     #[arg(long, value_parser = value_parser!(u32).range(1..))]
     pub num_commits: Option<u32>,
 
+    /// Create a Lix checkpoint after every N replayed Git commits.
+    #[arg(long, value_parser = value_parser!(u32).range(1..))]
+    pub checkpoint_every: Option<u32>,
+
     /// Verify changed files after each commit and the complete final tree.
     #[arg(long, default_value_t = false)]
     pub verify_state: bool,

--- a/packages/cli/src/commands/exp/git_replay.rs
+++ b/packages/cli/src/commands/exp/git_replay.rs
@@ -123,6 +123,7 @@ struct ReplayProfilePhaseTotals {
     prepare_ms: f64,
     build_sql_ms: f64,
     execute_ms: f64,
+    checkpoint_ms: f64,
     verify_ms: f64,
     total_ms: f64,
 }
@@ -200,6 +201,7 @@ struct ReplayCommitProfile {
     prepare_ms: f64,
     build_sql_ms: f64,
     execute_ms: f64,
+    checkpoint_ms: Option<f64>,
     plugin_counters: ReplayPluginCounters,
     verify_ms: Option<f64>,
     total_ms: f64,
@@ -214,6 +216,7 @@ struct ReplayProfileReport {
     branch: String,
     from_commit: Option<String>,
     num_commits_requested: Option<u32>,
+    checkpoint_every: Option<u32>,
     verify_state: bool,
     plugin_install_ms: f64,
     baseline_seed_parent: Option<String>,
@@ -382,6 +385,7 @@ where
     let mut verified = 0usize;
     let mut phase_totals = ReplayProfilePhaseTotals::default();
     let mut commit_profiles = Vec::<ReplayCommitProfile>::with_capacity(commits.len());
+    let checkpoint_every = args.checkpoint_every.map(|interval| interval as usize);
 
     println!(
         "[git-replay] replaying {} commits from {} into {}",
@@ -436,6 +440,20 @@ where
         let plugin_counters = lix.plugin_v2_transition_counters().into();
         phase_totals.execute_ms += execute_ms;
         applied += 1;
+        let checkpoint_ms = if checkpoint_every.is_some_and(|interval| (index + 1) % interval == 0)
+        {
+            let checkpoint_started = Instant::now();
+            db::block_on(lix.create_checkpoint()).map_err(|error| {
+                CliError::msg(format!(
+                    "failed to checkpoint after replay commit {commit_sha}: {error}"
+                ))
+            })?;
+            let elapsed_ms = duration_to_ms(checkpoint_started.elapsed());
+            phase_totals.checkpoint_ms += elapsed_ms;
+            Some(elapsed_ms)
+        } else {
+            None
+        };
 
         if args.verify_state {
             let verify_started = Instant::now();
@@ -466,6 +484,7 @@ where
             prepare_ms,
             build_sql_ms,
             execute_ms,
+            checkpoint_ms,
             plugin_counters,
             verify_ms,
             total_ms,
@@ -554,6 +573,7 @@ where
                 branch: args.branch.clone(),
                 from_commit: args.from_commit.clone(),
                 num_commits_requested: args.num_commits,
+                checkpoint_every: args.checkpoint_every,
                 verify_state: args.verify_state,
                 plugin_install_ms,
                 baseline_seed_parent,
@@ -2595,6 +2615,7 @@ mod tests {
             branch: "missing-ref".to_string(),
             from_commit: None,
             num_commits: None,
+            checkpoint_every: None,
             verify_state: false,
             force: true,
             profile_json: None,
@@ -2896,6 +2917,7 @@ mod tests {
             branch: "main".to_string(),
             from_commit: None,
             num_commits: None,
+            checkpoint_every: Some(1),
             verify_state: true,
             force: false,
             profile_json: Some(profile.clone()),
@@ -2919,10 +2941,29 @@ mod tests {
             Some(1),
             "the empty Git commit must remain a Lix revision"
         );
+        assert_eq!(profile_json["checkpoint_every"], 1);
+        assert!(
+            profile_json["commits"]
+                .as_array()
+                .expect("profile commits should be an array")
+                .iter()
+                .all(|commit| commit["checkpoint_ms"].is_number()),
+            "checkpoint-every replay must profile every checkpoint"
+        );
 
         let storage = RocksDB::open(&output).expect("replay RocksDB should reopen");
         let lix = db::block_on(open_lix_with_storage(storage))
             .expect("replay Lix should reopen with installed plugin");
+        let checkpoint_rows =
+            db::block_on(lix.execute("SELECT count(*) AS count FROM lix_checkpoint", &[]))
+                .expect("checkpoint history should be queryable");
+        assert_eq!(
+            checkpoint_rows.rows()[0]
+                .get::<i64>("count")
+                .expect("checkpoint count should decode"),
+            5,
+            "initialization plus four replayed commits should publish five checkpoints"
+        );
         let text_rows = db::block_on(lix.execute(
             "SELECT lixcol_entity_pk FROM git_text_line_v2 WHERE lixcol_file_id = ?",
             &[Value::Text(stable_file_id(&git_path(b"docs/renamed.txt")))],
@@ -2982,6 +3023,7 @@ mod tests {
                     branch: "main".to_string(),
                     from_commit: None,
                     num_commits: Some(1),
+                    checkpoint_every: None,
                     verify_state: true,
                     force: false,
                     profile_json: Some(profile.clone()),
@@ -3081,6 +3123,7 @@ mod tests {
             branch: "main".to_string(),
             from_commit: None,
             num_commits: Some(100),
+            checkpoint_every: None,
             verify_state: true,
             force: false,
             profile_json: Some(profile.clone()),
@@ -3227,6 +3270,7 @@ mod tests {
             branch: "main".to_string(),
             from_commit: None,
             num_commits: Some(2),
+            checkpoint_every: None,
             verify_state: true,
             force: false,
             profile_json: Some(profile.clone()),

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -112,8 +112,8 @@ struct StoredCheckpointGcState {
 /// Stages one branch's recovery-root rotation.
 ///
 /// The caller owns the surrounding transaction. Replacing the key drops the
-/// prior interval from the next GC root set without ever exposing an
-/// intermediate root-less checkpoint.
+/// prior interval from the next GC root set without ever exposing a
+/// checkpoint that lacks durable commit-delta reconstruction authority.
 pub(crate) fn stage_recovery_ref_rotation(
     writes: &mut StorageWriteSet,
     recovery: &CheckpointRecoveryRef,

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -1866,6 +1866,41 @@ where
             false,
             None,
             None,
+            false,
+        )
+        .await
+    }
+
+    /// Publishes a checkpoint into the already-visible generation.
+    ///
+    /// The checkpoint selected refs are the complete dirty set for the
+    /// interval. Rewriting only those rows to `Clean` starts the next epoch
+    /// without copying every unchanged HOT row into a fresh generation.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn stage_checkpoint_current_state(
+        &mut self,
+        branch_id: &str,
+        generation: CommitId,
+        new_head: CommitId,
+        deltas: &[CurrentStateDeltaRef<'_>],
+        absence_guards: &BTreeSet<TrackedStateKey>,
+        checkpoint_commit_id: CommitId,
+        coverage: &mut WorkingDiffIndexCoverage,
+    ) -> Result<CommitId, LixError> {
+        self.stage_current_state_with_working_diff_inner(
+            branch_id,
+            Some(generation),
+            new_head,
+            deltas,
+            absence_guards,
+            None,
+            None,
+            Some(checkpoint_commit_id),
+            coverage,
+            false,
+            None,
+            None,
+            true,
         )
         .await
     }
@@ -1910,6 +1945,7 @@ where
                     true,
                     validated_absent_file_id,
                     None,
+                    false,
                 )
                 .await;
         }
@@ -1927,6 +1963,7 @@ where
             true,
             validated_absent_file_id,
             Some(absence_guards),
+            false,
         )
         .await
     }
@@ -1946,6 +1983,7 @@ where
         absence_guards_validated: bool,
         validated_absent_file_id: Option<&str>,
         borrowed_absence_guards: Option<&[TrackedStateKeyRef<'_>]>,
+        reset_working_diff_baselines: bool,
     ) -> Result<CommitId, LixError> {
         let generation = parent_generation.unwrap_or(new_head);
         let sorted = {
@@ -2059,7 +2097,14 @@ where
                     &mut retired_untracked_json_refs,
                 );
             }
-            created_ats.push(existing.created_at);
+            created_ats.push(if reset_working_diff_baselines && !delta.untracked {
+                // Checkpoint selection canonicalizes newly added rows to the
+                // changelog timestamp and preserves the original timestamp
+                // for modified/removed rows.
+                delta.created_at
+            } else {
+                existing.created_at
+            });
         }
         let unmatched_guards = if absence_guards_validated || absence_guards.is_empty() {
             BTreeSet::new()
@@ -2133,17 +2178,20 @@ where
                 // is always disabled. Do not decode the row a second time merely
                 // to rediscover that fact; the first decode above already handled
                 // retention validation and `created_at` preservation.
-                let (working_diff_baseline, newly_dirty) =
-                    if working_diff_capture_checkpoint_commit_id.is_some() && !delta.untracked {
-                        let previous = previous.as_deref().map(decode_head_value).transpose()?;
-                        next_hot_working_diff_baseline(
-                            working_diff_capture_checkpoint_commit_id,
-                            delta,
-                            previous,
-                        )?
-                    } else {
-                        (WorkingDiffBaseline::Disabled, false)
-                    };
+                let (working_diff_baseline, newly_dirty) = if reset_working_diff_baselines
+                    && !delta.untracked
+                {
+                    (WorkingDiffBaseline::Clean, false)
+                } else if working_diff_capture_checkpoint_commit_id.is_some() && !delta.untracked {
+                    let previous = previous.as_deref().map(decode_head_value).transpose()?;
+                    next_hot_working_diff_baseline(
+                        working_diff_capture_checkpoint_commit_id,
+                        delta,
+                        previous,
+                    )?
+                } else {
+                    (WorkingDiffBaseline::Disabled, false)
+                };
                 if newly_dirty {
                     let key = append_hot_diff_key_parts(
                         &mut diff_key_bytes,
@@ -2190,6 +2238,7 @@ where
             generation,
             &sorted,
             working_diff_capture_checkpoint_commit_id,
+            reset_working_diff_baselines,
             &mut next_coverage,
             &mut retired_untracked_json_refs,
         )
@@ -2302,6 +2351,7 @@ async fn stage_incremental_file_delete_cascades(
     generation: CommitId,
     deltas: &[&CurrentStateDeltaRef<'_>],
     working_diff_capture_checkpoint_commit_id: Option<CommitId>,
+    reset_working_diff_baselines: bool,
     coverage: &mut WorkingDiffIndexCoverage,
     retired_untracked_json_refs: &mut BTreeSet<[u8; JSON_REF_BYTES]>,
 ) -> Result<(), LixError> {
@@ -2414,10 +2464,11 @@ async fn stage_incremental_file_delete_cascades(
             mutations.file_deletes.push(file_key);
             continue;
         }
-        let (baseline, newly_dirty) = next_cascade_working_diff_baseline(
-            working_diff_capture_checkpoint_commit_id,
-            existing,
-        )?;
+        let (baseline, newly_dirty) = if reset_working_diff_baselines {
+            (WorkingDiffBaseline::Clean, false)
+        } else {
+            next_cascade_working_diff_baseline(working_diff_capture_checkpoint_commit_id, existing)?
+        };
         if newly_dirty {
             let key = append_hot_diff_key_parts(
                 &mut diff_key_bytes,
@@ -5961,6 +6012,7 @@ mod tests {
             generation,
             &deltas,
             None,
+            false,
             &mut coverage,
             &mut retired_untracked_json_refs,
         )

--- a/packages/engine/src/session/checkpoint.rs
+++ b/packages/engine/src/session/checkpoint.rs
@@ -23,7 +23,7 @@ const CHECKPOINT_GC_MIN_AGE: u64 = 64;
 // Once history is mature, each successful sweep grows the next interval in
 // proportion to retained checkpoint history. Full-sweep positions therefore
 // grow geometrically instead of producing fixed-cadence quadratic work.
-const CHECKPOINT_GC_HISTORY_FRACTION: u64 = 8;
+const CHECKPOINT_GC_HISTORY_FRACTION: u64 = 1;
 
 struct CreateCheckpointOutcome {
     receipt: CreateCheckpointReceipt,
@@ -249,7 +249,7 @@ mod tests {
         assert!(checkpoint_gc_due(early).expect("initial GC state should be due"));
 
         let last_gc_sequence = 8_000;
-        let scaled_age = last_gc_sequence / 8;
+        let scaled_age = last_gc_sequence;
         let mut mature = state(last_gc_sequence + scaled_age - 1, last_gc_sequence);
         assert!(!checkpoint_gc_due(mature).expect("mature GC state should be valid"));
         mature.checkpoint_sequence += 1;
@@ -269,7 +269,7 @@ mod tests {
             }
         }
         assert!(
-            sweep_count < 50,
+            sweep_count < 10,
             "geometric cadence unexpectedly scheduled {sweep_count} sweeps"
         );
     }

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -159,7 +159,14 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         .filter(|root| root.publish_head)
         .map(branch_ref_change_record)
         .collect::<Result<Vec<_>, _>>()?;
-    let has_checkpoint_publication = !prepared_writes.checkpoint_publications.is_empty();
+    // Checkpoints are logical compaction boundaries, not full immutable-tree
+    // snapshots. Their absolute commit-delta segments plus the previous
+    // checkpoint parent already form the persistent history representation;
+    // forcing a second full-state root made N checkpoints rewrite
+    // 1 + 2 + ... + N rows. Rootless history readers reconstruct from the
+    // nearest available ancestor root when a historical scan actually needs
+    // one, while eager HOT state remains complete at publication time.
+    let force_root_fence = false;
     // The current-state protocol publishes automatic tracked heads through
     // one direct control record.
     // Do not also synthesize a mutable `lix_branch_ref` current row for every
@@ -201,7 +208,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &[],
         &row_index.tracked_row_indices_by_commit,
         &commit_rows,
-        has_checkpoint_publication,
+        force_root_fence,
     )
     .instrument(tracing::debug_span!(
         target: "lix_perf",
@@ -247,7 +254,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &tracked_roots,
         &staged_commits,
         &insert_selection,
-        has_checkpoint_publication,
+        force_root_fence,
     )
     .instrument(tracing::debug_span!(
         target: "lix_perf",
@@ -894,9 +901,9 @@ fn current_state_delta_from_engine_row(
 }
 
 /// Stages a compact, identity-addressable change record for every tracked
-/// commit. Sparse immutable roots remain the scan/checkpoint structure; this
-/// index is the missing point-read structure for rootless first-parent
-/// history.
+/// commit. Immutable roots are optional cold accelerators; this index is the
+/// authoritative point-read and reconstruction structure for rootless
+/// first-parent history.
 async fn load_selected_change_records(
     read: &(impl StorageAdapterRead + ?Sized),
     staged_commits: &BTreeMap<CommitId, StagedChangelogCommit>,
@@ -3023,10 +3030,11 @@ async fn stage_tracked_roots(
     Ok(())
 }
 
-/// Immutable roots are a cold-path history structure. Keep them at topology
-/// and checkpoint fences, plus any staged first-parent ancestors necessary to
-/// build that fence in one atomic write set. Ordinary serial commits are
-/// represented only by the changelog and the durable current-state projection.
+/// Immutable roots are an optional cold-path history accelerator. A caller
+/// that explicitly requests a fence also stages any missing first-parent
+/// ancestors in the same atomic write set. Normal serial and checkpoint
+/// commits use compact absolute deltas plus the durable current-state
+/// projection.
 fn tracked_root_fence_ids(
     tracked_roots: &[PendingTrackedRoot],
     force_all: bool,

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -1099,9 +1099,15 @@ fn lifecycle_snapshot_commit_ids(
             (Some(parent_commit_id), Some(control))
                 if control.head_commit_id == parent_commit_id
         );
-        if !parent_is_published
-            || selected_refs_require_complete_snapshot(&staged.selected_change_batches)
-            || checkpoint_epochs.get(&root.branch_id) == Some(&root.commit_id)
+        let checkpoint_can_reuse_generation = checkpoint_epochs.get(&root.branch_id)
+            == Some(&root.commit_id)
+            && observations
+                .get(&root.branch_id)
+                .and_then(|observation| observation.control)
+                .is_some();
+        if !checkpoint_can_reuse_generation
+            && (!parent_is_published
+                || selected_refs_require_complete_snapshot(&staged.selected_change_batches))
         {
             required.insert(root.commit_id);
         }
@@ -1792,7 +1798,10 @@ async fn stage_tracked_head(
                 certified_fresh_plugin_file_id,
             )
         };
+        let checkpoint_commit_id = checkpoint_epochs.get(&root.branch_id).copied();
+        let is_checkpoint_publication = checkpoint_commit_id == Some(root.commit_id);
         let parent_generation = match (root.parent_commit_id, parent_control) {
+            (_, Some(control)) if is_checkpoint_publication => Some(control.generation),
             (Some(parent_commit_id), Some(control))
                 if control.head_commit_id == parent_commit_id =>
             {
@@ -1800,7 +1809,6 @@ async fn stage_tracked_head(
             }
             _ => None,
         };
-        let checkpoint_commit_id = checkpoint_epochs.get(&root.branch_id).copied();
 
         if !staged.selected_change_batches.is_empty() {
             reject_selected_tracked_refs_with_untracked_rows(
@@ -1975,7 +1983,26 @@ async fn stage_tracked_head(
         let has_validated_insert_deltas = staged.selected_change_batches.is_empty()
             && (!absence_guards.is_empty() || certified_fresh_plugin_file_id.is_some());
         let mut writer = tracked_head.writer(read, writes);
-        let generation = if has_validated_insert_deltas {
+        let generation = if is_checkpoint_publication {
+            let checkpoint_commit_id =
+                checkpoint_commit_id.expect("checkpoint publication has an epoch commit id");
+            coverage = WorkingDiffIndexCoverage::default();
+            writer
+                .stage_checkpoint_current_state(
+                    &root.branch_id,
+                    parent_generation,
+                    root.commit_id,
+                    &deltas,
+                    &owned_absence_guards(&absence_guards),
+                    checkpoint_commit_id,
+                    &mut coverage,
+                )
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.materialization.tracked_head.stage_checkpoint"
+                ))
+                .await?
+        } else if has_validated_insert_deltas {
             writer
                 .stage_validated_insert_current_state_with_working_diff(
                     &root.branch_id,
@@ -2308,10 +2335,9 @@ fn selected_tracked_ref_untracked_collision_error(
     }))
 }
 
-/// A checkpoint materializes one complete hot generation. Every tracked row
-/// in that generation is encoded as a clean row-local baseline, so its sparse
-/// dirty-key index starts empty and later ordinary writes capture their own
-/// first-before images without querying a separate diff store.
+/// A checkpoint cleans exactly its selected interval changes in the current
+/// hot generation. Unchanged rows were already clean, so rotating to an empty
+/// sparse dirty-key index starts the next epoch without a full-state rewrite.
 fn stage_checkpoint_working_diff_epochs(
     writes: &mut StorageWriteSet,
     publications: &[crate::gc::CheckpointPublication],


### PR DESCRIPTION
## Summary

- checkpoint eager HOT state in its existing generation, rewriting only interval deltas as clean rows
- retain eager semantic materialization and WASM plugins
- store logical checkpoint commits as compact absolute rootless deltas instead of rebuilding a complete immutable root on every checkpoint
- double repository-GC sweep intervals, bounding cumulative full-scan maintenance to linear work
- add `lix exp git-replay --checkpoint-every N` and checkpoint timings to the JSON profile

Stacked on #967, which fixes derived semantic change identity and cascade tombstones uncovered by the replay.

## Data

OpenClaw, SlateDB, bundled text/CSV/Markdown/Excalidraw WASM plugins, eager materialization, checkpoint after every Git commit, first 200 commits:

| | baseline | HOT in-place only | this PR |
|---|---:|---:|---:|
| replay | 309.38 s | 146.87 s | **10.17 s** |
| checkpoint | 298.51 s | 139.12 s | **1.77 s** |
| physical storage | 877.8 MB | 43.3 MB | **31.4 MB** |
| final 25 checkpoint mean | 3,283.5 ms | 1,562.0 ms | **4.49 ms** |

This is 30.4x faster end-to-end than baseline, 78.4x faster in checkpoint work, and 96.4% smaller physically. Checkpoint bands stay flat; the prior implementation grew with accumulated tree size.

Phase instrumentation at checkpoint 100 attributed ~792 ms of ~803 ms materialization to forced immutable-root staging, versus ~7 ms for eager HOT persistence and ~0.03 ms for the storage commit. Rootless checkpoint deltas remove that duplicate full-state representation; historical readers retain bounded reconstruction from the nearest available ancestor root.

The benchmark database and per-commit profiles are retained locally for storage/query inspection. The 10k replay is running with #968 layered only for the independent Markdown correctness fix.

## Validation

- 1,557 engine unit tests pass (6 ignored)
- 10 checkpoint/GC integration tests pass
- 44 history integration tests pass
- tracked-state rebuild tests pass
- Git replay checkpoint-every test reopens the database, verifies semantic plugin rows, checkpoint count, and per-checkpoint profile timings
- rebased on current `origin/main` (`cb2c418b5`)