### PR TITLE
fall back on structural plugin edits

### DIFF
--- a/packages/rs-sdk-tests/tests/e2e.rs
+++ b/packages/rs-sdk-tests/tests/e2e.rs
@@ -2502,6 +2502,42 @@ async fn json_scalar_to_container_edit_uses_full_reconciliation() {
 }
 
 #[tokio::test]
+async fn json_scalar_boundary_insert_adds_sibling_through_full_reconciliation() {
+    let lix = open_lix(OpenLixOptions::default()).await.unwrap();
+    install_reference_plugin_in_blank_registry(
+        &lix,
+        "plugin_json",
+        &build_json_plugin_archive(),
+        &["json_root", "json_object_member", "json_array_item"],
+    )
+    .await;
+
+    let path = "/scalar-sibling.json";
+    write_file(&lix, path, br#"{"a":1}"#.to_vec())
+        .await
+        .unwrap();
+    let successor = br#"{"a":1,"b":2}"#.to_vec();
+    write_file(&lix, path, successor.clone())
+        .await
+        .expect("a scalar-boundary sibling insertion must fall back to full reconciliation");
+
+    assert_eq!(read_file(&lix, path).await.unwrap(), Some(successor));
+    let members = lix
+        .execute(
+            "SELECT key, scalar_json FROM json_object_member ORDER BY key",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(members.len(), 2);
+    assert_eq!(members.rows()[0].get::<String>("key").unwrap(), "a");
+    assert_eq!(members.rows()[1].get::<String>("key").unwrap(), "b");
+    assert_eq!(members.rows()[1].get::<String>("scalar_json").unwrap(), "2");
+
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
 async fn v2_json_roundtrips_recursive_state_and_keeps_leaf_edits_sparse() {
     let archive = build_json_plugin_archive();
     let lix = open_lix(OpenLixOptions::default()).await.unwrap();
@@ -5594,6 +5630,45 @@ async fn v2_excalidraw_roundtrips_and_renders_local_element_edits() {
         .collect::<Vec<_>>();
     assert_eq!(ids, ["b", "c"]);
     assert_eq!(read_file(&lix, path).await.unwrap(), Some(renamed));
+
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn excalidraw_element_boundary_insert_adds_element_through_full_reconciliation() {
+    let lix = open_lix(OpenLixOptions::default()).await.unwrap();
+    install_reference_plugin_in_blank_registry(
+        &lix,
+        "plugin_excalidraw",
+        &build_excalidraw_plugin_archive(),
+        &["excalidraw_scene", "excalidraw_element", "excalidraw_file"],
+    )
+    .await;
+
+    let path = "/element-insert.excalidraw";
+    let before =
+        br#"{"type":"excalidraw","version":2,"elements":[{"id":"a","type":"rectangle"}]}"#.to_vec();
+    write_file(&lix, path, before).await.unwrap();
+    let successor = br#"{"type":"excalidraw","version":2,"elements":[{"id":"a","type":"rectangle"},{"id":"b","type":"ellipse"}]}"#.to_vec();
+    write_file(&lix, path, successor.clone())
+        .await
+        .expect("an element-boundary insertion must fall back to full reconciliation");
+
+    assert_eq!(read_file(&lix, path).await.unwrap(), Some(successor));
+    let elements = lix
+        .execute(
+            "SELECT id, element_type FROM excalidraw_element ORDER BY id",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(elements.len(), 2);
+    assert_eq!(elements.rows()[0].get::<String>("id").unwrap(), "a");
+    assert_eq!(elements.rows()[1].get::<String>("id").unwrap(), "b");
+    assert_eq!(
+        elements.rows()[1].get::<String>("element_type").unwrap(),
+        "ellipse"
+    );
 
     lix.close().await.unwrap();
 }

--- a/plugins/excalidraw/src/core.rs
+++ b/plugins/excalidraw/src/core.rs
@@ -230,12 +230,21 @@ impl ElementEntity {
         leading_json: String,
         element_json: String,
     ) -> Result<Self, String> {
+        let value: Value = serde_json::from_str(&element_json)
+            .map_err(|error| format!("invalid Excalidraw element JSON: {error}"))?;
+        Self::from_parsed_source(order_key, leading_json, element_json, value)
+    }
+
+    fn from_parsed_source(
+        order_key: String,
+        leading_json: String,
+        element_json: String,
+        value: Value,
+    ) -> Result<Self, String> {
         validate_order_key(&order_key)?;
         if !is_json_whitespace(&leading_json) {
             return Err("element leading_json must contain only JSON whitespace".to_owned());
         }
-        let value: Value = serde_json::from_str(&element_json)
-            .map_err(|error| format!("invalid Excalidraw element JSON: {error}"))?;
         let object = value
             .as_object()
             .ok_or_else(|| "Excalidraw elements must be JSON objects".to_owned())?;
@@ -533,7 +542,15 @@ impl Document {
         leading_json: String,
         element_json: String,
     ) -> Result<Option<EntityChange>, String> {
-        let element = ElementEntity::from_source(order_key, leading_json, element_json)?;
+        let value = match serde_json::from_str(&element_json) {
+            Ok(value) => value,
+            // A structural insertion can make the old element span contain
+            // two adjacent objects. Let the full-document path validate and
+            // reconcile that successor instead of rejecting it here.
+            Err(_) => return Ok(None),
+        };
+        let element =
+            ElementEntity::from_parsed_source(order_key, leading_json, element_json, value)?;
         if element.id != id {
             return Ok(None);
         }

--- a/plugins/excalidraw/src/lib.rs
+++ b/plugins/excalidraw/src/lib.rs
@@ -754,4 +754,24 @@ mod tests {
         assert!(!add_element_shift(&mut shifts, u32::MAX, 1).expect("request index rebuild"));
         assert_eq!(encode_shifts(&shifts).len(), MAX_ELEMENT_SHIFT_RECORDS * 12);
     }
+
+    #[test]
+    fn sparse_element_path_falls_back_when_edit_adds_an_element() {
+        let element_and_sibling = concat!(
+            r#"{"id":"a","type":"rectangle"}"#,
+            ",",
+            r#"{"id":"b","type":"ellipse"}"#
+        );
+
+        assert_eq!(
+            Document::element_change_from_source(
+                "a",
+                "80".to_owned(),
+                String::new(),
+                element_and_sibling.to_owned(),
+            )
+            .expect("structural edit is an optimization miss"),
+            None
+        );
+    }
 }

--- a/plugins/json/src/core.rs
+++ b/plugins/json/src/core.rs
@@ -1252,8 +1252,10 @@ impl Document {
     ) -> Result<Option<EntityChange>, String> {
         let kind = match parse_complete_scalar(scalar) {
             Ok(kind) => kind,
-            Err(error) if error == "expected a JSON scalar, got a container" => return Ok(None),
-            Err(error) => return Err(error),
+            // The indexed scalar span may now contain adjacent structural
+            // syntax (for example `1,"b":2`). That is a valid optimization
+            // miss: the complete-document fallback owns validation.
+            Err(_) => return Ok(None),
         };
         let scalar = std::str::from_utf8(scalar)
             .map_err(|error| format!("JSON scalar must be UTF-8: {error}"))?;

--- a/plugins/json/src/lib.rs
+++ b/plugins/json/src/lib.rs
@@ -1217,4 +1217,25 @@ mod tests {
             records
         );
     }
+
+    #[test]
+    fn scalar_sparse_path_falls_back_when_edit_adds_a_sibling() {
+        let metadata = ArenaJsonScalar {
+            start: 5,
+            length: 1,
+            relation: ArenaJsonRelation::Object,
+            entity_pk: vec!["root".to_owned(), "a".to_owned()],
+            parent_id: None,
+            order_key: Some("80".to_owned()),
+            prefix_json: Some("\"a\":".to_owned()),
+            suffix_json: None,
+            empty_json: None,
+        };
+
+        assert_eq!(
+            Document::scalar_change_from_arena(metadata, br#"1,"b":2"#)
+                .expect("structural edit is an optimization miss"),
+            None
+        );
+    }
 }


### PR DESCRIPTION
## What changed

- Treat JSON scalar parse failures in the sparse arena path as optimization misses, allowing full-document reconciliation.
- Treat Excalidraw element parse failures in the sparse span path the same way.
- Preserve validation errors from successfully parsed scalar/element records.
- Add unit and real Wasm end-to-end regressions for sibling/element insertion at an indexed span boundary.

## Why

The sparse paths assumed an edit contained by an existing scalar or element span must still describe exactly one scalar or element. Valid structural inserts at the old span boundary violate that assumption: the local slice contains adjacent syntax while the complete successor remains valid. Rejecting the local parse prevented the intended full-document fallback.

## Validation

- `cargo test -p plugin_json`
- `cargo test -p plugin_excalidraw`
- `cargo test -p lix_sdk_tests --test e2e json_scalar_boundary_insert_adds_sibling_through_full_reconciliation -- --nocapture`
- `cargo test -p lix_sdk_tests --test e2e excalidraw_element_boundary_insert_adds_element_through_full_reconciliation -- --nocapture`
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- `git diff --check`
