### PR TITLE
perf(engine): route exact file ID batches natively

### DIFF
--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -1810,6 +1810,19 @@ where
                             )
                             .await?
                         }
+                        ExactFilesystemRead::IdManifestBatch(file_ids) => {
+                            sql2::execute_exact_lix_file_id_manifest_batch_read(
+                                &active_branch_id,
+                                live_state,
+                                filesystem_path_index,
+                                branch_ref,
+                                blob_reader,
+                                self.plugin_host.clone(),
+                                file_view_collector.clone(),
+                                &file_ids,
+                            )
+                            .await?
+                        }
                         ExactFilesystemRead::RootFileListing
                         | ExactFilesystemRead::RootDirectoryListing => unreachable!(
                             "root filesystem listings handled before file data readers"
@@ -2753,6 +2766,7 @@ enum ExactFilesystemRead {
     RootDirectoryListing,
     Point(sql2::ExactLixFileReadSelector, sql2::ExactLixFileReadColumn),
     PathDataBatch(BTreeSet<String>),
+    IdManifestBatch(BTreeSet<String>),
 }
 
 fn exact_filesystem_read_route(
@@ -2773,7 +2787,12 @@ fn exact_filesystem_read_route(
     if point_read.table_name != "lix_file" || !point_read.exact_table_shape {
         return None;
     }
-    exact_path_data_batch(point_read.select, params).map(ExactFilesystemRead::PathDataBatch)
+    exact_path_data_batch(point_read.select, params)
+        .map(ExactFilesystemRead::PathDataBatch)
+        .or_else(|| {
+            exact_id_manifest_batch(point_read.select, params)
+                .map(ExactFilesystemRead::IdManifestBatch)
+        })
 }
 
 fn exact_lix_file_root_listing(statement: &DataFusionStatement, params: &[Value]) -> bool {
@@ -2936,6 +2955,60 @@ fn exact_path_data_batch(select: &Select, params: &[Value]) -> Option<BTreeSet<S
         paths.insert(path.clone());
     }
     Some(paths)
+}
+
+/// Recognizes the exact changed-file manifest verification shape. Keeping the
+/// projection and parameter-only id list strict avoids changing general SQL
+/// semantics while bypassing repeated DataFusion setup for bounded exact
+/// batches.
+fn exact_id_manifest_batch(select: &Select, params: &[Value]) -> Option<BTreeSet<String>> {
+    let [
+        SelectItem::UnnamedExpr(id_projection),
+        SelectItem::UnnamedExpr(path_projection),
+        SelectItem::UnnamedExpr(data_projection),
+        SelectItem::UnnamedExpr(metadata_projection),
+    ] = select.projection.as_slice()
+    else {
+        return None;
+    };
+    if exact_point_column(id_projection).as_deref() != Some("id")
+        || exact_point_column(path_projection).as_deref() != Some("path")
+        || exact_point_column(data_projection).as_deref() != Some("data")
+        || exact_point_column(metadata_projection).as_deref() != Some("lixcol_metadata")
+    {
+        return None;
+    }
+    let Expr::InList {
+        expr,
+        list,
+        negated: false,
+    } = select.selection.as_ref()?
+    else {
+        return None;
+    };
+    if exact_point_column(expr).as_deref() != Some("id")
+        || list.is_empty()
+        || list.len() != params.len()
+    {
+        return None;
+    }
+    let mut ids = BTreeSet::new();
+    for (index, (expression, param)) in list.iter().zip(params).enumerate() {
+        let Expr::Value(value) = expression else {
+            return None;
+        };
+        let SqlValue::Placeholder(placeholder) = &value.value else {
+            return None;
+        };
+        if placeholder != &format!("${}", index + 1) {
+            return None;
+        }
+        let Value::Text(id) = param else {
+            return None;
+        };
+        ids.insert(id.clone());
+    }
+    (ids.len() == list.len()).then_some(ids)
 }
 
 fn exact_point_identity(expression: &Expr, params: &[Value]) -> Option<(String, String)> {
@@ -3429,6 +3502,24 @@ mod tests {
             Some(ExactFilesystemRead::PathDataBatch(BTreeSet::from([
                 "/a.txt".to_string(),
                 "/b.txt".to_string(),
+            ])))
+        );
+
+        let manifests_by_id = sql2::parse_statement(
+            "SELECT id, path, data, lixcol_metadata FROM lix_file WHERE id IN ($1, $2)",
+        )
+        .unwrap();
+        assert_eq!(
+            exact_filesystem_read_route(
+                &manifests_by_id,
+                &[
+                    Value::Text("01920000-0000-7000-8000-0000000000a2".to_string()),
+                    Value::Text("01920000-0000-7000-8000-0000000000a1".to_string()),
+                ],
+            ),
+            Some(ExactFilesystemRead::IdManifestBatch(BTreeSet::from([
+                "01920000-0000-7000-8000-0000000000a1".to_string(),
+                "01920000-0000-7000-8000-0000000000a2".to_string(),
             ])))
         );
 
@@ -4920,6 +5011,57 @@ mod tests {
             result.rows()[0].value("data").unwrap(),
             &Value::Blob(b"alpha".to_vec().into())
         );
+        assert_eq!(result.rows()[1].get::<String>("path").unwrap(), "/b.txt");
+        assert_eq!(
+            result.rows()[1].value("data").unwrap(),
+            &Value::Blob(b"bravo".to_vec().into())
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_id_manifest_batch_preserves_bytes_and_metadata() {
+        let session = open_session().await;
+        let a = "01920000-0000-7000-8000-0000000000a1";
+        let b = "01920000-0000-7000-8000-0000000000a2";
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, data, lixcol_metadata) \
+                 VALUES ($1, $2, $3, $4), ($5, $6, $7, $8)",
+                &[
+                    Value::Text(b.to_string()),
+                    Value::Text("/b.txt".to_string()),
+                    Value::Blob(b"bravo".to_vec().into()),
+                    Value::Json(serde_json::json!({"git_mode":"100644","git_oid":"b"})),
+                    Value::Text(a.to_string()),
+                    Value::Text("/a.txt".to_string()),
+                    Value::Blob(b"alpha".to_vec().into()),
+                    Value::Json(serde_json::json!({"git_mode":"100644","git_oid":"a"})),
+                ],
+            )
+            .await
+            .unwrap();
+
+        let result = session
+            .execute(
+                "SELECT id, path, data, lixcol_metadata FROM lix_file WHERE id IN ($1, $2)",
+                &[Value::Text(b.to_string()), Value::Text(a.to_string())],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.columns(), &["id", "path", "data", "lixcol_metadata"]);
+        assert_eq!(result.rows().len(), 2);
+        assert_eq!(result.rows()[0].get::<String>("id").unwrap(), a);
+        assert_eq!(result.rows()[0].get::<String>("path").unwrap(), "/a.txt");
+        assert_eq!(
+            result.rows()[0].value("data").unwrap(),
+            &Value::Blob(b"alpha".to_vec().into())
+        );
+        assert_eq!(
+            result.rows()[0].value("lixcol_metadata").unwrap(),
+            &Value::Json(serde_json::json!({"git_mode":"100644","git_oid":"a"}))
+        );
+        assert_eq!(result.rows()[1].get::<String>("id").unwrap(), b);
         assert_eq!(result.rows()[1].get::<String>("path").unwrap(), "/b.txt");
         assert_eq!(
             result.rows()[1].value("data").unwrap(),

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -72,7 +72,7 @@ pub(crate) use planning_cache::SqlPlanningCache;
 pub(crate) use providers::{
     ExactLixFileReadColumn, ExactLixFileReadSelector, FastLixFilePathWriteConflict,
     execute_exact_lix_directory_root_listing, execute_exact_lix_file_batch_read,
-    execute_exact_lix_file_read, execute_exact_lix_file_root_listing,
-    execute_fast_lix_file_path_writes,
+    execute_exact_lix_file_id_manifest_batch_read, execute_exact_lix_file_read,
+    execute_exact_lix_file_root_listing, execute_fast_lix_file_path_writes,
 };
 pub use script::{SqlScriptPlan, SqlScriptStatement, parse_sql_script};

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -770,6 +770,85 @@ pub(crate) async fn execute_exact_lix_file_batch_read(
     })
 }
 
+/// Executes an exact active-branch manifest batch selected by file id without
+/// constructing a DataFusion catalog or plan. This is the multi-row analogue
+/// of [`execute_exact_lix_file_read`] for callers that need to verify durable
+/// file identity, bytes, and metadata together.
+pub(crate) async fn execute_exact_lix_file_id_manifest_batch_read(
+    active_branch_id: &str,
+    live_state: Arc<dyn LiveStateReader>,
+    filesystem_path_index: Arc<dyn FilesystemPathIndexReader>,
+    branch_ref: Arc<dyn BranchRefReader>,
+    blob_reader: Arc<dyn BlobDataReader>,
+    plugin_host: PluginRuntimeHost,
+    session_file_views: Option<SessionFileViews>,
+    file_ids: &BTreeSet<String>,
+) -> Result<SqlQueryResult, LixError> {
+    let base_schema = lix_file_schema();
+    let schema = Arc::new(Schema::new(
+        ["id", "path", "data", "lixcol_metadata"]
+            .into_iter()
+            .map(|name| {
+                base_schema
+                    .field_with_name(name)
+                    .expect("lix_file manifest column should exist")
+                    .clone()
+            })
+            .collect::<Vec<_>>(),
+    ));
+    let mut request = lix_file_scan_request(Some(active_branch_id), Some(schema.as_ref()), None);
+    let branch_binding = BranchBinding::active(active_branch_id);
+    request.filter.branch_ids = resolve_provider_branch_ids(
+        branch_ref.as_ref(),
+        &branch_binding,
+        request.filter.branch_ids,
+    )
+    .await?;
+
+    let index = filesystem_path_index
+        .path_index(
+            &FilesystemPathIndexRequest::new(request.filter.branch_ids.clone())
+                .with_blob_refs(true)
+                .with_cached_blob_data(true),
+        )
+        .await?;
+    let matches = indexed_file_id_matches(index, file_ids, &FilePathPredicate::All);
+    let rows = scan_indexed_file_batch(&matches, true)?;
+    let mut prepared = prepare_indexed_lix_file_rows(&matches, rows)?;
+    let acknowledge_plugin_data = session_file_views.is_some();
+    let plugin_render = if prepared.needs_plugin_render(true) || acknowledge_plugin_data {
+        plugin_render_context_for_lix_file_scan(
+            Arc::clone(&live_state),
+            &request,
+            plugin_host,
+            &prepared,
+            acknowledge_plugin_data,
+        )
+        .await?
+        .map(|context| context.with_session_file_views(session_file_views))
+    } else {
+        None
+    };
+    hydrate_derived_materialization_rows(
+        live_state,
+        &request,
+        plugin_render.as_ref(),
+        &mut prepared,
+    )
+    .await?;
+    let batch =
+        lix_file_record_batch_from_prepared(&schema, &blob_reader, plugin_render, true, prepared)
+            .await?;
+    crate::sql2::exec::datafusion::query_result_from_batches(
+        &schema
+            .fields()
+            .iter()
+            .map(|field| field.as_ref().clone())
+            .collect::<Vec<_>>(),
+        &[batch],
+    )
+}
+
 fn lix_file_dml_source_state(
     captured: &SharedLixFileDmlSourceState,
     action: &str,

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -42,10 +42,10 @@ use datafusion::logical_expr::TableSource;
 pub(crate) use directory::execute_exact_lix_directory_root_listing;
 pub(crate) use file::{
     ExactLixFileReadColumn, ExactLixFileReadSelector, FastLixFilePathWriteConflict,
-    execute_exact_lix_file_batch_read, execute_exact_lix_file_read,
-    execute_exact_lix_file_root_listing, execute_fast_lix_file_data_update_by_id,
-    execute_fast_lix_file_data_update_by_id_with_metadata, execute_fast_lix_file_id_path_writes,
-    execute_fast_lix_file_path_writes,
+    execute_exact_lix_file_batch_read, execute_exact_lix_file_id_manifest_batch_read,
+    execute_exact_lix_file_read, execute_exact_lix_file_root_listing,
+    execute_fast_lix_file_data_update_by_id, execute_fast_lix_file_data_update_by_id_with_metadata,
+    execute_fast_lix_file_id_path_writes, execute_fast_lix_file_path_writes,
 };
 #[cfg(test)]
 pub(crate) use filesystem_working_change::filesystem_working_change_schema;


### PR DESCRIPTION
## What

Add a native engine route for the strict exact-ID file manifest query:

```sql
SELECT id, path, data, lixcol_metadata
FROM lix_file
WHERE id IN (...)
```

The route preserves blob-backed and derived materialization, plugin ownership acknowledgement, path-index semantics, and the universal `lixcol_metadata` column.

## Why

Replay verification repeatedly asks for exact file IDs. That shape was falling through to DataFusion planning/execution even though the engine already has the IDs and can resolve the file manifest directly. This is API-neutral and independent of plugin API v3, so it is isolated against `main`.

## Benchmark

Identical 50-commit `vscode-docs` replay, SlateDB, all Wasm plugins, eager per-commit state verification and checkpointing:

| phase | main route | native route | delta |
|---|---:|---:|---:|
| verification | 34.370 s | 28.639 s | **-16.7%** |
| total replay | 131.341 s | 128.930 s | -1.8% |

Execution varied upward by 3.1% in the second full replay, masking part of the verification improvement in total time. This PR is scoped to the exact-read route and does not claim to solve the separate plugin cold-state regression.

Both lanes verified all 50 commits and the final Git tree exactly.

## Checks

- focused exact-route parser coverage
- end-to-end exact ID manifest batch test preserving bytes and `lixcol_metadata`
- `git diff --check origin/main...HEAD`
- retained 50-commit correctness/performance replay