### PR TITLE
fix(engine): cut repository protocol for LXCD8

### DIFF
--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -791,6 +791,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn predecessor_v33_commit_delta_coordinates_are_rejected() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let storage_adapter = StorageAdapter::new(storage.clone());
+        let mut writes = storage_adapter.new_write_set();
+        writes.put(
+            crate::init::REPOSITORY_PROTOCOL_SPACE,
+            crate::init::REPOSITORY_PROTOCOL_KEY,
+            &b"checkpoint-source-delta.v33"[..],
+        );
+        storage_adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("V33 protocol marker should commit");
+
+        let Err(error) = Engine::new(storage).await else {
+            panic!("V33 repositories must fail closed before LXCD7 locators are decoded");
+        };
+        assert_eq!(error.code, "LIX_ERROR_UNSUPPORTED_STORAGE_FORMAT");
+    }
+
+    #[tokio::test]
     async fn tracked_entity_fast_path_serves_broad_sql_rows() {
         let storage = Memory::new();
         Engine::initialize(storage.clone())

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -39,14 +39,13 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 
 /// Repository-wide compatibility gate for physical storage protocols.
 ///
-/// V32 adds source-addressed checkpoint deltas and their selection certificate
-/// to the packed history plane.
-/// Older manifests have a different packed field layout and must fail closed
-/// before they can be decoded as source aliases.
+/// V34 widens certified commit-delta segment coordinates for the LXCD8 packed
+/// history format. Older manifests and locators must fail closed before their
+/// LXCD7 coordinates can be decoded with the wider layout.
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"checkpoint-source-delta.v33";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"wide-commit-delta-coordinates.v34";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately


### PR DESCRIPTION
Advances the repository protocol marker to V34 for the LXCD8 packed commit-delta format and adds a regression proving V33 repositories fail closed before LXCD7 locators are decoded.

Root cause: #1021 widened segment coordinates and changed the format magic without changing the repository-wide compatibility marker.

Validation:
- cargo fmt --all
- git diff --check
- production lix_engine compilation completed locally
- focused test linking and test-metadata compilation exceeded the constrained local RAM ceiling and were SIGKILLed; CI is the execution gate