### PR TITLE
perf(engine): store dense text imports as certified pages

### DIFF
--- a/.changenotes/dense-git-text-authority.md
+++ b/.changenotes/dense-git-text-authority.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Large eager generic-text imports now persist host-certified semantic pages as current-state authority instead of duplicating every line in HOT storage.

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -593,7 +593,9 @@ pub(crate) async fn stage_certified_entity_batches(
             for (page_index, page) in batch.pages.iter().enumerate() {
                 let (first_local_ref, last_local_ref) = match batch.format {
                     1 => certified_csv_page_local_ref_range(page)?,
-                    2 => certified_packet_page_local_ref_range(page)?.unwrap_or((0, u32::MAX)),
+                    2 | crate::wasm::HOST_CERTIFIED_PACKET_FORMAT => {
+                        certified_packet_page_local_ref_range(page)?.unwrap_or((0, u32::MAX))
+                    }
                     _ => (0, u32::MAX),
                 };
                 value.extend_from_slice(&first_local_ref.to_le_bytes());
@@ -742,31 +744,32 @@ fn certified_external_page_plan(
         high: input.u64()?,
         low: input.u32()?,
     };
-    let selected_local_refs = ((format == 1 || format == 2)
-        && !request.filter.entity_pks.is_empty())
-    .then(|| {
-        let high = creates.high.to_be_bytes();
-        let low = creates.low.to_be_bytes();
-        request
-            .filter
-            .entity_pks
-            .iter()
-            .map(|entity_pk| match entity_pk.components.as_slice() {
-                [crate::entity_pk::EntityPkComponent::Uuid(bytes)]
-                    if bytes[..8] == high && bytes[8..12] == low =>
-                {
-                    Ok(u32::from_be_bytes(
-                        bytes[12..]
-                            .try_into()
-                            .expect("UUID local-reference suffix is four bytes"),
-                    ))
-                }
-                _ => Err(()),
-            })
-            .collect::<Result<BTreeSet<_>, _>>()
-            .ok()
-    })
-    .flatten();
+    let selected_local_refs =
+        ((format == 1 || format == 2 || format == crate::wasm::HOST_CERTIFIED_PACKET_FORMAT)
+            && !request.filter.entity_pks.is_empty())
+        .then(|| {
+            let high = creates.high.to_be_bytes();
+            let low = creates.low.to_be_bytes();
+            request
+                .filter
+                .entity_pks
+                .iter()
+                .map(|entity_pk| match entity_pk.components.as_slice() {
+                    [crate::entity_pk::EntityPkComponent::Uuid(bytes)]
+                        if bytes[..8] == high && bytes[8..12] == low =>
+                    {
+                        Ok(u32::from_be_bytes(
+                            bytes[12..]
+                                .try_into()
+                                .expect("UUID local-reference suffix is four bytes"),
+                        ))
+                    }
+                    _ => Err(()),
+                })
+                .collect::<Result<BTreeSet<_>, _>>()
+                .ok()
+        })
+        .flatten();
     let page_count = input.u32()?;
     let mut pages = Vec::with_capacity(page_count as usize);
     for page_index in 0..page_count {
@@ -1002,7 +1005,7 @@ fn decode_certified_entity_batch_rows(
     );
     let timestamp = LixTimestamp::parse(input.text()?).map_err(head_value_error)?;
     let format = input.u16()?;
-    if format != 1 && format != 2 {
+    if format != 1 && format != 2 && format != crate::wasm::HOST_CERTIFIED_PACKET_FORMAT {
         return Err(head_value_error(format!(
             "unsupported certified entity batch format {format}"
         )));
@@ -1062,7 +1065,7 @@ fn decode_certified_entity_batch_rows(
             let page_len = input.u32()? as usize;
             input.bytes(page_len)?
         };
-        if format == 2 {
+        if format == 2 || format == crate::wasm::HOST_CERTIFIED_PACKET_FORMAT {
             decoded_rows = decoded_rows.saturating_add(decode_certified_packet_rows(
                 page,
                 &creates,
@@ -1751,6 +1754,7 @@ fn stage_incremental_collection_controls(
     deltas: &[&CurrentStateDeltaRef<'_>],
     previous_values: &[Option<Bytes>],
     mut controls: BTreeMap<(String, Option<String>), HotCollectionControl>,
+    certified_live_increments: &BTreeMap<(String, Option<String>), u64>,
 ) -> Result<(), LixError> {
     use crate::collection_generation::{
         COLLECTION_GENERATION_SCHEMA_KEY, CollectionScopeRef, collection_scope_from_entity_pk,
@@ -1813,6 +1817,16 @@ fn stage_incremental_collection_controls(
                     .ok_or_else(|| head_value_error("hot collection live count underflow"))?
             };
         }
+    }
+
+    for (scope, increment) in certified_live_increments {
+        let control = controls
+            .get_mut(scope)
+            .expect("certified collection scope was loaded above");
+        control.live_count = control
+            .live_count
+            .checked_add(*increment)
+            .ok_or_else(|| head_value_error("hot collection live count exceeds u64"))?;
     }
 
     for ((schema_key, file_id), control) in controls {
@@ -2731,6 +2745,38 @@ where
             None,
             None,
             false,
+            &BTreeMap::new(),
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn stage_current_state_with_certified_counts(
+        &mut self,
+        branch_id: &str,
+        parent_generation: Option<CommitId>,
+        new_head: CommitId,
+        deltas: &[CurrentStateDeltaRef<'_>],
+        absence_guards: &BTreeSet<TrackedStateKey>,
+        working_diff_capture_checkpoint_commit_id: Option<CommitId>,
+        coverage: &mut WorkingDiffIndexCoverage,
+        certified_live_increments: &BTreeMap<(String, Option<String>), u64>,
+    ) -> Result<CommitId, LixError> {
+        self.stage_current_state_with_working_diff_inner(
+            branch_id,
+            parent_generation,
+            new_head,
+            deltas,
+            absence_guards,
+            None,
+            None,
+            working_diff_capture_checkpoint_commit_id,
+            coverage,
+            false,
+            None,
+            None,
+            false,
+            certified_live_increments,
         )
         .await
     }
@@ -2765,6 +2811,7 @@ where
             None,
             None,
             true,
+            &BTreeMap::new(),
         )
         .await
     }
@@ -2810,6 +2857,7 @@ where
                     validated_absent_file_id,
                     None,
                     false,
+                    &BTreeMap::new(),
                 )
                 .await;
         }
@@ -2828,6 +2876,7 @@ where
             validated_absent_file_id,
             Some(absence_guards),
             false,
+            &BTreeMap::new(),
         )
         .await
     }
@@ -2848,6 +2897,7 @@ where
         validated_absent_file_id: Option<&str>,
         borrowed_absence_guards: Option<&[TrackedStateKeyRef<'_>]>,
         reset_working_diff_baselines: bool,
+        certified_live_increments: &BTreeMap<(String, Option<String>), u64>,
     ) -> Result<CommitId, LixError> {
         let generation = parent_generation.unwrap_or(new_head);
         let sorted = {
@@ -2940,9 +2990,40 @@ where
             })
             .collect::<Vec<_>>();
         debug_assert_eq!(loaded_previous_values.len(), 0);
-        let collection_controls =
+        let mut collection_controls =
             load_incremental_collection_controls(self.store, branch_id, generation, &sorted)
                 .await?;
+        let missing_certified_scopes = certified_live_increments
+            .keys()
+            .filter(|scope| !collection_controls.contains_key(*scope))
+            .map(
+                |(schema_key, file_id)| crate::collection_generation::CollectionScopeRef {
+                    schema_key,
+                    file_id: file_id.as_deref(),
+                },
+            )
+            .collect::<Vec<_>>();
+        let missing_certified_controls = load_hot_collection_controls(
+            self.store,
+            branch_id,
+            generation,
+            &missing_certified_scopes,
+        )
+        .await?;
+        collection_controls.extend(
+            missing_certified_scopes
+                .into_iter()
+                .zip(missing_certified_controls)
+                .map(|(scope, control)| {
+                    (
+                        (
+                            scope.schema_key.to_owned(),
+                            scope.file_id.map(str::to_owned),
+                        ),
+                        control,
+                    )
+                }),
+        );
         for (delta, previous) in sorted.iter().zip(&mut previous_values) {
             if delta.schema_key == crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY {
                 continue;
@@ -3118,6 +3199,7 @@ where
             &sorted,
             &previous_values,
             collection_controls,
+            certified_live_increments,
         )?;
 
         let _stage_span = tracing::debug_span!(

--- a/packages/engine/src/plugin/incremental.rs
+++ b/packages/engine/src/plugin/incremental.rs
@@ -1808,6 +1808,108 @@ fn validate_certified_entity_batches(
     Ok(())
 }
 
+const HOST_CERTIFIED_PACKET_TARGET_BYTES: usize = 256 * 1024;
+const HOST_CERTIFIED_PACKET_MIN_ROWS: usize = 64;
+const DENSE_TEXT_SCHEMA_KEY: &str = "git_text_line_v2";
+
+/// Retains a complete, eagerly validated generic-text import in dense packet
+/// pages. The ordinary v2 change list remains intact for changelog and
+/// transaction materialization; the tracked-head writer may use this complete
+/// batch as the authoritative current-state owner instead of persisting a
+/// second expanded HOT row per line.
+pub(crate) fn certify_dense_v2_fresh_file(
+    transition: &mut ValidatedFileTransition,
+    creates: crate::wasm::WasmCreateContext,
+    schemas: &V2SchemaAllowlist,
+) -> Result<(), LixError> {
+    if !transition.certified_batches.is_empty()
+        || transition.changes.changes.len() < HOST_CERTIFIED_PACKET_MIN_ROWS
+    {
+        return Ok(());
+    }
+    if !transition.changes.changes.iter().all(|change| {
+        matches!(
+            change,
+            WasmEntityChange::Create {
+                schema_key,
+                resolved_key: None,
+                snapshot_content: WasmHostBytes::CanonicalJson(_),
+                ..
+            } if schema_key == DENSE_TEXT_SCHEMA_KEY
+        )
+    }) {
+        return Ok(());
+    }
+    schemas.validate(DENSE_TEXT_SCHEMA_KEY)?;
+
+    let mut pages = Vec::new();
+    let mut page = Vec::with_capacity(HOST_CERTIFIED_PACKET_TARGET_BYTES);
+    for change in &transition.changes.changes {
+        let WasmEntityChange::Create {
+            schema_key,
+            local_ref,
+            snapshot_content: WasmHostBytes::CanonicalJson(snapshot),
+            ..
+        } = change
+        else {
+            unreachable!("dense text eligibility was checked above");
+        };
+        let schema_bytes = schema_key.as_bytes();
+        let snapshot_bytes = snapshot.normalized().as_bytes();
+        let record_len = 1_usize
+            .checked_add(4)
+            .and_then(|len| len.checked_add(schema_bytes.len()))
+            .and_then(|len| len.checked_add(8 + 1 + 4))
+            .and_then(|len| len.checked_add(snapshot_bytes.len()))
+            .ok_or_else(|| invalid_guest("host certified packet record size overflowed"))?;
+        let framed_len = 4_usize
+            .checked_add(record_len)
+            .ok_or_else(|| invalid_guest("host certified packet frame size overflowed"))?;
+        if !page.is_empty()
+            && page.len().saturating_add(framed_len) > HOST_CERTIFIED_PACKET_TARGET_BYTES
+        {
+            pages.push(Bytes::from(std::mem::take(&mut page)));
+            page = Vec::with_capacity(HOST_CERTIFIED_PACKET_TARGET_BYTES.max(framed_len));
+        }
+        page.extend_from_slice(
+            &u32::try_from(record_len)
+                .map_err(|_| invalid_guest("host certified packet record exceeds u32"))?
+                .to_le_bytes(),
+        );
+        page.push(2);
+        page.extend_from_slice(
+            &u32::try_from(schema_bytes.len())
+                .map_err(|_| invalid_guest("host certified packet schema exceeds u32"))?
+                .to_le_bytes(),
+        );
+        page.extend_from_slice(schema_bytes);
+        page.extend_from_slice(&local_ref.to_le_bytes());
+        page.push(0);
+        page.extend_from_slice(
+            &u32::try_from(snapshot_bytes.len())
+                .map_err(|_| invalid_guest("host certified packet snapshot exceeds u32"))?
+                .to_le_bytes(),
+        );
+        page.extend_from_slice(snapshot_bytes);
+    }
+    if !page.is_empty() {
+        pages.push(Bytes::from(page));
+    }
+    let batch = WasmCertifiedEntityBatch {
+        // Format 3 is the host-only equivalent of the format-2 packet codec.
+        // Guest batches are validated before this synthesis point and the
+        // guest-facing validator intentionally rejects format 3.
+        format: crate::wasm::HOST_CERTIFIED_PACKET_FORMAT,
+        schema_keys: vec![DENSE_TEXT_SCHEMA_KEY.to_owned()],
+        row_count: transition.changes.changes.len() as u64,
+        creates,
+        complete_file_state: true,
+        pages,
+    };
+    transition.certified_batches.push(batch);
+    Ok(())
+}
+
 fn validate_certified_snapshot_packets(
     batch: &WasmCertifiedEntityBatch,
     schemas: &V2SchemaAllowlist,

--- a/packages/engine/src/plugin/mod.rs
+++ b/packages/engine/src/plugin/mod.rs
@@ -30,10 +30,10 @@ pub(crate) use incremental::{
     ArcByteSource, FileBytesSha256, LiveBatchEntitySource, V2SchemaAllowlist,
     ValidatedConflictTransition, ValidatedFileTransition, ValidatedSameLengthOutputSplice,
     VecEntityChangeSource, VecEntityConflictSource, VecEntitySource, build_file_update_splices,
-    canonicalize_v2_snapshot, drain_conflict_transition_resolutions, drain_entity_transition_edits,
-    drain_file_transition_changes, host_entity_change_with_lazy_snapshot,
-    host_entity_with_lazy_snapshot, transport_splice_preserves_git_text,
-    transport_splice_preserves_utf8,
+    canonicalize_v2_snapshot, certify_dense_v2_fresh_file, drain_conflict_transition_resolutions,
+    drain_entity_transition_edits, drain_file_transition_changes,
+    host_entity_change_with_lazy_snapshot, host_entity_with_lazy_snapshot,
+    transport_splice_preserves_git_text, transport_splice_preserves_utf8,
 };
 pub(crate) use install::{PluginArchiveInstallPlan, plugin_install_plan_from_archive_path};
 pub(crate) use manifest::{

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -86,6 +86,48 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         crate::transaction::validation::fresh_plugin_file_import_certificate(&prepared_writes)
             .is_some()
             .then(|| prepared_writes.file_data_writes[0].file_id.clone());
+    let mut host_certified_file_schemas =
+        BTreeMap::<String, BTreeMap<String, BTreeSet<String>>>::new();
+    let mut host_certified_live_increments =
+        BTreeMap::<String, BTreeMap<(String, Option<String>), u64>>::new();
+    for file in &prepared_writes.file_data_writes {
+        for batch in file.certified_entity_batches().iter().filter(|batch| {
+            batch.complete_file_state && batch.format == crate::wasm::HOST_CERTIFIED_PACKET_FORMAT
+        }) {
+            let [schema_key] = batch.schema_keys.as_slice() else {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "host-certified packet batch must own exactly one schema",
+                ));
+            };
+            host_certified_file_schemas
+                .entry(file.branch_id.clone())
+                .or_default()
+                .entry(file.file_id.clone())
+                .or_default()
+                .extend(batch.schema_keys.iter().cloned());
+            let increments = host_certified_live_increments
+                .entry(file.branch_id.clone())
+                .or_default();
+            for scope in [
+                (schema_key.clone(), None),
+                (schema_key.clone(), Some(file.file_id.clone())),
+            ] {
+                let next = increments
+                    .get(&scope)
+                    .copied()
+                    .unwrap_or_default()
+                    .checked_add(batch.row_count)
+                    .ok_or_else(|| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            "host-certified collection live count exceeds u64",
+                        )
+                    })?;
+                increments.insert(scope, next);
+            }
+        }
+    }
     let mut writes = StorageWriteSet::new();
     let mut preconditions = Vec::new();
     for publication in &prepared_writes.checkpoint_publications {
@@ -122,6 +164,10 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     if !prepared_writes.file_data_writes.is_empty() {
         let mut blob_writer = binary_cas.writer_skipping_existing_chunks(&*read, &mut writes);
         for write in &prepared_writes.file_data_writes {
+            if !write.stage_payload_at_commit() {
+                debug_assert!(write.auxiliary_payloads().is_empty());
+                continue;
+            }
             blob_writer
                 .stage_file_payload(write.payload(), write.same_length_blob_splice())
                 .instrument(tracing::debug_span!(
@@ -272,6 +318,8 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &selected_change_payloads,
         &insert_selection,
         certified_fresh_plugin_file_id.as_deref(),
+        &host_certified_file_schemas,
+        &host_certified_live_increments,
         &explicit_branch_targets,
         &branch_control_observations,
         &checkpoint_epochs,
@@ -1678,6 +1726,8 @@ async fn stage_tracked_head(
     >,
     insert_selection: &PreparedInsertSelection,
     certified_fresh_plugin_file_id: Option<&str>,
+    host_certified_file_schemas: &BTreeMap<String, BTreeMap<String, BTreeSet<String>>>,
+    host_certified_live_increments: &BTreeMap<String, BTreeMap<(String, Option<String>), u64>>,
     explicit_branch_targets: &BTreeMap<String, ExplicitBranchHeadTarget>,
     observations: &BTreeMap<String, BranchHeadControlObservation>,
     checkpoint_epochs: &BTreeMap<String, CommitId>,
@@ -1901,6 +1951,7 @@ async fn stage_tracked_head(
             .map(|epoch| epoch.coverage)
             .unwrap_or_default();
         let can_defer_fresh_hot = certified_fresh_plugin_file_id.is_some()
+            && !host_certified_live_increments.contains_key(&root.branch_id)
             && tracked_roots.len() == 1
             && state_row_indices.len() == state_rows.len()
             && staged.selected_change_batches.is_empty()
@@ -1954,6 +2005,15 @@ async fn stage_tracked_head(
             .entered();
             state_row_indices
                 .iter()
+                .filter(|&&row_index| {
+                    let row = state_rows.row(row_index);
+                    !row.file_id.is_some_and(|file_id| {
+                        host_certified_file_schemas
+                            .get(&root.branch_id)
+                            .and_then(|files| files.get(file_id.as_str()))
+                            .is_some_and(|schemas| schemas.contains(row.schema_key.as_str()))
+                    })
+                })
                 .map(|&row_index| current_state_delta_from_state_row(state_rows.row(row_index)))
                 .collect::<Result<Vec<_>, _>>()?
         };
@@ -2007,6 +2067,26 @@ async fn stage_tracked_head(
                 .instrument(tracing::debug_span!(
                     target: "lix_perf",
                     "lix.perf.materialization.tracked_head.stage_checkpoint"
+                ))
+                .await?
+        } else if let Some(certified_live_increments) =
+            host_certified_live_increments.get(&root.branch_id)
+        {
+            let owned_absence_guards = owned_absence_guards(&absence_guards);
+            writer
+                .stage_current_state_with_certified_counts(
+                    &root.branch_id,
+                    Some(parent_generation),
+                    root.commit_id,
+                    &deltas,
+                    &owned_absence_guards,
+                    working_diff_capture_checkpoint_commit_id,
+                    &mut coverage,
+                    certified_live_increments,
+                )
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.materialization.tracked_head.stage_current_state"
                 ))
                 .await?
         } else if has_validated_insert_deltas {

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -902,6 +902,24 @@ fn current_state_delta_from_state_row(
     })
 }
 
+fn host_certified_batch_owns_live_row(
+    row: PreparedStateRowRef<'_>,
+    branch_id: &str,
+    host_certified_file_schemas: &BTreeMap<String, BTreeMap<String, BTreeSet<String>>>,
+) -> bool {
+    // A complete certified batch replaces only the incoming live rows. An
+    // ownership transition may stage tombstones for the previous plugin under
+    // the same file/schema pair; those must remain HOT overlays so the old
+    // entity identities disappear and collection counts are decremented.
+    row.snapshot.is_some()
+        && row.file_id.is_some_and(|file_id| {
+            host_certified_file_schemas
+                .get(branch_id)
+                .and_then(|files| files.get(file_id.as_str()))
+                .is_some_and(|schemas| schemas.contains(row.schema_key.as_str()))
+        })
+}
+
 impl crate::live_state::DeferredFreshHotRows for PreparedStateBatch {
     fn row(&self, index: usize) -> crate::live_state::DeferredFreshHotRowRef<'_> {
         let row = PreparedStateBatch::row(self, index);
@@ -2007,12 +2025,11 @@ async fn stage_tracked_head(
                 .iter()
                 .filter(|&&row_index| {
                     let row = state_rows.row(row_index);
-                    !row.file_id.is_some_and(|file_id| {
-                        host_certified_file_schemas
-                            .get(&root.branch_id)
-                            .and_then(|files| files.get(file_id.as_str()))
-                            .is_some_and(|schemas| schemas.contains(row.schema_key.as_str()))
-                    })
+                    !host_certified_batch_owns_live_row(
+                        row,
+                        &root.branch_id,
+                        host_certified_file_schemas,
+                    )
                 })
                 .map(|&row_index| current_state_delta_from_state_row(state_rows.row(row_index)))
                 .collect::<Result<Vec<_>, _>>()?
@@ -3451,6 +3468,47 @@ mod tests {
 
     fn ts(value: &str) -> LixTimestamp {
         LixTimestamp::expect_parse("timestamp", value)
+    }
+
+    #[test]
+    fn host_certified_ownership_change_preserves_old_plugin_tombstone() {
+        let mut old_plugin_tombstone = tracked_branch_row("main", "old-plugin-delete");
+        old_plugin_tombstone.entity_pk = EntityPk::single("old-plugin-line");
+        old_plugin_tombstone.schema_key = "git_text_line_v2".into();
+        old_plugin_tombstone.file_id = Some("file-a".into());
+        old_plugin_tombstone.snapshot = None;
+
+        let mut new_plugin_live = tracked_branch_row("main", "new-plugin-create");
+        new_plugin_live.entity_pk = EntityPk::single("new-plugin-line");
+        new_plugin_live.schema_key = "git_text_line_v2".into();
+        new_plugin_live.file_id = Some("file-a".into());
+
+        let certified = BTreeMap::from([(
+            "main".to_string(),
+            BTreeMap::from([(
+                "file-a".to_string(),
+                BTreeSet::from(["git_text_line_v2".to_string()]),
+            )]),
+        )]);
+
+        assert!(
+            !host_certified_batch_owns_live_row(
+                old_plugin_tombstone.borrowed(),
+                "main",
+                &certified,
+            ),
+            "the previous owner's tombstone must remain in HOT publication",
+        );
+        assert!(
+            current_state_delta_from_state_row(old_plugin_tombstone.borrowed())
+                .expect("ownership tombstone should lower")
+                .deleted,
+            "the retained row must decrement collection counts as a deletion",
+        );
+        assert!(
+            host_certified_batch_owns_live_row(new_plugin_live.borrowed(), "main", &certified),
+            "the certified batch owns the replacement live row",
+        );
     }
 
     #[test]

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -2066,12 +2066,20 @@ where
                 }
                 let file_data = file_data
                     .into_iter()
-                    .filter(|write| {
-                        let key = PluginFileWriteKey::from(write);
-                        !reconciliation.file_keys.contains(&key)
+                    .filter_map(|mut write| {
+                        let key = PluginFileWriteKey::from(&write);
+                        let retain_payload = !reconciliation.file_keys.contains(&key)
                             && !reconciliation.derived_materializations.contains_key(&key)
                             && (!write.is_empty()
-                                || reconciliation.materialized_file_keys.contains(&key))
+                                || reconciliation.materialized_file_keys.contains(&key));
+                        if retain_payload {
+                            return Some(write);
+                        }
+                        if write.certified_entity_batches().is_empty() {
+                            return None;
+                        }
+                        write.retain_certified_batches_only();
+                        Some(write)
                     })
                     .collect();
                 Ok((
@@ -3412,7 +3420,7 @@ where
                                 "lix.perf.plugin_open_file"
                             ))
                             .await?;
-                        let validated = drain_file_transition_changes(
+                        let mut validated = drain_file_transition_changes(
                             actor.as_mut(),
                             transition,
                             &schemas,
@@ -3423,6 +3431,11 @@ where
                             "lix.perf.plugin_open_file_drain"
                         ))
                         .await?;
+                        crate::plugin::certify_dense_v2_fresh_file(
+                            &mut validated,
+                            creates,
+                            &schemas,
+                        )?;
                         Ok((actor, validated))
                     });
                     PendingFreshPluginOpen {
@@ -4054,7 +4067,7 @@ where
                         "lix.perf.plugin_open_file"
                     ))
                     .await?;
-                let validated = drain_file_transition_changes(
+                let mut validated = drain_file_transition_changes(
                     actor.as_mut(),
                     transition,
                     &schemas,
@@ -4065,6 +4078,7 @@ where
                     "lix.perf.plugin_open_file_drain"
                 ))
                 .await?;
+                crate::plugin::certify_dense_v2_fresh_file(&mut validated, creates, &schemas)?;
                 let certified_row_count = validated
                     .certified_batches
                     .iter()

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -1116,6 +1116,10 @@ pub(crate) struct TransactionFileData {
     /// Plugin installation uses this for the extracted WASM component so
     /// steady-state reads can load it directly without reopening the archive.
     auxiliary_payloads: Vec<BlobPayload>,
+    /// Reconciliation may retain this record only as the owner of certified
+    /// semantic batches after its file payload has already been materialized
+    /// through the ordinary plugin path.
+    stage_payload_at_commit: bool,
     /// Certified v3 semantic owners which remain encoded through commit.
     certified_entity_batches: Vec<WasmCertifiedEntityBatch>,
 }
@@ -1144,6 +1148,7 @@ impl TransactionFileData {
             mutation_identity: None,
             payload: BlobPayload::from_bytes(data),
             auxiliary_payloads: Vec::new(),
+            stage_payload_at_commit: true,
             certified_entity_batches: Vec::new(),
         }
     }
@@ -1188,6 +1193,14 @@ impl TransactionFileData {
 
     pub(crate) fn certified_entity_batches(&self) -> &[WasmCertifiedEntityBatch] {
         &self.certified_entity_batches
+    }
+
+    pub(crate) fn retain_certified_batches_only(&mut self) {
+        self.stage_payload_at_commit = false;
+    }
+
+    pub(crate) fn stage_payload_at_commit(&self) -> bool {
+        self.stage_payload_at_commit
     }
 
     pub(crate) fn data(&self) -> &[u8] {

--- a/packages/engine/src/wasm/component_v2.rs
+++ b/packages/engine/src/wasm/component_v2.rs
@@ -1561,6 +1561,11 @@ pub struct WasmCertifiedEntityBatch {
     pub pages: Vec<Bytes>,
 }
 
+/// Dense snapshot packets synthesized only after ordinary v2 guest output has
+/// completed host validation. Guest-emitted certified batches intentionally
+/// cannot claim this format.
+pub(crate) const HOST_CERTIFIED_PACKET_FORMAT: u16 = 3;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WasmEntityTransition {
     pub transition: WasmTransitionHandle,


### PR DESCRIPTION
## Summary

- eagerly synthesize host-certified packet pages after ordinary WASM v2 output has been fully drained, validated, and canonicalized
- make those complete pages authoritative for fresh `git_text_line_v2` current state, avoiding a duplicate expanded HOT row per line while preserving changelog/history facts
- integrate certified rows with #977 collection-generation live-count controls and keep later mutations as sparse HOT overlays
- retain the WASM plugin boundary: format 3 is host-only and guest-emitted batches cannot claim it

This is stacked on #979, which fixes the native storage profiler inventory so certified namespaces are measured correctly.

## Data

Exact 100-commit OpenClaw replay, all md/csv/text WASM plugins enabled, eager materialization, checkpoint every Git commit, final state verified against Git:

| Metric | `origin/main` after #977 | Candidate | Change |
|---|---:|---:|---:|
| Execute | 3,672.3 ms | 3,792.7 ms | +3.3% |
| Checkpoint | 1,005.2 ms | 480.0 ms | **-52.3%** |
| Execute + checkpoint | 4,677.5 ms | 4,272.6 ms | **-8.7%** |
| Total incl. verification | 7,233.5 ms | 7,177.4 ms | -0.8% |
| Logical key+value bytes | 21,348,668 | 15,329,085 | **-28.2%** |
| HOT rows | 20,318 | 6,710 | **-67.0%** |
| Commit delta segments | 527 | 326 | -38.1% |

Change-locator cardinality remains identical at 29,277, demonstrating history facts were retained. Candidate storage contains 38 certified headers, 38 manifests, and 41 packet pages. The retained replay databases are:

- baseline: `/root/projects/openclaw-perf-data/main977-100-db`
- candidate: `/root/projects/openclaw-perf-data/dense-text-pages-no-cas-100-db`

## Validation

- `cargo test -p lix_engine --features all-simulations` (green: 782 simulation tests, 3 doctests)
- `cargo test -p lix_engine --features all-simulations --lib` (green: 1,572 passed, 6 ignored)
- focused collection-generation and transaction staging tests
- exact 100/100 OpenClaw replay with checkpoint-per-commit and final Git-tree verification
