### PR TITLE
clean immutable HOT rows at checkpoint

### DIFF
--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -2979,9 +2979,9 @@ mod tests {
         );
 
         // A checkpoint that selects the already-authoritative immutable
-        // change must not rewrite the HOT row just to clear its dirty
-        // baseline. The checkpoint owner on that baseline makes it stale for
-        // the next interval without touching the value.
+        // change still has to clear its row-local dirty baseline. Leaving the
+        // stale before-image physically attached would make retained current
+        // state grow with every checkpoint interval.
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
@@ -3015,7 +3015,7 @@ mod tests {
             .expect("stage no-op checkpoint publication");
         assert_eq!(no_op_coverage, WorkingDiffIndexCoverage::default());
         assert!(
-            !writes.contains_put(
+            writes.contains_put(
                 HOT_ROW_SPACE,
                 &hot::encode_hot_row_key(&HeadIdentity {
                     branch_id: branch_id.to_owned(),
@@ -3025,11 +3025,7 @@ mod tests {
                     file_id: None,
                 }),
             ),
-            "an identical selected change must not rewrite its HOT row"
-        );
-        assert!(
-            writes.is_empty(),
-            "an identical selection must not rewrite unchanged collection controls"
+            "an identical dirty selected change must be rewritten clean"
         );
         stage_tracked_working_diff_epoch(
             &mut writes,
@@ -3057,6 +3053,31 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("open no-op checkpoint epoch read");
+        let hot_key = hot::encode_hot_row_key(&HeadIdentity {
+            branch_id: branch_id.to_owned(),
+            generation: checkpoint,
+            schema_key: "schema".to_owned(),
+            entity_pk: entity_pk.clone(),
+            file_id: None,
+        });
+        let value = PointReadPlan::new(HOT_ROW_SPACE, &[StorageKey(Bytes::from(hot_key))])
+            .materialize(&read, StorageGetOptions::default())
+            .await
+            .expect("read cleaned checkpoint HOT row")
+            .value
+            .into_iter()
+            .next()
+            .flatten()
+            .expect("cleaned checkpoint HOT row exists");
+        let StorageProjectedValue::FullValue(value) = value else {
+            panic!("cleaned checkpoint HOT row unexpectedly omitted its value");
+        };
+        assert_eq!(
+            decode_head_value(&value)
+                .expect("cleaned checkpoint HOT value decodes")
+                .working_diff_baseline,
+            WorkingDiffBaseline::Clean,
+        );
         assert_eq!(
             TrackedHeadContext::new()
                 .reader(read)

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -4217,9 +4217,11 @@ where
         // only changes the row-local dirty marker and commit ownership, even
         // though the checkpoint delta already records historical membership.
         //
-        // Retain only this provably identical case. A squashed selection has
-        // a new change ID and must still be written so canonical timestamps
-        // and payload ownership match historical rebuilds.
+        // Retain only a provably identical row whose baseline is already
+        // clean. A dirty identical row still needs one compacting rewrite to
+        // discard its stale before-image; a squashed selection has a new
+        // change ID and must likewise be written so canonical timestamps and
+        // payload ownership match historical rebuilds.
         let (sorted, previous_values, created_ats) = if reset_working_diff_baselines {
             let mut retained_deltas = Vec::with_capacity(sorted.len());
             let mut retained_previous = Vec::with_capacity(previous_values.len());
@@ -4243,6 +4245,7 @@ where
                                 && value.deleted == delta.deleted
                                 && value.created_at == delta.created_at
                                 && value.updated_at == delta.updated_at
+                                && value.working_diff_baseline == WorkingDiffBaseline::Clean
                         });
                 if identical_immutable_change {
                     continue;


### PR DESCRIPTION
## What changed

- require an identical immutable HOT row to already be `Clean` before checkpoint publication skips its rewrite
- rewrite dirty identical rows once so their stale working-diff before-image and fingerprints are discarded
- extend the working-diff checkpoint regression to assert the physical HOT value is clean after publication

## Root cause

The identical-change fast path treated the prior checkpoint owner as enough to make a dirty baseline logically stale. That preserved query correctness, but it also retained the physical `BeforeAbsent`/`BeforePresent` payload indefinitely. Replaying Git with a checkpoint after every commit therefore left almost every tracked HOT row physically dirty.

## Measured impact

OpenClaw, all bundled WASM plugins, SlateDB, checkpoint every Git commit, state verification enabled:

- 50 commits: dirty tracked rows `2,365 -> 22`
- 50 commits: HOT logical values `676,068 -> 454,894` bytes (`-32.7%`)
- 50 commits: HOT physical SST `306,695 -> 158,037` bytes (`-48.5%`)
- 50 commits: replay `51.551s -> 51.138s` (`-0.8%`)
- 500 commits: dirty tracked rows `33,620 -> 510`
- 500 commits: HOT logical values `8,343,854 -> 5,078,454` bytes (`-39.1%`)
- 500 commits: HOT physical SST `3,705,430 -> 2,214,255` bytes (`-40.2%`)

The 500-commit candidate database and profile are retained locally for follow-up storage queries.

## Validation

- `cargo test -p lix_engine working_diff_restarts_after_a_checkpoint_generation_and_verifies_coverage --lib`
- `cargo test -p lix_engine checkpoint_ --lib`
- `cargo check -p lix_engine --all-targets`
- verified 50/50 replay commits and final Git tree
- verified 500/500 replay commits and final Git tree

Stacked on #1018.
