### PR TITLE
perf(engine): retain unchanged HOT rows across checkpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3355,10 +3355,12 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
+ "slatedb",
  "smallvec",
  "tempfile",
  "tokio",
  "tracing-subscriber",
+ "ulid",
  "xxhash-rust",
 ]
 

--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 default = ["rocksdb"]
 rocksdb = ["dep:lix_rocksdb_storage"]
 sqlite = ["dep:lix_sqlite_storage", "dep:rusqlite"]
-slatedb = ["dep:lix_slatedb_storage", "dep:object_store"]
+slatedb = ["dep:lix_slatedb_storage", "dep:object_store", "dep:slatedb", "dep:ulid"]
 storage-benches = ["lix_engine/storage-benches", "rocksdb", "sqlite"]
 
 [dependencies]
@@ -24,7 +24,9 @@ lix_engine = { workspace = true }
 lix_rocksdb_storage = { workspace = true, optional = true }
 lix_slatedb_storage = { workspace = true, optional = true }
 lix_sqlite_storage = { workspace = true, optional = true }
-object_store = { version = "0.14", default-features = false, optional = true }
+object_store = { version = "0.14", default-features = false, features = ["fs"], optional = true }
+slatedb = { version = "0.14.1", default-features = false, features = ["moka", "zstd"], optional = true }
+ulid = { version = "1.2.1", optional = true }
 rusqlite = { version = "0.32", features = ["bundled"], optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/packages/engine-benchmarks/examples/storage_layout.rs
+++ b/packages/engine-benchmarks/examples/storage_layout.rs
@@ -1,0 +1,505 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+use std::sync::Arc;
+
+use lix_engine::storage_adapter::{StorageAdapter, StorageReadOptions};
+use lix_engine::storage_bench::{
+    commit_delta_layout_accounting, layout_accounting, space_inventory,
+};
+use lix_slatedb_storage::SlateDB;
+use object_store::local::LocalFileSystem;
+use slatedb::{SstReader, ValueDeletable};
+
+const HOT_SPACE: &str = "live_state.hot_row.v19";
+
+#[derive(Default)]
+struct HotGroup {
+    schema: String,
+    file_id: Option<String>,
+    prefix_len: usize,
+    rows: Vec<HotRow>,
+}
+
+struct HotRow {
+    key_len: usize,
+    suffix_len: usize,
+    value_len: usize,
+}
+
+#[derive(Default)]
+struct PageEstimate {
+    pages: usize,
+    key_bytes: usize,
+    value_bytes: usize,
+}
+
+#[tokio::main]
+async fn main() {
+    let path = std::env::args_os()
+        .nth(1)
+        .expect("usage: storage_layout <slatedb-path>");
+    let logical_only = std::env::args_os()
+        .nth(2)
+        .is_some_and(|arg| arg == "--logical-only");
+    let storage = StorageAdapter::new(SlateDB::open(&path).expect("open SlateDB"));
+    let read = storage
+        .begin_read(StorageReadOptions::default())
+        .await
+        .expect("open storage snapshot");
+    let mut total_rows = 0_u64;
+    let mut total_keys = 0_u64;
+    let mut total_values = 0_u64;
+    let accounting = layout_accounting(&read).await;
+    let space_names = accounting
+        .iter()
+        .map(|entry| (entry.space_id, entry.space))
+        .collect::<BTreeMap<_, _>>();
+    for entry in accounting {
+        println!(
+            "SPACE\t{}\t{}\t{}\t{}\t{}",
+            entry.space_id, entry.space, entry.rows, entry.key_bytes, entry.value_bytes
+        );
+        total_rows += entry.rows;
+        total_keys += entry.key_bytes;
+        total_values += entry.value_bytes;
+    }
+    println!("SPACE\tTOTAL\tTOTAL\t{total_rows}\t{total_keys}\t{total_values}");
+    for entry in commit_delta_layout_accounting(&read)
+        .await
+        .expect("decode commit-delta inventory")
+    {
+        println!(
+            "COMMIT_DELTA\tcommit={}\tsegments={}\tmembers={}\tauthored={}\tselected={}\tselected_tombstones={}\tcertified={}\tselected_certified={}",
+            entry.commit_id,
+            entry.segment_count,
+            entry.members,
+            entry.authored_members,
+            entry.selected_members,
+            entry.selected_tombstones,
+            entry.certified_members,
+            entry.selected_certified_members,
+        );
+    }
+
+    let inventory = space_inventory(&read, HOT_SPACE).await;
+    let mut groups = BTreeMap::<Vec<u8>, HotGroup>::new();
+    for (key, value) in inventory {
+        let decoded = decode_hot_group(&key).expect("valid HOT V19 key");
+        let group = groups
+            .entry(key[..decoded.prefix_len].to_vec())
+            .or_insert_with(|| HotGroup {
+                schema: decoded.schema,
+                file_id: decoded.file_id,
+                prefix_len: decoded.prefix_len,
+                rows: Vec::new(),
+            });
+        group.rows.push(HotRow {
+            key_len: key.len(),
+            suffix_len: key.len() - decoded.prefix_len,
+            value_len: value.len(),
+        });
+    }
+
+    let mut cardinalities = groups
+        .values()
+        .map(|group| group.rows.len())
+        .collect::<Vec<_>>();
+    cardinalities.sort_unstable();
+    let file_groups = groups
+        .values()
+        .filter(|group| group.file_id.is_some())
+        .count();
+    let rows = groups.values().map(|group| group.rows.len()).sum::<usize>();
+    let key_bytes = groups
+        .values()
+        .flat_map(|group| &group.rows)
+        .map(|row| row.key_len)
+        .sum::<usize>();
+    let suffix_bytes = groups
+        .values()
+        .flat_map(|group| &group.rows)
+        .map(|row| row.suffix_len)
+        .sum::<usize>();
+    let value_bytes = groups
+        .values()
+        .flat_map(|group| &group.rows)
+        .map(|row| row.value_len)
+        .sum::<usize>();
+    println!(
+        "HOT_SUMMARY\trows={rows}\tgroups={}\tfile_groups={file_groups}\tkey_bytes={key_bytes}\tgroup_prefix_bytes={}\tsuffix_bytes={suffix_bytes}\tvalue_bytes={value_bytes}\tp50={}\tp90={}\tp95={}\tp99={}\tmax={}",
+        groups.len(),
+        key_bytes - suffix_bytes,
+        percentile(&cardinalities, 50),
+        percentile(&cardinalities, 90),
+        percentile(&cardinalities, 95),
+        percentile(&cardinalities, 99),
+        cardinalities.last().copied().unwrap_or(0),
+    );
+    for page_rows in [64, 128, 256, 512] {
+        let estimate = estimate_pages(groups.values(), page_rows);
+        let packed_total = estimate.key_bytes + estimate.value_bytes;
+        let current_total = key_bytes + value_bytes;
+        println!(
+            "HOT_PAGE_ESTIMATE\trows_per_page={page_rows}\tpages={}\tkey_bytes={}\tvalue_bytes={}\ttotal_bytes={packed_total}\tsaved_bytes={}\tsaved_pct={:.2}",
+            estimate.pages,
+            estimate.key_bytes,
+            estimate.value_bytes,
+            current_total.saturating_sub(packed_total),
+            100.0 * (current_total.saturating_sub(packed_total) as f64) / current_total as f64,
+        );
+    }
+
+    let mut largest = groups.values().collect::<Vec<_>>();
+    largest.sort_unstable_by(|left, right| right.rows.len().cmp(&left.rows.len()));
+    for group in largest.into_iter().take(30) {
+        let group_key_bytes = group.rows.iter().map(|row| row.key_len).sum::<usize>();
+        let group_value_bytes = group.rows.iter().map(|row| row.value_len).sum::<usize>();
+        println!(
+            "HOT_GROUP\trows={}\tprefix_len={}\tkey_bytes={group_key_bytes}\tvalue_bytes={group_value_bytes}\tschema={}\tfile={}",
+            group.rows.len(),
+            group.prefix_len,
+            group.schema,
+            group.file_id.as_deref().unwrap_or("<null>"),
+        );
+    }
+
+    if !logical_only {
+        inspect_ssts(Path::new(&path), &space_names).await;
+    }
+}
+
+#[derive(Default)]
+struct PhysicalSpace {
+    blocks: usize,
+    compressed_bytes: u64,
+    raw_key_bytes: u64,
+    raw_value_bytes: u64,
+    rows: u64,
+    puts: u64,
+    tombstones: u64,
+    merges: u64,
+    unique_keys: BTreeSet<Vec<u8>>,
+    min_seq: u64,
+    max_seq: u64,
+    seq_rows: BTreeMap<u64, (u64, u64, u64)>,
+    hot_versions: BTreeMap<Vec<u8>, Vec<(u64, Vec<u8>)>>,
+}
+
+async fn inspect_ssts(path: &Path, space_names: &BTreeMap<u32, &'static str>) {
+    let object_store: Arc<dyn object_store::ObjectStore> =
+        Arc::new(LocalFileSystem::new_with_prefix(path.join("db")).expect("local object store"));
+    let reader = SstReader::new("lix-space-segments-v2", object_store, None, None);
+    let compacted = path.join("db/lix-space-segments-v2/compacted");
+    let mut files = std::fs::read_dir(&compacted)
+        .expect("read compacted directory")
+        .map(|entry| entry.expect("read compacted entry").path())
+        .filter(|path| path.extension().is_some_and(|extension| extension == "sst"))
+        .collect::<Vec<_>>();
+    files.sort();
+    let mut spaces = BTreeMap::<u32, PhysicalSpace>::new();
+    let mut total_file_bytes = 0_u64;
+    let mut total_block_bytes = 0_u64;
+    let mut total_overhead_bytes = 0_u64;
+    let mut cross_space_blocks = 0_usize;
+    for path in files {
+        let id = path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .expect("UTF-8 SST stem")
+            .parse::<ulid::Ulid>()
+            .expect("ULID SST stem");
+        let file = reader.open(id).await.expect("open SST");
+        let file_bytes = path.metadata().expect("SST metadata").len();
+        total_file_bytes += file_bytes;
+        let index = file.index().await.expect("read SST index");
+        let data_end = file.info().filter_offset;
+        let mut sst_block_bytes = 0_u64;
+        for (block_index, (offset, _)) in index.iter().enumerate() {
+            let end = index
+                .get(block_index + 1)
+                .map_or(data_end, |(next_offset, _)| *next_offset);
+            let compressed_bytes = end.saturating_sub(*offset);
+            let rows = file.read_block(block_index).await.expect("read SST block");
+            let mut raw_by_space =
+                BTreeMap::<u32, (u64, u64, u64, u64, u64, u64, BTreeSet<Vec<u8>>, u64, u64)>::new();
+            for row in rows {
+                let space_id = u32::from_be_bytes(
+                    row.key
+                        .get(..4)
+                        .expect("physical key has space prefix")
+                        .try_into()
+                        .expect("space prefix has fixed length"),
+                );
+                let raw_key = row.key.len() as u64;
+                let (raw_value, puts, tombstones, merges) = match row.value {
+                    ValueDeletable::Value(value) => (value.len() as u64, 1, 0, 0),
+                    ValueDeletable::Merge(value) => (value.len() as u64, 0, 0, 1),
+                    ValueDeletable::Tombstone => (0, 0, 1, 0),
+                };
+                let entry = raw_by_space.entry(space_id).or_default();
+                entry.0 += raw_key;
+                entry.1 += raw_value;
+                entry.2 += 1;
+                entry.3 += puts;
+                entry.4 += tombstones;
+                entry.5 += merges;
+                entry.6.insert(row.key.to_vec());
+                if entry.7 == 0 || row.seq < entry.7 {
+                    entry.7 = row.seq;
+                }
+                entry.8 = entry.8.max(row.seq);
+            }
+            if raw_by_space.len() > 1 {
+                cross_space_blocks += 1;
+            }
+            let raw_total = raw_by_space
+                .values()
+                .map(|(keys, values, ..)| keys + values)
+                .sum::<u64>();
+            let mut remaining = compressed_bytes;
+            let space_count = raw_by_space.len();
+            for (
+                index,
+                (
+                    space_id,
+                    (keys, values, rows, puts, tombstones, merges, unique_keys, min_seq, max_seq),
+                ),
+            ) in raw_by_space.into_iter().enumerate()
+            {
+                let share = if index + 1 == space_count {
+                    remaining
+                } else if raw_total == 0 {
+                    compressed_bytes / space_count as u64
+                } else {
+                    compressed_bytes.saturating_mul(keys + values) / raw_total
+                };
+                remaining = remaining.saturating_sub(share);
+                let entry = spaces.entry(space_id).or_default();
+                entry.blocks += 1;
+                entry.compressed_bytes += share;
+                entry.raw_key_bytes += keys;
+                entry.raw_value_bytes += values;
+                entry.rows += rows;
+                entry.puts += puts;
+                entry.tombstones += tombstones;
+                entry.merges += merges;
+                entry.unique_keys.extend(unique_keys);
+                if entry.min_seq == 0 || min_seq < entry.min_seq {
+                    entry.min_seq = min_seq;
+                }
+                entry.max_seq = entry.max_seq.max(max_seq);
+                for row in file
+                    .read_block(block_index)
+                    .await
+                    .expect("reread SST block for sequence accounting")
+                {
+                    let row_space_id = u32::from_be_bytes(
+                        row.key
+                            .get(..4)
+                            .expect("physical key has space prefix")
+                            .try_into()
+                            .expect("space prefix has fixed length"),
+                    );
+                    if row_space_id != space_id {
+                        continue;
+                    }
+                    let value_len = row.value.len() as u64;
+                    let seq = entry.seq_rows.entry(row.seq).or_default();
+                    seq.0 += 1;
+                    seq.1 += row.key.len() as u64;
+                    seq.2 += value_len;
+                    if space_id == 0x0004_001b {
+                        entry
+                            .hot_versions
+                            .entry(row.key.to_vec())
+                            .or_default()
+                            .push((
+                                row.seq,
+                                row.value
+                                    .as_bytes()
+                                    .map_or_else(Vec::new, |value| value.to_vec()),
+                            ));
+                    }
+                }
+            }
+            sst_block_bytes += compressed_bytes;
+        }
+        total_block_bytes += sst_block_bytes;
+        total_overhead_bytes += file_bytes.saturating_sub(sst_block_bytes);
+    }
+    let mut spaces = spaces.into_iter().collect::<Vec<_>>();
+    spaces.sort_unstable_by(|left, right| right.1.compressed_bytes.cmp(&left.1.compressed_bytes));
+    println!(
+        "SST_SUMMARY\tfile_bytes={total_file_bytes}\tdata_block_bytes={total_block_bytes}\toverhead_bytes={total_overhead_bytes}\tcross_space_blocks={cross_space_blocks}"
+    );
+    for (space_id, entry) in spaces {
+        println!(
+            "SST_SPACE\tspace_id={space_id}\tspace={}\tblocks={}\tcompressed_bytes={}\traw_key_bytes={}\traw_value_bytes={}\trows={}\tputs={}\ttombstones={}\tmerges={}\tunique_keys={}\tversions_per_key={:.3}\tmin_seq={}\tmax_seq={}\tcompression_ratio={:.3}",
+            space_names.get(&space_id).copied().unwrap_or("<unknown>"),
+            entry.blocks,
+            entry.compressed_bytes,
+            entry.raw_key_bytes,
+            entry.raw_value_bytes,
+            entry.rows,
+            entry.puts,
+            entry.tombstones,
+            entry.merges,
+            entry.unique_keys.len(),
+            entry.rows as f64 / entry.unique_keys.len() as f64,
+            entry.min_seq,
+            entry.max_seq,
+            (entry.raw_key_bytes + entry.raw_value_bytes) as f64 / entry.compressed_bytes as f64,
+        );
+        if matches!(
+            space_id,
+            0x0004_001a | 0x0004_001b | 0x0004_0022 | 0x0004_0023
+        ) {
+            for (seq, (rows, keys, values)) in &entry.seq_rows {
+                println!(
+                    "SST_SPACE_SEQ\tspace_id={space_id}\tseq={seq}\trows={rows}\traw_key_bytes={keys}\traw_value_bytes={values}"
+                );
+            }
+        }
+        if space_id == 0x0004_001b {
+            compare_hot_sequences(&entry.hot_versions, 7, 9);
+        }
+    }
+}
+
+fn compare_hot_sequences(
+    versions: &BTreeMap<Vec<u8>, Vec<(u64, Vec<u8>)>>,
+    left_seq: u64,
+    right_seq: u64,
+) {
+    let mut both = 0_u64;
+    let mut equal = 0_u64;
+    let mut same_len = 0_u64;
+    let mut left_bytes = 0_u64;
+    let mut right_bytes = 0_u64;
+    let mut first_difference = None;
+    for values in versions.values() {
+        let left = values
+            .iter()
+            .find_map(|(seq, value)| (*seq == left_seq).then_some(value));
+        let right = values
+            .iter()
+            .find_map(|(seq, value)| (*seq == right_seq).then_some(value));
+        let (Some(left), Some(right)) = (left, right) else {
+            continue;
+        };
+        both += 1;
+        equal += u64::from(left == right);
+        same_len += u64::from(left.len() == right.len());
+        left_bytes += left.len() as u64;
+        right_bytes += right.len() as u64;
+        if first_difference.is_none() && left != right {
+            first_difference = Some((left.clone(), right.clone()));
+        }
+    }
+    println!(
+        "HOT_SEQ_COMPARE\tleft_seq={left_seq}\tright_seq={right_seq}\tboth={both}\tequal={equal}\tsame_len={same_len}\tleft_bytes={left_bytes}\tright_bytes={right_bytes}"
+    );
+    if let Some((left, right)) = first_difference {
+        println!(
+            "HOT_SEQ_SAMPLE\tleft_len={}\tright_len={}\tleft={}\tright={}",
+            left.len(),
+            right.len(),
+            hex_prefix(&left),
+            hex_prefix(&right),
+        );
+    }
+}
+
+fn hex_prefix(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .take(96)
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn estimate_pages<'a>(
+    groups: impl Iterator<Item = &'a HotGroup>,
+    rows_per_page: usize,
+) -> PageEstimate {
+    let mut estimate = PageEstimate::default();
+    for group in groups {
+        for rows in group.rows.chunks(rows_per_page) {
+            estimate.pages += 1;
+            // Page key: the complete group prefix followed by a big-endian page ordinal.
+            estimate.key_bytes += group.prefix_len + 4;
+            // Conservative payload: version + row count, followed by fixed-width
+            // suffix/value lengths and the exact row suffix/value bytes.
+            estimate.value_bytes += 1 + 4;
+            estimate.value_bytes += rows
+                .iter()
+                .map(|row| 8 + row.suffix_len + row.value_len)
+                .sum::<usize>();
+        }
+    }
+    estimate
+}
+
+struct DecodedHotGroup {
+    prefix_len: usize,
+    schema: String,
+    file_id: Option<String>,
+}
+
+fn decode_hot_group(bytes: &[u8]) -> Result<DecodedHotGroup, String> {
+    let mut offset = 0;
+    let _branch = read_key_string(bytes, &mut offset, "branch")?;
+    offset = offset
+        .checked_add(16)
+        .filter(|offset| *offset <= bytes.len())
+        .ok_or_else(|| "truncated generation".to_string())?;
+    let schema = read_key_string(bytes, &mut offset, "schema")?;
+    let file_tag = *bytes
+        .get(offset)
+        .ok_or_else(|| "truncated file tag".to_string())?;
+    offset += 1;
+    let file_id = match file_tag {
+        0 => None,
+        1 => Some(read_key_string(bytes, &mut offset, "file")?),
+        _ => return Err(format!("invalid file tag {file_tag}")),
+    };
+    Ok(DecodedHotGroup {
+        prefix_len: offset,
+        schema,
+        file_id,
+    })
+}
+
+fn read_key_string(bytes: &[u8], offset: &mut usize, field: &str) -> Result<String, String> {
+    let mut value = Vec::new();
+    loop {
+        let byte = *bytes
+            .get(*offset)
+            .ok_or_else(|| format!("truncated {field}"))?;
+        *offset += 1;
+        if byte != 0 {
+            value.push(byte);
+            continue;
+        }
+        let terminator = *bytes
+            .get(*offset)
+            .ok_or_else(|| format!("truncated {field} terminator"))?;
+        *offset += 1;
+        if terminator == 0xff {
+            value.push(0);
+            continue;
+        }
+        if terminator != 0 {
+            return Err(format!("invalid {field} terminator {terminator}"));
+        }
+        return String::from_utf8(value).map_err(|error| format!("invalid {field} UTF-8: {error}"));
+    }
+}
+
+fn percentile(sorted: &[usize], percentile: usize) -> usize {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let index = (sorted.len() - 1) * percentile / 100;
+    sorted[index]
+}

--- a/packages/engine-benchmarks/examples/storage_layout.rs
+++ b/packages/engine-benchmarks/examples/storage_layout.rs
@@ -10,7 +10,7 @@ use lix_slatedb_storage::SlateDB;
 use object_store::local::LocalFileSystem;
 use slatedb::{SstReader, ValueDeletable};
 
-const HOT_SPACE: &str = "live_state.hot_row.v19";
+const HOT_SPACE: &str = "live_state.hot_row.v20";
 
 #[derive(Default)]
 struct HotGroup {

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -738,6 +738,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn predecessor_v26_hot_baseline_protocol_is_rejected() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let storage_adapter = StorageAdapter::new(storage.clone());
+        let mut writes = storage_adapter.new_write_set();
+        writes.put(
+            crate::init::REPOSITORY_PROTOCOL_SPACE,
+            crate::init::REPOSITORY_PROTOCOL_KEY,
+            &b"selected-payload-reference.v26"[..],
+        );
+        storage_adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("V26 protocol marker should commit");
+
+        let Err(error) = Engine::new(storage).await else {
+            panic!("V26 repositories must fail closed before V7 HOT rows are decoded");
+        };
+        assert_eq!(error.code, "LIX_ERROR_UNSUPPORTED_STORAGE_FORMAT");
+    }
+
+    #[tokio::test]
     async fn tracked_entity_fast_path_serves_broad_sql_rows() {
         let storage = Memory::new();
         Engine::initialize(storage.clone())

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -39,13 +39,13 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 
 /// Repository-wide compatibility gate for physical storage protocols.
 ///
-/// V26 replaces duplicated selected commit-delta payloads with canonical
-/// references. Opening an older store must fail closed before its differently
-/// framed payload sidecars are decoded as the current layout.
+/// V27 gives dirty HOT baselines an explicit checkpoint owner so checkpoint
+/// publication can retain semantically identical rows without confusing a
+/// prior interval's baseline with the active interval.
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"selected-payload-reference.v26";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"checkpoint-owned-hot-baseline.v27";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -1350,6 +1350,33 @@ impl HeadValueView<'_> {
     }
 }
 
+fn working_diff_checkpoint_owner(baseline: WorkingDiffBaseline) -> Option<CommitId> {
+    match baseline {
+        WorkingDiffBaseline::BeforeAbsent {
+            checkpoint_commit_id,
+        }
+        | WorkingDiffBaseline::BeforePresent {
+            checkpoint_commit_id,
+            ..
+        } => Some(checkpoint_commit_id),
+        WorkingDiffBaseline::Disabled | WorkingDiffBaseline::Clean => None,
+    }
+}
+
+fn effective_hot_commit_id(
+    value: HeadValueView<'_>,
+    active_checkpoint_commit_id: Option<CommitId>,
+) -> Option<CommitId> {
+    let commit_id = value.commit_id?;
+    match (
+        active_checkpoint_commit_id,
+        working_diff_checkpoint_owner(value.working_diff_baseline),
+    ) {
+        (Some(active), Some(owner)) if owner != active => Some(active),
+        _ => Some(commit_id),
+    }
+}
+
 impl WorkingDiffVersion {
     fn payload_eq(self, other: Self) -> bool {
         // Keep the accelerator's net-change classification identical to the
@@ -1936,6 +1963,7 @@ async fn materialize_live_entries<I>(
     entries: Vec<(I, Bytes)>,
     projection: ChangeRecordProjection,
     branch_id: &str,
+    active_checkpoint_commit_id: Option<CommitId>,
 ) -> Result<MaterializedLiveStateBatch, LixError>
 where
     I: LiveMaterializationIdentity,
@@ -1974,7 +2002,7 @@ where
             value.updated_at,
             global,
             value.change_id,
-            value.commit_id,
+            effective_hot_commit_id(value, active_checkpoint_commit_id),
             value.untracked,
             branch_id,
         );
@@ -3094,6 +3122,31 @@ mod tests {
             .expect("no-op checkpoint direct diff should read")
             .expect("no-op checkpoint direct diff should be known empty");
         assert!(empty_diff.diff.entries.is_empty());
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open exact no-op checkpoint read");
+        let exact_empty_diff = TrackedHeadContext::new()
+            .reader(read)
+            .working_diff_for_control(
+                branch_id,
+                control(no_op_checkpoint, checkpoint, no_op_checkpoint),
+                &TrackedStateDiffRequest {
+                    filter: TrackedStateFilter {
+                        schema_keys: vec!["schema".to_owned()],
+                        entity_pks: vec![entity_pk.clone()],
+                        ..TrackedStateFilter::default()
+                    },
+                    ..TrackedStateDiffRequest::default()
+                },
+            )
+            .await
+            .expect("exact no-op checkpoint diff should read")
+            .expect("exact no-op checkpoint diff should be current");
+        assert!(
+            exact_empty_diff.diff.entries.is_empty(),
+            "finite diff reads must ignore a baseline owned by the prior checkpoint"
+        );
 
         let read = storage
             .begin_read(StorageReadOptions::default())

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -139,9 +139,12 @@ enum WorkingDiffBaseline {
     /// and has not changed since.
     Clean,
     /// The first mutation after the checkpoint created this identity.
-    BeforeAbsent,
+    BeforeAbsent { checkpoint_commit_id: CommitId },
     /// The first mutation after the checkpoint replaced this tracked value.
-    BeforePresent(WorkingDiffVersion),
+    BeforePresent {
+        checkpoint_commit_id: CommitId,
+        version: WorkingDiffVersion,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -155,6 +158,7 @@ const WORKING_DIFF_SLOT_REF: u8 = 1;
 const WORKING_DIFF_SLOT_INLINE: u8 = 2;
 const WORKING_DIFF_VERSION_BYTES: usize =
     16 + 16 + 1 + 8 + 8 + 1 + JSON_REF_BYTES + 1 + JSON_REF_BYTES;
+const WORKING_DIFF_CHECKPOINT_BYTES: usize = 16;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, musli::Encode, musli::Decode)]
 #[musli(packed)]
@@ -1161,6 +1165,13 @@ fn encode_working_diff_slot(encoded: &mut Vec<u8>, slot: WorkingDiffSlotFingerpr
     encoded.extend_from_slice(&slot.hash);
 }
 
+fn decode_working_diff_checkpoint(bytes: &[u8], offset: &mut usize) -> Result<CommitId, LixError> {
+    Ok(CommitId::new(uuid_from_working_diff_bytes(
+        take_working_diff_bytes(bytes, offset, WORKING_DIFF_CHECKPOINT_BYTES)?,
+        "checkpoint commit id",
+    )?))
+}
+
 fn decode_working_diff_version(
     bytes: &[u8],
     offset: &mut usize,
@@ -1284,7 +1295,7 @@ fn working_diff_error(message: &str) -> LixError {
 /// Persisting fingerprints only while a row is dirty keeps repeated diff
 /// classification independent of payload size without taxing checkpointed
 /// current state.
-const HEAD_VALUE_VERSION: u8 = 6;
+const HEAD_VALUE_VERSION: u8 = 7;
 const HEAD_VALUE_HEADER_BYTES: usize = 58;
 const HEAD_VALUE_DELETED: u8 = 0b0000_0001;
 const HEAD_VALUE_SNAPSHOT_SHIFT: u8 = 1;
@@ -1489,7 +1500,7 @@ fn append_head_value_parts(
 ) -> Result<std::ops::Range<usize>, LixError> {
     let fingerprint_inline = matches!(
         value.working_diff_baseline,
-        WorkingDiffBaseline::BeforeAbsent | WorkingDiffBaseline::BeforePresent(_)
+        WorkingDiffBaseline::BeforeAbsent { .. } | WorkingDiffBaseline::BeforePresent { .. }
     );
     let snapshot_kind = encoded_slot_kind(value.snapshot, fingerprint_inline);
     let metadata_kind = encoded_slot_kind(value.metadata, fingerprint_inline);
@@ -1533,10 +1544,11 @@ fn append_head_value_parts(
         .and_then(|bytes| bytes.checked_add(metadata_len))
         .and_then(|bytes| {
             bytes.checked_add(match value.working_diff_baseline {
-                WorkingDiffBaseline::BeforePresent(_) => WORKING_DIFF_VERSION_BYTES,
-                WorkingDiffBaseline::Disabled
-                | WorkingDiffBaseline::Clean
-                | WorkingDiffBaseline::BeforeAbsent => 0,
+                WorkingDiffBaseline::BeforePresent { .. } => {
+                    WORKING_DIFF_CHECKPOINT_BYTES + WORKING_DIFF_VERSION_BYTES
+                }
+                WorkingDiffBaseline::BeforeAbsent { .. } => WORKING_DIFF_CHECKPOINT_BYTES,
+                WorkingDiffBaseline::Disabled | WorkingDiffBaseline::Clean => 0,
             })
         })
         .ok_or_else(|| head_value_error("encoded row length overflow"))?;
@@ -1568,8 +1580,18 @@ fn append_head_value_parts(
     );
     append_slot_payload(bytes, value.snapshot, fingerprint_inline);
     append_slot_payload(bytes, value.metadata, fingerprint_inline);
-    if let WorkingDiffBaseline::BeforePresent(version) = value.working_diff_baseline {
-        encode_working_diff_version(bytes, version);
+    match value.working_diff_baseline {
+        WorkingDiffBaseline::BeforeAbsent {
+            checkpoint_commit_id,
+        } => bytes.extend_from_slice(checkpoint_commit_id.as_uuid().as_bytes()),
+        WorkingDiffBaseline::BeforePresent {
+            checkpoint_commit_id,
+            version,
+        } => {
+            bytes.extend_from_slice(checkpoint_commit_id.as_uuid().as_bytes());
+            encode_working_diff_version(bytes, version);
+        }
+        WorkingDiffBaseline::Disabled | WorkingDiffBaseline::Clean => {}
     }
     debug_assert_eq!(bytes.len() - start, capacity);
     Ok(start..bytes.len())
@@ -1579,8 +1601,8 @@ fn encode_working_diff_baseline_tag(baseline: WorkingDiffBaseline) -> u8 {
     match baseline {
         WorkingDiffBaseline::Disabled => HEAD_WORKING_DIFF_DISABLED,
         WorkingDiffBaseline::Clean => HEAD_WORKING_DIFF_CLEAN,
-        WorkingDiffBaseline::BeforeAbsent => HEAD_WORKING_DIFF_BEFORE_ABSENT,
-        WorkingDiffBaseline::BeforePresent(_) => HEAD_WORKING_DIFF_BEFORE_PRESENT,
+        WorkingDiffBaseline::BeforeAbsent { .. } => HEAD_WORKING_DIFF_BEFORE_ABSENT,
+        WorkingDiffBaseline::BeforePresent { .. } => HEAD_WORKING_DIFF_BEFORE_PRESENT,
     }
 }
 
@@ -1670,10 +1692,13 @@ fn decode_head_value(bytes: &[u8]) -> Result<HeadValueView<'_>, LixError> {
     let working_diff_baseline = match baseline_tag {
         HEAD_WORKING_DIFF_DISABLED => WorkingDiffBaseline::Disabled,
         HEAD_WORKING_DIFF_CLEAN => WorkingDiffBaseline::Clean,
-        HEAD_WORKING_DIFF_BEFORE_ABSENT => WorkingDiffBaseline::BeforeAbsent,
-        HEAD_WORKING_DIFF_BEFORE_PRESENT => WorkingDiffBaseline::BeforePresent(
-            decode_working_diff_version(bytes, &mut baseline_offset)?,
-        ),
+        HEAD_WORKING_DIFF_BEFORE_ABSENT => WorkingDiffBaseline::BeforeAbsent {
+            checkpoint_commit_id: decode_working_diff_checkpoint(bytes, &mut baseline_offset)?,
+        },
+        HEAD_WORKING_DIFF_BEFORE_PRESENT => WorkingDiffBaseline::BeforePresent {
+            checkpoint_commit_id: decode_working_diff_checkpoint(bytes, &mut baseline_offset)?,
+            version: decode_working_diff_version(bytes, &mut baseline_offset)?,
+        },
         _ => unreachable!("two-bit working-diff baseline tag is exhaustive"),
     };
     if baseline_offset != bytes.len() {
@@ -2251,7 +2276,8 @@ mod tests {
     }
 
     #[test]
-    fn v6_value_codec_embeds_a_tracked_first_before_baseline() {
+    fn v7_value_codec_embeds_a_checkpoint_owned_tracked_first_before_baseline() {
+        let checkpoint_commit_id = CommitId::for_test_label("baseline-checkpoint");
         let baseline = WorkingDiffVersion {
             change_id: ChangeId::for_test_label("before-change"),
             commit_id: CommitId::for_test_label("before-commit"),
@@ -2276,21 +2302,28 @@ mod tests {
             updated_at: ts("2026-01-02T00:00:00Z"),
             snapshot: JsonSlotRef::Inline("{\"current\":true}"),
             metadata: JsonSlotRef::None,
-            working_diff_baseline: WorkingDiffBaseline::BeforePresent(baseline),
+            working_diff_baseline: WorkingDiffBaseline::BeforePresent {
+                checkpoint_commit_id,
+                version: baseline,
+            },
         };
 
-        let bytes = encode_head_value(&value).expect("encode v6 row with baseline");
+        let bytes = encode_head_value(&value).expect("encode v7 row with baseline");
         assert_eq!(
             bytes.len(),
             HEAD_VALUE_HEADER_BYTES
                 + JSON_REF_BYTES
                 + "{\"current\":true}".len()
+                + WORKING_DIFF_CHECKPOINT_BYTES
                 + WORKING_DIFF_VERSION_BYTES
         );
-        let decoded = decode_head_value(&bytes).expect("decode v6 row with baseline");
+        let decoded = decode_head_value(&bytes).expect("decode v7 row with baseline");
         assert_eq!(
             decoded.working_diff_baseline,
-            WorkingDiffBaseline::BeforePresent(baseline)
+            WorkingDiffBaseline::BeforePresent {
+                checkpoint_commit_id,
+                version: baseline,
+            }
         );
     }
 
@@ -2955,47 +2988,65 @@ mod tests {
             ChangeId::for_test_label("initial-change")
         );
 
-        // A checkpoint republishes a complete serving generation. Its tracked
-        // rows are all Clean in that new generation, so the old first-before
-        // baselines are neither read nor inherited by the next epoch.
+        // A checkpoint that selects the already-authoritative immutable
+        // change must not rewrite the HOT row just to clear its dirty
+        // baseline. The checkpoint owner on that baseline makes it stale for
+        // the next interval without touching the value.
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
             .expect("open no-op checkpoint write read");
         let mut writes = StorageWriteSet::new();
         let mut no_op_coverage = WorkingDiffIndexCoverage::default();
+        let selected = TrackedHeadDeltaRef {
+            schema_key: "schema",
+            file_id: None,
+            entity_pk: &entity_pk,
+            change_id: ChangeId::for_test_label("first-change"),
+            commit_id: first_head,
+            deleted: false,
+            created_at: ts("2026-01-01T00:00:00Z"),
+            updated_at: ts("2026-01-02T00:00:00Z"),
+            snapshot: JsonSlotRef::Inline("{\"value\":\"two\"}"),
+            metadata: JsonSlotRef::None,
+        };
         TrackedHeadContext::new()
             .writer(&read, &mut writes)
-            .stage_commit_with_working_diff(
+            .stage_checkpoint_current_state(
                 branch_id,
-                None,
+                checkpoint,
                 no_op_checkpoint,
-                &[],
+                &[selected.as_current()],
                 &BTreeSet::new(),
-                Some(vec![MaterializedTrackedStateRow {
-                    entity_pk: entity_pk.clone(),
-                    schema_key: "schema".to_string(),
-                    file_id: None,
-                    snapshot_content: Some("{\"value\":\"two\"}".into()),
-                    metadata: None,
-                    deleted: false,
-                    created_at: "2026-01-01T00:00:00Z".to_string(),
-                    updated_at: "2026-01-02T00:00:00Z".to_string(),
-                    change_id: ChangeId::for_test_label("first-change"),
-                    commit_id: first_head,
-                }]),
-                Some(no_op_checkpoint),
+                no_op_checkpoint,
                 &mut no_op_coverage,
             )
             .await
-            .expect("stage no-op checkpoint generation");
+            .expect("stage no-op checkpoint publication");
         assert_eq!(no_op_coverage, WorkingDiffIndexCoverage::default());
+        assert!(
+            !writes.contains_put(
+                HOT_ROW_SPACE,
+                &hot::encode_hot_row_key(&HeadIdentity {
+                    branch_id: branch_id.to_owned(),
+                    generation: checkpoint,
+                    schema_key: "schema".to_owned(),
+                    entity_pk: entity_pk.clone(),
+                    file_id: None,
+                }),
+            ),
+            "an identical selected change must not rewrite its HOT row"
+        );
+        assert!(
+            writes.is_empty(),
+            "an identical selection must not rewrite unchanged collection controls"
+        );
         stage_tracked_working_diff_epoch(
             &mut writes,
             branch_id,
             TrackedWorkingDiffEpoch {
                 checkpoint_commit_id: no_op_checkpoint,
-                generation: no_op_checkpoint,
+                generation: checkpoint,
                 coverage: no_op_coverage,
             },
         )
@@ -3003,7 +3054,7 @@ mod tests {
         stage_branch_head_control(
             &mut writes,
             branch_id,
-            control(no_op_checkpoint, no_op_checkpoint, no_op_checkpoint),
+            control(no_op_checkpoint, checkpoint, no_op_checkpoint),
         )
         .expect("stage no-op checkpoint control");
         drop(read);
@@ -3024,7 +3075,7 @@ mod tests {
                 .expect("no-op checkpoint epoch should decode"),
             Some(TrackedWorkingDiffEpoch {
                 checkpoint_commit_id: no_op_checkpoint,
-                generation: no_op_checkpoint,
+                generation: checkpoint,
                 coverage: WorkingDiffIndexCoverage::default(),
             })
         );
@@ -3036,7 +3087,7 @@ mod tests {
             .reader(read)
             .working_diff_for_control(
                 branch_id,
-                control(no_op_checkpoint, no_op_checkpoint, no_op_checkpoint),
+                control(no_op_checkpoint, checkpoint, no_op_checkpoint),
                 &TrackedStateDiffRequest::default(),
             )
             .await
@@ -3054,7 +3105,7 @@ mod tests {
             .writer(&read, &mut writes)
             .stage_commit_with_working_diff(
                 branch_id,
-                Some(no_op_checkpoint),
+                Some(checkpoint),
                 second_head,
                 &[TrackedHeadDeltaRef {
                     schema_key: "schema",
@@ -3080,7 +3131,7 @@ mod tests {
             branch_id,
             TrackedWorkingDiffEpoch {
                 checkpoint_commit_id: no_op_checkpoint,
-                generation: no_op_checkpoint,
+                generation: checkpoint,
                 coverage: second_coverage,
             },
         )
@@ -3088,7 +3139,7 @@ mod tests {
         stage_branch_head_control(
             &mut writes,
             branch_id,
-            control(second_head, no_op_checkpoint, no_op_checkpoint),
+            control(second_head, checkpoint, no_op_checkpoint),
         )
         .expect("stage second control");
         drop(read);
@@ -3105,7 +3156,7 @@ mod tests {
             .reader(read)
             .working_diff_for_control(
                 branch_id,
-                control(second_head, no_op_checkpoint, no_op_checkpoint),
+                control(second_head, checkpoint, no_op_checkpoint),
                 &TrackedStateDiffRequest::default(),
             )
             .await
@@ -3137,7 +3188,7 @@ mod tests {
             branch_id,
             TrackedWorkingDiffEpoch {
                 checkpoint_commit_id: stale_checkpoint,
-                generation: no_op_checkpoint,
+                generation: checkpoint,
                 coverage: second_coverage,
             },
         )
@@ -3165,7 +3216,7 @@ mod tests {
                     .reader(read)
                     .working_diff_for_control(
                         branch_id,
-                        control(second_head, no_op_checkpoint, no_op_checkpoint),
+                        control(second_head, checkpoint, no_op_checkpoint),
                         &request,
                     )
                     .await
@@ -3181,7 +3232,7 @@ mod tests {
             branch_id,
             TrackedWorkingDiffEpoch {
                 checkpoint_commit_id: no_op_checkpoint,
-                generation: no_op_checkpoint,
+                generation: checkpoint,
                 coverage: WorkingDiffIndexCoverage::default(),
             },
         )
@@ -3199,7 +3250,7 @@ mod tests {
                 .reader(read)
                 .working_diff_for_control(
                     branch_id,
-                    control(second_head, no_op_checkpoint, no_op_checkpoint),
+                    control(second_head, checkpoint, no_op_checkpoint),
                     &TrackedStateDiffRequest::default(),
                 )
                 .await

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -2205,8 +2205,13 @@ where
         control: BranchHeadControl,
         request: &TrackedStateScanRequest,
     ) -> Result<MaterializedLiveStateBatch, LixError> {
-        self.scan_live_batch_for_generation(branch_id, control.generation, request)
-            .await
+        self.scan_live_batch_for_generation(
+            branch_id,
+            control.generation,
+            control.working_diff_checkpoint_commit_id,
+            request,
+        )
+        .await
     }
 
     pub(crate) async fn scan_live_rows(
@@ -2319,9 +2324,14 @@ where
             return Ok(None);
         };
         Ok(Some(
-            self.scan_live_batch_for_generation(branch_id, control.generation, request)
-                .await?
-                .into_rows(),
+            self.scan_live_batch_for_generation(
+                branch_id,
+                control.generation,
+                control.working_diff_checkpoint_commit_id,
+                request,
+            )
+            .await?
+            .into_rows(),
         ))
     }
 
@@ -2329,6 +2339,7 @@ where
         &self,
         branch_id: &str,
         generation: CommitId,
+        active_checkpoint_commit_id: Option<CommitId>,
         request: &TrackedStateScanRequest,
     ) -> Result<MaterializedLiveStateBatch, LixError> {
         let collection_control = match request.filter.schema_keys.as_slice() {
@@ -2358,11 +2369,20 @@ where
         // A storage prefix is ordered by identity, but tombstones are filtered
         // only after decoding the value. Applying SQL LIMIT to the raw scan
         // would therefore let one tombstone hide a later live row.
-        let entries =
+        let mut entries =
             hot_scan_entries(&self.store, branch_id, generation, &request.filter, None).await?;
+        if let Some(control) = replaced_generation {
+            filter_hot_scan_entries_by_collection_generation(&mut entries, control)?;
+        }
         let projection = ChangeRecordProjection::from_columns(&request.read_columns.columns);
-        let rows =
-            materialize_hot_scan_entries(&self.store, entries, projection, branch_id).await?;
+        let rows = materialize_hot_scan_entries(
+            &self.store,
+            entries,
+            projection,
+            branch_id,
+            active_checkpoint_commit_id,
+        )
+        .await?;
         let overlay_identities = rows
             .iter()
             .map(|row| {
@@ -2426,13 +2446,7 @@ where
             return Ok(rows);
         }
         Ok(rows.filter(
-            |row| {
-                let in_active_generation = replaced_generation.is_none_or(|control| {
-                    row.commit_id()
-                        .is_some_and(|commit_id| commit_id > control.active_generation)
-                });
-                in_active_generation && (request.filter.include_tombstones || !row.deleted())
-            },
+            |row| request.filter.include_tombstones || !row.deleted(),
             request.limit,
         ))
     }
@@ -2502,6 +2516,7 @@ where
         self.load_projected_live_batch_for_generation_refs(
             branch_id,
             control.generation,
+            control.working_diff_checkpoint_commit_id,
             keys,
             projection,
         )
@@ -2512,6 +2527,7 @@ where
         &self,
         branch_id: &str,
         generation: CommitId,
+        active_checkpoint_commit_id: Option<CommitId>,
         keys: &[TrackedStateKeyRef<'_>],
         projection: &ChangeRecordProjection,
     ) -> Result<MaterializedLiveStateExactBatch, LixError> {
@@ -2574,7 +2590,14 @@ where
                 ordinal
             }));
         }
-        let rows = materialize_live_entries(&self.store, entries, *projection, branch_id).await?;
+        let rows = materialize_live_entries(
+            &self.store,
+            entries,
+            *projection,
+            branch_id,
+            active_checkpoint_commit_id,
+        )
+        .await?;
         if slots.iter().all(Option::is_some) {
             return MaterializedLiveStateExactBatch::new(rows, slots);
         }
@@ -3859,9 +3882,10 @@ fn next_cascade_working_diff_baseline(
             false,
         )),
         WorkingDiffBaseline::BeforeAbsent { .. } | WorkingDiffBaseline::BeforePresent { .. } => {
-            let before = previous
+            let mut before = previous
                 .working_diff_version()
                 .ok_or_else(|| head_value_error("tracked cascade member has no version"))?;
+            before.commit_id = active_checkpoint_commit_id;
             Ok((
                 WorkingDiffBaseline::BeforePresent {
                     checkpoint_commit_id: active_checkpoint_commit_id,
@@ -3937,9 +3961,10 @@ fn next_hot_working_diff_baseline(
             false,
         )),
         WorkingDiffBaseline::BeforeAbsent { .. } | WorkingDiffBaseline::BeforePresent { .. } => {
-            let before = previous
+            let mut before = previous
                 .working_diff_version()
                 .ok_or_else(|| head_value_error("tracked mutation has no working-diff version"))?;
+            before.commit_id = active_checkpoint_commit_id;
             Ok((
                 WorkingDiffBaseline::BeforePresent {
                     checkpoint_commit_id: active_checkpoint_commit_id,
@@ -5242,6 +5267,43 @@ enum HotScanEntries<'a> {
     Decoded(Vec<(HotScanIdentity, Bytes)>),
 }
 
+fn filter_hot_scan_entries_by_collection_generation(
+    entries: &mut HotScanEntries<'_>,
+    control: HotCollectionControl,
+) -> Result<(), LixError> {
+    let visible = |bytes: &Bytes| -> Result<bool, LixError> {
+        Ok(decode_head_value(bytes)?
+            .commit_id
+            .is_some_and(|commit_id| commit_id > control.active_generation))
+    };
+    match entries {
+        HotScanEntries::Decoded(rows) => {
+            let mut retained = Vec::with_capacity(rows.len());
+            for (identity, bytes) in rows.drain(..) {
+                if visible(&bytes)? {
+                    retained.push((identity, bytes));
+                }
+            }
+            *rows = retained;
+        }
+        HotScanEntries::Finite(batches) => {
+            for batch in batches {
+                for value in &mut batch.values {
+                    if value
+                        .as_ref()
+                        .map(&visible)
+                        .transpose()?
+                        .is_some_and(|visible| !visible)
+                    {
+                        *value = None;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 fn hot_exact_identity_batches<'a>(
     branch_id: &'a str,
     generation: CommitId,
@@ -5346,10 +5408,18 @@ async fn materialize_hot_scan_entries(
     entries: HotScanEntries<'_>,
     projection: ChangeRecordProjection,
     branch_id: &str,
+    active_checkpoint_commit_id: Option<CommitId>,
 ) -> Result<MaterializedLiveStateBatch, LixError> {
     match entries {
         HotScanEntries::Decoded(entries) => {
-            materialize_live_entries(store, entries, projection, branch_id).await
+            materialize_live_entries(
+                store,
+                entries,
+                projection,
+                branch_id,
+                active_checkpoint_commit_id,
+            )
+            .await
         }
         HotScanEntries::Finite(batches) => {
             let row_count = batches
@@ -5366,7 +5436,14 @@ async fn materialize_hot_scan_entries(
                     entries.push((batch.identities.key_ref(index), value));
                 }
             }
-            materialize_live_entries(store, entries, projection, branch_id).await
+            materialize_live_entries(
+                store,
+                entries,
+                projection,
+                branch_id,
+                active_checkpoint_commit_id,
+            )
+            .await
         }
     }
 }
@@ -5492,10 +5569,19 @@ async fn hot_load_file_scope_identities(
 
 fn working_diff_baseline_before(
     baseline: WorkingDiffBaseline,
+    checkpoint_commit_id: CommitId,
 ) -> Option<Option<WorkingDiffVersion>> {
     match baseline {
-        WorkingDiffBaseline::BeforeAbsent { .. } => Some(None),
-        WorkingDiffBaseline::BeforePresent { version, .. } => Some(Some(version)),
+        WorkingDiffBaseline::BeforeAbsent {
+            checkpoint_commit_id: owner,
+        } if owner == checkpoint_commit_id => Some(None),
+        WorkingDiffBaseline::BeforePresent {
+            checkpoint_commit_id: owner,
+            version,
+        } if owner == checkpoint_commit_id => Some(Some(version)),
+        WorkingDiffBaseline::BeforeAbsent { .. } | WorkingDiffBaseline::BeforePresent { .. } => {
+            None
+        }
         WorkingDiffBaseline::Disabled | WorkingDiffBaseline::Clean => None,
     }
 }
@@ -5512,8 +5598,14 @@ async fn hot_working_diff_entries(
     filter: &TrackedStateFilter,
 ) -> Result<Option<Vec<TrackedStateDiffEntry>>, LixError> {
     if !filter.schema_keys.is_empty() && !filter.entity_pks.is_empty() {
-        return hot_working_diff_entries_for_finite_filter(store, branch_id, generation, filter)
-            .await;
+        return hot_working_diff_entries_for_finite_filter(
+            store,
+            branch_id,
+            checkpoint_commit_id,
+            generation,
+            filter,
+        )
+        .await;
     }
 
     let scope = encode_working_diff_scope_prefix(branch_id, checkpoint_commit_id, generation);
@@ -5604,7 +5696,9 @@ async fn hot_working_diff_entries(
         if after.untracked {
             return Ok(None);
         }
-        let Some(before) = working_diff_baseline_before(after.working_diff_baseline) else {
+        let Some(before) =
+            working_diff_baseline_before(after.working_diff_baseline, checkpoint_commit_id)
+        else {
             return Ok(None);
         };
         let Some(after) = after.working_diff_version() else {
@@ -5627,6 +5721,7 @@ async fn hot_working_diff_entries(
 async fn hot_working_diff_entries_for_finite_filter(
     store: &(impl StorageAdapterRead + ?Sized),
     branch_id: &str,
+    checkpoint_commit_id: CommitId,
     generation: CommitId,
     filter: &TrackedStateFilter,
 ) -> Result<Option<Vec<TrackedStateDiffEntry>>, LixError> {
@@ -5635,7 +5730,8 @@ async fn hot_working_diff_entries_for_finite_filter(
         HotScanEntries::Decoded(rows) => {
             let mut candidates = Vec::with_capacity(rows.len());
             for (identity, bytes) in rows {
-                let Some(versions) = finite_working_diff_versions(&bytes) else {
+                let Some(versions) = finite_working_diff_versions(&bytes, checkpoint_commit_id)
+                else {
                     return Ok(None);
                 };
                 let Some((before, after)) = versions else {
@@ -5656,7 +5752,8 @@ async fn hot_working_diff_entries_for_finite_filter(
                     let Some(bytes) = bytes else {
                         continue;
                     };
-                    let Some(versions) = finite_working_diff_versions(&bytes) else {
+                    let Some(versions) = finite_working_diff_versions(&bytes, checkpoint_commit_id)
+                    else {
                         return Ok(None);
                     };
                     let Some((before, after)) = versions else {
@@ -5672,12 +5769,18 @@ async fn hot_working_diff_entries_for_finite_filter(
 
 fn finite_working_diff_versions(
     bytes: &Bytes,
+    checkpoint_commit_id: CommitId,
 ) -> Option<Option<(Option<WorkingDiffVersion>, WorkingDiffVersion)>> {
     let after = decode_head_value(bytes).ok()?;
     if after.untracked || after.working_diff_baseline == WorkingDiffBaseline::Clean {
         return Some(None);
     }
-    let before = working_diff_baseline_before(after.working_diff_baseline)?;
+    if working_diff_checkpoint_owner(after.working_diff_baseline)
+        .is_some_and(|owner| owner != checkpoint_commit_id)
+    {
+        return Some(None);
+    }
+    let before = working_diff_baseline_before(after.working_diff_baseline, checkpoint_commit_id)?;
     let after = after.working_diff_version()?;
     Some(Some((before, after)))
 }

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -1,4 +1,4 @@
-//! V19 row-addressable current state with dirty-inline fingerprints.
+//! V20 row-addressable current state with checkpoint-owned dirty baselines.
 //!
 //! V12 packed every file member of one logical entity into a group. That made
 //! a logical-PK lookup cheap, but it also made every normal commit read,
@@ -27,7 +27,7 @@ use crate::wasm::WasmCertifiedEntityBatch;
 
 use super::*;
 
-pub(crate) const HOT_ROW_NAMESPACE: &str = "live_state.hot_row.v19";
+pub(crate) const HOT_ROW_NAMESPACE: &str = "live_state.hot_row.v20";
 pub(crate) const HOT_FILE_NAMESPACE: &str = "live_state.hot_file_schema.v18";
 pub(crate) const HOT_DIFF_NAMESPACE: &str = "live_state.hot_diff.v17";
 pub(crate) const HOT_COLLECTION_CONTROL_NAMESPACE: &str = "live_state.hot_collection_control.v1";
@@ -356,8 +356,10 @@ impl DeferredFinalPutSource for DeferredFreshHotSource {
                     &mut value_bytes,
                     &delta.value_ref(
                         delta.created_at,
-                        if self.plan.checkpoint_commit_id.is_some() {
-                            WorkingDiffBaseline::BeforeAbsent
+                        if let Some(checkpoint_commit_id) = self.plan.checkpoint_commit_id {
+                            WorkingDiffBaseline::BeforeAbsent {
+                                checkpoint_commit_id,
+                            }
                         } else {
                             WorkingDiffBaseline::Disabled
                         },
@@ -1979,6 +1981,7 @@ fn stage_incremental_collection_controls(
     use crate::collection_generation::{
         COLLECTION_GENERATION_SCHEMA_KEY, CollectionScopeRef, collection_scope_from_entity_pk,
     };
+    let mut dirty_scopes = BTreeSet::new();
     for (delta, previous) in deltas.iter().zip(previous_values) {
         if delta.schema_key == COLLECTION_GENERATION_SCHEMA_KEY {
             let scope = collection_scope_from_entity_pk(delta.entity_pk)?;
@@ -1994,6 +1997,7 @@ fn stage_incremental_collection_controls(
                 head_value_error("tracked collection-generation row lacks commit_id")
             })?;
             control.live_count = 0;
+            dirty_scopes.insert(scope);
             continue;
         }
 
@@ -2036,6 +2040,7 @@ fn stage_incremental_collection_controls(
                     .checked_sub(1)
                     .ok_or_else(|| head_value_error("hot collection live count underflow"))?
             };
+            dirty_scopes.insert(scope);
         }
     }
 
@@ -2047,9 +2052,13 @@ fn stage_incremental_collection_controls(
             .live_count
             .checked_add(*increment)
             .ok_or_else(|| head_value_error("hot collection live count exceeds u64"))?;
+        dirty_scopes.insert(scope.clone());
     }
 
     for ((schema_key, file_id), control) in controls {
+        if !dirty_scopes.contains(&(schema_key.clone(), file_id.clone())) {
+            continue;
+        }
         stage_hot_collection_control(
             writes,
             branch_id,
@@ -3309,20 +3318,60 @@ where
                 existing.created_at
             });
         }
+        let validated_delta_keys = sorted
+            .iter()
+            .map(|delta| TrackedStateKey {
+                schema_key: delta.schema_key.to_string(),
+                entity_pk: delta.entity_pk.clone(),
+                file_id: delta.file_id.map(str::to_string),
+            })
+            .collect::<BTreeSet<_>>();
+        // A checkpoint often selects immutable change records whose HOT row
+        // is already the exact authoritative value. Re-publishing those rows
+        // only changes the row-local dirty marker and commit ownership, even
+        // though the checkpoint delta already records historical membership.
+        //
+        // Retain only this provably identical case. A squashed selection has
+        // a new change ID and must still be written so canonical timestamps
+        // and payload ownership match historical rebuilds.
+        let (sorted, previous_values, created_ats) = if reset_working_diff_baselines {
+            let mut retained_deltas = Vec::with_capacity(sorted.len());
+            let mut retained_previous = Vec::with_capacity(previous_values.len());
+            let mut retained_created_ats = Vec::with_capacity(created_ats.len());
+            for ((delta, previous), created_at) in
+                sorted.into_iter().zip(previous_values).zip(created_ats)
+            {
+                let identical_immutable_change = !delta.untracked
+                    && delta.schema_key
+                        != crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY
+                    && previous
+                        .as_deref()
+                        .map(decode_head_value)
+                        .transpose()?
+                        .is_some_and(|value| {
+                            value.change_id == delta.change_id
+                                && value.deleted == delta.deleted
+                                && value.created_at == delta.created_at
+                                && value.updated_at == delta.updated_at
+                        });
+                if identical_immutable_change {
+                    continue;
+                }
+                retained_deltas.push(delta);
+                retained_previous.push(previous);
+                retained_created_ats.push(created_at);
+            }
+            (retained_deltas, retained_previous, retained_created_ats)
+        } else {
+            (sorted, previous_values, created_ats)
+        };
+        let identities = encode_hot_mutation_identities(branch_id, generation, &sorted);
         let unmatched_guards = if absence_guards_validated || absence_guards.is_empty() {
             BTreeSet::new()
         } else {
-            let delta_keys = sorted
-                .iter()
-                .map(|delta| TrackedStateKey {
-                    schema_key: delta.schema_key.to_string(),
-                    entity_pk: delta.entity_pk.clone(),
-                    file_id: delta.file_id.map(str::to_string),
-                })
-                .collect::<BTreeSet<_>>();
             absence_guards
                 .iter()
-                .filter(|key| !delta_keys.contains(*key))
+                .filter(|key| !validated_delta_keys.contains(*key))
                 .cloned()
                 .collect::<BTreeSet<_>>()
         };
@@ -3743,7 +3792,7 @@ struct HotCascadeMutationBuffers {
 impl HotCascadeMutationBuffers {
     fn with_capacity(row_capacity: usize, key_capacity: usize, active_checkpoint: bool) -> Self {
         let checkpoint_bytes = if active_checkpoint {
-            WORKING_DIFF_VERSION_BYTES
+            WORKING_DIFF_CHECKPOINT_BYTES + WORKING_DIFF_VERSION_BYTES
         } else {
             0
         };
@@ -3775,19 +3824,51 @@ fn next_cascade_working_diff_baseline(
     active_checkpoint_commit_id: Option<CommitId>,
     previous: HeadValueView<'_>,
 ) -> Result<(WorkingDiffBaseline, bool), LixError> {
-    if active_checkpoint_commit_id.is_none() {
+    let Some(active_checkpoint_commit_id) = active_checkpoint_commit_id else {
         return Ok((WorkingDiffBaseline::Disabled, false));
-    }
+    };
     match previous.working_diff_baseline {
         WorkingDiffBaseline::Clean => {
             let before = previous
                 .working_diff_version()
                 .ok_or_else(|| head_value_error("tracked cascade member has no version"))?;
-            Ok((WorkingDiffBaseline::BeforePresent(before), true))
+            Ok((
+                WorkingDiffBaseline::BeforePresent {
+                    checkpoint_commit_id: active_checkpoint_commit_id,
+                    version: before,
+                },
+                true,
+            ))
         }
-        WorkingDiffBaseline::BeforeAbsent => Ok((WorkingDiffBaseline::BeforeAbsent, false)),
-        WorkingDiffBaseline::BeforePresent(before) => {
-            Ok((WorkingDiffBaseline::BeforePresent(before), false))
+        WorkingDiffBaseline::BeforeAbsent {
+            checkpoint_commit_id,
+        } if checkpoint_commit_id == active_checkpoint_commit_id => Ok((
+            WorkingDiffBaseline::BeforeAbsent {
+                checkpoint_commit_id,
+            },
+            false,
+        )),
+        WorkingDiffBaseline::BeforePresent {
+            checkpoint_commit_id,
+            version,
+        } if checkpoint_commit_id == active_checkpoint_commit_id => Ok((
+            WorkingDiffBaseline::BeforePresent {
+                checkpoint_commit_id,
+                version,
+            },
+            false,
+        )),
+        WorkingDiffBaseline::BeforeAbsent { .. } | WorkingDiffBaseline::BeforePresent { .. } => {
+            let before = previous
+                .working_diff_version()
+                .ok_or_else(|| head_value_error("tracked cascade member has no version"))?;
+            Ok((
+                WorkingDiffBaseline::BeforePresent {
+                    checkpoint_commit_id: active_checkpoint_commit_id,
+                    version: before,
+                },
+                true,
+            ))
         }
         WorkingDiffBaseline::Disabled => Err(head_value_error(
             "active checkpoint generation contains a cascade member without a baseline",
@@ -3805,11 +3886,19 @@ fn next_hot_working_diff_baseline(
     delta: &CurrentStateDeltaRef<'_>,
     previous: Option<HeadValueView<'_>>,
 ) -> Result<(WorkingDiffBaseline, bool), LixError> {
-    if delta.untracked || active_checkpoint_commit_id.is_none() {
+    let Some(active_checkpoint_commit_id) = active_checkpoint_commit_id else {
+        return Ok((WorkingDiffBaseline::Disabled, false));
+    };
+    if delta.untracked {
         return Ok((WorkingDiffBaseline::Disabled, false));
     }
     let Some(previous) = previous else {
-        return Ok((WorkingDiffBaseline::BeforeAbsent, true));
+        return Ok((
+            WorkingDiffBaseline::BeforeAbsent {
+                checkpoint_commit_id: active_checkpoint_commit_id,
+            },
+            true,
+        ));
     };
     if previous.untracked {
         return Err(head_value_error(
@@ -3821,11 +3910,43 @@ fn next_hot_working_diff_baseline(
             let before = previous
                 .working_diff_version()
                 .ok_or_else(|| head_value_error("tracked mutation has no working-diff version"))?;
-            Ok((WorkingDiffBaseline::BeforePresent(before), true))
+            Ok((
+                WorkingDiffBaseline::BeforePresent {
+                    checkpoint_commit_id: active_checkpoint_commit_id,
+                    version: before,
+                },
+                true,
+            ))
         }
-        WorkingDiffBaseline::BeforeAbsent => Ok((WorkingDiffBaseline::BeforeAbsent, false)),
-        WorkingDiffBaseline::BeforePresent(before) => {
-            Ok((WorkingDiffBaseline::BeforePresent(before), false))
+        WorkingDiffBaseline::BeforeAbsent {
+            checkpoint_commit_id,
+        } if checkpoint_commit_id == active_checkpoint_commit_id => Ok((
+            WorkingDiffBaseline::BeforeAbsent {
+                checkpoint_commit_id,
+            },
+            false,
+        )),
+        WorkingDiffBaseline::BeforePresent {
+            checkpoint_commit_id,
+            version,
+        } if checkpoint_commit_id == active_checkpoint_commit_id => Ok((
+            WorkingDiffBaseline::BeforePresent {
+                checkpoint_commit_id,
+                version,
+            },
+            false,
+        )),
+        WorkingDiffBaseline::BeforeAbsent { .. } | WorkingDiffBaseline::BeforePresent { .. } => {
+            let before = previous
+                .working_diff_version()
+                .ok_or_else(|| head_value_error("tracked mutation has no working-diff version"))?;
+            Ok((
+                WorkingDiffBaseline::BeforePresent {
+                    checkpoint_commit_id: active_checkpoint_commit_id,
+                    version: before,
+                },
+                true,
+            ))
         }
         WorkingDiffBaseline::Disabled => Err(head_value_error(
             "active checkpoint generation contains a tracked row without a baseline",
@@ -4263,7 +4384,7 @@ fn checked_add_hot_next_value_capacity(
     u32::try_from(snapshot_len).ok()?;
     u32::try_from(metadata_len).ok()?;
     let baseline_len = if active_checkpoint && !delta.untracked {
-        WORKING_DIFF_VERSION_BYTES
+        WORKING_DIFF_CHECKPOINT_BYTES + WORKING_DIFF_VERSION_BYTES
     } else {
         0
     };
@@ -5373,8 +5494,8 @@ fn working_diff_baseline_before(
     baseline: WorkingDiffBaseline,
 ) -> Option<Option<WorkingDiffVersion>> {
     match baseline {
-        WorkingDiffBaseline::BeforeAbsent => Some(None),
-        WorkingDiffBaseline::BeforePresent(version) => Some(Some(version)),
+        WorkingDiffBaseline::BeforeAbsent { .. } => Some(None),
+        WorkingDiffBaseline::BeforePresent { version, .. } => Some(Some(version)),
         WorkingDiffBaseline::Disabled | WorkingDiffBaseline::Clean => None,
     }
 }
@@ -5952,7 +6073,7 @@ fn hot_scope_prefix(branch_id: &str, generation: CommitId) -> Vec<u8> {
 }
 
 #[cfg(test)]
-fn encode_hot_row_key(identity: &HeadIdentity) -> Vec<u8> {
+pub(super) fn encode_hot_row_key(identity: &HeadIdentity) -> Vec<u8> {
     encode_hot_row_key_parts(
         &identity.branch_id,
         identity.generation,
@@ -7869,8 +7990,14 @@ mod tests {
             })
             .expect("checkpoint test values have a representable encoded size");
         let checkpoint_baselines = [
-            WorkingDiffBaseline::BeforePresent(before),
-            WorkingDiffBaseline::BeforePresent(before),
+            WorkingDiffBaseline::BeforePresent {
+                checkpoint_commit_id: CommitId::for_test_label("checkpoint"),
+                version: before,
+            },
+            WorkingDiffBaseline::BeforePresent {
+                checkpoint_commit_id: CommitId::for_test_label("checkpoint"),
+                version: before,
+            },
             WorkingDiffBaseline::Disabled,
             WorkingDiffBaseline::Disabled,
         ];
@@ -7895,8 +8022,12 @@ mod tests {
         assert_eq!(checkpoint.capacity(), checkpoint_capacity);
         assert_eq!(checkpoint.as_ptr(), checkpoint_allocation);
 
-        let before_absent =
-            tracked.value_ref(tracked.created_at, WorkingDiffBaseline::BeforeAbsent);
+        let before_absent = tracked.value_ref(
+            tracked.created_at,
+            WorkingDiffBaseline::BeforeAbsent {
+                checkpoint_commit_id: CommitId::for_test_label("checkpoint"),
+            },
+        );
         let before_absent_bytes =
             encode_head_value(&before_absent).expect("encode before-absent checkpoint value");
         let tracked_checkpoint_capacity = checked_add_hot_next_value_capacity(0, &tracked, true)
@@ -7978,15 +8109,16 @@ mod tests {
             updated_at: timestamp(),
             snapshot: JsonSlotRef::None,
             metadata: JsonSlotRef::None,
-            working_diff_baseline: WorkingDiffBaseline::BeforePresent(working_diff_version(
-                "cascade-reserve-before",
-            )),
+            working_diff_baseline: WorkingDiffBaseline::BeforePresent {
+                checkpoint_commit_id: CommitId::for_test_label("cascade-reserve-checkpoint"),
+                version: working_diff_version("cascade-reserve-before"),
+            },
         };
         let encoded_tombstone =
             encode_head_value(&tombstone).expect("encode maximum cascade tombstone");
         assert_eq!(
             encoded_tombstone.len(),
-            HEAD_VALUE_HEADER_BYTES + WORKING_DIFF_VERSION_BYTES,
+            HEAD_VALUE_HEADER_BYTES + WORKING_DIFF_CHECKPOINT_BYTES + WORKING_DIFF_VERSION_BYTES,
             "the cascade value reservation must cover the largest checkpoint tombstone"
         );
 
@@ -8007,7 +8139,10 @@ mod tests {
 
         assert_eq!(
             buffers.value_bytes.len(),
-            ROW_COUNT * (HEAD_VALUE_HEADER_BYTES + WORKING_DIFF_VERSION_BYTES)
+            ROW_COUNT
+                * (HEAD_VALUE_HEADER_BYTES
+                    + WORKING_DIFF_CHECKPOINT_BYTES
+                    + WORKING_DIFF_VERSION_BYTES)
         );
         assert_eq!(buffers.value_bytes.as_ptr(), value_allocation);
         assert_eq!(buffers.row_puts.as_ptr(), row_put_allocation);

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -311,6 +311,78 @@ pub struct StorageLayoutAccounting {
     pub value_bytes: u64,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CommitDeltaLayoutAccounting {
+    pub commit_id: String,
+    pub segment_count: usize,
+    pub members: usize,
+    pub authored_members: usize,
+    pub selected_members: usize,
+    pub selected_tombstones: usize,
+    pub certified_members: usize,
+    pub selected_certified_members: usize,
+}
+
+pub async fn commit_delta_layout_accounting<R>(
+    read: &R,
+) -> Result<Vec<CommitDeltaLayoutAccounting>, crate::LixError>
+where
+    R: StorageAdapterRead,
+{
+    let inventory = crate::tracked_state::scan_commit_delta_inventory(read).await?;
+    let certified_change_ids = inventory
+        .commits
+        .values()
+        .flat_map(|entry| &entry.members)
+        .filter(|member| member.is_certified_payload_ref())
+        .map(|member| member.value.change_id)
+        .collect::<std::collections::BTreeSet<_>>();
+    Ok(inventory
+        .commits
+        .into_iter()
+        .map(|(commit_id, entry)| {
+            let authored_members = entry
+                .members
+                .iter()
+                .filter(|member| member.authored)
+                .count();
+            let selected_members = entry
+                .members
+                .iter()
+                .filter(|member| member.is_selected_payload_ref())
+                .count();
+            let selected_tombstones = entry
+                .members
+                .len()
+                .saturating_sub(authored_members)
+                .saturating_sub(selected_members);
+            let certified_members = entry
+                .members
+                .iter()
+                .filter(|member| member.is_certified_payload_ref())
+                .count();
+            let selected_certified_members = entry
+                .members
+                .iter()
+                .filter(|member| {
+                    member.is_selected_payload_ref()
+                        && certified_change_ids.contains(&member.value.change_id)
+                })
+                .count();
+            CommitDeltaLayoutAccounting {
+                commit_id: commit_id.to_string(),
+                segment_count: entry.segment_count,
+                members: entry.members.len(),
+                authored_members,
+                selected_members,
+                selected_tombstones,
+                certified_members,
+                selected_certified_members,
+            }
+        })
+        .collect())
+}
+
 pub(crate) async fn commit_write_set_for_bench<StorageImpl>(
     storage: &StorageAdapter<StorageImpl>,
     writes: StorageWriteSet,

--- a/packages/engine/tests/integration/sql/checkpoint.rs
+++ b/packages/engine/tests/integration/sql/checkpoint.rs
@@ -152,7 +152,7 @@ simulation_test!(
 
         let timestamps_before_rebuild = select_rows(
             &session,
-            "SELECT lixcol_created_at, lixcol_updated_at \
+            "SELECT lixcol_created_at, lixcol_updated_at, lixcol_commit_id \
              FROM lix_key_value WHERE key = 'checkpoint-key'",
         )
         .await;
@@ -160,6 +160,11 @@ simulation_test!(
         assert_eq!(
             timestamps_before_rebuild[0][0], timestamps_before_rebuild[0][1],
             "a newly added row must use the changelog's canonical timestamp"
+        );
+        assert_eq!(
+            timestamps_before_rebuild[0][2],
+            Value::Text(receipt.commit_id.clone()),
+            "retained HOT rows must project the checkpoint as their live commit owner"
         );
 
         engine
@@ -169,7 +174,7 @@ simulation_test!(
         assert_eq!(
             select_rows(
                 &session,
-                "SELECT lixcol_created_at, lixcol_updated_at \
+                "SELECT lixcol_created_at, lixcol_updated_at, lixcol_commit_id \
                  FROM lix_key_value WHERE key = 'checkpoint-key'",
             )
             .await,


### PR DESCRIPTION
## What changed

- add checkpoint ownership to dirty HOT baselines and hard-cut the row codec/repository protocol to V27
- retain checkpoint-selected HOT rows when their immutable change, deletion state, and timestamps already match
- continue publishing collection-generation markers because their commit ownership is a visibility fence
- write collection controls only when their generation or live count changes
- add a SlateDB SST-space profiler for physical attribution

## Why

Checkpoint publication was rewriting nearly the complete eagerly materialized plugin state only to clear row-local working-diff baselines. On the retained 50-commit `vscode-docs` replay, HOT rows were 1.962 physical versions per key and collection controls were 1.982 versions per key. The initial checkpoint alone duplicated about 53.8k HOT rows and 30.6k controls.

Dirty rows now carry the checkpoint that owns their before-image. Advancing the working-diff epoch makes an old baseline stale without rewriting an otherwise identical current-state row. Squashed rows and collection-generation fences still publish normally.

## Measured impact

All measurements use SlateDB, all bundled WASM plugins, eager semantic materialization, verification after every commit, and one Lix checkpoint per Git commit.

Retained 50-commit `vscode-docs` replay:

- end-to-end database bytes: 50,348,872 -> 43,365,071 (-13.9%)
- compacted SST bytes: 49,722,940 -> 43,301,163 (-12.9%)
- HOT compressed bytes: 12,956,273 -> 8,260,546 (-36.2%)
- HOT versions/key: 1.962 -> 1.014
- collection-control compressed bytes: 1,605,782 -> 815,139 (-49.2%)
- collection-control versions/key: 1.982 -> 1.004
- total checkpoint time: 3,217.6 ms -> 2,949.9 ms (-8.3%)

The retained six-commit correctness gate also verified every commit and the final Git tree.

## Validation

- `cargo test -p lix_engine` (1,617 unit tests, 429 integration tests, 3 doctests)
- `cargo clippy -p lix_engine --all-features --all-targets -- -D warnings`
- focused checkpoint, partial-checkpoint, collection delete/recreate, protocol rejection, and 10k cascade-capacity regressions
- retained 6-commit and 50-commit all-plugin SlateDB replays with checkpoint-per-commit and Git-tree verification
