### PR TITLE
bench(engine): scale tracked CRUD to one million rows

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/accounting.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/accounting.rs
@@ -33,7 +33,7 @@ fn print_write_accounting(runtime: &tokio::runtime::Runtime, rows: &[WorkloadRow
         "| ----- | ------- | --------- | -----------: | ---: | ------------: | ------------: | -------------: | ------------: | ----------: | -------------: | ------------: | ------: | ---------: |"
     );
 
-    for profile in STORAGE_PROFILES {
+    for &profile in STORAGE_PROFILES {
         let mut kv_insert = runtime.block_on(kv_layout::empty_fixture(profile, rows));
         print_kv_write(
             profile,
@@ -127,7 +127,7 @@ fn print_layout_accounting(runtime: &tokio::runtime::Runtime, rows: &[WorkloadRo
     println!("| Layer | Storage | Space id | Space | Rows | Key bytes | Value bytes |");
     println!("| ----- | ------- | -------: | ----- | ---: | --------: | ----------: |");
 
-    for profile in STORAGE_PROFILES {
+    for &profile in STORAGE_PROFILES {
         let kv = runtime.block_on(kv_layout::seeded_fixture(profile, rows));
         for row in runtime.block_on(kv.layout_accounting()) {
             print_kv_layout(profile, "kv_layout", row);

--- a/packages/engine-benchmarks/benches/tracked_state_crud/accounting.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/accounting.rs
@@ -1,5 +1,5 @@
 use crate::kv_layout::{self, KvLayoutAccounting, KvWriteAccounting};
-use crate::storage::{STORAGE_PROFILES, StorageProfile};
+use crate::storage::{KV_STORAGE_PROFILES, STORAGE_PROFILES, StorageProfile};
 use crate::transaction_api::{self, TransactionLayoutAccounting, TransactionWriteAccounting};
 use crate::workload::{WorkloadRow, row_label};
 
@@ -33,7 +33,7 @@ fn print_write_accounting(runtime: &tokio::runtime::Runtime, rows: &[WorkloadRow
         "| ----- | ------- | --------- | -----------: | ---: | ------------: | ------------: | -------------: | ------------: | ----------: | -------------: | ------------: | ------: | ---------: |"
     );
 
-    for &profile in STORAGE_PROFILES {
+    for &profile in KV_STORAGE_PROFILES {
         let mut kv_insert = runtime.block_on(kv_layout::empty_fixture(profile, rows));
         print_kv_write(
             profile,
@@ -73,7 +73,9 @@ fn print_write_accounting(runtime: &tokio::runtime::Runtime, rows: &[WorkloadRow
             "delete_one_by_pk",
             runtime.block_on(kv_delete_one.delete_one_by_pk_accounting()),
         );
+    }
 
+    for &profile in STORAGE_PROFILES {
         let mut transaction_insert =
             runtime.block_on(transaction_api::empty_fixture(profile, rows));
         print_transaction_write(
@@ -127,12 +129,14 @@ fn print_layout_accounting(runtime: &tokio::runtime::Runtime, rows: &[WorkloadRo
     println!("| Layer | Storage | Space id | Space | Rows | Key bytes | Value bytes |");
     println!("| ----- | ------- | -------: | ----- | ---: | --------: | ----------: |");
 
-    for &profile in STORAGE_PROFILES {
+    for &profile in KV_STORAGE_PROFILES {
         let kv = runtime.block_on(kv_layout::seeded_fixture(profile, rows));
         for row in runtime.block_on(kv.layout_accounting()) {
             print_kv_layout(profile, "kv_layout", row);
         }
+    }
 
+    for &profile in STORAGE_PROFILES {
         let transaction = runtime.block_on(transaction_api::seeded_fixture(profile, rows));
         for row in runtime.block_on(transaction.layout_accounting()) {
             print_transaction_layout(profile, "transaction", row);

--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -18,7 +18,7 @@ mod storage;
 mod transaction_api;
 mod workload;
 
-use storage::{STORAGE_PROFILES, StorageProfile};
+use storage::{KV_STORAGE_PROFILES, STORAGE_PROFILES, StorageProfile};
 use workload::{REAL_WORKLOAD_ROWS, SMOKE_ROWS, WorkloadRow, fixture_rows, row_label};
 
 const READ_MANY_PK_COUNT: usize = 10;
@@ -39,8 +39,10 @@ fn tracked_state_crud_benches(c: &mut Criterion) {
 
     for (label, row_count) in [("smoke", SMOKE_ROWS), ("real_workload", REAL_WORKLOAD_ROWS)] {
         bench_raw_sqlite(c, &rows[..row_count], label);
-        for &profile in STORAGE_PROFILES {
+        for &profile in KV_STORAGE_PROFILES {
             bench_kv_layout(c, &runtime, profile, &rows[..row_count], label);
+        }
+        for &profile in STORAGE_PROFILES {
             bench_transaction_api(c, &runtime, profile, &rows[..row_count], label);
             bench_sql_session(c, &runtime, profile, &rows[..row_count], label);
         }

--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -28,18 +28,18 @@ fn tracked_state_crud_benches(c: &mut Criterion) {
         .enable_all()
         .build()
         .expect("create tokio runtime for tracked_state_crud benchmarks");
-    let rows = fixture_rows();
     if std::env::var_os("LIX_TRACKED_STATE_CRUD_PROFILE").is_some() {
-        let row_count = profile_row_count(rows.len());
-        profile_operation(&runtime, &rows[..row_count]);
+        let rows = fixture_rows(profile_row_count());
+        profile_operation(&runtime, &rows);
         return;
     }
+    let rows = fixture_rows(REAL_WORKLOAD_ROWS);
     io_stats::maybe_print_io_report();
     accounting::maybe_print_accounting_report(&runtime, &rows[..SMOKE_ROWS]);
 
     for (label, row_count) in [("smoke", SMOKE_ROWS), ("real_workload", REAL_WORKLOAD_ROWS)] {
         bench_raw_sqlite(c, &rows[..row_count], label);
-        for profile in STORAGE_PROFILES {
+        for &profile in STORAGE_PROFILES {
             bench_kv_layout(c, &runtime, profile, &rows[..row_count], label);
             bench_transaction_api(c, &runtime, profile, &rows[..row_count], label);
             bench_sql_session(c, &runtime, profile, &rows[..row_count], label);
@@ -47,22 +47,20 @@ fn tracked_state_crud_benches(c: &mut Criterion) {
     }
 }
 
-/// Profile mode defaults to the representative 10k fixture, but supports a
-/// bounded prefix for scaling studies without changing the steady-state
-/// Criterion benchmark definitions.
-fn profile_row_count(max_rows: usize) -> usize {
+/// Profile mode defaults to the representative 10k fixture and extends it with
+/// deterministic ordered rows for explicit scaling studies without inflating
+/// the steady-state Criterion benchmark definitions.
+fn profile_row_count() -> usize {
     let Some(value) = std::env::var_os("LIX_TRACKED_STATE_CRUD_PROFILE_ROW_COUNT") else {
         return REAL_WORKLOAD_ROWS;
     };
     let value = value.to_string_lossy();
     let row_count = value.parse::<usize>().unwrap_or_else(|_| {
-        panic!(
-            "LIX_TRACKED_STATE_CRUD_PROFILE_ROW_COUNT must be an integer between 1 and {max_rows}, got '{value}'"
-        )
+        panic!("LIX_TRACKED_STATE_CRUD_PROFILE_ROW_COUNT must be a positive integer, got '{value}'")
     });
     assert!(
-        (1..=max_rows).contains(&row_count),
-        "LIX_TRACKED_STATE_CRUD_PROFILE_ROW_COUNT must be between 1 and {max_rows}, got {row_count}"
+        row_count > 0,
+        "LIX_TRACKED_STATE_CRUD_PROFILE_ROW_COUNT must be positive"
     );
     row_count
 }
@@ -328,8 +326,10 @@ fn profile_sql_session_storage() -> StorageProfile {
     match std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_STORAGE").as_deref() {
         Ok("sqlite") => StorageProfile::SQLite,
         Ok("rocksdb") | Err(_) => StorageProfile::RocksDB,
+        #[cfg(feature = "slatedb")]
+        Ok("slatedb") => StorageProfile::SlateDB,
         Ok(other) => panic!(
-            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_STORAGE '{other}'; expected rocksdb or sqlite"
+            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_STORAGE '{other}'; expected rocksdb, sqlite, or slatedb"
         ),
     }
 }

--- a/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
@@ -2,6 +2,8 @@ use std::fmt::Write as _;
 
 use lix_engine::{Engine, ExecuteBatchStatement, ExecuteResult, SessionContext, Storage, Value};
 
+#[cfg(feature = "slatedb")]
+use crate::storage::SlateDB;
 use crate::storage::{ProfileStorage, RocksDB, SQLite, StorageProfile};
 use crate::workload::{WorkloadRow, sql_string};
 
@@ -26,6 +28,8 @@ impl UntrackedFixture {
 pub(crate) enum SqlFixture {
     SQLite(GenericSqlFixture<SQLite>),
     RocksDB(GenericSqlFixture<RocksDB>),
+    #[cfg(feature = "slatedb")]
+    SlateDB(GenericSqlFixture<SlateDB>),
 }
 
 pub(crate) struct GenericSqlFixture<StorageImpl: Storage> {
@@ -83,9 +87,13 @@ pub(crate) async fn empty_fixture_with_read_many_pk_count(
             dir,
         )),
         #[cfg(feature = "slatedb")]
-        ProfileStorage::SlateDB { .. } => {
-            unreachable!("SlateDB is currently profiled through the transaction CRUD layer")
-        }
+        ProfileStorage::SlateDB { storage, _dir: dir } => SqlFixture::SlateDB(fixture_for_session(
+            prepare_session(storage).await,
+            rows,
+            read_many_by_pk_count,
+            untracked_fixture,
+            dir,
+        )),
     }
 }
 
@@ -109,6 +117,8 @@ impl SqlFixture {
         match self {
             Self::SQLite(fixture) => fixture.insert_all().await,
             Self::RocksDB(fixture) => fixture.insert_all().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.insert_all().await,
         }
     }
 
@@ -116,6 +126,8 @@ impl SqlFixture {
         match self {
             Self::SQLite(fixture) => fixture.insert_untracked_probe().await,
             Self::RocksDB(fixture) => fixture.insert_untracked_probe().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.insert_untracked_probe().await,
         }
     }
 
@@ -123,6 +135,8 @@ impl SqlFixture {
         match self {
             Self::SQLite(fixture) => fixture.read_all().await,
             Self::RocksDB(fixture) => fixture.read_all().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.read_all().await,
         }
     }
 
@@ -132,6 +146,8 @@ impl SqlFixture {
         match self {
             Self::SQLite(fixture) => fixture.read_all_result().await,
             Self::RocksDB(fixture) => fixture.read_all_result().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.read_all_result().await,
         }
     }
 
@@ -139,6 +155,8 @@ impl SqlFixture {
         match self {
             Self::SQLite(fixture) => fixture.read_many_by_pk().await,
             Self::RocksDB(fixture) => fixture.read_many_by_pk().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.read_many_by_pk().await,
         }
     }
 
@@ -148,6 +166,8 @@ impl SqlFixture {
         match self {
             Self::SQLite(fixture) => fixture.read_many_by_pk_result().await,
             Self::RocksDB(fixture) => fixture.read_many_by_pk_result().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.read_many_by_pk_result().await,
         }
     }
 
@@ -155,6 +175,8 @@ impl SqlFixture {
         match self {
             Self::SQLite(fixture) => fixture.read_one_by_pk().await,
             Self::RocksDB(fixture) => fixture.read_one_by_pk().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.read_one_by_pk().await,
         }
     }
 
@@ -164,6 +186,8 @@ impl SqlFixture {
         match self {
             Self::SQLite(fixture) => fixture.read_one_by_pk_result().await,
             Self::RocksDB(fixture) => fixture.read_one_by_pk_result().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.read_one_by_pk_result().await,
         }
     }
 
@@ -171,6 +195,8 @@ impl SqlFixture {
         match self {
             Self::SQLite(fixture) => fixture.update_all().await,
             Self::RocksDB(fixture) => fixture.update_all().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.update_all().await,
         }
     }
 
@@ -181,6 +207,8 @@ impl SqlFixture {
         match self {
             Self::SQLite(fixture) => fixture.update_all_bound().await,
             Self::RocksDB(fixture) => fixture.update_all_bound().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.update_all_bound().await,
         }
     }
 
@@ -188,6 +216,8 @@ impl SqlFixture {
         match self {
             Self::SQLite(fixture) => fixture.update_bound_rows(row_count).await,
             Self::RocksDB(fixture) => fixture.update_bound_rows(row_count).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.update_bound_rows(row_count).await,
         }
     }
 
@@ -195,6 +225,8 @@ impl SqlFixture {
         match self {
             Self::SQLite(fixture) => fixture.update_spread_bound_rows(row_count).await,
             Self::RocksDB(fixture) => fixture.update_spread_bound_rows(row_count).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.update_spread_bound_rows(row_count).await,
         }
     }
 
@@ -202,6 +234,8 @@ impl SqlFixture {
         match self {
             Self::SQLite(fixture) => fixture.update_one_by_pk().await,
             Self::RocksDB(fixture) => fixture.update_one_by_pk().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.update_one_by_pk().await,
         }
     }
 
@@ -209,6 +243,8 @@ impl SqlFixture {
         match self {
             Self::SQLite(fixture) => fixture.delete_all().await,
             Self::RocksDB(fixture) => fixture.delete_all().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.delete_all().await,
         }
     }
 
@@ -216,6 +252,8 @@ impl SqlFixture {
         match self {
             Self::SQLite(fixture) => fixture.delete_one_by_pk().await,
             Self::RocksDB(fixture) => fixture.delete_one_by_pk().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.delete_one_by_pk().await,
         }
     }
 }

--- a/packages/engine-benchmarks/benches/tracked_state_crud/storage.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/storage.rs
@@ -12,8 +12,15 @@ pub(crate) enum StorageProfile {
     SlateDB,
 }
 
-pub(crate) const STORAGE_PROFILES: [StorageProfile; 2] =
-    [StorageProfile::SQLite, StorageProfile::RocksDB];
+#[cfg(not(feature = "slatedb"))]
+pub(crate) const STORAGE_PROFILES: &[StorageProfile] =
+    &[StorageProfile::SQLite, StorageProfile::RocksDB];
+#[cfg(feature = "slatedb")]
+pub(crate) const STORAGE_PROFILES: &[StorageProfile] = &[
+    StorageProfile::SQLite,
+    StorageProfile::RocksDB,
+    StorageProfile::SlateDB,
+];
 
 impl StorageProfile {
     pub(crate) fn name(self) -> &'static str {

--- a/packages/engine-benchmarks/benches/tracked_state_crud/storage.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/storage.rs
@@ -12,6 +12,9 @@ pub(crate) enum StorageProfile {
     SlateDB,
 }
 
+pub(crate) const KV_STORAGE_PROFILES: &[StorageProfile] =
+    &[StorageProfile::SQLite, StorageProfile::RocksDB];
+
 #[cfg(not(feature = "slatedb"))]
 pub(crate) const STORAGE_PROFILES: &[StorageProfile] =
     &[StorageProfile::SQLite, StorageProfile::RocksDB];

--- a/packages/engine-benchmarks/benches/tracked_state_crud/workload.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/workload.rs
@@ -12,12 +12,34 @@ pub(crate) struct WorkloadRow {
     pub(crate) updated_value_json: String,
 }
 
-pub(crate) fn fixture_rows() -> Vec<WorkloadRow> {
+pub(crate) fn fixture_rows(row_count: usize) -> Vec<WorkloadRow> {
+    assert!(row_count > 0, "tracked-state CRUD fixture cannot be empty");
     let json: JsonValue = serde_json::from_str(PNPM_LOCK_JSON).expect("parse pnpm-lock fixture");
     let mut rows = Vec::new();
     flatten_json("", &json, &mut rows);
     rows.sort_by(|left, right| left.path.cmp(&right.path));
     assert!(rows.len() >= REAL_WORKLOAD_ROWS);
+    if row_count <= rows.len() {
+        rows.truncate(row_count);
+        return rows;
+    }
+
+    rows.reserve(row_count - rows.len());
+    for ordinal in rows.len()..row_count {
+        let path = format!("/~lix-scale/{ordinal:09}");
+        let value_json = format!(r#"{{"ordinal":{ordinal},"lane":"scale"}}"#);
+        let updated_value_json =
+            format!(r#"{{"ordinal":{ordinal},"lane":"scale","updated":true}}"#);
+        rows.push(WorkloadRow {
+            path,
+            value_json,
+            updated_value_json,
+        });
+    }
+    // Synthetic rows intentionally extend the real fixture rather than
+    // replacing it. Restore physical-key order once so dense mutation profiles
+    // at 1M rows exercise the same ordered transaction path as the 10k case.
+    rows.sort_by(|left, right| left.path.cmp(&right.path));
     rows
 }
 
@@ -60,6 +82,7 @@ pub(crate) fn row_label(row_count: usize) -> &'static str {
     match row_count {
         SMOKE_ROWS => "1k",
         REAL_WORKLOAD_ROWS => "10k",
+        1_000_000 => "1m",
         _ => "custom",
     }
 }

--- a/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
+++ b/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
@@ -74,3 +74,21 @@ fn scaling_fixture_extends_the_real_workload_in_physical_key_order() {
         "rows beyond the embedded real workload must use deterministic synthetic identities"
     );
 }
+
+#[test]
+fn slatedb_is_not_routed_through_the_unsupported_kv_layer() {
+    assert_eq!(
+        storage::KV_STORAGE_PROFILES
+            .iter()
+            .map(|profile| profile.name())
+            .collect::<Vec<_>>(),
+        vec!["lix_sqlite", "lix_rocksdb"]
+    );
+    #[cfg(feature = "slatedb")]
+    assert!(
+        storage::STORAGE_PROFILES
+            .iter()
+            .any(|profile| profile.name() == "lix_slatedb"),
+        "SlateDB must remain covered by transaction and SQL-session profiles"
+    );
+}

--- a/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
+++ b/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
@@ -14,11 +14,10 @@ mod storage;
 #[path = "../benches/tracked_state_crud/workload.rs"]
 mod workload;
 
-use storage::StorageProfile;
 use workload::WorkloadRow;
 
 #[tokio::test]
-async fn standalone_sqlite_public_results_match_lix_sql_results() {
+async fn standalone_sqlite_public_results_match_every_lix_adapter() {
     let rows = [
         WorkloadRow {
             path: "/alpha".to_string(),
@@ -41,20 +40,37 @@ async fn standalone_sqlite_public_results_match_lix_sql_results() {
             updated_value_json: r#""updated""#.to_string(),
         },
     ];
-    let mut raw = raw_sqlite::seeded_fixture(&rows);
-    let lix = sql_session::seeded_fixture(StorageProfile::RocksDB, &rows).await;
+    for &profile in storage::STORAGE_PROFILES {
+        let mut raw = raw_sqlite::seeded_fixture(&rows);
+        let lix = sql_session::seeded_fixture(profile, &rows).await;
 
-    assert_eq!(raw.read_all_public_result(), lix.read_all_result().await);
-    assert_eq!(
-        raw.read_one_by_pk_public_result(),
-        lix.read_one_by_pk_result().await
-    );
-    assert_eq!(
-        raw.read_many_by_pk_public_result(READ_MANY_PK_COUNT),
-        lix.read_many_by_pk_result().await
-    );
+        assert_eq!(raw.read_all_public_result(), lix.read_all_result().await);
+        assert_eq!(
+            raw.read_one_by_pk_public_result(),
+            lix.read_one_by_pk_result().await
+        );
+        assert_eq!(
+            raw.read_many_by_pk_public_result(READ_MANY_PK_COUNT),
+            lix.read_many_by_pk_result().await
+        );
 
-    assert_eq!(raw.update_all_literal(), rows.len());
-    assert_eq!(lix.update_all_bound().await, rows.len());
-    assert_eq!(raw.read_all_public_result(), lix.read_all_result().await);
+        assert_eq!(raw.update_all_literal(), rows.len());
+        assert_eq!(lix.update_all_bound().await, rows.len());
+        assert_eq!(raw.read_all_public_result(), lix.read_all_result().await);
+    }
+}
+
+#[test]
+fn scaling_fixture_extends_the_real_workload_in_physical_key_order() {
+    let rows = workload::fixture_rows(20_000);
+
+    assert_eq!(rows.len(), 20_000);
+    assert!(
+        rows.windows(2).all(|pair| pair[0].path < pair[1].path),
+        "scaling identities must remain strictly ordered for comparable dense writes"
+    );
+    assert!(
+        rows.iter().any(|row| row.path.starts_with("/~lix-scale/")),
+        "rows beyond the embedded real workload must use deterministic synthetic identities"
+    );
 }


### PR DESCRIPTION
## Summary

Second layer of the tracked-state CRUD performance stack; stacked on #972.

- extend the representative 10k fixture deterministically to any requested row count, including 1M
- keep synthetic identities in strict physical-key order so 10k and 1M exercise the same dense mutation path
- run SlateDB through the public SQL-session harness, not only the direct transaction harness
- include SlateDB in all-feature Criterion/accounting profiles
- verify owned public-result parity across Lix SQLite, RocksDB, and SlateDB

## 1M diagnostic snapshot (one sample)

| operation | standalone SQLite | Lix/RocksDB transaction | Lix/SlateDB transaction |
|---|---:|---:|---:|
| insert all | 0.743 s | 8.25 s | 9.09 s |
| read all (owned result) | 1.62 s | 1.23 s | 1.12 s |
| update all | 1.02 s | 7.42 s | 11.98 s |
| delete all | 19.6 ms | 9.92 s | 14.21 s |
| read one | 180 µs | 681 µs | 345 µs |
| update one | 963 µs | 775 µs | 692 µs |
| delete one | 3.69 ms | 831 µs | 1.21 ms |

Public SQL/RocksDB at 1M: insert 9.87 s, read-all 1.46 s, literal update-all 52.1 s. The literal update result isolates a separate per-row SQL planning/execution problem from the 7.42 s transaction/storage path.

Single-sample 1M numbers are diagnostic, not stable regression thresholds. The 10k multi-sample scorecard remains the short-run comparison.

## Validation

- `cargo bench -p lix_engine_benchmarks --bench tracked_state_crud --features storage-benches,slatedb --no-run`
- `cargo test -p lix_engine_benchmarks --test tracked_state_crud_public_result --features storage-benches,slatedb`
- 10k public SQL SlateDB CRUD profile
- 1M standalone SQLite and direct RocksDB/SlateDB CRUD profiles
- selected 1M public SQL/RocksDB profiles

Stack: 2 / generation-delete and remaining CRUD hot-path layers follow.