### PR TITLE
perf(engine): certify dense commits and compile typed insert layouts once

### DIFF
--- a/.changenotes/dense-commit-selection-certificates.md
+++ b/.changenotes/dense-commit-selection-certificates.md
@@ -2,4 +2,4 @@
 type: patch
 ---
 
-Tracked history now certifies ordered bulk commits from their dense address inventory instead of hashing every row independently.
+Tracked history now certifies ordered bulk commits from their dense address inventory instead of hashing every row independently. Typed SQL parameter batches also compile their fixed schema layout once and serialize escape-free strings directly.

--- a/.changenotes/dense-commit-selection-certificates.md
+++ b/.changenotes/dense-commit-selection-certificates.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Tracked history now certifies ordered bulk commits from their dense address inventory instead of hashing every row independently.

--- a/packages/engine/src/catalog/mod.rs
+++ b/packages/engine/src/catalog/mod.rs
@@ -11,5 +11,5 @@ pub(crate) use schema::{
 };
 pub(crate) use snapshot::{
     CatalogFingerprint, CatalogSnapshot, DefaultPlan, StateDeleteReferencePlan, TransactionCatalog,
-    TypedJsonObjectFieldRef, TypedJsonScalarRef,
+    TypedJsonScalarRef,
 };

--- a/packages/engine/src/catalog/snapshot.rs
+++ b/packages/engine/src/catalog/snapshot.rs
@@ -416,10 +416,77 @@ pub(crate) enum TypedJsonScalarRef<'a> {
     String(&'a str),
 }
 
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct TypedJsonObjectFieldRef<'a> {
-    pub(crate) name: &'a str,
-    pub(crate) value: TypedJsonScalarRef<'a>,
+/// Batch-stable validation compiled once for a fixed typed object layout.
+///
+/// SQL and future typed producers reuse the resolved property validators and
+/// primary-key column positions for every row instead of repeating structural
+/// schema work in the hot loop.
+pub(crate) struct TypedJsonObjectLayoutCertificate<'a> {
+    schema_key: &'a str,
+    field_names: Vec<String>,
+    field_validations: Vec<Option<&'a FastValueValidation>>,
+    primary_key_field_indices: Vec<usize>,
+    primary_key_component_types: &'a [crate::entity_pk::EntityPkComponentType],
+}
+
+impl TypedJsonObjectLayoutCertificate<'_> {
+    pub(crate) fn certify_row(
+        &self,
+        values: &[TypedJsonScalarRef<'_>],
+        entity_pk: &[&str],
+    ) -> Result<(), LixError> {
+        if values.len() != self.field_validations.len() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "typed object row does not match its certified layout",
+            ));
+        }
+        for ((name, validation), value) in self
+            .field_names
+            .iter()
+            .zip(&self.field_validations)
+            .zip(values.iter().copied())
+        {
+            if validation.is_some_and(|validation| !validation.accepts_typed(value)) {
+                return Err(typed_object_validation_error(
+                    self.schema_key,
+                    &format!("property '{name}' does not satisfy its schema"),
+                ));
+            }
+        }
+        if entity_pk.len() != self.primary_key_field_indices.len() {
+            return Err(typed_object_validation_error(
+                self.schema_key,
+                "snapshot primary-key component count does not match the emitted entity_pk",
+            ));
+        }
+        for (&field_index, expected) in self.primary_key_field_indices.iter().zip(entity_pk) {
+            let actual = match values[field_index] {
+                TypedJsonScalarRef::String(value) => Some(value),
+                TypedJsonScalarRef::Null | TypedJsonScalarRef::Boolean => None,
+            };
+            if actual != Some(*expected) {
+                return Err(typed_object_validation_error(
+                    self.schema_key,
+                    &format!(
+                        "snapshot primary-key property '{}' does not match the emitted entity_pk",
+                        self.field_names[field_index]
+                    ),
+                ));
+            }
+        }
+        EntityPk::validate_external_parts(entity_pk, self.primary_key_component_types).map_err(
+            |error| {
+                LixError::new(
+                    LixError::CODE_SCHEMA_VALIDATION,
+                    format!(
+                        "typed entity_pk is invalid for schema '{}': {error}",
+                        self.schema_key
+                    ),
+                )
+            },
+        )
+    }
 }
 
 impl SchemaPlan {
@@ -437,18 +504,11 @@ impl SchemaPlan {
             .is_some_and(|plan| plan.accepts(value))
     }
 
-    /// Certifies one already-typed object row without constructing or parsing
-    /// a JSON DOM.
-    ///
-    /// Typed producers can keep scalar columns in their native representation,
-    /// validate them against the same compiled schema plan, and serialize
-    /// canonical storage bytes only once.
-    pub(crate) fn certify_typed_object_row(
-        &self,
+    pub(crate) fn certify_typed_object_layout<'a>(
+        &'a self,
         schema_key: &str,
-        fields: &[TypedJsonObjectFieldRef<'_>],
-        entity_pk: &[&str],
-    ) -> Result<(), LixError> {
+        field_names: &[&str],
+    ) -> Result<TypedJsonObjectLayoutCertificate<'a>, LixError> {
         if !self.accepts_canonical_certificate() {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
@@ -468,7 +528,7 @@ impl SchemaPlan {
             .fast_object_validation
             .as_ref()
             .expect("certificate eligibility requires fast object validation");
-        if fields.len() < validation.min_properties {
+        if field_names.len() < validation.min_properties {
             return Err(typed_object_validation_error(
                 &self.key.schema_key,
                 "object has fewer properties than minProperties",
@@ -477,71 +537,52 @@ impl SchemaPlan {
         if let Some(required) = validation
             .required
             .iter()
-            .find(|required| !fields.iter().any(|field| field.name == required.as_str()))
+            .find(|required| !field_names.contains(&required.as_str()))
         {
             return Err(typed_object_validation_error(
                 &self.key.schema_key,
                 &format!("required property '{required}' is missing"),
             ));
         }
-        for field in fields {
-            let accepted = validation
-                .properties
-                .get(field.name)
-                .map_or(validation.additional_properties, |property| {
-                    property.accepts_typed(field.value)
-                });
-            if !accepted {
-                return Err(typed_object_validation_error(
-                    &self.key.schema_key,
-                    &format!("property '{}' does not satisfy its schema", field.name),
-                ));
+        let mut field_validations = Vec::with_capacity(field_names.len());
+        for &name in field_names {
+            match validation.properties.get(name) {
+                Some(property) => field_validations.push(Some(property)),
+                None if validation.additional_properties => field_validations.push(None),
+                None => {
+                    return Err(typed_object_validation_error(
+                        &self.key.schema_key,
+                        &format!("property '{name}' does not satisfy its schema"),
+                    ));
+                }
             }
         }
-
         let primary_key_paths = self
             .primary_key
             .as_deref()
             .expect("certificate eligibility requires a primary key");
-        if primary_key_paths.len() != entity_pk.len() {
-            return Err(typed_object_validation_error(
-                &self.key.schema_key,
-                "snapshot primary-key component count does not match the emitted entity_pk",
-            ));
-        }
-        for (path, expected) in primary_key_paths.iter().zip(entity_pk) {
+        let mut primary_key_field_indices = Vec::with_capacity(primary_key_paths.len());
+        for path in primary_key_paths {
             let [name] = path.as_slice() else {
                 unreachable!("certificate eligibility requires top-level primary keys");
             };
-            let actual =
-                fields
-                    .iter()
-                    .find(|field| field.name == name)
-                    .and_then(|field| match field.value {
-                        TypedJsonScalarRef::String(value) => Some(value),
-                        TypedJsonScalarRef::Null | TypedJsonScalarRef::Boolean => None,
-                    });
-            if actual != Some(*expected) {
+            let Some(field_index) = field_names.iter().position(|field| field == name) else {
                 return Err(typed_object_validation_error(
                     &self.key.schema_key,
-                    &format!(
-                        "snapshot primary-key property '{name}' does not match the emitted entity_pk"
-                    ),
+                    &format!("required primary-key property '{name}' is missing"),
                 ));
-            }
+            };
+            primary_key_field_indices.push(field_index);
         }
-        let component_types = self
-            .primary_key_component_types
-            .as_deref()
-            .expect("certificate eligibility requires typed primary-key components");
-        EntityPk::validate_external_parts(entity_pk, component_types).map_err(|error| {
-            LixError::new(
-                LixError::CODE_SCHEMA_VALIDATION,
-                format!(
-                    "typed entity_pk is invalid for schema '{}': {error}",
-                    self.key.schema_key
-                ),
-            )
+        Ok(TypedJsonObjectLayoutCertificate {
+            schema_key: &self.key.schema_key,
+            field_names: field_names.iter().map(|name| (*name).to_string()).collect(),
+            field_validations,
+            primary_key_field_indices,
+            primary_key_component_types: self
+                .primary_key_component_types
+                .as_deref()
+                .expect("certificate eligibility requires typed primary-key components"),
         })
     }
 
@@ -3031,36 +3072,22 @@ mod tests {
         .expect("typed-row schema should compile");
         assert!(plan.accepts_canonical_certificate());
 
-        let fields = [
-            TypedJsonObjectFieldRef {
-                name: "active",
-                value: TypedJsonScalarRef::Boolean,
-            },
-            TypedJsonObjectFieldRef {
-                name: "id",
-                value: TypedJsonScalarRef::String("row-1"),
-            },
+        let layout = plan
+            .certify_typed_object_layout("typed_rows", &["active", "id"])
+            .expect("typed-row layout should certify");
+        let values = [
+            TypedJsonScalarRef::Boolean,
+            TypedJsonScalarRef::String("row-1"),
         ];
-        plan.certify_typed_object_row("typed_rows", &fields, &["row-1"])
+        layout
+            .certify_row(&values, &["row-1"])
             .expect("matching typed row should certify");
 
-        let short_id = [
-            fields[0],
-            TypedJsonObjectFieldRef {
-                name: "id",
-                value: TypedJsonScalarRef::String("x"),
-            },
-        ];
+        let short_id = [TypedJsonScalarRef::Boolean, TypedJsonScalarRef::String("x")];
+        assert!(layout.certify_row(&short_id, &["x"]).is_err());
+        assert!(layout.certify_row(&values, &["other"]).is_err());
         assert!(
-            plan.certify_typed_object_row("typed_rows", &short_id, &["x"])
-                .is_err()
-        );
-        assert!(
-            plan.certify_typed_object_row("typed_rows", &fields, &["other"])
-                .is_err()
-        );
-        assert!(
-            plan.certify_typed_object_row("other", &fields, &["row-1"])
+            plan.certify_typed_object_layout("other", &["active", "id"])
                 .is_err()
         );
     }

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -39,14 +39,14 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 
 /// Repository-wide compatibility gate for physical storage protocols.
 ///
-/// V36 combines LXCD8's wider certified commit-delta coordinates with the
-/// tagged immutable binary-CAS object envelope. Older locators and inline or
-/// ambiguously encoded chunk rows must fail closed before either physical
-/// representation is decoded.
+/// V37 retains the tagged immutable binary-CAS envelope and hard-cuts
+/// commit-delta manifests to LXCD9. Ordered, fully addressable manifests use a
+/// dense address inventory; generic manifests retain their multiset
+/// fingerprint. Older physical layouts fail closed before either is decoded.
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"lxcd8-tagged-immutable-binary-cas.v36";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"lxcd9-dense-selection.v37";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately

--- a/packages/engine/src/session/checkpoint.rs
+++ b/packages/engine/src/session/checkpoint.rs
@@ -113,6 +113,7 @@ where
                         };
                         let mut selected_changes =
                             StagedCommitChangeBatchBuilder::with_capacity(entries.len());
+                        let mut source_membership_exact = true;
                         for entry in entries.into_iter().filter(|entry| {
                             entry.identity.schema_key() != CHECKPOINT_MARKER_SCHEMA_KEY
                         }) {
@@ -126,9 +127,14 @@ where
                                     ),
                                 )
                             })?;
-                            push_selected_change(&mut selected_changes, row, entry.kind);
+                            source_membership_exact &=
+                                push_selected_change(&mut selected_changes, row, entry.kind);
                         }
-                        selected_changes.finish_source_certified()
+                        if source_membership_exact {
+                            selected_changes.finish_source_certified()
+                        } else {
+                            selected_changes.finish()
+                        }
                     };
                     gc_state.checkpoint_sequence = gc_state
                         .checkpoint_sequence
@@ -205,7 +211,7 @@ fn push_selected_change(
     selected_changes: &mut StagedCommitChangeBatchBuilder,
     row: TrackedStateDiffRow,
     kind: TrackedStateDiffKind,
-) {
+) -> bool {
     // A changelog change durably stores one timestamp, which rebuild uses for
     // both timestamps when the entity is absent from the parent checkpoint.
     // Canonicalize newly added rows to that representation so checkpoint roots
@@ -214,6 +220,7 @@ fn push_selected_change(
         TrackedStateDiffKind::Added => row.updated_at,
         TrackedStateDiffKind::Modified | TrackedStateDiffKind::Removed => row.created_at,
     };
+    let source_membership_exact = created_at == row.created_at;
     let deleted = row.deleted;
     let source_commit_id = row.commit_id;
     let change_id = row.change_id;
@@ -226,12 +233,54 @@ fn push_selected_change(
         created_at,
         updated_at,
     );
+    source_membership_exact
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{CHECKPOINT_GC_MIN_AGE, checkpoint_gc_due};
+    use super::{CHECKPOINT_GC_MIN_AGE, checkpoint_gc_due, push_selected_change};
+    use crate::changelog::{ChangeId, CommitId};
+    use crate::common::LixTimestamp;
+    use crate::entity_pk::EntityPk;
     use crate::gc::CheckpointGcState;
+    use crate::tracked_state::{
+        TrackedStateDiffIdentity, TrackedStateDiffKind, TrackedStateDiffRow, TrackedStateKey,
+    };
+    use crate::transaction::types::StagedCommitChangeBatchBuilder;
+
+    #[test]
+    fn canonicalized_added_timestamp_declines_source_membership_certificate() {
+        let created_at = LixTimestamp::expect_parse("created_at", "2026-01-01T00:00:00Z");
+        let updated_at = LixTimestamp::expect_parse("updated_at", "2026-01-02T00:00:00Z");
+        let mut selected = StagedCommitChangeBatchBuilder::with_capacity(1);
+        let source_membership_exact = push_selected_change(
+            &mut selected,
+            TrackedStateDiffRow {
+                identity: TrackedStateDiffIdentity::from_key(TrackedStateKey {
+                    schema_key: "test_schema".to_string(),
+                    file_id: None,
+                    entity_pk: EntityPk::single("entity"),
+                }),
+                deleted: false,
+                created_at,
+                updated_at,
+                change_id: ChangeId::for_test_label("checkpoint-canonicalized-change"),
+                commit_id: CommitId::for_test_label("checkpoint-canonicalized-commit"),
+            },
+            TrackedStateDiffKind::Added,
+        );
+        let selected = if source_membership_exact {
+            selected.finish_source_certified()
+        } else {
+            selected.finish()
+        };
+
+        assert!(!selected.source_membership_certified());
+        assert_eq!(
+            selected.iter().next().expect("one selected row").created_at,
+            updated_at
+        );
+    }
 
     fn state(sequence: u64, last_gc_sequence: u64) -> CheckpointGcState {
         CheckpointGcState {

--- a/packages/engine/src/session/checkpoint.rs
+++ b/packages/engine/src/session/checkpoint.rs
@@ -128,7 +128,7 @@ where
                             })?;
                             push_selected_change(&mut selected_changes, row, entry.kind);
                         }
-                        selected_changes.finish()
+                        selected_changes.finish_source_certified()
                     };
                     gc_state.checkpoint_sequence = gc_state
                         .checkpoint_sequence

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -5,7 +5,7 @@ use datafusion::common::ScalarValue;
 use serde_json::Value as JsonValue;
 use tracing::Instrument;
 
-use crate::catalog::{TypedJsonObjectFieldRef, TypedJsonScalarRef};
+use crate::catalog::TypedJsonScalarRef;
 use crate::changelog::CommitId;
 use crate::common::{
     ExecuteStatementMetadata, RequestBlobSpliceProvenance, SharedStr, validate_row_metadata,
@@ -2582,6 +2582,24 @@ struct DirectParameterInsertColumn {
     read_nullable: bool,
 }
 
+fn append_canonical_json_string(output: &mut Vec<u8>, value: &str) -> Result<(), LixError> {
+    if value
+        .as_bytes()
+        .iter()
+        .all(|&byte| byte >= b' ' && byte != b'"' && byte != b'\\')
+    {
+        output.push(b'"');
+        output.extend_from_slice(value.as_bytes());
+        output.push(b'"');
+        return Ok(());
+    }
+    serde_json::to_writer(output, value).map_err(|error| {
+        LixError::unknown(format!(
+            "certified INSERT value serialization failed: {error}"
+        ))
+    })
+}
+
 fn certified_direct_parameter_insert_batch(
     ctx: &mut dyn SqlWriteExecutionContext,
     plan: &LogicalWritePlan,
@@ -2718,12 +2736,18 @@ fn certified_direct_parameter_insert_batch(
     let mut previous_primary_key_row = None;
     let mut unordered_entity_pks = None::<std::collections::HashSet<EntityPk>>;
     let mut primary_key_parts = Vec::with_capacity(primary_key_columns.len());
-    let mut typed_fields = Vec::with_capacity(columns.len());
+    let field_names = columns
+        .iter()
+        .map(|column| column.name.as_str())
+        .collect::<Vec<_>>();
+    let row_certificate =
+        schema_plan.certify_typed_object_layout(&layout.schema_key, &field_names)?;
+    let mut typed_values = Vec::with_capacity(columns.len());
 
     for statement_index in 0..row_count {
         let row_result = (|| -> Result<bool, LixError> {
             let start = normalized.len();
-            typed_fields.clear();
+            typed_values.clear();
             normalized.push(b'{');
             for (field_index, column) in columns.iter().enumerate() {
                 if field_index != 0 {
@@ -2748,23 +2772,13 @@ fn certified_direct_parameter_insert_batch(
                         ));
                     }
                     normalized.extend_from_slice(b"null");
-                    typed_fields.push(TypedJsonObjectFieldRef {
-                        name: &column.name,
-                        value: TypedJsonScalarRef::Null,
-                    });
+                    typed_values.push(TypedJsonScalarRef::Null);
                     continue;
                 }
                 match (column.column_type, parameter_value) {
                     (EntityColumnType::String, DirectParameterValue::String(value)) => {
-                        serde_json::to_writer(&mut normalized, value).map_err(|error| {
-                            LixError::unknown(format!(
-                                "certified INSERT value serialization failed: {error}"
-                            ))
-                        })?;
-                        typed_fields.push(TypedJsonObjectFieldRef {
-                            name: &column.name,
-                            value: TypedJsonScalarRef::String(value),
-                        });
+                        append_canonical_json_string(&mut normalized, value)?;
+                        typed_values.push(TypedJsonScalarRef::String(value));
                     }
                     (EntityColumnType::Boolean, DirectParameterValue::Boolean(value)) => {
                         normalized.extend_from_slice(if value {
@@ -2772,10 +2786,7 @@ fn certified_direct_parameter_insert_batch(
                         } else {
                             b"false".as_slice()
                         });
-                        typed_fields.push(TypedJsonObjectFieldRef {
-                            name: &column.name,
-                            value: TypedJsonScalarRef::Boolean,
-                        });
+                        typed_values.push(TypedJsonScalarRef::Boolean);
                     }
                     _ => unreachable!("direct parameter column type was certified"),
                 }
@@ -2802,19 +2813,6 @@ fn certified_direct_parameter_insert_batch(
                 }
             }
             let derived_entity_pk = if shared_string_primary_keys {
-                EntityPk::validate_external_parts(
-                    &primary_key_parts,
-                    &spec.primary_key_component_types,
-                )
-                .map_err(|error| {
-                    LixError::new(
-                        LixError::CODE_SCHEMA_VALIDATION,
-                        format!(
-                            "INSERT failed to derive entity primary key for schema '{}': {error}",
-                            layout.schema_key
-                        ),
-                    )
-                })?;
                 None
             } else {
                 Some(
@@ -2833,11 +2831,7 @@ fn certified_direct_parameter_insert_batch(
                     })?,
                 )
             };
-            schema_plan.certify_typed_object_row(
-                &layout.schema_key,
-                &typed_fields,
-                &primary_key_parts,
-            )?;
+            row_certificate.certify_row(&typed_values, &primary_key_parts)?;
             if shared_string_primary_keys {
                 if let Some(previous_row) = previous_primary_key_row {
                     let ordering = primary_key_columns
@@ -4958,6 +4952,16 @@ fn entity_action(op: &BoundWriteOp) -> &'static str {
 mod primary_key_route_tests {
     use super::*;
     use crate::sql2::bind::expr::{BoundColumnRef, BoundParamRef};
+
+    #[test]
+    fn canonical_string_fast_path_matches_serde_for_safe_and_escaped_utf8() {
+        for value in ["plain", "café", "quote\"", "slash\\", "line\nfeed", "nul\0"] {
+            let mut actual = Vec::new();
+            append_canonical_json_string(&mut actual, value)
+                .expect("canonical string should serialize");
+            assert_eq!(actual, serde_json::to_vec(value).unwrap());
+        }
+    }
 
     #[test]
     fn compiles_single_text_primary_key_parameter_once() {

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -31,7 +31,7 @@ pub(crate) use row_materialization::{
 pub(crate) use storage::load_commit_delta_change_ids;
 pub(crate) use storage::{
     CommitDeltaChangeLocator, CommitDeltaMember, commit_delta_contains_schema,
-    load_change_record_by_id, load_commit_delta_change_records,
+    direct_change_locator, load_change_record_by_id, load_commit_delta_change_records,
     load_commit_delta_members_with_payloads, load_commit_delta_selection_certificate,
     load_owned_commit_delta_entries, scan_change_records_from_commit_deltas,
     scan_commit_delta_inventory, scan_commit_delta_values, selected_change_selection_fingerprint,
@@ -44,7 +44,7 @@ pub(crate) use storage::{
 pub(crate) use storage::{
     TRACKED_STATE_CHANGE_LOCATOR_SPACE, TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
     TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, TRACKED_STATE_COMMIT_ROOT_SPACE,
-    TRACKED_STATE_TREE_CHUNK_SPACE, decode_change_locator, direct_change_locator,
+    TRACKED_STATE_TREE_CHUNK_SPACE, decode_change_locator,
 };
 pub(crate) use types::{
     MaterializedTrackedStateRow, TrackedStateCommitDeltaRef, TrackedStateDeltaRef,

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -71,7 +71,7 @@ const COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 512;
 const GENERIC_COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 128;
 const GENERIC_COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 28 * 1024;
 const ORDERED_COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 64 * 1024;
-const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD8";
+const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD9";
 const COMMIT_DELTA_PAYLOAD_OFFSET_BYTES: usize = size_of::<u32>();
 #[cfg(not(test))]
 const COMMIT_DELTA_MAX_SIDECAR_BYTES: usize = 64 * 1024 * 1024;
@@ -396,6 +396,9 @@ struct CommitDeltaManifest {
     selected_source_commit_id: Option<[u8; 16]>,
     member_count: u32,
     selection_fingerprint: [u8; 32],
+    /// Exact dense address inventory for ordered, fully addressable commits.
+    /// An empty column denotes the generic unordered/mixed-address layout.
+    direct_segment_row_counts: Vec<u16>,
     /// A complete leaf payload for a commit that fits in one segment. Keeping
     /// it in the directory preserves the one-record shape of tiny commits;
     /// larger commits use the indexed segment list below.
@@ -404,10 +407,11 @@ struct CommitDeltaManifest {
     segments: Vec<CommitDeltaSegmentBounds>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct CommitDeltaSelectionCertificate {
     pub(crate) member_count: u32,
     pub(crate) selection_fingerprint: [u8; 32],
+    pub(crate) direct_segment_row_counts: Vec<u16>,
     pub(crate) selected_source_commit_id: Option<CommitId>,
 }
 
@@ -865,6 +869,9 @@ where
             )
         })?,
         selection_fingerprint: [0; 32],
+        direct_segment_row_counts: Vec::with_capacity(
+            row_count.div_ceil(COMMIT_DELTA_SEGMENT_MAX_ROWS),
+        ),
         inline_segment: Vec::new(),
         segments: Vec::with_capacity(row_count.div_ceil(COMMIT_DELTA_SEGMENT_MAX_ROWS)),
     };
@@ -880,7 +887,7 @@ where
         }
         let segment_index = segment_row_counts.len();
         let mut candidate_len = pending.len();
-        let (bounds, encoded, segment_fingerprint) = loop {
+        let (bounds, encoded) = loop {
             match encode_ordered_addressable_commit_delta_segment(
                 commit_id,
                 segment_index,
@@ -888,11 +895,11 @@ where
                 candidate_len,
                 &mut compressor,
             ) {
-                Ok((bounds, encoded, segment_fingerprint))
+                Ok((bounds, encoded))
                     if encoded.len() <= ORDERED_COMMIT_DELTA_SEGMENT_TARGET_BYTES
                         || candidate_len == 1 =>
                 {
-                    break (bounds, encoded, segment_fingerprint);
+                    break (bounds, encoded);
                 }
                 Ok(_) | Err(CommitDeltaSegmentEncodeError::SidecarTooLarge)
                     if candidate_len > 1 =>
@@ -903,15 +910,9 @@ where
                 Ok(_) => unreachable!("single-row segment exits through the guarded success arm"),
             }
         };
-        for (target, source) in manifest
-            .selection_fingerprint
-            .iter_mut()
-            .zip(segment_fingerprint)
-        {
-            *target ^= source;
-        }
         let row_count_u16 =
             u16::try_from(candidate_len).expect("commit-delta segment row count fits u16");
+        manifest.direct_segment_row_counts.push(row_count_u16);
         segment_row_counts.push(row_count_u16);
         for _ in 0..candidate_len {
             pending.pop_front();
@@ -979,7 +980,7 @@ fn encode_ordered_addressable_commit_delta_segment<'a>(
     deltas: impl Iterator<Item = TrackedStateCommitDeltaRef<'a>>,
     row_count: usize,
     compressor: &mut crate::compression::ZstdLevel1Compressor,
-) -> Result<(CommitDeltaSegmentBounds, Vec<u8>, [u8; 32]), CommitDeltaSegmentEncodeError> {
+) -> Result<(CommitDeltaSegmentBounds, Vec<u8>), CommitDeltaSegmentEncodeError> {
     let mut entries = TrackedStateMutationBatchBuilder::with_row_capacity(row_count);
     let mut payloads = Vec::with_capacity(row_count);
     for (ordinal, delta) in deltas.enumerate() {
@@ -1028,19 +1029,8 @@ fn encode_ordered_addressable_commit_delta_segment<'a>(
             .key
             .to_vec(),
     };
-    let selection_fingerprint = selection_fingerprint(entries.iter().map(|entry| {
-        let value = decode_value(&entry.value)
-            .expect("ordered commit-delta values were encoded by the trusted builder");
-        (
-            entry.key.as_ref(),
-            value.change_id,
-            value.deleted,
-            value.created_at,
-            value.updated_at,
-        )
-    }));
     let encoded = try_encode_commit_delta_segment_with_payloads(&entries, &payloads, compressor)?;
-    Ok((bounds, encoded, selection_fingerprint))
+    Ok((bounds, encoded))
 }
 
 fn stage_commit_deltas_inner(
@@ -1223,6 +1213,7 @@ fn stage_commit_deltas_inner(
                     .map(|commit_id| *commit_id.as_uuid().as_bytes()),
                 member_count,
                 selection_fingerprint,
+                direct_segment_row_counts: Vec::new(),
                 inline_segment,
                 segments: Vec::new(),
             })?),
@@ -1243,6 +1234,7 @@ fn stage_commit_deltas_inner(
             .map(|commit_id| *commit_id.as_uuid().as_bytes()),
         member_count,
         selection_fingerprint,
+        direct_segment_row_counts: Vec::new(),
         inline_segment: Vec::new(),
         segments: Vec::with_capacity(segment_count),
     };
@@ -3569,6 +3561,7 @@ pub(crate) async fn load_commit_delta_selection_certificate(
             member_count: manifest.member_count,
             selection_fingerprint: manifest.selection_fingerprint,
             selected_source_commit_id: manifest.selected_source_commit_id(),
+            direct_segment_row_counts: manifest.direct_segment_row_counts,
         }))
 }
 
@@ -3601,6 +3594,36 @@ async fn load_commit_delta_manifest(
 }
 
 fn validate_commit_delta_manifest(manifest: &CommitDeltaManifest) -> Result<(), LixError> {
+    if !manifest.direct_segment_row_counts.is_empty() {
+        if manifest.selected_source_commit_id.is_some()
+            || manifest
+                .direct_segment_row_counts
+                .iter()
+                .any(|&count| count == 0 || usize::from(count) > COMMIT_DELTA_SEGMENT_MAX_ROWS)
+            || manifest
+                .direct_segment_row_counts
+                .iter()
+                .map(|&count| u64::from(count))
+                .sum::<u64>()
+                != u64::from(manifest.member_count)
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state commit_delta manifest has an invalid dense address inventory",
+            ));
+        }
+        let expected_segment_count = if manifest.inline_segment.is_empty() {
+            manifest.segments.len()
+        } else {
+            1
+        };
+        if manifest.direct_segment_row_counts.len() != expected_segment_count {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state commit_delta dense address inventory does not match its segments",
+            ));
+        }
+    }
     if !manifest.inline_segment.is_empty() {
         if !manifest.segments.is_empty() {
             return Err(LixError::new(
@@ -4804,6 +4827,20 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("streamed addressable read should open");
+        let certificate = super::load_commit_delta_selection_certificate(&read, commit_id)
+            .await
+            .expect("dense selection certificate should load")
+            .expect("ordered commit should have a selection certificate");
+        assert!(!certificate.direct_segment_row_counts.is_empty());
+        assert_eq!(
+            certificate
+                .direct_segment_row_counts
+                .iter()
+                .map(|&count| usize::from(count))
+                .sum::<usize>(),
+            fixtures.len()
+        );
+        assert_eq!(certificate.selection_fingerprint, [0; 32]);
         let generic_read = generic_storage
             .begin_read(StorageReadOptions::default())
             .await
@@ -5824,6 +5861,7 @@ mod tests {
                     selected_source_commit_id: None,
                     member_count: 0,
                     selection_fingerprint: [0; 32],
+                    direct_segment_row_counts: Vec::new(),
                     inline_segment: segment,
                     segments: Vec::new(),
                 })
@@ -6303,9 +6341,9 @@ mod tests {
         );
 
         let mut old = encoded.clone();
-        old[..COMMIT_DELTA_FORMAT_MAGIC.len()].copy_from_slice(b"LXCD5");
+        old[..COMMIT_DELTA_FORMAT_MAGIC.len()].copy_from_slice(b"LXCD8");
         let error = decode_commit_delta_with_payloads(&old, None)
-            .expect_err("LXCD5 segments must be rejected");
+            .expect_err("LXCD8 segments must be rejected");
         assert!(
             error
                 .to_string()
@@ -6562,6 +6600,7 @@ mod tests {
                     selected_source_commit_id: None,
                     member_count: 0,
                     selection_fingerprint: [0; 32],
+                    direct_segment_row_counts: Vec::new(),
                     inline_segment: encode_commit_delta_segment(&entries),
                     segments: Vec::new(),
                 })
@@ -6791,7 +6830,7 @@ mod tests {
 
     #[test]
     fn packed_commit_delta_manifest_rejects_unknown_format() {
-        let error = decode_commit_delta_manifest(b"LXCD1not-a-v2-manifest")
+        let error = decode_commit_delta_manifest(b"LXCD8not-an-lxcd9-manifest")
             .expect_err("old packed manifests must fail loudly");
         assert!(
             error

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -561,6 +561,60 @@ fn selected_change_count(batches: &[StagedCommitChangeBatch]) -> usize {
     batches.iter().map(StagedCommitChangeBatch::len).sum()
 }
 
+fn dense_selected_source_is_exact<'a>(
+    source_commit_id: CommitId,
+    segment_row_counts: &[u16],
+    source_membership_certified: bool,
+    selected: impl Iterator<Item = StagedCommitChangeRef<'a>>,
+) -> bool {
+    if !source_membership_certified {
+        return false;
+    }
+    let expected_count = segment_row_counts
+        .iter()
+        .map(|&count| usize::from(count))
+        .sum::<usize>();
+    let mut members = Vec::with_capacity(expected_count);
+    for change_ref in selected {
+        if change_ref.source_commit_id != source_commit_id {
+            return false;
+        }
+        let Some(locator) = crate::tracked_state::direct_change_locator(change_ref.change_id)
+        else {
+            return false;
+        };
+        if locator.commit_id != source_commit_id {
+            return false;
+        }
+        members.push((locator.segment_index, locator.ordinal));
+    }
+    if members.len() != expected_count {
+        return false;
+    }
+    if !members
+        .windows(2)
+        .all(|pair| (pair[0].0, pair[0].1) < (pair[1].0, pair[1].1))
+    {
+        members.sort_unstable_by_key(|member| (member.0, member.1));
+    }
+    let mut member_index = 0usize;
+    for (segment_index, &row_count) in segment_row_counts.iter().enumerate() {
+        let Ok(segment_index) = u32::try_from(segment_index) else {
+            return false;
+        };
+        for ordinal in 0..row_count {
+            if members
+                .get(member_index)
+                .is_none_or(|member| (member.0, member.1) != (segment_index, ordinal))
+            {
+                return false;
+            }
+            member_index += 1;
+        }
+    }
+    member_index == members.len()
+}
+
 async fn stage_changelog_commits(
     read: &mut impl StorageAdapterRead,
     writes: &mut StorageWriteSet,
@@ -1256,35 +1310,6 @@ async fn stage_tracked_commit_delta_index(
                 .first_key_value()
                 .expect("one selected source exists")
                 .0;
-            let selected = selected_changes(&staged.selected_change_batches)
-                .map(|change_ref| {
-                    (
-                        encode_key_ref(TrackedStateKeyRef {
-                            schema_key: change_ref.schema_key(),
-                            file_id: change_ref.file_id(),
-                            entity_pk: change_ref.entity_pk(),
-                        }),
-                        (
-                            change_ref.change_id,
-                            change_ref.deleted,
-                            change_ref.created_at,
-                            change_ref.updated_at,
-                        ),
-                    )
-                })
-                .collect::<HashMap<_, _>>();
-            let selected_fingerprint =
-                crate::tracked_state::selected_change_selection_fingerprint(selected.iter().map(
-                    |(key, (change_id, deleted, created_at, updated_at))| {
-                        (
-                            key.as_slice(),
-                            *change_id,
-                            *deleted,
-                            *created_at,
-                            *updated_at,
-                        )
-                    },
-                ));
             let source = crate::tracked_state::load_commit_delta_selection_certificate(
                 read,
                 source_commit_id,
@@ -1292,9 +1317,55 @@ async fn stage_tracked_commit_delta_index(
             .await?;
             source
                 .is_some_and(|source| {
-                    source.selected_source_commit_id.is_none()
-                        && usize::try_from(source.member_count).ok() == Some(selected.len())
-                        && source.selection_fingerprint == selected_fingerprint
+                    if source.selected_source_commit_id.is_some()
+                        || usize::try_from(source.member_count).ok()
+                            != Some(selected_change_count(&staged.selected_change_batches))
+                    {
+                        return false;
+                    }
+                    if source.direct_segment_row_counts.is_empty() {
+                        let selected = selected_changes(&staged.selected_change_batches)
+                            .map(|change_ref| {
+                                (
+                                    encode_key_ref(TrackedStateKeyRef {
+                                        schema_key: change_ref.schema_key(),
+                                        file_id: change_ref.file_id(),
+                                        entity_pk: change_ref.entity_pk(),
+                                    }),
+                                    (
+                                        change_ref.change_id,
+                                        change_ref.deleted,
+                                        change_ref.created_at,
+                                        change_ref.updated_at,
+                                    ),
+                                )
+                            })
+                            .collect::<HashMap<_, _>>();
+                        return usize::try_from(source.member_count).ok() == Some(selected.len())
+                            && source.selection_fingerprint
+                                == crate::tracked_state::selected_change_selection_fingerprint(
+                                    selected.iter().map(
+                                        |(key, (change_id, deleted, created_at, updated_at))| {
+                                            (
+                                                key.as_slice(),
+                                                *change_id,
+                                                *deleted,
+                                                *created_at,
+                                                *updated_at,
+                                            )
+                                        },
+                                    ),
+                                );
+                    }
+                    dense_selected_source_is_exact(
+                        source_commit_id,
+                        &source.direct_segment_row_counts,
+                        staged
+                            .selected_change_batches
+                            .iter()
+                            .all(StagedCommitChangeBatch::source_membership_certified),
+                        selected_changes(&staged.selected_change_batches),
+                    )
                 })
                 .then_some(source_commit_id)
         } else {
@@ -3903,6 +3974,86 @@ mod tests {
 
     fn ts(value: &str) -> LixTimestamp {
         LixTimestamp::expect_parse("timestamp", value)
+    }
+
+    #[test]
+    fn dense_checkpoint_certificate_requires_provenance_and_exact_coordinates() {
+        let source_commit_id = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x0192_0000_0000_7000_8000_1234_0000_0000,
+        ));
+        let direct_change_id = |packed: u32| {
+            let mut bytes = *source_commit_id.as_uuid().as_bytes();
+            bytes[12..].copy_from_slice(&packed.to_be_bytes());
+            ChangeId::new(uuid::Uuid::from_bytes(bytes))
+        };
+        let created_at = ts("2026-01-01T00:00:00Z");
+        let identities = ["a", "b"].map(|entity_pk| TrackedStateKey {
+            schema_key: "test_schema".to_string(),
+            file_id: None,
+            entity_pk: EntityPk::single(entity_pk),
+        });
+        let change_ids = [direct_change_id(1), direct_change_id(2)];
+        let row_counts = [2_u16];
+        let mut selected = StagedCommitChangeBatchBuilder::with_capacity(2);
+        for (identity, change_id) in identities.iter().cloned().zip(change_ids) {
+            selected.push(
+                crate::tracked_state::TrackedStateDiffIdentity::from_key(identity),
+                source_commit_id,
+                change_id,
+                false,
+                created_at,
+                created_at,
+            );
+        }
+        let selected = selected.finish_source_certified();
+        assert!(dense_selected_source_is_exact(
+            source_commit_id,
+            &row_counts,
+            selected.source_membership_certified(),
+            selected.iter(),
+        ));
+
+        let mut uncertified = StagedCommitChangeBatchBuilder::with_capacity(2);
+        for (identity, change_id) in identities.iter().cloned().zip(change_ids) {
+            uncertified.push(
+                crate::tracked_state::TrackedStateDiffIdentity::from_key(identity),
+                source_commit_id,
+                change_id,
+                false,
+                created_at,
+                created_at,
+            );
+        }
+        let uncertified = uncertified.finish();
+        assert!(!dense_selected_source_is_exact(
+            source_commit_id,
+            &row_counts,
+            uncertified.source_membership_certified(),
+            uncertified.iter(),
+        ));
+
+        let mut duplicate_coordinate = StagedCommitChangeBatchBuilder::with_capacity(2);
+        for identity in identities {
+            duplicate_coordinate.push(
+                crate::tracked_state::TrackedStateDiffIdentity::from_key(TrackedStateKey {
+                    schema_key: identity.schema_key,
+                    file_id: identity.file_id,
+                    entity_pk: identity.entity_pk,
+                }),
+                source_commit_id,
+                change_ids[0],
+                false,
+                created_at,
+                created_at,
+            );
+        }
+        let duplicate_coordinate = duplicate_coordinate.finish_source_certified();
+        assert!(!dense_selected_source_is_exact(
+            source_commit_id,
+            &row_counts,
+            duplicate_coordinate.source_membership_certified(),
+            duplicate_coordinate.iter(),
+        ));
     }
 
     #[test]

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -6000,8 +6000,8 @@ where
                 push_checkpoint_selected_change(&mut unselected, target, entry.kind);
             }
         }
-        let selected = selected.finish();
-        let unselected = unselected.finish();
+        let selected = selected.finish_source_certified();
+        let unselected = unselected.finish_source_certified();
         if matched != requested {
             return Err(stale_or_unknown_diff_id());
         }

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -5978,6 +5978,8 @@ where
         let mut matched = BTreeSet::new();
         let mut selected = StagedCommitChangeBatchBuilder::with_capacity(diff.entries.len());
         let mut unselected = StagedCommitChangeBatchBuilder::with_capacity(diff.entries.len());
+        let mut selected_source_membership_exact = true;
+        let mut unselected_source_membership_exact = true;
         for entry in diff
             .entries
             .into_iter()
@@ -5995,13 +5997,23 @@ where
             })?;
             if requested.contains(&diff_id) {
                 matched.insert(diff_id);
-                push_checkpoint_selected_change(&mut selected, target, entry.kind);
+                selected_source_membership_exact &=
+                    push_checkpoint_selected_change(&mut selected, target, entry.kind);
             } else {
-                push_checkpoint_selected_change(&mut unselected, target, entry.kind);
+                unselected_source_membership_exact &=
+                    push_checkpoint_selected_change(&mut unselected, target, entry.kind);
             }
         }
-        let selected = selected.finish_source_certified();
-        let unselected = unselected.finish_source_certified();
+        let selected = if selected_source_membership_exact {
+            selected.finish_source_certified()
+        } else {
+            selected.finish()
+        };
+        let unselected = if unselected_source_membership_exact {
+            unselected.finish_source_certified()
+        } else {
+            unselected.finish()
+        };
         if matched != requested {
             return Err(stale_or_unknown_diff_id());
         }
@@ -6148,11 +6160,12 @@ fn push_checkpoint_selected_change(
     selected: &mut StagedCommitChangeBatchBuilder,
     row: crate::tracked_state::TrackedStateDiffRow,
     kind: TrackedStateDiffKind,
-) {
+) -> bool {
     let created_at = match kind {
         TrackedStateDiffKind::Added => row.updated_at,
         TrackedStateDiffKind::Modified | TrackedStateDiffKind::Removed => row.created_at,
     };
+    let source_membership_exact = created_at == row.created_at;
     selected.push(
         row.identity,
         row.commit_id,
@@ -6161,6 +6174,7 @@ fn push_checkpoint_selected_change(
         created_at,
         row.updated_at,
     );
+    source_membership_exact
 }
 
 fn incremental_filesystem_index_enabled() -> bool {

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -2990,6 +2990,9 @@ struct StagedCommitChangeColumns {
 #[derive(Debug, Clone)]
 pub(crate) struct StagedCommitChangeBatch {
     columns: Arc<StagedCommitChangeColumns>,
+    /// Every `(source_commit_id, change_id, identity)` tuple was produced by
+    /// the tracked diff reader from immutable commit authority.
+    source_membership_certified: bool,
     /// Present only when duplicate identities were filtered while combining
     /// independently supplied batches. The normal merge/checkpoint path views
     /// every row directly and allocates no selection column.
@@ -3045,6 +3048,21 @@ impl StagedCommitChangeBatchBuilder {
     pub(crate) fn finish(self) -> StagedCommitChangeBatch {
         StagedCommitChangeBatch {
             columns: Arc::new(self.columns),
+            source_membership_certified: false,
+            selection: None,
+        }
+    }
+
+    /// Finishes rows materialized directly from a tracked-state diff.
+    ///
+    /// The diff reader binds every direct change address to the decoded source
+    /// identity before exposing the row. Checkpoint lowering may therefore
+    /// prove a complete dense source selection from coordinates alone instead
+    /// of hashing all identity bytes again.
+    pub(crate) fn finish_source_certified(self) -> StagedCommitChangeBatch {
+        StagedCommitChangeBatch {
+            columns: Arc::new(self.columns),
+            source_membership_certified: true,
             selection: None,
         }
     }
@@ -3100,9 +3118,14 @@ impl StagedCommitChangeBatch {
         } else {
             Self {
                 columns: self.columns,
+                source_membership_certified: self.source_membership_certified,
                 selection: Some(selection.into()),
             }
         }
+    }
+
+    pub(crate) fn source_membership_certified(&self) -> bool {
+        self.source_membership_certified
     }
 
     #[cfg(test)]


### PR DESCRIPTION
## What changed

- hard-cut tracked commit-delta storage to LXCD9 / repository protocol V37
- replace ordered commits' per-row selection fingerprint with a dense `(segment, ordinal)` inventory
- certify checkpoint source membership at the immutable diff-reader boundary and prove exact selections from direct change coordinates
- compile typed SQL insert schema layouts once per parameter batch instead of repeating fixed property/required/primary-key lookups per row
- serialize canonical strings directly when the UTF-8 requires no JSON escaping, with the serde path retained for escaped values
- keep generic/unordered commit selections on the existing multiset fingerprint path

There is deliberately no backward shim. LXCD8 repositories fail closed and must be recreated.

## Why

The ordered create path was hashing every selected row after it had already assigned a direct immutable address. At the SQL boundary, the certified parameter batch then repeated structural schema work for every row. Together these costs were material at 10k and scaled linearly at 100k.

## Performance

Paired SQL-session `insert_all` profile, 15 independent samples, same host and exact current-main control binary:

| Rows | Adapter | Main median | PR median | Change |
| ---: | --- | ---: | ---: | ---: |
| 10k | RocksDB | 26.469 ms | 21.534 ms | -18.6% |
| 10k | SlateDB | — | 19.291 ms | — |
| 100k | RocksDB | 156.245 ms | 122.839 ms | -21.4% |
| 100k | SlateDB | — | 118.175 ms | — |

The 100k trace identified batch certification as the next scaling cost; compiling the layout once is what takes the combined stack over the 20% publication threshold at scale.

Focused history controls remained noise-scale or improved. Repeated checkpoint medians were 19.430 → 20.275 ms on RocksDB and 15.083 → 14.437 ms on SlateDB. Merge preview was 137.919 → 139.086 ms on RocksDB and 129.706 → 125.283 ms on SlateDB; committed merge was 14.227 → 15.460 ms and 19.628 → 18.550 ms respectively. Working-diff scans remained within single-digit variance.

## Validation

- `cargo check -p lix_engine --all-features`
- `cargo test -p lix_engine --all-features`
  - 1,664 unit tests passed
  - 790 integration tests passed, 2 ignored
  - 3 doctests passed
- focused dense selection, canonical history alias, checkpoint, typed schema, canonical string escaping, and certified parameter-batch regressions
- feature-complete RocksDB + SlateDB release benchmarks linked with mold and at most two compiler jobs
