### PR TITLE
Deduplicate certified history payloads

### DIFF
--- a/packages/engine/src/commit_graph/context.rs
+++ b/packages/engine/src/commit_graph/context.rs
@@ -1105,6 +1105,7 @@ mod tests {
                     metadata: change.metadata.as_ref_slot(),
                     origin_key: change.origin_key.as_deref(),
                     authored: true,
+                    certified: false,
                 })
                 .collect::<Vec<_>>();
             stage_commit_deltas(&mut writes, &deltas).expect("packed commit members should stage");

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -714,6 +714,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn predecessor_v25_commit_delta_payload_protocol_is_rejected() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let storage_adapter = StorageAdapter::new(storage.clone());
+        let mut writes = storage_adapter.new_write_set();
+        writes.put(
+            crate::init::REPOSITORY_PROTOCOL_SPACE,
+            crate::init::REPOSITORY_PROTOCOL_KEY,
+            &b"hot-inline-fingerprint.v25"[..],
+        );
+        storage_adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("V25 protocol marker should commit");
+
+        let Err(error) = Engine::new(storage).await else {
+            panic!("V25 repositories must fail closed before LXCD6 payloads are decoded");
+        };
+        assert_eq!(error.code, "LIX_ERROR_UNSUPPORTED_STORAGE_FORMAT");
+    }
+
+    #[tokio::test]
     async fn tracked_entity_fast_path_serves_broad_sql_rows() {
         let storage = Memory::new();
         Engine::initialize(storage.clone())
@@ -1204,6 +1228,83 @@ mod tests {
                 .map(|row| row.get::<String>("path").expect("row path"))
                 .collect::<Vec<_>>(),
             ["/after-checkpoint", "/checkpointed", "/workspace"]
+        );
+    }
+
+    #[tokio::test]
+    async fn checkpoint_reclaims_the_superseded_physical_working_diff_epoch() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let engine = Engine::new(storage.clone())
+            .await
+            .expect("initialized engine should open");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("workspace session should open");
+        register_json_pointer_schema(&session).await;
+        session
+            .execute(
+                "INSERT INTO json_pointer (path, value) \
+                 VALUES ('/dirty', lix_json('{\"value\":\"before-checkpoint\"}'))",
+                &[],
+            )
+            .await
+            .expect("tracked row should create a working diff");
+
+        let adapter = StorageAdapter::new(storage.clone());
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("working-diff inventory read should open");
+        let before = ScanPlan::prefix(
+            crate::live_state::HOT_DIFF_SPACE,
+            StoragePrefix {
+                bytes: Bytes::new(),
+            },
+        )
+        .collect(&read, StorageScanOptions::default())
+        .await
+        .expect("working-diff inventory should scan");
+        assert!(
+            !before.value.entries.is_empty(),
+            "tracked mutation must persist a physical dirty-key epoch"
+        );
+        drop(read);
+
+        session
+            .create_checkpoint()
+            .await
+            .expect("checkpoint should publish a clean working state");
+
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("post-checkpoint inventory read should open");
+        let after = ScanPlan::prefix(
+            crate::live_state::HOT_DIFF_SPACE,
+            StoragePrefix {
+                bytes: Bytes::new(),
+            },
+        )
+        .collect(&read, StorageScanOptions::default())
+        .await
+        .expect("post-checkpoint working-diff inventory should scan");
+        assert!(
+            after.value.entries.is_empty(),
+            "the superseded epoch must not remain until repository GC"
+        );
+        let logical = session
+            .execute("SELECT COUNT(*) AS entries FROM lix_working_diff", &[])
+            .await
+            .expect("post-checkpoint logical diff should execute");
+        assert_eq!(
+            logical.rows()[0]
+                .get::<i64>("entries")
+                .expect("working-diff count should be numeric"),
+            0
         );
     }
 

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -567,6 +567,52 @@ where
         pending.extend(commits.parent_commit_ids(commit).iter().copied());
     }
 
+    // A selected cascade tombstone intentionally carries no payload and
+    // cannot be promoted into canonical change authority. If it is the only
+    // surviving reference to a change, retain the authored owner's commit
+    // ancestry as an authority root. Ordinary selected rows carry matching
+    // identity and are promoted below, so they do not retain dead history.
+    let referenced_change_ids = live_commits
+        .iter()
+        .filter_map(|commit_id| packed.commits.get(commit_id))
+        .flat_map(|entry| entry.members.iter().map(|member| member.value.change_id))
+        .collect::<BTreeSet<_>>();
+    let promotable_change_ids = live_commits
+        .iter()
+        .filter_map(|commit_id| packed.commits.get(commit_id))
+        .flat_map(|entry| entry.members.iter())
+        .filter(|member| member.authored || member.is_selected_payload_ref())
+        .map(|member| member.value.change_id)
+        .collect::<BTreeSet<_>>();
+    let mut authority_roots = packed
+        .commits
+        .iter()
+        .filter(|(commit_id, _)| !live_commits.contains(commit_id))
+        .filter_map(|(commit_id, entry)| {
+            entry
+                .members
+                .iter()
+                .any(|member| {
+                    member.authored
+                        && referenced_change_ids.contains(&member.value.change_id)
+                        && !promotable_change_ids.contains(&member.value.change_id)
+                })
+                .then_some(*commit_id)
+        })
+        .collect::<Vec<_>>();
+    while let Some(commit_id) = authority_roots.pop() {
+        if !live_commits.insert(commit_id) {
+            continue;
+        }
+        let commit = commits.get(commit_id).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("canonical authority references missing commit '{commit_id}'"),
+            )
+        })?;
+        authority_roots.extend(commits.parent_commit_ids(commit).iter().copied());
+    }
+
     let standalone_root_ids = roots
         .iter()
         .filter_map(|root| match root {
@@ -651,6 +697,50 @@ where
         writes,
         dead_packed_change_ids.difference(&live_change_ids).copied(),
     );
+    // Selected commit rows persist only a canonical-reference tag. When GC
+    // removes the original authored owner, promote a surviving full selected
+    // row in-place before relocating the locator. This keeps immutable
+    // history self-contained without retaining an otherwise dead commit.
+    let mut promoted_locators = Vec::new();
+    for commit_id in &live_commits {
+        let Some(entry) = packed.commits.get(commit_id) else {
+            continue;
+        };
+        if !entry.members.iter().any(|member| {
+            dead_packed_change_ids.contains(&member.value.change_id)
+                && member.is_selected_payload_ref()
+        }) {
+            continue;
+        }
+        let deltas = entry
+            .members
+            .iter()
+            .map(|member| crate::tracked_state::TrackedStateCommitDeltaRef {
+                delta: crate::tracked_state::TrackedStateDeltaRef {
+                    schema_key: &member.key.schema_key,
+                    file_id: member.key.file_id.as_deref(),
+                    entity_pk: &member.key.entity_pk,
+                    change_id: member.value.change_id,
+                    commit_id: *commit_id,
+                    deleted: member.value.deleted,
+                    created_at: member.value.created_at,
+                    updated_at: member.value.updated_at,
+                },
+                snapshot: member.change.snapshot.as_ref_slot(),
+                metadata: member.change.metadata.as_ref_slot(),
+                origin_key: member.change.origin_key.as_deref(),
+                authored: member.authored
+                    || (dead_packed_change_ids.contains(&member.value.change_id)
+                        && member.is_selected_payload_ref()),
+                certified: member.is_certified_payload_ref(),
+            })
+            .collect::<Vec<_>>();
+        promoted_locators.extend(
+            crate::tracked_state::stage_commit_deltas(writes, &deltas)?
+                .into_iter()
+                .filter(|locator| dead_packed_change_ids.contains(&locator.change_id)),
+        );
+    }
     let relocated_locators = live_commits
         .iter()
         .filter_map(|commit_id| {
@@ -664,7 +754,9 @@ where
             entry.members.iter().filter_map(move |member| {
                 dead_packed_change_ids
                     .contains(&member.value.change_id)
-                    .then_some(crate::tracked_state::CommitDeltaChangeLocator {
+                    .then_some(member)
+                    .filter(|member| member.authored)
+                    .map(|member| crate::tracked_state::CommitDeltaChangeLocator {
                         change_id: member.value.change_id,
                         commit_id,
                         segment_index: member.segment_index,
@@ -673,6 +765,15 @@ where
                     })
             })
         })
+        .fold(BTreeMap::new(), |mut locators, locator| {
+            locators.entry(locator.change_id).or_insert(locator);
+            locators
+        })
+        .into_values()
+        .collect::<Vec<_>>();
+    let relocated_locators = promoted_locators
+        .into_iter()
+        .chain(relocated_locators)
         .fold(BTreeMap::new(), |mut locators, locator| {
             locators.entry(locator.change_id).or_insert(locator);
             locators
@@ -1595,6 +1696,7 @@ mod tests {
                 metadata: change.metadata.as_ref_slot(),
                 origin_key: change.origin_key.as_deref(),
                 authored: true,
+                certified: false,
             })
             .collect()
     }

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -735,11 +735,11 @@ where
                 certified: member.is_certified_payload_ref(),
             })
             .collect::<Vec<_>>();
-        promoted_locators.extend(
-            crate::tracked_state::stage_commit_deltas(writes, &deltas)?
-                .into_iter()
-                .filter(|locator| dead_packed_change_ids.contains(&locator.change_id)),
-        );
+        promoted_locators.extend(authoritative_promoted_locators(
+            &deltas,
+            crate::tracked_state::stage_commit_deltas(writes, &deltas)?,
+            &dead_packed_change_ids,
+        )?);
     }
     let relocated_locators = live_commits
         .iter()
@@ -826,6 +826,37 @@ where
         },
         repair: GcRepairSet::default(),
     })
+}
+
+fn authoritative_promoted_locators(
+    deltas: &[crate::tracked_state::TrackedStateCommitDeltaRef<'_>],
+    staged_locators: Vec<crate::tracked_state::CommitDeltaChangeLocator>,
+    dead_change_ids: &BTreeSet<ChangeId>,
+) -> Result<Vec<crate::tracked_state::CommitDeltaChangeLocator>, LixError> {
+    if staged_locators.len() != deltas.len() {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "promoted commit-delta locator count does not match its members",
+        ));
+    }
+    // The caller supplies decoded members and staged locators in the same
+    // physical-key order. Only rows that are authoritative after promotion
+    // may become canonical locator targets; selected cascade tombstones
+    // intentionally remain payload-free even when another row causes this
+    // commit to be packed again.
+    let mut promoted = Vec::new();
+    for (delta, locator) in deltas.iter().zip(staged_locators) {
+        if delta.delta.change_id != locator.change_id {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "promoted commit-delta locator order does not match its members",
+            ));
+        }
+        if delta.authored && dead_change_ids.contains(&locator.change_id) {
+            promoted.push(locator);
+        }
+    }
+    Ok(promoted)
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -960,6 +991,7 @@ fn elapsed_micros(started: Instant) -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
     use std::sync::Arc;
 
     use crate::branch::{BranchHeadControlContext, stage_branch_head_control};
@@ -1499,6 +1531,41 @@ mod tests {
         );
     }
 
+    #[test]
+    fn promoted_locator_filter_excludes_selected_tombstones() {
+        let commit_id = CommitId::for_test_label("mixed-promotion-commit");
+        let change_id = ChangeId::for_test_label("shared-promotion-change");
+        let mut tombstone =
+            packed_change("selected-tombstone", "a-selected-tombstone", JsonSlot::None);
+        tombstone.change_id = change_id;
+        let mut promoted = packed_change("promoted-owner", "z-promoted-owner", JsonSlot::None);
+        promoted.change_id = change_id;
+        let changes = [tombstone, promoted];
+        let mut deltas = commit_delta_refs(commit_id, &changes);
+        deltas[0].authored = false;
+        let locators = vec![
+            crate::tracked_state::CommitDeltaChangeLocator {
+                change_id,
+                commit_id,
+                segment_index: 0,
+                ordinal: 0,
+            },
+            crate::tracked_state::CommitDeltaChangeLocator {
+                change_id,
+                commit_id,
+                segment_index: 0,
+                ordinal: 1,
+            },
+        ];
+
+        let filtered =
+            super::authoritative_promoted_locators(&deltas, locators, &BTreeSet::from([change_id]))
+                .expect("mixed promotion locators should filter");
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].ordinal, 1);
+    }
+
     #[tokio::test]
     async fn repository_gc_reclaims_candidate_after_last_live_untracked_owner_disappears() {
         let storage = Memory::new();
@@ -1584,7 +1651,7 @@ mod tests {
                     snapshot: snapshot_slot.as_ref_slot(),
                     metadata: crate::json_store::JsonSlotRef::None,
                 }],
-                &std::collections::BTreeSet::new(),
+                &BTreeSet::new(),
                 None,
                 None,
                 None,

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -738,7 +738,6 @@ where
         promoted_locators.extend(authoritative_promoted_locators(
             &deltas,
             crate::tracked_state::stage_commit_deltas(writes, &deltas)?,
-            &dead_packed_change_ids,
         )?);
     }
     let relocated_locators = live_commits
@@ -831,7 +830,6 @@ where
 fn authoritative_promoted_locators(
     deltas: &[crate::tracked_state::TrackedStateCommitDeltaRef<'_>],
     staged_locators: Vec<crate::tracked_state::CommitDeltaChangeLocator>,
-    dead_change_ids: &BTreeSet<ChangeId>,
 ) -> Result<Vec<crate::tracked_state::CommitDeltaChangeLocator>, LixError> {
     if staged_locators.len() != deltas.len() {
         return Err(LixError::new(
@@ -852,7 +850,7 @@ fn authoritative_promoted_locators(
                 "promoted commit-delta locator order does not match its members",
             ));
         }
-        if delta.authored && dead_change_ids.contains(&locator.change_id) {
+        if delta.authored {
             promoted.push(locator);
         }
     }
@@ -1540,7 +1538,14 @@ mod tests {
         tombstone.change_id = change_id;
         let mut promoted = packed_change("promoted-owner", "z-promoted-owner", JsonSlot::None);
         promoted.change_id = change_id;
-        let changes = [tombstone, promoted];
+        let unrelated_change_id = ChangeId::for_test_label("unrelated-authored-change");
+        let mut unrelated = packed_change(
+            "unrelated-authority",
+            "zz-unrelated-authority",
+            JsonSlot::None,
+        );
+        unrelated.change_id = unrelated_change_id;
+        let changes = [tombstone, promoted, unrelated];
         let mut deltas = commit_delta_refs(commit_id, &changes);
         deltas[0].authored = false;
         let locators = vec![
@@ -1556,14 +1561,25 @@ mod tests {
                 segment_index: 0,
                 ordinal: 1,
             },
+            crate::tracked_state::CommitDeltaChangeLocator {
+                change_id: unrelated_change_id,
+                commit_id,
+                segment_index: 1,
+                ordinal: 0,
+            },
         ];
 
-        let filtered =
-            super::authoritative_promoted_locators(&deltas, locators, &BTreeSet::from([change_id]))
-                .expect("mixed promotion locators should filter");
+        let filtered = super::authoritative_promoted_locators(&deltas, locators)
+            .expect("mixed promotion locators should filter");
 
-        assert_eq!(filtered.len(), 1);
-        assert_eq!(filtered[0].ordinal, 1);
+        assert_eq!(filtered.len(), 2);
+        assert_eq!(
+            filtered
+                .iter()
+                .map(|locator| locator.change_id)
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([change_id, unrelated_change_id]),
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -39,13 +39,13 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 
 /// Repository-wide compatibility gate for physical storage protocols.
 ///
-/// V25 persists content fingerprints beside inline HOT JSON. Opening an older
-/// store must fail closed before its differently framed current-state rows are
-/// decoded as the current layout.
+/// V26 replaces duplicated selected commit-delta payloads with canonical
+/// references. Opening an older store must fail closed before its differently
+/// framed payload sidecars are decoded as the current layout.
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"hot-inline-fingerprint.v25";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"selected-payload-reference.v26";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately
@@ -359,6 +359,7 @@ where
                 metadata: change.metadata.as_ref_slot(),
                 origin_key: change.origin_key.as_deref(),
                 authored: true,
+                certified: false,
             })
             .collect::<Vec<_>>();
         let locators = crate::tracked_state::stage_commit_deltas(&mut writes, &commit_deltas)?;

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -2342,6 +2342,7 @@ mod tests {
                     metadata: change.metadata.as_ref_slot(),
                     origin_key: change.origin_key.as_deref(),
                     authored: true,
+                    certified: false,
                 })
                 .collect::<Vec<_>>();
             stage_commit_deltas(writes, &commit_deltas)?;

--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -20,7 +20,8 @@ pub(crate) use tracked_head::{
     HOT_FILE_SPACE, HOT_ROW_SPACE, HotTrackedSnapshot, TRACKED_WORKING_DIFF_MARKER_SPACE,
     TrackedHeadContext, TrackedWorkingDiff, TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage,
     scan_certified_history_rows, stage_certified_entity_batches,
-    stage_collect_stale_working_diff_indexes, stage_tracked_working_diff_epoch,
+    stage_collect_stale_working_diff_indexes, stage_delete_tracked_working_diff_epoch,
+    stage_tracked_working_diff_epoch,
 };
 #[allow(unused_imports)]
 pub(crate) use types::{

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -711,6 +711,20 @@ where
     hot::stage_collect_stale_hot_diff_records(store, writes, &active).await
 }
 
+pub(crate) async fn stage_delete_tracked_working_diff_epoch<S>(
+    store: &S,
+    writes: &mut StorageWriteSet,
+    branch_id: &str,
+    checkpoint_commit_id: CommitId,
+    generation: CommitId,
+) -> Result<(), LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    hot::stage_delete_hot_diff_scope(store, writes, branch_id, checkpoint_commit_id, generation)
+        .await
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct ActiveWorkingDiffScope {
     checkpoint_commit_id: CommitId,

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -1079,50 +1079,70 @@ pub(crate) async fn scan_certified_history_rows(
         .any(|column| column == "snapshot_content");
     let mut builder = MaterializedLiveStateBatchBuilder::with_capacity(commit_ids.len() * 1024);
     for commit_id in commit_ids {
-        let page = ScanPlan::prefix(
+        let plan = ScanPlan::prefix(
             CERTIFIED_ENTITY_BATCH_SPACE,
             StoragePrefix {
                 bytes: Bytes::copy_from_slice(commit_id.as_uuid().as_bytes()),
             },
-        )
-        .collect(store, StorageScanOptions::default())
-        .await?;
-        for entry in page.value.entries {
-            let value = full_value_bytes(entry.value)?;
-            if certified_batch_commit_id(&value)? != *commit_id {
-                continue;
-            }
-            let external_plan =
-                certified_external_page_plan(&value, entry.key.0.as_ref(), request)?;
-            let external_pages = if let Some(plan) = &external_plan {
-                let keys = plan.iter().map(|(_, key)| key.clone()).collect::<Vec<_>>();
-                let values = PointReadPlan::new(CERTIFIED_ENTITY_BATCH_PAGE_SPACE, &keys)
-                    .materialize(store, StorageGetOptions::default())
-                    .await?
-                    .value;
-                Some(
-                    plan.iter()
-                        .zip(values)
-                        .map(|((page_index, _), value)| {
-                            let value = value.ok_or_else(|| {
-                                head_value_error("certified history batch page is missing")
-                            })?;
-                            Ok((*page_index, full_value_bytes(value)?))
-                        })
-                        .collect::<Result<Vec<_>, LixError>>()?,
+        );
+        let mut resume_after = None;
+        loop {
+            let page = plan
+                .collect(
+                    store,
+                    StorageScanOptions {
+                        resume_after,
+                        ..StorageScanOptions::default()
+                    },
                 )
-            } else {
-                None
-            };
-            decode_certified_entity_batch_rows(
-                &value,
-                external_pages.as_deref(),
-                "",
-                request,
-                needs_snapshot,
-                None,
-                &mut builder,
-            )?;
+                .await?;
+            let has_more = page.value.has_more;
+            resume_after = page.value.entries.last().map(|entry| entry.key.clone());
+            for entry in page.value.entries {
+                let value = full_value_bytes(entry.value)?;
+                if certified_batch_commit_id(&value)? != *commit_id {
+                    continue;
+                }
+                let external_plan =
+                    certified_external_page_plan(&value, entry.key.0.as_ref(), request)?;
+                let external_pages = if let Some(plan) = &external_plan {
+                    let keys = plan.iter().map(|(_, key)| key.clone()).collect::<Vec<_>>();
+                    let values = PointReadPlan::new(CERTIFIED_ENTITY_BATCH_PAGE_SPACE, &keys)
+                        .materialize(store, StorageGetOptions::default())
+                        .await?
+                        .value;
+                    Some(
+                        plan.iter()
+                            .zip(values)
+                            .map(|((page_index, _), value)| {
+                                let value = value.ok_or_else(|| {
+                                    head_value_error("certified history batch page is missing")
+                                })?;
+                                Ok((*page_index, full_value_bytes(value)?))
+                            })
+                            .collect::<Result<Vec<_>, LixError>>()?,
+                    )
+                } else {
+                    None
+                };
+                decode_certified_entity_batch_rows(
+                    &value,
+                    external_pages.as_deref(),
+                    "",
+                    request,
+                    needs_snapshot,
+                    None,
+                    &mut builder,
+                )?;
+            }
+            if !has_more {
+                break;
+            }
+            if resume_after.is_none() {
+                return Err(head_value_error(
+                    "certified history scan reported more rows without a resume key",
+                ));
+            }
         }
     }
     Ok(builder.finish().into_rows())
@@ -6844,6 +6864,69 @@ mod tests {
         .expect("unrelated malformed batch must not affect the requested commit");
 
         assert!(rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn certified_history_scan_paginates_past_1024_batches() {
+        fn empty_batch(commit_id: CommitId, file_id: &str) -> Vec<u8> {
+            let mut value = CERTIFIED_ENTITY_BATCH_MAGIC_V2.to_vec();
+            value.extend_from_slice(&1_u16.to_le_bytes());
+            append_batch_text(&mut value, "test_schema").unwrap();
+            append_batch_text(&mut value, file_id).unwrap();
+            value.extend_from_slice(commit_id.as_uuid().as_bytes());
+            append_batch_text(&mut value, "2026-01-01T00:00:00Z").unwrap();
+            value.extend_from_slice(&crate::wasm::HOST_CERTIFIED_PACKET_FORMAT.to_le_bytes());
+            value.extend_from_slice(&0_u64.to_le_bytes());
+            value.extend_from_slice(&0_u64.to_le_bytes());
+            value.extend_from_slice(&0_u32.to_le_bytes());
+            value.extend_from_slice(&0_u32.to_le_bytes());
+            value
+        }
+
+        let storage = StorageAdapter::new(Memory::new());
+        let commit_id = CommitId::for_test_label("paginated-certified-history");
+        let mut writes = storage.new_write_set();
+        for index in 0..crate::storage_adapter::MAX_SCAN_PAGE_ROWS {
+            let file_id = format!("file-{index:04}");
+            let mut key = commit_id.as_uuid().as_bytes().to_vec();
+            append_batch_text(&mut key, &file_id).unwrap();
+            writes.put(
+                CERTIFIED_ENTITY_BATCH_SPACE,
+                StorageKey(Bytes::from(key)),
+                StorageValue {
+                    bytes: Bytes::from(empty_batch(commit_id, &file_id)),
+                },
+            );
+        }
+        let mut malformed_key = commit_id.as_uuid().as_bytes().to_vec();
+        append_batch_text(&mut malformed_key, "zzzz-after-first-page").unwrap();
+        writes.put(
+            CERTIFIED_ENTITY_BATCH_SPACE,
+            StorageKey(Bytes::from(malformed_key)),
+            StorageValue {
+                bytes: Bytes::from_static(b"malformed"),
+            },
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("paginated certified fixture should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("certified history read should open");
+        assert!(
+            scan_certified_history_rows(
+                &read,
+                &BTreeSet::from([commit_id]),
+                &TrackedStateScanRequest::default(),
+            )
+            .await
+            .expect_err("the malformed batch after row 1024 must be visited")
+            .to_string()
+            .contains("certified"),
+        );
     }
 
     #[test]

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -1065,7 +1065,7 @@ async fn scan_certified_entity_batch_rows(
 }
 
 pub(crate) async fn scan_certified_history_rows(
-    store: &impl StorageAdapterRead,
+    store: &(impl StorageAdapterRead + ?Sized),
     commit_ids: &BTreeSet<CommitId>,
     request: &TrackedStateScanRequest,
 ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
@@ -6709,6 +6709,54 @@ where
                 writes.delete(HOT_DIFF_SPACE, entry.key);
             }
         }
+        if !page.value.has_more || resume_after.is_none() {
+            break;
+        }
+    }
+    Ok(())
+}
+
+/// Reclaims one superseded working-diff epoch without scanning any other
+/// branch or checkpoint. A checkpoint already performs work linear in its
+/// selected dirty set; this prefix-local scan keeps reclamation on the same
+/// bound while preventing unreachable epochs from accumulating until GC.
+pub(super) async fn stage_delete_hot_diff_scope<S>(
+    store: &S,
+    writes: &mut StorageWriteSet,
+    branch_id: &str,
+    checkpoint_commit_id: CommitId,
+    generation: CommitId,
+) -> Result<(), LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    let plan = ScanPlan::prefix(
+        HOT_DIFF_SPACE,
+        StoragePrefix {
+            bytes: Bytes::from(encode_working_diff_scope_prefix(
+                branch_id,
+                checkpoint_commit_id,
+                generation,
+            )),
+        },
+    );
+    let mut resume_after = None;
+    loop {
+        let page = plan
+            .collect(
+                store,
+                StorageScanOptions {
+                    projection: StorageCoreProjection::KeyOnly,
+                    resume_after: resume_after.clone(),
+                    ..StorageScanOptions::default()
+                },
+            )
+            .await?;
+        resume_after = page.value.entries.last().map(|entry| entry.key.clone());
+        writes.delete_batch(
+            HOT_DIFF_SPACE,
+            page.value.entries.into_iter().map(|entry| entry.key),
+        );
         if !page.value.has_more || resume_after.is_none() {
             break;
         }

--- a/packages/engine/src/test_support.rs
+++ b/packages/engine/src/test_support.rs
@@ -258,6 +258,7 @@ pub(crate) async fn stage_tracked_root_from_materialized(
                 metadata: change.metadata.as_ref_slot(),
                 origin_key: change.origin_key.as_deref(),
                 authored: true,
+                certified: false,
             }
         })
         .collect::<Vec<_>>();
@@ -336,6 +337,7 @@ pub(crate) async fn stage_rootless_tracked_commit_from_materialized(
                 metadata: change.metadata.as_ref_slot(),
                 origin_key: change.origin_key.as_deref(),
                 authored: true,
+                certified: false,
             }
         })
         .collect::<Vec<_>>();
@@ -410,6 +412,7 @@ pub(crate) async fn stage_tracked_root_from_materialized_with_parents(
                 metadata: change.metadata.as_ref_slot(),
                 origin_key: change.origin_key.as_deref(),
                 authored: true,
+                certified: false,
             }
         })
         .collect::<Vec<_>>();

--- a/packages/engine/src/tracked_state/bench_support.rs
+++ b/packages/engine/src/tracked_state/bench_support.rs
@@ -392,6 +392,7 @@ impl PackedHistoryDelta {
             metadata: JsonSlotRef::None,
             origin_key: None,
             authored: true,
+            certified: false,
         }
     }
 }

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -7030,6 +7030,19 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("certified locator read should open");
+        let inventory = crate::tracked_state::scan_commit_delta_inventory(&read)
+            .await
+            .expect("certified inventory should hydrate");
+        let inventory_member = inventory
+            .commits
+            .get(&commit_id)
+            .and_then(|entry| entry.members.first())
+            .expect("certified inventory member should exist");
+        assert!(inventory_member.change.snapshot.is_some());
+        assert!(
+            inventory_member.is_certified_payload_ref(),
+            "hydration must preserve certified wire provenance for GC re-encoding",
+        );
         let canonical = crate::tracked_state::load_change_record_by_id(&read, durable_change_id)
             .await
             .expect("certified locator should hydrate")

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -6971,6 +6971,72 @@ mod tests {
             file_id: Some(FILE_ID.to_owned()),
             entity_pk: EntityPk::uuid_from_bytes(id),
         };
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("certified authority read should open");
+        let certified = crate::live_state::scan_certified_history_rows(
+            &read,
+            &BTreeSet::from([commit_id]),
+            &TrackedStateScanRequest {
+                filter: crate::tracked_state::TrackedStateFilter {
+                    schema_keys: vec![SCHEMA_KEY.to_owned()],
+                    entity_pks: vec![key.entity_pk.clone()],
+                    file_ids: vec![crate::NullableKeyFilter::Value(FILE_ID.to_owned())],
+                    include_tombstones: true,
+                },
+                read_columns: crate::tracked_state::TrackedStateReadColumns {
+                    columns: vec!["snapshot_content".to_owned(), "metadata".to_owned()],
+                },
+                limit: None,
+            },
+        )
+        .await
+        .expect("certified authority should scan");
+        let certified_change_id = certified[0]
+            .change_id
+            .expect("certified row should carry a change id");
+        let durable_change_id = ChangeId::for_test_label("certified-reference-durable-change-id");
+        assert_ne!(durable_change_id, certified_change_id);
+        let mut writes = storage.new_write_set();
+        let locators = crate::tracked_state::stage_commit_deltas(
+            &mut writes,
+            &[crate::tracked_state::TrackedStateCommitDeltaRef {
+                delta: TrackedStateDeltaRef {
+                    schema_key: SCHEMA_KEY,
+                    file_id: Some(FILE_ID),
+                    entity_pk: &key.entity_pk,
+                    change_id: durable_change_id,
+                    commit_id,
+                    deleted: false,
+                    created_at: control.created_at,
+                    updated_at: control.created_at,
+                },
+                snapshot: crate::json_store::JsonSlotRef::None,
+                metadata: crate::json_store::JsonSlotRef::None,
+                origin_key: Some("certified-origin"),
+                authored: true,
+                certified: true,
+            }],
+        )
+        .expect("certified commit delta should stage");
+        crate::tracked_state::stage_change_locators(&mut writes, &locators);
+        drop(read);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("certified commit delta should commit");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("certified locator read should open");
+        let canonical = crate::tracked_state::load_change_record_by_id(&read, durable_change_id)
+            .await
+            .expect("certified locator should hydrate")
+            .expect("certified locator should exist");
+        assert!(canonical.snapshot.is_some());
+        assert_eq!(canonical.origin_key.as_deref(), Some("certified-origin"));
+        drop(read);
         let exact = tracked_state
             .reader(
                 storage

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -4454,6 +4454,91 @@ mod tests {
             changes[0].snapshot,
             crate::json_store::JsonSlot::Inline(shared_snapshot.into())
         );
+        assert_selected_direct_address_hydrates_inventory_gc_and_root_rebuild_paths().await;
+    }
+
+    async fn assert_selected_direct_address_hydrates_inventory_gc_and_root_rebuild_paths() {
+        let storage = StorageAdapter::new(Memory::new());
+        let mut fixture = packed_commit_delta_fixtures()
+            .into_iter()
+            .find(|fixture| !fixture.deleted)
+            .expect("fixture should exist");
+        let owner_commit = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x0192_0000_0000_7000_8000_4321_0000_0000,
+        ));
+        let selected_commit = CommitId::for_test_label("selected-direct-address");
+        let snapshot = r#"{"direct":true}"#;
+        let owner = commit_delta_ref(
+            owner_commit,
+            &fixture,
+            crate::json_store::JsonSlotRef::Inline(snapshot),
+            crate::json_store::JsonSlotRef::None,
+            None,
+        );
+        let mut writes = storage.new_write_set();
+        let staged = super::stage_addressable_commit_deltas(&mut writes, &[owner], &[true])
+            .expect("direct owner should stage");
+        assert!(staged.locators.is_empty());
+        fixture.change_id = staged.assigned_change_ids[0];
+
+        let mut selected = commit_delta_ref(
+            selected_commit,
+            &fixture,
+            crate::json_store::JsonSlotRef::None,
+            crate::json_store::JsonSlotRef::None,
+            None,
+        );
+        selected.authored = false;
+        let selected_locators =
+            stage_commit_deltas(&mut writes, &[selected]).expect("selected row should stage");
+        assert_eq!(selected_locators.len(), 1);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("direct owner and selected reference should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("selected direct-address read should open");
+        assert!(
+            super::load_change_locator_by_id(&read, fixture.change_id)
+                .await
+                .expect("locator absence should read")
+                .is_none(),
+            "ordinary direct-addressed owners intentionally persist no locator row"
+        );
+        let owner = load_change_record_by_id(&read, fixture.change_id)
+            .await
+            .expect("direct owner read should succeed")
+            .expect("direct owner should exist");
+        assert_eq!(
+            owner.snapshot,
+            crate::json_store::JsonSlot::Inline(snapshot.into())
+        );
+        let selected_members = load_commit_delta_members_with_payloads(&read, selected_commit)
+            .await
+            .expect("root rebuild should hydrate the selected direct-address payload");
+        assert_eq!(selected_members.len(), 1);
+        assert_eq!(
+            selected_members[0].change.snapshot,
+            crate::json_store::JsonSlot::Inline(snapshot.into())
+        );
+        let inventory = scan_commit_delta_inventory(&read)
+            .await
+            .expect("GC inventory should hydrate the selected direct-address payload");
+        assert_eq!(inventory.commits.len(), 2);
+        assert_eq!(
+            inventory.commits[&selected_commit].members[0]
+                .change
+                .snapshot,
+            crate::json_store::JsonSlot::Inline(snapshot.into())
+        );
+        let changes = scan_change_records_from_commit_deltas(&read)
+            .await
+            .expect("canonical history should deduplicate selected direct authority");
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].change_id, fixture.change_id);
     }
 
     fn decoded_commit_delta_rows(

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -1844,7 +1844,6 @@ async fn hydrate_certified_members(
         };
         members[index].change.snapshot = snapshot;
         members[index].change.metadata = metadata;
-        members[index].certified_ref = false;
     }
     Ok(())
 }

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -28,6 +28,7 @@ use crate::tracked_state::types::{
 };
 use crate::{LixError, storage_codec};
 use bytes::Bytes;
+use futures_util::{StreamExt, TryStreamExt, stream};
 
 pub(crate) const TRACKED_STATE_TREE_CHUNK_NAMESPACE: &str = "tracked_state.tree_chunk";
 pub(crate) const TRACKED_STATE_COMMIT_ROOT_NAMESPACE: &str = "tracked_state.commit_root";
@@ -1107,6 +1108,32 @@ async fn load_change_records_by_ids(
 ) -> Result<Vec<crate::changelog::ChangeRecord>, LixError> {
     if change_ids.is_empty() {
         return Ok(Vec::new());
+    }
+    // Fresh changes use their commit-delta coordinates as their IDs and
+    // intentionally have no locator rows. Keep the legacy locator batch below
+    // for wholly explicit IDs; mixed/direct batches must validate the direct
+    // candidate and retain the existing explicit-locator fallback.
+    if change_ids
+        .iter()
+        .copied()
+        .any(|change_id| direct_change_locator(change_id).is_some())
+    {
+        return stream::iter(change_ids.iter().copied())
+            .map(|change_id| async move {
+                load_change_record_by_id(store, change_id)
+                    .await?
+                    .ok_or_else(|| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            format!(
+                                "tracked_state selected change '{change_id}' has no authoritative locator"
+                            ),
+                        )
+                    })
+            })
+            .buffered(64)
+            .try_collect()
+            .await;
     }
     let locator_keys = change_ids
         .iter()
@@ -3926,6 +3953,11 @@ mod tests {
         assert_eq!(loaded.change_id, change_id);
         assert_eq!(loaded.schema_key, fixtures[source_index].schema_key);
         assert_eq!(loaded.entity_pk, fixtures[source_index].entity_pk);
+        let batch = super::load_change_records_by_ids(&read, &[change_id])
+            .await
+            .expect("direct address batch should read");
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0], loaded);
     }
 
     #[tokio::test]
@@ -3978,6 +4010,10 @@ mod tests {
         assert_eq!(loaded.schema_key, explicit.schema_key);
         assert_eq!(loaded.entity_pk, explicit.entity_pk);
         assert_ne!(loaded.entity_pk, address_target.entity_pk);
+        let batch = super::load_change_records_by_ids(&read, &[explicit_change_id])
+            .await
+            .expect("explicit collision batch should fall back to its locator");
+        assert_eq!(batch, vec![loaded]);
         let canonical = super::load_canonical_change_locator(&read, explicit_change_id)
             .await
             .expect("canonical locator read should succeed")

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -1404,11 +1404,13 @@ async fn try_load_change_record_at_locator_in_manifest(
     };
     let mut loaded = vec![Some(decode_change_at_locator(&segment, bounds, locator)?)];
     hydrate_certified_loaded_entries(store, &mut loaded).await?;
-    Ok(loaded
-        .pop()
-        .flatten()
-        .expect("one decoded change locator must remain")
-        .change_record)
+    Ok(Some(
+        loaded
+            .pop()
+            .flatten()
+            .expect("one decoded change locator must remain")
+            .change_record,
+    ))
 }
 
 fn decode_change_locator(

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -32,9 +32,9 @@ use bytes::Bytes;
 pub(crate) const TRACKED_STATE_TREE_CHUNK_NAMESPACE: &str = "tracked_state.tree_chunk";
 pub(crate) const TRACKED_STATE_COMMIT_ROOT_NAMESPACE: &str = "tracked_state.commit_root";
 pub(crate) const TRACKED_STATE_COMMIT_DELTA_MANIFEST_NAMESPACE: &str =
-    "tracked_state.commit_delta_manifest.v2";
+    "tracked_state.commit_delta_manifest.v3";
 pub(crate) const TRACKED_STATE_COMMIT_DELTA_SEGMENT_NAMESPACE: &str =
-    "tracked_state.commit_delta_segment.v2";
+    "tracked_state.commit_delta_segment.v3";
 pub(crate) const TRACKED_STATE_CHANGE_LOCATOR_NAMESPACE: &str = "tracked_state.change_locator.v1";
 pub(crate) const TRACKED_STATE_TREE_CHUNK_SPACE: StorageSpace = StorageSpace::new(
     StorageSpaceId(0x0004_0001),
@@ -68,7 +68,7 @@ pub(crate) const TRACKED_STATE_CHANGE_LOCATOR_SPACE: StorageSpace = StorageSpace
 
 const COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 128;
 const COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 28 * 1024;
-const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD6";
+const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD7";
 const COMMIT_DELTA_PAYLOAD_OFFSET_BYTES: usize = size_of::<u32>();
 #[cfg(not(test))]
 const COMMIT_DELTA_MAX_SIDECAR_BYTES: usize = 64 * 1024 * 1024;
@@ -104,18 +104,66 @@ struct CommitDeltaPayloadRef<'a> {
     #[musli(with = storage_codec::option)]
     origin_key: Option<&'a str>,
     authored: bool,
+    certified: bool,
+}
+
+#[derive(Clone, Copy, musli::Encode)]
+#[musli(packed)]
+struct CommitDeltaAuthoredPayloadRef<'a> {
+    #[musli(with = crate::json_store::json_slot_storage_ref)]
+    snapshot: crate::json_store::JsonSlotRef<'a>,
+    #[musli(with = crate::json_store::json_slot_storage_ref)]
+    metadata: crate::json_store::JsonSlotRef<'a>,
+    #[musli(with = storage_codec::option)]
+    origin_key: Option<&'a str>,
+}
+
+#[derive(Clone, Copy, musli::Encode)]
+#[musli(packed)]
+struct CommitDeltaCertifiedPayloadRef<'a> {
+    #[musli(with = storage_codec::option)]
+    origin_key: Option<&'a str>,
 }
 
 #[derive(Debug, musli::Decode)]
 #[musli(packed)]
-struct CommitDeltaPayload {
+struct CommitDeltaCertifiedPayload {
+    #[musli(with = storage_codec::option)]
+    origin_key: Option<String>,
+}
+
+const COMMIT_DELTA_PAYLOAD_AUTHORED: u8 = 0;
+const COMMIT_DELTA_PAYLOAD_SELECTED_REF: u8 = 1;
+const COMMIT_DELTA_PAYLOAD_SELECTED_TOMBSTONE: u8 = 2;
+const COMMIT_DELTA_PAYLOAD_CERTIFIED_REF: u8 = 3;
+
+#[derive(Debug, musli::Decode)]
+#[musli(packed)]
+struct CommitDeltaAuthoredPayload {
     #[musli(with = crate::json_store::json_slot_storage)]
     snapshot: crate::json_store::JsonSlot,
     #[musli(with = crate::json_store::json_slot_storage)]
     metadata: crate::json_store::JsonSlot,
     #[musli(with = storage_codec::option)]
     origin_key: Option<String>,
-    authored: bool,
+}
+
+#[derive(Debug)]
+enum CommitDeltaPayload {
+    Authored(CommitDeltaAuthoredPayload),
+    SelectedRef,
+    SelectedTombstone,
+    CertifiedRef(Option<String>),
+}
+
+#[cfg(test)]
+impl CommitDeltaPayload {
+    fn authored_payload(&self) -> &CommitDeltaAuthoredPayload {
+        let Self::Authored(payload) = self else {
+            panic!("test expected an authored commit-delta payload");
+        };
+        payload
+    }
 }
 
 /// Borrowed fixed-width directory over independently encoded payload records.
@@ -146,9 +194,43 @@ impl<'a> CommitDeltaPayloadIndexRef<'a> {
                 "tracked_state commit_delta member is missing its authoritative payload",
             ));
         }
-        let payload: CommitDeltaPayload =
-            storage_codec::decode("tracked_state indexed commit_delta payload", range)?;
-        Ok(payload)
+        let (&tag, payload) = range.split_first().ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state commit_delta member has an empty payload record",
+            )
+        })?;
+        match tag {
+            COMMIT_DELTA_PAYLOAD_AUTHORED => {
+                let payload = storage_codec::decode(
+                    "tracked_state indexed authored commit_delta payload",
+                    payload,
+                )?;
+                Ok(CommitDeltaPayload::Authored(payload))
+            }
+            COMMIT_DELTA_PAYLOAD_SELECTED_REF if payload.is_empty() => {
+                Ok(CommitDeltaPayload::SelectedRef)
+            }
+            COMMIT_DELTA_PAYLOAD_SELECTED_TOMBSTONE if payload.is_empty() => {
+                Ok(CommitDeltaPayload::SelectedTombstone)
+            }
+            COMMIT_DELTA_PAYLOAD_CERTIFIED_REF => {
+                let origin_key = if payload.is_empty() {
+                    None
+                } else {
+                    storage_codec::decode::<CommitDeltaCertifiedPayload>(
+                        "tracked_state indexed certified commit_delta payload",
+                        payload,
+                    )?
+                    .origin_key
+                };
+                Ok(CommitDeltaPayload::CertifiedRef(origin_key))
+            }
+            _ => Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state commit_delta member has an invalid payload tag",
+            )),
+        }
     }
 
     fn payload_range(&self, entry_index: usize) -> Result<&[u8], LixError> {
@@ -202,6 +284,9 @@ pub(crate) struct LoadedCommitDeltaEntry {
     #[cfg(test)]
     pub(crate) value: TrackedStateIndexValue,
     pub(crate) change_record: crate::changelog::ChangeRecord,
+    selected_ref: bool,
+    certified_ref: bool,
+    owner_commit_id: CommitId,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -227,6 +312,18 @@ pub(crate) struct CommitDeltaMember {
     pub(crate) segment_index: u32,
     pub(crate) ordinal: u32,
     pub(crate) authored: bool,
+    selected_tombstone: bool,
+    certified_ref: bool,
+}
+
+impl CommitDeltaMember {
+    pub(crate) fn is_selected_payload_ref(&self) -> bool {
+        !self.authored && !self.selected_tombstone
+    }
+
+    pub(crate) fn is_certified_payload_ref(&self) -> bool {
+        self.certified_ref
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -665,6 +762,7 @@ fn stage_commit_deltas_inner(
             metadata: delta.metadata,
             origin_key: delta.origin_key,
             authored: delta.authored,
+            certified: delta.certified,
         });
     }
     let mutations = entries
@@ -1003,6 +1101,220 @@ async fn load_change_locator_by_id(
     decode_change_locator(change_id, &locator).map(Some)
 }
 
+async fn load_change_records_by_ids(
+    store: &(impl StorageAdapterRead + ?Sized),
+    change_ids: &[crate::changelog::ChangeId],
+) -> Result<Vec<crate::changelog::ChangeRecord>, LixError> {
+    if change_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let locator_keys = change_ids
+        .iter()
+        .map(|change_id| StorageKey(Bytes::copy_from_slice(change_id.as_uuid().as_bytes())))
+        .collect::<Vec<_>>();
+    let locator_values = PointReadPlan::new(TRACKED_STATE_CHANGE_LOCATOR_SPACE, &locator_keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?;
+    let locators = change_ids
+        .iter()
+        .copied()
+        .zip(locator_values.value)
+        .map(|(change_id, value)| {
+            let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "tracked_state selected change '{change_id}' has no authoritative locator"
+                    ),
+                )
+            })?;
+            decode_change_locator(change_id, &bytes)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let commit_ids = locators
+        .iter()
+        .map(|locator| locator.commit_id)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let manifest_keys = commit_ids
+        .iter()
+        .map(|commit_id| StorageKey(Bytes::from(commit_delta_manifest_key(*commit_id))))
+        .collect::<Vec<_>>();
+    let manifest_values =
+        PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE, &manifest_keys)
+            .materialize(store, StorageGetOptions::default())
+            .await?;
+    let manifests = commit_ids
+        .into_iter()
+        .zip(manifest_values.value)
+        .map(|(commit_id, value)| {
+            let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "tracked_state selected change references missing commit '{commit_id}'"
+                    ),
+                )
+            })?;
+            Ok((commit_id, decode_commit_delta_manifest(&bytes)?))
+        })
+        .collect::<Result<BTreeMap<_, _>, LixError>>()?;
+
+    let routes = locators
+        .iter()
+        .filter_map(|locator| {
+            let manifest = &manifests[&locator.commit_id];
+            manifest.inline_segment().is_none().then_some((
+                locator.commit_id,
+                usize::try_from(locator.segment_index).expect("u32 fits usize"),
+            ))
+        })
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let segment_keys = routes
+        .iter()
+        .map(|&(commit_id, segment_index)| {
+            commit_delta_segment_key(commit_id, segment_index)
+                .map(|key| StorageKey(Bytes::from(key)))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let segment_values =
+        PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, &segment_keys)
+            .materialize(store, StorageGetOptions::default())
+            .await?;
+    let segments = routes
+        .into_iter()
+        .zip(segment_values.value)
+        .map(|(route, value)| {
+            value
+                .and_then(full_value_bytes)
+                .map(|bytes| (route, bytes))
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!(
+                            "tracked_state selected change references absent segment {} of commit '{}'",
+                            route.1, route.0
+                        ),
+                    )
+                })
+        })
+        .collect::<Result<BTreeMap<_, _>, _>>()?;
+
+    let loaded = locators
+        .into_iter()
+        .map(|locator| {
+            let manifest = &manifests[&locator.commit_id];
+            let segment_index = usize::try_from(locator.segment_index).expect("u32 fits usize");
+            let (bytes, bounds) = if let Some(inline) = manifest.inline_segment() {
+                if segment_index != 0 {
+                    return Err(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "tracked_state selected change references a nonzero inline segment",
+                    ));
+                }
+                (inline, None)
+            } else {
+                let bounds = manifest.segments.get(segment_index).ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "tracked_state selected change references an undeclared segment",
+                    )
+                })?;
+                (
+                    segments[&(locator.commit_id, segment_index)].as_ref(),
+                    Some(bounds),
+                )
+            };
+            decode_change_at_locator(bytes, bounds, locator).map(Some)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut loaded = loaded;
+    hydrate_certified_loaded_entries(store, &mut loaded).await?;
+    loaded
+        .into_iter()
+        .map(|entry| {
+            entry.map(|entry| entry.change_record).ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state authoritative change unexpectedly disappeared",
+                )
+            })
+        })
+        .collect()
+}
+
+fn decode_change_at_locator(
+    segment: &[u8],
+    bounds: Option<&CommitDeltaSegmentBounds>,
+    locator: CommitDeltaChangeLocator,
+) -> Result<LoadedCommitDeltaEntry, LixError> {
+    let change_id = locator.change_id;
+    let (leaf, payloads) = decode_commit_delta_with_payloads(segment, bounds)?;
+    let ordinal = usize::from(locator.ordinal);
+    let entry = leaf.entry(ordinal)?.ok_or_else(|| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "tracked_state change locator for '{change_id}' references absent ordinal {}",
+                locator.ordinal
+            ),
+        )
+    })?;
+    let value = decode_value(entry.value)?;
+    if value.change_id != change_id || value.commit_id != locator.commit_id {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("tracked_state change locator for '{change_id}' points to the wrong row"),
+        ));
+    }
+    let key = decode_key(entry.key)?;
+    let (snapshot, metadata, origin_key, certified_ref) = match payloads.decode(ordinal)? {
+        CommitDeltaPayload::Authored(payload) => (
+            payload.snapshot,
+            payload.metadata,
+            payload.origin_key,
+            false,
+        ),
+        CommitDeltaPayload::CertifiedRef(origin_key) => (
+            crate::json_store::JsonSlot::None,
+            crate::json_store::JsonSlot::None,
+            origin_key,
+            true,
+        ),
+        CommitDeltaPayload::SelectedRef | CommitDeltaPayload::SelectedTombstone => {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "tracked_state authoritative change locator for '{change_id}' points to a selected row"
+                ),
+            ));
+        }
+    };
+    let updated_at = value.updated_at;
+    Ok(LoadedCommitDeltaEntry {
+        #[cfg(test)]
+        value,
+        change_record: crate::changelog::ChangeRecord {
+            format_version: 2,
+            change_id,
+            schema_key: key.schema_key,
+            entity_pk: key.entity_pk,
+            file_id: key.file_id,
+            snapshot,
+            metadata,
+            created_at: updated_at,
+            origin_key,
+        },
+        selected_ref: false,
+        certified_ref,
+        owner_commit_id: locator.commit_id,
+    })
+}
+
 async fn load_change_record_at_locator(
     store: &(impl StorageAdapterRead + ?Sized),
     locator: CommitDeltaChangeLocator,
@@ -1090,40 +1402,13 @@ async fn try_load_change_record_at_locator_in_manifest(
         })?;
         (segment, Some(bounds))
     };
-    let (leaf, payloads) = decode_commit_delta_with_payloads(&segment, bounds)?;
-    let ordinal = usize::from(locator.ordinal);
-    let entry = leaf.entry(ordinal)?.ok_or_else(|| {
-        LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!(
-                "tracked_state change locator for '{change_id}' references absent ordinal {}",
-                locator.ordinal
-            ),
-        )
-    })?;
-    let value = decode_value(entry.value)?;
-    if value.commit_id != locator.commit_id {
-        return Err(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!("tracked_state change locator for '{change_id}' points to the wrong row"),
-        ));
-    }
-    if value.change_id != change_id {
-        return Ok(None);
-    }
-    let key = decode_key(entry.key)?;
-    let payload = payloads.decode(ordinal)?;
-    Ok(Some(crate::changelog::ChangeRecord {
-        format_version: 2,
-        change_id,
-        schema_key: key.schema_key,
-        entity_pk: key.entity_pk,
-        file_id: key.file_id,
-        snapshot: payload.snapshot,
-        metadata: payload.metadata,
-        created_at: value.updated_at,
-        origin_key: payload.origin_key,
-    }))
+    let mut loaded = vec![Some(decode_change_at_locator(&segment, bounds, locator)?)];
+    hydrate_certified_loaded_entries(store, &mut loaded).await?;
+    Ok(loaded
+        .pop()
+        .flatten()
+        .expect("one decoded change locator must remain")
+        .change_record)
 }
 
 fn decode_change_locator(
@@ -1418,8 +1703,150 @@ async fn load_commit_delta_members_from_manifest(
             )?;
         }
     }
+    hydrate_selected_members(store, &mut members).await?;
     validate_commit_delta_member_order_and_ids(commit_id, &members)?;
     Ok(members)
+}
+
+async fn hydrate_selected_members(
+    store: &(impl StorageAdapterRead + ?Sized),
+    members: &mut [CommitDeltaMember],
+) -> Result<(), LixError> {
+    let selected = members
+        .iter()
+        .enumerate()
+        .filter(|(_, member)| !member.authored && !member.selected_tombstone)
+        .map(|(index, member)| (index, member.value.change_id))
+        .collect::<Vec<_>>();
+    let change_ids = selected
+        .iter()
+        .map(|(_, change_id)| *change_id)
+        .collect::<Vec<_>>();
+    let canonical = load_change_records_by_ids(store, &change_ids).await?;
+    for ((index, _), change_record) in selected.into_iter().zip(canonical) {
+        let member = &mut members[index];
+        if change_record.schema_key != member.key.schema_key
+            || change_record.file_id != member.key.file_id
+            || change_record.entity_pk != member.key.entity_pk
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "tracked_state selected change '{}' references canonical authority for a different identity",
+                    member.value.change_id
+                ),
+            ));
+        }
+        member.change.snapshot = change_record.snapshot;
+        member.change.metadata = change_record.metadata;
+        member.change.origin_key = change_record.origin_key;
+    }
+    hydrate_certified_members(store, members).await?;
+    Ok(())
+}
+
+async fn hydrate_certified_members(
+    store: &(impl StorageAdapterRead + ?Sized),
+    members: &mut [CommitDeltaMember],
+) -> Result<(), LixError> {
+    let pending = members
+        .iter()
+        .enumerate()
+        .filter(|(_, member)| member.certified_ref)
+        .map(|(index, member)| {
+            (
+                index,
+                member.value.commit_id,
+                member.value.change_id,
+                member.key.clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+    if pending.is_empty() {
+        return Ok(());
+    }
+    let commit_ids = pending
+        .iter()
+        .map(|(_, commit_id, _, _)| *commit_id)
+        .collect::<BTreeSet<_>>();
+    let request = crate::tracked_state::TrackedStateScanRequest {
+        filter: crate::tracked_state::TrackedStateFilter {
+            schema_keys: pending
+                .iter()
+                .map(|(_, _, _, key)| key.schema_key.clone())
+                .collect(),
+            entity_pks: pending
+                .iter()
+                .map(|(_, _, _, key)| key.entity_pk.clone())
+                .collect(),
+            file_ids: pending
+                .iter()
+                .map(|(_, _, _, key)| {
+                    key.file_id.clone().map_or(
+                        crate::NullableKeyFilter::Null,
+                        crate::NullableKeyFilter::Value,
+                    )
+                })
+                .collect(),
+            include_tombstones: true,
+        },
+        read_columns: crate::tracked_state::TrackedStateReadColumns {
+            columns: vec!["snapshot_content".to_owned(), "metadata".to_owned()],
+        },
+        limit: None,
+    };
+    let rows = crate::live_state::scan_certified_history_rows(store, &commit_ids, &request).await?;
+    let mut payloads = BTreeMap::new();
+    for row in rows {
+        let Some(commit_id) = row.commit_id else {
+            continue;
+        };
+        payloads.insert(
+            (commit_id, row.schema_key, row.file_id, row.entity_pk),
+            (
+                row.snapshot_content
+                    .map_or(crate::json_store::JsonSlot::None, |json| {
+                        crate::json_store::JsonSlot::Inline(json.as_str().into())
+                    }),
+                row.metadata
+                    .map_or(crate::json_store::JsonSlot::None, |json| {
+                        crate::json_store::JsonSlot::Inline(json.as_str().into())
+                    }),
+            ),
+        );
+    }
+    for (index, commit_id, change_id, key) in pending {
+        let lookup = (
+            commit_id,
+            key.schema_key.clone(),
+            key.file_id.clone(),
+            key.entity_pk.clone(),
+        );
+        let Some((snapshot, metadata)) = payloads.remove(&lookup) else {
+            let candidates = payloads
+                .keys()
+                .filter(|(candidate_commit, schema_key, file_id, _)| {
+                    *candidate_commit == commit_id
+                        && schema_key == &key.schema_key
+                        && file_id == &key.file_id
+                })
+                .take(5)
+                .map(|(_, _, _, entity_pk)| format!("{entity_pk:?}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "tracked_state certified change '{change_id}' has no certified payload at commit '{commit_id}' for schema '{}' file {:?} entity {:?}; candidates: {candidates}",
+                    key.schema_key, key.file_id, key.entity_pk
+                ),
+            ));
+        };
+        members[index].change.snapshot = snapshot;
+        members[index].change.metadata = metadata;
+        members[index].certified_ref = false;
+    }
+    Ok(())
 }
 
 pub(crate) async fn scan_commit_delta_members(
@@ -1535,6 +1962,7 @@ pub(crate) async fn load_owned_commit_delta_entries(
     }
 
     if lookups_by_segment.is_empty() {
+        hydrate_selected_loaded_entries(store, &mut output).await?;
         return Ok(output);
     }
 
@@ -1587,7 +2015,121 @@ pub(crate) async fn load_owned_commit_delta_entries(
                 find_loaded_commit_delta_entry(&leaf, &payloads, &encoded_key, commit_id)?;
         }
     }
+    hydrate_selected_loaded_entries(store, &mut output).await?;
     Ok(output)
+}
+
+async fn hydrate_selected_loaded_entries(
+    store: &(impl StorageAdapterRead + ?Sized),
+    entries: &mut [Option<LoadedCommitDeltaEntry>],
+) -> Result<(), LixError> {
+    let selected = entries
+        .iter()
+        .enumerate()
+        .filter_map(|(index, entry)| {
+            entry
+                .as_ref()
+                .filter(|entry| entry.selected_ref)
+                .map(|entry| (index, entry.change_record.change_id))
+        })
+        .collect::<Vec<_>>();
+    let change_ids = selected
+        .iter()
+        .map(|(_, change_id)| *change_id)
+        .collect::<Vec<_>>();
+    let canonical = load_change_records_by_ids(store, &change_ids).await?;
+    for ((index, _), change_record) in selected.into_iter().zip(canonical) {
+        let entry = entries[index]
+            .as_mut()
+            .expect("selected entry came from the output batch");
+        if entry.change_record.schema_key != change_record.schema_key
+            || entry.change_record.file_id != change_record.file_id
+            || entry.change_record.entity_pk != change_record.entity_pk
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "tracked_state selected change '{}' references canonical authority for a different identity",
+                    entry.change_record.change_id
+                ),
+            ));
+        }
+        entry.change_record.snapshot = change_record.snapshot;
+        entry.change_record.metadata = change_record.metadata;
+        entry.change_record.origin_key = change_record.origin_key;
+        entry.selected_ref = false;
+    }
+    hydrate_certified_loaded_entries(store, entries).await?;
+    Ok(())
+}
+
+async fn hydrate_certified_loaded_entries(
+    store: &(impl StorageAdapterRead + ?Sized),
+    entries: &mut [Option<LoadedCommitDeltaEntry>],
+) -> Result<(), LixError> {
+    let pending = entries
+        .iter()
+        .enumerate()
+        .filter_map(|(index, entry)| {
+            entry
+                .as_ref()
+                .filter(|entry| entry.certified_ref)
+                .map(|entry| {
+                    (
+                        index,
+                        entry.owner_commit_id,
+                        entry.change_record.change_id,
+                        TrackedStateKey {
+                            schema_key: entry.change_record.schema_key.clone(),
+                            file_id: entry.change_record.file_id.clone(),
+                            entity_pk: entry.change_record.entity_pk.clone(),
+                        },
+                    )
+                })
+        })
+        .collect::<Vec<_>>();
+    if pending.is_empty() {
+        return Ok(());
+    }
+    let mut members = pending
+        .iter()
+        .map(|(_, commit_id, change_id, key)| CommitDeltaMember {
+            key: key.clone(),
+            value: TrackedStateIndexValue {
+                change_id: *change_id,
+                commit_id: *commit_id,
+                deleted: false,
+                created_at: crate::common::LixTimestamp::from_unix_millis_utc_lossy(0),
+                updated_at: crate::common::LixTimestamp::from_unix_millis_utc_lossy(0),
+            },
+            change: crate::changelog::ChangeRecord {
+                format_version: 2,
+                change_id: *change_id,
+                schema_key: key.schema_key.clone(),
+                entity_pk: key.entity_pk.clone(),
+                file_id: key.file_id.clone(),
+                snapshot: crate::json_store::JsonSlot::None,
+                metadata: crate::json_store::JsonSlot::None,
+                created_at: crate::common::LixTimestamp::from_unix_millis_utc_lossy(0),
+                origin_key: None,
+            },
+            segment_index: 0,
+            ordinal: 0,
+            authored: true,
+            selected_tombstone: false,
+            certified_ref: true,
+        })
+        .collect::<Vec<_>>();
+    hydrate_certified_members(store, &mut members).await?;
+    for ((index, _, _, _), member) in pending.into_iter().zip(members) {
+        let entry = entries[index]
+            .as_mut()
+            .expect("certified entry came from the output batch");
+        entry.change_record.snapshot = member.change.snapshot;
+        entry.change_record.metadata = member.change.metadata;
+        entry.certified_ref = false;
+    }
+    Ok(())
 }
 
 /// Scans only the mutations in one commit that belong to one of the requested
@@ -1888,6 +2430,7 @@ pub(crate) async fn scan_commit_delta_inventory(
                 )?;
             }
         }
+        hydrate_selected_members(store, &mut members).await?;
         validate_commit_delta_member_order_and_ids(commit_id, &members)?;
         for member in &members {
             if is_payload_free_selected_tombstone(member) {
@@ -2122,16 +2665,51 @@ fn collect_strict_commit_delta_members(
         }
         let payload = payloads.decode(entry_index)?;
         let key = decode_key(entry.key)?;
+        let (snapshot, metadata, origin_key, authored, selected_tombstone, certified_ref) =
+            match payload {
+                CommitDeltaPayload::Authored(payload) => (
+                    payload.snapshot,
+                    payload.metadata,
+                    payload.origin_key,
+                    true,
+                    false,
+                    false,
+                ),
+                CommitDeltaPayload::SelectedRef => (
+                    crate::json_store::JsonSlot::None,
+                    crate::json_store::JsonSlot::None,
+                    None,
+                    false,
+                    false,
+                    false,
+                ),
+                CommitDeltaPayload::SelectedTombstone => (
+                    crate::json_store::JsonSlot::None,
+                    crate::json_store::JsonSlot::None,
+                    None,
+                    false,
+                    true,
+                    false,
+                ),
+                CommitDeltaPayload::CertifiedRef(origin_key) => (
+                    crate::json_store::JsonSlot::None,
+                    crate::json_store::JsonSlot::None,
+                    origin_key,
+                    true,
+                    false,
+                    true,
+                ),
+            };
         let change = crate::changelog::ChangeRecord {
             format_version: 2,
             change_id: value.change_id,
             schema_key: key.schema_key.clone(),
             entity_pk: key.entity_pk.clone(),
             file_id: key.file_id.clone(),
-            snapshot: payload.snapshot,
-            metadata: payload.metadata,
+            snapshot,
+            metadata,
             created_at: value.updated_at,
-            origin_key: payload.origin_key,
+            origin_key,
         };
         members.push(CommitDeltaMember {
             key,
@@ -2139,7 +2717,9 @@ fn collect_strict_commit_delta_members(
             change,
             segment_index,
             ordinal: u32::try_from(entry_index).expect("segment ordinal fits u32"),
-            authored: payload.authored,
+            authored,
+            selected_tombstone,
+            certified_ref,
         });
     }
     Ok(())
@@ -2177,11 +2757,7 @@ fn validate_commit_delta_member_order_and_ids(
 }
 
 fn is_payload_free_selected_tombstone(member: &CommitDeltaMember) -> bool {
-    !member.authored
-        && member.value.deleted
-        && member.change.snapshot.is_none()
-        && member.change.metadata.is_none()
-        && member.change.origin_key.is_none()
+    member.selected_tombstone
 }
 
 fn encode_commit_delta_manifest(manifest: &CommitDeltaManifest) -> Result<Vec<u8>, LixError> {
@@ -2343,6 +2919,7 @@ fn encode_commit_delta_segment(entries: &[EncodedLeafEntry]) -> Vec<u8> {
             metadata: crate::json_store::JsonSlotRef::None,
             origin_key: None,
             authored: true,
+            certified: false,
         };
         entries.len()
     ];
@@ -2365,14 +2942,51 @@ fn encode_commit_delta_segment_layout(
     let leaf = encode_leaf_node(entries);
     let mut payload_offsets = Vec::with_capacity(payloads.len() + 1);
     let mut payload_bytes = Vec::new();
-    for payload in payloads {
+    for (entry, payload) in entries.iter().zip(payloads) {
         payload_offsets.push(
             u32::try_from(payload_bytes.len()).expect("commit-delta payload sidecar fits u32"),
         );
-        payload_bytes.extend_from_slice(
-            &storage_codec::encode("tracked_state indexed commit_delta payload", payload)
+        if payload.certified {
+            debug_assert!(payload.authored);
+            payload_bytes.push(COMMIT_DELTA_PAYLOAD_CERTIFIED_REF);
+            if payload.origin_key.is_some() {
+                payload_bytes.extend_from_slice(
+                    &storage_codec::encode(
+                        "tracked_state indexed certified commit_delta payload",
+                        &CommitDeltaCertifiedPayloadRef {
+                            origin_key: payload.origin_key,
+                        },
+                    )
+                    .expect("certified commit-delta payload refs are infallible to encode"),
+                );
+            }
+        } else if payload.authored {
+            payload_bytes.push(COMMIT_DELTA_PAYLOAD_AUTHORED);
+            let authored = CommitDeltaAuthoredPayloadRef {
+                snapshot: payload.snapshot,
+                metadata: payload.metadata,
+                origin_key: payload.origin_key,
+            };
+            payload_bytes.extend_from_slice(
+                &storage_codec::encode(
+                    "tracked_state indexed authored commit_delta payload",
+                    &authored,
+                )
                 .expect("commit-delta payload refs are infallible to encode"),
-        );
+            );
+        } else {
+            let value = decode_value(&entry.value)
+                .expect("commit-delta entries were encoded by the mutation builder");
+            let payload_free_tombstone = value.deleted
+                && matches!(payload.snapshot, crate::json_store::JsonSlotRef::None)
+                && matches!(payload.metadata, crate::json_store::JsonSlotRef::None)
+                && payload.origin_key.is_none();
+            payload_bytes.push(if payload_free_tombstone {
+                COMMIT_DELTA_PAYLOAD_SELECTED_TOMBSTONE
+            } else {
+                COMMIT_DELTA_PAYLOAD_SELECTED_REF
+            });
+        }
     }
     payload_offsets
         .push(u32::try_from(payload_bytes.len()).expect("commit-delta payload sidecar fits u32"));
@@ -2743,21 +3357,54 @@ fn find_loaded_commit_delta_entry(
     }
     let payload = payloads.decode(index)?;
     let key = decode_key(entry.key)?;
+    let (snapshot, metadata, origin_key, selected_ref, certified_ref) = match payload {
+        CommitDeltaPayload::Authored(payload) => (
+            payload.snapshot,
+            payload.metadata,
+            payload.origin_key,
+            false,
+            false,
+        ),
+        CommitDeltaPayload::SelectedRef => (
+            crate::json_store::JsonSlot::None,
+            crate::json_store::JsonSlot::None,
+            None,
+            true,
+            false,
+        ),
+        CommitDeltaPayload::SelectedTombstone => (
+            crate::json_store::JsonSlot::None,
+            crate::json_store::JsonSlot::None,
+            None,
+            false,
+            false,
+        ),
+        CommitDeltaPayload::CertifiedRef(origin_key) => (
+            crate::json_store::JsonSlot::None,
+            crate::json_store::JsonSlot::None,
+            origin_key,
+            false,
+            true,
+        ),
+    };
     let change_record = crate::changelog::ChangeRecord {
         format_version: 2,
         change_id: value.change_id,
         schema_key: key.schema_key,
         entity_pk: key.entity_pk,
         file_id: key.file_id,
-        snapshot: payload.snapshot,
-        metadata: payload.metadata,
+        snapshot,
+        metadata,
         created_at: value.updated_at,
-        origin_key: payload.origin_key,
+        origin_key,
     };
     Ok(Some(LoadedCommitDeltaEntry {
         #[cfg(test)]
         value,
         change_record,
+        selected_ref,
+        certified_ref,
+        owner_commit_id: expected_commit_id,
     }))
 }
 
@@ -3167,6 +3814,7 @@ mod tests {
             metadata,
             origin_key,
             authored: true,
+            certified: false,
         }
     }
 
@@ -3589,6 +4237,7 @@ mod tests {
                 metadata: crate::json_store::JsonSlotRef::None,
                 origin_key: None,
                 authored: true,
+                certified: false,
             }],
         );
         let mut writes = orphan_storage.new_write_set();
@@ -3667,7 +4316,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn global_inventory_allows_shared_payload_and_rejects_conflicting_payload() {
+    async fn global_inventory_hydrates_selected_payloads_from_canonical_authority() {
         let storage = StorageAdapter::new(Memory::new());
         let fixture = packed_commit_delta_fixtures()
             .into_iter()
@@ -3704,6 +4353,24 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("shared authority read should open");
+        let selected_manifest = super::load_commit_delta_manifest(&read, second_commit)
+            .await
+            .expect("selected manifest should load")
+            .expect("selected manifest should exist");
+        let (_, selected_payloads) = decode_commit_delta_with_payloads(
+            selected_manifest
+                .inline_segment()
+                .expect("one selected row should stay inline"),
+            None,
+        )
+        .expect("selected segment should decode");
+        assert_eq!(
+            selected_payloads
+                .payload_range(0)
+                .expect("selected payload range"),
+            &[super::COMMIT_DELTA_PAYLOAD_SELECTED_REF],
+            "selected rows must persist only the canonical-reference tag"
+        );
         assert_eq!(
             scan_commit_delta_inventory(&read)
                 .await
@@ -3738,21 +4405,17 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("conflicting authority read should open");
-        let error = scan_commit_delta_inventory(&read)
+        let inventory = scan_commit_delta_inventory(&read)
             .await
-            .expect_err("conflicting payloads for one change id must fail");
-        assert!(
-            error
-                .to_string()
-                .contains("conflicting authoritative packed payloads")
-        );
-        let error = scan_change_records_from_commit_deltas(&read)
+            .expect("selected wire rows must ignore repeated caller payload bytes");
+        assert_eq!(inventory.commits.len(), 3);
+        let changes = scan_change_records_from_commit_deltas(&read)
             .await
-            .expect_err("streaming scan must reject conflicting packed payloads");
-        assert!(
-            error
-                .to_string()
-                .contains("conflicting authoritative packed payloads")
+            .expect("streaming scan must hydrate selected rows from canonical authority");
+        assert_eq!(changes.len(), 1);
+        assert_eq!(
+            changes[0].snapshot,
+            crate::json_store::JsonSlot::Inline(shared_snapshot.into())
         );
     }
 
@@ -4060,6 +4723,7 @@ mod tests {
                 metadata: crate::json_store::JsonSlotRef::None,
                 origin_key: None,
                 authored: true,
+                certified: false,
             }],
         );
         segment.pop();
@@ -4149,18 +4813,21 @@ mod tests {
                 metadata: crate::json_store::JsonSlotRef::None,
                 origin_key: Some("first"),
                 authored: true,
+                certified: false,
             },
             CommitDeltaPayloadRef {
                 snapshot: crate::json_store::JsonSlotRef::Inline(snapshots[1]),
                 metadata: crate::json_store::JsonSlotRef::None,
                 origin_key: None,
                 authored: true,
+                certified: false,
             },
             CommitDeltaPayloadRef {
                 snapshot: crate::json_store::JsonSlotRef::Inline(snapshots[2]),
                 metadata: crate::json_store::JsonSlotRef::None,
                 origin_key: Some("last"),
                 authored: true,
+                certified: false,
             },
         ];
         let mut encoded = encode_commit_delta_segment_with_raw_sidecar(&entries, &payloads);
@@ -4173,6 +4840,7 @@ mod tests {
                 index
                     .decode(0)
                     .expect("first payload should decode")
+                    .authored_payload()
                     .snapshot,
                 crate::json_store::JsonSlot::Inline(snapshots[0].into())
             );
@@ -4180,6 +4848,7 @@ mod tests {
                 index
                     .decode(1)
                     .expect("sparse payload should decode")
+                    .authored_payload()
                     .snapshot,
                 crate::json_store::JsonSlot::Inline(snapshots[1].into()),
                 "every commit member must carry an authoritative payload"
@@ -4198,6 +4867,7 @@ mod tests {
             index
                 .decode(0)
                 .expect("an uncorrupted requested payload should still decode")
+                .authored_payload()
                 .origin_key
                 .as_deref(),
             Some("first"),
@@ -4207,9 +4877,10 @@ mod tests {
             .decode(2)
             .expect_err("a corrupt requested payload must fail");
         assert!(
-            error
-                .to_string()
-                .contains("failed to decode tracked_state indexed commit_delta payload"),
+            error.to_string().contains("invalid payload tag")
+                || error.to_string().contains(
+                    "failed to decode tracked_state indexed authored commit_delta payload"
+                ),
             "unexpected error: {error}"
         );
     }
@@ -4248,12 +4919,14 @@ mod tests {
                 metadata: crate::json_store::JsonSlotRef::None,
                 origin_key: None,
                 authored: true,
+                certified: false,
             },
             CommitDeltaPayloadRef {
                 snapshot: crate::json_store::JsonSlotRef::Inline(&second_snapshot),
                 metadata: crate::json_store::JsonSlotRef::None,
                 origin_key: None,
                 authored: true,
+                certified: false,
             },
         ];
         let encoded = encode_commit_delta_segment_with_payloads(&entries, &payloads);
@@ -4273,11 +4946,11 @@ mod tests {
         let (_, decoded) =
             decode_commit_delta_with_payloads(&encoded, None).expect("sidecar should decode");
         assert_eq!(
-            decoded.decode(0).unwrap().snapshot,
+            decoded.decode(0).unwrap().authored_payload().snapshot,
             crate::json_store::JsonSlot::Inline(first_snapshot.into_boxed_str())
         );
         assert_eq!(
-            decoded.decode(1).unwrap().snapshot,
+            decoded.decode(1).unwrap().authored_payload().snapshot,
             crate::json_store::JsonSlot::Inline(second_snapshot.into_boxed_str())
         );
 
@@ -4331,6 +5004,7 @@ mod tests {
                 metadata: crate::json_store::JsonSlotRef::None,
                 origin_key: None,
                 authored: true,
+                certified: false,
             }],
         );
         let leaf_len = usize::try_from(u32::from_be_bytes(
@@ -4379,12 +5053,14 @@ mod tests {
                 metadata: crate::json_store::JsonSlotRef::None,
                 origin_key: None,
                 authored: true,
+                certified: false,
             },
             CommitDeltaPayloadRef {
                 snapshot: crate::json_store::JsonSlotRef::Inline(r#"{"second":true}"#),
                 metadata: crate::json_store::JsonSlotRef::None,
                 origin_key: None,
                 authored: true,
+                certified: false,
             },
         ];
         let mut encoded = encode_commit_delta_segment_with_raw_sidecar(&entries, &payloads);
@@ -4531,6 +5207,7 @@ mod tests {
                 metadata: crate::json_store::JsonSlotRef::None,
                 origin_key: None,
                 authored: true,
+                certified: false,
             }],
         );
 

--- a/packages/engine/src/tracked_state/types.rs
+++ b/packages/engine/src/tracked_state/types.rs
@@ -61,6 +61,9 @@ pub(crate) struct TrackedStateCommitDeltaRef<'a> {
     pub(crate) metadata: crate::json_store::JsonSlotRef<'a>,
     pub(crate) origin_key: Option<&'a str>,
     pub(crate) authored: bool,
+    /// The durable payload is already present in a host-certified batch for
+    /// this commit and identity.
+    pub(crate) certified: bool,
 }
 
 /// One ordered tracked-root mutation with its insert-collision contract.

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -918,13 +918,15 @@ fn current_state_delta_from_state_row(
 fn host_certified_batch_owns_live_row(
     row: PreparedStateRowRef<'_>,
     branch_id: &str,
+    certified_commit_id: CommitId,
     host_certified_file_schemas: &BTreeMap<String, BTreeMap<String, BTreeSet<String>>>,
 ) -> bool {
     // A complete certified batch replaces only the incoming live rows. An
     // ownership transition may stage tombstones for the previous plugin under
     // the same file/schema pair; those must remain HOT overlays so the old
     // entity identities disappear and collection counts are decremented.
-    row.snapshot.is_some()
+    row.commit_id == Some(certified_commit_id)
+        && row.snapshot.is_some()
         && row.file_id.is_some_and(|file_id| {
             host_certified_file_schemas
                 .get(branch_id)
@@ -1125,11 +1127,13 @@ fn stage_tracked_commit_delta_index(
             let row = state_rows.row(row_index);
             addressable.push(row.addressable_change_id);
             let mut delta = tracked_commit_delta_from_state_row(row)?;
-            delta.certified = host_certified_batch_owns_live_row(
-                row,
-                &root.branch_id,
-                host_certified_file_schemas,
-            );
+            delta.certified = root.publish_head
+                && host_certified_batch_owns_live_row(
+                    row,
+                    &root.branch_id,
+                    root.commit_id,
+                    host_certified_file_schemas,
+                );
             deltas.push(delta);
         }
         for change_ref in selected_changes(&staged.selected_change_batches) {
@@ -2074,6 +2078,7 @@ async fn stage_tracked_head(
                     !host_certified_batch_owns_live_row(
                         row,
                         &root.branch_id,
+                        root.commit_id,
                         host_certified_file_schemas,
                     )
                 })
@@ -3575,6 +3580,9 @@ mod tests {
         new_plugin_live.entity_pk = EntityPk::single("new-plugin-line");
         new_plugin_live.schema_key = "git_text_line_v2".into();
         new_plugin_live.file_id = Some("file-a".into());
+        let published_commit_id = new_plugin_live
+            .commit_id
+            .expect("test live row should have a commit");
 
         let certified = BTreeMap::from([(
             "main".to_string(),
@@ -3588,6 +3596,7 @@ mod tests {
             !host_certified_batch_owns_live_row(
                 old_plugin_tombstone.borrowed(),
                 "main",
+                published_commit_id,
                 &certified,
             ),
             "the previous owner's tombstone must remain in HOT publication",
@@ -3599,8 +3608,50 @@ mod tests {
             "the retained row must decrement collection counts as a deletion",
         );
         assert!(
-            host_certified_batch_owns_live_row(new_plugin_live.borrowed(), "main", &certified),
+            host_certified_batch_owns_live_row(
+                new_plugin_live.borrowed(),
+                "main",
+                published_commit_id,
+                &certified,
+            ),
             "the certified batch owns the replacement live row",
+        );
+    }
+
+    #[test]
+    fn host_certified_batch_does_not_own_intermediate_commit_rows() {
+        let published_commit_id = commit_id("published-certified-batch");
+        let mut published = tracked_branch_row("main", "published-live-row");
+        published.commit_id = Some(published_commit_id);
+        published.schema_key = "git_text_line_v2".into();
+        published.file_id = Some("file-a".into());
+
+        let mut intermediate = published.clone();
+        intermediate.commit_id = Some(commit_id("intermediate-write"));
+        intermediate.change_id = Some(change_id("intermediate-live-row"));
+
+        let certified = BTreeMap::from([(
+            "main".to_string(),
+            BTreeMap::from([(
+                "file-a".to_string(),
+                BTreeSet::from(["git_text_line_v2".to_string()]),
+            )]),
+        )]);
+
+        assert!(host_certified_batch_owns_live_row(
+            published.borrowed(),
+            "main",
+            published_commit_id,
+            &certified,
+        ));
+        assert!(
+            !host_certified_batch_owns_live_row(
+                intermediate.borrowed(),
+                "main",
+                published_commit_id,
+                &certified,
+            ),
+            "an intermediate commit has no certified batch under its own commit id",
         );
     }
 

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -23,7 +23,8 @@ use crate::functions::FunctionContext;
 use crate::json_store::{JsonStoreContext, JsonWritePlacementRef, NormalizedJsonRef};
 use crate::live_state::{
     HotTrackedSnapshot, MaterializedLiveStateRow, TrackedHeadContext, TrackedWorkingDiffEpoch,
-    WorkingDiffIndexCoverage, stage_tracked_working_diff_epoch,
+    WorkingDiffIndexCoverage, stage_delete_tracked_working_diff_epoch,
+    stage_tracked_working_diff_epoch,
 };
 use crate::storage_adapter::{StorageAdapterRead, StoragePrecondition, StorageWriteSet};
 use crate::tracked_state::{
@@ -259,6 +260,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &tracked_roots,
         &commit_rows,
         &selected_change_records,
+        &host_certified_file_schemas,
     )?;
 
     let staged_commits = stage_changelog_commits(
@@ -346,10 +348,13 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         );
     }
     stage_checkpoint_working_diff_epochs(
+        read,
         &mut writes,
         &prepared_writes.checkpoint_publications,
         &staged_hot_heads.controls,
-    )?;
+        &branch_control_observations,
+    )
+    .await?;
     let published_branch_controls = stage_branch_head_control_publications(
         read,
         &mut writes,
@@ -810,6 +815,7 @@ fn tracked_commit_delta_from_state_row(
         ),
         origin_key: row.origin_key.map(crate::common::SharedStr::as_str),
         authored: true,
+        certified: false,
     })
 }
 
@@ -865,6 +871,7 @@ fn tracked_commit_delta_from_selected_change_ref<'a>(
         }),
         origin_key: record.and_then(|record| record.origin_key.as_deref()),
         authored: false,
+        certified: false,
     })
 }
 
@@ -1090,6 +1097,7 @@ fn stage_tracked_commit_delta_index(
     tracked_roots: &[PendingTrackedRoot],
     commit_rows: &[FinalizedCommitRow],
     selected_change_records: &HashMap<SelectedChangeKey, ChangeRecord>,
+    host_certified_file_schemas: &BTreeMap<String, BTreeMap<String, BTreeSet<String>>>,
 ) -> Result<(), LixError> {
     let commit_rows = commit_rows
         .iter()
@@ -1116,7 +1124,13 @@ fn stage_tracked_commit_delta_index(
         for &row_index in state_row_indices {
             let row = state_rows.row(row_index);
             addressable.push(row.addressable_change_id);
-            deltas.push(tracked_commit_delta_from_state_row(row)?);
+            let mut delta = tracked_commit_delta_from_state_row(row)?;
+            delta.certified = host_certified_batch_owns_live_row(
+                row,
+                &root.branch_id,
+                host_certified_file_schemas,
+            );
+            deltas.push(delta);
         }
         for change_ref in selected_changes(&staged.selected_change_batches) {
             let key = selected_change_key(change_ref);
@@ -2474,10 +2488,12 @@ fn selected_tracked_ref_untracked_collision_error(
 /// A checkpoint cleans exactly its selected interval changes in the current
 /// hot generation. Unchanged rows were already clean, so rotating to an empty
 /// sparse dirty-key index starts the next epoch without a full-state rewrite.
-fn stage_checkpoint_working_diff_epochs(
+async fn stage_checkpoint_working_diff_epochs(
+    read: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
     publications: &[crate::gc::CheckpointPublication],
     controls: &BTreeMap<String, BranchHeadControl>,
+    observations: &BTreeMap<String, BranchHeadControlObservation>,
 ) -> Result<(), LixError> {
     let mut branches = BTreeSet::new();
     for publication in publications {
@@ -2516,6 +2532,22 @@ fn stage_checkpoint_working_diff_epochs(
         // the remaining working diff from the two durable roots.
         if control.head_commit_id != recovery.checkpoint_commit_id {
             continue;
+        }
+        if let Some(previous) = observations
+            .get(&recovery.branch_id)
+            .and_then(|observation| observation.control)
+            && let Some(previous_checkpoint) = previous.working_diff_checkpoint_commit_id
+            && (previous_checkpoint != recovery.checkpoint_commit_id
+                || previous.generation != control.generation)
+        {
+            stage_delete_tracked_working_diff_epoch(
+                read,
+                writes,
+                &recovery.branch_id,
+                previous_checkpoint,
+                previous.generation,
+            )
+            .await?;
         }
         stage_tracked_working_diff_epoch(
             writes,

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[cfg(test)]
-use std::sync::Mutex;
+use std::cell::Cell;
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -324,34 +324,31 @@ struct TransactionPathIndexBuildStats {
 }
 
 #[cfg(test)]
-static TRANSACTION_PATH_INDEX_BUILD_STATS: Mutex<TransactionPathIndexBuildStats> =
-    Mutex::new(TransactionPathIndexBuildStats {
-        builds: 0,
-        descriptor_rows: 0,
-    });
+thread_local! {
+    static TRANSACTION_PATH_INDEX_BUILD_STATS: Cell<TransactionPathIndexBuildStats> =
+        const { Cell::new(TransactionPathIndexBuildStats {
+            builds: 0,
+            descriptor_rows: 0,
+        }) };
+}
 
 #[cfg(test)]
 fn reset_transaction_path_index_build_stats() {
-    *TRANSACTION_PATH_INDEX_BUILD_STATS
-        .lock()
-        .expect("transaction path index build stats lock") =
-        TransactionPathIndexBuildStats::default();
+    TRANSACTION_PATH_INDEX_BUILD_STATS.set(TransactionPathIndexBuildStats::default());
 }
 
 #[cfg(test)]
 fn transaction_path_index_build_stats() -> TransactionPathIndexBuildStats {
-    *TRANSACTION_PATH_INDEX_BUILD_STATS
-        .lock()
-        .expect("transaction path index build stats lock")
+    TRANSACTION_PATH_INDEX_BUILD_STATS.get()
 }
 
 #[cfg(test)]
 fn record_transaction_path_index_build(descriptor_rows: usize) {
-    let mut stats = TRANSACTION_PATH_INDEX_BUILD_STATS
-        .lock()
-        .expect("transaction path index build stats lock");
-    stats.builds += 1;
-    stats.descriptor_rows += descriptor_rows;
+    let stats = TRANSACTION_PATH_INDEX_BUILD_STATS.get();
+    TRANSACTION_PATH_INDEX_BUILD_STATS.set(TransactionPathIndexBuildStats {
+        builds: stats.builds + 1,
+        descriptor_rows: stats.descriptor_rows + descriptor_rows,
+    });
 }
 
 /// One execution-scoped transaction capability for engine write paths.


### PR DESCRIPTION
## What changed

- Hard-cut the repository protocol to LXCD7 / V26 for the new commit-delta payload representation.
- Encode checkpoint/merge-selected payloads as compact references to canonical authored changes and hydrate them in batches on reads.
- Encode host-certified semantic commit-delta payloads as references to immutable certified entity pages instead of duplicating canonical JSON.
- Promote surviving references during GC so retained history never depends on reclaimed authority.
- Reclaim only the superseded physical working-diff epoch at each checkpoint, preserving linear checkpoint behavior.

Eager semantic materialization and WASM plugins are unchanged.

## Why

The retained plugin replay showed that canonical semantic JSON was persisted multiple times across HOT state, certified pages, JSON storage, and commit deltas. The commit-delta copies were redundant: their durable identity already maps exactly to canonical authored or host-certified authority. Replacing only those duplicate payloads with compact references cuts physical storage without making materialization lazy.

## Measured impact

50-commit VS Code docs replay, all bundled plugins enabled, eager materialization, SlateDB, verification after every commit, checkpoint after every commit:

- Physical database: **89,651,152 B → 49,790,100 B (-44.5%)**
- Engine execute: **97,301.97 ms → 95,693.63 ms (-1.7%)**
- Checkpoint: **4,154.76 ms → 3,217.60 ms (-22.6%)**
- Total replay: **115,383.10 ms → 127,062.45 ms (+10.1%)**; the difference is verification (**13,850.88 ms → 28,076.61 ms**), outside eager plugin materialization/persistence.
- Largest 298-path commit: **44,535.24 ms → 45,234.65 ms (+1.6%)** with current API v4 and verification enabled.

The final database is retained locally for physical-layout queries.

## Validation

- 50/50 replay commits applied and verified; final Git tree verified.
- 32/32 packed tracked-state storage tests.
- 20/20 certified-path tests and 9/9 GC tests.
- Focused regressions for protocol predecessor rejection, checkpoint reclamation, selected/certified hydration, intermediate-commit ownership, >1,024 certified-batch pagination, tombstone locator exclusion, and full authoritative locator restaging after GC repacking.
- Release CLI build and focused Clippy.
- 5/5 GitHub CI checks green on exact head `f26236a8e`.
- Exact-head Codex review found no major issues.