### PR TITLE
Avoid WASM for remote client state

### DIFF
--- a/packages/js-sdk/src/client-state.ts
+++ b/packages/js-sdk/src/client-state.ts
@@ -1,19 +1,24 @@
 import type { LixBinding } from "./binding-types.js";
 import { isSnapshotPersistenceAfterCommitError } from "./snapshot-persistence.js";
-import type { JsonValue } from "./types.js";
+import type { JsonValue, LixSnapshotStorage } from "./types.js";
 import { Value } from "./value.js";
 
 export const ACTIVE_BRANCH_CLIENT_STATE_KEY = "lix_active_branch_id";
+const STORED_CLIENT_STATE_HEADER = "lix-client-state-v1\n";
 
 export type LixClientState = {
 	/** Returns the hydrated client-local value without a network round trip. */
 	get<T extends JsonValue = JsonValue>(key: string): T | undefined;
-	/** Commits the value through the local Rust Lix and then persists its snapshot. */
+	/** Persists a client-local value in the configured client storage. */
 	set(key: string, value: JsonValue): Promise<void>;
-	/** Deletes the value through the local Rust Lix and then persists its snapshot. */
+	/** Deletes a client-local value from the configured client storage. */
 	delete(key: string): Promise<void>;
 	/** Subscribes to successful mutations made through this client-state handle. */
 	subscribe(listener: () => void): () => void;
+};
+
+export type ManagedClientState = LixClientState & {
+	close(): Promise<void>;
 };
 
 export function unavailableClientState(): LixClientState {
@@ -200,6 +205,179 @@ export class ManagedLixClientState implements LixClientState {
 			throw new Error("Lix client state is closed");
 		}
 	}
+}
+
+/**
+ * Opens client state directly over snapshot storage without starting a local
+ * Lix runtime. This is used by remote Lix connections, where the storage
+ * option persists client-local state rather than the remote workspace.
+ */
+export async function openStoredClientState(options: {
+	readonly storage: LixSnapshotStorage;
+	readonly namespace: string;
+}): Promise<ManagedClientState> {
+	const snapshot = await options.storage.load(options.namespace);
+	if (snapshot !== undefined && !(snapshot instanceof Uint8Array)) {
+		throw new TypeError("Client-state storage load() must return a Uint8Array");
+	}
+	return new StoredClientState(
+		options.storage,
+		options.namespace,
+		decodeStoredClientState(snapshot),
+	);
+}
+
+class StoredClientState implements ManagedClientState {
+	readonly #storage: LixSnapshotStorage;
+	readonly #namespace: string;
+	readonly #values: Map<string, JsonValue>;
+	readonly #listeners = new Set<() => void>();
+	#operationQueue: Promise<void> = Promise.resolve();
+	#closePromise: Promise<void> | undefined;
+	#acceptingOperations = true;
+	#dirty = false;
+
+	constructor(
+		storage: LixSnapshotStorage,
+		namespace: string,
+		values: Map<string, JsonValue>,
+	) {
+		this.#storage = storage;
+		this.#namespace = namespace;
+		this.#values = values;
+	}
+
+	get<T extends JsonValue = JsonValue>(key: string): T | undefined {
+		assertClientStateKey(key);
+		const value = this.#values.get(key);
+		return value === undefined ? undefined : (cloneJsonValue(value) as T);
+	}
+
+	set(key: string, value: JsonValue): Promise<void> {
+		assertClientStateKey(key);
+		assertJsonValue(value);
+		this.#assertOpen();
+		const nextValue = cloneJsonValue(value);
+		return this.#enqueue(async () => {
+			this.#values.set(key, nextValue);
+			this.#dirty = true;
+			this.#publish();
+			await this.#persist();
+		});
+	}
+
+	delete(key: string): Promise<void> {
+		assertClientStateKey(key);
+		this.#assertOpen();
+		return this.#enqueue(async () => {
+			if (this.#values.delete(key)) this.#publish();
+			this.#dirty = true;
+			await this.#persist();
+		});
+	}
+
+	subscribe(listener: () => void): () => void {
+		if (typeof listener !== "function") {
+			throw new TypeError("clientState.subscribe() requires a function");
+		}
+		this.#assertOpen();
+		this.#listeners.add(listener);
+		return () => this.#listeners.delete(listener);
+	}
+
+	async close(): Promise<void> {
+		if (this.#closePromise) return this.#closePromise;
+		this.#acceptingOperations = false;
+		this.#closePromise = (async () => {
+			await this.#operationQueue;
+			if (this.#dirty) await this.#persist();
+			this.#listeners.clear();
+		})();
+		return this.#closePromise;
+	}
+
+	#enqueue(operation: () => Promise<void>): Promise<void> {
+		const result = this.#operationQueue.then(operation, operation);
+		this.#operationQueue = result.then(
+			() => undefined,
+			() => undefined,
+		);
+		return result;
+	}
+
+	async #persist(): Promise<void> {
+		await this.#storage.save(
+			this.#namespace,
+			encodeStoredClientState(this.#values),
+		);
+		this.#dirty = false;
+	}
+
+	#publish(): void {
+		for (const listener of [...this.#listeners]) {
+			try {
+				listener();
+			} catch {
+				// Subscribers do not participate in the completed mutation.
+			}
+		}
+	}
+
+	#assertOpen(): void {
+		if (!this.#acceptingOperations) {
+			throw new Error("Lix client state is closed");
+		}
+	}
+}
+
+function encodeStoredClientState(values: Map<string, JsonValue>): Uint8Array {
+	const entries = [...values].map(([key, value]) => [
+		key,
+		cloneJsonValue(value),
+	]);
+	return new TextEncoder().encode(
+		`${STORED_CLIENT_STATE_HEADER}${JSON.stringify(entries)}`,
+	);
+}
+
+function decodeStoredClientState(
+	snapshot: Uint8Array | undefined,
+): Map<string, JsonValue> {
+	if (snapshot === undefined) return new Map();
+	const header = new TextEncoder().encode(STORED_CLIENT_STATE_HEADER);
+	if (
+		snapshot.length < header.length ||
+		header.some((byte, index) => snapshot[index] !== byte)
+	) {
+		// Remote storage previously contained a full Lix snapshot. Backward
+		// compatibility is intentionally not provided: start with empty state and
+		// replace it on the next write.
+		return new Map();
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(
+			new TextDecoder().decode(snapshot.subarray(header.length)),
+		);
+	} catch (error) {
+		throw new Error("Stored Lix client state is invalid", { cause: error });
+	}
+	if (!Array.isArray(parsed)) {
+		throw new Error("Stored Lix client state entries must be an array");
+	}
+
+	const values = new Map<string, JsonValue>();
+	for (const entry of parsed) {
+		if (!Array.isArray(entry) || entry.length !== 2) {
+			throw new Error("Stored Lix client state entry is invalid");
+		}
+		const [key, value] = entry;
+		assertClientStateKey(key);
+		assertJsonValue(value);
+		values.set(key, cloneJsonValue(value));
+	}
+	return values;
 }
 
 function assertClientStateKey(key: string): void {

--- a/packages/js-sdk/src/lix.ts
+++ b/packages/js-sdk/src/lix.ts
@@ -2,7 +2,7 @@ import { invalidArgument } from "./errors.js";
 import {
 	ACTIVE_BRANCH_CLIENT_STATE_KEY,
 	type LixClientState,
-	type ManagedLixClientState,
+	type ManagedClientState,
 	unavailableClientState,
 } from "./client-state.js";
 import type {
@@ -64,7 +64,7 @@ export class Lix {
 
 	constructor(
 		private readonly binding: LixBinding,
-		private readonly managedClientState?: ManagedLixClientState,
+		private readonly managedClientState?: ManagedClientState,
 	) {
 		this.clientState = managedClientState
 			? {

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -6,6 +6,7 @@ import type { LixBinding } from "./binding-types.js";
 import {
 	ACTIVE_BRANCH_CLIENT_STATE_KEY,
 	openClientState,
+	openStoredClientState,
 } from "./client-state.js";
 import { Lix } from "./lix.js";
 import type {
@@ -115,22 +116,10 @@ export async function openLix(options: OpenLixOptions = {}): Promise<Lix> {
 			return new Lix(await openRemoteLixBinding(options.server));
 		}
 		assertSnapshotStorage(options.storage);
-		const { openPersistentLixWorkerBinding } =
-			await import("./worker/client.js");
-		const clientBinding = await openPersistentLixWorkerBinding({
+		const clientState = await openStoredClientState({
 			storage: options.storage,
 			namespace: remoteClientStateNamespace(options.server.url),
 		});
-		let clientState;
-		try {
-			clientState = await openClientState({
-				binding: clientBinding,
-				closeBinding: true,
-			});
-		} catch (error) {
-			await clientBinding.close().catch(() => undefined);
-			throw error;
-		}
 
 		const restoredBranchId = clientState.get<string>(
 			ACTIVE_BRANCH_CLIENT_STATE_KEY,

--- a/packages/js-sdk/src/stored-client-state.test.ts
+++ b/packages/js-sdk/src/stored-client-state.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "vitest";
+import { openStoredClientState } from "./client-state.js";
+import type { LixSnapshotStorage } from "./types.js";
+
+test("stored client state replaces an unsupported legacy snapshot", async () => {
+	let snapshot: Uint8Array | undefined = new TextEncoder().encode(
+		"SQLite format 3",
+	);
+	const storage: LixSnapshotStorage = {
+		load: async () => snapshot,
+		save: async (_namespace, nextSnapshot) => {
+			snapshot = nextSnapshot.slice();
+		},
+	};
+
+	const first = await openStoredClientState({
+		storage,
+		namespace: "remote:https://example.com/workspace",
+	});
+	expect(first.get("legacy")).toBeUndefined();
+	await first.set("atelier", { focusedPanel: "right" });
+	await first.close();
+
+	const reopened = await openStoredClientState({
+		storage,
+		namespace: "remote:https://example.com/workspace",
+	});
+	expect(reopened.get("atelier")).toEqual({ focusedPanel: "right" });
+	await reopened.close();
+});


### PR DESCRIPTION
## Summary

- persist remote `lix.clientState` directly through the configured snapshot storage adapter
- keep the existing `openLix({ server, storage: new LocalStorage() })` API unchanged
- retain full snapshot/WASM behavior for local Lix instances
- treat unsupported legacy remote snapshots as empty, without migration

## Why

Passing client storage to a remote Lix connection previously started a complete local Rust worker and loaded the roughly 43 MB WASM module solely to persist client-local state. Every browser tab instantiated its own worker and WASM runtime, increasing memory pressure and making Chrome tab discard more likely.

Remote client state is now a lightweight versioned byte envelope handled in TypeScript. The storage adapter remains opaque and structurally unchanged, so LocalStorage, IndexedDB-backed adapters, and custom adapters continue to work through the same public API.

## Impact

Remote workspace tabs no longer fetch or instantiate the Lix WASM runtime for client state. Branch restoration, subscriptions, queued mutations, storage failure behavior, and close-time persistence are preserved.

## Validation

- `pnpm --dir packages/js-sdk run build:ts`
- `pnpm --dir packages/js-sdk run typecheck`
- `vitest run src/stored-client-state.test.ts src/lix-lifecycle.test.ts` — 4 passed
- browser `src/open-lix.browser.test.ts` — 17 passed, 1 skipped
- Lixray workspace smoke test — zero `.wasm` requests