### PR TITLE
Compress inline binary history with bounded dictionaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4670,9 +4670,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ruzstd"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ff0cc5e135c8870a775d3320910cd9b564ec036b4dc0b8741629020be63f01"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
 
 [[package]]
 name = "ryu"

--- a/packages/engine-benchmarks/examples/storage_layout.rs
+++ b/packages/engine-benchmarks/examples/storage_layout.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 
 use lix_engine::storage_adapter::{StorageAdapter, StorageReadOptions};
 use lix_engine::storage_bench::{
-    commit_delta_layout_accounting, layout_accounting, layout_space_catalog, space_inventory,
+    binary_manifest_layout_accounting, commit_delta_layout_accounting, layout_accounting,
+    layout_space_catalog, space_inventory,
 };
 use lix_slatedb_storage::SlateDB;
 use object_store::local::LocalFileSystem;
@@ -53,6 +54,13 @@ async fn main() {
         .expect("open storage snapshot");
     if mode
         .as_deref()
+        .is_some_and(|arg| arg == "--binary-manifest-only")
+    {
+        print_binary_manifest_layout(&read).await;
+        return;
+    }
+    if mode
+        .as_deref()
         .is_some_and(|arg| arg == "--commit-delta-only")
     {
         print_commit_delta_inventory(&read).await;
@@ -77,6 +85,7 @@ async fn main() {
     }
     println!("SPACE\tTOTAL\tTOTAL\t{total_rows}\t{total_keys}\t{total_values}");
     print_commit_delta_inventory(&read).await;
+    print_binary_manifest_layout(&read).await;
 
     let inventory = space_inventory(&read, HOT_SPACE).await;
     let mut groups = BTreeMap::<Vec<u8>, HotGroup>::new();
@@ -165,14 +174,42 @@ async fn main() {
     }
 }
 
+async fn print_binary_manifest_layout(read: &impl lix_engine::storage_adapter::StorageAdapterRead) {
+    let layout = binary_manifest_layout_accounting(read)
+        .await
+        .expect("decode binary manifest layout");
+    println!(
+        "BINARY_MANIFEST\tmanifests={}\tencoded_bytes={}\tinline={}\tinline_original_bytes={}\tinline_payload_bytes={}\tinline_raw={}\tinline_zstd={}\tconcat_zstd1_bytes={}\tconcat_zstd3_bytes={}\tconcat_zstd9_bytes={}\tdict64k_zstd3_bytes={}\tdict64k_bytes={}\tindividual_zstd3_bytes={}\tindividual_zstd9_bytes={}\tempty={}\tsingle_chunk={}\tchunked={}",
+        layout.manifests,
+        layout.encoded_bytes,
+        layout.inline_manifests,
+        layout.inline_original_bytes,
+        layout.inline_payload_bytes,
+        layout.inline_raw_manifests,
+        layout.inline_zstd_manifests,
+        layout.inline_concat_zstd1_bytes,
+        layout.inline_concat_zstd3_bytes,
+        layout.inline_concat_zstd9_bytes,
+        layout.inline_dict64k_zstd3_bytes,
+        layout.inline_dict64k_bytes,
+        layout.inline_individual_zstd3_bytes,
+        layout.inline_individual_zstd9_bytes,
+        layout.empty_manifests,
+        layout.single_chunk_manifests,
+        layout.chunked_manifests,
+    );
+}
+
 async fn print_commit_delta_inventory(read: &impl lix_engine::storage_adapter::StorageAdapterRead) {
     for entry in commit_delta_layout_accounting(read)
         .await
         .expect("decode commit-delta inventory")
     {
         println!(
-            "COMMIT_DELTA\tcommit={}\tsegments={}\tmembers={}\tauthored={}\tselected={}\tselected_tombstones={}\tcertified={}\tselected_certified={}",
+            "COMMIT_DELTA\tcommit={}\tphysical_key_bytes={}\tphysical_value_bytes={}\tsegments={}\tmembers={}\tauthored={}\tselected={}\tselected_tombstones={}\tcertified={}\tselected_certified={}\tselected_direct_addresses={}\tselected_source_commits={}\tdominant_selected_source_members={}",
             entry.commit_id,
+            entry.physical_key_bytes,
+            entry.physical_value_bytes,
             entry.segment_count,
             entry.members,
             entry.authored_members,
@@ -180,6 +217,9 @@ async fn print_commit_delta_inventory(read: &impl lix_engine::storage_adapter::S
             entry.selected_tombstones,
             entry.certified_members,
             entry.selected_certified_members,
+            entry.selected_direct_addresses,
+            entry.selected_source_commits,
+            entry.dominant_selected_source_members,
         );
     }
 }

--- a/packages/engine/src/binary_cas/codec.rs
+++ b/packages/engine/src/binary_cas/codec.rs
@@ -31,6 +31,32 @@ pub(crate) enum BinaryCasManifest {
         #[musli(bytes)]
         payload: Vec<u8>,
     },
+    InlineDelta {
+        size_bytes: u64,
+        base_blob_hash: [u8; HASH_BYTES],
+        prefix_len: u64,
+        suffix_len: u64,
+        middle_len: u64,
+        codec: BinaryChunkCodec,
+        #[musli(bytes)]
+        payload: Vec<u8>,
+    },
+    InlineDictionary {
+        size_bytes: u64,
+        dictionary_hash: [u8; HASH_BYTES],
+        #[musli(bytes)]
+        payload: Vec<u8>,
+    },
+    InlineDictionaryDelta {
+        size_bytes: u64,
+        base_blob_hash: [u8; HASH_BYTES],
+        prefix_len: u64,
+        suffix_len: u64,
+        middle_len: u64,
+        dictionary_hash: [u8; HASH_BYTES],
+        #[musli(bytes)]
+        payload: Vec<u8>,
+    },
 }
 
 #[derive(Encode, Decode)]
@@ -58,6 +84,35 @@ enum InlineBinaryCasManifestRef<'a> {
         #[musli(bytes)]
         payload: &'a [u8],
     },
+    #[musli(Binary, name = 5)]
+    InlineDictionary {
+        size_bytes: u64,
+        dictionary_hash: [u8; HASH_BYTES],
+        #[musli(bytes)]
+        payload: &'a [u8],
+    },
+    #[musli(Binary, name = 6)]
+    InlineDictionaryDelta {
+        size_bytes: u64,
+        base_blob_hash: [u8; HASH_BYTES],
+        prefix_len: u64,
+        suffix_len: u64,
+        middle_len: u64,
+        dictionary_hash: [u8; HASH_BYTES],
+        #[musli(bytes)]
+        payload: &'a [u8],
+    },
+    #[musli(Binary, name = 4)]
+    InlineDelta {
+        size_bytes: u64,
+        base_blob_hash: [u8; HASH_BYTES],
+        prefix_len: u64,
+        suffix_len: u64,
+        middle_len: u64,
+        codec: BinaryChunkCodec,
+        #[musli(bytes)]
+        payload: &'a [u8],
+    },
 }
 
 impl BinaryCasManifest {
@@ -66,7 +121,10 @@ impl BinaryCasManifest {
             Self::Empty { size_bytes }
             | Self::SingleChunk { size_bytes, .. }
             | Self::Chunked { size_bytes, .. }
-            | Self::Inline { size_bytes, .. } => *size_bytes,
+            | Self::Inline { size_bytes, .. }
+            | Self::InlineDelta { size_bytes, .. }
+            | Self::InlineDictionary { size_bytes, .. }
+            | Self::InlineDictionaryDelta { size_bytes, .. } => *size_bytes,
         }
     }
 }
@@ -125,6 +183,70 @@ pub(crate) fn encode_inline_binary_cas_manifest(
         },
     )
     .expect("inline binary CAS manifest storage encoding should not fail")
+}
+
+pub(crate) fn encode_inline_delta_binary_cas_manifest(
+    size_bytes: u64,
+    base_blob_hash: [u8; HASH_BYTES],
+    prefix_len: u64,
+    suffix_len: u64,
+    middle_len: u64,
+    codec: BinaryChunkCodec,
+    payload: &[u8],
+) -> Vec<u8> {
+    storage_codec::encode(
+        "inline delta binary CAS manifest",
+        &InlineBinaryCasManifestRef::InlineDelta {
+            size_bytes,
+            base_blob_hash,
+            prefix_len,
+            suffix_len,
+            middle_len,
+            codec,
+            payload,
+        },
+    )
+    .expect("inline delta binary CAS manifest storage encoding should not fail")
+}
+
+pub(crate) fn encode_inline_dictionary_binary_cas_manifest(
+    size_bytes: u64,
+    dictionary_hash: [u8; HASH_BYTES],
+    payload: &[u8],
+) -> Vec<u8> {
+    storage_codec::encode(
+        "inline dictionary binary CAS manifest",
+        &InlineBinaryCasManifestRef::InlineDictionary {
+            size_bytes,
+            dictionary_hash,
+            payload,
+        },
+    )
+    .expect("inline dictionary binary CAS manifest storage encoding should not fail")
+}
+
+pub(crate) fn encode_inline_dictionary_delta_binary_cas_manifest(
+    size_bytes: u64,
+    base_blob_hash: [u8; HASH_BYTES],
+    prefix_len: u64,
+    suffix_len: u64,
+    middle_len: u64,
+    dictionary_hash: [u8; HASH_BYTES],
+    payload: &[u8],
+) -> Vec<u8> {
+    storage_codec::encode(
+        "inline dictionary delta binary CAS manifest",
+        &InlineBinaryCasManifestRef::InlineDictionaryDelta {
+            size_bytes,
+            base_blob_hash,
+            prefix_len,
+            suffix_len,
+            middle_len,
+            dictionary_hash,
+            payload,
+        },
+    )
+    .expect("inline dictionary delta binary CAS manifest storage encoding should not fail")
 }
 
 pub(crate) fn encode_binary_cas_manifest_chunk(
@@ -249,6 +371,67 @@ mod tests {
             b"hello".len() + INLINE_MANIFEST_STORAGE_OVERHEAD_BYTES
         );
         assert_eq!(decode_binary_cas_manifest(&encoded).unwrap(), manifest);
+    }
+
+    #[test]
+    fn inline_delta_and_dictionary_manifests_roundtrip_borrowed_payload_bytes() {
+        let base_hash = binary_blob_hash_bytes(b"base");
+        let dictionary_hash = binary_blob_hash_bytes(b"dictionary");
+        let cases = [
+            (
+                BinaryCasManifest::InlineDelta {
+                    size_bytes: 9,
+                    base_blob_hash: base_hash,
+                    prefix_len: 3,
+                    suffix_len: 3,
+                    middle_len: 3,
+                    codec: BinaryChunkCodec::Raw,
+                    payload: b"new".to_vec(),
+                },
+                encode_inline_delta_binary_cas_manifest(
+                    9,
+                    base_hash,
+                    3,
+                    3,
+                    3,
+                    BinaryChunkCodec::Raw,
+                    b"new",
+                ),
+            ),
+            (
+                BinaryCasManifest::InlineDictionary {
+                    size_bytes: 5,
+                    dictionary_hash,
+                    payload: b"frame".to_vec(),
+                },
+                encode_inline_dictionary_binary_cas_manifest(5, dictionary_hash, b"frame"),
+            ),
+            (
+                BinaryCasManifest::InlineDictionaryDelta {
+                    size_bytes: 9,
+                    base_blob_hash: base_hash,
+                    prefix_len: 3,
+                    suffix_len: 3,
+                    middle_len: 3,
+                    dictionary_hash,
+                    payload: b"frame".to_vec(),
+                },
+                encode_inline_dictionary_delta_binary_cas_manifest(
+                    9,
+                    base_hash,
+                    3,
+                    3,
+                    3,
+                    dictionary_hash,
+                    b"frame",
+                ),
+            ),
+        ];
+
+        for (manifest, encoded) in cases {
+            assert_eq!(encoded, encode_binary_cas_manifest(&manifest));
+            assert_eq!(decode_binary_cas_manifest(&encoded).unwrap(), manifest);
+        }
     }
 
     #[test]

--- a/packages/engine/src/binary_cas/context.rs
+++ b/packages/engine/src/binary_cas/context.rs
@@ -95,6 +95,8 @@ where
     chunking: BinaryCasChunking,
     blob_hashes: HashSet<[u8; 32]>,
     chunk_keys: HashSet<Vec<u8>>,
+    dictionary_sample_slots: HashSet<u8>,
+    dictionary: Option<Option<crate::binary_cas::kv::BinaryCasDictionary>>,
 }
 
 impl<'a, S> ExistingChunkAwareBinaryCasWriter<'a, S>
@@ -108,6 +110,8 @@ where
             chunking,
             blob_hashes: HashSet::new(),
             chunk_keys: HashSet::new(),
+            dictionary_sample_slots: HashSet::new(),
+            dictionary: None,
         }
     }
 
@@ -134,8 +138,15 @@ where
     pub(crate) async fn stage_file_payload(
         &mut self,
         payload: &BlobPayload,
+        base_blob_hash: Option<BlobHash>,
         same_length_splice: Option<BlobSameLengthSplice>,
     ) -> Result<(), LixError> {
+        if self.dictionary.is_none() {
+            self.dictionary = Some(
+                crate::binary_cas::kv::load_or_train_dictionary(self.store, self.writes).await?,
+            );
+        }
+        let dictionary = self.dictionary.as_ref().and_then(Option::as_ref).cloned();
         if let Some(splice) = same_length_splice
             && crate::binary_cas::kv::try_stage_blob_write_reusing_same_length_splice(
                 self.store,
@@ -148,9 +159,67 @@ where
             )
             .await?
         {
+            if dictionary.is_none() {
+                crate::binary_cas::kv::stage_dictionary_sample(
+                    self.writes,
+                    &mut self.dictionary_sample_slots,
+                    payload.bytes(),
+                    payload.hash(),
+                );
+            }
+            return Ok(());
+        }
+        if let Some(base_blob_hash) = base_blob_hash
+            && crate::binary_cas::kv::try_stage_inline_delta(
+                self.store,
+                self.writes,
+                &mut self.blob_hashes,
+                payload.bytes(),
+                payload.hash(),
+                base_blob_hash,
+                dictionary.as_ref(),
+            )
+            .await?
+        {
+            if dictionary.is_none() {
+                crate::binary_cas::kv::stage_dictionary_sample(
+                    self.writes,
+                    &mut self.dictionary_sample_slots,
+                    payload.bytes(),
+                    payload.hash(),
+                );
+            }
+            return Ok(());
+        }
+        if crate::binary_cas::kv::try_stage_inline_dictionary(
+            self.store,
+            self.writes,
+            &mut self.blob_hashes,
+            payload.bytes(),
+            payload.hash(),
+            dictionary.as_ref(),
+        )
+        .await?
+        {
+            if dictionary.is_none() {
+                crate::binary_cas::kv::stage_dictionary_sample(
+                    self.writes,
+                    &mut self.dictionary_sample_slots,
+                    payload.bytes(),
+                    payload.hash(),
+                );
+            }
             return Ok(());
         }
         self.stage_payload(payload).await?;
+        if dictionary.is_none() {
+            crate::binary_cas::kv::stage_dictionary_sample(
+                self.writes,
+                &mut self.dictionary_sample_slots,
+                payload.bytes(),
+                payload.hash(),
+            );
+        }
         Ok(())
     }
 }

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -9,13 +9,15 @@ use crate::binary_cas::codec::{
     BinaryCasManifest, BinaryChunkCodec, decode_binary_cas_chunk, decode_binary_cas_manifest,
     decode_binary_cas_manifest_chunk, encode_binary_cas_chunk, encode_binary_cas_manifest,
     encode_binary_cas_manifest_chunk, encode_inline_binary_cas_manifest,
+    encode_inline_delta_binary_cas_manifest, encode_inline_dictionary_binary_cas_manifest,
+    encode_inline_dictionary_delta_binary_cas_manifest,
 };
 use crate::binary_cas::compression::{decode_zstd_chunk, encode_chunk_payload};
 use crate::binary_cas::{
     BinaryCasChunking, BlobBytesBatch, BlobHash, BlobLayout, BlobMetadata, BlobMetadataBatch,
     BlobSameLengthSplice, BlobWriteReceipt, InlineBlob,
 };
-#[cfg(test)]
+#[cfg(any(test, not(target_family = "wasm")))]
 use crate::storage_adapter::StoragePrefix;
 use crate::storage_adapter::{
     PointReadPlan, ScanPlan, StorageAdapterRead, StorageSpace, StorageWriteSet,
@@ -40,6 +42,9 @@ pub(crate) const BINARY_CAS_MANIFEST_NAMESPACE: &str = "binary_cas.manifest";
 pub(crate) const BINARY_CAS_MANIFEST_CHUNK_NAMESPACE: &str = "binary_cas.manifest_chunk";
 pub(crate) const BINARY_CAS_CHUNK_NAMESPACE: &str = "binary_cas.chunk";
 pub(crate) const BINARY_CAS_CHUNK_PRESENCE_NAMESPACE: &str = "binary_cas.chunk_presence";
+pub(crate) const BINARY_CAS_DICTIONARY_NAMESPACE: &str = "binary_cas.dictionary";
+pub(crate) const BINARY_CAS_DICTIONARY_CONTROL_NAMESPACE: &str = "binary_cas.dictionary_control";
+pub(crate) const BINARY_CAS_DICTIONARY_SAMPLE_NAMESPACE: &str = "binary_cas.dictionary_sample";
 pub(crate) const BINARY_CAS_MANIFEST_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0005_0001), BINARY_CAS_MANIFEST_NAMESPACE);
 pub(crate) const BINARY_CAS_MANIFEST_CHUNK_SPACE: StorageSpace = StorageSpace::new(
@@ -52,6 +57,20 @@ pub(crate) const BINARY_CAS_CHUNK_PRESENCE_SPACE: StorageSpace = StorageSpace::n
     StorageSpaceId(0x0005_0004),
     BINARY_CAS_CHUNK_PRESENCE_NAMESPACE,
 );
+pub(crate) const BINARY_CAS_DICTIONARY_SPACE: StorageSpace =
+    StorageSpace::new(StorageSpaceId(0x0005_0005), BINARY_CAS_DICTIONARY_NAMESPACE);
+pub(crate) const BINARY_CAS_DICTIONARY_CONTROL_SPACE: StorageSpace = StorageSpace::new(
+    StorageSpaceId(0x0005_0006),
+    BINARY_CAS_DICTIONARY_CONTROL_NAMESPACE,
+);
+pub(crate) const BINARY_CAS_DICTIONARY_SAMPLE_SPACE: StorageSpace = StorageSpace::new(
+    StorageSpaceId(0x0005_0007),
+    BINARY_CAS_DICTIONARY_SAMPLE_NAMESPACE,
+);
+const BINARY_CAS_DICTIONARY_CONTROL_KEY: &[u8] = b"current";
+const BINARY_CAS_DICTIONARY_SAMPLE_COUNT: usize = 32;
+const BINARY_CAS_DICTIONARY_SAMPLE_SLOTS: usize = 64;
+const BINARY_CAS_DICTIONARY_BYTES: usize = 64 * 1024;
 
 #[derive(Debug)]
 struct BlobWritePlan {
@@ -66,6 +85,48 @@ struct PreparedChunk {
     start: usize,
     end: usize,
     hash: BlobHash,
+}
+
+#[derive(Clone)]
+pub(in crate::binary_cas) struct BinaryCasDictionary {
+    pub(in crate::binary_cas) hash: BlobHash,
+    pub(in crate::binary_cas) bytes: Vec<u8>,
+    #[cfg(not(target_family = "wasm"))]
+    compressor: std::sync::Arc<
+        std::sync::OnceLock<Result<crate::compression::ZstdDictionaryCompressor, String>>,
+    >,
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn binary_cas_dictionary(hash: BlobHash, bytes: Vec<u8>) -> Result<BinaryCasDictionary, LixError> {
+    if BlobHash::from_content(&bytes) != hash {
+        return Err(LixError::new(
+            LixError::CODE_UNKNOWN,
+            format!(
+                "binary CAS dictionary '{}' failed content-address verification",
+                hash.to_hex()
+            ),
+        ));
+    }
+    Ok(BinaryCasDictionary {
+        hash,
+        bytes,
+        compressor: std::sync::Arc::new(std::sync::OnceLock::new()),
+    })
+}
+
+#[cfg(target_family = "wasm")]
+fn binary_cas_dictionary(hash: BlobHash, bytes: Vec<u8>) -> Result<BinaryCasDictionary, LixError> {
+    if BlobHash::from_content(&bytes) != hash {
+        return Err(LixError::new(
+            LixError::CODE_UNKNOWN,
+            format!(
+                "binary CAS dictionary '{}' failed content-address verification",
+                hash.to_hex()
+            ),
+        ));
+    }
+    Ok(BinaryCasDictionary { hash, bytes })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -136,7 +197,7 @@ pub(crate) async fn scan_manifest_chunks(
 /// declared ordinal range keeps stale suffix rows harmless; the caller still
 /// rejects missing declared rows by comparing the resulting count.
 async fn load_declared_manifest_chunks(
-    store: &impl StorageAdapterRead,
+    store: &(impl StorageAdapterRead + ?Sized),
     blob_hash: BlobHash,
     chunk_count: u32,
 ) -> Result<Vec<KvBlobManifestChunk>, LixError> {
@@ -270,7 +331,7 @@ async fn scan_all_values(
 }
 
 async fn scan_all_values_for_plan(
-    store: &impl StorageAdapterRead,
+    store: &(impl StorageAdapterRead + ?Sized),
     plan: &ScanPlan,
 ) -> Result<Vec<Vec<u8>>, LixError> {
     let mut values = Vec::new();
@@ -301,7 +362,7 @@ async fn scan_all_values_for_plan(
 }
 
 pub(crate) async fn load_metadata_many(
-    store: &impl StorageAdapterRead,
+    store: &(impl StorageAdapterRead + ?Sized),
     hashes: &[BlobHash],
 ) -> Result<BlobMetadataBatch, LixError> {
     if hashes.is_empty() {
@@ -338,10 +399,106 @@ pub(crate) async fn load_metadata_many(
 }
 
 pub(crate) async fn load_bytes_many(
-    store: &impl StorageAdapterRead,
+    store: &(impl StorageAdapterRead + ?Sized),
     hashes: &[BlobHash],
 ) -> Result<BlobBytesBatch, LixError> {
     let metadata = load_metadata_many(store, hashes).await?.into_vec();
+    let delta_base_hashes = metadata
+        .iter()
+        .filter_map(|metadata| match metadata.as_ref()?.inline_blob.as_ref()? {
+            InlineBlob::Delta { base_blob_hash, .. } => Some(*base_blob_hash),
+            InlineBlob::Full { .. } => None,
+        })
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let delta_base_metadata = load_metadata_many(store, &delta_base_hashes)
+        .await?
+        .into_vec();
+    let dictionary_hashes = metadata
+        .iter()
+        .chain(delta_base_metadata.iter())
+        .filter_map(|metadata| match metadata.as_ref()?.inline_blob.as_ref()? {
+            InlineBlob::Full {
+                dictionary_hash, ..
+            }
+            | InlineBlob::Delta {
+                dictionary_hash, ..
+            } => *dictionary_hash,
+        })
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let dictionary_rows = point_values(
+        store,
+        BINARY_CAS_DICTIONARY_SPACE,
+        dictionary_hashes
+            .iter()
+            .map(|hash| hash.as_bytes().to_vec())
+            .collect(),
+    )
+    .await?;
+    let dictionaries_by_hash = dictionary_hashes
+        .into_iter()
+        .zip(dictionary_rows)
+        .map(|(hash, row)| {
+            let bytes = row.ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_UNKNOWN,
+                    format!("binary CAS dictionary '{}' is missing", hash.to_hex()),
+                )
+            })?;
+            if BlobHash::from_content(&bytes) != hash {
+                return Err(LixError::new(
+                    LixError::CODE_UNKNOWN,
+                    format!(
+                        "binary CAS dictionary '{}' failed content-address verification",
+                        hash.to_hex()
+                    ),
+                ));
+            }
+            let decoder =
+                crate::compression::ZstdDictionaryDecoder::new(&bytes).map_err(|error| {
+                    LixError::new(
+                        LixError::CODE_UNKNOWN,
+                        format!(
+                            "binary CAS dictionary '{}' failed to initialize: {error}",
+                            hash.to_hex()
+                        ),
+                    )
+                })?;
+            Ok((hash, decoder))
+        })
+        .collect::<Result<HashMap<_, _>, LixError>>()?;
+    let mut delta_bases_by_hash = HashMap::with_capacity(delta_base_hashes.len());
+    for (base_hash, metadata) in delta_base_hashes.into_iter().zip(delta_base_metadata) {
+        let metadata = metadata.ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_UNKNOWN,
+                format!(
+                    "binary CAS inline delta base '{}' is missing",
+                    base_hash.to_hex()
+                ),
+            )
+        })?;
+        if !matches!(metadata.inline_blob, Some(InlineBlob::Full { .. })) {
+            return Err(LixError::new(
+                LixError::CODE_UNKNOWN,
+                format!(
+                    "binary CAS inline delta base '{}' is not one full inline blob",
+                    base_hash.to_hex()
+                ),
+            ));
+        }
+        let bytes = assemble_blob_bytes(
+            metadata,
+            &HashMap::new(),
+            None,
+            &HashMap::new(),
+            &dictionaries_by_hash,
+        )?;
+        delta_bases_by_hash.insert(base_hash, bytes);
+    }
     let mut seen_manifest_hashes = HashSet::new();
     let chunked_blobs = metadata
         .iter()
@@ -449,6 +606,8 @@ pub(crate) async fn load_bytes_many(
                         metadata,
                         &chunk_rows_by_hash,
                         chunked_manifests_by_hash.get(&hash),
+                        &delta_bases_by_hash,
+                        &dictionaries_by_hash,
                     )
                 })
                 .transpose()
@@ -458,7 +617,7 @@ pub(crate) async fn load_bytes_many(
 }
 
 async fn load_chunk_rows(
-    store: &impl StorageAdapterRead,
+    store: &(impl StorageAdapterRead + ?Sized),
     hashes: &[BlobHash],
 ) -> Result<Vec<Option<Bytes>>, LixError> {
     if hashes.is_empty() {
@@ -473,7 +632,7 @@ async fn load_chunk_rows(
 }
 
 async fn point_values(
-    store: &impl StorageAdapterRead,
+    store: &(impl StorageAdapterRead + ?Sized),
     space: StorageSpace,
     keys: Vec<Vec<u8>>,
 ) -> Result<Vec<Option<Bytes>>, LixError> {
@@ -489,6 +648,206 @@ async fn point_values(
         .into_iter()
         .map(|value| value.and_then(full_value))
         .collect())
+}
+
+async fn point_value(
+    store: &(impl StorageAdapterRead + ?Sized),
+    space: StorageSpace,
+    key: Vec<u8>,
+) -> Result<Option<Bytes>, LixError> {
+    Ok(point_values(store, space, vec![key])
+        .await?
+        .into_iter()
+        .next()
+        .flatten())
+}
+
+#[cfg(not(target_family = "wasm"))]
+pub(in crate::binary_cas) async fn load_or_train_dictionary(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+) -> Result<Option<BinaryCasDictionary>, LixError> {
+    if let Some(control) = point_value(
+        store,
+        BINARY_CAS_DICTIONARY_CONTROL_SPACE,
+        BINARY_CAS_DICTIONARY_CONTROL_KEY.to_vec(),
+    )
+    .await?
+    {
+        let hash_bytes: [u8; 32] = control.as_ref().try_into().map_err(|_| {
+            LixError::new(
+                LixError::CODE_UNKNOWN,
+                "binary CAS dictionary control is not one hash",
+            )
+        })?;
+        let hash = BlobHash::from_bytes(hash_bytes);
+        let bytes = point_value(store, BINARY_CAS_DICTIONARY_SPACE, hash.as_bytes().to_vec())
+            .await?
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_UNKNOWN,
+                    format!(
+                        "binary CAS active dictionary '{}' is missing",
+                        hash.to_hex()
+                    ),
+                )
+            })?;
+        return binary_cas_dictionary(hash, bytes.to_vec()).map(Some);
+    }
+
+    let plan = ScanPlan::prefix(
+        BINARY_CAS_DICTIONARY_SAMPLE_SPACE,
+        StoragePrefix {
+            bytes: Bytes::new(),
+        },
+    );
+    let samples = plan
+        .collect(
+            store,
+            StorageScanOptions {
+                projection: StorageCoreProjection::FullValue,
+                limit_rows: BINARY_CAS_DICTIONARY_SAMPLE_SLOTS,
+                ..StorageScanOptions::default()
+            },
+        )
+        .await?;
+    if samples.value.entries.len() < BINARY_CAS_DICTIONARY_SAMPLE_COUNT {
+        return Ok(None);
+    }
+    let sample_keys = samples
+        .value
+        .entries
+        .into_iter()
+        .map(|entry| {
+            let _: [u8; 1] = entry.key.0.as_ref().try_into().map_err(|_| {
+                LixError::new(
+                    LixError::CODE_UNKNOWN,
+                    "binary CAS dictionary sample key is not one slot",
+                )
+            })?;
+            let StorageProjectedValue::FullValue(hash_bytes) = entry.value else {
+                unreachable!("dictionary sample scan requested full values");
+            };
+            let hash: [u8; 32] = hash_bytes.as_ref().try_into().map_err(|_| {
+                LixError::new(
+                    LixError::CODE_UNKNOWN,
+                    "binary CAS dictionary sample slot value is not one hash",
+                )
+            })?;
+            Ok((entry.key, BlobHash::from_bytes(hash)))
+        })
+        .collect::<Result<Vec<_>, LixError>>()?;
+    let sample_hashes = sample_keys
+        .iter()
+        .take(BINARY_CAS_DICTIONARY_SAMPLE_COUNT)
+        .map(|(_, hash)| *hash)
+        .collect::<Vec<_>>();
+    let sample_bytes = load_bytes_many(store, &sample_hashes)
+        .await?
+        .into_vec()
+        .into_iter()
+        .collect::<Option<Vec<_>>>()
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_UNKNOWN,
+                "binary CAS dictionary sample blob is missing",
+            )
+        })?;
+    let sample_refs = sample_bytes.iter().map(Vec::as_slice).collect::<Vec<_>>();
+    let bytes =
+        zstd::dict::from_samples(&sample_refs, BINARY_CAS_DICTIONARY_BYTES).map_err(|error| {
+            LixError::new(
+                LixError::CODE_UNKNOWN,
+                format!("binary CAS dictionary training failed: {error}"),
+            )
+        })?;
+    let hash = BlobHash::from_content(&bytes);
+    writes.put(
+        BINARY_CAS_DICTIONARY_SPACE,
+        key(hash.as_bytes().to_vec()),
+        value(bytes.clone()),
+    );
+    writes.put(
+        BINARY_CAS_DICTIONARY_CONTROL_SPACE,
+        key(BINARY_CAS_DICTIONARY_CONTROL_KEY.to_vec()),
+        value(hash.as_bytes().to_vec()),
+    );
+    writes.delete_batch(
+        BINARY_CAS_DICTIONARY_SAMPLE_SPACE,
+        sample_keys.into_iter().map(|(key, _)| key),
+    );
+    binary_cas_dictionary(hash, bytes).map(Some)
+}
+
+#[cfg(target_family = "wasm")]
+pub(in crate::binary_cas) async fn load_or_train_dictionary(
+    store: &(impl StorageAdapterRead + ?Sized),
+    _writes: &mut StorageWriteSet,
+) -> Result<Option<BinaryCasDictionary>, LixError> {
+    let Some(control) = point_value(
+        store,
+        BINARY_CAS_DICTIONARY_CONTROL_SPACE,
+        BINARY_CAS_DICTIONARY_CONTROL_KEY.to_vec(),
+    )
+    .await?
+    else {
+        return Ok(None);
+    };
+    let hash_bytes: [u8; 32] = control.as_ref().try_into().map_err(|_| {
+        LixError::new(
+            LixError::CODE_UNKNOWN,
+            "binary CAS dictionary control is not one hash",
+        )
+    })?;
+    let hash = BlobHash::from_bytes(hash_bytes);
+    let bytes = point_value(store, BINARY_CAS_DICTIONARY_SPACE, hash.as_bytes().to_vec())
+        .await?
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_UNKNOWN,
+                format!(
+                    "binary CAS active dictionary '{}' is missing",
+                    hash.to_hex()
+                ),
+            )
+        })?;
+    binary_cas_dictionary(hash, bytes.to_vec()).map(Some)
+}
+
+#[cfg(not(target_family = "wasm"))]
+pub(in crate::binary_cas) fn stage_dictionary_sample(
+    writes: &mut StorageWriteSet,
+    staged_sample_slots: &mut HashSet<u8>,
+    bytes: &[u8],
+    hash: Option<BlobHash>,
+) {
+    let Some(hash) = hash else {
+        return;
+    };
+    if bytes.len() < 512
+        || bytes.len() > INLINE_BINARY_CAS_MAX_BYTES
+        || std::str::from_utf8(bytes).is_err()
+    {
+        return;
+    }
+    let slot = hash.as_bytes()[0] & (BINARY_CAS_DICTIONARY_SAMPLE_SLOTS as u8 - 1);
+    if !staged_sample_slots.insert(slot) {
+        return;
+    }
+    writes.put(
+        BINARY_CAS_DICTIONARY_SAMPLE_SPACE,
+        key(vec![slot]),
+        value(hash.as_bytes().to_vec()),
+    );
+}
+
+#[cfg(target_family = "wasm")]
+pub(in crate::binary_cas) fn stage_dictionary_sample(
+    _writes: &mut StorageWriteSet,
+    _staged_sample_slots: &mut HashSet<u8>,
+    _bytes: &[u8],
+    _hash: Option<BlobHash>,
+) {
 }
 
 fn key(bytes: Vec<u8>) -> StorageKey {
@@ -512,6 +871,8 @@ fn assemble_blob_bytes(
     mut metadata: BlobMetadata,
     chunk_rows_by_hash: &HashMap<BlobHash, Option<Bytes>>,
     chunked_manifest: Option<&Vec<KvBlobManifestChunk>>,
+    delta_bases_by_hash: &HashMap<BlobHash, Vec<u8>>,
+    dictionaries_by_hash: &HashMap<BlobHash, crate::compression::ZstdDictionaryDecoder>,
 ) -> Result<Vec<u8>, LixError> {
     let expected_blob_size = persisted_size_to_usize(metadata.size_bytes, "binary CAS blob")?;
     let bytes = match &metadata.layout {
@@ -537,15 +898,42 @@ fn assemble_blob_bytes(
                     ),
                 )
             })?;
-            decode_and_verify_payload(
-                inline_blob.codec,
-                metadata.size_bytes,
-                Cow::Owned(inline_blob.payload),
-                expected_blob_size,
-                metadata.hash,
-                metadata.hash,
-            )?
-            .into_owned()
+            match inline_blob {
+                InlineBlob::Full {
+                    codec,
+                    dictionary_hash,
+                    payload,
+                } => decode_inline_payload(
+                    metadata.hash,
+                    expected_blob_size,
+                    codec,
+                    dictionary_hash,
+                    payload,
+                    dictionaries_by_hash,
+                    true,
+                )?,
+                InlineBlob::Delta {
+                    base_blob_hash,
+                    prefix_len,
+                    suffix_len,
+                    middle_len,
+                    codec,
+                    dictionary_hash,
+                    payload,
+                } => assemble_inline_delta(
+                    metadata.hash,
+                    expected_blob_size,
+                    base_blob_hash,
+                    prefix_len,
+                    suffix_len,
+                    middle_len,
+                    codec,
+                    dictionary_hash,
+                    payload,
+                    delta_bases_by_hash,
+                    dictionaries_by_hash,
+                )?,
+            }
         }
         BlobLayout::SingleChunk { chunk_hash } => {
             let chunk = decode_chunk_from_map(
@@ -626,6 +1014,137 @@ fn assemble_blob_bytes(
         }
     };
     Ok(bytes)
+}
+
+#[expect(clippy::too_many_arguments)]
+fn assemble_inline_delta(
+    blob_hash: BlobHash,
+    expected_blob_size: usize,
+    base_blob_hash: BlobHash,
+    prefix_len: u64,
+    suffix_len: u64,
+    middle_len: u64,
+    codec: BinaryChunkCodec,
+    dictionary_hash: Option<BlobHash>,
+    payload: Vec<u8>,
+    delta_bases_by_hash: &HashMap<BlobHash, Vec<u8>>,
+    dictionaries_by_hash: &HashMap<BlobHash, crate::compression::ZstdDictionaryDecoder>,
+) -> Result<Vec<u8>, LixError> {
+    let base = delta_bases_by_hash.get(&base_blob_hash).ok_or_else(|| {
+        LixError::new(
+            LixError::CODE_UNKNOWN,
+            format!(
+                "binary CAS inline delta base '{}' was not loaded",
+                base_blob_hash.to_hex()
+            ),
+        )
+    })?;
+    let prefix_len = persisted_size_to_usize(prefix_len, "inline delta prefix")?;
+    let suffix_len = persisted_size_to_usize(suffix_len, "inline delta suffix")?;
+    let middle_len = persisted_size_to_usize(middle_len, "inline delta middle")?;
+    if prefix_len.saturating_add(suffix_len) > base.len()
+        || prefix_len
+            .checked_add(middle_len)
+            .and_then(|len| len.checked_add(suffix_len))
+            != Some(expected_blob_size)
+    {
+        return Err(LixError::new(
+            LixError::CODE_UNKNOWN,
+            format!(
+                "binary CAS inline delta '{}' has invalid ranges",
+                blob_hash.to_hex()
+            ),
+        ));
+    }
+    let middle = decode_inline_payload(
+        blob_hash,
+        middle_len,
+        codec,
+        dictionary_hash,
+        payload,
+        dictionaries_by_hash,
+        false,
+    )?;
+    if middle.len() != middle_len {
+        return Err(LixError::new(
+            LixError::CODE_UNKNOWN,
+            format!(
+                "binary CAS inline delta '{}' expected {middle_len} middle bytes, got {}",
+                blob_hash.to_hex(),
+                middle.len()
+            ),
+        ));
+    }
+    let mut out = Vec::with_capacity(expected_blob_size);
+    out.extend_from_slice(&base[..prefix_len]);
+    out.extend_from_slice(&middle);
+    out.extend_from_slice(&base[base.len() - suffix_len..]);
+    if BlobHash::from_content(&out) != blob_hash {
+        return Err(LixError::new(
+            LixError::CODE_UNKNOWN,
+            format!(
+                "binary CAS inline delta '{}' failed content verification",
+                blob_hash.to_hex()
+            ),
+        ));
+    }
+    Ok(out)
+}
+
+fn decode_inline_payload(
+    blob_hash: BlobHash,
+    uncompressed_len: usize,
+    codec: BinaryChunkCodec,
+    dictionary_hash: Option<BlobHash>,
+    payload: Vec<u8>,
+    dictionaries_by_hash: &HashMap<BlobHash, crate::compression::ZstdDictionaryDecoder>,
+    verify_content_hash: bool,
+) -> Result<Vec<u8>, LixError> {
+    let decoded = match (codec, dictionary_hash) {
+        (BinaryChunkCodec::Raw, None) => Ok(payload),
+        (BinaryChunkCodec::Zstd, None) => {
+            crate::compression::decompress_zstd(&payload, uncompressed_len)
+        }
+        (BinaryChunkCodec::Zstd, Some(dictionary_hash)) => {
+            let dictionary = dictionaries_by_hash.get(&dictionary_hash).ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_UNKNOWN,
+                    format!(
+                        "binary CAS dictionary '{}' was not loaded",
+                        dictionary_hash.to_hex()
+                    ),
+                )
+            })?;
+            dictionary.decompress(&payload, uncompressed_len)
+        }
+        (BinaryChunkCodec::Raw, Some(_)) => {
+            return Err(LixError::new(
+                LixError::CODE_UNKNOWN,
+                "binary CAS raw payload cannot reference a dictionary",
+            ));
+        }
+    }
+    .map_err(|error| {
+        LixError::new(
+            LixError::CODE_UNKNOWN,
+            format!(
+                "binary CAS inline payload '{}' decompression failed: {error}",
+                blob_hash.to_hex()
+            ),
+        )
+    })?;
+    if decoded.len() != uncompressed_len
+        || (verify_content_hash && BlobHash::from_content(&decoded) != blob_hash)
+    {
+        return Err(LixError::new(
+            LixError::CODE_UNKNOWN,
+            format!(
+                "binary CAS inline payload '{}' failed content-address verification",
+                blob_hash.to_hex()
+            ),
+        ));
+    }
+    Ok(decoded)
 }
 
 fn decode_chunk_from_map(
@@ -884,6 +1403,229 @@ where
         );
     }
     Ok(true)
+}
+
+pub(in crate::binary_cas) async fn try_stage_inline_delta<S>(
+    store: &S,
+    writes: &mut StorageWriteSet,
+    blob_hashes: &mut HashSet<[u8; 32]>,
+    bytes: &[u8],
+    precomputed_hash: Option<BlobHash>,
+    base_blob_hash: BlobHash,
+    dictionary: Option<&BinaryCasDictionary>,
+) -> Result<bool, LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    if bytes.is_empty() || bytes.len() > INLINE_BINARY_CAS_MAX_BYTES {
+        return Ok(false);
+    }
+    let blob_hash = precomputed_hash.unwrap_or_else(|| BlobHash::from_content(bytes));
+    if blob_hash == base_blob_hash {
+        return Ok(true);
+    }
+    if blob_hashes.contains(&blob_hash.into_bytes()) {
+        return Ok(true);
+    }
+    let mut metadata = load_metadata_many(store, &[base_blob_hash, blob_hash])
+        .await?
+        .into_vec();
+    if metadata.get(1).is_some_and(Option::is_some) {
+        blob_hashes.insert(blob_hash.into_bytes());
+        return Ok(true);
+    }
+    let Some(base_metadata) = metadata.get_mut(0).and_then(Option::take) else {
+        return Ok(false);
+    };
+    if !matches!(base_metadata.inline_blob, Some(InlineBlob::Full { .. })) {
+        return Ok(false);
+    }
+    let dictionaries = dictionary
+        .map(|dictionary| {
+            crate::compression::ZstdDictionaryDecoder::new(&dictionary.bytes)
+                .map(|decoder| (dictionary.hash, decoder))
+                .map_err(|error| {
+                    LixError::new(
+                        LixError::CODE_UNKNOWN,
+                        format!(
+                            "binary CAS dictionary '{}' failed to initialize: {error}",
+                            dictionary.hash.to_hex()
+                        ),
+                    )
+                })
+        })
+        .transpose()?
+        .into_iter()
+        .collect::<HashMap<_, _>>();
+    let base = assemble_blob_bytes(
+        base_metadata,
+        &HashMap::new(),
+        None,
+        &HashMap::new(),
+        &dictionaries,
+    )?;
+    let shared = base.len().min(bytes.len());
+    let prefix_len = base
+        .iter()
+        .zip(bytes)
+        .take(shared)
+        .take_while(|(left, right)| left == right)
+        .count();
+    let suffix_limit = (base.len() - prefix_len).min(bytes.len() - prefix_len);
+    let suffix_len = base
+        .iter()
+        .rev()
+        .zip(bytes.iter().rev())
+        .take(suffix_limit)
+        .take_while(|(left, right)| left == right)
+        .count();
+    let middle = &bytes[prefix_len..bytes.len() - suffix_len];
+    let encoded_middle = encode_chunk_payload(blob_hash, middle)?;
+    let mut delta = encode_inline_delta_binary_cas_manifest(
+        bytes.len() as u64,
+        base_blob_hash.into_bytes(),
+        prefix_len as u64,
+        suffix_len as u64,
+        middle.len() as u64,
+        encoded_middle.codec,
+        &encoded_middle.data,
+    );
+    let encoded_full_payload = encode_chunk_payload(blob_hash, bytes)?;
+    let mut full = encode_inline_binary_cas_manifest(
+        bytes.len() as u64,
+        encoded_full_payload.codec,
+        &encoded_full_payload.data,
+    );
+    if let Some(dictionary) = dictionary {
+        if let Some(compressed) = compress_with_dictionary(middle, dictionary)? {
+            let candidate = encode_inline_dictionary_delta_binary_cas_manifest(
+                bytes.len() as u64,
+                base_blob_hash.into_bytes(),
+                prefix_len as u64,
+                suffix_len as u64,
+                middle.len() as u64,
+                dictionary.hash.into_bytes(),
+                &compressed,
+            );
+            if candidate.len() < delta.len() {
+                delta = candidate;
+            }
+        }
+        if let Some(compressed) = compress_with_dictionary(bytes, dictionary)? {
+            let candidate = encode_inline_dictionary_binary_cas_manifest(
+                bytes.len() as u64,
+                dictionary.hash.into_bytes(),
+                &compressed,
+            );
+            if candidate.len() < full.len() {
+                full = candidate;
+            }
+        }
+    }
+    // The extra base point read must buy a material physical reduction.
+    // Requiring at least 12.5% and 128 bytes mirrors chunk compression's
+    // existing CPU/space gate and rejects noisy near-equal versions.
+    let minimum_savings = 128_usize.max(full.len().div_ceil(8));
+    if full.len().saturating_sub(delta.len()) < minimum_savings {
+        return Ok(false);
+    }
+    blob_hashes.insert(blob_hash.into_bytes());
+    writes.put(
+        BINARY_CAS_MANIFEST_SPACE,
+        key(manifest_key(blob_hash)),
+        value(delta),
+    );
+    Ok(true)
+}
+
+pub(in crate::binary_cas) async fn try_stage_inline_dictionary<S>(
+    store: &S,
+    writes: &mut StorageWriteSet,
+    blob_hashes: &mut HashSet<[u8; 32]>,
+    bytes: &[u8],
+    precomputed_hash: Option<BlobHash>,
+    dictionary: Option<&BinaryCasDictionary>,
+) -> Result<bool, LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    let Some(dictionary) = dictionary else {
+        return Ok(false);
+    };
+    if bytes.is_empty() || bytes.len() > INLINE_BINARY_CAS_MAX_BYTES {
+        return Ok(false);
+    }
+    let blob_hash = precomputed_hash.unwrap_or_else(|| BlobHash::from_content(bytes));
+    if blob_hashes.contains(&blob_hash.into_bytes()) {
+        return Ok(true);
+    }
+    if load_metadata_many(store, &[blob_hash])
+        .await?
+        .into_vec()
+        .into_iter()
+        .next()
+        .flatten()
+        .is_some()
+    {
+        blob_hashes.insert(blob_hash.into_bytes());
+        return Ok(true);
+    }
+    let Some(compressed) = compress_with_dictionary(bytes, dictionary)? else {
+        return Ok(false);
+    };
+    let candidate = encode_inline_dictionary_binary_cas_manifest(
+        bytes.len() as u64,
+        dictionary.hash.into_bytes(),
+        &compressed,
+    );
+    let ordinary = encode_chunk_payload(blob_hash, bytes)?;
+    let ordinary =
+        encode_inline_binary_cas_manifest(bytes.len() as u64, ordinary.codec, &ordinary.data);
+    let minimum_savings = 128_usize.max(ordinary.len().div_ceil(8));
+    if ordinary.len().saturating_sub(candidate.len()) < minimum_savings {
+        return Ok(false);
+    }
+    blob_hashes.insert(blob_hash.into_bytes());
+    writes.put(
+        BINARY_CAS_MANIFEST_SPACE,
+        key(manifest_key(blob_hash)),
+        value(candidate),
+    );
+    Ok(true)
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn compress_with_dictionary(
+    bytes: &[u8],
+    dictionary: &BinaryCasDictionary,
+) -> Result<Option<Vec<u8>>, LixError> {
+    if bytes.len() < 512 {
+        return Ok(None);
+    }
+    let compressor = dictionary
+        .compressor
+        .get_or_init(|| crate::compression::ZstdDictionaryCompressor::new(&dictionary.bytes))
+        .as_ref()
+        .map_err(|error| {
+            LixError::new(
+                LixError::CODE_UNKNOWN,
+                format!("binary CAS dictionary compression failed: {error}"),
+            )
+        })?;
+    compressor.compress(bytes).map(Some).map_err(|error| {
+        LixError::new(
+            LixError::CODE_UNKNOWN,
+            format!("binary CAS dictionary compression failed: {error}"),
+        )
+    })
+}
+
+#[cfg(target_family = "wasm")]
+fn compress_with_dictionary(
+    _bytes: &[u8],
+    _dictionary: &BinaryCasDictionary,
+) -> Result<Option<Vec<u8>>, LixError> {
+    Ok(None)
 }
 
 fn prepare_blob_write(
@@ -1200,7 +1942,99 @@ fn metadata_from_manifest(
                     ),
                 ));
             }
-            (BlobLayout::Inline, Some(InlineBlob { codec, payload }))
+            (
+                BlobLayout::Inline,
+                Some(InlineBlob::Full {
+                    codec,
+                    dictionary_hash: None,
+                    payload,
+                }),
+            )
+        }
+        BinaryCasManifest::InlineDelta {
+            size_bytes,
+            base_blob_hash,
+            prefix_len,
+            suffix_len,
+            middle_len,
+            codec,
+            payload,
+        } => {
+            if size_bytes == 0 || size_bytes > INLINE_BINARY_CAS_MAX_BYTES as u64 {
+                return Err(LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    format!(
+                        "binary CAS inline delta blob '{}' has invalid size {size_bytes}",
+                        hash.to_hex()
+                    ),
+                ));
+            }
+            (
+                BlobLayout::Inline,
+                Some(InlineBlob::Delta {
+                    base_blob_hash: BlobHash::from_bytes(base_blob_hash),
+                    prefix_len,
+                    suffix_len,
+                    middle_len,
+                    codec,
+                    dictionary_hash: None,
+                    payload,
+                }),
+            )
+        }
+        BinaryCasManifest::InlineDictionary {
+            size_bytes,
+            dictionary_hash,
+            payload,
+        } => {
+            if size_bytes == 0 || size_bytes > INLINE_BINARY_CAS_MAX_BYTES as u64 {
+                return Err(LixError::new(
+                    LixError::CODE_UNKNOWN,
+                    format!(
+                        "binary CAS dictionary inline blob '{}' has invalid size {size_bytes}",
+                        hash.to_hex()
+                    ),
+                ));
+            }
+            (
+                BlobLayout::Inline,
+                Some(InlineBlob::Full {
+                    codec: BinaryChunkCodec::Zstd,
+                    dictionary_hash: Some(BlobHash::from_bytes(dictionary_hash)),
+                    payload,
+                }),
+            )
+        }
+        BinaryCasManifest::InlineDictionaryDelta {
+            size_bytes,
+            base_blob_hash,
+            prefix_len,
+            suffix_len,
+            middle_len,
+            dictionary_hash,
+            payload,
+        } => {
+            if size_bytes == 0 || size_bytes > INLINE_BINARY_CAS_MAX_BYTES as u64 {
+                return Err(LixError::new(
+                    LixError::CODE_UNKNOWN,
+                    format!(
+                        "binary CAS dictionary inline delta '{}' has invalid size {size_bytes}",
+                        hash.to_hex()
+                    ),
+                ));
+            }
+            (
+                BlobLayout::Inline,
+                Some(InlineBlob::Delta {
+                    base_blob_hash: BlobHash::from_bytes(base_blob_hash),
+                    prefix_len,
+                    suffix_len,
+                    middle_len,
+                    codec: BinaryChunkCodec::Zstd,
+                    dictionary_hash: Some(BlobHash::from_bytes(dictionary_hash)),
+                    payload,
+                }),
+            )
         }
         BinaryCasManifest::SingleChunk { chunk_hash, .. } => (
             BlobLayout::SingleChunk {
@@ -1499,7 +2333,11 @@ mod tests {
             .expect("test blob read should open");
         BinaryCasContext::new()
             .writer_skipping_existing_chunks(&store, writes)
-            .stage_file_payload(payload, same_length_splice)
+            .stage_file_payload(
+                payload,
+                same_length_splice.map(|splice| splice.base_blob_hash),
+                same_length_splice,
+            )
             .await
             .expect("test file payload should stage");
     }
@@ -2008,6 +2846,281 @@ mod tests {
                 .into_vec(),
             vec![Some(data)]
         );
+    }
+
+    #[tokio::test]
+    async fn inline_updates_use_one_hop_prefix_suffix_deltas() {
+        let storage = StorageAdapter::new(Memory::new());
+        let base = deterministic_high_entropy_bytes(24 * 1024);
+        let mut updated = base.clone();
+        let edit = updated.len() / 2;
+        updated[edit..edit + 32].copy_from_slice(&[0x5a; 32]);
+        let base_hash = BlobHash::from_content(&base);
+        let updated_hash = BlobHash::from_content(&updated);
+
+        {
+            let mut writes = storage.new_write_set();
+            stage_test_bytes(&storage, &mut writes, &base).await;
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .expect("base blob should commit");
+        }
+        {
+            let store = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("delta staging read should open");
+            let mut writes = storage.new_write_set();
+            BinaryCasContext::new()
+                .writer_skipping_existing_chunks(&store, &mut writes)
+                .stage_file_payload(
+                    &BlobPayload::from_bytes(updated.clone()),
+                    Some(base_hash),
+                    None,
+                )
+                .await
+                .expect("delta blob should stage");
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .expect("delta blob should commit");
+        }
+
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("delta read should open");
+        let manifest = load_manifest(&store, updated_hash)
+            .await
+            .expect("delta manifest should load")
+            .expect("delta manifest should exist");
+        assert!(matches!(
+            manifest,
+            BinaryCasManifest::InlineDelta {
+                base_blob_hash: stored_base,
+                ..
+            } if stored_base == base_hash.into_bytes()
+        ));
+        assert_eq!(
+            load_bytes_many(&store, &[updated_hash])
+                .await
+                .expect("delta blob should load")
+                .into_vec(),
+            vec![Some(updated)]
+        );
+    }
+
+    #[tokio::test]
+    async fn dictionary_training_consumes_a_bounded_sample_set_once() {
+        let storage = StorageAdapter::new(Memory::new());
+        let mut staged_sample_slots = HashSet::new();
+        let mut writes = storage.new_write_set();
+        let mut ordinal = 0;
+        while staged_sample_slots.len() < BINARY_CAS_DICTIONARY_SAMPLE_SLOTS {
+            let sample = format!(
+                "component-{ordinal:04}: {}\n",
+                "shared repository vocabulary with a distinct field ".repeat(64)
+            )
+            .into_bytes();
+            let hash = BlobHash::from_content(&sample);
+            writes.put(
+                BINARY_CAS_MANIFEST_SPACE,
+                key(manifest_key(hash)),
+                value(encode_inline_binary_cas_manifest(
+                    sample.len() as u64,
+                    BinaryChunkCodec::Raw,
+                    &sample,
+                )),
+            );
+            stage_dictionary_sample(&mut writes, &mut staged_sample_slots, &sample, Some(hash));
+            ordinal += 1;
+            assert!(ordinal < 10_000, "test samples should fill every slot");
+        }
+        assert_eq!(
+            staged_sample_slots.len(),
+            BINARY_CAS_DICTIONARY_SAMPLE_SLOTS
+        );
+        assert_eq!(
+            writes.stats().staged_puts,
+            ordinal as u64 + BINARY_CAS_DICTIONARY_SAMPLE_SLOTS as u64
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("dictionary samples should commit");
+
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("dictionary training read should open");
+        let mut writes = storage.new_write_set();
+        let trained = load_or_train_dictionary(&store, &mut writes)
+            .await
+            .expect("dictionary should train")
+            .expect("enough samples should produce a dictionary");
+        assert!(!trained.bytes.is_empty());
+        assert!(trained.bytes.len() <= BINARY_CAS_DICTIONARY_BYTES);
+        assert_eq!(writes.stats().staged_puts, 2);
+        assert_eq!(
+            writes.stats().staged_deletes,
+            BINARY_CAS_DICTIONARY_SAMPLE_SLOTS as u64
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("trained dictionary should commit");
+
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("dictionary reuse read should open");
+        let mut writes = storage.new_write_set();
+        let reused = load_or_train_dictionary(&store, &mut writes)
+            .await
+            .expect("dictionary should load")
+            .expect("dictionary control should remain active");
+        assert_eq!(reused.hash, trained.hash);
+        assert_eq!(reused.bytes, trained.bytes);
+        assert_eq!(writes.stats().staged_puts, 0);
+        assert_eq!(writes.stats().staged_deletes, 0);
+        assert!(
+            scan_all_values(&store, BINARY_CAS_DICTIONARY_SAMPLE_SPACE, Vec::new())
+                .await
+                .expect("dictionary sample scan should complete")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn dictionary_inline_delta_roundtrips_and_authenticates_the_dictionary() {
+        let storage = StorageAdapter::new(Memory::new());
+        let training_samples = (0..128)
+            .map(|ordinal| {
+                format!(
+                    "section-{ordinal:04}: {}\n",
+                    "shared markdown vocabulary and stable document structure ".repeat(32)
+                )
+                .into_bytes()
+            })
+            .collect::<Vec<_>>();
+        let sample_refs = training_samples
+            .iter()
+            .map(Vec::as_slice)
+            .collect::<Vec<_>>();
+        let dictionary = zstd::dict::from_samples(&sample_refs, BINARY_CAS_DICTIONARY_BYTES)
+            .expect("test dictionary should train");
+        let dictionary_hash = BlobHash::from_content(&dictionary);
+
+        let base = [
+            b"stable-prefix\n".repeat(256),
+            b"old middle section\n".repeat(32),
+            b"stable-suffix\n".repeat(256),
+        ]
+        .concat();
+        let middle = b"shared markdown vocabulary and stable document structure\n".repeat(32);
+        let updated = [
+            b"stable-prefix\n".repeat(256),
+            middle.clone(),
+            b"stable-suffix\n".repeat(256),
+        ]
+        .concat();
+        let base_hash = BlobHash::from_content(&base);
+        let updated_hash = BlobHash::from_content(&updated);
+        let compressed_middle = crate::compression::ZstdDictionaryCompressor::new(&dictionary)
+            .expect("dictionary compressor should open")
+            .compress(&middle)
+            .expect("dictionary middle should compress");
+
+        let mut writes = storage.new_write_set();
+        writes.put(
+            BINARY_CAS_DICTIONARY_SPACE,
+            key(dictionary_hash.as_bytes().to_vec()),
+            value(dictionary),
+        );
+        writes.put(
+            BINARY_CAS_MANIFEST_SPACE,
+            key(manifest_key(base_hash)),
+            value(encode_inline_binary_cas_manifest(
+                base.len() as u64,
+                BinaryChunkCodec::Raw,
+                &base,
+            )),
+        );
+        writes.put(
+            BINARY_CAS_MANIFEST_SPACE,
+            key(manifest_key(updated_hash)),
+            value(encode_inline_dictionary_delta_binary_cas_manifest(
+                updated.len() as u64,
+                base_hash.into_bytes(),
+                (b"stable-prefix\n".len() * 256) as u64,
+                (b"stable-suffix\n".len() * 256) as u64,
+                middle.len() as u64,
+                dictionary_hash.into_bytes(),
+                &compressed_middle,
+            )),
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("dictionary delta fixture should commit");
+
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("dictionary delta read should open");
+        assert_eq!(
+            load_bytes_many(&store, &[updated_hash])
+                .await
+                .expect("dictionary delta should load")
+                .into_vec(),
+            vec![Some(updated)]
+        );
+
+        let missing_dictionary = BlobHash::from_content(b"missing dictionary");
+        let broken_hash = BlobHash::from_content(b"broken dictionary payload");
+        let mut writes = storage.new_write_set();
+        writes.put(
+            BINARY_CAS_MANIFEST_SPACE,
+            key(manifest_key(broken_hash)),
+            value(encode_inline_dictionary_binary_cas_manifest(
+                b"broken dictionary payload".len() as u64,
+                missing_dictionary.into_bytes(),
+                b"not a frame",
+            )),
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("broken dictionary fixture should commit");
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("broken dictionary read should open");
+        let error = load_bytes_many(&store, &[broken_hash])
+            .await
+            .expect_err("missing dictionary must be rejected");
+        assert!(error.message.contains("dictionary"));
+        assert!(error.message.contains("missing"));
+
+        let mut writes = storage.new_write_set();
+        writes.put(
+            BINARY_CAS_DICTIONARY_SPACE,
+            key(missing_dictionary.as_bytes().to_vec()),
+            value(b"wrong dictionary bytes".to_vec()),
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("corrupt dictionary fixture should commit");
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("corrupt dictionary read should open");
+        let error = load_bytes_many(&store, &[broken_hash])
+            .await
+            .expect_err("content-addressed dictionary must authenticate");
+        assert!(error.message.contains("content-address verification"));
     }
 
     #[tokio::test]

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -1437,10 +1437,14 @@ where
     let Some(base_metadata) = metadata.get_mut(0).and_then(Option::take) else {
         return Ok(false);
     };
-    if !matches!(base_metadata.inline_blob, Some(InlineBlob::Full { .. })) {
+    let Some(InlineBlob::Full {
+        dictionary_hash: base_dictionary_hash,
+        ..
+    }) = base_metadata.inline_blob.as_ref()
+    else {
         return Ok(false);
-    }
-    let dictionaries = dictionary
+    };
+    let mut dictionaries = dictionary
         .map(|dictionary| {
             crate::compression::ZstdDictionaryDecoder::new(&dictionary.bytes)
                 .map(|decoder| (dictionary.hash, decoder))
@@ -1457,6 +1461,26 @@ where
         .transpose()?
         .into_iter()
         .collect::<HashMap<_, _>>();
+    if let Some(base_dictionary_hash) = base_dictionary_hash
+        && !dictionaries.contains_key(base_dictionary_hash)
+    {
+        let Some(bytes) = point_value(
+            store,
+            BINARY_CAS_DICTIONARY_SPACE,
+            base_dictionary_hash.as_bytes().to_vec(),
+        )
+        .await?
+        else {
+            return Ok(false);
+        };
+        if BlobHash::from_content(&bytes) != *base_dictionary_hash {
+            return Ok(false);
+        }
+        let Ok(decoder) = crate::compression::ZstdDictionaryDecoder::new(&bytes) else {
+            return Ok(false);
+        };
+        dictionaries.insert(*base_dictionary_hash, decoder);
+    }
     let base = assemble_blob_bytes(
         base_metadata,
         &HashMap::new(),
@@ -2906,6 +2930,98 @@ mod tests {
             load_bytes_many(&store, &[updated_hash])
                 .await
                 .expect("delta blob should load")
+                .into_vec(),
+            vec![Some(updated)]
+        );
+    }
+
+    #[tokio::test]
+    async fn inline_delta_loads_the_base_dictionary_when_another_is_current() {
+        let storage = StorageAdapter::new(Memory::new());
+        let base = deterministic_high_entropy_bytes(24 * 1024);
+        let mut updated = base.clone();
+        let edit = updated.len() / 2;
+        updated[edit..edit + 32].copy_from_slice(&[b'x'; 32]);
+        let first_dictionary = base[..8 * 1024].to_vec();
+        let mut second_dictionary = deterministic_high_entropy_bytes(8 * 1024);
+        for byte in &mut second_dictionary {
+            *byte ^= 0xa5;
+        }
+        let first_hash = BlobHash::from_content(&first_dictionary);
+        let second_hash = BlobHash::from_content(&second_dictionary);
+        assert_ne!(first_hash, second_hash);
+
+        let base_hash = BlobHash::from_content(&base);
+        let updated_hash = BlobHash::from_content(&updated);
+        let compressed_base = crate::compression::ZstdDictionaryCompressor::new(&first_dictionary)
+            .expect("first dictionary compressor should open")
+            .compress(&base)
+            .expect("base should compress");
+
+        let mut writes = storage.new_write_set();
+        writes.put(
+            BINARY_CAS_DICTIONARY_SPACE,
+            key(first_hash.as_bytes().to_vec()),
+            value(first_dictionary),
+        );
+        writes.put(
+            BINARY_CAS_DICTIONARY_SPACE,
+            key(second_hash.as_bytes().to_vec()),
+            value(second_dictionary),
+        );
+        writes.put(
+            BINARY_CAS_DICTIONARY_CONTROL_SPACE,
+            key(BINARY_CAS_DICTIONARY_CONTROL_KEY.to_vec()),
+            value(second_hash.as_bytes().to_vec()),
+        );
+        writes.put(
+            BINARY_CAS_MANIFEST_SPACE,
+            key(manifest_key(base_hash)),
+            value(encode_inline_dictionary_binary_cas_manifest(
+                base.len() as u64,
+                first_hash.into_bytes(),
+                &compressed_base,
+            )),
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("concurrent dictionary fixture should commit");
+
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("delta staging read should open");
+        let mut writes = storage.new_write_set();
+        BinaryCasContext::new()
+            .writer_skipping_existing_chunks(&store, &mut writes)
+            .stage_file_payload(
+                &BlobPayload::from_bytes(updated.clone()),
+                Some(base_hash),
+                None,
+            )
+            .await
+            .expect("a non-current base dictionary should remain delta eligible");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("delta should commit");
+
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("delta read should open");
+        assert!(matches!(
+            load_manifest(&store, updated_hash)
+                .await
+                .expect("updated manifest should load"),
+            Some(BinaryCasManifest::InlineDelta { .. })
+                | Some(BinaryCasManifest::InlineDictionaryDelta { .. })
+        ));
+        assert_eq!(
+            load_bytes_many(&store, &[updated_hash])
+                .await
+                .expect("delta should read through its historical base dictionary")
                 .into_vec(),
             vec![Some(updated)]
         );

--- a/packages/engine/src/binary_cas/mod.rs
+++ b/packages/engine/src/binary_cas/mod.rs
@@ -9,6 +9,8 @@ mod stats;
 mod types;
 
 pub(crate) use chunking::BinaryCasChunking;
+#[cfg(feature = "storage-benches")]
+pub(crate) use codec::{BinaryCasManifest, BinaryChunkCodec, decode_binary_cas_manifest};
 pub(crate) use context::{BinaryCasContext, BlobDataReader};
 pub(crate) use kv::load_bytes_many;
 pub(crate) use types::{

--- a/packages/engine/src/binary_cas/mod.rs
+++ b/packages/engine/src/binary_cas/mod.rs
@@ -9,6 +9,8 @@ mod stats;
 mod types;
 
 pub(crate) use chunking::BinaryCasChunking;
+#[cfg(all(feature = "storage-benches", test))]
+pub(crate) use codec::encode_binary_cas_manifest;
 #[cfg(feature = "storage-benches")]
 pub(crate) use codec::{BinaryCasManifest, BinaryChunkCodec, decode_binary_cas_manifest};
 pub(crate) use context::{BinaryCasContext, BlobDataReader};

--- a/packages/engine/src/binary_cas/stats.rs
+++ b/packages/engine/src/binary_cas/stats.rs
@@ -48,7 +48,12 @@ where
             stats.logical_blob_bytes += manifest.size_bytes();
             match manifest {
                 BinaryCasManifest::Empty { .. } => stats.empty_blob_rows += 1,
-                BinaryCasManifest::Inline { .. } => stats.inline_blob_rows += 1,
+                BinaryCasManifest::Inline { .. }
+                | BinaryCasManifest::InlineDelta { .. }
+                | BinaryCasManifest::InlineDictionary { .. }
+                | BinaryCasManifest::InlineDictionaryDelta { .. } => {
+                    stats.inline_blob_rows += 1;
+                }
                 BinaryCasManifest::SingleChunk { .. } => {
                     stats.single_chunk_blob_rows += 1;
                     stats.total_chunk_refs += 1;

--- a/packages/engine/src/binary_cas/types.rs
+++ b/packages/engine/src/binary_cas/types.rs
@@ -102,9 +102,21 @@ pub(crate) enum BlobLayout {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct InlineBlob {
-    pub(crate) codec: BinaryChunkCodec,
-    pub(crate) payload: Vec<u8>,
+pub(crate) enum InlineBlob {
+    Full {
+        codec: BinaryChunkCodec,
+        dictionary_hash: Option<BlobHash>,
+        payload: Vec<u8>,
+    },
+    Delta {
+        base_blob_hash: BlobHash,
+        prefix_len: u64,
+        suffix_len: u64,
+        middle_len: u64,
+        codec: BinaryChunkCodec,
+        dictionary_hash: Option<BlobHash>,
+        payload: Vec<u8>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/packages/engine/src/compression.rs
+++ b/packages/engine/src/compression.rs
@@ -61,6 +61,105 @@ pub(crate) fn decompress_zstd(
     zstd::bulk::decompress(compressed_payload, uncompressed_len).map_err(|error| error.to_string())
 }
 
+#[cfg(not(target_family = "wasm"))]
+pub(crate) struct ZstdDictionaryCompressor {
+    compressor: std::sync::Mutex<zstd::bulk::Compressor<'static>>,
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl ZstdDictionaryCompressor {
+    pub(crate) fn new(dictionary: &[u8]) -> Result<Self, String> {
+        Ok(Self {
+            compressor: std::sync::Mutex::new(
+                zstd::bulk::Compressor::with_dictionary(1, dictionary)
+                    .map_err(|error| error.to_string())?,
+            ),
+        })
+    }
+
+    pub(crate) fn compress(&self, data: &[u8]) -> Result<Vec<u8>, String> {
+        self.compressor
+            .lock()
+            .map_err(|_| "zstd dictionary compressor lock was poisoned".to_string())?
+            .compress(data)
+            .map_err(|error| error.to_string())
+    }
+}
+
+pub(crate) struct ZstdDictionaryDecoder {
+    #[cfg(not(target_family = "wasm"))]
+    decompressor: std::sync::Mutex<zstd::bulk::Decompressor<'static>>,
+    #[cfg(target_family = "wasm")]
+    dictionary: Vec<u8>,
+}
+
+impl ZstdDictionaryDecoder {
+    pub(crate) fn new(dictionary: &[u8]) -> Result<Self, String> {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            Ok(Self {
+                decompressor: std::sync::Mutex::new(
+                    zstd::bulk::Decompressor::with_dictionary(dictionary)
+                        .map_err(|error| error.to_string())?,
+                ),
+            })
+        }
+        #[cfg(target_family = "wasm")]
+        {
+            Ok(Self {
+                dictionary: dictionary.to_vec(),
+            })
+        }
+    }
+
+    pub(crate) fn decompress(
+        &self,
+        compressed_payload: &[u8],
+        uncompressed_len: usize,
+    ) -> Result<Vec<u8>, String> {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            self.decompressor
+                .lock()
+                .map_err(|_| "zstd dictionary decompressor lock was poisoned".to_string())?
+                .decompress(compressed_payload, uncompressed_len)
+                .map_err(|error| error.to_string())
+        }
+        #[cfg(target_family = "wasm")]
+        {
+            decompress_zstd_with_dictionary(compressed_payload, uncompressed_len, &self.dictionary)
+        }
+    }
+}
+
+#[cfg(target_family = "wasm")]
+pub(crate) fn decompress_zstd_with_dictionary(
+    compressed_payload: &[u8],
+    uncompressed_len: usize,
+    dictionary: &[u8],
+) -> Result<Vec<u8>, String> {
+    use std::io::Read as _;
+
+    validate_zstd_frame_limits(compressed_payload, uncompressed_len)?;
+    let dictionary =
+        ruzstd::decoding::Dictionary::decode_dict(dictionary).map_err(|error| error.to_string())?;
+    let mut frame = ruzstd::decoding::FrameDecoder::new();
+    frame
+        .add_dict(dictionary)
+        .map_err(|error| error.to_string())?;
+    let decoder = ruzstd::decoding::StreamingDecoder::new_with_decoder(compressed_payload, frame)
+        .map_err(|error| error.to_string())?;
+    let output_limit = u64::try_from(uncompressed_len)
+        .unwrap_or(u64::MAX)
+        .saturating_add(1);
+    let mut limited = decoder.take(output_limit);
+    let mut output = Vec::new();
+    limited
+        .read_to_end(&mut output)
+        .map_err(|error| error.to_string())?;
+    Ok(output)
+}
+
 #[cfg(target_family = "wasm")]
 pub(crate) fn decompress_zstd(
     compressed_payload: &[u8],

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -45,7 +45,7 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"packed-current-checkpoint-baseline.v28";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"binary-history-dictionary.v29";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -311,9 +311,32 @@ pub struct StorageLayoutAccounting {
     pub value_bytes: u64,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BinaryManifestLayoutAccounting {
+    pub manifests: u64,
+    pub encoded_bytes: u64,
+    pub inline_manifests: u64,
+    pub inline_original_bytes: u64,
+    pub inline_payload_bytes: u64,
+    pub inline_raw_manifests: u64,
+    pub inline_zstd_manifests: u64,
+    pub inline_concat_zstd1_bytes: u64,
+    pub inline_concat_zstd3_bytes: u64,
+    pub inline_concat_zstd9_bytes: u64,
+    pub inline_dict64k_zstd3_bytes: u64,
+    pub inline_dict64k_bytes: u64,
+    pub inline_individual_zstd3_bytes: u64,
+    pub inline_individual_zstd9_bytes: u64,
+    pub empty_manifests: u64,
+    pub single_chunk_manifests: u64,
+    pub chunked_manifests: u64,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CommitDeltaLayoutAccounting {
     pub commit_id: String,
+    pub physical_key_bytes: u64,
+    pub physical_value_bytes: u64,
     pub segment_count: usize,
     pub members: usize,
     pub authored_members: usize,
@@ -321,6 +344,9 @@ pub struct CommitDeltaLayoutAccounting {
     pub selected_tombstones: usize,
     pub certified_members: usize,
     pub selected_certified_members: usize,
+    pub selected_direct_addresses: usize,
+    pub selected_source_commits: usize,
+    pub dominant_selected_source_members: usize,
 }
 
 pub async fn commit_delta_layout_accounting<R>(
@@ -330,6 +356,54 @@ where
     R: StorageAdapterRead,
 {
     let inventory = crate::tracked_state::scan_commit_delta_inventory(read).await?;
+    let mut physical_bytes_by_commit =
+        std::collections::BTreeMap::<crate::changelog::CommitId, (u64, u64)>::new();
+    for space in [
+        crate::tracked_state::TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
+        crate::tracked_state::TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
+    ] {
+        for entry in scan_layout_entries(read, space).await {
+            let commit_id_bytes: [u8; 16] = entry
+                .key
+                .0
+                .get(..16)
+                .and_then(|bytes| bytes.try_into().ok())
+                .ok_or_else(|| {
+                    crate::LixError::new(
+                        crate::LixError::CODE_INTERNAL_ERROR,
+                        "benchmark commit-delta key has no commit UUID",
+                    )
+                })?;
+            let commit_id =
+                crate::changelog::CommitId::new(uuid::Uuid::from_bytes(commit_id_bytes));
+            let physical = physical_bytes_by_commit.entry(commit_id).or_default();
+            physical.0 += entry.key.0.len() as u64 + 4;
+            physical.1 += match entry.value {
+                StorageProjectedValue::KeyOnly => 0,
+                StorageProjectedValue::FullValue(value) => value.len() as u64,
+            };
+        }
+    }
+    let locator_entries = scan_layout_entries(
+        read,
+        crate::tracked_state::TRACKED_STATE_CHANGE_LOCATOR_SPACE,
+    )
+    .await;
+    let mut locator_commit_by_change_id = std::collections::BTreeMap::new();
+    for entry in locator_entries {
+        let change_id_bytes: [u8; 16] = entry.key.0.as_ref().try_into().map_err(|_| {
+            crate::LixError::new(
+                crate::LixError::CODE_INTERNAL_ERROR,
+                "benchmark change locator key is not one UUID",
+            )
+        })?;
+        let change_id = crate::changelog::ChangeId::new(uuid::Uuid::from_bytes(change_id_bytes));
+        let StorageProjectedValue::FullValue(value) = entry.value else {
+            unreachable!("change locator layout scan requests full values");
+        };
+        let locator = crate::tracked_state::decode_change_locator(change_id, &value)?;
+        locator_commit_by_change_id.insert(change_id, locator.commit_id);
+    }
     let certified_change_ids = inventory
         .commits
         .values()
@@ -337,6 +411,17 @@ where
         .filter(|member| member.is_certified_payload_ref())
         .map(|member| member.value.change_id)
         .collect::<std::collections::BTreeSet<_>>();
+    let authored_commit_by_change_id = inventory
+        .commits
+        .iter()
+        .flat_map(|(commit_id, entry)| {
+            entry
+                .members
+                .iter()
+                .filter(|member| member.authored)
+                .map(|member| (member.value.change_id, *commit_id))
+        })
+        .collect::<std::collections::BTreeMap<_, _>>();
     Ok(inventory
         .commits
         .into_iter()
@@ -369,8 +454,47 @@ where
                         && certified_change_ids.contains(&member.value.change_id)
                 })
                 .count();
+            let selected_direct_addresses = entry
+                .members
+                .iter()
+                .filter(|member| {
+                    member.is_selected_payload_ref()
+                        && crate::tracked_state::direct_change_locator(member.value.change_id)
+                            .is_some()
+                })
+                .count();
+            let mut selected_members_by_source = std::collections::BTreeMap::<_, usize>::new();
+            for member in entry
+                .members
+                .iter()
+                .filter(|member| member.is_selected_payload_ref())
+            {
+                if let Some(source_commit_id) = authored_commit_by_change_id
+                    .get(&member.value.change_id)
+                    .copied()
+                    .or_else(|| {
+                        crate::tracked_state::direct_change_locator(member.value.change_id)
+                            .map(|locator| locator.commit_id)
+                    })
+                    .or_else(|| {
+                        locator_commit_by_change_id
+                            .get(&member.value.change_id)
+                            .copied()
+                    })
+                {
+                    *selected_members_by_source
+                        .entry(source_commit_id)
+                        .or_default() += 1;
+                }
+            }
             CommitDeltaLayoutAccounting {
                 commit_id: commit_id.to_string(),
+                physical_key_bytes: physical_bytes_by_commit
+                    .get(&commit_id)
+                    .map_or(0, |bytes| bytes.0),
+                physical_value_bytes: physical_bytes_by_commit
+                    .get(&commit_id)
+                    .map_or(0, |bytes| bytes.1),
                 segment_count: entry.segment_count,
                 members: entry.members.len(),
                 authored_members,
@@ -378,6 +502,13 @@ where
                 selected_tombstones,
                 certified_members,
                 selected_certified_members,
+                selected_direct_addresses,
+                selected_source_commits: selected_members_by_source.len(),
+                dominant_selected_source_members: selected_members_by_source
+                    .values()
+                    .copied()
+                    .max()
+                    .unwrap_or_default(),
             }
         })
         .collect())
@@ -405,6 +536,131 @@ where
         accounting.push(scan_layout_space(read, *space).await);
     }
     accounting
+}
+
+pub async fn binary_manifest_layout_accounting<R>(
+    read: &R,
+) -> Result<BinaryManifestLayoutAccounting, crate::LixError>
+where
+    R: StorageAdapterRead,
+{
+    let entries = scan_layout_entries(read, crate::binary_cas::kv::BINARY_CAS_MANIFEST_SPACE).await;
+    let mut accounting = BinaryManifestLayoutAccounting::default();
+    let mut inline_contents = Vec::new();
+    let mut inline_samples = Vec::new();
+    for entry in entries {
+        let StorageProjectedValue::FullValue(value) = entry.value else {
+            unreachable!("binary manifest layout scan requests full values");
+        };
+        accounting.manifests += 1;
+        accounting.encoded_bytes += value.len() as u64;
+        match crate::binary_cas::decode_binary_cas_manifest(&value)? {
+            crate::binary_cas::BinaryCasManifest::Empty { .. } => {
+                accounting.empty_manifests += 1;
+            }
+            crate::binary_cas::BinaryCasManifest::SingleChunk { .. } => {
+                accounting.single_chunk_manifests += 1;
+            }
+            crate::binary_cas::BinaryCasManifest::Chunked { .. } => {
+                accounting.chunked_manifests += 1;
+            }
+            crate::binary_cas::BinaryCasManifest::Inline {
+                size_bytes,
+                codec,
+                payload,
+            } => {
+                accounting.inline_manifests += 1;
+                accounting.inline_original_bytes += size_bytes;
+                accounting.inline_payload_bytes += payload.len() as u64;
+                match codec {
+                    crate::binary_cas::BinaryChunkCodec::Raw => {
+                        accounting.inline_raw_manifests += 1;
+                        inline_contents.extend_from_slice(&payload);
+                        inline_samples.push(payload);
+                    }
+                    crate::binary_cas::BinaryChunkCodec::Zstd => {
+                        accounting.inline_zstd_manifests += 1;
+                        let decoded = crate::compression::decompress_zstd(
+                            &payload,
+                            usize::try_from(size_bytes).expect("inline size fits usize"),
+                        )
+                        .map_err(|error| {
+                            crate::LixError::new(
+                                crate::LixError::CODE_INTERNAL_ERROR,
+                                format!(
+                                    "benchmark binary manifest payload failed to decode: {error}"
+                                ),
+                            )
+                        })?;
+                        inline_contents.extend_from_slice(&decoded);
+                        inline_samples.push(decoded);
+                    }
+                }
+            }
+            crate::binary_cas::BinaryCasManifest::InlineDelta { .. } => {
+                // Delta layouts require their base manifest to reconstruct
+                // original bytes. The retained baseline profiler predates
+                // this format; candidate accounting is added with the codec.
+                accounting.inline_manifests += 1;
+            }
+            crate::binary_cas::BinaryCasManifest::InlineDictionary {
+                size_bytes,
+                payload,
+                ..
+            } => {
+                accounting.inline_manifests += 1;
+                accounting.inline_original_bytes += size_bytes;
+                accounting.inline_payload_bytes += payload.len() as u64;
+                accounting.inline_zstd_manifests += 1;
+            }
+            crate::binary_cas::BinaryCasManifest::InlineDictionaryDelta { payload, .. } => {
+                accounting.inline_manifests += 1;
+                accounting.inline_payload_bytes += payload.len() as u64;
+                accounting.inline_zstd_manifests += 1;
+            }
+        }
+    }
+    accounting.inline_concat_zstd1_bytes = zstd::bulk::compress(&inline_contents, 1)
+        .expect("benchmark zstd-1 should encode")
+        .len() as u64;
+    accounting.inline_concat_zstd3_bytes = zstd::bulk::compress(&inline_contents, 3)
+        .expect("benchmark zstd-3 should encode")
+        .len() as u64;
+    accounting.inline_concat_zstd9_bytes = zstd::bulk::compress(&inline_contents, 9)
+        .expect("benchmark zstd-9 should encode")
+        .len() as u64;
+    let sample_refs = inline_samples.iter().map(Vec::as_slice).collect::<Vec<_>>();
+    let dictionary = zstd::dict::from_samples(&sample_refs, 64 * 1024)
+        .expect("benchmark dictionary should train");
+    let mut compressor = zstd::bulk::Compressor::with_dictionary(3, &dictionary)
+        .expect("benchmark dictionary compressor should initialize");
+    accounting.inline_dict64k_zstd3_bytes = inline_samples
+        .iter()
+        .map(|sample| {
+            compressor
+                .compress(sample)
+                .expect("benchmark dictionary frame should encode")
+                .len() as u64
+        })
+        .sum();
+    accounting.inline_dict64k_bytes = dictionary.len() as u64;
+    accounting.inline_individual_zstd3_bytes = inline_samples
+        .iter()
+        .map(|sample| {
+            zstd::bulk::compress(sample, 3)
+                .expect("benchmark individual zstd-3 frame should encode")
+                .len() as u64
+        })
+        .sum();
+    accounting.inline_individual_zstd9_bytes = inline_samples
+        .iter()
+        .map(|sample| {
+            zstd::bulk::compress(sample, 9)
+                .expect("benchmark individual zstd-9 frame should encode")
+                .len() as u64
+        })
+        .sum();
+    Ok(accounting)
 }
 
 /// Per-row (key, value bytes) inventory of one space.
@@ -469,6 +725,9 @@ fn native_storage_spaces() -> &'static [crate::storage_adapter::StorageSpace] {
         crate::binary_cas::kv::BINARY_CAS_MANIFEST_CHUNK_SPACE,
         crate::binary_cas::kv::BINARY_CAS_CHUNK_PRESENCE_SPACE,
         crate::binary_cas::kv::BINARY_CAS_CHUNK_SPACE,
+        crate::binary_cas::kv::BINARY_CAS_DICTIONARY_SPACE,
+        crate::binary_cas::kv::BINARY_CAS_DICTIONARY_CONTROL_SPACE,
+        crate::binary_cas::kv::BINARY_CAS_DICTIONARY_SAMPLE_SPACE,
         crate::changelog::COMMIT_SPACE,
         crate::changelog::CHANGE_SPACE,
         crate::changelog::COMMIT_CHANGE_ID_SPACE,

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -597,11 +597,23 @@ where
                     }
                 }
             }
-            crate::binary_cas::BinaryCasManifest::InlineDelta { .. } => {
-                // Delta layouts require their base manifest to reconstruct
-                // original bytes. The retained baseline profiler predates
-                // this format; candidate accounting is added with the codec.
+            crate::binary_cas::BinaryCasManifest::InlineDelta {
+                size_bytes,
+                codec,
+                payload,
+                ..
+            } => {
                 accounting.inline_manifests += 1;
+                accounting.inline_original_bytes += size_bytes;
+                accounting.inline_payload_bytes += payload.len() as u64;
+                match codec {
+                    crate::binary_cas::BinaryChunkCodec::Raw => {
+                        accounting.inline_raw_manifests += 1;
+                    }
+                    crate::binary_cas::BinaryChunkCodec::Zstd => {
+                        accounting.inline_zstd_manifests += 1;
+                    }
+                }
             }
             crate::binary_cas::BinaryCasManifest::InlineDictionary {
                 size_bytes,
@@ -613,37 +625,63 @@ where
                 accounting.inline_payload_bytes += payload.len() as u64;
                 accounting.inline_zstd_manifests += 1;
             }
-            crate::binary_cas::BinaryCasManifest::InlineDictionaryDelta { payload, .. } => {
+            crate::binary_cas::BinaryCasManifest::InlineDictionaryDelta {
+                size_bytes,
+                payload,
+                ..
+            } => {
                 accounting.inline_manifests += 1;
+                accounting.inline_original_bytes += size_bytes;
                 accounting.inline_payload_bytes += payload.len() as u64;
                 accounting.inline_zstd_manifests += 1;
             }
         }
     }
-    accounting.inline_concat_zstd1_bytes = zstd::bulk::compress(&inline_contents, 1)
-        .expect("benchmark zstd-1 should encode")
-        .len() as u64;
-    accounting.inline_concat_zstd3_bytes = zstd::bulk::compress(&inline_contents, 3)
-        .expect("benchmark zstd-3 should encode")
-        .len() as u64;
-    accounting.inline_concat_zstd9_bytes = zstd::bulk::compress(&inline_contents, 9)
-        .expect("benchmark zstd-9 should encode")
-        .len() as u64;
-    let sample_refs = inline_samples.iter().map(Vec::as_slice).collect::<Vec<_>>();
-    let dictionary = zstd::dict::from_samples(&sample_refs, 64 * 1024)
-        .expect("benchmark dictionary should train");
-    let mut compressor = zstd::bulk::Compressor::with_dictionary(3, &dictionary)
-        .expect("benchmark dictionary compressor should initialize");
-    accounting.inline_dict64k_zstd3_bytes = inline_samples
-        .iter()
-        .map(|sample| {
-            compressor
-                .compress(sample)
-                .expect("benchmark dictionary frame should encode")
-                .len() as u64
-        })
-        .sum();
-    accounting.inline_dict64k_bytes = dictionary.len() as u64;
+    if !inline_contents.is_empty() {
+        accounting.inline_concat_zstd1_bytes = zstd::bulk::compress(&inline_contents, 1)
+            .expect("benchmark zstd-1 should encode")
+            .len() as u64;
+        accounting.inline_concat_zstd3_bytes = zstd::bulk::compress(&inline_contents, 3)
+            .expect("benchmark zstd-3 should encode")
+            .len() as u64;
+        accounting.inline_concat_zstd9_bytes = zstd::bulk::compress(&inline_contents, 9)
+            .expect("benchmark zstd-9 should encode")
+            .len() as u64;
+    }
+    if inline_samples.len() >= 32 && inline_samples.iter().map(Vec::len).sum::<usize>() >= 32 * 512
+    {
+        let sample_refs = inline_samples.iter().map(Vec::as_slice).collect::<Vec<_>>();
+        let dictionary = zstd::dict::from_samples(&sample_refs, 64 * 1024).map_err(|error| {
+            crate::LixError::new(
+                crate::LixError::CODE_INTERNAL_ERROR,
+                format!("benchmark dictionary failed to train: {error}"),
+            )
+        })?;
+        let mut compressor =
+            zstd::bulk::Compressor::with_dictionary(3, &dictionary).map_err(|error| {
+                crate::LixError::new(
+                    crate::LixError::CODE_INTERNAL_ERROR,
+                    format!("benchmark dictionary compressor failed to initialize: {error}"),
+                )
+            })?;
+        accounting.inline_dict64k_zstd3_bytes = inline_samples
+            .iter()
+            .map(|sample| {
+                compressor
+                    .compress(sample)
+                    .map(|encoded| encoded.len() as u64)
+                    .map_err(|error| {
+                        crate::LixError::new(
+                            crate::LixError::CODE_INTERNAL_ERROR,
+                            format!("benchmark dictionary frame failed to encode: {error}"),
+                        )
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .sum();
+        accounting.inline_dict64k_bytes = dictionary.len() as u64;
+    }
     accounting.inline_individual_zstd3_bytes = inline_samples
         .iter()
         .map(|sample| {
@@ -839,12 +877,15 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        CheckpointCommitScanBenchMode, plan_repository_gc_for_bench,
+        BinaryManifestLayoutAccounting, CheckpointCommitScanBenchMode,
+        binary_manifest_layout_accounting, plan_repository_gc_for_bench,
         scan_checkpoint_commits_for_bench,
     };
     use crate::Engine;
     use crate::changelog::bench::{append_ordered_commits, stage_append_once};
-    use crate::storage_adapter::{Memory, StorageAdapter};
+    use crate::storage_adapter::{
+        Memory, StorageAdapter, StorageKey, StorageValue, StorageWriteOptions,
+    };
 
     #[tokio::test]
     async fn checkpoint_commit_scan_baseline_matches_materialized_records_across_pages() {
@@ -903,6 +944,78 @@ mod tests {
                 .map(|(_, value)| value.len() as u64)
                 .sum::<u64>()
         );
+    }
+
+    #[tokio::test]
+    async fn binary_manifest_accounting_handles_empty_and_delta_only_repositories() {
+        let adapter = StorageAdapter::new(Memory::new());
+        let read = adapter
+            .begin_read(crate::ReadOptions::default())
+            .await
+            .expect("begin empty manifest accounting read");
+        assert_eq!(
+            binary_manifest_layout_accounting(&read)
+                .await
+                .expect("empty manifest accounting should not train a dictionary"),
+            BinaryManifestLayoutAccounting::default()
+        );
+        drop(read);
+
+        let mut writes = adapter.new_write_set();
+        writes.put(
+            crate::binary_cas::kv::BINARY_CAS_MANIFEST_SPACE,
+            StorageKey(bytes::Bytes::from(vec![1; 32])),
+            StorageValue {
+                bytes: bytes::Bytes::from(crate::binary_cas::encode_binary_cas_manifest(
+                    &crate::binary_cas::BinaryCasManifest::InlineDelta {
+                        size_bytes: 1_000,
+                        base_blob_hash: [3; 32],
+                        prefix_len: 400,
+                        suffix_len: 590,
+                        middle_len: 10,
+                        codec: crate::binary_cas::BinaryChunkCodec::Raw,
+                        payload: vec![4; 10],
+                    },
+                )),
+            },
+        );
+        writes.put(
+            crate::binary_cas::kv::BINARY_CAS_MANIFEST_SPACE,
+            StorageKey(bytes::Bytes::from(vec![2; 32])),
+            StorageValue {
+                bytes: bytes::Bytes::from(crate::binary_cas::encode_binary_cas_manifest(
+                    &crate::binary_cas::BinaryCasManifest::InlineDictionaryDelta {
+                        size_bytes: 2_000,
+                        base_blob_hash: [5; 32],
+                        prefix_len: 900,
+                        suffix_len: 1_080,
+                        middle_len: 20,
+                        dictionary_hash: [6; 32],
+                        payload: vec![7; 20],
+                    },
+                )),
+            },
+        );
+        adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("delta manifest fixtures should commit");
+
+        let read = adapter
+            .begin_read(crate::ReadOptions::default())
+            .await
+            .expect("begin delta manifest accounting read");
+        let accounting = binary_manifest_layout_accounting(&read)
+            .await
+            .expect("delta-only accounting should not train a dictionary");
+        assert_eq!(accounting.manifests, 2);
+        assert_eq!(accounting.inline_manifests, 2);
+        assert_eq!(accounting.inline_original_bytes, 3_000);
+        assert_eq!(accounting.inline_payload_bytes, 30);
+        assert_eq!(accounting.inline_raw_manifests, 1);
+        assert_eq!(accounting.inline_zstd_manifests, 1);
+        assert_eq!(accounting.inline_dict64k_bytes, 0);
+        assert_eq!(accounting.inline_dict64k_zstd3_bytes, 0);
     }
 
     #[tokio::test]

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -42,7 +42,7 @@ pub(crate) use storage::{
 pub(crate) use storage::{
     TRACKED_STATE_CHANGE_LOCATOR_SPACE, TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
     TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, TRACKED_STATE_COMMIT_ROOT_SPACE,
-    TRACKED_STATE_TREE_CHUNK_SPACE,
+    TRACKED_STATE_TREE_CHUNK_SPACE, decode_change_locator, direct_change_locator,
 };
 pub(crate) use types::{
     MaterializedTrackedStateRow, TrackedStateCommitDeltaRef, TrackedStateDeltaRef,

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -1323,7 +1323,7 @@ async fn load_canonical_change_locator(
     direct_error.map_or(Ok(None), Err)
 }
 
-fn direct_change_locator(
+pub(crate) fn direct_change_locator(
     change_id: crate::changelog::ChangeId,
 ) -> Option<CommitDeltaChangeLocator> {
     let mut commit_bytes = *change_id.as_uuid().as_bytes();
@@ -1701,7 +1701,7 @@ async fn try_load_change_record_at_locator_in_manifest(
     ))
 }
 
-fn decode_change_locator(
+pub(crate) fn decode_change_locator(
     change_id: crate::changelog::ChangeId,
     bytes: &[u8],
 ) -> Result<CommitDeltaChangeLocator, LixError> {
@@ -3985,8 +3985,9 @@ mod tests {
 
     use crate::LixError;
     use crate::binary_cas::kv::{
-        BINARY_CAS_CHUNK_PRESENCE_SPACE, BINARY_CAS_CHUNK_SPACE, BINARY_CAS_MANIFEST_CHUNK_SPACE,
-        BINARY_CAS_MANIFEST_SPACE,
+        BINARY_CAS_CHUNK_PRESENCE_SPACE, BINARY_CAS_CHUNK_SPACE,
+        BINARY_CAS_DICTIONARY_CONTROL_SPACE, BINARY_CAS_DICTIONARY_SAMPLE_SPACE,
+        BINARY_CAS_DICTIONARY_SPACE, BINARY_CAS_MANIFEST_CHUNK_SPACE, BINARY_CAS_MANIFEST_SPACE,
     };
     use crate::branch::BRANCH_HEAD_CONTROL_SPACE;
     use crate::changelog::{
@@ -6224,6 +6225,9 @@ mod tests {
             BINARY_CAS_MANIFEST_CHUNK_SPACE,
             BINARY_CAS_CHUNK_PRESENCE_SPACE,
             BINARY_CAS_CHUNK_SPACE,
+            BINARY_CAS_DICTIONARY_SPACE,
+            BINARY_CAS_DICTIONARY_CONTROL_SPACE,
+            BINARY_CAS_DICTIONARY_SAMPLE_SPACE,
             COMMIT_SPACE,
             CHANGE_SPACE,
             COMMIT_CHANGE_ID_SPACE,

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -182,7 +182,11 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
                 continue;
             }
             blob_writer
-                .stage_file_payload(write.payload(), write.same_length_blob_splice())
+                .stage_file_payload(
+                    write.payload(),
+                    write.base_blob_hash(),
+                    write.same_length_blob_splice(),
+                )
                 .instrument(tracing::debug_span!(
                     target: "lix_perf",
                     "lix.perf.binary_cas_stage_payload"

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -1360,7 +1360,6 @@ impl TransactionFileData {
         self.same_length_blob_splice
     }
 
-    #[cfg(test)]
     pub(crate) fn base_blob_hash(&self) -> Option<BlobHash> {
         self.base_blob_hash
     }


### PR DESCRIPTION
## Summary

- encode small binary history as authenticated one-hop prefix/suffix deltas when a full inline base is available
- train one content-addressed 64 KiB zstd dictionary from a hard-bounded repository sample set
- keep sample state constant at 64 hash slots, consume the first 32 occupied slots once, and remove all sample rows after training
- cache native zstd dictionary contexts per write/read batch
- let WASM readers decode native dictionary-backed manifests with `ruzstd` 0.8.3; WASM never trains or writes dictionary samples
- hard-cut the repository protocol to `binary-history-dictionary.v29`
- extend storage-layout profiling with physical/logical binary-manifest and commit-delta source accounting

The delta base is always a full inline manifest, so reads remain one hop. Dictionary rows and reconstructed blobs are content-address authenticated.

## Data

OpenClaw replay with Markdown/CSV/text plugins and a checkpoint after every Git commit:

| Replay | Baseline | Candidate | Change |
|---|---:|---:|---:|
| 50 commits, DB bytes | 3,588,044 | 3,291,024 | -8.28% |
| 50 commits, replay | 1.152 s | 1.091 s | -5.3% |
| 500 commits, DB bytes | 26,174,143 | 23,458,765 | -10.37% |

The 500-commit candidate verified all 500 checkpoints and final state. Its raw replay was 25.555 s versus an older 24.152 s baseline, but 1.041 s of the 1.119 s checkpoint delta was one compaction/GC outlier at a different commit than the equivalent outlier in the prior candidate run. Excluding that unrelated event leaves about 1.5%; the baseline also predates the latest runtime merges, so this is not presented as a clean runtime comparison.

The measured dictionary setup hot path improved from 26.644 ms to 2.377 ms for 2,000 payloads (11.2x), and the 500-commit candidate spent about 350 ms less reading blobs.

Git LFS/binary coverage used two `vscode-docs` commits with 6,973 materialized LFS files totaling 2,724,026,017 bytes. All commits and the full final tree verified; the retained Lix DB is 2,587,692,411 bytes.

All replay databases were retained for storage inspection and follow-up queries.

## Validation

- `cargo check -p lix_engine --all-targets --features storage-benches`
- `cargo clippy -p lix_engine --all-targets --features storage-benches -- -D warnings`
- `cargo test -p lix_engine binary_cas:: --lib` (46 passed)
- `cargo test -p lix_engine merge --lib` (48 passed)
- `cargo test -p lix_engine diff --lib` (84 passed)
- `cargo test -p lix_engine checkpoint --lib` (17 passed)
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check -p lix_js_sdk --target wasm32-unknown-unknown`

Native Rust validation used mold for linking.
