### PR TITLE
compress eager Markdown semantic pages

### DIFF
--- a/.changenotes/compress-markdown-certified-pages.md
+++ b/.changenotes/compress-markdown-certified-pages.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Large eager Markdown imports now persist host-certified semantic pages with bounded zstd compression, batch broad page reads, and seek exact-file manifests directly.

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -630,6 +630,9 @@ pub(crate) async fn stage_certified_entity_batches(
                     2 | crate::wasm::HOST_CERTIFIED_PACKET_FORMAT => {
                         certified_packet_page_local_ref_range(page)?.unwrap_or((0, u32::MAX))
                     }
+                    crate::wasm::HOST_CERTIFIED_ZSTD_PACKET_FORMAT => {
+                        certified_zstd_packet_page_header(page)?.0
+                    }
                     _ => (0, u32::MAX),
                 };
                 value.extend_from_slice(&first_local_ref.to_le_bytes());
@@ -756,6 +759,59 @@ fn certified_packet_page_local_ref_range(page: &[u8]) -> Result<Option<(u32, u32
     Ok(first.zip(last))
 }
 
+fn certified_zstd_packet_page_header(page: &[u8]) -> Result<((u32, u32), usize, &[u8]), LixError> {
+    let (header, compressed) = page
+        .split_at_checked(12)
+        .ok_or_else(|| head_value_error("compressed certified packet page is truncated"))?;
+    let first_local_ref = u32::from_le_bytes(
+        header[..4]
+            .try_into()
+            .expect("compressed packet first local ref"),
+    );
+    let last_local_ref = u32::from_le_bytes(
+        header[4..8]
+            .try_into()
+            .expect("compressed packet last local ref"),
+    );
+    if first_local_ref > last_local_ref {
+        return Err(head_value_error(
+            "compressed certified packet page has an inverted local-ref range",
+        ));
+    }
+    let uncompressed_len = u32::from_le_bytes(
+        header[8..12]
+            .try_into()
+            .expect("compressed packet uncompressed length"),
+    ) as usize;
+    if uncompressed_len == 0 || uncompressed_len > 64 * 1024 * 1024 {
+        return Err(head_value_error(
+            "compressed certified packet page has an invalid uncompressed length",
+        ));
+    }
+    Ok((
+        (first_local_ref, last_local_ref),
+        uncompressed_len,
+        compressed,
+    ))
+}
+
+fn decode_certified_zstd_packet_page(page: &[u8]) -> Result<Vec<u8>, LixError> {
+    let (_, uncompressed_len, compressed) = certified_zstd_packet_page_header(page)?;
+    let decoded =
+        crate::compression::decompress_zstd(compressed, uncompressed_len).map_err(|error| {
+            head_value_error(format!(
+                "compressed certified packet page failed to decode: {error}"
+            ))
+        })?;
+    if decoded.len() != uncompressed_len {
+        return Err(head_value_error(format!(
+            "compressed certified packet page decoded to {} bytes, expected {uncompressed_len}",
+            decoded.len(),
+        )));
+    }
+    Ok(decoded)
+}
+
 fn certified_external_page_plan(
     bytes: &[u8],
     content_key: &[u8],
@@ -778,32 +834,34 @@ fn certified_external_page_plan(
         high: input.u64()?,
         low: input.u32()?,
     };
-    let selected_local_refs =
-        ((format == 1 || format == 2 || format == crate::wasm::HOST_CERTIFIED_PACKET_FORMAT)
-            && !request.filter.entity_pks.is_empty())
-        .then(|| {
-            let high = creates.high.to_be_bytes();
-            let low = creates.low.to_be_bytes();
-            request
-                .filter
-                .entity_pks
-                .iter()
-                .map(|entity_pk| match entity_pk.components.as_slice() {
-                    [crate::entity_pk::EntityPkComponent::Uuid(bytes)]
-                        if bytes[..8] == high && bytes[8..12] == low =>
-                    {
-                        Ok(u32::from_be_bytes(
-                            bytes[12..]
-                                .try_into()
-                                .expect("UUID local-reference suffix is four bytes"),
-                        ))
-                    }
-                    _ => Err(()),
-                })
-                .collect::<Result<BTreeSet<_>, _>>()
-                .ok()
-        })
-        .flatten();
+    let selected_local_refs = ((format == 1
+        || format == 2
+        || format == crate::wasm::HOST_CERTIFIED_PACKET_FORMAT
+        || format == crate::wasm::HOST_CERTIFIED_ZSTD_PACKET_FORMAT)
+        && !request.filter.entity_pks.is_empty())
+    .then(|| {
+        let high = creates.high.to_be_bytes();
+        let low = creates.low.to_be_bytes();
+        request
+            .filter
+            .entity_pks
+            .iter()
+            .map(|entity_pk| match entity_pk.components.as_slice() {
+                [crate::entity_pk::EntityPkComponent::Uuid(bytes)]
+                    if bytes[..8] == high && bytes[8..12] == low =>
+                {
+                    Ok(u32::from_be_bytes(
+                        bytes[12..]
+                            .try_into()
+                            .expect("UUID local-reference suffix is four bytes"),
+                    ))
+                }
+                _ => Err(()),
+            })
+            .collect::<Result<BTreeSet<_>, _>>()
+            .ok()
+    })
+    .flatten();
     let page_count = input.u32()?;
     let mut pages = Vec::with_capacity(page_count as usize);
     for page_index in 0..page_count {
@@ -841,17 +899,50 @@ async fn scan_certified_entity_batch_rows(
     if matches!(limit, Some(0)) {
         return Ok(MaterializedLiveStateBatch::default());
     }
-    let manifests = ScanPlan::prefix(
-        CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE,
-        StoragePrefix {
-            bytes: Bytes::copy_from_slice(generation.as_uuid().as_bytes()),
-        },
-    )
-    .collect(store, StorageScanOptions::default())
-    .await?;
-    let content_keys = manifests
-        .value
-        .entries
+    let exact_file_ids = (!request.filter.file_ids.is_empty()
+        && !request
+            .filter
+            .file_ids
+            .iter()
+            .any(|file_id| matches!(file_id, NullableKeyFilter::Any)))
+    .then(|| {
+        request
+            .filter
+            .file_ids
+            .iter()
+            .filter_map(|file_id| match file_id {
+                NullableKeyFilter::Value(file_id) => Some(file_id.as_str()),
+                NullableKeyFilter::Any | NullableKeyFilter::Null => None,
+            })
+            .collect::<BTreeSet<_>>()
+    });
+    let mut manifest_entries = Vec::new();
+    if let Some(file_ids) = exact_file_ids {
+        for file_id in file_ids {
+            let mut prefix = generation.as_uuid().as_bytes().to_vec();
+            append_batch_text(&mut prefix, file_id)?;
+            let manifests = ScanPlan::prefix(
+                CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE,
+                StoragePrefix {
+                    bytes: Bytes::from(prefix),
+                },
+            )
+            .collect(store, StorageScanOptions::default())
+            .await?;
+            manifest_entries.extend(manifests.value.entries);
+        }
+    } else {
+        let manifests = ScanPlan::prefix(
+            CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE,
+            StoragePrefix {
+                bytes: Bytes::copy_from_slice(generation.as_uuid().as_bytes()),
+            },
+        )
+        .collect(store, StorageScanOptions::default())
+        .await?;
+        manifest_entries = manifests.value.entries;
+    }
+    let content_keys = manifest_entries
         .into_iter()
         .map(|entry| full_value_bytes(entry.value).map(StorageKey))
         .collect::<Result<Vec<_>, _>>()?;
@@ -867,35 +958,46 @@ async fn scan_certified_entity_batch_rows(
             .columns
             .iter()
             .any(|column| column == "snapshot_content");
-    let mut builder = MaterializedLiveStateBatchBuilder::with_capacity(
-        limit.unwrap_or_else(|| contents.len().saturating_mul(1024)),
-    );
+    let mut decode_inputs = Vec::with_capacity(content_keys.len());
+    let mut page_routes = Vec::new();
+    let mut page_keys = Vec::new();
     for (content_key, value) in content_keys.into_iter().zip(contents) {
         let Some(value) = value else {
             continue;
         };
         let value = full_value_bytes(value)?;
         let external_plan = certified_external_page_plan(&value, content_key.0.as_ref(), request)?;
-        let external_pages = if let Some(plan) = &external_plan {
-            let keys = plan.iter().map(|(_, key)| key.clone()).collect::<Vec<_>>();
-            let values = PointReadPlan::new(CERTIFIED_ENTITY_BATCH_PAGE_SPACE, &keys)
-                .materialize(store, StorageGetOptions::default())
-                .await?
-                .value;
-            Some(
-                plan.iter()
-                    .zip(values)
-                    .map(|((page_index, _), value)| {
-                        let value = value.ok_or_else(|| {
-                            head_value_error("certified entity batch page is missing")
-                        })?;
-                        Ok((*page_index, full_value_bytes(value)?))
-                    })
-                    .collect::<Result<Vec<_>, LixError>>()?,
-            )
-        } else {
-            None
-        };
+        let input_index = decode_inputs.len();
+        let external_pages = external_plan
+            .as_ref()
+            .map(|plan| Vec::with_capacity(plan.len()));
+        if let Some(plan) = external_plan {
+            for (page_index, key) in plan {
+                page_routes.push((input_index, page_index));
+                page_keys.push(key);
+            }
+        }
+        decode_inputs.push((value, external_pages));
+    }
+    if !page_keys.is_empty() {
+        let page_values = PointReadPlan::new(CERTIFIED_ENTITY_BATCH_PAGE_SPACE, &page_keys)
+            .materialize(store, StorageGetOptions::default())
+            .await?
+            .value;
+        for ((input_index, page_index), value) in page_routes.into_iter().zip(page_values) {
+            let value =
+                value.ok_or_else(|| head_value_error("certified entity batch page is missing"))?;
+            decode_inputs[input_index]
+                .1
+                .as_mut()
+                .expect("external page route belongs to an external batch")
+                .push((page_index, full_value_bytes(value)?));
+        }
+    }
+    let mut builder = MaterializedLiveStateBatchBuilder::with_capacity(
+        limit.unwrap_or_else(|| decode_inputs.len().saturating_mul(1024)),
+    );
+    for (value, external_pages) in decode_inputs {
         decode_certified_entity_batch_rows(
             &value,
             external_pages.as_deref(),
@@ -1041,7 +1143,11 @@ fn decode_certified_entity_batch_rows(
     );
     let timestamp = LixTimestamp::parse(input.text()?).map_err(head_value_error)?;
     let format = input.u16()?;
-    if format != 1 && format != 2 && format != crate::wasm::HOST_CERTIFIED_PACKET_FORMAT {
+    if format != 1
+        && format != 2
+        && format != crate::wasm::HOST_CERTIFIED_PACKET_FORMAT
+        && format != crate::wasm::HOST_CERTIFIED_ZSTD_PACKET_FORMAT
+    {
         return Err(head_value_error(format!(
             "unsupported certified entity batch format {format}"
         )));
@@ -1101,7 +1207,17 @@ fn decode_certified_entity_batch_rows(
             let page_len = input.u32()? as usize;
             input.bytes(page_len)?
         };
-        if format == 2 || format == crate::wasm::HOST_CERTIFIED_PACKET_FORMAT {
+        let decoded_page;
+        let page = if format == crate::wasm::HOST_CERTIFIED_ZSTD_PACKET_FORMAT {
+            decoded_page = decode_certified_zstd_packet_page(page)?;
+            decoded_page.as_slice()
+        } else {
+            page
+        };
+        if format == 2
+            || format == crate::wasm::HOST_CERTIFIED_PACKET_FORMAT
+            || format == crate::wasm::HOST_CERTIFIED_ZSTD_PACKET_FORMAT
+        {
             decoded_rows = decoded_rows.saturating_add(decode_certified_packet_rows(
                 page,
                 &creates,
@@ -6537,11 +6653,46 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use bytes::Bytes;
 
     use super::*;
     use crate::branch::{BranchHeadControl, stage_branch_head_control};
-    use crate::storage_adapter::{Memory, StorageAdapter, StorageReadOptions, StorageWriteOptions};
+    use crate::storage_adapter::{
+        Memory, StorageAdapter, StorageGetManyRequest, StorageGetManyResult, StorageKeyRange,
+        StorageReadOptions, StorageScanChunk, StorageScanOptions, StorageSpaceId,
+        StorageWriteOptions,
+    };
+
+    struct CountingRead<R> {
+        inner: R,
+        get_many_calls: Arc<AtomicUsize>,
+    }
+
+    impl<R: StorageAdapterRead> StorageAdapterRead for CountingRead<R> {
+        fn snapshot_cache_key(&self) -> Option<u128> {
+            self.inner.snapshot_cache_key()
+        }
+
+        async fn get_many(
+            &self,
+            requests: &[StorageGetManyRequest<'_>],
+        ) -> Result<StorageGetManyResult, crate::storage_adapter::StorageError> {
+            self.get_many_calls.fetch_add(1, Ordering::Relaxed);
+            self.inner.get_many(requests).await
+        }
+
+        async fn scan(
+            &self,
+            space: StorageSpaceId,
+            range: StorageKeyRange,
+            opts: StorageScanOptions,
+        ) -> Result<StorageScanChunk, crate::storage_adapter::StorageError> {
+            self.inner.scan(space, range, opts).await
+        }
+    }
 
     fn timestamp() -> LixTimestamp {
         LixTimestamp::expect_parse("hot working-diff test timestamp", "2026-01-01T00:00:00Z")
@@ -6631,6 +6782,86 @@ mod tests {
         assert_eq!(certified_packet_page_local_ref_range(&keyed).unwrap(), None);
     }
 
+    #[test]
+    fn compressed_certified_page_rejects_invalid_bounds_and_corruption() {
+        let mut inverted = Vec::new();
+        inverted.extend_from_slice(&2_u32.to_le_bytes());
+        inverted.extend_from_slice(&1_u32.to_le_bytes());
+        inverted.extend_from_slice(&1_u32.to_le_bytes());
+        inverted.push(0);
+        assert!(certified_zstd_packet_page_header(&inverted).is_err());
+
+        let mut oversized = Vec::new();
+        oversized.extend_from_slice(&1_u32.to_le_bytes());
+        oversized.extend_from_slice(&2_u32.to_le_bytes());
+        oversized.extend_from_slice(&(64_u32 * 1024 * 1024 + 1).to_le_bytes());
+        oversized.push(0);
+        assert!(certified_zstd_packet_page_header(&oversized).is_err());
+
+        let mut corrupt = Vec::new();
+        corrupt.extend_from_slice(&1_u32.to_le_bytes());
+        corrupt.extend_from_slice(&2_u32.to_le_bytes());
+        corrupt.extend_from_slice(&16_u32.to_le_bytes());
+        corrupt.extend_from_slice(b"not a zstd frame");
+        assert!(decode_certified_zstd_packet_page(&corrupt).is_err());
+    }
+
+    #[tokio::test]
+    async fn exact_file_certified_scan_does_not_read_unrelated_manifest() {
+        let storage = StorageAdapter::new(Memory::new());
+        let generation = CommitId::for_test_label("exact-certified-file-generation");
+        let malformed_content_key = StorageKey(Bytes::from_static(b"malformed-content"));
+        let mut manifest_key = generation.as_uuid().as_bytes().to_vec();
+        append_batch_text(&mut manifest_key, "unrelated.md").unwrap();
+        manifest_key
+            .extend_from_slice(&crate::wasm::HOST_CERTIFIED_ZSTD_PACKET_FORMAT.to_le_bytes());
+        manifest_key.extend_from_slice(
+            CommitId::for_test_label("unrelated-certified-commit")
+                .as_uuid()
+                .as_bytes(),
+        );
+        let mut writes = storage.new_write_set();
+        writes.put(
+            CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE,
+            StorageKey(Bytes::from(manifest_key)),
+            StorageValue {
+                bytes: malformed_content_key.0.clone(),
+            },
+        );
+        writes.put(
+            CERTIFIED_ENTITY_BATCH_SPACE,
+            malformed_content_key,
+            StorageValue {
+                bytes: Bytes::from_static(b"malformed"),
+            },
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .unwrap();
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .unwrap();
+        let rows = scan_certified_entity_batch_rows(
+            &read,
+            "main",
+            generation,
+            &TrackedStateScanRequest {
+                filter: TrackedStateFilter {
+                    file_ids: vec![NullableKeyFilter::Value("requested.md".to_owned())],
+                    ..TrackedStateFilter::default()
+                },
+                ..TrackedStateScanRequest::default()
+            },
+            None,
+        )
+        .await
+        .expect("exact-file scan must not decode unrelated certified content");
+        assert!(rows.is_empty());
+    }
+
     #[tokio::test]
     async fn branch_creation_inherits_certified_manifests_from_same_head() {
         const EMPTY_BRANCH: &str = "a-empty";
@@ -6638,6 +6869,7 @@ mod tests {
         const SECOND_DONOR_BRANCH: &str = "donor-two";
         const CREATED_BRANCH: &str = "created";
         const FILE_ID: &str = "inherited.csv";
+        const SECOND_FILE_ID: &str = "inherited-two.csv";
         const SCHEMA_KEY: &str = "inherited_row";
 
         let storage = StorageAdapter::new(Memory::new());
@@ -6677,19 +6909,34 @@ mod tests {
         page.extend_from_slice(&1_u16.to_le_bytes());
         page.extend_from_slice(&5_u32.to_le_bytes());
         page.extend_from_slice(b"value");
-        let batches = [WasmCertifiedEntityBatch {
+        let batch = WasmCertifiedEntityBatch {
             format: 1,
             schema_keys: vec![SCHEMA_KEY.to_owned()],
             row_count: 1,
             creates,
             complete_file_state: true,
             pages: vec![Bytes::from(page)],
+        };
+        let batches = [batch.clone()];
+        let second_batches = [WasmCertifiedEntityBatch {
+            creates: WasmCreateContext {
+                low: creates.low + 1,
+                ..creates
+            },
+            ..batch
         }];
-        let files = [CertifiedEntityBatchFileRef {
-            branch_id: DONOR_BRANCH,
-            file_id: FILE_ID,
-            batches: &batches,
-        }];
+        let files = [
+            CertifiedEntityBatchFileRef {
+                branch_id: DONOR_BRANCH,
+                file_id: FILE_ID,
+                batches: &batches,
+            },
+            CertifiedEntityBatchFileRef {
+                branch_id: DONOR_BRANCH,
+                file_id: SECOND_FILE_ID,
+                batches: &second_batches,
+            },
+        ];
 
         let read = storage
             .begin_read(StorageReadOptions::default())
@@ -6787,6 +7034,11 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("created branch verification read should open");
+        let get_many_calls = Arc::new(AtomicUsize::new(0));
+        let read = CountingRead {
+            inner: read,
+            get_many_calls: Arc::clone(&get_many_calls),
+        };
         let rows = scan_certified_entity_batch_rows(
             &read,
             CREATED_BRANCH,
@@ -6805,9 +7057,15 @@ mod tests {
         )
         .await
         .expect("created branch certified rows should scan");
-        assert_eq!(rows.len(), 1);
+        assert_eq!(rows.len(), 2);
         assert_eq!(rows.row(0).schema_key(), SCHEMA_KEY);
         assert_eq!(rows.row(0).file_id(), Some(FILE_ID));
+        assert_eq!(rows.row(1).file_id(), Some(SECOND_FILE_ID));
+        assert_eq!(
+            get_many_calls.load(Ordering::Relaxed),
+            2,
+            "one content read and one page read must serve every certified batch"
+        );
     }
 
     fn diff_identity(branch_id: &str, generation: CommitId, entity: &str) -> HeadIdentity {

--- a/packages/engine/src/plugin/incremental.rs
+++ b/packages/engine/src/plugin/incremental.rs
@@ -1810,7 +1810,10 @@ fn validate_certified_entity_batches(
 
 const HOST_CERTIFIED_PACKET_TARGET_BYTES: usize = 256 * 1024;
 const HOST_CERTIFIED_PACKET_MIN_ROWS: usize = 64;
-const DENSE_TEXT_SCHEMA_KEY: &str = "git_text_line_v2";
+
+fn host_certified_dense_schema(schema_key: &str) -> bool {
+    matches!(schema_key, "git_text_line_v2" | "markdown_node_v2")
+}
 
 /// Retains a complete, eagerly validated generic-text import in dense packet
 /// pages. The ordinary v2 change list remains intact for changelog and
@@ -1827,23 +1830,34 @@ pub(crate) fn certify_dense_v2_fresh_file(
     {
         return Ok(());
     }
+    let Some(schema_key) = transition.changes.changes.first().and_then(|change| {
+        let WasmEntityChange::Create { schema_key, .. } = change else {
+            return None;
+        };
+        host_certified_dense_schema(schema_key).then_some(schema_key.as_str())
+    }) else {
+        return Ok(());
+    };
     if !transition.changes.changes.iter().all(|change| {
         matches!(
             change,
             WasmEntityChange::Create {
-                schema_key,
+                schema_key: candidate_schema_key,
                 resolved_key: None,
                 snapshot_content: WasmHostBytes::CanonicalJson(_),
                 ..
-            } if schema_key == DENSE_TEXT_SCHEMA_KEY
+            } if candidate_schema_key == schema_key
         )
     }) {
         return Ok(());
     }
-    schemas.validate(DENSE_TEXT_SCHEMA_KEY)?;
+    schemas.validate(schema_key)?;
+    let compressed_pages = schema_key == "markdown_node_v2";
 
     let mut pages = Vec::new();
     let mut page = Vec::with_capacity(HOST_CERTIFIED_PACKET_TARGET_BYTES);
+    let mut page_first_local_ref = None;
+    let mut page_last_local_ref = None;
     for change in &transition.changes.changes {
         let WasmEntityChange::Create {
             schema_key,
@@ -1865,12 +1879,25 @@ pub(crate) fn certify_dense_v2_fresh_file(
         let framed_len = 4_usize
             .checked_add(record_len)
             .ok_or_else(|| invalid_guest("host certified packet frame size overflowed"))?;
+        let page_local_ref = u32::try_from(*local_ref)
+            .map_err(|_| invalid_guest("host certified packet local reference exceeds u32"))?;
         if !page.is_empty()
             && page.len().saturating_add(framed_len) > HOST_CERTIFIED_PACKET_TARGET_BYTES
         {
-            pages.push(Bytes::from(std::mem::take(&mut page)));
+            pages.push(finish_host_certified_packet_page(
+                std::mem::take(&mut page),
+                page_first_local_ref
+                    .take()
+                    .expect("non-empty packet page has a first local ref"),
+                page_last_local_ref
+                    .take()
+                    .expect("non-empty packet page has a last local ref"),
+                compressed_pages,
+            )?);
             page = Vec::with_capacity(HOST_CERTIFIED_PACKET_TARGET_BYTES.max(framed_len));
         }
+        page_first_local_ref.get_or_insert(page_local_ref);
+        page_last_local_ref = Some(page_local_ref);
         page.extend_from_slice(
             &u32::try_from(record_len)
                 .map_err(|_| invalid_guest("host certified packet record exceeds u32"))?
@@ -1893,14 +1920,23 @@ pub(crate) fn certify_dense_v2_fresh_file(
         page.extend_from_slice(snapshot_bytes);
     }
     if !page.is_empty() {
-        pages.push(Bytes::from(page));
+        pages.push(finish_host_certified_packet_page(
+            page,
+            page_first_local_ref.expect("non-empty packet page has a first local ref"),
+            page_last_local_ref.expect("non-empty packet page has a last local ref"),
+            compressed_pages,
+        )?);
     }
     let batch = WasmCertifiedEntityBatch {
-        // Format 3 is the host-only equivalent of the format-2 packet codec.
-        // Guest batches are validated before this synthesis point and the
-        // guest-facing validator intentionally rejects format 3.
-        format: crate::wasm::HOST_CERTIFIED_PACKET_FORMAT,
-        schema_keys: vec![DENSE_TEXT_SCHEMA_KEY.to_owned()],
+        // Formats 3 and 4 are host-only equivalents of the format-2 packet
+        // codec. Guest batches are validated before this synthesis point and
+        // the guest-facing validator intentionally rejects both formats.
+        format: if compressed_pages {
+            crate::wasm::HOST_CERTIFIED_ZSTD_PACKET_FORMAT
+        } else {
+            crate::wasm::HOST_CERTIFIED_PACKET_FORMAT
+        },
+        schema_keys: vec![schema_key.to_owned()],
         row_count: transition.changes.changes.len() as u64,
         creates,
         complete_file_state: true,
@@ -1908,6 +1944,33 @@ pub(crate) fn certify_dense_v2_fresh_file(
     };
     transition.certified_batches.push(batch);
     Ok(())
+}
+
+fn finish_host_certified_packet_page(
+    page: Vec<u8>,
+    first_local_ref: u32,
+    last_local_ref: u32,
+    compressed: bool,
+) -> Result<Bytes, LixError> {
+    if !compressed {
+        return Ok(Bytes::from(page));
+    }
+    let compressed = crate::compression::compress_zstd_level_1(&page).map_err(|error| {
+        LixError::new(
+            LixError::CODE_UNKNOWN,
+            format!("host-certified packet compression failed: {error}"),
+        )
+    })?;
+    let mut encoded = Vec::with_capacity(12 + compressed.len());
+    encoded.extend_from_slice(&first_local_ref.to_le_bytes());
+    encoded.extend_from_slice(&last_local_ref.to_le_bytes());
+    encoded.extend_from_slice(
+        &u32::try_from(page.len())
+            .map_err(|_| invalid_guest("host-certified packet page exceeds u32"))?
+            .to_le_bytes(),
+    );
+    encoded.extend_from_slice(&compressed);
+    Ok(Bytes::from(encoded))
 }
 
 fn validate_certified_snapshot_packets(
@@ -3223,6 +3286,23 @@ mod tests {
                     .into(),
             ),
         }
+    }
+
+    #[test]
+    fn compressed_host_certified_packet_page_roundtrips() {
+        let packet = vec![b'x'; 32 * 1024];
+        let encoded = finish_host_certified_packet_page(packet.clone(), 7, 11, true).unwrap();
+        let first = u32::from_le_bytes(encoded[..4].try_into().unwrap());
+        let last = u32::from_le_bytes(encoded[4..8].try_into().unwrap());
+        let uncompressed_len = u32::from_le_bytes(encoded[8..12].try_into().unwrap()) as usize;
+        let compressed = &encoded[12..];
+        assert_eq!((first, last), (7, 11));
+        assert_eq!(uncompressed_len, packet.len());
+        assert!(compressed.len() < packet.len());
+        assert_eq!(
+            crate::compression::decompress_zstd(compressed, uncompressed_len).unwrap(),
+            packet
+        );
     }
 
     #[test]

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -92,7 +92,12 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         BTreeMap::<String, BTreeMap<(String, Option<String>), u64>>::new();
     for file in &prepared_writes.file_data_writes {
         for batch in file.certified_entity_batches().iter().filter(|batch| {
-            batch.complete_file_state && batch.format == crate::wasm::HOST_CERTIFIED_PACKET_FORMAT
+            batch.complete_file_state
+                && matches!(
+                    batch.format,
+                    crate::wasm::HOST_CERTIFIED_PACKET_FORMAT
+                        | crate::wasm::HOST_CERTIFIED_ZSTD_PACKET_FORMAT
+                )
         }) {
             let [schema_key] = batch.schema_keys.as_slice() else {
                 return Err(LixError::new(

--- a/packages/engine/src/wasm/component_v2.rs
+++ b/packages/engine/src/wasm/component_v2.rs
@@ -1565,6 +1565,7 @@ pub struct WasmCertifiedEntityBatch {
 /// completed host validation. Guest-emitted certified batches intentionally
 /// cannot claim this format.
 pub(crate) const HOST_CERTIFIED_PACKET_FORMAT: u16 = 3;
+pub(crate) const HOST_CERTIFIED_ZSTD_PACKET_FORMAT: u16 = 4;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WasmEntityTransition {


### PR DESCRIPTION
## What changed

- Extend host-certified dense semantic pages from `git_text_line_v2` to eager `markdown_node_v2` materialization.
- Store Markdown packet pages with bounded zstd level-1 compression while retaining WASM plugins and eager semantic materialization.
- Batch all certified page point reads for a broad scan into one storage call instead of one call per semantic owner.
- Seek exact-file certified manifests by `(generation, file_id)` rather than scanning every manifest in the generation.
- Preserve existing HOT overlays, history payloads, collection counts, branch inheritance, and ownership-change tombstones.

## Why

Retained VS Code Docs profiling showed certified Markdown snapshots could remove substantial HOT duplication, but the first implementation regressed reads because a full file-tree scan issued 543 sequential page-read plans. Batching those reads removes that false serialization. The remaining largest physical target is commit-delta payload sidecars: 39.06 MB in the retained 50-commit store.

## Retained replay benchmark

Exact 50-commit first-parent VS Code Docs replay, all bundled WASM plugins enabled, eager semantic materialization, SlateDB, checkpoint after every Git commit, per-commit verification, and final Git tree verification.

| Metric | text-certified main | this PR | Change |
| --- | ---: | ---: | ---: |
| Logical storage | 226.38 MB | 176.56 MB | **-22.0%** |
| Physical directory | 112.03 MB | 104.89 MB | -6.4% |
| Parent-tree seed | 112.67 s | 96.72 s | **-14.2%** |
| Replay | 139.62 s | 112.58 s | **-19.4%** |
| Execute | 112.23 s | 94.71 s | **-15.6%** |
| Checkpoint | 12.59 s | 4.20 s | **-66.6%** |
| Final tree verify | 24.63 s | 11.95 s | **-51.5%** |
| Seed + replay + final verify | 276.92 s | 221.26 s | **-20.1%** |

All 50 commits and the final 8,082-file Git tree verified exactly. The retained candidate database remains available for follow-up layout queries.

## Correctness and safety

- Compressed page headers bound decompression to 64 MiB and reject truncated, inverted-range, oversized, or corrupt pages.
- Exact-file regression proves unrelated malformed manifests are not read.
- Multi-owner regression asserts one content read plus one batched page read serves all certified batches.
- Host-only format 4 cannot be claimed by guest WASM plugins.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p lix_engine --features all-simulations --lib --tests`
- `cargo test -p lix_engine --features all-simulations` (1,587 engine tests, 782 simulations, 3 doctests)
- Exact retained VS Code Docs replay described above (50/50 commits and final tree verified)