### PR TITLE
Make storage point-write batches final

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -217,8 +217,11 @@ Use `Prefix::to_range()` to lower a byte prefix to its equivalent `KeyRange`.
 
 A `StorageWrite` handle stages mutations for one atomic commit. `put_many` and
 `delete_many` operate on one space at a time and accept at most one mutation per
-key in each batch. `delete_range` deletes all keys in the supplied range; a
-fully unbounded range clears that space and may be implemented as a truncate.
+key in each batch. Range deletions must be staged before point puts in the same
+write transaction; the storage contract does not support deleting a range over
+already-staged puts. `delete_range` deletes all previously stored keys in the
+supplied range; a fully unbounded range clears that space and may be implemented
+as a truncate.
 
 `commit` atomically publishes the handle's staged mutations and returns a
 `CommitResult` with provider commit information and `WriteStats`. `rollback`

--- a/packages/engine-benchmarks/benches/storage_final_write_batches_results.md
+++ b/packages/engine-benchmarks/benches/storage_final_write_batches_results.md
@@ -1,0 +1,61 @@
+# Final point-write batch results
+
+This benchmark covers the hard cut from separate `put_many` and
+`put_many_final` storage-adapter lanes to one final `put_many` lane. Range
+deletions now precede point puts in a write transaction. This matches Lix's
+write-set lowering order and lets RocksDB stream physical keys directly into
+its atomic `WriteBatch`, rather than retaining every point key in a second
+transaction-sized arena in case a later range deletion needs reconciliation.
+
+The design follows established LSM practice: RocksDB applies one `WriteBatch`
+atomically, while key prefixes and filters keep related logical key ranges
+adjacent. See the upstream [RocksDB overview][rocks-overview], [prefix seek
+guidance][rocks-prefix], and [Bloom filter guidance][rocks-bloom].
+
+## Method
+
+- Source: `main` at `991236c1532ffec774a186b20faa807601f18a72`, plus the
+  parent Zstd blob-compression change.
+- Candidate release binary SHA-256:
+  `9c65dda7d76545bd33f2e4ccb50e17776563629d7ba29d9cc67a049ddf114747`.
+- `lix exp git-replay --plugins all`, with a scoped parent-tree bootstrap and
+  final Git-tree verification excluded from replay time.
+- Fixed windows: `vscode-docs` 100 commits/checkpoint 25, `brands` 80/20,
+  and `wesnoth` 15/5.
+- RocksDB before data is the parent change's binary
+  (`686a4a01ba04414b480f6c1be73c5b6641338970469152cb24e2322c7a5ff9b2`).
+  SlateDB uses the original baseline binary because the parent changes only a
+  RocksDB option (`a13a8d4eb397183c1a5dbd1190932f51532fb6a0bfceb660fedb55dfc27649eb`).
+- Database bytes are `du -sb` after explicit storage flush. Timings below are
+  one before/after run because the acceptance criterion is no regression, not
+  a small timing win.
+
+## Results
+
+| repository | adapter | replay before | replay after | delta | execute before/after | checkpoint before/after | flush before/after | bytes before | bytes after | size delta |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `microsoft/vscode-docs` | RocksDB | 4584.217 ms | 4624.477 ms | +0.88% | 4395.968 / 4432.820 ms | 106.053 / 108.219 ms | 56.053 / 67.256 ms | 79,797,770 | 79,633,004 | -0.21% |
+| `microsoft/vscode-docs` | SlateDB | 4804.175 ms | 4857.188 ms | +1.10% | 4604.119 / 4654.335 ms | 117.914 / 120.085 ms | 0.854 / 0.853 ms | 79,771,939 | 79,760,567 | -0.01% |
+| `home-assistant/brands` | RocksDB | 306.244 ms | 313.514 ms | +2.37% | 265.534 / 272.647 ms | 13.911 / 14.076 ms | 25.658 / 25.325 ms | 15,854,220 | 15,854,439 | +0.00% |
+| `home-assistant/brands` | SlateDB | 366.294 ms | 374.780 ms | +2.32% | 325.950 / 334.085 ms | 13.585 / 13.536 ms | 0.910 / 0.916 ms | 15,860,206 | 15,898,061 | +0.24% |
+| `wesnoth/wesnoth` | RocksDB | 127.074 ms | 125.481 ms | -1.25% | 107.802 / 106.353 ms | 13.374 / 13.382 ms | 12.471 / 12.347 ms | 4,488,069 | 4,487,302 | -0.02% |
+| `wesnoth/wesnoth` | SlateDB | 125.762 ms | 125.817 ms | +0.04% | 108.789 / 108.842 ms | 11.271 / 11.262 ms | 1.055 / 1.193 ms | 4,478,848 | 4,484,039 | +0.12% |
+
+All final-tree checks passed. Replay changes range from -1.25% to +2.37%, and
+physical-size changes range from -0.21% to +0.24%; these are noise-level
+movements rather than a workload regression.
+
+## Allocation accounting
+
+Before the cut, a RocksDB transaction retained a second copy of every physical
+point key plus one `Range<usize>` per point put until commit. After the cut it
+retains one reusable physical-key buffer sized to the largest point key in the
+current batch. For `N` point puts with physical key lengths `K_i`, retained key
+payload falls from `sum(K_i)` to `max(K_i)` for each batch, and the `N`
+range descriptors are eliminated. The engine's normal write-set path already
+obeyed range-first ordering, so this removes the fallback cost without changing
+CRUD, diff, merge, or checkpoint semantics on the measured path.
+
+[rocks-overview]: https://github.com/facebook/rocksdb/wiki/RocksDB-Overview
+[rocks-prefix]: https://github.com/facebook/rocksdb/wiki/Prefix-Seek
+[rocks-bloom]: https://github.com/facebook/rocksdb/wiki/RocksDB-Bloom-Filter

--- a/packages/engine/src/storage/conformance/baseline.rs
+++ b/packages/engine/src/storage/conformance/baseline.rs
@@ -57,10 +57,6 @@ where
         delete_range_removes_exact_range
     );
     run!(
-        "baseline::delete_range_applies_after_staged_puts",
-        delete_range_applies_after_staged_puts
-    );
-    run!(
         "baseline::put_many_applies_after_delete_range",
         put_many_applies_after_delete_range
     );
@@ -380,48 +376,6 @@ where
             ("d", Some("D")),
             ("e", Some("E")),
         ],
-    )
-    .await
-}
-
-async fn delete_range_applies_after_staged_puts<F>(factory: &F) -> ConformanceResult
-where
-    F: StorageFactory,
-{
-    let storage = open_storage(factory).await;
-    let test_space = space(1);
-    seed_full_values(&storage, test_space, [("a", "A"), ("c", "C"), ("d", "D")]).await?;
-
-    let mut write = storage
-        .begin_write(WriteOptions::default())
-        .await
-        .map_err(|error| format!("begin_write failed: {error}"))?;
-    write
-        .put_many(
-            TEST_SPACE,
-            put_batch([full_put(key("b"), "B"), full_put(key("c"), "C2")]),
-        )
-        .await
-        .map_err(|error| format!("put_many failed: {error}"))?;
-    write
-        .delete_range(
-            TEST_SPACE,
-            KeyRange {
-                lower: Bound::Included(key("b")),
-                upper: Bound::Excluded(key("d")),
-            },
-        )
-        .await
-        .map_err(|error| format!("delete_range failed: {error}"))?;
-    write
-        .commit()
-        .await
-        .map_err(|error| format!("commit failed: {error}"))?;
-
-    assert_get_entries(
-        &storage,
-        test_space,
-        &[("a", Some("A")), ("b", None), ("c", None), ("d", Some("D"))],
     )
     .await
 }

--- a/packages/engine/src/storage/conformance/mod.rs
+++ b/packages/engine/src/storage/conformance/mod.rs
@@ -73,7 +73,6 @@ mod tests {
                 "baseline::delete_many_missing_keys_is_idempotent",
                 "baseline::delete_many_removes_existing_keys",
                 "baseline::delete_range_removes_exact_range",
-                "baseline::delete_range_applies_after_staged_puts",
                 "baseline::put_many_applies_after_delete_range",
                 "baseline::put_many_overwrites_existing_value",
                 "baseline::scan_range_sees_overwritten_existing_value",

--- a/packages/engine/src/storage/conformance/model_based.rs
+++ b/packages/engine/src/storage/conformance/model_based.rs
@@ -85,10 +85,25 @@ where
         let mut staged = models.clone();
 
         let mutation_count = 1 + rng.usize(8);
-        for mutation_index in 0..mutation_count {
+        let range_mutation_count = rng.usize(mutation_count + 1);
+        for mutation_index in 0..range_mutation_count {
+            let space = TEST_SPACES[rng.usize(TEST_SPACES.len())];
+            let range = random_range(&mut rng, keys);
+            write
+                .delete_range(space, range.clone())
+                .await
+                .map_err(|error| {
+                    format!("{label}, mutation {mutation_index}: delete_range failed: {error}")
+                })?;
+            staged
+                .get_mut(&space)
+                .expect("test space has a model")
+                .delete_range(&range);
+        }
+        for mutation_index in range_mutation_count..mutation_count {
             let space = TEST_SPACES[rng.usize(TEST_SPACES.len())];
             let target_key = keys[rng.usize(keys.len())].clone();
-            match rng.usize(4) {
+            match rng.usize(3) {
                 0 | 1 => {
                     let value = random_value(&mut rng, step, mutation_index);
                     write
@@ -119,21 +134,7 @@ where
                         .expect("test space has a model")
                         .delete(&target_key);
                 }
-                _ => {
-                    let range = random_range(&mut rng, keys);
-                    write
-                        .delete_range(space, range.clone())
-                        .await
-                        .map_err(|error| {
-                            format!(
-                                "{label}, mutation {mutation_index}: delete_range failed: {error}"
-                            )
-                        })?;
-                    staged
-                        .get_mut(&space)
-                        .expect("test space has a model")
-                        .delete_range(&range);
-                }
+                _ => unreachable!("bounded random choice"),
             }
         }
 

--- a/packages/engine/src/storage/traits.rs
+++ b/packages/engine/src/storage/traits.rs
@@ -90,27 +90,14 @@ pub trait StorageWrite: Send {
     ///
     /// Batches hold at most one mutation per key. Engine write-set lowering
     /// produces batches sorted ascending by key; other callers may pass
-    /// unsorted batches.
+    /// unsorted batches. Point batches are final for their keys: callers must
+    /// issue every range deletion before calling `put_many` in the same write
+    /// transaction. Exact point deletes remain valid after a put batch.
     fn put_many(
         &mut self,
         space: SpaceId,
         entries: PutBatch,
     ) -> impl Future<Output = Result<(), StorageError>> + Send;
-
-    /// Applies a point batch that no later range deletion in this write
-    /// transaction needs to observe.
-    ///
-    /// The default preserves ordinary [`Self::put_many`] behavior. Backends
-    /// that retain point keys only to reconcile future range deletes may
-    /// override this lane and stream the entries directly into their atomic
-    /// write batch. Exact point deletes remain valid after this call.
-    fn put_many_final(
-        &mut self,
-        space: SpaceId,
-        entries: PutBatch,
-    ) -> impl Future<Output = Result<(), StorageError>> + Send {
-        self.put_many(space, entries)
-    }
 
     /// Deletes the given keys of one space. Batches hold at most one
     /// mutation per key; engine write-set lowering produces sorted keys.
@@ -120,9 +107,10 @@ pub trait StorageWrite: Send {
         keys: &[Key],
     ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
-    /// Deletes every key of one space within the range. An unbounded range
-    /// clears the whole space; storage implementations may fast-path that case (for
-    /// example by truncating the space's table).
+    /// Deletes every key of one space within the range. Range deletions must
+    /// precede point puts in the same write transaction. An unbounded range
+    /// clears the whole space; storage implementations may fast-path that case
+    /// (for example by truncating the space's table).
     fn delete_range(
         &mut self,
         space: SpaceId,

--- a/packages/engine/src/storage_adapter/write_set.rs
+++ b/packages/engine/src/storage_adapter/write_set.rs
@@ -773,7 +773,7 @@ impl StorageWriteSet {
                 stats.put_batches += 1;
                 stats.storage_calls += 1;
                 write
-                    .put_many_final(space.id, PutBatch { entries: puts })
+                    .put_many(space.id, PutBatch { entries: puts })
                     .await
                     .map_err(StorageWriteSetError::Storage)?;
             }
@@ -800,7 +800,7 @@ impl StorageWriteSet {
                 stats.put_batches += 1;
                 stats.storage_calls += 1;
                 write
-                    .put_many_final(page.space.id, page.entries)
+                    .put_many(page.space.id, page.entries)
                     .instrument(tracing::debug_span!(
                         target: "lix_perf",
                         "lix.perf.storage_lowering.deferred_put_page"

--- a/packages/rocksdb-storage/src/rocksdb.rs
+++ b/packages/rocksdb-storage/src/rocksdb.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 use std::future::Future;
-use std::ops::{Bound, Range};
+use std::ops::Bound;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, Weak};
@@ -61,8 +61,6 @@ pub struct RocksDBWrite {
     inner: Arc<RocksDBInner>,
     _writer_permit: OwnedMutexGuard<()>,
     batch: WriteBatch,
-    staged_put_key_bytes: Vec<u8>,
-    staged_put_key_ranges: Vec<Range<usize>>,
     stats: WriteStats,
 }
 
@@ -179,8 +177,6 @@ impl Storage for RocksDB {
                 } else {
                     WriteBatch::with_capacity_bytes(opts.batch_capacity_hint_bytes)
                 },
-                staged_put_key_bytes: Vec::new(),
-                staged_put_key_ranges: Vec::new(),
                 stats: WriteStats::default(),
             })
         }
@@ -378,37 +374,6 @@ impl StorageWrite for RocksDBWrite {
         entries: PutBatch,
     ) -> impl Future<Output = Result<(), StorageError>> + Send {
         async move {
-            let physical_key_bytes = entries.entries.iter().fold(0_usize, |bytes, entry| {
-                bytes.saturating_add(4).saturating_add(entry.key.0.len())
-            });
-            self.staged_put_key_bytes.reserve(physical_key_bytes);
-            self.staged_put_key_ranges.reserve(entries.entries.len());
-            let space_prefix = space.0.to_be_bytes();
-            for entry in entries.entries {
-                let key_start = self.staged_put_key_bytes.len();
-                self.staged_put_key_bytes.extend_from_slice(&space_prefix);
-                self.staged_put_key_bytes.extend_from_slice(&entry.key.0);
-                let key_end = self.staged_put_key_bytes.len();
-                let value = stored_value_bytes(entry.value);
-                self.stats.put_entries += 1;
-                self.stats.written_bytes += value.len() as u64;
-                self.batch.put(
-                    &self.staged_put_key_bytes[key_start..key_end],
-                    value.as_ref(),
-                );
-                self.staged_put_key_ranges.push(key_start..key_end);
-            }
-            self.stats.storage_calls += 1;
-            Ok(())
-        }
-    }
-
-    fn put_many_final(
-        &mut self,
-        space: SpaceId,
-        entries: PutBatch,
-    ) -> impl Future<Output = Result<(), StorageError>> + Send {
-        async move {
             let max_key_bytes = entries
                 .entries
                 .iter()
@@ -481,13 +446,6 @@ impl StorageWrite for RocksDBWrite {
                     }
                     self.batch.delete(encoded_key);
                 }
-
-                for key in &self.staged_put_key_ranges {
-                    let key = &self.staged_put_key_bytes[key.clone()];
-                    if bounds.contains(key) {
-                        self.batch.delete(key);
-                    }
-                }
             }
             self.stats.deleted_ranges += 1;
             self.stats.storage_calls += 1;
@@ -557,17 +515,6 @@ impl EncodedBounds {
     }
 
     fn before_upper(&self, encoded_key: &[u8]) -> bool {
-        match &self.upper {
-            Bound::Included(upper) => encoded_key <= upper.as_slice(),
-            Bound::Excluded(upper) => encoded_key < upper.as_slice(),
-            Bound::Unbounded => true,
-        }
-    }
-
-    fn contains(&self, encoded_key: &[u8]) -> bool {
-        if !self.after_lower(encoded_key) {
-            return false;
-        }
         match &self.upper {
             Bound::Included(upper) => encoded_key <= upper.as_slice(),
             Bound::Excluded(upper) => encoded_key < upper.as_slice(),


### PR DESCRIPTION
## Summary

- hard-cut `StorageWrite` to one final `put_many` lane
- require range deletes before point puts, matching engine write-set lowering
- remove RocksDB transaction-sized staged-key arena and range reconciliation
- update conformance generation and storage contract docs

Stacked on #1045 and intended to land on `main` after it.

## Benchmark/profile

All bundled plugins were enabled. Fixed Git replay windows covered `microsoft/vscode-docs` (100 commits), `home-assistant/brands` (80), and `wesnoth/wesnoth` (15), on both RocksDB and SlateDB. Final Git-tree verification passed in every run.

Replay delta is -1.25% to +2.37%; physical size delta is -0.21% to +0.24%, both within single-run noise. RocksDB retained point-key transaction memory changes deterministically from `sum(key lengths) + N range descriptors` to one `max(key length)` reusable buffer per batch.

Full method, phase timings, sizes, binary hashes, and upstream RocksDB references: `packages/engine-benchmarks/benches/storage_final_write_batches_results.md`.

## Validation

- `cargo test -p lix_rocksdb_storage`
- `cargo test -p lix_slatedb_storage`
- `cargo test -p lix_sqlite_storage`
- `cargo test -p lix_engine --features all-simulations`
- six all-plugin Git replay profiles with final-tree verification

No changenote: internal storage trait and unpublished physical format work.