### PR TITLE
Bound binary replay memory and profile physical storage

### DIFF
--- a/packages/cli/src/commands/exp/git_replay.rs
+++ b/packages/cli/src/commands/exp/git_replay.rs
@@ -20,6 +20,10 @@ use zip::write::SimpleFileOptions;
 
 const PROGRESS_EVERY: usize = 10;
 const DEFAULT_INSERT_BATCH_ROWS: usize = 100;
+const TREE_BLOB_READ_BATCH_ROWS: usize = 8;
+const TREE_TRANSACTION_TARGET_BYTES: usize = 128 * 1024 * 1024;
+const FINAL_VERIFY_MAX_ROWS: usize = 512;
+const FINAL_VERIFY_TARGET_BYTES: usize = 128 * 1024 * 1024;
 // Four SHA-256 `<oid>\n` requests are 260 bytes, below POSIX `PIPE_BUF`.
 // Keeping each flush below that floor lets the caller enqueue a small request
 // window before draining responses without depending on a platform's larger
@@ -95,7 +99,7 @@ struct WriteRow {
     git_oid: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct PreparedBatch {
     deletes: Vec<String>,
     inserts: Vec<WriteRow>,
@@ -112,6 +116,7 @@ struct SqlStatement {
 struct ExpectedFile {
     path: String,
     sha256: Option<String>,
+    size_bytes: Option<usize>,
     git_mode: String,
     git_oid: String,
 }
@@ -225,6 +230,7 @@ struct ReplayProfileReport {
     baseline_seed_parent: Option<String>,
     baseline_seed_ms: f64,
     baseline_seed_files: usize,
+    baseline_seed_batches: usize,
     final_tree_verify_ms: Option<f64>,
     replay_elapsed_ms: f64,
     storage_flush_ms: f64,
@@ -355,6 +361,7 @@ where
         .and_then(|commit| commit.first_parent.clone());
     let mut baseline_seed_ms = 0.0;
     let mut baseline_seed_files = 0usize;
+    let mut baseline_seed_batches = 0usize;
     let seeded_blob_reader = if let Some(parent) = baseline_seed_parent.as_deref() {
         let seed_started = Instant::now();
         let mut blob_reader = GitBlobReader::spawn(&repo_path, args.git_lfs)?;
@@ -367,7 +374,8 @@ where
             args.verify_state,
             &lix,
         )?;
-        baseline_seed_files = seeded;
+        baseline_seed_files = seeded.files;
+        baseline_seed_batches = seeded.batches;
         baseline_seed_ms = duration_to_ms(seed_started.elapsed());
         Some(blob_reader)
     } else {
@@ -558,7 +566,7 @@ where
     }
     if let Some(parent) = &baseline_seed_parent {
         println!(
-            "[git-replay] parent-tree bootstrap excluded from replay timing: {baseline_seed_ms:.3}ms ({baseline_seed_files} files from {parent})"
+            "[git-replay] parent-tree bootstrap excluded from replay timing: {baseline_seed_ms:.3}ms ({baseline_seed_files} files in {baseline_seed_batches} transactions from {parent})"
         );
     }
     println!("[git-replay] replay elapsed: {replay_elapsed_ms:.3}ms");
@@ -592,6 +600,7 @@ where
                 baseline_seed_parent,
                 baseline_seed_ms,
                 baseline_seed_files,
+                baseline_seed_batches,
                 final_tree_verify_ms,
                 replay_elapsed_ms,
                 storage_flush_ms,
@@ -802,6 +811,12 @@ fn resolve_replay_ref_oid(repo_path: &Path, raw: &str) -> Result<String, CliErro
     Ok(oid.to_string())
 }
 
+#[derive(Debug, Default, PartialEq, Eq)]
+struct SeedResult {
+    files: usize,
+    batches: usize,
+}
+
 fn seed_parent_tree<StorageImpl>(
     repo_path: &Path,
     parent_commit: &str,
@@ -810,18 +825,79 @@ fn seed_parent_tree<StorageImpl>(
     expected_state_by_id: &mut HashMap<String, ExpectedFile>,
     verify_state: bool,
     lix: &Lix<StorageImpl>,
-) -> Result<usize, CliError>
+) -> Result<SeedResult, CliError>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
     let changes = read_tree_snapshot_changes(repo_path, parent_commit)?;
-    let wanted_blob_ids = collect_wanted_blob_ids(&changes);
-    let blob_by_oid = blob_reader.read_blobs(&wanted_blob_ids)?;
-    let prepared = prepare_commit_changes(state, &changes, &blob_by_oid)?;
-    let statements = build_replay_commit_statements(&prepared, DEFAULT_INSERT_BATCH_ROWS);
-    if !statements.is_empty() {
-        execute_statements_as_transaction(lix, &statements, parent_commit)?;
+    let mut pending = PreparedBatch::default();
+    let mut result = SeedResult::default();
+    for change_batch in changes.chunks(TREE_BLOB_READ_BATCH_ROWS) {
+        let wanted_blob_ids = collect_wanted_blob_ids(change_batch);
+        let blob_by_oid = blob_reader.read_blobs(&wanted_blob_ids)?;
+        let prepared = prepare_commit_changes(state, change_batch, &blob_by_oid)?;
+        let pending_bytes = prepared_blob_bytes(&pending);
+        let prepared_bytes = prepared_blob_bytes(&prepared);
+        if pending_bytes > 0
+            && pending_bytes.saturating_add(prepared_bytes) > TREE_TRANSACTION_TARGET_BYTES
+        {
+            let inserted = flush_seed_batch(
+                &mut pending,
+                expected_state_by_id,
+                verify_state,
+                lix,
+                parent_commit,
+            )?;
+            result.files += inserted;
+            result.batches += usize::from(inserted > 0);
+        }
+        append_prepared_batch(&mut pending, prepared);
+        if prepared_blob_bytes(&pending) >= TREE_TRANSACTION_TARGET_BYTES {
+            let inserted = flush_seed_batch(
+                &mut pending,
+                expected_state_by_id,
+                verify_state,
+                lix,
+                parent_commit,
+            )?;
+            result.files += inserted;
+            result.batches += usize::from(inserted > 0);
+        }
     }
+    let inserted = flush_seed_batch(
+        &mut pending,
+        expected_state_by_id,
+        verify_state,
+        lix,
+        parent_commit,
+    )?;
+    result.files += inserted;
+    result.batches += usize::from(inserted > 0);
+    Ok(result)
+}
+
+fn append_prepared_batch(target: &mut PreparedBatch, mut source: PreparedBatch) {
+    target.deletes.append(&mut source.deletes);
+    target.inserts.append(&mut source.inserts);
+    target.updates.append(&mut source.updates);
+}
+
+fn flush_seed_batch<StorageImpl>(
+    pending: &mut PreparedBatch,
+    expected_state_by_id: &mut HashMap<String, ExpectedFile>,
+    verify_state: bool,
+    lix: &Lix<StorageImpl>,
+    parent_commit: &str,
+) -> Result<usize, CliError>
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    if pending.deletes.is_empty() && pending.inserts.is_empty() && pending.updates.is_empty() {
+        return Ok(0);
+    }
+    let prepared = std::mem::take(pending);
+    let statements = build_replay_commit_statements(&prepared, DEFAULT_INSERT_BATCH_ROWS);
+    execute_statements_as_transaction(lix, &statements, parent_commit)?;
     if verify_state {
         apply_prepared_to_expected_state(expected_state_by_id, &prepared);
         verify_commit_changes(lix, expected_state_by_id, &prepared, parent_commit)?;
@@ -1826,6 +1902,7 @@ fn apply_prepared_to_expected_state(
             ExpectedFile {
                 path: row.path.clone(),
                 sha256: row.data.as_deref().map(sha256_hex),
+                size_bytes: row.data.as_ref().map(Vec::len),
                 git_mode: row.git_mode.clone(),
                 git_oid: row.git_oid.clone(),
             },
@@ -1933,85 +2010,126 @@ where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
     let tree_changes = read_tree_snapshot_changes(repo_path, commit_sha)?;
-    let blob_by_oid = blob_reader.read_blobs(&collect_wanted_blob_ids(&tree_changes))?;
     let mut expected_by_path = HashMap::<String, ExpectedFile>::with_capacity(tree_changes.len());
-    for change in tree_changes {
-        let path = change
-            .new_path
-            .as_ref()
-            .ok_or_else(|| CliError::msg("Git tree snapshot entry has no path"))?
-            .lix_path();
-        let sha256 = if change.new_is_blob() {
-            let bytes = blob_by_oid.get(&change.new_oid).ok_or_else(|| {
-                CliError::msg(format!(
-                    "Git tree blob {} was not returned for {path}",
-                    change.new_oid
-                ))
-            })?;
-            Some(sha256_hex(bytes))
-        } else {
-            None
-        };
-        if expected_by_path.contains_key(&path) {
-            return Err(CliError::msg(format!(
-                "Git tree snapshot contains duplicate path {path}"
-            )));
+    for change_batch in tree_changes.chunks(TREE_BLOB_READ_BATCH_ROWS) {
+        let blob_by_oid = blob_reader.read_blobs(&collect_wanted_blob_ids(change_batch))?;
+        for change in change_batch {
+            let path = change
+                .new_path
+                .as_ref()
+                .ok_or_else(|| CliError::msg("Git tree snapshot entry has no path"))?
+                .lix_path();
+            let data = if change.new_is_blob() {
+                Some(blob_by_oid.get(&change.new_oid).ok_or_else(|| {
+                    CliError::msg(format!(
+                        "Git tree blob {} was not returned for {path}",
+                        change.new_oid
+                    ))
+                })?)
+            } else {
+                None
+            };
+            if expected_by_path.contains_key(&path) {
+                return Err(CliError::msg(format!(
+                    "Git tree snapshot contains duplicate path {path}"
+                )));
+            }
+            expected_by_path.insert(
+                path.clone(),
+                ExpectedFile {
+                    path,
+                    sha256: data.map(|bytes| sha256_hex(bytes)),
+                    size_bytes: data.map(|bytes| bytes.len()),
+                    git_mode: change.new_mode.clone(),
+                    git_oid: change.new_oid.clone(),
+                },
+            );
         }
-        expected_by_path.insert(
-            path.clone(),
-            ExpectedFile {
-                path,
-                sha256,
-                git_mode: change.new_mode,
-                git_oid: change.new_oid,
-            },
-        );
     }
 
-    let result = db::block_on(lix.execute(
-        "SELECT path, data, lixcol_metadata FROM lix_file \
+    let count = db::block_on(lix.execute(
+        "SELECT COUNT(*) FROM lix_file \
          WHERE path NOT LIKE '/.lix/plugins/%'",
         &[],
     ))
-    .map_err(|error| CliError::msg(format!("failed to query Lix final tree: {error}")))?;
-    let rows = result.rows();
-    if rows.len() != expected_by_path.len() {
+    .map_err(|error| CliError::msg(format!("failed to count Lix final tree: {error}")))?;
+    let lix_count = match count.rows().first().and_then(|row| row.get_index(0)) {
+        Some(Value::Integer(value)) => usize::try_from(*value)
+            .map_err(|_| CliError::msg("Lix final tree count does not fit usize"))?,
+        _ => return Err(CliError::msg("Lix final tree count is not an integer")),
+    };
+    if lix_count != expected_by_path.len() {
         return Err(CliError::msg(format!(
             "final tree mismatch at {commit_sha}: row count differs (lix={}, git={})",
-            rows.len(),
+            lix_count,
             expected_by_path.len()
         )));
     }
 
-    let mut seen = HashSet::with_capacity(rows.len());
-    for (index, row) in rows.iter().enumerate() {
-        let path = value_to_string(
-            row.get_index(0)
-                .ok_or_else(|| CliError::msg(format!("missing final.path[{index}]")))?,
-            &format!("final.path[{index}]"),
-        )?;
-        let data = value_to_optional_blob(
-            row.get_index(1)
-                .ok_or_else(|| CliError::msg(format!("missing final.data[{index}]")))?,
-            &format!("final.data[{index}]"),
-        )?;
-        let metadata = value_to_json(
-            row.get_index(2)
-                .ok_or_else(|| CliError::msg(format!("missing final.metadata[{index}]")))?,
-            &format!("final.metadata[{index}]"),
-        )?;
-        let expected = expected_by_path.get(&path).ok_or_else(|| {
-            CliError::msg(format!(
-                "final tree mismatch at {commit_sha}: unexpected Lix path {path}"
-            ))
-        })?;
-        verify_file_manifest_entry(&path, data, metadata, expected, commit_sha)?;
-        seen.insert(path);
-    }
-    if seen.len() != expected_by_path.len() {
-        return Err(CliError::msg(format!(
-            "final tree mismatch at {commit_sha}: Lix is missing Git paths"
-        )));
+    let mut expected = expected_by_path.values().collect::<Vec<_>>();
+    expected.sort_unstable_by(|left, right| left.path.cmp(&right.path));
+    let mut offset = 0usize;
+    while offset < expected.len() {
+        let mut end = offset;
+        let mut expected_bytes = 0usize;
+        while end < expected.len() && end - offset < FINAL_VERIFY_MAX_ROWS {
+            let row_bytes = expected[end].size_bytes.unwrap_or_default();
+            if end > offset && expected_bytes.saturating_add(row_bytes) > FINAL_VERIFY_TARGET_BYTES
+            {
+                break;
+            }
+            expected_bytes = expected_bytes.saturating_add(row_bytes);
+            end += 1;
+        }
+        let batch = &expected[offset..end];
+        let placeholders = vec!["?"; batch.len()].join(", ");
+        let sql = format!(
+            "SELECT path, data, lixcol_metadata FROM lix_file WHERE path IN ({placeholders})"
+        );
+        let params = batch
+            .iter()
+            .map(|expected| Value::Text(expected.path.clone()))
+            .collect::<Vec<_>>();
+        let result = db::block_on(lix.execute(&sql, &params))
+            .map_err(|error| CliError::msg(format!("failed to query Lix final tree: {error}")))?;
+        if result.rows().len() != batch.len() {
+            return Err(CliError::msg(format!(
+                "final tree mismatch at {commit_sha}: expected {} bounded rows, got {}",
+                batch.len(),
+                result.rows().len()
+            )));
+        }
+        let mut seen = HashSet::with_capacity(batch.len());
+        for (index, row) in result.rows().iter().enumerate() {
+            let path = value_to_string(
+                row.get_index(0)
+                    .ok_or_else(|| CliError::msg(format!("missing final.path[{index}]")))?,
+                &format!("final.path[{index}]"),
+            )?;
+            let data = value_to_optional_blob(
+                row.get_index(1)
+                    .ok_or_else(|| CliError::msg(format!("missing final.data[{index}]")))?,
+                &format!("final.data[{index}]"),
+            )?;
+            let metadata = value_to_json(
+                row.get_index(2)
+                    .ok_or_else(|| CliError::msg(format!("missing final.metadata[{index}]")))?,
+                &format!("final.metadata[{index}]"),
+            )?;
+            let expected = expected_by_path.get(&path).ok_or_else(|| {
+                CliError::msg(format!(
+                    "final tree mismatch at {commit_sha}: unexpected Lix path {path}"
+                ))
+            })?;
+            verify_file_manifest_entry(&path, data, metadata, expected, commit_sha)?;
+            seen.insert(path);
+        }
+        if batch.iter().any(|expected| !seen.contains(&expected.path)) {
+            return Err(CliError::msg(format!(
+                "final tree mismatch at {commit_sha}: Lix is missing a bounded Git path"
+            )));
+        }
+        offset = end;
     }
     Ok(())
 }
@@ -2030,6 +2148,11 @@ fn verify_file_manifest_entry(
             )));
         }
     } else {
+        if expected.size_bytes != data.map(<[u8]>::len) {
+            return Err(CliError::msg(format!(
+                "state mismatch at {commit_sha}: byte length differs for path {path}"
+            )));
+        }
         let hash = data.map(sha256_hex);
         if expected.sha256 != hash {
             return Err(CliError::msg(format!(

--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -48,6 +48,11 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 
+[[example]]
+name = "storage_layout"
+path = "examples/storage_layout.rs"
+required-features = ["storage-benches", "slatedb"]
+
 [[test]]
 name = "exact_file_read_benchmark"
 path = "tests/exact_file_read_benchmark.rs"

--- a/packages/engine-benchmarks/examples/storage_layout.rs
+++ b/packages/engine-benchmarks/examples/storage_layout.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use lix_engine::storage_adapter::{StorageAdapter, StorageReadOptions};
 use lix_engine::storage_bench::{
-    commit_delta_layout_accounting, layout_accounting, space_inventory,
+    commit_delta_layout_accounting, layout_accounting, layout_space_catalog, space_inventory,
 };
 use lix_slatedb_storage::SlateDB;
 use object_store::local::LocalFileSystem;
@@ -38,14 +38,26 @@ async fn main() {
     let path = std::env::args_os()
         .nth(1)
         .expect("usage: storage_layout <slatedb-path>");
-    let logical_only = std::env::args_os()
-        .nth(2)
-        .is_some_and(|arg| arg == "--logical-only");
+    let mode = std::env::args_os().nth(2);
+    let logical_only = mode.as_deref().is_some_and(|arg| arg == "--logical-only");
+    let physical_only = mode.as_deref().is_some_and(|arg| arg == "--physical-only");
+    if physical_only {
+        let space_names = layout_space_catalog().into_iter().collect();
+        inspect_ssts_fast(Path::new(&path), &space_names).await;
+        return;
+    }
     let storage = StorageAdapter::new(SlateDB::open(&path).expect("open SlateDB"));
     let read = storage
         .begin_read(StorageReadOptions::default())
         .await
         .expect("open storage snapshot");
+    if mode
+        .as_deref()
+        .is_some_and(|arg| arg == "--commit-delta-only")
+    {
+        print_commit_delta_inventory(&read).await;
+        return;
+    }
     let mut total_rows = 0_u64;
     let mut total_keys = 0_u64;
     let mut total_values = 0_u64;
@@ -64,22 +76,7 @@ async fn main() {
         total_values += entry.value_bytes;
     }
     println!("SPACE\tTOTAL\tTOTAL\t{total_rows}\t{total_keys}\t{total_values}");
-    for entry in commit_delta_layout_accounting(&read)
-        .await
-        .expect("decode commit-delta inventory")
-    {
-        println!(
-            "COMMIT_DELTA\tcommit={}\tsegments={}\tmembers={}\tauthored={}\tselected={}\tselected_tombstones={}\tcertified={}\tselected_certified={}",
-            entry.commit_id,
-            entry.segment_count,
-            entry.members,
-            entry.authored_members,
-            entry.selected_members,
-            entry.selected_tombstones,
-            entry.certified_members,
-            entry.selected_certified_members,
-        );
-    }
+    print_commit_delta_inventory(&read).await;
 
     let inventory = space_inventory(&read, HOT_SPACE).await;
     let mut groups = BTreeMap::<Vec<u8>, HotGroup>::new();
@@ -168,6 +165,25 @@ async fn main() {
     }
 }
 
+async fn print_commit_delta_inventory(read: &impl lix_engine::storage_adapter::StorageAdapterRead) {
+    for entry in commit_delta_layout_accounting(read)
+        .await
+        .expect("decode commit-delta inventory")
+    {
+        println!(
+            "COMMIT_DELTA\tcommit={}\tsegments={}\tmembers={}\tauthored={}\tselected={}\tselected_tombstones={}\tcertified={}\tselected_certified={}",
+            entry.commit_id,
+            entry.segment_count,
+            entry.members,
+            entry.authored_members,
+            entry.selected_members,
+            entry.selected_tombstones,
+            entry.certified_members,
+            entry.selected_certified_members,
+        );
+    }
+}
+
 #[derive(Default)]
 struct PhysicalSpace {
     blocks: usize,
@@ -183,6 +199,71 @@ struct PhysicalSpace {
     max_seq: u64,
     seq_rows: BTreeMap<u64, (u64, u64, u64)>,
     hot_versions: BTreeMap<Vec<u8>, Vec<(u64, Vec<u8>)>>,
+}
+
+async fn inspect_ssts_fast(path: &Path, space_names: &BTreeMap<u32, &'static str>) {
+    let object_store: Arc<dyn object_store::ObjectStore> =
+        Arc::new(LocalFileSystem::new_with_prefix(path.join("db")).expect("local object store"));
+    let reader = SstReader::new("lix-space-segments-v2", object_store, None, None);
+    let compacted = path.join("db/lix-space-segments-v2/compacted");
+    let mut files = std::fs::read_dir(&compacted)
+        .expect("read compacted directory")
+        .map(|entry| entry.expect("read compacted entry").path())
+        .filter(|path| path.extension().is_some_and(|extension| extension == "sst"))
+        .collect::<Vec<_>>();
+    files.sort();
+    let mut spaces = BTreeMap::<u32, (usize, u64)>::new();
+    let mut total_file_bytes = 0_u64;
+    let mut total_block_bytes = 0_u64;
+    for path in files {
+        let id = path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .expect("UTF-8 SST stem")
+            .parse::<ulid::Ulid>()
+            .expect("ULID SST stem");
+        let file = reader.open(id).await.expect("open SST");
+        total_file_bytes += path.metadata().expect("SST metadata").len();
+        let index = file.index().await.expect("read SST index");
+        let data_end = file.info().filter_offset;
+        for (block_index, (offset, first_key)) in index.iter().enumerate() {
+            let end = index
+                .get(block_index + 1)
+                .map_or(data_end, |(next_offset, _)| *next_offset);
+            let compressed_bytes = end.saturating_sub(*offset);
+            total_block_bytes += compressed_bytes;
+            let space_id = if first_key.len() >= 4 {
+                physical_space_id(first_key)
+            } else {
+                let rows = file.read_block(block_index).await.expect("read SST block");
+                physical_space_id(&rows.first().expect("indexed SST block is not empty").key)
+            };
+            let entry = spaces.entry(space_id).or_default();
+            entry.0 += 1;
+            entry.1 += compressed_bytes;
+        }
+    }
+    println!(
+        "SST_SUMMARY_FAST\tfile_bytes={total_file_bytes}\tdata_block_bytes={total_block_bytes}\toverhead_bytes={}\tspace_attribution=first_key",
+        total_file_bytes.saturating_sub(total_block_bytes),
+    );
+    let mut spaces = spaces.into_iter().collect::<Vec<_>>();
+    spaces.sort_unstable_by(|left, right| right.1.1.cmp(&left.1.1));
+    for (space_id, (blocks, compressed_bytes)) in spaces {
+        println!(
+            "SST_SPACE_FAST\tspace_id={space_id}\tspace={}\tblocks={blocks}\tcompressed_bytes={compressed_bytes}",
+            space_names.get(&space_id).copied().unwrap_or("<unknown>"),
+        );
+    }
+}
+
+fn physical_space_id(key: &[u8]) -> u32 {
+    u32::from_be_bytes(
+        key.get(..4)
+            .expect("physical key has space prefix")
+            .try_into()
+            .expect("space prefix has fixed length"),
+    )
 }
 
 async fn inspect_ssts(path: &Path, space_names: &BTreeMap<u32, &'static str>) {

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -434,6 +434,17 @@ where
         .collect()
 }
 
+/// Physical storage-space IDs and names without scanning their contents.
+///
+/// Offline SST profiling uses this catalog to attribute blocks from databases
+/// that may predate the current logical codecs.
+pub fn layout_space_catalog() -> Vec<(u32, &'static str)> {
+    native_storage_spaces()
+        .iter()
+        .map(|space| (space.id.0, space.name))
+        .collect()
+}
+
 fn native_storage_spaces() -> &'static [crate::storage_adapter::StorageSpace] {
     &[
         crate::init::REPOSITORY_PROTOCOL_SPACE,


### PR DESCRIPTION
## What changed

- bound parent-tree Git/LFS reads and seed transactions by payload size instead of retaining an entire multi-gigabyte tree in memory
- bound final tree verification by both payload bytes and path count, while preserving full byte-length, SHA-256, mode, and Git OID verification
- report parent seed transaction counts in replay profiles
- add fast offline SlateDB SST-space profiling that works without decoding historical logical codecs
- declare the profiler example feature requirements explicitly

## Why

The real VS Code Docs Git LFS corpus materializes roughly 2.7 GiB of binary assets. The previous bootstrap and final verifier accumulated the whole tree at once and were killed by the OOM killer. Separately, logical layout inspection could not profile retained databases after codec changes. Both issues blocked data-driven physical-layout work.

## Evidence

The retained head-adjacent two-commit gate seeded 8,352 files and 2,724,026,017 unique Git LFS bytes in 22 bounded transactions, replayed/checkpointed 2/2 commits, and verified the final tree in 8.73 seconds. The retained root-history gate authenticated 1,898 unique LFS objects / 698,800,904 bytes across 2,308 changed paths.

Offline profiling of the retained failed OpenClaw checkpoint-every-commit run through about 511 commits attributed 4.62 MiB (17.4% of all data blocks and 44.8% of non-binary blocks) to commit delta segments/manifests, establishing the next optimization target.

## Validation

- `cargo test -p lix_cli git_replay --lib` (26 passed)
- `cargo clippy -p lix_cli --all-targets --no-deps -- -D warnings`
- `cargo clippy -p lix_engine_benchmarks --example storage_layout --features storage-benches,slatedb -- -D warnings`
- real VS Code Docs historical Git LFS two-commit gate
- real VS Code Docs head-adjacent 2.7 GiB bootstrap/checkpoint/final-verification gate

All Rust linking used mold.