### PR TITLE
Retain more decoded plugin checkpoints

### DIFF
--- a/packages/engine/src/plugin/actor.rs
+++ b/packages/engine/src/plugin/actor.rs
@@ -19,7 +19,11 @@ use crate::wasm::{WasmComponentActor, WasmDocumentCheckpoint, WasmDocumentHandle
 use crate::{Blob, LixError};
 
 pub(crate) const DEFAULT_MAX_LIVE_PLUGIN_STORES: usize = 16;
-const DEFAULT_MAX_DECODED_CHECKPOINT_BYTES: u64 = 64 * 1024 * 1024;
+// The vscode-docs 303-path transition needs roughly 80-96 MiB to retain one
+// decoded predecessor per touched file. At 64 MiB the cache reparses 115
+// documents; 96 MiB retains the complete measured working set while remaining
+// well below the aggregate live-Store budget.
+const DEFAULT_MAX_DECODED_CHECKPOINT_BYTES: u64 = 96 * 1024 * 1024;
 // One predecessor is enough for the required two-reader serialization while
 // keeping each file actor's retained working set bounded.
 pub(crate) const DEFAULT_MAX_PLUGIN_FILE_HISTORY: usize = 1;
@@ -1590,7 +1594,7 @@ mod tests {
         let cache = PluginActorCache::new(2).unwrap();
         let first_key = key("main", "/first.csv", "g1");
         let second_key = key("main", "/second.csv", "g1");
-        let retained_bytes = 40 * 1024 * 1024;
+        let retained_bytes = DEFAULT_MAX_DECODED_CHECKPOINT_BYTES / 2 + 1;
         let first = cache
             .stage_checkpoint(
                 first_key.clone(),


### PR DESCRIPTION
## What changed

- raise the shared pending+published decoded plugin-checkpoint budget from 64 MiB to 96 MiB
- keep the existing byte-accounted LRU eviction and hard aggregate bound unchanged
- make the hard-budget regression derive its oversized test entries from the configured limit

## Why

The 64 MiB cache falls below the working-set cliff on large multi-file commits. The exact vscode-docs 303-path transition re-materializes 16,439 durable semantic rows and reparses 115 documents because decoded predecessors churn out of the cache. At 96 MiB, 281 transitions restore their exact decoded checkpoint, only seven genuinely reparse, and no durable semantic rows are reconstructed.

80 MiB was also measured and rejected: it retained only 259 checkpoints and reintroduced 3,145 semantic rows. 128 MiB improved hit rate no further on the large transition and cost more RSS over 50 commits.

## Benchmarks

All lanes use SlateDB, all bundled WASM plugins, checkpoint every commit, and exact state verification. Native release builds use mold.

### vscode-docs commit `0892da1a` (303 changed paths, three-sample medians)

| Metric | 64 MiB baseline | 96 MiB | Change |
| --- | ---: | ---: | ---: |
| replay | 8.887 s | 7.198 s | -19.0% |
| execute | 5.877 s | 3.899 s | -33.7% |
| peak RSS | 1,044,112 KiB | 1,055,668 KiB | +1.1% |
| checkpoint hits | 173 | 281 | +108 |
| reparses | 115 | 7 | -93.9% |
| semantic rows materialized | 16,439 | 0 | -100% |

### vscode-docs 50-commit replay

| Metric | current main | 96 MiB | Change |
| --- | ---: | ---: | ---: |
| replay | 48.866 s | 46.718 s | -4.4% |
| execute | 18.989 s | 17.132 s | -9.8% |
| peak RSS | 1,024,900 KiB | 1,049,208 KiB | +2.4% |
| reparses | 189 | 64 | -66.1% |
| semantic rows materialized | 18,479 | 567 | -96.9% |

Both replays and the final Git tree verified exactly.

## Validation

- all 28 `plugin::actor::tests`
- focused pending/published hard-budget test
- focused exact actor/root checkpoint identity test
- `cargo fmt --check`
- `git diff --check`
- exact one-commit and 50-commit real-repository replays described above
