### PR TITLE
fix SQL catalog discovery

### DIFF
--- a/packages/engine/src/sql2/error.rs
+++ b/packages/engine/src/sql2/error.rs
@@ -95,7 +95,11 @@ fn classify_datafusion_error(error: &DataFusionError) -> LixError {
             || lower.contains("does not exist")
             || lower.contains("no field named"))
     {
-        return LixError::new(LixError::CODE_COLUMN_NOT_FOUND, message);
+        let error = LixError::new(LixError::CODE_COLUMN_NOT_FOUND, message);
+        if lower.contains("no field named metadata.") && lower.contains("lixcol_metadata") {
+            return error.with_hint("Did you mean lixcol_metadata?");
+        }
+        return error;
     }
 
     if lower.contains("schema validation") {

--- a/packages/engine/src/sql2/information_schema.rs
+++ b/packages/engine/src/sql2/information_schema.rs
@@ -434,7 +434,12 @@ fn public_sql_type(data_type: &DataType) -> String {
 fn character_lengths(data_type: &DataType) -> (Option<u64>, Option<u64>) {
     match data_type {
         DataType::Utf8 | DataType::Binary => (None, Some(i32::MAX as u64)),
-        DataType::LargeUtf8 | DataType::LargeBinary => (None, Some(i64::MAX as u64)),
+        // Arrow's large variable-width types are bounded by an implementation
+        // offset, not by the public SQL column contract. Advertising i64::MAX
+        // as an octet length is both misleading and outside JavaScript's safe
+        // integer range, which makes SELECT * on information_schema.columns
+        // impossible to return through the JS SDK.
+        DataType::LargeUtf8 | DataType::LargeBinary => (None, None),
         _ => (None, None),
     }
 }

--- a/packages/engine/tests/integration/sql/information_schema.rs
+++ b/packages/engine/tests/integration/sql/information_schema.rs
@@ -3,6 +3,58 @@ use lix_engine::{LixError, Value};
 use super::assert_rows_eq;
 
 simulation_test!(
+    information_schema_columns_select_star_is_safe_for_public_results,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        let result = session
+            .execute(
+                "SELECT * FROM information_schema.columns WHERE table_name = 'lix_file'",
+                &[],
+            )
+            .await
+            .expect("the complete lix_file column contract should be readable");
+        assert!(!result.rows().is_empty());
+        assert!(
+            result
+                .columns()
+                .iter()
+                .any(|column| column == "lix_value_kind")
+        );
+        assert!(
+            result
+                .columns()
+                .iter()
+                .any(|column| column == "lix_insert_policy")
+        );
+
+        let data_row = result
+            .rows()
+            .iter()
+            .find(|row| {
+                row.value("column_name")
+                    .expect("column_name should be present")
+                    == &Value::Text("data".to_string())
+            })
+            .expect("lix_file data column should be described");
+        assert_eq!(
+            data_row
+                .value("character_octet_length")
+                .expect("character_octet_length should be present"),
+            &Value::Null,
+            "unbounded binary data must not advertise an artificial i64::MAX length",
+        );
+    }
+);
+
+simulation_test!(
     information_schema_exposes_executable_lix_column_contract,
     |sim| async move {
         let engine = sim.boot_engine().await;

--- a/packages/engine/tests/integration/sql/lix_file.rs
+++ b/packages/engine/tests/integration/sql/lix_file.rs
@@ -296,6 +296,26 @@ simulation_test!(
 );
 
 simulation_test!(
+    lix_file_unknown_metadata_column_suggests_public_name,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        let error = session
+            .execute("SELECT metadata FROM lix_file", &[])
+            .await
+            .expect_err("metadata should not be a public column");
+        assert_eq!(error.code, LixError::CODE_COLUMN_NOT_FOUND);
+        assert_eq!(error.hint.as_deref(), Some("Did you mean lixcol_metadata?"));
+    }
+);
+
+simulation_test!(
     lix_file_lower_path_like_keeps_the_blob_revision_for_guarded_updates,
     |sim| async move {
         let engine = sim.boot_engine().await;

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -1745,6 +1745,25 @@ test("execute accepts explicit Value parameters", async () => {
 	await lix.close();
 });
 
+test("information_schema.columns SELECT * exposes the Lix column contract", async () => {
+	const lix = await openLix();
+
+	const result = await lix.execute(
+		"SELECT * FROM information_schema.columns WHERE table_name = 'lix_file'",
+	);
+
+	expect(result.rows.length).toBeGreaterThan(0);
+	expect(result.columns).toContain("lix_value_kind");
+	expect(result.columns).toContain("lix_insert_policy");
+	expect(
+		result.rows.find((row) => row.get("column_name") === "data")?.get(
+			"character_octet_length",
+		),
+	).toBeNull();
+
+	await lix.close();
+});
+
 test("execute rejects invalid explicit Value parameters", async () => {
 	const lix = await openLix();
 


### PR DESCRIPTION
## What changed

- report standard `NULL` character lengths for unbounded Arrow `LargeUtf8` and `LargeBinary` columns
- add Rust and JS regressions for the exact `SELECT * FROM information_schema.columns WHERE table_name = 'lix_file'` query
- add `Did you mean lixcol_metadata?` to the exact unknown-`metadata` column error when that public column is available

## Root cause

`information_schema.columns.character_octet_length` advertised the Arrow offset limit (`i64::MAX`) as if it were a SQL contract limit. The JS binding represented that out-of-safe-range integer as a `bigint`, and the public `Value` constructor rejected it. Explicit projections happened to avoid the offending catalog field, which hid `lix_insert_policy` and `lix_value_kind` from discovery.

## Impact

`SELECT *` now returns the full executable column contract through the JS SDK, including Lix's `lix_insert_policy` and `lix_value_kind` extensions. Unbounded SQL values use standard `NULL` metadata instead of an implementation limit.

## Validation

- `cargo test -p lix_engine --features all-simulations information_schema_columns_select_star_is_safe_for_public_results`
- `cargo test -p lix_engine --features all-simulations lix_file_unknown_metadata_column_suggests_public_name`
- `npx vitest run src/open-lix.test.ts -t "information_schema.columns SELECT * exposes the Lix column contract"`
- `cargo fmt --check`
- `git diff --check`