### PR TITLE
Fix Markdown arena EOF ranges

### DIFF
--- a/plugins/markdown/src/core.rs
+++ b/plugins/markdown/src/core.rs
@@ -2115,7 +2115,7 @@ impl Document {
         }
         let mut children = Vec::with_capacity(blocks.len());
         let mut ranges = Vec::with_capacity(blocks.len());
-        for block in blocks {
+        for (ordinal, block) in blocks.into_iter().enumerate() {
             let child = serde_json::from_slice(&block.tree_json).map_err(|error| {
                 PluginError::InvalidInput(format!("invalid Markdown arena block: {error}"))
             })?;
@@ -2126,9 +2126,10 @@ impl Document {
                 PluginError::InvalidInput("Markdown arena block end exceeds usize".to_owned())
             })?;
             if start > end || end > bytes.len() {
-                return Err(PluginError::InvalidInput(
-                    "Markdown arena block range is outside accepted bytes".to_owned(),
-                ));
+                return Err(PluginError::InvalidInput(format!(
+                    "Markdown arena block {ordinal} range {start}..{end} is outside accepted length {}",
+                    bytes.len()
+                )));
             }
             children.push(child);
             ranges.push(start..end);
@@ -2158,14 +2159,15 @@ impl Document {
             PluginError::Internal(format!("serialize Markdown arena root: {error}"))
         })?);
         let mut blocks = Vec::with_capacity(self.top_level_ranges.len());
+        let bytes_len = self.bytes.len;
         for (index, range) in self.top_level_ranges.iter().enumerate() {
             let tree = self.tree.top_level_tree(index).ok_or_else(|| {
                 PluginError::Internal("Markdown arena range has no matching block".to_owned())
             })?;
             blocks.push(ArenaMarkdownBlock {
-                start: u64::try_from(range.start)
+                start: u64::try_from(range.start.min(bytes_len))
                     .map_err(|_| PluginError::Internal("Markdown range exceeds u64".to_owned()))?,
-                end: u64::try_from(range.end)
+                end: u64::try_from(range.end.min(bytes_len))
                     .map_err(|_| PluginError::Internal("Markdown range exceeds u64".to_owned()))?,
                 tree_json: serde_json::to_vec(tree).map_err(|error| {
                     PluginError::Internal(format!("serialize Markdown arena block: {error}"))

--- a/plugins/markdown/src/lib.rs
+++ b/plugins/markdown/src/lib.rs
@@ -974,4 +974,19 @@ mod tests {
             MAX_BLOCK_SHIFT_RECORDS * 12
         );
     }
+
+    #[test]
+    fn persisted_arena_ranges_exclude_parser_only_eof_sentinels() {
+        let bytes = b"# Heading\n\nFirst paragraph.\n\nSecond paragraph.\n".to_vec();
+        let namespace = IdNamespace::from_halves(7, 11);
+        let (document, _) =
+            Document::open_file(bytes.clone(), Some("doc.md"), namespace).expect("parse Markdown");
+        let (_, blocks) = document.arena_state().expect("arena state");
+        assert!(
+            blocks
+                .iter()
+                .all(|block| block.start <= block.end && block.end <= bytes.len() as u64),
+            "persisted arena ranges must exclude parser-only EOF sentinels",
+        );
+    }
 }


### PR DESCRIPTION
## What changed

- clamp serialized Markdown arena block ranges to the exact accepted byte length
- include block ordinal and exact range in future invalid-state diagnostics
- add a regression proving parser-only EOF sentinels are never persisted

## Root cause

The Markdown parser can expose top-level ranges ending at a virtual two-byte EOF sentinel. `arena_state()` persisted those parser coordinates directly. After actor eviction/hydration, the next transition rejected the durable arena because a block ended at byte 4002 for an exact 4000-byte accepted file.

## Validation

- `cargo test -p plugin_markdown persisted_arena_ranges_exclude_parser_only_eof_sentinels -- --nocapture`
- exact six-commit VS Code docs SlateDB replay with all plugins, checkpoints, and `--verify-state`
- replay completed 6/6 commits and verified the final Git tree manifest
