### PR TITLE
Avoid quadratic collection replacement checks

### DIFF
--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -1066,10 +1066,30 @@ where
             | TransactionWrite::RowsWithFileData { rows, .. } => rows,
         };
         let staged = self.staged_writes.staging_overlay()?;
+        let mut first_checked_scope = None;
+        let mut additional_checked_scopes = None;
         for row in rows.iter() {
             if row.schema_key.as_str()
                 == crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY
             {
+                continue;
+            }
+            let scope = (
+                row.branch_id.as_str(),
+                row.schema_key.as_str(),
+                row.file_id.map(SharedStr::as_str),
+            );
+            let already_checked = match first_checked_scope {
+                None => {
+                    first_checked_scope = Some(scope);
+                    false
+                }
+                Some(first) if first == scope => true,
+                Some(first) => !additional_checked_scopes
+                    .get_or_insert_with(|| std::collections::HashSet::from([first]))
+                    .insert(scope),
+            };
+            if already_checked {
                 continue;
             }
             if StagedLiveStateRows::collection_replaced(

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -1898,16 +1898,24 @@ impl crate::live_state::StagedLiveStateRows for PreparedStateRowOverlay {
                 "failed to acquire transaction staged writes lock",
             )
         })?;
-        let StagedPreparedRows::Indexed { rows, .. } = &*rows_guard else {
+        let StagedPreparedRows::Indexed {
+            rows, by_candidate, ..
+        } = &*rows_guard
+        else {
             return Ok(false);
         };
-        for index in 0..rows.len() {
-            let row = rows.row(index);
-            if row.schema_key.as_str()
-                != crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY
-                || row.branch_id.as_str() != branch_id
-                || row.snapshot.is_none()
-            {
+        let Some(marker_slots) = by_candidate
+            .slots_by_schema
+            .get(crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY)
+        else {
+            return Ok(false);
+        };
+        for slot in marker_slots {
+            let RowSlot::State(index) = *slot;
+            let Some(row) = rows.get(index) else {
+                continue;
+            };
+            if row.branch_id.as_str() != branch_id || row.snapshot.is_none() {
                 continue;
             }
             let (target_schema_key, target_file_id) =


### PR DESCRIPTION
## What changed

- Deduplicate collection scopes before checking whether a staged write follows a collection replacement.
- Use the staged schema candidate index to inspect only `lix_collection_generation` markers instead of scanning every staged entity row.
- Keep the common single-scope write allocation-free; allocate a set only for genuinely multi-scope batches.

## Why

Every ordinary INSERT row called `collection_replaced`, and that method scanned all rows already staged in the explicit transaction. The tracked-state CRUD bulk create workload uses 500-row chunks, so a 100k insert performed a quadratic scan over its growing transaction overlay. RocksDB commit was not the bottleneck.

In the focused RocksDB 100k `insert_all` profile, measured latency fell from **38.745 s** to **1.766 s** with tracing enabled (about **22x faster**). A subsequent non-tracing 3-sample control measured a **1.084 s median**. The raw SQLite median is **75.8 ms**, so parameterized bulk INSERT execution remains follow-up work rather than being hidden in this fix.

## Validation

- `cargo test -p lix_engine transaction::staging --lib` (44 passed)
- `cargo test -p lix_engine whole_entity_collection_delete_is_visible_inside_explicit_transaction --lib`
- `cargo test -p lix_engine --features all-simulations`
- `cargo fmt --all`
- `git diff --check`

The storage adapter API and implementations are unchanged.