### PR TITLE
alias complete checkpoint commit deltas

### DIFF
--- a/packages/cli/src/commands/exp/git_replay.rs
+++ b/packages/cli/src/commands/exp/git_replay.rs
@@ -3313,6 +3313,16 @@ mod tests {
 
     #[test]
     fn replay_profiles_plugin_controls_on_both_storage_adapters() {
+        thread::Builder::new()
+            .name("git-replay-storage-plugin-matrix".to_string())
+            .stack_size(16 * 1024 * 1024)
+            .spawn(replay_profiles_plugin_controls_on_both_storage_adapters_inner)
+            .expect("replay matrix thread should spawn")
+            .join()
+            .expect("replay matrix thread should complete");
+    }
+
+    fn replay_profiles_plugin_controls_on_both_storage_adapters_inner() {
         let fixture = unique_temp_dir();
         let repo = fixture.join("repo");
         fs::create_dir_all(&repo).expect("fixture repository should be created");

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -706,10 +706,15 @@ where
         let Some(entry) = packed.commits.get(commit_id) else {
             continue;
         };
-        if !entry.members.iter().any(|member| {
-            dead_packed_change_ids.contains(&member.value.change_id)
-                && member.is_selected_payload_ref()
-        }) {
+        let borrowed_source_is_swept = entry
+            .selected_source_commit_id
+            .is_some_and(|source_commit_id| sweep_commits.contains(&source_commit_id));
+        if !borrowed_source_is_swept
+            && !entry.members.iter().any(|member| {
+                dead_packed_change_ids.contains(&member.value.change_id)
+                    && member.is_selected_payload_ref()
+            })
+        {
             continue;
         }
         let deltas = entry
@@ -730,6 +735,7 @@ where
                 metadata: member.change.metadata.as_ref_slot(),
                 origin_key: member.change.origin_key.as_deref(),
                 authored: member.authored
+                    || borrowed_source_is_swept
                     || (dead_packed_change_ids.contains(&member.value.change_id)
                         && member.is_selected_payload_ref()),
                 certified: member.is_certified_payload_ref(),
@@ -1011,7 +1017,8 @@ mod tests {
     use crate::tracked_state::{
         TrackedStateCommitDeltaRef, TrackedStateContext, TrackedStateDeltaRef,
         load_change_record_by_id, scan_change_records_from_commit_deltas,
-        scan_commit_delta_inventory, stage_change_locators, stage_commit_deltas,
+        scan_commit_delta_inventory, stage_addressable_commit_deltas_with_selected_source,
+        stage_change_locators, stage_commit_deltas,
     };
     use crate::{Engine, GLOBAL_BRANCH_ID, Value};
     use bytes::Bytes;
@@ -1327,6 +1334,136 @@ mod tests {
             .await
             .expect("tracked owner should remain readable");
         assert_eq!(tracked.rows()[0].values(), &[Value::Json(shared_value)]);
+    }
+
+    #[tokio::test]
+    async fn authority_gc_materializes_tombstone_only_checkpoint_alias_before_source_sweep() {
+        let storage = Memory::new();
+        let storage_adapter = StorageAdapter::new(storage);
+        let source_commit = CommitId::for_test_label("gc-tombstone-alias-source");
+        let alias_commit = CommitId::for_test_label("gc-tombstone-alias-live");
+        let authority_commit = CommitId::for_test_label("gc-tombstone-alias-authority");
+        let live_head = CommitId::for_test_label("gc-tombstone-alias-head");
+        let source_change = packed_change(
+            "gc-tombstone-alias-source-change",
+            "deleted-source-member",
+            JsonSlot::None,
+        );
+        let marker_change = packed_change(
+            "gc-tombstone-alias-marker-change",
+            "deleted-local-marker",
+            JsonSlot::None,
+        );
+        let timestamp =
+            LixTimestamp::expect_parse("tombstone alias timestamp", "2026-01-01T00:00:00Z");
+        let commits = [
+            CommitRecord {
+                format_version: 1,
+                commit_id: source_commit,
+                parent_commit_ids: Vec::new(),
+                tracked_state_rootless: true,
+                change_id: ChangeId::for_test_label("gc-tombstone-alias-source-header"),
+                author_account_ids: Vec::new(),
+                created_at: timestamp,
+            },
+            CommitRecord {
+                format_version: 1,
+                commit_id: alias_commit,
+                parent_commit_ids: Vec::new(),
+                tracked_state_rootless: true,
+                change_id: ChangeId::for_test_label("gc-tombstone-alias-live-header"),
+                author_account_ids: Vec::new(),
+                created_at: timestamp,
+            },
+            CommitRecord {
+                format_version: 1,
+                commit_id: authority_commit,
+                parent_commit_ids: Vec::new(),
+                tracked_state_rootless: true,
+                change_id: ChangeId::for_test_label("gc-tombstone-alias-authority-header"),
+                author_account_ids: Vec::new(),
+                created_at: timestamp,
+            },
+            CommitRecord {
+                format_version: 1,
+                commit_id: live_head,
+                parent_commit_ids: vec![alias_commit, authority_commit],
+                tracked_state_rootless: true,
+                change_id: ChangeId::for_test_label("gc-tombstone-alias-head-header"),
+                author_account_ids: Vec::new(),
+                created_at: timestamp,
+            },
+        ];
+
+        let mut read = storage_adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("tombstone alias fixture read should open");
+        let mut writes = storage_adapter.new_write_set();
+        ChangelogContext::new()
+            .writer(&mut read, &mut writes)
+            .stage_append(ChangelogAppend {
+                commits: commits.to_vec(),
+                changes: Vec::new(),
+            })
+            .await
+            .expect("tombstone alias headers should stage");
+        let source_deltas = commit_delta_refs(source_commit, std::slice::from_ref(&source_change));
+        let source_locators = stage_commit_deltas(&mut writes, &source_deltas)
+            .expect("source tombstone should stage");
+        stage_change_locators(&mut writes, &source_locators);
+        let authority_deltas =
+            commit_delta_refs(authority_commit, std::slice::from_ref(&source_change));
+        stage_commit_deltas(&mut writes, &authority_deltas)
+            .expect("surviving tombstone authority should stage");
+        let alias_local = commit_delta_refs(alias_commit, std::slice::from_ref(&marker_change));
+        stage_addressable_commit_deltas_with_selected_source(
+            &mut writes,
+            &alias_local,
+            &[false],
+            source_commit,
+        )
+        .expect("tombstone-only alias should stage");
+        storage_adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("tombstone alias fixture should commit");
+
+        let read = SharedStorageAdapterRead::new(
+            storage_adapter
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("tombstone alias GC read should open"),
+        );
+        let mut writes = storage_adapter.new_write_set();
+        let plan = super::plan_and_stage_authority_gc(
+            &read,
+            &mut writes,
+            &[GcRoot::BranchHead(live_head)],
+        )
+        .await
+        .expect("tombstone alias GC should plan");
+        assert!(plan.sweep.commits.contains(&source_commit));
+        storage_adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("tombstone alias GC should commit");
+
+        let read = storage_adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("tombstone alias verification read should open");
+        let inventory = scan_commit_delta_inventory(&read)
+            .await
+            .expect("materialized tombstone alias inventory should load");
+        assert!(!inventory.commits.contains_key(&source_commit));
+        let alias = inventory
+            .commits
+            .get(&alias_commit)
+            .expect("live alias should remain materialized");
+        assert_eq!(alias.selected_source_commit_id, None);
+        assert_eq!(alias.members.len(), 2);
+        assert!(alias.members.iter().all(|member| member.value.deleted));
     }
 
     #[tokio::test]

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -735,7 +735,7 @@ where
                 metadata: member.change.metadata.as_ref_slot(),
                 origin_key: member.change.origin_key.as_deref(),
                 authored: member.authored
-                    || borrowed_source_is_swept
+                    || (borrowed_source_is_swept && !member.is_selected_tombstone())
                     || (dead_packed_change_ids.contains(&member.value.change_id)
                         && member.is_selected_payload_ref()),
                 certified: member.is_certified_payload_ref(),
@@ -1464,6 +1464,18 @@ mod tests {
         assert_eq!(alias.selected_source_commit_id, None);
         assert_eq!(alias.members.len(), 2);
         assert!(alias.members.iter().all(|member| member.value.deleted));
+        assert_eq!(
+            alias
+                .members
+                .iter()
+                .filter(|member| member.authored)
+                .count(),
+            1,
+            "the local marker stays authored while the borrowed cascade tombstone does not"
+        );
+        scan_change_records_from_commit_deltas(&read)
+            .await
+            .expect("materialized cascade tombstone must preserve canonical history");
     }
 
     #[tokio::test]

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -46,7 +46,7 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"checkpoint-source-delta.v32";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"checkpoint-source-delta.v33";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -39,13 +39,13 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 
 /// Repository-wide compatibility gate for physical storage protocols.
 ///
-/// V28 combines branch-scoped immutable current-state bases with explicitly
-/// checkpoint-owned dirty HOT baselines. Opening either predecessor must fail
-/// closed before its partial layout is interpreted as the combined protocol.
+/// V31 adds source-addressed checkpoint deltas to the packed history plane.
+/// Older manifests have a different packed field layout and must fail closed
+/// before they can be decoded as source aliases.
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"binary-history-dictionary.v29";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"checkpoint-source-delta.v31";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -39,13 +39,14 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 
 /// Repository-wide compatibility gate for physical storage protocols.
 ///
-/// V31 adds source-addressed checkpoint deltas to the packed history plane.
+/// V32 adds source-addressed checkpoint deltas and their selection certificate
+/// to the packed history plane.
 /// Older manifests have a different packed field layout and must fail closed
 /// before they can be decoded as source aliases.
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"checkpoint-source-delta.v31";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"checkpoint-source-delta.v32";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -34,9 +34,10 @@ pub(crate) use storage::{
     load_change_record_by_id, load_commit_delta_change_records,
     load_commit_delta_members_with_payloads, load_owned_commit_delta_entries,
     scan_change_records_from_commit_deltas, scan_commit_delta_inventory, scan_commit_delta_values,
-    stage_addressable_commit_deltas, stage_change_locators, stage_commit_deltas,
-    stage_delete_change_locators, stage_delete_commit_delta_inventory_entry,
-    stage_delete_commit_roots, stage_ordered_addressable_commit_deltas,
+    stage_addressable_commit_deltas, stage_addressable_commit_deltas_with_selected_source,
+    stage_change_locators, stage_commit_deltas, stage_delete_change_locators,
+    stage_delete_commit_delta_inventory_entry, stage_delete_commit_roots,
+    stage_ordered_addressable_commit_deltas,
 };
 #[cfg(feature = "storage-benches")]
 pub(crate) use storage::{

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -32,8 +32,9 @@ pub(crate) use storage::load_commit_delta_change_ids;
 pub(crate) use storage::{
     CommitDeltaChangeLocator, CommitDeltaMember, commit_delta_contains_schema,
     load_change_record_by_id, load_commit_delta_change_records,
-    load_commit_delta_members_with_payloads, load_owned_commit_delta_entries,
-    scan_change_records_from_commit_deltas, scan_commit_delta_inventory, scan_commit_delta_values,
+    load_commit_delta_members_with_payloads, load_commit_delta_selection_certificate,
+    load_owned_commit_delta_entries, scan_change_records_from_commit_deltas,
+    scan_commit_delta_inventory, scan_commit_delta_values, selected_change_selection_fingerprint,
     stage_addressable_commit_deltas, stage_addressable_commit_deltas_with_selected_source,
     stage_change_locators, stage_commit_deltas, stage_delete_change_locators,
     stage_delete_commit_delta_inventory_entry, stage_delete_commit_roots,

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -2340,6 +2340,28 @@ pub(crate) async fn load_owned_commit_delta_entries(
     requests: &[(CommitId, TrackedStateKey)],
 ) -> Result<Vec<Option<LoadedCommitDeltaEntry>>, LixError> {
     let mut output = load_local_owned_commit_delta_entries(store, requests).await?;
+    let owner_commit_ids = requests
+        .iter()
+        .enumerate()
+        .filter_map(|(request_index, (commit_id, _))| {
+            output[request_index].is_none().then_some(*commit_id)
+        })
+        .collect::<BTreeSet<_>>();
+    let manifest_keys = owner_commit_ids
+        .iter()
+        .map(|commit_id| StorageKey(Bytes::from(commit_delta_manifest_key(*commit_id))))
+        .collect::<Vec<_>>();
+    let manifest_values =
+        PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE, &manifest_keys)
+            .materialize(store, StorageGetOptions::default())
+            .await?;
+    let mut owner_manifests = BTreeMap::new();
+    for (commit_id, value) in owner_commit_ids.into_iter().zip(manifest_values.value) {
+        let Some(bytes) = value.and_then(full_value_bytes) else {
+            continue;
+        };
+        owner_manifests.insert(commit_id, decode_commit_delta_manifest(&bytes)?);
+    }
     let mut source_requests = Vec::new();
     let mut source_outputs = Vec::new();
     let mut source_owner_commits = Vec::new();
@@ -2347,7 +2369,7 @@ pub(crate) async fn load_owned_commit_delta_entries(
         if output[request_index].is_some() {
             continue;
         }
-        let Some(manifest) = load_commit_delta_manifest(store, *commit_id).await? else {
+        let Some(manifest) = owner_manifests.get(commit_id) else {
             continue;
         };
         let Some(source_commit_id) = manifest.selected_source_commit_id() else {
@@ -2358,10 +2380,9 @@ pub(crate) async fn load_owned_commit_delta_entries(
         source_requests.push((source_commit_id, key.clone()));
     }
     let selected = load_local_owned_commit_delta_entries(store, &source_requests).await?;
-    for (((request_index, owner_commit_id), source_request), entry) in source_outputs
+    for ((request_index, owner_commit_id), entry) in source_outputs
         .into_iter()
         .zip(source_owner_commits)
-        .zip(source_requests)
         .zip(selected)
     {
         if let Some(mut entry) = entry {
@@ -2370,14 +2391,6 @@ pub(crate) async fn load_owned_commit_delta_entries(
             entry.certified_ref = false;
             entry.owner_commit_id = owner_commit_id;
             output[request_index] = Some(entry);
-        } else {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "selected-source commit delta '{}' is missing borrowed identity {:?}",
-                    owner_commit_id, source_request.1
-                ),
-            ));
         }
     }
     Ok(output)
@@ -5403,6 +5416,19 @@ mod tests {
                 .flatten()
                 .all(|value| value.commit_id == alias_commit)
         );
+
+        let missing_key = TrackedStateKey {
+            schema_key: fixtures[0].schema_key.clone(),
+            file_id: fixtures[0].file_id.clone(),
+            entity_pk: EntityPk::single("missing-cascade-member"),
+        };
+        let missing_requests = (0..2_048)
+            .map(|_| (alias_commit, missing_key.clone()))
+            .collect::<Vec<_>>();
+        let missing = load_owned_commit_delta_entries(&read, &missing_requests)
+            .await
+            .expect("alias misses should remain available to cascade fallback");
+        assert!(missing.iter().all(Option::is_none));
 
         let members = load_commit_delta_members_with_payloads(&read, alias_commit)
             .await

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -362,6 +362,7 @@ impl CommitDeltaMember {
 pub(crate) struct CommitDeltaInventoryEntry {
     pub(crate) members: Vec<CommitDeltaMember>,
     pub(crate) segment_count: usize,
+    pub(crate) selected_source_commit_id: Option<CommitId>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -383,6 +384,10 @@ const TRACKED_STATE_COMMIT_ROOT_MAGIC: &[u8] = b"LXTR3";
 #[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
 #[musli(packed)]
 struct CommitDeltaManifest {
+    /// Complete selected state borrowed from one ordinary source commit.
+    /// Local inline/external segments are a disjoint authored overlay.
+    #[musli(with = storage_codec::option)]
+    selected_source_commit_id: Option<[u8; 16]>,
     /// A complete leaf payload for a commit that fits in one segment. Keeping
     /// it in the directory preserves the one-record shape of tiny commits;
     /// larger commits use the indexed segment list below.
@@ -738,7 +743,7 @@ pub(crate) fn stage_commit_deltas(
     writes: &mut StorageWriteSet,
     deltas: &[TrackedStateCommitDeltaRef<'_>],
 ) -> Result<Vec<CommitDeltaChangeLocator>, LixError> {
-    Ok(stage_commit_deltas_inner(writes, deltas, None)?.locators)
+    Ok(stage_commit_deltas_inner(writes, deltas, None, None)?.locators)
 }
 
 pub(crate) fn stage_addressable_commit_deltas(
@@ -752,7 +757,27 @@ pub(crate) fn stage_addressable_commit_deltas(
             "tracked_state addressability column does not match commit deltas",
         ));
     }
-    stage_commit_deltas_inner(writes, deltas, Some(addressable))
+    stage_commit_deltas_inner(writes, deltas, Some(addressable), None)
+}
+
+pub(crate) fn stage_addressable_commit_deltas_with_selected_source(
+    writes: &mut StorageWriteSet,
+    deltas: &[TrackedStateCommitDeltaRef<'_>],
+    addressable: &[bool],
+    selected_source_commit_id: CommitId,
+) -> Result<AddressableCommitDeltaStage, LixError> {
+    if addressable.len() != deltas.len() {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state addressability column does not match commit deltas",
+        ));
+    }
+    stage_commit_deltas_inner(
+        writes,
+        deltas,
+        Some(addressable),
+        Some(selected_source_commit_id),
+    )
 }
 
 /// Streams an already ordered, fully addressable commit into bounded segments.
@@ -814,6 +839,7 @@ where
     let mut pending = VecDeque::with_capacity(COMMIT_DELTA_SEGMENT_MAX_ROWS);
     let mut first_segment = None::<(CommitDeltaSegmentBounds, Vec<u8>)>;
     let mut manifest = CommitDeltaManifest {
+        selected_source_commit_id: None,
         inline_segment: Vec::new(),
         segments: Vec::with_capacity(row_count.div_ceil(COMMIT_DELTA_SEGMENT_MAX_ROWS)),
     };
@@ -977,6 +1003,7 @@ fn stage_commit_deltas_inner(
     writes: &mut StorageWriteSet,
     deltas: &[TrackedStateCommitDeltaRef<'_>],
     addressable: Option<&[bool]>,
+    selected_source_commit_id: Option<CommitId>,
 ) -> Result<AddressableCommitDeltaStage, LixError> {
     let Some(&commit_id) = deltas.first().map(|delta| &delta.delta.commit_id) else {
         return Ok(AddressableCommitDeltaStage {
@@ -1130,6 +1157,8 @@ fn stage_commit_deltas_inner(
             TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
             key(commit_delta_manifest_key(commit_id)),
             value(encode_commit_delta_manifest(&CommitDeltaManifest {
+                selected_source_commit_id: selected_source_commit_id
+                    .map(|commit_id| *commit_id.as_uuid().as_bytes()),
                 inline_segment,
                 segments: Vec::new(),
             })?),
@@ -1146,6 +1175,8 @@ fn stage_commit_deltas_inner(
     }
     writes.reserve_space(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, segment_count, 0);
     let mut manifest = CommitDeltaManifest {
+        selected_source_commit_id: selected_source_commit_id
+            .map(|commit_id| *commit_id.as_uuid().as_bytes()),
         inline_segment: Vec::new(),
         segments: Vec::with_capacity(segment_count),
     };
@@ -1843,6 +1874,31 @@ pub(crate) async fn load_commit_delta_values_encoded(
     commit_id: CommitId,
     encoded_keys: &[Bytes],
 ) -> Result<Vec<Option<TrackedStateIndexValue>>, LixError> {
+    let Some(manifest) = load_commit_delta_manifest(store, commit_id).await? else {
+        return Ok(vec![None; encoded_keys.len()]);
+    };
+    let Some(source_commit_id) = manifest.selected_source_commit_id() else {
+        return load_local_commit_delta_values_encoded(store, commit_id, encoded_keys).await;
+    };
+    let mut values =
+        load_local_commit_delta_values_encoded(store, source_commit_id, encoded_keys).await?;
+    for value in values.iter_mut().flatten() {
+        value.commit_id = commit_id;
+    }
+    let local = load_local_commit_delta_values_encoded(store, commit_id, encoded_keys).await?;
+    for (value, local) in values.iter_mut().zip(local) {
+        if local.is_some() {
+            *value = local;
+        }
+    }
+    Ok(values)
+}
+
+async fn load_local_commit_delta_values_encoded(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+    encoded_keys: &[Bytes],
+) -> Result<Vec<Option<TrackedStateIndexValue>>, LixError> {
     if encoded_keys.is_empty() {
         return Ok(Vec::new());
     }
@@ -1954,7 +2010,44 @@ pub(crate) async fn load_commit_delta_members_with_payloads(
     let Some(manifest) = load_commit_delta_manifest(store, commit_id).await? else {
         return Ok(Vec::new());
     };
-    load_commit_delta_members_from_manifest(store, commit_id, &manifest).await
+    let mut local = load_commit_delta_members_from_manifest(store, commit_id, &manifest).await?;
+    let Some(source_commit_id) = manifest.selected_source_commit_id() else {
+        return Ok(local);
+    };
+    let source_manifest = load_commit_delta_manifest(store, source_commit_id)
+        .await?
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "selected-source commit delta '{}' references missing source '{}'",
+                    commit_id, source_commit_id
+                ),
+            )
+        })?;
+    if source_manifest.selected_source_commit_id().is_some() {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "selected-source commit delta chains are unsupported",
+        ));
+    }
+    let mut members =
+        load_commit_delta_members_from_manifest(store, source_commit_id, &source_manifest).await?;
+    for member in &mut members {
+        member.value.commit_id = commit_id;
+        member.authored = false;
+        member.certified_ref = false;
+        member.selected_tombstone = member.value.deleted;
+    }
+    members.append(&mut local);
+    members.sort_unstable_by(|left, right| left.key.cmp(&right.key));
+    if members.windows(2).any(|pair| pair[0].key == pair[1].key) {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("selected-source commit delta '{commit_id}' has overlapping local rows"),
+        ));
+    }
+    Ok(members)
 }
 
 async fn load_commit_delta_members_from_manifest(
@@ -2188,6 +2281,54 @@ pub(crate) async fn load_commit_delta_change_ids(
 /// a second. Each selected segment is decoded once for both its index values
 /// and payload sidecar, preserving request order without topology replay.
 pub(crate) async fn load_owned_commit_delta_entries(
+    store: &(impl StorageAdapterRead + ?Sized),
+    requests: &[(CommitId, TrackedStateKey)],
+) -> Result<Vec<Option<LoadedCommitDeltaEntry>>, LixError> {
+    let mut output = load_local_owned_commit_delta_entries(store, requests).await?;
+    let mut source_requests = Vec::new();
+    let mut source_outputs = Vec::new();
+    let mut source_owner_commits = Vec::new();
+    for (request_index, (commit_id, key)) in requests.iter().enumerate() {
+        if output[request_index].is_some() {
+            continue;
+        }
+        let Some(manifest) = load_commit_delta_manifest(store, *commit_id).await? else {
+            continue;
+        };
+        let Some(source_commit_id) = manifest.selected_source_commit_id() else {
+            continue;
+        };
+        source_outputs.push(request_index);
+        source_owner_commits.push(*commit_id);
+        source_requests.push((source_commit_id, key.clone()));
+    }
+    let selected = load_local_owned_commit_delta_entries(store, &source_requests).await?;
+    for (((request_index, owner_commit_id), source_request), entry) in source_outputs
+        .into_iter()
+        .zip(source_owner_commits)
+        .zip(source_requests)
+        .zip(selected)
+    {
+        if let Some(mut entry) = entry {
+            entry.value.commit_id = owner_commit_id;
+            entry.selected_ref = true;
+            entry.certified_ref = false;
+            entry.owner_commit_id = owner_commit_id;
+            output[request_index] = Some(entry);
+        } else {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "selected-source commit delta '{}' is missing borrowed identity {:?}",
+                    owner_commit_id, source_request.1
+                ),
+            ));
+        }
+    }
+    Ok(output)
+}
+
+async fn load_local_owned_commit_delta_entries(
     store: &(impl StorageAdapterRead + ?Sized),
     requests: &[(CommitId, TrackedStateKey)],
 ) -> Result<Vec<Option<LoadedCommitDeltaEntry>>, LixError> {
@@ -2433,6 +2574,22 @@ pub(crate) async fn scan_commit_delta_values(
     let Some(manifest) = load_commit_delta_manifest(store, commit_id).await? else {
         return Ok(DecodedCommitDeltaBatch::default());
     };
+    let Some(source_commit_id) = manifest.selected_source_commit_id() else {
+        return scan_local_commit_delta_values(store, commit_id, schema_keys).await;
+    };
+    let source = scan_local_commit_delta_values(store, source_commit_id, schema_keys).await?;
+    let local = scan_local_commit_delta_values(store, commit_id, schema_keys).await?;
+    merge_selected_source_batches(source, local, commit_id)
+}
+
+async fn scan_local_commit_delta_values(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+    schema_keys: &[String],
+) -> Result<DecodedCommitDeltaBatch, LixError> {
+    let Some(manifest) = load_commit_delta_manifest(store, commit_id).await? else {
+        return Ok(DecodedCommitDeltaBatch::default());
+    };
     let requested_schemas = schema_keys
         .iter()
         .map(String::as_str)
@@ -2480,11 +2637,113 @@ pub(crate) async fn scan_commit_delta_values(
     Ok(batch.finish())
 }
 
+fn merge_selected_source_batches(
+    mut source: DecodedCommitDeltaBatch,
+    mut local: DecodedCommitDeltaBatch,
+    commit_id: CommitId,
+) -> Result<DecodedCommitDeltaBatch, LixError> {
+    let arena_offset = u32::try_from(source.arenas.len()).map_err(|_| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "selected-source commit delta has too many arenas",
+        )
+    })?;
+    let schema_offset = u32::try_from(source.schema_keys.len()).map_err(|_| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "selected-source commit delta has too many schema keys",
+        )
+    })?;
+    let file_offset = u32::try_from(source.file_ids.len()).map_err(|_| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "selected-source commit delta has too many file ids",
+        )
+    })?;
+    let mut entries = BTreeMap::<Vec<u8>, (DecodedCommitDeltaRow, TrackedStateIndexValue)>::new();
+    for (row, mut value) in source.rows.drain(..).zip(source.values.drain(..)) {
+        let key = source.arenas[row.arena_ordinal as usize]
+            .key(row.entry_ordinal as usize)?
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "selected-source commit delta references a missing source key",
+                )
+            })?
+            .to_vec();
+        value.commit_id = commit_id;
+        entries.insert(key, (row, value));
+    }
+    for (mut row, value) in local.rows.drain(..).zip(local.values.drain(..)) {
+        let key = local.arenas[row.arena_ordinal as usize]
+            .key(row.entry_ordinal as usize)?
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "selected-source commit delta references a missing local key",
+                )
+            })?
+            .to_vec();
+        row.arena_ordinal = row.arena_ordinal.checked_add(arena_offset).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "commit delta arena ordinal overflow",
+            )
+        })?;
+        row.schema_key_ordinal = row
+            .schema_key_ordinal
+            .checked_add(schema_offset)
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "commit delta schema ordinal overflow",
+                )
+            })?;
+        if row.file_id_ordinal != u32::MAX {
+            row.file_id_ordinal =
+                row.file_id_ordinal
+                    .checked_add(file_offset)
+                    .ok_or_else(|| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            "commit delta file ordinal overflow",
+                        )
+                    })?;
+        }
+        entries.insert(key, (row, value));
+    }
+    source.arenas.append(&mut local.arenas);
+    source.schema_keys.append(&mut local.schema_keys);
+    source.file_ids.append(&mut local.file_ids);
+    for (_, (row, value)) in entries {
+        source.rows.push(row);
+        source.values.push(value);
+    }
+    Ok(source)
+}
+
 /// Answers schema membership from the packed commit directory.
 ///
 /// Segmented commits are decided from manifest bounds without reading any
 /// payload page. Tiny inline commits inspect at most one bounded leaf.
 pub(crate) async fn commit_delta_contains_schema(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+    schema_key: &str,
+) -> Result<bool, LixError> {
+    let Some(manifest) = load_commit_delta_manifest(store, commit_id).await? else {
+        return Ok(false);
+    };
+    if local_commit_delta_contains_schema(store, commit_id, schema_key).await? {
+        return Ok(true);
+    }
+    let Some(source_commit_id) = manifest.selected_source_commit_id() else {
+        return Ok(false);
+    };
+    local_commit_delta_contains_schema(store, source_commit_id, schema_key).await
+}
+
+async fn local_commit_delta_contains_schema(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
     schema_key: &str,
@@ -2721,9 +2980,7 @@ pub(crate) async fn scan_commit_delta_inventory(
         mut segments,
     } = scan_commit_delta_plane(store).await?;
     let mut inventory = CommitDeltaInventory::default();
-    let mut authoritative_changes =
-        BTreeMap::<crate::changelog::ChangeId, crate::changelog::ChangeRecord>::new();
-    for (commit_id, manifest) in manifests {
+    for (&commit_id, manifest) in &manifests {
         let physical_segments = segments.remove(&commit_id).unwrap_or_default();
         let segment_count = manifest.segments.len();
         let mut members = Vec::new();
@@ -2751,7 +3008,65 @@ pub(crate) async fn scan_commit_delta_inventory(
         }
         hydrate_selected_members(store, &mut members).await?;
         validate_commit_delta_member_order_and_ids(commit_id, &members)?;
-        for member in &members {
+        inventory.commits.insert(
+            commit_id,
+            CommitDeltaInventoryEntry {
+                members,
+                segment_count,
+                selected_source_commit_id: manifest.selected_source_commit_id(),
+            },
+        );
+    }
+    for (&commit_id, manifest) in &manifests {
+        let Some(source_commit_id) = manifest.selected_source_commit_id() else {
+            continue;
+        };
+        if manifests
+            .get(&source_commit_id)
+            .is_some_and(|source| source.selected_source_commit_id().is_some())
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "selected-source commit delta chains are unsupported",
+            ));
+        }
+        let mut selected = inventory
+            .commits
+            .get(&source_commit_id)
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "selected-source commit delta '{commit_id}' references missing source '{source_commit_id}'"
+                    ),
+                )
+            })?
+            .members
+            .clone();
+        for member in &mut selected {
+            member.value.commit_id = commit_id;
+            member.authored = false;
+            member.certified_ref = false;
+            member.selected_tombstone = member.value.deleted;
+        }
+        let local = inventory
+            .commits
+            .get_mut(&commit_id)
+            .expect("alias manifest was inventoried locally");
+        selected.append(&mut local.members);
+        selected.sort_unstable_by(|left, right| left.key.cmp(&right.key));
+        if selected.windows(2).any(|pair| pair[0].key == pair[1].key) {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("selected-source commit delta '{commit_id}' has overlapping local rows"),
+            ));
+        }
+        local.members = selected;
+    }
+    let mut authoritative_changes =
+        BTreeMap::<crate::changelog::ChangeId, crate::changelog::ChangeRecord>::new();
+    for entry in inventory.commits.values() {
+        for member in &entry.members {
             if is_payload_free_selected_tombstone(member) {
                 continue;
             }
@@ -2768,13 +3083,6 @@ pub(crate) async fn scan_commit_delta_inventory(
                 ));
             }
         }
-        inventory.commits.insert(
-            commit_id,
-            CommitDeltaInventoryEntry {
-                members,
-                segment_count,
-            },
-        );
     }
     debug_assert!(segments.is_empty());
     Ok(inventory)
@@ -3157,6 +3465,11 @@ fn validate_commit_delta_manifest(manifest: &CommitDeltaManifest) -> Result<(), 
 }
 
 impl CommitDeltaManifest {
+    fn selected_source_commit_id(&self) -> Option<CommitId> {
+        self.selected_source_commit_id
+            .map(|bytes| CommitId::new(uuid::Uuid::from_bytes(bytes)))
+    }
+
     fn inline_segment(&self) -> Option<&[u8]> {
         (!self.inline_segment.is_empty()).then_some(self.inline_segment.as_slice())
     }
@@ -4025,7 +4338,8 @@ mod tests {
         load_commit_delta_change_records, load_commit_delta_members_with_payloads,
         load_commit_delta_values_encoded, load_owned_commit_delta_entries,
         scan_change_records_from_commit_deltas, scan_commit_delta_inventory,
-        scan_commit_delta_members, scan_commit_delta_values, stage_change_locators,
+        scan_commit_delta_members, scan_commit_delta_values,
+        stage_addressable_commit_deltas_with_selected_source, stage_change_locators,
         stage_commit_deltas, stage_delete_commit_delta_inventory_entry, value,
     };
 
@@ -4920,6 +5234,87 @@ mod tests {
         assert_eq!(changes[0].change_id, fixture.change_id);
     }
 
+    #[tokio::test]
+    async fn selected_source_alias_preserves_exact_members_inventory_and_canonical_history() {
+        let storage = StorageAdapter::new(Memory::new());
+        let source_commit = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x0192_0000_0000_7000_8000_7777_0000_0000,
+        ));
+        let alias_commit = CommitId::for_test_label("selected-source-alias");
+        let mut fixtures = packed_commit_delta_fixtures()
+            .into_iter()
+            .take(3)
+            .collect::<Vec<_>>();
+
+        let mut writes = storage.new_write_set();
+        let source_deltas = commit_delta_refs(source_commit, &fixtures[..2]);
+        let source_stage = super::stage_addressable_commit_deltas(
+            &mut writes,
+            &source_deltas,
+            &vec![true; source_deltas.len()],
+        )
+        .expect("source commit should stage direct addresses");
+        drop(source_deltas);
+        for (fixture, change_id) in fixtures[..2]
+            .iter_mut()
+            .zip(source_stage.assigned_change_ids)
+        {
+            fixture.change_id = change_id;
+        }
+
+        let overlay = commit_delta_refs(alias_commit, &fixtures[2..]);
+        stage_addressable_commit_deltas_with_selected_source(
+            &mut writes,
+            &overlay,
+            &[false],
+            source_commit,
+        )
+        .expect("source alias should stage one disjoint local overlay");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("source and alias commits should publish atomically");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("source alias read should open");
+        let keys = fixtures
+            .iter()
+            .map(CommitDeltaFixture::key)
+            .collect::<Vec<_>>();
+        let values = load_commit_delta_values_for_test(&read, alias_commit, &keys)
+            .await
+            .expect("alias exact values should load");
+        assert!(values.iter().all(Option::is_some));
+        assert!(
+            values
+                .iter()
+                .flatten()
+                .all(|value| value.commit_id == alias_commit)
+        );
+
+        let members = load_commit_delta_members_with_payloads(&read, alias_commit)
+            .await
+            .expect("alias root-rebuild members should load");
+        assert_eq!(members.len(), 3);
+        assert_eq!(members.iter().filter(|member| member.authored).count(), 1);
+        assert_eq!(members.iter().filter(|member| !member.authored).count(), 2);
+
+        let inventory = scan_commit_delta_inventory(&read)
+            .await
+            .expect("alias GC inventory should load");
+        assert_eq!(
+            inventory.commits[&alias_commit].selected_source_commit_id,
+            Some(source_commit)
+        );
+        assert_eq!(inventory.commits[&alias_commit].members.len(), 3);
+        let canonical = scan_change_records_from_commit_deltas(&read)
+            .await
+            .expect("alias history should retain one canonical source authority");
+        assert_eq!(canonical.len(), 3);
+    }
+
     fn decoded_commit_delta_rows(
         batch: &DecodedCommitDeltaBatch,
     ) -> Vec<(TrackedStateKey, TrackedStateIndexValue)> {
@@ -5234,6 +5629,7 @@ mod tests {
             key(commit_delta_manifest_key(commit_id)),
             value(
                 encode_commit_delta_manifest(&CommitDeltaManifest {
+                    selected_source_commit_id: None,
                     inline_segment: segment,
                     segments: Vec::new(),
                 })
@@ -5969,6 +6365,7 @@ mod tests {
             key(commit_delta_manifest_key(commit_id)),
             value(
                 encode_commit_delta_manifest(&CommitDeltaManifest {
+                    selected_source_commit_id: None,
                     inline_segment: encode_commit_delta_segment(&entries),
                     segments: Vec::new(),
                 })

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -388,12 +388,21 @@ struct CommitDeltaManifest {
     /// Local inline/external segments are a disjoint authored overlay.
     #[musli(with = storage_codec::option)]
     selected_source_commit_id: Option<[u8; 16]>,
+    member_count: u32,
+    selection_fingerprint: [u8; 32],
     /// A complete leaf payload for a commit that fits in one segment. Keeping
     /// it in the directory preserves the one-record shape of tiny commits;
     /// larger commits use the indexed segment list below.
     #[musli(bytes)]
     inline_segment: Vec<u8>,
     segments: Vec<CommitDeltaSegmentBounds>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct CommitDeltaSelectionCertificate {
+    pub(crate) member_count: u32,
+    pub(crate) selection_fingerprint: [u8; 32],
+    pub(crate) selected_source_commit_id: Option<CommitId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
@@ -840,6 +849,13 @@ where
     let mut first_segment = None::<(CommitDeltaSegmentBounds, Vec<u8>)>;
     let mut manifest = CommitDeltaManifest {
         selected_source_commit_id: None,
+        member_count: u32::try_from(row_count).map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state commit_delta member count exceeds the manifest format",
+            )
+        })?,
+        selection_fingerprint: [0; 32],
         inline_segment: Vec::new(),
         segments: Vec::with_capacity(row_count.div_ceil(COMMIT_DELTA_SEGMENT_MAX_ROWS)),
     };
@@ -855,7 +871,7 @@ where
         }
         let segment_index = segment_row_counts.len();
         let mut candidate_len = pending.len();
-        let (bounds, encoded) = loop {
+        let (bounds, encoded, segment_fingerprint) = loop {
             match encode_ordered_addressable_commit_delta_segment(
                 commit_id,
                 segment_index,
@@ -863,10 +879,10 @@ where
                 candidate_len,
                 &mut compressor,
             ) {
-                Ok((bounds, encoded))
+                Ok((bounds, encoded, segment_fingerprint))
                     if encoded.len() <= COMMIT_DELTA_SEGMENT_TARGET_BYTES || candidate_len == 1 =>
                 {
-                    break (bounds, encoded);
+                    break (bounds, encoded, segment_fingerprint);
                 }
                 Ok(_) | Err(CommitDeltaSegmentEncodeError::SidecarTooLarge)
                     if candidate_len > 1 =>
@@ -877,6 +893,13 @@ where
                 Ok(_) => unreachable!("single-row segment exits through the guarded success arm"),
             }
         };
+        for (target, source) in manifest
+            .selection_fingerprint
+            .iter_mut()
+            .zip(segment_fingerprint)
+        {
+            *target ^= source;
+        }
         let row_count_u8 =
             u8::try_from(candidate_len).expect("commit-delta segment row count fits u8");
         segment_row_counts.push(row_count_u8);
@@ -946,7 +969,7 @@ fn encode_ordered_addressable_commit_delta_segment<'a>(
     deltas: impl Iterator<Item = TrackedStateCommitDeltaRef<'a>>,
     row_count: usize,
     compressor: &mut crate::compression::ZstdLevel1Compressor,
-) -> Result<(CommitDeltaSegmentBounds, Vec<u8>), CommitDeltaSegmentEncodeError> {
+) -> Result<(CommitDeltaSegmentBounds, Vec<u8>, [u8; 32]), CommitDeltaSegmentEncodeError> {
     let mut entries = TrackedStateMutationBatchBuilder::with_row_capacity(row_count);
     let mut payloads = Vec::with_capacity(row_count);
     for (ordinal, delta) in deltas.enumerate() {
@@ -995,8 +1018,13 @@ fn encode_ordered_addressable_commit_delta_segment<'a>(
             .key
             .to_vec(),
     };
+    let selection_fingerprint = selection_fingerprint(entries.iter().map(|entry| {
+        let value = decode_value(&entry.value)
+            .expect("ordered commit-delta values were encoded by the trusted builder");
+        (entry.key.as_ref(), value.change_id)
+    }));
     let encoded = try_encode_commit_delta_segment_with_payloads(&entries, &payloads, compressor)?;
-    Ok((bounds, encoded))
+    Ok((bounds, encoded, selection_fingerprint))
 }
 
 fn stage_commit_deltas_inner(
@@ -1147,6 +1175,17 @@ fn stage_commit_deltas_inner(
         encoded_segments.push((segment_start..segment_end, encoded));
         segment_start = segment_end;
     }
+    let member_count = u32::try_from(entries.len()).map_err(|_| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit_delta member count exceeds the manifest format",
+        )
+    })?;
+    let selection_fingerprint = selection_fingerprint(entries.iter().map(|entry| {
+        let value = decode_value(&entry.value)
+            .expect("staged commit-delta values were encoded by the trusted builder");
+        (entry.key.as_ref(), value.change_id)
+    }));
     let segment_count = encoded_segments.len();
     writes.reserve_space(TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE, 1, 0);
     if segment_count == 1 {
@@ -1159,6 +1198,8 @@ fn stage_commit_deltas_inner(
             value(encode_commit_delta_manifest(&CommitDeltaManifest {
                 selected_source_commit_id: selected_source_commit_id
                     .map(|commit_id| *commit_id.as_uuid().as_bytes()),
+                member_count,
+                selection_fingerprint,
                 inline_segment,
                 segments: Vec::new(),
             })?),
@@ -1177,6 +1218,8 @@ fn stage_commit_deltas_inner(
     let mut manifest = CommitDeltaManifest {
         selected_source_commit_id: selected_source_commit_id
             .map(|commit_id| *commit_id.as_uuid().as_bytes()),
+        member_count,
+        selection_fingerprint,
         inline_segment: Vec::new(),
         segments: Vec::with_capacity(segment_count),
     };
@@ -3393,6 +3436,42 @@ fn encode_commit_delta_manifest(manifest: &CommitDeltaManifest) -> Result<Vec<u8
     encoded.extend_from_slice(COMMIT_DELTA_FORMAT_MAGIC);
     encoded.extend_from_slice(&payload);
     Ok(encoded)
+}
+
+fn selection_fingerprint<'a>(
+    members: impl IntoIterator<Item = (&'a [u8], crate::changelog::ChangeId)>,
+) -> [u8; 32] {
+    let mut fingerprint = [0_u8; 32];
+    for (key, change_id) in members {
+        let mut member = blake3::Hasher::new();
+        member.update(b"lix.commit_delta.selection.v1");
+        member.update(&(key.len() as u64).to_be_bytes());
+        member.update(key);
+        member.update(change_id.as_uuid().as_bytes());
+        for (target, source) in fingerprint.iter_mut().zip(member.finalize().as_bytes()) {
+            *target ^= source;
+        }
+    }
+    fingerprint
+}
+
+pub(crate) fn selected_change_selection_fingerprint<'a>(
+    members: impl IntoIterator<Item = (&'a [u8], crate::changelog::ChangeId)>,
+) -> [u8; 32] {
+    selection_fingerprint(members)
+}
+
+pub(crate) async fn load_commit_delta_selection_certificate(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+) -> Result<Option<CommitDeltaSelectionCertificate>, LixError> {
+    Ok(load_commit_delta_manifest(store, commit_id)
+        .await?
+        .map(|manifest| CommitDeltaSelectionCertificate {
+            member_count: manifest.member_count,
+            selection_fingerprint: manifest.selection_fingerprint,
+            selected_source_commit_id: manifest.selected_source_commit_id(),
+        }))
 }
 
 fn decode_commit_delta_manifest(bytes: &[u8]) -> Result<CommitDeltaManifest, LixError> {
@@ -5630,6 +5709,8 @@ mod tests {
             value(
                 encode_commit_delta_manifest(&CommitDeltaManifest {
                     selected_source_commit_id: None,
+                    member_count: 0,
+                    selection_fingerprint: [0; 32],
                     inline_segment: segment,
                     segments: Vec::new(),
                 })
@@ -6366,6 +6447,8 @@ mod tests {
             value(
                 encode_commit_delta_manifest(&CommitDeltaManifest {
                     selected_source_commit_id: None,
+                    member_count: 0,
+                    selection_fingerprint: [0; 32],
                     inline_segment: encode_commit_delta_segment(&entries),
                     segments: Vec::new(),
                 })

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -1021,7 +1021,13 @@ fn encode_ordered_addressable_commit_delta_segment<'a>(
     let selection_fingerprint = selection_fingerprint(entries.iter().map(|entry| {
         let value = decode_value(&entry.value)
             .expect("ordered commit-delta values were encoded by the trusted builder");
-        (entry.key.as_ref(), value.change_id)
+        (
+            entry.key.as_ref(),
+            value.change_id,
+            value.deleted,
+            value.created_at,
+            value.updated_at,
+        )
     }));
     let encoded = try_encode_commit_delta_segment_with_payloads(&entries, &payloads, compressor)?;
     Ok((bounds, encoded, selection_fingerprint))
@@ -1184,7 +1190,13 @@ fn stage_commit_deltas_inner(
     let selection_fingerprint = selection_fingerprint(entries.iter().map(|entry| {
         let value = decode_value(&entry.value)
             .expect("staged commit-delta values were encoded by the trusted builder");
-        (entry.key.as_ref(), value.change_id)
+        (
+            entry.key.as_ref(),
+            value.change_id,
+            value.deleted,
+            value.created_at,
+            value.updated_at,
+        )
     }));
     let segment_count = encoded_segments.len();
     writes.reserve_space(TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE, 1, 0);
@@ -3439,15 +3451,26 @@ fn encode_commit_delta_manifest(manifest: &CommitDeltaManifest) -> Result<Vec<u8
 }
 
 fn selection_fingerprint<'a>(
-    members: impl IntoIterator<Item = (&'a [u8], crate::changelog::ChangeId)>,
+    members: impl IntoIterator<
+        Item = (
+            &'a [u8],
+            crate::changelog::ChangeId,
+            bool,
+            crate::common::LixTimestamp,
+            crate::common::LixTimestamp,
+        ),
+    >,
 ) -> [u8; 32] {
     let mut fingerprint = [0_u8; 32];
-    for (key, change_id) in members {
+    for (key, change_id, deleted, created_at, updated_at) in members {
         let mut member = blake3::Hasher::new();
-        member.update(b"lix.commit_delta.selection.v1");
+        member.update(b"lix.commit_delta.selection.v2");
         member.update(&(key.len() as u64).to_be_bytes());
         member.update(key);
         member.update(change_id.as_uuid().as_bytes());
+        member.update(&[u8::from(deleted)]);
+        member.update(&created_at.packed().to_be_bytes());
+        member.update(&updated_at.packed().to_be_bytes());
         for (target, source) in fingerprint.iter_mut().zip(member.finalize().as_bytes()) {
             *target ^= source;
         }
@@ -3456,7 +3479,15 @@ fn selection_fingerprint<'a>(
 }
 
 pub(crate) fn selected_change_selection_fingerprint<'a>(
-    members: impl IntoIterator<Item = (&'a [u8], crate::changelog::ChangeId)>,
+    members: impl IntoIterator<
+        Item = (
+            &'a [u8],
+            crate::changelog::ChangeId,
+            bool,
+            crate::common::LixTimestamp,
+            crate::common::LixTimestamp,
+        ),
+    >,
 ) -> [u8; 32] {
     selection_fingerprint(members)
 }

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -353,6 +353,10 @@ impl CommitDeltaMember {
         !self.authored && !self.selected_tombstone
     }
 
+    pub(crate) fn is_selected_tombstone(&self) -> bool {
+        self.selected_tombstone
+    }
+
     pub(crate) fn is_certified_payload_ref(&self) -> bool {
         self.certified_ref
     }

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -265,6 +265,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     let selected_change_records = load_selected_change_records(read, &commit_rows).await?;
 
     stage_tracked_commit_delta_index(
+        read,
         &mut writes,
         &mut state_rows,
         &row_index.tracked_row_indices_by_commit,
@@ -272,7 +273,8 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &commit_rows,
         &selected_change_records,
         &host_certified_file_schemas,
-    )?;
+    )
+    .await?;
 
     let staged_commits = stage_changelog_commits(
         read,
@@ -1107,7 +1109,8 @@ async fn materialize_selected_change_payloads(
         .collect()
 }
 
-fn stage_tracked_commit_delta_index(
+async fn stage_tracked_commit_delta_index(
+    read: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
     state_rows: &mut PreparedStateBatch,
     tracked_row_indices_by_commit: &BTreeMap<CommitId, Vec<RowIndex>>,
@@ -1182,6 +1185,7 @@ fn stage_tracked_commit_delta_index(
             state_row_indices.len() + selected_change_count(&staged.selected_change_batches),
         );
         let mut addressable = Vec::with_capacity(deltas.capacity());
+        let mut selected_members_by_source = BTreeMap::<CommitId, usize>::new();
         for &row_index in state_row_indices {
             let row = state_rows.row(row_index);
             addressable.push(row.addressable_change_id);
@@ -1196,6 +1200,9 @@ fn stage_tracked_commit_delta_index(
             deltas.push(delta);
         }
         for change_ref in selected_changes(&staged.selected_change_batches) {
+            *selected_members_by_source
+                .entry(change_ref.source_commit_id)
+                .or_default() += 1;
             let key = selected_change_key(change_ref);
             let record = selected_change_records.get(&key);
             deltas.push(tracked_commit_delta_from_selected_change_ref(
@@ -1205,6 +1212,49 @@ fn stage_tracked_commit_delta_index(
             )?);
             addressable.push(false);
         }
+        if !selected_members_by_source.is_empty() {
+            tracing::info!(
+                target: "lix_perf",
+                commit_id = %root.commit_id,
+                selected_members = selected_members_by_source.values().sum::<usize>(),
+                selected_source_commits = selected_members_by_source.len(),
+                dominant_selected_source_members = selected_members_by_source
+                    .values()
+                    .copied()
+                    .max()
+                    .unwrap_or_default(),
+                "lix.perf.commit_delta_selected_sources"
+            );
+        }
+        let selected_source_alias = if selected_members_by_source.len() == 1 {
+            let source_commit_id = *selected_members_by_source
+                .first_key_value()
+                .expect("one selected source exists")
+                .0;
+            let selected = selected_changes(&staged.selected_change_batches)
+                .map(|change_ref| {
+                    (
+                        encode_key_ref(TrackedStateKeyRef {
+                            schema_key: change_ref.schema_key(),
+                            file_id: change_ref.file_id(),
+                            entity_pk: change_ref.entity_pk(),
+                        }),
+                        change_ref.change_id,
+                    )
+                })
+                .collect::<HashMap<_, _>>();
+            let source =
+                crate::tracked_state::scan_commit_delta_values(read, source_commit_id, &[]).await?;
+            (source.len() == selected.len()
+                && source.iter().all(|row| {
+                    selected
+                        .get(row.encoded_key_ref())
+                        .is_some_and(|change_id| *change_id == row.value().change_id)
+                }))
+            .then_some(source_commit_id)
+        } else {
+            None
+        };
         let authored_change_ids = state_row_indices
             .iter()
             .filter_map(|&row_index| {
@@ -1214,7 +1264,18 @@ fn stage_tracked_commit_delta_index(
                     .flatten()
             })
             .collect::<std::collections::HashSet<_>>();
-        let staged = stage_addressable_commit_deltas(writes, &deltas, &addressable)?;
+        let staged = if let Some(source_commit_id) = selected_source_alias {
+            deltas.truncate(state_row_indices.len());
+            addressable.truncate(state_row_indices.len());
+            crate::tracked_state::stage_addressable_commit_deltas_with_selected_source(
+                writes,
+                &deltas,
+                &addressable,
+                source_commit_id,
+            )?
+        } else {
+            stage_addressable_commit_deltas(writes, &deltas, &addressable)?
+        };
         drop(deltas);
         for (source_index, &row_index) in state_row_indices.iter().enumerate() {
             if !state_rows.row(row_index).addressable_change_id {

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -16,6 +16,7 @@ use crate::changelog::{
     ChangelogWriter, CommitId, CommitLoadRequest as ChangelogCommitLoadRequest, CommitRecord,
     TransactionChangeRecordRef, TransactionChangelogAppend,
 };
+use crate::checkpoint::CHECKPOINT_MARKER_SCHEMA_KEY;
 use crate::common::{LixTimestamp, compose_directory_path, compose_file_path};
 use crate::entity_pk::EntityPk;
 use crate::filesystem::stage_path_index_revision;
@@ -1226,7 +1227,11 @@ async fn stage_tracked_commit_delta_index(
                 "lix.perf.commit_delta_selected_sources"
             );
         }
-        let selected_source_alias = if selected_members_by_source.len() == 1 {
+        let is_checkpoint_commit = state_row_indices.iter().any(|&row_index| {
+            state_rows.row(row_index).schema_key.as_str() == CHECKPOINT_MARKER_SCHEMA_KEY
+        });
+        let selected_source_alias = if is_checkpoint_commit && selected_members_by_source.len() == 1
+        {
             let source_commit_id = *selected_members_by_source
                 .first_key_value()
                 .expect("one selected source exists")
@@ -1239,15 +1244,27 @@ async fn stage_tracked_commit_delta_index(
                             file_id: change_ref.file_id(),
                             entity_pk: change_ref.entity_pk(),
                         }),
-                        change_ref.change_id,
+                        (
+                            change_ref.change_id,
+                            change_ref.deleted,
+                            change_ref.created_at,
+                            change_ref.updated_at,
+                        ),
                     )
                 })
                 .collect::<HashMap<_, _>>();
-            let selected_fingerprint = crate::tracked_state::selected_change_selection_fingerprint(
-                selected
-                    .iter()
-                    .map(|(key, change_id)| (key.as_slice(), *change_id)),
-            );
+            let selected_fingerprint =
+                crate::tracked_state::selected_change_selection_fingerprint(selected.iter().map(
+                    |(key, (change_id, deleted, created_at, updated_at))| {
+                        (
+                            key.as_slice(),
+                            *change_id,
+                            *deleted,
+                            *created_at,
+                            *updated_at,
+                        )
+                    },
+                ));
             let source = crate::tracked_state::load_commit_delta_selection_certificate(
                 read,
                 source_commit_id,

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -1243,15 +1243,23 @@ async fn stage_tracked_commit_delta_index(
                     )
                 })
                 .collect::<HashMap<_, _>>();
-            let source =
-                crate::tracked_state::scan_commit_delta_values(read, source_commit_id, &[]).await?;
-            (source.len() == selected.len()
-                && source.iter().all(|row| {
-                    selected
-                        .get(row.encoded_key_ref())
-                        .is_some_and(|change_id| *change_id == row.value().change_id)
-                }))
-            .then_some(source_commit_id)
+            let selected_fingerprint = crate::tracked_state::selected_change_selection_fingerprint(
+                selected
+                    .iter()
+                    .map(|(key, change_id)| (key.as_slice(), *change_id)),
+            );
+            let source = crate::tracked_state::load_commit_delta_selection_certificate(
+                read,
+                source_commit_id,
+            )
+            .await?;
+            source
+                .is_some_and(|source| {
+                    source.selected_source_commit_id.is_none()
+                        && usize::try_from(source.member_count).ok() == Some(selected.len())
+                        && source.selection_fingerprint == selected_fingerprint
+                })
+                .then_some(source_commit_id)
         } else {
             None
         };


### PR DESCRIPTION
## What changed

- represent complete single-source checkpoint selections as a certified source-commit alias plus the checkpoint's local authored overlay
- persist an order-independent member count/fingerprint certificate in every commit-delta manifest so checkpoint admission is O(selected rows) without scanning the source segment
- teach point history, schema scans, root rebuild, inventory, canonical-history, and GC paths to resolve the compact checkpoint representation
- hard-cut the repository protocol to `checkpoint-source-delta.v33`; no migration or backward compatibility is provided
- restrict alias admission to checkpoint-marker commits and certify identity, change ID, deletion state, and timestamps

## Why

Checkpointing every replayed Git commit previously re-encoded and persisted the selected semantic rows even when the selection was exactly one immutable source commit. OpenClaw profiling showed 496/497 eligible checkpoints in the first 500 commits. The compact representation removes that checkpoint CPU/write amplification while preserving eager semantic materialization and WASM plugins.

## Measured impact

Release-mode OpenClaw replay, all plugins enabled, SlateDB, checkpoint every commit, state verification enabled:

| 500 commits | exact parent | candidate | change |
| --- | ---: | ---: | ---: |
| replay elapsed | 29.89 s | 26.38 s | -11.7% |
| checkpoint phase | 4.14 s | 2.55 s | -38.5% |
| verify phase | 5.55 s | 5.43 s | -2.2% |

The retained candidate compacted 418 checkpoint manifests covering 43,513 selected rows into about 105 KiB of local manifests. Compressed commit-history SST bytes changed only about -0.5% because SlateDB already compresses adjacent duplicate checkpoint rows efficiently; this PR is a checkpoint CPU/write-amplification optimization, not a disk-capacity claim.

Retained evidence:

- `/root/projects/openclaw-perf-data/openclaw-v35-checkpoint-certificate-500-candidate-db`
- `/root/projects/openclaw-perf-data/openclaw-v35-checkpoint-certificate-500-candidate-profile.json`
- `/root/projects/openclaw-perf-data/openclaw-v33-exact-parent-500-baseline-db`
- `/root/projects/openclaw-perf-data/openclaw-v33-exact-parent-500-baseline-profile.json`

## Validation

- OpenClaw: 500/500 commits verified plus final Git tree
- post-fix release protocol gate: 6/6 commits verified plus final Git tree
- `cargo test -p lix_engine --all-features` (1,653 unit, 790 integration, 3 doctests; 0 failures)
- focused apply/revert/checkpoint selection tests in base and rebuilt-state modes
- focused repeated disjoint merge fuzz in base and rebuilt-state modes
- `cargo clippy -p lix_engine --all-targets --all-features -- -D warnings`
