### PR TITLE
Compress RocksDB blob files with Zstd

### DIFF
--- a/packages/engine-benchmarks/benches/rocksdb_zstd_blob_results.md
+++ b/packages/engine-benchmarks/benches/rocksdb_zstd_blob_results.md
@@ -1,0 +1,51 @@
+# RocksDB Zstd blob compression
+
+Measured from `991236c1532ffec774a186b20faa807601f18a72` with the
+release `lix exp git-replay` binary. Every replay installed all bundled
+plugins and created four or more evenly spaced checkpoints. Database size is
+`du -sb` after Lix close and the explicit storage flush.
+
+The candidate sets RocksDB's integrated blob compression to Zstd. SSTs already
+used Zstd level 1; the baseline left blob files at RocksDB's default
+`kNoCompression`. This is a physical-format cut and does not migrate existing
+databases.
+
+| Repository / window | Replay before | Replay after | Delta | Bytes before | Bytes after | Delta |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `microsoft/vscode-docs`, 100 commits from `3c1f5bf3` | 4,824.505 ms | 4,584.217 ms | -4.98% | 99,407,629 | 79,797,770 | -19.73% |
+| `home-assistant/brands`, 80 commits from `d923dadb` | 313.377 ms | 306.244 ms | -2.28% | 16,002,393 | 15,854,220 | -0.93% |
+| `wesnoth/wesnoth`, 15 commits from `e4a9a7d1` | 124.679 ms | 127.074 ms | +1.92% | 6,690,831 | 4,488,069 | -32.92% |
+
+The small `brands` workload has no values large enough to benefit materially.
+The two repositories with large values shrink by 19.7-32.9%. Timed replay
+improves on the largest lane and stays within 2% on the smallest lane.
+
+The repository windows are intentionally pinned. A longer `brands` window
+hits a pre-existing filesystem namespace conflict, and a longer `wesnoth`
+all-plugin window hits a pre-existing nested Wasmtime runtime panic. Those
+semantic/plugin edge cases are outside this storage-format measurement.
+
+Representative command (substitute repository, ref, window, and adapter):
+
+```sh
+lix exp git-replay \
+  --repo-path /bench/vscode-docs \
+  --output-path /bench/output/vscode-docs-rocksdb \
+  --storage rocksdb \
+  --plugins all \
+  --branch main \
+  --from-commit 3c1f5bf3dabbc38d99940e731a4d7cc69d30f50c \
+  --num-commits 100 \
+  --checkpoint-every 25 \
+  --profile-json /bench/profiles/vscode-docs-rocksdb.json
+```
+
+Validation:
+
+```sh
+cargo test -p lix_rocksdb_storage
+```
+
+RocksDB persists `blob_compression_type=kZSTD` in its options file. The adapter
+test asserts that setting in addition to exercising storage conformance,
+snapshot reads, deletes, process locking, and large-value blob placement.

--- a/packages/rocksdb-storage/src/rocksdb.rs
+++ b/packages/rocksdb-storage/src/rocksdb.rs
@@ -703,6 +703,7 @@ fn open_rocksdb(path: &Path) -> Result<DB, StorageError> {
     options.set_enable_blob_files(true);
     options.set_min_blob_size(DEFAULT_BLOB_MIN_SIZE);
     options.set_blob_file_size(DEFAULT_BLOB_FILE_SIZE);
+    options.set_blob_compression_type(rocksdb::DBCompressionType::Zstd);
     options.set_enable_blob_gc(true);
     options.set_blob_gc_age_cutoff(DEFAULT_BLOB_GC_AGE_CUTOFF);
     DB::open(&options, path).map_err(|error| rocksdb_open_error(error, path))

--- a/packages/rocksdb-storage/tests/storage/rocksdb_specific.rs
+++ b/packages/rocksdb-storage/tests/storage/rocksdb_specific.rs
@@ -197,7 +197,7 @@ fn writes_large_values_to_blob_files() {
 }
 
 #[test]
-fn uses_fast_zstd_compression_for_sst_files() {
+fn uses_fast_zstd_compression_for_sst_and_blob_files() {
     let temp_dir = tempfile::tempdir().expect("create temp dir");
     let path = temp_dir.path().join("storage.rocksdb");
     let storage = RocksDB::open(&path).expect("open storage");
@@ -215,6 +215,10 @@ fn uses_fast_zstd_compression_for_sst_files() {
     assert!(
         options.contains("compression=kZSTD"),
         "SST compression should use Zstd"
+    );
+    assert!(
+        options.contains("blob_compression_type=kZSTD"),
+        "blob compression should use Zstd"
     );
     assert!(
         options.contains("compression_opts={")


### PR DESCRIPTION
## Summary

- compress RocksDB integrated blob files with Zstd, matching the existing SST codec
- assert the persisted RocksDB physical-format options for both SST and blob files
- record the exact all-plugin Git replay windows, profiles, and physical-size accounting

This is intentionally a hard physical-format cut. Existing RocksDB databases are not migrated.

## Why

RocksDB's integrated blob files defaulted to `kNoCompression` even though Lix already compresses SSTs with fast Zstd. The measured baseline was 24-49% larger than the equivalent SlateDB output on repositories with large values.

This follows RocksDB's integrated BlobDB design: large values live outside the LSM while the column-family option controls their physical compression. See the upstream [BlobDB documentation](https://github.com/facebook/rocksdb/wiki/BlobDB).

## Before / after

Release Git replay from `991236c1532ffec774a186b20faa807601f18a72`, all bundled plugins enabled, with evenly spaced checkpoints:

| Repository / window | Replay before | Replay after | Delta | Bytes before | Bytes after | Delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `microsoft/vscode-docs`, 100 commits from `3c1f5bf3` | 4,824.505 ms | 4,584.217 ms | -4.98% | 99,407,629 | 79,797,770 | -19.73% |
| `home-assistant/brands`, 80 commits from `d923dadb` | 313.377 ms | 306.244 ms | -2.28% | 16,002,393 | 15,854,220 | -0.93% |
| `wesnoth/wesnoth`, 15 commits from `e4a9a7d1` | 124.679 ms | 127.074 ms | +1.92% | 6,690,831 | 4,488,069 | -32.92% |

The large-value lanes shrink by 19.7-32.9%. Replay improves on the largest lane and stays within 2% on the smallest. `brands` has no large compressible values and is neutral.

The committed benchmark note contains the full commands and explains the pinned happy-path windows. Longer `brands` and `wesnoth` all-plugin windows hit pre-existing semantic/plugin failures unrelated to storage.

## Validation

- `cargo test -p lix_rocksdb_storage`
- release `lix exp git-replay` before/after profiles for all three repositories
- post-close `du -sb` physical accounting
- no changenote (requested)
