### PR TITLE
store eager hot state values once

### DIFF
--- a/.changenotes/file-first-hot-state-layout.md
+++ b/.changenotes/file-first-hot-state-layout.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Current state now stores each eagerly materialized row value once in a file-first primary layout, reducing plugin-heavy repository storage and checkpoint write amplification.

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -618,6 +618,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn predecessor_v21_hot_row_order_is_rejected() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let storage_adapter = StorageAdapter::new(storage.clone());
+        let mut writes = storage_adapter.new_write_set();
+        writes.put(
+            crate::init::REPOSITORY_PROTOCOL_SPACE,
+            crate::init::REPOSITORY_PROTOCOL_KEY,
+            &b"file-descriptor-ownership.v21"[..],
+        );
+        storage_adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("V21 protocol marker should commit");
+
+        let Err(error) = Engine::new(storage).await else {
+            panic!("V21 repositories must fail closed before hot rows are decoded");
+        };
+        assert_eq!(error.code, "LIX_ERROR_UNSUPPORTED_STORAGE_FORMAT");
+    }
+
+    #[tokio::test]
     async fn tracked_entity_fast_path_serves_broad_sql_rows() {
         let storage = Memory::new();
         Engine::initialize(storage.clone())

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -39,13 +39,14 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 
 /// Repository-wide compatibility gate for physical storage protocols.
 ///
-/// V21 makes a file descriptor's `file_id` part of every durable row identity.
-/// Opening an older store must fail closed rather than mixing null-scoped
-/// descriptor identities with file-owned descriptor identities.
+/// V22 orders the authoritative hot-state identity by
+/// `(schema_key, file_id, entity_pk)`. Opening an older store must fail closed
+/// rather than decoding or mixing V21 `(schema_key, entity_pk, file_id)` rows
+/// under the new physical order.
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"file-descriptor-ownership.v21";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"file-first-hot-state.v22";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -1,6 +1,6 @@
 //! Unified, materialized live state for one branch head.
 //!
-//! The V16 hot index has one row per full identity. Each row is tagged
+//! The V17 hot index has one file-first row per full identity. Each row is tagged
 //! `tracked` or `untracked`: tracked mutations also enter history, while
 //! untracked mutations exist only in this serving plane. Normal reads consult
 //! this single index rather than merging a tracked snapshot with an untracked
@@ -383,7 +383,7 @@ impl TrackedHeadContext {
 
     /// Reclaims derived current-state generations that no durable branch
     /// control can select and returns their history-free payload refs. Both
-    /// the authoritative hot rows and their explicit file-id projections are
+    /// the authoritative hot rows and their key-only file membership index are
     /// generation-scoped, so the control is the one ownership root for both
     /// spaces. The caller compares the returned refs with its complete live
     /// payload set before staging physical JSON deletion.
@@ -596,27 +596,6 @@ async fn materialize_entity_snapshot_refs(
             Some(bytes);
     }
     Ok(snapshots)
-}
-
-fn scan_prefixes(scope: &[u8], filter: &TrackedStateFilter) -> Vec<Vec<u8>> {
-    if filter.schema_keys.is_empty() {
-        return vec![scope.to_vec()];
-    }
-    let mut prefixes = Vec::new();
-    for schema_key in &filter.schema_keys {
-        let mut schema_prefix = scope.to_vec();
-        write_key_string(&mut schema_prefix, schema_key, KEY_PART_FINAL);
-        if filter.entity_pks.is_empty() {
-            prefixes.push(schema_prefix);
-            continue;
-        }
-        for entity_pk in &filter.entity_pks {
-            let mut entity_prefix = schema_prefix.clone();
-            write_entity_pk(&mut entity_prefix, entity_pk);
-            prefixes.push(entity_prefix);
-        }
-    }
-    prefixes
 }
 
 fn matches_filter(identity: &HeadRowIdentity, filter: &TrackedStateFilter) -> bool {
@@ -3333,7 +3312,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn file_id_reads_use_file_first_hot_projection() {
+    async fn file_id_reads_use_file_first_primary_values() {
         let storage = StorageAdapter::new(Memory::new());
         let branch_id = "branch";
         let head = CommitId::for_test_label("head");
@@ -3491,36 +3470,6 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].file_id, None);
 
-        // Remove every authoritative primary row to prove that file-id reads
-        // are served by the complete file-first projection. This intentionally
-        // creates an impossible committed state; it validates the physical
-        // read route without depending on sibling-row decoding.
-        let primary_read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("open primary hot-row verification read");
-        let primary_rows = ScanPlan::prefix(
-            HOT_ROW_SPACE,
-            StoragePrefix {
-                bytes: Bytes::new(),
-            },
-        )
-        .collect(&primary_read, StorageScanOptions::default())
-        .await
-        .expect("primary hot rows should scan")
-        .value
-        .entries;
-        assert_eq!(primary_rows.len(), 4);
-        drop(primary_read);
-        let mut writes = StorageWriteSet::new();
-        for row in primary_rows {
-            writes.delete(HOT_ROW_SPACE, row.key);
-        }
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("remove primary rows for route proof");
-
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
@@ -3551,9 +3500,10 @@ mod tests {
             Some("01920000-0000-7000-8000-0000000000b2")
         );
 
-        // A schema-scoped `file_id = ?` query also stays on the file-first
-        // projection. This is the access pattern used by filesystem-backed
-        // entity scans, where the entity PK is not known before the query.
+        // A schema-scoped `file_id = ?` query reads the hydrated file-first
+        // primary range directly. This is the access pattern used by
+        // filesystem-backed entity scans, where the entity PK is not known
+        // before the query.
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
@@ -3590,8 +3540,8 @@ mod tests {
         );
 
         // The branch control validates the published hot generation. Exact
-        // file identity and schema-scoped file-id reads still route to the
-        // V16 file projection even when every primary row is absent.
+        // file identity and schema-scoped file-id reads route through the V17
+        // file-first primary index.
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
@@ -4046,22 +3996,12 @@ mod tests {
         .value
         .entries;
         assert_eq!(projections.len(), 2);
-        let projection_changes = projections
-            .into_iter()
-            .map(|projection| {
-                let bytes = full_value_bytes(projection.value).expect("projection has full bytes");
-                decode_head_value(&bytes)
-                    .expect("projection decodes")
-                    .change_id
-                    .expect("tracked projection has a change id")
-            })
-            .collect::<Vec<_>>();
-        assert!(projection_changes.contains(&ChangeId::for_test_label(
-            "01920000-0000-7000-8000-0000000000a2-second"
-        )));
-        assert!(projection_changes.contains(&ChangeId::for_test_label(
-            "01920000-0000-7000-8000-0000000000b2-first"
-        )));
+        assert!(
+            projections.into_iter().all(|projection| {
+                full_value_bytes(projection.value).is_ok_and(|bytes| bytes.is_empty())
+            }),
+            "file-first projections retain only identity keys"
+        );
     }
 
     #[tokio::test]
@@ -4763,7 +4703,7 @@ mod tests {
             .expect("open current-state GC verification read");
         for (label, space) in [
             ("primary hot row", HOT_ROW_SPACE),
-            ("file-first hot projection", HOT_FILE_SPACE),
+            ("file-first hot index", HOT_FILE_SPACE),
         ] {
             let entries = ScanPlan::prefix(
                 space,
@@ -4780,6 +4720,10 @@ mod tests {
             let encoded =
                 full_value_bytes(entries.into_iter().next().expect("one hot value").value)
                     .expect("hot value is present");
+            if space == HOT_FILE_SPACE {
+                assert!(encoded.is_empty(), "file-first index remains key-only");
+                continue;
+            }
             let value = decode_head_value(&encoded).expect("active hot value decodes");
             assert!(value.untracked, "active hot value remains untracked");
             match value.snapshot {

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -3312,6 +3312,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn entity_snapshot_scan_restores_logical_primary_key_order() {
+        let storage = StorageAdapter::new(Memory::new());
+        let branch_id = "branch";
+        let generation = CommitId::for_test_label("generation");
+        let head = CommitId::for_test_label("head");
+        let control = BranchHeadControl {
+            head_commit_id: head,
+            generation,
+            current_state_revision: 0,
+            schema_presence_bloom: [u64::MAX; 4],
+            working_diff_checkpoint_commit_id: None,
+            created_at: ts("2026-01-01T00:00:00Z"),
+            updated_at: ts("2026-01-01T00:00:00Z"),
+            ref_change_id: ChangeId::for_test_label("branch-ref"),
+        };
+        let mut writes = StorageWriteSet::new();
+        for (entity, file_id) in [("a", "z-file"), ("b", "a-file")] {
+            let identity = HeadIdentity {
+                branch_id: branch_id.to_string(),
+                generation,
+                schema_key: "schema".to_string(),
+                entity_pk: EntityPk::single(entity),
+                file_id: Some(file_id.to_string()),
+            };
+            stage_put(
+                &mut writes,
+                &identity,
+                &HeadValue {
+                    change_id: Some(ChangeId::for_test_label(entity)),
+                    commit_id: Some(head),
+                    untracked: false,
+                    deleted: false,
+                    created_at: ts("2026-01-01T00:00:00Z"),
+                    updated_at: ts("2026-01-01T00:00:00Z"),
+                    snapshot: JsonSlot::from_json(&format!(r#"{{"entity":"{entity}"}}"#)),
+                    metadata: JsonSlot::None,
+                },
+            )
+            .expect("stage file-backed row");
+        }
+        stage_branch_head_control(&mut writes, branch_id, control)
+            .expect("stage matching branch control");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit file-backed rows");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open entity snapshot read");
+        let snapshots = TrackedHeadContext::new()
+            .reader(read)
+            .scan_entity_snapshots(branch_id, control, "schema", &[], None)
+            .await
+            .expect("scan snapshots");
+        let snapshots = snapshots
+            .into_iter()
+            .map(|snapshot| {
+                String::from_utf8(snapshot.expect("row has a snapshot").to_vec())
+                    .expect("snapshot is UTF-8")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(snapshots, [r#"{"entity":"a"}"#, r#"{"entity":"b"}"#]);
+    }
+
+    #[tokio::test]
     async fn file_id_reads_use_file_first_primary_values() {
         let storage = StorageAdapter::new(Memory::new());
         let branch_id = "branch";

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -1679,7 +1679,7 @@ where
         let mut snapshots = Vec::new();
         let mut json_refs = Vec::new();
         let mut deferred = Vec::new();
-        for bytes in hot_scan_values(entries) {
+        for bytes in hot_scan_values_in_logical_order(entries) {
             let value = decode_head_value(&bytes)?;
             if value.deleted {
                 continue;
@@ -4020,9 +4020,12 @@ async fn materialize_hot_scan_entries(
     }
 }
 
-fn hot_scan_values(entries: HotScanEntries<'_>) -> Vec<Bytes> {
+fn hot_scan_values_in_logical_order(entries: HotScanEntries<'_>) -> Vec<Bytes> {
     match entries {
-        HotScanEntries::Decoded(entries) => entries.into_iter().map(|(_, value)| value).collect(),
+        HotScanEntries::Decoded(mut entries) => {
+            entries.sort_by(|left, right| left.0.cmp(&right.0));
+            entries.into_iter().map(|(_, value)| value).collect()
+        }
         HotScanEntries::Finite(batches) => batches
             .into_iter()
             .flat_map(|batch| batch.values.into_iter().flatten())

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -1,10 +1,11 @@
-//! V16 row-addressable current state with compact UUIDv7 entity keys.
+//! V17 row-addressable current state with file-first physical keys.
 //!
 //! V12 packed every file member of one logical entity into a group. That made
 //! a logical-PK lookup cheap, but it also made every normal commit read,
-//! decode, merge, and rewrite each predecessor group. V16 keeps the same
-//! fixed row value codec and branch-control publication fence, while making a
-//! full row identity the physical mutation unit.
+//! decode, merge, and rewrite each predecessor group. V17 keeps the fixed row
+//! value codec and branch-control publication fence, makes a full row identity
+//! the physical mutation unit, and stores each value only in the authoritative
+//! file-first row index.
 
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
@@ -26,12 +27,12 @@ use crate::wasm::WasmCertifiedEntityBatch;
 
 use super::*;
 
-pub(crate) const HOT_ROW_NAMESPACE: &str = "live_state.hot_row.v16";
-pub(crate) const HOT_FILE_NAMESPACE: &str = "live_state.hot_file.v16";
+pub(crate) const HOT_ROW_NAMESPACE: &str = "live_state.hot_row.v17";
+pub(crate) const HOT_FILE_NAMESPACE: &str = "live_state.hot_file.v17";
 pub(crate) const HOT_DIFF_NAMESPACE: &str = "live_state.hot_diff.v17";
 pub(crate) const HOT_ROW_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_001b), HOT_ROW_NAMESPACE);
-/// File-id-first projection. The primary hot row remains authoritative.
+/// File-id-first key-only index. The primary hot row owns every value.
 pub(crate) const HOT_FILE_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_001c), HOT_FILE_NAMESPACE);
 /// Reserved for the row-level first-before working-diff index.
@@ -137,16 +138,9 @@ impl DeferredFreshHotPlan {
                     .ok_or_else(|| {
                         head_value_error("deferred fresh hot value length overflowed")
                     })?;
-            let value_copies = 1_u64 + u64::from(delta.file_id.is_some());
+            let entry_count = 1_u64 + u64::from(delta.file_id.is_some());
             written_bytes = written_bytes
-                .checked_add(
-                    u64::try_from(value_len)
-                        .unwrap_or(u64::MAX)
-                        .checked_mul(value_copies)
-                        .ok_or_else(|| {
-                            head_value_error("deferred fresh hot written bytes overflowed")
-                        })?,
-                )
+                .checked_add(u64::try_from(value_len).unwrap_or(u64::MAX))
                 .ok_or_else(|| head_value_error("deferred fresh hot written bytes overflowed"))?;
             backend_capacity_hint_bytes = backend_capacity_hint_bytes
                 .checked_add(key_len)
@@ -154,17 +148,15 @@ impl DeferredFreshHotPlan {
                     Some(_) => capacity.checked_add(key_len),
                     None => Some(capacity),
                 })
+                .and_then(|capacity| capacity.checked_add(value_len))
                 .and_then(|capacity| {
-                    capacity.checked_add(value_len.checked_mul(value_copies as usize)?)
-                })
-                .and_then(|capacity| {
-                    capacity.checked_add(16_usize.checked_mul(value_copies as usize)?)
+                    capacity.checked_add(16_usize.checked_mul(entry_count as usize)?)
                 })
                 .ok_or_else(|| {
                     head_value_error("deferred fresh hot backend capacity overflowed")
                 })?;
             put_count = put_count
-                .checked_add(value_copies)
+                .checked_add(entry_count)
                 .ok_or_else(|| head_value_error("deferred fresh hot put count overflowed"))?;
             if let Some(diff_scope) = diff_scope.as_deref() {
                 coverage_key.clear();
@@ -345,7 +337,9 @@ impl DeferredFinalPutSource for DeferredFreshHotSource {
                     key: StorageKey(
                         key_bytes.slice(file_key.offset()..file_key.offset() + file_key.len()),
                     ),
-                    value,
+                    value: StorageValue {
+                        bytes: Bytes::new(),
+                    },
                 });
             }
         }
@@ -2457,8 +2451,8 @@ async fn stage_incremental_file_delete_cascades(
             &identity.schema_key,
             KEY_PART_FINAL,
         );
-        write_entity_pk(&mut mutations.key_bytes, &identity.entity_pk);
         write_file_id(&mut mutations.key_bytes, identity.file_id.as_deref());
+        write_entity_pk(&mut mutations.key_bytes, &identity.entity_pk);
         let row_key = BufferRange::new(row_start, mutations.key_bytes.len() - row_start);
         let file_start = mutations.key_bytes.len();
         mutations.key_bytes.extend_from_slice(&scope);
@@ -2952,8 +2946,8 @@ fn append_hot_mutation_identity(
     let row_start = encoded.len();
     encoded.extend_from_slice(scope);
     write_key_string(encoded, delta.schema_key, KEY_PART_FINAL);
-    write_entity_pk(encoded, delta.entity_pk);
     write_file_id(encoded, delta.file_id);
+    write_entity_pk(encoded, delta.entity_pk);
     let row_key = BufferRange::new(row_start, encoded.len() - row_start);
 
     let file_key = delta.file_id.map(|file_id| {
@@ -3147,7 +3141,7 @@ fn stage_hot_encoded_mutation_ranges(
     value_bytes: Bytes,
     row_puts: Vec<EncodedPut>,
     row_deletes: Vec<BufferRange>,
-    file_puts: Vec<EncodedPut>,
+    mut file_puts: Vec<EncodedPut>,
     file_deletes: Vec<BufferRange>,
 ) {
     let row_batch = EncodedMutationBatch::try_new(
@@ -3159,8 +3153,11 @@ fn stage_hot_encoded_mutation_ranges(
     .expect("hot row ranges originate in the supplied encoded buffers");
     writes.stage_encoded_batch(HOT_ROW_SPACE, row_batch);
     if !file_puts.is_empty() || !file_deletes.is_empty() {
+        for put in &mut file_puts {
+            put.value = BufferRange::new(0, 0);
+        }
         let file_batch =
-            EncodedMutationBatch::try_new(key_bytes, value_bytes, file_puts, file_deletes)
+            EncodedMutationBatch::try_new(key_bytes, Bytes::new(), file_puts, file_deletes)
                 .expect("hot file ranges originate in the supplied encoded buffers");
         writes.stage_encoded_batch(HOT_FILE_SPACE, file_batch);
     }
@@ -3324,8 +3321,8 @@ fn stage_complete_hot_rows(
         let row_start = key_bytes.len();
         key_bytes.extend_from_slice(&scope);
         write_key_string(&mut key_bytes, &identity.schema_key, KEY_PART_FINAL);
-        write_entity_pk(&mut key_bytes, &identity.entity_pk);
         write_file_id(&mut key_bytes, identity.file_id.as_deref());
+        write_entity_pk(&mut key_bytes, &identity.entity_pk);
         row_puts.push(EncodedPut {
             key: BufferRange::new(row_start, key_bytes.len() - row_start),
             value,
@@ -3339,7 +3336,7 @@ fn stage_complete_hot_rows(
             write_entity_pk(&mut key_bytes, &identity.entity_pk);
             file_puts.push(EncodedPut {
                 key: BufferRange::new(file_start, key_bytes.len() - file_start),
-                value,
+                value: BufferRange::new(0, 0),
             });
         }
     }
@@ -3351,7 +3348,7 @@ fn stage_complete_hot_rows(
     writes.stage_encoded_batch(HOT_ROW_SPACE, row_batch);
     if !file_puts.is_empty() {
         let file_batch =
-            EncodedMutationBatch::try_new(key_bytes, value_bytes, file_puts, Vec::new())
+            EncodedMutationBatch::try_new(key_bytes, Bytes::new(), file_puts, Vec::new())
                 .expect("complete hot file ranges originate in the supplied encoded buffers");
         writes.stage_encoded_batch(HOT_FILE_SPACE, file_batch);
     }
@@ -3574,7 +3571,6 @@ async fn reject_hot_absence_guards(
 #[derive(Clone, Copy)]
 struct EncodedHotPointKeyRanges {
     primary: BufferRange,
-    serving: BufferRange,
 }
 
 struct EncodedHotPointKeys {
@@ -3585,10 +3581,6 @@ struct EncodedHotPointKeys {
 impl EncodedHotPointKeys {
     fn primary_key(&self, index: usize) -> StorageKey {
         self.key_for_range(self.ranges[index].primary)
-    }
-
-    fn serving_key(&self, index: usize) -> StorageKey {
-        self.key_for_range(self.ranges[index].serving)
     }
 
     fn primary_key_bytes(&self, index: usize) -> &[u8] {
@@ -3621,13 +3613,7 @@ fn encode_hot_point_keys_with<'a>(
         let key = key_at(index);
         let primary_len =
             encoded_hot_identity_key_len(scope.len(), key.schema_key, key.entity_pk, key.file_id)?;
-        total
-            .checked_add(primary_len)?
-            .checked_add(if key.file_id.is_some() {
-                primary_len
-            } else {
-                0
-            })
+        total.checked_add(primary_len)
     });
     let capacity = planned_capacity.unwrap_or(0);
     let mut bytes = Vec::with_capacity(capacity);
@@ -3637,21 +3623,11 @@ fn encode_hot_point_keys_with<'a>(
         let primary_start = bytes.len();
         bytes.extend_from_slice(&scope);
         write_key_string(&mut bytes, key.schema_key, KEY_PART_FINAL);
-        write_entity_pk(&mut bytes, key.entity_pk);
         write_file_id(&mut bytes, key.file_id);
+        write_entity_pk(&mut bytes, key.entity_pk);
         let primary = BufferRange::new(primary_start, bytes.len() - primary_start);
 
-        let serving = if key.file_id.is_some() {
-            let serving_start = bytes.len();
-            bytes.extend_from_slice(&scope);
-            write_key_string(&mut bytes, key.schema_key, KEY_PART_FINAL);
-            write_file_id(&mut bytes, key.file_id);
-            write_entity_pk(&mut bytes, key.entity_pk);
-            BufferRange::new(serving_start, bytes.len() - serving_start)
-        } else {
-            primary
-        };
-        ranges.push(EncodedHotPointKeyRanges { primary, serving });
+        ranges.push(EncodedHotPointKeyRanges { primary });
     }
     debug_assert!(planned_capacity.is_none() || bytes.len() == capacity);
     EncodedHotPointKeys {
@@ -3670,8 +3646,8 @@ struct FiniteHotIdentityRef<'a> {
 /// once for the entire point-read batch.
 ///
 /// Entity and file descriptors borrow the caller's filter. Physical primary
-/// and file-projection keys share one immutable arena, so a dense-range probe
-/// can reuse the exact same primary ranges before falling back to MultiGet.
+/// keys share one immutable arena, so a dense-range probe can reuse the exact
+/// same ranges before falling back to MultiGet.
 struct FiniteHotIdentityBatchRef<'a> {
     branch_id: &'a str,
     generation: CommitId,
@@ -3965,32 +3941,16 @@ async fn hot_load_finite_identity_bytes(
     if batch.identities.is_empty() {
         return Ok(Vec::new());
     }
-    let mut output = vec![None; batch.len()];
-    for (is_file, space) in [(false, HOT_ROW_SPACE), (true, HOT_FILE_SPACE)] {
-        let indices = batch
-            .identities
-            .iter()
-            .enumerate()
-            .filter_map(|(index, identity)| {
-                (identity.file_id.is_some() == is_file).then_some(index)
-            })
-            .collect::<Vec<_>>();
-        if indices.is_empty() {
-            continue;
-        }
-        let keys = indices
-            .iter()
-            .map(|&index| batch.encoded.serving_key(index))
-            .collect::<Vec<_>>();
-        let values = PointReadPlan::new(space, &keys)
-            .materialize(store, StorageGetOptions::default())
-            .await?
-            .value;
-        for (index, value) in indices.into_iter().zip(values) {
-            output[index] = value.map(full_value_bytes).transpose()?;
-        }
-    }
-    Ok(output)
+    let keys = (0..batch.len())
+        .map(|index| batch.encoded.primary_key(index))
+        .collect::<Vec<_>>();
+    PointReadPlan::new(HOT_ROW_SPACE, &keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?
+        .value
+        .into_iter()
+        .map(|value| value.map(full_value_bytes).transpose())
+        .collect()
 }
 
 async fn hot_scan_finite_identity_batches<'a>(
@@ -4080,36 +4040,19 @@ async fn hot_load_identity_ref_bytes(
         return Ok(Vec::new());
     }
     let encoded = encode_hot_point_keys(branch_id, generation, identities);
-    let mut output = vec![None; identities.len()];
-    for (is_file, space) in [(false, HOT_ROW_SPACE), (true, HOT_FILE_SPACE)] {
-        let indices = identities
-            .iter()
-            .enumerate()
-            .filter_map(|(index, identity)| {
-                (identity.file_id.is_some() == is_file).then_some(index)
-            })
-            .collect::<Vec<_>>();
-        if indices.is_empty() {
-            continue;
-        }
-        let keys = indices
-            .iter()
-            .map(|&index| encoded.serving_key(index))
-            .collect::<Vec<_>>();
-        let values = PointReadPlan::new(space, &keys)
-            .materialize(store, StorageGetOptions::default())
-            .await?
-            .value;
-        for (index, value) in indices.into_iter().zip(values) {
-            output[index] = value.map(full_value_bytes).transpose()?;
-        }
-    }
-    Ok(output)
+    let keys = (0..identities.len())
+        .map(|index| encoded.primary_key(index))
+        .collect::<Vec<_>>();
+    PointReadPlan::new(HOT_ROW_SPACE, &keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?
+        .value
+        .into_iter()
+        .map(|value| value.map(full_value_bytes).transpose())
+        .collect()
 }
 
-/// Loads the authoritative primary row for every identity. File-backed
-/// identities normally read through `HOT_FILE_SPACE`, but mutation validation
-/// and diff capture must never treat that duplicate projection as ownership.
+/// Loads the authoritative primary row for every identity.
 async fn hot_load_primary_identity_bytes(
     store: &(impl StorageAdapterRead + ?Sized),
     identities: &[HeadIdentity],
@@ -4509,11 +4452,9 @@ async fn hot_scan_entries<'a>(
         }
     }
 
-    // The primary hot index is ordered by logical PK. Filesystem queries such
-    // as `WHERE file_id = ?` need the inverse order, otherwise one matching
-    // file would force a scan of every entity in its schema. Keep the full
-    // value in the file projection so this is a direct serving route rather
-    // than an index lookup followed by a second primary read.
+    // The authoritative hot index is file-first, so filesystem queries such as
+    // `WHERE file_id = ?` read one contiguous hydrated range without a second
+    // value projection or random point-read hydration.
     if let Some(prefixes) = hot_file_scan_prefixes(branch_id, generation, filter) {
         return scan_hot_file_entries(store, branch_id, generation, prefixes, filter, limit)
             .await
@@ -4521,7 +4462,7 @@ async fn hot_scan_entries<'a>(
     }
 
     let scope = hot_scope_prefix(branch_id, generation);
-    let mut prefixes = scan_prefixes(&scope, filter);
+    let mut prefixes = hot_row_scan_prefixes(&scope, filter);
     prefixes.sort();
     prefixes.dedup();
     let mut rows = Vec::new();
@@ -4588,6 +4529,9 @@ async fn hot_scan_dense_encoded_key_range<'a>(
     if key_count == 0 {
         return Ok(Some(Vec::new()));
     }
+    if (1..key_count).any(|index| key_at(index - 1) > key_at(index)) {
+        return Ok(None);
+    }
     let first_key = StorageKey(Bytes::copy_from_slice(key_at(0)));
     let last_key = StorageKey(Bytes::copy_from_slice(key_at(key_count - 1)));
     let plan = ScanPlan::range(
@@ -4634,6 +4578,21 @@ async fn hot_scan_dense_encoded_key_range<'a>(
     }
 }
 
+fn hot_row_scan_prefixes(scope: &[u8], filter: &TrackedStateFilter) -> Vec<Vec<u8>> {
+    if filter.schema_keys.is_empty() {
+        return vec![scope.to_vec()];
+    }
+    filter
+        .schema_keys
+        .iter()
+        .map(|schema_key| {
+            let mut prefix = scope.to_vec();
+            write_key_string(&mut prefix, schema_key, KEY_PART_FINAL);
+            prefix
+        })
+        .collect()
+}
+
 fn hot_file_scan_prefixes(
     branch_id: &str,
     generation: CommitId,
@@ -4678,7 +4637,7 @@ async fn scan_hot_file_entries(
     let mut rows = Vec::new();
     for prefix in prefixes {
         let plan = ScanPlan::prefix(
-            HOT_FILE_SPACE,
+            HOT_ROW_SPACE,
             StoragePrefix {
                 bytes: Bytes::from(prefix),
             },
@@ -4696,7 +4655,7 @@ async fn scan_hot_file_entries(
                 .await?;
             resume_after = page.value.entries.last().map(|entry| entry.key.clone());
             for entry in page.value.entries {
-                let identity = decode_hot_scan_file_key_in_scope(entry.key.0, &scope)?;
+                let identity = decode_hot_scan_row_key_in_scope(entry.key.0, &scope)?;
                 if identity.matches_filter(filter) {
                     rows.push((identity, full_value_bytes(entry.value)?));
                 }
@@ -4706,9 +4665,9 @@ async fn scan_hot_file_entries(
             }
         }
     }
-    // A file projection is ordered `(schema, file_id, entity_pk)`, while SQL
-    // rows are ordered `(schema, entity_pk, file_id)`. Restore the public
-    // order after multi-file scans and defend against repeated predicates.
+    // Physical rows are ordered `(schema, file_id, entity_pk)`, while SQL rows
+    // are ordered `(schema, entity_pk, file_id)`. Restore the public order
+    // after multi-file scans and defend against repeated predicates.
     rows.sort_by(|left, right| left.0.cmp(&right.0));
     rows.dedup_by(|left, right| left.0 == right.0);
     if let Some(limit) = limit {
@@ -4787,8 +4746,8 @@ fn encode_hot_row_key_parts(
 ) -> Vec<u8> {
     let mut key = hot_scope_prefix(branch_id, generation);
     write_key_string(&mut key, schema_key, KEY_PART_FINAL);
-    write_entity_pk(&mut key, entity_pk);
     write_file_id(&mut key, file_id);
+    write_entity_pk(&mut key, entity_pk);
     key
 }
 
@@ -4893,8 +4852,8 @@ fn decode_hot_scan_row_key_in_scope(key: Bytes, scope: &[u8]) -> Result<HotScanI
             "hot row schema key has an invalid terminator",
         ));
     }
-    let entity_pk = read_hot_scan_entity_pk(&key, &mut offset)?;
     let file_id = read_hot_scan_file_id(&key, &mut offset)?;
+    let entity_pk = read_hot_scan_entity_pk(&key, &mut offset)?;
     if offset != key.len() {
         return Err(key_codec_error("hot row key has trailing bytes"));
     }
@@ -4906,6 +4865,7 @@ fn decode_hot_scan_row_key_in_scope(key: Bytes, scope: &[u8]) -> Result<HotScanI
     })
 }
 
+#[cfg(test)]
 fn decode_hot_scan_file_key_in_scope(
     key: Bytes,
     scope: &[u8],
@@ -5144,6 +5104,7 @@ fn read_hot_scan_shared_bytes(
         .map(|(value, terminator)| (Bytes::from(value), terminator))
 }
 
+#[cfg(test)]
 fn decode_hot_row_key_in_scope(bytes: &[u8], scope: &[u8]) -> Result<HeadRowIdentity, LixError> {
     if !bytes.starts_with(scope) {
         return Err(key_codec_error(
@@ -5157,8 +5118,8 @@ fn decode_hot_row_key_in_scope(bytes: &[u8], scope: &[u8]) -> Result<HeadRowIden
             "hot row schema key has an invalid terminator",
         ));
     }
-    let entity_pk = read_entity_pk(bytes, &mut offset)?;
     let file_id = read_file_id(bytes, &mut offset)?;
+    let entity_pk = read_entity_pk(bytes, &mut offset)?;
     if offset != bytes.len() {
         return Err(key_codec_error("hot row key has trailing bytes"));
     }
@@ -5184,8 +5145,8 @@ fn decode_hot_row_key(bytes: &[u8]) -> Result<HeadIdentity, LixError> {
             "hot row schema key has an invalid terminator",
         ));
     }
-    let entity_pk = read_entity_pk(bytes, &mut offset)?;
     let file_id = read_file_id(bytes, &mut offset)?;
+    let entity_pk = read_entity_pk(bytes, &mut offset)?;
     if offset != bytes.len() {
         return Err(key_codec_error("hot row key has trailing bytes"));
     }
@@ -5264,7 +5225,28 @@ struct HotDiffSegmentScope {
 }
 
 fn decode_hot_diff_key_in_scope(bytes: &[u8], scope: &[u8]) -> Result<HeadRowIdentity, LixError> {
-    decode_hot_row_key_in_scope(bytes, scope)
+    if !bytes.starts_with(scope) {
+        return Err(key_codec_error(
+            "hot diff row does not begin with its scanned scope",
+        ));
+    }
+    let mut offset = scope.len();
+    let (schema_key, schema_terminator) = read_key_string(bytes, &mut offset, "schema key")?;
+    if schema_terminator != KEY_PART_FINAL {
+        return Err(key_codec_error(
+            "hot diff row schema key has an invalid terminator",
+        ));
+    }
+    let entity_pk = read_entity_pk(bytes, &mut offset)?;
+    let file_id = read_file_id(bytes, &mut offset)?;
+    if offset != bytes.len() {
+        return Err(key_codec_error("hot diff row key has trailing bytes"));
+    }
+    Ok(HeadRowIdentity {
+        schema_key,
+        entity_pk,
+        file_id,
+    })
 }
 
 fn decode_hot_diff_segment_key(bytes: &[u8]) -> Result<HotDiffSegmentScope, LixError> {
@@ -5341,7 +5323,7 @@ fn visit_hot_diff_segment(
         coverage
             .add_encoded_group_key(&full_key)
             .ok_or_else(|| head_value_error("hot working-diff index count exceeds u64"))?;
-        visit(decode_hot_row_key_in_scope(&full_key, scope)?);
+        visit(decode_hot_diff_key_in_scope(&full_key, scope)?);
         offset = suffix_end;
     }
     if offset != bytes.len() {
@@ -5413,9 +5395,8 @@ where
         &mut stale_untracked_refs,
     )
     .await?;
-    // The file projection duplicates primary values. Sweep it independently
-    // so an orphaned projection cannot keep a history-free JSON payload alive
-    // after its branch generation becomes unreachable.
+    // Sweep the key-only file index independently so orphaned generations do
+    // not retain file-scoped lookup entries.
     stage_collect_stale_hot_space(
         store,
         writes,
@@ -5679,7 +5660,7 @@ mod tests {
     }
 
     #[test]
-    fn ten_thousand_finite_hot_identities_share_scope_and_one_key_arena() {
+    fn ten_thousand_finite_hot_identities_share_one_primary_key_arena() {
         let generation = CommitId::for_test_label("point-key-generation");
         let entity_pks = (0..5_000)
             .map(|index| EntityPk::single(format!("entity-{index:05}")))
@@ -5703,7 +5684,7 @@ mod tests {
                 .encoded
                 .ranges
                 .last()
-                .map(|ranges| ranges.serving.offset() + ranges.serving.len()),
+                .map(|ranges| ranges.primary.offset() + ranges.primary.len()),
             Some(batch.encoded.bytes.len())
         );
         for index in [0, 1, 9_999] {
@@ -5716,13 +5697,6 @@ mod tests {
                 key.0.as_ptr(),
                 batch.encoded.bytes[primary.offset()..].as_ptr(),
                 "primary point key {index} must remain a slice of the batch arena"
-            );
-            let serving = batch.encoded.ranges[index].serving;
-            let key = batch.encoded.serving_key(index);
-            assert_eq!(
-                key.0.as_ptr(),
-                batch.encoded.bytes[serving.offset()..].as_ptr(),
-                "serving point key {index} must remain a slice of the same batch arena"
             );
         }
     }
@@ -5750,13 +5724,12 @@ mod tests {
         let ranges = entity_pks
             .iter()
             .map(|entity_pk| {
-                append_hot_diff_key_parts(
-                    &mut key_bytes,
-                    &scope,
-                    schema_key,
-                    entity_pk,
-                    Some(file_id),
-                )
+                let start = key_bytes.len();
+                key_bytes.extend_from_slice(&scope);
+                write_key_string(&mut key_bytes, schema_key, KEY_PART_FINAL);
+                write_file_id(&mut key_bytes, Some(file_id));
+                write_entity_pk(&mut key_bytes, entity_pk);
+                start..key_bytes.len()
             })
             .collect::<Vec<_>>();
         assert_eq!(key_bytes.len(), capacity);


### PR DESCRIPTION
## What changed

- bump the row-addressable current-state layout to V17
- order the authoritative hot row key by `(schema, file_id, entity_pk)`
- store each eager current-state value only once in `HOT_ROW`
- retain `HOT_FILE` as a key-only membership index
- serve file-scoped reads directly from the contiguous authoritative range
- avoid duplicate point-key encoding and fall back to MultiGet when a finite batch is not physically monotonic

This deliberately makes a breaking physical-layout change. It does not change eager semantic materialization or the WASM plugin model.

## Why

Raw SlateDB inspection of a retained 10,000-commit OpenClaw replay found 3.09M `HOT_ROW` records and 3.09M `HOT_FILE` records carrying the same current-state values. The duplicate value projection was removable entropy and write amplification. A first key-only experiment reduced storage but regressed large-file operations because it enumerated the secondary index and randomly hydrated primary rows. Making the authoritative row file-first preserves contiguous hydrated file reads.

## Measured impact

Controlled OpenClaw replay, 1,000 commits, all text/CSV/Markdown/Excalidraw WASM plugins enabled, checkpoint every commit, SlateDB:

| Metric | main | this PR | change |
| --- | ---: | ---: | ---: |
| physical store | 297.8 MB | 174.7 MB | **-41.3%** |
| replay wall time | 311.9 s | 287.7 s | **-7.7%** |
| execute total | 226.7 s | 219.0 s | **-3.4%** |
| checkpoint total | 83.9 s | 67.6 s | **-19.4%** |
| execute p99 | 3.016 s | 3.005 s | flat |
| checkpoint p90 | 11.03 ms | 9.50 ms | **-13.9%** |

The rejected secondary-index hydration variant was 2.1% slower overall and nearly doubled execute p99, which is why this PR changes primary order instead.

Dedicated 10k-file exact-read probes stayed within run-to-run noise. A 1,000-row SlateDB CRUD hot profile improved update-one by 4.4% and put read-many within 6.4% of main. The 1,000-row diff command medians improved across working diff, revert, apply, and partial checkpoint.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p lix_engine`
  - 1,559 unit tests passed
  - 424 integration tests passed
- `cargo test -p lix_engine --features all-simulations`
  - all base and tracked-state-rebuild simulations passed
- focused post-rebase tracked-head tests: 38 passed
- controlled retained SlateDB physical-layout scan
- OpenClaw plugin-enabled replay comparison
- 10k-file exact-read benchmark on Memory, RocksDB, and SlateDB
- tracked-state CRUD profiles on SlateDB
- diff/revert/apply/partial-checkpoint profiles
