### PR TITLE
perf(plugin): retain host-validated entity authority

### DIFF
--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -8844,6 +8844,7 @@ mod tests {
             schema_keys: vec![SCHEMA_KEY.to_owned()],
             row_count: 1,
             creates,
+            create_ranges: Vec::new(),
             complete_file_state: true,
             pages: vec![Bytes::from(page)],
         };

--- a/packages/engine/src/plugin/actor.rs
+++ b/packages/engine/src/plugin/actor.rs
@@ -5,7 +5,7 @@
 //! deliberately keys path, incarnation, and plugin generation in addition to
 //! the file id: none of those identities may be inferred from equal bytes.
 
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -15,7 +15,10 @@ use tokio::sync::{
 };
 
 use super::incremental::FileBytesSha256;
-use crate::wasm::{WasmComponentActor, WasmDocumentCheckpoint, WasmDocumentHandle};
+use crate::wasm::{
+    WasmComponentActor, WasmCreateContext, WasmDocumentCheckpoint, WasmDocumentHandle,
+    WasmEntityKey,
+};
 use crate::{Blob, LixError};
 
 pub(crate) const DEFAULT_MAX_LIVE_PLUGIN_STORES: usize = 16;
@@ -27,6 +30,222 @@ const DEFAULT_MAX_DECODED_CHECKPOINT_BYTES: u64 = 96 * 1024 * 1024;
 // One predecessor is enough for the required two-reader serialization while
 // keeping each file actor's retained working set bounded.
 pub(crate) const DEFAULT_MAX_PLUGIN_FILE_HISTORY: usize = 1;
+
+/// Host-proven identities for schemas whose primary keys are allocated by the
+/// mutation create context. Successors retain sparse persistent overlays rather
+/// than cloning the complete document-sized set for every tiny edit.
+#[derive(Clone)]
+pub(crate) struct PluginEntityAuthorities {
+    node: Arc<PluginEntityAuthorityNode>,
+}
+
+enum PluginEntityAuthorityNode {
+    Base {
+        ranges: Vec<PluginEntityAuthorityRange>,
+        inserted: BTreeSet<WasmEntityKey>,
+        removed: BTreeSet<WasmEntityKey>,
+    },
+    Delta {
+        parent: PluginEntityAuthorities,
+        inserted: BTreeSet<WasmEntityKey>,
+        removed: BTreeSet<WasmEntityKey>,
+        depth: u8,
+    },
+}
+
+#[derive(Clone)]
+pub(crate) struct PluginEntityAuthorityRange {
+    schema_key: String,
+    namespace: [u8; 12],
+    first_local_ref: u32,
+    last_local_ref: u32,
+}
+
+impl PluginEntityAuthorityRange {
+    pub(crate) fn new(
+        schema_key: String,
+        creates: WasmCreateContext,
+        first_local_ref: u32,
+        last_local_ref: u32,
+    ) -> Self {
+        let uuid = creates
+            .component_uuid_bytes(0)
+            .expect("zero local ref always fits the create context");
+        let mut namespace = [0_u8; 12];
+        namespace.copy_from_slice(&uuid[..12]);
+        Self {
+            schema_key,
+            namespace,
+            first_local_ref,
+            last_local_ref,
+        }
+    }
+
+    fn contains(&self, key: &WasmEntityKey) -> bool {
+        let [id] = key.entity_pk.as_slice() else {
+            return false;
+        };
+        if key.schema_key.as_str() != self.schema_key {
+            return false;
+        }
+        let Ok(bytes) = uuid::Uuid::parse_str(id).map(uuid::Uuid::into_bytes) else {
+            return false;
+        };
+        if bytes[..12] != self.namespace {
+            return false;
+        }
+        let local_ref = u32::from_be_bytes(
+            bytes[12..]
+                .try_into()
+                .expect("UUID local-ref suffix is four bytes"),
+        );
+        self.first_local_ref <= local_ref && local_ref <= self.last_local_ref
+    }
+}
+
+impl PluginEntityAuthorities {
+    const MAX_DELTA_DEPTH: u8 = 16;
+
+    pub(crate) fn empty() -> Self {
+        Self::from_keys(BTreeSet::new())
+    }
+
+    pub(crate) fn from_keys(keys: BTreeSet<WasmEntityKey>) -> Self {
+        Self {
+            node: Arc::new(PluginEntityAuthorityNode::Base {
+                ranges: Vec::new(),
+                inserted: keys,
+                removed: BTreeSet::new(),
+            }),
+        }
+    }
+
+    pub(crate) fn with_ranges(&self, ranges: Vec<PluginEntityAuthorityRange>) -> Self {
+        if ranges.is_empty() {
+            return self.clone();
+        }
+        let (mut existing_ranges, inserted, removed) = self.flatten();
+        existing_ranges.extend(ranges);
+        Self {
+            node: Arc::new(PluginEntityAuthorityNode::Base {
+                ranges: existing_ranges,
+                inserted,
+                removed,
+            }),
+        }
+    }
+
+    pub(crate) fn contains(&self, key: &WasmEntityKey) -> bool {
+        match self.node.as_ref() {
+            PluginEntityAuthorityNode::Base {
+                ranges,
+                inserted,
+                removed,
+            } => {
+                if inserted.contains(key) {
+                    true
+                } else if removed.contains(key) {
+                    false
+                } else {
+                    ranges.iter().any(|range| range.contains(key))
+                }
+            }
+            PluginEntityAuthorityNode::Delta {
+                parent,
+                inserted,
+                removed,
+                ..
+            } => {
+                if inserted.contains(key) {
+                    true
+                } else if removed.contains(key) {
+                    false
+                } else {
+                    parent.contains(key)
+                }
+            }
+        }
+    }
+
+    pub(crate) fn with_delta(
+        &self,
+        inserted: BTreeSet<WasmEntityKey>,
+        removed: BTreeSet<WasmEntityKey>,
+    ) -> Self {
+        if inserted.is_empty() && removed.is_empty() {
+            return self.clone();
+        }
+        let depth = match self.node.as_ref() {
+            PluginEntityAuthorityNode::Base { .. } => 1,
+            PluginEntityAuthorityNode::Delta { depth, .. } => depth.saturating_add(1),
+        };
+        if depth > Self::MAX_DELTA_DEPTH {
+            let (ranges, mut base_inserted, mut base_removed) = self.flatten();
+            for key in removed {
+                base_inserted.remove(&key);
+                base_removed.insert(key);
+            }
+            for key in inserted {
+                base_removed.remove(&key);
+                base_inserted.insert(key);
+            }
+            return Self {
+                node: Arc::new(PluginEntityAuthorityNode::Base {
+                    ranges,
+                    inserted: base_inserted,
+                    removed: base_removed,
+                }),
+            };
+        }
+        Self {
+            node: Arc::new(PluginEntityAuthorityNode::Delta {
+                parent: self.clone(),
+                inserted,
+                removed,
+                depth,
+            }),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        let (_, inserted, removed) = self.flatten();
+        inserted.len().saturating_sub(removed.len())
+    }
+
+    fn flatten(
+        &self,
+    ) -> (
+        Vec<PluginEntityAuthorityRange>,
+        BTreeSet<WasmEntityKey>,
+        BTreeSet<WasmEntityKey>,
+    ) {
+        match self.node.as_ref() {
+            PluginEntityAuthorityNode::Base {
+                ranges,
+                inserted,
+                removed,
+            } => (ranges.clone(), inserted.clone(), removed.clone()),
+            PluginEntityAuthorityNode::Delta {
+                parent,
+                inserted,
+                removed,
+                ..
+            } => {
+                let (ranges, mut base_inserted, mut base_removed) = parent.flatten();
+                for key in removed {
+                    base_inserted.remove(key);
+                    base_removed.insert(key.clone());
+                }
+                for key in inserted {
+                    base_removed.remove(key);
+                    base_inserted.insert(key.clone());
+                }
+                (ranges, base_inserted, base_removed)
+            }
+        }
+    }
+}
 
 /// Complete authority identity for one mutable guest instance.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -73,6 +292,7 @@ struct PluginActorAcceptedState {
     bytes: Blob,
     bytes_sha256: Option<FileBytesSha256>,
     semantic_root: Arc<str>,
+    entity_authorities: PluginEntityAuthorities,
     history: VecDeque<PluginActorHistoricalState>,
 }
 
@@ -499,6 +719,7 @@ impl PluginActorCache {
 
     /// Publishes an already-opened document. Callers invoke this only after
     /// the semantic state and its rendered bytes are durably committed.
+    #[cfg(test)]
     pub(crate) fn install(
         &self,
         key: PluginActorKey,
@@ -506,6 +727,25 @@ impl PluginActorCache {
         document: WasmDocumentHandle,
         bytes: Blob,
         semantic_root: impl Into<Arc<str>>,
+    ) -> PluginObservation {
+        self.install_with_authorities(
+            key,
+            store,
+            document,
+            bytes,
+            semantic_root,
+            PluginEntityAuthorities::empty(),
+        )
+    }
+
+    pub(crate) fn install_with_authorities(
+        &self,
+        key: PluginActorKey,
+        store: PluginActorStore,
+        document: WasmDocumentHandle,
+        bytes: Blob,
+        semantic_root: impl Into<Arc<str>>,
+        entity_authorities: PluginEntityAuthorities,
     ) -> PluginObservation {
         let semantic_root = semantic_root.into();
         let bytes_sha256 = Some(FileBytesSha256::compute(&bytes));
@@ -525,6 +765,7 @@ impl PluginActorCache {
                 bytes,
                 bytes_sha256,
                 semantic_root: Arc::clone(&semantic_root),
+                entity_authorities,
                 history: VecDeque::new(),
             })),
         });
@@ -546,6 +787,7 @@ impl PluginActorCache {
     /// by the slower cold candidate. The losing Store is explicitly retired,
     /// then the caller observes the winner only if it represents the same
     /// semantic root.
+    #[cfg(test)]
     pub(crate) async fn install_cold_if_absent(
         &self,
         cold_install: PluginActorColdInstall,
@@ -555,6 +797,30 @@ impl PluginActorCache {
         bytes: Blob,
         bytes_sha256: impl Into<Option<FileBytesSha256>>,
         semantic_root: impl Into<Arc<str>>,
+    ) -> Result<PluginObservation, LixError> {
+        self.install_cold_if_absent_with_authorities(
+            cold_install,
+            key,
+            store,
+            document,
+            bytes,
+            bytes_sha256,
+            semantic_root,
+            PluginEntityAuthorities::empty(),
+        )
+        .await
+    }
+
+    pub(crate) async fn install_cold_if_absent_with_authorities(
+        &self,
+        cold_install: PluginActorColdInstall,
+        key: PluginActorKey,
+        store: PluginActorStore,
+        document: WasmDocumentHandle,
+        bytes: Blob,
+        bytes_sha256: impl Into<Option<FileBytesSha256>>,
+        semantic_root: impl Into<Arc<str>>,
+        entity_authorities: PluginEntityAuthorities,
     ) -> Result<PluginObservation, LixError> {
         let semantic_root = semantic_root.into();
         let bytes_sha256 = bytes_sha256.into();
@@ -567,7 +833,7 @@ impl PluginActorCache {
                 "cold plugin actor install token belongs to a different key",
             ));
         }
-        let mut candidate = Some((store, document, bytes, bytes_sha256));
+        let mut candidate = Some((store, document, bytes, bytes_sha256, entity_authorities));
         let expected_guard = match &cold_install.expected_stale {
             Some(expected) => Some(Arc::clone(&expected.slot.state).lock_owned().await),
             None => None,
@@ -599,7 +865,7 @@ impl PluginActorCache {
             if !may_install {
                 None
             } else {
-                let (store, document, bytes, bytes_sha256) = candidate
+                let (store, document, bytes, bytes_sha256, entity_authorities) = candidate
                     .take()
                     .expect("vacant cold install retains its candidate");
                 state.clock = state.clock.wrapping_add(1);
@@ -617,6 +883,7 @@ impl PluginActorCache {
                         bytes,
                         bytes_sha256,
                         semantic_root: Arc::clone(&semantic_root),
+                        entity_authorities,
                         history: VecDeque::new(),
                     })),
                 });
@@ -637,7 +904,7 @@ impl PluginActorCache {
             return Ok(observation);
         }
 
-        let (mut store, document, _, _) =
+        let (mut store, document, _, _, _) =
             candidate.expect("occupied cold install retains its candidate");
         let _ = store.actor.drop_document(document).await;
         let _ = store.actor.retire().await;
@@ -974,6 +1241,7 @@ struct PluginActorSuccessor {
     bytes: Blob,
     bytes_sha256: Option<FileBytesSha256>,
     semantic_root: Arc<str>,
+    entity_authorities: PluginEntityAuthorities,
 }
 
 /// Opaque authority for one guest call based on the actor's latest private
@@ -983,6 +1251,7 @@ pub(crate) struct PluginActorPendingCall {
     document: WasmDocumentHandle,
     bytes: Blob,
     semantic_root: Arc<str>,
+    entity_authorities: PluginEntityAuthorities,
     previous_successor: Option<PluginActorSuccessor>,
 }
 
@@ -997,6 +1266,10 @@ impl PluginActorPendingCall {
 
     pub(crate) fn semantic_root(&self) -> &str {
         &self.semantic_root
+    }
+
+    pub(crate) fn entity_authorities(&self) -> &PluginEntityAuthorities {
+        &self.entity_authorities
     }
 }
 
@@ -1067,6 +1340,14 @@ impl PluginActorLease {
             .semantic_root
     }
 
+    pub(crate) fn accepted_entity_authorities(&self) -> &PluginEntityAuthorities {
+        &self
+            .guard
+            .as_deref()
+            .expect("actor lease guard exists")
+            .entity_authorities
+    }
+
     pub(crate) fn require_accepted_semantic_root(
         &self,
         visible_root: &str,
@@ -1094,26 +1375,29 @@ impl PluginActorLease {
             ));
         }
         let previous_successor = self.successor.take();
-        let (document, bytes, semantic_root) = if let Some(successor) = previous_successor.as_ref()
-        {
-            (
-                successor.document,
-                successor.bytes.clone(),
-                Arc::clone(&successor.semantic_root),
-            )
-        } else {
-            let accepted = self.guard.as_deref().expect("actor lease guard exists");
-            (
-                accepted.document,
-                accepted.bytes.clone(),
-                Arc::clone(&accepted.semantic_root),
-            )
-        };
+        let (document, bytes, semantic_root, entity_authorities) =
+            if let Some(successor) = previous_successor.as_ref() {
+                (
+                    successor.document,
+                    successor.bytes.clone(),
+                    Arc::clone(&successor.semantic_root),
+                    successor.entity_authorities.clone(),
+                )
+            } else {
+                let accepted = self.guard.as_deref().expect("actor lease guard exists");
+                (
+                    accepted.document,
+                    accepted.bytes.clone(),
+                    Arc::clone(&accepted.semantic_root),
+                    accepted.entity_authorities.clone(),
+                )
+            };
         self.uncertain_guest_call = true;
         Ok(PluginActorPendingCall {
             document,
             bytes,
             semantic_root,
+            entity_authorities,
             previous_successor,
         })
     }
@@ -1173,6 +1457,7 @@ impl PluginActorLease {
             bytes,
             bytes_sha256,
             semantic_root: semantic_root.into(),
+            entity_authorities: call.entity_authorities.clone(),
         });
         if let Some(previous_successor) = previous_successor {
             if let Err(error) = self
@@ -1250,7 +1535,25 @@ impl PluginActorLease {
             bytes,
             bytes_sha256,
             semantic_root: semantic_root.into(),
+            entity_authorities: self.accepted_entity_authorities().clone(),
         });
+        Ok(())
+    }
+
+    /// Replaces the host-proven identity set for the staged successor. This is
+    /// called only after create materialization and exact validation have
+    /// succeeded, so guest-provided keys never become authority by assertion.
+    pub(crate) fn set_successor_entity_authorities(
+        &mut self,
+        entity_authorities: PluginEntityAuthorities,
+    ) -> Result<(), LixError> {
+        let successor = self.successor.as_mut().ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "plugin authority publication is missing a validated successor",
+            )
+        })?;
+        successor.entity_authorities = entity_authorities;
         Ok(())
     }
 
@@ -1314,6 +1617,10 @@ impl PluginActorLease {
             let old_semantic_root = std::mem::replace(
                 &mut accepted.semantic_root,
                 Arc::clone(&successor.semantic_root),
+            );
+            let _old_entity_authorities = std::mem::replace(
+                &mut accepted.entity_authorities,
+                successor.entity_authorities.clone(),
             );
             accepted.history.push_back(PluginActorHistoricalState {
                 revision: old_revision,
@@ -1656,6 +1963,107 @@ mod tests {
                 .as_ref(),
             b"after"
         );
+    }
+
+    #[tokio::test]
+    async fn entity_authority_delta_publishes_only_with_successor_commit() {
+        let cache = PluginActorCache::new(2).unwrap();
+        let actor_key = key("main", "/data.json", "g1");
+        let before_key =
+            WasmEntityKey::from_owned_parts("json_node".to_owned(), vec!["before".to_owned()]);
+        let after_key =
+            WasmEntityKey::from_owned_parts("json_node".to_owned(), vec!["after".to_owned()]);
+        let before = PluginEntityAuthorities::from_keys(BTreeSet::from([before_key.clone()]));
+        let observation = cache.install_with_authorities(
+            actor_key,
+            PluginActorStore::new(Box::new(TestActor::default()), cache.admit_store().unwrap()),
+            WasmDocumentHandle(1),
+            b"before".as_slice().into(),
+            Arc::<str>::from("root-1"),
+            before,
+        );
+        let mut lease = cache.lease(&observation).await.unwrap();
+        lease.begin_guest_call().unwrap();
+        lease
+            .complete_guest_call(
+                WasmDocumentHandle(2),
+                None,
+                b"after".as_slice().into(),
+                FileBytesSha256::compute(b"after"),
+                Arc::<str>::from("root-2"),
+            )
+            .unwrap();
+        let successor_authorities = lease.accepted_entity_authorities().with_delta(
+            BTreeSet::from([after_key.clone()]),
+            BTreeSet::from([before_key.clone()]),
+        );
+        lease
+            .set_successor_entity_authorities(successor_authorities)
+            .unwrap();
+
+        assert!(lease.accepted_entity_authorities().contains(&before_key));
+        assert!(!lease.accepted_entity_authorities().contains(&after_key));
+        let successor = lease.commit_successor().await.unwrap();
+        let committed = cache.lease(&successor).await.unwrap();
+        assert!(
+            !committed
+                .accepted_entity_authorities()
+                .contains(&before_key)
+        );
+        assert!(committed.accepted_entity_authorities().contains(&after_key));
+    }
+
+    #[test]
+    fn entity_authority_deltas_compact_without_losing_membership() {
+        let retained =
+            WasmEntityKey::from_owned_parts("node".to_owned(), vec!["retained".to_owned()]);
+        let mut authorities =
+            PluginEntityAuthorities::from_keys(BTreeSet::from([retained.clone()]));
+        for ordinal in 0..=PluginEntityAuthorities::MAX_DELTA_DEPTH {
+            let inserted = WasmEntityKey::from_owned_parts(
+                "node".to_owned(),
+                vec![format!("inserted-{ordinal}")],
+            );
+            authorities = authorities.with_delta(BTreeSet::from([inserted]), BTreeSet::new());
+        }
+        assert!(authorities.contains(&retained));
+        assert_eq!(
+            authorities.len(),
+            usize::from(PluginEntityAuthorities::MAX_DELTA_DEPTH) + 2
+        );
+    }
+
+    #[test]
+    fn compact_entity_authority_ranges_preserve_sparse_overrides() {
+        let creates = WasmCreateContext {
+            high: 0x0123_4567_89ab_cdef,
+            low: 0xfedc_ba98,
+        };
+        let key = |local_ref| {
+            WasmEntityKey::from_owned_parts(
+                "markdown_block".to_owned(),
+                creates
+                    .entity_pk(local_ref)
+                    .expect("test local ref should fit"),
+            )
+        };
+        let inside = key(12);
+        let removed = key(13);
+        let outside = key(20);
+        let authorities = PluginEntityAuthorities::empty()
+            .with_ranges(vec![PluginEntityAuthorityRange::new(
+                "markdown_block".to_owned(),
+                creates,
+                10,
+                15,
+            )])
+            .with_delta(BTreeSet::new(), BTreeSet::from([removed.clone()]))
+            .with_delta(BTreeSet::from([outside.clone()]), BTreeSet::new());
+
+        assert!(authorities.contains(&inside));
+        assert!(!authorities.contains(&removed));
+        assert!(authorities.contains(&outside));
+        assert!(!authorities.contains(&key(9)));
     }
 
     #[tokio::test]

--- a/packages/engine/src/plugin/incremental.rs
+++ b/packages/engine/src/plugin/incremental.rs
@@ -1985,6 +1985,7 @@ pub(crate) fn certify_dense_fresh_file(
         schema_keys: vec![schema_key.to_owned()],
         row_count: transition.changes.changes.len() as u64,
         creates,
+        create_ranges: Vec::new(),
         complete_file_state: true,
         pages,
     };

--- a/packages/engine/src/plugin/mod.rs
+++ b/packages/engine/src/plugin/mod.rs
@@ -18,7 +18,7 @@ mod storage;
 pub(crate) use actor::{
     DEFAULT_MAX_LIVE_PLUGIN_STORES, PluginActorCache, PluginActorColdInstall, PluginActorColdOpen,
     PluginActorKey, PluginActorLease, PluginActorStagedCheckpoint, PluginActorStore,
-    PluginActorStorePermit, PluginObservation,
+    PluginActorStorePermit, PluginEntityAuthorities, PluginEntityAuthorityRange, PluginObservation,
 };
 pub(crate) use archive::{ParsedPluginArchive, parse_plugin_archive_for_install};
 pub(crate) use component::{DEFAULT_PLUGIN_MEMORY_BYTES, PluginRuntimeHost};

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -6916,6 +6916,7 @@ mod tests {
             schema_keys: vec![SCHEMA_KEY.to_owned()],
             row_count: 1,
             creates,
+            create_ranges: Vec::new(),
             complete_file_state: true,
             pages: vec![Bytes::from(page)],
         }];

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -4135,11 +4135,12 @@ where
                                     Some(&observed_existing_authorities),
                                 )
                                 .await?;
-                            let entity_authorities = plugin_entity_authorities_after_changes(
+                            let entity_authorities = plugin_entity_authorities_after_transition(
                                 selected,
                                 &cold_base_authorities,
                                 &changes,
-                            );
+                                write.certified_entity_batches(),
+                            )?;
                             let mut counters = validated.counters;
                             counters.host_full_diff_bytes_compared = host_full_diff_bytes_compared;
                             counters.host_content_classification_bytes =
@@ -4383,11 +4384,12 @@ where
                             return Err(lease.handle_guest_call_error(error));
                         }
                     };
-                    let successor_entity_authorities = plugin_entity_authorities_after_changes(
+                    let successor_entity_authorities = plugin_entity_authorities_after_transition(
                         selected,
                         &accepted_entity_authorities,
                         &changes,
-                    );
+                        &detected_transition.certified_batches,
+                    )?;
                     let (successor_document, materialized_bytes, materialized_bytes_sha256) =
                         if observation_is_current {
                             // The actor lease serializes this file and the durable
@@ -7232,19 +7234,35 @@ fn plugin_entity_authorities_after_changes(
     base.with_delta(inserted, removed)
 }
 
-fn plugin_entity_authorities_from_changes(
-    plugin: &PluginRegistryEntry,
-    changes: &WasmHostEntityChanges,
-) -> PluginEntityAuthorities {
-    plugin_entity_authorities_after_changes(plugin, &PluginEntityAuthorities::empty(), changes)
-}
-
 fn plugin_entity_authorities_from_transition(
     plugin: &PluginRegistryEntry,
     changes: &WasmHostEntityChanges,
     certified_batches: &[WasmCertifiedEntityBatch],
 ) -> Result<PluginEntityAuthorities, LixError> {
-    let base = plugin_entity_authorities_from_changes(plugin, changes);
+    plugin_entity_authorities_after_transition(
+        plugin,
+        &PluginEntityAuthorities::empty(),
+        changes,
+        certified_batches,
+    )
+}
+
+fn plugin_entity_authorities_after_transition(
+    plugin: &PluginRegistryEntry,
+    prior: &PluginEntityAuthorities,
+    changes: &WasmHostEntityChanges,
+    certified_batches: &[WasmCertifiedEntityBatch],
+) -> Result<PluginEntityAuthorities, LixError> {
+    let empty = PluginEntityAuthorities::empty();
+    let base = if certified_batches
+        .iter()
+        .any(|batch| batch.complete_file_state)
+    {
+        &empty
+    } else {
+        prior
+    };
+    let base = plugin_entity_authorities_after_changes(plugin, base, changes);
     let mut ranges = Vec::new();
     for batch in certified_batches {
         for range in &batch.create_ranges {
@@ -10432,6 +10450,48 @@ mod tests {
             std::iter::repeat_n('a', 64).collect::<String>(),
             "the previously loaded authoritative entry remains untouched on rejection"
         );
+    }
+
+    #[test]
+    fn complete_certified_transition_replaces_prior_entity_authority() {
+        let plugin = upgrade_test_entry('a');
+        let prior_key =
+            WasmEntityKey::from_owned_parts("csv_row".to_owned(), vec!["removed-row".to_owned()]);
+        let prior = PluginEntityAuthorities::from_keys(BTreeSet::from([prior_key.clone()]));
+        let creates = crate::wasm::WasmCreateContext {
+            high: 0x019a_0000_0000_7000,
+            low: 0x8000_0000,
+        };
+        let replacement_key = WasmEntityKey::from_owned_parts(
+            "csv_row".to_owned(),
+            creates.entity_pk(7).expect("replacement identity"),
+        );
+        let certified = WasmCertifiedEntityBatch {
+            format: 1,
+            schema_keys: vec!["csv_row".to_owned()],
+            row_count: 1,
+            creates,
+            create_ranges: vec![crate::wasm::WasmCertifiedCreateRange {
+                schema_key: "csv_row".to_owned(),
+                first_local_ref: 7,
+                last_local_ref: 7,
+            }],
+            complete_file_state: true,
+            pages: vec![Bytes::new()],
+        };
+
+        let successor = plugin_entity_authorities_after_transition(
+            &plugin,
+            &prior,
+            &WasmHostEntityChanges {
+                changes: Vec::new(),
+            },
+            &[certified],
+        )
+        .expect("complete certified authority should rebuild");
+
+        assert!(!successor.contains(&prior_key));
+        assert!(successor.contains(&replacement_key));
     }
 
     #[tokio::test]

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -65,9 +65,10 @@ use crate::plugin::{
     LiveBatchEntitySource, PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY, PluginActorCache,
     PluginActorColdInstall, PluginActorColdOpen, PluginActorKey, PluginActorLease,
     PluginActorStagedCheckpoint, PluginActorStore, PluginActorStorePermit,
-    PluginArchiveInstallPlan, PluginContentType, PluginFileOwner, PluginMaterialization,
-    PluginObservation, PluginRegistry, PluginRegistryEntry, PluginRegistryEntryInput,
-    PluginRuntimeHost, SchemaAllowlist, ValidatedConflictTransition, ValidatedFileTransition,
+    PluginArchiveInstallPlan, PluginContentType, PluginEntityAuthorities,
+    PluginEntityAuthorityRange, PluginFileOwner, PluginMaterialization, PluginObservation,
+    PluginRegistry, PluginRegistryEntry, PluginRegistryEntryInput, PluginRuntimeHost,
+    SchemaAllowlist, ValidatedConflictTransition, ValidatedFileTransition,
     ValidatedSameLengthOutputSplice, VecEntityChangeSource, VecEntityConflictSource,
     VecEntitySource, build_file_update_splices, canonicalize_snapshot,
     drain_conflict_transition_resolutions, drain_entity_transition_edits,
@@ -168,11 +169,11 @@ use crate::transaction::validation::{
     validate_certified_tracked_insert_identities, validate_prepared_writes,
 };
 use crate::wasm::{
-    WasmChangeEffect, WasmColdFileUpdate, WasmComponentActor, WasmComponentFactory,
-    WasmConflictUpdate, WasmDocumentCheckpoint, WasmDocumentHandle, WasmEntityChange,
-    WasmEntityConflict, WasmEntityKey, WasmEntityUpdate, WasmFileDescriptor, WasmFileUpdate,
-    WasmHostBytes, WasmHostEntity, WasmHostEntityChanges, WasmOpenEntitiesInput, WasmOpenFileInput,
-    WasmPluginSelection, WasmTransitionLimits,
+    WasmCertifiedEntityBatch, WasmChangeEffect, WasmColdFileUpdate, WasmComponentActor,
+    WasmComponentFactory, WasmConflictUpdate, WasmDocumentCheckpoint, WasmDocumentHandle,
+    WasmEntityChange, WasmEntityConflict, WasmEntityKey, WasmEntityUpdate, WasmFileDescriptor,
+    WasmFileUpdate, WasmHostBytes, WasmHostEntity, WasmHostEntityChanges, WasmOpenEntitiesInput,
+    WasmOpenFileInput, WasmPluginSelection, WasmTransitionLimits,
 };
 use crate::{LixError, NullableKeyFilter, SqlQueryResult, Value};
 
@@ -1494,6 +1495,8 @@ where
         };
         let entity_ordinals =
             v2_host_entity_ordinals_from_live_batch(&rows, &file_key, plugin.schema_keys())?;
+        let entity_authorities =
+            plugin_entity_authorities_from_live_batch(plugin, &rows, &entity_ordinals);
         let entity_count = entity_ordinals.len();
         if let VisibleMaterializationBytes::Derived { path, .. } = &materialization.bytes
             && descriptor.path.as_deref() != Some(path.as_str())
@@ -1643,7 +1646,7 @@ where
             u64::from(derived_materialization || !cold_open_hydrates_without_render);
         self.plugin_host.record_transition_counters(counters);
         cache
-            .install_cold_if_absent(
+            .install_cold_if_absent_with_authorities(
                 cold_install,
                 actor_key.clone(),
                 PluginActorStore::new(actor, store_permit),
@@ -1651,6 +1654,7 @@ where
                 materialized_bytes,
                 materialized_bytes_sha256,
                 Arc::<str>::from(semantic_root),
+                entity_authorities,
             )
             .await
     }
@@ -1779,7 +1783,7 @@ where
         bound: BoundCreateContext,
         file_key: &PluginFileWriteKey,
         existing_reservation: Option<&MaterializedLiveStateRow>,
-        known_existing_authorities: Option<&BTreeSet<WasmEntityKey>>,
+        known_existing_authorities: Option<&PluginEntityAuthorities>,
     ) -> Result<RawWriteBatch, LixError> {
         let mut validation = validate_create_changes(plugin, changes)?;
         if let Some(known) = known_existing_authorities {
@@ -3578,8 +3582,6 @@ where
                     .iter()
                     .map(|batch| batch.row_count)
                     .sum::<u64>();
-                file_data[pending.file_index]
-                    .set_certified_entity_batches(validated.certified_batches);
                 let mut changes = validated.changes;
                 let create_rows = self
                     .v2_create_rows(
@@ -3591,6 +3593,13 @@ where
                         None,
                     )
                     .await?;
+                let entity_authorities = plugin_entity_authorities_from_transition(
+                    &pending.selected,
+                    &changes,
+                    &validated.certified_batches,
+                )?;
+                file_data[pending.file_index]
+                    .set_certified_entity_batches(validated.certified_batches);
                 let mut counters = validated.counters;
                 counters.host_content_classification_bytes = content_classification_bytes
                     .get(&pending.file_key)
@@ -3649,6 +3658,7 @@ where
                         document: validated.document,
                         bytes: pending.submitted_bytes,
                         semantic_root: Arc::from(pending.materialization_version),
+                        entity_authorities,
                         view: pending.view,
                     });
                 reconciled_file_keys.insert(pending.file_key);
@@ -3989,6 +3999,8 @@ where
                                     "lix.perf.plugin_actor_instantiate"
                                 ))
                                 .await?;
+                            let mut cold_base_authorities: PluginEntityAuthorities =
+                                PluginEntityAuthorities::empty();
                             let transition_result = if let Some(checkpoint) = decoded_checkpoint {
                                 drop(base);
                                 drop(read);
@@ -4041,6 +4053,11 @@ where
                                     selected.schema_keys(),
                                 )?;
                                 let entity_count = entity_ordinals.len();
+                                cold_base_authorities = plugin_entity_authorities_from_live_batch(
+                                    selected,
+                                    &entity_rows,
+                                    &entity_ordinals,
+                                );
                                 let entity_source = LiveBatchEntitySource::new(
                                     entity_rows,
                                     entity_ordinals,
@@ -4106,6 +4123,8 @@ where
                                 .suppress_format_only_noops(selected, changes, &file_key)
                                 .await?;
                             changes = filtered;
+                            let observed_existing_authorities =
+                                PluginEntityAuthorities::from_keys(observed_existing_authorities);
                             let create_rows = self
                                 .v2_create_rows(
                                     selected,
@@ -4116,6 +4135,11 @@ where
                                     Some(&observed_existing_authorities),
                                 )
                                 .await?;
+                            let entity_authorities = plugin_entity_authorities_after_changes(
+                                selected,
+                                &cold_base_authorities,
+                                &changes,
+                            );
                             let mut counters = validated.counters;
                             counters.host_full_diff_bytes_compared = host_full_diff_bytes_compared;
                             counters.host_content_classification_bytes =
@@ -4150,6 +4174,7 @@ where
                                     document: validated.document,
                                     bytes: submitted_bytes.clone(),
                                     semantic_root: Arc::from(materialization_version.clone()),
+                                    entity_authorities,
                                     view,
                                 },
                                 submitted_bytes.clone(),
@@ -4310,7 +4335,8 @@ where
                     );
                     let detection_document = detected_transition.document;
                     let mut counters = detected_transition.counters;
-                    let (mut changes, observed_existing_authorities) = match self
+                    let accepted_entity_authorities = lease.accepted_entity_authorities().clone();
+                    let (mut changes, _observed_existing_authorities) = match self
                         .suppress_format_only_noops(
                             selected,
                             detected_transition.changes,
@@ -4339,7 +4365,7 @@ where
                             create_context,
                             &file_key,
                             existing_create_reservation.as_ref(),
-                            Some(&observed_existing_authorities),
+                            Some(&accepted_entity_authorities),
                         )
                         .instrument(tracing::debug_span!(
                             target: "lix_perf",
@@ -4357,6 +4383,11 @@ where
                             return Err(lease.handle_guest_call_error(error));
                         }
                     };
+                    let successor_entity_authorities = plugin_entity_authorities_after_changes(
+                        selected,
+                        &accepted_entity_authorities,
+                        &changes,
+                    );
                     let (successor_document, materialized_bytes, materialized_bytes_sha256) =
                         if observation_is_current {
                             // The actor lease serializes this file and the durable
@@ -4470,6 +4501,7 @@ where
                         materialized_bytes_sha256,
                         materialization_version.clone(),
                     )?;
+                    lease.set_successor_entity_authorities(successor_entity_authorities)?;
                     (
                         changes,
                         PendingPluginActorPublication::Existing {
@@ -4527,7 +4559,6 @@ where
                     .iter()
                     .map(|batch| batch.row_count)
                     .sum::<u64>();
-                write.set_certified_entity_batches(validated.certified_batches);
                 let mut changes = validated.changes;
                 let create_rows = self
                     .v2_create_rows(
@@ -4543,6 +4574,12 @@ where
                         "lix.perf.plugin_create_rows"
                     ))
                     .await?;
+                let entity_authorities = plugin_entity_authorities_from_transition(
+                    selected,
+                    &changes,
+                    &validated.certified_batches,
+                )?;
+                write.set_certified_entity_batches(validated.certified_batches);
                 let mut counters = validated.counters;
                 counters.host_content_classification_bytes = content_classification_bytes
                     .get(&file_key)
@@ -4563,6 +4600,7 @@ where
                         document: validated.document,
                         bytes: submitted_bytes.clone(),
                         semantic_root: Arc::from(materialization_version.clone()),
+                        entity_authorities,
                         view,
                     },
                     submitted_bytes.clone(),
@@ -4847,6 +4885,7 @@ where
             let materialization_version = self.functions.call_uuid_v7().to_string();
             let transition = render_semantic_changes_with_lease(
                 lease,
+                &group.plugin,
                 successor_key,
                 publication_view,
                 descriptor,
@@ -7157,6 +7196,93 @@ fn plugin_entity_pk(
     })
 }
 
+fn plugin_schema_is_creatable(plugin: &PluginRegistryEntry, schema_key: &str) -> bool {
+    plugin
+        .create_schema_keys()
+        .binary_search_by(|candidate| candidate.as_str().cmp(schema_key))
+        .is_ok()
+}
+
+fn plugin_entity_authorities_after_changes(
+    plugin: &PluginRegistryEntry,
+    base: &PluginEntityAuthorities,
+    changes: &WasmHostEntityChanges,
+) -> PluginEntityAuthorities {
+    let mut inserted = BTreeSet::new();
+    let mut removed = BTreeSet::new();
+    for change in &changes.changes {
+        match change {
+            WasmEntityChange::Upsert { entity, .. }
+                if plugin_schema_is_creatable(plugin, &entity.key.schema_key) =>
+            {
+                removed.remove(&entity.key);
+                inserted.insert(entity.key.clone());
+            }
+            WasmEntityChange::Delete(key)
+                if plugin_schema_is_creatable(plugin, &key.schema_key) =>
+            {
+                inserted.remove(key);
+                removed.insert(key.clone());
+            }
+            WasmEntityChange::Create { .. }
+            | WasmEntityChange::Upsert { .. }
+            | WasmEntityChange::Delete(_) => {}
+        }
+    }
+    base.with_delta(inserted, removed)
+}
+
+fn plugin_entity_authorities_from_changes(
+    plugin: &PluginRegistryEntry,
+    changes: &WasmHostEntityChanges,
+) -> PluginEntityAuthorities {
+    plugin_entity_authorities_after_changes(plugin, &PluginEntityAuthorities::empty(), changes)
+}
+
+fn plugin_entity_authorities_from_transition(
+    plugin: &PluginRegistryEntry,
+    changes: &WasmHostEntityChanges,
+    certified_batches: &[WasmCertifiedEntityBatch],
+) -> Result<PluginEntityAuthorities, LixError> {
+    let base = plugin_entity_authorities_from_changes(plugin, changes);
+    let mut ranges = Vec::new();
+    for batch in certified_batches {
+        for range in &batch.create_ranges {
+            if !plugin_schema_is_creatable(plugin, &range.schema_key) {
+                continue;
+            }
+            ranges.push(PluginEntityAuthorityRange::new(
+                range.schema_key.clone(),
+                batch.creates,
+                range.first_local_ref,
+                range.last_local_ref,
+            ));
+        }
+    }
+    Ok(base.with_ranges(ranges))
+}
+
+fn plugin_entity_authorities_from_live_batch(
+    plugin: &PluginRegistryEntry,
+    rows: &MaterializedLiveStateBatch,
+    ordinals: &[u32],
+) -> PluginEntityAuthorities {
+    PluginEntityAuthorities::from_keys(
+        ordinals
+            .iter()
+            .filter_map(|ordinal| {
+                let row = rows.row(*ordinal as usize);
+                plugin_schema_is_creatable(plugin, row.schema_key()).then(|| {
+                    WasmEntityKey::from_owned_parts(
+                        row.schema_key().to_owned(),
+                        row.entity_pk().clone().into_parts(),
+                    )
+                })
+            })
+            .collect(),
+    )
+}
+
 fn v2_host_entities_from_live_batch_ordinals(
     rows: &MaterializedLiveStateBatch,
     ordinals: &[u32],
@@ -7739,6 +7865,7 @@ enum PendingPluginActorPublication {
         checkpoint: Option<WasmDocumentCheckpoint>,
         bytes: crate::Blob,
         semantic_root: Arc<str>,
+        entity_authorities: PluginEntityAuthorities,
         view: PendingPluginActorView,
     },
     /// The plugin transition has already produced its durable rows, but the
@@ -7835,12 +7962,20 @@ impl PendingPluginActorPublication {
                 checkpoint,
                 bytes,
                 semantic_root,
+                entity_authorities,
                 view,
             } => {
                 let path = key.path.clone();
                 cache.remember_checkpoint(&key, &semantic_root, checkpoint);
                 (
-                    Some(cache.install(key, store, document, bytes, semantic_root)),
+                    Some(cache.install_with_authorities(
+                        key,
+                        store,
+                        document,
+                        bytes,
+                        semantic_root,
+                        entity_authorities,
+                    )),
                     view,
                     path,
                 )
@@ -7944,6 +8079,7 @@ fn semantic_rendered_file_data(
 
 async fn render_semantic_changes_with_lease(
     mut lease: PluginActorLease,
+    plugin: &PluginRegistryEntry,
     successor_key: PluginActorKey,
     view: PendingPluginActorView,
     descriptor: WasmFileDescriptor,
@@ -7973,10 +8109,6 @@ async fn render_semantic_changes_with_lease(
         },
     };
     let change_count = u64::try_from(changes.entity_change_count()).unwrap_or(u64::MAX);
-    let change_source = match VecEntityChangeSource::new(changes, limits) {
-        Ok(source) => source,
-        Err(error) => return Err((error, publication(lease))),
-    };
     let call = match lease.begin_pending_guest_call() {
         Ok(call) => call,
         Err(error) => return Err((error, publication(lease))),
@@ -7989,6 +8121,15 @@ async fn render_semantic_changes_with_lease(
         let error = lease.handle_pending_guest_call_error(call, error);
         return Err((error, publication(lease)));
     }
+    let successor_entity_authorities =
+        plugin_entity_authorities_after_changes(plugin, call.entity_authorities(), &changes);
+    let change_source = match VecEntityChangeSource::new(changes, limits) {
+        Ok(source) => source,
+        Err(error) => {
+            let error = lease.handle_pending_guest_call_error(call, error);
+            return Err((error, publication(lease)));
+        }
+    };
     let base_document = call.document();
     let base_bytes = call.bytes();
     let renderer_input = match lease.actor_mut().fork_document(base_document).await {
@@ -8065,6 +8206,9 @@ async fn render_semantic_changes_with_lease(
         )
         .await
     {
+        return Err((error, publication(lease)));
+    }
+    if let Err(error) = lease.set_successor_entity_authorities(successor_entity_authorities) {
         return Err((error, publication(lease)));
     }
     Ok((

--- a/packages/engine/src/wasm/component.rs
+++ b/packages/engine/src/wasm/component.rs
@@ -1706,11 +1706,22 @@ pub struct WasmFileTransition {
 /// id selects a registered engine codec; pages retain the guest's bounded
 /// framing and share their backing buffers through transaction commit.
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WasmCertifiedCreateRange {
+    pub schema_key: String,
+    pub first_local_ref: u32,
+    pub last_local_ref: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WasmCertifiedEntityBatch {
     pub format: u16,
     pub schema_keys: Vec<String>,
     pub row_count: u64,
     pub creates: WasmCreateContext,
+    /// Host-validated compact identities created by this batch. Keeping ranges
+    /// here avoids reparsing or expanding certified packet payloads merely to
+    /// establish successor authority.
+    pub create_ranges: Vec<WasmCertifiedCreateRange>,
     /// True when this batch replaces every prior segment for the file.
     /// Incremental transitions emit sparse overlays instead.
     pub complete_file_state: bool,

--- a/packages/rs-sdk/src/default_wasm_runtime_component.rs
+++ b/packages/rs-sdk/src/default_wasm_runtime_component.rs
@@ -17,15 +17,16 @@ use lix_engine::wasm::v3::{
     Transaction as ArenaTransaction,
 };
 use lix_engine::wasm::{
-    PACKET_FORMAT_V1, WasmByteOutputsHandle, WasmCertifiedEntityBatch, WasmChangeCursorHandle,
-    WasmChangeEffect, WasmChangePage, WasmColdFileUpdate, WasmComponentActor, WasmComponentFactory,
-    WasmConflictResolution, WasmConflictResolutionPage, WasmConflictTake, WasmConflictTransition,
-    WasmConflictUpdate, WasmCreateContext, WasmDocumentCheckpoint, WasmDocumentHandle,
-    WasmEditCursorHandle, WasmEditPage, WasmEntity, WasmEntityChange, WasmEntityChanges,
-    WasmEntityKey, WasmEntityTransition, WasmEntityUpdate, WasmFileTransition, WasmFileUpdate,
-    WasmGuestBytes, WasmGuestEntityChanges, WasmHostBytes, WasmHostEntityConflict, WasmInputBytes,
-    WasmOpenEntitiesInput, WasmOpenFileInput, WasmOutputRange, WasmOutputSplice,
-    WasmResolutionCursorHandle, WasmTransitionCounters, WasmTransitionHandle, WasmTransitionLimits,
+    PACKET_FORMAT_V1, WasmByteOutputsHandle, WasmCertifiedCreateRange, WasmCertifiedEntityBatch,
+    WasmChangeCursorHandle, WasmChangeEffect, WasmChangePage, WasmColdFileUpdate,
+    WasmComponentActor, WasmComponentFactory, WasmConflictResolution, WasmConflictResolutionPage,
+    WasmConflictTake, WasmConflictTransition, WasmConflictUpdate, WasmCreateContext,
+    WasmDocumentCheckpoint, WasmDocumentHandle, WasmEditCursorHandle, WasmEditPage, WasmEntity,
+    WasmEntityChange, WasmEntityChanges, WasmEntityKey, WasmEntityTransition, WasmEntityUpdate,
+    WasmFileTransition, WasmFileUpdate, WasmGuestBytes, WasmGuestEntityChanges, WasmHostBytes,
+    WasmHostEntityConflict, WasmInputBytes, WasmOpenEntitiesInput, WasmOpenFileInput,
+    WasmOutputRange, WasmOutputSplice, WasmResolutionCursorHandle, WasmTransitionCounters,
+    WasmTransitionHandle, WasmTransitionLimits,
 };
 use lix_engine::{LixError, SharedStr};
 use wasmtime::Store;
@@ -1797,11 +1798,16 @@ fn validate_typed_csv_rows(row_count: u32, payload: &[u8]) -> Result<(u32, u32),
     }
     let mut input = TypedCsvReader { payload, offset: 0 };
     let mut first_local_ref = None;
-    let mut previous_local_ref = None;
+    let mut previous_local_ref: Option<u32> = None;
     for _ in 0..row_count {
         let local_ref = input.u32()?;
-        if previous_local_ref.is_some_and(|previous| previous >= local_ref) {
-            return Err("typed CSV local refs must be strictly increasing".to_owned());
+        if let Some(previous) = previous_local_ref {
+            if previous >= local_ref {
+                return Err("typed CSV local refs must be strictly increasing".to_owned());
+            }
+            if previous.checked_add(1) != Some(local_ref) {
+                return Err("typed CSV local refs must be contiguous within a page".to_owned());
+            }
         }
         first_local_ref.get_or_insert(local_ref);
         previous_local_ref = Some(local_ref);
@@ -2088,6 +2094,52 @@ impl CertifiedPacketEntityKeys {
             keys.explicit_create_refs.extend(page.explicit_create_refs);
             keys.create_ref_ranges.extend(page.create_ref_ranges);
         }
+    }
+
+    fn take_create_ranges_for(&mut self, schema_keys: &[String]) -> Vec<WasmCertifiedCreateRange> {
+        let mut output = Vec::new();
+        for schema_key in schema_keys {
+            let Some(keys) = self.schemas.remove(schema_key) else {
+                continue;
+            };
+            let mut ranges = keys
+                .create_ref_ranges
+                .into_iter()
+                .chain(
+                    keys.create_refs
+                        .into_iter()
+                        .map(|local_ref| (local_ref, local_ref)),
+                )
+                .chain(
+                    keys.explicit_create_refs
+                        .into_iter()
+                        .map(|local_ref| (local_ref, local_ref)),
+                )
+                .collect::<Vec<_>>();
+            ranges.sort_unstable();
+            let mut compact = Vec::<(u64, u64)>::with_capacity(ranges.len());
+            for (first, last) in ranges {
+                if let Some((_, compact_last)) = compact.last_mut()
+                    && first <= compact_last.saturating_add(1)
+                {
+                    *compact_last = (*compact_last).max(last);
+                    continue;
+                }
+                compact.push((first, last));
+            }
+            output.extend(
+                compact
+                    .into_iter()
+                    .map(|(first, last)| WasmCertifiedCreateRange {
+                        schema_key: schema_key.clone(),
+                        first_local_ref: u32::try_from(first)
+                            .expect("validated create local ref fits u32"),
+                        last_local_ref: u32::try_from(last)
+                            .expect("validated create local ref fits u32"),
+                    }),
+            );
+        }
+        output
     }
 }
 
@@ -4066,24 +4118,34 @@ impl WasmComponentActor for V3Actor {
         };
         let mut batches = Vec::with_capacity(2);
         if let Some(creates) = cursor.certified_csv_creates.take() {
+            let schema_keys = vec!["csv_v2_row".to_owned()];
+            let create_ranges = cursor
+                .certified_packet_entity_keys
+                .take_create_ranges_for(&schema_keys);
             batches.push(WasmCertifiedEntityBatch {
                 format: CERTIFIED_TYPED_CSV_V1,
-                schema_keys: vec!["csv_v2_row".to_owned()],
+                schema_keys,
                 row_count: std::mem::take(&mut cursor.certified_csv_rows),
                 creates,
+                create_ranges,
                 complete_file_state: cursor.complete_file_state,
                 pages: std::mem::take(&mut cursor.certified_csv_pages),
             });
         }
         if let Some(creates) = cursor.certified_packet_creates.take() {
+            let schema_keys = std::mem::take(&mut cursor.certified_packet_schema_keys)
+                .into_iter()
+                .collect::<Vec<_>>();
+            let create_ranges = cursor
+                .certified_packet_entity_keys
+                .take_create_ranges_for(&schema_keys);
             cursor.certified_packet_entity_keys = CertifiedPacketEntityKeys::default();
             batches.push(WasmCertifiedEntityBatch {
                 format: CERTIFIED_CREATED_PACKET_V1,
-                schema_keys: std::mem::take(&mut cursor.certified_packet_schema_keys)
-                    .into_iter()
-                    .collect(),
+                schema_keys,
                 row_count: std::mem::take(&mut cursor.certified_packet_rows),
                 creates,
+                create_ranges,
                 complete_file_state: cursor.complete_file_state,
                 pages: std::mem::take(&mut cursor.certified_packet_pages),
             });
@@ -4443,6 +4505,36 @@ mod tests {
     }
 
     #[test]
+    fn certified_create_authorities_are_exported_as_compact_ranges() {
+        let creates = WasmCreateContext {
+            high: 0x019a_0000_0000_7000,
+            low: 0x8000_0000,
+        };
+        let mut keys = CertifiedPacketEntityKeys::default();
+        for local_ref in [7, 8, 9, 12] {
+            accept_page(&create_page("row", local_ref), creates, &mut keys)
+                .expect("create identity is unique");
+        }
+
+        assert_eq!(
+            keys.take_create_ranges_for(&["row".to_owned()]),
+            vec![
+                WasmCertifiedCreateRange {
+                    schema_key: "row".to_owned(),
+                    first_local_ref: 7,
+                    last_local_ref: 9,
+                },
+                WasmCertifiedCreateRange {
+                    schema_key: "row".to_owned(),
+                    first_local_ref: 12,
+                    last_local_ref: 12,
+                },
+            ]
+        );
+        assert!(keys.schemas.is_empty());
+    }
+
+    #[test]
     fn hydration_replacement_deletes_the_complete_accepted_blob() {
         assert_eq!(
             hydration_replacement_edit(17, 41),
@@ -4525,6 +4617,26 @@ mod tests {
         assert_eq!(
             validate_typed_csv_rows(1, &row(&[1, 2], 9)).unwrap_err(),
             "typed CSV quote layout has bits beyond the final field"
+        );
+    }
+
+    #[test]
+    fn typed_csv_certification_rejects_authority_holes() {
+        fn append_row(payload: &mut Vec<u8>, local_ref: u32) {
+            payload.extend_from_slice(&local_ref.to_le_bytes());
+            payload.extend_from_slice(&1_u64.to_le_bytes());
+            payload.push(0);
+            payload.extend_from_slice(&0_u32.to_le_bytes());
+            payload.extend_from_slice(&1_u16.to_le_bytes());
+            payload.extend_from_slice(&0_u32.to_le_bytes());
+        }
+
+        let mut payload = Vec::new();
+        append_row(&mut payload, 1);
+        append_row(&mut payload, 3);
+        assert_eq!(
+            validate_typed_csv_rows(2, &payload).unwrap_err(),
+            "typed CSV local refs must be contiguous within a page"
         );
     }
 

--- a/packages/rs-sdk/src/default_wasm_runtime_component.rs
+++ b/packages/rs-sdk/src/default_wasm_runtime_component.rs
@@ -2096,6 +2096,19 @@ impl CertifiedPacketEntityKeys {
         }
     }
 
+    fn extend_ref(&mut self, page: &Self) {
+        for (schema_key, page) in &page.schemas {
+            let keys = self.schemas.entry(schema_key.clone()).or_default();
+            keys.create_refs.extend(page.create_refs.iter().copied());
+            keys.explicit_keys
+                .extend(page.explicit_keys.iter().copied());
+            keys.explicit_create_refs
+                .extend(page.explicit_create_refs.iter().copied());
+            keys.create_ref_ranges
+                .extend(page.create_ref_ranges.iter().copied());
+        }
+    }
+
     fn take_create_ranges_for(&mut self, schema_keys: &[String]) -> Vec<WasmCertifiedCreateRange> {
         let mut output = Vec::new();
         for schema_key in schema_keys {
@@ -3440,6 +3453,8 @@ struct CursorState {
     certified_csv_rows: u64,
     certified_csv_creates: Option<WasmCreateContext>,
     certified_csv_last_local_ref: Option<u32>,
+    certified_all_entity_keys: CertifiedPacketEntityKeys,
+    certified_csv_entity_keys: CertifiedPacketEntityKeys,
     certified_packet_pages: Vec<Bytes>,
     certified_packet_rows: u64,
     certified_packet_creates: Option<WasmCreateContext>,
@@ -3634,6 +3649,8 @@ impl WasmComponentActor for V3Actor {
                 certified_csv_rows: 0,
                 certified_csv_creates: None,
                 certified_csv_last_local_ref: None,
+                certified_all_entity_keys: CertifiedPacketEntityKeys::default(),
+                certified_csv_entity_keys: CertifiedPacketEntityKeys::default(),
                 certified_packet_pages: Vec::new(),
                 certified_packet_rows: 0,
                 certified_packet_creates: None,
@@ -3738,6 +3755,8 @@ impl WasmComponentActor for V3Actor {
                 certified_csv_rows: 0,
                 certified_csv_creates: None,
                 certified_csv_last_local_ref: None,
+                certified_all_entity_keys: CertifiedPacketEntityKeys::default(),
+                certified_csv_entity_keys: CertifiedPacketEntityKeys::default(),
                 certified_packet_pages: Vec::new(),
                 certified_packet_rows: 0,
                 certified_packet_creates: None,
@@ -3788,6 +3807,8 @@ impl WasmComponentActor for V3Actor {
                 certified_csv_rows: 0,
                 certified_csv_creates: None,
                 certified_csv_last_local_ref: None,
+                certified_all_entity_keys: CertifiedPacketEntityKeys::default(),
+                certified_csv_entity_keys: CertifiedPacketEntityKeys::default(),
                 certified_packet_pages: Vec::new(),
                 certified_packet_rows: 0,
                 certified_packet_creates: None,
@@ -3999,7 +4020,7 @@ impl WasmComponentActor for V3Actor {
                         "csv_v2_row",
                         u64::from(first_local_ref),
                         u64::from(last_local_ref),
-                        &cursor.certified_packet_entity_keys,
+                        &cursor.certified_all_entity_keys,
                     )?;
                     cursor.certified_csv_creates = Some(creates);
                     cursor.certified_csv_rows = cursor
@@ -4008,7 +4029,8 @@ impl WasmComponentActor for V3Actor {
                         .ok_or_else(|| v3_error("certified CSV row count overflowed"))?;
                     cursor.certified_csv_last_local_ref = Some(last_local_ref);
                     cursor.certified_csv_pages.push(Bytes::from(payload));
-                    cursor.certified_packet_entity_keys.extend(page_keys);
+                    cursor.certified_all_entity_keys.extend_ref(&page_keys);
+                    cursor.certified_csv_entity_keys.extend(page_keys);
                 }
                 Some(page @ PendingChangePage::Packet { .. }) => {
                     let PendingChangePage::Packet {
@@ -4042,9 +4064,9 @@ impl WasmComponentActor for V3Actor {
                             let page_keys = validate_ordinary_packet_page_keys(
                                 &decoded,
                                 creates,
-                                &cursor.certified_packet_entity_keys,
+                                &cursor.certified_all_entity_keys,
                             )?;
-                            cursor.certified_packet_entity_keys.extend(page_keys);
+                            cursor.certified_all_entity_keys.extend(page_keys);
                             return Ok(Some(decoded));
                         }
                         if cursor
@@ -4057,7 +4079,7 @@ impl WasmComponentActor for V3Actor {
                         }
                         let (schema_keys, page_keys) = validate_new_certified_packet_keys(
                             validated_page,
-                            &cursor.certified_packet_entity_keys,
+                            &cursor.certified_all_entity_keys,
                         )?;
                         cursor.certified_packet_creates = Some(creates);
                         cursor.certified_packet_rows = cursor
@@ -4065,6 +4087,7 @@ impl WasmComponentActor for V3Actor {
                             .checked_add(u64::from(record_count))
                             .ok_or_else(|| v3_error("certified packet row count overflowed"))?;
                         cursor.certified_packet_schema_keys.extend(schema_keys);
+                        cursor.certified_all_entity_keys.extend_ref(&page_keys);
                         cursor.certified_packet_entity_keys.extend(page_keys);
                         cursor.certified_packet_pages.push(Bytes::from(payload));
                     } else {
@@ -4079,9 +4102,9 @@ impl WasmComponentActor for V3Actor {
                         let page_keys = validate_ordinary_packet_page_keys(
                             &decoded,
                             creates,
-                            &cursor.certified_packet_entity_keys,
+                            &cursor.certified_all_entity_keys,
                         )?;
-                        cursor.certified_packet_entity_keys.extend(page_keys);
+                        cursor.certified_all_entity_keys.extend(page_keys);
                         return Ok(Some(decoded));
                     }
                 }
@@ -4123,7 +4146,7 @@ impl WasmComponentActor for V3Actor {
         if let Some(creates) = cursor.certified_csv_creates.take() {
             let schema_keys = vec!["csv_v2_row".to_owned()];
             let create_ranges = cursor
-                .certified_packet_entity_keys
+                .certified_csv_entity_keys
                 .take_create_ranges_for(&schema_keys);
             batches.push(WasmCertifiedEntityBatch {
                 format: CERTIFIED_TYPED_CSV_V1,
@@ -4153,6 +4176,8 @@ impl WasmComponentActor for V3Actor {
                 pages: std::mem::take(&mut cursor.certified_packet_pages),
             });
         }
+        cursor.certified_all_entity_keys = CertifiedPacketEntityKeys::default();
+        cursor.certified_csv_entity_keys = CertifiedPacketEntityKeys::default();
         batches
     }
 
@@ -4518,6 +4543,45 @@ mod tests {
         assert_eq!(
             duplicate_csv.message,
             "a component entity key may occur only once across certified packet pages"
+        );
+    }
+
+    #[test]
+    fn certified_authority_ranges_stay_partitioned_by_batch_context() {
+        let mut csv_keys = CertifiedPacketEntityKeys::default();
+        csv_keys
+            .insert_create_ref_range("csv_v2_row", 1, 1, &CertifiedPacketEntityKeys::default())
+            .expect("CSV identity is unique");
+        let mut packet_keys = CertifiedPacketEntityKeys::default();
+        packet_keys
+            .insert(
+                CreatedPacketIdentity::Create {
+                    schema_key: "csv_v2_row".to_owned(),
+                    local_ref: 2,
+                },
+                WasmCreateContext {
+                    high: 0x019b_0000_0000_7000,
+                    low: 0x8000_0000,
+                },
+                &csv_keys,
+            )
+            .expect("packet identity is unique across the transition");
+
+        assert_eq!(
+            csv_keys.take_create_ranges_for(&["csv_v2_row".to_owned()]),
+            vec![WasmCertifiedCreateRange {
+                schema_key: "csv_v2_row".to_owned(),
+                first_local_ref: 1,
+                last_local_ref: 1,
+            }]
+        );
+        assert_eq!(
+            packet_keys.take_create_ranges_for(&["csv_v2_row".to_owned()]),
+            vec![WasmCertifiedCreateRange {
+                schema_key: "csv_v2_row".to_owned(),
+                first_local_ref: 2,
+                last_local_ref: 2,
+            }]
         );
     }
 

--- a/packages/rs-sdk/src/default_wasm_runtime_component.rs
+++ b/packages/rs-sdk/src/default_wasm_runtime_component.rs
@@ -2269,6 +2269,9 @@ fn validate_created_packet_page(
             }
             2 => {
                 let local_ref = record.u64()?;
+                if u32::try_from(local_ref).is_err() {
+                    return Err("packet create local ref exceeds u32".to_owned());
+                }
                 if previous_local_ref.is_some_and(|previous| previous >= local_ref) {
                     return Err("packet create local refs must be strictly increasing".to_owned());
                 }
@@ -4424,6 +4427,20 @@ mod tests {
             &mut component_boundaries,
         )
         .expect("component lengths must delimit the compact fingerprint");
+    }
+
+    #[test]
+    fn certified_packet_rejects_create_refs_outside_authority_format() {
+        let creates = WasmCreateContext {
+            high: 0x019a_0000_0000_7000,
+            low: 0x8000_0000,
+        };
+        let result =
+            validate_created_packet_page(1, &create_page("row", u64::from(u32::MAX) + 1), creates);
+        assert!(matches!(
+            result,
+            Err(message) if message == "packet create local ref exceeds u32"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- retain host-validated entity identity authority with each live plugin actor
- represent dense certified create identities as compact UUID namespace ranges
- use that authority to bypass redundant exact durable reads for keyed successor changes
- keep sparse insert/delete overlays persistent and publish them atomically with the successor document

## Why

A tiny edit to the 1.24 MiB `vscode-api.md` document was materializing the complete 3,808-row certified segment merely to prove that one keyed Markdown block already existed. The actor already owned a validated semantic document, but discarded the host's proof of which creatable identities belonged to it.

This retains only host-proven authority; unknown identities still take the durable exact-read path. Guest-provided identifiers are never trusted as authority.

## Performance

Large vscode-api Markdown exact transition, current main baseline → candidate:

- p50: 8.979 ms → ~6.9 ms (about 23% faster)
- cumulative host allocation: 40.77 MB → 22.27 MB (about 45% less)
- `plugin_create_rows`: 1.2–2.0 ms → ~0.006 ms
- exact semantic output and all 3,808 rows preserved

Cross-format guard lanes:

- 10.68 MiB / 220,001-row typed CSV: 119.80 ms p50
- 10 MiB JSON sparse successor: 8.42 ms p50
- 1.85 MiB / 20,000-element Excalidraw successor: 3.98 ms p50

## Validation

- `cargo check -p lix_sdk`
- focused actor authority publication, compaction, and range override tests
- focused certified create-range runtime test
- `cargo clippy -p lix_engine -p lix_sdk --all-targets`
- 3-commit / 26-path real Lix repository replay with all WASM plugins, checkpoint every commit, state verification every commit, and final Git tree verification
