### PR TITLE
Bound plugin packet buffer reservations

### DIFF
--- a/plugins/csv/src/lib.rs
+++ b/plugins/csv/src/lib.rs
@@ -21,6 +21,7 @@ const ID_NAMESPACE_STATE: &[u8] = b"csv/id-namespace-v1";
 const CSV_INDEX_HEADER_BYTES: u32 = 36;
 const CSV_INDEX_PAGE_BYTES: usize = 1024 * 1024;
 const CSV_STATE_PAGE_BYTES: usize = 1024 * 1024;
+const PACKET_PAGE_INITIAL_CAPACITY: usize = 64 * 1024;
 
 impl sdk::FormatPlugin for CsvPlugin {
     fn cold_file_changed(
@@ -727,6 +728,10 @@ fn apply_edits(mut bytes: Vec<u8>, edits: &[core::ByteEdit]) -> sdk::Result<Vec<
     Ok(bytes)
 }
 
+fn packet_page_buffer(max_bytes: usize) -> Vec<u8> {
+    Vec::with_capacity(max_bytes.min(PACKET_PAGE_INITIAL_CAPACITY))
+}
+
 struct BatchEncoder {
     max_bytes: usize,
     payload: Vec<u8>,
@@ -737,7 +742,7 @@ impl BatchEncoder {
     fn new(max_bytes: u32) -> Self {
         Self {
             max_bytes: max_bytes as usize,
-            payload: Vec::with_capacity(max_bytes as usize),
+            payload: packet_page_buffer(max_bytes as usize),
             records: 0,
         }
     }
@@ -770,7 +775,7 @@ impl BatchEncoder {
         if self.records == 0 {
             return Ok(());
         }
-        let payload = std::mem::replace(&mut self.payload, Vec::with_capacity(self.max_bytes));
+        let payload = std::mem::replace(&mut self.payload, packet_page_buffer(self.max_bytes));
         let records = std::mem::take(&mut self.records);
         sink.emit_changes(records, payload)
     }
@@ -893,6 +898,15 @@ lix_plugin_api::export_plugin!(CsvPlugin);
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn packet_page_buffer_does_not_preallocate_the_record_ceiling() {
+        assert_eq!(
+            packet_page_buffer(16 * 1024 * 1024).capacity(),
+            PACKET_PAGE_INITIAL_CAPACITY
+        );
+        assert_eq!(packet_page_buffer(1024).capacity(), 1024);
+    }
 
     #[test]
     fn large_row_index_is_split_into_bounded_pages() {

--- a/plugins/excalidraw/src/lib.rs
+++ b/plugins/excalidraw/src/lib.rs
@@ -19,6 +19,7 @@ const ELEMENT_INDEX_HEADER_BYTES: u32 = 16;
 const ELEMENT_INDEX_ENTRY_BYTES: u32 = 32;
 const ELEMENT_INDEX_PAGE_BYTES: usize = 1024 * 1024;
 const MAX_ELEMENT_SHIFT_RECORDS: usize = 4096;
+const PACKET_PAGE_INITIAL_CAPACITY: usize = 64 * 1024;
 
 impl sdk::FormatPlugin for ExcalidrawPlugin {
     fn cold_file_changed(
@@ -679,6 +680,10 @@ where
     encoder.flush(sink)
 }
 
+fn packet_page_buffer(max_bytes: usize) -> Vec<u8> {
+    Vec::with_capacity(max_bytes.min(PACKET_PAGE_INITIAL_CAPACITY))
+}
+
 struct BatchEncoder {
     max_bytes: usize,
     payload: Vec<u8>,
@@ -689,7 +694,7 @@ impl BatchEncoder {
     fn new(max_bytes: u32) -> Self {
         Self {
             max_bytes: max_bytes as usize,
-            payload: Vec::with_capacity(max_bytes as usize),
+            payload: packet_page_buffer(max_bytes as usize),
             records: 0,
         }
     }
@@ -717,7 +722,7 @@ impl BatchEncoder {
         if self.records == 0 {
             return Ok(());
         }
-        let payload = std::mem::replace(&mut self.payload, Vec::with_capacity(self.max_bytes));
+        let payload = std::mem::replace(&mut self.payload, packet_page_buffer(self.max_bytes));
         let records = std::mem::take(&mut self.records);
         sink.emit_changes(records, payload)
     }
@@ -791,6 +796,15 @@ lix_plugin_api::export_plugin!(ExcalidrawPlugin);
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn packet_page_buffer_does_not_preallocate_the_record_ceiling() {
+        assert_eq!(
+            packet_page_buffer(16 * 1024 * 1024).capacity(),
+            PACKET_PAGE_INITIAL_CAPACITY
+        );
+        assert_eq!(packet_page_buffer(1024).capacity(), 1024);
+    }
 
     #[test]
     fn large_element_index_is_split_into_bounded_pages() {

--- a/plugins/json/src/lib.rs
+++ b/plugins/json/src/lib.rs
@@ -22,6 +22,7 @@ const SCALAR_INDEX_HEADER_BYTES: u32 = 16;
 const SCALAR_INDEX_ENTRY_BYTES: u32 = 20;
 const SCALAR_PAGE_BYTES: usize = 1024 * 1024;
 const STATE_PAGE_BYTES: usize = 1024 * 1024;
+const PACKET_PAGE_INITIAL_CAPACITY: usize = 64 * 1024;
 
 impl sdk::FormatPlugin for JsonPlugin {
     fn cold_file_changed(
@@ -1074,6 +1075,10 @@ where
     encoder.flush(sink)
 }
 
+fn packet_page_buffer(max_bytes: usize) -> Vec<u8> {
+    Vec::with_capacity(max_bytes.min(PACKET_PAGE_INITIAL_CAPACITY))
+}
+
 struct BatchEncoder {
     max_bytes: usize,
     payload: Vec<u8>,
@@ -1085,7 +1090,7 @@ impl BatchEncoder {
     fn new(max_bytes: u32) -> Self {
         Self {
             max_bytes: max_bytes as usize,
-            payload: Vec::with_capacity(max_bytes as usize),
+            payload: packet_page_buffer(max_bytes as usize),
             records: 0,
             creates_only: None,
         }
@@ -1125,7 +1130,7 @@ impl BatchEncoder {
         if self.records == 0 {
             return Ok(());
         }
-        let payload = std::mem::replace(&mut self.payload, Vec::with_capacity(self.max_bytes));
+        let payload = std::mem::replace(&mut self.payload, packet_page_buffer(self.max_bytes));
         let records = std::mem::take(&mut self.records);
         self.creates_only = None;
         sink.emit_changes(records, payload)
@@ -1244,6 +1249,15 @@ lix_plugin_api::export_plugin!(JsonPlugin);
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn packet_page_buffer_does_not_preallocate_the_record_ceiling() {
+        assert_eq!(
+            packet_page_buffer(16 * 1024 * 1024).capacity(),
+            PACKET_PAGE_INITIAL_CAPACITY
+        );
+        assert_eq!(packet_page_buffer(1024).capacity(), 1024);
+    }
 
     #[test]
     fn scalar_shift_overlay_compacts_repeated_and_zero_delta_edits() {

--- a/plugins/markdown/src/lib.rs
+++ b/plugins/markdown/src/lib.rs
@@ -24,6 +24,7 @@ const BLOCK_INDEX_HEADER_BYTES: u32 = 16;
 const BLOCK_INDEX_ENTRY_BYTES: u32 = 28;
 const BLOCK_PAGE_BYTES: usize = 1024 * 1024;
 const MAX_BLOCK_SHIFT_RECORDS: usize = 4096;
+const PACKET_PAGE_INITIAL_CAPACITY: usize = 64 * 1024;
 
 impl sdk::FormatPlugin for MarkdownPlugin {
     fn cold_file_changed(
@@ -778,6 +779,10 @@ fn emit_changes(
     encoder.flush(sink)
 }
 
+fn packet_page_buffer(max_bytes: usize) -> Vec<u8> {
+    Vec::with_capacity(max_bytes.min(PACKET_PAGE_INITIAL_CAPACITY))
+}
+
 struct BatchEncoder {
     max_bytes: usize,
     payload: Vec<u8>,
@@ -789,7 +794,7 @@ impl BatchEncoder {
     fn new(max_bytes: u32) -> Self {
         Self {
             max_bytes: max_bytes as usize,
-            payload: Vec::with_capacity(max_bytes as usize),
+            payload: packet_page_buffer(max_bytes as usize),
             records: 0,
             creates_only: None,
         }
@@ -828,7 +833,7 @@ impl BatchEncoder {
         if self.records == 0 {
             return Ok(());
         }
-        let payload = std::mem::replace(&mut self.payload, Vec::with_capacity(self.max_bytes));
+        let payload = std::mem::replace(&mut self.payload, packet_page_buffer(self.max_bytes));
         let records = std::mem::take(&mut self.records);
         self.creates_only = None;
         sink.emit_changes(records, payload)
@@ -946,6 +951,15 @@ lix_plugin_api::export_plugin!(MarkdownPlugin);
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn packet_page_buffer_does_not_preallocate_the_record_ceiling() {
+        assert_eq!(
+            packet_page_buffer(16 * 1024 * 1024).capacity(),
+            PACKET_PAGE_INITIAL_CAPACITY
+        );
+        assert_eq!(packet_page_buffer(1024).capacity(), 1024);
+    }
 
     #[test]
     fn large_block_index_is_split_into_bounded_pages() {

--- a/plugins/text/src/lib.rs
+++ b/plugins/text/src/lib.rs
@@ -18,6 +18,7 @@ const ID_NAMESPACE_STATE: &[u8] = b"git-text/id-namespace-v1";
 const LINE_IDENTITIES_STATE: &[u8] = b"git-text/line-identities-v1";
 const LINE_IDENTITIES_MAGIC: &[u8; 4] = b"GTI1";
 const STATE_PAGE_BYTES: usize = 1024 * 1024;
+const PACKET_PAGE_INITIAL_CAPACITY: usize = 64 * 1024;
 
 impl sdk::FormatPlugin for GitTextPlugin {
     fn cold_file_changed(
@@ -405,6 +406,10 @@ where
     encoder.flush(sink)
 }
 
+fn packet_page_buffer(max_bytes: usize) -> Vec<u8> {
+    Vec::with_capacity(max_bytes.min(PACKET_PAGE_INITIAL_CAPACITY))
+}
+
 struct BatchEncoder {
     max_bytes: usize,
     payload: Vec<u8>,
@@ -415,7 +420,7 @@ impl BatchEncoder {
     fn new(max_bytes: u32) -> Self {
         Self {
             max_bytes: max_bytes as usize,
-            payload: Vec::with_capacity(max_bytes as usize),
+            payload: packet_page_buffer(max_bytes as usize),
             records: 0,
         }
     }
@@ -448,7 +453,7 @@ impl BatchEncoder {
         if self.records == 0 {
             return Ok(());
         }
-        let payload = std::mem::replace(&mut self.payload, Vec::with_capacity(self.max_bytes));
+        let payload = std::mem::replace(&mut self.payload, packet_page_buffer(self.max_bytes));
         let records = std::mem::take(&mut self.records);
         sink.emit_changes(records, payload)
     }

--- a/plugins/text/src/tests.rs
+++ b/plugins/text/src/tests.rs
@@ -4,7 +4,19 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use serde_json::{Value, json};
 
 use crate::core::{Document, InputSplice, LINE_SCHEMA_KEY, Line};
-use crate::{STATE_PAGE_BYTES, decode_identities, decode_identity_manifest, encode_identities};
+use crate::{
+    PACKET_PAGE_INITIAL_CAPACITY, STATE_PAGE_BYTES, decode_identities, decode_identity_manifest,
+    encode_identities, packet_page_buffer,
+};
+
+#[test]
+fn packet_page_buffer_does_not_preallocate_the_record_ceiling() {
+    assert_eq!(
+        packet_page_buffer(16 * 1024 * 1024).capacity(),
+        PACKET_PAGE_INITIAL_CAPACITY
+    );
+    assert_eq!(packet_page_buffer(1024).capacity(), 1024);
+}
 
 fn open(bytes: &[u8]) -> (Document, Vec<lix::EntityChange>) {
     let (document, changes) =


### PR DESCRIPTION
## What changed

- cap the initial generic change-packet buffer reservation at 64 KiB in CSV, JSON, Markdown, Excalidraw, and Git text
- retain the negotiated record/page ceiling as a hard validation limit
- allow genuinely large records to grow the buffer on demand

## Root cause

The large-record admission fix scales a transition page as high as 16 MiB. Every generic plugin packet encoder treated that ceiling as an allocation request, reserving it once at construction and again after flush even when it emitted only a tiny record. This duplicated tens of MiB inside the Wasm guest.

## Exact A/B

Baseline and candidate use commit ea240192b, identical release builds and fixtures. Candidate p50/runtime and guest high-water:

- CSV 10.68 MiB: 140.082 ms versus 133.704 ms; 36,962,304 versus 70,516,736 bytes (-47.6%)
- JSON 10 MiB: 303.864 ms versus 298.938 ms; 50,790,400 versus 59,179,008 bytes (-14.2%)
- Markdown vscode-api.md: 8.195 ms versus 8.596 ms; 53.477 versus 87.032 MB (-38.6%)
- Excalidraw 1.85 MiB: 3.503 ms versus 3.728 ms; 37.749 versus 58.720 MB (-35.7%)

No format regresses by 5%; exact output and semantic row assertions pass.

## Validation

- all 31 unit tests across the five plugins
- cargo fmt --all -- --check
- git diff --check
- exact two-commit OpenClaw replay through c5c50a2141f2cdd805ae9b70a14a2e66dabac9b6 with all Wasm plugins, SlateDB, checkpoint every commit, per-commit state verification, and final-tree verification (3,929 changed paths)
