### PR TITLE
Admit bounded large plugin entity pages

### DIFF
--- a/packages/engine/src/plugin/incremental.rs
+++ b/packages/engine/src/plugin/incremental.rs
@@ -1554,12 +1554,10 @@ impl VecSourceState {
                 "component packet source page size must be positive",
             ));
         }
-        if requested > self.limits.max_page_bytes {
-            return Err(invalid_input(
-                "component packet source page request exceeds max_page_bytes",
-            ));
-        }
-        Ok(u64::from(requested))
+        // `max-bytes` is an upper bound supplied by the consumer, not an
+        // exact-size demand. A source with a smaller fixed schedule remains
+        // valid and must simply return a smaller page.
+        Ok(u64::from(requested.min(self.limits.max_page_bytes)))
     }
 
     fn accept_page(&mut self, inline_bytes: u64, refs: u32) -> Result<(), LixError> {
@@ -4118,6 +4116,19 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn vec_entity_source_clamps_a_larger_consumer_page_hint() {
+        let limits = WasmTransitionLimits::default();
+        let mut source = VecEntitySource::new(vec![host_entity("a")], limits).unwrap();
+
+        let page = source
+            .next_page(limits.max_page_bytes.saturating_mul(4))
+            .expect("larger consumer hint should be clamped")
+            .expect("one entity page");
+
+        assert_eq!(page.entities.len(), 1);
     }
 
     #[test]

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -3787,7 +3787,6 @@ where
                 .with_hint("combine the byte edits into one file update"));
             }
             let descriptor = v2_file_descriptor(write, selected);
-            let limits = WasmTransitionLimits::default();
             let schemas = SchemaAllowlist::from_catalog(
                 selected.schema_keys(),
                 Arc::clone(&self.sql_schema_snapshot),
@@ -3810,6 +3809,9 @@ where
                 };
             let materialization_version = self.functions.call_uuid_v7().to_string();
             let submitted_bytes = write.payload().shared_bytes();
+            let limits = WasmTransitionLimits::for_file_bytes(
+                u64::try_from(submitted_bytes.len()).unwrap_or(u64::MAX),
+            );
             let mut verified_same_length_blob_splice = None;
 
             let (changes, publication, materialized_bytes, create_rows) = if same_plugin_owner {

--- a/packages/engine/src/wasm/component.rs
+++ b/packages/engine/src/wasm/component.rs
@@ -28,6 +28,8 @@ pub const EDIT_SPLICE_METADATA_BYTES: u64 = 24;
 const MIB: u64 = 1024 * 1024;
 const MIB_U32: u32 = 1024 * 1024;
 const TRANSITION_PAGE_BYTES: u32 = 2 * MIB_U32;
+const COLD_TRANSITION_MAX_PAGE_BYTES: u64 = 16 * MIB;
+const COLD_TRANSITION_RECORD_OVERHEAD_BYTES: u64 = 64 * 1024;
 const COLD_FILE_MAX_DEADLINE_NANOSECONDS: u64 = 60_000_000_000;
 const COLD_FILE_EXTRA_DEADLINE_NANOSECONDS_PER_MIB: u64 = 1_000_000_000;
 
@@ -68,6 +70,14 @@ impl Default for WasmTransitionLimits {
 }
 
 impl WasmTransitionLimits {
+    /// Returns the normal transition budget with enough bounded page space for
+    /// one semantic record derived from the supplied file bytes.
+    pub fn for_file_bytes(file_bytes: u64) -> Self {
+        let mut limits = Self::default();
+        limits.scale_page_for_file_bytes(file_bytes);
+        limits
+    }
+
     /// Returns a bounded budget for a first cold parse of one submitted file.
     ///
     /// A fresh `open-file` must legitimately examine all input bytes, unlike a
@@ -77,6 +87,7 @@ impl WasmTransitionLimits {
     /// for a plugin to make the hot path proportional to file size.
     pub fn for_cold_file_bytes(file_bytes: u64) -> Self {
         let mut limits = Self::default();
+        limits.scale_page_for_file_bytes(file_bytes);
         let extra = file_bytes
             .div_ceil(MIB)
             .saturating_mul(COLD_FILE_EXTRA_DEADLINE_NANOSECONDS_PER_MIB);
@@ -85,6 +96,24 @@ impl WasmTransitionLimits {
             .saturating_add(extra)
             .min(COLD_FILE_MAX_DEADLINE_NANOSECONDS);
         limits
+    }
+
+    fn scale_page_for_file_bytes(&mut self, file_bytes: u64) {
+        // Text entities encode their byte-exact content as unpadded base64.
+        // A generated/source-map file may legitimately be one long line, so
+        // its single semantic record can be larger than the normal 2 MiB
+        // scheduling page. Retain a hard 16 MiB page bound; small files and
+        // ordinary sparse transitions keep the fixed 2 MiB schedule.
+        let encoded_record_bytes = file_bytes
+            .saturating_mul(4)
+            .div_ceil(3)
+            .saturating_add(COLD_TRANSITION_RECORD_OVERHEAD_BYTES);
+        let cold_page_bytes = encoded_record_bytes
+            .max(u64::from(TRANSITION_PAGE_BYTES))
+            .min(COLD_TRANSITION_MAX_PAGE_BYTES)
+            .min(self.max_total_bytes);
+        self.max_page_bytes = u32::try_from(cold_page_bytes).unwrap_or(u32::MAX);
+        self.max_record_bytes = self.max_page_bytes;
     }
 
     pub fn validate(self) -> Result<Self, LixError> {
@@ -2205,6 +2234,36 @@ mod tests {
             WasmTransitionLimits::for_cold_file_bytes(128 * MIB).total_deadline_nanoseconds,
             COLD_FILE_MAX_DEADLINE_NANOSECONDS
         );
+    }
+
+    #[test]
+    fn cold_file_page_fits_one_base64_encoded_source_map_line() {
+        const OPENCLAW_SOURCE_MAP_BYTES: u64 = 5_298_078;
+        let limits = WasmTransitionLimits::for_cold_file_bytes(OPENCLAW_SOURCE_MAP_BYTES);
+        let encoded_line_bytes = OPENCLAW_SOURCE_MAP_BYTES.saturating_mul(4).div_ceil(3);
+
+        assert!(u64::from(limits.max_record_bytes) > encoded_line_bytes);
+        assert_eq!(limits.max_record_bytes, limits.max_page_bytes);
+        assert!(u64::from(limits.max_page_bytes) <= COLD_TRANSITION_MAX_PAGE_BYTES);
+        limits
+            .validate()
+            .expect("scaled cold limits should validate");
+    }
+
+    #[test]
+    fn warm_file_page_also_fits_one_base64_encoded_source_map_line() {
+        const OPENCLAW_SOURCE_MAP_BYTES: u64 = 5_298_078;
+        let limits = WasmTransitionLimits::for_file_bytes(OPENCLAW_SOURCE_MAP_BYTES);
+        let encoded_line_bytes = OPENCLAW_SOURCE_MAP_BYTES.saturating_mul(4).div_ceil(3);
+
+        assert!(u64::from(limits.max_record_bytes) > encoded_line_bytes);
+        assert_eq!(
+            limits.total_deadline_nanoseconds,
+            WasmTransitionLimits::default().total_deadline_nanoseconds
+        );
+        limits
+            .validate()
+            .expect("scaled warm limits should validate");
     }
 
     #[test]

--- a/packages/rs-sdk/src/default_wasm_runtime_component.rs
+++ b/packages/rs-sdk/src/default_wasm_runtime_component.rs
@@ -36,7 +36,10 @@ use super::{
     add_to_linker_sync, create_store, reset_store_limits, wasm_runtime_error,
 };
 
-const V3_MAX_BATCH_BYTES: u32 = 2 * 1024 * 1024;
+// Warm transitions normally retain the engine's 2 MiB fixed page schedule.
+// Cold admission may scale as high as 16 MiB so a valid single text entity
+// (for example a one-line source map) can cross the fused push sink.
+const V3_MAX_BATCH_BYTES: u32 = 16 * 1024 * 1024;
 // Admit one fused export per compiled plugin component before allocating its
 // Wasmtime Store. This bounds both actor and pushed-page residency without
 // creating an executor thread or serializing different plugin types.
@@ -4433,6 +4436,16 @@ mod tests {
         limits.max_total_bytes = 10;
         assert!(validate_source_admission(10, limits).is_ok());
         assert!(validate_source_admission(11, limits).is_err());
+    }
+
+    #[test]
+    fn v3_binding_preserves_scaled_cold_pages() {
+        let cold = WasmTransitionLimits::for_cold_file_bytes(5_298_078);
+        let admitted = v3_transition_limits(cold).expect("scaled cold page should be admitted");
+
+        assert!(admitted.max_page_bytes > 7 * 1024 * 1024);
+        assert_eq!(admitted.max_record_bytes, admitted.max_page_bytes);
+        assert!(admitted.max_page_bytes <= V3_MAX_BATCH_BYTES);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- scale plugin transition record/page admission for large file-derived entities while retaining the normal 2 MiB schedule for small files
- cap scaled pages at 16 MiB within the existing aggregate transition budget
- treat `next-page(max-bytes)` as an upper-bound hint and clamp to a source's smaller internal schedule
- apply the scaled bound to both cold and warm byte transitions

## Root cause

OpenClaw commit `c5c50a2141f2cdd805ae9b70a14a2e66dabac9b6` contains a 5,298,036-byte one-line source map. Git-text preserves that line byte-exactly as a base64 semantic snapshot (~7.06 MiB), which cannot fit the fixed 2 MiB push page. Cold successor hydration also rejected a consumer page hint larger than the source's internal schedule instead of returning a smaller valid page.

## Impact

Large, valid one-line text entities now cross the fused WASM push sink without weakening the aggregate byte budget. The same bounded policy covers initial open, cold successor, and later warm edits.

## Validation

- focused engine transition-limit and source-page tests
- focused rs-sdk binding admission test
- all 11 `plugin_git_text` unit tests
- release build with mold
- exact one-commit OpenClaw replay at `c5c50a2141f2cdd805ae9b70a14a2e66dabac9b6`, SlateDB, all WASM plugins, checkpoint every commit, per-commit state verification, and final Git-tree verification: 3,423 changed paths, success
