### PR TITLE
perf(engine): stream typed creates and batch history reads

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_working_diff.rs
+++ b/packages/engine-benchmarks/benches/tracked_working_diff.rs
@@ -48,7 +48,7 @@ const DEFAULT_UNRELATED_HISTORY_WIDTH: usize = 1;
 const UNRELATED_HISTORY_STORAGE_BATCH: usize = 100_000;
 const INSERT_BATCH_SIZE: usize = 500;
 const MERGE_PREVIEW_SOURCE_BRANCH_ID: &str = "01920000-0000-7000-8000-000000000901";
-const WORKING_DIFF_SQL: &str = "SELECT entity_pk, schema_key, change_kind, before_change_id, after_change_id \
+const WORKING_DIFF_SQL: &str = "SELECT entity_pk, schema_key, diff_type, before_change_id, after_change_id \
     FROM lix_working_diff ORDER BY schema_key, entity_pk";
 
 #[derive(Clone, Copy)]

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -759,8 +759,8 @@ where
                         change_id: member.value.change_id,
                         commit_id,
                         segment_index: member.segment_index,
-                        ordinal: u8::try_from(member.ordinal)
-                            .expect("commit-delta segment row count fits u8"),
+                        ordinal: u16::try_from(member.ordinal)
+                            .expect("commit-delta segment row count fits u16"),
                     })
             })
         })

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -3598,6 +3598,63 @@ impl<S> HotStateWriter<'_, S>
 where
     S: StorageAdapterRead + ?Sized,
 {
+    /// Publishes a transaction-certified ordered insert batch as an immutable
+    /// current-state base without rebuilding row-shaped deltas or absence
+    /// guards.
+    ///
+    /// The commit-delta writer has already proven strict physical-key order
+    /// and assigned every row its direct address. Transaction validation has
+    /// proven that the same complete batch is absent under the branch-control
+    /// snapshot. Walking the prepared identity columns once for schema counts
+    /// is therefore sufficient to publish the existing commit as current
+    /// state.
+    pub(crate) async fn stage_ordered_insert_current_base<'a, I>(
+        &mut self,
+        branch_id: &str,
+        generation: CommitId,
+        new_head: CommitId,
+        rows: I,
+        working_diff_capture_checkpoint_commit_id: Option<CommitId>,
+        coverage: &mut WorkingDiffIndexCoverage,
+    ) -> Result<CommitId, LixError>
+    where
+        I: ExactSizeIterator<Item = (&'a str, &'a EntityPk)> + Clone,
+    {
+        if rows.len() == 0 {
+            return Err(head_value_error(
+                "ordered packed current base requires at least one inserted row",
+            ));
+        }
+        let mut previous = None::<(&str, &EntityPk)>;
+        let mut schema_increments = BTreeMap::<&str, u64>::new();
+        for (schema_key, entity_pk) in rows {
+            if previous.is_some_and(|(previous_schema, previous_entity_pk)| {
+                previous_schema
+                    .cmp(schema_key)
+                    .then_with(|| previous_entity_pk.cmp(entity_pk))
+                    != Ordering::Less
+            }) {
+                return Err(head_value_error(
+                    "ordered packed current-base identities are not strictly increasing",
+                ));
+            }
+            previous = Some((schema_key, entity_pk));
+            let increment = schema_increments.entry(schema_key).or_default();
+            *increment = increment
+                .checked_add(1)
+                .ok_or_else(|| head_value_error("packed current-base row count exceeds u64"))?;
+        }
+        self.stage_packed_insert_current_base_manifest(
+            branch_id,
+            generation,
+            new_head,
+            schema_increments,
+            working_diff_capture_checkpoint_commit_id,
+            coverage,
+        )
+        .await
+    }
+
     /// Publishes validated, tracked, unfiled creates as an immutable base.
     ///
     /// The commit-delta plane already owns the sorted identities and payloads,
@@ -3656,6 +3713,33 @@ where
             ));
         }
 
+        let mut schema_increments = BTreeMap::<&str, u64>::new();
+        for delta in &sorted {
+            let increment = schema_increments.entry(delta.schema_key).or_default();
+            *increment = increment
+                .checked_add(1)
+                .ok_or_else(|| head_value_error("packed current-base row count exceeds u64"))?;
+        }
+        self.stage_packed_insert_current_base_manifest(
+            branch_id,
+            generation,
+            new_head,
+            schema_increments,
+            working_diff_capture_checkpoint_commit_id,
+            coverage,
+        )
+        .await
+    }
+
+    async fn stage_packed_insert_current_base_manifest(
+        &mut self,
+        branch_id: &str,
+        generation: CommitId,
+        new_head: CommitId,
+        schema_increments: BTreeMap<&str, u64>,
+        working_diff_capture_checkpoint_commit_id: Option<CommitId>,
+        coverage: &mut WorkingDiffIndexCoverage,
+    ) -> Result<CommitId, LixError> {
         let mut manifest_key = hot_scope_prefix(branch_id, generation);
         manifest_key.reserve(16);
         manifest_key.extend_from_slice(new_head.as_uuid().as_bytes());
@@ -3665,13 +3749,6 @@ where
                 .ok_or_else(|| head_value_error("packed current-base diff count exceeds u64"))?;
         }
 
-        let mut schema_increments = BTreeMap::<&str, u64>::new();
-        for delta in &sorted {
-            let increment = schema_increments.entry(delta.schema_key).or_default();
-            *increment = increment
-                .checked_add(1)
-                .ok_or_else(|| head_value_error("packed current-base row count exceeds u64"))?;
-        }
         let scopes = schema_increments
             .keys()
             .map(

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -2280,9 +2280,6 @@ where
         .iter()
         .map(|statement| statement.params.as_slice())
         .collect::<Vec<_>>();
-    let Some(parameter_batch) = sql2::parameter_record_batch(&parameter_rows)? else {
-        return Ok(None);
-    };
 
     let previous_origin_key = transaction.replace_origin_key(options.origin_key.clone());
     let execution = async {
@@ -2292,6 +2289,15 @@ where
                 .first()
                 .expect("non-empty transaction batch has a parsed statement"),
         )?;
+        if let Some(results) =
+            sql2::execute_write_logical_plan_value_batch(transaction, &plan, &parameter_rows)
+                .await?
+        {
+            return Ok(Some(results));
+        }
+        let Some(parameter_batch) = sql2::parameter_record_batch(&parameter_rows)? else {
+            return Ok(None);
+        };
         sql2::execute_write_logical_plan_parameter_batch(transaction, plan, &parameter_batch).await
     }
     .await;
@@ -4118,6 +4124,71 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(rows.rows()[0].get::<String>("id").unwrap(), "b");
         assert_eq!(rows.rows()[0].get::<String>("value").unwrap(), "updated-b");
+    }
+
+    #[tokio::test]
+    async fn large_ordered_parameter_insert_reuses_commit_delta_as_current_base() {
+        const ROW_COUNT: usize = 1_024;
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "x-lix-key": "ordered_packed_insert_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": { "type": "string" }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+
+        crate::transaction::take_ordered_packed_current_base_publications();
+        let sql = "INSERT INTO ordered_packed_insert_probe (id, value) VALUES ($1, $2)";
+        let statements = (0..ROW_COUNT)
+            .map(|row_index| ExecuteBatchStatement {
+                sql: sql.to_string(),
+                params: vec![
+                    Value::Text(format!("{row_index:04}")),
+                    Value::Text(format!("value-{row_index:04}")),
+                ],
+            })
+            .collect::<Vec<_>>();
+        let affected = session
+            .execute_batch(&statements)
+            .await
+            .unwrap()
+            .iter()
+            .map(ExecuteResult::rows_affected)
+            .sum::<u64>();
+        assert_eq!(affected, ROW_COUNT as u64);
+        assert_eq!(
+            crate::transaction::take_ordered_packed_current_base_publications(),
+            1,
+            "the certified ordered batch must publish its commit delta directly as current state"
+        );
+
+        let rows = session
+            .execute(
+                "SELECT id, value FROM ordered_packed_insert_probe WHERE id IN ('0000', '1023') ORDER BY id",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows.rows()[0].get::<String>("value").unwrap(), "value-0000");
+        assert_eq!(rows.rows()[1].get::<String>("value").unwrap(), "value-1023");
+        session
+            .create_checkpoint()
+            .await
+            .expect("ordered packed current base should remain checkpointable");
     }
 
     #[tokio::test]

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -86,6 +86,89 @@ pub(crate) enum BoundPublicWriteExecution {
     Unsupported,
 }
 
+#[derive(Clone, Copy)]
+enum EntityInsertParameterBatch<'a> {
+    Arrow(&'a RecordBatch),
+    Values(&'a [&'a [Value]]),
+}
+
+#[derive(Clone, Copy)]
+enum DirectParameterValue<'a> {
+    Null,
+    String(&'a str),
+    Boolean(bool),
+}
+
+impl<'a> EntityInsertParameterBatch<'a> {
+    fn num_rows(self) -> usize {
+        match self {
+            Self::Arrow(batch) => batch.num_rows(),
+            Self::Values(rows) => rows.len(),
+        }
+    }
+
+    fn num_columns(self) -> usize {
+        match self {
+            Self::Arrow(batch) => batch.num_columns(),
+            Self::Values(rows) => rows.first().map_or(0, |row| row.len()),
+        }
+    }
+
+    fn column_matches(self, parameter_index: usize, column_type: EntityColumnType) -> bool {
+        match self {
+            Self::Arrow(batch) => {
+                let Some(array) = batch.columns().get(parameter_index) else {
+                    return false;
+                };
+                if crate::sql2::result_metadata::field_is_json(
+                    batch.schema().field(parameter_index),
+                ) {
+                    return false;
+                }
+                match column_type {
+                    EntityColumnType::String => array.as_any().is::<StringArray>(),
+                    EntityColumnType::Boolean => array.as_any().is::<BooleanArray>(),
+                    _ => false,
+                }
+            }
+            Self::Values(rows) => rows.iter().all(|row| {
+                matches!(
+                    (column_type, row.get(parameter_index)),
+                    (EntityColumnType::String, Some(Value::Text(_) | Value::Null))
+                        | (
+                            EntityColumnType::Boolean,
+                            Some(Value::Boolean(_) | Value::Null)
+                        )
+                )
+            }),
+        }
+    }
+
+    fn value(self, parameter_index: usize, row_index: usize) -> DirectParameterValue<'a> {
+        match self {
+            Self::Arrow(batch) => {
+                let array = &batch.columns()[parameter_index];
+                if array.is_null(row_index) {
+                    return DirectParameterValue::Null;
+                }
+                if let Some(array) = array.as_any().downcast_ref::<StringArray>() {
+                    DirectParameterValue::String(array.value(row_index))
+                } else if let Some(array) = array.as_any().downcast_ref::<BooleanArray>() {
+                    DirectParameterValue::Boolean(array.value(row_index))
+                } else {
+                    unreachable!("direct parameter column type was certified")
+                }
+            }
+            Self::Values(rows) => match &rows[row_index][parameter_index] {
+                Value::Null => DirectParameterValue::Null,
+                Value::Text(value) => DirectParameterValue::String(value),
+                Value::Boolean(value) => DirectParameterValue::Boolean(*value),
+                _ => unreachable!("direct parameter value type was certified"),
+            },
+        }
+    }
+}
+
 /// Executes independent parameterized entity INSERT statements as one dense
 /// transaction write. The public batch still returns one affected-row result
 /// per logical statement, while parsing, binding, and transaction staging
@@ -94,6 +177,35 @@ pub(crate) async fn try_execute_entity_insert_parameter_batch(
     ctx: &mut dyn SqlWriteExecutionContext,
     plan: &LogicalWritePlan,
     parameter_batch: &RecordBatch,
+) -> Result<Option<Vec<SqlWriteResult>>, LixError> {
+    try_execute_entity_insert_batch(
+        ctx,
+        plan,
+        EntityInsertParameterBatch::Arrow(parameter_batch),
+        true,
+    )
+    .await
+}
+
+pub(crate) async fn try_execute_entity_insert_value_batch<'a>(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    plan: &LogicalWritePlan,
+    parameter_rows: &'a [&'a [Value]],
+) -> Result<Option<Vec<SqlWriteResult>>, LixError> {
+    try_execute_entity_insert_batch(
+        ctx,
+        plan,
+        EntityInsertParameterBatch::Values(parameter_rows),
+        false,
+    )
+    .await
+}
+
+async fn try_execute_entity_insert_batch(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    plan: &LogicalWritePlan,
+    parameter_batch: EntityInsertParameterBatch<'_>,
+    allow_generic_fallback: bool,
 ) -> Result<Option<Vec<SqlWriteResult>>, LixError> {
     let BoundWriteTarget::Entity(EntityWriteSurface::Base { schema_key }) = &plan.bound.target
     else {
@@ -141,6 +253,7 @@ pub(crate) async fn try_execute_entity_insert_parameter_batch(
         &layout,
         values,
         parameter_batch,
+        allow_generic_fallback,
         active_branch_commit_id.as_ref(),
     )?
     else {
@@ -2423,7 +2536,8 @@ fn certified_entity_insert_parameter_batch(
     spec: &EntitySurfaceSpec,
     layout: &InsertRowLayout,
     values: &BoundInsertValues,
-    parameter_batch: &RecordBatch,
+    parameter_batch: EntityInsertParameterBatch<'_>,
+    allow_generic_fallback: bool,
     active_branch_commit_id: Option<&CommitId>,
 ) -> Result<Option<RawWriteBatch>, LixError> {
     let [row] = values.rows.as_slice() else {
@@ -2434,6 +2548,12 @@ fn certified_entity_insert_parameter_batch(
     {
         return Ok(Some(rows));
     }
+    if !allow_generic_fallback {
+        return Ok(None);
+    }
+    let EntityInsertParameterBatch::Arrow(parameter_batch) = parameter_batch else {
+        unreachable!("generic parameter fallback is only available for Arrow batches")
+    };
     certified_entity_insert_rows(
         ctx,
         plan,
@@ -2468,7 +2588,7 @@ fn certified_direct_parameter_insert_batch(
     spec: &EntitySurfaceSpec,
     layout: &InsertRowLayout,
     row: &[BoundExpr],
-    parameter_batch: &RecordBatch,
+    parameter_batch: EntityInsertParameterBatch<'_>,
 ) -> Result<Option<RawWriteBatch>, LixError> {
     if plan.bound.conflict.is_some()
         || !spec.defaults.is_empty()
@@ -2507,27 +2627,14 @@ fn certified_direct_parameter_insert_batch(
             return Ok(None);
         }
         let parameter_index = param.index.saturating_sub(1);
-        let Some(array) = parameter_batch.columns().get(parameter_index) else {
+        if parameter_index >= parameter_batch.num_columns() {
             return Err(LixError::unknown(format!(
                 "SQL parameter ${} is outside a {} column batch",
                 param.index,
                 parameter_batch.num_columns()
             )));
-        };
-        if crate::sql2::result_metadata::field_is_json(
-            parameter_batch.schema().field(parameter_index),
-        ) {
-            // Utf8 is also the physical carrier for public JSON parameters.
-            // Direct decoding as text would turn JSON objects/arrays into
-            // string literals and diverge from sequential type validation.
-            return Ok(None);
         }
-        let type_matches = match column_type {
-            EntityColumnType::String => array.as_any().is::<StringArray>(),
-            EntityColumnType::Boolean => array.as_any().is::<BooleanArray>(),
-            _ => false,
-        };
-        if !type_matches {
+        if !parameter_batch.column_matches(parameter_index, *column_type) {
             return Ok(None);
         }
         let mut name_prefix = serde_json::to_vec(name).map_err(|error| {
@@ -2592,6 +2699,23 @@ fn certified_direct_parameter_insert_batch(
         })?);
     let mut offsets = Vec::with_capacity(row_count);
     let mut entity_pks = Vec::with_capacity(row_count);
+    let shared_string_primary_keys =
+        spec.primary_key_component_types
+            .iter()
+            .all(|component_type| {
+                matches!(
+                    component_type,
+                    crate::entity_pk::EntityPkComponentType::String
+                )
+            });
+    let mut primary_key_arena = Vec::with_capacity(
+        row_count
+            .saturating_mul(primary_key_columns.len())
+            .saturating_mul(16),
+    );
+    let mut primary_key_ranges =
+        Vec::<(u32, u32)>::with_capacity(row_count.saturating_mul(primary_key_columns.len()));
+    let mut previous_primary_key_row = None;
     let mut unordered_entity_pks = None::<std::collections::HashSet<EntityPk>>;
     let mut primary_key_parts = Vec::with_capacity(primary_key_columns.len());
     let mut typed_fields = Vec::with_capacity(columns.len());
@@ -2606,8 +2730,9 @@ fn certified_direct_parameter_insert_batch(
                     normalized.push(b',');
                 }
                 normalized.extend_from_slice(&column.name_prefix);
-                let array = &parameter_batch.columns()[column.parameter_index];
-                if array.is_null(statement_index) {
+                let parameter_value =
+                    parameter_batch.value(column.parameter_index, statement_index);
+                if matches!(parameter_value, DirectParameterValue::Null) {
                     if !column.read_nullable {
                         let InsertColumnTarget::Visible { name, .. } =
                             &layout.columns[column.layout_index]
@@ -2629,29 +2754,20 @@ fn certified_direct_parameter_insert_batch(
                     });
                     continue;
                 }
-                match column.column_type {
-                    EntityColumnType::String => {
-                        let array = array
-                            .as_any()
-                            .downcast_ref::<StringArray>()
-                            .expect("direct string parameter type was certified");
-                        serde_json::to_writer(&mut normalized, array.value(statement_index))
-                            .map_err(|error| {
-                                LixError::unknown(format!(
-                                    "certified INSERT value serialization failed: {error}"
-                                ))
-                            })?;
+                match (column.column_type, parameter_value) {
+                    (EntityColumnType::String, DirectParameterValue::String(value)) => {
+                        serde_json::to_writer(&mut normalized, value).map_err(|error| {
+                            LixError::unknown(format!(
+                                "certified INSERT value serialization failed: {error}"
+                            ))
+                        })?;
                         typed_fields.push(TypedJsonObjectFieldRef {
                             name: &column.name,
-                            value: TypedJsonScalarRef::String(array.value(statement_index)),
+                            value: TypedJsonScalarRef::String(value),
                         });
                     }
-                    EntityColumnType::Boolean => {
-                        let array = array
-                            .as_any()
-                            .downcast_ref::<BooleanArray>()
-                            .expect("direct boolean parameter type was certified");
-                        normalized.extend_from_slice(if array.value(statement_index) {
+                    (EntityColumnType::Boolean, DirectParameterValue::Boolean(value)) => {
+                        normalized.extend_from_slice(if value {
                             b"true".as_slice()
                         } else {
                             b"false".as_slice()
@@ -2669,59 +2785,120 @@ fn certified_direct_parameter_insert_batch(
             primary_key_parts.clear();
             for &column_index in &primary_key_columns {
                 let column = &columns[column_index];
-                let array = parameter_batch.columns()[column.parameter_index]
-                    .as_any()
-                    .downcast_ref::<StringArray>()
-                    .expect("direct primary-key parameter is a string");
-                if array.is_null(statement_index) {
-                    return Err(LixError::new(
+                match parameter_batch.value(column.parameter_index, statement_index) {
+                    DirectParameterValue::String(value) => primary_key_parts.push(value),
+                    DirectParameterValue::Null => {
+                        return Err(LixError::new(
+                            LixError::CODE_SCHEMA_VALIDATION,
+                            format!(
+                                "INSERT failed to derive entity primary key for schema '{}': missing primary-key value",
+                                layout.schema_key
+                            ),
+                        ));
+                    }
+                    DirectParameterValue::Boolean(_) => {
+                        unreachable!("direct primary-key parameter is a string")
+                    }
+                }
+            }
+            let derived_entity_pk = if shared_string_primary_keys {
+                EntityPk::validate_external_parts(
+                    &primary_key_parts,
+                    &spec.primary_key_component_types,
+                )
+                .map_err(|error| {
+                    LixError::new(
                         LixError::CODE_SCHEMA_VALIDATION,
                         format!(
-                            "INSERT failed to derive entity primary key for schema '{}': missing primary-key value",
+                            "INSERT failed to derive entity primary key for schema '{}': {error}",
                             layout.schema_key
                         ),
-                    ));
-                }
-                primary_key_parts.push(array.value(statement_index));
-            }
-            let entity_pk = EntityPk::from_shared_external_parts(
-                primary_key_parts.iter().map(|part| SharedStr::from(*part)),
-                &spec.primary_key_component_types,
-            )
-            .map_err(|error| {
-                LixError::new(
-                    LixError::CODE_SCHEMA_VALIDATION,
-                    format!(
-                        "INSERT failed to derive entity primary key for schema '{}': {error}",
-                        layout.schema_key
-                    ),
+                    )
+                })?;
+                None
+            } else {
+                Some(
+                    EntityPk::from_shared_external_parts(
+                        primary_key_parts.iter().map(|part| SharedStr::from(*part)),
+                        &spec.primary_key_component_types,
+                    )
+                    .map_err(|error| {
+                        LixError::new(
+                            LixError::CODE_SCHEMA_VALIDATION,
+                            format!(
+                                "INSERT failed to derive entity primary key for schema '{}': {error}",
+                                layout.schema_key
+                            ),
+                        )
+                    })?,
                 )
-            })?;
+            };
             schema_plan.certify_typed_object_row(
                 &layout.schema_key,
                 &typed_fields,
                 &primary_key_parts,
             )?;
-            if let Some(unique) = &mut unordered_entity_pks {
-                if !unique.insert(entity_pk.clone()) {
-                    return Ok(false);
+            if shared_string_primary_keys {
+                if let Some(previous_row) = previous_primary_key_row {
+                    let ordering = primary_key_columns
+                        .iter()
+                        .zip(&primary_key_parts)
+                        .map(|(&column_index, current)| {
+                            let column = &columns[column_index];
+                            let DirectParameterValue::String(previous) =
+                                parameter_batch.value(column.parameter_index, previous_row)
+                            else {
+                                unreachable!("direct primary-key parameter is a string")
+                            };
+                            previous.cmp(current)
+                        })
+                        .find(|ordering| !ordering.is_eq())
+                        .unwrap_or(std::cmp::Ordering::Equal);
+                    if ordering != std::cmp::Ordering::Less {
+                        // The common bulk producer is already ordered. Keep
+                        // this arena route allocation-free and let the
+                        // established generic certified path preserve
+                        // statement-attributed duplicate handling for the
+                        // uncommon unordered batch.
+                        return Ok(false);
+                    }
                 }
-            } else if let Some(previous) = entity_pks.last()
-                && previous >= &entity_pk
-            {
-                // Ordered parameter batches prove uniqueness by adjacency and
-                // need no hash table. On the first disorder, seed the fallback
-                // index with exactly the already accepted prefix so duplicate
-                // detection and later validation retain statement order.
-                let mut unique = std::collections::HashSet::with_capacity(row_count);
-                unique.extend(entity_pks.iter().cloned());
-                if !unique.insert(entity_pk.clone()) {
-                    return Ok(false);
+                previous_primary_key_row = Some(statement_index);
+                for part in &primary_key_parts {
+                    let start = u32::try_from(primary_key_arena.len()).map_err(|_| {
+                        LixError::unknown("certified primary-key arena exceeds u32")
+                    })?;
+                    primary_key_arena.extend_from_slice(part.as_bytes());
+                    let end = u32::try_from(primary_key_arena.len()).map_err(|_| {
+                        LixError::unknown("certified primary-key arena exceeds u32")
+                    })?;
+                    primary_key_ranges.push((start, end));
                 }
-                unordered_entity_pks = Some(unique);
+            } else {
+                let entity_pk =
+                    derived_entity_pk.expect("non-string primary key was materialized above");
+                if let Some(unique) = &mut unordered_entity_pks {
+                    if !unique.insert(entity_pk.clone()) {
+                        return Ok(false);
+                    }
+                } else if let Some(previous) = entity_pks.last()
+                    && previous >= &entity_pk
+                {
+                    // Ordered parameter batches prove uniqueness by adjacency
+                    // and need no hash table. On the first disorder, seed the
+                    // fallback index with exactly the already accepted prefix
+                    // so duplicate detection and later validation retain
+                    // statement order.
+                    let mut unique = std::collections::HashSet::with_capacity(row_count);
+                    unique.extend(entity_pks.iter().cloned());
+                    if !unique.insert(entity_pk.clone()) {
+                        return Ok(false);
+                    }
+                    unordered_entity_pks = Some(unique);
+                }
+                entity_pks.push(entity_pk);
             }
             offsets.push((start, normalized.len()));
-            entity_pks.push(entity_pk);
             Ok(true)
         })();
         if !row_result
@@ -2731,6 +2908,32 @@ fn certified_direct_parameter_insert_batch(
         }
     }
 
+    if shared_string_primary_keys {
+        let primary_key_arena = SharedStr::from_utf8(bytes::Bytes::from(primary_key_arena))
+            .map_err(|_| LixError::unknown("certified primary-key arena is not valid UTF-8"))?;
+        entity_pks.reserve(row_count);
+        for ranges in primary_key_ranges.chunks_exact(primary_key_columns.len()) {
+            entity_pks.push(
+                EntityPk::from_shared_external_parts(
+                    ranges.iter().map(|&(start, end)| {
+                        primary_key_arena
+                            .slice(start as usize..end as usize)
+                            .expect("certified primary-key ranges preserve UTF-8 boundaries")
+                    }),
+                    &spec.primary_key_component_types,
+                )
+                .map_err(|error| {
+                    LixError::new(
+                        LixError::CODE_SCHEMA_VALIDATION,
+                        format!(
+                            "INSERT failed to derive entity primary key for schema '{}': {error}",
+                            layout.schema_key
+                        ),
+                    )
+                })?,
+            );
+        }
+    }
     let snapshots = TransactionJson::from_certified_row_content_arena(normalized, offsets)?;
     let schema_key: SharedStr = layout.schema_key.as_str().into();
     let branch_id: SharedStr = ctx.active_branch_id().into();

--- a/packages/engine/src/sql2/exec/mod.rs
+++ b/packages/engine/src/sql2/exec/mod.rs
@@ -86,7 +86,7 @@ pub(crate) use write::{
     WriteLogicalPlan as SqlWriteLogicalPlan, create_write_logical_plan_from_template,
     create_write_plan_template_from_parsed, diff_command_query,
     execute_write_logical_plan_parameter_batch, execute_write_logical_plan_result_with_metadata,
-    parameter_record_batch,
+    execute_write_logical_plan_value_batch, parameter_record_batch,
 };
 
 pub(crate) enum SqlLogicalPlan {

--- a/packages/engine/src/sql2/exec/write.rs
+++ b/packages/engine/src/sql2/exec/write.rs
@@ -346,6 +346,30 @@ pub(crate) async fn execute_write_logical_plan_parameter_batch(
     .map_err(normalize_bound_public_write_error)
 }
 
+pub(crate) async fn execute_write_logical_plan_value_batch<'a>(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    plan: &SqlLogicalPlan,
+    parameter_rows: &'a [&'a [Value]],
+) -> Result<Option<Vec<SqlWriteResult>>, LixError> {
+    let SqlLogicalPlan::Write(write_plan) = plan else {
+        return Ok(None);
+    };
+    let Some(first) = parameter_rows.first() else {
+        return Ok(None);
+    };
+    if parameter_rows.iter().any(|row| row.len() != first.len()) {
+        return Ok(None);
+    }
+    validate_write_parameter_count(&write_plan.plan, first.len())?;
+    super::bound_public_write::try_execute_entity_insert_value_batch(
+        ctx,
+        &write_plan.plan,
+        parameter_rows,
+    )
+    .await
+    .map_err(normalize_bound_public_write_error)
+}
+
 #[cfg(test)]
 pub(crate) async fn execute_write_logical_plan_with_mode(
     ctx: &mut dyn SqlWriteExecutionContext,

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -51,7 +51,8 @@ pub(crate) use exec::{
     create_write_plan_template_from_parsed, diff_command_query, execute_read_statement_from_parsed,
     execute_read_statement_in_session_from_parsed, execute_transaction_read_statement_from_parsed,
     execute_write_logical_plan_parameter_batch, execute_write_logical_plan_result_with_metadata,
-    parameter_record_batch, prepare_read_session, prepare_read_session_at_head,
+    execute_write_logical_plan_value_batch, parameter_record_batch, prepare_read_session,
+    prepare_read_session_at_head,
 };
 #[cfg(test)]
 pub(crate) use exec::{

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -36,7 +36,7 @@ pub(crate) const TRACKED_STATE_COMMIT_DELTA_MANIFEST_NAMESPACE: &str =
     "tracked_state.commit_delta_manifest.v3";
 pub(crate) const TRACKED_STATE_COMMIT_DELTA_SEGMENT_NAMESPACE: &str =
     "tracked_state.commit_delta_segment.v3";
-pub(crate) const TRACKED_STATE_CHANGE_LOCATOR_NAMESPACE: &str = "tracked_state.change_locator.v1";
+pub(crate) const TRACKED_STATE_CHANGE_LOCATOR_NAMESPACE: &str = "tracked_state.change_locator.v2";
 pub(crate) const TRACKED_STATE_TREE_CHUNK_SPACE: StorageSpace = StorageSpace::new(
     StorageSpaceId(0x0004_0001),
     TRACKED_STATE_TREE_CHUNK_NAMESPACE,
@@ -67,9 +67,11 @@ pub(crate) const TRACKED_STATE_CHANGE_LOCATOR_SPACE: StorageSpace = StorageSpace
     TRACKED_STATE_CHANGE_LOCATOR_NAMESPACE,
 );
 
-const COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 128;
-const COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 28 * 1024;
-const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD7";
+const COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 512;
+const GENERIC_COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 128;
+const GENERIC_COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 28 * 1024;
+const ORDERED_COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 64 * 1024;
+const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD8";
 const COMMIT_DELTA_PAYLOAD_OFFSET_BYTES: usize = size_of::<u32>();
 #[cfg(not(test))]
 const COMMIT_DELTA_MAX_SIDECAR_BYTES: usize = 64 * 1024 * 1024;
@@ -294,7 +296,7 @@ pub(crate) struct CommitDeltaChangeLocator {
     pub(crate) change_id: crate::changelog::ChangeId,
     pub(crate) commit_id: CommitId,
     pub(crate) segment_index: u32,
-    pub(crate) ordinal: u8,
+    pub(crate) ordinal: u16,
 }
 
 pub(crate) struct AddressableCommitDeltaStage {
@@ -311,7 +313,7 @@ pub(crate) struct AddressableCommitDeltaStage {
 /// write batch are simultaneously live.
 pub(crate) struct OrderedAddressableCommitDeltaStage {
     commit_id: CommitId,
-    segment_row_counts: Vec<u8>,
+    segment_row_counts: Vec<u16>,
     row_count: usize,
 }
 
@@ -838,7 +840,8 @@ where
                 &mut compressor,
             ) {
                 Ok((bounds, encoded))
-                    if encoded.len() <= COMMIT_DELTA_SEGMENT_TARGET_BYTES || candidate_len == 1 =>
+                    if encoded.len() <= ORDERED_COMMIT_DELTA_SEGMENT_TARGET_BYTES
+                        || candidate_len == 1 =>
                 {
                     break (bounds, encoded);
                 }
@@ -851,9 +854,9 @@ where
                 Ok(_) => unreachable!("single-row segment exits through the guarded success arm"),
             }
         };
-        let row_count_u8 =
-            u8::try_from(candidate_len).expect("commit-delta segment row count fits u8");
-        segment_row_counts.push(row_count_u8);
+        let row_count_u16 =
+            u16::try_from(candidate_len).expect("commit-delta segment row count fits u16");
+        segment_row_counts.push(row_count_u16);
         for _ in 0..candidate_len {
             pending.pop_front();
         }
@@ -1072,7 +1075,8 @@ fn stage_commit_deltas_inner(
             )
         })?;
     while segment_start < entries.len() {
-        let mut segment_end = (segment_start + COMMIT_DELTA_SEGMENT_MAX_ROWS).min(entries.len());
+        let mut segment_end =
+            (segment_start + GENERIC_COMMIT_DELTA_SEGMENT_MAX_ROWS).min(entries.len());
         let segment_index = encoded_segments.len();
         let (encoded, assigned_entries, segment_assignments) = loop {
             let mut candidate = entries[segment_start..segment_end].to_vec();
@@ -1099,7 +1103,7 @@ fn stage_commit_deltas_inner(
                 &mut sidecar_compressor,
             ) {
                 Ok(encoded)
-                    if encoded.len() <= COMMIT_DELTA_SEGMENT_TARGET_BYTES
+                    if encoded.len() <= GENERIC_COMMIT_DELTA_SEGMENT_TARGET_BYTES
                         || segment_end - segment_start == 1 =>
                 {
                     break (encoded, candidate, candidate_assignments);
@@ -1209,9 +1213,11 @@ fn addressable_change_id(
             "tracked_state commit_delta segment index exceeds direct address space",
         )
     })?;
-    let ordinal = u8::try_from(ordinal).expect("commit-delta segment row count fits u8");
+    let ordinal = u16::try_from(ordinal).expect("commit-delta segment row count fits u16");
     let packed = segment
-        .checked_mul(256)
+        .checked_mul(
+            u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS).expect("segment row limit fits u32"),
+        )
         .and_then(|value| value.checked_add(u32::from(ordinal)))
         .and_then(|value| value.checked_add(1))
         .ok_or_else(|| {
@@ -1242,7 +1248,7 @@ fn commit_delta_change_locators(
         .iter()
         .enumerate()
         .map(|(ordinal, entry)| {
-            let ordinal = u8::try_from(ordinal).expect("commit-delta segment row count fits u8");
+            let ordinal = u16::try_from(ordinal).expect("commit-delta segment row count fits u16");
             let change_id = decode_value(&entry.value)?.change_id;
             Ok(CommitDeltaChangeLocator {
                 change_id,
@@ -1329,7 +1335,9 @@ fn direct_change_locator(
     let mut commit_bytes = *change_id.as_uuid().as_bytes();
     let packed = u32::from_be_bytes(commit_bytes[12..].try_into().expect("four address bytes"));
     let packed = packed.checked_sub(1)?;
-    let ordinal = u8::try_from(packed % 256).ok()?;
+    let segment_row_limit =
+        u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS).expect("segment row limit fits u32");
+    let ordinal = u16::try_from(packed % segment_row_limit).ok()?;
     if usize::from(ordinal) >= COMMIT_DELTA_SEGMENT_MAX_ROWS {
         return None;
     }
@@ -1337,7 +1345,7 @@ fn direct_change_locator(
     Some(CommitDeltaChangeLocator {
         change_id,
         commit_id: CommitId::new(uuid::Uuid::from_bytes(commit_bytes)),
-        segment_index: packed / 256,
+        segment_index: packed / segment_row_limit,
         ordinal,
     })
 }
@@ -1375,6 +1383,22 @@ async fn load_change_records_by_ids(
     // intentionally have no locator rows. Keep the legacy locator batch below
     // for wholly explicit IDs; mixed/direct batches must validate the direct
     // candidate and retain the existing explicit-locator fallback.
+    if let Some(direct_locators) = change_ids
+        .iter()
+        .copied()
+        .map(direct_change_locator)
+        .collect::<Option<Vec<_>>>()
+    {
+        // Certified commits encode their authoritative coordinates directly
+        // in every change ID. Resolve the whole selection as one physical
+        // batch so a large segment is read and decoded once rather than once
+        // per selected change. Address-shaped explicit IDs are rare and keep
+        // the established locator fallback below if candidate validation
+        // rejects the direct route.
+        if let Ok(records) = load_change_records_at_locators(store, &direct_locators).await {
+            return Ok(records);
+        }
+    }
     if change_ids
         .iter()
         .copied()
@@ -1420,7 +1444,13 @@ async fn load_change_records_by_ids(
             decode_change_locator(change_id, &bytes)
         })
         .collect::<Result<Vec<_>, _>>()?;
+    load_change_records_at_locators(store, &locators).await
+}
 
+async fn load_change_records_at_locators(
+    store: &(impl StorageAdapterRead + ?Sized),
+    locators: &[CommitDeltaChangeLocator],
+) -> Result<Vec<crate::changelog::ChangeRecord>, LixError> {
     let commit_ids = locators
         .iter()
         .map(|locator| locator.commit_id)
@@ -1493,35 +1523,44 @@ async fn load_change_records_by_ids(
         })
         .collect::<Result<BTreeMap<_, _>, _>>()?;
 
-    let loaded = locators
-        .into_iter()
-        .map(|locator| {
-            let manifest = &manifests[&locator.commit_id];
-            let segment_index = usize::try_from(locator.segment_index).expect("u32 fits usize");
-            let (bytes, bounds) = if let Some(inline) = manifest.inline_segment() {
-                if segment_index != 0 {
-                    return Err(LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        "tracked_state selected change references a nonzero inline segment",
-                    ));
-                }
-                (inline, None)
-            } else {
-                let bounds = manifest.segments.get(segment_index).ok_or_else(|| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        "tracked_state selected change references an undeclared segment",
-                    )
-                })?;
-                (
-                    segments[&(locator.commit_id, segment_index)].as_ref(),
-                    Some(bounds),
+    let mut locator_groups = BTreeMap::<(CommitId, usize), Vec<usize>>::new();
+    for (locator_index, locator) in locators.iter().enumerate() {
+        locator_groups
+            .entry((
+                locator.commit_id,
+                usize::try_from(locator.segment_index).expect("u32 fits usize"),
+            ))
+            .or_default()
+            .push(locator_index);
+    }
+    let mut loaded = (0..locators.len()).map(|_| None).collect::<Vec<_>>();
+    for ((commit_id, segment_index), locator_indices) in locator_groups {
+        let manifest = &manifests[&commit_id];
+        let (bytes, bounds) = if let Some(inline) = manifest.inline_segment() {
+            if segment_index != 0 {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state selected change references a nonzero inline segment",
+                ));
+            }
+            (inline, None)
+        } else {
+            let bounds = manifest.segments.get(segment_index).ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state selected change references an undeclared segment",
                 )
-            };
-            decode_change_at_locator(bytes, bounds, locator).map(Some)
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    let mut loaded = loaded;
+            })?;
+            (segments[&(commit_id, segment_index)].as_ref(), Some(bounds))
+        };
+        let (leaf, payloads) = decode_commit_delta_with_payloads(bytes, bounds)?;
+        for locator_index in locator_indices {
+            let locator = locators[locator_index];
+            loaded[locator_index] = Some(decode_change_at_locator_from_decoded(
+                &leaf, &payloads, locator,
+            )?);
+        }
+    }
     hydrate_certified_loaded_entries(store, &mut loaded).await?;
     loaded
         .into_iter()
@@ -1541,8 +1580,16 @@ fn decode_change_at_locator(
     bounds: Option<&CommitDeltaSegmentBounds>,
     locator: CommitDeltaChangeLocator,
 ) -> Result<LoadedCommitDeltaEntry, LixError> {
-    let change_id = locator.change_id;
     let (leaf, payloads) = decode_commit_delta_with_payloads(segment, bounds)?;
+    decode_change_at_locator_from_decoded(&leaf, &payloads, locator)
+}
+
+fn decode_change_at_locator_from_decoded(
+    leaf: &DecodedLeafNodeRef,
+    payloads: &CommitDeltaPayloadIndexRef<'_>,
+    locator: CommitDeltaChangeLocator,
+) -> Result<LoadedCommitDeltaEntry, LixError> {
+    let change_id = locator.change_id;
     let ordinal = usize::from(locator.ordinal);
     let entry = leaf.entry(ordinal)?.ok_or_else(|| {
         LixError::new(
@@ -1756,8 +1803,8 @@ fn decode_change_locator(
         .ok_or_else(|| invalid_change_locator(change_id, "has an invalid ordinal"))?;
     let segment_index = u32::try_from(packed_ordinal / COMMIT_DELTA_SEGMENT_MAX_ROWS as u64)
         .map_err(|_| invalid_change_locator(change_id, "has an invalid segment"))?;
-    let ordinal = u8::try_from(packed_ordinal % COMMIT_DELTA_SEGMENT_MAX_ROWS as u64)
-        .expect("segment remainder fits u8");
+    let ordinal = u16::try_from(packed_ordinal % COMMIT_DELTA_SEGMENT_MAX_ROWS as u64)
+        .expect("segment remainder fits u16");
     Ok(CommitDeltaChangeLocator {
         change_id,
         commit_id: CommitId::new(commit_id),
@@ -4012,8 +4059,8 @@ mod tests {
     };
 
     use super::{
-        COMMIT_DELTA_FORMAT_MAGIC, COMMIT_DELTA_SEGMENT_MAX_ROWS, CommitDeltaChangeLocator,
-        CommitDeltaManifest, CommitDeltaPayloadRef, DecodedCommitDeltaBatch,
+        COMMIT_DELTA_FORMAT_MAGIC, CommitDeltaChangeLocator, CommitDeltaManifest,
+        CommitDeltaPayloadRef, DecodedCommitDeltaBatch, GENERIC_COMMIT_DELTA_SEGMENT_MAX_ROWS,
         TRACKED_STATE_CHANGE_LOCATOR_SPACE, TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
         TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, TRACKED_STATE_COMMIT_ROOT_MAGIC,
         TRACKED_STATE_COMMIT_ROOT_SPACE, TRACKED_STATE_TREE_CHUNK_SPACE, TrackedStateChunkOverlay,
@@ -4298,7 +4345,6 @@ mod tests {
             &vec![true; deltas.len()],
         )
         .expect("generic addressable deltas should stage");
-        assert_eq!(assigned, generic.assigned_change_ids);
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
@@ -4316,16 +4362,6 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("generic addressable read should open");
-        for space in [
-            TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
-            TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
-        ] {
-            assert_eq!(
-                super::scan_full_space(&read, space).await.unwrap(),
-                super::scan_full_space(&generic_read, space).await.unwrap(),
-                "streaming must preserve the exact packed history bytes"
-            );
-        }
         for source_index in [0, 127, 128, fixtures.len() - 1] {
             let loaded = load_change_record_by_id(&read, assigned[source_index])
                 .await
@@ -4335,6 +4371,18 @@ mod tests {
             assert_eq!(loaded.schema_key, fixtures[source_index].schema_key);
             assert_eq!(loaded.entity_pk, fixtures[source_index].entity_pk);
             assert_eq!(loaded.snapshot.is_none(), fixtures[source_index].deleted);
+            let generic_loaded =
+                load_change_record_by_id(&generic_read, generic.assigned_change_ids[source_index])
+                    .await
+                    .expect("direct generic address should read")
+                    .expect("direct generic address should resolve");
+            assert_eq!(generic_loaded.schema_key, loaded.schema_key);
+            assert_eq!(generic_loaded.entity_pk, loaded.entity_pk);
+            assert_eq!(generic_loaded.file_id, loaded.file_id);
+            assert_eq!(generic_loaded.snapshot, loaded.snapshot);
+            assert_eq!(generic_loaded.metadata, loaded.metadata);
+            assert_eq!(generic_loaded.created_at, loaded.created_at);
+            assert_eq!(generic_loaded.origin_key, loaded.origin_key);
         }
     }
 
@@ -5005,7 +5053,7 @@ mod tests {
         assert_eq!(
             writes.stats().staged_puts,
             4,
-            "300 payload-bearing rows should use one manifest and three byte-bounded segments"
+            "generic history keeps 300 compact rows in three read-friendly segments plus its manifest"
         );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -6079,14 +6127,14 @@ mod tests {
         let storage = StorageAdapter::new(Memory::new());
         let inline_commit_id = CommitId::for_test_label("packed-delta-inline-boundary");
         let indexed_commit_id = CommitId::for_test_label("packed-delta-indexed-boundary");
-        let fixtures = (0..257)
+        let fixtures = (0..129)
             .map(|index| CommitDeltaFixture {
                 schema_key: match index {
-                    255 => "sparse".to_string(),
-                    256 => "zeta".to_string(),
+                    127 => "sparse".to_string(),
+                    128 => "zeta".to_string(),
                     _ => "alpha".to_string(),
                 },
-                file_id: (index == 255).then(|| "sparse-file".to_string()),
+                file_id: (index == 127).then(|| "sparse-file".to_string()),
                 entity_pk: EntityPk::single(format!("boundary-{index:04}")),
                 change_id: ChangeId::for_test_label(&format!("boundary-change-{index}")),
                 deleted: false,
@@ -6096,10 +6144,10 @@ mod tests {
             .collect::<Vec<_>>();
 
         let mut inline_writes = storage.new_write_set();
-        let inline_deltas = commit_delta_refs(inline_commit_id, &fixtures[..256]);
+        let inline_deltas = commit_delta_refs(inline_commit_id, &fixtures[..128]);
         stage_commit_deltas(&mut inline_writes, &inline_deltas)
-            .expect("256 deltas should split at the byte boundary");
-        assert_eq!(inline_writes.stats().staged_puts, 3);
+            .expect("128 generic deltas should fit the history read boundary");
+        assert_eq!(inline_writes.stats().staged_puts, 1);
         storage
             .commit_write_set(inline_writes, StorageWriteOptions::default())
             .await
@@ -6108,8 +6156,8 @@ mod tests {
         let mut indexed_writes = storage.new_write_set();
         let indexed_deltas = commit_delta_refs(indexed_commit_id, &fixtures);
         stage_commit_deltas(&mut indexed_writes, &indexed_deltas)
-            .expect("257 deltas should use indexed segments");
-        assert_eq!(indexed_writes.stats().staged_puts, 4);
+            .expect("129 generic deltas should use indexed segments");
+        assert_eq!(indexed_writes.stats().staged_puts, 3);
         storage
             .commit_write_set(indexed_writes, StorageWriteOptions::default())
             .await
@@ -6119,7 +6167,7 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
-        let sparse = &fixtures[255];
+        let sparse = &fixtures[127];
         assert_eq!(
             load_commit_delta_values_for_test(&read, indexed_commit_id, &[sparse.key()])
                 .await
@@ -6171,11 +6219,13 @@ mod tests {
         assert_eq!(batch.file_dictionary_len(), 1);
         assert_eq!(
             batch.arena_count(),
-            fixtures.len().div_ceil(COMMIT_DELTA_SEGMENT_MAX_ROWS),
+            fixtures
+                .len()
+                .div_ceil(GENERIC_COMMIT_DELTA_SEGMENT_MAX_ROWS),
             "the batch retains one decoded arena per packed segment, never one owner per row"
         );
         assert!(
-            batch.arena_count() * COMMIT_DELTA_SEGMENT_MAX_ROWS >= batch.len(),
+            batch.arena_count() * GENERIC_COMMIT_DELTA_SEGMENT_MAX_ROWS >= batch.len(),
             "segment arena ownership must stay bounded independently of row metadata"
         );
         let first = batch.iter().next().expect("large batch has a first row");

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -54,6 +54,17 @@ type RowIndex = usize;
 // amplification dominates the cost of retaining one immutable manifest.
 const PACKED_CURRENT_BASE_MIN_ROWS: usize = 1_024;
 
+#[cfg(test)]
+std::thread_local! {
+    static ORDERED_PACKED_CURRENT_BASE_PUBLICATIONS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn take_ordered_packed_current_base_publications() -> usize {
+    ORDERED_PACKED_CURRENT_BASE_PUBLICATIONS.with(|publications| publications.replace(0))
+}
+
 /// Commits prepared transaction rows into tracked history and unified current
 /// live state.
 ///
@@ -260,7 +271,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
 
     let selected_change_records = load_selected_change_records(read, &commit_rows).await?;
 
-    stage_tracked_commit_delta_index(
+    let ordered_addressable_commits = stage_tracked_commit_delta_index(
         &mut writes,
         &mut state_rows,
         &row_index.tracked_row_indices_by_commit,
@@ -342,6 +353,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &explicit_branch_targets,
         &branch_control_observations,
         &checkpoint_epochs,
+        &ordered_addressable_commits,
     ))
     .instrument(tracing::debug_span!(
         target: "lix_perf",
@@ -1111,7 +1123,8 @@ fn stage_tracked_commit_delta_index(
     commit_rows: &[FinalizedCommitRow],
     selected_change_records: &HashMap<SelectedChangeKey, ChangeRecord>,
     host_certified_file_schemas: &BTreeMap<String, BTreeMap<String, BTreeSet<String>>>,
-) -> Result<(), LixError> {
+) -> Result<BTreeSet<CommitId>, LixError> {
+    let mut ordered_addressable_commits = BTreeSet::new();
     let commit_rows = commit_rows
         .iter()
         .map(|commit| (commit.commit_id, commit))
@@ -1171,6 +1184,7 @@ fn stage_tracked_commit_delta_index(
                 {
                     state_rows.set_change_id(row_index, Some(change_id));
                 }
+                ordered_addressable_commits.insert(root.commit_id);
                 continue;
             }
         }
@@ -1232,7 +1246,7 @@ fn stage_tracked_commit_delta_index(
             .collect::<Vec<_>>();
         stage_change_locators(writes, &authored_locators);
     }
-    Ok(())
+    Ok(ordered_addressable_commits)
 }
 
 struct StagedHotHeads {
@@ -1854,6 +1868,7 @@ async fn stage_tracked_head(
     explicit_branch_targets: &BTreeMap<String, ExplicitBranchHeadTarget>,
     observations: &BTreeMap<String, BranchHeadControlObservation>,
     checkpoint_epochs: &BTreeMap<String, CommitId>,
+    ordered_addressable_commits: &BTreeSet<CommitId>,
 ) -> Result<StagedHotHeads, LixError> {
     let lifecycle_ids = lifecycle_snapshot_commit_ids(
         tracked_roots,
@@ -1965,7 +1980,39 @@ async fn stage_tracked_head(
                 .filter(|row| row.branch_id == root.branch_id)
                 .map(current_state_delta_from_engine_row),
         );
-        let absence_guards = {
+        let checkpoint_commit_id = checkpoint_epochs.get(&root.branch_id).copied();
+        let is_checkpoint_publication = checkpoint_commit_id == Some(root.commit_id);
+        let can_publish_ordered_packed_current_base = ordered_addressable_commits
+            .contains(&root.commit_id)
+            && !is_checkpoint_publication
+            && state_row_indices.len() >= PACKED_CURRENT_BASE_MIN_ROWS
+            && certified_fresh_plugin_file_id.is_none()
+            && !host_certified_live_increments.contains_key(&root.branch_id)
+            && staged.selected_change_batches.is_empty()
+            && selected_materialization.is_none()
+            && untracked_deltas.is_empty()
+            && engine_rows.is_empty()
+            && explicit_branch_targets.is_empty()
+            && state_row_indices.len() == state_rows.len()
+            && insert_selection.len() == state_rows.len()
+            && state_row_indices.iter().all(|&row_index| {
+                let row = state_rows.row(row_index);
+                insert_selection.contains(row_index)
+                    && row.branch_id.as_str() == root.branch_id
+                    && !row.untracked
+                    && row.snapshot.is_some()
+                    && row.file_id.is_none()
+                    && row.schema_key != BRANCH_REF_SCHEMA_KEY
+                    && row.schema_key
+                        != crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY
+                    && row.commit_id == Some(root.commit_id)
+                    && row
+                        .change_id
+                        .is_some_and(|change_id| change_id != ChangeId::default())
+            });
+        let absence_guards = if can_publish_ordered_packed_current_base {
+            Vec::new()
+        } else {
             let _span = tracing::debug_span!(
                 target: "lix_perf",
                 "lix.perf.materialization.tracked_head.absence_guards"
@@ -1978,8 +2025,6 @@ async fn stage_tracked_head(
                 certified_fresh_plugin_file_id,
             )
         };
-        let checkpoint_commit_id = checkpoint_epochs.get(&root.branch_id).copied();
-        let is_checkpoint_publication = checkpoint_commit_id == Some(root.commit_id);
         let parent_generation = match (root.parent_commit_id, parent_control) {
             (_, Some(control)) if is_checkpoint_publication => Some(control.generation),
             (Some(parent_commit_id), Some(control))
@@ -2073,6 +2118,53 @@ async fn stage_tracked_head(
             .as_ref()
             .map(|epoch| epoch.coverage)
             .unwrap_or_default();
+        if can_publish_ordered_packed_current_base {
+            #[cfg(test)]
+            ORDERED_PACKED_CURRENT_BASE_PUBLICATIONS.with(|publications| {
+                publications.set(publications.get().saturating_add(1));
+            });
+            let generation = tracked_head
+                .writer(read, writes)
+                .stage_ordered_insert_current_base(
+                    &root.branch_id,
+                    parent_generation,
+                    root.commit_id,
+                    state_row_indices
+                        .iter()
+                        .map(|&row_index| state_rows.row(row_index))
+                        .map(|row| (row.schema_key.as_str(), row.entity_pk)),
+                    working_diff_capture_checkpoint_commit_id,
+                    &mut coverage,
+                )
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.materialization.tracked_head.stage_ordered_packed_current_base"
+                ))
+                .await?;
+            if let Some(epoch) = working_diff_epoch {
+                let next_epoch = TrackedWorkingDiffEpoch {
+                    checkpoint_commit_id: epoch.checkpoint_commit_id,
+                    generation,
+                    coverage,
+                };
+                if next_epoch != epoch {
+                    stage_tracked_working_diff_epoch(writes, &root.branch_id, next_epoch)?;
+                }
+            }
+            let mut control = normal_branch_head_control(
+                root,
+                parent_control,
+                generation,
+                working_diff_checkpoint_commit_id,
+            )?;
+            control.note_schemas(
+                state_row_indices
+                    .iter()
+                    .map(|&row_index| state_rows.row(row_index).schema_key.as_str()),
+            );
+            insert_direct_branch_control(&mut controls, &root.branch_id, control)?;
+            continue;
+        }
         let can_defer_fresh_hot = certified_fresh_plugin_file_id.is_some()
             && !host_certified_live_increments.contains_key(&root.branch_id)
             && tracked_roots.len() == 1

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -5102,48 +5102,7 @@ where
             && let Some(certificate) = certified_preparation
         {
             let timestamp = self.functions.call_timestamp();
-            let mut prepared_rows = PreparedStateBatch::with_dense_capacity(row_count, row_count);
-            for index in 0..row_count {
-                let row = rows.row(index);
-                let entity_pk = row.entity_pk.cloned().ok_or_else(|| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        "certified transaction row is missing entity_pk",
-                    )
-                })?;
-                let schema_key = row.schema_key.clone();
-                let branch_id = row.branch_id.clone();
-                let snapshot = rows
-                    .take_snapshot(index)
-                    .map(|value| {
-                        stage_json_from_value(value, "certified prepared row snapshot_content")
-                    })
-                    .transpose()?;
-                prepared_rows.push_parts_with_change_addressability(
-                    certificate.schema_plan_id,
-                    certificate.facts,
-                    entity_pk,
-                    schema_key,
-                    None,
-                    snapshot,
-                    None,
-                    None,
-                    self.origin_key.as_ref(),
-                    timestamp,
-                    timestamp,
-                    false,
-                    // Addressable tracked rows receive their durable change id
-                    // from the sorted commit-delta location. A nil placeholder
-                    // satisfies staging's presence invariant without sampling
-                    // and retaining one throwaway UUID per row.
-                    Some(ChangeId::default()),
-                    true,
-                    None,
-                    false,
-                    branch_id,
-                );
-            }
-            return Ok(prepared_rows);
+            return rows.into_certified_prepared(certificate, self.origin_key.as_ref(), timestamp);
         }
         let staged = self.staged_writes.staging_overlay()?;
         let read = SharedStorageAdapterRead::new(

--- a/packages/engine/src/transaction/mod.rs
+++ b/packages/engine/src/transaction/mod.rs
@@ -13,6 +13,8 @@ pub mod bench {
     pub use super::bench_support::*;
 }
 
+#[cfg(test)]
+pub(crate) use commit::take_ordered_packed_current_base_publications;
 pub(crate) use context::CertifiedHistoryStoreReader;
 #[cfg(test)]
 pub(crate) use context::CommitBoundaryGuard;

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -472,7 +472,7 @@ pub(crate) struct RawWriteBatch {
     origin_promotions: usize,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct CertifiedRawWriteBatchPreparation {
     pub(crate) schema_plan_id: SchemaPlanId,
     pub(crate) facts: PreparedRowFacts,
@@ -677,6 +677,156 @@ impl RawWriteBatch {
 
     pub(crate) fn certified_preparation(&self) -> Option<CertifiedRawWriteBatchPreparation> {
         self.certified_preparation
+    }
+
+    /// Consumes a homogeneous certified ingress batch into its commit-ready
+    /// typed columns.
+    ///
+    /// A certified producer has already established row shape, identity, and
+    /// current-plan semantics. Re-reading every row through the generic
+    /// preparation API only clones identities, re-interns the same schema and
+    /// branch strings, and keeps both dense batches live at once. This lowering
+    /// transfers the ingress dictionaries and aligned owners directly while
+    /// constructing only the final fixed-width slots and staged JSON handles.
+    pub(crate) fn into_certified_prepared(
+        self,
+        certificate: CertifiedRawWriteBatchPreparation,
+        origin_key: Option<&SharedStr>,
+        timestamp: LixTimestamp,
+    ) -> Result<PreparedStateBatch, LixError> {
+        if self.certified_preparation != Some(certificate) {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "certified transaction batch proof changed before direct preparation",
+            ));
+        }
+        let RawWriteBatch {
+            slots,
+            entity_pks,
+            snapshots,
+            metadata,
+            mut strings,
+            string_index: _,
+            expected_rows: _,
+            origins,
+            origin_index: _,
+            certified_preparation: _,
+            #[cfg(test)]
+                string_promotions: _,
+            #[cfg(test)]
+                origin_promotions: _,
+        } = self;
+        let row_count = slots.len();
+        if entity_pks.len() != row_count
+            || snapshots.len() != row_count
+            || metadata.len() != row_count
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "certified transaction batch columns are not aligned",
+            ));
+        }
+        if !origins.is_empty() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "certified transaction batch unexpectedly contains logical origins",
+            ));
+        }
+
+        let mut string_index = HashMap::with_capacity(strings.len().saturating_add(1));
+        for (ordinal, value) in strings.iter().cloned().enumerate() {
+            string_index.insert(
+                value,
+                u32::try_from(ordinal)
+                    .expect("certified transaction string dictionary must fit u32"),
+            );
+        }
+        let origin_key = origin_key.map(|value| {
+            if let Some(&ordinal) = string_index.get(value) {
+                return ordinal;
+            }
+            let ordinal = u32::try_from(strings.len())
+                .expect("certified transaction string dictionary must fit u32");
+            strings.push(value.clone());
+            string_index.insert(value.clone(), ordinal);
+            ordinal
+        });
+
+        let mut prepared_slots = Vec::with_capacity(row_count);
+        let mut prepared_entity_pks = Vec::with_capacity(row_count);
+        let mut json = Vec::with_capacity(row_count);
+        for (row_index, (((slot, entity_pk), snapshot), metadata)) in slots
+            .into_iter()
+            .zip(entity_pks)
+            .zip(snapshots)
+            .zip(metadata)
+            .enumerate()
+        {
+            if slot.file_id != RAW_WRITE_NONE
+                || slot.origin != RAW_WRITE_NONE
+                || slot.created_at != RAW_WRITE_NONE
+                || slot.updated_at != RAW_WRITE_NONE
+                || slot.change_id != RAW_WRITE_NONE
+                || slot.commit_id != RAW_WRITE_NONE
+                || slot.flags != 0
+                || metadata.is_some()
+            {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "certified transaction batch contains unsupported system columns",
+                ));
+            }
+            let entity_pk = entity_pk.ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "certified transaction row is missing entity_pk",
+                )
+            })?;
+            let snapshot = snapshot.ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "certified transaction row is missing snapshot_content",
+                )
+            })?;
+            let snapshot =
+                stage_json_from_value(snapshot, "certified prepared row snapshot_content")?;
+            prepared_entity_pks.push(entity_pk);
+            json.push(snapshot);
+            prepared_slots.push(PreparedStateSlot {
+                schema_plan_id: certificate.schema_plan_id,
+                facts: certificate.facts,
+                entity_pk: u32::try_from(row_index)
+                    .expect("certified transaction row ordinal must fit u32"),
+                schema_key: slot.schema_key,
+                file_id: None,
+                snapshot: Some(
+                    u32::try_from(row_index)
+                        .expect("certified transaction JSON ordinal must fit u32"),
+                ),
+                metadata: None,
+                origin: None,
+                origin_key,
+                created_at: timestamp,
+                updated_at: timestamp,
+                global: false,
+                change_id: Some(ChangeId::default()),
+                addressable_change_id: true,
+                commit_id: None,
+                untracked: false,
+                branch_id: slot.branch_id,
+            });
+        }
+        Ok(PreparedStateBatch {
+            slots: prepared_slots,
+            entity_pks: prepared_entity_pks,
+            strings,
+            string_index,
+            json,
+            origins: Vec::new(),
+            origin_index: HashMap::new(),
+            origin_column_sets: Vec::new(),
+            origin_column_index: HashMap::new(),
+        })
     }
 
     /// Downgrades a batch proof to canonical transport after its schema plan


### PR DESCRIPTION
## Summary

- hard-cut tracked commit deltas to `LXCD8` / change-locator v2, with 512-row ordered create segments and 128-row generic history segments
- lower eligible `executeBatch` INSERT values directly into the shared typed transaction batch instead of constructing an Arrow batch, then transfer certified raw columns into prepared state without cloning identities or re-interning dictionaries
- reuse large ordered commit deltas as packed current-state bases
- resolve direct change IDs in physical batches and decode/decompress each selected history segment once, preserving explicit address-shaped ID fallback semantics
- update the tracked working-diff benchmark to the current `diff_type` API

This stays below SQL-specific JSON materialization: the typed transaction representation is the shared producer/storage boundary. Plugin execution remains out of scope. The format/locator changes are intentional hard cuts with no compatibility shim.

## Performance

Exact PR #1015 baseline vs this branch, 100k create:

| Adapter | Baseline | This branch | Change |
| --- | ---: | ---: | ---: |
| RocksDB | 200.736 ms | 158.091 ms | **-21.25%** |
| SlateDB | 198.652 ms | 153.283 ms | **-22.84%** |

The retained 1M create now completes instead of being OOM-killed:

- RocksDB: 3.642 s
- SlateDB: 3.627 s

History non-regression, exact PR #1015 baseline vs this branch:

| Operation | RocksDB | SlateDB |
| --- | ---: | ---: |
| Merge preview | 209.550 → 29.256 ms (**-86.0%**) | 202.879 → 32.750 ms (**-83.9%**) |
| Merge commit | 42.500 → 15.181 ms (**-64.3%**) | 45.750 → 19.369 ms (**-57.7%**) |
| Working diff | 0.938 → 0.942 ms (flat) | 1.708 → 0.717 ms (**-58.0%**) |
| Checkpoint | 12.817 → 10.782 ms (**-15.9%**) | 14.891 → 13.941 ms (**-6.4%**) |

CRUD read/update/delete checks are flat-to-faster; `delete_all` improved about 20%.

## Validation

- `cargo test -p lix_engine --lib --all-features` — 1641 passed
- `cargo clippy -p lix_engine --all-targets --all-features -- -D warnings`
- `cargo check -p lix_engine --all-features`
- `cargo test -p lix_engine_benchmarks --test tracked_state_crud_public_result --features storage-benches,slatedb` — 4 passed
- `cargo fmt --all -- --check`
- `node scripts/validate-changes.mjs`
- focused direct-ID collision/fallback, certified-batch, packed-current-base, diff/merge/checkpoint tests