### PR TITLE
bound lazy snapshot reads by transition page limit

### DIFF
--- a/packages/plugin-api/src/lib.rs
+++ b/packages/plugin-api/src/lib.rs
@@ -539,7 +539,12 @@ impl EntityChangeReader<'_> {
                 }
                 Some(snapshot)
             }
-            (Some(length), None) => Some(read_entity_snapshot(self.source, index, length)?),
+            (Some(length), None) => Some(read_entity_snapshot(
+                self.source,
+                index,
+                length,
+                self.max_page_bytes,
+            )?),
             (None, Some(_)) => {
                 return Err(Error::invalid_input(
                     "inline entity snapshot is missing its length metadata",
@@ -558,15 +563,21 @@ impl EntityChangeReader<'_> {
     }
 }
 
-fn read_entity_snapshot(source: &EntityChangeSource, ordinal: u32, length: u64) -> Result<Vec<u8>> {
+fn read_entity_snapshot(
+    source: &EntityChangeSource,
+    ordinal: u32,
+    length: u64,
+    max_page_bytes: u32,
+) -> Result<Vec<u8>> {
     const READ_BYTES: u32 = 1024 * 1024;
     let capacity = usize::try_from(length)
         .map_err(|_| Error::limit_exceeded("entity snapshot exceeds guest address space"))?;
     let mut output = Vec::with_capacity(capacity);
     while output.len() < capacity {
         let offset = output.len() as u64;
-        let chunk = u32::try_from((capacity - output.len()).min(READ_BYTES as usize))
-            .expect("bounded entity snapshot read fits u32");
+        let chunk =
+            u32::try_from((capacity - output.len()).min(READ_BYTES.min(max_page_bytes) as usize))
+                .expect("bounded entity snapshot read fits u32");
         let bytes = source
             .read_snapshot(ordinal, offset, chunk)
             .map_err(|error| host_error("host entity snapshot read failed", error))?

--- a/packages/rs-sdk-tests/tests/e2e.rs
+++ b/packages/rs-sdk-tests/tests/e2e.rs
@@ -14,7 +14,7 @@ use lix_sdk::{
     WasmByteSource, WasmColdFileUpdate, WasmCreateContext, WasmEntity, WasmEntityChange,
     WasmEntityKey, WasmEntityPage, WasmEntitySource, WasmFileDescriptor, WasmFileUpdate,
     WasmHostBytes, WasmHostEntity, WasmInputBytes, WasmInputSplice, WasmOpenEntitiesInput,
-    WasmPluginSelection, WasmTransitionLimits,
+    WasmPluginSelection, WasmSourceRange, WasmSourceSlice, WasmTransitionLimits,
 };
 use sha2::{Digest as _, Sha256};
 use std::collections::BTreeMap;
@@ -4674,8 +4674,18 @@ async fn v3_json_direct_cold_successor_preserves_durable_identity() {
             generation: "direct".to_owned(),
         },
     };
-    let before = br#"{"a":"one","b":"two"}"#.to_vec();
-    let after = br#"{"a":"ONE","b":"two"}"#.to_vec();
+    let large_value = "x".repeat(96 * 1024);
+    let before = format!(r#"{{"a":"one","b":"{large_value}"}}"#).into_bytes();
+    let after = format!(r#"{{"a":"ONE","b":"{large_value}"}}"#).into_bytes();
+    let oversized_snapshot = serde_json::to_vec(&serde_json::json!({
+        "parent_id": "root",
+        "key": "b",
+        "order_key": "80",
+        "kind": "string",
+        "scalar_json": serde_json::to_string(&large_value).unwrap(),
+    }))
+    .unwrap();
+    let oversized_snapshot_len = oversized_snapshot.len() as u64;
     let entities = vec![
         WasmEntity {
             key: WasmEntityKey::from_owned_parts("json_root", vec!["root".to_owned()]),
@@ -4697,9 +4707,13 @@ async fn v3_json_direct_cold_successor_preserves_durable_identity() {
                 "json_object_member",
                 vec!["root".to_owned(), "b".to_owned()],
             ),
-            snapshot_content: WasmHostBytes::Inline(Bytes::from_static(
-                br#"{"parent_id":"root","key":"b","order_key":"80","kind":"string","scalar_json":"\"two\""}"#,
-            )),
+            snapshot_content: WasmHostBytes::Source(WasmSourceSlice {
+                source: Arc::new(BenchmarkByteSource(oversized_snapshot)),
+                range: WasmSourceRange {
+                    offset: 0,
+                    length: oversized_snapshot_len,
+                },
+            }),
         },
     ];
     let original_keys = entities
@@ -4708,10 +4722,10 @@ async fn v3_json_direct_cold_successor_preserves_durable_identity() {
         .collect::<Vec<_>>();
 
     let limits = WasmTransitionLimits {
-        max_page_bytes: 64 * 1024,
-        max_record_bytes: 64 * 1024,
-        max_total_bytes: 64 * 1024,
-        max_inline_input_bytes: 64 * 1024,
+        max_page_bytes: 32 * 1024,
+        max_record_bytes: 32 * 1024,
+        max_total_bytes: 1024 * 1024,
+        max_inline_input_bytes: 32 * 1024,
         ..WasmTransitionLimits::default()
     };
     let mut actor = factory.instantiate_actor().await.unwrap();


### PR DESCRIPTION
## What changed

- cap plugin SDK lazy entity-snapshot reads by the transition-advertised `max_page_bytes`
- preserve the existing 1 MiB preferred chunk ceiling when the transition permits it
- extend the direct JSON cold-successor regression with a 96 KiB lazy durable snapshot under a 32 KiB page limit

## Why

Plugin API v4 correctly pages entity records at the advertised bound, but lazy snapshot attachments still requested fixed 1 MiB chunks. Hosts reject those imports with `LimitExceeded` whenever a transition uses a smaller page limit. The shared `EntityChangeReader` serves hydration, semantic changes, and cold successors, so bounding its attachment reads fixes all three paths.

This is the isolated follow-up to the exact-head review finding intentionally deferred while merging #995 to unblock retained replay work.

## Validation

- `cargo test -p lix_sdk_tests --test e2e v3_json_direct_cold_successor_preserves_durable_identity -- --exact --nocapture`
- `cargo clippy -p lix_plugin_api -p lix_sdk_tests --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`