### PR TITLE
perf(engine): reduce bulk transaction read and JSON work

### DIFF
--- a/packages/engine-benchmarks/benches/slatedb_file_api.rs
+++ b/packages/engine-benchmarks/benches/slatedb_file_api.rs
@@ -318,11 +318,11 @@ impl SingletonWriteFixture {
                     schema_key: "json_pointer".to_string(),
                     file_id: None,
                     entity_pk: path.clone(),
-                    value: json!({"path": path, "value": format!("seed-{index:04}")}),
-                    updated_value: json!({
+                    value: Arc::new(json!({"path": path, "value": format!("seed-{index:04}")})),
+                    updated_value: Arc::new(json!({
                         "path": format!("/singleton/{index:04}"),
                         "value": format!("updated-{index:04}"),
-                    }),
+                    })),
                 }
             })
             .collect();

--- a/packages/engine-benchmarks/benches/tracked_state_crud/transaction_api.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/transaction_api.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use lix_engine::storage_adapter::StorageAdapter;
 use lix_engine::transaction::bench::{
     BenchLayoutAccounting, BenchTransactionFixture, BenchTransactionRow, BenchWriteAccounting,
@@ -201,13 +203,14 @@ fn bench_rows(rows: &[WorkloadRow]) -> Vec<BenchTransactionRow> {
             schema_key: "json_pointer".to_string(),
             file_id: None,
             entity_pk: row.path.clone(),
-            value: serde_json::from_str(&snapshot_value(&row.path, &row.value_json))
-                .expect("transaction bench value should parse"),
-            updated_value: serde_json::from_str(&snapshot_value(
-                &row.path,
-                &row.updated_value_json,
-            ))
-            .expect("transaction bench updated value should parse"),
+            value: Arc::new(
+                serde_json::from_str(&snapshot_value(&row.path, &row.value_json))
+                    .expect("transaction bench value should parse"),
+            ),
+            updated_value: Arc::new(
+                serde_json::from_str(&snapshot_value(&row.path, &row.updated_value_json))
+                    .expect("transaction bench updated value should parse"),
+            ),
         })
         .collect()
 }

--- a/packages/engine-benchmarks/benches/uuid_v7_physical_keys.rs
+++ b/packages/engine-benchmarks/benches/uuid_v7_physical_keys.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::large_futures)]
 
 use std::path::Path;
+use std::sync::Arc;
 use std::time::Instant;
 
 use criterion::{Criterion, criterion_group, criterion_main};
@@ -42,14 +43,14 @@ fn rows(count: usize) -> Vec<BenchTransactionRow> {
                 schema_key: "lix_account".to_string(),
                 file_id: None,
                 entity_pk: entity_pk.clone(),
-                value: json!({
+                value: Arc::new(json!({
                     "id": &entity_pk,
                     "name": format!("account-{index}"),
-                }),
-                updated_value: json!({
+                })),
+                updated_value: Arc::new(json!({
                     "id": entity_pk,
                     "name": format!("updated-account-{index}"),
-                }),
+                })),
             }
         })
         .collect()

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -1632,6 +1632,11 @@ async fn hot_load_primary_mutation_identity_refs(
     if read_count == 0 {
         return Ok(Vec::new());
     }
+    if read_count == deltas.len()
+        && let Some(values) = hot_scan_dense_mutation_identity_range(store, identities).await?
+    {
+        return Ok(values);
+    }
     let mut keys = Vec::with_capacity(read_count);
     for (identity, delta) in identities.key_ranges.iter().zip(deltas) {
         if hot_delta_is_guarded_by_absent_file(
@@ -1655,6 +1660,18 @@ async fn hot_load_primary_mutation_identity_refs(
         .into_iter()
         .map(|value| value.map(full_value_bytes).transpose())
         .collect()
+}
+
+async fn hot_scan_dense_mutation_identity_range(
+    store: &(impl StorageAdapterRead + ?Sized),
+    identities: &EncodedHotMutationIdentities,
+) -> Result<Option<Vec<Option<Bytes>>>, LixError> {
+    hot_scan_dense_encoded_key_range(store, identities.key_ranges.len(), |index| {
+        let range = identities.key_ranges[index].row_key;
+        let start = range.offset();
+        &identities.key_bytes[start..start.saturating_add(range.len())]
+    })
+    .await
 }
 
 fn hot_delta_is_guarded_by_absent_file(
@@ -3073,15 +3090,25 @@ async fn hot_scan_dense_identity_range(
     store: &(impl StorageAdapterRead + ?Sized),
     identities: &FiniteHotIdentityBatchRef<'_>,
 ) -> Result<Option<Vec<Option<Bytes>>>, LixError> {
-    if identities.len() < HOT_DENSE_SCAN_MIN_IDENTITIES {
+    hot_scan_dense_encoded_key_range(store, identities.len(), |index| {
+        identities.encoded.primary_key_bytes(index)
+    })
+    .await
+}
+
+async fn hot_scan_dense_encoded_key_range<'a>(
+    store: &(impl StorageAdapterRead + ?Sized),
+    key_count: usize,
+    key_at: impl Fn(usize) -> &'a [u8],
+) -> Result<Option<Vec<Option<Bytes>>>, LixError> {
+    if key_count < HOT_DENSE_SCAN_MIN_IDENTITIES {
         return Ok(None);
     }
-
-    if identities.identities.is_empty() {
+    if key_count == 0 {
         return Ok(Some(Vec::new()));
     }
-    let first_key = identities.encoded.primary_key(0);
-    let last_key = identities.encoded.primary_key(identities.len() - 1);
+    let first_key = StorageKey(Bytes::copy_from_slice(key_at(0)));
+    let last_key = StorageKey(Bytes::copy_from_slice(key_at(key_count - 1)));
     let plan = ScanPlan::range(
         HOT_ROW_SPACE,
         crate::storage_adapter::StorageKeyRange {
@@ -3089,11 +3116,11 @@ async fn hot_scan_dense_identity_range(
             upper: std::ops::Bound::Included(last_key),
         },
     );
-    let scan_budget = identities.len().saturating_mul(HOT_DENSE_SCAN_MAX_OVERREAD);
+    let scan_budget = key_count.saturating_mul(HOT_DENSE_SCAN_MAX_OVERREAD);
     let mut scanned = 0;
     let mut requested_index = 0;
     let mut resume_after = None;
-    let mut values = vec![None; identities.len()];
+    let mut values = vec![None; key_count];
     loop {
         let remaining_budget = scan_budget.saturating_sub(scanned);
         if remaining_budget == 0 {
@@ -3112,19 +3139,15 @@ async fn hot_scan_dense_identity_range(
         resume_after = page.value.entries.last().map(|entry| entry.key.clone());
         scanned += page.value.entries.len();
         for entry in page.value.entries {
-            while requested_index < identities.len()
-                && identities.encoded.primary_key_bytes(requested_index) < entry.key.0.as_ref()
-            {
+            while requested_index < key_count && key_at(requested_index) < entry.key.0.as_ref() {
                 requested_index += 1;
             }
-            if requested_index < identities.len()
-                && identities.encoded.primary_key_bytes(requested_index) == entry.key.0.as_ref()
-            {
+            if requested_index < key_count && key_at(requested_index) == entry.key.0.as_ref() {
                 values[requested_index] = Some(full_value_bytes(entry.value)?);
                 requested_index += 1;
             }
         }
-        if requested_index == identities.len() || !page.value.has_more || resume_after.is_none() {
+        if requested_index == key_count || !page.value.has_more || resume_after.is_none() {
             return Ok(Some(values));
         }
     }
@@ -4681,6 +4704,86 @@ mod tests {
             "ordinary imports must return before allocating the batch-sized explicit identity index"
         );
         assert!(writes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn dense_mutation_identity_range_scan_matches_point_reads() {
+        let storage = StorageAdapter::new(Memory::new());
+        let generation = CommitId::for_test_label("dense-mutation-generation");
+        let entity_pks = (0..HOT_DENSE_SCAN_MIN_IDENTITIES)
+            .map(|index| EntityPk::single(format!("{index:04}")))
+            .collect::<Vec<_>>();
+        let timestamp = timestamp();
+        let deltas = entity_pks
+            .iter()
+            .map(|entity_pk| CurrentStateDeltaRef {
+                schema_key: "schema",
+                file_id: None,
+                entity_pk,
+                change_id: None,
+                commit_id: None,
+                untracked: true,
+                deleted: false,
+                created_at: timestamp,
+                updated_at: timestamp,
+                snapshot: JsonSlotRef::Inline("{}"),
+                metadata: JsonSlotRef::None,
+            })
+            .collect::<Vec<_>>();
+        let delta_refs = deltas.iter().collect::<Vec<_>>();
+        let encoded = encode_hot_mutation_identities("branch", generation, &delta_refs);
+        let keys = encoded
+            .key_ranges
+            .iter()
+            .map(|ranges| {
+                let start = ranges.row_key.offset();
+                StorageKey(
+                    encoded
+                        .key_bytes
+                        .slice(start..start.saturating_add(ranges.row_key.len())),
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut writes = StorageWriteSet::new();
+        for key in &keys {
+            writes.put(
+                HOT_ROW_SPACE,
+                key.clone(),
+                StorageValue {
+                    bytes: Bytes::from_static(b"row"),
+                },
+            );
+        }
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit dense mutation fixture");
+        let read = crate::storage_adapter::SharedStorageAdapterRead::new(
+            storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("open dense mutation read"),
+        );
+
+        let dense = hot_scan_dense_mutation_identity_range(&read, &encoded)
+            .await
+            .expect("scan dense mutation range")
+            .expect("dense mutation range should stay on the scan path");
+        let point = PointReadPlan::new(HOT_ROW_SPACE, &keys)
+            .materialize(&read, StorageGetOptions::default())
+            .await
+            .expect("point-read dense mutation identities")
+            .value
+            .into_iter()
+            .map(|value| value.map(full_value_bytes).transpose())
+            .collect::<Result<Vec<_>, _>>()
+            .expect("decode dense mutation point reads");
+
+        assert_eq!(dense, point);
+        assert_eq!(
+            dense.iter().flatten().count(),
+            HOT_DENSE_SCAN_MIN_IDENTITIES
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/transaction/bench_support.rs
+++ b/packages/engine/src/transaction/bench_support.rs
@@ -36,8 +36,8 @@ pub struct BenchTransactionRow {
     pub schema_key: String,
     pub file_id: Option<String>,
     pub entity_pk: String,
-    pub value: JsonValue,
-    pub updated_value: JsonValue,
+    pub value: Arc<JsonValue>,
+    pub updated_value: Arc<JsonValue>,
 }
 
 #[expect(missing_debug_implementations)]
@@ -421,12 +421,14 @@ fn write_accounting(logical_rows: usize, stats: StorageWriteSetStats) -> BenchWr
     }
 }
 
-fn transaction_row(row: &BenchTransactionRow, value: &JsonValue) -> TransactionWriteRow {
+fn transaction_row(row: &BenchTransactionRow, value: &Arc<JsonValue>) -> TransactionWriteRow {
     TransactionWriteRow {
         entity_pk: Some(EntityPk::single(row.entity_pk.clone())),
         schema_key: row.schema_key.as_str().into(),
         file_id: row.file_id.as_deref().map(Into::into),
-        snapshot: Some(TransactionJson::from_value_unchecked(value.clone())),
+        snapshot: Some(TransactionJson::from_shared_value_unchecked(Arc::clone(
+            value,
+        ))),
         metadata: None,
         origin: None,
         created_at: None,

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
     fmt,
+    io::{self, Write as _},
     ops::Deref,
     sync::{Arc, OnceLock},
 };
@@ -1572,7 +1573,7 @@ pub(crate) fn canonicalize_transaction_json_batch<'a>(
     }
 
     let mut offsets = Vec::with_capacity(values.len());
-    let mut normalized = Vec::with_capacity(decoded_capacity_hint.min(u32::MAX as usize));
+    let mut normalized = CanonicalJsonArena::new(decoded_capacity_hint, context)?;
     let mut serialize_count = 0usize;
     for (value, cached) in values.iter().zip(&cached_normalized) {
         let start = u32::try_from(normalized.len()).map_err(|_| {
@@ -1582,12 +1583,19 @@ pub(crate) fn canonicalize_transaction_json_batch<'a>(
             )
         })?;
         if let Some(cached) = cached {
-            normalized.extend_from_slice(cached.as_bytes());
+            normalized
+                .append(cached.as_bytes())
+                .map_err(|failure| canonical_json_arena_error(context, failure))?;
         } else {
             serde_json::to_writer(&mut normalized, value).map_err(|error| {
-                LixError::new(
-                    LixError::CODE_UNKNOWN,
-                    format!("{context} failed to serialize normalized JSON: {error}"),
+                normalized.failure().map_or_else(
+                    || {
+                        LixError::new(
+                            LixError::CODE_UNKNOWN,
+                            format!("{context} failed to serialize normalized JSON: {error}"),
+                        )
+                    },
+                    |failure| canonical_json_arena_error(context, failure),
                 )
             })?;
             serialize_count += 1;
@@ -1602,7 +1610,7 @@ pub(crate) fn canonicalize_transaction_json_batch<'a>(
     }
     let rows = WasmCanonicalJson::from_batch_parts(
         values,
-        normalized,
+        normalized.into_bytes(),
         offsets,
         positions.len(),
         serialize_count,
@@ -1612,6 +1620,105 @@ pub(crate) fn canonicalize_transaction_json_batch<'a>(
         *slots[position] = Some(TransactionJson::from_canonical_batch(row));
     }
     Ok(())
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CanonicalJsonArenaFailure {
+    ExceedsU32,
+    Allocation,
+}
+
+struct CanonicalJsonArena {
+    bytes: Vec<u8>,
+    limit: usize,
+    failure: Option<CanonicalJsonArenaFailure>,
+}
+
+impl CanonicalJsonArena {
+    fn new(capacity_hint: usize, context: &str) -> Result<Self, LixError> {
+        Self::with_limit(capacity_hint, u32::MAX as usize)
+            .map_err(|failure| canonical_json_arena_error(context, failure))
+    }
+
+    fn with_limit(capacity_hint: usize, limit: usize) -> Result<Self, CanonicalJsonArenaFailure> {
+        let mut bytes = Vec::new();
+        bytes
+            .try_reserve_exact(capacity_hint.min(limit))
+            .map_err(|_| CanonicalJsonArenaFailure::Allocation)?;
+        Ok(Self {
+            bytes,
+            limit,
+            failure: None,
+        })
+    }
+
+    fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    fn failure(&self) -> Option<CanonicalJsonArenaFailure> {
+        self.failure
+    }
+
+    fn append(&mut self, bytes: &[u8]) -> Result<(), CanonicalJsonArenaFailure> {
+        self.write_all(bytes).map_err(|_| {
+            self.failure
+                .unwrap_or(CanonicalJsonArenaFailure::Allocation)
+        })
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+}
+
+impl io::Write for CanonicalJsonArena {
+    fn write(&mut self, source: &[u8]) -> io::Result<usize> {
+        let required = self
+            .bytes
+            .len()
+            .checked_add(source.len())
+            .filter(|&required| required <= self.limit)
+            .ok_or_else(|| {
+                self.failure = Some(CanonicalJsonArenaFailure::ExceedsU32);
+                io::Error::other("canonical JSON arena exceeds its wire-format limit")
+            })?;
+        if required > self.bytes.capacity() {
+            let doubled = self
+                .bytes
+                .capacity()
+                .max(1)
+                .saturating_mul(2)
+                .min(self.limit);
+            let target = required.max(doubled);
+            if self
+                .bytes
+                .try_reserve_exact(target - self.bytes.len())
+                .is_err()
+            {
+                self.failure = Some(CanonicalJsonArenaFailure::Allocation);
+                return Err(io::Error::other("canonical JSON arena allocation failed"));
+            }
+        }
+        self.bytes.extend_from_slice(source);
+        Ok(source.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn canonical_json_arena_error(context: &str, failure: CanonicalJsonArenaFailure) -> LixError {
+    let message = match failure {
+        CanonicalJsonArenaFailure::ExceedsU32 => {
+            format!("{context} canonical JSON batch exceeds u32")
+        }
+        CanonicalJsonArenaFailure::Allocation => {
+            format!("{context} canonical JSON batch allocation failed")
+        }
+    };
+    LixError::new(LixError::CODE_UNKNOWN, message)
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -3639,6 +3746,24 @@ mod tests {
             first.validation_counts(),
             (2, 1),
             "only the uncached row should invoke canonical serialization"
+        );
+    }
+
+    #[test]
+    fn canonical_json_arena_rejects_uncached_bytes_before_exceeding_its_limit() {
+        let mut arena =
+            CanonicalJsonArena::with_limit(0, 8).expect("create bounded canonical JSON arena");
+        let error = serde_json::to_writer(
+            &mut arena,
+            &serde_json::json!("payload larger than the test wire limit"),
+        )
+        .expect_err("oversized uncached JSON must fail through the bounded writer");
+
+        assert!(error.is_io());
+        assert_eq!(arena.failure(), Some(CanonicalJsonArenaFailure::ExceedsU32));
+        assert!(
+            arena.len() <= 8,
+            "the arena must reject a write before growing beyond its wire limit"
         );
     }
 

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -51,10 +51,17 @@ enum TransactionJsonCertificate {
 
 impl TransactionJson {
     pub(crate) fn from_value(value: JsonValue, context: &str) -> Result<Self, LixError> {
+        Self::from_shared_value(Arc::new(value), context)
+    }
+
+    pub(crate) fn from_shared_value(
+        value: Arc<JsonValue>,
+        context: &str,
+    ) -> Result<Self, LixError> {
         let _ = context;
         Ok(Self {
             storage: TransactionJsonStorage::Decoded {
-                value: Arc::new(value),
+                value,
                 normalized: OnceLock::new(),
             },
         })
@@ -62,6 +69,12 @@ impl TransactionJson {
 
     pub(crate) fn from_value_unchecked(value: JsonValue) -> Self {
         Self::from_value(value, "transaction JSON")
+            .expect("serializing serde_json::Value should not fail")
+    }
+
+    #[cfg(feature = "storage-benches")]
+    pub(crate) fn from_shared_value_unchecked(value: Arc<JsonValue>) -> Self {
+        Self::from_shared_value(value, "transaction JSON")
             .expect("serializing serde_json::Value should not fail")
     }
 
@@ -1469,9 +1482,11 @@ pub(crate) fn stage_json_from_value(
 ///
 /// Plugin-produced rows already carry a bounded canonical page handle and are
 /// left untouched. SQL-produced values reach this boundary without a
-/// per-row serialized `String`; the batch counts encoded lengths without
-/// allocating, reserves the exact arena once, serializes each row once, and
-/// replaces the row-owned values with cheap batch handles.
+/// per-row serialized `String`; the batch appends every row into one amortized
+/// arena, serializes each row once, and replaces the row-owned values with
+/// cheap batch handles. Avoiding an exact-size structural prepass matters for
+/// bulk writes: walking every JSON tree twice costs more than the bounded
+/// geometric growth of one shared arena.
 pub(crate) fn canonicalize_transaction_json_batch<'a>(
     slots: impl IntoIterator<Item = &'a mut Option<TransactionJson>>,
     context: &str,
@@ -1529,27 +1544,27 @@ pub(crate) fn canonicalize_transaction_json_batch<'a>(
         return Ok(());
     }
 
-    // Count an allocation upper bound without invoking Serialize. This is a
-    // cheap structural walk (numbers reserve their bounded maximum width);
-    // the loop below is the only canonical serialization of each snapshot.
-    let normalized_capacity =
-        values
-            .iter()
-            .zip(&cached_normalized)
-            .try_fold(0_usize, |total, (value, cached)| {
-                total
-                    .checked_add(match cached {
-                        Some(cached) => cached.len(),
-                        None => canonical_json_capacity(value)?,
-                    })
-                    .ok_or_else(|| {
-                        LixError::new(
-                            LixError::CODE_UNKNOWN,
-                            format!("{context} canonical JSON batch size overflowed"),
-                        )
-                    })
-            })?;
-    if u32::try_from(normalized_capacity).is_err() {
+    let cached_capacity = cached_normalized
+        .iter()
+        .flatten()
+        .try_fold(0_usize, |total, cached| total.checked_add(cached.len()))
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_UNKNOWN,
+                format!("{context} canonical JSON batch size overflowed"),
+            )
+        })?;
+    let decoded_capacity_hint = values
+        .len()
+        .checked_mul(256)
+        .and_then(|capacity| capacity.checked_add(cached_capacity))
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_UNKNOWN,
+                format!("{context} canonical JSON batch size overflowed"),
+            )
+        })?;
+    if u32::try_from(cached_capacity).is_err() {
         return Err(LixError::new(
             LixError::CODE_UNKNOWN,
             format!("{context} canonical JSON batch exceeds u32"),
@@ -1557,7 +1572,7 @@ pub(crate) fn canonicalize_transaction_json_batch<'a>(
     }
 
     let mut offsets = Vec::with_capacity(values.len());
-    let mut normalized = Vec::with_capacity(normalized_capacity);
+    let mut normalized = Vec::with_capacity(decoded_capacity_hint.min(u32::MAX as usize));
     let mut serialize_count = 0usize;
     for (value, cached) in values.iter().zip(&cached_normalized) {
         let start = u32::try_from(normalized.len()).map_err(|_| {
@@ -1585,7 +1600,6 @@ pub(crate) fn canonicalize_transaction_json_batch<'a>(
         })?;
         offsets.push((start, end));
     }
-    debug_assert!(normalized.len() <= normalized.capacity());
     let rows = WasmCanonicalJson::from_batch_parts(
         values,
         normalized,
@@ -1598,66 +1612,6 @@ pub(crate) fn canonicalize_transaction_json_batch<'a>(
         *slots[position] = Some(TransactionJson::from_canonical_batch(row));
     }
     Ok(())
-}
-
-/// Returns a tight canonical-JSON allocation upper bound without serializing.
-///
-/// String escaping is counted exactly. `serde_json::Number` is bounded by the
-/// crate's non-arbitrary-precision i64/u64/f64 representation, so 32 bytes is
-/// a conservative constant and avoids allocating a temporary number string.
-fn canonical_json_capacity(value: &JsonValue) -> Result<usize, LixError> {
-    fn add(total: &mut usize, amount: usize) -> Result<(), LixError> {
-        *total = total.checked_add(amount).ok_or_else(|| {
-            LixError::new(LixError::CODE_UNKNOWN, "canonical JSON capacity overflowed")
-        })?;
-        Ok(())
-    }
-
-    fn string_capacity(value: &str, total: &mut usize) -> Result<(), LixError> {
-        add(total, 2)?;
-        for scalar in value.chars() {
-            add(
-                total,
-                match scalar {
-                    '"' | '\\' => 2,
-                    scalar if scalar <= '\u{1f}' => 6,
-                    scalar => scalar.len_utf8(),
-                },
-            )?;
-        }
-        Ok(())
-    }
-
-    fn visit(value: &JsonValue, total: &mut usize) -> Result<(), LixError> {
-        match value {
-            JsonValue::Null | JsonValue::Bool(true) => add(total, 4),
-            JsonValue::Bool(false) => add(total, 5),
-            JsonValue::Number(_) => add(total, 32),
-            JsonValue::String(value) => string_capacity(value, total),
-            JsonValue::Array(values) => {
-                add(total, 2)?;
-                add(total, values.len().saturating_sub(1))?;
-                for value in values {
-                    visit(value, total)?;
-                }
-                Ok(())
-            }
-            JsonValue::Object(values) => {
-                add(total, 2)?;
-                add(total, values.len().saturating_sub(1))?;
-                for (key, value) in values {
-                    string_capacity(key, total)?;
-                    add(total, 1)?;
-                    visit(value, total)?;
-                }
-                Ok(())
-            }
-        }
-    }
-
-    let mut total = 0;
-    visit(value, &mut total)?;
-    Ok(total)
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

First layer of the tracked-state CRUD performance stack.

- use a bounded dense range scan for large ordered mutation batches instead of one RocksDB/SlateDB point-result allocation per row
- canonicalize decoded transaction JSON into one amortized arena without a full exact-size JSON-tree prepass
- share parsed benchmark transaction values through `Arc` so the benchmark measures the transaction boundary rather than fixture deep-clones
- retain the exact point-read fallback for sparse mutations

## 10k local profile (median)

| operation | backend | main | this PR | change |
|---|---:|---:|---:|---:|
| update all | RocksDB | 93.9 ms | 74.9 ms | -20% |
| update all | SlateDB | 83.7 ms | 69.1 ms | -17% |
| delete all | RocksDB | 62.4 ms | 47.5 ms | -24% |
| delete all | SlateDB | 72.1 ms | 61.1 ms | -15% |
| read all | RocksDB | 6.59 ms | 6.58 ms | neutral |

The remaining bulk-delete gap is architectural and is intentionally not hidden here; a later stack layer will add collection-generation invalidation.

## Validation

- `cargo test -p lix_engine` (1,978 tests + doctests passed; 8 ignored)
- `cargo test -p lix_engine --features all-simulations` (2,336 tests + doctests passed; 8 ignored)
- `cargo bench -p lix_engine_benchmarks --bench tracked_state_crud --features storage-benches,slatedb --no-run`
- five-sample local RocksDB and SlateDB CRUD profiles at 10k rows

Stack: 1 / planned benchmark-scaling, generation-delete, and remaining CRUD hot-path layers.