### PR TITLE
feat(engine): support entity insert returning

### DIFF
--- a/packages/engine/src/sql2/bind/statement.rs
+++ b/packages/engine/src/sql2/bind/statement.rs
@@ -214,7 +214,7 @@ pub(super) fn bind_delete_bound(
     let table = bind_delete_target(catalog, &delete.from)?;
     require_write_capability(&table.surface, BoundWriteOp::Delete)?;
     let predicate = bind_optional_predicate(&table, delete.selection.as_ref(), &mut params)?;
-    let returning = bind_delete_returning(&table, delete.returning.as_ref(), &mut params)?;
+    let returning = bind_row_returning(&table, delete.returning.as_ref(), &mut params, "DELETE")?;
     let branch_scope = bind_write_branch_scope(
         &table.surface.kind,
         &BoundWriteInput::None,
@@ -237,10 +237,11 @@ pub(super) fn bind_delete_bound(
 /// Bind the `RETURNING` list against the target surface itself.  It is not a
 /// nested SELECT: expressions are evaluated from the exact pre-delete row
 /// batch at execution time, before that batch is staged as tombstones.
-fn bind_delete_returning(
+fn bind_row_returning(
     table: &BoundTable,
     returning: Option<&Vec<SelectItem>>,
     params: &mut ParamBinder,
+    action: &str,
 ) -> Result<Option<BoundReturning>, LixError> {
     let Some(returning) = returning else {
         return Ok(None);
@@ -264,9 +265,9 @@ fn bind_delete_returning(
                 }
             }
             SelectItem::QualifiedWildcard(_, _) => {
-                return Err(super::error::unsupported(
-                    "qualified wildcards in DELETE RETURNING are not supported",
-                ));
+                return Err(super::error::unsupported(format!(
+                    "qualified wildcards in {action} RETURNING are not supported"
+                )));
             }
             SelectItem::UnnamedExpr(sql_expr) => {
                 let expr = bind_expr(table, sql_expr, params)?;
@@ -286,9 +287,9 @@ fn bind_delete_returning(
     }
 
     if items.is_empty() {
-        return Err(super::error::unsupported(
-            "DELETE RETURNING requires at least one result expression",
-        ));
+        return Err(super::error::unsupported(format!(
+            "{action} RETURNING requires at least one result expression"
+        )));
     }
 
     Ok(Some(BoundReturning { items }))
@@ -302,6 +303,12 @@ fn bind_insert_returning(
     let Some(returning) = returning else {
         return Ok(None);
     };
+    if matches!(
+        table.surface.kind,
+        PublicSurfaceKind::EntityBase { .. } | PublicSurfaceKind::EntityByBranch { .. }
+    ) {
+        return bind_row_returning(table, Some(returning), params, "INSERT");
+    }
     if !matches!(
         table.surface.kind,
         PublicSurfaceKind::Revert | PublicSurfaceKind::Apply | PublicSurfaceKind::CreateCheckpoint

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -988,16 +988,14 @@ async fn execute_entity_write(
         BoundWriteOp::Insert => {
             if no_op {
                 entity_insert_batch(ctx, plan, &spec, params, active_branch_commit_id.as_ref())?;
-                return Ok(SqlWriteResult::affected(0));
+                return Ok(empty_entity_returning_result(plan));
             }
             if plan.bound.conflict.is_some() {
                 entity_upsert(ctx, plan, &spec, params, active_branch_commit_id.as_ref())
                     .await
                     .map(SqlWriteResult::affected)
             } else {
-                entity_insert(ctx, plan, &spec, params, active_branch_commit_id.as_ref())
-                    .await
-                    .map(SqlWriteResult::affected)
+                entity_insert(ctx, plan, &spec, params, active_branch_commit_id.as_ref()).await
             }
         }
         BoundWriteOp::Update => {
@@ -1010,7 +1008,7 @@ async fn execute_entity_write(
         }
         BoundWriteOp::Delete => {
             if no_op {
-                return Ok(empty_entity_delete_returning_result(plan));
+                return Ok(empty_entity_returning_result(plan));
             }
             if matches!(surface, EntityWriteSurface::Base { .. })
                 && matches!(plan.bound.predicate, BoundPredicate::True)
@@ -1542,9 +1540,50 @@ async fn entity_insert(
     spec: &EntitySurfaceSpec,
     params: &[Value],
     active_branch_commit_id: Option<&CommitId>,
-) -> Result<u64, LixError> {
+) -> Result<SqlWriteResult, LixError> {
     let write_rows = entity_insert_batch(ctx, plan, spec, params, active_branch_commit_id)?;
-    stage_rows(ctx, TransactionWriteMode::Insert, write_rows).await
+    let returning_rows = plan
+        .bound
+        .returning
+        .as_ref()
+        .map(|returning| {
+            write_rows
+                .iter()
+                .map(|row| {
+                    let snapshot = row.snapshot.ok_or_else(|| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            "entity INSERT RETURNING requires snapshot_content",
+                        )
+                    })?;
+                    entity_returning_row(
+                        returning,
+                        &EntityEvalContext::insert(snapshot.value(), &spec.columns),
+                        spec,
+                        ctx,
+                        params,
+                        active_branch_commit_id,
+                    )
+                })
+                .collect::<Result<Vec<_>, LixError>>()
+        })
+        .transpose()?;
+    let rows_affected = stage_rows(ctx, TransactionWriteMode::Insert, write_rows).await?;
+    Ok(match (plan.bound.returning.as_ref(), returning_rows) {
+        (Some(returning), Some(rows)) => SqlWriteResult::returning(
+            rows_affected,
+            crate::SqlQueryResult {
+                columns: returning
+                    .items
+                    .iter()
+                    .map(|item| item.output_name.clone())
+                    .collect(),
+                rows,
+                notices: Vec::new(),
+            },
+        ),
+        _ => SqlWriteResult::affected(rows_affected),
+    })
 }
 
 async fn entity_upsert(
@@ -1798,7 +1837,7 @@ async fn entity_delete(
     }
 }
 
-fn empty_entity_delete_returning_result(plan: &LogicalWritePlan) -> SqlWriteResult {
+fn empty_entity_returning_result(plan: &LogicalWritePlan) -> SqlWriteResult {
     plan.bound.returning.as_ref().map_or_else(
         || SqlWriteResult::affected(0),
         |returning| {
@@ -4097,19 +4136,12 @@ fn validate_bound_write_supported(
             validate_expr_supported(&item.expr)?;
         }
     }
-    if plan.bound.returning.is_some() && plan.bound.op != BoundWriteOp::Delete {
-        let action = match plan.bound.op {
-            BoundWriteOp::Insert => "INSERT",
-            BoundWriteOp::Update => "UPDATE",
-            BoundWriteOp::Delete => unreachable!("DELETE RETURNING is supported"),
-        };
+    if plan.bound.returning.is_some() && plan.bound.op == BoundWriteOp::Update {
         return Err(LixError::new(
             LixError::CODE_UNSUPPORTED_SQL,
-            format!("{action} RETURNING is not supported for registered entity surfaces"),
+            "UPDATE RETURNING is not supported for registered entity surfaces",
         )
-        .with_hint(format!(
-            "Run the {action} without RETURNING, then SELECT the row explicitly."
-        )));
+        .with_hint("Run the UPDATE without RETURNING, then SELECT the row explicitly."));
     }
     Ok(())
 }

--- a/packages/engine/tests/integration/sql/information_schema.rs
+++ b/packages/engine/tests/integration/sql/information_schema.rs
@@ -1257,30 +1257,28 @@ simulation_test!(
             assert_eq!(error.code, LixError::CODE_TYPE_MISMATCH);
         }
 
-        for sql in [
-            "INSERT INTO engine_excluded_typed_default (id, status) \
-             VALUES ('unsupported-returning-insert', 'x') RETURNING id",
-            "UPDATE engine_excluded_typed_default SET status = 'changed' \
-             WHERE id = 'same' RETURNING id",
-        ] {
-            let error = session
-                .execute(sql, &[])
-                .await
-                .expect_err("unsupported entity RETURNING must not be silently ignored");
-            assert_eq!(error.code, LixError::CODE_UNSUPPORTED_SQL, "{sql}");
-            assert!(error.message.contains("RETURNING"), "{error:?}");
-        }
         assert_rows_eq(
             session
                 .execute(
-                    "SELECT id FROM engine_excluded_typed_default \
-                     WHERE id = 'unsupported-returning-insert'",
+                    "INSERT INTO engine_excluded_typed_default (id, status) \
+                     VALUES ('insert-returning', 'x') RETURNING id, status AS inserted_status",
                     &[],
                 )
                 .await
-                .expect("rejected INSERT RETURNING must not write"),
-            vec![],
+                .expect("entity INSERT RETURNING should expose the staged row"),
+            vec![vec![
+                Value::Text("insert-returning".to_string()),
+                Value::Text("x".to_string()),
+            ]],
         );
+        let update_sql = "UPDATE engine_excluded_typed_default SET status = 'changed' \
+                          WHERE id = 'same' RETURNING id";
+        let error = session
+            .execute(update_sql, &[])
+            .await
+            .expect_err("unsupported UPDATE RETURNING must not be silently ignored");
+        assert_eq!(error.code, LixError::CODE_UNSUPPORTED_SQL);
+        assert!(error.message.contains("RETURNING"), "{error:?}");
         assert_rows_eq(
             session
                 .execute(


### PR DESCRIPTION
## Summary
- bind `INSERT ... RETURNING` for registered entity surfaces
- materialize returned values directly from the certified staged snapshots
- preserve aliases, wildcard projections, and empty-result behavior without a compatibility SELECT

## Performance

In the inlang Sherlock nested-insert benchmark, removing three compatibility readbacks reduced Lix mean latency from **3.08 ms to 1.20 ms** (**61% faster**). SQLite WASM measured 0.316 ms in the same run.

## Validation
- `cargo test -p lix_engine --features all-simulations typed_entity_upsert_materializes_omitted_defaults_in_excluded`
- `cargo test -p lix_engine bind_statement_allows_only_commit_id_for_diff_command_insert_returning`
- inlang `common-operations.bench.ts -t "insert bundle"`

No changenote: performance/compatibility stack under active development.