### PR TITLE
perf(engine): lower certified inserts into typed transaction arenas

### DIFF
--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -31,7 +31,7 @@ use crate::sql2::value_contract::{json_bigint_value, json_double_value};
 use crate::transaction::types::{
     RawWriteBatch, RawWriteRowRef, TransactionJson, TransactionWrite, TransactionWriteMode,
 };
-use crate::wasm::{WasmCanonicalJson, WasmEntityKey};
+use crate::wasm::WasmEntityKey;
 use crate::{LixError, NullableKeyFilter, Value, parse_row_metadata_value};
 
 use super::SqlWriteResult;
@@ -2714,14 +2714,7 @@ fn certified_direct_parameter_insert_batch(
         }
     }
 
-    let snapshots = WasmCanonicalJson::from_certified_arena_parts(
-        normalized,
-        offsets,
-        entity_pks.clone(),
-        vec![schema_plan.shared_fingerprint()],
-        vec![0; row_count],
-        row_count,
-    )?;
+    let snapshots = TransactionJson::from_certified_row_content_arena(normalized, offsets)?;
     let schema_key: SharedStr = layout.schema_key.as_str().into();
     let branch_id: SharedStr = ctx.active_branch_id().into();
     let mut rows = RawWriteBatch::with_capacity(row_count);
@@ -2730,7 +2723,7 @@ fn certified_direct_parameter_insert_batch(
             Some(entity_pk),
             schema_key.clone(),
             None,
-            Some(TransactionJson::from_canonical_batch(snapshot)),
+            Some(snapshot),
             None,
             None,
             None,
@@ -3056,21 +3049,14 @@ fn certified_entity_insert_rows<'a>(
     }
 
     let row_count = offsets.len();
-    let snapshots = WasmCanonicalJson::from_certified_arena_parts(
-        normalized,
-        offsets,
-        entity_pks.clone(),
-        vec![schema_plan.shared_fingerprint()],
-        vec![0; row_count],
-        row_count,
-    )?;
+    let snapshots = TransactionJson::from_certified_row_content_arena(normalized, offsets)?;
     let mut rows = RawWriteBatch::with_capacity(row_count);
     for ((entity_pk, snapshot), row) in entity_pks.into_iter().zip(snapshots).zip(row_parts) {
         rows.push_parts(
             Some(entity_pk),
             layout.schema_key.as_str().into(),
             row.file_id,
-            Some(TransactionJson::from_canonical_batch(snapshot)),
+            Some(snapshot),
             row.metadata,
             None,
             None,

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -10713,14 +10713,8 @@ mod tests {
         )
         .expect("explicit row timestamps should plan");
 
-        assert_eq!(
-            planned.created_at.to_string(),
-            "2026-04-23T00:00:00.123Z"
-        );
-        assert_eq!(
-            planned.updated_at.to_string(),
-            "2026-04-24T00:00:00.456Z"
-        );
+        assert_eq!(planned.created_at.to_string(), "2026-04-23T00:00:00.123Z");
+        assert_eq!(planned.updated_at.to_string(), "2026-04-24T00:00:00.456Z");
         assert_eq!(default_timestamp, None);
         assert_eq!(
             functions.deterministic_sequence_persist_highest_seen(),

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -5026,6 +5026,12 @@ where
         allow_homogeneous: bool,
     ) -> Result<PreparedStateBatch, LixError> {
         let row_count = rows.len();
+        // SQL statement time is stable across every row in one write batch.
+        // Besides matching mature database semantics, this avoids formatting
+        // and sampling the wall clock once per row on bulk writes. Keep the
+        // sample lazy so normalization errors retain precedence over scalar
+        // provider calls.
+        let mut default_timestamp = None;
         let staged = self.staged_writes.staging_overlay()?;
         let read = SharedStorageAdapterRead::new(
             self.storage
@@ -5048,6 +5054,7 @@ where
                     rows.row(index),
                     normalized,
                     &functions,
+                    *default_timestamp.get_or_insert_with(|| functions.call_timestamp()),
                 )?);
             }
             if rows.iter().any(|row| {
@@ -5144,6 +5151,7 @@ where
                         .take()
                         .expect("normalized domain row must have facts"),
                     &functions,
+                    *default_timestamp.get_or_insert_with(|| functions.call_timestamp()),
                 )?;
                 scalar_ordinal_by_row[index] = scalar_facts.schema_plan_ids.len();
                 scalar_facts.push(scalar);
@@ -6316,6 +6324,7 @@ fn plan_prepared_row_scalars(
     row: RawWriteRowRef<'_>,
     normalized: NormalizedRowFacts,
     functions: &FunctionProviderHandle,
+    default_timestamp: LixTimestamp,
 ) -> Result<PreparedScalarRow, LixError> {
     let NormalizedRowFacts {
         schema_plan_id,
@@ -6323,7 +6332,7 @@ fn plan_prepared_row_scalars(
     } = normalized;
     let updated_at = match row.updated_at {
         Some(updated_at) => parse_prepared_timestamp("updated_at", updated_at)?,
-        None => functions.call_timestamp(),
+        None => default_timestamp,
     };
     let created_at = match row.created_at {
         Some(created_at) => parse_prepared_timestamp("created_at", created_at)?,

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -5054,7 +5054,7 @@ where
                     rows.row(index),
                     normalized,
                     &functions,
-                    *default_timestamp.get_or_insert_with(|| functions.call_timestamp()),
+                    &mut default_timestamp,
                 )?);
             }
             if rows.iter().any(|row| {
@@ -5151,7 +5151,7 @@ where
                         .take()
                         .expect("normalized domain row must have facts"),
                     &functions,
-                    *default_timestamp.get_or_insert_with(|| functions.call_timestamp()),
+                    &mut default_timestamp,
                 )?;
                 scalar_ordinal_by_row[index] = scalar_facts.schema_plan_ids.len();
                 scalar_facts.push(scalar);
@@ -6324,7 +6324,7 @@ fn plan_prepared_row_scalars(
     row: RawWriteRowRef<'_>,
     normalized: NormalizedRowFacts,
     functions: &FunctionProviderHandle,
-    default_timestamp: LixTimestamp,
+    default_timestamp: &mut Option<LixTimestamp>,
 ) -> Result<PreparedScalarRow, LixError> {
     let NormalizedRowFacts {
         schema_plan_id,
@@ -6332,7 +6332,7 @@ fn plan_prepared_row_scalars(
     } = normalized;
     let updated_at = match row.updated_at {
         Some(updated_at) => parse_prepared_timestamp("updated_at", updated_at)?,
-        None => default_timestamp,
+        None => *default_timestamp.get_or_insert_with(|| functions.call_timestamp()),
     };
     let created_at = match row.created_at {
         Some(created_at) => parse_prepared_timestamp("created_at", created_at)?,
@@ -9392,7 +9392,7 @@ mod tests {
     use crate::GLOBAL_BRANCH_ID;
     use crate::NullableKeyFilter;
     use crate::branch::BranchContext;
-    use crate::functions::FunctionProvider;
+    use crate::functions::{DeterministicFunctionProvider, FunctionProvider};
     use crate::storage_adapter::{Memory, StorageReadOptions};
     use crate::tracked_state::{
         TrackedStateDiffIdentity, TrackedStateKey, TrackedStateScanRequest,
@@ -10688,6 +10688,43 @@ mod tests {
         assert_eq!(
             rows.row(0).updated_at().to_string(),
             "2026-04-23T00:00:00.123Z"
+        );
+    }
+
+    #[test]
+    fn explicit_row_timestamps_do_not_advance_deterministic_sequence() {
+        let mut row = key_value_stage_row("explicit-timestamps", "value", true);
+        row.created_at = Some("2026-04-23T00:00:00.123Z".to_string());
+        row.updated_at = Some("2026-04-24T00:00:00.456Z".to_string());
+        row.change_id = Some(ChangeId::for_test_label("explicit-change").to_string());
+        let rows = raw_write_rows(vec![row]);
+        let functions =
+            FunctionProviderHandle::shared(Box::new(DeterministicFunctionProvider::new(0, false)));
+        let mut default_timestamp = None;
+
+        let planned = plan_prepared_row_scalars(
+            rows.row(0),
+            NormalizedRowFacts {
+                schema_plan_id: SchemaPlanId::for_test(0),
+                facts: PreparedRowFacts::default(),
+            },
+            &functions,
+            &mut default_timestamp,
+        )
+        .expect("explicit row timestamps should plan");
+
+        assert_eq!(
+            planned.created_at.to_string(),
+            "2026-04-23T00:00:00.123Z"
+        );
+        assert_eq!(
+            planned.updated_at.to_string(),
+            "2026-04-24T00:00:00.456Z"
+        );
+        assert_eq!(default_timestamp, None);
+        assert_eq!(
+            functions.deterministic_sequence_persist_highest_seen(),
+            None
         );
     }
 

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -121,6 +121,50 @@ impl TransactionJson {
         }
     }
 
+    /// Constructs certified row content as zero-copy views over one canonical
+    /// UTF-8 arena.
+    ///
+    /// Typed engine producers have already proven row identity and schema
+    /// semantics before reaching this boundary. Retaining those rows directly
+    /// avoids constructing a decoded/certificate transport batch only for
+    /// transaction normalization to immediately dismantle it again.
+    pub(crate) fn from_certified_row_content_arena(
+        normalized: Vec<u8>,
+        offsets: Vec<(usize, usize)>,
+    ) -> Result<Vec<Self>, LixError> {
+        let invalid_arena = |message| LixError::new(LixError::CODE_INVALID_PARAM, message);
+        let arena = SharedStr::from_utf8(bytes::Bytes::from(normalized))
+            .map_err(|_| invalid_arena("certified transaction JSON arena is not UTF-8"))?;
+        let arena_len = u32::try_from(arena.len())
+            .map_err(|_| invalid_arena("certified transaction JSON arena exceeds u32"))?;
+        let mut previous_end = 0_u32;
+        let mut rows = Vec::with_capacity(offsets.len());
+        for (start, end) in offsets {
+            let start = u32::try_from(start)
+                .map_err(|_| invalid_arena("certified transaction JSON row offset exceeds u32"))?;
+            let end = u32::try_from(end)
+                .map_err(|_| invalid_arena("certified transaction JSON row offset exceeds u32"))?;
+            if start != previous_end || end < start || end > arena_len {
+                return Err(invalid_arena(
+                    "certified transaction JSON arena offsets are invalid or non-contiguous",
+                ));
+            }
+            let normalized = arena.slice(start as usize..end as usize).ok_or_else(|| {
+                invalid_arena("certified transaction JSON arena offsets split a UTF-8 scalar")
+            })?;
+            rows.push(Self::from_certified_shared_normalized_row_content(
+                normalized,
+            ));
+            previous_end = end;
+        }
+        if previous_end != arena_len {
+            return Err(invalid_arena(
+                "certified transaction JSON arena offsets do not cover the arena",
+            ));
+        }
+        Ok(rows)
+    }
+
     /// Retains canonical engine-owned metadata whose semantic validity is
     /// established by the typed producer.
     pub(crate) fn from_certified_shared_normalized_metadata(normalized: SharedStr) -> Self {
@@ -1488,12 +1532,17 @@ pub(crate) fn stage_json_from_value(
             value: OnceLock::new(),
             normalized,
         },
-        TransactionJsonStorage::CertifiedShared { normalized, .. } => {
-            StageJsonStorage::CertifiedShared {
-                value: OnceLock::new(),
-                normalized,
-            }
-        }
+        TransactionJsonStorage::CertifiedShared {
+            normalized,
+            certificate: TransactionJsonCertificate::RowContent,
+        } => StageJsonStorage::ValidatedShared { normalized },
+        TransactionJsonStorage::CertifiedShared {
+            normalized,
+            certificate: TransactionJsonCertificate::Metadata,
+        } => StageJsonStorage::CertifiedShared {
+            value: OnceLock::new(),
+            normalized,
+        },
         TransactionJsonStorage::CanonicalShared { value, normalized } => {
             StageJsonStorage::CertifiedShared { value, normalized }
         }
@@ -2238,26 +2287,45 @@ impl PreparedStateBatch {
     }
 
     pub(crate) fn release_validated_canonical_value_columns(&mut self) {
-        let old_json = std::mem::take(&mut self.json);
-        let mut ordinal_remap = vec![u32::MAX; old_json.len()];
-        let mut live_json = Vec::with_capacity(self.slots.len().saturating_mul(2));
-        for slot in &mut self.slots {
-            for ordinal in [&mut slot.snapshot, &mut slot.metadata] {
-                let Some(old_ordinal) = *ordinal else {
-                    continue;
-                };
-                let remapped = &mut ordinal_remap[old_ordinal as usize];
-                if *remapped == u32::MAX {
-                    *remapped = u32::try_from(live_json.len())
-                        .expect("prepared live JSON ordinal must fit u32");
-                    live_json.push(old_json[old_ordinal as usize].clone());
-                }
-                *ordinal = Some(*remapped);
+        let live_json_count = self
+            .slots
+            .iter()
+            .map(|slot| usize::from(slot.snapshot.is_some()) + usize::from(slot.metadata.is_some()))
+            .sum::<usize>();
+        #[cfg(debug_assertions)]
+        if live_json_count == self.json.len() {
+            let mut referenced = vec![false; self.json.len()];
+            for ordinal in self
+                .slots
+                .iter()
+                .flat_map(|slot| [slot.snapshot, slot.metadata].into_iter().flatten())
+            {
+                assert!(
+                    !std::mem::replace(&mut referenced[ordinal as usize], true),
+                    "prepared JSON ordinals must remain unique"
+                );
             }
         }
-        self.json = live_json;
-        drop(old_json);
-        drop(ordinal_remap);
+        if live_json_count != self.json.len() {
+            let old_json = std::mem::take(&mut self.json);
+            let mut ordinal_remap = vec![u32::MAX; old_json.len()];
+            let mut live_json = Vec::with_capacity(live_json_count);
+            for slot in &mut self.slots {
+                for ordinal in [&mut slot.snapshot, &mut slot.metadata] {
+                    let Some(old_ordinal) = *ordinal else {
+                        continue;
+                    };
+                    let remapped = &mut ordinal_remap[old_ordinal as usize];
+                    if *remapped == u32::MAX {
+                        *remapped = u32::try_from(live_json.len())
+                            .expect("prepared live JSON ordinal must fit u32");
+                        live_json.push(old_json[old_ordinal as usize].clone());
+                    }
+                    *ordinal = Some(*remapped);
+                }
+            }
+            self.json = live_json;
+        }
         if self.json.is_empty() {
             return;
         }
@@ -3690,6 +3758,65 @@ mod tests {
             .is_err(),
             "validated owned JSON must not retain or reparse a decoded value"
         );
+    }
+
+    #[test]
+    fn dense_certified_transaction_arena_releases_in_place() {
+        const ROW_COUNT: usize = 32;
+        let mut normalized = Vec::new();
+        let mut offsets = Vec::with_capacity(ROW_COUNT);
+        for index in 0..ROW_COUNT {
+            let start = normalized.len();
+            serde_json::to_writer(
+                &mut normalized,
+                &serde_json::json!({"id": format!("entity-{index}")}),
+            )
+            .expect("fixture should serialize");
+            offsets.push((start, normalized.len()));
+        }
+        let snapshots = TransactionJson::from_certified_row_content_arena(normalized, offsets)
+            .expect("certified transaction arena");
+        assert!(snapshots.iter().all(TransactionJson::row_content_certified));
+        let origin_key: SharedStr = "dense-certified-arena".into();
+        let mut batch = PreparedStateBatch::from_test_rows(
+            snapshots
+                .into_iter()
+                .enumerate()
+                .map(|(index, snapshot)| {
+                    prepared_fixture_row(
+                        &format!("entity-{index}"),
+                        Some(
+                            stage_json_from_value(snapshot, "certified transaction arena")
+                                .expect("certified JSON should stage"),
+                        ),
+                        TransactionWriteOperation::Insert,
+                        &origin_key,
+                    )
+                })
+                .collect(),
+        );
+        let json_allocation = batch.json.as_ptr();
+        let first = batch
+            .row(0)
+            .snapshot
+            .expect("first snapshot")
+            .materialize_shared();
+        assert!(batch.iter().skip(1).all(|row| {
+            first.shares_buffer_with(&row.snapshot.expect("snapshot").materialize_shared())
+        }));
+
+        batch.release_validated_canonical_value_columns();
+
+        assert_eq!(
+            batch.json.as_ptr(),
+            json_allocation,
+            "a dense JSON owner column must not be cloned during validation release"
+        );
+        assert!(batch.iter().all(|row| {
+            !row.snapshot
+                .expect("snapshot")
+                .retains_decoded_value_for_tests()
+        }));
     }
 
     #[test]

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -3820,11 +3820,13 @@ mod tests {
     fn certified_row_content_remains_decodable_until_validation_release() {
         let normalized = br#"{"id":"entity-1"}"#.to_vec();
         let normalized_len = normalized.len();
-        let snapshot =
-            TransactionJson::from_certified_row_content_arena(normalized, vec![(0, normalized_len)])
-                .expect("certified transaction arena")
-                .pop()
-                .expect("certified row");
+        let snapshot = TransactionJson::from_certified_row_content_arena(
+            normalized,
+            vec![(0, normalized_len)],
+        )
+        .expect("certified transaction arena")
+        .pop()
+        .expect("certified row");
         let mut staged =
             stage_json_from_value(snapshot, "certified transaction arena").expect("staged JSON");
 

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -1534,11 +1534,8 @@ pub(crate) fn stage_json_from_value(
         },
         TransactionJsonStorage::CertifiedShared {
             normalized,
-            certificate: TransactionJsonCertificate::RowContent,
-        } => StageJsonStorage::ValidatedShared { normalized },
-        TransactionJsonStorage::CertifiedShared {
-            normalized,
-            certificate: TransactionJsonCertificate::Metadata,
+            certificate:
+                TransactionJsonCertificate::RowContent | TransactionJsonCertificate::Metadata,
         } => StageJsonStorage::CertifiedShared {
             value: OnceLock::new(),
             normalized,
@@ -3817,6 +3814,26 @@ mod tests {
                 .expect("snapshot")
                 .retains_decoded_value_for_tests()
         }));
+    }
+
+    #[test]
+    fn certified_row_content_remains_decodable_until_validation_release() {
+        let normalized = br#"{"id":"entity-1"}"#.to_vec();
+        let normalized_len = normalized.len();
+        let snapshot =
+            TransactionJson::from_certified_row_content_arena(normalized, vec![(0, normalized_len)])
+                .expect("certified transaction arena")
+                .pop()
+                .expect("certified row");
+        let mut staged =
+            stage_json_from_value(snapshot, "certified transaction arena").expect("staged JSON");
+
+        assert!(!staged.retains_decoded_value_for_tests());
+        assert_eq!(staged.value()["id"], "entity-1");
+        assert!(staged.retains_decoded_value_for_tests());
+        assert!(staged.release_validated_canonical_value_column());
+        assert!(!staged.retains_decoded_value_for_tests());
+        assert_eq!(staged.normalized(), r#"{"id":"entity-1"}"#);
     }
 
     #[test]

--- a/packages/engine/src/wasm/component.rs
+++ b/packages/engine/src/wasm/component.rs
@@ -367,14 +367,6 @@ enum WasmCanonicalJsonStorage {
         normalized: Box<[SharedStr]>,
         normalized_len: u32,
     },
-    CertifiedArena {
-        decoded_values: OnceLock<Box<[OnceLock<JsonValue>]>>,
-        entity_pks: Box<[EntityPk]>,
-        schema_fingerprints: Box<[Arc<SchemaPlanFingerprint>]>,
-        schema_fingerprint_indices: Box<[u32]>,
-        normalized: SharedStr,
-        offsets: Box<[WasmCanonicalJsonOffset]>,
-    },
 }
 
 /// Schema and identity facts proven while streaming one exact canonical guest
@@ -579,76 +571,6 @@ impl WasmCanonicalJson {
         })
     }
 
-    pub(crate) fn from_certified_arena_parts(
-        normalized: Vec<u8>,
-        offsets: Vec<(usize, usize)>,
-        entity_pks: Vec<EntityPk>,
-        schema_fingerprints: Vec<Arc<SchemaPlanFingerprint>>,
-        schema_fingerprint_indices: Vec<u32>,
-        parse_count: usize,
-    ) -> Result<Vec<Self>, LixError> {
-        if offsets.len() != entity_pks.len() || offsets.len() != schema_fingerprint_indices.len() {
-            return Err(invalid_param(
-                "certified canonical JSON arena row and metadata counts differ",
-            ));
-        }
-        if schema_fingerprint_indices
-            .iter()
-            .any(|index| *index as usize >= schema_fingerprints.len())
-        {
-            return Err(invalid_param(
-                "certified canonical JSON arena schema index is invalid",
-            ));
-        }
-
-        let arena_allocation_count = u8::from(normalized.capacity() != 0);
-        let normalized = SharedStr::from_utf8(Bytes::from(normalized))
-            .map_err(|_| invalid_param("certified canonical JSON arena is not UTF-8"))?;
-        let arena_len = u32::try_from(normalized.len())
-            .map_err(|_| invalid_param("certified canonical JSON arena exceeds u32"))?;
-        let mut previous_end = 0_u32;
-        let mut validated_offsets = Vec::with_capacity(offsets.len());
-        for (start, end) in offsets {
-            let start = u32::try_from(start)
-                .map_err(|_| invalid_param("certified canonical JSON row offset exceeds u32"))?;
-            let end = u32::try_from(end)
-                .map_err(|_| invalid_param("certified canonical JSON row offset exceeds u32"))?;
-            if start != previous_end || end < start || end > arena_len {
-                return Err(invalid_param(
-                    "certified canonical JSON arena offsets are invalid or non-contiguous",
-                ));
-            }
-            if !normalized.as_str().is_char_boundary(start as usize)
-                || !normalized.as_str().is_char_boundary(end as usize)
-            {
-                return Err(invalid_param(
-                    "certified canonical JSON arena offsets split a UTF-8 scalar",
-                ));
-            }
-            previous_end = end;
-            validated_offsets.push(WasmCanonicalJsonOffset { start, end });
-        }
-        if previous_end != arena_len {
-            return Err(invalid_param(
-                "certified canonical JSON arena offsets do not cover the arena",
-            ));
-        }
-
-        Self::from_validated_batch(WasmCanonicalJsonBatch {
-            storage: WasmCanonicalJsonStorage::CertifiedArena {
-                decoded_values: OnceLock::new(),
-                entity_pks: entity_pks.into_boxed_slice(),
-                schema_fingerprints: schema_fingerprints.into_boxed_slice(),
-                schema_fingerprint_indices: schema_fingerprint_indices.into_boxed_slice(),
-                normalized,
-                offsets: validated_offsets.into_boxed_slice(),
-            },
-            parse_count,
-            serialize_count: 0,
-            arena_allocation_count,
-        })
-    }
-
     fn from_validated_batch(batch: WasmCanonicalJsonBatch) -> Result<Vec<Self>, LixError> {
         let batch = Arc::new(batch);
         let mut rows = Vec::with_capacity(batch.row_count());
@@ -678,23 +600,6 @@ impl WasmCanonicalJson {
                 serde_json::from_str(normalized[self.row_index()].as_str())
                     .expect("certified canonical JSON must parse")
             }),
-            WasmCanonicalJsonStorage::CertifiedArena {
-                decoded_values,
-                normalized,
-                offsets,
-                ..
-            } => decoded_values
-                .get_or_init(|| (0..offsets.len()).map(|_| OnceLock::new()).collect())
-                [self.row_index()]
-            .get_or_init(|| {
-                serde_json::from_str(
-                    normalized
-                        .as_str()
-                        .get(offset_range(offsets[self.row_index()]))
-                        .expect("certified canonical JSON row offsets were validated"),
-                )
-                .expect("certified canonical JSON must parse")
-            }),
         }
     }
 
@@ -704,12 +609,6 @@ impl WasmCanonicalJson {
                 .as_ref()
                 .map(WasmCanonicalJsonCertificate::borrowed),
             WasmCanonicalJsonStorage::CertifiedRows {
-                entity_pks,
-                schema_fingerprints,
-                schema_fingerprint_indices,
-                ..
-            }
-            | WasmCanonicalJsonStorage::CertifiedArena {
                 entity_pks,
                 schema_fingerprints,
                 schema_fingerprint_indices,
@@ -735,14 +634,6 @@ impl WasmCanonicalJson {
             WasmCanonicalJsonStorage::CertifiedRows { normalized, .. } => {
                 normalized[self.row_index()].as_str()
             }
-            WasmCanonicalJsonStorage::CertifiedArena {
-                normalized,
-                offsets,
-                ..
-            } => normalized
-                .as_str()
-                .get(offset_range(offsets[self.row_index()]))
-                .expect("certified canonical JSON row offsets were validated"),
         }
     }
 
@@ -758,13 +649,6 @@ impl WasmCanonicalJson {
             WasmCanonicalJsonStorage::CertifiedRows { normalized, .. } => {
                 normalized[self.row_index()].clone()
             }
-            WasmCanonicalJsonStorage::CertifiedArena {
-                normalized,
-                offsets,
-                ..
-            } => normalized
-                .slice(offset_range(offsets[self.row_index()]))
-                .expect("certified canonical JSON row offsets were validated"),
         }
     }
 
@@ -782,7 +666,6 @@ impl WasmCanonicalJson {
             WasmCanonicalJsonStorage::CertifiedRows { normalized_len, .. } => {
                 *normalized_len as usize
             }
-            WasmCanonicalJsonStorage::CertifiedArena { normalized, .. } => normalized.len(),
         }
     }
 
@@ -808,10 +691,6 @@ impl WasmCanonicalJson {
                 .get()
                 .map(|values| values.iter().filter(|value| value.get().is_some()).count())
                 .unwrap_or(0),
-            WasmCanonicalJsonStorage::CertifiedArena { decoded_values, .. } => decoded_values
-                .get()
-                .map(|values| values.iter().filter(|value| value.get().is_some()).count())
-                .unwrap_or(0),
         }
     }
 
@@ -820,10 +699,6 @@ impl WasmCanonicalJson {
         match &self.batch.storage {
             WasmCanonicalJsonStorage::Arena { .. } => 0,
             WasmCanonicalJsonStorage::CertifiedRows {
-                schema_fingerprints,
-                ..
-            }
-            | WasmCanonicalJsonStorage::CertifiedArena {
                 schema_fingerprints,
                 ..
             } => schema_fingerprints.len(),
@@ -836,7 +711,6 @@ impl WasmCanonicalJsonBatch {
         match &self.storage {
             WasmCanonicalJsonStorage::Arena { offsets, .. } => offsets.len(),
             WasmCanonicalJsonStorage::CertifiedRows { normalized, .. } => normalized.len(),
-            WasmCanonicalJsonStorage::CertifiedArena { offsets, .. } => offsets.len(),
         }
     }
 }


### PR DESCRIPTION
## What

- lower certified SQL insert arenas directly into transaction JSON row views
- retain already-validated row content without constructing and dismantling a Wasm canonical batch
- release validated canonical columns in place when no remap is needed
- sample the implicit statement timestamp once per batch, lazily after normalization
- hard-remove the superseded Wasm canonical arena constructor path; no compatibility shim

## Why

The retained 1M trace showed the process being OOM-killed after storage lowering, before RocksDB commit. Certification, staging, validation, and materialization retained overlapping full-batch representations. This prerequisite cuts an avoidable transport representation and shortens typed-batch lifetimes before the physical-layout change in the next PR.

## Scope

Engine-owned certified SQL writes only. The plugin execution path is intentionally out of scope.

## Validation

- cargo test -p lix_engine --features all-simulations --lib (1611 passed, 6 ignored)
- cargo test -p lix_engine --features all-simulations --test integration (788 passed, 2 ignored)
- cargo test -p lix_rocksdb_storage --test storage (12 passed)
- cargo test -p lix_slatedb_storage --test storage (8 passed)
- release all-features tracked_state_crud benchmark build with two compiler jobs and mold

## Stack

Prerequisite for the packed-current-base physical-layout PR. The completed 1M run was not repeated.