### PR TITLE
advance staged filesystem path indexes

### DIFF
--- a/packages/engine/src/filesystem/path_index.rs
+++ b/packages/engine/src/filesystem/path_index.rs
@@ -1321,6 +1321,68 @@ impl FilesystemPathIndexCache {
             entries.remove(0);
         }
     }
+
+    /// Advances cached views whose revision can be mapped to a successor.
+    ///
+    /// Transaction-local path indexes use a composite revision that changes
+    /// after every staged descriptor batch. Applying that batch directly
+    /// avoids rebuilding the complete visible filesystem for the next
+    /// statement in the same transaction.
+    pub(crate) fn advance_revisions(
+        &self,
+        rows: &[MaterializedLiveStateRow],
+        next_revision_for: impl Fn(&[u8]) -> Option<Vec<u8>>,
+    ) {
+        let invalidates_delta = rows.iter().any(|row| row.global || row.untracked);
+        let mut entries = self
+            .entries
+            .lock()
+            .expect("filesystem path cache lock poisoned");
+        let mut advanced = Vec::new();
+        entries.retain(|candidate| {
+            let Some(previous_revision) = candidate.key.revision.as_deref() else {
+                return true;
+            };
+            let Some(next_revision) = next_revision_for(previous_revision) else {
+                return true;
+            };
+            if invalidates_delta || candidate.key.branch_ids.len() != 1 {
+                return false;
+            }
+            let request = FilesystemPathIndexRequest::new(candidate.key.branch_ids.clone())
+                .with_blob_refs(candidate.key.include_blob_refs)
+                .with_cached_blob_data(candidate.key.cache_small_blob_data);
+            if let Ok(index) =
+                candidate
+                    .index
+                    .apply_committed_rows(&request, rows, Some(next_revision.as_slice()))
+            {
+                advanced.push((request, next_revision, Arc::new(index)));
+            }
+            false
+        });
+        for (request, revision, index) in advanced {
+            let key = CacheKey {
+                branch_ids: request.branch_ids,
+                revision: Some(revision),
+                include_blob_refs: request.include_blob_refs,
+                cache_small_blob_data: request.cache_small_blob_data,
+            };
+            let bytes = size_of::<CachedIndex>()
+                + key.estimated_heap_bytes()
+                + index.estimated_heap_bytes();
+            entries.push(CachedIndex { key, index, bytes });
+        }
+        while entries.len() > 1
+            && entries
+                .iter()
+                .map(|candidate| candidate.bytes)
+                .sum::<usize>()
+                > MAX_CACHE_BYTES
+        {
+            entries.remove(0);
+        }
+    }
 }
 
 pub(crate) async fn load_path_index_revision(

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -1062,8 +1062,8 @@ where
             discard_plugin_actor_publications(actor_publications).await;
             return Err(error);
         }
-        let affects_filesystem_path_index =
-            prepared_transaction_write_affects_filesystem_path_index(&write);
+        let (affects_filesystem_path_index, filesystem_delta_rows) =
+            prepared_transaction_write_filesystem_index_impact(&write);
         let stage_result = tracing::debug_span!(
             target: "lix_perf",
             "lix.perf.transaction_buffer_stage"
@@ -1082,8 +1082,22 @@ where
             }
         };
         if affects_filesystem_path_index {
-            self.filesystem_path_index_epoch
+            let previous_epoch = self
+                .filesystem_path_index_epoch
                 .fetch_add(1, Ordering::SeqCst);
+            let next_epoch = previous_epoch.wrapping_add(1);
+            if incremental_filesystem_index_enabled() && !filesystem_delta_rows.is_empty() {
+                self.filesystem_path_index_cache.advance_revisions(
+                    &filesystem_delta_rows,
+                    |revision| {
+                        advance_transaction_path_index_cache_revision(
+                            revision,
+                            previous_epoch,
+                            next_epoch,
+                        )
+                    },
+                );
+            }
         }
         self.pending_file_view_mutations.extend(file_view_mutations);
         self.pending_plugin_actor_publications
@@ -6685,18 +6699,22 @@ where
     }
 }
 
-fn prepared_transaction_write_affects_filesystem_path_index(
+fn prepared_transaction_write_filesystem_index_impact(
     write: &PreparedTransactionWrite,
-) -> bool {
-    prepared_transaction_write_rows(write).iter().any(|row| {
-        matches!(
-            row.schema_key.as_str(),
-            "lix_file_descriptor"
-                | "lix_directory_descriptor"
-                | BLOB_REF_SCHEMA_KEY
-                | BRANCH_REF_SCHEMA_KEY
-        )
-    })
+) -> (bool, Vec<MaterializedLiveStateRow>) {
+    let mut affects_index = false;
+    let mut delta_rows = Vec::new();
+    for row in prepared_transaction_write_rows(write).iter() {
+        match row.schema_key.as_str() {
+            FILE_DESCRIPTOR_SCHEMA_KEY | DIRECTORY_DESCRIPTOR_SCHEMA_KEY | BLOB_REF_SCHEMA_KEY => {
+                affects_index = true;
+                delta_rows.push(MaterializedLiveStateRow::from(row));
+            }
+            BRANCH_REF_SCHEMA_KEY => affects_index = true,
+            _ => {}
+        }
+    }
+    (affects_index, delta_rows)
 }
 
 fn prepared_transaction_write_rows(write: &PreparedTransactionWrite) -> &PreparedStateBatch {
@@ -6745,6 +6763,24 @@ fn transaction_path_index_cache_revision(
         None => cache_revision.push(0),
     }
     cache_revision
+}
+
+fn advance_transaction_path_index_cache_revision(
+    revision: &[u8],
+    previous_epoch: usize,
+    next_epoch: usize,
+) -> Option<Vec<u8>> {
+    const PREFIX: &[u8] = b"transaction-path-index-v1";
+    let epoch_end = PREFIX.len().checked_add(size_of::<usize>())?;
+    if revision.len() < epoch_end
+        || !revision.starts_with(PREFIX)
+        || revision[PREFIX.len()..epoch_end] != previous_epoch.to_be_bytes()
+    {
+        return None;
+    }
+    let mut next_revision = revision.to_vec();
+    next_revision[PREFIX.len()..epoch_end].copy_from_slice(&next_epoch.to_be_bytes());
+    Some(next_revision)
 }
 
 const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
@@ -10029,6 +10065,71 @@ mod tests {
             std::iter::repeat_n('a', 64).collect::<String>(),
             "the previously loaded authoritative entry remains untouched on rejection"
         );
+    }
+
+    #[tokio::test]
+    async fn staged_descriptor_batches_advance_transaction_path_index() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("storage should initialize");
+        let engine = Engine::new(storage)
+            .await
+            .expect("engine should open initialized storage");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("workspace session should open");
+
+        let values = (0..32)
+            .map(|index| format!("('/seed-{index:02}.md', X'01')"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        session
+            .execute(
+                &format!("INSERT INTO lix_file (path, data) VALUES {values}"),
+                &[],
+            )
+            .await
+            .expect("fixture files should commit");
+
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("transaction should begin");
+        reset_transaction_path_index_build_stats();
+        for index in 0..5 {
+            transaction
+                .execute(
+                    &format!(
+                        "INSERT INTO lix_file (path, data) VALUES ('/staged-{index}.md', X'02')"
+                    ),
+                    &[],
+                )
+                .await
+                .expect("descriptor batch should stage");
+            transaction
+                .execute(
+                    "UPDATE lix_file SET data = X'03' WHERE path = '/seed-00.md'",
+                    &[],
+                )
+                .await
+                .expect("path lookup after the staged descriptor should succeed");
+        }
+
+        let stats = transaction_path_index_build_stats();
+        assert_eq!(
+            stats.builds, 1,
+            "the first staged revision may build once; later revisions must advance by delta"
+        );
+        assert!(
+            stats.descriptor_rows > 0,
+            "the regression must exercise a real transaction path-index build"
+        );
+        transaction
+            .rollback()
+            .await
+            .expect("transaction should roll back");
     }
 
     #[tokio::test]

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -1062,7 +1062,7 @@ where
             discard_plugin_actor_publications(actor_publications).await;
             return Err(error);
         }
-        let (affects_filesystem_path_index, filesystem_delta_rows) =
+        let (affects_filesystem_path_index, mut filesystem_delta_rows) =
             prepared_transaction_write_filesystem_index_impact(&write);
         let stage_result = tracing::debug_span!(
             target: "lix_perf",
@@ -1082,6 +1082,25 @@ where
             }
         };
         if affects_filesystem_path_index {
+            let tracked_branch_ids = filesystem_delta_rows
+                .iter()
+                .filter(|row| !row.untracked)
+                .map(|row| row.branch_id.to_string())
+                .collect::<BTreeSet<_>>();
+            let mut commit_ids = BTreeMap::new();
+            for branch_id in tracked_branch_ids {
+                commit_ids.insert(
+                    branch_id.clone(),
+                    self.staged_writes.commit_id_for_branch(&branch_id)?,
+                );
+            }
+            for row in &mut filesystem_delta_rows {
+                row.commit_id = if row.untracked {
+                    None
+                } else {
+                    commit_ids.get(row.branch_id.as_ref()).copied().flatten()
+                };
+            }
             let previous_epoch = self
                 .filesystem_path_index_epoch
                 .fetch_add(1, Ordering::SeqCst);
@@ -10115,12 +10134,24 @@ mod tests {
                 )
                 .await
                 .expect("path lookup after the staged descriptor should succeed");
+            let rows = transaction
+                .execute(
+                    &format!(
+                        "SELECT lixcol_commit_id FROM lix_file WHERE path = '/staged-{index}.md'"
+                    ),
+                    &[],
+                )
+                .await
+                .expect("the advanced path-index row should remain queryable");
+            rows.rows()[0]
+                .get::<String>("lixcol_commit_id")
+                .expect("the advanced descriptor must retain its staged commit id");
         }
 
         let stats = transaction_path_index_build_stats();
         assert_eq!(
-            stats.builds, 1,
-            "the first staged revision may build once; later revisions must advance by delta"
+            stats.builds, 2,
+            "the data and metadata projections may each build once; later revisions must advance by delta"
         );
         assert!(
             stats.descriptor_rows > 0,


### PR DESCRIPTION
## What changed

- advance transaction-local filesystem path indexes from each staged descriptor/blob delta
- preserve rebuild fallback for global, untracked, multi-branch, branch-ref, or failed delta application cases
- add a regression proving repeated staged descriptor batches cause one full path-index build

## Root cause

Every filesystem-affecting staged write incremented the transaction path-index revision. The next statement then rebuilt the complete visible filesystem index, even though the transaction already had a valid cached index and only a small immutable descriptor delta had changed.

Large Git commits stage hundreds of file writes in one transaction, turning this into repeated full materialization.

## Impact

Exact VS Code Docs replay, commit `0892da1a3afa8c1ee5d6e0ffe9c0476bca104212`, 303 changed paths, SlateDB, all WASM plugins, checkpoint + state verification:

| | PR #999 baseline | This PR |
|---|---:|---:|
| execute | 30,898 ms | 8,292 ms |
| total | 34,360 ms | 11,719 ms |

That is 3.73× faster execute time (−73.2%) and 2.93× faster total time. The replay verified the changed commit and exact final Git tree.

Profiles:

- baseline: `/root/projects/lix-replay-pr999-0892-profile.json`
- candidate: `/root/projects/lix-replay-path-delta-e713-0892-profile.json`

## Validation

- `cargo test -p lix_engine --features all-simulations`
- `cargo clippy -p lix_engine --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- exact one-commit VS Code Docs SlateDB replay with all WASM plugins and `--verify-state`
