### PR TITLE
perf(engine): stream certified parameter inserts

### DIFF
--- a/.changenotes/stream-certified-parameter-inserts.md
+++ b/.changenotes/stream-certified-parameter-inserts.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Large bound tracked-entity INSERT batches now stage certified typed columns directly and avoid repeated per-row transaction bookkeeping.
+
+Million-row creates use less peak memory and complete more than 20% faster on both RocksDB and SlateDB while retaining the existing history page granularity.

--- a/packages/engine/src/entity_pk.rs
+++ b/packages/engine/src/entity_pk.rs
@@ -201,6 +201,29 @@ impl EntityPk {
         )
     }
 
+    /// Builds an all-string identity after a typed producer has validated the
+    /// component count and scalar types against the active schema plan.
+    pub(crate) fn from_validated_shared_string_parts(
+        parts: impl IntoIterator<Item = SharedStr>,
+    ) -> Self {
+        let components = parts
+            .into_iter()
+            .map(EntityPkComponent::String)
+            .collect::<EntityPkComponentBuffer>();
+        debug_assert!(!components.is_empty());
+        Self {
+            components: EntityPkComponents::from_smallvec(components),
+        }
+    }
+
+    /// Builds the dominant one-column string identity without assembling an
+    /// intermediate component buffer after typed ingress validation.
+    pub(crate) fn from_validated_shared_string(value: SharedStr) -> Self {
+        Self {
+            components: EntityPkComponents::Single(EntityPkComponent::String(value)),
+        }
+    }
+
     pub(crate) fn into_parts(self) -> Vec<String> {
         self.components
             .iter()

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -4401,6 +4401,117 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn consecutive_certified_batches_preserve_local_conflict_statement_index() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "x-lix-key": "consecutive_parameter_insert_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": { "type": "string" }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+        session
+            .execute(
+                "INSERT INTO consecutive_parameter_insert_probe (id, value) VALUES ('z', 'old')",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let sql = "INSERT INTO consecutive_parameter_insert_probe (id, value) VALUES ($1, $2)";
+        let first_statements = [
+            ExecuteBatchStatement {
+                sql: sql.to_string(),
+                params: vec![
+                    Value::Text("a".to_string()),
+                    Value::Text("first-a".to_string()),
+                ],
+            },
+            ExecuteBatchStatement {
+                sql: sql.to_string(),
+                params: vec![
+                    Value::Text("b".to_string()),
+                    Value::Text("first-b".to_string()),
+                ],
+            },
+        ];
+        let second_statements = [
+            ExecuteBatchStatement {
+                sql: sql.to_string(),
+                params: vec![
+                    Value::Text("c".to_string()),
+                    Value::Text("second-c".to_string()),
+                ],
+            },
+            ExecuteBatchStatement {
+                sql: sql.to_string(),
+                params: vec![
+                    Value::Text("z".to_string()),
+                    Value::Text("duplicate-z".to_string()),
+                ],
+            },
+        ];
+        let mut transaction = session.begin_transaction().await.unwrap();
+        let mut conflict = None;
+        for (batch_index, statements) in [&first_statements[..], &second_statements[..]]
+            .into_iter()
+            .enumerate()
+        {
+            let parsed = TransactionBatchStatements::Shared {
+                statement: sql2::parse_statement(sql).unwrap(),
+                len: statements.len(),
+            };
+            let parameter_route = AtomicBool::new(false);
+            let staged = try_execute_transaction_parameter_batch(
+                transaction.transaction_mut().unwrap(),
+                statements,
+                &parsed,
+                &ExecuteOptions::default(),
+                &vec![ExecuteStatementMetadata::default(); statements.len()],
+                &parameter_route,
+            )
+            .await;
+            if batch_index == 0 {
+                assert!(
+                    staged.unwrap().is_some(),
+                    "the first batch should take the certified route"
+                );
+            } else {
+                conflict =
+                    Some(staged.expect_err(
+                        "the second row in the second batch conflicts with committed z",
+                    ));
+            }
+        }
+
+        let error = conflict.expect("the second batch must report its committed conflict");
+        assert_eq!(error.code, LixError::CODE_UNIQUE);
+        assert_eq!(error.details.unwrap()["statementIndex"], 1);
+        drop(transaction);
+        let rows = session
+            .execute(
+                "SELECT id FROM consecutive_parameter_insert_probe ORDER BY id",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1, "both staged batches must roll back");
+        assert_eq!(rows.rows()[0].get::<String>("id").unwrap(), "z");
+    }
+
+    #[tokio::test]
     async fn execute_batch_declines_uncertified_entity_insert_rows() {
         let session = open_session().await;
         let schema = serde_json::json!({

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -2907,61 +2907,48 @@ fn certified_direct_parameter_insert_batch(
             return Ok(None);
         }
     }
-
     if shared_string_primary_keys {
         let primary_key_arena = SharedStr::from_utf8(bytes::Bytes::from(primary_key_arena))
             .map_err(|_| LixError::unknown("certified primary-key arena is not valid UTF-8"))?;
         entity_pks.reserve(row_count);
         for ranges in primary_key_ranges.chunks_exact(primary_key_columns.len()) {
-            entity_pks.push(
-                EntityPk::from_shared_external_parts(
+            if let [(start, end)] = ranges {
+                entity_pks.push(EntityPk::from_validated_shared_string(
+                    primary_key_arena
+                        .slice(*start as usize..*end as usize)
+                        .expect("certified primary-key ranges preserve UTF-8 boundaries"),
+                ));
+            } else {
+                entity_pks.push(EntityPk::from_validated_shared_string_parts(
                     ranges.iter().map(|&(start, end)| {
                         primary_key_arena
                             .slice(start as usize..end as usize)
                             .expect("certified primary-key ranges preserve UTF-8 boundaries")
                     }),
-                    &spec.primary_key_component_types,
-                )
-                .map_err(|error| {
-                    LixError::new(
-                        LixError::CODE_SCHEMA_VALIDATION,
-                        format!(
-                            "INSERT failed to derive entity primary key for schema '{}': {error}",
-                            layout.schema_key
-                        ),
-                    )
-                })?,
-            );
+                ));
+            }
         }
     }
+    let tracked_keys_strictly_ordered =
+        shared_string_primary_keys || unordered_entity_pks.is_none();
     let snapshots = TransactionJson::from_certified_row_content_arena(normalized, offsets)?;
     let schema_key: SharedStr = layout.schema_key.as_str().into();
     let branch_id: SharedStr = ctx.active_branch_id().into();
-    let mut rows = RawWriteBatch::with_capacity(row_count);
-    for (entity_pk, snapshot) in entity_pks.into_iter().zip(snapshots) {
-        rows.push_parts(
-            Some(entity_pk),
-            schema_key.clone(),
-            None,
-            Some(snapshot),
-            None,
-            None,
-            None,
-            None,
-            false,
-            None,
-            None,
-            false,
-            branch_id.clone(),
-        );
-    }
-    rows.certify_preparation(CertifiedRawWriteBatchPreparation {
+    let certificate = CertifiedRawWriteBatchPreparation {
         schema_plan_id,
         facts: PreparedRowFacts {
             row_content_validated: true,
             requires_transaction_validation: false,
         },
-    });
+        tracked_keys_strictly_ordered,
+    };
+    let rows = RawWriteBatch::from_certified_parameter_insert(
+        entity_pks,
+        snapshots,
+        schema_key,
+        branch_id,
+        certificate,
+    )?;
     Ok(Some(rows))
 }
 

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -768,6 +768,7 @@ pub(crate) fn stage_addressable_commit_deltas(
 pub(crate) fn stage_ordered_addressable_commit_deltas<'a, I>(
     writes: &mut StorageWriteSet,
     deltas: I,
+    order_certified: bool,
 ) -> Result<Option<OrderedAddressableCommitDeltaStage>, LixError>
 where
     I: ExactSizeIterator<Item = Result<TrackedStateCommitDeltaRef<'a>, LixError>> + Clone,
@@ -787,23 +788,25 @@ where
         file_id: first.delta.file_id,
         entity_pk: first.delta.entity_pk,
     };
-    for delta in probe {
-        let delta = delta?;
-        if delta.delta.commit_id != commit_id {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                "tracked_state cannot pack deltas from different commits together",
-            ));
+    if !order_certified {
+        for delta in probe {
+            let delta = delta?;
+            if delta.delta.commit_id != commit_id {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state cannot pack deltas from different commits together",
+                ));
+            }
+            let key = TrackedStateKeyRef {
+                schema_key: delta.delta.schema_key,
+                file_id: delta.delta.file_id,
+                entity_pk: delta.delta.entity_pk,
+            };
+            if compare_tracked_state_key_refs(previous_key, key) != std::cmp::Ordering::Less {
+                return Ok(None);
+            }
+            previous_key = key;
         }
-        let key = TrackedStateKeyRef {
-            schema_key: delta.delta.schema_key,
-            file_id: delta.delta.file_id,
-            entity_pk: delta.delta.entity_pk,
-        };
-        if compare_tracked_state_key_refs(previous_key, key) != std::cmp::Ordering::Less {
-            return Ok(None);
-        }
-        previous_key = key;
     }
 
     let mut compressor = crate::compression::ZstdLevel1Compressor::new().map_err(|error| {
@@ -4327,6 +4330,7 @@ mod tests {
         let staged = super::stage_ordered_addressable_commit_deltas(
             &mut writes,
             deltas.iter().copied().map(Ok::<_, LixError>),
+            false,
         )
         .expect("ordered addressable deltas should stage")
         .expect("sorted deltas should use the streaming route");

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -1169,7 +1169,13 @@ fn stage_tracked_commit_delta_index(
                         );
                     Ok(delta)
                 });
-                stage_ordered_addressable_commit_deltas(writes, deltas)?
+                let order_certified = state_rows.certified_ordered_insert()
+                    && state_row_indices.len() == state_rows.len()
+                    && state_row_indices
+                        .iter()
+                        .enumerate()
+                        .all(|(index, &row_index)| index == row_index);
+                stage_ordered_addressable_commit_deltas(writes, deltas, order_certified)?
             };
             if let Some(ordered_stage) = ordered_stage {
                 if ordered_stage.row_count() != state_row_indices.len() {

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -981,6 +981,71 @@ where
         self.stage_write_inner(write, Some(statement_indices)).await
     }
 
+    /// Stages the fixed-shape public parameter INSERT proof without routing it
+    /// through plugin reconciliation, storage-scope scans, or filesystem path
+    /// preflight. The producer certificate excludes every system column those
+    /// generic passes inspect; committed and transaction-local INSERT
+    /// collision checks remain in the normal prepared journal.
+    async fn stage_certified_parameter_batch_insert(
+        &mut self,
+        rows: RawWriteBatch,
+    ) -> Result<TransactionWriteOutcome, LixError> {
+        let row_count = rows.len();
+        if row_count == 0 {
+            return Ok(TransactionWriteOutcome { count: 0 });
+        }
+        debug_assert!(rows.certified_preparation().is_some());
+        self.ensure_plugin_generation_read_guard().await;
+
+        let first = rows.row(0);
+        let branch_id = first.branch_id.clone();
+        let schema_key = first.schema_key.clone();
+        let staged = self.staged_writes.staging_overlay()?;
+        if StagedLiveStateRows::collection_replaced(
+            &staged,
+            branch_id.as_str(),
+            schema_key.as_str(),
+            None,
+        )? {
+            return Err(LixError::new(
+                LixError::CODE_CONSTRAINT_VIOLATION,
+                format!("collection '{schema_key}' was deleted earlier in this transaction"),
+            )
+            .with_hint(
+                "Commit the collection deletion before recreating rows in its next generation.",
+            ));
+        }
+
+        #[cfg(feature = "storage-benches")]
+        {
+            crate::storage_bench::record_transaction_rows_staged(row_count);
+            crate::storage_bench::record_transaction_untracked_rows(0);
+        }
+        let prepared = self
+            .prepare_transaction_rows(rows)
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.transaction_prepare_rows"
+            ))
+            .await?;
+        if prepared.len() != row_count {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "certified parameter INSERT preparation changed row cardinality",
+            ));
+        }
+        tracing::debug_span!(target: "lix_perf", "lix.perf.transaction_buffer_stage").in_scope(
+            || {
+                self.staged_writes.stage_certified_parameter_batch_insert(
+                    PreparedTransactionWrite::Rows {
+                        mode: TransactionWriteMode::Insert,
+                        rows: prepared,
+                    },
+                )
+            },
+        )
+    }
+
     async fn stage_write_inner(
         &mut self,
         write: TransactionWrite,
@@ -6765,6 +6830,9 @@ where
         &mut self,
         rows: RawWriteBatch,
     ) -> Result<TransactionWriteOutcome, LixError> {
+        if rows.certified_preparation().is_some() {
+            return self.stage_certified_parameter_batch_insert(rows).await;
+        }
         let statement_indices = (0..rows.len())
             .map(|index| {
                 u32::try_from(index).map_err(|_| {

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -323,6 +323,7 @@ pub(crate) struct PreparedInsertSelection {
     bits: Vec<u64>,
     origins: Vec<Option<TransactionWriteOrigin>>,
     statement_indices: Vec<u32>,
+    statement_indices_are_row_ordinals: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -348,6 +349,7 @@ impl PreparedInsertSelection {
             bits: Vec::with_capacity(row_capacity.div_ceil(Self::WORD_BITS)),
             origins: Vec::with_capacity(row_capacity),
             statement_indices: Vec::new(),
+            statement_indices_are_row_ordinals: false,
         }
     }
 
@@ -391,9 +393,30 @@ impl PreparedInsertSelection {
     }
 
     fn push(&mut self, origin: Option<&TransactionWriteOrigin>, statement_index: Option<usize>) {
+        self.materialize_statement_indices();
         let row_index = self.row_count;
         self.resize_rows(row_index + 1);
         self.mark(row_index, origin, statement_index);
+    }
+
+    fn push_certified_ordinal_inserts(&mut self, row_count: usize) {
+        if self.row_count != 0 || self.count != 0 {
+            self.reserve_rows(row_count, true);
+            for statement_index in 0..row_count {
+                self.push(None, Some(statement_index));
+            }
+            return;
+        }
+        self.row_count = row_count;
+        self.count = row_count;
+        self.bits = vec![u64::MAX; row_count.div_ceil(Self::WORD_BITS)];
+        if let Some(last) = self.bits.last_mut()
+            && !row_count.is_multiple_of(Self::WORD_BITS)
+        {
+            *last = (1_u64 << (row_count % Self::WORD_BITS)) - 1;
+        }
+        self.origins.resize(row_count, None);
+        self.statement_indices_are_row_ordinals = true;
     }
 
     fn push_not_insert(&mut self) {
@@ -439,6 +462,7 @@ impl PreparedInsertSelection {
         origin: Option<&TransactionWriteOrigin>,
         statement_index: Option<usize>,
     ) {
+        self.materialize_statement_indices();
         debug_assert!(row_index < self.row_count);
         let word = row_index / Self::WORD_BITS;
         let bit = row_index % Self::WORD_BITS;
@@ -464,7 +488,19 @@ impl PreparedInsertSelection {
         }
     }
 
+    fn materialize_statement_indices(&mut self) {
+        if self.statement_indices_are_row_ordinals {
+            self.statement_indices = (0..self.row_count)
+                .map(|index| u32::try_from(index).expect("batch statement index must fit u32"))
+                .collect();
+            self.statement_indices_are_row_ordinals = false;
+        }
+    }
+
     fn statement_index(&self, row_index: usize) -> Option<usize> {
+        if self.statement_indices_are_row_ordinals && row_index < self.row_count {
+            return Some(row_index);
+        }
         self.statement_indices
             .get(row_index)
             .copied()
@@ -837,10 +873,12 @@ impl TransactionWriteBuffer {
         statement_indices: Option<&[u32]>,
     ) -> Result<AppendOnlyStage, LixError> {
         let inserts = mode == Some(TransactionWriteMode::Insert);
+        let certified_ordered_insert = inserts && rows.certified_ordered_insert();
         if !matches!(
             mode,
             Some(TransactionWriteMode::Replace | TransactionWriteMode::Insert)
-        ) || (inserts
+        ) || (!certified_ordered_insert
+            && inserts
             && !rows
                 .iter()
                 .all(|row| row_is_insert(mode, row) && row.snapshot.is_some()))
@@ -861,7 +899,18 @@ impl TransactionWriteBuffer {
         else {
             return Ok(AppendOnlyStage::Fallback(rows));
         };
-        if !rows_are_append_only_tracked(&rows, last_key.as_ref()) {
+        let append_shape_matches = if certified_ordered_insert {
+            rows.first().is_none_or(|first| {
+                is_normal_tracked_append_row(first)
+                    && first.snapshot.is_some()
+                    && last_key.as_ref().is_none_or(|previous| {
+                        compare_tracked_key_to_row(previous, first) == std::cmp::Ordering::Less
+                    })
+            })
+        } else {
+            rows_are_append_only_tracked(&rows, last_key.as_ref())
+        };
+        if !append_shape_matches {
             return Ok(AppendOnlyStage::Fallback(rows));
         }
 
@@ -888,19 +937,21 @@ impl TransactionWriteBuffer {
                 .expect("branch change refs were inserted above");
             let commit_id = change_refs.commit_id;
             change_refs.add_change_count(rows.len());
-            for index in 0..rows.len() {
-                rows.set_commit_id(index, Some(commit_id));
-            }
+            rows.set_commit_id_all(commit_id);
         }
-        insert_selection.reserve_rows(rows.len(), inserts);
-        for (row_index, row) in rows.iter().enumerate() {
-            if inserts {
-                insert_selection.push(
-                    row.origin,
-                    statement_indices.map(|indices| indices[row_index] as usize),
-                );
-            } else {
-                insert_selection.push_not_insert();
+        if certified_ordered_insert {
+            insert_selection.push_certified_ordinal_inserts(rows.len());
+        } else {
+            insert_selection.reserve_rows(rows.len(), inserts);
+            for (row_index, row) in rows.iter().enumerate() {
+                if inserts {
+                    insert_selection.push(
+                        row.origin,
+                        statement_indices.map(|indices| indices[row_index] as usize),
+                    );
+                } else {
+                    insert_selection.push_not_insert();
+                }
             }
         }
         if let Some(row) = rows.last() {
@@ -1416,6 +1467,45 @@ impl TransactionWriteBuffer {
         statement_indices: Vec<u32>,
     ) -> Result<TransactionWriteOutcome, LixError> {
         self.stage_write_inner(write, Some(statement_indices))
+    }
+
+    pub(crate) fn stage_certified_parameter_batch_insert(
+        &self,
+        write: PreparedTransactionWrite,
+    ) -> Result<TransactionWriteOutcome, LixError> {
+        let (mode, count) = match &write {
+            PreparedTransactionWrite::Rows { mode, rows } => (Some(*mode), rows.len() as u64),
+            PreparedTransactionWrite::RowsWithFileData { .. } => {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "certified parameter INSERT unexpectedly contains file data",
+                ));
+            }
+        };
+        let (rows, file_data_writes) = self.state_rows_from_stage_write(write);
+        debug_assert!(file_data_writes.is_empty());
+        match self.stage_append_only_if_possible(mode, rows, None)? {
+            AppendOnlyStage::Staged => Ok(TransactionWriteOutcome { count }),
+            AppendOnlyStage::Fallback(rows) => {
+                let statement_indices = (0..rows.len())
+                    .map(|index| {
+                        u32::try_from(index).map_err(|_| {
+                            LixError::new(
+                                LixError::CODE_INVALID_PARAM,
+                                "parameter batch row count exceeds u32",
+                            )
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                self.stage_write_inner(
+                    PreparedTransactionWrite::Rows {
+                        mode: TransactionWriteMode::Insert,
+                        rows,
+                    },
+                    Some(statement_indices),
+                )
+            }
+        }
     }
 
     fn stage_write_inner(
@@ -2462,6 +2552,17 @@ mod tests {
         ($($row:expr),* $(,)?) => {
             PreparedStateBatch::from_test_rows(vec![$($row),*])
         };
+    }
+
+    #[test]
+    fn generic_insert_after_certified_batch_does_not_inherit_statement_index() {
+        let mut selection = PreparedInsertSelection::new();
+        selection.push_certified_ordinal_inserts(2);
+        selection.push(None, None);
+
+        assert_eq!(selection.statement_index(0), Some(0));
+        assert_eq!(selection.statement_index(1), Some(1));
+        assert_eq!(selection.statement_index(2), None);
     }
 
     #[test]

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -476,6 +476,7 @@ pub(crate) struct RawWriteBatch {
 pub(crate) struct CertifiedRawWriteBatchPreparation {
     pub(crate) schema_plan_id: SchemaPlanId,
     pub(crate) facts: PreparedRowFacts,
+    pub(crate) tracked_keys_strictly_ordered: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -536,6 +537,63 @@ impl RawWriteBatch {
             #[cfg(test)]
             origin_promotions: 0,
         }
+    }
+
+    /// Constructs the fixed-shape public INSERT ingress batch without
+    /// interning the same schema/branch pair and appending seven null system
+    /// columns once per row.
+    pub(crate) fn from_certified_parameter_insert(
+        entity_pks: Vec<EntityPk>,
+        snapshots: Vec<TransactionJson>,
+        schema_key: SharedStr,
+        branch_id: SharedStr,
+        certificate: CertifiedRawWriteBatchPreparation,
+    ) -> Result<Self, LixError> {
+        if entity_pks.len() != snapshots.len() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "certified parameter INSERT columns are not aligned",
+            ));
+        }
+        let row_count = entity_pks.len();
+        if row_count >= RAW_WRITE_NONE as usize {
+            return Err(LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                "certified parameter INSERT row count exceeds u32",
+            ));
+        }
+        let (strings, schema_key_ordinal, branch_id_ordinal) = if schema_key == branch_id {
+            (vec![schema_key], 0, 0)
+        } else {
+            (vec![schema_key, branch_id], 0, 1)
+        };
+        let slot = RawWriteSlot {
+            schema_key: schema_key_ordinal,
+            file_id: RAW_WRITE_NONE,
+            origin: RAW_WRITE_NONE,
+            created_at: RAW_WRITE_NONE,
+            updated_at: RAW_WRITE_NONE,
+            change_id: RAW_WRITE_NONE,
+            commit_id: RAW_WRITE_NONE,
+            branch_id: branch_id_ordinal,
+            flags: 0,
+        };
+        Ok(Self {
+            slots: vec![slot; row_count],
+            entity_pks: entity_pks.into_iter().map(Some).collect(),
+            snapshots: snapshots.into_iter().map(Some).collect(),
+            metadata: std::iter::repeat_with(|| None).take(row_count).collect(),
+            strings,
+            string_index: None,
+            expected_rows: row_count,
+            origins: Vec::new(),
+            origin_index: None,
+            certified_preparation: Some(certificate),
+            #[cfg(test)]
+            string_promotions: 0,
+            #[cfg(test)]
+            origin_promotions: 0,
+        })
     }
 
     #[cfg(test)]
@@ -669,10 +727,6 @@ impl RawWriteBatch {
     pub(crate) fn append_taken_row(&mut self, source: &mut Self, index: usize) {
         self.certified_preparation = None;
         source.move_row_into(index, self);
-    }
-
-    pub(crate) fn certify_preparation(&mut self, certificate: CertifiedRawWriteBatchPreparation) {
-        self.certified_preparation = Some(certificate);
     }
 
     pub(crate) fn certified_preparation(&self) -> Option<CertifiedRawWriteBatchPreparation> {
@@ -826,6 +880,7 @@ impl RawWriteBatch {
             origin_index: HashMap::new(),
             origin_column_sets: Vec::new(),
             origin_column_index: HashMap::new(),
+            certified_ordered_insert: certificate.tracked_keys_strictly_ordered,
         })
     }
 
@@ -2093,6 +2148,9 @@ pub(crate) struct PreparedStateBatch {
     origin_index: HashMap<TransactionWriteOrigin, u32>,
     origin_column_sets: Vec<Arc<[String]>>,
     origin_column_index: HashMap<Arc<[String]>, u32>,
+    /// The typed producer proved one strictly ordered, unique, ordinary
+    /// tracked INSERT batch. Any row topology change clears this proof.
+    certified_ordered_insert: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2192,6 +2250,7 @@ impl PreparedStateBatch {
             origin_index: HashMap::new(),
             origin_column_sets: Vec::new(),
             origin_column_index: HashMap::new(),
+            certified_ordered_insert: false,
         }
     }
 
@@ -2201,6 +2260,10 @@ impl PreparedStateBatch {
 
     pub(crate) fn is_empty(&self) -> bool {
         self.slots.is_empty()
+    }
+
+    pub(crate) fn certified_ordered_insert(&self) -> bool {
+        self.certified_ordered_insert
     }
 
     pub(crate) fn iter(&self) -> PreparedStateRows<'_> {
@@ -2378,6 +2441,7 @@ impl PreparedStateBatch {
             *self = other;
             return;
         }
+        self.certified_ordered_insert = false;
         let entity_base =
             u32::try_from(self.entity_pks.len()).expect("prepared entity column must fit u32");
         let json_base = u32::try_from(self.json.len()).expect("prepared JSON column must fit u32");
@@ -2432,6 +2496,7 @@ impl PreparedStateBatch {
     }
 
     pub(crate) fn swap_rows(&mut self, left: usize, right: usize) {
+        self.certified_ordered_insert = false;
         self.slots.swap(left, right);
     }
 
@@ -2440,6 +2505,7 @@ impl PreparedStateBatch {
     /// Only compact slots move; typed owner columns remain stable and are
     /// still shared by the selected row ordinals.
     pub(crate) fn select_rows(&mut self, source_by_destination: &[usize]) {
+        self.certified_ordered_insert = false;
         debug_assert!(
             source_by_destination
                 .iter()
@@ -2481,6 +2547,9 @@ impl PreparedStateBatch {
     /// Unlike `select_rows`, this path allocates no O(live_rows) permutation
     /// buffers. Generic staging uses it for sparse point replacements.
     pub(crate) fn truncate_rows(&mut self, retained_len: usize) {
+        if retained_len != self.slots.len() {
+            self.certified_ordered_insert = false;
+        }
         self.slots.truncate(retained_len);
         if !self.should_compact_owner_columns(retained_len) {
             return;
@@ -2494,6 +2563,12 @@ impl PreparedStateBatch {
 
     pub(crate) fn set_commit_id(&mut self, index: usize, commit_id: Option<CommitId>) {
         self.slots[index].commit_id = commit_id;
+    }
+
+    pub(crate) fn set_commit_id_all(&mut self, commit_id: CommitId) {
+        for slot in &mut self.slots {
+            slot.commit_id = Some(commit_id);
+        }
     }
 
     pub(crate) fn set_change_id(&mut self, index: usize, change_id: Option<ChangeId>) {


### PR DESCRIPTION
## Summary

- construct fixed-shape certified parameter INSERT batches directly from typed identity and snapshot columns, including a single-column identity path with no component scratch buffer
- stage this exact active-branch tracked shape without generic plugin reconciliation, storage-scope scans, filesystem preflight, or per-row commit-id writes
- carry a strict physical-key-order certificate into commit lowering so staging and addressable history publication can skip redundant O(rows) proof scans
- represent first-batch INSERT statement attribution as implicit row ordinals, materializing an explicit column only if later transaction writes require it
- preserve fallback attribution for unordered/irregular batches and consecutive explicit-transaction batches

This is stacked on #1021. Plugin execution remains out of scope. The experimented 1,024/2,048-row history granules are deliberately **not** included; this PR retains #1021's 512-row / 64 KiB history layout after exact-read controls showed that write granularity must be evaluated separately.

## Performance

Exact #1021 baseline versus this branch, tracked SQL `executeBatch` create:

| Rows | Adapter | #1021 | This branch | Change |
| ---: | --- | ---: | ---: | ---: |
| 100k | RocksDB | 158.091 ms | 130.483 ms | **-17.5%** |
| 100k | SlateDB | 153.283 ms | 125.916 ms | **-17.9%** |
| 1M | RocksDB | 3.642 s | 2.746 s | **-24.6%** |
| 1M | SlateDB | 3.627 s | 2.798 s | **-22.9%** |

The 1M runs complete without OOM at about 2.31 GiB RocksDB / 2.35 GiB SlateDB peak RSS.

The exact local #1021 control and candidate retain the same physical history layout. Repeated working-diff runs were flat within run variance (RocksDB 1.221 vs 1.258 ms; SlateDB 1.154 vs 1.162 ms). Checkpoint was faster on RocksDB (12.450 to 6.036 ms) and flat on SlateDB (12.802 vs 13.163 ms). Merge/diff/checkpoint correctness remains covered by the full engine suite.

At 10k rows the current end-to-end create path remains about 2.5x raw SQLite (20.50 ms RocksDB / 20.04 ms SlateDB versus 8.24 ms SQLite in the retained measurement), so this PR is one stacked layer rather than completion of the 1.2x objective.

## Correctness

- certified ordering is produced from the already validated typed primary-key stream and is cleared by every topology-changing batch operation
- uncommon fallback paths reconstruct explicit statement indices
- consecutive certified batches preserve the failing batch's local `statementIndex`
- a later generic insert cannot inherit an implicit ordinal from an earlier certified batch
- collection-generation replacement semantics remain checked before direct staging

## Validation

- `cargo test -p lix_engine --lib --all-features` — 1,643 passed, 6 ignored
- `cargo clippy -p lix_engine --all-targets --all-features -- -D warnings`
- `cargo check -p lix_engine --all-features`
- `cargo test -p lix_engine_benchmarks --test tracked_state_crud_public_result --features storage-benches,slatedb` — 4 passed
- `cargo fmt --all -- --check`
- `node scripts/validate-changes.mjs`
- focused certified batch, consecutive-batch attribution, generic-after-certified attribution, and ordered addressable history tests
