### PR TITLE
fix lix_file public timestamps

### DIFF
--- a/packages/engine/src/filesystem/path_index.rs
+++ b/packages/engine/src/filesystem/path_index.rs
@@ -142,8 +142,14 @@ impl FilesystemPathEntry {
         &self.created_at
     }
 
-    pub(crate) fn updated_at(&self) -> &str {
-        &self.updated_at
+    pub(crate) fn updated_at(&self) -> String {
+        self.blob_ref
+            .as_ref()
+            .filter(|_| self.kind == FilesystemPathKind::File)
+            .map_or_else(
+                || self.updated_at.clone(),
+                |blob_ref| blob_ref.updated_at.to_string(),
+            )
     }
 
     pub(crate) fn change_id(&self) -> Option<ChangeId> {
@@ -790,6 +796,12 @@ impl FilesystemPathIndex {
         }
 
         let mut entry = self.entry_from_row(row, key, kind)?;
+        if let Some(prior) = prior.as_ref() {
+            // Descriptor writes in the transaction overlay carry the current
+            // change timestamp. Replacing the same identity must retain the
+            // entity's first visible timestamp.
+            entry.created_at.clone_from(&prior.created_at);
+        }
         entry.blob_ref = prior_blob_ref;
         entry.cached_blob_data = prior_cached_blob_data;
         self.insert_entry(Arc::new(entry));

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -917,6 +917,7 @@ impl TableSpec for LixFileSpec {
         .map_err(lix_error_to_datafusion_error)?;
         let needs_data = scan_needs_data(&self.schema, projection, &filters);
         let needs_blob_rows = scan_needs_blob_rows(&self.schema, projection, &filters);
+        let needs_file_timestamps = scan_needs_file_timestamps(&self.schema, projection, &filters);
         let target_file_ids = file_id_constraint_from_filters(&filters)?;
         let target_directory_ids =
             exact_string_column_constraint_from_filters(&filters, "directory_id")?;
@@ -935,6 +936,7 @@ impl TableSpec for LixFileSpec {
         // A path predicate or exact file/directory ids can narrow those loads
         // to matching cached descriptors instead of scanning complete state.
         let use_path_index = should_use_path_index(&indexed_path_predicate, needs_blob_rows)
+            || needs_file_timestamps
             || matches!(&target_file_ids, FileIdConstraint::Ids(_))
             || matches!(&target_directory_ids, FileIdConstraint::Ids(_))
             || root_directory_filter;
@@ -4810,6 +4812,14 @@ async fn lix_file_record_batch_from_prepared(
             })
             .or_else(|| live_rows.row(file.live).change_id());
         let live = live_rows.row(file.live);
+        let content_live = blob_rows
+            .get(&blob_key)
+            .map(|blob_ref| live_rows.row(blob_ref.live))
+            .or_else(|| {
+                derived_rows
+                    .get(&blob_key)
+                    .map(|derived| live_rows.row(derived.live))
+            });
         let FileDescriptorRecord {
             id,
             directory_id,
@@ -4827,7 +4837,7 @@ async fn lix_file_record_batch_from_prepared(
             global: live.global(),
             change_id: projected_change_id.map(|id| id.to_string()),
             created_at: live.created_at().to_string(),
-            updated_at: live.updated_at().to_string(),
+            updated_at: content_live.unwrap_or(live).updated_at().to_string(),
             commit_id: live.commit_id().map(|id| id.to_string()),
             untracked: live.untracked(),
             metadata: live.metadata().map(|value| serialize_row_metadata(value)),
@@ -5662,19 +5672,42 @@ fn scan_needs_blob_rows(
         Some(indices) => indices.iter().any(|index| {
             matches!(
                 base_schema.field(*index).name().as_str(),
-                "data" | "lixcol_change_id"
+                "data" | "lixcol_change_id" | "lixcol_updated_at"
             )
         }),
         None => true,
     };
     projects_blob_column
         || filters.iter().any(|filter| {
-            contains_column(filter, "data") || contains_column(filter, "lixcol_change_id")
+            contains_column(filter, "data")
+                || contains_column(filter, "lixcol_change_id")
+                || contains_column(filter, "lixcol_updated_at")
         })
 }
 
 fn should_use_path_index(path_predicate: &FilePathPredicate, needs_blob_rows: bool) -> bool {
     path_predicate != &FilePathPredicate::All || !needs_blob_rows
+}
+
+fn scan_needs_file_timestamps(
+    base_schema: &SchemaRef,
+    projection: Option<&Vec<usize>>,
+    filters: &[Expr],
+) -> bool {
+    let projects_timestamp = match projection {
+        Some(indices) => indices.iter().any(|index| {
+            matches!(
+                base_schema.field(*index).name().as_str(),
+                "lixcol_created_at" | "lixcol_updated_at"
+            )
+        }),
+        None => true,
+    };
+    projects_timestamp
+        || filters.iter().any(|filter| {
+            contains_column(filter, "lixcol_created_at")
+                || contains_column(filter, "lixcol_updated_at")
+        })
 }
 
 fn lix_file_scan_request(

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -916,7 +916,10 @@ impl TableSpec for LixFileSpec {
         .await
         .map_err(lix_error_to_datafusion_error)?;
         let needs_data = scan_needs_data(&self.schema, projection, &filters);
-        let needs_blob_rows = scan_needs_blob_rows(&self.schema, projection, &filters);
+        let needs_required_blob_rows =
+            scan_needs_required_blob_rows(&self.schema, projection, &filters);
+        let needs_blob_rows = needs_required_blob_rows
+            || scan_needs_content_updated_at(&self.schema, projection, &filters);
         let needs_file_timestamps = scan_needs_file_timestamps(&self.schema, projection, &filters);
         let target_file_ids = file_id_constraint_from_filters(&filters)?;
         let target_directory_ids =
@@ -1018,6 +1021,7 @@ impl TableSpec for LixFileSpec {
                     self.session_file_views.clone(),
                     needs_data,
                     needs_blob_rows,
+                    needs_required_blob_rows,
                     limit,
                 ),
                 |(
@@ -1035,10 +1039,11 @@ impl TableSpec for LixFileSpec {
                     session_file_views,
                     needs_data,
                     needs_blob_rows,
+                    needs_required_blob_rows,
                     limit,
                 )| async move {
                     if let Some(indexed_matches) = indexed_matches.as_ref()
-                        && !needs_blob_rows
+                        && !needs_required_blob_rows
                     {
                         // Without residual filters, the path-index order is the
                         // output order. Materialize only projected columns and
@@ -1101,7 +1106,7 @@ impl TableSpec for LixFileSpec {
                         ))
                     })?;
                     let acknowledge_plugin_data = needs_data && session_file_views.is_some();
-                    let plugin_render = if prepared.needs_plugin_render(needs_blob_rows)
+                    let plugin_render = if prepared.needs_plugin_render(needs_required_blob_rows)
                         || acknowledge_plugin_data
                     {
                         plugin_render_context_for_lix_file_scan(
@@ -5663,7 +5668,7 @@ fn scan_needs_data(
     projected_needs_data || filters.iter().any(|filter| contains_column(filter, "data"))
 }
 
-fn scan_needs_blob_rows(
+fn scan_needs_required_blob_rows(
     base_schema: &SchemaRef,
     projection: Option<&Vec<usize>>,
     filters: &[Expr],
@@ -5672,17 +5677,32 @@ fn scan_needs_blob_rows(
         Some(indices) => indices.iter().any(|index| {
             matches!(
                 base_schema.field(*index).name().as_str(),
-                "data" | "lixcol_change_id" | "lixcol_updated_at"
+                "data" | "lixcol_change_id"
             )
         }),
         None => true,
     };
     projects_blob_column
         || filters.iter().any(|filter| {
-            contains_column(filter, "data")
-                || contains_column(filter, "lixcol_change_id")
-                || contains_column(filter, "lixcol_updated_at")
+            contains_column(filter, "data") || contains_column(filter, "lixcol_change_id")
         })
+}
+
+fn scan_needs_content_updated_at(
+    base_schema: &SchemaRef,
+    projection: Option<&Vec<usize>>,
+    filters: &[Expr],
+) -> bool {
+    let projects_updated_at = match projection {
+        Some(indices) => indices
+            .iter()
+            .any(|index| base_schema.field(*index).name() == "lixcol_updated_at"),
+        None => true,
+    };
+    projects_updated_at
+        || filters
+            .iter()
+            .any(|filter| contains_column(filter, "lixcol_updated_at"))
 }
 
 fn should_use_path_index(path_predicate: &FilePathPredicate, needs_blob_rows: bool) -> bool {

--- a/packages/engine/tests/integration/sql/lix_file.rs
+++ b/packages/engine/tests/integration/sql/lix_file.rs
@@ -7,6 +7,143 @@ use serde_json::json;
 use super::assert_rows_eq;
 
 simulation_test!(
+    lix_file_public_timestamps_cover_descriptor_and_content_revisions,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        let file_id = "74696d65-7374-816d-8073-000000000001";
+        session
+            .execute(
+                &format!(
+                    "INSERT INTO lix_file (id, path, data) \
+                     VALUES ('{file_id}', '/timestamps.txt', X'6F6E65')"
+                ),
+                &[],
+            )
+            .await
+            .expect("file insert should succeed");
+
+        let initial = session
+            .execute(
+                &format!(
+                    "SELECT lixcol_created_at, lixcol_updated_at, lixcol_change_id \
+                     FROM lix_file WHERE id = '{file_id}'"
+                ),
+                &[],
+            )
+            .await
+            .expect("inserted file should be readable");
+        let initial_created_at = initial.rows()[0]
+            .get::<String>("lixcol_created_at")
+            .expect("created_at should be text");
+        let initial_updated_at = initial.rows()[0]
+            .get::<String>("lixcol_updated_at")
+            .expect("updated_at should be text");
+        let initial_change_id = initial.rows()[0]
+            .get::<String>("lixcol_change_id")
+            .expect("change_id should be text");
+
+        session
+            .execute(
+                &format!("UPDATE lix_file SET data = X'74776F' WHERE id = '{file_id}'"),
+                &[],
+            )
+            .await
+            .expect("content update should succeed");
+        let content_update = session
+            .execute(
+                &format!(
+                    "SELECT lixcol_created_at, lixcol_updated_at, lixcol_change_id \
+                     FROM lix_file WHERE id = '{file_id}'"
+                ),
+                &[],
+            )
+            .await
+            .expect("content-updated file should be readable");
+        let content_created_at = content_update.rows()[0]
+            .get::<String>("lixcol_created_at")
+            .expect("created_at should be text");
+        let content_updated_at = content_update.rows()[0]
+            .get::<String>("lixcol_updated_at")
+            .expect("updated_at should be text");
+        let content_change_id = content_update.rows()[0]
+            .get::<String>("lixcol_change_id")
+            .expect("change_id should be text");
+        assert_eq!(content_created_at, initial_created_at);
+        assert_ne!(content_updated_at, initial_updated_at);
+        assert_ne!(content_change_id, initial_change_id);
+
+        let renamed_file_id = "74696d65-7374-816d-8073-000000000002";
+        session
+            .execute(
+                &format!(
+                    "INSERT INTO lix_file (id, path, data) \
+                     VALUES ('{renamed_file_id}', '/before-rename.txt', X'6F6E65')"
+                ),
+                &[],
+            )
+            .await
+            .expect("rename fixture insert should succeed");
+        let before_rename = session
+            .execute(
+                &format!(
+                    "SELECT lixcol_created_at, lixcol_updated_at \
+                     FROM lix_file WHERE id = '{renamed_file_id}'"
+                ),
+                &[],
+            )
+            .await
+            .expect("rename fixture should be readable");
+        let rename_created_at = before_rename.rows()[0]
+            .get::<String>("lixcol_created_at")
+            .expect("created_at should be text");
+        let rename_updated_at = before_rename.rows()[0]
+            .get::<String>("lixcol_updated_at")
+            .expect("updated_at should be text");
+
+        session
+            .execute(
+                &format!(
+                    "UPDATE lix_file SET path = '/renamed-timestamps.txt' \
+                     WHERE id = '{renamed_file_id}'"
+                ),
+                &[],
+            )
+            .await
+            .expect("rename should succeed");
+        let renamed = session
+            .execute(
+                &format!(
+                    "SELECT lixcol_created_at, lixcol_updated_at \
+                     FROM lix_file \
+                     WHERE path = '/renamed-timestamps.txt' AND id = '{renamed_file_id}'"
+                ),
+                &[],
+            )
+            .await
+            .expect("renamed file should be readable");
+        assert_eq!(
+            renamed.rows()[0]
+                .get::<String>("lixcol_created_at")
+                .expect("created_at should be text"),
+            rename_created_at,
+        );
+        assert_eq!(
+            renamed.rows()[0]
+                .get::<String>("lixcol_updated_at")
+                .expect("updated_at should be text"),
+            rename_updated_at,
+        );
+    }
+);
+
+simulation_test!(
     file_descriptor_changes_always_carry_their_file_id,
     |sim| async move {
         let engine = sim.boot_engine().await;


### PR DESCRIPTION
## What changed

- source `lixcol_updated_at` from the file's content ref (blob or derived ref), with descriptor fallback for files without content
- keep `lixcol_created_at` sourced from the descriptor identity
- preserve the descriptor's first-visible timestamp when a path update replaces the same identity in the transaction path-index overlay
- load content refs whenever `lixcol_updated_at` is projected or filtered
- route timestamp scans through the filesystem index so staged descriptor lifecycle data remains stable

## Root cause

`lix_file` is composed from multiple underlying entities. The public `lixcol_change_id` for a content write came from the blob ref, while `lixcol_updated_at` came from the unchanged descriptor. Renames also replaced the staged descriptor row with its current change timestamp, making creation time appear to reset before durable state materialization restored entity ancestry.

## Impact

Content writes now advance `lixcol_updated_at`, and renames retain `lixcol_created_at`. The implementation uses entity roles rather than ordering timestamp values, so it remains correct under tracked-state rebuilds that deliberately shuffle timestamps.

## Validation

- `cargo test -p lix_engine --features all-simulations lix_file_public_timestamps_cover_descriptor_and_content_revisions`
- `cargo fmt --check`
- `git diff --check`