### PR TITLE
Read certified rows at plugin merge bases

### DIFF
--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -910,56 +910,58 @@ pub(crate) async fn scan_certified_history_rows(
     if commit_ids.is_empty() {
         return Ok(Vec::new());
     }
-    let page = ScanPlan::prefix(
-        CERTIFIED_ENTITY_BATCH_SPACE,
-        StoragePrefix {
-            bytes: Bytes::new(),
-        },
-    )
-    .collect(store, StorageScanOptions::default())
-    .await?;
     let needs_snapshot = request
         .read_columns
         .columns
         .iter()
         .any(|column| column == "snapshot_content");
-    let mut builder =
-        MaterializedLiveStateBatchBuilder::with_capacity(page.value.entries.len() * 1024);
-    for entry in page.value.entries {
-        let value = full_value_bytes(entry.value)?;
-        if !commit_ids.contains(&certified_batch_commit_id(&value)?) {
-            continue;
+    let mut builder = MaterializedLiveStateBatchBuilder::with_capacity(commit_ids.len() * 1024);
+    for commit_id in commit_ids {
+        let page = ScanPlan::prefix(
+            CERTIFIED_ENTITY_BATCH_SPACE,
+            StoragePrefix {
+                bytes: Bytes::copy_from_slice(commit_id.as_uuid().as_bytes()),
+            },
+        )
+        .collect(store, StorageScanOptions::default())
+        .await?;
+        for entry in page.value.entries {
+            let value = full_value_bytes(entry.value)?;
+            if certified_batch_commit_id(&value)? != *commit_id {
+                continue;
+            }
+            let external_plan =
+                certified_external_page_plan(&value, entry.key.0.as_ref(), request)?;
+            let external_pages = if let Some(plan) = &external_plan {
+                let keys = plan.iter().map(|(_, key)| key.clone()).collect::<Vec<_>>();
+                let values = PointReadPlan::new(CERTIFIED_ENTITY_BATCH_PAGE_SPACE, &keys)
+                    .materialize(store, StorageGetOptions::default())
+                    .await?
+                    .value;
+                Some(
+                    plan.iter()
+                        .zip(values)
+                        .map(|((page_index, _), value)| {
+                            let value = value.ok_or_else(|| {
+                                head_value_error("certified history batch page is missing")
+                            })?;
+                            Ok((*page_index, full_value_bytes(value)?))
+                        })
+                        .collect::<Result<Vec<_>, LixError>>()?,
+                )
+            } else {
+                None
+            };
+            decode_certified_entity_batch_rows(
+                &value,
+                external_pages.as_deref(),
+                "",
+                request,
+                needs_snapshot,
+                None,
+                &mut builder,
+            )?;
         }
-        let external_plan = certified_external_page_plan(&value, entry.key.0.as_ref(), request)?;
-        let external_pages = if let Some(plan) = &external_plan {
-            let keys = plan.iter().map(|(_, key)| key.clone()).collect::<Vec<_>>();
-            let values = PointReadPlan::new(CERTIFIED_ENTITY_BATCH_PAGE_SPACE, &keys)
-                .materialize(store, StorageGetOptions::default())
-                .await?
-                .value;
-            Some(
-                plan.iter()
-                    .zip(values)
-                    .map(|((page_index, _), value)| {
-                        let value = value.ok_or_else(|| {
-                            head_value_error("certified history batch page is missing")
-                        })?;
-                        Ok((*page_index, full_value_bytes(value)?))
-                    })
-                    .collect::<Result<Vec<_>, LixError>>()?,
-            )
-        } else {
-            None
-        };
-        decode_certified_entity_batch_rows(
-            &value,
-            external_pages.as_deref(),
-            "",
-            request,
-            needs_snapshot,
-            None,
-            &mut builder,
-        )?;
     }
     Ok(builder.finish().into_rows())
 }
@@ -6427,6 +6429,41 @@ mod tests {
 
     fn timestamp() -> LixTimestamp {
         LixTimestamp::expect_parse("hot working-diff test timestamp", "2026-01-01T00:00:00Z")
+    }
+
+    #[tokio::test]
+    async fn certified_history_scan_ignores_malformed_unrequested_commit() {
+        let storage = StorageAdapter::new(Memory::new());
+        let requested_commit = CommitId::for_test_label("requested-certified-history");
+        let unrelated_commit = CommitId::for_test_label("malformed-certified-history");
+        let mut writes = storage.new_write_set();
+        writes.put(
+            CERTIFIED_ENTITY_BATCH_SPACE,
+            StorageKey(Bytes::copy_from_slice(
+                unrelated_commit.as_uuid().as_bytes(),
+            )),
+            StorageValue {
+                bytes: Bytes::from_static(b"malformed"),
+            },
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("malformed unrelated certified batch should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("certified history read should open");
+        let rows = scan_certified_history_rows(
+            &read,
+            &BTreeSet::from([requested_commit]),
+            &TrackedStateScanRequest::default(),
+        )
+        .await
+        .expect("unrelated malformed batch must not affect the requested commit");
+
+        assert!(rows.is_empty());
     }
 
     #[test]

--- a/packages/engine/src/session/merge/branch.rs
+++ b/packages/engine/src/session/merge/branch.rs
@@ -1323,6 +1323,11 @@ fn verify_historical_conflict_row_ref(
     match (row, expected) {
         (None, None) => Ok(()),
         (Some(row), Some(expected)) if row.change_id() == expected.change_id => Ok(()),
+        // Certified fresh-import rows intentionally have no expanded
+        // tracked-root entry. Merge analysis can therefore represent their
+        // common ancestor as absent even though the authoritative certified
+        // segment at the base commit contains the row.
+        (Some(_), None) if side == "base" => Ok(()),
         _ => Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
             format!("historical {side} row did not match merge analysis"),
@@ -1910,6 +1915,32 @@ mod tests {
             change_id: ChangeId::for_test_label(incarnation),
             commit_id: CommitId::for_test_label("owner-commit"),
         }
+    }
+
+    #[test]
+    fn certified_base_row_may_fill_merge_analysis_absence() {
+        let batch = crate::tracked_state::MaterializedTrackedStateBatch::from_rows(vec![
+            MaterializedTrackedStateRow {
+                entity_pk: EntityPk::single("certified-row"),
+                schema_key: "certified_schema".to_owned(),
+                file_id: Some("certified-file".to_owned()),
+                snapshot_content: Some(r#"{"value":"base"}"#.into()),
+                metadata: None,
+                deleted: false,
+                created_at: "2026-01-01T00:00:00Z".to_owned(),
+                updated_at: "2026-01-01T00:00:00Z".to_owned(),
+                change_id: ChangeId::for_test_label("certified-base-change"),
+                commit_id: CommitId::for_test_label("certified-base-commit"),
+            },
+        ])
+        .expect("certified base fixture should materialize");
+
+        verify_historical_conflict_row_ref(Some(batch.row(0)), None, "base")
+            .expect("certified base may be absent from expanded tracked roots");
+        assert!(
+            verify_historical_conflict_row_ref(Some(batch.row(0)), None, "target").is_err(),
+            "target/source variants must still match merge analysis"
+        );
     }
 
     fn derived_file_ref_conflict(file_id: &str) -> TrackedStateMergeConflict {

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -1170,7 +1170,46 @@ where
             .collect();
         let batch =
             materialize_batch_from_index_entry_refs(&self.store, entries, projection).await?;
-        MaterializedTrackedStateExactBatch::new(batch, slots)
+        let batch = MaterializedTrackedStateExactBatch::new(batch, slots)?;
+        if !batch.has_missing() || keys.iter().all(|key| key.schema_key.starts_with("lix_")) {
+            return Ok(batch);
+        }
+        let commit_id = CommitId::parse_lix(commit_id, "certified historical exact read")?;
+        let certified = crate::live_state::scan_certified_history_rows(
+            &self.store,
+            &BTreeSet::from([commit_id]),
+            &TrackedStateScanRequest {
+                filter: crate::tracked_state::TrackedStateFilter {
+                    schema_keys: keys.iter().map(|key| key.schema_key.to_owned()).collect(),
+                    entity_pks: keys.iter().map(|key| key.entity_pk.clone()).collect(),
+                    file_ids: keys
+                        .iter()
+                        .map(|key| {
+                            key.file_id.map_or(NullableKeyFilter::Null, |file_id| {
+                                NullableKeyFilter::Value(file_id.to_owned())
+                            })
+                        })
+                        .collect(),
+                    include_tombstones: true,
+                },
+                read_columns: crate::tracked_state::TrackedStateReadColumns {
+                    columns: [
+                        projection.snapshot_content.then_some("snapshot_content"),
+                        projection.metadata.then_some("metadata"),
+                    ]
+                    .into_iter()
+                    .flatten()
+                    .map(str::to_owned)
+                    .collect(),
+                },
+                limit: None,
+            },
+        )
+        .await?;
+        if certified.is_empty() {
+            return Ok(batch);
+        }
+        batch.fill_missing_from_certified(keys, certified)
     }
 
     #[cfg(any(test, feature = "storage-benches"))]
@@ -3913,9 +3952,12 @@ fn nullable_key_filter_allows(filters: &[NullableKeyFilter<String>], value: Opti
 mod tests {
     use super::*;
     use crate::NullableKeyFilter;
+    use crate::branch::BranchHeadControl;
     use crate::changelog::CommitRecord;
+    use crate::live_state::CertifiedEntityBatchFileRef;
     use crate::storage_adapter::StorageAdapter;
     use crate::storage_adapter::{Memory, StorageReadOptions, StorageWriteOptions};
+    use crate::wasm::{WasmCertifiedEntityBatch, WasmCreateContext};
 
     fn commit_root_key(label: &str) -> crate::storage_adapter::StorageKey {
         crate::storage_adapter::StorageKey(Bytes::copy_from_slice(
@@ -6713,6 +6755,123 @@ mod tests {
                 .expect("root probe should succeed")
                 .is_none(),
             "the batch must resolve from rootless deltas, not a rebuilt durable tree"
+        );
+    }
+
+    #[tokio::test]
+    async fn historical_exact_read_fills_missing_root_row_from_certified_batch() {
+        const COMMIT_LABEL: &str = "certified-historical-exact";
+        const BRANCH_ID: &str = "certified-branch";
+        const FILE_ID: &str = "certified.csv";
+        const SCHEMA_KEY: &str = "certified_row";
+
+        let storage = StorageAdapter::new(Memory::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_for_test(&storage, &tracked_state, COMMIT_LABEL, None, &[])
+            .await
+            .expect("empty tracked root should write");
+
+        let commit_id = CommitId::for_test_label(COMMIT_LABEL);
+        let creates = WasmCreateContext {
+            high: 0x0192_0000_0000_7000,
+            low: 0x8000_0000,
+        };
+        let local_ref = 7_u32;
+        let mut page = Vec::new();
+        page.extend_from_slice(&local_ref.to_le_bytes());
+        page.extend_from_slice(&1_u64.to_le_bytes());
+        page.push(0);
+        page.extend_from_slice(&0_u32.to_le_bytes());
+        page.extend_from_slice(&1_u16.to_le_bytes());
+        page.extend_from_slice(&5_u32.to_le_bytes());
+        page.extend_from_slice(b"value");
+        let batches = [WasmCertifiedEntityBatch {
+            format: 1,
+            schema_keys: vec![SCHEMA_KEY.to_owned()],
+            row_count: 1,
+            creates,
+            complete_file_state: true,
+            pages: vec![Bytes::from(page)],
+        }];
+        let files = [CertifiedEntityBatchFileRef {
+            branch_id: BRANCH_ID,
+            file_id: FILE_ID,
+            batches: &batches,
+        }];
+        let control = BranchHeadControl {
+            head_commit_id: commit_id,
+            generation: commit_id,
+            current_state_revision: 0,
+            schema_presence_bloom: [u64::MAX; 4],
+            working_diff_checkpoint_commit_id: None,
+            created_at: crate::common::LixTimestamp::expect_parse(
+                "certified test timestamp",
+                "2026-01-01T00:00:00Z",
+            ),
+            updated_at: crate::common::LixTimestamp::expect_parse(
+                "certified test timestamp",
+                "2026-01-01T00:00:00Z",
+            ),
+            ref_change_id: ChangeId::for_test_label("certified-branch-ref"),
+        };
+        let controls = BTreeMap::from([(BRANCH_ID.to_owned(), control)]);
+        let commit_created_at = BTreeMap::from([(commit_id, control.created_at)]);
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("certified batch read should open");
+        let mut writes = storage.new_write_set();
+        crate::live_state::stage_certified_entity_batches(
+            &read,
+            &mut writes,
+            &files,
+            &controls,
+            &BTreeMap::new(),
+            &commit_created_at,
+        )
+        .await
+        .expect("certified batch should stage");
+        drop(read);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("certified batch should commit");
+
+        let id = creates
+            .component_uuid_bytes(u64::from(local_ref))
+            .expect("certified local reference should form an id");
+        let key = TrackedStateKey {
+            schema_key: SCHEMA_KEY.to_owned(),
+            file_id: Some(FILE_ID.to_owned()),
+            entity_pk: EntityPk::uuid_from_bytes(id),
+        };
+        let exact = tracked_state
+            .reader(
+                storage
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .expect("historical exact read should open"),
+            )
+            .load_projected_batch_at_commit(
+                &commit_id.to_string(),
+                &[key],
+                &ChangeRecordProjection::full(),
+            )
+            .await
+            .expect("certified historical exact row should load");
+        let row = exact
+            .row(0)
+            .expect("certified row must fill the missing slot");
+        assert_eq!(row.schema_key(), SCHEMA_KEY);
+        assert_eq!(row.file_id(), Some(FILE_ID));
+        assert_eq!(row.commit_id(), commit_id);
+        let expected_snapshot = format!(
+            r#"{{"cells":["value"],"id":"{}","order_key":"0000000000000001"}}"#,
+            uuid::Uuid::from_bytes(id)
+        );
+        assert_eq!(
+            row.snapshot_content().map(SharedStr::as_str),
+            Some(expected_snapshot.as_str())
         );
     }
 

--- a/packages/engine/src/tracked_state/row_materialization.rs
+++ b/packages/engine/src/tracked_state/row_materialization.rs
@@ -13,6 +13,7 @@ use crate::changelog::{
 };
 use crate::common::{LixTimestamp, SharedStr};
 use crate::entity_pk::EntityPk;
+use crate::live_state::MaterializedLiveStateRow;
 use crate::storage_adapter::StorageAdapterRead;
 use crate::tracked_state::MaterializedTrackedStateRow;
 use crate::tracked_state::types::{TrackedStateIndexValue, TrackedStateKey, TrackedStateKeyRef};
@@ -307,6 +308,105 @@ impl MaterializedTrackedStateExactBatch {
             .map(|ordinal| self.batch.row(ordinal as usize))
     }
 
+    pub(crate) fn has_missing(&self) -> bool {
+        self.slots.iter().any(Option::is_none)
+    }
+
+    /// Fills missing historical exact-read slots from immutable certified
+    /// segment rows without changing the tracked-tree result for any present
+    /// identity.
+    pub(crate) fn fill_missing_from_certified(
+        &self,
+        keys: &[TrackedStateKeyRef<'_>],
+        certified_rows: Vec<MaterializedLiveStateRow>,
+    ) -> Result<Self, LixError> {
+        if keys.len() != self.slots.len() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "certified historical fallback lost exact-read alignment",
+            ));
+        }
+        let certified = certified_rows
+            .into_iter()
+            .filter_map(|row| {
+                Some((
+                    TrackedStateKey {
+                        schema_key: row.schema_key.clone(),
+                        file_id: row.file_id.clone(),
+                        entity_pk: row.entity_pk.clone(),
+                    },
+                    (
+                        TrackedStateIndexValue {
+                            change_id: row.change_id?,
+                            commit_id: row.commit_id?,
+                            deleted: row.deleted,
+                            created_at: row.created_at,
+                            updated_at: row.updated_at,
+                        },
+                        row.snapshot_content,
+                        row.metadata,
+                    ),
+                ))
+            })
+            .collect::<BTreeMap<_, _>>();
+
+        let mut builder = MaterializedTrackedStateBatchBuilder::with_capacity(keys.len());
+        let mut slots = Vec::with_capacity(keys.len());
+        let mut ordinal_by_key = BTreeMap::<TrackedStateKey, u32>::new();
+        for (index, key) in keys.iter().copied().enumerate() {
+            let lookup = TrackedStateKey {
+                schema_key: key.schema_key.to_owned(),
+                file_id: key.file_id.map(str::to_owned),
+                entity_pk: key.entity_pk.clone(),
+            };
+            if let Some(ordinal) = ordinal_by_key.get(&lookup).copied() {
+                slots.push(Some(ordinal));
+                continue;
+            }
+            if let Some(row) = self.row(index) {
+                let ordinal = u32::try_from(builder.rows.len()).map_err(|_| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "historical exact-read fallback exceeds u32 rows",
+                    )
+                })?;
+                builder.push_ref(
+                    TrackedStateKeyRef {
+                        schema_key: row.schema_key(),
+                        file_id: row.file_id(),
+                        entity_pk: row.entity_pk(),
+                    },
+                    TrackedStateIndexValue {
+                        change_id: row.change_id(),
+                        commit_id: row.commit_id(),
+                        deleted: row.deleted(),
+                        created_at: row.created_at(),
+                        updated_at: row.updated_at(),
+                    },
+                    row.snapshot_content().cloned(),
+                    row.metadata().cloned(),
+                );
+                ordinal_by_key.insert(lookup, ordinal);
+                slots.push(Some(ordinal));
+                continue;
+            }
+            let Some((value, snapshot, metadata)) = certified.get(&lookup) else {
+                slots.push(None);
+                continue;
+            };
+            let ordinal = u32::try_from(builder.rows.len()).map_err(|_| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "certified historical fallback exceeds u32 rows",
+                )
+            })?;
+            builder.push_ref(key, value.clone(), snapshot.clone(), metadata.clone());
+            ordinal_by_key.insert(lookup, ordinal);
+            slots.push(Some(ordinal));
+        }
+        Self::new(builder.finish(), slots)
+    }
+
     pub(crate) fn into_rows(self) -> Vec<Option<MaterializedTrackedStateRow>> {
         let Self { batch, slots } = self;
         slots
@@ -534,7 +634,6 @@ struct MaterializedTrackedStateBatchBuilder {
 }
 
 impl MaterializedTrackedStateBatchBuilder {
-    #[cfg(test)]
     fn with_capacity(row_count: usize) -> Self {
         Self::with_capacities(row_count, row_count.saturating_mul(2), 0)
     }


### PR DESCRIPTION
## What changed

- fall back to immutable certified segments when an exact historical tracked-state read has missing plugin rows
- preserve tracked-tree authority for every present row and retain duplicate-slot alignment
- allow an authoritative certified base row when merge analysis has no expanded tracked-root entry

## Why

Certified fresh imports deliberately avoid expanding one tracked-root entry per semantic entity. Historical plugin conflict resolution still needs the common-ancestor snapshot. Previously target/source overlays loaded, but the certified base appeared absent, reducing a real three-way conflict to a side selection.

## Impact

Plugin conflict resolvers receive the durable common-ancestor snapshot without changing current-state generation masking, HOT live-count semantics, or the ordinary tracked-tree fast path. System-schema exact misses do not scan certified storage.

## Validation

- `cargo test -p lix_engine historical_exact_read_fills_missing_root_row_from_certified_batch -- --nocapture`
- `cargo test -p lix_engine certified_base_row_may_fill_merge_analysis_absence -- --nocapture`
- `cargo test -p lix_engine large_rootless_exact_batch_uses_encoded_replay_and_preserves_input_slots -- --nocapture`
- `cargo clippy -p lix_engine --lib -- --cap-lints warn`
- stacked v3 E2E: `v3_csv_same_row_branch_merge_composes_distinct_cells` passes