### PR TITLE
perf(engine): index bounded entity joins

### DIFF
--- a/packages/engine/src/common/mod.rs
+++ b/packages/engine/src/common/mod.rs
@@ -22,3 +22,26 @@ pub(crate) use metadata::{
 pub(crate) use timestamp::LixTimestamp;
 pub use types::{Blob, LixNotice, NullableKeyFilter, SharedStr, SqlQueryResult, Value};
 pub use wire::{WireQueryResult, WireValue};
+
+/// Renders a JSON value through the public SQL string-column coercion.
+///
+/// Registered schemas are validated separately. The SQL surface has
+/// historically kept malformed stored values readable by coercing any
+/// non-null JSON scalar or container to text, so native indexes and joins
+/// must use this exact representation too.
+pub(crate) fn json_value_to_string(value: &serde_json::Value) -> Result<Option<String>, LixError> {
+    Ok(match value {
+        serde_json::Value::Null => None,
+        serde_json::Value::String(value) => Some(value.clone()),
+        serde_json::Value::Bool(value) => Some(value.to_string()),
+        serde_json::Value::Number(value) => Some(value.to_string()),
+        serde_json::Value::Array(_) | serde_json::Value::Object(_) => {
+            Some(serde_json::to_string(value).map_err(|error| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("failed to render JSON string value: {error}"),
+                )
+            })?)
+        }
+    })
+}

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::borrow_deref_ref, clippy::clone_on_copy)]
 
+use super::EntitySnapshotFieldIndexCache;
 use crate::GLOBAL_BRANCH_ID;
 use crate::LixError;
 use crate::NullableKeyFilter;
@@ -40,6 +41,7 @@ pub(crate) struct LiveStateContext {
     tracked_head: TrackedHeadContext,
     commit_graph: CommitGraphContext,
     filesystem_path_index_cache: std::sync::Arc<FilesystemPathIndexCache>,
+    entity_field_index_cache: std::sync::Arc<EntitySnapshotFieldIndexCache>,
 }
 
 impl LiveStateContext {
@@ -51,6 +53,7 @@ impl LiveStateContext {
             tracked_head: TrackedHeadContext::new(),
             commit_graph,
             filesystem_path_index_cache: std::sync::Arc::new(FilesystemPathIndexCache::default()),
+            entity_field_index_cache: std::sync::Arc::new(EntitySnapshotFieldIndexCache::default()),
         }
     }
 
@@ -64,6 +67,7 @@ impl LiveStateContext {
             tracked_head: self.tracked_head,
             commit_graph: self.commit_graph.clone(),
             filesystem_path_index_cache: std::sync::Arc::clone(&self.filesystem_path_index_cache),
+            entity_field_index_cache: std::sync::Arc::clone(&self.entity_field_index_cache),
         }
     }
 
@@ -84,6 +88,7 @@ pub(crate) struct LiveStateStoreReader<S> {
     tracked_head: TrackedHeadContext,
     commit_graph: CommitGraphContext,
     filesystem_path_index_cache: std::sync::Arc<FilesystemPathIndexCache>,
+    entity_field_index_cache: std::sync::Arc<EntitySnapshotFieldIndexCache>,
 }
 
 impl<S> LiveStateStoreReader<S>
@@ -100,6 +105,81 @@ where
         &self,
         request: &LiveStateScanRequest,
     ) -> Result<Option<Vec<Option<Bytes>>>, LixError> {
+        let Some((requested_branch_id, requested_control, schema_key)) =
+            self.direct_entity_snapshot_scope(request).await?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(
+            self.tracked_head
+                .reader(&self.store)
+                .scan_entity_snapshots(
+                    &requested_branch_id,
+                    requested_control,
+                    &schema_key,
+                    &request.filter.entity_pks,
+                    request.limit,
+                )
+                .await?,
+        ))
+    }
+
+    pub(crate) async fn scan_direct_entity_snapshots_by_string_field(
+        &self,
+        request: &LiveStateScanRequest,
+        column: &str,
+        values: &[String],
+    ) -> Result<Option<Vec<Option<Bytes>>>, LixError> {
+        let Some((branch_id, control, schema_key)) =
+            self.direct_entity_snapshot_scope(request).await?
+        else {
+            return Ok(None);
+        };
+        let generation = format!("{}:{}", control.generation, control.current_state_revision);
+        if let Some(rows) =
+            self.entity_field_index_cache
+                .get(&branch_id, &generation, &schema_key, column, values)
+        {
+            return Ok(Some(rows));
+        }
+        let snapshots = self
+            .tracked_head
+            .reader(&self.store)
+            .scan_entity_snapshots(&branch_id, control, &schema_key, &[], None)
+            .await?;
+        let mut rows_by_value = std::collections::BTreeMap::<String, Vec<Option<Bytes>>>::new();
+        for snapshot in snapshots {
+            let Some(bytes) = snapshot else { continue };
+            let snapshot =
+                serde_json::from_slice::<serde_json::Value>(&bytes).map_err(|error| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!("entity field index expected valid snapshot JSON: {error}"),
+                    )
+                })?;
+            let value = snapshot
+                .get(column)
+                .map(crate::common::json_value_to_string)
+                .transpose()?
+                .flatten();
+            if let Some(value) = value {
+                rows_by_value.entry(value).or_default().push(Some(bytes));
+            }
+        }
+        Ok(Some(self.entity_field_index_cache.insert(
+            &branch_id,
+            &generation,
+            &schema_key,
+            column,
+            rows_by_value,
+            values,
+        )))
+    }
+
+    async fn direct_entity_snapshot_scope(
+        &self,
+        request: &LiveStateScanRequest,
+    ) -> Result<Option<(String, BranchHeadControl, String)>, LixError> {
         // The hot index carries tracked and untracked rows in one serving
         // plane, so this route never probes a separate retention index.
         if request.filter.untracked.is_some()
@@ -132,25 +212,17 @@ where
         let tracked_head = self.tracked_head.reader(&self.store);
         if requested_branch_id != GLOBAL_BRANCH_ID
             && let Some(global_control) = scope.branch_heads.get(GLOBAL_BRANCH_ID).copied()
-        {
-            let global_has_rows = tracked_head
+            && tracked_head
                 .has_schema_rows(GLOBAL_BRANCH_ID, global_control, schema_key)
-                .await?;
-            if global_has_rows {
-                return Ok(None);
-            }
+                .await?
+        {
+            return Ok(None);
         }
-        Ok(Some(
-            tracked_head
-                .scan_entity_snapshots(
-                    requested_branch_id,
-                    requested_control,
-                    schema_key,
-                    &request.filter.entity_pks,
-                    request.limit,
-                )
-                .await?,
-        ))
+        Ok(Some((
+            requested_branch_id.clone(),
+            requested_control,
+            schema_key.clone(),
+        )))
     }
 
     pub(crate) async fn scan_batch(

--- a/packages/engine/src/live_state/entity_field_index.rs
+++ b/packages/engine/src/live_state/entity_field_index.rs
@@ -1,0 +1,211 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::mem::size_of;
+use std::sync::Mutex;
+
+use bytes::Bytes;
+
+const MAX_FIELD_INDEX_CACHE_BYTES: usize = 64 * 1024 * 1024;
+
+#[derive(Debug, PartialEq, Eq)]
+struct FieldIndexKey {
+    branch_id: String,
+    generation: String,
+    schema_key: String,
+    column: String,
+}
+
+#[derive(Debug)]
+struct CachedFieldIndex {
+    key: FieldIndexKey,
+    rows_by_value: BTreeMap<String, Vec<Option<Bytes>>>,
+    bytes: usize,
+}
+
+/// Bounded, current-generation secondary indexes for registered string
+/// columns. A generation change replaces the prior index for the same
+/// branch/schema/column, so readers never observe stale rows and historical
+/// generations cannot accumulate without bound.
+#[derive(Debug, Default)]
+pub(crate) struct EntitySnapshotFieldIndexCache {
+    entries: Mutex<Vec<CachedFieldIndex>>,
+}
+
+impl EntitySnapshotFieldIndexCache {
+    pub(crate) fn get(
+        &self,
+        branch_id: &str,
+        generation: &str,
+        schema_key: &str,
+        column: &str,
+        values: &[String],
+    ) -> Option<Vec<Option<Bytes>>> {
+        let mut entries = self
+            .entries
+            .lock()
+            .expect("entity field index cache lock poisoned");
+        let position = entries.iter().position(|entry| {
+            entry.key.branch_id == branch_id
+                && entry.key.generation == generation
+                && entry.key.schema_key == schema_key
+                && entry.key.column == column
+        })?;
+        let entry = entries.remove(position);
+        let result = collect_index_values(&entry.rows_by_value, values);
+        entries.push(entry);
+        Some(result)
+    }
+
+    pub(crate) fn insert(
+        &self,
+        branch_id: &str,
+        generation: &str,
+        schema_key: &str,
+        column: &str,
+        rows_by_value: BTreeMap<String, Vec<Option<Bytes>>>,
+        values: &[String],
+    ) -> Vec<Option<Bytes>> {
+        self.insert_with_limit(
+            branch_id,
+            generation,
+            schema_key,
+            column,
+            rows_by_value,
+            values,
+            MAX_FIELD_INDEX_CACHE_BYTES,
+        )
+    }
+
+    #[expect(clippy::too_many_arguments)]
+    fn insert_with_limit(
+        &self,
+        branch_id: &str,
+        generation: &str,
+        schema_key: &str,
+        column: &str,
+        rows_by_value: BTreeMap<String, Vec<Option<Bytes>>>,
+        values: &[String],
+        max_bytes: usize,
+    ) -> Vec<Option<Bytes>> {
+        let mut entries = self
+            .entries
+            .lock()
+            .expect("entity field index cache lock poisoned");
+        if let Some(entry) = entries.iter().find(|entry| {
+            entry.key.branch_id == branch_id
+                && entry.key.generation == generation
+                && entry.key.schema_key == schema_key
+                && entry.key.column == column
+        }) {
+            return collect_index_values(&entry.rows_by_value, values);
+        }
+        let key = FieldIndexKey {
+            branch_id: branch_id.to_owned(),
+            generation: generation.to_owned(),
+            schema_key: schema_key.to_owned(),
+            column: column.to_owned(),
+        };
+        let bytes = size_of::<CachedFieldIndex>()
+            + key.branch_id.capacity()
+            + key.generation.capacity()
+            + key.schema_key.capacity()
+            + key.column.capacity()
+            + rows_by_value
+                .iter()
+                .map(|(value, rows)| {
+                    value.capacity()
+                        + rows.capacity() * size_of::<Option<Bytes>>()
+                        + rows.iter().flatten().map(Bytes::len).sum::<usize>()
+                })
+                .sum::<usize>();
+        let result = collect_index_values(&rows_by_value, values);
+        entries.retain(|entry| {
+            entry.key.branch_id != branch_id
+                || entry.key.schema_key != schema_key
+                || entry.key.column != column
+        });
+        if bytes > max_bytes {
+            return result;
+        }
+        entries.push(CachedFieldIndex {
+            key,
+            rows_by_value,
+            bytes,
+        });
+        while entries.iter().map(|entry| entry.bytes).sum::<usize>() > max_bytes {
+            entries.remove(0);
+        }
+        result
+    }
+}
+
+fn collect_index_values(
+    rows_by_value: &BTreeMap<String, Vec<Option<Bytes>>>,
+    values: &[String],
+) -> Vec<Option<Bytes>> {
+    values
+        .iter()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .flat_map(|value| rows_by_value.get(value).into_iter().flatten().cloned())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EntitySnapshotFieldIndexCache;
+    use bytes::Bytes;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn field_index_is_value_scoped_and_replaced_by_new_revision() {
+        let cache = EntitySnapshotFieldIndexCache::default();
+        let first = BTreeMap::from([
+            ("a".to_string(), vec![Some(Bytes::from_static(b"a1"))]),
+            ("b".to_string(), vec![Some(Bytes::from_static(b"b1"))]),
+        ]);
+        assert_eq!(
+            cache.insert("main", "g:1", "message", "bundleId", first, &["b".into()]),
+            [Some(Bytes::from_static(b"b1"))]
+        );
+        assert_eq!(
+            cache.get(
+                "main",
+                "g:1",
+                "message",
+                "bundleId",
+                &["a".into(), "a".into()]
+            ),
+            Some(vec![Some(Bytes::from_static(b"a1"))])
+        );
+
+        let second = BTreeMap::from([("a".to_string(), vec![Some(Bytes::from_static(b"a2"))])]);
+        cache.insert("main", "g:2", "message", "bundleId", second, &[]);
+        assert!(
+            cache
+                .get("main", "g:1", "message", "bundleId", &["a".into()])
+                .is_none(),
+            "the superseded branch/schema/column revision must be evicted"
+        );
+        assert_eq!(
+            cache.get("main", "g:2", "message", "bundleId", &["a".into()]),
+            Some(vec![Some(Bytes::from_static(b"a2"))])
+        );
+    }
+
+    #[test]
+    fn oversized_field_index_is_returned_without_being_cached() {
+        let cache = EntitySnapshotFieldIndexCache::default();
+        let rows = BTreeMap::from([(
+            "a".to_string(),
+            vec![Some(Bytes::from_static(b"oversized"))],
+        )]);
+        assert_eq!(
+            cache.insert_with_limit("main", "g:1", "message", "bundleId", rows, &["a".into()], 1),
+            [Some(Bytes::from_static(b"oversized"))]
+        );
+        assert_eq!(
+            cache.get("main", "g:1", "message", "bundleId", &["a".into()]),
+            None
+        );
+    }
+}

--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -1,4 +1,5 @@
 mod context;
+mod entity_field_index;
 mod reader;
 mod tracked_head;
 mod types;
@@ -6,6 +7,7 @@ pub(crate) mod visibility;
 
 #[allow(unused_imports)]
 pub(crate) use context::{LiveStateContext, LiveStateStoreReader};
+pub(crate) use entity_field_index::EntitySnapshotFieldIndexCache;
 #[allow(unused_imports)]
 pub(crate) use reader::LiveStateReader;
 #[cfg(test)]

--- a/packages/engine/src/sql2/entity_batch.rs
+++ b/packages/engine/src/sql2/entity_batch.rs
@@ -30,6 +30,15 @@ pub(crate) trait EntitySnapshotReader: Send + Sync {
         &self,
         request: LiveStateScanRequest,
     ) -> Result<Option<Vec<Option<Bytes>>>, LixError>;
+
+    async fn scan_entity_snapshots_by_string_field(
+        &self,
+        _request: LiveStateScanRequest,
+        _column: &str,
+        _values: &[String],
+    ) -> Result<Option<Vec<Option<Bytes>>>, LixError> {
+        Ok(None)
+    }
 }
 
 pub(crate) struct CurrentEntitySnapshotReader<S> {
@@ -58,6 +67,21 @@ where
         self.live_state
             .reader(self.store.clone())
             .scan_direct_entity_snapshots(&request)
+            .await
+    }
+
+    async fn scan_entity_snapshots_by_string_field(
+        &self,
+        request: LiveStateScanRequest,
+        column: &str,
+        values: &[String],
+    ) -> Result<Option<Vec<Option<Bytes>>>, LixError> {
+        if !direct_entity_snapshot_request(&request) || !request.filter.entity_pks.is_empty() {
+            return Ok(None);
+        }
+        self.live_state
+            .reader(self.store.clone())
+            .scan_direct_entity_snapshots_by_string_field(&request, column, values)
             .await
     }
 }

--- a/packages/engine/src/sql2/entity_projection.rs
+++ b/packages/engine/src/sql2/entity_projection.rs
@@ -360,23 +360,7 @@ fn parse_json_value(raw: &RawValue) -> Result<JsonValue, LixError> {
 }
 
 fn raw_string_text(raw: &RawValue) -> Result<Option<String>, LixError> {
-    let json = raw.get();
-    let trimmed = json.trim();
-    if trimmed == "null" {
-        return Ok(None);
-    }
-    if trimmed == "true" || trimmed == "false" {
-        return Ok(Some(trimmed.to_string()));
-    }
-    if trimmed.starts_with('"') {
-        return serde_json::from_str::<String>(json)
-            .map(Some)
-            .map_err(snapshot_decode_error);
-    }
-    serde_json::from_str::<JsonValue>(json)
-        .and_then(|value| serde_json::to_string(&value))
-        .map(Some)
-        .map_err(snapshot_decode_error)
+    crate::common::json_value_to_string(&parse_json_value(raw)?)
 }
 
 fn raw_bool(raw: &RawValue) -> Option<bool> {

--- a/packages/engine/src/sql2/exec/bound_public_read.rs
+++ b/packages/engine/src/sql2/exec/bound_public_read.rs
@@ -10,8 +10,9 @@ use std::collections::BTreeSet;
 
 use datafusion::sql::parser::Statement as DataFusionStatement;
 use datafusion::sql::sqlparser::ast::{
-    BinaryOperator, Expr, GroupByExpr, OrderByKind, Query, Select, SelectFlavor, SetExpr,
-    Statement as SqlStatement, TableFactor, Value as SqlValue,
+    BinaryOperator, Expr, GroupByExpr, Ident, JoinConstraint, JoinOperator, OrderByKind, Query,
+    Select, SelectFlavor, SelectItem, SetExpr, Statement as SqlStatement, TableFactor,
+    Value as SqlValue,
 };
 use serde_json::Value as JsonValue;
 
@@ -36,6 +37,14 @@ pub(crate) async fn try_execute_bound_public_read<C>(
 where
     C: SqlExecutionContext + ?Sized,
 {
+    if let Some(shape) = strict_entity_left_join_read(statement, params) {
+        crate::sql2::bind_read_statement(sql, statement)?;
+        let catalog = ctx.public_catalog().await?;
+        if let Some(result) = execute_entity_left_join_read(ctx, &catalog, shape).await? {
+            return Ok(Some(result));
+        }
+        return Ok(None);
+    }
     let Some(shape) = strict_entity_primary_key_read(statement, params)
         .map(StrictEntityRead::PrimaryKey)
         .or_else(|| strict_entity_broad_read(statement, params).map(StrictEntityRead::Broad))
@@ -169,6 +178,229 @@ where
     }
 }
 
+async fn execute_entity_left_join_read<C>(
+    ctx: &C,
+    catalog: &crate::sql2::catalog::PublicCatalog,
+    shape: StrictEntityLeftJoinRead,
+) -> Result<Option<SqlQueryResult>, LixError>
+where
+    C: SqlExecutionContext + ?Sized,
+{
+    let Some(reader) = ctx.entity_snapshot_reader() else {
+        return Ok(None);
+    };
+    let mut specs = std::collections::BTreeMap::new();
+    for table in &shape.tables {
+        let Some(surface) = catalog.surface(table) else {
+            return Ok(None);
+        };
+        let PublicSurfaceKind::EntityBase { schema_key } = &surface.kind else {
+            return Ok(None);
+        };
+        let Some(spec) = catalog.entity_spec(schema_key) else {
+            return Ok(None);
+        };
+        specs.insert(table.clone(), spec);
+    }
+    if single_top_level_string_primary_key(specs[&shape.root_table])
+        != Some(shape.root_primary_key_column.as_str())
+    {
+        return Ok(None);
+    }
+    for projection in &shape.projection {
+        let Some(column) = specs
+            .get(&projection.table)
+            .and_then(|spec| spec.visible_column(&projection.column))
+        else {
+            return Ok(None);
+        };
+        if !matches!(
+            column.column_type,
+            EntityColumnType::String | EntityColumnType::Json
+        ) {
+            return Ok(None);
+        }
+    }
+    for join in &shape.joins {
+        let left_type = specs
+            .get(&join.left_table)
+            .and_then(|spec| spec.visible_column(&join.left_column))
+            .map(|column| column.column_type);
+        let right_type = specs
+            .get(&join.right_table)
+            .and_then(|spec| spec.visible_column(&join.right_column))
+            .map(|column| column.column_type);
+        if left_type != Some(EntityColumnType::String)
+            || right_type != Some(EntityColumnType::String)
+        {
+            return Ok(None);
+        }
+    }
+
+    let root_spec = specs[&shape.root_table];
+    let root_request = entity_snapshot_request(
+        ctx.active_branch_id(),
+        &root_spec.schema_key,
+        vec![EntityPk::single(shape.root_primary_key_value.clone())],
+    );
+    let Some(root_snapshots) = reader.scan_entity_snapshots(root_request).await? else {
+        return Ok(None);
+    };
+    type JoinedRow<'a> = std::collections::BTreeMap<&'a str, Option<std::sync::Arc<JsonValue>>>;
+    let mut joined = parse_join_snapshots(root_snapshots)?
+        .into_iter()
+        .map(|row| JoinedRow::from([(shape.root_table.as_str(), Some(row))]))
+        .collect::<Vec<_>>();
+    for join in &shape.joins {
+        if joined.is_empty() {
+            break;
+        }
+        let values = joined
+            .iter()
+            .map(|row| {
+                let value = row
+                    .get(join.left_table.as_str())
+                    .and_then(Option::as_deref)
+                    .and_then(|value| value.get(&join.left_column));
+                value
+                    .map(crate::common::json_value_to_string)
+                    .transpose()
+                    .map(Option::flatten)
+            })
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .flatten()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        if values.is_empty() {
+            for row in &mut joined {
+                row.insert(join.right_table.as_str(), None);
+            }
+            continue;
+        }
+        let right_spec = specs[&join.right_table];
+        let request =
+            entity_snapshot_request(ctx.active_branch_id(), &right_spec.schema_key, Vec::new());
+        let snapshots = if let Some(snapshots) = reader
+            .scan_entity_snapshots_by_string_field(request.clone(), &join.right_column, &values)
+            .await?
+        {
+            snapshots
+        } else {
+            let Some(snapshots) = reader.scan_entity_snapshots(request).await? else {
+                return Ok(None);
+            };
+            snapshots
+        };
+        let right_rows = parse_join_snapshots(snapshots)?;
+        let mut next = Vec::new();
+        for row in joined {
+            let left_value = row
+                .get(join.left_table.as_str())
+                .and_then(Option::as_deref)
+                .and_then(|value| value.get(&join.left_column))
+                .map(crate::common::json_value_to_string)
+                .transpose()?
+                .flatten();
+            let mut matched = false;
+            if let Some(left_value) = left_value.as_deref() {
+                for right in &right_rows {
+                    let right_value = right
+                        .get(&join.right_column)
+                        .map(crate::common::json_value_to_string)
+                        .transpose()?
+                        .flatten();
+                    if right_value.as_deref() == Some(left_value) {
+                        let mut result = row.clone();
+                        result.insert(
+                            join.right_table.as_str(),
+                            Some(std::sync::Arc::clone(right)),
+                        );
+                        next.push(result);
+                        matched = true;
+                    }
+                }
+            }
+            if !matched {
+                let mut result = row;
+                result.insert(join.right_table.as_str(), None);
+                next.push(result);
+            }
+        }
+        joined = next;
+    }
+
+    let rows = joined
+        .into_iter()
+        .map(|row| {
+            shape
+                .projection
+                .iter()
+                .map(|projection| {
+                    let spec = specs[&projection.table];
+                    let column = spec
+                        .visible_column(&projection.column)
+                        .expect("join projection was validated");
+                    let value = row
+                        .get(projection.table.as_str())
+                        .and_then(Option::as_deref)
+                        .and_then(|row| row.get(&projection.column));
+                    materialize_value(column.column_type, value)
+                })
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Some(SqlQueryResult {
+        columns: shape
+            .projection
+            .into_iter()
+            .map(|projection| projection.alias)
+            .collect(),
+        rows,
+        notices: Vec::new(),
+    }))
+}
+
+fn entity_snapshot_request(
+    branch_id: &str,
+    schema_key: &str,
+    entity_pks: Vec<EntityPk>,
+) -> LiveStateScanRequest {
+    LiveStateScanRequest {
+        filter: LiveStateFilter {
+            schema_keys: vec![schema_key.to_owned()],
+            entity_pks,
+            branch_ids: vec![branch_id.to_owned()],
+            include_tombstones: false,
+            ..LiveStateFilter::default()
+        },
+        projection: LiveStateProjection {
+            columns: vec!["snapshot_content".to_string()],
+        },
+        limit: None,
+    }
+}
+
+fn parse_join_snapshots(
+    snapshots: Vec<Option<bytes::Bytes>>,
+) -> Result<Vec<std::sync::Arc<JsonValue>>, LixError> {
+    snapshots
+        .into_iter()
+        .flatten()
+        .map(|snapshot| {
+            serde_json::from_slice(&snapshot)
+                .map(std::sync::Arc::new)
+                .map_err(|error| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!("direct entity join expected valid snapshot JSON: {error}"),
+                    )
+                })
+        })
+        .collect()
+}
+
 fn single_top_level_string_primary_key(
     spec: &crate::sql2::catalog::EntitySurfaceSpec,
 ) -> Option<&str> {
@@ -288,6 +520,164 @@ struct StrictEntityBroadRead {
     primary_key_column: String,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct StrictEntityJoinProjection {
+    table: String,
+    column: String,
+    alias: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct StrictEntityJoin {
+    left_table: String,
+    left_column: String,
+    right_table: String,
+    right_column: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct StrictEntityLeftJoinRead {
+    root_table: String,
+    root_primary_key_column: String,
+    root_primary_key_value: String,
+    tables: Vec<String>,
+    joins: Vec<StrictEntityJoin>,
+    projection: Vec<StrictEntityJoinProjection>,
+}
+
+/// Recognizes the document point-read shape emitted by query builders: an
+/// exact root lookup followed by a chain of simple left joins. Keeping this
+/// contract deliberately narrow lets the native route preserve SQL semantics
+/// without embedding a second general-purpose query engine.
+fn strict_entity_left_join_read(
+    statement: &DataFusionStatement,
+    params: &[Value],
+) -> Option<StrictEntityLeftJoinRead> {
+    let DataFusionStatement::Statement(statement) = statement else {
+        return None;
+    };
+    let SqlStatement::Query(query) = statement.as_ref() else {
+        return None;
+    };
+    if query.with.is_some()
+        || query.order_by.is_some()
+        || query.limit_clause.is_some()
+        || query.fetch.is_some()
+        || !query.locks.is_empty()
+        || query.for_clause.is_some()
+        || query.settings.is_some()
+        || query.format_clause.is_some()
+        || !query.pipe_operators.is_empty()
+    {
+        return None;
+    }
+    let SetExpr::Select(select) = query.body.as_ref() else {
+        return None;
+    };
+    if !strict_plain_select(select) {
+        return None;
+    }
+    let [from] = select.from.as_slice() else {
+        return None;
+    };
+    if from.joins.is_empty() {
+        return None;
+    }
+    let root_table = strict_table_name(&from.relation)?;
+    let mut tables = vec![root_table.clone()];
+    let mut joins = Vec::with_capacity(from.joins.len());
+    for join in &from.joins {
+        let right_table = strict_table_name(&join.relation)?;
+        if tables.contains(&right_table) {
+            return None;
+        }
+        let constraint = match &join.join_operator {
+            JoinOperator::Left(constraint) | JoinOperator::LeftOuter(constraint) => constraint,
+            _ => return None,
+        };
+        let JoinConstraint::On(Expr::BinaryOp {
+            left,
+            op: BinaryOperator::Eq,
+            right,
+        }) = constraint
+        else {
+            return None;
+        };
+        let (left_table, left_column) = strict_qualified_column(left)?;
+        let (candidate_right_table, right_column) = strict_qualified_column(right)?;
+        let (left_table, left_column, candidate_right_table, right_column) =
+            if candidate_right_table == right_table && tables.contains(&left_table) {
+                (left_table, left_column, candidate_right_table, right_column)
+            } else if left_table == right_table && tables.contains(&candidate_right_table) {
+                (candidate_right_table, right_column, left_table, left_column)
+            } else {
+                return None;
+            };
+        joins.push(StrictEntityJoin {
+            left_table,
+            left_column,
+            right_table: candidate_right_table,
+            right_column,
+        });
+        tables.push(right_table);
+    }
+
+    let projection = select
+        .projection
+        .iter()
+        .map(|item| {
+            let SelectItem::ExprWithAlias { expr, alias } = item else {
+                return None;
+            };
+            let (table, column) = strict_qualified_column(expr)?;
+            tables.contains(&table).then(|| StrictEntityJoinProjection {
+                table,
+                column,
+                alias: alias.value.clone(),
+            })
+        })
+        .collect::<Option<Vec<_>>>()?;
+    if projection.is_empty() {
+        return None;
+    }
+
+    let Expr::BinaryOp {
+        left,
+        op: BinaryOperator::Eq,
+        right,
+    } = select.selection.as_ref()?
+    else {
+        return None;
+    };
+    let mut highest_parameter = 0;
+    let ((filter_table, root_primary_key_column), root_primary_key_value) = match (
+        strict_qualified_column(left),
+        strict_qualified_column(right),
+    ) {
+        (Some(column), None) => (
+            column,
+            strict_text_value(right, params, &mut highest_parameter)?,
+        ),
+        (None, Some(column)) => (
+            column,
+            strict_text_value(left, params, &mut highest_parameter)?,
+        ),
+        _ => return None,
+    };
+    if filter_table != root_table || params.len() != highest_parameter {
+        return None;
+    }
+
+    Some(StrictEntityLeftJoinRead {
+        root_table,
+        root_primary_key_column,
+        root_primary_key_value,
+        tables,
+        joins,
+        projection,
+    })
+}
+
 /// Recognizes a single, active entity table with an `IN`/`=` primary-key
 /// predicate and canonical ascending primary-key order. It intentionally does
 /// not inspect catalog metadata: catalog mismatches are handled by the caller
@@ -362,25 +752,7 @@ fn strict_single_table_select(
     let SetExpr::Select(select) = query.body.as_ref() else {
         return None;
     };
-    if select.flavor != SelectFlavor::Standard
-        || select.optimizer_hint.is_some()
-        || select.distinct.is_some()
-        || select.select_modifiers.is_some()
-        || select.top.is_some()
-        || select.exclude.is_some()
-        || select.into.is_some()
-        || !select.lateral_views.is_empty()
-        || select.prewhere.is_some()
-        || !select.connect_by.is_empty()
-        || !group_by_is_empty(&select.group_by)
-        || !select.cluster_by.is_empty()
-        || !select.distribute_by.is_empty()
-        || !select.sort_by.is_empty()
-        || select.having.is_some()
-        || !select.named_window.is_empty()
-        || select.qualify.is_some()
-        || select.value_table_mode.is_some()
-    {
+    if !strict_plain_select(select) {
         return None;
     }
     let [from] = select.from.as_slice() else {
@@ -389,6 +761,31 @@ fn strict_single_table_select(
     if !from.joins.is_empty() {
         return None;
     }
+    Some((query, select, strict_table_name(&from.relation)?))
+}
+
+fn strict_plain_select(select: &Select) -> bool {
+    select.flavor == SelectFlavor::Standard
+        && select.optimizer_hint.is_none()
+        && select.distinct.is_none()
+        && select.select_modifiers.is_none()
+        && select.top.is_none()
+        && select.exclude.is_none()
+        && select.into.is_none()
+        && select.lateral_views.is_empty()
+        && select.prewhere.is_none()
+        && select.connect_by.is_empty()
+        && group_by_is_empty(&select.group_by)
+        && select.cluster_by.is_empty()
+        && select.distribute_by.is_empty()
+        && select.sort_by.is_empty()
+        && select.having.is_none()
+        && select.named_window.is_empty()
+        && select.qualify.is_none()
+        && select.value_table_mode.is_none()
+}
+
+fn strict_table_name(table: &TableFactor) -> Option<String> {
     let TableFactor::Table {
         name,
         alias,
@@ -401,7 +798,7 @@ fn strict_single_table_select(
         sample,
         index_hints,
         ..
-    } = &from.relation
+    } = table
     else {
         return None;
     };
@@ -419,25 +816,40 @@ fn strict_single_table_select(
         return None;
     }
     let table_identifier = name.0.first()?.as_ident()?;
-    if table_identifier.quote_style.is_some() {
-        return None;
-    }
-    Some((query, select, table_identifier.value.to_ascii_lowercase()))
+    Some(strict_identifier_name(table_identifier))
 }
 
-fn strict_projection(
-    projection: &[datafusion::sql::sqlparser::ast::SelectItem],
-) -> Option<Vec<String>> {
-    let columns =
-        projection
-            .iter()
-            .map(|item| match item {
-                datafusion::sql::sqlparser::ast::SelectItem::UnnamedExpr(Expr::Identifier(
-                    column,
-                )) if column.quote_style.is_none() => Some(column.value.to_ascii_lowercase()),
-                _ => None,
-            })
-            .collect::<Option<Vec<_>>>()?;
+fn strict_qualified_column(expression: &Expr) -> Option<(String, String)> {
+    let Expr::CompoundIdentifier(identifiers) = expression else {
+        return None;
+    };
+    let [table, column] = identifiers.as_slice() else {
+        return None;
+    };
+    Some((
+        strict_identifier_name(table),
+        strict_identifier_name(column),
+    ))
+}
+
+fn strict_identifier_name(identifier: &Ident) -> String {
+    if identifier.quote_style.is_some() {
+        identifier.value.clone()
+    } else {
+        identifier.value.to_ascii_lowercase()
+    }
+}
+
+fn strict_projection(projection: &[SelectItem]) -> Option<Vec<String>> {
+    let columns = projection
+        .iter()
+        .map(|item| match item {
+            SelectItem::UnnamedExpr(Expr::Identifier(column)) if column.quote_style.is_none() => {
+                Some(column.value.to_ascii_lowercase())
+            }
+            _ => None,
+        })
+        .collect::<Option<Vec<_>>>()?;
     let unique_count = columns.iter().collect::<BTreeSet<_>>().len();
     (unique_count == columns.len()).then_some(columns)
 }
@@ -577,6 +989,52 @@ mod tests {
         assert_eq!(shape.table_name, "json_pointer");
         assert_eq!(shape.projection, ["path", "value"]);
         assert_eq!(shape.primary_key_column, "path");
+    }
+
+    #[test]
+    fn recognizes_document_point_read_left_join_chain() {
+        let shape = strict_entity_left_join_read(
+            &parse(
+                r#"SELECT "bundle"."id" AS "bundleId",
+                    "bundle"."declarations" AS "bundleDeclarations",
+                    "message"."id" AS "messageId",
+                    "message"."locale" AS "messageLocale",
+                    "variant"."id" AS "variantId",
+                    "variant"."pattern" AS "variantPattern"
+                FROM "bundle"
+                LEFT JOIN "message" ON "message"."bundleId" = "bundle"."id"
+                LEFT JOIN "variant" ON "variant"."messageId" = "message"."id"
+                WHERE "bundle"."id" = $1"#,
+            ),
+            &[Value::Text("bundle-1".to_string())],
+        )
+        .expect("document point read should use direct route");
+
+        assert_eq!(shape.root_table, "bundle");
+        assert_eq!(shape.root_primary_key_column, "id");
+        assert_eq!(shape.root_primary_key_value, "bundle-1");
+        assert_eq!(shape.tables, ["bundle", "message", "variant"]);
+        assert_eq!(shape.joins[0].left_table, "bundle");
+        assert_eq!(shape.joins[0].right_table, "message");
+        assert_eq!(shape.joins[0].right_column, "bundleId");
+        assert_eq!(shape.projection[0].alias, "bundleId");
+        assert_eq!(shape.projection[1].column, "declarations");
+    }
+
+    #[test]
+    fn join_read_rejects_shapes_that_need_general_sql() {
+        let params = [Value::Text("bundle-1".to_string())];
+        for sql in [
+            r#"SELECT "bundle"."id" AS "id" FROM "bundle" JOIN "message" ON "message"."bundleId" = "bundle"."id" WHERE "bundle"."id" = $1"#,
+            r#"SELECT "bundle"."id" AS "id" FROM "bundle" LEFT JOIN "message" ON "message"."bundleId" = "bundle"."id" WHERE "message"."id" = $1"#,
+            r#"SELECT count(*) AS "count" FROM "bundle" LEFT JOIN "message" ON "message"."bundleId" = "bundle"."id" WHERE "bundle"."id" = $1"#,
+            r#"SELECT "bundle"."id" AS "id" FROM "bundle" LEFT JOIN "message" ON "message"."bundleId" = "bundle"."id" WHERE "bundle"."id" = $1 ORDER BY "bundle"."id""#,
+        ] {
+            assert!(
+                strict_entity_left_join_read(&parse(sql), &params).is_none(),
+                "{sql} must fall back"
+            );
+        }
     }
 
     #[test]

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -2423,6 +2423,9 @@ mod tests {
         snapshots: Vec<Option<Bytes>>,
         requests: Arc<Mutex<Vec<LiveStateScanRequest>>>,
     }
+    struct SchemaEntitySnapshotReader {
+        snapshots: std::collections::BTreeMap<String, Vec<Option<Bytes>>>,
+    }
     struct DummyCommitGraphReader;
     struct DummyBranchRefReader;
     fn test_read_scope(storage: &StorageAdapter<Memory>) -> StorageAdapterReadScope<MemoryRead> {
@@ -3159,6 +3162,46 @@ mod tests {
     }
 
     #[async_trait]
+    impl EntitySnapshotReader for SchemaEntitySnapshotReader {
+        async fn scan_entity_snapshots(
+            &self,
+            request: LiveStateScanRequest,
+        ) -> Result<Option<Vec<Option<Bytes>>>, LixError> {
+            let [schema_key] = request.filter.schema_keys.as_slice() else {
+                return Ok(None);
+            };
+            Ok(self.snapshots.get(schema_key).cloned())
+        }
+
+        async fn scan_entity_snapshots_by_string_field(
+            &self,
+            request: LiveStateScanRequest,
+            column: &str,
+            values: &[String],
+        ) -> Result<Option<Vec<Option<Bytes>>>, LixError> {
+            let [schema_key] = request.filter.schema_keys.as_slice() else {
+                return Ok(None);
+            };
+            let Some(snapshots) = self.snapshots.get(schema_key) else {
+                return Ok(None);
+            };
+            let mut matched = Vec::new();
+            for snapshot in snapshots.iter().flatten() {
+                let value: serde_json::Value = serde_json::from_slice(snapshot).unwrap();
+                let value = value
+                    .get(column)
+                    .map(crate::common::json_value_to_string)
+                    .transpose()?
+                    .flatten();
+                if value.as_ref().is_some_and(|value| values.contains(value)) {
+                    matched.push(Some(snapshot.clone()));
+                }
+            }
+            Ok(Some(matched))
+        }
+    }
+
+    #[async_trait]
     impl BlobDataReader for DummyBlobReader {
         async fn load_bytes_many(
             &self,
@@ -3549,6 +3592,114 @@ mod tests {
             [
                 crate::entity_pk::EntityPk::single("entity-a"),
                 crate::entity_pk::EntityPk::single("entity-b"),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn native_entity_left_join_preserves_matches_and_null_extension() {
+        let sql = r#"SELECT "bundle"."id" AS "bundleId",
+                         "message"."id" AS "messageId",
+                         "variant"."id" AS "variantId",
+                         "variant"."pattern" AS "variantPattern"
+                    FROM "bundle"
+                    LEFT JOIN "message" ON "message"."bundleId" = "bundle"."id"
+                    LEFT JOIN "variant" ON "variant"."messageId" = "message"."id"
+                   WHERE "bundle"."id" = $1"#;
+        let snapshot_reader = Arc::new(SchemaEntitySnapshotReader {
+            snapshots: std::collections::BTreeMap::from([
+                (
+                    "bundle".to_string(),
+                    vec![Some(Bytes::from_static(br#"{"id":"b1"}"#))],
+                ),
+                (
+                    "message".to_string(),
+                    vec![
+                        // Stored JSON can violate a registered string type.
+                        // The established SQL projection coerces it to text,
+                        // and native join operands must do the same.
+                        Some(Bytes::from_static(br#"{"id":true,"bundleId":"b1"}"#)),
+                        Some(Bytes::from_static(br#"{"id":"m2","bundleId":"b1"}"#)),
+                    ],
+                ),
+                (
+                    "variant".to_string(),
+                    vec![Some(Bytes::from_static(
+                        br#"{"id":"v1","messageId":true,"pattern":"Hello"}"#,
+                    ))],
+                ),
+            ]),
+        });
+        let ctx = DummySqlExecutionContext {
+            active_branch_id: "01920000-0000-7000-8000-0000000000a1",
+            blob_reader: Arc::new(DummyBlobReader),
+            live_state: Arc::new(DummyLiveStateReader),
+            entity_snapshot_reader: Some(snapshot_reader),
+            schema_definitions: vec![
+                json!({
+                    "x-lix-key": "bundle",
+                    "x-lix-primary-key": ["/id"],
+                    "type": "object",
+                    "properties": { "id": { "type": "string" } },
+                    "required": ["id"],
+                    "additionalProperties": false
+                }),
+                json!({
+                    "x-lix-key": "message",
+                    "x-lix-primary-key": ["/id"],
+                    "type": "object",
+                    "properties": {
+                        "id": { "type": "string" },
+                        "bundleId": { "type": "string" }
+                    },
+                    "required": ["id", "bundleId"],
+                    "additionalProperties": false
+                }),
+                json!({
+                    "x-lix-key": "variant",
+                    "x-lix-primary-key": ["/id"],
+                    "type": "object",
+                    "properties": {
+                        "id": { "type": "string" },
+                        "messageId": { "type": "string" },
+                        "pattern": { "type": "string" }
+                    },
+                    "required": ["id", "messageId", "pattern"],
+                    "additionalProperties": false
+                }),
+            ],
+        };
+        let statement = crate::sql2::parse_statement(sql).expect("test SQL should parse");
+
+        let result = super::super::bound_public_read::try_execute_bound_public_read(
+            &ctx,
+            sql,
+            &statement,
+            &[Value::Text("b1".to_string())],
+        )
+        .await
+        .expect("native route should execute")
+        .expect("strict entity join should use native route");
+
+        assert_eq!(
+            result.columns,
+            ["bundleId", "messageId", "variantId", "variantPattern"]
+        );
+        assert_eq!(
+            result.rows,
+            vec![
+                vec![
+                    Value::Text("b1".to_string()),
+                    Value::Text("true".to_string()),
+                    Value::Text("v1".to_string()),
+                    Value::Text("Hello".to_string()),
+                ],
+                vec![
+                    Value::Text("b1".to_string()),
+                    Value::Text("m2".to_string()),
+                    Value::Null,
+                    Value::Null,
+                ],
             ]
         );
     }


### PR DESCRIPTION
Stacked on #1042.

## Summary
- recognize the strict registered-entity point-read shape emitted by inlang: one exact root lookup followed by equality `LEFT JOIN` chains
- execute that shape directly over current-state snapshots instead of constructing a DataFusion plan
- maintain a 64 MiB bounded, revision-keyed secondary index for demanded string join columns and evict superseded revisions
- preserve fallback to the general SQL executor for every unsupported shape

## Performance
`packages/sdk/benchmark/common-operations.bench.ts`, release native build:

| Query | #1042 baseline | This PR | SQLite WASM | vs #1042 | Lix / SQLite |
| --- | ---: | ---: | ---: | ---: | ---: |
| select one nested bundle | 5.916 ms | 0.230 ms | 0.177 ms | 96.1% faster | 1.29x |
| select 500 bundles / 1,000 messages | 31.24 ms | 30.72 ms | 50.68 ms | 1.7% faster | 0.61x |

A second run measured the point read at 0.246 ms versus 0.174 ms SQLite (1.41x).

## Validation
- `cargo test -p lix_engine --features all-simulations --quiet`
  - 1,650 unit tests passed
  - 788 integration/simulation tests passed
  - 3 doctests passed
- two release benchmark runs
- no changenote