### PR TITLE
fix JS Value docs and expose SQL surfaces

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,23 +75,16 @@ const result = await lix.execute(
 );
 
 const row = result.rows[0]!;
-console.log(row.value("title").asText(), row.value("done").asBoolean());
+console.log(row.get("title"), row.get("done"));
 ```
 
 `execute()` returns `{ columns, rows, rowsAffected, notices }`.
 
 ## Read result values
 
-Each row is a `Row`. Use `row.value(name)` for a typed `Value`, or `row.get(name)` / `row.toObject()` for plain JavaScript values.
-
-| Accessor      | Use for                                                 |
-| ------------- | ------------------------------------------------------- |
-| `asText()`    | text columns                                            |
-| `asBoolean()` | boolean columns                                         |
-| `asInteger()` | integer columns                                         |
-| `asReal()`    | decimal columns                                         |
-| `asJson()`    | JSON columns such as `snapshot_content` and `entity_pk` |
-| `asBytes()`   | binary columns such as `lix_file.data`                  |
+Each row is a `Row`. Use `row.get(name)` or `row.toObject()` for plain
+JavaScript values. Use `row.value(name).toJS()` when you also need the value's
+SQL kind, and `row.value(name).asBytes()` for a defensive copy of binary data.
 
 Use `asBytes()` for byte content:
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -79,7 +79,7 @@ const branch = await lix.execute(
   "SELECT commit_id FROM lix_branch WHERE id = $1",
   [branchId],
 );
-const commitId = branch.rows[0].value("commit_id").asText();
+const commitId = branch.rows[0].get("commit_id") as string;
 
 const history = await lix.execute(
   `SELECT id, title, lixcol_depth

--- a/docs/js-api-reference.md
+++ b/docs/js-api-reference.md
@@ -126,7 +126,7 @@ const result = await lix.execute(
 	["/hello.txt"],
 );
 
-const path = result.rows[0]?.value("path").asText();
+const path = result.rows[0]?.get("path");
 const data = result.rows[0]?.value("data").asBytes();
 ```
 
@@ -298,20 +298,12 @@ Rows are returned by `execute()`.
 const row = result.rows[0]!;
 ```
 
-| Surface                    | Return type                      | Description                                                    |
-| -------------------------- | -------------------------------- | -------------------------------------------------------------- |
-| `row.columns`              | `string[]`                       | Column names for this row.                                     |
-| `row.get(columnName)`      | `LixNativeValue`                 | Native JS value for a column. Throws if the column is missing. |
-| `row.tryGet(columnName)`   | `LixNativeValue \| undefined`    | Native JS value, or `undefined` when the column is missing.    |
-| `row.value(columnName)`    | `Value`                          | Typed `Value` for a column. Throws if the column is missing.   |
-| `row.tryValue(columnName)` | `Value \| undefined`             | Typed `Value`, or `undefined` when the column is missing.      |
-| `row.getAt(index)`         | `LixNativeValue`                 | Native JS value by column index.                               |
-| `row.valueAt(index)`       | `Value`                          | Typed `Value` by column index.                                 |
-| `row.values()`             | `Value[]`                        | All typed values in column order.                              |
-| `row.toObject()`           | `Record<string, LixNativeValue>` | Object of native JS values keyed by column name.               |
-| `row.toValueMap()`         | `Record<string, Value>`          | Object of typed values keyed by column name.                   |
-
-`LixNativeValue` is `null`, boolean, number, string, JSON, or `Uint8Array`.
+| Surface                 | Return type              | Description                                                    |
+| ----------------------- | ------------------------ | -------------------------------------------------------------- |
+| `row.get(columnName)`   | `unknown`                | Native JS value for a column. Throws if the column is missing. |
+| `row.value(columnName)` | `Value`                  | Typed `Value` for a column. Throws if the column is missing.   |
+| `row.toObject()`        | `Record<string, unknown>` | Object of native JS values keyed by column name.              |
+| `row.toValueMap()`      | `Record<string, Value>`  | Object of typed values keyed by column name.                   |
 
 ## Value
 
@@ -319,15 +311,10 @@ const row = result.rows[0]!;
 
 Accessors:
 
-| Method        | Return type               | Description                           |
-| ------------- | ------------------------- | ------------------------------------- |
-| `asInteger()` | `number \| undefined`     | Returns a number for integer values.  |
-| `asBoolean()` | `boolean \| undefined`    | Returns a boolean for boolean values. |
-| `asReal()`    | `number \| undefined`     | Returns a number for real values.     |
-| `asText()`    | `string \| undefined`     | Returns a string for text values.     |
-| `asJson()`    | `JsonValue \| undefined`  | Returns a JSON value for JSON values. |
-| `asBytes()`   | `Uint8Array \| undefined` | Returns bytes for blob values.        |
-| `toJSON()`    | `LixValue`                | Serializes the typed value.           |
+| Method      | Return type               | Description                                      |
+| ----------- | ------------------------- | ------------------------------------------------ |
+| `toJS()`    | `unknown`                 | Returns a defensive copy of the native JS value. |
+| `asBytes()` | `Uint8Array \| undefined` | Returns a defensive copy for blob values.        |
 
 Constructors:
 

--- a/docs/sql-functions.md
+++ b/docs/sql-functions.md
@@ -51,7 +51,7 @@ const { rows } = await lix.execute(
   "SELECT commit_id FROM lix_branch WHERE id = $1",
   [branchId],
 );
-const commitId = rows[0].value("commit_id").asText();
+const commitId = rows[0].get("commit_id") as string;
 
 await lix.execute(
   `SELECT lixcol_depth, title

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -115,6 +115,23 @@ console.log(bytes && new TextDecoder().decode(bytes));
 await lix.close();
 ```
 
+## Discover the SQL contract
+
+Lix extends the standard `information_schema.columns` relation with
+`lix_value_kind` and `lix_insert_policy`. Inspect it before generating writes:
+
+```sql
+SELECT table_name, column_name, data_type, is_nullable, column_default,
+       lix_value_kind, lix_insert_policy
+FROM information_schema.columns
+WHERE table_name = 'lix_file'
+ORDER BY ordinal_position;
+```
+
+`lix_insert_policy` distinguishes `REQUIRED`, `DEFAULT`, `CONDITIONAL`, and
+`READ_ONLY` columns. For the complete table and history-function map, see
+[SQL Surfaces](https://lix.dev/docs/surfaces).
+
 ## Branches
 
 ```ts


### PR DESCRIPTION
## What changed

- replace documentation for nonexistent `Value.asText()`, `asBoolean()`, `asInteger()`, `asReal()`, `asJson()`, and `toJSON()` methods with the actual `Row.get()`, `Value.toJS()`, and `Value.asBytes()` API
- remove other nonexistent `Row` methods from the JS API reference
- add the executable `information_schema.columns` discovery query to the packaged JS SDK README
- link the packaged README directly to the SQL Surfaces documentation

## Why

The docs taught methods that do not exist in `value.ts`, while the SQL surface contract—including `lix_insert_policy` and `lix_value_kind`—was not reachable from the installed package. This made correct write generation unnecessarily dependent on trial and error.

## Impact

The package now leads users and agents to the introspectable SQL contract and all JS examples use APIs that actually exist.

## Validation

- searched the documentation tree to confirm the nonexistent accessors and Row methods are gone
- `git diff --check`