### PR TITLE
perf(engine): carry certified inserts into typed batches

### DIFF
--- a/packages/engine/src/compression.rs
+++ b/packages/engine/src/compression.rs
@@ -3,6 +3,30 @@ pub(crate) fn compress_zstd_level_1(data: &[u8]) -> Result<Vec<u8>, String> {
     zstd::bulk::compress(data, 1).map_err(|error| error.to_string())
 }
 
+/// Reusable level-1 compressor for page/segment loops.
+///
+/// `zstd::bulk::compress` constructs a fresh context for every call. History
+/// staging emits thousands of bounded segments at scale, so retaining one
+/// context for the batch avoids repeating allocator and dictionary setup while
+/// producing the same independent zstd frames.
+#[cfg(not(target_family = "wasm"))]
+pub(crate) struct ZstdLevel1Compressor {
+    inner: zstd::bulk::Compressor<'static>,
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl ZstdLevel1Compressor {
+    pub(crate) fn new() -> Result<Self, String> {
+        zstd::bulk::Compressor::new(1)
+            .map(|inner| Self { inner })
+            .map_err(|error| error.to_string())
+    }
+
+    pub(crate) fn compress(&mut self, data: &[u8]) -> Result<Vec<u8>, String> {
+        self.inner.compress(data).map_err(|error| error.to_string())
+    }
+}
+
 #[cfg(target_family = "wasm")]
 #[expect(
     clippy::unnecessary_wraps,
@@ -13,6 +37,20 @@ pub(crate) fn compress_zstd_level_1(data: &[u8]) -> Result<Vec<u8>, String> {
         data,
         ruzstd::encoding::CompressionLevel::Fastest,
     ))
+}
+
+#[cfg(target_family = "wasm")]
+pub(crate) struct ZstdLevel1Compressor;
+
+#[cfg(target_family = "wasm")]
+impl ZstdLevel1Compressor {
+    pub(crate) fn new() -> Result<Self, String> {
+        Ok(Self)
+    }
+
+    pub(crate) fn compress(&mut self, data: &[u8]) -> Result<Vec<u8>, String> {
+        compress_zstd_level_1(data)
+    }
 }
 
 #[cfg(not(target_family = "wasm"))]

--- a/packages/engine/src/json_store/types.rs
+++ b/packages/engine/src/json_store/types.rs
@@ -16,7 +16,7 @@ impl NormalizedJson {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub(crate) struct JsonRef {
     hash: [u8; 32],
 }

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -4121,6 +4121,109 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn certified_parameter_batch_revalidates_after_staged_schema_amendment() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "x-lix-key": "amended_parameter_insert_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": { "type": "string" }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+
+        let amended_schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "x-lix-key": "amended_parameter_insert_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": { "type": "string" },
+                "source": { "type": "string", "default": "amended-plan" }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        let mut transaction = session.begin_transaction().await.unwrap();
+        transaction
+            .execute(
+                "UPDATE lix_registered_schema SET value = $1 \
+                 WHERE lixcol_entity_pk = lix_json('[\"amended_parameter_insert_probe\"]')",
+                &[Value::Json(amended_schema)],
+            )
+            .await
+            .expect("compatible schema amendment should stage");
+
+        let sql = "INSERT INTO amended_parameter_insert_probe (id, value) VALUES ($1, $2)";
+        let statements = [
+            ExecuteBatchStatement {
+                sql: sql.to_string(),
+                params: vec![
+                    Value::Text("a".to_string()),
+                    Value::Text("first".to_string()),
+                ],
+            },
+            ExecuteBatchStatement {
+                sql: sql.to_string(),
+                params: vec![
+                    Value::Text("b".to_string()),
+                    Value::Text("second".to_string()),
+                ],
+            },
+        ];
+        let parsed = TransactionBatchStatements::Shared {
+            statement: sql2::parse_statement(sql).unwrap(),
+            len: statements.len(),
+        };
+        let parameter_route = AtomicBool::new(false);
+        let staged = try_execute_transaction_parameter_batch(
+            transaction.transaction_mut().unwrap(),
+            &statements,
+            &parsed,
+            &ExecuteOptions::default(),
+            &vec![ExecuteStatementMetadata::default(); statements.len()],
+            &parameter_route,
+        )
+        .await
+        .expect("parameter batch should be revalidated");
+        assert!(
+            staged.is_some(),
+            "the SQL batch should still use its typed parameter route"
+        );
+        transaction
+            .commit()
+            .await
+            .expect("rows valid under the amended schema should commit");
+
+        let rows = session
+            .execute(
+                "SELECT id, source FROM amended_parameter_insert_probe ORDER BY id",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 2);
+        assert!(
+            rows.rows()
+                .iter()
+                .all(|row| row.get::<String>("source").unwrap() == "amended-plan"),
+            "transaction normalization must apply the staged schema's default"
+        );
+    }
+
+    #[tokio::test]
     async fn certified_empty_batch_rechecks_concurrent_insert_at_commit_snapshot() {
         let storage = Memory::default();
         Engine::initialize(storage.clone())

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -29,7 +29,8 @@ use crate::sql2::plan::predicate::{BoundPredicate, FilterSet};
 use crate::sql2::read_only::reject_read_only_entity_surface;
 use crate::sql2::value_contract::{json_bigint_value, json_double_value};
 use crate::transaction::types::{
-    RawWriteBatch, RawWriteRowRef, TransactionJson, TransactionWrite, TransactionWriteMode,
+    CertifiedRawWriteBatchPreparation, PreparedRowFacts, RawWriteBatch, RawWriteRowRef,
+    TransactionJson, TransactionWrite, TransactionWriteMode,
 };
 use crate::wasm::WasmEntityKey;
 use crate::{LixError, NullableKeyFilter, Value, parse_row_metadata_value};
@@ -2478,7 +2479,8 @@ fn certified_direct_parameter_insert_batch(
     let Some(schema_catalog) = ctx.schema_catalog_snapshot() else {
         return Ok(None);
     };
-    let Some((_, schema_plan)) = schema_catalog.plan_for_key(&layout.schema_key) else {
+    let Some((schema_plan_id, schema_plan)) = schema_catalog.plan_for_key(&layout.schema_key)
+    else {
         return Ok(None);
     };
     if !schema_plan.accepts_canonical_certificate() {
@@ -2590,7 +2592,7 @@ fn certified_direct_parameter_insert_batch(
         })?);
     let mut offsets = Vec::with_capacity(row_count);
     let mut entity_pks = Vec::with_capacity(row_count);
-    let mut unique_entity_pks = std::collections::HashSet::with_capacity(row_count);
+    let mut unordered_entity_pks = None::<std::collections::HashSet<EntityPk>>;
     let mut primary_key_parts = Vec::with_capacity(primary_key_columns.len());
     let mut typed_fields = Vec::with_capacity(columns.len());
 
@@ -2700,8 +2702,23 @@ fn certified_direct_parameter_insert_batch(
                 &typed_fields,
                 &primary_key_parts,
             )?;
-            if !unique_entity_pks.insert(entity_pk.clone()) {
-                return Ok(false);
+            if let Some(unique) = &mut unordered_entity_pks {
+                if !unique.insert(entity_pk.clone()) {
+                    return Ok(false);
+                }
+            } else if let Some(previous) = entity_pks.last()
+                && previous >= &entity_pk
+            {
+                // Ordered parameter batches prove uniqueness by adjacency and
+                // need no hash table. On the first disorder, seed the fallback
+                // index with exactly the already accepted prefix so duplicate
+                // detection and later validation retain statement order.
+                let mut unique = std::collections::HashSet::with_capacity(row_count);
+                unique.extend(entity_pks.iter().cloned());
+                if !unique.insert(entity_pk.clone()) {
+                    return Ok(false);
+                }
+                unordered_entity_pks = Some(unique);
             }
             offsets.push((start, normalized.len()));
             entity_pks.push(entity_pk);
@@ -2735,6 +2752,13 @@ fn certified_direct_parameter_insert_batch(
             branch_id.clone(),
         );
     }
+    rows.certify_preparation(CertifiedRawWriteBatchPreparation {
+        schema_plan_id,
+        facts: PreparedRowFacts {
+            row_content_validated: true,
+            requires_transaction_validation: false,
+        },
+    });
     Ok(Some(rows))
 }
 

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -786,7 +786,12 @@ fn stage_commit_deltas_inner(
             )
         })
         .collect::<Vec<_>>();
-    pending.sort_unstable_by(|left, right| left.0.key.cmp(&right.0.key));
+    if !pending
+        .windows(2)
+        .all(|pair| pair[0].0.key <= pair[1].0.key)
+    {
+        pending.sort_unstable_by(|left, right| left.0.key.cmp(&right.0.key));
+    }
     let mut entries = Vec::with_capacity(pending.len());
     let mut payloads = Vec::with_capacity(pending.len());
     let mut addressable = Vec::with_capacity(pending.len());
@@ -809,6 +814,13 @@ fn stage_commit_deltas_inner(
     let mut encoded_segments = Vec::new();
     let mut assigned_change_ids = vec![crate::changelog::ChangeId::default(); deltas.len()];
     let mut segment_start = 0usize;
+    let mut sidecar_compressor =
+        crate::compression::ZstdLevel1Compressor::new().map_err(|error| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("tracked_state commit_delta compressor initialization failed: {error}"),
+            )
+        })?;
     while segment_start < entries.len() {
         let mut segment_end = (segment_start + COMMIT_DELTA_SEGMENT_MAX_ROWS).min(entries.len());
         let segment_index = encoded_segments.len();
@@ -834,6 +846,7 @@ fn stage_commit_deltas_inner(
             match try_encode_commit_delta_segment_with_payloads(
                 &candidate,
                 &payloads[segment_start..segment_end],
+                &mut sidecar_compressor,
             ) {
                 Ok(encoded)
                     if encoded.len() <= COMMIT_DELTA_SEGMENT_TARGET_BYTES
@@ -2985,14 +2998,15 @@ fn encode_commit_delta_segment(entries: &[EncodedLeafEntry]) -> Vec<u8> {
 fn try_encode_commit_delta_segment_with_payloads(
     entries: &[EncodedLeafEntry],
     payloads: &[CommitDeltaPayloadRef<'_>],
+    compressor: &mut crate::compression::ZstdLevel1Compressor,
 ) -> Result<Vec<u8>, CommitDeltaSegmentEncodeError> {
-    encode_commit_delta_segment_layout(entries, payloads, true)
+    encode_commit_delta_segment_layout(entries, payloads, Some(compressor))
 }
 
 fn encode_commit_delta_segment_layout(
     entries: &[EncodedLeafEntry],
     payloads: &[CommitDeltaPayloadRef<'_>],
-    compress_sidecar: bool,
+    compressor: Option<&mut crate::compression::ZstdLevel1Compressor>,
 ) -> Result<Vec<u8>, CommitDeltaSegmentEncodeError> {
     debug_assert_eq!(entries.len(), payloads.len());
     let leaf = encode_leaf_node(entries);
@@ -3062,8 +3076,8 @@ fn encode_commit_delta_segment_layout(
         sidecar.extend_from_slice(&offset.to_be_bytes());
     }
     sidecar.extend_from_slice(&payload_bytes);
-    let compressed = compress_sidecar
-        .then(|| crate::compression::compress_zstd_level_1(&sidecar))
+    let compressed = compressor
+        .map(|compressor| compressor.compress(&sidecar))
         .transpose()
         .map_err(|error| {
             CommitDeltaSegmentEncodeError::Codec(LixError::new(
@@ -3098,7 +3112,9 @@ fn encode_commit_delta_segment_with_payloads(
     entries: &[EncodedLeafEntry],
     payloads: &[CommitDeltaPayloadRef<'_>],
 ) -> Vec<u8> {
-    try_encode_commit_delta_segment_with_payloads(entries, payloads)
+    let mut compressor =
+        crate::compression::ZstdLevel1Compressor::new().expect("test compressor should initialize");
+    try_encode_commit_delta_segment_with_payloads(entries, payloads, &mut compressor)
         .map_err(CommitDeltaSegmentEncodeError::into_lix_error)
         .expect("test commit-delta segment should encode")
 }
@@ -3108,7 +3124,7 @@ fn encode_commit_delta_segment_with_raw_sidecar(
     entries: &[EncodedLeafEntry],
     payloads: &[CommitDeltaPayloadRef<'_>],
 ) -> Vec<u8> {
-    encode_commit_delta_segment_layout(entries, payloads, false)
+    encode_commit_delta_segment_layout(entries, payloads, None)
         .map_err(CommitDeltaSegmentEncodeError::into_lix_error)
         .expect("test raw commit-delta segment should encode")
 }

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -5074,7 +5074,7 @@ where
 
     async fn prepare_transaction_rows_with_homogeneous(
         &mut self,
-        rows: RawWriteBatch,
+        mut rows: RawWriteBatch,
         allow_homogeneous: bool,
     ) -> Result<PreparedStateBatch, LixError> {
         let row_count = rows.len();
@@ -5084,6 +5084,51 @@ where
         // sample lazy so normalization errors retain precedence over scalar
         // provider calls.
         let mut default_timestamp = None;
+        if allow_homogeneous && let Some(certificate) = rows.certified_preparation() {
+            let timestamp = self.functions.call_timestamp();
+            let mut prepared_rows = PreparedStateBatch::with_dense_capacity(row_count, row_count);
+            for index in 0..row_count {
+                let row = rows.row(index);
+                let entity_pk = row.entity_pk.cloned().ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "certified transaction row is missing entity_pk",
+                    )
+                })?;
+                let schema_key = row.schema_key.clone();
+                let branch_id = row.branch_id.clone();
+                let snapshot = rows
+                    .take_snapshot(index)
+                    .map(|value| {
+                        stage_json_from_value(value, "certified prepared row snapshot_content")
+                    })
+                    .transpose()?;
+                prepared_rows.push_parts_with_change_addressability(
+                    certificate.schema_plan_id,
+                    certificate.facts,
+                    entity_pk,
+                    schema_key,
+                    None,
+                    snapshot,
+                    None,
+                    None,
+                    self.origin_key.as_ref(),
+                    timestamp,
+                    timestamp,
+                    false,
+                    // Addressable tracked rows receive their durable change id
+                    // from the sorted commit-delta location. A nil placeholder
+                    // satisfies staging's presence invariant without sampling
+                    // and retaining one throwaway UUID per row.
+                    Some(ChangeId::default()),
+                    true,
+                    None,
+                    false,
+                    branch_id,
+                );
+            }
+            return Ok(prepared_rows);
+        }
         let staged = self.staged_writes.staging_overlay()?;
         let read = SharedStorageAdapterRead::new(
             self.storage
@@ -5098,7 +5143,6 @@ where
                 .catalog_for_row_normalization(&live_state, &staged, &domain)
                 .await?;
             let mut scalar_facts = PreparedScalarBatch::with_capacity(rows.len());
-            let mut rows = rows;
             for index in 0..rows.len() {
                 let normalized =
                     normalize_raw_write_row_in_place(&mut rows, index, catalog, functions.clone())?;

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -5084,7 +5084,23 @@ where
         // sample lazy so normalization errors retain precedence over scalar
         // provider calls.
         let mut default_timestamp = None;
-        if allow_homogeneous && let Some(certificate) = rows.certified_preparation() {
+        let certified_preparation = rows.certified_preparation();
+        let certified_domain =
+            certified_preparation.and_then(|_| homogeneous_row_normalization_domain(&rows));
+        let certified_plan_is_current = allow_homogeneous
+            && match certified_domain.as_ref() {
+                Some(domain) => !self
+                    .staged_writes
+                    .has_staged_schema_catalog_change(domain)?,
+                None => false,
+            };
+        if certified_preparation.is_some() && !certified_plan_is_current {
+            rows.revoke_certified_preparation();
+        }
+        if allow_homogeneous
+            && certified_plan_is_current
+            && let Some(certificate) = certified_preparation
+        {
             let timestamp = self.functions.call_timestamp();
             let mut prepared_rows = PreparedStateBatch::with_dense_capacity(row_count, row_count);
             for index in 0..row_count {

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -757,6 +757,33 @@ impl TransactionWriteBuffer {
         }
     }
 
+    /// Returns whether this transaction has changed the schema catalog used
+    /// by `domain` without promoting the append-only staging journal.
+    ///
+    /// Typed SQL certificates are bound to the session's pinned catalog.
+    /// A transaction-local registered-schema row therefore invalidates those
+    /// certificates for the same branch/durability scope.
+    pub(crate) fn has_staged_schema_catalog_change(
+        &self,
+        domain: &Domain,
+    ) -> Result<bool, LixError> {
+        let rows = self.rows.lock().map_err(|_| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "failed to acquire transaction staged writes lock",
+            )
+        })?;
+        let rows = match &*rows {
+            StagedPreparedRows::AppendOnly { rows, .. }
+            | StagedPreparedRows::Indexed { rows, .. } => rows,
+        };
+        Ok(rows.iter().any(|row| {
+            row.schema_key.as_str() == crate::transaction::normalization::REGISTERED_SCHEMA_KEY
+                && row.branch_id.as_str() == domain.branch_id()
+                && (row.untracked == domain.untracked() || (domain.untracked() && !row.untracked))
+        }))
+    }
+
     /// Promotes the compact ordered journal into the existing identity overlay
     /// only when a read or an irregular write needs read-your-writes lookup.
     fn ensure_identity_index(&self, materialize_empty: bool) -> Result<(), LixError> {

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -213,6 +213,25 @@ impl TransactionJson {
         )
     }
 
+    /// Revokes a row-content proof while retaining its canonical bytes.
+    ///
+    /// A typed frontend can certify against its pinned catalog before an
+    /// explicit transaction stages a schema amendment. In that case the
+    /// transport remains useful, but transaction normalization must decode
+    /// and validate it against the amended plan.
+    fn revoke_row_content_certificate(self) -> Self {
+        match self.storage {
+            TransactionJsonStorage::CertifiedShared {
+                normalized,
+                certificate: TransactionJsonCertificate::RowContent,
+            } => Self::from_unvalidated_shared_normalized_content(normalized),
+            TransactionJsonStorage::Certified { normalized } => {
+                Self::from_unvalidated_shared_normalized_content(normalized.as_ref().into())
+            }
+            storage => Self { storage },
+        }
+    }
+
     pub(crate) fn canonical_batch_certificate(
         &self,
     ) -> Option<WasmCanonicalJsonCertificateRef<'_>> {
@@ -658,6 +677,17 @@ impl RawWriteBatch {
 
     pub(crate) fn certified_preparation(&self) -> Option<CertifiedRawWriteBatchPreparation> {
         self.certified_preparation
+    }
+
+    /// Downgrades a batch proof to canonical transport after its schema plan
+    /// has been invalidated by transaction-local catalog changes.
+    pub(crate) fn revoke_certified_preparation(&mut self) {
+        self.certified_preparation = None;
+        for snapshot in &mut self.snapshots {
+            if let Some(value) = snapshot.take() {
+                *snapshot = Some(value.revoke_row_content_certificate());
+            }
+        }
     }
 
     pub(crate) fn reserve(&mut self, additional: usize) {

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -444,10 +444,19 @@ pub(crate) struct RawWriteBatch {
     expected_rows: usize,
     origins: Vec<TransactionWriteOrigin>,
     origin_index: Option<HashMap<TransactionWriteOrigin, u32>>,
+    /// Exact homogeneous row-normalization proof produced by a typed
+    /// frontend. Any operation that changes row contents clears this proof.
+    certified_preparation: Option<CertifiedRawWriteBatchPreparation>,
     #[cfg(test)]
     string_promotions: usize,
     #[cfg(test)]
     origin_promotions: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CertifiedRawWriteBatchPreparation {
+    pub(crate) schema_plan_id: SchemaPlanId,
+    pub(crate) facts: PreparedRowFacts,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -502,6 +511,7 @@ impl RawWriteBatch {
             expected_rows: row_capacity,
             origins: Vec::with_capacity(row_capacity.min(INLINE_DICTIONARY_LIMIT)),
             origin_index: None,
+            certified_preparation: None,
             #[cfg(test)]
             string_promotions: 0,
             #[cfg(test)]
@@ -558,6 +568,7 @@ impl RawWriteBatch {
     }
 
     pub(crate) fn push(&mut self, row: TransactionWriteRow) {
+        self.certified_preparation = None;
         self.push_parts(
             row.entity_pk,
             row.schema_key,
@@ -592,6 +603,7 @@ impl RawWriteBatch {
         untracked: bool,
         branch_id: SharedStr,
     ) {
+        self.certified_preparation = None;
         assert!(
             self.slots.len() < RAW_WRITE_NONE as usize,
             "raw write row count must fit a non-null u32 ordinal"
@@ -624,6 +636,7 @@ impl RawWriteBatch {
     }
 
     pub(crate) fn append(&mut self, mut other: Self) {
+        self.certified_preparation = None;
         self.reserve(other.len());
         for index in 0..other.len() {
             other.move_row_into(index, self);
@@ -635,7 +648,16 @@ impl RawWriteBatch {
     /// The caller owns source ordinal selection, so the moved source slot is
     /// intentionally left as a hole and must not be read again.
     pub(crate) fn append_taken_row(&mut self, source: &mut Self, index: usize) {
+        self.certified_preparation = None;
         source.move_row_into(index, self);
+    }
+
+    pub(crate) fn certify_preparation(&mut self, certificate: CertifiedRawWriteBatchPreparation) {
+        self.certified_preparation = Some(certificate);
+    }
+
+    pub(crate) fn certified_preparation(&self) -> Option<CertifiedRawWriteBatchPreparation> {
+        self.certified_preparation
     }
 
     pub(crate) fn reserve(&mut self, additional: usize) {
@@ -665,6 +687,7 @@ impl RawWriteBatch {
     }
 
     pub(crate) fn entity_pk_mut(&mut self, index: usize) -> &mut Option<EntityPk> {
+        self.certified_preparation = None;
         &mut self.entity_pks[index]
     }
 
@@ -677,6 +700,7 @@ impl RawWriteBatch {
     }
 
     pub(crate) fn set_snapshot(&mut self, index: usize, value: Option<TransactionJson>) {
+        self.certified_preparation = None;
         self.snapshots[index] = value;
     }
 
@@ -697,16 +721,19 @@ impl RawWriteBatch {
     }
 
     pub(crate) fn set_origin(&mut self, index: usize, origin: Option<TransactionWriteOrigin>) {
+        self.certified_preparation = None;
         let ordinal = self.intern_optional_origin(origin);
         self.slots[index].origin = ordinal;
     }
 
     pub(crate) fn set_change_id(&mut self, index: usize, change_id: Option<SharedStr>) {
+        self.certified_preparation = None;
         let ordinal = self.intern_optional_string(change_id);
         self.slots[index].change_id = ordinal;
     }
 
     pub(crate) fn set_file_id(&mut self, index: usize, file_id: Option<SharedStr>) {
+        self.certified_preparation = None;
         let ordinal = self.intern_optional_string(file_id);
         self.slots[index].file_id = ordinal;
     }
@@ -716,6 +743,7 @@ impl RawWriteBatch {
     /// Dictionaries remain shared until more than half their slots are dead;
     /// the uncommon compaction rebuild keeps repeated metadata interned.
     pub(crate) fn retain(&mut self, mut keep: impl FnMut(RawWriteRowRef<'_>) -> bool) {
+        self.certified_preparation = None;
         let mut destination = 0usize;
         for source in 0..self.len() {
             if !keep(self.row(source)) {
@@ -1509,7 +1537,8 @@ impl StageJson {
 
 impl PartialEq for StageJson {
     fn eq(&self, other: &Self) -> bool {
-        self.json_ref == other.json_ref && self.normalized() == other.normalized()
+        self.normalized() == other.normalized()
+            && (self.is_inline() || other.is_inline() || self.json_ref == other.json_ref)
     }
 }
 
@@ -1520,7 +1549,15 @@ pub(crate) fn stage_json_from_value(
     value: TransactionJson,
     _context: &str,
 ) -> Result<StageJson, LixError> {
-    let json_ref = JsonRef::for_content(value.normalized().as_bytes());
+    // Inline values carry their bytes as the authoritative durable payload.
+    // Computing and retaining a content hash for every small row only to
+    // discard it at `JsonSlotRef::Inline` doubled the canonical-byte walk on
+    // bulk inserts. Out-of-band values still require the exact content ref.
+    let json_ref = if value.normalized().len() <= crate::json_store::JSON_INLINE_MAX_BYTES {
+        JsonRef::default()
+    } else {
+        JsonRef::for_content(value.normalized().as_bytes())
+    };
     let storage = match value.storage {
         TransactionJsonStorage::Decoded { value, normalized } => StageJsonStorage::Owned {
             value: OnceLock::from(value),
@@ -3612,6 +3649,28 @@ mod tests {
             staged.value(),
             &serde_json::json!({"path": "/a", "value": {"nested": true}})
         );
+        assert_eq!(
+            staged.json_ref,
+            JsonRef::default(),
+            "inline JSON must not pay for an unused content hash"
+        );
+    }
+
+    #[test]
+    fn out_of_band_json_retains_its_content_hash() {
+        let normalized = format!(
+            r#"{{"value":"{}"}}"#,
+            "x".repeat(crate::json_store::JSON_INLINE_MAX_BYTES)
+        );
+        let expected = JsonRef::for_content(normalized.as_bytes());
+        let staged = stage_json_from_value(
+            TransactionJson::from_certified_normalized_row_content(normalized.into()),
+            "large certified test row",
+        )
+        .expect("large certified JSON should prepare");
+
+        assert!(!staged.is_inline());
+        assert_eq!(staged.json_ref, expected);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- carry certified canonical INSERT content from SQL binding through the typed transaction batch into storage lowering
- avoid rebuilding canonical JSON DOMs and recomputing content hashes after validation
- release parsed validation columns while retaining the compact canonical arena needed by commit
- reuse zstd compression contexts and skip redundant commit-delta sorting when input order is already certified

## Why

The retained 1M trace showed that peak memory and lifetime overlap across typed rows, transaction materialization, and adapter batches is the scaling failure. This change moves the certified representation across the transaction/storage boundary so validated INSERTs do not rematerialize richer JSON structures on the commit path.

## Measurement

Retained cached, untraced 10k-row RocksDB INSERT measurement:

- main/baseline: 36.820125 ms
- this change: 30.990964 ms
- improvement: 15.8%

The branch rebased cleanly onto main after #1009 merged, so completed scale benchmarks were not rerun solely for freshness.

## Validation

- `cargo check -p lix_engine --all-features`
- `cargo test -p lix_engine --lib transaction::types -- --nocapture` (23 passed)
- `cargo test -p lix_engine --lib commit_delta -- --nocapture` (8 passed)
- `cargo test -p lix_engine --lib session::execute::tests::execute_batch_lowers_distinct_bound_entity_inserts_once -- --exact --nocapture`

Builds used two compiler jobs and mold for native linking.