### PR TITLE
Stream cold plugin entities from live-state batches

### DIFF
--- a/packages/engine/src/plugin/incremental.rs
+++ b/packages/engine/src/plugin/incremental.rs
@@ -18,6 +18,7 @@ use tracing::Instrument as _;
 use crate::catalog::{CatalogSnapshot, SchemaPlan, SchemaPlanFingerprint};
 use crate::common::{RequestBlobSpliceProvenance, SharedStr};
 use crate::entity_pk::EntityPk;
+use crate::live_state::MaterializedLiveStateBatch;
 use crate::wasm::{
     EDIT_SPLICE_METADATA_BYTES, PACKET_FORMAT_V1, WasmByteOutputsHandle, WasmByteSource,
     WasmCanonicalJson, WasmCanonicalJsonCertificate, WasmCertifiedEntityBatch,
@@ -1200,6 +1201,117 @@ impl WasmEntitySource for VecEntitySource {
                     .pop_front()
                     .expect("front entity was just inspected"),
             );
+        }
+        self.state.accept_page(page_bytes, page_refs)?;
+        Ok(Some(WasmEntityPage { entities }))
+    }
+}
+
+/// Page-lazy complete-entity source backed by the engine's columnar live-state
+/// batch. This keeps shared snapshot buffers in their storage-native owner and
+/// constructs generic Wasm entities only for the page currently crossing the
+/// component boundary.
+#[derive(Debug)]
+pub(crate) struct LiveBatchEntitySource {
+    rows: MaterializedLiveStateBatch,
+    ordinals: VecDeque<u32>,
+    pending: Option<WasmHostEntity>,
+    state: VecSourceState,
+}
+
+impl LiveBatchEntitySource {
+    pub(crate) fn new(
+        rows: MaterializedLiveStateBatch,
+        ordinals: Vec<u32>,
+        limits: WasmTransitionLimits,
+    ) -> Result<Self, LixError> {
+        for pair in ordinals.windows(2) {
+            let left = rows.row(pair[0] as usize);
+            let right = rows.row(pair[1] as usize);
+            if left.schema_key() == right.schema_key() && left.entity_pk() == right.entity_pk() {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "durable v2 entity hydration returned duplicate keys",
+                ));
+            }
+        }
+        Ok(Self {
+            rows,
+            ordinals: ordinals.into(),
+            pending: None,
+            state: VecSourceState::new(limits)?,
+        })
+    }
+
+    fn next_entity(&mut self) -> Result<Option<WasmHostEntity>, LixError> {
+        if let Some(entity) = self.pending.take() {
+            return Ok(Some(entity));
+        }
+        let Some(ordinal) = self.ordinals.pop_front() else {
+            return Ok(None);
+        };
+        let row = self.rows.get(ordinal as usize).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "plugin state selection references a row outside its batch owner",
+            )
+        })?;
+        let snapshot = row.snapshot_content().ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "plugin state selection references a tombstoned row",
+            )
+        })?;
+        host_entity_with_lazy_snapshot(
+            crate::wasm::WasmEntityKey::from_owned_parts(
+                row.schema_key().to_owned(),
+                row.entity_pk().clone().into_parts(),
+            ),
+            snapshot.clone().into_bytes(),
+            self.state.limits,
+        )
+        .map(Some)
+    }
+}
+
+impl WasmEntitySource for LiveBatchEntitySource {
+    fn next_page(&mut self, max_bytes: u32) -> Result<Option<WasmEntityPage>, LixError> {
+        if self.state.reached_eof {
+            return Ok(None);
+        }
+        let page_limit = self.state.page_limit(max_bytes)?;
+        let mut page_bytes = 0_u64;
+        let mut page_refs = 0_u32;
+        let mut entities = Vec::new();
+        while let Some(entity) = self.next_entity()? {
+            let record_bytes = encoded_entity_record_bytes(&entity)?;
+            if record_bytes > u64::from(self.state.limits.max_record_bytes) {
+                return Err(invalid_input("v2 entity record exceeds max_record_bytes"));
+            }
+            let framed_bytes = record_bytes
+                .checked_add(4)
+                .ok_or_else(|| invalid_input("v2 entity frame length overflowed"))?;
+            if page_bytes
+                .checked_add(framed_bytes)
+                .is_none_or(|size| size > page_limit)
+            {
+                if entities.is_empty() {
+                    return Err(invalid_input(
+                        "v2 entity record does not fit the requested page",
+                    ));
+                }
+                self.pending = Some(entity);
+                break;
+            }
+            page_bytes += framed_bytes;
+            page_refs = page_refs
+                .checked_add(host_bytes_attachment_refs(&entity.snapshot_content))
+                .ok_or_else(|| invalid_input("v2 entity attachment count overflowed"))?;
+            entities.push(entity);
+        }
+        if entities.is_empty() {
+            self.state.reached_eof = true;
+            return Ok(None);
         }
         self.state.accept_page(page_bytes, page_refs)?;
         Ok(Some(WasmEntityPage { entities }))

--- a/packages/engine/src/plugin/mod.rs
+++ b/packages/engine/src/plugin/mod.rs
@@ -27,10 +27,10 @@ pub(crate) use create_context::{
     validate_create_changes, validate_create_reservation,
 };
 pub(crate) use incremental::{
-    ArcByteSource, FileBytesSha256, V2SchemaAllowlist, ValidatedConflictTransition,
-    ValidatedFileTransition, ValidatedSameLengthOutputSplice, VecEntityChangeSource,
-    VecEntityConflictSource, VecEntitySource, build_file_update_splices, canonicalize_v2_snapshot,
-    drain_conflict_transition_resolutions, drain_entity_transition_edits,
+    ArcByteSource, FileBytesSha256, LiveBatchEntitySource, V2SchemaAllowlist,
+    ValidatedConflictTransition, ValidatedFileTransition, ValidatedSameLengthOutputSplice,
+    VecEntityChangeSource, VecEntityConflictSource, VecEntitySource, build_file_update_splices,
+    canonicalize_v2_snapshot, drain_conflict_transition_resolutions, drain_entity_transition_edits,
     drain_file_transition_changes, host_entity_change_with_lazy_snapshot,
     host_entity_with_lazy_snapshot, transport_splice_preserves_git_text,
     transport_splice_preserves_utf8,

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -61,14 +61,14 @@ use crate::live_state::{
     overlay_load_exact_batch, overlay_scan_batch,
 };
 use crate::plugin::{
-    ArcByteSource, BoundCreateContext, CompiledPluginCatalog, FileBytesSha256, PLUGIN_OWNER_KEY,
-    PLUGIN_REGISTRY_KEY, PluginActorCache, PluginActorColdInstall, PluginActorColdOpen,
-    PluginActorKey, PluginActorLease, PluginActorStore, PluginActorStorePermit,
-    PluginArchiveInstallPlan, PluginContentType, PluginFileOwner, PluginMaterialization,
-    PluginObservation, PluginRegistry, PluginRegistryEntry, PluginRegistryEntryInput,
-    PluginRuntimeHost, V2SchemaAllowlist, ValidatedConflictTransition, ValidatedFileTransition,
-    ValidatedSameLengthOutputSplice, VecEntityChangeSource, VecEntityConflictSource,
-    VecEntitySource, build_file_update_splices, canonicalize_v2_snapshot,
+    ArcByteSource, BoundCreateContext, CompiledPluginCatalog, FileBytesSha256,
+    LiveBatchEntitySource, PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY, PluginActorCache,
+    PluginActorColdInstall, PluginActorColdOpen, PluginActorKey, PluginActorLease,
+    PluginActorStore, PluginActorStorePermit, PluginArchiveInstallPlan, PluginContentType,
+    PluginFileOwner, PluginMaterialization, PluginObservation, PluginRegistry, PluginRegistryEntry,
+    PluginRegistryEntryInput, PluginRuntimeHost, V2SchemaAllowlist, ValidatedConflictTransition,
+    ValidatedFileTransition, ValidatedSameLengthOutputSplice, VecEntityChangeSource,
+    VecEntityConflictSource, VecEntitySource, build_file_update_splices, canonicalize_v2_snapshot,
     drain_conflict_transition_resolutions, drain_entity_transition_edits,
     drain_file_transition_changes, host_entity_change_with_lazy_snapshot,
     host_entity_with_lazy_snapshot, inferred_media_type_for_path, is_plugin_storage_path,
@@ -1347,6 +1347,7 @@ where
                 Err(error) => return Err(error),
             }
         };
+        let limits = WasmTransitionLimits::default();
         let rows = overlay_scan_batch(
             &base,
             &staged,
@@ -1363,10 +1364,9 @@ where
             },
         )
         .await?;
-        let limits = WasmTransitionLimits::default();
-        let entities =
-            v2_host_entities_from_live_batch(&rows, &file_key, plugin.schema_keys(), limits)?;
-        let entity_count = entities.len();
+        let entity_ordinals =
+            v2_host_entity_ordinals_from_live_batch(&rows, &file_key, plugin.schema_keys())?;
+        let entity_count = entity_ordinals.len();
         let mut actor = factory.instantiate_actor().await?;
         if let VisibleV2MaterializationBytes::Derived { path, .. } = &materialization.bytes
             && descriptor.path.as_deref() != Some(path.as_str())
@@ -1407,7 +1407,7 @@ where
                     )
                 })?
                 .into();
-                let source = VecEntitySource::new(entities, limits)?;
+                let source = LiveBatchEntitySource::new(rows, entity_ordinals, limits)?;
                 let transition = match actor
                     .open_entities(
                         limits,
@@ -1447,7 +1447,7 @@ where
             VisibleV2MaterializationBytes::Derived {
                 sha256, size_bytes, ..
             } => {
-                let source = VecEntitySource::new(entities, limits)?;
+                let source = LiveBatchEntitySource::new(rows, entity_ordinals, limits)?;
                 let transition = match actor
                     .open_entities(
                         limits,
@@ -6498,15 +6498,15 @@ fn v2_host_entities_from_live_batch_ordinals(
     Ok(entities)
 }
 
-fn v2_host_entities_from_live_batch(
+fn v2_host_entity_ordinals_from_live_batch(
     rows: &MaterializedLiveStateBatch,
     file_key: &PluginFileWriteKey,
     schema_keys: &[String],
-    limits: WasmTransitionLimits,
-) -> Result<Vec<WasmHostEntity>, LixError> {
-    let mut entities = rows
+) -> Result<Vec<u32>, LixError> {
+    let mut ordinals = rows
         .iter()
-        .filter(|row| {
+        .enumerate()
+        .filter(|(_, row)| {
             row.branch_id() == file_key.branch_id
                 && row.file_id() == Some(file_key.file_id.as_str())
                 && !row.global()
@@ -6516,30 +6516,33 @@ fn v2_host_entities_from_live_batch(
                     .binary_search_by(|schema_key| schema_key.as_str().cmp(row.schema_key()))
                     .is_ok()
         })
-        .map(|row| {
-            host_entity_with_lazy_snapshot(
-                WasmEntityKey::from_owned_parts(
-                    row.schema_key().to_owned(),
-                    row.entity_pk().clone().into_parts(),
-                ),
-                row.snapshot_content()
-                    .expect("filtered v2 row carries a live snapshot")
-                    .clone()
-                    .into_bytes(),
-                limits,
-            )
+        .map(|(ordinal, _)| {
+            u32::try_from(ordinal).map_err(|_| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "durable plugin state exceeds u32 row ordinals",
+                )
+            })
         })
         .collect::<Result<Vec<_>, _>>()?;
-    entities.sort_by(|left, right| left.key.cmp(&right.key));
-    for pair in entities.windows(2) {
-        if pair[0].key == pair[1].key {
+    ordinals.sort_unstable_by(|left, right| {
+        let left = rows.row(*left as usize);
+        let right = rows.row(*right as usize);
+        left.schema_key()
+            .cmp(right.schema_key())
+            .then_with(|| left.entity_pk().cmp(right.entity_pk()))
+    });
+    for pair in ordinals.windows(2) {
+        let left = rows.row(pair[0] as usize);
+        let right = rows.row(pair[1] as usize);
+        if left.schema_key() == right.schema_key() && left.entity_pk() == right.entity_pk() {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 "durable v2 entity hydration returned duplicate keys",
             ));
         }
     }
-    Ok(entities)
+    Ok(ordinals)
 }
 
 fn v2_host_changes_from_prepared_rows(


### PR DESCRIPTION
## Summary

- retain the columnar live-state batch during cold plugin hydration
- sort compact row ordinals instead of materializing a full Vec<WasmHostEntity>
- construct and validate generic Wasm entities one bounded page at a time
- preserve packet ordering, duplicate detection, page limits, and v2 behavior

## Benchmark

10 MiB JSON cold successor, 39,871 semantic rows, release build:

- cumulative host allocation: 400.4 MB -> 368.1 MB (-8.1%)
- peak live host allocation: 78.2 MB -> 69.3 MB (-11.4%)
- elapsed time remained within run variance (single-sample 568.7 ms -> 557.8 ms)

This is API-neutral and intentionally isolated from the plugin API v3 prototype.

## Validation

- cargo check -p lix_engine
- existing end-to-end cold hydration benchmark and correctness assertions on the prototype worktree