### PR TITLE
lower typed inserts into compact transaction arenas

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -24,6 +24,7 @@ use workload::{REAL_WORKLOAD_ROWS, SMOKE_ROWS, WorkloadRow, fixture_rows, row_la
 const READ_MANY_PK_COUNT: usize = 10;
 
 fn tracked_state_crud_benches(c: &mut Criterion) {
+    init_perf_tracing();
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -46,6 +47,16 @@ fn tracked_state_crud_benches(c: &mut Criterion) {
             bench_transaction_api(c, &runtime, profile, &rows[..row_count], label);
             bench_sql_session(c, &runtime, profile, &rows[..row_count], label);
         }
+    }
+}
+
+fn init_perf_tracing() {
+    if std::env::var_os("LIX_TRACKED_STATE_CRUD_TRACE").is_some() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter("lix_perf=debug")
+            .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
+            .with_target(false)
+            .try_init();
     }
 }
 

--- a/packages/engine/src/catalog/mod.rs
+++ b/packages/engine/src/catalog/mod.rs
@@ -11,4 +11,5 @@ pub(crate) use schema::{
 };
 pub(crate) use snapshot::{
     CatalogFingerprint, CatalogSnapshot, DefaultPlan, StateDeleteReferencePlan, TransactionCatalog,
+    TypedJsonObjectFieldRef, TypedJsonScalarRef,
 };

--- a/packages/engine/src/catalog/snapshot.rs
+++ b/packages/engine/src/catalog/snapshot.rs
@@ -409,6 +409,19 @@ pub(crate) struct CertifiedPluginRow {
     pub(crate) normalized: Option<Vec<u8>>,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum TypedJsonScalarRef<'a> {
+    Null,
+    Boolean,
+    String(&'a str),
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct TypedJsonObjectFieldRef<'a> {
+    pub(crate) name: &'a str,
+    pub(crate) value: TypedJsonScalarRef<'a>,
+}
+
 impl SchemaPlan {
     pub(crate) fn fingerprint(&self) -> &SchemaPlanFingerprint {
         self.fingerprint.as_ref()
@@ -422,6 +435,114 @@ impl SchemaPlan {
         self.fast_object_validation
             .as_ref()
             .is_some_and(|plan| plan.accepts(value))
+    }
+
+    /// Certifies one already-typed object row without constructing or parsing
+    /// a JSON DOM.
+    ///
+    /// Typed producers can keep scalar columns in their native representation,
+    /// validate them against the same compiled schema plan, and serialize
+    /// canonical storage bytes only once.
+    pub(crate) fn certify_typed_object_row(
+        &self,
+        schema_key: &str,
+        fields: &[TypedJsonObjectFieldRef<'_>],
+        entity_pk: &[&str],
+    ) -> Result<(), LixError> {
+        if !self.accepts_canonical_certificate() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "typed object certification requires a canonical schema plan",
+            ));
+        }
+        if schema_key != self.key.schema_key {
+            return Err(LixError::new(
+                LixError::CODE_SCHEMA_VALIDATION,
+                format!(
+                    "typed snapshot schema '{schema_key}' does not match schema plan '{}'",
+                    self.key.schema_key
+                ),
+            ));
+        }
+        let validation = self
+            .fast_object_validation
+            .as_ref()
+            .expect("certificate eligibility requires fast object validation");
+        if fields.len() < validation.min_properties {
+            return Err(typed_object_validation_error(
+                &self.key.schema_key,
+                "object has fewer properties than minProperties",
+            ));
+        }
+        if let Some(required) = validation
+            .required
+            .iter()
+            .find(|required| !fields.iter().any(|field| field.name == required.as_str()))
+        {
+            return Err(typed_object_validation_error(
+                &self.key.schema_key,
+                &format!("required property '{required}' is missing"),
+            ));
+        }
+        for field in fields {
+            let accepted = validation
+                .properties
+                .get(field.name)
+                .map_or(validation.additional_properties, |property| {
+                    property.accepts_typed(field.value)
+                });
+            if !accepted {
+                return Err(typed_object_validation_error(
+                    &self.key.schema_key,
+                    &format!("property '{}' does not satisfy its schema", field.name),
+                ));
+            }
+        }
+
+        let primary_key_paths = self
+            .primary_key
+            .as_deref()
+            .expect("certificate eligibility requires a primary key");
+        if primary_key_paths.len() != entity_pk.len() {
+            return Err(typed_object_validation_error(
+                &self.key.schema_key,
+                "snapshot primary-key component count does not match the emitted entity_pk",
+            ));
+        }
+        for (path, expected) in primary_key_paths.iter().zip(entity_pk) {
+            let [name] = path.as_slice() else {
+                unreachable!("certificate eligibility requires top-level primary keys");
+            };
+            let actual =
+                fields
+                    .iter()
+                    .find(|field| field.name == name)
+                    .and_then(|field| match field.value {
+                        TypedJsonScalarRef::String(value) => Some(value),
+                        TypedJsonScalarRef::Null | TypedJsonScalarRef::Boolean => None,
+                    });
+            if actual != Some(*expected) {
+                return Err(typed_object_validation_error(
+                    &self.key.schema_key,
+                    &format!(
+                        "snapshot primary-key property '{name}' does not match the emitted entity_pk"
+                    ),
+                ));
+            }
+        }
+        let component_types = self
+            .primary_key_component_types
+            .as_deref()
+            .expect("certificate eligibility requires typed primary-key components");
+        EntityPk::validate_external_parts(entity_pk, component_types).map_err(|error| {
+            LixError::new(
+                LixError::CODE_SCHEMA_VALIDATION,
+                format!(
+                    "typed entity_pk is invalid for schema '{}': {error}",
+                    self.key.schema_key
+                ),
+            )
+        })
     }
 
     /// Parses, validates, and, only when necessary, canonicalizes one v2
@@ -836,6 +957,37 @@ impl FastValueValidation {
         }
     }
 
+    fn accepts_typed(&self, value: TypedJsonScalarRef<'_>) -> bool {
+        match (self, value) {
+            (Self::Types(types), TypedJsonScalarRef::Null) => {
+                types.accepts_canonical_kind(CanonicalJsonKind::Null)
+            }
+            (Self::Types(types), TypedJsonScalarRef::Boolean) => {
+                types.accepts_canonical_kind(CanonicalJsonKind::Boolean)
+            }
+            (Self::Types(types), TypedJsonScalarRef::String(_)) => {
+                types.accepts_canonical_kind(CanonicalJsonKind::String)
+            }
+            (Self::String(validation), TypedJsonScalarRef::String(value)) => {
+                validation.accepts(value)
+            }
+            (Self::StringOrNull(_), TypedJsonScalarRef::Null) => true,
+            (Self::StringOrNull(validation), TypedJsonScalarRef::String(value)) => {
+                validation.accepts(value)
+            }
+            (
+                Self::String(_) | Self::StringOrNull(_),
+                TypedJsonScalarRef::Boolean | TypedJsonScalarRef::Null,
+            )
+            | (
+                Self::Array(_) | Self::Object(_),
+                TypedJsonScalarRef::Null
+                | TypedJsonScalarRef::Boolean
+                | TypedJsonScalarRef::String(_),
+            ) => false,
+        }
+    }
+
     fn supports_canonical_streaming(&self) -> bool {
         match self {
             Self::Types(_) | Self::String(_) | Self::StringOrNull(_) => true,
@@ -846,6 +998,13 @@ impl FastValueValidation {
             Self::Object(validation) => validation.supports_canonical_streaming(),
         }
     }
+}
+
+fn typed_object_validation_error(schema_key: &str, message: &str) -> LixError {
+    LixError::new(
+        LixError::CODE_SCHEMA_VALIDATION,
+        format!("snapshot_content validation failed for schema '{schema_key}': {message}"),
+    )
 }
 
 fn fast_property_keyword(key: &str) -> bool {
@@ -2847,6 +3006,63 @@ mod tests {
             assert!(!plan.accepts_row_content_fast(&value));
             assert!(!plan.compiled_schema.is_valid(&value));
         }
+    }
+
+    #[test]
+    fn typed_object_certification_matches_compiled_scalar_constraints() {
+        let plan = SchemaPlan::compile(
+            SchemaCatalogKey {
+                schema_key: "typed_rows".to_string(),
+            },
+            json!({
+                "type": "object",
+                "properties": {
+                    "active": { "type": "boolean" },
+                    "id": { "type": "string", "minLength": 2 }
+                },
+                "required": ["active", "id"],
+                "additionalProperties": false,
+                "x-lix-key": "typed_rows",
+                "x-lix-primary-key": ["/id"]
+            }),
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+        )
+        .expect("typed-row schema should compile");
+        assert!(plan.accepts_canonical_certificate());
+
+        let fields = [
+            TypedJsonObjectFieldRef {
+                name: "active",
+                value: TypedJsonScalarRef::Boolean,
+            },
+            TypedJsonObjectFieldRef {
+                name: "id",
+                value: TypedJsonScalarRef::String("row-1"),
+            },
+        ];
+        plan.certify_typed_object_row("typed_rows", &fields, &["row-1"])
+            .expect("matching typed row should certify");
+
+        let short_id = [
+            fields[0],
+            TypedJsonObjectFieldRef {
+                name: "id",
+                value: TypedJsonScalarRef::String("x"),
+            },
+        ];
+        assert!(
+            plan.certify_typed_object_row("typed_rows", &short_id, &["x"])
+                .is_err()
+        );
+        assert!(
+            plan.certify_typed_object_row("typed_rows", &fields, &["other"])
+                .is_err()
+        );
+        assert!(
+            plan.certify_typed_object_row("other", &fields, &["row-1"])
+                .is_err()
+        );
     }
 
     #[test]

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -663,6 +663,22 @@ where
         Self::load_exact_batch(self, request).await
     }
 
+    async fn collection_generation(
+        &self,
+        branch_id: &str,
+        scope: crate::collection_generation::CollectionScopeRef<'_>,
+    ) -> Result<Option<crate::collection_generation::CollectionGeneration>, LixError> {
+        let controls = load_branch_head_controls(&self.store, &[branch_id.to_owned()]).await?;
+        let Some(control) = controls.get(branch_id).copied() else {
+            return Ok(None);
+        };
+        self.tracked_head
+            .reader(&self.store)
+            .collection_generation(branch_id, control.generation, scope)
+            .await
+            .map(Some)
+    }
+
     async fn scan_tracked_batch(
         &self,
         request: &LiveStateScanRequest,

--- a/packages/engine/src/live_state/reader.rs
+++ b/packages/engine/src/live_state/reader.rs
@@ -65,6 +65,18 @@ pub(crate) trait LiveStateReader: Send + Sync {
         &self,
         request: &LiveStateExactBatchRequest,
     ) -> Result<MaterializedLiveStateExactBatch, LixError>;
+
+    /// Loads collection control from this reader's coherent storage snapshot.
+    ///
+    /// Readers without a published tracked-head projection conservatively
+    /// decline the proof so callers retain their ordinary identity scans.
+    async fn collection_generation(
+        &self,
+        _branch_id: &str,
+        _scope: crate::collection_generation::CollectionScopeRef<'_>,
+    ) -> Result<Option<crate::collection_generation::CollectionGeneration>, LixError> {
+        Ok(None)
+    }
 }
 
 #[cfg(test)]

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
 use std::ops::ControlFlow;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use crate::branch::BranchRefReader;
@@ -1342,72 +1343,86 @@ where
         idempotency: Option<ExecuteIdempotency>,
     ) -> Result<Vec<ExecuteResult>, LixError> {
         let telemetry_sink = self.telemetry.clone();
-        self.with_write_transaction(move |transaction| {
-            Box::pin(async move {
-                if let Some(results) = try_execute_transaction_parameter_batch(
-                    transaction,
-                    &statements,
-                    &parsed,
-                    &options,
-                    &statement_metadata,
-                    telemetry_sink.as_ref(),
-                )
-                .await?
-                {
+        let statements = Arc::new(statements);
+        let transaction_statements = Arc::clone(&statements);
+        let parameter_route = Arc::new(AtomicBool::new(false));
+        let transaction_parameter_route = Arc::clone(&parameter_route);
+        let transaction_telemetry_sink = telemetry_sink.clone();
+        let result = self
+            .with_write_transaction(move |transaction| {
+                Box::pin(async move {
+                    if let Some(results) = try_execute_transaction_parameter_batch(
+                        transaction,
+                        &transaction_statements,
+                        &parsed,
+                        &options,
+                        &statement_metadata,
+                        &transaction_parameter_route,
+                    )
+                    .await?
+                    {
+                        if let Some(idempotency) = &idempotency {
+                            let receipt = ExecuteIdempotencyReceipt::batch(idempotency, &results)?;
+                            transaction.stage_execute_idempotency_receipt(idempotency, &receipt)?;
+                        }
+                        return Ok(results);
+                    }
+                    let mut results = Vec::with_capacity(transaction_statements.len());
+                    let parsed = parsed.into_vec();
+                    for (statement_index, ((statement, parsed), metadata)) in transaction_statements
+                        .iter()
+                        .zip(parsed)
+                        .zip(statement_metadata)
+                        .enumerate()
+                    {
+                        let telemetry = SqlStatementTelemetry::start(
+                            transaction_telemetry_sink.as_ref(),
+                            &statement.sql,
+                            "batch",
+                            Some(statement_index),
+                        );
+                        let operation = async {
+                            execute_transaction_statement(
+                                transaction,
+                                &statement.sql,
+                                parsed,
+                                &statement.params,
+                                options.clone(),
+                                metadata,
+                            )
+                            .await
+                            .map_err(|error| {
+                                with_batch_statement_index(
+                                    normalize_sql_surface_error(error, &statement.sql),
+                                    statement_index,
+                                )
+                            })
+                        };
+                        let result = match telemetry.as_ref() {
+                            Some(telemetry) => telemetry.instrument(operation).await,
+                            None => operation.await,
+                        };
+                        if let Some(telemetry) = telemetry {
+                            telemetry.finish(&result);
+                        }
+                        results.push(result?);
+                    }
                     if let Some(idempotency) = &idempotency {
                         let receipt = ExecuteIdempotencyReceipt::batch(idempotency, &results)?;
                         transaction.stage_execute_idempotency_receipt(idempotency, &receipt)?;
                     }
-                    return Ok(results);
-                }
-                let mut results = Vec::with_capacity(statements.len());
-                let parsed = parsed.into_vec();
-                for (statement_index, ((statement, parsed), metadata)) in statements
-                    .iter()
-                    .zip(parsed)
-                    .zip(statement_metadata)
-                    .enumerate()
-                {
-                    let telemetry = SqlStatementTelemetry::start(
-                        telemetry_sink.as_ref(),
-                        &statement.sql,
-                        "batch",
-                        Some(statement_index),
-                    );
-                    let operation = async {
-                        execute_transaction_statement(
-                            transaction,
-                            &statement.sql,
-                            parsed,
-                            &statement.params,
-                            options.clone(),
-                            metadata,
-                        )
-                        .await
-                        .map_err(|error| {
-                            with_batch_statement_index(
-                                normalize_sql_surface_error(error, &statement.sql),
-                                statement_index,
-                            )
-                        })
-                    };
-                    let result = match telemetry.as_ref() {
-                        Some(telemetry) => telemetry.instrument(operation).await,
-                        None => operation.await,
-                    };
-                    if let Some(telemetry) = telemetry {
-                        telemetry.finish(&result);
-                    }
-                    results.push(result?);
-                }
-                if let Some(idempotency) = &idempotency {
-                    let receipt = ExecuteIdempotencyReceipt::batch(idempotency, &results)?;
-                    transaction.stage_execute_idempotency_receipt(idempotency, &receipt)?;
-                }
-                Ok(results)
+                    Ok(results)
+                })
             })
-        })
-        .await
+            .await;
+        if parameter_route.load(Ordering::Relaxed) {
+            finish_parameter_batch_statement_telemetry(
+                telemetry_sink.as_ref(),
+                &statements,
+                &result,
+            );
+        }
+        result
     }
 
     async fn execute_read_only_batch(
@@ -2222,7 +2237,7 @@ async fn try_execute_transaction_parameter_batch<StorageImpl>(
     parsed: &TransactionBatchStatements,
     options: &ExecuteOptions,
     statement_metadata: &[ExecuteStatementMetadata],
-    telemetry_sink: Option<&Arc<dyn crate::telemetry::TelemetrySink>>,
+    parameter_route: &AtomicBool,
 ) -> Result<Option<Vec<ExecuteResult>>, LixError>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
@@ -2286,17 +2301,19 @@ where
                 with_batch_statement_index(error, 0)
             }
         });
-    finish_parameter_batch_statement_telemetry(telemetry_sink, statements, &result);
+    if !matches!(result, Ok(None)) {
+        parameter_route.store(true, Ordering::Relaxed);
+    }
     result
 }
 
 fn finish_parameter_batch_statement_telemetry(
     telemetry_sink: Option<&Arc<dyn crate::telemetry::TelemetrySink>>,
     statements: &[ExecuteBatchStatement],
-    result: &Result<Option<Vec<ExecuteResult>>, LixError>,
+    result: &Result<Vec<ExecuteResult>, LixError>,
 ) {
     match result {
-        Ok(Some(results)) => {
+        Ok(results) => {
             for (statement_index, (statement, result)) in statements.iter().zip(results).enumerate()
             {
                 let Some(telemetry) = SqlStatementTelemetry::start(
@@ -2325,7 +2342,6 @@ fn finish_parameter_batch_statement_telemetry(
             };
             telemetry.finish(&Err(error.clone()));
         }
-        Ok(None) => {}
     }
 }
 
@@ -4026,13 +4042,14 @@ mod tests {
             len: first_statements.len(),
         };
         let mut first_transaction = first.begin_transaction().await.unwrap();
+        let parameter_route = AtomicBool::new(false);
         let staged = try_execute_transaction_parameter_batch(
             first_transaction.transaction_mut().unwrap(),
             &first_statements,
             &parsed,
             &ExecuteOptions::default(),
             &vec![ExecuteStatementMetadata::default(); first_statements.len()],
-            None,
+            &parameter_route,
         )
         .await
         .unwrap();
@@ -4066,6 +4083,7 @@ mod tests {
             .await
             .expect_err("commit snapshot must observe the concurrent identity");
         assert_eq!(error.code, LixError::CODE_UNIQUE);
+        assert_eq!(error.details.unwrap()["statementIndex"], 1);
         let rows = second
             .execute(
                 "SELECT value FROM concurrent_parameter_insert_probe WHERE id = 'shared'",

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -4153,6 +4153,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_batch_declines_json_marked_utf8_for_string_columns() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "x-lix-key": "parameter_insert_json_string_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": { "type": "string" }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+
+        sql2::take_certified_entity_insert_parameter_batch_executions();
+        let sql = "INSERT INTO parameter_insert_json_string_probe (id, value) VALUES ($1, $2)";
+        let error = session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("a".to_string()),
+                        Value::Json(serde_json::json!({"not": "text"})),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("b".to_string()),
+                        Value::Json(serde_json::json!({"also": "not text"})),
+                    ],
+                },
+            ])
+            .await
+            .expect_err("JSON objects must not be coerced into string column values");
+        assert_eq!(error.details.unwrap()["statementIndex"], 0);
+        assert_eq!(
+            sql2::take_certified_entity_insert_parameter_batch_executions(),
+            0
+        );
+        let rows = session
+            .execute("SELECT id FROM parameter_insert_json_string_probe", &[])
+            .await
+            .unwrap();
+        assert!(rows.rows().is_empty());
+    }
+
+    #[tokio::test]
     async fn execute_batch_preserves_later_missing_branch_index() {
         let session = open_session().await;
         let schema = serde_json::json!({

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -3973,6 +3973,110 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn certified_empty_batch_rechecks_concurrent_insert_at_commit_snapshot() {
+        let storage = Memory::default();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("storage should initialize");
+        let engine = Engine::new(storage)
+            .await
+            .expect("initialized storage should create engine");
+        let setup = engine.open_workspace_session().await.unwrap();
+        let schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "x-lix-key": "concurrent_parameter_insert_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": { "type": "string" }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        setup
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+
+        let first = engine.open_workspace_session().await.unwrap();
+        let second = engine.open_workspace_session().await.unwrap();
+        let sql = "INSERT INTO concurrent_parameter_insert_probe (id, value) VALUES ($1, $2)";
+        let first_statements = [
+            ExecuteBatchStatement {
+                sql: sql.to_string(),
+                params: vec![
+                    Value::Text("first-only".to_string()),
+                    Value::Text("first".to_string()),
+                ],
+            },
+            ExecuteBatchStatement {
+                sql: sql.to_string(),
+                params: vec![
+                    Value::Text("shared".to_string()),
+                    Value::Text("first".to_string()),
+                ],
+            },
+        ];
+        let parsed = TransactionBatchStatements::Shared {
+            statement: sql2::parse_statement(sql).unwrap(),
+            len: first_statements.len(),
+        };
+        let mut first_transaction = first.begin_transaction().await.unwrap();
+        let staged = try_execute_transaction_parameter_batch(
+            first_transaction.transaction_mut().unwrap(),
+            &first_statements,
+            &parsed,
+            &ExecuteOptions::default(),
+            &vec![ExecuteStatementMetadata::default(); first_statements.len()],
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(
+            staged.is_some(),
+            "first batch should take the certified route"
+        );
+
+        second
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("second-only".to_string()),
+                        Value::Text("second".to_string()),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("shared".to_string()),
+                        Value::Text("second".to_string()),
+                    ],
+                },
+            ])
+            .await
+            .expect("concurrent batch should commit first");
+
+        let error = first_transaction
+            .commit()
+            .await
+            .expect_err("commit snapshot must observe the concurrent identity");
+        assert_eq!(error.code, LixError::CODE_UNIQUE);
+        let rows = second
+            .execute(
+                "SELECT value FROM concurrent_parameter_insert_probe WHERE id = 'shared'",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(rows.rows()[0].get::<String>("value").unwrap(), "second");
+    }
+
+    #[tokio::test]
     async fn execute_batch_declines_uncertified_entity_insert_rows() {
         let session = open_session().await;
         let schema = serde_json::json!({

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -4209,6 +4209,67 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_batch_preserves_early_duplicate_before_later_schema_error() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "x-lix-key": "parameter_insert_error_order_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": { "type": "string", "minLength": 1 }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+
+        sql2::take_certified_entity_insert_parameter_batch_executions();
+        let sql = "INSERT INTO parameter_insert_error_order_probe (id, value) VALUES ($1, $2)";
+        let error = session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("a".to_string()),
+                        Value::Text("valid".to_string()),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("a".to_string()),
+                        Value::Text("also valid".to_string()),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![Value::Text("b".to_string()), Value::Text(String::new())],
+                },
+            ])
+            .await
+            .expect_err("the earlier duplicate must precede later schema validation");
+        assert_eq!(error.code, LixError::CODE_UNIQUE);
+        assert_eq!(error.details.unwrap()["statementIndex"], 1);
+        assert_eq!(
+            sql2::take_certified_entity_insert_parameter_batch_executions(),
+            0
+        );
+        let rows = session
+            .execute("SELECT id FROM parameter_insert_error_order_probe", &[])
+            .await
+            .unwrap();
+        assert!(rows.rows().is_empty());
+    }
+
+    #[tokio::test]
     async fn execute_batch_preserves_later_missing_branch_index() {
         let session = open_session().await;
         let schema = serde_json::json!({

--- a/packages/engine/src/sql2/context.rs
+++ b/packages/engine/src/sql2/context.rs
@@ -24,7 +24,9 @@ use crate::live_state::{
 use crate::plugin::PluginRuntimeHost;
 use crate::storage_adapter::StorageAdapterRead;
 use crate::tracked_state::TrackedStateScanRequest;
-use crate::transaction::types::{TransactionWrite, TransactionWriteOutcome};
+use crate::transaction::types::{
+    RawWriteBatch, TransactionWrite, TransactionWriteMode, TransactionWriteOutcome,
+};
 use crate::wasm::UnsupportedWasmRuntime;
 
 use super::change_materialization::MaterializedChange;
@@ -208,6 +210,17 @@ pub(crate) trait SqlWriteExecutionContext: Send {
         &mut self,
         write: TransactionWrite,
     ) -> Result<TransactionWriteOutcome, LixError>;
+
+    async fn stage_parameter_batch_insert(
+        &mut self,
+        rows: RawWriteBatch,
+    ) -> Result<TransactionWriteOutcome, LixError> {
+        self.stage_write(TransactionWrite::Rows {
+            mode: TransactionWriteMode::Insert,
+            rows,
+        })
+        .await
+    }
 
     async fn execute_diff_command(
         &mut self,

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -145,22 +145,6 @@ pub(crate) async fn try_execute_entity_insert_parameter_batch(
     else {
         return Ok(None);
     };
-    let mut unique_identities =
-        std::collections::HashSet::with_capacity(parameter_batch.num_rows());
-    for candidate in write_rows.iter() {
-        let Some(entity_pk) = candidate.entity_pk else {
-            return Ok(None);
-        };
-        if !unique_identities.insert((
-            candidate.schema_key.clone(),
-            entity_pk.clone(),
-            candidate.file_id.cloned(),
-            candidate.branch_id.clone(),
-        )) {
-            return Ok(None);
-        }
-    }
-    drop(unique_identities);
     drop(certification_span);
     let committed = if collection_is_certifiably_empty(ctx, &spec.schema_key).await? {
         MaterializedLiveStateBatch::default()
@@ -2606,11 +2590,12 @@ fn certified_direct_parameter_insert_batch(
         })?);
     let mut offsets = Vec::with_capacity(row_count);
     let mut entity_pks = Vec::with_capacity(row_count);
+    let mut unique_entity_pks = std::collections::HashSet::with_capacity(row_count);
     let mut primary_key_parts = Vec::with_capacity(primary_key_columns.len());
     let mut typed_fields = Vec::with_capacity(columns.len());
 
     for statement_index in 0..row_count {
-        let row_result = (|| -> Result<(), LixError> {
+        let row_result = (|| -> Result<bool, LixError> {
             let start = normalized.len();
             typed_fields.clear();
             normalized.push(b'{');
@@ -2715,11 +2700,18 @@ fn certified_direct_parameter_insert_batch(
                 &typed_fields,
                 &primary_key_parts,
             )?;
+            if !unique_entity_pks.insert(entity_pk.clone()) {
+                return Ok(false);
+            }
             offsets.push((start, normalized.len()));
             entity_pks.push(entity_pk);
-            Ok(())
+            Ok(true)
         })();
-        row_result.map_err(|error| with_parameter_batch_statement_index(error, statement_index))?;
+        if !row_result
+            .map_err(|error| with_parameter_batch_statement_index(error, statement_index))?
+        {
+            return Ok(None);
+        }
     }
 
     let snapshots = WasmCanonicalJson::from_certified_arena_parts(
@@ -2839,6 +2831,7 @@ fn certified_entity_insert_rows<'a>(
     let mut offsets = Vec::with_capacity(row_count);
     let mut entity_pks = Vec::with_capacity(row_count);
     let mut row_parts = Vec::with_capacity(row_count);
+    let mut unique_identities = std::collections::HashSet::with_capacity(row_count);
     let mut row_values = (0..layout.columns.len())
         .map(|_| None)
         .collect::<Vec<Option<JsonValue>>>();
@@ -2849,7 +2842,7 @@ fn certified_entity_insert_rows<'a>(
         let row = input.row;
         let params = input.params.as_slice();
         let statement_index = input.statement_index;
-        let row_result = (|| -> Result<(), LixError> {
+        let row_result = (|| -> Result<bool, LixError> {
             if row.len() != layout.columns.len() {
                 return Err(LixError::new(
                     LixError::CODE_UNSUPPORTED_SQL,
@@ -3029,25 +3022,37 @@ fn certified_entity_insert_rows<'a>(
                 normalized.extend_from_slice(&canonical);
             }
             let end = normalized.len();
-            offsets.push((start, end));
-            entity_pks.push(certified.entity_pk);
             let global = global.unwrap_or(false);
-            row_parts.push(CertifiedInsertRow {
+            let row_parts_entry = CertifiedInsertRow {
                 file_id: file_id.map(Into::into),
                 metadata,
                 global,
                 untracked: untracked.unwrap_or(false),
                 branch_id: entity_row_branch_id(plan, explicit_branch_id, global)?.into(),
-            });
+            };
+            if !unique_identities.insert((
+                certified.entity_pk.clone(),
+                row_parts_entry.file_id.clone(),
+                row_parts_entry.branch_id.clone(),
+                global,
+            )) {
+                return Ok(false);
+            }
+            offsets.push((start, end));
+            entity_pks.push(certified.entity_pk);
+            row_parts.push(row_parts_entry);
             for value in &mut row_values {
                 *value = None;
             }
-            Ok(())
+            Ok(true)
         })();
-        row_result.map_err(|error| match statement_index {
+        let unique = row_result.map_err(|error| match statement_index {
             Some(index) => with_parameter_batch_statement_index(error, index),
             None => error,
         })?;
+        if !unique {
+            return Ok(None);
+        }
     }
 
     let row_count = offsets.len();

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -2528,6 +2528,14 @@ fn certified_direct_parameter_insert_batch(
                 parameter_batch.num_columns()
             )));
         };
+        if crate::sql2::result_metadata::field_is_json(
+            parameter_batch.schema().field(parameter_index),
+        ) {
+            // Utf8 is also the physical carrier for public JSON parameters.
+            // Direct decoding as text would turn JSON objects/arrays into
+            // string literals and diverge from sequential type validation.
+            return Ok(None);
+        }
         let type_matches = match column_type {
             EntityColumnType::String => array.as_any().is::<StringArray>(),
             EntityColumnType::Boolean => array.as_any().is::<BooleanArray>(),

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -1,10 +1,11 @@
-use bytes::Bytes;
+use datafusion::arrow::array::{Array, BooleanArray, StringArray};
 use datafusion::arrow::datatypes::DataType;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::ScalarValue;
 use serde_json::Value as JsonValue;
 use tracing::Instrument;
 
+use crate::catalog::{TypedJsonObjectFieldRef, TypedJsonScalarRef};
 use crate::changelog::CommitId;
 use crate::common::{
     ExecuteStatementMetadata, RequestBlobSpliceProvenance, SharedStr, validate_row_metadata,
@@ -127,34 +128,26 @@ pub(crate) async fn try_execute_entity_insert_parameter_batch(
     {
         return Ok(None);
     }
-    let mut write_rows = RawWriteBatch::with_capacity(parameter_batch.num_rows());
-    let mut unique_identities =
-        std::collections::HashSet::with_capacity(parameter_batch.num_rows());
     let certification_span = tracing::debug_span!(
         target: "lix_perf",
         "lix.perf.entity_insert_parameter_batch.certify"
     )
     .entered();
-    for row_index in 0..parameter_batch.num_rows() {
-        let params = super::write::parameter_row(parameter_batch, row_index)
-            .map_err(|error| with_parameter_batch_statement_index(error, row_index))?;
-        let Some(mut row) = certified_entity_insert_batch(
-            ctx,
-            plan,
-            &spec,
-            &layout,
-            values,
-            &params,
-            active_branch_commit_id.as_ref(),
-        )
-        .map_err(|error| with_parameter_batch_statement_index(error, row_index))?
-        else {
-            return Ok(None);
-        };
-        if row.len() != 1 {
-            return Ok(None);
-        }
-        let candidate = row.row(0);
+    let Some(write_rows) = certified_entity_insert_parameter_batch(
+        ctx,
+        plan,
+        &spec,
+        &layout,
+        values,
+        parameter_batch,
+        active_branch_commit_id.as_ref(),
+    )?
+    else {
+        return Ok(None);
+    };
+    let mut unique_identities =
+        std::collections::HashSet::with_capacity(parameter_batch.num_rows());
+    for candidate in write_rows.iter() {
         let Some(entity_pk) = candidate.entity_pk else {
             return Ok(None);
         };
@@ -166,15 +159,20 @@ pub(crate) async fn try_execute_entity_insert_parameter_batch(
         )) {
             return Ok(None);
         }
-        write_rows.append_taken_row(&mut row, 0);
     }
+    drop(unique_identities);
     drop(certification_span);
-    let committed = scan_entity_conflict_candidates(ctx, &spec, &write_rows)
-        .instrument(tracing::debug_span!(
-            target: "lix_perf",
-            "lix.perf.entity_insert_parameter_batch.conflict_scan"
-        ))
-        .await?;
+    let collection_was_empty = collection_is_certifiably_empty(ctx, &spec.schema_key).await?;
+    let committed = if collection_was_empty {
+        MaterializedLiveStateBatch::default()
+    } else {
+        scan_entity_conflict_candidates(ctx, &spec, &write_rows)
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.entity_insert_parameter_batch.conflict_scan"
+            ))
+            .await?
+    };
     let conflict_attribution_span = tracing::debug_span!(
         target: "lix_perf",
         "lix.perf.entity_insert_parameter_batch.conflict_attribution"
@@ -246,7 +244,18 @@ pub(crate) async fn try_execute_entity_insert_parameter_batch(
         conflict
     };
     drop(conflict_attribution_span);
-    stage_rows(ctx, TransactionWriteMode::Insert, write_rows)
+    drop(committed);
+    // The empty-collection certificate proves both committed and staged
+    // absence for every row in this homogeneous batch. Staging it as a
+    // replacement preserves the resulting state and changelog while avoiding
+    // a second O(rows log rows) committed-identity proof at transaction commit.
+    // The transaction's branch-head guard still rejects a concurrent change.
+    let stage_mode = if collection_was_empty {
+        TransactionWriteMode::Replace
+    } else {
+        TransactionWriteMode::Insert
+    };
+    stage_rows(ctx, stage_mode, write_rows)
         .instrument(tracing::debug_span!(
             target: "lix_perf",
             "lix.perf.entity_insert_parameter_batch.stage_rows"
@@ -266,6 +275,24 @@ pub(crate) async fn try_execute_entity_insert_parameter_batch(
             .map(|_| SqlWriteResult::affected(1))
             .collect(),
     ))
+}
+
+async fn collection_is_certifiably_empty(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    schema_key: &str,
+) -> Result<bool, LixError> {
+    let branch_id = ctx.active_branch_id().to_string();
+    let scope = crate::collection_generation::CollectionScopeRef {
+        schema_key,
+        file_id: None,
+    };
+    if ctx.has_staged_collection_rows(&branch_id, scope)? {
+        return Ok(false);
+    }
+    Ok(ctx
+        .load_collection_generation(&branch_id, scope)
+        .await?
+        .is_some_and(|generation| generation.live_count == 0))
 }
 
 /// Executes a certified run of independent point updates as one physical
@@ -2370,6 +2397,26 @@ struct CertifiedInsertRow {
     branch_id: SharedStr,
 }
 
+enum CertifiedInsertParams<'a> {
+    Borrowed(&'a [Value]),
+    Owned(Vec<Value>),
+}
+
+impl CertifiedInsertParams<'_> {
+    fn as_slice(&self) -> &[Value] {
+        match self {
+            Self::Borrowed(params) => params,
+            Self::Owned(params) => params,
+        }
+    }
+}
+
+struct CertifiedInsertInput<'a> {
+    row: &'a [BoundExpr],
+    params: CertifiedInsertParams<'a>,
+    statement_index: Option<usize>,
+}
+
 fn certified_entity_insert_batch(
     ctx: &mut dyn SqlWriteExecutionContext,
     plan: &LogicalWritePlan,
@@ -2377,6 +2424,345 @@ fn certified_entity_insert_batch(
     layout: &InsertRowLayout,
     values: &BoundInsertValues,
     params: &[Value],
+    active_branch_commit_id: Option<&CommitId>,
+) -> Result<Option<RawWriteBatch>, LixError> {
+    certified_entity_insert_rows(
+        ctx,
+        plan,
+        spec,
+        layout,
+        values.rows.len(),
+        values.rows.iter().map(|row| {
+            Ok(CertifiedInsertInput {
+                row,
+                params: CertifiedInsertParams::Borrowed(params),
+                statement_index: None,
+            })
+        }),
+        active_branch_commit_id,
+    )
+}
+
+fn certified_entity_insert_parameter_batch(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    plan: &LogicalWritePlan,
+    spec: &EntitySurfaceSpec,
+    layout: &InsertRowLayout,
+    values: &BoundInsertValues,
+    parameter_batch: &RecordBatch,
+    active_branch_commit_id: Option<&CommitId>,
+) -> Result<Option<RawWriteBatch>, LixError> {
+    let [row] = values.rows.as_slice() else {
+        return Ok(None);
+    };
+    if let Some(rows) =
+        certified_direct_parameter_insert_batch(ctx, plan, spec, layout, row, parameter_batch)?
+    {
+        return Ok(Some(rows));
+    }
+    certified_entity_insert_rows(
+        ctx,
+        plan,
+        spec,
+        layout,
+        parameter_batch.num_rows(),
+        (0..parameter_batch.num_rows()).map(|statement_index| {
+            super::write::parameter_row(parameter_batch, statement_index)
+                .map(|params| CertifiedInsertInput {
+                    row,
+                    params: CertifiedInsertParams::Owned(params),
+                    statement_index: Some(statement_index),
+                })
+                .map_err(|error| with_parameter_batch_statement_index(error, statement_index))
+        }),
+        active_branch_commit_id,
+    )
+}
+
+struct DirectParameterInsertColumn {
+    layout_index: usize,
+    parameter_index: usize,
+    name: String,
+    name_prefix: Vec<u8>,
+    column_type: EntityColumnType,
+    read_nullable: bool,
+}
+
+fn certified_direct_parameter_insert_batch(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    plan: &LogicalWritePlan,
+    spec: &EntitySurfaceSpec,
+    layout: &InsertRowLayout,
+    row: &[BoundExpr],
+    parameter_batch: &RecordBatch,
+) -> Result<Option<RawWriteBatch>, LixError> {
+    if plan.bound.conflict.is_some()
+        || !spec.defaults.is_empty()
+        || row.len() != layout.columns.len()
+    {
+        return Ok(None);
+    }
+    let Some(schema_catalog) = ctx.schema_catalog_snapshot() else {
+        return Ok(None);
+    };
+    let Some((_, schema_plan)) = schema_catalog.plan_for_key(&layout.schema_key) else {
+        return Ok(None);
+    };
+    if !schema_plan.accepts_canonical_certificate() {
+        return Ok(None);
+    }
+
+    let mut columns = Vec::with_capacity(layout.columns.len());
+    for (layout_index, (expr, target)) in row.iter().zip(&layout.columns).enumerate() {
+        let BoundExpr::Param(param) = expr else {
+            return Ok(None);
+        };
+        let InsertColumnTarget::Visible {
+            name,
+            column_type,
+            read_nullable,
+        } = target
+        else {
+            return Ok(None);
+        };
+        if !matches!(
+            column_type,
+            EntityColumnType::String | EntityColumnType::Boolean
+        ) {
+            return Ok(None);
+        }
+        let parameter_index = param.index.saturating_sub(1);
+        let Some(array) = parameter_batch.columns().get(parameter_index) else {
+            return Err(LixError::unknown(format!(
+                "SQL parameter ${} is outside a {} column batch",
+                param.index,
+                parameter_batch.num_columns()
+            )));
+        };
+        let type_matches = match column_type {
+            EntityColumnType::String => array.as_any().is::<StringArray>(),
+            EntityColumnType::Boolean => array.as_any().is::<BooleanArray>(),
+            _ => false,
+        };
+        if !type_matches {
+            return Ok(None);
+        }
+        let mut name_prefix = serde_json::to_vec(name).map_err(|error| {
+            LixError::unknown(format!(
+                "certified INSERT key serialization failed: {error}"
+            ))
+        })?;
+        name_prefix.push(b':');
+        columns.push(DirectParameterInsertColumn {
+            layout_index,
+            parameter_index,
+            name: name.clone(),
+            name_prefix,
+            column_type: *column_type,
+            read_nullable: *read_nullable,
+        });
+    }
+    if spec.columns.iter().any(|column| {
+        column.insert_required
+            && !columns.iter().any(|candidate| {
+                matches!(
+                    &layout.columns[candidate.layout_index],
+                    InsertColumnTarget::Visible { name, .. } if name == &column.name
+                )
+            })
+    }) {
+        return Ok(None);
+    }
+    columns.sort_unstable_by(|left, right| left.name.cmp(&right.name));
+    let primary_key_columns = spec
+        .primary_key_paths
+        .iter()
+        .map(|path| {
+            let [name] = path.as_slice() else {
+                return None;
+            };
+            columns.iter().position(|column| {
+                matches!(
+                    &layout.columns[column.layout_index],
+                    InsertColumnTarget::Visible {
+                        name: candidate,
+                        column_type: EntityColumnType::String,
+                        ..
+                    } if candidate == name
+                )
+            })
+        })
+        .collect::<Option<Vec<_>>>();
+    let Some(primary_key_columns) = primary_key_columns else {
+        return Ok(None);
+    };
+
+    let row_count = parameter_batch.num_rows();
+    let estimated_row_bytes = columns
+        .iter()
+        .map(|column| column.name_prefix.len().saturating_add(34))
+        .sum::<usize>()
+        .saturating_add(columns.len().saturating_add(1));
+    let mut normalized =
+        Vec::with_capacity(row_count.checked_mul(estimated_row_bytes).ok_or_else(|| {
+            LixError::unknown("certified parameter INSERT batch size overflowed")
+        })?);
+    let mut offsets = Vec::with_capacity(row_count);
+    let mut entity_pks = Vec::with_capacity(row_count);
+    let mut primary_key_parts = Vec::with_capacity(primary_key_columns.len());
+    let mut typed_fields = Vec::with_capacity(columns.len());
+
+    for statement_index in 0..row_count {
+        let row_result = (|| -> Result<(), LixError> {
+            let start = normalized.len();
+            typed_fields.clear();
+            normalized.push(b'{');
+            for (field_index, column) in columns.iter().enumerate() {
+                if field_index != 0 {
+                    normalized.push(b',');
+                }
+                normalized.extend_from_slice(&column.name_prefix);
+                let array = &parameter_batch.columns()[column.parameter_index];
+                if array.is_null(statement_index) {
+                    if !column.read_nullable {
+                        let InsertColumnTarget::Visible { name, .. } =
+                            &layout.columns[column.layout_index]
+                        else {
+                            unreachable!("direct parameter columns are visible");
+                        };
+                        return Err(LixError::new(
+                            LixError::CODE_SCHEMA_VALIDATION,
+                            format!(
+                                "INSERT into {} column '{name}' does not allow explicit NULL",
+                                layout.schema_key
+                            ),
+                        ));
+                    }
+                    normalized.extend_from_slice(b"null");
+                    typed_fields.push(TypedJsonObjectFieldRef {
+                        name: &column.name,
+                        value: TypedJsonScalarRef::Null,
+                    });
+                    continue;
+                }
+                match column.column_type {
+                    EntityColumnType::String => {
+                        let array = array
+                            .as_any()
+                            .downcast_ref::<StringArray>()
+                            .expect("direct string parameter type was certified");
+                        serde_json::to_writer(&mut normalized, array.value(statement_index))
+                            .map_err(|error| {
+                                LixError::unknown(format!(
+                                    "certified INSERT value serialization failed: {error}"
+                                ))
+                            })?;
+                        typed_fields.push(TypedJsonObjectFieldRef {
+                            name: &column.name,
+                            value: TypedJsonScalarRef::String(array.value(statement_index)),
+                        });
+                    }
+                    EntityColumnType::Boolean => {
+                        let array = array
+                            .as_any()
+                            .downcast_ref::<BooleanArray>()
+                            .expect("direct boolean parameter type was certified");
+                        normalized.extend_from_slice(if array.value(statement_index) {
+                            b"true".as_slice()
+                        } else {
+                            b"false".as_slice()
+                        });
+                        typed_fields.push(TypedJsonObjectFieldRef {
+                            name: &column.name,
+                            value: TypedJsonScalarRef::Boolean,
+                        });
+                    }
+                    _ => unreachable!("direct parameter column type was certified"),
+                }
+            }
+            normalized.push(b'}');
+
+            primary_key_parts.clear();
+            for &column_index in &primary_key_columns {
+                let column = &columns[column_index];
+                let array = parameter_batch.columns()[column.parameter_index]
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .expect("direct primary-key parameter is a string");
+                if array.is_null(statement_index) {
+                    return Err(LixError::new(
+                        LixError::CODE_SCHEMA_VALIDATION,
+                        format!(
+                            "INSERT failed to derive entity primary key for schema '{}': missing primary-key value",
+                            layout.schema_key
+                        ),
+                    ));
+                }
+                primary_key_parts.push(array.value(statement_index));
+            }
+            let entity_pk = EntityPk::from_shared_external_parts(
+                primary_key_parts.iter().map(|part| SharedStr::from(*part)),
+                &spec.primary_key_component_types,
+            )
+            .map_err(|error| {
+                LixError::new(
+                    LixError::CODE_SCHEMA_VALIDATION,
+                    format!(
+                        "INSERT failed to derive entity primary key for schema '{}': {error}",
+                        layout.schema_key
+                    ),
+                )
+            })?;
+            schema_plan.certify_typed_object_row(
+                &layout.schema_key,
+                &typed_fields,
+                &primary_key_parts,
+            )?;
+            offsets.push((start, normalized.len()));
+            entity_pks.push(entity_pk);
+            Ok(())
+        })();
+        row_result.map_err(|error| with_parameter_batch_statement_index(error, statement_index))?;
+    }
+
+    let snapshots = WasmCanonicalJson::from_certified_arena_parts(
+        normalized,
+        offsets,
+        entity_pks.clone(),
+        vec![schema_plan.shared_fingerprint()],
+        vec![0; row_count],
+        row_count,
+    )?;
+    let schema_key: SharedStr = layout.schema_key.as_str().into();
+    let branch_id: SharedStr = ctx.active_branch_id().into();
+    let mut rows = RawWriteBatch::with_capacity(row_count);
+    for (entity_pk, snapshot) in entity_pks.into_iter().zip(snapshots) {
+        rows.push_parts(
+            Some(entity_pk),
+            schema_key.clone(),
+            None,
+            Some(TransactionJson::from_canonical_batch(snapshot)),
+            None,
+            None,
+            None,
+            None,
+            false,
+            None,
+            None,
+            false,
+            branch_id.clone(),
+        );
+    }
+    Ok(Some(rows))
+}
+
+fn certified_entity_insert_rows<'a>(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    plan: &LogicalWritePlan,
+    spec: &EntitySurfaceSpec,
+    layout: &InsertRowLayout,
+    row_count: usize,
+    inputs: impl IntoIterator<Item = Result<CertifiedInsertInput<'a>, LixError>>,
     active_branch_commit_id: Option<&CommitId>,
 ) -> Result<Option<RawWriteBatch>, LixError> {
     if plan.bound.conflict.is_some() {
@@ -2449,114 +2835,121 @@ fn certified_entity_insert_batch(
         .map(|(_, name)| name.len().saturating_add(35))
         .sum::<usize>()
         .saturating_add(2);
-    let estimated_batch_bytes = values
-        .rows
-        .len()
+    let estimated_batch_bytes = row_count
         .checked_mul(estimated_row_bytes)
         .ok_or_else(|| LixError::unknown("certified INSERT batch size overflowed"))?;
     let mut normalized = Vec::with_capacity(estimated_batch_bytes);
-    let mut offsets = Vec::with_capacity(values.rows.len());
-    let mut entity_pks = Vec::with_capacity(values.rows.len());
-    let mut row_parts = Vec::with_capacity(values.rows.len());
+    let mut offsets = Vec::with_capacity(row_count);
+    let mut entity_pks = Vec::with_capacity(row_count);
+    let mut row_parts = Vec::with_capacity(row_count);
     let mut row_values = (0..layout.columns.len())
         .map(|_| None)
         .collect::<Vec<Option<JsonValue>>>();
     let context = EntityEvalContext::insert(&JsonValue::Null, &layout.visible_columns);
 
-    for row in &values.rows {
-        if row.len() != layout.columns.len() {
-            return Err(LixError::new(
-                LixError::CODE_UNSUPPORTED_SQL,
-                "entity INSERT rows must have a consistent column layout",
-            ));
-        }
-
-        let mut explicit_entity_pk = None;
-        let mut file_id = None;
-        let mut metadata = None;
-        let mut global = None;
-        let mut untracked = None;
-        let mut explicit_branch_id = None;
-        for (index, (expr, target)) in row.iter().zip(layout.columns.iter()).enumerate() {
-            if let InsertColumnTarget::Visible { column_type, .. } = target {
-                reject_direct_blob_json_value(expr, *column_type, params)?;
-            }
-            let eval_value = eval_expr_value(expr, &context, ctx, params, active_branch_commit_id)?;
-            if matches!(
-                target,
-                InsertColumnTarget::Global | InsertColumnTarget::Untracked
-            ) && entity_eval_value_is_null(&eval_value)
-            {
-                let column_name = match target {
-                    InsertColumnTarget::Global => "lixcol_global",
-                    InsertColumnTarget::Untracked => "lixcol_untracked",
-                    _ => unreachable!("matched defaulted boolean system column"),
-                };
+    for input in inputs {
+        let input = input?;
+        let row = input.row;
+        let params = input.params.as_slice();
+        let statement_index = input.statement_index;
+        let row_result = (|| -> Result<(), LixError> {
+            if row.len() != layout.columns.len() {
                 return Err(LixError::new(
-                    LixError::CODE_TYPE_MISMATCH,
-                    format!(
-                        "INSERT into {} column '{column_name}' may be omitted to use its default, but explicit NULL is not allowed",
-                        layout.schema_key
-                    ),
+                    LixError::CODE_UNSUPPORTED_SQL,
+                    "entity INSERT rows must have a consistent column layout",
                 ));
             }
-            if matches!(target, InsertColumnTarget::Metadata) {
-                metadata = optional_metadata_from_eval_value(
-                    eval_value,
-                    "lixcol_metadata",
-                    &layout.schema_key,
-                )?;
-                continue;
-            }
-            if let InsertColumnTarget::Visible {
-                name,
-                column_type,
-                read_nullable,
-            } = target
-            {
-                if !read_nullable && entity_eval_value_is_null(&eval_value) {
+
+            let mut explicit_entity_pk = None;
+            let mut file_id = None;
+            let mut metadata = None;
+            let mut global = None;
+            let mut untracked = None;
+            let mut explicit_branch_id = None;
+            for (index, (expr, target)) in row.iter().zip(layout.columns.iter()).enumerate() {
+                if let InsertColumnTarget::Visible { column_type, .. } = target {
+                    reject_direct_blob_json_value(expr, *column_type, params)?;
+                }
+                let eval_value =
+                    eval_expr_value(expr, &context, ctx, params, active_branch_commit_id)?;
+                if matches!(
+                    target,
+                    InsertColumnTarget::Global | InsertColumnTarget::Untracked
+                ) && entity_eval_value_is_null(&eval_value)
+                {
+                    let column_name = match target {
+                        InsertColumnTarget::Global => "lixcol_global",
+                        InsertColumnTarget::Untracked => "lixcol_untracked",
+                        _ => unreachable!("matched defaulted boolean system column"),
+                    };
                     return Err(LixError::new(
-                        LixError::CODE_SCHEMA_VALIDATION,
+                        LixError::CODE_TYPE_MISMATCH,
                         format!(
-                            "INSERT into {} column '{name}' does not allow explicit NULL",
+                            "INSERT into {} column '{column_name}' may be omitted to use its default, but explicit NULL is not allowed",
                             layout.schema_key
                         ),
                     ));
                 }
-                row_values[index] = Some(entity_json_value(
-                    expr,
-                    eval_value,
-                    *column_type,
-                    &layout.schema_key,
+                if matches!(target, InsertColumnTarget::Metadata) {
+                    metadata = optional_metadata_from_eval_value(
+                        eval_value,
+                        "lixcol_metadata",
+                        &layout.schema_key,
+                    )?;
+                    continue;
+                }
+                if let InsertColumnTarget::Visible {
                     name,
-                )?);
-                continue;
+                    column_type,
+                    read_nullable,
+                } = target
+                {
+                    if !read_nullable && entity_eval_value_is_null(&eval_value) {
+                        return Err(LixError::new(
+                            LixError::CODE_SCHEMA_VALIDATION,
+                            format!(
+                                "INSERT into {} column '{name}' does not allow explicit NULL",
+                                layout.schema_key
+                            ),
+                        ));
+                    }
+                    row_values[index] = Some(entity_json_value(
+                        expr,
+                        eval_value,
+                        *column_type,
+                        &layout.schema_key,
+                        name,
+                    )?);
+                    continue;
+                }
+                let value = eval_value.into_json();
+                match target {
+                    InsertColumnTarget::Visible { .. } => {
+                        unreachable!("visible columns handled above")
+                    }
+                    InsertColumnTarget::EntityPk => {
+                        explicit_entity_pk =
+                            Some(entity_pk_from_value(&value, "lixcol_entity_pk")?);
+                    }
+                    InsertColumnTarget::FileId => {
+                        file_id = text_value(value, "lixcol_file_id")?;
+                    }
+                    InsertColumnTarget::Metadata => {
+                        unreachable!("metadata handled before JSON value coercion")
+                    }
+                    InsertColumnTarget::Global => {
+                        global = bool_value(value, "lixcol_global")?;
+                    }
+                    InsertColumnTarget::Untracked => {
+                        untracked = bool_value(value, "lixcol_untracked")?;
+                    }
+                    InsertColumnTarget::BranchId => {
+                        explicit_branch_id = text_value(value, "lixcol_branch_id")?;
+                    }
+                }
             }
-            let value = eval_value.into_json();
-            match target {
-                InsertColumnTarget::Visible { .. } => unreachable!("visible columns handled above"),
-                InsertColumnTarget::EntityPk => {
-                    explicit_entity_pk = Some(entity_pk_from_value(&value, "lixcol_entity_pk")?);
-                }
-                InsertColumnTarget::FileId => {
-                    file_id = text_value(value, "lixcol_file_id")?;
-                }
-                InsertColumnTarget::Metadata => {
-                    unreachable!("metadata handled before JSON value coercion")
-                }
-                InsertColumnTarget::Global => {
-                    global = bool_value(value, "lixcol_global")?;
-                }
-                InsertColumnTarget::Untracked => {
-                    untracked = bool_value(value, "lixcol_untracked")?;
-                }
-                InsertColumnTarget::BranchId => {
-                    explicit_branch_id = text_value(value, "lixcol_branch_id")?;
-                }
-            }
-        }
 
-        let primary_key_values = primary_key_indices
+            let primary_key_values = primary_key_indices
             .iter()
             .map(|index| {
                 row_values[*index].as_ref().ok_or_else(|| {
@@ -2570,99 +2963,100 @@ fn certified_entity_insert_batch(
                 })
             })
             .collect::<Result<Vec<_>, _>>()?;
-        let derived_entity_pk = EntityPk::from_json_values(
-            &primary_key_values
-                .iter()
-                .map(|value| (*value).clone())
-                .collect::<Vec<_>>(),
-            &spec.primary_key_component_types,
-        )
-        .map_err(|error| {
-            LixError::new(
-                LixError::CODE_SCHEMA_VALIDATION,
-                format!(
-                    "INSERT failed to derive entity primary key for schema '{}': {error}",
-                    layout.schema_key
-                ),
-            )
-        })?;
-        if explicit_entity_pk.as_ref().is_some_and(|explicit| {
-            explicit.clone().into_parts() != derived_entity_pk.clone().into_parts()
-        }) {
-            return Err(LixError::new(
-                LixError::CODE_SCHEMA_VALIDATION,
-                format!(
-                    "INSERT into {} has lixcol_entity_pk that does not match its public primary-key columns",
-                    layout.schema_key
-                ),
-            ));
-        }
-
-        let start = normalized.len();
-        normalized.push(b'{');
-        for (field_index, (value_index, name)) in visible_indices.iter().enumerate() {
-            if field_index != 0 {
-                normalized.push(b',');
-            }
-            serde_json::to_writer(&mut normalized, name).map_err(|error| {
-                LixError::unknown(format!(
-                    "certified INSERT key serialization failed: {error}"
-                ))
-            })?;
-            normalized.push(b':');
-            serde_json::to_writer(
-                &mut normalized,
-                row_values[*value_index]
-                    .as_ref()
-                    .expect("visible INSERT value was evaluated"),
+            let derived_entity_pk = EntityPk::from_json_values(
+                &primary_key_values
+                    .iter()
+                    .map(|value| (*value).clone())
+                    .collect::<Vec<_>>(),
+                &spec.primary_key_component_types,
             )
             .map_err(|error| {
-                LixError::unknown(format!(
-                    "certified INSERT value serialization failed: {error}"
-                ))
+                LixError::new(
+                    LixError::CODE_SCHEMA_VALIDATION,
+                    format!(
+                        "INSERT failed to derive entity primary key for schema '{}': {error}",
+                        layout.schema_key
+                    ),
+                )
             })?;
-        }
-        normalized.push(b'}');
-        let key = WasmEntityKey::from_owned_parts(
-            layout.schema_key.clone(),
-            derived_entity_pk.clone().into_parts(),
-        );
-        let certified = schema_plan
-            .certify_or_normalize_plugin_row(&normalized[start..], &key)?
-            .ok_or_else(|| {
-                LixError::unknown("eligible certified INSERT row declined its schema certificate")
-            })?;
-        if let Some(canonical) = certified.normalized {
-            normalized.truncate(start);
-            normalized.extend_from_slice(&canonical);
-        }
-        let end = normalized.len();
-        offsets.push((start, end));
-        entity_pks.push(certified.entity_pk);
-        let global = global.unwrap_or(false);
-        row_parts.push(CertifiedInsertRow {
-            file_id: file_id.map(Into::into),
-            metadata,
-            global,
-            untracked: untracked.unwrap_or(false),
-            branch_id: entity_row_branch_id(plan, explicit_branch_id, global)?.into(),
-        });
-        for value in &mut row_values {
-            *value = None;
-        }
+            if explicit_entity_pk.as_ref().is_some_and(|explicit| {
+                explicit.clone().into_parts() != derived_entity_pk.clone().into_parts()
+            }) {
+                return Err(LixError::new(
+                    LixError::CODE_SCHEMA_VALIDATION,
+                    format!(
+                        "INSERT into {} has lixcol_entity_pk that does not match its public primary-key columns",
+                        layout.schema_key
+                    ),
+                ));
+            }
+
+            let start = normalized.len();
+            normalized.push(b'{');
+            for (field_index, (value_index, name)) in visible_indices.iter().enumerate() {
+                if field_index != 0 {
+                    normalized.push(b',');
+                }
+                serde_json::to_writer(&mut normalized, name).map_err(|error| {
+                    LixError::unknown(format!(
+                        "certified INSERT key serialization failed: {error}"
+                    ))
+                })?;
+                normalized.push(b':');
+                serde_json::to_writer(
+                    &mut normalized,
+                    row_values[*value_index]
+                        .as_ref()
+                        .expect("visible INSERT value was evaluated"),
+                )
+                .map_err(|error| {
+                    LixError::unknown(format!(
+                        "certified INSERT value serialization failed: {error}"
+                    ))
+                })?;
+            }
+            normalized.push(b'}');
+            let key = WasmEntityKey::from_owned_parts(
+                layout.schema_key.clone(),
+                derived_entity_pk.clone().into_parts(),
+            );
+            let certified = schema_plan
+                .certify_or_normalize_plugin_row(&normalized[start..], &key)?
+                .ok_or_else(|| {
+                    LixError::unknown(
+                        "eligible certified INSERT row declined its schema certificate",
+                    )
+                })?;
+            if let Some(canonical) = certified.normalized {
+                normalized.truncate(start);
+                normalized.extend_from_slice(&canonical);
+            }
+            let end = normalized.len();
+            offsets.push((start, end));
+            entity_pks.push(certified.entity_pk);
+            let global = global.unwrap_or(false);
+            row_parts.push(CertifiedInsertRow {
+                file_id: file_id.map(Into::into),
+                metadata,
+                global,
+                untracked: untracked.unwrap_or(false),
+                branch_id: entity_row_branch_id(plan, explicit_branch_id, global)?.into(),
+            });
+            for value in &mut row_values {
+                *value = None;
+            }
+            Ok(())
+        })();
+        row_result.map_err(|error| match statement_index {
+            Some(index) => with_parameter_batch_statement_index(error, index),
+            None => error,
+        })?;
     }
 
-    let normalized = Bytes::from(normalized);
-    let normalized_rows = offsets
-        .into_iter()
-        .map(|(start, end)| {
-            SharedStr::from_utf8(normalized.slice(start..end))
-                .map_err(|_| LixError::unknown("certified INSERT row is not UTF-8"))
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    let row_count = normalized_rows.len();
-    let snapshots = WasmCanonicalJson::from_certified_batch_parts(
-        normalized_rows,
+    let row_count = offsets.len();
+    let snapshots = WasmCanonicalJson::from_certified_arena_parts(
+        normalized,
+        offsets,
         entity_pks.clone(),
         vec![schema_plan.shared_fingerprint()],
         vec![0; row_count],

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -162,8 +162,7 @@ pub(crate) async fn try_execute_entity_insert_parameter_batch(
     }
     drop(unique_identities);
     drop(certification_span);
-    let collection_was_empty = collection_is_certifiably_empty(ctx, &spec.schema_key).await?;
-    let committed = if collection_was_empty {
+    let committed = if collection_is_certifiably_empty(ctx, &spec.schema_key).await? {
         MaterializedLiveStateBatch::default()
     } else {
         scan_entity_conflict_candidates(ctx, &spec, &write_rows)
@@ -245,17 +244,7 @@ pub(crate) async fn try_execute_entity_insert_parameter_batch(
     };
     drop(conflict_attribution_span);
     drop(committed);
-    // The empty-collection certificate proves both committed and staged
-    // absence for every row in this homogeneous batch. Staging it as a
-    // replacement preserves the resulting state and changelog while avoiding
-    // a second O(rows log rows) committed-identity proof at transaction commit.
-    // The transaction's branch-head guard still rejects a concurrent change.
-    let stage_mode = if collection_was_empty {
-        TransactionWriteMode::Replace
-    } else {
-        TransactionWriteMode::Insert
-    };
-    stage_rows(ctx, stage_mode, write_rows)
+    stage_rows(ctx, TransactionWriteMode::Insert, write_rows)
         .instrument(tracing::debug_span!(
             target: "lix_perf",
             "lix.perf.entity_insert_parameter_batch.stage_rows"

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -3,6 +3,7 @@ use datafusion::arrow::datatypes::DataType;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::ScalarValue;
 use serde_json::Value as JsonValue;
+use tracing::Instrument;
 
 use crate::changelog::CommitId;
 use crate::common::{
@@ -129,6 +130,11 @@ pub(crate) async fn try_execute_entity_insert_parameter_batch(
     let mut write_rows = RawWriteBatch::with_capacity(parameter_batch.num_rows());
     let mut unique_identities =
         std::collections::HashSet::with_capacity(parameter_batch.num_rows());
+    let certification_span = tracing::debug_span!(
+        target: "lix_perf",
+        "lix.perf.entity_insert_parameter_batch.certify"
+    )
+    .entered();
     for row_index in 0..parameter_batch.num_rows() {
         let params = super::write::parameter_row(parameter_batch, row_index)
             .map_err(|error| with_parameter_batch_statement_index(error, row_index))?;
@@ -162,7 +168,18 @@ pub(crate) async fn try_execute_entity_insert_parameter_batch(
         }
         write_rows.append_taken_row(&mut row, 0);
     }
-    let committed = scan_entity_conflict_candidates(ctx, &spec, &write_rows).await?;
+    drop(certification_span);
+    let committed = scan_entity_conflict_candidates(ctx, &spec, &write_rows)
+        .instrument(tracing::debug_span!(
+            target: "lix_perf",
+            "lix.perf.entity_insert_parameter_batch.conflict_scan"
+        ))
+        .await?;
+    let conflict_attribution_span = tracing::debug_span!(
+        target: "lix_perf",
+        "lix.perf.entity_insert_parameter_batch.conflict_attribution"
+    )
+    .entered();
     let committed_conflict = if committed.is_empty() {
         None
     } else {
@@ -228,7 +245,13 @@ pub(crate) async fn try_execute_entity_insert_parameter_batch(
         }
         conflict
     };
-    stage_rows(ctx, TransactionWriteMode::Insert, write_rows).await?;
+    drop(conflict_attribution_span);
+    stage_rows(ctx, TransactionWriteMode::Insert, write_rows)
+        .instrument(tracing::debug_span!(
+            target: "lix_perf",
+            "lix.perf.entity_insert_parameter_batch.stage_rows"
+        ))
+        .await?;
     if let Some(error) = committed_conflict {
         return Err(error);
     }

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -244,7 +244,7 @@ pub(crate) async fn try_execute_entity_insert_parameter_batch(
     };
     drop(conflict_attribution_span);
     drop(committed);
-    stage_rows(ctx, TransactionWriteMode::Insert, write_rows)
+    ctx.stage_parameter_batch_insert(write_rows)
         .instrument(tracing::debug_span!(
             target: "lix_perf",
             "lix.perf.entity_insert_parameter_batch.stage_rows"

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -971,6 +971,25 @@ where
         &mut self,
         write: TransactionWrite,
     ) -> Result<TransactionWriteOutcome, LixError> {
+        self.stage_write_inner(write, None).await
+    }
+
+    async fn stage_parameter_batch_insert(
+        &mut self,
+        write: TransactionWrite,
+        statement_indices: Vec<u32>,
+    ) -> Result<TransactionWriteOutcome, LixError> {
+        self.stage_write_inner(write, Some(statement_indices)).await
+    }
+
+    async fn stage_write_inner(
+        &mut self,
+        write: TransactionWrite,
+        statement_indices: Option<Vec<u32>>,
+    ) -> Result<TransactionWriteOutcome, LixError> {
+        if let Some(statement_indices) = &statement_indices {
+            debug_assert_eq!(statement_indices.len(), transaction_write_row_count(&write));
+        }
         // Staging is transaction-local. Commit validates and materializes from
         // one coherent snapshot, then fences that snapshot in the durable
         // write. Re-checking it for every staged batch only repeats point
@@ -1022,6 +1041,15 @@ where
                 return Err(error);
             }
         };
+        if let Some(statement_indices) = &statement_indices
+            && statement_indices.len() != prepared_transaction_write_rows(&write).len()
+        {
+            discard_plugin_actor_publications(actor_publications).await;
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "parameter batch normalization changed row cardinality",
+            ));
+        }
         if let Err(error) = self
             .preflight_derived_path_stability_before_stage(&write)
             .instrument(tracing::debug_span!(
@@ -1035,12 +1063,17 @@ where
         }
         let affects_filesystem_path_index =
             prepared_transaction_write_affects_filesystem_path_index(&write);
-        let outcome = match tracing::debug_span!(
+        let stage_result = tracing::debug_span!(
             target: "lix_perf",
             "lix.perf.transaction_buffer_stage"
         )
-        .in_scope(|| self.staged_writes.stage_write(write))
-        {
+        .in_scope(|| match statement_indices {
+            Some(indices) => self
+                .staged_writes
+                .stage_parameter_batch_insert(write, indices),
+            None => self.staged_writes.stage_write(write),
+        });
+        let outcome = match stage_result {
             Ok(outcome) => outcome,
             Err(error) => {
                 discard_plugin_actor_publications(actor_publications).await;
@@ -6294,6 +6327,31 @@ where
         write: TransactionWrite,
     ) -> Result<TransactionWriteOutcome, LixError> {
         Self::stage_write(self, write).await
+    }
+
+    async fn stage_parameter_batch_insert(
+        &mut self,
+        rows: RawWriteBatch,
+    ) -> Result<TransactionWriteOutcome, LixError> {
+        let statement_indices = (0..rows.len())
+            .map(|index| {
+                u32::try_from(index).map_err(|_| {
+                    LixError::new(
+                        LixError::CODE_INVALID_PARAM,
+                        "parameter batch row count exceeds u32",
+                    )
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Self::stage_parameter_batch_insert(
+            self,
+            TransactionWrite::Rows {
+                mode: TransactionWriteMode::Insert,
+                rows,
+            },
+            statement_indices,
+        )
+        .await
     }
 
     async fn execute_diff_command(

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -8909,7 +8909,6 @@ fn transaction_write_branch_ids(write: &TransactionWrite) -> BTreeSet<String> {
     }
 }
 
-#[cfg(feature = "storage-benches")]
 fn transaction_write_row_count(write: &TransactionWrite) -> usize {
     match write {
         TransactionWrite::Rows { rows, .. } => rows.len(),

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -322,6 +322,7 @@ pub(crate) struct PreparedInsertSelection {
     count: usize,
     bits: Vec<u64>,
     origins: Vec<Option<TransactionWriteOrigin>>,
+    statement_indices: Vec<u32>,
 }
 
 #[derive(Clone, Copy)]
@@ -329,10 +330,12 @@ pub(crate) struct PreparedInsertRef<'a> {
     pub(crate) row_index: usize,
     pub(crate) row: PreparedStateRowRef<'a>,
     pub(crate) origin: Option<&'a TransactionWriteOrigin>,
+    pub(crate) statement_index: Option<usize>,
 }
 
 impl PreparedInsertSelection {
     const WORD_BITS: usize = u64::BITS as usize;
+    const NO_STATEMENT_INDEX: u32 = u32::MAX;
 
     pub(crate) fn new() -> Self {
         Self::default()
@@ -344,6 +347,7 @@ impl PreparedInsertSelection {
             count: 0,
             bits: Vec::with_capacity(row_capacity.div_ceil(Self::WORD_BITS)),
             origins: Vec::with_capacity(row_capacity),
+            statement_indices: Vec::new(),
         }
     }
 
@@ -382,13 +386,14 @@ impl PreparedInsertSelection {
                 row_index,
                 row: rows.row(row_index),
                 origin: self.origins[row_index].as_ref(),
+                statement_index: self.statement_index(row_index),
             })
     }
 
-    fn push(&mut self, origin: Option<&TransactionWriteOrigin>) {
+    fn push(&mut self, origin: Option<&TransactionWriteOrigin>, statement_index: Option<usize>) {
         let row_index = self.row_count;
         self.resize_rows(row_index + 1);
-        self.mark(row_index, origin);
+        self.mark(row_index, origin, statement_index);
     }
 
     fn push_not_insert(&mut self) {
@@ -421,10 +426,19 @@ impl PreparedInsertSelection {
         if !self.bits.is_empty() {
             self.bits.resize(row_count.div_ceil(Self::WORD_BITS), 0);
         }
+        if !self.statement_indices.is_empty() {
+            self.statement_indices
+                .resize(row_count, Self::NO_STATEMENT_INDEX);
+        }
         self.row_count = row_count;
     }
 
-    fn mark(&mut self, row_index: usize, origin: Option<&TransactionWriteOrigin>) {
+    fn mark(
+        &mut self,
+        row_index: usize,
+        origin: Option<&TransactionWriteOrigin>,
+        statement_index: Option<usize>,
+    ) {
         debug_assert!(row_index < self.row_count);
         let word = row_index / Self::WORD_BITS;
         let bit = row_index % Self::WORD_BITS;
@@ -439,6 +453,23 @@ impl PreparedInsertSelection {
             self.count += 1;
             self.origins[row_index] = origin.cloned();
         }
+        if let Some(statement_index) = statement_index {
+            let statement_index =
+                u32::try_from(statement_index).expect("batch statement index must fit u32");
+            if self.statement_indices.is_empty() {
+                self.statement_indices
+                    .resize(self.row_count, Self::NO_STATEMENT_INDEX);
+            }
+            self.statement_indices[row_index] = statement_index;
+        }
+    }
+
+    fn statement_index(&self, row_index: usize) -> Option<usize> {
+        self.statement_indices
+            .get(row_index)
+            .copied()
+            .filter(|index| *index != Self::NO_STATEMENT_INDEX)
+            .map(|index| index as usize)
     }
 
     pub(crate) fn select_rows(&mut self, source_by_destination: &[usize]) {
@@ -449,7 +480,7 @@ impl PreparedInsertSelection {
         let mut selected = Self::with_row_capacity(source_by_destination.len());
         for &source in source_by_destination {
             if self.contains(source) {
-                selected.push(self.origins[source].as_ref());
+                selected.push(self.origins[source].as_ref(), self.statement_index(source));
             } else {
                 selected.push_not_insert();
             }
@@ -624,6 +655,7 @@ impl<'a> PreparedWriteValidationSet<'a> {
                 row_index,
                 row: self.state_rows.row(row_index),
                 origin: self.insert_selection.origin(row_index),
+                statement_index: self.insert_selection.statement_index(row_index),
             }
         })
     }
@@ -706,7 +738,8 @@ impl PreparedWriteSet {
             .iter()
             .position(|candidate| PreparedStateRowIdentity::from(candidate) == identity)
             .expect("test INSERT row must already exist in the prepared batch");
-        self.insert_selection.mark(row_index, row.origin.as_ref());
+        self.insert_selection
+            .mark(row_index, row.origin.as_ref(), None);
     }
 }
 
@@ -774,6 +807,7 @@ impl TransactionWriteBuffer {
         &self,
         mode: Option<TransactionWriteMode>,
         mut rows: PreparedStateBatch,
+        statement_indices: Option<&[u32]>,
     ) -> Result<AppendOnlyStage, LixError> {
         let inserts = mode == Some(TransactionWriteMode::Insert);
         if !matches!(
@@ -832,9 +866,12 @@ impl TransactionWriteBuffer {
             }
         }
         insert_selection.reserve_rows(rows.len(), inserts);
-        for row in &rows {
+        for (row_index, row) in rows.iter().enumerate() {
             if inserts {
-                insert_selection.push(row.origin);
+                insert_selection.push(
+                    row.origin,
+                    statement_indices.map(|indices| indices[row_index] as usize),
+                );
             } else {
                 insert_selection.push_not_insert();
             }
@@ -952,7 +989,7 @@ impl TransactionWriteBuffer {
         for index in 0..rows.len() {
             let row = rows.row(index);
             if row_is_insert(mode, row) {
-                insert_selection.push(row.origin);
+                insert_selection.push(row.origin, None);
             } else {
                 insert_selection.push_not_insert();
             }
@@ -1343,11 +1380,31 @@ impl TransactionWriteBuffer {
         &self,
         write: PreparedTransactionWrite,
     ) -> Result<TransactionWriteOutcome, LixError> {
+        self.stage_write_inner(write, None)
+    }
+
+    pub(crate) fn stage_parameter_batch_insert(
+        &self,
+        write: PreparedTransactionWrite,
+        statement_indices: Vec<u32>,
+    ) -> Result<TransactionWriteOutcome, LixError> {
+        self.stage_write_inner(write, Some(statement_indices))
+    }
+
+    fn stage_write_inner(
+        &self,
+        write: PreparedTransactionWrite,
+        statement_indices: Option<Vec<u32>>,
+    ) -> Result<TransactionWriteOutcome, LixError> {
         let (mode, count) = match &write {
             PreparedTransactionWrite::Rows { mode, rows } => (Some(*mode), rows.len() as u64),
             PreparedTransactionWrite::RowsWithFileData { mode, count, .. } => (Some(*mode), *count),
         };
         let (mut rows, file_data_writes) = self.state_rows_from_stage_write(write);
+        if let Some(statement_indices) = &statement_indices {
+            debug_assert_eq!(mode, Some(TransactionWriteMode::Insert));
+            debug_assert_eq!(statement_indices.len(), rows.len());
+        }
         if rows.is_empty() {
             if !file_data_writes.is_empty() {
                 self.file_data_writes
@@ -1363,7 +1420,7 @@ impl TransactionWriteBuffer {
             return Ok(TransactionWriteOutcome { count });
         }
         if file_data_writes.is_empty() {
-            match self.stage_append_only_if_possible(mode, rows)? {
+            match self.stage_append_only_if_possible(mode, rows, statement_indices.as_deref())? {
                 AppendOnlyStage::Staged => return Ok(TransactionWriteOutcome { count }),
                 AppendOnlyStage::Fallback(fallback_rows) => rows = fallback_rows,
             }
@@ -1475,7 +1532,12 @@ impl TransactionWriteBuffer {
                 );
                 let identity = PreparedStateRowIdentity::from(row);
                 if is_insert {
-                    insert_selection.push(row.origin);
+                    insert_selection.push(
+                        row.origin,
+                        statement_indices
+                            .as_ref()
+                            .map(|indices| indices[index] as usize),
+                    );
                 } else {
                     insert_selection.push_not_insert();
                 }
@@ -1524,8 +1586,13 @@ impl TransactionWriteBuffer {
             let commit_id =
                 add_row_to_commit_change_refs(&mut commit_change_refs_guard, row, &self.functions);
             let identity = PreparedStateRowIdentity::from(row);
-            let insert_origin = if is_insert {
-                Some(row.origin.cloned())
+            let insert_metadata = if is_insert {
+                Some((
+                    row.origin.cloned(),
+                    statement_indices
+                        .as_ref()
+                        .map(|indices| indices[source_index] as usize),
+                ))
             } else {
                 None
             };
@@ -1539,8 +1606,8 @@ impl TransactionWriteBuffer {
                     index
                 }
             };
-            if let Some(origin) = insert_origin {
-                inserted_destinations.push((destination, origin));
+            if let Some(metadata) = insert_metadata {
+                inserted_destinations.push((destination, metadata));
             }
             placements.push((destination, source_index));
             latest_incoming_source_by_destination.insert(destination, source_index);
@@ -1558,8 +1625,8 @@ impl TransactionWriteBuffer {
         }
         staged_rows.truncate_rows(next_destination);
         insert_selection.resize_rows(next_destination);
-        for (destination, origin) in inserted_destinations {
-            insert_selection.mark(destination, origin.as_ref());
+        for (destination, (origin, statement_index)) in inserted_destinations {
+            insert_selection.mark(destination, origin.as_ref(), statement_index);
         }
         for index in new_candidate_destinations {
             by_candidate.insert(staged_rows.row(index), RowSlot::State(index));

--- a/packages/engine/src/transaction/validation.rs
+++ b/packages/engine/src/transaction/validation.rs
@@ -1374,6 +1374,32 @@ pub(crate) async fn validate_certified_tracked_insert_identities(
     live_state: &dyn LiveStateReader,
     prepared_writes: &PreparedWriteSet,
 ) -> Result<(), LixError> {
+    let mut inserts = prepared_writes
+        .insert_selection
+        .iter(&prepared_writes.state_rows);
+    if let Some(first) = inserts.next()
+        && inserts.all(|insert| {
+            insert.row.branch_id == first.row.branch_id
+                && insert.row.schema_key == first.row.schema_key
+                && insert.row.file_id == first.row.file_id
+        })
+    {
+        let scope = crate::collection_generation::CollectionScopeRef {
+            schema_key: first.row.schema_key,
+            file_id: first.row.file_id.map(crate::common::SharedStr::as_str),
+        };
+        if live_state
+            .collection_generation(first.row.branch_id, scope)
+            .await?
+            .is_some_and(|generation| generation.live_count == 0)
+        {
+            // This proof comes from the exact coherent read used to resolve
+            // commit parents and branch-control preconditions. A concurrent
+            // insert before the read makes the count nonzero; one after the
+            // read invalidates the publication CAS.
+            return Ok(());
+        }
+    }
     validate_committed_insert_identity_entries(
         live_state,
         prepared_writes

--- a/packages/engine/src/transaction/validation.rs
+++ b/packages/engine/src/transaction/validation.rs
@@ -1506,27 +1506,54 @@ where
                 } else {
                     "tracked"
                 };
-                return Err(LixError::new(
-                    LixError::CODE_UNIQUE,
-                    format!(
-                        "cannot insert {requested} row for schema '{}' entity_pk {:?}: a canonical {existing} row already exists; delete it first",
-                        insert.row.schema_key, insert.row.entity_pk,
+                return Err(with_insert_statement_index(
+                    LixError::new(
+                        LixError::CODE_UNIQUE,
+                        format!(
+                            "cannot insert {requested} row for schema '{}' entity_pk {:?}: a canonical {existing} row already exists; delete it first",
+                            insert.row.schema_key, insert.row.entity_pk,
+                        ),
                     ),
+                    insert.statement_index,
                 ));
             }
-            return Err(LixError::new(
-                LixError::CODE_UNIQUE,
-                duplicate_insert_identity_message(
-                    insert.row.schema_key,
-                    insert.row.entity_pk,
-                    None,
-                    insert.origin,
+            return Err(with_insert_statement_index(
+                LixError::new(
+                    LixError::CODE_UNIQUE,
+                    duplicate_insert_identity_message(
+                        insert.row.schema_key,
+                        insert.row.entity_pk,
+                        None,
+                        insert.origin,
+                    ),
                 ),
+                insert.statement_index,
             ));
         }
         group_start = group_end;
     }
     Ok(())
+}
+
+fn with_insert_statement_index(mut error: LixError, statement_index: Option<usize>) -> LixError {
+    let Some(statement_index) = statement_index else {
+        return error;
+    };
+    let mut details = match error.details.take() {
+        Some(serde_json::Value::Object(details)) => details,
+        Some(details) => {
+            let mut wrapped = serde_json::Map::new();
+            wrapped.insert("cause".to_string(), details);
+            wrapped
+        }
+        None => serde_json::Map::new(),
+    };
+    details.insert(
+        "statementIndex".to_string(),
+        serde_json::Value::from(statement_index),
+    );
+    error.details = Some(serde_json::Value::Object(details));
+    error
 }
 
 fn insert_scope_key<'a>(

--- a/packages/engine/src/wasm/component.rs
+++ b/packages/engine/src/wasm/component.rs
@@ -367,6 +367,14 @@ enum WasmCanonicalJsonStorage {
         normalized: Box<[SharedStr]>,
         normalized_len: u32,
     },
+    CertifiedArena {
+        decoded_values: OnceLock<Box<[OnceLock<JsonValue>]>>,
+        entity_pks: Box<[EntityPk]>,
+        schema_fingerprints: Box<[Arc<SchemaPlanFingerprint>]>,
+        schema_fingerprint_indices: Box<[u32]>,
+        normalized: SharedStr,
+        offsets: Box<[WasmCanonicalJsonOffset]>,
+    },
 }
 
 /// Schema and identity facts proven while streaming one exact canonical guest
@@ -571,6 +579,76 @@ impl WasmCanonicalJson {
         })
     }
 
+    pub(crate) fn from_certified_arena_parts(
+        normalized: Vec<u8>,
+        offsets: Vec<(usize, usize)>,
+        entity_pks: Vec<EntityPk>,
+        schema_fingerprints: Vec<Arc<SchemaPlanFingerprint>>,
+        schema_fingerprint_indices: Vec<u32>,
+        parse_count: usize,
+    ) -> Result<Vec<Self>, LixError> {
+        if offsets.len() != entity_pks.len() || offsets.len() != schema_fingerprint_indices.len() {
+            return Err(invalid_param(
+                "certified canonical JSON arena row and metadata counts differ",
+            ));
+        }
+        if schema_fingerprint_indices
+            .iter()
+            .any(|index| *index as usize >= schema_fingerprints.len())
+        {
+            return Err(invalid_param(
+                "certified canonical JSON arena schema index is invalid",
+            ));
+        }
+
+        let arena_allocation_count = u8::from(normalized.capacity() != 0);
+        let normalized = SharedStr::from_utf8(Bytes::from(normalized))
+            .map_err(|_| invalid_param("certified canonical JSON arena is not UTF-8"))?;
+        let arena_len = u32::try_from(normalized.len())
+            .map_err(|_| invalid_param("certified canonical JSON arena exceeds u32"))?;
+        let mut previous_end = 0_u32;
+        let mut validated_offsets = Vec::with_capacity(offsets.len());
+        for (start, end) in offsets {
+            let start = u32::try_from(start)
+                .map_err(|_| invalid_param("certified canonical JSON row offset exceeds u32"))?;
+            let end = u32::try_from(end)
+                .map_err(|_| invalid_param("certified canonical JSON row offset exceeds u32"))?;
+            if start != previous_end || end < start || end > arena_len {
+                return Err(invalid_param(
+                    "certified canonical JSON arena offsets are invalid or non-contiguous",
+                ));
+            }
+            if !normalized.as_str().is_char_boundary(start as usize)
+                || !normalized.as_str().is_char_boundary(end as usize)
+            {
+                return Err(invalid_param(
+                    "certified canonical JSON arena offsets split a UTF-8 scalar",
+                ));
+            }
+            previous_end = end;
+            validated_offsets.push(WasmCanonicalJsonOffset { start, end });
+        }
+        if previous_end != arena_len {
+            return Err(invalid_param(
+                "certified canonical JSON arena offsets do not cover the arena",
+            ));
+        }
+
+        Self::from_validated_batch(WasmCanonicalJsonBatch {
+            storage: WasmCanonicalJsonStorage::CertifiedArena {
+                decoded_values: OnceLock::new(),
+                entity_pks: entity_pks.into_boxed_slice(),
+                schema_fingerprints: schema_fingerprints.into_boxed_slice(),
+                schema_fingerprint_indices: schema_fingerprint_indices.into_boxed_slice(),
+                normalized,
+                offsets: validated_offsets.into_boxed_slice(),
+            },
+            parse_count,
+            serialize_count: 0,
+            arena_allocation_count,
+        })
+    }
+
     fn from_validated_batch(batch: WasmCanonicalJsonBatch) -> Result<Vec<Self>, LixError> {
         let batch = Arc::new(batch);
         let mut rows = Vec::with_capacity(batch.row_count());
@@ -600,6 +678,23 @@ impl WasmCanonicalJson {
                 serde_json::from_str(normalized[self.row_index()].as_str())
                     .expect("certified canonical JSON must parse")
             }),
+            WasmCanonicalJsonStorage::CertifiedArena {
+                decoded_values,
+                normalized,
+                offsets,
+                ..
+            } => decoded_values
+                .get_or_init(|| (0..offsets.len()).map(|_| OnceLock::new()).collect())
+                [self.row_index()]
+            .get_or_init(|| {
+                serde_json::from_str(
+                    normalized
+                        .as_str()
+                        .get(offset_range(offsets[self.row_index()]))
+                        .expect("certified canonical JSON row offsets were validated"),
+                )
+                .expect("certified canonical JSON must parse")
+            }),
         }
     }
 
@@ -609,6 +704,12 @@ impl WasmCanonicalJson {
                 .as_ref()
                 .map(WasmCanonicalJsonCertificate::borrowed),
             WasmCanonicalJsonStorage::CertifiedRows {
+                entity_pks,
+                schema_fingerprints,
+                schema_fingerprint_indices,
+                ..
+            }
+            | WasmCanonicalJsonStorage::CertifiedArena {
                 entity_pks,
                 schema_fingerprints,
                 schema_fingerprint_indices,
@@ -634,6 +735,14 @@ impl WasmCanonicalJson {
             WasmCanonicalJsonStorage::CertifiedRows { normalized, .. } => {
                 normalized[self.row_index()].as_str()
             }
+            WasmCanonicalJsonStorage::CertifiedArena {
+                normalized,
+                offsets,
+                ..
+            } => normalized
+                .as_str()
+                .get(offset_range(offsets[self.row_index()]))
+                .expect("certified canonical JSON row offsets were validated"),
         }
     }
 
@@ -649,6 +758,13 @@ impl WasmCanonicalJson {
             WasmCanonicalJsonStorage::CertifiedRows { normalized, .. } => {
                 normalized[self.row_index()].clone()
             }
+            WasmCanonicalJsonStorage::CertifiedArena {
+                normalized,
+                offsets,
+                ..
+            } => normalized
+                .slice(offset_range(offsets[self.row_index()]))
+                .expect("certified canonical JSON row offsets were validated"),
         }
     }
 
@@ -666,6 +782,7 @@ impl WasmCanonicalJson {
             WasmCanonicalJsonStorage::CertifiedRows { normalized_len, .. } => {
                 *normalized_len as usize
             }
+            WasmCanonicalJsonStorage::CertifiedArena { normalized, .. } => normalized.len(),
         }
     }
 
@@ -691,6 +808,10 @@ impl WasmCanonicalJson {
                 .get()
                 .map(|values| values.iter().filter(|value| value.get().is_some()).count())
                 .unwrap_or(0),
+            WasmCanonicalJsonStorage::CertifiedArena { decoded_values, .. } => decoded_values
+                .get()
+                .map(|values| values.iter().filter(|value| value.get().is_some()).count())
+                .unwrap_or(0),
         }
     }
 
@@ -699,6 +820,10 @@ impl WasmCanonicalJson {
         match &self.batch.storage {
             WasmCanonicalJsonStorage::Arena { .. } => 0,
             WasmCanonicalJsonStorage::CertifiedRows {
+                schema_fingerprints,
+                ..
+            }
+            | WasmCanonicalJsonStorage::CertifiedArena {
                 schema_fingerprints,
                 ..
             } => schema_fingerprints.len(),
@@ -711,6 +836,7 @@ impl WasmCanonicalJsonBatch {
         match &self.storage {
             WasmCanonicalJsonStorage::Arena { offsets, .. } => offsets.len(),
             WasmCanonicalJsonStorage::CertifiedRows { normalized, .. } => normalized.len(),
+            WasmCanonicalJsonStorage::CertifiedArena { offsets, .. } => offsets.len(),
         }
     }
 }


### PR DESCRIPTION
## What changed

- add shared typed scalar/object certification below SQL so producers can validate string/boolean/null values without constructing a JSON DOM
- lower eligible homogeneous parameter batches directly from Arrow columns into one canonical UTF-8 arena with compact row offsets
- retain that compact certified arena through transaction staging instead of expanding it into one shared owner per row
- release the large intra-batch uniqueness proof before staging
- certify an empty collection again from the coherent commit snapshot, avoiding the O(rows log rows) committed-identity scan without weakening INSERT conflict semantics
- preserve parameter-batch statement attribution in one lazy dense u32 sidecar through transaction coalescing and commit validation
- finalize fast-batch telemetry after commit so commit-time conflicts are not recorded as successes
- add opt-in phase tracing for the tracked CRUD benchmark

Plugin APIs are intentionally unchanged.

## Why

Profiling showed that JSON parsing was only part of create latency. At 1M rows the previous one-shot typed batch was OOM-killed after storage lowering because parameter data, row-owned canonical slices, transaction materialization, and the adapter batch overlapped at peak memory. The transaction also repeated committed INSERT-absence validation after SQL had already proven the collection empty.

The new path keeps typed values and canonical bytes in dense shared representations. Empty-collection reuse is tied to the commit coherent snapshot: a concurrent insert before that read forces exact conflict validation, while one after it invalidates the publication CAS. Commit-time conflicts retain the original batch ordinal without allocating a logical origin per row.

## Results

Affected create measurements on the final reviewed implementation only:

| adapter | rows | before | after | change |
| --- | ---: | ---: | ---: | ---: |
| RocksDB | 100k | 568.0 ms | 500.5 ms median (490.5–512.2 ms) | -11.9% |
| RocksDB | 1M | 11.93 s | 9.74 s median (8.87–11.02 s) | -18.3% |
| SlateDB | 100k | 470.1 ms | 406.9 ms median (399.1–422.4 ms) | -13.5% |
| SlateDB | 1M | 16.07 s | 16.05 s median (14.22–16.95 s) | -0.1% |

The retained 1M phase trace now completes instead of being OOM-killed. The coherent empty-generation proof keeps commit validation O(1) for an unchanged empty collection while preserving concurrent INSERT conflicts. SlateDB 1M remains noisy and effectively flat in this refresh; no faster earlier sample is substituted.

This is a meaningful scaling improvement but does not claim the overall 1.2x SQLite goal is reached. The next storage-layout cut is to remove the per-row change-locator plane by making new change IDs directly addressable to their commit-delta segment.

## Validation

- cargo clippy -p lix_engine --features storage-benches --all-targets -- -D warnings
- cargo test -p lix_engine --lib --features storage-benches (1602 passed, 6 ignored)
- cargo clippy -p lix_engine_benchmarks --all-targets --features storage-benches,slatedb -- -D warnings
- cargo test -p lix_engine_benchmarks --test tracked_state_crud_public_result --features storage-benches,slatedb (4 passed)
- focused concurrent-insert attribution, diff, merge, checkpoint, commit-delta replay, generation-delete, and executeBatch tests
