### PR TITLE
Retain decoded plugin checkpoints across Store eviction

### DIFF
--- a/packages/engine/src/plugin/actor.rs
+++ b/packages/engine/src/plugin/actor.rs
@@ -15,10 +15,11 @@ use tokio::sync::{
 };
 
 use super::incremental::FileBytesSha256;
-use crate::wasm::{WasmComponentActor, WasmDocumentHandle};
+use crate::wasm::{WasmComponentActor, WasmDocumentCheckpoint, WasmDocumentHandle};
 use crate::{Blob, LixError};
 
 pub(crate) const DEFAULT_MAX_LIVE_PLUGIN_STORES: usize = 16;
+const DEFAULT_MAX_DECODED_CHECKPOINT_BYTES: u64 = 64 * 1024 * 1024;
 // One predecessor is enough for the required two-reader serialization while
 // keeping each file actor's retained working set bounded.
 pub(crate) const DEFAULT_MAX_PLUGIN_FILE_HISTORY: usize = 1;
@@ -121,8 +122,15 @@ impl PluginActorSlot {
 
 struct PluginActorCacheState {
     actors: BTreeMap<PluginActorKey, Arc<PluginActorSlot>>,
+    checkpoints: BTreeMap<(PluginActorKey, String), PluginActorCheckpoint>,
+    checkpoint_bytes: u64,
     clock: u64,
     next_nonce: u64,
+}
+
+struct PluginActorCheckpoint {
+    checkpoint: WasmDocumentCheckpoint,
+    last_used: u64,
 }
 
 /// Workspace-local index and hard admission bound for per-file actors.
@@ -188,6 +196,8 @@ impl PluginActorCache {
             store_admission: Arc::new(Semaphore::new(capacity.get())),
             state: Arc::new(Mutex::new(PluginActorCacheState {
                 actors: BTreeMap::new(),
+                checkpoints: BTreeMap::new(),
+                checkpoint_bytes: 0,
                 clock: 0,
                 next_nonce: 1,
             })),
@@ -197,6 +207,97 @@ impl PluginActorCache {
 
     pub(crate) fn capacity(&self) -> usize {
         self.capacity.get()
+    }
+
+    /// Retains one decoded immutable arena root per actor identity. Unlike a
+    /// Wasmtime Store, this checkpoint owns no guest linear memory and can be
+    /// restored into a fresh actor after cache eviction.
+    pub(crate) fn remember_checkpoint(
+        &self,
+        key: &PluginActorKey,
+        semantic_root: &str,
+        checkpoint: Option<WasmDocumentCheckpoint>,
+    ) {
+        let Some(checkpoint) = checkpoint else {
+            return;
+        };
+        let retained_bytes = checkpoint.retained_bytes();
+        if retained_bytes > DEFAULT_MAX_DECODED_CHECKPOINT_BYTES {
+            return;
+        }
+        let mut state = self.lock();
+        let stale_keys = state
+            .checkpoints
+            .keys()
+            .filter(|(existing, _)| existing == key)
+            .cloned()
+            .collect::<Vec<_>>();
+        for stale_key in stale_keys {
+            if let Some(stale) = state.checkpoints.remove(&stale_key) {
+                state.checkpoint_bytes = state
+                    .checkpoint_bytes
+                    .saturating_sub(stale.checkpoint.retained_bytes());
+            }
+        }
+        state.clock = state.clock.wrapping_add(1);
+        let last_used = state.clock;
+        state.checkpoint_bytes = state.checkpoint_bytes.saturating_add(retained_bytes);
+        state.checkpoints.insert(
+            (key.clone(), semantic_root.to_owned()),
+            PluginActorCheckpoint {
+                checkpoint,
+                last_used,
+            },
+        );
+        while state.checkpoint_bytes > DEFAULT_MAX_DECODED_CHECKPOINT_BYTES {
+            let oldest = state
+                .checkpoints
+                .iter()
+                .min_by_key(|(_, entry)| entry.last_used)
+                .map(|(key, _)| key.clone());
+            let Some(oldest) = oldest else {
+                break;
+            };
+            if let Some(evicted) = state.checkpoints.remove(&oldest) {
+                state.checkpoint_bytes = state
+                    .checkpoint_bytes
+                    .saturating_sub(evicted.checkpoint.retained_bytes());
+            }
+        }
+    }
+
+    pub(crate) fn checkpoint(
+        &self,
+        key: &PluginActorKey,
+        semantic_root: &str,
+    ) -> Option<WasmDocumentCheckpoint> {
+        let mut state = self.lock();
+        state.clock = state.clock.wrapping_add(1);
+        let last_used = state.clock;
+        state
+            .checkpoints
+            .get_mut(&(key.clone(), semantic_root.to_owned()))
+            .map(|entry| {
+                entry.last_used = last_used;
+                entry.checkpoint.clone()
+            })
+    }
+
+    fn forget_checkpoints(&self, key: &PluginActorKey) {
+        let mut state = self.lock();
+        let stale_keys = state
+            .checkpoints
+            .keys()
+            .filter(|(existing, _)| existing == key)
+            .cloned()
+            .collect::<Vec<_>>();
+        for stale_key in stale_keys {
+            if let Some(stale) = state.checkpoints.remove(&stale_key) {
+                state.checkpoint_bytes = state
+                    .checkpoint_bytes
+                    .saturating_sub(stale.checkpoint.retained_bytes());
+            }
+        }
     }
 
     /// Serializes cold actor construction. The gate is workspace-wide rather
@@ -721,6 +822,7 @@ fn plugin_store_resource_limit(capacity: NonZeroUsize) -> LixError {
 
 struct PluginActorSuccessor {
     document: WasmDocumentHandle,
+    checkpoint: Option<WasmDocumentCheckpoint>,
     bytes: Blob,
     bytes_sha256: Option<FileBytesSha256>,
     semantic_root: Arc<str>,
@@ -903,6 +1005,7 @@ impl PluginActorLease {
         &mut self,
         mut call: PluginActorPendingCall,
         document: WasmDocumentHandle,
+        checkpoint: Option<WasmDocumentCheckpoint>,
         bytes: Blob,
         bytes_sha256: impl Into<Option<FileBytesSha256>>,
         semantic_root: impl Into<Arc<str>>,
@@ -918,6 +1021,7 @@ impl PluginActorLease {
         let previous_successor = call.previous_successor.take();
         self.successor = Some(PluginActorSuccessor {
             document,
+            checkpoint,
             bytes,
             bytes_sha256,
             semantic_root: semantic_root.into(),
@@ -979,6 +1083,7 @@ impl PluginActorLease {
     pub(crate) fn complete_guest_call(
         &mut self,
         document: WasmDocumentHandle,
+        checkpoint: Option<WasmDocumentCheckpoint>,
         bytes: Blob,
         bytes_sha256: impl Into<Option<FileBytesSha256>>,
         semantic_root: impl Into<Arc<str>>,
@@ -993,6 +1098,7 @@ impl PluginActorLease {
         self.uncertain_guest_call = false;
         self.successor = Some(PluginActorSuccessor {
             document,
+            checkpoint,
             bytes,
             bytes_sha256,
             semantic_root: semantic_root.into(),
@@ -1012,6 +1118,18 @@ impl PluginActorLease {
             self.slot.retire();
         }
         result
+    }
+
+    pub(crate) fn successor_checkpoint(
+        &self,
+    ) -> Option<(PluginActorCache, Arc<str>, Option<WasmDocumentCheckpoint>)> {
+        self.successor.as_ref().map(|successor| {
+            (
+                self.cache.clone(),
+                Arc::clone(&successor.semantic_root),
+                successor.checkpoint.clone(),
+            )
+        })
     }
 
     /// Publishes the successor only after durable commit. A failure here is a
@@ -1079,6 +1197,14 @@ impl PluginActorLease {
             self.cache.remove_if_same(&self.key, &self.slot);
             return Err(error);
         }
+        if self.key != successor_key {
+            self.cache.forget_checkpoints(&self.key);
+        }
+        self.cache.remember_checkpoint(
+            &successor_key,
+            &successor.semantic_root,
+            successor.checkpoint,
+        );
         Ok(PluginObservation {
             key: successor_key,
             actor_nonce: self.slot.nonce,
@@ -1291,6 +1417,30 @@ mod tests {
         )
     }
 
+    #[test]
+    fn decoded_checkpoints_require_exact_actor_and_semantic_root() {
+        let cache = PluginActorCache::new(2).unwrap();
+        let actor_key = key("main", "/data.csv", "g1");
+        cache.remember_checkpoint(
+            &actor_key,
+            "root-1",
+            Some(WasmDocumentCheckpoint::new(42_u64, 128)),
+        );
+
+        assert_eq!(
+            cache
+                .checkpoint(&actor_key, "root-1")
+                .and_then(|checkpoint| checkpoint.downcast_ref::<u64>().copied()),
+            Some(42)
+        );
+        assert!(cache.checkpoint(&actor_key, "root-2").is_none());
+        assert!(
+            cache
+                .checkpoint(&key("main", "/other.csv", "g1"), "root-1")
+                .is_none()
+        );
+    }
+
     #[tokio::test]
     async fn successor_is_not_visible_until_commit() {
         let cache = PluginActorCache::new(2).unwrap();
@@ -1301,6 +1451,7 @@ mod tests {
         lease
             .complete_guest_call(
                 WasmDocumentHandle(2),
+                None,
                 b"after".as_slice().into(),
                 FileBytesSha256::compute(b"after"),
                 Arc::<str>::from("root-2"),
@@ -1355,6 +1506,7 @@ mod tests {
             .complete_pending_guest_call(
                 first_call,
                 WasmDocumentHandle(2),
+                None,
                 b"middle".as_slice().into(),
                 FileBytesSha256::compute(b"middle"),
                 Arc::<str>::from("root-2"),
@@ -1370,6 +1522,7 @@ mod tests {
             .complete_pending_guest_call(
                 second_call,
                 WasmDocumentHandle(3),
+                None,
                 b"after".as_slice().into(),
                 FileBytesSha256::compute(b"after"),
                 Arc::<str>::from("root-3"),
@@ -1422,6 +1575,7 @@ mod tests {
             .complete_pending_guest_call(
                 first_call,
                 WasmDocumentHandle(2),
+                None,
                 b"middle".as_slice().into(),
                 FileBytesSha256::compute(b"middle"),
                 Arc::<str>::from("root-2"),
@@ -1433,6 +1587,7 @@ mod tests {
             .complete_pending_guest_call(
                 second_call,
                 WasmDocumentHandle(3),
+                None,
                 b"after".as_slice().into(),
                 FileBytesSha256::compute(b"after"),
                 Arc::<str>::from("root-3"),
@@ -1465,6 +1620,7 @@ mod tests {
             .complete_pending_guest_call(
                 first_call,
                 WasmDocumentHandle(2),
+                None,
                 b"middle".as_slice().into(),
                 FileBytesSha256::compute(b"middle"),
                 Arc::<str>::from("root-2"),
@@ -1523,6 +1679,7 @@ mod tests {
         lease
             .complete_guest_call(
                 WasmDocumentHandle(2),
+                None,
                 b"after".as_slice().into(),
                 after_hash,
                 Arc::<str>::from("root-2"),
@@ -1541,6 +1698,7 @@ mod tests {
         latest
             .complete_guest_call(
                 WasmDocumentHandle(3),
+                None,
                 b"later".as_slice().into(),
                 None,
                 Arc::<str>::from("root-3"),
@@ -1569,6 +1727,7 @@ mod tests {
         lease
             .complete_guest_call(
                 WasmDocumentHandle(2),
+                None,
                 b"same".as_slice().into(),
                 FileBytesSha256::compute(b"same"),
                 Arc::<str>::from("root-2"),
@@ -1607,6 +1766,7 @@ mod tests {
         first_lease
             .complete_guest_call(
                 WasmDocumentHandle(2),
+                None,
                 b"after-a".as_slice().into(),
                 FileBytesSha256::compute(b"after-a"),
                 Arc::<str>::from("root-2"),
@@ -1653,6 +1813,7 @@ mod tests {
             lease
                 .complete_guest_call(
                     WasmDocumentHandle(revision),
+                    None,
                     bytes.clone().into(),
                     FileBytesSha256::compute(&bytes),
                     Arc::<str>::from(format!("root-{revision}")),
@@ -1675,6 +1836,7 @@ mod tests {
         lease
             .complete_guest_call(
                 WasmDocumentHandle(2),
+                None,
                 b"rejected".as_slice().into(),
                 FileBytesSha256::compute(b"rejected"),
                 Arc::<str>::from("root-2"),
@@ -2077,6 +2239,7 @@ mod tests {
         lease
             .complete_guest_call(
                 WasmDocumentHandle(2),
+                None,
                 b"winner".as_slice().into(),
                 FileBytesSha256::compute(b"winner"),
                 Arc::<str>::from("root-winner"),

--- a/packages/engine/src/plugin/actor.rs
+++ b/packages/engine/src/plugin/actor.rs
@@ -123,12 +123,21 @@ impl PluginActorSlot {
 struct PluginActorCacheState {
     actors: BTreeMap<PluginActorKey, Arc<PluginActorSlot>>,
     checkpoints: BTreeMap<(PluginActorKey, String), PluginActorCheckpoint>,
+    pending_checkpoints: BTreeMap<u64, PluginActorPendingCheckpoint>,
     checkpoint_bytes: u64,
     clock: u64,
     next_nonce: u64,
+    next_checkpoint_nonce: u64,
 }
 
 struct PluginActorCheckpoint {
+    checkpoint: WasmDocumentCheckpoint,
+    last_used: u64,
+}
+
+struct PluginActorPendingCheckpoint {
+    key: PluginActorKey,
+    semantic_root: Arc<str>,
     checkpoint: WasmDocumentCheckpoint,
     last_used: u64,
 }
@@ -140,6 +149,27 @@ pub(crate) struct PluginActorCache {
     store_admission: Arc<Semaphore>,
     state: Arc<Mutex<PluginActorCacheState>>,
     cold_open_gate: Arc<AsyncMutex<()>>,
+}
+
+pub(crate) struct PluginActorStagedCheckpoint {
+    cache: PluginActorCache,
+    nonce: Option<u64>,
+}
+
+impl PluginActorStagedCheckpoint {
+    pub(crate) fn publish(mut self) {
+        if let Some(nonce) = self.nonce.take() {
+            self.cache.publish_staged_checkpoint(nonce);
+        }
+    }
+}
+
+impl Drop for PluginActorStagedCheckpoint {
+    fn drop(&mut self) {
+        if let Some(nonce) = self.nonce.take() {
+            self.cache.discard_staged_checkpoint(nonce);
+        }
+    }
 }
 
 /// RAII admission for exactly one live Component Store.
@@ -197,9 +227,11 @@ impl PluginActorCache {
             state: Arc::new(Mutex::new(PluginActorCacheState {
                 actors: BTreeMap::new(),
                 checkpoints: BTreeMap::new(),
+                pending_checkpoints: BTreeMap::new(),
                 checkpoint_bytes: 0,
                 clock: 0,
                 next_nonce: 1,
+                next_checkpoint_nonce: 1,
             })),
             cold_open_gate: Arc::new(AsyncMutex::new(())),
         })
@@ -250,18 +282,8 @@ impl PluginActorCache {
             },
         );
         while state.checkpoint_bytes > DEFAULT_MAX_DECODED_CHECKPOINT_BYTES {
-            let oldest = state
-                .checkpoints
-                .iter()
-                .min_by_key(|(_, entry)| entry.last_used)
-                .map(|(key, _)| key.clone());
-            let Some(oldest) = oldest else {
+            if !evict_oldest_checkpoint(&mut state) {
                 break;
-            };
-            if let Some(evicted) = state.checkpoints.remove(&oldest) {
-                state.checkpoint_bytes = state
-                    .checkpoint_bytes
-                    .saturating_sub(evicted.checkpoint.retained_bytes());
             }
         }
     }
@@ -281,6 +303,82 @@ impl PluginActorCache {
                 entry.last_used = last_used;
                 entry.checkpoint.clone()
             })
+    }
+
+    pub(crate) fn stage_checkpoint(
+        &self,
+        key: PluginActorKey,
+        semantic_root: Arc<str>,
+        checkpoint: Option<WasmDocumentCheckpoint>,
+    ) -> Option<PluginActorStagedCheckpoint> {
+        let checkpoint = checkpoint?;
+        let retained_bytes = checkpoint.retained_bytes();
+        if retained_bytes > DEFAULT_MAX_DECODED_CHECKPOINT_BYTES {
+            return None;
+        }
+        let mut state = self.lock();
+        state.clock = state.clock.wrapping_add(1);
+        let last_used = state.clock;
+        let nonce = state.next_checkpoint_nonce;
+        state.next_checkpoint_nonce = state.next_checkpoint_nonce.wrapping_add(1).max(1);
+        state.checkpoint_bytes = state.checkpoint_bytes.saturating_add(retained_bytes);
+        state.pending_checkpoints.insert(
+            nonce,
+            PluginActorPendingCheckpoint {
+                key,
+                semantic_root,
+                checkpoint,
+                last_used,
+            },
+        );
+        while state.checkpoint_bytes > DEFAULT_MAX_DECODED_CHECKPOINT_BYTES {
+            if !evict_oldest_checkpoint(&mut state) {
+                break;
+            }
+        }
+        drop(state);
+        Some(PluginActorStagedCheckpoint {
+            cache: self.clone(),
+            nonce: Some(nonce),
+        })
+    }
+
+    fn publish_staged_checkpoint(&self, nonce: u64) {
+        let mut state = self.lock();
+        let Some(mut pending) = state.pending_checkpoints.remove(&nonce) else {
+            return;
+        };
+        let stale_keys = state
+            .checkpoints
+            .keys()
+            .filter(|(existing, _)| existing == &pending.key)
+            .cloned()
+            .collect::<Vec<_>>();
+        for stale_key in stale_keys {
+            if let Some(stale) = state.checkpoints.remove(&stale_key) {
+                state.checkpoint_bytes = state
+                    .checkpoint_bytes
+                    .saturating_sub(stale.checkpoint.retained_bytes());
+            }
+        }
+        state.clock = state.clock.wrapping_add(1);
+        pending.last_used = state.clock;
+        state.checkpoints.insert(
+            (pending.key, pending.semantic_root.to_string()),
+            PluginActorCheckpoint {
+                checkpoint: pending.checkpoint,
+                last_used: pending.last_used,
+            },
+        );
+    }
+
+    fn discard_staged_checkpoint(&self, nonce: u64) {
+        let mut state = self.lock();
+        if let Some(pending) = state.pending_checkpoints.remove(&nonce) {
+            state.checkpoint_bytes = state
+                .checkpoint_bytes
+                .saturating_sub(pending.checkpoint.retained_bytes());
+        }
     }
 
     fn forget_checkpoints(&self, key: &PluginActorKey) {
@@ -804,6 +902,52 @@ impl PluginActorCache {
         self.state
             .lock()
             .expect("plugin actor cache mutex should not poison")
+    }
+}
+
+fn evict_oldest_checkpoint(state: &mut PluginActorCacheState) -> bool {
+    let committed = state
+        .checkpoints
+        .iter()
+        .min_by_key(|(_, entry)| entry.last_used)
+        .map(|(key, entry)| (entry.last_used, key.clone()));
+    let pending = state
+        .pending_checkpoints
+        .iter()
+        .min_by_key(|(_, entry)| entry.last_used)
+        .map(|(nonce, entry)| (entry.last_used, *nonce));
+    match (committed, pending) {
+        (None, None) => false,
+        (Some((_, key)), None) => {
+            if let Some(evicted) = state.checkpoints.remove(&key) {
+                state.checkpoint_bytes = state
+                    .checkpoint_bytes
+                    .saturating_sub(evicted.checkpoint.retained_bytes());
+            }
+            true
+        }
+        (None, Some((_, nonce))) => {
+            if let Some(evicted) = state.pending_checkpoints.remove(&nonce) {
+                state.checkpoint_bytes = state
+                    .checkpoint_bytes
+                    .saturating_sub(evicted.checkpoint.retained_bytes());
+            }
+            true
+        }
+        (Some((committed_used, key)), Some((pending_used, nonce))) => {
+            if committed_used <= pending_used {
+                if let Some(evicted) = state.checkpoints.remove(&key) {
+                    state.checkpoint_bytes = state
+                        .checkpoint_bytes
+                        .saturating_sub(evicted.checkpoint.retained_bytes());
+                }
+            } else if let Some(evicted) = state.pending_checkpoints.remove(&nonce) {
+                state.checkpoint_bytes = state
+                    .checkpoint_bytes
+                    .saturating_sub(evicted.checkpoint.retained_bytes());
+            }
+            true
+        }
     }
 }
 
@@ -1439,6 +1583,40 @@ mod tests {
                 .checkpoint(&key("main", "/other.csv", "g1"), "root-1")
                 .is_none()
         );
+    }
+
+    #[test]
+    fn pending_and_published_checkpoints_share_one_hard_budget() {
+        let cache = PluginActorCache::new(2).unwrap();
+        let first_key = key("main", "/first.csv", "g1");
+        let second_key = key("main", "/second.csv", "g1");
+        let retained_bytes = 40 * 1024 * 1024;
+        let first = cache
+            .stage_checkpoint(
+                first_key.clone(),
+                Arc::from("root-1"),
+                Some(WasmDocumentCheckpoint::new(1_u64, retained_bytes)),
+            )
+            .unwrap();
+        let second = cache
+            .stage_checkpoint(
+                second_key.clone(),
+                Arc::from("root-2"),
+                Some(WasmDocumentCheckpoint::new(2_u64, retained_bytes)),
+            )
+            .unwrap();
+
+        assert!(cache.checkpoint(&second_key, "root-2").is_none());
+        first.publish();
+        second.publish();
+        assert!(cache.checkpoint(&first_key, "root-1").is_none());
+        assert_eq!(
+            cache
+                .checkpoint(&second_key, "root-2")
+                .and_then(|checkpoint| checkpoint.downcast_ref::<u64>().copied()),
+            Some(2)
+        );
+        assert!(cache.lock().checkpoint_bytes <= DEFAULT_MAX_DECODED_CHECKPOINT_BYTES);
     }
 
     #[tokio::test]

--- a/packages/engine/src/plugin/mod.rs
+++ b/packages/engine/src/plugin/mod.rs
@@ -17,7 +17,8 @@ mod storage;
 
 pub(crate) use actor::{
     DEFAULT_MAX_LIVE_PLUGIN_STORES, PluginActorCache, PluginActorColdInstall, PluginActorColdOpen,
-    PluginActorKey, PluginActorLease, PluginActorStore, PluginActorStorePermit, PluginObservation,
+    PluginActorKey, PluginActorLease, PluginActorStagedCheckpoint, PluginActorStore,
+    PluginActorStorePermit, PluginObservation,
 };
 pub(crate) use archive::{ParsedPluginArchive, parse_plugin_archive_for_install};
 pub(crate) use component::{DEFAULT_PLUGIN_MEMORY_BYTES, PluginRuntimeHost};

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -64,11 +64,12 @@ use crate::plugin::{
     ArcByteSource, BoundCreateContext, CompiledPluginCatalog, FileBytesSha256,
     LiveBatchEntitySource, PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY, PluginActorCache,
     PluginActorColdInstall, PluginActorColdOpen, PluginActorKey, PluginActorLease,
-    PluginActorStore, PluginActorStorePermit, PluginArchiveInstallPlan, PluginContentType,
-    PluginFileOwner, PluginMaterialization, PluginObservation, PluginRegistry, PluginRegistryEntry,
-    PluginRegistryEntryInput, PluginRuntimeHost, SchemaAllowlist, ValidatedConflictTransition,
-    ValidatedFileTransition, ValidatedSameLengthOutputSplice, VecEntityChangeSource,
-    VecEntityConflictSource, VecEntitySource, build_file_update_splices, canonicalize_snapshot,
+    PluginActorStagedCheckpoint, PluginActorStore, PluginActorStorePermit,
+    PluginArchiveInstallPlan, PluginContentType, PluginFileOwner, PluginMaterialization,
+    PluginObservation, PluginRegistry, PluginRegistryEntry, PluginRegistryEntryInput,
+    PluginRuntimeHost, SchemaAllowlist, ValidatedConflictTransition, ValidatedFileTransition,
+    ValidatedSameLengthOutputSplice, VecEntityChangeSource, VecEntityConflictSource,
+    VecEntitySource, build_file_update_splices, canonicalize_snapshot,
     drain_conflict_transition_resolutions, drain_entity_transition_edits,
     drain_file_transition_changes, host_entity_change_with_lazy_snapshot,
     host_entity_with_lazy_snapshot, inferred_media_type_for_path, is_plugin_storage_path,
@@ -3956,6 +3957,7 @@ where
                             let decoded_checkpoint = cold_before.as_ref().and_then(|_| {
                                 cache.checkpoint(&actor_key, &visible_materialization.semantic_root)
                             });
+                            let restored_checkpoint = decoded_checkpoint.is_some();
                             let store_permit = loop {
                                 match cache.admit_cold_store(&mut cold_install) {
                                     Ok(permit) => break permit,
@@ -4121,7 +4123,8 @@ where
                                     .unwrap_or(0);
                             counters.full_state_semantic_rows_materialized =
                                 u64::try_from(entity_count).unwrap_or(u64::MAX);
-                            counters.full_document_reparses = 1;
+                            counters.private_document_cache_hits = u64::from(restored_checkpoint);
+                            counters.full_document_reparses = u64::from(!restored_checkpoint);
                             counters.full_renderer_invocations = u64::from(matches!(
                                 selected.materialization(),
                                 PluginMaterialization::Derived
@@ -7675,15 +7678,8 @@ enum PendingPluginActorPublication {
     Uncached {
         path: String,
         view: PendingPluginActorView,
-        checkpoint: Option<PendingPluginCheckpoint>,
+        checkpoint: Option<PluginActorStagedCheckpoint>,
     },
-}
-
-struct PendingPluginCheckpoint {
-    cache: PluginActorCache,
-    key: PluginActorKey,
-    semantic_root: Arc<str>,
-    checkpoint: Option<WasmDocumentCheckpoint>,
 }
 
 impl PendingPluginActorPublication {
@@ -7697,14 +7693,9 @@ impl PendingPluginActorPublication {
                 let checkpoint =
                     lease
                         .successor_checkpoint()
-                        .map(
-                            |(cache, semantic_root, checkpoint)| PendingPluginCheckpoint {
-                                cache,
-                                key: successor_key.clone(),
-                                semantic_root,
-                                checkpoint,
-                            },
-                        );
+                        .and_then(|(cache, semantic_root, checkpoint)| {
+                            cache.stage_checkpoint(successor_key.clone(), semantic_root, checkpoint)
+                        });
                 let _ = lease.discard_successor().await;
                 Self::Uncached {
                     path: successor_key.path,
@@ -7727,12 +7718,7 @@ impl PendingPluginActorPublication {
                 Self::Uncached {
                     path: key.path.clone(),
                     view,
-                    checkpoint: Some(PendingPluginCheckpoint {
-                        cache,
-                        key,
-                        semantic_root,
-                        checkpoint,
-                    }),
+                    checkpoint: cache.stage_checkpoint(key, semantic_root, checkpoint),
                 }
             }
             publication @ Self::Uncached { .. } => publication,
@@ -7794,11 +7780,7 @@ impl PendingPluginActorPublication {
                 checkpoint,
             } => {
                 if let Some(checkpoint) = checkpoint {
-                    checkpoint.cache.remember_checkpoint(
-                        &checkpoint.key,
-                        &checkpoint.semantic_root,
-                        checkpoint.checkpoint,
-                    );
+                    checkpoint.publish();
                 }
                 (None, view, path)
             }

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -168,10 +168,10 @@ use crate::transaction::validation::{
 };
 use crate::wasm::{
     WasmChangeEffect, WasmColdFileUpdate, WasmComponentActor, WasmComponentFactory,
-    WasmConflictUpdate, WasmDocumentHandle, WasmEntityChange, WasmEntityConflict, WasmEntityKey,
-    WasmEntityUpdate, WasmFileDescriptor, WasmFileUpdate, WasmHostBytes, WasmHostEntity,
-    WasmHostEntityChanges, WasmOpenEntitiesInput, WasmOpenFileInput, WasmPluginSelection,
-    WasmTransitionLimits,
+    WasmConflictUpdate, WasmDocumentCheckpoint, WasmDocumentHandle, WasmEntityChange,
+    WasmEntityConflict, WasmEntityKey, WasmEntityUpdate, WasmFileDescriptor, WasmFileUpdate,
+    WasmHostBytes, WasmHostEntity, WasmHostEntityChanges, WasmOpenEntitiesInput, WasmOpenFileInput,
+    WasmPluginSelection, WasmTransitionLimits,
 };
 use crate::{LixError, NullableKeyFilter, SqlQueryResult, Value};
 
@@ -3571,7 +3571,7 @@ where
                 return Err(error);
             }
 
-            for (pending, actor, validated) in completed_opens {
+            for (pending, mut actor, validated) in completed_opens {
                 let certified_row_count = validated
                     .certified_batches
                     .iter()
@@ -3643,6 +3643,7 @@ where
                     .push(PendingPluginActorPublication::New {
                         cache: self.plugin_host.actor_cache(),
                         key: pending.actor_key,
+                        checkpoint: actor.checkpoint_document(validated.document).await?,
                         store: PluginActorStore::new(actor, pending.store_permit),
                         document: validated.document,
                         bytes: pending.submitted_bytes,
@@ -3952,37 +3953,9 @@ where
                                     ));
                                 }
                             };
-                            let entity_rows = overlay_scan_batch(
-                                &base,
-                                &staged,
-                                &LiveStateScanRequest {
-                                    filter: LiveStateFilter {
-                                        schema_keys: selected.schema_keys().to_vec(),
-                                        branch_ids: vec![actor_key.branch_id.clone()],
-                                        file_ids: vec![NullableKeyFilter::Value(
-                                            actor_key.file_id.clone(),
-                                        )],
-                                        untracked: Some(false),
-                                        ..Default::default()
-                                    },
-                                    projection: plugin_state_live_state_projection(),
-                                    ..Default::default()
-                                },
-                            )
-                            .await?;
-                            let entity_ordinals = v2_host_entity_ordinals_from_live_batch(
-                                &entity_rows,
-                                &file_key,
-                                selected.schema_keys(),
-                            )?;
-                            let entity_count = entity_ordinals.len();
-                            let entity_source = LiveBatchEntitySource::new(
-                                entity_rows,
-                                entity_ordinals,
-                                cold_limits,
-                            )?;
-                            drop(base);
-                            drop(read);
+                            let decoded_checkpoint = cold_before.as_ref().and_then(|_| {
+                                cache.checkpoint(&actor_key, &visible_materialization.semantic_root)
+                            });
                             let store_permit = loop {
                                 match cache.admit_cold_store(&mut cold_install) {
                                     Ok(permit) => break permit,
@@ -4012,27 +3985,88 @@ where
                                     "lix.perf.plugin_actor_instantiate"
                                 ))
                                 .await?;
-                            let transition = match actor
-                                .cold_file_changed(
-                                    cold_limits,
-                                    WasmColdFileUpdate {
-                                        before_descriptor: cold_before_descriptor,
-                                        after_descriptor: descriptor.clone(),
-                                        before: cold_before,
-                                        edits: cold_edits,
-                                        after: Arc::new(ArcByteSource::new(
-                                            submitted_bytes.clone(),
-                                        )),
-                                        creates,
-                                        entities: Box::new(entity_source),
+                            let transition_result = if let Some(checkpoint) = decoded_checkpoint {
+                                drop(base);
+                                drop(read);
+                                let document = actor.restore_document(&checkpoint).await?;
+                                actor
+                                    .file_changed(
+                                        document,
+                                        cold_limits,
+                                        WasmFileUpdate {
+                                            before_descriptor: cold_before_descriptor,
+                                            after_descriptor: descriptor.clone(),
+                                            before: cold_before.expect(
+                                                "decoded checkpoints are used only for blob materializations",
+                                            ),
+                                            edits: cold_edits,
+                                            after: Arc::new(ArcByteSource::new(
+                                                submitted_bytes.clone(),
+                                            )),
+                                            creates,
+                                        },
+                                    )
+                                    .instrument(tracing::debug_span!(
+                                        target: "lix_perf",
+                                        "lix.perf.plugin_checkpoint_file_changed"
+                                    ))
+                                    .await
+                                    .map(|transition| (transition, 0))
+                            } else {
+                                let entity_rows = overlay_scan_batch(
+                                    &base,
+                                    &staged,
+                                    &LiveStateScanRequest {
+                                        filter: LiveStateFilter {
+                                            schema_keys: selected.schema_keys().to_vec(),
+                                            branch_ids: vec![actor_key.branch_id.clone()],
+                                            file_ids: vec![NullableKeyFilter::Value(
+                                                actor_key.file_id.clone(),
+                                            )],
+                                            untracked: Some(false),
+                                            ..Default::default()
+                                        },
+                                        projection: plugin_state_live_state_projection(),
+                                        ..Default::default()
                                     },
                                 )
-                                .instrument(tracing::debug_span!(
-                                    target: "lix_perf",
-                                    "lix.perf.plugin_cold_file_changed"
-                                ))
-                                .await
-                            {
+                                .await?;
+                                let entity_ordinals = v2_host_entity_ordinals_from_live_batch(
+                                    &entity_rows,
+                                    &file_key,
+                                    selected.schema_keys(),
+                                )?;
+                                let entity_count = entity_ordinals.len();
+                                let entity_source = LiveBatchEntitySource::new(
+                                    entity_rows,
+                                    entity_ordinals,
+                                    cold_limits,
+                                )?;
+                                drop(base);
+                                drop(read);
+                                actor
+                                    .cold_file_changed(
+                                        cold_limits,
+                                        WasmColdFileUpdate {
+                                            before_descriptor: cold_before_descriptor,
+                                            after_descriptor: descriptor.clone(),
+                                            before: cold_before,
+                                            edits: cold_edits,
+                                            after: Arc::new(ArcByteSource::new(
+                                                submitted_bytes.clone(),
+                                            )),
+                                            creates,
+                                            entities: Box::new(entity_source),
+                                        },
+                                    )
+                                    .instrument(tracing::debug_span!(
+                                        target: "lix_perf",
+                                        "lix.perf.plugin_cold_file_changed"
+                                    ))
+                                    .await
+                                    .map(|transition| (transition, entity_count))
+                            };
+                            let (transition, entity_count) = match transition_result {
                                 Ok(transition) => transition,
                                 Err(error) => {
                                     let _ = actor.retire().await;
@@ -4104,6 +4138,9 @@ where
                                 PendingPluginActorPublication::New {
                                     cache,
                                     key: actor_key,
+                                    checkpoint: actor
+                                        .checkpoint_document(validated.document)
+                                        .await?,
                                     store: PluginActorStore::new(actor, store_permit),
                                     document: validated.document,
                                     bytes: submitted_bytes.clone(),
@@ -4413,8 +4450,17 @@ where
                             .unwrap_or(u64::MAX)
                             .saturating_add(certified_row_count);
                     self.plugin_host.record_transition_counters(counters);
+                    let successor_checkpoint = match lease
+                        .actor_mut()
+                        .checkpoint_document(successor_document)
+                        .await
+                    {
+                        Ok(checkpoint) => checkpoint,
+                        Err(error) => return Err(lease.handle_guest_call_error(error)),
+                    };
                     lease.complete_guest_call(
                         successor_document,
+                        successor_checkpoint,
                         materialized_bytes.clone(),
                         materialized_bytes_sha256,
                         materialization_version.clone(),
@@ -4507,6 +4553,7 @@ where
                     PendingPluginActorPublication::New {
                         cache: self.plugin_host.actor_cache(),
                         key: actor_key,
+                        checkpoint: actor.checkpoint_document(validated.document).await?,
                         store: PluginActorStore::new(actor, store_permit),
                         document: validated.document,
                         bytes: submitted_bytes.clone(),
@@ -7615,6 +7662,7 @@ enum PendingPluginActorPublication {
         key: PluginActorKey,
         store: PluginActorStore,
         document: WasmDocumentHandle,
+        checkpoint: Option<WasmDocumentCheckpoint>,
         bytes: crate::Blob,
         semantic_root: Arc<str>,
         view: PendingPluginActorView,
@@ -7627,7 +7675,15 @@ enum PendingPluginActorPublication {
     Uncached {
         path: String,
         view: PendingPluginActorView,
+        checkpoint: Option<PendingPluginCheckpoint>,
     },
+}
+
+struct PendingPluginCheckpoint {
+    cache: PluginActorCache,
+    key: PluginActorKey,
+    semantic_root: Arc<str>,
+    checkpoint: Option<WasmDocumentCheckpoint>,
 }
 
 impl PendingPluginActorPublication {
@@ -7638,24 +7694,45 @@ impl PendingPluginActorPublication {
                 successor_key,
                 view,
             } => {
+                let checkpoint =
+                    lease
+                        .successor_checkpoint()
+                        .map(
+                            |(cache, semantic_root, checkpoint)| PendingPluginCheckpoint {
+                                cache,
+                                key: successor_key.clone(),
+                                semantic_root,
+                                checkpoint,
+                            },
+                        );
                 let _ = lease.discard_successor().await;
                 Self::Uncached {
                     path: successor_key.path,
                     view,
+                    checkpoint,
                 }
             }
             Self::New {
+                cache,
                 mut store,
                 key,
                 document,
+                checkpoint,
+                semantic_root,
                 view,
                 ..
             } => {
                 let _ = store.actor_mut().drop_document(document).await;
                 let _ = store.actor_mut().retire().await;
                 Self::Uncached {
-                    path: key.path,
+                    path: key.path.clone(),
                     view,
+                    checkpoint: Some(PendingPluginCheckpoint {
+                        cache,
+                        key,
+                        semantic_root,
+                        checkpoint,
+                    }),
                 }
             }
             publication @ Self::Uncached { .. } => publication,
@@ -7698,18 +7775,33 @@ impl PendingPluginActorPublication {
                 key,
                 store,
                 document,
+                checkpoint,
                 bytes,
                 semantic_root,
                 view,
             } => {
                 let path = key.path.clone();
+                cache.remember_checkpoint(&key, &semantic_root, checkpoint);
                 (
                     Some(cache.install(key, store, document, bytes, semantic_root)),
                     view,
                     path,
                 )
             }
-            Self::Uncached { path, view } => (None, view, path),
+            Self::Uncached {
+                path,
+                view,
+                checkpoint,
+            } => {
+                if let Some(checkpoint) = checkpoint {
+                    checkpoint.cache.remember_checkpoint(
+                        &checkpoint.key,
+                        &checkpoint.semantic_root,
+                        checkpoint.checkpoint,
+                    );
+                }
+                (None, view, path)
+            }
         };
         Ok((
             view.session_key,
@@ -7898,10 +7990,22 @@ async fn render_semantic_changes_with_lease(
     let mut counters = rendered.counters;
     counters.private_document_cache_hits = 1;
     counters.durable_semantic_changes = change_count;
+    let checkpoint = match lease
+        .actor_mut()
+        .checkpoint_document(rendered.document)
+        .await
+    {
+        Ok(checkpoint) => checkpoint,
+        Err(error) => {
+            let error = lease.handle_pending_guest_call_error(call, error);
+            return Err((error, publication(lease)));
+        }
+    };
     if let Err(error) = lease
         .complete_pending_guest_call(
             call,
             rendered.document,
+            checkpoint,
             rendered.bytes,
             rendered.bytes_sha256,
             materialization_version.to_string(),

--- a/packages/engine/src/wasm/component.rs
+++ b/packages/engine/src/wasm/component.rs
@@ -5,6 +5,7 @@
 //! each branch/file actor owns one isolated mutable instance and all document,
 //! cursor, output-table, and transition handles created by that instance.
 
+use std::any::Any;
 use std::fmt;
 use std::sync::{Arc, OnceLock};
 
@@ -1404,6 +1405,46 @@ macro_rules! handle_type {
 }
 
 handle_type!(WasmDocumentHandle);
+
+/// Runtime-private immutable document state retained outside a Wasm Store.
+///
+/// The engine treats the payload as opaque. A compatible component runtime
+/// may restore it into a fresh Store after actor eviction, avoiding durable
+/// entity hydration while preserving the same semantic authority checks.
+#[derive(Clone)]
+pub struct WasmDocumentCheckpoint {
+    payload: Arc<dyn Any + Send + Sync>,
+    retained_bytes: u64,
+}
+
+impl fmt::Debug for WasmDocumentCheckpoint {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("WasmDocumentCheckpoint")
+            .field("retained_bytes", &self.retained_bytes)
+            .finish_non_exhaustive()
+    }
+}
+
+impl WasmDocumentCheckpoint {
+    pub fn new<T>(payload: T, retained_bytes: u64) -> Self
+    where
+        T: Any + Send + Sync,
+    {
+        Self {
+            payload: Arc::new(payload),
+            retained_bytes,
+        }
+    }
+
+    pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
+        self.payload.downcast_ref()
+    }
+
+    pub fn retained_bytes(&self) -> u64 {
+        self.retained_bytes
+    }
+}
 handle_type!(WasmChangeCursorHandle);
 handle_type!(WasmResolutionCursorHandle);
 handle_type!(WasmEditCursorHandle);
@@ -1823,6 +1864,26 @@ pub trait WasmComponentActor: Send {
         &mut self,
         document: WasmDocumentHandle,
     ) -> Result<WasmDocumentHandle, LixError>;
+
+    /// Captures runtime-private immutable state without serializing it through
+    /// the Component boundary. Implementations that cannot externalize a
+    /// document return `None` and retain the normal hydration path.
+    async fn checkpoint_document(
+        &mut self,
+        _document: WasmDocumentHandle,
+    ) -> Result<Option<WasmDocumentCheckpoint>, LixError> {
+        Ok(None)
+    }
+
+    /// Restores a compatible runtime-private checkpoint into this fresh actor.
+    async fn restore_document(
+        &mut self,
+        _checkpoint: &WasmDocumentCheckpoint,
+    ) -> Result<WasmDocumentHandle, LixError> {
+        Err(invalid_param(
+            "this component actor does not support decoded document checkpoints",
+        ))
+    }
 
     async fn open_file(
         &mut self,

--- a/packages/plugin-arena/src/lib.rs
+++ b/packages/plugin-arena/src/lib.rs
@@ -281,6 +281,7 @@ pub struct ByteArena {
     len: u64,
     segments: Arc<[Segment]>,
     id: Digest,
+    retained_heap_bytes: usize,
 }
 
 impl ByteArena {
@@ -309,11 +310,20 @@ impl ByteArena {
             parts.push(segment.len.to_le_bytes().to_vec());
         }
         let id = digest(b"lix-plugin-v3/bytes\0", parts);
+        let retained_heap_bytes = size_of::<ByteArena>()
+            .saturating_add(segments.len().saturating_mul(size_of::<Segment>()))
+            .saturating_add(2 * size_of::<usize>())
+            .saturating_add(segments.iter().fold(0_usize, |total, segment| {
+                total
+                    .saturating_add(segment.page.bytes.len())
+                    .saturating_add(2 * size_of::<usize>())
+            }));
         Self {
             store,
             len,
             segments: segments.into(),
             id,
+            retained_heap_bytes,
         }
     }
 
@@ -532,6 +542,7 @@ pub struct MapArena {
     store: Store,
     entries: Arc<BTreeMap<Vec<u8>, ByteArena>>,
     id: Digest,
+    retained_heap_bytes: usize,
 }
 
 impl MapArena {
@@ -541,15 +552,22 @@ impl MapArena {
 
     fn from_entries(store: Store, entries: BTreeMap<Vec<u8>, ByteArena>) -> Self {
         let mut parts = Vec::with_capacity(entries.len() * 2);
+        let mut retained_heap_bytes = size_of::<MapArena>();
         for (key, value) in &entries {
             parts.push(key.clone());
             parts.push(value.id.0.to_vec());
+            retained_heap_bytes = retained_heap_bytes
+                .saturating_add(key.capacity())
+                .saturating_add(size_of::<(Vec<u8>, ByteArena)>())
+                .saturating_add(64)
+                .saturating_add(value.retained_heap_bytes);
         }
         let id = digest(b"lix-plugin-v3/map\0", parts);
         Self {
             store,
             entries: Arc::new(entries),
             id,
+            retained_heap_bytes,
         }
     }
 
@@ -643,6 +661,7 @@ pub struct Root {
     pub entities: MapArena,
     pub state: MapArena,
     id: Digest,
+    retained_heap_bytes: usize,
 }
 
 impl Root {
@@ -688,12 +707,17 @@ impl Root {
                 state.id.as_bytes(),
             ],
         );
+        let retained_heap_bytes = size_of::<Root>()
+            .saturating_add(bytes.retained_heap_bytes)
+            .saturating_add(entities.retained_heap_bytes)
+            .saturating_add(state.retained_heap_bytes);
         Self {
             generation,
             bytes,
             entities,
             state,
             id,
+            retained_heap_bytes,
         }
     }
 
@@ -703,39 +727,13 @@ impl Root {
 
     /// Approximate heap bytes retained by this immutable root.
     ///
-    /// This includes unique page payloads plus the per-entity keys, arenas,
+    /// This includes page payloads plus the per-entity keys, arenas,
     /// segment arrays, and a conservative allowance for `BTreeMap` nodes and
-    /// allocation headers. It deliberately overcounts shared metadata so a
-    /// decoded-root cache remains a hard memory bound without serializing or
-    /// copying payloads merely to measure them.
+    /// allocation headers. It deliberately overcounts shared pages and
+    /// metadata so a decoded-root cache remains a hard memory bound. The value
+    /// is maintained while immutable arenas are built, so reading it is O(1).
     pub fn retained_heap_bytes(&self) -> usize {
-        let mut pages = BTreeMap::<Digest, usize>::new();
-        record_byte_pages(&self.bytes, &mut pages);
-        let mut retained = byte_arena_metadata_bytes(&self.bytes);
-        for value in self.entities.entries.values() {
-            record_byte_pages(value, &mut pages);
-            retained = retained.saturating_add(byte_arena_metadata_bytes(value));
-        }
-        for value in self.state.entries.values() {
-            record_byte_pages(value, &mut pages);
-            retained = retained.saturating_add(byte_arena_metadata_bytes(value));
-        }
-        for (key, _) in self
-            .entities
-            .entries
-            .iter()
-            .chain(self.state.entries.iter())
-        {
-            retained = retained
-                .saturating_add(key.capacity())
-                .saturating_add(size_of::<(Vec<u8>, ByteArena)>())
-                .saturating_add(64);
-        }
-        pages.values().fold(retained, |total, payload| {
-            total
-                .saturating_add(*payload)
-                .saturating_add(2 * size_of::<usize>())
-        })
+        self.retained_heap_bytes
     }
 
     pub fn transaction(&self) -> Transaction {
@@ -818,20 +816,6 @@ impl Root {
             a.state.clone(),
         ))
     }
-}
-
-fn record_byte_pages(arena: &ByteArena, output: &mut BTreeMap<Digest, usize>) {
-    for segment in arena.segments.iter() {
-        output
-            .entry(segment.page.id)
-            .or_insert(segment.page.bytes.len());
-    }
-}
-
-fn byte_arena_metadata_bytes(arena: &ByteArena) -> usize {
-    size_of::<ByteArena>()
-        .saturating_add(arena.segments.len().saturating_mul(size_of::<Segment>()))
-        .saturating_add(2 * size_of::<usize>())
 }
 
 fn same_value(a: Option<&ByteArena>, b: Option<&ByteArena>) -> bool {

--- a/packages/plugin-arena/src/lib.rs
+++ b/packages/plugin-arena/src/lib.rs
@@ -13,6 +13,7 @@
 use parking_lot::Mutex;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;
+use std::mem::size_of;
 use std::ops::Range;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Weak};
@@ -700,6 +701,43 @@ impl Root {
         self.id
     }
 
+    /// Approximate heap bytes retained by this immutable root.
+    ///
+    /// This includes unique page payloads plus the per-entity keys, arenas,
+    /// segment arrays, and a conservative allowance for `BTreeMap` nodes and
+    /// allocation headers. It deliberately overcounts shared metadata so a
+    /// decoded-root cache remains a hard memory bound without serializing or
+    /// copying payloads merely to measure them.
+    pub fn retained_heap_bytes(&self) -> usize {
+        let mut pages = BTreeMap::<Digest, usize>::new();
+        record_byte_pages(&self.bytes, &mut pages);
+        let mut retained = byte_arena_metadata_bytes(&self.bytes);
+        for value in self.entities.entries.values() {
+            record_byte_pages(value, &mut pages);
+            retained = retained.saturating_add(byte_arena_metadata_bytes(value));
+        }
+        for value in self.state.entries.values() {
+            record_byte_pages(value, &mut pages);
+            retained = retained.saturating_add(byte_arena_metadata_bytes(value));
+        }
+        for (key, _) in self
+            .entities
+            .entries
+            .iter()
+            .chain(self.state.entries.iter())
+        {
+            retained = retained
+                .saturating_add(key.capacity())
+                .saturating_add(size_of::<(Vec<u8>, ByteArena)>())
+                .saturating_add(64);
+        }
+        pages.values().fold(retained, |total, payload| {
+            total
+                .saturating_add(*payload)
+                .saturating_add(2 * size_of::<usize>())
+        })
+    }
+
     pub fn transaction(&self) -> Transaction {
         Transaction {
             base: self.clone(),
@@ -780,6 +818,20 @@ impl Root {
             a.state.clone(),
         ))
     }
+}
+
+fn record_byte_pages(arena: &ByteArena, output: &mut BTreeMap<Digest, usize>) {
+    for segment in arena.segments.iter() {
+        output
+            .entry(segment.page.id)
+            .or_insert(segment.page.bytes.len());
+    }
+}
+
+fn byte_arena_metadata_bytes(arena: &ByteArena) -> usize {
+    size_of::<ByteArena>()
+        .saturating_add(arena.segments.len().saturating_mul(size_of::<Segment>()))
+        .saturating_add(2 * size_of::<usize>())
 }
 
 fn same_value(a: Option<&ByteArena>, b: Option<&ByteArena>) -> bool {
@@ -1107,6 +1159,30 @@ mod tests {
         let metrics = store.metrics();
         assert_eq!(metrics.page_reads, 1);
         assert_eq!(metrics.page_bytes_read, 2);
+    }
+
+    #[test]
+    fn retained_heap_accounting_includes_entity_index_overhead() {
+        let store = Store::new(64);
+        let empty = Root::empty(store.clone(), "generation-a");
+        let populated = Root::import(
+            store,
+            "generation-a",
+            b"x",
+            (0..1_000).map(|index| {
+                (
+                    format!("row/{index:04}").into_bytes(),
+                    format!("{{\"id\":{index}}}").into_bytes(),
+                )
+            }),
+            std::iter::empty(),
+        );
+
+        assert!(populated.retained_heap_bytes() > empty.retained_heap_bytes());
+        assert!(
+            populated.retained_heap_bytes() > 100_000,
+            "small entity snapshots still retain map, key, arena, and allocation metadata"
+        );
     }
 
     #[test]

--- a/packages/rs-sdk-tests/tests/e2e.rs
+++ b/packages/rs-sdk-tests/tests/e2e.rs
@@ -5109,6 +5109,8 @@ async fn v3_csv_cold_successor_after_eviction_and_reopen_preserves_identity() {
         eviction_counters.full_state_semantic_rows_materialized, 0,
         "an in-process decoded checkpoint must avoid durable entity hydration after Store eviction"
     );
+    assert_eq!(eviction_counters.private_document_cache_hits, 1);
+    assert_eq!(eviction_counters.full_document_reparses, 0);
     assert_eq!(eviction_counters.durable_semantic_changes, 1);
     assert_eq!(
         lix.execute("SELECT id FROM csv_v2_row ORDER BY order_key LIMIT 1", &[],)
@@ -5138,6 +5140,16 @@ async fn v3_csv_cold_successor_after_eviction_and_reopen_preserves_identity() {
             .full_state_semantic_rows_materialized
             > 0,
         "process restart must fall back to durable entity hydration"
+    );
+    assert_eq!(
+        reopened
+            .plugin_transition_counters()
+            .private_document_cache_hits,
+        0
+    );
+    assert_eq!(
+        reopened.plugin_transition_counters().full_document_reparses,
+        1
     );
     assert_eq!(
         reopened

--- a/packages/rs-sdk-tests/tests/e2e.rs
+++ b/packages/rs-sdk-tests/tests/e2e.rs
@@ -5105,6 +5105,10 @@ async fn v3_csv_cold_successor_after_eviction_and_reopen_preserves_identity() {
         eviction_counters.guest_export_calls, 1,
         "an acknowledged but evicted CSV actor must use cold successor directly"
     );
+    assert_eq!(
+        eviction_counters.full_state_semantic_rows_materialized, 0,
+        "an in-process decoded checkpoint must avoid durable entity hydration after Store eviction"
+    );
     assert_eq!(eviction_counters.durable_semantic_changes, 1);
     assert_eq!(
         lix.execute("SELECT id FROM csv_v2_row ORDER BY order_key LIMIT 1", &[],)
@@ -5127,6 +5131,13 @@ async fn v3_csv_cold_successor_after_eviction_and_reopen_preserves_identity() {
         reopened.plugin_transition_counters().guest_export_calls,
         1,
         "cold CSV reconciliation must not hydrate and re-enter the guest"
+    );
+    assert!(
+        reopened
+            .plugin_transition_counters()
+            .full_state_semantic_rows_materialized
+            > 0,
+        "process restart must fall back to durable entity hydration"
     );
     assert_eq!(
         reopened

--- a/packages/rs-sdk/src/default_wasm_runtime_component.rs
+++ b/packages/rs-sdk/src/default_wasm_runtime_component.rs
@@ -20,12 +20,12 @@ use lix_engine::wasm::{
     PACKET_FORMAT_V1, WasmByteOutputsHandle, WasmCertifiedEntityBatch, WasmChangeCursorHandle,
     WasmChangeEffect, WasmChangePage, WasmColdFileUpdate, WasmComponentActor, WasmComponentFactory,
     WasmConflictResolution, WasmConflictResolutionPage, WasmConflictTake, WasmConflictTransition,
-    WasmConflictUpdate, WasmCreateContext, WasmDocumentHandle, WasmEditCursorHandle, WasmEditPage,
-    WasmEntity, WasmEntityChange, WasmEntityChanges, WasmEntityKey, WasmEntityTransition,
-    WasmEntityUpdate, WasmFileTransition, WasmFileUpdate, WasmGuestBytes, WasmGuestEntityChanges,
-    WasmHostBytes, WasmHostEntityConflict, WasmInputBytes, WasmOpenEntitiesInput,
-    WasmOpenFileInput, WasmOutputRange, WasmOutputSplice, WasmResolutionCursorHandle,
-    WasmTransitionCounters, WasmTransitionHandle, WasmTransitionLimits,
+    WasmConflictUpdate, WasmCreateContext, WasmDocumentCheckpoint, WasmDocumentHandle,
+    WasmEditCursorHandle, WasmEditPage, WasmEntity, WasmEntityChange, WasmEntityChanges,
+    WasmEntityKey, WasmEntityTransition, WasmEntityUpdate, WasmFileTransition, WasmFileUpdate,
+    WasmGuestBytes, WasmGuestEntityChanges, WasmHostBytes, WasmHostEntityConflict, WasmInputBytes,
+    WasmOpenEntitiesInput, WasmOpenFileInput, WasmOutputRange, WasmOutputSplice,
+    WasmResolutionCursorHandle, WasmTransitionCounters, WasmTransitionHandle, WasmTransitionLimits,
 };
 use lix_engine::{LixError, SharedStr};
 use wasmtime::Store;
@@ -3406,6 +3406,37 @@ impl WasmComponentActor for V3Actor {
         let fork = self.worker.fork(document.0)?;
         self.next_document = self.next_document.max(fork.saturating_add(1));
         Ok(WasmDocumentHandle(fork))
+    }
+
+    async fn checkpoint_document(
+        &mut self,
+        document: WasmDocumentHandle,
+    ) -> Result<Option<WasmDocumentCheckpoint>, LixError> {
+        self.ensure_active()?;
+        let root = self
+            .worker
+            .documents
+            .get(&document.0)
+            .ok_or_else(|| v3_error("unknown v3 document handle"))?
+            .root
+            .clone();
+        let retained_bytes = u64::try_from(root.retained_heap_bytes()).unwrap_or(u64::MAX);
+        Ok(Some(WasmDocumentCheckpoint::new(root, retained_bytes)))
+    }
+
+    async fn restore_document(
+        &mut self,
+        checkpoint: &WasmDocumentCheckpoint,
+    ) -> Result<WasmDocumentHandle, LixError> {
+        self.ensure_active()?;
+        let root = checkpoint
+            .downcast_ref::<ArenaRoot>()
+            .ok_or_else(|| v3_error("v3 document checkpoint belongs to another runtime"))?
+            .clone();
+        let document = self.allocate_document()?;
+        self.worker.documents.insert(document, V3Document { root });
+        self.worker.next_document = self.worker.next_document.max(document.saturating_add(1));
+        Ok(WasmDocumentHandle(document))
     }
 
     async fn open_file(


### PR DESCRIPTION
## What changed

- retain runtime-private immutable plugin arena roots outside evicted Wasmtime Stores
- restore an exact `(actor identity, semantic root)` checkpoint into a fresh actor and run the normal fused `file_changed` transition
- keep derived materializations and process restarts on the durable-entity hydration fallback
- bound decoded checkpoints with a 64 MiB heap-accounted LRU
- publish checkpoints only after the corresponding durable transaction commits
- preserve checkpoints when completed actors are retired under Store-admission pressure

## Why

The 16-Store actor cache evicts files during multi-file workloads. Before this change, every cold successor scanned all durable semantic rows and rebuilt the complete plugin document even though the host arena root was immutable and safe to retain without guest linear memory.

## Performance

Exact `vscode-docs` SlateDB replay, all WASM plugins, checkpoint and state verification on every commit.

### 303-path commit `0892da1a`

| Metric | main | checkpoint cache | Change |
| --- | ---: | ---: | ---: |
| replay | 11.517 s | 9.895 s | 14.1% faster |
| execute | 8.278 s | 6.264 s | 24.3% faster |
| durable rows hydrated | 46,564 | 16,439 | 64.7% fewer |

### 50-commit window from `cd576805`

| Metric | main | checkpoint cache | Change |
| --- | ---: | ---: | ---: |
| replay | 56.744 s | 52.068 s | 8.2% faster |
| execute | 28.248 s | 22.079 s | 21.8% faster |
| durable rows hydrated | 104,559 | 18,479 | 82.3% fewer |
| Component boundary bytes | 101.5 MB | 34.9 MB | 65.6% fewer |
| peak RSS | 962,488 KiB | 1,012,812 KiB | +5.2% |

Both lanes reproduced exact Git trees and semantic state.

## Validation

- `cargo test -p lix_plugin_arena`
- `cargo test -p lix_engine decoded_checkpoints_require_exact_actor_and_semantic_root`
- `cargo test -p lix_sdk_tests --test e2e v3_csv_cold_ -- --nocapture`
- derived cold hydration regression
- `cargo clippy -p lix_plugin_arena -p lix_engine -p lix_sdk --all-targets -- -D warnings -A dead-code`
  - `dead-code` is suppressed only for three pre-existing unused items on current `main`; all other warnings remain denied
- exact verified 303-path replay
- exact verified 50-commit replay
- transaction-local and published checkpoints share the same 64 MiB budget
- checkpoint restore counters distinguish cache hits from full reparses
