### PR TITLE
Batch parameterized entity inserts

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use lix_engine::{Engine, ExecuteBatchStatement, ExecuteResult, SessionContext, Storage, Value};
 
 #[cfg(feature = "slatedb")]
@@ -5,9 +7,9 @@ use crate::storage::SlateDB;
 use crate::storage::{ProfileStorage, RocksDB, SQLite, StorageProfile};
 use crate::workload::{WorkloadRow, sql_string};
 
+const SQL_CHUNK_SIZE: usize = 500;
 const READ_MANY_PK_COUNT: usize = crate::READ_MANY_PK_COUNT;
-const BOUND_INSERT_ALL_SQL: &str =
-    "INSERT INTO json_pointer (path, value) VALUES ($1, lix_json($2))";
+const BOUND_INSERT_ALL_SQL: &str = "INSERT INTO tracked_crud_insert (path, value) VALUES ($1, $2)";
 const BOUND_UPDATE_ALL_SQL: &str = "UPDATE json_pointer SET value = lix_json($1) WHERE path = $2";
 const UNTRACKED_PROBE_PATH: &str = "/__lix_untracked_probe";
 
@@ -40,6 +42,7 @@ pub(crate) struct GenericSqlFixture<StorageImpl: Storage> {
     untracked_fixture: UntrackedFixture,
     read_many_by_pk_count: usize,
     bound_insert_all_batch: Vec<ExecuteBatchStatement>,
+    seed_sql_chunks: Vec<String>,
     select_all_sql: String,
     select_many_by_pk_sql: String,
     select_one_by_pk_sql: String,
@@ -106,7 +109,7 @@ pub(crate) async fn seeded_fixture_with_read_many_pk_count(
     read_many_by_pk_count: usize,
 ) -> SqlFixture {
     let fixture = empty_fixture_with_read_many_pk_count(profile, rows, read_many_by_pk_count).await;
-    fixture.insert_all().await;
+    fixture.seed_json_rows().await;
     fixture.insert_untracked_probe().await;
     fixture
 }
@@ -118,6 +121,15 @@ impl SqlFixture {
             Self::RocksDB(fixture) => fixture.insert_all().await,
             #[cfg(feature = "slatedb")]
             Self::SlateDB(fixture) => fixture.insert_all().await,
+        }
+    }
+
+    async fn seed_json_rows(&self) {
+        match self {
+            Self::SQLite(fixture) => fixture.seed_json_rows().await,
+            Self::RocksDB(fixture) => fixture.seed_json_rows().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.seed_json_rows().await,
         }
     }
 
@@ -263,6 +275,8 @@ where
 {
     #[expect(clippy::cast_possible_truncation)]
     async fn insert_all(&self) -> usize {
+        let _ =
+            lix_engine::storage_bench::take_certified_entity_insert_parameter_batch_executions();
         let affected = self
             .session
             .execute_batch(&self.bound_insert_all_batch)
@@ -272,7 +286,21 @@ where
             .map(ExecuteResult::rows_affected)
             .sum::<u64>();
         assert_eq!(affected as usize, self.row_count);
+        assert_eq!(
+            lix_engine::storage_bench::take_certified_entity_insert_parameter_batch_executions(),
+            1,
+            "tracked-state CRUD insert benchmark must execute one certified parameter batch"
+        );
         affected as usize
+    }
+
+    async fn seed_json_rows(&self) {
+        let affected = Box::pin(execute_many_in_transaction(
+            &self.session,
+            &self.seed_sql_chunks,
+        ))
+        .await;
+        assert_eq!(affected as usize, self.row_count);
     }
 
     async fn read_all(&self) -> usize {
@@ -441,6 +469,10 @@ where
                 ],
             })
             .collect(),
+        seed_sql_chunks: tracked_rows
+            .chunks(SQL_CHUNK_SIZE)
+            .map(insert_json_rows_sql)
+            .collect(),
         select_all_sql: "SELECT path, value FROM json_pointer ORDER BY path".to_string(),
         select_many_by_pk_sql: select_many_by_pk_sql(
             rows,
@@ -500,6 +532,7 @@ where
         .await
         .expect("open tracked-state crud session");
     register_json_pointer_schema(&session).await;
+    register_bulk_insert_schema(&session).await;
     session
 }
 
@@ -527,6 +560,32 @@ where
         )
         .await
         .expect("register json_pointer schema")
+        .rows_affected();
+    assert_eq!(affected, 1);
+}
+
+async fn register_bulk_insert_schema<StorageImpl>(session: &SessionContext<StorageImpl>)
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let schema = serde_json::json!({
+        "x-lix-key": "tracked_crud_insert",
+        "x-lix-primary-key": ["/path"],
+        "type": "object",
+        "required": ["path", "value"],
+        "properties": {
+            "path": { "type": "string" },
+            "value": { "type": "string" }
+        },
+        "additionalProperties": false
+    });
+    let affected = session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register tracked_crud_insert schema")
         .rows_affected();
     assert_eq!(affected, 1);
 }
@@ -565,6 +624,22 @@ where
         .await
         .expect("commit tracked-state CRUD transaction");
     affected
+}
+
+fn insert_json_rows_sql(rows: &[WorkloadRow]) -> String {
+    let mut sql = String::from("INSERT INTO json_pointer (path, value) VALUES ");
+    for (index, row) in rows.iter().enumerate() {
+        if index > 0 {
+            sql.push(',');
+        }
+        let _ = write!(
+            sql,
+            "('{}', lix_json('{}'))",
+            sql_string(row.path.as_str()),
+            sql_string(row.value_json.as_str())
+        );
+    }
+    sql
 }
 
 fn select_by_pk_sql(rows: &[WorkloadRow]) -> String {

--- a/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
@@ -1,5 +1,3 @@
-use std::fmt::Write as _;
-
 use lix_engine::{Engine, ExecuteBatchStatement, ExecuteResult, SessionContext, Storage, Value};
 
 #[cfg(feature = "slatedb")]
@@ -7,8 +5,9 @@ use crate::storage::SlateDB;
 use crate::storage::{ProfileStorage, RocksDB, SQLite, StorageProfile};
 use crate::workload::{WorkloadRow, sql_string};
 
-const SQL_CHUNK_SIZE: usize = 500;
 const READ_MANY_PK_COUNT: usize = crate::READ_MANY_PK_COUNT;
+const BOUND_INSERT_ALL_SQL: &str =
+    "INSERT INTO json_pointer (path, value) VALUES ($1, lix_json($2))";
 const BOUND_UPDATE_ALL_SQL: &str = "UPDATE json_pointer SET value = lix_json($1) WHERE path = $2";
 const UNTRACKED_PROBE_PATH: &str = "/__lix_untracked_probe";
 
@@ -40,7 +39,7 @@ pub(crate) struct GenericSqlFixture<StorageImpl: Storage> {
     visible_row_count: usize,
     untracked_fixture: UntrackedFixture,
     read_many_by_pk_count: usize,
-    insert_sql_chunks: Vec<String>,
+    bound_insert_all_batch: Vec<ExecuteBatchStatement>,
     select_all_sql: String,
     select_many_by_pk_sql: String,
     select_one_by_pk_sql: String,
@@ -264,11 +263,14 @@ where
 {
     #[expect(clippy::cast_possible_truncation)]
     async fn insert_all(&self) -> usize {
-        let affected = Box::pin(execute_many_in_transaction(
-            &self.session,
-            &self.insert_sql_chunks,
-        ))
-        .await;
+        let affected = self
+            .session
+            .execute_batch(&self.bound_insert_all_batch)
+            .await
+            .expect("execute tracked-state CRUD bound insert batch")
+            .iter()
+            .map(ExecuteResult::rows_affected)
+            .sum::<u64>();
         assert_eq!(affected as usize, self.row_count);
         affected as usize
     }
@@ -429,9 +431,15 @@ where
         visible_row_count: tracked_rows.len() + usize::from(untracked_fixture.has_untracked_row()),
         untracked_fixture,
         read_many_by_pk_count,
-        insert_sql_chunks: tracked_rows
-            .chunks(SQL_CHUNK_SIZE)
-            .map(insert_rows_sql)
+        bound_insert_all_batch: tracked_rows
+            .iter()
+            .map(|row| ExecuteBatchStatement {
+                sql: BOUND_INSERT_ALL_SQL.to_string(),
+                params: vec![
+                    Value::Text(row.path.clone()),
+                    Value::Text(row.value_json.clone()),
+                ],
+            })
             .collect(),
         select_all_sql: "SELECT path, value FROM json_pointer ORDER BY path".to_string(),
         select_many_by_pk_sql: select_many_by_pk_sql(
@@ -557,22 +565,6 @@ where
         .await
         .expect("commit tracked-state CRUD transaction");
     affected
-}
-
-fn insert_rows_sql(rows: &[WorkloadRow]) -> String {
-    let mut sql = String::from("INSERT INTO json_pointer (path, value) VALUES ");
-    for (index, row) in rows.iter().enumerate() {
-        if index > 0 {
-            sql.push(',');
-        }
-        let _ = write!(
-            sql,
-            "('{}', lix_json('{}'))",
-            sql_string(row.path.as_str()),
-            sql_string(row.value_json.as_str())
-        );
-    }
-    sql
 }
 
 fn select_by_pk_sql(rows: &[WorkloadRow]) -> String {

--- a/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
+++ b/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
@@ -60,6 +60,28 @@ async fn standalone_sqlite_public_results_match_every_lix_adapter() {
     }
 }
 
+#[tokio::test]
+async fn insert_benchmark_hits_certified_parameter_batch_on_every_adapter() {
+    let rows = [
+        WorkloadRow {
+            path: "/alpha".to_string(),
+            value_json: r#"{"enabled":true}"#.to_string(),
+            updated_value_json: r#"{"enabled":false}"#.to_string(),
+        },
+        WorkloadRow {
+            path: "/beta".to_string(),
+            value_json: r#"[1,2,3]"#.to_string(),
+            updated_value_json: r#"[4,5,6]"#.to_string(),
+        },
+    ];
+
+    for &profile in storage::STORAGE_PROFILES {
+        let fixture =
+            sql_session::empty_fixture_with_read_many_pk_count(profile, &rows, rows.len()).await;
+        assert_eq!(fixture.insert_all().await, rows.len());
+    }
+}
+
 #[test]
 fn scaling_fixture_extends_the_real_workload_in_physical_key_order() {
     let rows = workload::fixture_rows(20_000);

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -3973,6 +3973,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_batch_declines_uncertified_entity_insert_rows() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "x-lix-key": "parameter_insert_fallback_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": {
+                    "type": "object",
+                    "properties": { "ok": { "type": "boolean" } },
+                    "required": ["ok"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+
+        sql2::take_certified_entity_insert_parameter_batch_executions();
+        let sql =
+            "INSERT INTO parameter_insert_fallback_probe (id, value) VALUES ($1, lix_json($2))";
+        let error = session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("a".to_string()),
+                        Value::Text("\"invalid-shape\"".to_string()),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("b".to_string()),
+                        Value::Text("not-json".to_string()),
+                    ],
+                },
+            ])
+            .await
+            .expect_err("the first row's schema failure must precede later expression evaluation");
+        assert_eq!(error.code, LixError::CODE_SCHEMA_VALIDATION);
+        assert_eq!(error.details.unwrap()["statementIndex"], 0);
+        assert_eq!(
+            sql2::take_certified_entity_insert_parameter_batch_executions(),
+            0
+        );
+    }
+
+    #[tokio::test]
     async fn execute_batch_lowers_distinct_bound_entity_updates_once() {
         let session = open_session().await;
         let schema = serde_json::json!({

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -3850,6 +3850,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_batch_lowers_distinct_bound_entity_inserts_once() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "x-lix-key": "parameter_insert_batch_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": { "type": "string" }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+
+        sql2::take_certified_entity_insert_parameter_batch_executions();
+        let sql = "INSERT INTO parameter_insert_batch_probe (id, value) VALUES ($1, $2)";
+        let results = session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("a".to_string()),
+                        Value::Text("value-a".to_string()),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("b".to_string()),
+                        Value::Text("value-b".to_string()),
+                    ],
+                },
+            ])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            sql2::take_certified_entity_insert_parameter_batch_executions(),
+            1
+        );
+        assert_eq!(
+            results
+                .iter()
+                .map(ExecuteResult::rows_affected)
+                .collect::<Vec<_>>(),
+            vec![1, 1]
+        );
+        let rows = session
+            .execute(
+                "SELECT id, value FROM parameter_insert_batch_probe ORDER BY id",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(rows.rows()[0].get::<String>("value").unwrap(), "value-a");
+        assert_eq!(rows.rows()[1].get::<String>("value").unwrap(), "value-b");
+    }
+
+    #[tokio::test]
     async fn execute_batch_lowers_distinct_bound_entity_updates_once() {
         let session = open_session().await;
         let schema = serde_json::json!({
@@ -4166,6 +4233,32 @@ mod tests {
             )
             .await
             .unwrap();
+        sql2::take_certified_entity_insert_parameter_batch_executions();
+        let insert_sql = "INSERT INTO parameter_batch_repeat_probe (id, value) VALUES ($1, $2)";
+        let error = session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    sql: insert_sql.to_string(),
+                    params: vec![
+                        Value::Text("duplicate".to_string()),
+                        Value::Text("first".to_string()),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: insert_sql.to_string(),
+                    params: vec![
+                        Value::Text("duplicate".to_string()),
+                        Value::Text("second".to_string()),
+                    ],
+                },
+            ])
+            .await
+            .expect_err("the second INSERT repeats the first identity");
+        assert_eq!(error.details.unwrap()["statementIndex"], 1);
+        assert_eq!(
+            sql2::take_certified_entity_insert_parameter_batch_executions(),
+            0
+        );
         session
             .execute(
                 "INSERT INTO parameter_batch_repeat_probe (id, value) VALUES ('a', 'old')",
@@ -4303,6 +4396,32 @@ mod tests {
             )
             .await
             .unwrap();
+
+        sql2::take_certified_entity_insert_parameter_batch_executions();
+        let insert_sql = "INSERT INTO parameter_batch_constraint_probe (id, value) VALUES ($1, $2)";
+        session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    sql: insert_sql.to_string(),
+                    params: vec![
+                        Value::Text("c".to_string()),
+                        Value::Text("old-c".to_string()),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: insert_sql.to_string(),
+                    params: vec![
+                        Value::Text("d".to_string()),
+                        Value::Text("old-d".to_string()),
+                    ],
+                },
+            ])
+            .await
+            .unwrap();
+        assert_eq!(
+            sql2::take_certified_entity_insert_parameter_batch_executions(),
+            0
+        );
 
         sql2::take_entity_update_parameter_batch_executions();
         let sql = "UPDATE parameter_batch_constraint_probe SET value = $1 WHERE id = $2";

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -3914,6 +3914,43 @@ mod tests {
             .unwrap();
         assert_eq!(rows.rows()[0].get::<String>("value").unwrap(), "value-a");
         assert_eq!(rows.rows()[1].get::<String>("value").unwrap(), "value-b");
+
+        sql2::take_certified_entity_insert_parameter_batch_executions();
+        let error = session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("c".to_string()),
+                        Value::Text("value-c".to_string()),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("b".to_string()),
+                        Value::Text("duplicate-b".to_string()),
+                    ],
+                },
+            ])
+            .await
+            .expect_err("the second INSERT conflicts with committed row b");
+        assert_eq!(error.details.unwrap()["statementIndex"], 1);
+        assert_eq!(
+            sql2::take_certified_entity_insert_parameter_batch_executions(),
+            0
+        );
+        let rows = session
+            .execute(
+                "SELECT id FROM parameter_insert_batch_probe WHERE id = 'c'",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert!(
+            rows.is_empty(),
+            "the fresh prefix must roll back with the conflicting batch"
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -4100,6 +4100,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_batch_preserves_later_durability_domain_error_index() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "x-lix-key": "parameter_insert_durability_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": { "type": "string" }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema \
+                 (value, lixcol_global, lixcol_untracked) \
+                 VALUES (lix_json($1), false, true)",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+
+        let sql = "INSERT INTO parameter_insert_durability_probe \
+                   (id, value, lixcol_untracked) VALUES ($1, $2, $3)";
+        let error = session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("a".to_string()),
+                        Value::Text("value-a".to_string()),
+                        Value::Boolean(true),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("b".to_string()),
+                        Value::Text("value-b".to_string()),
+                        Value::Boolean(false),
+                    ],
+                },
+            ])
+            .await
+            .expect_err("the second row's tracked-catalog failure must retain its statement index");
+        assert_eq!(error.code, LixError::CODE_SCHEMA_DEFINITION);
+        assert_eq!(error.details.unwrap()["statementIndex"], 1);
+
+        let rows = session
+            .execute(
+                "SELECT id FROM parameter_insert_durability_probe WHERE id = 'a'",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert!(
+            rows.is_empty(),
+            "the untracked prefix must roll back with the mixed-durability batch"
+        );
+    }
+
+    #[tokio::test]
     async fn execute_batch_lowers_distinct_bound_entity_updates_once() {
         let session = open_session().await;
         let schema = serde_json::json!({

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -3859,7 +3859,7 @@ mod tests {
             "type": "object",
             "properties": {
                 "id": { "type": "string" },
-                "value": { "type": "string" }
+                "value": { "type": "string", "minLength": 3 }
             },
             "required": ["id", "value"],
             "additionalProperties": false
@@ -3951,6 +3951,25 @@ mod tests {
             rows.is_empty(),
             "the fresh prefix must roll back with the conflicting batch"
         );
+
+        let error = session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("b".to_string()),
+                        Value::Text("duplicate-b".to_string()),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![Value::Text("d".to_string()), Value::Text("x".to_string())],
+                },
+            ])
+            .await
+            .expect_err("the later normalization error must precede the committed conflict");
+        assert_eq!(error.code, LixError::CODE_SCHEMA_VALIDATION);
+        assert_eq!(error.details.unwrap()["statementIndex"], 1);
     }
 
     #[tokio::test]

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -4031,6 +4031,75 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_batch_preserves_later_missing_branch_index() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "x-lix-key": "parameter_insert_branch_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": { "type": "string" }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+        let active_branch_id = session
+            .execute("SELECT lix_active_branch_id() AS id", &[])
+            .await
+            .unwrap()
+            .rows()[0]
+            .get::<String>("id")
+            .unwrap();
+
+        let sql = "INSERT INTO parameter_insert_branch_probe_by_branch \
+                   (id, value, lixcol_branch_id) VALUES ($1, $2, $3)";
+        let error = session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("a".to_string()),
+                        Value::Text("value-a".to_string()),
+                        Value::Text(active_branch_id),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("b".to_string()),
+                        Value::Text("value-b".to_string()),
+                        Value::Text("00000000-0000-7000-8000-000000000404".to_string()),
+                    ],
+                },
+            ])
+            .await
+            .expect_err("the second row's missing branch must retain its statement index");
+        assert_eq!(error.code, LixError::CODE_BRANCH_NOT_FOUND);
+        assert_eq!(error.details.unwrap()["statementIndex"], 1);
+
+        let rows = session
+            .execute(
+                "SELECT id FROM parameter_insert_branch_probe WHERE id = 'a'",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert!(
+            rows.is_empty(),
+            "the valid prefix must roll back with the missing-branch batch"
+        );
+    }
+
+    #[tokio::test]
     async fn execute_batch_lowers_distinct_bound_entity_updates_once() {
         let session = open_session().await;
         let schema = serde_json::json!({

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -236,6 +236,8 @@ pub(crate) async fn try_execute_entity_insert_parameter_batch(
     CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_EXECUTIONS.with(|executions| {
         executions.set(executions.get().saturating_add(1));
     });
+    #[cfg(feature = "storage-benches")]
+    crate::storage_bench::record_certified_entity_insert_parameter_batch_execution();
     Ok(Some(
         (0..parameter_batch.num_rows())
             .map(|_| SqlWriteResult::affected(1))

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -42,6 +42,8 @@ std::thread_local! {
         const { std::cell::Cell::new(0) };
     static CERTIFIED_ENTITY_INSERT_BATCH_EXECUTIONS: std::cell::Cell<usize> =
         const { std::cell::Cell::new(0) };
+    static CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_EXECUTIONS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
 }
 
 #[cfg(test)]
@@ -60,6 +62,11 @@ pub(crate) fn take_certified_entity_insert_batch_executions() -> usize {
 }
 
 #[cfg(test)]
+pub(crate) fn take_certified_entity_insert_parameter_batch_executions() -> usize {
+    CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_EXECUTIONS.with(|executions| executions.replace(0))
+}
+
+#[cfg(test)]
 pub(crate) fn supports_bound_public_write(plan: &LogicalWritePlan) -> bool {
     match &plan.bound.target {
         BoundWriteTarget::Entity(_) => bound_public_write_shape_supported(plan),
@@ -74,6 +81,106 @@ pub(crate) fn supports_bound_public_write(plan: &LogicalWritePlan) -> bool {
 pub(crate) enum BoundPublicWriteExecution {
     Executed(SqlWriteResult),
     Unsupported,
+}
+
+/// Executes independent parameterized entity INSERT statements as one dense
+/// transaction write. The public batch still returns one affected-row result
+/// per logical statement, while parsing, binding, and transaction staging
+/// happen once for the homogeneous batch.
+pub(crate) async fn try_execute_entity_insert_parameter_batch(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    plan: &LogicalWritePlan,
+    parameter_batch: &RecordBatch,
+) -> Result<Option<Vec<SqlWriteResult>>, LixError> {
+    let BoundWriteTarget::Entity(EntityWriteSurface::Base { schema_key }) = &plan.bound.target
+    else {
+        return Ok(None);
+    };
+    let BoundWriteInput::Values(values) = &plan.bound.input else {
+        return Ok(None);
+    };
+    if plan.bound.op != BoundWriteOp::Insert
+        || values.rows.len() != 1
+        || plan.bound.conflict.is_some()
+        || plan.bound.returning.is_some()
+        || !matches!(plan.bound.branch_scope, BranchScope::Active { .. })
+    {
+        return Ok(None);
+    }
+
+    let spec = entity_spec(ctx, schema_key)?;
+    if spec.has_inter_row_constraints {
+        return Ok(None);
+    }
+    validate_bound_write_supported(plan, &spec)?;
+    let active_branch_commit_id = if plan_references_active_branch_commit_id(plan) {
+        Some(load_active_branch_commit_id(ctx).await?)
+    } else {
+        None
+    };
+    let layout = InsertRowLayout::from_values(&spec, values)?;
+    let mut write_rows = RawWriteBatch::with_capacity(parameter_batch.num_rows());
+    let mut unique_identities =
+        std::collections::HashSet::with_capacity(parameter_batch.num_rows());
+    for row_index in 0..parameter_batch.num_rows() {
+        let params = super::write::parameter_row(parameter_batch, row_index)
+            .map_err(|error| with_parameter_batch_statement_index(error, row_index))?;
+        let mut row = if let Some(row) = certified_entity_insert_batch(
+            ctx,
+            plan,
+            &spec,
+            &layout,
+            values,
+            &params,
+            active_branch_commit_id.as_ref(),
+        )
+        .map_err(|error| with_parameter_batch_statement_index(error, row_index))?
+        {
+            row
+        } else {
+            let mut row = RawWriteBatch::with_capacity(1);
+            append_entity_insert_row(
+                &mut row,
+                ctx,
+                plan,
+                &spec,
+                &layout,
+                &values.rows[0],
+                &params,
+                active_branch_commit_id.as_ref(),
+            )
+            .map_err(|error| with_parameter_batch_statement_index(error, row_index))?;
+            row
+        };
+        if row.len() != 1 {
+            return Ok(None);
+        }
+        let candidate = row.row(0);
+        let Some(entity_pk) = candidate.entity_pk else {
+            return Ok(None);
+        };
+        if !unique_identities.insert((
+            candidate.schema_key.clone(),
+            entity_pk.clone(),
+            candidate.file_id.cloned(),
+            candidate.branch_id.clone(),
+        )) {
+            return Ok(None);
+        }
+        write_rows.append_taken_row(&mut row, 0);
+    }
+    stage_rows(ctx, TransactionWriteMode::Insert, write_rows)
+        .await
+        .map(|_| {
+            #[cfg(test)]
+            CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_EXECUTIONS.with(|executions| {
+                executions.set(executions.get().saturating_add(1));
+            });
+            (0..parameter_batch.num_rows())
+                .map(|_| SqlWriteResult::affected(1))
+                .collect()
+        })
+        .map(Some)
 }
 
 /// Executes a certified run of independent point updates as one physical

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -122,7 +122,7 @@ pub(crate) async fn try_execute_entity_insert_parameter_batch(
     if layout
         .columns
         .iter()
-        .any(|target| matches!(target, InsertColumnTarget::BranchId))
+        .any(|target| !matches!(target, InsertColumnTarget::Visible { .. }))
     {
         return Ok(None);
     }

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -125,7 +125,7 @@ pub(crate) async fn try_execute_entity_insert_parameter_batch(
     for row_index in 0..parameter_batch.num_rows() {
         let params = super::write::parameter_row(parameter_batch, row_index)
             .map_err(|error| with_parameter_batch_statement_index(error, row_index))?;
-        let mut row = if let Some(row) = certified_entity_insert_batch(
+        let Some(mut row) = certified_entity_insert_batch(
             ctx,
             plan,
             &spec,
@@ -135,22 +135,8 @@ pub(crate) async fn try_execute_entity_insert_parameter_batch(
             active_branch_commit_id.as_ref(),
         )
         .map_err(|error| with_parameter_batch_statement_index(error, row_index))?
-        {
-            row
-        } else {
-            let mut row = RawWriteBatch::with_capacity(1);
-            append_entity_insert_row(
-                &mut row,
-                ctx,
-                plan,
-                &spec,
-                &layout,
-                &values.rows[0],
-                &params,
-                active_branch_commit_id.as_ref(),
-            )
-            .map_err(|error| with_parameter_batch_statement_index(error, row_index))?;
-            row
+        else {
+            return Ok(None);
         };
         if row.len() != 1 {
             return Ok(None);

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -170,7 +170,9 @@ pub(crate) async fn try_execute_entity_insert_parameter_batch(
         write_rows.append_taken_row(&mut row, 0);
     }
     let committed = scan_entity_conflict_candidates(ctx, &spec, &write_rows).await?;
-    if !committed.is_empty() {
+    let committed_conflict = if committed.is_empty() {
+        None
+    } else {
         let committed_identities = committed
             .iter()
             .map(|row| {
@@ -185,6 +187,7 @@ pub(crate) async fn try_execute_entity_insert_parameter_batch(
                 )
             })
             .collect::<std::collections::HashMap<_, _>>();
+        let mut conflict = None;
         for (row_index, row) in write_rows.iter().enumerate() {
             let entity_pk = row
                 .entity_pk
@@ -227,21 +230,24 @@ pub(crate) async fn try_execute_entity_insert_parameter_batch(
                     ),
                 )
             };
-            return Err(with_parameter_batch_statement_index(error, row_index));
+            conflict = Some(with_parameter_batch_statement_index(error, row_index));
+            break;
         }
+        conflict
+    };
+    stage_rows(ctx, TransactionWriteMode::Insert, write_rows).await?;
+    if let Some(error) = committed_conflict {
+        return Err(error);
     }
-    stage_rows(ctx, TransactionWriteMode::Insert, write_rows)
-        .await
-        .map(|_| {
-            #[cfg(test)]
-            CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_EXECUTIONS.with(|executions| {
-                executions.set(executions.get().saturating_add(1));
-            });
-            (0..parameter_batch.num_rows())
-                .map(|_| SqlWriteResult::affected(1))
-                .collect()
-        })
-        .map(Some)
+    #[cfg(test)]
+    CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_EXECUTIONS.with(|executions| {
+        executions.set(executions.get().saturating_add(1));
+    });
+    Ok(Some(
+        (0..parameter_batch.num_rows())
+            .map(|_| SqlWriteResult::affected(1))
+            .collect(),
+    ))
 }
 
 /// Executes a certified run of independent point updates as one physical

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -169,6 +169,67 @@ pub(crate) async fn try_execute_entity_insert_parameter_batch(
         }
         write_rows.append_taken_row(&mut row, 0);
     }
+    let committed = scan_entity_conflict_candidates(ctx, &spec, &write_rows).await?;
+    if !committed.is_empty() {
+        let committed_identities = committed
+            .iter()
+            .map(|row| {
+                (
+                    (
+                        row.entity_pk().clone(),
+                        row.file_id().map(SharedStr::from),
+                        SharedStr::from(row.branch_id()),
+                        row.global(),
+                    ),
+                    row.untracked(),
+                )
+            })
+            .collect::<std::collections::HashMap<_, _>>();
+        for (row_index, row) in write_rows.iter().enumerate() {
+            let entity_pk = row
+                .entity_pk
+                .expect("certified parameter INSERT rows have explicit identities");
+            let identity = (
+                entity_pk.clone(),
+                row.file_id.cloned(),
+                row.branch_id.clone(),
+                row.global,
+            );
+            let Some(existing_untracked) = committed_identities.get(&identity).copied() else {
+                continue;
+            };
+            let error = if existing_untracked != row.untracked {
+                let requested = if row.untracked {
+                    "untracked"
+                } else {
+                    "tracked"
+                };
+                let existing = if existing_untracked {
+                    "untracked"
+                } else {
+                    "tracked"
+                };
+                LixError::new(
+                    LixError::CODE_UNIQUE,
+                    format!(
+                        "cannot insert {requested} row for schema '{}' entity_pk {:?}: a canonical {existing} row already exists; delete it first",
+                        row.schema_key, entity_pk,
+                    ),
+                )
+            } else {
+                LixError::new(
+                    LixError::CODE_UNIQUE,
+                    crate::transaction::duplicate_insert_identity_message(
+                        row.schema_key,
+                        entity_pk,
+                        Some(row.branch_id),
+                        row.origin,
+                    ),
+                )
+            };
+            return Err(with_parameter_batch_statement_index(error, row_index));
+        }
+    }
     stage_rows(ctx, TransactionWriteMode::Insert, write_rows)
         .await
         .map(|_| {

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -119,6 +119,13 @@ pub(crate) async fn try_execute_entity_insert_parameter_batch(
         None
     };
     let layout = InsertRowLayout::from_values(&spec, values)?;
+    if layout
+        .columns
+        .iter()
+        .any(|target| matches!(target, InsertColumnTarget::BranchId))
+    {
+        return Ok(None);
+    }
     let mut write_rows = RawWriteBatch::with_capacity(parameter_batch.num_rows());
     let mut unique_identities =
         std::collections::HashSet::with_capacity(parameter_batch.num_rows());

--- a/packages/engine/src/sql2/exec/mod.rs
+++ b/packages/engine/src/sql2/exec/mod.rs
@@ -97,6 +97,7 @@ pub(crate) enum SqlLogicalPlan {
 #[cfg(test)]
 pub(crate) use bound_public_write::{
     take_certified_entity_insert_batch_executions,
+    take_certified_entity_insert_parameter_batch_executions,
     take_certified_replacement_parameter_batch_executions,
     take_entity_update_parameter_batch_executions,
 };

--- a/packages/engine/src/sql2/exec/write.rs
+++ b/packages/engine/src/sql2/exec/write.rs
@@ -314,7 +314,7 @@ fn scalar_parameter_value(scalar: ScalarValue, is_json: bool) -> Result<Value, L
     }
 }
 
-/// Attempts the one currently certified physical parameter-batch route.
+/// Attempts a certified physical parameter-batch route.
 ///
 /// `None` means the logical statements are not independent and must retain
 /// public `executeBatch`'s sequential execution semantics.
@@ -327,6 +327,16 @@ pub(crate) async fn execute_write_logical_plan_parameter_batch(
         return Ok(None);
     };
     validate_write_parameter_count(&write_plan.plan, parameter_batch.num_columns())?;
+    if let Some(results) = super::bound_public_write::try_execute_entity_insert_parameter_batch(
+        ctx,
+        &write_plan.plan,
+        parameter_batch,
+    )
+    .await
+    .map_err(normalize_bound_public_write_error)?
+    {
+        return Ok(Some(results));
+    }
     super::bound_public_write::try_execute_entity_update_parameter_batch(
         ctx,
         &write_plan.plan,

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -59,6 +59,7 @@ pub(crate) use exec::{
     execute_write_logical_plan_with_mode, execute_write_logical_plan_with_mode_and_trace,
     execute_write_logical_plan_with_mode_and_trace_result,
     execute_write_logical_plan_with_mode_result, take_certified_entity_insert_batch_executions,
+    take_certified_entity_insert_parameter_batch_executions,
     take_certified_replacement_parameter_batch_executions,
     take_entity_update_parameter_batch_executions,
 };

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -16,6 +16,19 @@ static TRANSACTION_VALIDATION_BRANCHS: AtomicU64 = AtomicU64::new(0);
 static TRANSACTION_SCHEMA_CATALOG_LOADS: AtomicU64 = AtomicU64::new(0);
 static TRANSACTION_SCHEMA_CATALOG_COMPILES: AtomicU64 = AtomicU64::new(0);
 static JSON_STORE_STAGE_BYTES: AtomicU64 = AtomicU64::new(0);
+static CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_EXECUTIONS: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) fn record_certified_entity_insert_parameter_batch_execution() {
+    CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_EXECUTIONS.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Returns and resets the number of certified parameter-batch INSERT routes.
+///
+/// Benchmark fixtures use this as a route certificate so a schema change
+/// cannot silently turn the measured bulk INSERT back into sequential writes.
+pub fn take_certified_entity_insert_parameter_batch_executions() -> u64 {
+    CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_EXECUTIONS.swap(0, Ordering::Relaxed)
+}
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct BinaryCasWriteAccounting {

--- a/packages/engine/src/transaction/mod.rs
+++ b/packages/engine/src/transaction/mod.rs
@@ -22,3 +22,4 @@ pub(crate) use context::TransactionCommitBoundary;
 pub(crate) use context::begin_commit_boundary;
 pub(crate) use context::commit_at_boundary;
 pub(crate) use context::open_transaction;
+pub(crate) use staging::duplicate_insert_identity_message;


### PR DESCRIPTION
## What changed

- Add a certified `executeBatch` path for homogeneous parameterized entity INSERTs.
- Parse and bind the SQL shape once, build one dense `RawWriteBatch`, and stage once per public batch.
- Certify explicit, distinct row identities before batching so repeated identities retain sequential execution and the correct failing `statementIndex`.
- Preflight committed conflicts in one batched read, then attribute failures in input order so later committed conflicts retain their actual statement index.
- Decline the route for conflict/RETURNING, explicit branch columns, multi-row-template, JSON-visible-column, and inter-row-constraint shapes.
- Preserve the JSON CRUD fixture for read/update/delete setup, and measure create against a separate eligible two-TEXT-column schema comparable to raw SQLite.
- Add a benchmark-only route certificate that fails the create benchmark unless it executes exactly one certified parameter batch.

## Why

After #986 removed the quadratic collection-replacement scan, a 100k create still parsed and planned 200 literal INSERT statements. Raw SQLite reuses one prepared statement. This change gives Lix the equivalent parse-once physical route while preserving public batch result and error semantics.

A review correctly found that the original benchmark still targeted a JSON-visible column, which the hardened route deliberately declines. The benchmark now uses a genuinely eligible string schema, while the JSON fixture remains seeded through the prior chunked setup path for the other CRUD operations.

## Performance

Corrected, route-certified RocksDB tracked-state CRUD `insert_all`:

- 10k, 3 samples: **141.8 ms median** (106.9–152.4 ms)
- 100k, 7 samples: **1.192 s median** (1.155–1.583 s)
- raw SQLite 100k control, unchanged from the prior run: **69.8 ms median**

These replace the invalid 94.8 ms / 856.9 ms figures. The benchmark now aborts if a future schema or eligibility change silently returns it to sequential execution. The corrected 100k result remains about **1.10x slower** than the 1.084 s post-#986 chunked JSON baseline; closing that gap is follow-up work in commit/materialization and conflict preflight.

## Validation

- Route-certified create benchmark regression across SQLite, RocksDB, and SlateDB adapters
- Focused eligible INSERT batch regression
- Repeated intra-batch identity fallback preserves `statementIndex = 1`
- Second-row committed conflict preserves `statementIndex = 1` and rolls back the fresh prefix
- Later-row invalid branch fallback preserves the actual statement index
- Inter-row constraints remain sequential
- `cargo test -p lix_engine_benchmarks --test tracked_state_crud_public_result --features storage-benches,slatedb`
- `cargo test -p lix_engine execute_batch_lowers_distinct_bound_entity_inserts_once --lib --features storage-benches`
- `cargo test -p lix_engine --features all-simulations`
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all`
- `git diff --check`
- Release benchmark build with RocksDB, SQLite, and SlateDB enabled

The storage adapter API and implementations are unchanged.