### PR TITLE
perf(engine): delete collections with generation facts

### DIFF
--- a/.changenotes/collection-generation-deletes.md
+++ b/.changenotes/collection-generation-deletes.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Whole-entity-table deletion now records one tracked collection-generation fact instead of expanding the operation into one tombstone per row.

--- a/packages/engine/src/collection_generation.rs
+++ b/packages/engine/src/collection_generation.rs
@@ -1,0 +1,95 @@
+use serde_json::json;
+
+use crate::LixError;
+use crate::changelog::CommitId;
+use crate::common::SharedStr;
+use crate::entity_pk::EntityPk;
+use crate::transaction::types::{TransactionJson, TransactionWriteRow};
+
+pub(crate) const COLLECTION_GENERATION_SCHEMA_KEY: &str = "lix_collection_generation";
+
+/// One logical collection whose current physical generation can be replaced
+/// without expanding the replacement into one tombstone per member.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct CollectionScopeRef<'a> {
+    pub(crate) schema_key: &'a str,
+    pub(crate) file_id: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CollectionGeneration {
+    pub(crate) active_generation: CommitId,
+    pub(crate) live_count: u64,
+}
+
+pub(crate) fn collection_scope_key(scope: CollectionScopeRef<'_>) -> String {
+    serde_json::to_string(&(scope.schema_key, scope.file_id))
+        .expect("serializing a collection scope tuple cannot fail")
+}
+
+pub(crate) fn collection_scope_from_entity_pk(
+    entity_pk: &EntityPk,
+) -> Result<(String, Option<String>), LixError> {
+    let scope_key = entity_pk.as_single_string()?;
+    serde_json::from_str(scope_key).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("collection-generation scope identity is malformed: {error}"),
+        )
+    })
+}
+
+pub(crate) fn collection_delete_stage_row(
+    branch_id: &str,
+    scope: CollectionScopeRef<'_>,
+) -> TransactionWriteRow {
+    TransactionWriteRow {
+        entity_pk: None,
+        schema_key: SharedStr::from_static(COLLECTION_GENERATION_SCHEMA_KEY),
+        file_id: None,
+        snapshot: Some(TransactionJson::from_value_unchecked(json!({
+            "scope_key": collection_scope_key(scope),
+            "schema_key": scope.schema_key,
+            "file_id": scope.file_id,
+            "live_count": 0,
+        }))),
+        metadata: None,
+        origin: None,
+        created_at: None,
+        updated_at: None,
+        global: false,
+        change_id: None,
+        commit_id: None,
+        untracked: false,
+        branch_id: branch_id.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stage_row_is_one_branch_local_negative_fact() {
+        let row = collection_delete_stage_row(
+            "01920000-0000-7000-8000-0000000000a1",
+            CollectionScopeRef {
+                schema_key: "json_pointer",
+                file_id: None,
+            },
+        );
+
+        assert_eq!(row.schema_key, COLLECTION_GENERATION_SCHEMA_KEY);
+        assert_eq!(row.file_id, None);
+        assert!(!row.global);
+        assert_eq!(
+            row.snapshot.as_ref().expect("marker snapshot").value(),
+            &json!({
+                "schema_key": "json_pointer",
+                "scope_key": "[\"json_pointer\",null]",
+                "file_id": null,
+                "live_count": 0,
+            })
+        );
+    }
+}

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -33,6 +33,7 @@ pub(crate) mod cel;
 #[allow(unused_imports)]
 pub mod changelog;
 pub(crate) mod checkpoint;
+pub(crate) mod collection_generation;
 pub(crate) mod commit_graph;
 mod common;
 pub(crate) mod compression;

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -30,6 +30,7 @@ use super::*;
 pub(crate) const HOT_ROW_NAMESPACE: &str = "live_state.hot_row.v17";
 pub(crate) const HOT_FILE_NAMESPACE: &str = "live_state.hot_file_schema.v18";
 pub(crate) const HOT_DIFF_NAMESPACE: &str = "live_state.hot_diff.v17";
+pub(crate) const HOT_COLLECTION_CONTROL_NAMESPACE: &str = "live_state.hot_collection_control.v1";
 pub(crate) const HOT_ROW_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_001b), HOT_ROW_NAMESPACE);
 /// Conservative `(branch, generation, schema)` file-membership markers.
@@ -42,6 +43,10 @@ pub(crate) const HOT_FILE_SPACE: StorageSpace =
 /// Reserved for the row-level first-before working-diff index.
 pub(crate) const HOT_DIFF_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_001d), HOT_DIFF_NAMESPACE);
+pub(crate) const HOT_COLLECTION_CONTROL_SPACE: StorageSpace = StorageSpace::new(
+    StorageSpaceId(0x0004_0023),
+    HOT_COLLECTION_CONTROL_NAMESPACE,
+);
 const HOT_DENSE_SCAN_MIN_IDENTITIES: usize = 64;
 const HOT_DENSE_SCAN_MAX_OVERREAD: usize = 2;
 const HOT_DIFF_SEGMENT_VERSION: u8 = 1;
@@ -1573,6 +1578,359 @@ impl<'a> CertifiedCsvReader<'a> {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+struct HotCollectionControl {
+    active_generation: CommitId,
+    live_count: u64,
+}
+
+fn hot_collection_control_key(
+    branch_id: &str,
+    branch_generation: CommitId,
+    scope: crate::collection_generation::CollectionScopeRef<'_>,
+) -> Vec<u8> {
+    let mut key = hot_scope_prefix(branch_id, branch_generation);
+    write_key_string(&mut key, scope.schema_key, KEY_PART_FINAL);
+    write_file_id(&mut key, scope.file_id);
+    key
+}
+
+async fn load_hot_collection_control(
+    store: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    branch_generation: CommitId,
+    scope: crate::collection_generation::CollectionScopeRef<'_>,
+) -> Result<HotCollectionControl, LixError> {
+    let key = StorageKey(Bytes::from(hot_collection_control_key(
+        branch_id,
+        branch_generation,
+        scope,
+    )));
+    let value = PointReadPlan::new(HOT_COLLECTION_CONTROL_SPACE, &[key])
+        .materialize(store, StorageGetOptions::default())
+        .await?
+        .value
+        .into_iter()
+        .next()
+        .flatten();
+    value.map_or(
+        Ok(HotCollectionControl {
+            active_generation: branch_generation,
+            live_count: 0,
+        }),
+        |value| {
+            let StorageProjectedValue::FullValue(bytes) = value else {
+                return Err(head_value_error(
+                    "hot collection-control read unexpectedly omitted its value",
+                ));
+            };
+            storage_codec::decode("hot collection control", &bytes)
+        },
+    )
+}
+
+async fn load_hot_collection_controls(
+    store: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    branch_generation: CommitId,
+    scopes: &[crate::collection_generation::CollectionScopeRef<'_>],
+) -> Result<Vec<HotCollectionControl>, LixError> {
+    if scopes.is_empty() {
+        return Ok(Vec::new());
+    }
+    let keys = scopes
+        .iter()
+        .copied()
+        .map(|scope| {
+            StorageKey(Bytes::from(hot_collection_control_key(
+                branch_id,
+                branch_generation,
+                scope,
+            )))
+        })
+        .collect::<Vec<_>>();
+    PointReadPlan::new(HOT_COLLECTION_CONTROL_SPACE, &keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?
+        .value
+        .into_iter()
+        .map(|value| {
+            value.map_or(
+                Ok(HotCollectionControl {
+                    active_generation: branch_generation,
+                    live_count: 0,
+                }),
+                |value| {
+                    let StorageProjectedValue::FullValue(bytes) = value else {
+                        return Err(head_value_error(
+                            "hot collection-control batch read unexpectedly omitted its value",
+                        ));
+                    };
+                    storage_codec::decode("hot collection control", &bytes)
+                },
+            )
+        })
+        .collect()
+}
+
+fn stage_hot_collection_control(
+    writes: &mut StorageWriteSet,
+    branch_id: &str,
+    branch_generation: CommitId,
+    scope: crate::collection_generation::CollectionScopeRef<'_>,
+    control: HotCollectionControl,
+) -> Result<(), LixError> {
+    writes.put(
+        HOT_COLLECTION_CONTROL_SPACE,
+        StorageKey(Bytes::from(hot_collection_control_key(
+            branch_id,
+            branch_generation,
+            scope,
+        ))),
+        StorageValue {
+            bytes: Bytes::from(storage_codec::encode("hot collection control", &control)?),
+        },
+    );
+    Ok(())
+}
+
+async fn load_incremental_collection_controls(
+    store: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    branch_generation: CommitId,
+    deltas: &[&CurrentStateDeltaRef<'_>],
+) -> Result<BTreeMap<(String, Option<String>), HotCollectionControl>, LixError> {
+    use crate::collection_generation::{
+        COLLECTION_GENERATION_SCHEMA_KEY, CollectionScopeRef, collection_scope_from_entity_pk,
+    };
+
+    let mut owned_scopes = BTreeSet::<(String, Option<String>)>::new();
+    for delta in deltas {
+        if delta.schema_key == COLLECTION_GENERATION_SCHEMA_KEY {
+            owned_scopes.insert(collection_scope_from_entity_pk(delta.entity_pk)?);
+            continue;
+        }
+        owned_scopes.insert((delta.schema_key.to_string(), None));
+        if let Some(file_id) = delta.file_id {
+            owned_scopes.insert((delta.schema_key.to_string(), Some(file_id.to_string())));
+        }
+    }
+    if owned_scopes.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+    let scopes = owned_scopes
+        .iter()
+        .map(|(schema_key, file_id)| CollectionScopeRef {
+            schema_key,
+            file_id: file_id.as_deref(),
+        })
+        .collect::<Vec<_>>();
+    let controls =
+        load_hot_collection_controls(store, branch_id, branch_generation, &scopes).await?;
+    Ok(scopes
+        .iter()
+        .copied()
+        .zip(controls)
+        .map(|(scope, control)| {
+            (
+                (
+                    scope.schema_key.to_string(),
+                    scope.file_id.map(str::to_string),
+                ),
+                control,
+            )
+        })
+        .collect())
+}
+
+fn stage_incremental_collection_controls(
+    writes: &mut StorageWriteSet,
+    branch_id: &str,
+    branch_generation: CommitId,
+    deltas: &[&CurrentStateDeltaRef<'_>],
+    previous_values: &[Option<Bytes>],
+    mut controls: BTreeMap<(String, Option<String>), HotCollectionControl>,
+) -> Result<(), LixError> {
+    use crate::collection_generation::{
+        COLLECTION_GENERATION_SCHEMA_KEY, CollectionScopeRef, collection_scope_from_entity_pk,
+    };
+    for (delta, previous) in deltas.iter().zip(previous_values) {
+        if delta.schema_key == COLLECTION_GENERATION_SCHEMA_KEY {
+            let scope = collection_scope_from_entity_pk(delta.entity_pk)?;
+            let control = controls
+                .get_mut(&scope)
+                .expect("collection marker target was loaded above");
+            if delta.deleted {
+                return Err(head_value_error(
+                    "collection-generation controls cannot be tombstoned",
+                ));
+            }
+            control.active_generation = delta.commit_id.ok_or_else(|| {
+                head_value_error("tracked collection-generation row lacks commit_id")
+            })?;
+            control.live_count = 0;
+            continue;
+        }
+
+        let previous_live = previous
+            .as_deref()
+            .map(decode_head_value)
+            .transpose()?
+            .is_some_and(|value| !value.deleted);
+        let schema_control = controls
+            .get(&(delta.schema_key.to_string(), None))
+            .expect("row schema collection scope was loaded above");
+        let belongs_to_active_generation = schema_control.active_generation == branch_generation
+            || delta
+                .commit_id
+                .is_some_and(|commit_id| commit_id > schema_control.active_generation);
+        let next_live = !delta.deleted && belongs_to_active_generation;
+        if previous_live == next_live {
+            continue;
+        }
+        for scope in [
+            Some((delta.schema_key.to_string(), None)),
+            delta
+                .file_id
+                .map(|file_id| (delta.schema_key.to_string(), Some(file_id.to_string()))),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            let control = controls
+                .get_mut(&scope)
+                .expect("row collection scope was loaded above");
+            control.live_count = if next_live {
+                control
+                    .live_count
+                    .checked_add(1)
+                    .ok_or_else(|| head_value_error("hot collection live count exceeds u64"))?
+            } else {
+                control
+                    .live_count
+                    .checked_sub(1)
+                    .ok_or_else(|| head_value_error("hot collection live count underflow"))?
+            };
+        }
+    }
+
+    for ((schema_key, file_id), control) in controls {
+        stage_hot_collection_control(
+            writes,
+            branch_id,
+            branch_generation,
+            CollectionScopeRef {
+                schema_key: &schema_key,
+                file_id: file_id.as_deref(),
+            },
+            control,
+        )?;
+    }
+    Ok(())
+}
+
+fn stage_complete_collection_controls(
+    writes: &mut StorageWriteSet,
+    branch_id: &str,
+    branch_generation: CommitId,
+    rows: &HotRowMap,
+) -> Result<(), LixError> {
+    use crate::collection_generation::{
+        COLLECTION_GENERATION_SCHEMA_KEY, CollectionScopeRef, collection_scope_from_entity_pk,
+    };
+
+    let mut controls = BTreeMap::<(String, Option<String>), HotCollectionControl>::new();
+    for (identity, bytes) in rows {
+        if identity.schema_key == COLLECTION_GENERATION_SCHEMA_KEY {
+            let target = collection_scope_from_entity_pk(&identity.entity_pk)?;
+            let marker = decode_head_value(bytes)?;
+            let active_generation = marker.commit_id.ok_or_else(|| {
+                head_value_error("tracked collection-generation row lacks commit_id")
+            })?;
+            controls.insert(
+                target,
+                HotCollectionControl {
+                    active_generation,
+                    live_count: 0,
+                },
+            );
+            continue;
+        }
+        controls
+            .entry((identity.schema_key.clone(), None))
+            .or_insert(HotCollectionControl {
+                active_generation: branch_generation,
+                live_count: 0,
+            });
+        if let Some(file_id) = &identity.file_id {
+            controls
+                .entry((identity.schema_key.clone(), Some(file_id.clone())))
+                .or_insert(HotCollectionControl {
+                    active_generation: branch_generation,
+                    live_count: 0,
+                });
+        }
+    }
+
+    for (identity, bytes) in rows {
+        if identity.schema_key == COLLECTION_GENERATION_SCHEMA_KEY {
+            continue;
+        }
+        let value = decode_head_value(bytes)?;
+        if value.deleted {
+            continue;
+        }
+        let schema_scope = (identity.schema_key.clone(), None);
+        let schema_control = controls
+            .get(&schema_scope)
+            .expect("complete row schema control was initialized above");
+        let visible_after_schema_generation = schema_control.active_generation == branch_generation
+            || value
+                .commit_id
+                .is_some_and(|commit_id| commit_id > schema_control.active_generation);
+        let file_scope = identity
+            .file_id
+            .as_ref()
+            .map(|file_id| (identity.schema_key.clone(), Some(file_id.clone())));
+        let visible_after_file_generation = file_scope
+            .as_ref()
+            .and_then(|scope| controls.get(scope))
+            .is_none_or(|control| {
+                control.active_generation == branch_generation
+                    || value
+                        .commit_id
+                        .is_some_and(|commit_id| commit_id > control.active_generation)
+            });
+        if !visible_after_schema_generation || !visible_after_file_generation {
+            continue;
+        }
+        for scope in [Some(schema_scope), file_scope].into_iter().flatten() {
+            let control = controls
+                .get_mut(&scope)
+                .expect("complete row collection control was initialized above");
+            control.live_count = control
+                .live_count
+                .checked_add(1)
+                .ok_or_else(|| head_value_error("hot collection live count exceeds u64"))?;
+        }
+    }
+
+    for ((schema_key, file_id), control) in controls {
+        stage_hot_collection_control(
+            writes,
+            branch_id,
+            branch_generation,
+            CollectionScopeRef {
+                schema_key: &schema_key,
+                file_id: file_id.as_deref(),
+            },
+            control,
+        )?;
+    }
+    Ok(())
+}
+
 /// Direct reader for one published hot generation.
 pub(crate) struct HotStateStoreReader<S> {
     pub(super) store: S,
@@ -1582,6 +1940,22 @@ impl<S> HotStateStoreReader<S>
 where
     S: StorageAdapterRead,
 {
+    pub(crate) async fn collection_generation(
+        &self,
+        branch_id: &str,
+        branch_generation: CommitId,
+        scope: crate::collection_generation::CollectionScopeRef<'_>,
+    ) -> Result<crate::collection_generation::CollectionGeneration, LixError> {
+        load_hot_collection_control(&self.store, branch_id, branch_generation, scope)
+            .await
+            .map(
+                |control| crate::collection_generation::CollectionGeneration {
+                    active_generation: control.active_generation,
+                    live_count: control.live_count,
+                },
+            )
+    }
+
     pub(crate) async fn scan_live_batch(
         &self,
         branch_id: &str,
@@ -1714,6 +2088,30 @@ where
         generation: CommitId,
         request: &TrackedStateScanRequest,
     ) -> Result<MaterializedLiveStateBatch, LixError> {
+        let collection_control = match request.filter.schema_keys.as_slice() {
+            [schema_key]
+                if schema_key != crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY =>
+            {
+                Some(
+                    load_hot_collection_control(
+                        &self.store,
+                        branch_id,
+                        generation,
+                        crate::collection_generation::CollectionScopeRef {
+                            schema_key,
+                            file_id: None,
+                        },
+                    )
+                    .await?,
+                )
+            }
+            _ => None,
+        };
+        let replaced_generation =
+            collection_control.filter(|control| control.active_generation != generation);
+        if replaced_generation.is_some_and(|control| control.live_count == 0) {
+            return Ok(MaterializedLiveStateBatch::default());
+        }
         // A storage prefix is ordered by identity, but tombstones are filtered
         // only after decoding the value. Applying SQL LIMIT to the raw scan
         // would therefore let one tombstone hide a later live row.
@@ -1765,11 +2163,20 @@ where
             combined.extend(certified_rows.into_rows());
             MaterializedLiveStateBatch::from_rows(combined)
         };
-        if request.filter.include_tombstones && request.limit.is_none() {
+        if request.filter.include_tombstones
+            && request.limit.is_none()
+            && replaced_generation.is_none()
+        {
             return Ok(rows);
         }
         Ok(rows.filter(
-            |row| request.filter.include_tombstones || !row.deleted(),
+            |row| {
+                let in_active_generation = replaced_generation.is_none_or(|control| {
+                    row.commit_id()
+                        .is_some_and(|commit_id| commit_id > control.active_generation)
+                });
+                in_active_generation && (request.filter.include_tombstones || !row.deleted())
+            },
             request.limit,
         ))
     }
@@ -1855,7 +2262,52 @@ where
         if keys.is_empty() {
             return Ok(MaterializedLiveStateExactBatch::default());
         }
-        let values = hot_load_identity_ref_bytes(&self.store, branch_id, generation, keys).await?;
+        let replaced_generation = keys
+            .first()
+            .filter(|first| keys.iter().all(|key| key.schema_key == first.schema_key))
+            .filter(|first| {
+                first.schema_key != crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY
+            })
+            .map(|first| async {
+                load_hot_collection_control(
+                    &self.store,
+                    branch_id,
+                    generation,
+                    crate::collection_generation::CollectionScopeRef {
+                        schema_key: first.schema_key,
+                        file_id: None,
+                    },
+                )
+                .await
+            });
+        let replaced_generation = match replaced_generation {
+            Some(control) => {
+                let control = control.await?;
+                (control.active_generation != generation).then_some(control)
+            }
+            None => None,
+        };
+        if replaced_generation.is_some_and(|control| control.live_count == 0) {
+            return MaterializedLiveStateExactBatch::new(
+                MaterializedLiveStateBatch::default(),
+                vec![None; keys.len()],
+            );
+        }
+        let mut values =
+            hot_load_identity_ref_bytes(&self.store, branch_id, generation, keys).await?;
+        if let Some(control) = replaced_generation {
+            for value in &mut values {
+                let visible = value
+                    .as_deref()
+                    .map(decode_head_value)
+                    .transpose()?
+                    .and_then(|value| value.commit_id)
+                    .is_some_and(|commit_id| commit_id > control.active_generation);
+                if !visible {
+                    *value = None;
+                }
+            }
+        }
         let mut slots = Vec::with_capacity(values.len());
         let mut entries = Vec::with_capacity(values.iter().flatten().count());
         for (identity, value) in keys.iter().copied().zip(values) {
@@ -1870,7 +2322,9 @@ where
         if slots.iter().all(Option::is_some) {
             return MaterializedLiveStateExactBatch::new(rows, slots);
         }
-        if keys.iter().all(|key| key.schema_key.starts_with("lix_")) {
+        if replaced_generation.is_some()
+            || keys.iter().all(|key| key.schema_key.starts_with("lix_"))
+        {
             return MaterializedLiveStateExactBatch::new(rows, slots);
         }
 
@@ -2032,6 +2486,21 @@ where
         if matches!(limit, Some(0)) {
             return Ok(Vec::new());
         }
+        let collection_control = load_hot_collection_control(
+            &self.store,
+            branch_id,
+            generation,
+            crate::collection_generation::CollectionScopeRef {
+                schema_key,
+                file_id: None,
+            },
+        )
+        .await?;
+        let replaced_generation =
+            (collection_control.active_generation != generation).then_some(collection_control);
+        if replaced_generation.is_some_and(|control| control.live_count == 0) {
+            return Ok(Vec::new());
+        }
         let use_finite_batch = !entity_pks.is_empty()
             && !hot_schema_has_file_member(&self.store, branch_id, generation, schema_key).await?;
         let fallback_filter = (!use_finite_batch).then(|| TrackedStateFilter {
@@ -2069,7 +2538,13 @@ where
         let mut deferred = Vec::new();
         for bytes in hot_scan_values_in_logical_order(entries) {
             let value = decode_head_value(&bytes)?;
-            if value.deleted {
+            if value.deleted
+                || replaced_generation.is_some_and(|control| {
+                    value
+                        .commit_id
+                        .is_none_or(|commit_id| commit_id <= control.active_generation)
+                })
+            {
                 continue;
             }
             let row_index = snapshots.len();
@@ -2448,7 +2923,7 @@ where
         ))
         .await?;
         let mut loaded_previous_values = loaded_previous_values.into_iter();
-        let previous_values = sorted
+        let mut previous_values = sorted
             .iter()
             .map(|delta| {
                 if hot_delta_is_guarded_by_absent_file(
@@ -2465,6 +2940,30 @@ where
             })
             .collect::<Vec<_>>();
         debug_assert_eq!(loaded_previous_values.len(), 0);
+        let collection_controls =
+            load_incremental_collection_controls(self.store, branch_id, generation, &sorted)
+                .await?;
+        for (delta, previous) in sorted.iter().zip(&mut previous_values) {
+            if delta.schema_key == crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY {
+                continue;
+            }
+            let Some(control) = collection_controls.get(&(delta.schema_key.to_string(), None))
+            else {
+                continue;
+            };
+            if control.active_generation == generation {
+                continue;
+            }
+            let belongs_to_retired_generation = previous
+                .as_deref()
+                .map(decode_head_value)
+                .transpose()?
+                .and_then(|value| value.commit_id)
+                .is_none_or(|commit_id| commit_id <= control.active_generation);
+            if belongs_to_retired_generation {
+                *previous = None;
+            }
+        }
         let mut created_ats = Vec::with_capacity(sorted.len());
         let mut retired_untracked_json_refs = BTreeSet::new();
         for (delta, previous) in sorted.iter().zip(&previous_values) {
@@ -2612,6 +3111,14 @@ where
             }
         }
         let next_value_bytes = Bytes::from(next_value_bytes);
+        stage_incremental_collection_controls(
+            self.writes,
+            branch_id,
+            generation,
+            &sorted,
+            &previous_values,
+            collection_controls,
+        )?;
 
         let _stage_span = tracing::debug_span!(
             target: "lix_perf",
@@ -2720,6 +3227,7 @@ where
             }
         }
 
+        stage_complete_collection_controls(self.writes, branch_id, generation, &rows)?;
         stage_complete_hot_rows(self.writes, branch_id, generation, rows);
         JsonStoreWriter::stage_untracked_reclaim_candidates(
             self.writes,
@@ -3919,6 +4427,7 @@ fn stage_hot_bootstrap(
             );
         }
     }
+    stage_complete_collection_controls(writes, branch_id, generation, &rows)?;
     stage_complete_hot_rows(writes, branch_id, generation, rows);
     JsonStoreWriter::stage_untracked_reclaim_candidates(
         writes,
@@ -5740,10 +6249,60 @@ where
         &mut stale_untracked_refs,
     )
     .await?;
+    stage_collect_stale_hot_collection_controls(store, writes, &active).await?;
     Ok(stale_untracked_refs
         .into_iter()
         .map(JsonRef::from_hash_bytes)
         .collect())
+}
+
+fn decode_hot_collection_control_scope(bytes: &[u8]) -> Result<(String, CommitId), LixError> {
+    let mut offset = 0;
+    let (branch_id, branch_terminator) = read_key_string(bytes, &mut offset, "branch id")?;
+    if branch_terminator != KEY_PART_FINAL {
+        return Err(key_codec_error(
+            "hot collection-control branch id has an invalid terminator",
+        ));
+    }
+    let generation = read_generation(bytes, &mut offset)?;
+    Ok((branch_id, generation))
+}
+
+async fn stage_collect_stale_hot_collection_controls(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    active: &BTreeSet<(String, CommitId)>,
+) -> Result<(), LixError> {
+    let plan = ScanPlan::prefix(
+        HOT_COLLECTION_CONTROL_SPACE,
+        StoragePrefix {
+            bytes: Bytes::new(),
+        },
+    );
+    let mut resume_after = None;
+    loop {
+        let page = plan
+            .collect(
+                store,
+                StorageScanOptions {
+                    resume_after: resume_after.clone(),
+                    ..StorageScanOptions::default()
+                },
+            )
+            .await?;
+        resume_after = page.value.entries.last().map(|entry| entry.key.clone());
+        for entry in page.value.entries {
+            let keep = decode_hot_collection_control_scope(entry.key.0.as_ref())
+                .is_ok_and(|scope| active.contains(&scope));
+            if !keep {
+                writes.delete(HOT_COLLECTION_CONTROL_SPACE, entry.key);
+            }
+        }
+        if !page.value.has_more || resume_after.is_none() {
+            break;
+        }
+    }
+    Ok(())
 }
 
 async fn stage_collect_stale_hot_space(

--- a/packages/engine/src/live_state/visibility.rs
+++ b/packages/engine/src/live_state/visibility.rs
@@ -35,6 +35,19 @@ pub(crate) trait StagedLiveStateRows {
         &self,
         request: &LiveStateExactBatchRequest,
     ) -> Result<MaterializedLiveStateExactBatch, LixError>;
+
+    /// Whether this transaction has replaced the requested collection with a
+    /// generation marker. Collection replacement suppresses committed members
+    /// without expanding them into staged row tombstones.
+    fn collection_replaced(
+        &self,
+        branch_id: &str,
+        schema_key: &str,
+        file_id: Option<&str>,
+    ) -> Result<bool, LixError> {
+        let _ = (branch_id, schema_key, file_id);
+        Ok(false)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -88,6 +101,20 @@ pub(crate) async fn overlay_scan_batch<S>(
 where
     S: StagedLiveStateRows + ?Sized,
 {
+    if let [schema_key] = request.filter.schema_keys.as_slice()
+        && request
+            .filter
+            .branch_ids
+            .iter()
+            .filter(|branch_id| branch_id.as_str() != GLOBAL_BRANCH_ID)
+            .try_fold(false, |replaced, branch_id| {
+                Ok::<_, LixError>(
+                    replaced || staged.collection_replaced(branch_id, schema_key, None)?,
+                )
+            })?
+    {
+        return Ok(MaterializedLiveStateBatch::default());
+    }
     let mut candidate_request = request.clone();
     candidate_request.limit = None;
     candidate_request.filter.include_tombstones = true;
@@ -205,6 +232,16 @@ where
     for (slot, (requested, (global_index, branch_index))) in
         request.rows.iter().zip(staged_indices).enumerate()
     {
+        if requested.branch_id != GLOBAL_BRANCH_ID
+            && staged.collection_replaced(
+                &requested.branch_id,
+                &requested.schema_key,
+                requested.file_id.as_deref(),
+            )?
+        {
+            slots.push(None);
+            continue;
+        }
         let mut winner = base_rows.row(slot).map(|row| {
             let tier = if row.global() {
                 OverlayTier::BaseGlobal

--- a/packages/engine/src/live_state/visibility.rs
+++ b/packages/engine/src/live_state/visibility.rs
@@ -101,24 +101,25 @@ pub(crate) async fn overlay_scan_batch<S>(
 where
     S: StagedLiveStateRows + ?Sized,
 {
-    if let [schema_key] = request.filter.schema_keys.as_slice()
-        && request
-            .filter
-            .branch_ids
-            .iter()
-            .filter(|branch_id| branch_id.as_str() != GLOBAL_BRANCH_ID)
-            .try_fold(false, |replaced, branch_id| {
-                Ok::<_, LixError>(
-                    replaced || staged.collection_replaced(branch_id, schema_key, None)?,
-                )
-            })?
-    {
+    let mut visible_branch_ids = request.filter.branch_ids.clone();
+    if let [schema_key] = request.filter.schema_keys.as_slice() {
+        let mut retained = Vec::with_capacity(visible_branch_ids.len());
+        for branch_id in visible_branch_ids {
+            if branch_id == GLOBAL_BRANCH_ID
+                || !staged.collection_replaced(&branch_id, schema_key, None)?
+            {
+                retained.push(branch_id);
+            }
+        }
+        visible_branch_ids = retained;
+    }
+    if !request.filter.branch_ids.is_empty() && visible_branch_ids.is_empty() {
         return Ok(MaterializedLiveStateBatch::default());
     }
     let mut candidate_request = request.clone();
     candidate_request.limit = None;
     candidate_request.filter.include_tombstones = true;
-    candidate_request.filter.branch_ids = expanded_branch_ids(&request.filter.branch_ids);
+    candidate_request.filter.branch_ids = expanded_branch_ids(&visible_branch_ids);
     let staged_rows = staged.staged_batch(&candidate_request)?;
     let rows = base.scan_batch(&candidate_request).await?;
     Ok(resolve_visible_batch(
@@ -126,7 +127,7 @@ where
         staged_rows,
         &VisibilityRequest {
             branch_scope: VisibilityBranchScope::BranchIds {
-                branch_ids: request.filter.branch_ids.clone(),
+                branch_ids: visible_branch_ids,
             },
             include_tombstones: request.filter.include_tombstones,
             limit: request.limit,
@@ -1007,6 +1008,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn overlay_scan_replacement_hides_only_its_branch() {
+        let replaced_branch = "01920000-0000-7000-8000-0000000000a1";
+        let unaffected_branch = "01920000-0000-7000-8000-0000000000a2";
+        let base = FilteringReader {
+            rows: vec![
+                row_at(
+                    replaced_branch,
+                    "replaced",
+                    "replaced-value",
+                    false,
+                    Some("change-replaced"),
+                ),
+                row_at(
+                    unaffected_branch,
+                    "unaffected",
+                    "unaffected-value",
+                    false,
+                    Some("change-unaffected"),
+                ),
+            ],
+        };
+        let staged = ReplacedBranchStagedRows {
+            replaced_branch,
+            schema_key: "schema",
+        };
+
+        let rows = overlay_scan_batch(
+            &base,
+            &staged,
+            &LiveStateScanRequest {
+                filter: crate::live_state::LiveStateFilter {
+                    branch_ids: vec![replaced_branch.to_string(), unaffected_branch.to_string()],
+                    schema_keys: vec!["schema".to_string()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("multi-branch replacement overlay should resolve")
+        .into_rows();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].branch_id.as_ref(), unaffected_branch);
+        assert_eq!(rows[0].entity_pk, EntityPk::single("unaffected"));
+    }
+
+    #[tokio::test]
     async fn exact_overlay_preserves_branch_global_precedence_and_tombstones() {
         let base = FilteringReader {
             rows: vec![
@@ -1241,6 +1290,41 @@ mod tests {
                 MaterializedLiveStateBatch::default(),
                 vec![None; request.rows.len()],
             )
+        }
+    }
+
+    struct ReplacedBranchStagedRows<'a> {
+        replaced_branch: &'a str,
+        schema_key: &'a str,
+    }
+
+    impl StagedLiveStateRows for ReplacedBranchStagedRows<'_> {
+        fn staged_batch(
+            &self,
+            _request: &LiveStateScanRequest,
+        ) -> Result<MaterializedLiveStateBatch, LixError> {
+            Ok(MaterializedLiveStateBatch::default())
+        }
+
+        fn load_exact_batch(
+            &self,
+            request: &LiveStateExactBatchRequest,
+        ) -> Result<MaterializedLiveStateExactBatch, LixError> {
+            MaterializedLiveStateExactBatch::new(
+                MaterializedLiveStateBatch::default(),
+                vec![None; request.rows.len()],
+            )
+        }
+
+        fn collection_replaced(
+            &self,
+            branch_id: &str,
+            schema_key: &str,
+            file_id: Option<&str>,
+        ) -> Result<bool, LixError> {
+            Ok(branch_id == self.replaced_branch
+                && schema_key == self.schema_key
+                && file_id.is_none())
         }
     }
 

--- a/packages/engine/src/schema/builtin/lix_collection_generation.json
+++ b/packages/engine/src/schema/builtin/lix_collection_generation.json
@@ -1,0 +1,39 @@
+{
+  "x-lix-key": "lix_collection_generation",
+  "description": "Internal tracked control row selecting the active physical generation for one schema/file collection. This schema is intentionally hidden from generated entity SQL surfaces.",
+  "x-lix-primary-key": [
+    "/scope_key"
+  ],
+  "type": "object",
+  "properties": {
+    "scope_key": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Canonical JSON tuple [schema_key, file_id] used as the internal row identity."
+    },
+    "schema_key": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Schema whose rows are controlled by this generation."
+    },
+    "file_id": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Optional file scope. Null selects the whole schema collection."
+    },
+    "live_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of live logical rows in the selected generation."
+    }
+  },
+  "required": [
+    "schema_key",
+    "scope_key",
+    "file_id",
+    "live_count"
+  ],
+  "additionalProperties": false
+}

--- a/packages/engine/src/schema/builtin/mod.rs
+++ b/packages/engine/src/schema/builtin/mod.rs
@@ -20,6 +20,7 @@ const LIX_DIRECTORY_DESCRIPTOR_SCHEMA_KEY: &str = "lix_directory_descriptor";
 const LIX_BINARY_BLOB_REF_SCHEMA_KEY: &str = "lix_binary_blob_ref";
 const LIX_DERIVED_FILE_REF_SCHEMA_KEY: &str = "lix_derived_file_ref";
 const LIX_CHECKPOINT_MARKER_SCHEMA_KEY: &str = "lix_checkpoint_marker";
+const LIX_COLLECTION_GENERATION_SCHEMA_KEY: &str = "lix_collection_generation";
 
 const LIX_REGISTERED_SCHEMA_JSON: &str = include_str!("lix_registered_schema.json");
 const LIX_KEY_VALUE_SCHEMA_JSON: &str = include_str!("lix_key_value.json");
@@ -38,6 +39,7 @@ const LIX_DIRECTORY_DESCRIPTOR_SCHEMA_JSON: &str = include_str!("lix_directory_d
 const LIX_BINARY_BLOB_REF_SCHEMA_JSON: &str = include_str!("lix_binary_blob_ref.json");
 const LIX_DERIVED_FILE_REF_SCHEMA_JSON: &str = include_str!("lix_derived_file_ref.json");
 const LIX_CHECKPOINT_MARKER_SCHEMA_JSON: &str = include_str!("lix_checkpoint_marker.json");
+const LIX_COLLECTION_GENERATION_SCHEMA_JSON: &str = include_str!("lix_collection_generation.json");
 
 static LIX_REGISTERED_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_KEY_VALUE_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
@@ -56,6 +58,7 @@ static LIX_DIRECTORY_DESCRIPTOR_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_BINARY_BLOB_REF_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_DERIVED_FILE_REF_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_CHECKPOINT_MARKER_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
+static LIX_COLLECTION_GENERATION_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 
 const BUILTIN_SCHEMA_KEYS: &[&str] = &[
     LIX_REGISTERED_SCHEMA_KEY,
@@ -75,6 +78,7 @@ const BUILTIN_SCHEMA_KEYS: &[&str] = &[
     LIX_BINARY_BLOB_REF_SCHEMA_KEY,
     LIX_DERIVED_FILE_REF_SCHEMA_KEY,
     LIX_CHECKPOINT_MARKER_SCHEMA_KEY,
+    LIX_COLLECTION_GENERATION_SCHEMA_KEY,
 ];
 
 pub(super) fn is_seed_schema_key(schema_key: &str) -> bool {
@@ -167,6 +171,14 @@ pub(super) fn seed_schema_definition(schema_key: &str) -> Option<&'static JsonVa
                 LIX_CHECKPOINT_MARKER_SCHEMA_JSON,
             )
         })),
+        LIX_COLLECTION_GENERATION_SCHEMA_KEY => {
+            Some(LIX_COLLECTION_GENERATION_SCHEMA.get_or_init(|| {
+                parse_builtin_schema(
+                    "lix_collection_generation.json",
+                    LIX_COLLECTION_GENERATION_SCHEMA_JSON,
+                )
+            }))
+        }
         _ => None,
     }
 }

--- a/packages/engine/src/sql2/bind/table.rs
+++ b/packages/engine/src/sql2/bind/table.rs
@@ -310,6 +310,7 @@ mod tests {
             "lix_state_by_branch",
             "lix_state_history",
             "lix_checkpoint_marker",
+            "lix_collection_generation",
             "lix_binary_blob_ref",
             "lix_binary_blob_ref_by_branch",
             "lix_binary_blob_ref_history",

--- a/packages/engine/src/sql2/catalog/entity_surface.rs
+++ b/packages/engine/src/sql2/catalog/entity_surface.rs
@@ -297,6 +297,7 @@ pub(crate) fn schema_exposed_as_entity_surface(schema_key: &str) -> bool {
             | "lix_directory_descriptor"
             | "lix_file_descriptor"
             | "lix_checkpoint_marker"
+            | "lix_collection_generation"
     )
 }
 

--- a/packages/engine/src/sql2/context.rs
+++ b/packages/engine/src/sql2/context.rs
@@ -188,6 +188,14 @@ pub(crate) trait SqlWriteExecutionContext: Send {
 
     async fn load_branch_head(&mut self, branch_id: &str) -> Result<Option<CommitId>, LixError>;
 
+    async fn load_collection_generation(
+        &mut self,
+        _branch_id: &str,
+        _scope: crate::collection_generation::CollectionScopeRef<'_>,
+    ) -> Result<Option<crate::collection_generation::CollectionGeneration>, LixError> {
+        Ok(None)
+    }
+
     async fn stage_write(
         &mut self,
         write: TransactionWrite,

--- a/packages/engine/src/sql2/context.rs
+++ b/packages/engine/src/sql2/context.rs
@@ -196,6 +196,14 @@ pub(crate) trait SqlWriteExecutionContext: Send {
         Ok(None)
     }
 
+    fn has_staged_collection_rows(
+        &self,
+        _branch_id: &str,
+        _scope: crate::collection_generation::CollectionScopeRef<'_>,
+    ) -> Result<bool, LixError> {
+        Ok(false)
+    }
+
     async fn stage_write(
         &mut self,
         write: TransactionWrite,

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -739,6 +739,13 @@ async fn entity_delete_collection(
     if global.is_some_and(|global| global.live_count != 0) {
         return Ok(None);
     }
+    // A generation control only counts committed HOT members. Ordinary staged
+    // rows can add, replace, or remove members from that count, so let the
+    // row-wise executor resolve the exact transaction overlay whenever any are
+    // present.
+    if ctx.has_staged_collection_rows(&active_branch_id, scope)? {
+        return Ok(None);
+    }
     let Some(previous) = ctx
         .load_collection_generation(&active_branch_id, scope)
         .await?

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -706,9 +706,52 @@ async fn execute_entity_write(
             if no_op {
                 return Ok(empty_entity_delete_returning_result(plan));
             }
+            if matches!(surface, EntityWriteSurface::Base { .. })
+                && matches!(plan.bound.predicate, BoundPredicate::True)
+                && plan.bound.returning.is_none()
+                && let Some(result) = entity_delete_collection(ctx, &spec).await?
+            {
+                return Ok(result);
+            }
             entity_delete(ctx, plan, &spec, params, active_branch_commit_id.as_ref()).await
         }
     }
+}
+
+async fn entity_delete_collection(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    spec: &EntitySurfaceSpec,
+) -> Result<Option<SqlWriteResult>, LixError> {
+    use crate::collection_generation::{CollectionScopeRef, collection_delete_stage_row};
+
+    let scope = CollectionScopeRef {
+        schema_key: &spec.schema_key,
+        file_id: None,
+    };
+    let active_branch_id = ctx.active_branch_id().to_string();
+    let global = ctx
+        .load_collection_generation(crate::GLOBAL_BRANCH_ID, scope)
+        .await?;
+    // A visible active-branch collection can shadow global rows with the same
+    // identity. Per-branch counts cannot recover that union cardinality
+    // exactly, so preserve the row-wise route until the projection itself has
+    // a certified count.
+    if global.is_some_and(|global| global.live_count != 0) {
+        return Ok(None);
+    }
+    let Some(previous) = ctx
+        .load_collection_generation(&active_branch_id, scope)
+        .await?
+    else {
+        return Ok(None);
+    };
+    if previous.live_count == 0 {
+        return Ok(Some(SqlWriteResult::affected(0)));
+    }
+    let mut rows = RawWriteBatch::with_capacity(1);
+    rows.push(collection_delete_stage_row(&active_branch_id, scope));
+    stage_rows(ctx, TransactionWriteMode::Replace, rows).await?;
+    Ok(Some(SqlWriteResult::affected(previous.live_count)))
 }
 
 fn plan_references_active_branch_commit_id(plan: &LogicalWritePlan) -> bool {

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -2398,7 +2398,7 @@ mod tests {
     use crate::transaction::types::{
         TransactionWrite, TransactionWriteOutcome, TransactionWriteRow,
     };
-    use crate::{Engine, ExecuteResult, SessionContext};
+    use crate::{CreateBranchOptions, Engine, ExecuteResult, MergeBranchOptions, SessionContext};
     use crate::{LixError, NullableKeyFilter, Value};
     use bytes::Bytes;
     use datafusion::common::ScalarValue;
@@ -3702,6 +3702,345 @@ mod tests {
                 )
             })?;
         Ok((session, head_commit_id))
+    }
+
+    #[tokio::test]
+    async fn whole_entity_collection_delete_uses_one_generation_fact_and_allows_recreation() {
+        let storage = Memory::new();
+        let init_receipt = Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let engine = Engine::new(storage).await.expect("engine should open");
+        let branch_id = init_receipt.main_branch_id.clone();
+        let session = engine
+            .open_session(init_receipt.main_branch_id)
+            .await
+            .expect("session should open");
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+                 VALUES (\
+                 lix_json('{\"x-lix-key\":\"test_state_schema\",\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"value\":{\"type\":\"string\"}},\"required\":[\"id\",\"value\"],\"additionalProperties\":false,\"x-lix-primary-key\":[\"/id\"]}'),\
+                 false,\
+                 false\
+                 )",
+                &[],
+            )
+            .await
+            .expect("test schema should register");
+        session
+            .execute(
+                "INSERT INTO test_state_schema (id, value) VALUES \
+                 ('a', 'A'), ('b', 'B'), ('c', 'C')",
+                &[],
+            )
+            .await
+            .expect("test rows should insert");
+        let before_delete = engine
+            .load_branch_head_commit_id(&branch_id)
+            .await
+            .expect("head before delete should load")
+            .expect("head before delete should exist");
+
+        let deleted = session
+            .execute("DELETE FROM test_state_schema", &[])
+            .await
+            .expect("whole collection should delete");
+        assert_eq!(deleted.rows_affected(), 3);
+        let after_delete = engine
+            .load_branch_head_commit_id(&branch_id)
+            .await
+            .expect("head after delete should load")
+            .expect("head after delete should exist");
+        let diff = session
+            .execute(
+                &format!(
+                    "SELECT schema_key, diff_type FROM lix_diff('{before_delete}', '{after_delete}')"
+                ),
+                &[],
+            )
+            .await
+            .expect("collection delete diff should query");
+        assert_eq!(
+            rows_from_execute_result(diff).1,
+            vec![vec![
+                Value::Text("lix_collection_generation".to_string()),
+                Value::Text("added".to_string())
+            ]]
+        );
+        let marker_changes = session
+            .execute(
+                "SELECT COUNT(*) AS changes FROM lix_change \
+                 WHERE schema_key = 'lix_collection_generation'",
+                &[],
+            )
+            .await
+            .expect("collection marker changelog should query")
+            .rows()[0]
+            .get::<i64>("changes")
+            .expect("marker count should be numeric");
+        assert_eq!(marker_changes, 1);
+        let expanded_tombstones = session
+            .execute(
+                "SELECT COUNT(*) AS changes FROM lix_change \
+                 WHERE schema_key = 'test_state_schema' AND snapshot_content IS NULL",
+                &[],
+            )
+            .await
+            .expect("entity tombstone changelog should query")
+            .rows()[0]
+            .get::<i64>("changes")
+            .expect("tombstone count should be numeric");
+        assert_eq!(expanded_tombstones, 0);
+        let selected = session
+            .execute("SELECT id FROM test_state_schema ORDER BY id", &[])
+            .await
+            .expect("deleted collection should remain queryable");
+        assert!(rows_from_execute_result(selected).1.is_empty());
+        session
+            .create_checkpoint()
+            .await
+            .expect("checkpoint should preserve a collection generation delete");
+        let selected = session
+            .execute("SELECT id FROM test_state_schema ORDER BY id", &[])
+            .await
+            .expect("checkpointed deleted collection should query");
+        assert!(rows_from_execute_result(selected).1.is_empty());
+        let checkout = session
+            .create_branch(CreateBranchOptions {
+                id: None,
+                name: "after-generation-delete".to_string(),
+                from_commit_id: None,
+            })
+            .await
+            .expect("branching from the deleted collection should succeed");
+        let checkout_session = engine
+            .open_session(checkout.id)
+            .await
+            .expect("checkout branch session should open");
+        let selected = checkout_session
+            .execute("SELECT id FROM test_state_schema ORDER BY id", &[])
+            .await
+            .expect("branch created from the deleted generation should query");
+        assert!(rows_from_execute_result(selected).1.is_empty());
+
+        session
+            .execute(
+                "INSERT INTO test_state_schema (id, value) VALUES ('a', 'A2')",
+                &[],
+            )
+            .await
+            .expect("a retired-generation identity should be reusable");
+        let selected = session
+            .execute("SELECT id, value FROM test_state_schema", &[])
+            .await
+            .expect("recreated generation should be visible");
+        assert_eq!(
+            rows_from_execute_result(selected).1,
+            vec![vec![
+                Value::Text("a".to_string()),
+                Value::Text("A2".to_string())
+            ]]
+        );
+
+        let deleted = session
+            .execute("DELETE FROM test_state_schema", &[])
+            .await
+            .expect("recreated collection should delete");
+        assert_eq!(deleted.rows_affected(), 1);
+    }
+
+    #[tokio::test]
+    async fn whole_entity_collection_delete_is_visible_inside_explicit_transaction() {
+        let storage = Memory::new();
+        let init_receipt = Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let engine = Engine::new(storage).await.expect("engine should open");
+        let session = engine
+            .open_session(init_receipt.main_branch_id)
+            .await
+            .expect("session should open");
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+                 VALUES (\
+                 lix_json('{\"x-lix-key\":\"test_state_schema\",\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"}},\"required\":[\"id\"],\"additionalProperties\":false,\"x-lix-primary-key\":[\"/id\"]}'),\
+                 false,\
+                 false\
+                 )",
+                &[],
+            )
+            .await
+            .expect("test schema should register");
+        session
+            .execute(
+                "INSERT INTO test_state_schema (id) VALUES ('a'), ('b')",
+                &[],
+            )
+            .await
+            .expect("test rows should insert");
+
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("explicit transaction should open");
+        let deleted = transaction
+            .execute("DELETE FROM test_state_schema", &[])
+            .await
+            .expect("collection delete should stage");
+        assert_eq!(deleted.rows_affected(), 2);
+        let selected = transaction
+            .execute("SELECT id FROM test_state_schema", &[])
+            .await
+            .expect("staged collection delete should be visible");
+        assert!(rows_from_execute_result(selected).1.is_empty());
+        let deleted_again = transaction
+            .execute("DELETE FROM test_state_schema", &[])
+            .await
+            .expect("repeated staged collection delete should be a no-op");
+        assert_eq!(deleted_again.rows_affected(), 0);
+        let recreate_error = transaction
+            .execute(
+                "INSERT INTO test_state_schema (id) VALUES ('next-generation')",
+                &[],
+            )
+            .await
+            .expect_err("recreation should require the deletion commit boundary");
+        assert_eq!(recreate_error.code, LixError::CODE_CONSTRAINT_VIOLATION);
+        assert_eq!(
+            recreate_error.hint.as_deref(),
+            Some("Commit the collection deletion before recreating rows in its next generation.")
+        );
+        transaction
+            .commit()
+            .await
+            .expect("collection delete should commit");
+    }
+
+    #[tokio::test]
+    async fn whole_entity_collection_delete_falls_back_for_global_members() {
+        let storage = Memory::new();
+        let init_receipt = Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let engine = Engine::new(storage).await.expect("engine should open");
+        let session = engine
+            .open_session(init_receipt.main_branch_id)
+            .await
+            .expect("session should open");
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value, lixcol_global) VALUES \
+                 ('local-only', lix_json('1'), false), \
+                 ('global-only', lix_json('2'), true), \
+                 ('shadowed', lix_json('3'), true), \
+                 ('shadowed', lix_json('4'), false)",
+                &[],
+            )
+            .await
+            .expect("local, global, and shadowing rows should insert");
+        let visible_before = session
+            .execute("SELECT COUNT(*) AS count FROM lix_key_value", &[])
+            .await
+            .expect("visible collection count should query")
+            .rows()[0]
+            .get::<i64>("count")
+            .expect("visible collection count should be numeric");
+
+        let deleted = session
+            .execute("DELETE FROM lix_key_value", &[])
+            .await
+            .expect("mixed global collection should delete through row fallback");
+        assert_eq!(deleted.rows_affected(), visible_before as u64);
+        let marker_count = session
+            .execute(
+                "SELECT COUNT(*) AS count FROM lix_change \
+                 WHERE schema_key = 'lix_collection_generation'",
+                &[],
+            )
+            .await
+            .expect("marker count should query")
+            .rows()[0]
+            .get::<i64>("count")
+            .expect("marker count should be numeric");
+        assert_eq!(marker_count, 0);
+    }
+
+    #[tokio::test]
+    async fn merge_applies_collection_generation_delete_without_expanding_members() {
+        let storage = Memory::new();
+        let init_receipt = Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let engine = Engine::new(storage).await.expect("engine should open");
+        let main = engine
+            .open_session(init_receipt.main_branch_id)
+            .await
+            .expect("main session should open");
+        main.execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (\
+             lix_json('{\"x-lix-key\":\"test_state_schema\",\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"}},\"required\":[\"id\"],\"additionalProperties\":false,\"x-lix-primary-key\":[\"/id\"]}'),\
+             false,\
+             false\
+             )",
+            &[],
+        )
+        .await
+        .expect("test schema should register");
+        main.execute(
+            "INSERT INTO test_state_schema (id) VALUES ('a'), ('b'), ('c')",
+            &[],
+        )
+        .await
+        .expect("test rows should insert");
+        let source = main
+            .create_branch(CreateBranchOptions {
+                id: None,
+                name: "delete-source".to_string(),
+                from_commit_id: None,
+            })
+            .await
+            .expect("source branch should create");
+        let source_session = engine
+            .open_session(source.id.clone())
+            .await
+            .expect("source session should open");
+        let deleted = source_session
+            .execute("DELETE FROM test_state_schema", &[])
+            .await
+            .expect("source collection should delete");
+        assert_eq!(deleted.rows_affected(), 3);
+
+        let before_merge = main
+            .execute("SELECT id FROM test_state_schema", &[])
+            .await
+            .expect("target collection should query before merge");
+        assert_eq!(rows_from_execute_result(before_merge).1.len(), 3);
+        main.merge_branch(MergeBranchOptions {
+            source_branch_id: source.id,
+        })
+        .await
+        .expect("collection delete should merge");
+        let after_merge = main
+            .execute("SELECT id FROM test_state_schema", &[])
+            .await
+            .expect("target collection should query after merge");
+        assert!(rows_from_execute_result(after_merge).1.is_empty());
+
+        let expanded_tombstones = main
+            .execute(
+                "SELECT COUNT(*) AS changes FROM lix_change \
+                 WHERE schema_key = 'test_state_schema' AND snapshot_content IS NULL",
+                &[],
+            )
+            .await
+            .expect("merged entity tombstones should query")
+            .rows()[0]
+            .get::<i64>("changes")
+            .expect("tombstone count should be numeric");
+        assert_eq!(expanded_tombstones, 0);
     }
 
     #[tokio::test]

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -3916,6 +3916,70 @@ mod tests {
             .commit()
             .await
             .expect("collection delete should commit");
+
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("explicit transaction on the empty collection should open");
+        transaction
+            .execute(
+                "INSERT INTO test_state_schema (id) VALUES ('only-staged')",
+                &[],
+            )
+            .await
+            .expect("member should stage against an empty committed collection");
+        let deleted = transaction
+            .execute("DELETE FROM test_state_schema", &[])
+            .await
+            .expect("staged-only collection should delete");
+        assert_eq!(deleted.rows_affected(), 1);
+        let selected = transaction
+            .execute("SELECT id FROM test_state_schema", &[])
+            .await
+            .expect("staged-only collection delete should be visible");
+        assert!(rows_from_execute_result(selected).1.is_empty());
+        transaction
+            .commit()
+            .await
+            .expect("staged-only collection delete should commit");
+        let selected = session
+            .execute("SELECT id FROM test_state_schema", &[])
+            .await
+            .expect("committed staged-only collection delete should query");
+        assert!(rows_from_execute_result(selected).1.is_empty());
+
+        session
+            .execute(
+                "INSERT INTO test_state_schema (id) VALUES ('committed-a'), ('committed-b')",
+                &[],
+            )
+            .await
+            .expect("committed members should recreate the collection");
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("explicit transaction on the nonempty collection should open");
+        transaction
+            .execute(
+                "INSERT INTO test_state_schema (id) VALUES ('staged-c')",
+                &[],
+            )
+            .await
+            .expect("additional member should stage");
+        let deleted = transaction
+            .execute("DELETE FROM test_state_schema", &[])
+            .await
+            .expect("committed and staged members should delete together");
+        assert_eq!(deleted.rows_affected(), 3);
+        let selected = transaction
+            .execute("SELECT id FROM test_state_schema", &[])
+            .await
+            .expect("mixed committed and staged collection delete should be visible");
+        assert!(rows_from_execute_result(selected).1.is_empty());
+        transaction
+            .commit()
+            .await
+            .expect("mixed committed and staged collection delete should commit");
     }
 
     #[tokio::test]

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -2233,6 +2233,7 @@ mod tests {
             "lix_derived_file_ref",
             "lix_change",
             "lix_checkpoint_marker",
+            "lix_collection_generation",
             "lix_directory_descriptor",
             "lix_file_descriptor",
         ] {

--- a/packages/engine/src/sql2/read_only.rs
+++ b/packages/engine/src/sql2/read_only.rs
@@ -52,6 +52,9 @@ fn read_only_schema_message(schema_key: &str) -> Option<&'static str> {
         "lix_checkpoint_marker" => Some(
             "Checkpoint markers are internal; use the create_checkpoint API to create checkpoints.",
         ),
+        "lix_collection_generation" => Some(
+            "Collection generations are internal; use whole-collection delete operations to replace a generation.",
+        ),
         _ => None,
     }
 }

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -982,6 +982,7 @@ where
             // ordinary mutation and then swap authority ahead of it.
             self.ensure_plugin_generation_read_guard().await;
         }
+        self.reject_write_after_collection_replacement(&write)?;
         require_valid_transaction_write_storage_scopes(&write)?;
         // A normal write targets the branch this transaction already opened
         // against, so its existence is checked together with the coherent
@@ -1054,6 +1055,42 @@ where
         self.pending_plugin_actor_publications
             .extend(actor_publications);
         Ok(outcome)
+    }
+
+    fn reject_write_after_collection_replacement(
+        &self,
+        write: &TransactionWrite,
+    ) -> Result<(), LixError> {
+        let rows = match write {
+            TransactionWrite::Rows { rows, .. }
+            | TransactionWrite::RowsWithFileData { rows, .. } => rows,
+        };
+        let staged = self.staged_writes.staging_overlay()?;
+        for row in rows.iter() {
+            if row.schema_key.as_str()
+                == crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY
+            {
+                continue;
+            }
+            if StagedLiveStateRows::collection_replaced(
+                &staged,
+                row.branch_id,
+                row.schema_key,
+                row.file_id.map(SharedStr::as_str),
+            )? {
+                return Err(LixError::new(
+                    LixError::CODE_CONSTRAINT_VIOLATION,
+                    format!(
+                        "collection '{}' was deleted earlier in this transaction",
+                        row.schema_key
+                    ),
+                )
+                .with_hint(
+                    "Commit the collection deletion before recreating rows in its next generation.",
+                ));
+            }
+        }
+        Ok(())
     }
 
     /// Validates descriptor-path changes against the current batch before it
@@ -6162,6 +6199,39 @@ where
             .ref_reader(read)
             .load_head_commit_id(branch_id)
             .await
+    }
+
+    async fn load_collection_generation(
+        &mut self,
+        branch_id: &str,
+        scope: crate::collection_generation::CollectionScopeRef<'_>,
+    ) -> Result<Option<crate::collection_generation::CollectionGeneration>, LixError> {
+        let read = SharedStorageAdapterRead::new(
+            self.storage
+                .begin_read(StorageReadOptions::default())
+                .await?,
+        );
+        let Some(control) = BranchHeadControlContext::new()
+            .reader(read.clone())
+            .load(branch_id)
+            .await?
+        else {
+            return Ok(None);
+        };
+        let mut generation = TrackedHeadContext::new()
+            .reader(read)
+            .collection_generation(branch_id, control.generation, scope)
+            .await?;
+        let staged = self.staged_writes.staging_overlay()?;
+        if StagedLiveStateRows::collection_replaced(
+            &staged,
+            branch_id,
+            scope.schema_key,
+            scope.file_id,
+        )? {
+            generation.live_count = 0;
+        }
+        Ok(Some(generation))
     }
 
     async fn stage_write(

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -6234,6 +6234,31 @@ where
         Ok(Some(generation))
     }
 
+    fn has_staged_collection_rows(
+        &self,
+        branch_id: &str,
+        scope: crate::collection_generation::CollectionScopeRef<'_>,
+    ) -> Result<bool, LixError> {
+        let staged = self.staged_writes.staging_overlay()?;
+        let file_ids = scope
+            .file_id
+            .map(|file_id| vec![NullableKeyFilter::Value(file_id.to_string())])
+            .unwrap_or_default();
+        Ok(!staged
+            .staged_batch(&LiveStateScanRequest {
+                filter: LiveStateFilter {
+                    schema_keys: vec![scope.schema_key.to_string()],
+                    branch_ids: vec![branch_id.to_string()],
+                    file_ids,
+                    include_tombstones: true,
+                    ..Default::default()
+                },
+                limit: Some(1),
+                ..Default::default()
+            })?
+            .is_empty())
+    }
+
     async fn stage_write(
         &mut self,
         write: TransactionWrite,

--- a/packages/engine/src/transaction/normalization.rs
+++ b/packages/engine/src/transaction/normalization.rs
@@ -54,7 +54,7 @@ pub(crate) fn normalize_raw_write_row_in_place(
 ) -> Result<NormalizedRowFacts, LixError> {
     let row = rows.row(row_index);
     validate_transaction_write_row_schema_identity(row)?;
-    ensure_internal_checkpoint_schema(row, schema_catalog)?;
+    ensure_internal_control_schema(row, schema_catalog)?;
 
     let Some((schema_plan_id, schema_plan)) =
         schema_catalog.snapshot().plan_for_key(&row.schema_key)
@@ -289,25 +289,27 @@ fn validate_normalized_row_content(
     Ok(())
 }
 
-/// Checkpoint markers were introduced after repositories already existed.
-///
-/// Their schema is fixed and intentionally hidden from public entity
-/// surfaces, so legacy stores can validate this one engine-owned row from the
-/// compile-time definition without mutating their visible schema catalog.
-fn ensure_internal_checkpoint_schema(
+/// Engine-owned control rows have fixed schemas and are intentionally hidden
+/// from public entity surfaces. Internal producers may therefore validate
+/// them from the compile-time definition without first materializing that
+/// definition in the transaction's visible schema catalog.
+fn ensure_internal_control_schema(
     row: RawWriteRowRef<'_>,
     schema_catalog: &mut TransactionCatalog,
 ) -> Result<(), LixError> {
-    if row.schema_key != crate::checkpoint::CHECKPOINT_MARKER_SCHEMA_KEY
-        || schema_catalog.snapshot().schema(&row.schema_key).is_some()
-    {
+    let internal = matches!(
+        row.schema_key.as_str(),
+        crate::checkpoint::CHECKPOINT_MARKER_SCHEMA_KEY
+            | crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY
+    );
+    if !internal || schema_catalog.snapshot().schema(&row.schema_key).is_some() {
         return Ok(());
     }
     let schema = crate::schema::seed_schema_definition(&row.schema_key)
         .ok_or_else(|| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
-                "compile-time checkpoint marker schema is missing",
+                "compile-time internal control schema is missing",
             )
         })?
         .clone();

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -1884,6 +1884,42 @@ impl crate::live_state::StagedLiveStateRows for PreparedStateRowOverlay {
             .collect();
         MaterializedLiveStateExactBatch::new(builder.finish(), slots)
     }
+
+    fn collection_replaced(
+        &self,
+        branch_id: &str,
+        schema_key: &str,
+        file_id: Option<&str>,
+    ) -> Result<bool, LixError> {
+        self.staged_writes.ensure_identity_index(false)?;
+        let rows_guard = self.staged_writes.rows.lock().map_err(|_| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "failed to acquire transaction staged writes lock",
+            )
+        })?;
+        let StagedPreparedRows::Indexed { rows, .. } = &*rows_guard else {
+            return Ok(false);
+        };
+        for index in 0..rows.len() {
+            let row = rows.row(index);
+            if row.schema_key.as_str()
+                != crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY
+                || row.branch_id.as_str() != branch_id
+                || row.snapshot.is_none()
+            {
+                continue;
+            }
+            let (target_schema_key, target_file_id) =
+                crate::collection_generation::collection_scope_from_entity_pk(row.entity_pk)?;
+            if target_schema_key == schema_key
+                && (target_file_id.is_none() || target_file_id.as_deref() == file_id)
+            {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What changed

- add a hidden tracked `lix_collection_generation` control schema
- maintain per-branch/schema and per-file generation controls with exact live counts in HOT state
- lower unfiltered base-entity `DELETE` to one collection-generation fact instead of one tombstone per member
- mask retired generations in scans, exact reads, snapshot reads, transaction overlays, branch creation, checkpoint, and merge materialization
- reclaim stale generation controls together with stale HOT generations
- preserve exact affected-row semantics by falling back to row deletion when global members make per-branch cardinalities overlap
- make collection deletion immediately visible in explicit transactions; recreation starts after the deletion commit boundary

## Why

The previous delete-all path expanded a logical collection deletion into O(rows) changelog, tracked-tree, and HOT writes. That made a 10k delete take roughly 47 ms on RocksDB and 61 ms on SlateDB. A collection generation is the required negative fact in compressed form: one tracked marker distinguishes deleted from absent/inherited state while preserving history, diff, merge, checkout, and replay.

## Performance

Focused setup-excluded SQL-session measurements after rebasing onto #976:

- 10k RocksDB delete-all: 531.6 µs median (previously ~47.5 ms)
- 10k SlateDB delete-all: 530.5 µs median (previously ~61.1 ms)
- 1M SlateDB delete-all: 1.46 ms (raw SQLite: 16.45 ms)
- 1M RocksDB delete-all: ~141 ms (previously ~9.9 s)

The RocksDB 1M residual is not row expansion. RocksDB logs and targeted profiling show no L0/write stall after controlling memtable rotation; it remains a Rocks-specific post-bulk read/write cost for a follow-up. No speculative adapter tuning is included here.

At 10k, the new path is still about 3.2x raw SQLite (~164 µs), so this PR is a large bounded step toward—but does not claim to finish—the 1.2x CRUD goal.

## Semantics

- diff records the single collection-generation fact, not expanded user tombstones
- checkpoint and branch creation preserve the deleted projection
- merge applies the generation fact without expanding members
- recreating a retired identity in a later commit is visible
- mixed global/local collections retain the existing exact row-wise route
- `DELETE ... RETURNING` and filtered deletes retain the existing row-wise route

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p lix_engine --features all-simulations` (782 passed, 2 ignored; doctests passed)
- focused generation delete, explicit transaction, global fallback, checkpoint/branch, merge, and #976 HOT schema-marker tests
- `cargo test -p lix_rocksdb_storage --test storage` (12 passed)
- `cargo test -p lix_slatedb_storage` (43 unit + 8 conformance passed)
- `cargo clippy -p lix_engine --all-targets --features all-simulations` (passes with three pre-existing dead-code warnings on main)