### PR TITLE
perf(engine): decode packed read payloads once

### DIFF
--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -2460,7 +2460,77 @@ async fn scan_packed_current_base_rows(
     }
     let single_base = base_refs.len() == 1;
     let mut winners = BTreeMap::new();
+    let mut ordered_winners = None;
     for base_ref in base_refs {
+        let scan_members_with_payloads = request.filter.schema_keys.len() == 1
+            && request.filter.entity_pks.is_empty()
+            && request.filter.file_ids.is_empty()
+            && request.limit.is_none()
+            && request.read_columns.columns.as_slice() == ["snapshot_content"];
+        if scan_members_with_payloads {
+            // Native broad entity reads need every payload in the selected
+            // schema. Decode each packed segment once with its payload sidecar
+            // instead of first scanning the identity/value plane and then
+            // issuing a second manifest + segment pass for the same rows.
+            let members =
+                crate::tracked_state::load_commit_delta_members_with_payloads_for_schemas(
+                    store,
+                    base_ref.commit_id,
+                    &request.filter.schema_keys,
+                    512,
+                )
+                .await?;
+            if single_base {
+                if let Some(members) = members {
+                    let mut ordered = Vec::with_capacity(members.len());
+                    for member in members {
+                        if member.value.deleted
+                            || !packed_member_matches_filter(&member, &request.filter)
+                        {
+                            continue;
+                        }
+                        ordered.push((member.key, member.value, member.change));
+                    }
+                    if ordered.iter().any(|row| row.0.file_id.is_some()) {
+                        ordered.sort_unstable_by(|left, right| {
+                            (&left.0.schema_key, &left.0.entity_pk, &left.0.file_id).cmp(&(
+                                &right.0.schema_key,
+                                &right.0.entity_pk,
+                                &right.0.file_id,
+                            ))
+                        });
+                    }
+                    ordered_winners = Some(ordered);
+                    break;
+                }
+            } else if let Some(members) = members {
+                for member in members {
+                    if member.value.deleted
+                        || !packed_member_matches_filter(&member, &request.filter)
+                    {
+                        continue;
+                    }
+                    let key = member.key;
+                    let identity = (
+                        key.schema_key.clone(),
+                        key.entity_pk.clone(),
+                        key.file_id.clone(),
+                    );
+                    match winners.entry(identity) {
+                        std::collections::btree_map::Entry::Vacant(entry) => {
+                            entry.insert((key, member.value, member.change));
+                        }
+                        std::collections::btree_map::Entry::Occupied(mut entry)
+                            if entry.get().1.commit_id < member.value.commit_id =>
+                        {
+                            entry.insert((key, member.value, member.change));
+                        }
+                        std::collections::btree_map::Entry::Occupied(_) => {}
+                    }
+                }
+                continue;
+            }
+        }
         let compact = crate::tracked_state::scan_commit_delta_values(
             store,
             base_ref.commit_id,
@@ -2521,12 +2591,13 @@ async fn scan_packed_current_base_rows(
         }
     }
     let projection = ChangeRecordProjection::from_columns(&request.read_columns.columns);
-    let row_capacity = limit.map_or(winners.len(), |limit| limit.min(winners.len()));
+    let winner_rows = ordered_winners.unwrap_or_else(|| winners.into_values().collect::<Vec<_>>());
+    let row_capacity = limit.map_or(winner_rows.len(), |limit| limit.min(winner_rows.len()));
     let mut rows = MaterializedLiveStateBatchBuilder::with_capacity(row_capacity);
     let mut json_refs = Vec::new();
     let mut deferred = Vec::new();
     let global = branch_id == crate::GLOBAL_BRANCH_ID;
-    for (_, (key, value, change)) in winners.into_iter().take(row_capacity) {
+    for (key, value, change) in winner_rows.into_iter().take(row_capacity) {
         let row_index = rows.len();
         let snapshot = materialize_packed_slot(
             projection.snapshot_content,

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -32,13 +32,13 @@ pub(crate) use storage::load_commit_delta_change_ids;
 pub(crate) use storage::{
     CommitDeltaChangeLocator, CommitDeltaMember, commit_delta_contains_schema,
     direct_change_locator, load_change_record_by_id, load_commit_delta_change_records,
-    load_commit_delta_members_with_payloads, load_commit_delta_selection_certificate,
-    load_owned_commit_delta_entries, scan_change_records_from_commit_deltas,
-    scan_commit_delta_inventory, scan_commit_delta_values, selected_change_selection_fingerprint,
-    stage_addressable_commit_deltas, stage_addressable_commit_deltas_with_selected_source,
-    stage_change_locators, stage_commit_deltas, stage_delete_change_locators,
-    stage_delete_commit_delta_inventory_entry, stage_delete_commit_roots,
-    stage_ordered_addressable_commit_deltas,
+    load_commit_delta_members_with_payloads, load_commit_delta_members_with_payloads_for_schemas,
+    load_commit_delta_selection_certificate, load_owned_commit_delta_entries,
+    scan_change_records_from_commit_deltas, scan_commit_delta_inventory, scan_commit_delta_values,
+    selected_change_selection_fingerprint, stage_addressable_commit_deltas,
+    stage_addressable_commit_deltas_with_selected_source, stage_change_locators,
+    stage_commit_deltas, stage_delete_change_locators, stage_delete_commit_delta_inventory_entry,
+    stage_delete_commit_roots, stage_ordered_addressable_commit_deltas,
 };
 #[cfg(feature = "storage-benches")]
 pub(crate) use storage::{

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -2108,32 +2108,89 @@ pub(crate) async fn load_commit_delta_members_with_payloads(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
 ) -> Result<Vec<CommitDeltaMember>, LixError> {
+    Ok(
+        load_commit_delta_members_with_payloads_for_schemas(store, commit_id, &[], usize::MAX)
+            .await?
+            .expect("unbounded commit-delta payload scan cannot exceed its segment limit"),
+    )
+}
+
+/// Loads tracked members and payloads for only the requested schemas.
+///
+/// Segment bounds route around unrelated schema ranges before payload-sidecar
+/// decoding. An empty schema list retains the full inventory behavior used by
+/// history, rebuild, and lifecycle callers.
+pub(crate) async fn load_commit_delta_members_with_payloads_for_schemas(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+    schema_keys: &[String],
+    max_segment_count: usize,
+) -> Result<Option<Vec<CommitDeltaMember>>, LixError> {
     let Some(manifest) = load_commit_delta_manifest(store, commit_id).await? else {
-        return Ok(Vec::new());
+        return Ok(Some(Vec::new()));
     };
-    let mut local = load_commit_delta_members_from_manifest(store, commit_id, &manifest).await?;
-    let Some(source_commit_id) = manifest.selected_source_commit_id() else {
-        return Ok(local);
+    let requested_schemas = schema_keys
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let local_segment_count = if manifest.inline_segment().is_some() {
+        1
+    } else {
+        commit_delta_segment_count_for_schemas_up_to(
+            &manifest,
+            &requested_schemas,
+            max_segment_count,
+        )
     };
-    let source_manifest = load_commit_delta_manifest(store, source_commit_id)
-        .await?
-        .ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "selected-source commit delta '{}' references missing source '{}'",
-                    commit_id, source_commit_id
-                ),
+    if local_segment_count > max_segment_count {
+        return Ok(None);
+    }
+    let source = if let Some(source_commit_id) = manifest.selected_source_commit_id() {
+        let source_manifest = load_commit_delta_manifest(store, source_commit_id)
+            .await?
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "selected-source commit delta '{}' references missing source '{}'",
+                        commit_id, source_commit_id
+                    ),
+                )
+            })?;
+        let source_segment_count = if source_manifest.inline_segment().is_some() {
+            1
+        } else {
+            commit_delta_segment_count_for_schemas_up_to(
+                &source_manifest,
+                &requested_schemas,
+                max_segment_count.saturating_sub(local_segment_count),
             )
-        })?;
+        };
+        if local_segment_count.saturating_add(source_segment_count) > max_segment_count {
+            return Ok(None);
+        }
+        Some((source_commit_id, source_manifest))
+    } else {
+        None
+    };
+    let mut local =
+        load_commit_delta_members_from_manifest(store, commit_id, &manifest, schema_keys).await?;
+    let Some((source_commit_id, source_manifest)) = source else {
+        return Ok(Some(local));
+    };
     if source_manifest.selected_source_commit_id().is_some() {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
             "selected-source commit delta chains are unsupported",
         ));
     }
-    let mut members =
-        load_commit_delta_members_from_manifest(store, source_commit_id, &source_manifest).await?;
+    let mut members = load_commit_delta_members_from_manifest(
+        store,
+        source_commit_id,
+        &source_manifest,
+        schema_keys,
+    )
+    .await?;
     for member in &mut members {
         member.value.commit_id = commit_id;
         member.authored = false;
@@ -2148,20 +2205,27 @@ pub(crate) async fn load_commit_delta_members_with_payloads(
             format!("selected-source commit delta '{commit_id}' has overlapping local rows"),
         ));
     }
-    Ok(members)
+    Ok(Some(members))
 }
 
 async fn load_commit_delta_members_from_manifest(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
     manifest: &CommitDeltaManifest,
+    schema_keys: &[String],
 ) -> Result<Vec<CommitDeltaMember>, LixError> {
+    let requested_schemas = schema_keys
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
     let mut members = Vec::new();
     if let Some(inline_segment) = manifest.inline_segment() {
         collect_strict_commit_delta_members(inline_segment, None, commit_id, 0, &mut members)?;
     } else {
-        let segment_keys = (0..manifest.segments.len())
-            .map(|segment_index| {
+        let segment_indices = commit_delta_segments_for_schemas(manifest, &requested_schemas);
+        let segment_keys = segment_indices
+            .iter()
+            .map(|&segment_index| {
                 commit_delta_segment_key(commit_id, segment_index)
                     .map(|key| StorageKey(Bytes::from(key)))
             })
@@ -2169,7 +2233,7 @@ async fn load_commit_delta_members_from_manifest(
         let segments = PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, &segment_keys)
             .materialize(store, StorageGetOptions::default())
             .await?;
-        for (segment_index, value) in segments.value.into_iter().enumerate() {
+        for (segment_index, value) in segment_indices.into_iter().zip(segments.value) {
             let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
                 LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
@@ -2186,6 +2250,9 @@ async fn load_commit_delta_members_from_manifest(
                 &mut members,
             )?;
         }
+    }
+    if !requested_schemas.is_empty() {
+        members.retain(|member| requested_schemas.contains(member.key.schema_key.as_str()));
     }
     hydrate_selected_members(store, &mut members).await?;
     validate_commit_delta_member_order_and_ids(commit_id, &members)?;
@@ -2944,7 +3011,7 @@ pub(crate) async fn visit_change_records_from_commit_deltas(
             let commit_id = commit_id_from_delta_key(&entry.key)?;
             let manifest = decode_commit_delta_manifest(bytes)?;
             let members =
-                load_commit_delta_members_from_manifest(store, commit_id, &manifest).await?;
+                load_commit_delta_members_from_manifest(store, commit_id, &manifest, &[]).await?;
             for member in members {
                 if member.authored {
                     visit(member.change)?;
@@ -3717,6 +3784,27 @@ fn commit_delta_segments_for_schemas(
                 .then_some(segment_index)
         })
         .collect()
+}
+
+fn commit_delta_segment_count_for_schemas_up_to(
+    manifest: &CommitDeltaManifest,
+    schema_keys: &BTreeSet<&str>,
+    limit: usize,
+) -> usize {
+    if schema_keys.is_empty() {
+        return manifest.segments.len().min(limit.saturating_add(1));
+    }
+    manifest
+        .segments
+        .iter()
+        .filter(|bounds| {
+            schema_keys
+                .iter()
+                .copied()
+                .any(|schema_key| commit_delta_segment_overlaps_schema(bounds, schema_key))
+        })
+        .take(limit.saturating_add(1))
+        .count()
 }
 
 fn commit_delta_segment_overlaps_schema(
@@ -5681,6 +5769,39 @@ mod tests {
         assert_eq!(all.len(), fixtures.len());
         let all_keys = all.iter().map(|row| row.encoded_key()).collect::<Vec<_>>();
         assert!(all_keys.windows(2).all(|pair| pair[0] < pair[1]));
+
+        let alpha_members = super::load_commit_delta_members_with_payloads_for_schemas(
+            &read,
+            commit_id,
+            &["alpha".to_string()],
+            usize::MAX,
+        )
+        .await
+        .expect("schema-routed payload scan should load packed deltas")
+        .expect("unbounded schema-routed payload scan should be accepted");
+        assert_eq!(alpha_members.len(), 150);
+        assert!(
+            alpha_members
+                .iter()
+                .all(|member| member.key.schema_key == "alpha")
+        );
+        assert!(
+            alpha_members
+                .windows(2)
+                .all(|pair| pair[0].key < pair[1].key)
+        );
+        assert!(
+            super::load_commit_delta_members_with_payloads_for_schemas(
+                &read,
+                commit_id,
+                &["alpha".to_string()],
+                0,
+            )
+            .await
+            .expect("bounded payload scan should remain valid")
+            .is_none(),
+            "payload scans above the segment budget must defer to the streaming path"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- decode packed commit-delta identity/value data and payload sidecars in one pass for broad native entity reads
- route the payload scan to requested schema segments only
- move the common single-base result directly into materialization without per-row identity clones or B-tree insertion
- bound the one-pass path to 512 segments; larger layouts retain the existing streaming path after profiling exposed a SlateDB scaling regression

## Performance

Immediate performance parent: PR #1036 at `65b4c8b8f` (now merged into main).

10k rows, public Lix SQL `SELECT *`, 400 hot repeats:

| Adapter | PR #1036 | This PR | Improvement |
| --- | ---: | ---: | ---: |
| RocksDB | 33.74–34.98 ms | 22.10–25.62 ms | 24–35% |
| SlateDB | 33.86–35.14 ms | 23.43–25.31 ms | 25–33% |

1M rows, public Lix SQL `SELECT *`, two hot repeats:

| Adapter | PR #1036 | This PR |
| --- | ---: | ---: |
| RocksDB | 5.99 s | 5.14 s |
| SlateDB | 5.24 s | 5.07 s |

Peak RSS remained in the existing ~4.2 GiB band during 1M-row validation.

## Validation

- `cargo test -p lix_engine --lib`: 1,644 passed, 6 ignored
- RocksDB storage and conformance suites: 15 passed
- SlateDB storage and conformance suites: 58 passed
- explicit segmented schema-routing and bounded-fallback coverage
- tracked-head branch, merge ordering, checkpoint, GC, and working-diff tests pass
