### PR TITLE
Index certified plugin pages for exact reads

### DIFF
--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -14,13 +14,13 @@ pub(crate) use reader::load_exact_batch_via_scan_for_test;
 pub(crate) use tracked_head::TrackedHeadDeltaRef;
 #[allow(unused_imports)]
 pub(crate) use tracked_head::{
-    CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE, CERTIFIED_ENTITY_BATCH_SPACE,
-    CertifiedEntityBatchFileRef, CurrentStateDeltaRef, DeferredFreshHotPlan,
-    DeferredFreshHotRowRef, DeferredFreshHotRows, HOT_DIFF_SPACE, HOT_FILE_SPACE, HOT_ROW_SPACE,
-    HotTrackedSnapshot, TRACKED_WORKING_DIFF_MARKER_SPACE, TrackedHeadContext, TrackedWorkingDiff,
-    TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage, scan_certified_history_rows,
-    stage_certified_entity_batches, stage_collect_stale_working_diff_indexes,
-    stage_tracked_working_diff_epoch,
+    CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE, CERTIFIED_ENTITY_BATCH_PAGE_SPACE,
+    CERTIFIED_ENTITY_BATCH_SPACE, CertifiedEntityBatchFileRef, CurrentStateDeltaRef,
+    DeferredFreshHotPlan, DeferredFreshHotRowRef, DeferredFreshHotRows, HOT_DIFF_SPACE,
+    HOT_FILE_SPACE, HOT_ROW_SPACE, HotTrackedSnapshot, TRACKED_WORKING_DIFF_MARKER_SPACE,
+    TrackedHeadContext, TrackedWorkingDiff, TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage,
+    scan_certified_history_rows, stage_certified_entity_batches,
+    stage_collect_stale_working_diff_indexes, stage_tracked_working_diff_epoch,
 };
 #[allow(unused_imports)]
 pub(crate) use types::{

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -9,10 +9,10 @@
 mod hot;
 
 pub(crate) use hot::{
-    CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE, CERTIFIED_ENTITY_BATCH_SPACE,
-    CertifiedEntityBatchFileRef, DeferredFreshHotPlan, DeferredFreshHotRowRef,
-    DeferredFreshHotRows, HOT_DIFF_SPACE, HOT_FILE_SPACE, HOT_ROW_SPACE, HotTrackedSnapshot,
-    scan_certified_history_rows, stage_certified_entity_batches,
+    CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE, CERTIFIED_ENTITY_BATCH_PAGE_SPACE,
+    CERTIFIED_ENTITY_BATCH_SPACE, CertifiedEntityBatchFileRef, DeferredFreshHotPlan,
+    DeferredFreshHotRowRef, DeferredFreshHotRows, HOT_DIFF_SPACE, HOT_FILE_SPACE, HOT_ROW_SPACE,
+    HotTrackedSnapshot, scan_certified_history_rows, stage_certified_entity_batches,
 };
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -1348,10 +1348,7 @@ fn insert_created_id_into_canonical_object(snapshot: &[u8], id: &str) -> Result<
         }
         let key_end = json_string_end(snapshot, entry_start)?;
         let encoded_key = &snapshot[entry_start..key_end];
-        let key = if encoded_key[1..encoded_key.len() - 1]
-            .iter()
-            .any(|byte| *byte == b'\\')
-        {
+        let key = if encoded_key[1..encoded_key.len() - 1].contains(&b'\\') {
             serde_json::from_slice::<String>(encoded_key)
                 .map_err(|error| head_value_error(format!("invalid canonical key: {error}")))?
         } else {

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -558,10 +558,10 @@ pub(crate) async fn stage_certified_entity_batches(
                     .to_le_bytes(),
             );
             for (page_index, page) in batch.pages.iter().enumerate() {
-                let (first_local_ref, last_local_ref) = if batch.format == 1 {
-                    certified_csv_page_local_ref_range(page)?
-                } else {
-                    (0, u32::MAX)
+                let (first_local_ref, last_local_ref) = match batch.format {
+                    1 => certified_csv_page_local_ref_range(page)?,
+                    2 => certified_packet_page_local_ref_range(page)?.unwrap_or((0, u32::MAX)),
+                    _ => (0, u32::MAX),
                 };
                 value.extend_from_slice(&first_local_ref.to_le_bytes());
                 value.extend_from_slice(&last_local_ref.to_le_bytes());
@@ -654,6 +654,39 @@ fn certified_csv_page_local_ref_range(page: &[u8]) -> Result<(u32, u32), LixErro
         .ok_or_else(|| head_value_error("certified CSV page is empty"))
 }
 
+/// Returns an ordinal range only when every packet row is a keyless create
+/// and those local references are strictly increasing. A keyed or mixed page
+/// remains conservatively unindexed.
+fn certified_packet_page_local_ref_range(page: &[u8]) -> Result<Option<(u32, u32)>, LixError> {
+    let mut rows = CertifiedCsvReader {
+        bytes: page,
+        offset: 0,
+    };
+    let mut first = None;
+    let mut last = None;
+    while rows.offset < rows.bytes.len() {
+        let record_len = rows.u32()? as usize;
+        let record_bytes = rows.bytes(record_len)?;
+        let mut record = CertifiedCsvReader {
+            bytes: record_bytes,
+            offset: 0,
+        };
+        if record.u8()? != 2 {
+            return Ok(None);
+        }
+        let schema_len = record.u32()? as usize;
+        let _schema = record.bytes(schema_len)?;
+        let local_ref = u32::try_from(record.u64()?)
+            .map_err(|_| head_value_error("certified packet local reference exceeds u32"))?;
+        if last.is_some_and(|previous| previous >= local_ref) {
+            return Ok(None);
+        }
+        first.get_or_insert(local_ref);
+        last = Some(local_ref);
+    }
+    Ok(first.zip(last))
+}
+
 fn certified_external_page_plan(
     bytes: &[u8],
     content_key: &[u8],
@@ -676,27 +709,31 @@ fn certified_external_page_plan(
         high: input.u64()?,
         low: input.u32()?,
     };
-    let selected_local_refs = (format == 1 && !request.filter.entity_pks.is_empty()).then(|| {
+    let selected_local_refs = ((format == 1 || format == 2)
+        && !request.filter.entity_pks.is_empty())
+    .then(|| {
         let high = creates.high.to_be_bytes();
         let low = creates.low.to_be_bytes();
         request
             .filter
             .entity_pks
             .iter()
-            .filter_map(|entity_pk| match entity_pk.components.as_slice() {
+            .map(|entity_pk| match entity_pk.components.as_slice() {
                 [crate::entity_pk::EntityPkComponent::Uuid(bytes)]
                     if bytes[..8] == high && bytes[8..12] == low =>
                 {
-                    Some(u32::from_be_bytes(
+                    Ok(u32::from_be_bytes(
                         bytes[12..]
                             .try_into()
                             .expect("UUID local-reference suffix is four bytes"),
                     ))
                 }
-                _ => None,
+                _ => Err(()),
             })
-            .collect::<BTreeSet<_>>()
-    });
+            .collect::<Result<BTreeSet<_>, _>>()
+            .ok()
+    })
+    .flatten();
     let page_count = input.u32()?;
     let mut pages = Vec::with_capacity(page_count as usize);
     for page_index in 0..page_count {
@@ -1234,19 +1271,10 @@ fn decode_certified_packet_rows(
         }
         let snapshot = if needs_snapshot {
             if let Some(id) = &created_id {
-                let mut snapshot: serde_json::Value = serde_json::from_slice(snapshot_bytes)
-                    .map_err(|error| {
-                        head_value_error(format!("invalid certified JSON: {error}"))
-                    })?;
-                let object = snapshot.as_object_mut().ok_or_else(|| {
-                    head_value_error("certified create snapshot is not a JSON object")
-                })?;
-                object.insert(
-                    "id".to_owned(),
-                    serde_json::Value::String(uuid::Uuid::from_bytes(*id).to_string()),
-                );
-                let json = serde_json::to_vec(&snapshot)
-                    .map_err(|error| head_value_error(error.to_string()))?;
+                let json = insert_created_id_into_canonical_object(
+                    snapshot_bytes,
+                    &uuid::Uuid::from_bytes(*id).to_string(),
+                )?;
                 Some(
                     SharedStr::from_utf8(Bytes::from(json))
                         .map_err(|error| head_value_error(error.to_string()))?,
@@ -1290,6 +1318,136 @@ fn decode_certified_packet_rows(
         }
     }
     Ok(decoded)
+}
+
+/// Inserts the generated `id` into an already validated canonical JSON object
+/// without materializing its value tree. Keys emitted by serde_json are
+/// lexicographically ordered, so locating the top-level insertion boundary is
+/// sufficient to reproduce the exact canonical snapshot.
+fn insert_created_id_into_canonical_object(snapshot: &[u8], id: &str) -> Result<Vec<u8>, LixError> {
+    if snapshot.first() != Some(&b'{') || snapshot.last() != Some(&b'}') {
+        return Err(head_value_error(
+            "certified create snapshot is not a JSON object",
+        ));
+    }
+    let field = format!("\"id\":\"{id}\"");
+    if snapshot == b"{}" {
+        let mut output = Vec::with_capacity(field.len() + 2);
+        output.push(b'{');
+        output.extend_from_slice(field.as_bytes());
+        output.push(b'}');
+        return Ok(output);
+    }
+
+    let mut entry_start = 1;
+    loop {
+        if snapshot.get(entry_start) != Some(&b'"') {
+            return Err(head_value_error(
+                "certified canonical object has an invalid key",
+            ));
+        }
+        let key_end = json_string_end(snapshot, entry_start)?;
+        let encoded_key = &snapshot[entry_start..key_end];
+        let key = if encoded_key[1..encoded_key.len() - 1]
+            .iter()
+            .any(|byte| *byte == b'\\')
+        {
+            serde_json::from_slice::<String>(encoded_key)
+                .map_err(|error| head_value_error(format!("invalid canonical key: {error}")))?
+        } else {
+            std::str::from_utf8(&encoded_key[1..encoded_key.len() - 1])
+                .map_err(|error| head_value_error(format!("invalid canonical key: {error}")))?
+                .to_owned()
+        };
+        if key.as_str() >= "id" {
+            if key == "id" {
+                return Err(head_value_error(
+                    "certified keyless create snapshot already contains id",
+                ));
+            }
+            let mut output = Vec::with_capacity(snapshot.len() + field.len() + 1);
+            output.extend_from_slice(&snapshot[..entry_start]);
+            output.extend_from_slice(field.as_bytes());
+            output.push(b',');
+            output.extend_from_slice(&snapshot[entry_start..]);
+            return Ok(output);
+        }
+
+        let colon = snapshot
+            .get(key_end..)
+            .and_then(|tail| tail.iter().position(|byte| *byte == b':'))
+            .map(|offset| key_end + offset)
+            .ok_or_else(|| head_value_error("certified canonical object key has no value"))?;
+        match json_top_level_value_end(snapshot, colon + 1)? {
+            JsonObjectBoundary::Next(next) => entry_start = next,
+            JsonObjectBoundary::End(end) => {
+                let mut output = Vec::with_capacity(snapshot.len() + field.len() + 1);
+                output.extend_from_slice(&snapshot[..end]);
+                output.push(b',');
+                output.extend_from_slice(field.as_bytes());
+                output.extend_from_slice(&snapshot[end..]);
+                return Ok(output);
+            }
+        }
+    }
+}
+
+fn json_string_end(bytes: &[u8], start: usize) -> Result<usize, LixError> {
+    let mut escaped = false;
+    for (offset, byte) in bytes[start + 1..].iter().enumerate() {
+        if escaped {
+            escaped = false;
+        } else if *byte == b'\\' {
+            escaped = true;
+        } else if *byte == b'"' {
+            return Ok(start + offset + 2);
+        }
+    }
+    Err(head_value_error("unterminated canonical JSON string"))
+}
+
+enum JsonObjectBoundary {
+    Next(usize),
+    End(usize),
+}
+
+fn json_top_level_value_end(bytes: &[u8], start: usize) -> Result<JsonObjectBoundary, LixError> {
+    let mut depth = 0_u32;
+    let mut in_string = false;
+    let mut escaped = false;
+    for (offset, byte) in bytes[start..].iter().enumerate() {
+        let index = start + offset;
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if *byte == b'\\' {
+                escaped = true;
+            } else if *byte == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match *byte {
+            b'"' => in_string = true,
+            b'[' | b'{' => {
+                depth = depth
+                    .checked_add(1)
+                    .ok_or_else(|| head_value_error("canonical JSON nesting overflowed"))?;
+            }
+            b']' => {
+                depth = depth
+                    .checked_sub(1)
+                    .ok_or_else(|| head_value_error("invalid canonical JSON array"))?;
+            }
+            b'}' if depth > 0 => depth -= 1,
+            b',' if depth == 0 => return Ok(JsonObjectBoundary::Next(index + 1)),
+            b'}' if depth == 0 => return Ok(JsonObjectBoundary::End(index)),
+            _ => {}
+        }
+    }
+    Err(head_value_error(
+        "canonical JSON object has no closing boundary",
+    ))
 }
 
 struct CertifiedBatchReader<'a> {
@@ -5742,6 +5900,55 @@ mod tests {
 
     fn timestamp() -> LixTimestamp {
         LixTimestamp::expect_parse("hot working-diff test timestamp", "2026-01-01T00:00:00Z")
+    }
+
+    #[test]
+    fn created_id_is_inserted_without_materializing_canonical_json() {
+        let id = "018f47a2-cafe-7000-8000-000000000001";
+        assert_eq!(
+            insert_created_id_into_canonical_object(b"{}", id).unwrap(),
+            format!(r#"{{"id":"{id}"}}"#).as_bytes()
+        );
+        assert_eq!(
+            insert_created_id_into_canonical_object(
+                br#"{"format":{"nested":"},\\\""},"kind":"paragraph","parent_id":null}"#,
+                id,
+            )
+            .unwrap(),
+            format!(
+                r#"{{"format":{{"nested":"}},\\\""}},"id":"{id}","kind":"paragraph","parent_id":null}}"#
+            )
+            .as_bytes()
+        );
+        assert_eq!(
+            insert_created_id_into_canonical_object(br#"{"alpha":1}"#, id).unwrap(),
+            format!(r#"{{"alpha":1,"id":"{id}"}}"#).as_bytes()
+        );
+    }
+
+    #[test]
+    fn create_only_packet_pages_expose_their_local_ref_range() {
+        fn create_record(local_ref: u64) -> Vec<u8> {
+            let mut record = vec![2];
+            record.extend_from_slice(&6_u32.to_le_bytes());
+            record.extend_from_slice(b"schema");
+            record.extend_from_slice(&local_ref.to_le_bytes());
+            let mut framed = Vec::new();
+            framed.extend_from_slice(&(record.len() as u32).to_le_bytes());
+            framed.extend_from_slice(&record);
+            framed
+        }
+
+        let mut page = create_record(7);
+        page.extend_from_slice(&create_record(11));
+        assert_eq!(
+            certified_packet_page_local_ref_range(&page).unwrap(),
+            Some((7, 11))
+        );
+
+        let mut keyed = create_record(7);
+        keyed[4] = 0;
+        assert_eq!(certified_packet_page_local_ref_range(&keyed).unwrap(), None);
     }
 
     fn diff_identity(branch_id: &str, generation: CommitId, entity: &str) -> HeadIdentity {

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -48,7 +48,8 @@ const HOT_DIFF_SEGMENT_MAX_IDENTITIES: u32 = 4_096;
 // storage amplification, so retain their allocation-free direct-key path.
 const HOT_DIFF_PACK_MIN_IDENTITIES: usize = 64;
 const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
-const CERTIFIED_ENTITY_BATCH_MAGIC: &[u8; 4] = b"CEB1";
+const CERTIFIED_ENTITY_BATCH_MAGIC_V1: &[u8; 4] = b"CEB1";
+const CERTIFIED_ENTITY_BATCH_MAGIC_V2: &[u8; 4] = b"CEB2";
 pub(crate) const CERTIFIED_ENTITY_BATCH_SPACE: StorageSpace = StorageSpace::new(
     StorageSpaceId(0x0004_001f),
     "live_state.certified_entity_batch.v1",
@@ -56,6 +57,10 @@ pub(crate) const CERTIFIED_ENTITY_BATCH_SPACE: StorageSpace = StorageSpace::new(
 pub(crate) const CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE: StorageSpace = StorageSpace::new(
     StorageSpaceId(0x0004_0021),
     "live_state.certified_entity_batch_manifest.v1",
+);
+pub(crate) const CERTIFIED_ENTITY_BATCH_PAGE_SPACE: StorageSpace = StorageSpace::new(
+    StorageSpaceId(0x0004_0022),
+    "live_state.certified_entity_batch_page.v1",
 );
 const DEFERRED_FRESH_HOT_ROWS_PER_PAGE: usize = 4_096;
 const DEFERRED_FRESH_HOT_SPACES: [StorageSpace; 3] =
@@ -512,11 +517,6 @@ pub(crate) async fn stage_certified_entity_batches(
             append_batch_text(&mut content_key, file.file_id)?;
             content_key.extend_from_slice(&batch.format.to_le_bytes());
 
-            let page_bytes = batch
-                .pages
-                .iter()
-                .try_fold(0usize, |total, page| total.checked_add(4 + page.len()))
-                .ok_or_else(|| head_value_error("certified entity batch size overflowed"))?;
             let schema_bytes = batch
                 .schema_keys
                 .iter()
@@ -534,9 +534,9 @@ pub(crate) async fn stage_certified_entity_batches(
                     + 8
                     + 4
                     + 4
-                    + page_bytes,
+                    + batch.pages.len().saturating_mul(12),
             );
-            value.extend_from_slice(CERTIFIED_ENTITY_BATCH_MAGIC);
+            value.extend_from_slice(CERTIFIED_ENTITY_BATCH_MAGIC_V2);
             value.extend_from_slice(
                 &u16::try_from(batch.schema_keys.len())
                     .map_err(|_| head_value_error("certified batch has too many schemas"))?
@@ -557,13 +557,31 @@ pub(crate) async fn stage_certified_entity_batches(
                     .map_err(|_| head_value_error("certified entity batch has too many pages"))?
                     .to_le_bytes(),
             );
-            for page in &batch.pages {
+            for (page_index, page) in batch.pages.iter().enumerate() {
+                let (first_local_ref, last_local_ref) = if batch.format == 1 {
+                    certified_csv_page_local_ref_range(page)?
+                } else {
+                    (0, u32::MAX)
+                };
+                value.extend_from_slice(&first_local_ref.to_le_bytes());
+                value.extend_from_slice(&last_local_ref.to_le_bytes());
                 value.extend_from_slice(
                     &u32::try_from(page.len())
                         .map_err(|_| head_value_error("certified entity batch page exceeds 4GiB"))?
                         .to_le_bytes(),
                 );
-                value.extend_from_slice(page);
+                writes.put(
+                    CERTIFIED_ENTITY_BATCH_PAGE_SPACE,
+                    certified_entity_batch_page_key(
+                        &content_key,
+                        u32::try_from(page_index).map_err(|_| {
+                            head_value_error("certified entity batch has too many pages")
+                        })?,
+                    ),
+                    StorageValue {
+                        bytes: page.clone(),
+                    },
+                );
             }
             writes.put(
                 CERTIFIED_ENTITY_BATCH_SPACE,
@@ -596,6 +614,114 @@ fn append_batch_text(output: &mut Vec<u8>, value: &str) -> Result<(), LixError> 
     );
     output.extend_from_slice(value.as_bytes());
     Ok(())
+}
+
+fn certified_entity_batch_page_key(content_key: &[u8], page_index: u32) -> StorageKey {
+    let mut key = Vec::with_capacity(content_key.len() + 4);
+    key.extend_from_slice(content_key);
+    key.extend_from_slice(&page_index.to_be_bytes());
+    StorageKey(Bytes::from(key))
+}
+
+fn certified_csv_page_local_ref_range(page: &[u8]) -> Result<(u32, u32), LixError> {
+    let mut rows = CertifiedCsvReader {
+        bytes: page,
+        offset: 0,
+    };
+    let mut first = None;
+    let mut last = None;
+    while rows.offset < rows.bytes.len() {
+        let local_ref = rows.u32()?;
+        if last.is_some_and(|previous| previous >= local_ref) {
+            return Err(head_value_error(
+                "certified CSV page local refs are not strictly increasing",
+            ));
+        }
+        first.get_or_insert(local_ref);
+        last = Some(local_ref);
+        let _order_rank = rows.u64()?;
+        let _ending = rows.u8()?;
+        let quote_layout_len = rows.u32()? as usize;
+        let _quote_layout = rows.bytes(quote_layout_len)?;
+        let field_count = rows.u16()?;
+        for _ in 0..field_count {
+            let cell_len = rows.u32()? as usize;
+            let _cell = rows.bytes(cell_len)?;
+        }
+    }
+    first
+        .zip(last)
+        .ok_or_else(|| head_value_error("certified CSV page is empty"))
+}
+
+fn certified_external_page_plan(
+    bytes: &[u8],
+    content_key: &[u8],
+    request: &TrackedStateScanRequest,
+) -> Result<Option<Vec<(u32, StorageKey)>>, LixError> {
+    let mut input = CertifiedBatchReader::new(bytes)?;
+    if !input.external_pages {
+        return Ok(None);
+    }
+    let schema_count = input.u16()? as usize;
+    for _ in 0..schema_count {
+        let _schema = input.text()?;
+    }
+    let _file_id = input.text()?;
+    let _commit_id = input.bytes(16)?;
+    let _timestamp = input.text()?;
+    let format = input.u16()?;
+    let _declared_rows = input.u64()?;
+    let creates = WasmCreateContext {
+        high: input.u64()?,
+        low: input.u32()?,
+    };
+    let selected_local_refs = (format == 1 && !request.filter.entity_pks.is_empty()).then(|| {
+        let high = creates.high.to_be_bytes();
+        let low = creates.low.to_be_bytes();
+        request
+            .filter
+            .entity_pks
+            .iter()
+            .filter_map(|entity_pk| match entity_pk.components.as_slice() {
+                [crate::entity_pk::EntityPkComponent::Uuid(bytes)]
+                    if bytes[..8] == high && bytes[8..12] == low =>
+                {
+                    Some(u32::from_be_bytes(
+                        bytes[12..]
+                            .try_into()
+                            .expect("UUID local-reference suffix is four bytes"),
+                    ))
+                }
+                _ => None,
+            })
+            .collect::<BTreeSet<_>>()
+    });
+    let page_count = input.u32()?;
+    let mut pages = Vec::with_capacity(page_count as usize);
+    for page_index in 0..page_count {
+        let first_local_ref = input.u32()?;
+        let last_local_ref = input.u32()?;
+        let _page_len = input.u32()?;
+        let selected = selected_local_refs.as_ref().is_none_or(|local_refs| {
+            local_refs
+                .range(first_local_ref..=last_local_ref)
+                .next()
+                .is_some()
+        });
+        if selected {
+            pages.push((
+                page_index,
+                certified_entity_batch_page_key(content_key, page_index),
+            ));
+        }
+    }
+    if input.offset != input.bytes.len() {
+        return Err(head_value_error(
+            "certified entity batch header has trailing bytes",
+        ));
+    }
+    Ok(Some(pages))
 }
 
 async fn scan_certified_entity_batch_rows(
@@ -637,10 +763,35 @@ async fn scan_certified_entity_batch_rows(
     let mut builder = MaterializedLiveStateBatchBuilder::with_capacity(
         limit.unwrap_or_else(|| contents.len().saturating_mul(1024)),
     );
-    for value in contents.into_iter().flatten() {
+    for (content_key, value) in content_keys.into_iter().zip(contents) {
+        let Some(value) = value else {
+            continue;
+        };
         let value = full_value_bytes(value)?;
+        let external_plan = certified_external_page_plan(&value, content_key.0.as_ref(), request)?;
+        let external_pages = if let Some(plan) = &external_plan {
+            let keys = plan.iter().map(|(_, key)| key.clone()).collect::<Vec<_>>();
+            let values = PointReadPlan::new(CERTIFIED_ENTITY_BATCH_PAGE_SPACE, &keys)
+                .materialize(store, StorageGetOptions::default())
+                .await?
+                .value;
+            Some(
+                plan.iter()
+                    .zip(values)
+                    .map(|((page_index, _), value)| {
+                        let value = value.ok_or_else(|| {
+                            head_value_error("certified entity batch page is missing")
+                        })?;
+                        Ok((*page_index, full_value_bytes(value)?))
+                    })
+                    .collect::<Result<Vec<_>, LixError>>()?,
+            )
+        } else {
+            None
+        };
         decode_certified_entity_batch_rows(
             &value,
+            external_pages.as_deref(),
             branch_id,
             request,
             needs_snapshot,
@@ -709,8 +860,30 @@ pub(crate) async fn scan_certified_history_rows(
         if !commit_ids.contains(&certified_batch_commit_id(&value)?) {
             continue;
         }
+        let external_plan = certified_external_page_plan(&value, entry.key.0.as_ref(), request)?;
+        let external_pages = if let Some(plan) = &external_plan {
+            let keys = plan.iter().map(|(_, key)| key.clone()).collect::<Vec<_>>();
+            let values = PointReadPlan::new(CERTIFIED_ENTITY_BATCH_PAGE_SPACE, &keys)
+                .materialize(store, StorageGetOptions::default())
+                .await?
+                .value;
+            Some(
+                plan.iter()
+                    .zip(values)
+                    .map(|((page_index, _), value)| {
+                        let value = value.ok_or_else(|| {
+                            head_value_error("certified history batch page is missing")
+                        })?;
+                        Ok((*page_index, full_value_bytes(value)?))
+                    })
+                    .collect::<Result<Vec<_>, LixError>>()?,
+            )
+        } else {
+            None
+        };
         decode_certified_entity_batch_rows(
             &value,
+            external_pages.as_deref(),
             "",
             request,
             needs_snapshot,
@@ -736,6 +909,7 @@ fn certified_batch_commit_id(bytes: &[u8]) -> Result<CommitId, LixError> {
 
 fn decode_certified_entity_batch_rows(
     bytes: &[u8],
+    external_pages: Option<&[(u32, Bytes)]>,
     branch_id: &str,
     request: &TrackedStateScanRequest,
     needs_snapshot: bool,
@@ -792,10 +966,32 @@ fn decode_certified_entity_batch_rows(
         return Ok(());
     }
 
+    let complete_pages = !input.external_pages
+        || external_pages.is_some_and(|pages| pages.len() == page_count as usize);
     let mut decoded_rows = 0_u64;
-    for _ in 0..page_count {
-        let page_len = input.u32()? as usize;
-        let page = input.bytes(page_len)?;
+    for page_index in 0..page_count {
+        let page = if input.external_pages {
+            let _first_local_ref = input.u32()?;
+            let _last_local_ref = input.u32()?;
+            let page_len = input.u32()? as usize;
+            let Some((_, page)) = external_pages.and_then(|pages| {
+                pages
+                    .binary_search_by_key(&page_index, |(page_index, _)| *page_index)
+                    .ok()
+                    .map(|index| &pages[index])
+            }) else {
+                continue;
+            };
+            if page.len() != page_len {
+                return Err(head_value_error(
+                    "certified entity batch page length does not match its header",
+                ));
+            }
+            page.as_ref()
+        } else {
+            let page_len = input.u32()? as usize;
+            input.bytes(page_len)?
+        };
         if format == 2 {
             decoded_rows = decoded_rows.saturating_add(decode_certified_packet_rows(
                 page,
@@ -926,7 +1122,7 @@ fn decode_certified_entity_batch_rows(
             }
         }
     }
-    if decoded_rows != declared_rows {
+    if complete_pages && decoded_rows != declared_rows {
         return Err(head_value_error(format!(
             "certified entity batch declared {declared_rows} rows but decoded {decoded_rows}"
         )));
@@ -1099,14 +1295,23 @@ fn decode_certified_packet_rows(
 struct CertifiedBatchReader<'a> {
     bytes: &'a [u8],
     offset: usize,
+    external_pages: bool,
 }
 
 impl<'a> CertifiedBatchReader<'a> {
     fn new(bytes: &'a [u8]) -> Result<Self, LixError> {
-        if !bytes.starts_with(CERTIFIED_ENTITY_BATCH_MAGIC) {
+        let external_pages = if bytes.starts_with(CERTIFIED_ENTITY_BATCH_MAGIC_V1) {
+            false
+        } else if bytes.starts_with(CERTIFIED_ENTITY_BATCH_MAGIC_V2) {
+            true
+        } else {
             return Err(head_value_error("invalid certified entity batch magic"));
-        }
-        Ok(Self { bytes, offset: 4 })
+        };
+        Ok(Self {
+            bytes,
+            offset: 4,
+            external_pages,
+        })
     }
 
     fn bytes(&mut self, length: usize) -> Result<&'a [u8], LixError> {

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -1595,7 +1595,7 @@ where
         plugin: &PluginRegistryEntry,
         changes: WasmHostEntityChanges,
         file_key: &PluginFileWriteKey,
-    ) -> Result<WasmHostEntityChanges, LixError> {
+    ) -> Result<(WasmHostEntityChanges, BTreeSet<WasmEntityKey>), LixError> {
         let format_only_keys = changes
             .changes
             .iter()
@@ -1610,7 +1610,7 @@ where
             })
             .collect::<Vec<_>>();
         if format_only_keys.is_empty() {
-            return Ok(changes);
+            return Ok((changes, BTreeSet::new()));
         }
 
         let requests = format_only_keys
@@ -1632,7 +1632,16 @@ where
                 include_tombstones: false,
             })
             .await?;
-        suppress_v2_format_only_noops_against_batch(changes, &format_only_keys, &current)
+        let observed_existing = format_only_keys
+            .iter()
+            .enumerate()
+            .filter(|(slot, _)| current.row(*slot).is_some())
+            .map(|(_, key)| key.clone())
+            .collect();
+        Ok((
+            suppress_v2_format_only_noops_against_batch(changes, &format_only_keys, &current)?,
+            observed_existing,
+        ))
     }
 
     /// Materializes keyless creates and returns the one durable mutation
@@ -1645,8 +1654,14 @@ where
         bound: BoundCreateContext,
         file_key: &PluginFileWriteKey,
         existing_reservation: Option<&MaterializedLiveStateRow>,
+        known_existing_authorities: Option<&BTreeSet<WasmEntityKey>>,
     ) -> Result<RawWriteBatch, LixError> {
-        let validation = validate_create_changes(plugin, changes)?;
+        let mut validation = validate_create_changes(plugin, changes)?;
+        if let Some(known) = known_existing_authorities {
+            validation
+                .existing_authorities
+                .retain(|key| !known.contains(key));
+        }
         materialize_keyless_creates(changes, bound.creates())?;
         if !validation.requires_reservation && validation.existing_authorities.is_empty() {
             return Ok(RawWriteBatch::new());
@@ -3439,6 +3454,7 @@ where
                         pending.create_context,
                         &pending.file_key,
                         pending.existing_create_reservation.as_ref(),
+                        None,
                     )
                     .await?;
                 let mut counters = validated.counters;
@@ -3820,7 +3836,7 @@ where
                 write.set_certified_entity_batches(detected_transition.certified_batches.clone());
                 let detection_document = detected_transition.document;
                 let mut counters = detected_transition.counters;
-                let mut changes = match self
+                let (mut changes, observed_existing_authorities) = match self
                     .suppress_v2_format_only_noops(selected, detected_transition.changes, &file_key)
                     .instrument(tracing::debug_span!(
                         target: "lix_perf",
@@ -3845,6 +3861,7 @@ where
                         create_context,
                         &file_key,
                         existing_create_reservation.as_ref(),
+                        Some(&observed_existing_authorities),
                     )
                     .instrument(tracing::debug_span!(
                         target: "lix_perf",
@@ -4025,6 +4042,7 @@ where
                         create_context,
                         &file_key,
                         existing_create_reservation.as_ref(),
+                        None,
                     )
                     .instrument(tracing::debug_span!(
                         target: "lix_perf",


### PR DESCRIPTION
## What changed

- store certified entity batches as independently addressable immutable pages
- index monotonic keyless packet-create pages by their local-reference range
- select only overlapping packet pages for exact namespace-UUID reads
- insert generated create IDs directly into canonical JSON bytes instead of materializing a `serde_json::Value` tree
- reuse the exact authority proof already obtained while suppressing format-only no-ops

Keyed or mixed packet pages remain conservatively unindexed, so the optimization does not weaken validation.

## Why

Sparse plugin successors were reading and decoding complete certified batches even when they addressed one exact entity. Created snapshots also paid for a full JSON value tree solely to insert the host-generated ID, and reconciliation repeated an exact authority read that had already proved the same entity existed.

These changes keep the storage and validation semantics intact while removing those redundant reads and materializations. They are engine-level improvements and do not depend on plugin API v3.

## Prototype measurements

Measured on the 1.24 MB VS Code Markdown exact-transition workload during the v3 runtime profile:

- packet page range selection: about 49.2 ms to 35.4 ms, with cumulative host allocation from 109.9 MB to 93.8 MB
- direct canonical-ID insertion: cumulative host allocation from 93.8 MB to 54.2 MB and peak live allocation from 17.0 MB to 12.9 MB
- authority-proof reuse: create validation phase from about 2.5 ms to 0.45 ms; full transition p50 from about 34.0 ms to 30.3 ms

The branch was rebased onto `origin/main` after #972, #973, and #974 merged. No conflict resolution or measured code changed, so the existing measurements remain applicable.

## Validation

- `cargo fmt --all`
- `cargo check --release -p lix_engine`
- `cargo test --release -p lix_engine --lib created_id_is_inserted_without_materializing_canonical_json`
- `cargo test --release -p lix_engine --lib create_only_packet_pages_expose_their_local_ref_range`
- full release lib suite: 1,562 passed, 6 ignored; 3 unrelated content-address verification tests fail independently and this branch has no diff in those paths
