### PR TITLE
Support standard INSERT DEFAULT VALUES for registered schema tables

### DIFF
--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -135,6 +135,11 @@ path = "benches/diff_commands.rs"
 harness = false
 
 [[bench]]
+name = "entity_default_values"
+path = "benches/entity_default_values.rs"
+harness = false
+
+[[bench]]
 name = "small_blob_cas"
 path = "benches/small_blob_cas.rs"
 harness = false

--- a/packages/engine-benchmarks/benches/entity_default_values.rs
+++ b/packages/engine-benchmarks/benches/entity_default_values.rs
@@ -1,0 +1,91 @@
+//! Measures a one-row registered-schema insert using standard SQL
+//! `INSERT ... DEFAULT VALUES`, excluding engine and schema-registration setup.
+
+use std::hint::black_box;
+
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+use lix_engine::storage::Memory;
+use lix_engine::{Engine, SessionContext, Value};
+use serde_json::json;
+
+const DEFAULT_VALUES_SQL: &str = "INSERT INTO bench_default_values DEFAULT VALUES";
+const EXPLICIT_VALUES_SQL: &str = "INSERT INTO bench_default_values (label) VALUES ('untitled')";
+
+fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("create benchmark runtime")
+}
+
+fn fixture(runtime: &tokio::runtime::Runtime) -> SessionContext<Memory> {
+    runtime.block_on(async {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("initialize benchmark storage");
+        let engine = Engine::new(storage).await.expect("open benchmark engine");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("open benchmark session");
+        let schema = json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "x-lix-key": "bench_default_values",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "x-lix-default": "lix_uuid_v7()"
+                },
+                "label": { "type": "string", "default": "untitled" }
+            },
+            "required": ["id", "label"],
+            "additionalProperties": false
+        });
+        let registered = session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES ($1)",
+                &[Value::Json(schema)],
+            )
+            .await
+            .expect("register benchmark schema");
+        assert_eq!(registered.rows_affected(), 1);
+        session
+    })
+}
+
+fn execute(runtime: &tokio::runtime::Runtime, session: &SessionContext<Memory>, sql: &str) {
+    black_box(
+        runtime
+            .block_on(session.execute(sql, &[]))
+            .expect("execute benchmark SQL"),
+    );
+}
+
+fn entity_default_values(c: &mut Criterion) {
+    let runtime = runtime();
+    let mut group = c.benchmark_group("entity_default_values");
+    group.throughput(Throughput::Elements(1));
+    // Each sample receives a fresh preconfigured session, so this captures
+    // cold transaction behavior without charging engine boot or registration.
+    group.bench_function("cold_standard_sql", |b| {
+        b.iter_batched_ref(
+            || fixture(&runtime),
+            |session| execute(&runtime, session, DEFAULT_VALUES_SQL),
+            BatchSize::LargeInput,
+        );
+    });
+    group.bench_function("cold_explicit_values_control", |b| {
+        b.iter_batched_ref(
+            || fixture(&runtime),
+            |session| execute(&runtime, session, EXPLICIT_VALUES_SQL),
+            BatchSize::LargeInput,
+        );
+    });
+    group.finish();
+}
+
+criterion_group!(benches, entity_default_values);
+criterion_main!(benches);

--- a/packages/engine/src/sql2/bind/statement.rs
+++ b/packages/engine/src/sql2/bind/statement.rs
@@ -86,7 +86,16 @@ pub(super) fn bind_insert_bound(
     };
     let table = bind_public_table(catalog, name)?;
     require_write_capability(&table.surface, BoundWriteOp::Insert)?;
-    if insert.columns.is_empty() {
+    // sqlparser represents standard `INSERT INTO table DEFAULT VALUES` as an
+    // INSERT without a source and without target columns. Support it only for
+    // registered-schema base tables, where omitted properties are materialized
+    // by the schema's default machinery. Keep it distinct from `INSERT INTO
+    // table VALUES (...)`, whose implicit public column list is deliberately
+    // unsupported.
+    let default_values = matches!(table.surface.kind, PublicSurfaceKind::EntityBase { .. })
+        && insert.columns.is_empty()
+        && insert.source.is_none();
+    if insert.columns.is_empty() && !default_values {
         return Err(super::error::unsupported(
             "INSERT requires an explicit public column list",
         ));
@@ -102,12 +111,22 @@ pub(super) fn bind_insert_bound(
             BoundWriteOp::Insert,
         )?);
     }
-    let input = bind_insert_input(
-        &table.surface.kind,
-        &columns,
-        insert.source.as_deref(),
-        &mut params,
-    )?;
+    let input = if default_values {
+        // Preserve the cardinality of `DEFAULT VALUES`: it inserts one row,
+        // whose public columns are all omitted and therefore materialized by
+        // the target schema's existing default machinery.
+        BoundWriteInput::Values(BoundInsertValues {
+            columns: Vec::new(),
+            rows: vec![Vec::new()],
+        })
+    } else {
+        bind_insert_input(
+            &table.surface.kind,
+            &columns,
+            insert.source.as_deref(),
+            &mut params,
+        )?
+    };
     let returning = bind_insert_returning(&table, insert.returning.as_ref(), &mut params)?;
     let conflict = bind_insert_conflict(insert.on.as_ref(), &table, &mut params)?;
     if conflict.is_some() {
@@ -1735,6 +1754,55 @@ mod tests {
                 .message
                 .contains("INSERT requires an explicit public column list")
         );
+    }
+
+    #[test]
+    fn bind_statement_rejects_default_values_for_non_entity_tables() {
+        let statement = parse_statement("INSERT INTO lix_file DEFAULT VALUES");
+        let error = bind_statement(&statement, &[], "branch1")
+            .expect_err("DEFAULT VALUES should remain unsupported outside registered schemas");
+
+        assert_eq!(error.code, LixError::CODE_UNSUPPORTED_SQL);
+        assert!(
+            error
+                .message
+                .contains("INSERT requires an explicit public column list")
+        );
+    }
+
+    #[test]
+    fn bind_statement_binds_standard_insert_default_values_as_one_empty_row() {
+        let statement = parse_statement("INSERT INTO test_state_schema DEFAULT VALUES");
+        let bound = bind_statement(
+            &statement,
+            &[serde_json::json!({
+                "x-lix-key": "test_state_schema",
+                "x-lix-primary-key": ["/id"],
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string", "x-lix-default": "lix_uuid_v7()" },
+                    "label": { "type": "string", "default": "untitled" }
+                },
+                "required": ["id", "label"],
+                "additionalProperties": false
+            })],
+            "branch1",
+        )
+        .expect("standard DEFAULT VALUES should bind");
+
+        assert!(matches!(
+            bound.target,
+            BoundWriteTarget::Entity(EntityWriteSurface::Base { .. })
+        ));
+        assert!(matches!(
+            bound.branch_scope,
+            BranchScope::Active { ref branch_id } if branch_id == "branch1"
+        ));
+        let BoundWriteInput::Values(values) = bound.input else {
+            panic!("DEFAULT VALUES should bind as a VALUES input");
+        };
+        assert!(values.columns.is_empty());
+        assert_eq!(values.rows, vec![Vec::new()]);
     }
 
     #[test]

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -4572,6 +4572,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_sql_insert_default_values_uses_the_native_entity_writer() {
+        let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
+        let live_state = Arc::new(DummyLiveStateReader);
+        let staged_writes = Arc::new(Mutex::new(CapturingStagedWrites::default()));
+        let mut ctx = DummySqlWriteExecutionContext {
+            active_branch_id: "01920000-0000-7000-8000-0000000000a1",
+            blob_reader,
+            live_state,
+            staged_writes: Arc::clone(&staged_writes),
+            schema_definitions: vec![json!({
+                "x-lix-key": "default_values_probe",
+                "x-lix-primary-key": ["/id"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "x-lix-default": "lix_uuid_v7()"
+                    },
+                    "label": { "type": "string", "default": "untitled" }
+                },
+                "required": ["id", "label"],
+                "additionalProperties": false
+            })],
+        };
+
+        let (result, path) = execute_write_sql_trace(
+            &mut ctx,
+            "INSERT INTO default_values_probe DEFAULT VALUES",
+            &[],
+            WriteExecutorMode::ForceFast,
+        )
+        .await
+        .expect("DEFAULT VALUES should not require the DataFusion writer");
+
+        assert_eq!(path, WriteExecutorPath::Fast);
+        assert_eq!(result.rows, vec![vec![Value::Integer(1)]]);
+        let staged_writes = staged_writes.lock().expect("staged writes lock");
+        let overlay = staged_writes.deltas[0]
+            .pending_write_overlay()
+            .expect("staged delta should expose pending overlay");
+        let rows = overlay.visible_semantic_rows(false, "default_values_probe");
+        assert_eq!(rows.len(), 1);
+        let snapshot = serde_json::from_str::<JsonValue>(
+            rows[0]
+                .snapshot_content
+                .as_deref()
+                .expect("inserted entity should have a snapshot"),
+        )
+        .expect("defaulted snapshot should be JSON");
+        let id = snapshot["id"]
+            .as_str()
+            .expect("UUID default should materialize a string");
+        assert_eq!(
+            uuid::Uuid::parse_str(id)
+                .expect("UUID default should be parseable")
+                .get_version_num(),
+            7
+        );
+        assert_eq!(snapshot["label"], "untitled");
+    }
+
+    #[tokio::test]
     async fn execute_sql_insert_into_active_entity_does_not_probe_active_head_during_lowering() {
         let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
         let live_state = Arc::new(DummyLiveStateReader);

--- a/packages/engine/tests/integration/sql/lix_registered_schema.rs
+++ b/packages/engine/tests/integration/sql/lix_registered_schema.rs
@@ -94,6 +94,108 @@ simulation_test!(
 );
 
 simulation_test!(
+    registered_schema_default_values_materializes_generated_and_literal_defaults,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        let schema = json!({
+            "x-lix-key": "default_values_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "x-lix-default": "lix_uuid_v7()",
+                },
+                "label": {
+                    "type": "string",
+                    "default": "untitled",
+                },
+            },
+            "required": ["id", "label"],
+            "additionalProperties": false,
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES ($1)",
+                &[Value::Json(schema)],
+            )
+            .await
+            .expect("schema registration should succeed");
+
+        let inserted = session
+            .execute("INSERT INTO default_values_probe DEFAULT VALUES", &[])
+            .await
+            .expect("DEFAULT VALUES should materialize registered-schema defaults");
+        assert_eq!(inserted, ExecuteResult::from_rows_affected(1));
+
+        let selected = session
+            .execute("SELECT id, label FROM default_values_probe", &[])
+            .await
+            .expect("defaulted entity should be readable");
+        assert_eq!(selected.len(), 1);
+        let [Value::Text(id), Value::Text(label)] = selected.rows()[0].values() else {
+            panic!("generated and literal defaults should produce text columns");
+        };
+        let id = uuid::Uuid::parse_str(id).expect("generated default should be a UUID");
+        assert_eq!(id.get_version_num(), 7);
+        assert_eq!(label, "untitled");
+    }
+);
+
+simulation_test!(
+    registered_schema_default_values_still_validates_missing_required_properties,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        let schema = json!({
+            "x-lix-key": "default_values_missing_required",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "x-lix-default": "lix_uuid_v7()",
+                },
+                "label": { "type": "string" },
+            },
+            "required": ["id", "label"],
+            "additionalProperties": false,
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES ($1)",
+                &[Value::Json(schema)],
+            )
+            .await
+            .expect("schema registration should succeed");
+
+        let error = session
+            .execute(
+                "INSERT INTO default_values_missing_required DEFAULT VALUES",
+                &[],
+            )
+            .await
+            .expect_err("missing required properties must remain a validation error");
+        assert_eq!(error.code, LixError::CODE_SCHEMA_VALIDATION);
+    }
+);
+
+simulation_test!(
     sql_catalog_templates_follow_committed_transaction_snapshots,
     |sim| async move {
         let engine = sim.boot_engine().await;


### PR DESCRIPTION
Fixes #1041

## Summary

- Accept standard `INSERT INTO <registered-schema-table> DEFAULT VALUES` for registered-schema base tables.
- Materialize JSON Schema `default` and `x-lix-default` through the existing native entity writer and normal validation path.
- Keep implicit `INSERT INTO t VALUES (...)` and non-entity `DEFAULT VALUES` rejected as before.
- Add a dedicated cold-session Criterion benchmark using standard SQL only for the measured paths.

## Performance

Local release benchmark (fresh preconfigured session; engine boot and schema registration excluded):

| Path | Time | Throughput |
| --- | --- | --- |
| `DEFAULT VALUES` | 2.5471–2.5759 ms | 388.21–392.61 rows/s |
| Explicit `(label) VALUES ('untitled')` control | 2.6714–2.7510 ms | 363.51–374.33 rows/s |

The fast-path regression test forces the native writer, preventing DataFusion fallback. A three-run `perf stat` profile of the standard path completed with 15.86B cycles, 34.96B instructions, and 149.36M branch misses per benchmark process (includes Criterion warm-up and harness).

## Validation

- `cargo test -p lix_engine --lib --quiet` — 1,649 passed, 6 ignored
- `cargo test -p lix_engine --test integration registered_schema_default_values -- --nocapture` — 2 passed
- `cargo bench -p lix_engine_benchmarks --bench entity_default_values --no-default-features --no-run`
- `cargo fmt --all -- --check`
- `git diff --check`