### PR TITLE
Stabilize Rust workspace test stacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,10 @@ jobs:
 
       - name: Run Rust workspace tests
         if: matrix.task == 'test'
+        env:
+          # The CRUD public-result parity test exercises every adapter in one
+          # libtest worker and can exceed Rust's 2 MiB worker-stack default.
+          RUST_MIN_STACK: 8388608
         run: cargo test --profile test --workspace --all-features
 
       - name: Verify the packaged plugin API contract


### PR DESCRIPTION
## Summary
- raise libtest worker stack size for the Rust workspace test step
- prevent the CRUD public-result parity test from intermittently aborting with a stack overflow

## Evidence
The same PR head reached this unrelated benchmark test four times and aborted in `standalone_sqlite_public_results_match_every_lix_adapter`; focused tests pass locally. This changes CI execution only.