### PR TITLE
inline medium JSON without diff regressions

### DIFF
--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -690,6 +690,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn predecessor_v24_hot_inline_protocol_is_rejected() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let storage_adapter = StorageAdapter::new(storage.clone());
+        let mut writes = storage_adapter.new_write_set();
+        writes.put(
+            crate::init::REPOSITORY_PROTOCOL_SPACE,
+            crate::init::REPOSITORY_PROTOCOL_KEY,
+            &b"commit-delta-sidecar-zstd.v24"[..],
+        );
+        storage_adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("V24 protocol marker should commit");
+
+        let Err(error) = Engine::new(storage).await else {
+            panic!("V24 repositories must fail closed before HOT rows are decoded");
+        };
+        assert_eq!(error.code, "LIX_ERROR_UNSUPPORTED_STORAGE_FORMAT");
+    }
+
+    #[tokio::test]
     async fn tracked_entity_fast_path_serves_broad_sql_rows() {
         let storage = Memory::new();
         Engine::initialize(storage.clone())

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -39,13 +39,13 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 
 /// Repository-wide compatibility gate for physical storage protocols.
 ///
-/// V24 compresses packed commit-delta sidecars under the existing manifest
-/// and segment space IDs. Opening an older store must fail closed before its
-/// differently framed LXCD5 values are decoded as the current layout.
+/// V25 persists content fingerprints beside inline HOT JSON. Opening an older
+/// store must fail closed before its differently framed current-state rows are
+/// decoded as the current layout.
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"commit-delta-sidecar-zstd.v24";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"hot-inline-fingerprint.v25";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately

--- a/packages/engine/src/json_store/types.rs
+++ b/packages/engine/src/json_store/types.rs
@@ -205,7 +205,7 @@ pub(crate) enum JsonSlot {
 
 /// Inline threshold in bytes. Payloads at or under this length skip the
 /// json_store entirely.
-pub(crate) const JSON_INLINE_MAX_BYTES: usize = 256;
+pub(crate) const JSON_INLINE_MAX_BYTES: usize = 1024;
 
 impl JsonSlot {
     pub(crate) fn from_json(json: &str) -> Self {

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -1253,7 +1253,7 @@ fn working_diff_error(message: &str) -> LixError {
 /// every row before it was copied into a live-state row.
 ///
 /// ```text
-///  0      format version (5)
+///  0      format version (6)
 ///  1      deleted + untracked + snapshot/metadata kinds + diff baseline kind
 ///  2..18  change UUID
 /// 18..34  commit UUID
@@ -1265,10 +1265,12 @@ fn working_diff_error(message: &str) -> LixError {
 ///          checkpoint before-image when the baseline kind is BeforePresent
 /// ```
 ///
-/// Slot payloads are either inline UTF-8 JSON or a fixed 32-byte `JsonRef`.
-/// This makes parsing bounded and lets the scan path build the final
-/// `MaterializedLiveStateRow` in one pass.
-const HEAD_VALUE_VERSION: u8 = 5;
+/// Slot payloads are either inline UTF-8 JSON, a fixed 32-byte `JsonRef`, or
+/// that same fingerprint followed by inline JSON for dirty working-diff rows.
+/// Persisting fingerprints only while a row is dirty keeps repeated diff
+/// classification independent of payload size without taxing checkpointed
+/// current state.
+const HEAD_VALUE_VERSION: u8 = 6;
 const HEAD_VALUE_HEADER_BYTES: usize = 58;
 const HEAD_VALUE_DELETED: u8 = 0b0000_0001;
 const HEAD_VALUE_SNAPSHOT_SHIFT: u8 = 1;
@@ -1280,6 +1282,7 @@ const HEAD_VALUE_WORKING_DIFF_MASK: u8 = 0b11;
 const HEAD_SLOT_NONE: u8 = 0;
 const HEAD_SLOT_REF: u8 = 1;
 const HEAD_SLOT_INLINE: u8 = 2;
+const HEAD_SLOT_INLINE_FINGERPRINTED: u8 = 3;
 const HEAD_WORKING_DIFF_DISABLED: u8 = 0;
 const HEAD_WORKING_DIFF_CLEAN: u8 = 1;
 const HEAD_WORKING_DIFF_BEFORE_ABSENT: u8 = 2;
@@ -1292,6 +1295,7 @@ enum HeadSlotView<'a> {
     None,
     Ref(JsonRef),
     Inline(&'a str),
+    InlineFingerprinted { json_ref: JsonRef, json: &'a str },
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1356,6 +1360,10 @@ fn working_diff_slot_fingerprint(slot: HeadSlotView<'_>) -> WorkingDiffSlotFinge
             kind: WORKING_DIFF_SLOT_INLINE,
             hash: *JsonRef::for_content(json.as_bytes()).as_hash_array(),
         },
+        HeadSlotView::InlineFingerprinted { json_ref, .. } => WorkingDiffSlotFingerprint {
+            kind: WORKING_DIFF_SLOT_INLINE,
+            hash: *json_ref.as_hash_array(),
+        },
     }
 }
 
@@ -1363,7 +1371,10 @@ fn working_diff_slot_fingerprint(slot: HeadSlotView<'_>) -> WorkingDiffSlotFinge
 enum HeadSlotEncode<'a> {
     None,
     Ref(JsonRef),
-    Inline(&'a str),
+    Inline {
+        json_ref: Option<JsonRef>,
+        json: &'a str,
+    },
 }
 
 impl<'a> From<JsonSlotRef<'a>> for HeadSlotEncode<'a> {
@@ -1371,7 +1382,10 @@ impl<'a> From<JsonSlotRef<'a>> for HeadSlotEncode<'a> {
         match value {
             JsonSlotRef::None => Self::None,
             JsonSlotRef::Ref(value) => Self::Ref(*value),
-            JsonSlotRef::Inline(value) => Self::Inline(value),
+            JsonSlotRef::Inline(json) => Self::Inline {
+                json_ref: None,
+                json,
+            },
         }
     }
 }
@@ -1381,7 +1395,14 @@ impl<'a> From<HeadSlotView<'a>> for HeadSlotEncode<'a> {
         match value {
             HeadSlotView::None => Self::None,
             HeadSlotView::Ref(value) => Self::Ref(value),
-            HeadSlotView::Inline(value) => Self::Inline(value),
+            HeadSlotView::Inline(json) => Self::Inline {
+                json_ref: None,
+                json,
+            },
+            HeadSlotView::InlineFingerprinted { json_ref, json } => Self::Inline {
+                json_ref: Some(json_ref),
+                json,
+            },
         }
     }
 }
@@ -1452,8 +1473,12 @@ fn append_head_value_parts(
     bytes: &mut Vec<u8>,
     value: HeadValueEncode<'_>,
 ) -> Result<std::ops::Range<usize>, LixError> {
-    let snapshot_kind = encoded_slot_kind(value.snapshot);
-    let metadata_kind = encoded_slot_kind(value.metadata);
+    let fingerprint_inline = matches!(
+        value.working_diff_baseline,
+        WorkingDiffBaseline::BeforeAbsent | WorkingDiffBaseline::BeforePresent(_)
+    );
+    let snapshot_kind = encoded_slot_kind(value.snapshot, fingerprint_inline);
+    let metadata_kind = encoded_slot_kind(value.metadata, fingerprint_inline);
     if value.deleted && (snapshot_kind != HEAD_SLOT_NONE || metadata_kind != HEAD_SLOT_NONE) {
         return Err(head_value_error(
             "deleted current-state rows must not carry JSON payloads",
@@ -1487,8 +1512,8 @@ fn append_head_value_parts(
             "untracked current-state rows must not carry a working-diff baseline",
         ));
     }
-    let snapshot_len = encoded_slot_len(value.snapshot);
-    let metadata_len = encoded_slot_len(value.metadata);
+    let snapshot_len = encoded_slot_len(value.snapshot, fingerprint_inline);
+    let metadata_len = encoded_slot_len(value.metadata, fingerprint_inline);
     let capacity = HEAD_VALUE_HEADER_BYTES
         .checked_add(snapshot_len)
         .and_then(|bytes| bytes.checked_add(metadata_len))
@@ -1519,16 +1544,16 @@ fn append_head_value_parts(
     bytes.extend_from_slice(&value.updated_at.packed().to_be_bytes());
     bytes.extend_from_slice(
         &u32::try_from(snapshot_len)
-            .map_err(|_| head_value_error("snapshot payload exceeds v5 u32 limit"))?
+            .map_err(|_| head_value_error("snapshot payload exceeds v6 u32 limit"))?
             .to_be_bytes(),
     );
     bytes.extend_from_slice(
         &u32::try_from(metadata_len)
-            .map_err(|_| head_value_error("metadata payload exceeds v5 u32 limit"))?
+            .map_err(|_| head_value_error("metadata payload exceeds v6 u32 limit"))?
             .to_be_bytes(),
     );
-    append_slot_payload(bytes, value.snapshot);
-    append_slot_payload(bytes, value.metadata);
+    append_slot_payload(bytes, value.snapshot, fingerprint_inline);
+    append_slot_payload(bytes, value.metadata, fingerprint_inline);
     if let WorkingDiffBaseline::BeforePresent(version) = value.working_diff_baseline {
         encode_working_diff_version(bytes, version);
     }
@@ -1545,27 +1570,36 @@ fn encode_working_diff_baseline_tag(baseline: WorkingDiffBaseline) -> u8 {
     }
 }
 
-fn encoded_slot_kind(slot: HeadSlotEncode<'_>) -> u8 {
+fn encoded_slot_kind(slot: HeadSlotEncode<'_>, fingerprint_inline: bool) -> u8 {
     match slot {
         HeadSlotEncode::None => HEAD_SLOT_NONE,
         HeadSlotEncode::Ref(_) => HEAD_SLOT_REF,
-        HeadSlotEncode::Inline(_) => HEAD_SLOT_INLINE,
+        HeadSlotEncode::Inline { .. } if fingerprint_inline => HEAD_SLOT_INLINE_FINGERPRINTED,
+        HeadSlotEncode::Inline { .. } => HEAD_SLOT_INLINE,
     }
 }
 
-fn encoded_slot_len(slot: HeadSlotEncode<'_>) -> usize {
+fn encoded_slot_len(slot: HeadSlotEncode<'_>, fingerprint_inline: bool) -> usize {
     match slot {
         HeadSlotEncode::None => 0,
         HeadSlotEncode::Ref(_) => JSON_REF_BYTES,
-        HeadSlotEncode::Inline(json) => json.len(),
+        HeadSlotEncode::Inline { json, .. } if fingerprint_inline => {
+            JSON_REF_BYTES.saturating_add(json.len())
+        }
+        HeadSlotEncode::Inline { json, .. } => json.len(),
     }
 }
 
-fn append_slot_payload(bytes: &mut Vec<u8>, slot: HeadSlotEncode<'_>) {
+fn append_slot_payload(bytes: &mut Vec<u8>, slot: HeadSlotEncode<'_>, fingerprint_inline: bool) {
     match slot {
         HeadSlotEncode::None => {}
         HeadSlotEncode::Ref(json_ref) => bytes.extend_from_slice(json_ref.as_hash_bytes()),
-        HeadSlotEncode::Inline(json) => bytes.extend_from_slice(json.as_bytes()),
+        HeadSlotEncode::Inline { json_ref, json } if fingerprint_inline => {
+            let json_ref = json_ref.unwrap_or_else(|| JsonRef::for_content(json.as_bytes()));
+            bytes.extend_from_slice(json_ref.as_hash_bytes());
+            bytes.extend_from_slice(json.as_bytes());
+        }
+        HeadSlotEncode::Inline { json, .. } => bytes.extend_from_slice(json.as_bytes()),
     }
 }
 
@@ -1580,7 +1614,7 @@ fn full_value_bytes(value: StorageProjectedValue) -> Result<Bytes, LixError> {
 
 fn decode_head_value(bytes: &[u8]) -> Result<HeadValueView<'_>, LixError> {
     if bytes.len() < HEAD_VALUE_HEADER_BYTES {
-        return Err(head_value_error("row is shorter than the v5 fixed header"));
+        return Err(head_value_error("row is shorter than the v6 fixed header"));
     }
     if bytes[0] != HEAD_VALUE_VERSION {
         return Err(head_value_error(&format!(
@@ -1684,7 +1718,7 @@ fn decode_head_value(bytes: &[u8]) -> Result<HeadValueView<'_>, LixError> {
 fn uuid_from_head_bytes(bytes: &[u8], field: &str) -> Result<uuid::Uuid, LixError> {
     let bytes: [u8; UUID_BYTES] = bytes.try_into().map_err(|_| {
         head_value_error(&format!(
-            "{field} must have {UUID_BYTES} bytes in the v5 header"
+            "{field} must have {UUID_BYTES} bytes in the v6 header"
         ))
     })?;
     Ok(uuid::Uuid::from_bytes(bytes))
@@ -1726,6 +1760,25 @@ fn decode_slot<'a>(kind: u8, bytes: &'a [u8], field: &str) -> Result<HeadSlotVie
             .map_err(|error| {
                 head_value_error(&format!("{field} inline payload is not UTF-8: {error}"))
             }),
+        HEAD_SLOT_INLINE_FINGERPRINTED if bytes.len() >= JSON_REF_BYTES => {
+            let (hash, json) = bytes.split_at(JSON_REF_BYTES);
+            let hash: [u8; JSON_REF_BYTES] = hash.try_into().map_err(|_| {
+                head_value_error(&format!(
+                    "{field} inline fingerprint must have {JSON_REF_BYTES} bytes"
+                ))
+            })?;
+            std::str::from_utf8(json)
+                .map(|json| HeadSlotView::InlineFingerprinted {
+                    json_ref: JsonRef::from_hash_bytes(hash),
+                    json,
+                })
+                .map_err(|error| {
+                    head_value_error(&format!("{field} inline payload is not UTF-8: {error}"))
+                })
+        }
+        HEAD_SLOT_INLINE_FINGERPRINTED => Err(head_value_error(&format!(
+            "{field} inline payload is shorter than its {JSON_REF_BYTES}-byte fingerprint"
+        ))),
         _ => Err(head_value_error(&format!(
             "{field} has an unknown slot kind {kind}"
         ))),
@@ -1938,7 +1991,7 @@ fn materialize_live_slot(
     }
     match slot {
         HeadSlotView::None => None,
-        HeadSlotView::Inline(json) => Some(
+        HeadSlotView::Inline(json) | HeadSlotView::InlineFingerprinted { json, .. } => Some(
             SharedStr::from_utf8_slice(owner.clone(), json)
                 .expect("decoded inline JSON points into its head-value buffer"),
         ),
@@ -2106,7 +2159,7 @@ mod tests {
     }
 
     #[test]
-    fn v5_value_codec_roundtrips_fixed_header_inline_and_ref_slots() {
+    fn v6_value_codec_roundtrips_clean_inline_and_ref_slots() {
         let snapshot_ref = JsonRef::from_hash_bytes([7; JSON_REF_BYTES]);
         let value = HeadValueRef {
             change_id: Some(ChangeId::for_test_label("change")),
@@ -2120,13 +2173,13 @@ mod tests {
             working_diff_baseline: WorkingDiffBaseline::Disabled,
         };
 
-        let bytes = encode_head_value(&value).expect("encode v5 row");
+        let bytes = encode_head_value(&value).expect("encode v6 row");
         assert_eq!(bytes[0], HEAD_VALUE_VERSION);
         assert_eq!(
             bytes.len(),
             HEAD_VALUE_HEADER_BYTES + "{\"snapshot\":true}".len() + JSON_REF_BYTES
         );
-        let decoded = decode_head_value(&bytes).expect("decode v5 row");
+        let decoded = decode_head_value(&bytes).expect("decode v6 row");
         assert_eq!(decoded.change_id, value.change_id);
         assert_eq!(decoded.commit_id, value.commit_id);
         assert_eq!(decoded.created_at, value.created_at);
@@ -2151,8 +2204,8 @@ mod tests {
             metadata: JsonSlotRef::Inline("{\"source\":\"test\"}"),
             working_diff_baseline: WorkingDiffBaseline::Disabled,
         };
-        let bytes = Bytes::from(encode_head_value(&value).expect("encode v5 row"));
-        let decoded = decode_head_value(&bytes).expect("decode v5 row");
+        let bytes = Bytes::from(encode_head_value(&value).expect("encode v6 row"));
+        let decoded = decode_head_value(&bytes).expect("decode v6 row");
         let mut json_refs = Vec::new();
         let mut deferred = Vec::new();
         let snapshot = materialize_live_slot(
@@ -2184,7 +2237,7 @@ mod tests {
     }
 
     #[test]
-    fn v5_value_codec_embeds_a_tracked_first_before_baseline() {
+    fn v6_value_codec_embeds_a_tracked_first_before_baseline() {
         let baseline = WorkingDiffVersion {
             change_id: ChangeId::for_test_label("before-change"),
             commit_id: CommitId::for_test_label("before-commit"),
@@ -2212,12 +2265,15 @@ mod tests {
             working_diff_baseline: WorkingDiffBaseline::BeforePresent(baseline),
         };
 
-        let bytes = encode_head_value(&value).expect("encode v5 row with baseline");
+        let bytes = encode_head_value(&value).expect("encode v6 row with baseline");
         assert_eq!(
             bytes.len(),
-            HEAD_VALUE_HEADER_BYTES + "{\"current\":true}".len() + WORKING_DIFF_VERSION_BYTES
+            HEAD_VALUE_HEADER_BYTES
+                + JSON_REF_BYTES
+                + "{\"current\":true}".len()
+                + WORKING_DIFF_VERSION_BYTES
         );
-        let decoded = decode_head_value(&bytes).expect("decode v5 row with baseline");
+        let decoded = decode_head_value(&bytes).expect("decode v6 row with baseline");
         assert_eq!(
             decoded.working_diff_baseline,
             WorkingDiffBaseline::BeforePresent(baseline)
@@ -2695,6 +2751,7 @@ mod tests {
                 file_ids: vec![NullableKeyFilter::Value(file_id.to_string())],
                 ..Default::default()
             },
+            ..Default::default()
         };
         let diff = read_working_diff(
             &storage,
@@ -3082,6 +3139,7 @@ mod tests {
                     entity_pks: vec![entity_pk.clone()],
                     ..Default::default()
                 },
+                ..Default::default()
             },
         ] {
             let read = storage

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -1,4 +1,4 @@
-//! V18 row-addressable current state with schema-level file membership.
+//! V19 row-addressable current state with dirty-inline fingerprints.
 //!
 //! V12 packed every file member of one logical entity into a group. That made
 //! a logical-PK lookup cheap, but it also made every normal commit read,
@@ -27,7 +27,7 @@ use crate::wasm::WasmCertifiedEntityBatch;
 
 use super::*;
 
-pub(crate) const HOT_ROW_NAMESPACE: &str = "live_state.hot_row.v17";
+pub(crate) const HOT_ROW_NAMESPACE: &str = "live_state.hot_row.v19";
 pub(crate) const HOT_FILE_NAMESPACE: &str = "live_state.hot_file_schema.v18";
 pub(crate) const HOT_DIFF_NAMESPACE: &str = "live_state.hot_diff.v17";
 pub(crate) const HOT_COLLECTION_CONTROL_NAMESPACE: &str = "live_state.hot_collection_control.v1";
@@ -2716,7 +2716,8 @@ where
             let row_index = snapshots.len();
             match value.snapshot {
                 HeadSlotView::None => snapshots.push(None),
-                HeadSlotView::Inline(snapshot) => {
+                HeadSlotView::Inline(snapshot)
+                | HeadSlotView::InlineFingerprinted { json: snapshot, .. } => {
                     snapshots.push(Some(bytes.slice_ref(snapshot.as_bytes())));
                 }
                 HeadSlotView::Ref(json_ref) => {
@@ -4173,8 +4174,8 @@ fn checked_add_hot_next_value_capacity(
         (0, 0)
     } else {
         (
-            encoded_hot_slot_len(delta.snapshot),
-            encoded_hot_slot_len(delta.metadata),
+            encoded_hot_slot_len(delta.snapshot, active_checkpoint),
+            encoded_hot_slot_len(delta.metadata, active_checkpoint),
         )
     };
     // Keep the plan bounded by the same on-disk u32 fields the encoder checks.
@@ -4192,10 +4193,13 @@ fn checked_add_hot_next_value_capacity(
     total.checked_add(encoded_len)
 }
 
-fn encoded_hot_slot_len(slot: JsonSlotRef<'_>) -> usize {
+fn encoded_hot_slot_len(slot: JsonSlotRef<'_>, fingerprint_inline: bool) -> usize {
     match slot {
         JsonSlotRef::None => 0,
         JsonSlotRef::Ref(_) => JSON_REF_BYTES,
+        JsonSlotRef::Inline(json) if fingerprint_inline => {
+            JSON_REF_BYTES.saturating_add(json.len())
+        }
         JsonSlotRef::Inline(json) => json.len(),
     }
 }

--- a/packages/engine/src/sql2/providers/diff.rs
+++ b/packages/engine/src/sql2/providers/diff.rs
@@ -222,6 +222,7 @@ impl DiffRoute {
                         .collect(),
                     include_tombstones: true,
                 },
+                retain_payloads: false,
             },
             contradictory,
         }

--- a/packages/engine/src/sql2/providers/filesystem_working_change.rs
+++ b/packages/engine/src/sql2/providers/filesystem_working_change.rs
@@ -252,6 +252,7 @@ where
                     include_tombstones: true,
                     ..TrackedStateFilter::default()
                 },
+                retain_payloads: false,
             },
         )
         .await?;

--- a/packages/engine/src/sql2/providers/working_change.rs
+++ b/packages/engine/src/sql2/providers/working_change.rs
@@ -278,6 +278,7 @@ impl WorkingChangeRoute {
                         .collect(),
                     include_tombstones: true,
                 },
+                retain_payloads: false,
             },
             contradictory,
         })

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -6422,36 +6422,64 @@ mod tests {
 
     #[tokio::test]
     async fn inline_threshold_boundary_routes_payloads_deterministically() {
-        // 256 bytes inlines into the change record; 257 takes the
-        // json_store ref path. Both must read back identically.
+        // The exact threshold inlines into the change record; one byte over
+        // takes the json_store ref path. Both must read back identically.
         let storage = StorageAdapter::new(Memory::new());
         let tracked_state = TrackedStateContext::new();
         // row_with_value wraps values as {"value":"<v>"} (12 framing bytes);
         // size the inner strings so the stored payloads land exactly at the
         // threshold and one byte over.
+        let at_len = crate::json_store::JSON_INLINE_MAX_BYTES;
+        let over_len = at_len + 1;
         let rows = [
-            row_with_value("entity-at", "change-at", "commit-1", &"a".repeat(256 - 12)),
+            row_with_value(
+                "entity-at",
+                "change-at",
+                "commit-1",
+                &"a".repeat(at_len - 12),
+            ),
             row_with_value(
                 "entity-over",
                 "change-over",
                 "commit-1",
-                &"b".repeat(257 - 12),
+                &"b".repeat(over_len - 12),
             ),
         ];
         let at_threshold = rows[0].snapshot_content.clone().expect("payload");
         let over_threshold = rows[1].snapshot_content.clone().expect("payload");
-        assert_eq!(at_threshold.len(), 256);
-        assert_eq!(over_threshold.len(), 257);
+        assert_eq!(at_threshold.len(), at_len);
+        assert_eq!(over_threshold.len(), over_len);
         write_root_for_test(&storage, &tracked_state, "commit-1", None, &rows)
             .await
             .expect("root should write");
 
-        let mut reader = tracked_state.reader(
-            storage
-                .begin_read(StorageReadOptions::default())
-                .await
-                .expect("read should open"),
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let json_refs = [
+            crate::json_store::JsonRef::for_content(at_threshold.as_bytes()),
+            crate::json_store::JsonRef::for_content(over_threshold.as_bytes()),
+        ];
+        let stored = crate::json_store::JsonStoreContext::new()
+            .load_bytes_many(
+                &read,
+                crate::json_store::JsonLoadRequestRef {
+                    refs: &json_refs,
+                    scope: crate::json_store::JsonReadScopeRef::OutOfBand,
+                },
+            )
+            .await
+            .expect("json_store boundary rows should load")
+            .into_values();
+        assert_eq!(stored[0], None, "threshold payload must stay inline");
+        assert_eq!(
+            stored[1].as_deref(),
+            Some(over_threshold.as_bytes()),
+            "over-threshold payload must use the json_store"
         );
+
+        let mut reader = tracked_state.reader(read);
         let scanned = reader
             .scan_batch_at_commit("commit-1", &test_schema_scan_request())
             .await

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -1280,6 +1280,104 @@ where
         )
     }
 
+    pub(crate) async fn load_tree_diff_comparison_payloads(
+        &mut self,
+        batch: &TrackedStateTreeDiffBatch,
+    ) -> Result<TrackedStatePayloadBatch, LixError> {
+        self.validate_tree_diff_batch_against_delta_index(batch)
+            .await?;
+        let changes = self
+            .load_routed_tree_diff_changes(&batch.comparison_rows())
+            .await?;
+        TrackedStatePayloadBatch::from_payloads(
+            changes
+                .into_iter()
+                .map(|(change_id, change)| (change_id, change.snapshot, change.metadata)),
+        )
+    }
+
+    async fn validate_tree_diff_batch_against_delta_index(
+        &self,
+        batch: &TrackedStateTreeDiffBatch,
+    ) -> Result<(), LixError> {
+        let rows = batch.side_rows().collect::<Vec<_>>();
+        let mut by_commit = BTreeMap::<CommitId, Vec<TrackedStateTreeDiffRowRef<'_>>>::new();
+        for row in rows {
+            by_commit.entry(row.commit_id()).or_default().push(row);
+        }
+        for (commit_id, commit_rows) in by_commit {
+            let mut encoded_keys =
+                TrackedStateKeyBatchBuilder::with_row_capacity(commit_rows.len());
+            for row in &commit_rows {
+                encoded_keys.push(TrackedStateKeyRef {
+                    schema_key: row.schema_key(),
+                    file_id: row.file_id(),
+                    entity_pk: row.entity_pk(),
+                });
+            }
+            let loaded = storage::load_commit_delta_values_encoded(
+                &self.store,
+                commit_id,
+                &encoded_keys.finish(),
+            )
+            .await?;
+            let mut fallback_rows = Vec::new();
+            let mut fallback_keys =
+                TrackedStateKeyBatchBuilder::with_row_capacity(commit_rows.len());
+            for (index, (row, value)) in commit_rows.iter().zip(&loaded).enumerate() {
+                if value.is_none()
+                    && row.deleted()
+                    && let Some(file_id) = row.file_id()
+                {
+                    let key = cascade_payload_key(file_id);
+                    fallback_keys.push(TrackedStateKeyRef {
+                        schema_key: &key.schema_key,
+                        file_id: key.file_id.as_deref(),
+                        entity_pk: &key.entity_pk,
+                    });
+                    fallback_rows.push(index);
+                }
+            }
+            let fallback_values = storage::load_commit_delta_values_encoded(
+                &self.store,
+                commit_id,
+                &fallback_keys.finish(),
+            )
+            .await?;
+            let mut fallbacks = vec![None; commit_rows.len()];
+            for (index, value) in fallback_rows.into_iter().zip(fallback_values) {
+                fallbacks[index] = value;
+            }
+            for ((row, value), fallback) in commit_rows.iter().zip(loaded).zip(fallbacks) {
+                if value.as_ref().is_some_and(|value| {
+                    value.change_id == row.change_id()
+                        && value.commit_id == row.commit_id()
+                        && value.deleted == row.deleted()
+                        && value.updated_at() == row.updated_at()
+                }) {
+                    continue;
+                }
+                if let Some(cascade) = fallback
+                    && cascade.deleted
+                    && cascade.change_id == row.change_id()
+                    && cascade.commit_id == row.commit_id()
+                    && cascade.updated_at() == row.updated_at()
+                {
+                    continue;
+                }
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "tracked-state diff row '{}' does not match commit '{}' delta index",
+                        row.change_id(),
+                        commit_id
+                    ),
+                ));
+            }
+        }
+        Ok(())
+    }
+
     async fn load_and_validate_diff_row_changes(
         &mut self,
         rows: &[&TrackedStateDiffRow],
@@ -6987,6 +7085,7 @@ mod tests {
                         file_ids: vec![NullableKeyFilter::Value(FILE_ID.to_string())],
                         ..Default::default()
                     },
+                    ..Default::default()
                 },
             )
             .await
@@ -7098,6 +7197,7 @@ mod tests {
                         file_ids: vec![NullableKeyFilter::Value(FILE_ID.to_string())],
                         ..Default::default()
                     },
+                    ..Default::default()
                 },
             )
             .await
@@ -7143,6 +7243,7 @@ mod tests {
                         file_ids: vec![NullableKeyFilter::Value(FILE_ID.to_string())],
                         ..Default::default()
                     },
+                    ..Default::default()
                 },
             )
             .await
@@ -7268,6 +7369,7 @@ mod tests {
                         entity_pks: vec![EntityPk::single("line-1")],
                         ..Default::default()
                     },
+                    ..Default::default()
                 },
             )
             .await
@@ -7426,6 +7528,7 @@ mod tests {
                 schema_keys: vec!["test_schema".to_string()],
                 ..Default::default()
             },
+            ..Default::default()
         }
     }
 

--- a/packages/engine/src/tracked_state/diff.rs
+++ b/packages/engine/src/tracked_state/diff.rs
@@ -17,9 +17,19 @@ use crate::tracked_state::types::{
 use crate::tracked_state::{TrackedStateFilter, TrackedStateStoreReader};
 
 /// Filter for comparing two tracked-state commit roots.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TrackedStateDiffRequest {
     pub(crate) filter: TrackedStateFilter,
+    pub(crate) retain_payloads: bool,
+}
+
+impl Default for TrackedStateDiffRequest {
+    fn default() -> Self {
+        Self {
+            filter: TrackedStateFilter::default(),
+            retain_payloads: true,
+        }
+    }
 }
 
 /// Changed tracked-state rows between two commit roots.
@@ -39,10 +49,10 @@ impl Eq for TrackedStateDiff {}
 
 /// Change payload columns retained by a tracked-state diff.
 ///
-/// Diff validation already loads every changed row's immutable changelog
-/// record. Keeping those payload slots behind one `Arc` lets subsequent merge
-/// analysis compare cross-branch change ids without reading or cloning the
-/// same records again. Logical rows are resolved through the change-id
+/// Merge/checkpoint diff validation loads every changed row's immutable
+/// payload. Identity-only SQL diffs retain only the live/live comparison
+/// subset. Keeping either set behind one `Arc` lets downstream analysis reuse
+/// it without cloning records. Logical rows resolve through the change-id
 /// ordinal index and borrow the snapshot/metadata columns in place.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TrackedStatePayloadBatch {
@@ -329,11 +339,13 @@ impl TrackedStateDiff {
 
 /// Diffs two tracked-state commit roots with hash-guided subtree skipping.
 ///
-/// Commit-root first-parent metadata is bound to the changelog. Every emitted
-/// row point-loads its change record and validates identity, deletion, and
-/// update time. Winner reachability, inherited creation time, and absence of
-/// omitted unchanged rows belong to the explicit full-root integrity audit;
-/// proving those here would make sparse diff O(total rows).
+/// Commit-root first-parent metadata is bound to the changelog. Payload-
+/// retaining consumers validate every emitted row against its immutable
+/// change record. Identity-only SQL consumers validate the packed delta leaf
+/// and hydrate payloads only for live/live equality classification. Winner
+/// reachability, inherited creation time, and absence of omitted unchanged
+/// rows belong to the explicit full-root integrity audit; proving those here
+/// would make sparse diff O(total rows).
 pub(crate) async fn diff_commits<S>(
     reader: &mut TrackedStateStoreReader<S>,
     left_commit_id: &str,
@@ -353,13 +365,18 @@ where
     // turn every sparse diff back into an O(total rows) scan.
     //
     // Rootless rows still come from an independently stored packed-delta
-    // index. Validate its identity, deletion flag, and timestamp against the
-    // referenced immutable ChangeRecord exactly as we do for durable tree
-    // rows. This also makes a missing ChangeRecord an error instead of letting
-    // an added/removed diff proceed without its authoritative payload.
-    let payloads = reader
-        .validate_tree_diff_batch_and_load_payloads(&tree_diff)
-        .await?;
+    // index. Merge/checkpoint consumers retain full payload authority; SQL
+    // consumers validate the allocation-free leaf index and avoid decoding
+    // payload sidecars for added/removed rows.
+    let payloads = if request.retain_payloads {
+        reader
+            .validate_tree_diff_batch_and_load_payloads(&tree_diff)
+            .await?
+    } else {
+        reader
+            .load_tree_diff_comparison_payloads(&tree_diff)
+            .await?
+    };
 
     // Rows are identity-only; payload equality needs the change records when
     // a live/live pair carries different change ids (cross-branch writes can
@@ -563,6 +580,34 @@ impl TrackedStateTreeDiffBatch {
                     })
             },
         )
+    }
+
+    pub(crate) fn comparison_rows(&self) -> Vec<TrackedStateTreeDiffRowRef<'_>> {
+        let Some(identities) = self.identities.as_deref() else {
+            return Vec::new();
+        };
+        let mut rows = Vec::new();
+        for (ordinal, (before, after)) in self.before.iter().zip(&self.after).enumerate() {
+            let (Some(before), Some(after)) = (before.as_ref(), after.as_ref()) else {
+                continue;
+            };
+            if before.deleted || after.deleted || before.change_id == after.change_id {
+                continue;
+            }
+            let ordinal =
+                u32::try_from(ordinal).expect("tree diff batch row count is bounded to u32");
+            rows.push(TrackedStateTreeDiffRowRef {
+                identities,
+                ordinal,
+                value: before,
+            });
+            rows.push(TrackedStateTreeDiffRowRef {
+                identities,
+                ordinal,
+                value: after,
+            });
+        }
+        rows
     }
 
     fn into_columns(
@@ -1637,6 +1682,7 @@ mod tests {
                         )],
                         ..Default::default()
                     },
+                    ..Default::default()
                 },
             )
             .await
@@ -1947,6 +1993,27 @@ mod tests {
                 .contains("does not match changelog change identity")
                 || error.message.contains("changelog commit"),
             "unexpected error: {error}"
+        );
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let error = tracked_state
+            .reader(read)
+            .diff_commits(
+                "left",
+                "right-corrupt",
+                &TrackedStateDiffRequest {
+                    retain_payloads: false,
+                    ..TrackedStateDiffRequest::default()
+                },
+            )
+            .await
+            .expect_err("identity-only diff must validate the packed delta leaf");
+        assert!(
+            error.message.contains("delta index") || error.message.contains("changelog commit"),
+            "unexpected identity-only validation error: {error}"
         );
     }
 


### PR DESCRIPTION
## What changed

- raise the deterministic JSON inline threshold from 256 to 1,024 bytes
- add a V6 HOT row slot that persists content fingerprints only while inline rows are dirty
- make identity-only SQL diff surfaces validate allocation-free commit-delta leaves and hydrate payloads only for live/live equality checks
- retain full eager payload batches for merge and checkpoint consumers
- bump the repository protocol to V25; no migration or backward compatibility

## Why

Retained real-repository profiling showed that medium semantic JSON dominated `json_store` indirection. Raising the threshold removes those rows, but a constant-only change made working diff repeatedly hash inline payloads and made historical SQL diff decompress payload sidecars for rows whose classification did not require content. Dirty-only fingerprints and projection-aware eager hydration remove both regressions.

## Retained replay

VS Code Docs, 50 first-parent commits, all bundled WASM plugins, eager semantic materialization, SlateDB, checkpoint every Git commit, changed-file verification after every commit, and final Git tree verification:

- logical bytes: 147,883,439 -> 117,975,640 (-20.2%)
- physical bytes: 105,435,166 -> 89,260,884 (-15.3%)
- replay: 115,432.867 ms -> 115,383.104 ms (-0.04%)
- execute: 97,075.792 ms -> 97,301.970 ms (+0.23%)
- checkpoint: 4,315.573 ms -> 4,154.759 ms (-3.7%)
- final tree verification: 12,619.835 ms -> 12,551.529 ms (-0.5%)

The retained candidate database is:

`/root/projects/openclaw-perf-data/vscode-json-inline-fingerprint-50-db`

## CRUD/diff A/B

Memory storage, 1,000 rows with 800-byte values, seven warm samples, compared with the preserved 256-byte baseline:

- working diff: 2.291 -> 2.236 ms (-2.4%)
- revert 100: 5.698 -> 5.502 ms (-3.4%)
- apply 100: 6.749 -> 6.031 ms (-10.6%)
- partial checkpoint 500: 18.368 -> 17.066 ms (-7.1%)

## Validation

- `cargo test -p lix_engine --features all-simulations`
  - 1,593 unit tests passed
  - 782 simulation/integration tests passed, 2 ignored
  - 3 doc tests passed
- focused HOT codec, working-diff, protocol rejection, corruption, and tracked-state rebuild regressions
- retained replay verified all 50 per-commit states and the complete final Git tree
