### PR TITLE
feat(engine): support RETURNING across SQL CRUD

### DIFF
--- a/.changenotes/sql-crud-returning.md
+++ b/.changenotes/sql-crud-returning.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+SQL writes now support `RETURNING` across registered entities and writable filesystem and branch surfaces. INSERT and UPDATE return final post-write values (including generated defaults), while DELETE continues to return the removed row values.

--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -191,3 +191,8 @@ required-features = ["lix_engine/storage-benches", "rocksdb", "slatedb"]
 name = "entity_pk_layout"
 path = "benches/entity_pk_layout.rs"
 harness = false
+
+[[bench]]
+name = "registered_entity_returning"
+path = "benches/registered_entity_returning.rs"
+harness = false

--- a/packages/engine-benchmarks/benches/registered_entity_returning.rs
+++ b/packages/engine-benchmarks/benches/registered_entity_returning.rs
@@ -1,0 +1,603 @@
+//! Opt-in SQL profiling probe for registered-entity `RETURNING` writes.
+//!
+//! The timer encloses only the target write. Each sample receives a fresh
+//! in-memory engine, registered schema, and (for UPDATE) seeded rows before
+//! timing starts, so fixture construction and seed writes are excluded. Cases
+//! are rotated on every round to avoid a fixed run-order advantage.
+//!
+//! ```text
+//! LIX_RETURNING_PROFILE=1 cargo bench -p lix_engine_benchmarks \
+//!   --no-default-features --bench registered_entity_returning
+//!
+//! LIX_RETURNING_PROFILE=1 LIX_RETURNING_PROFILE_ROWS=10000 \
+//! LIX_RETURNING_PROFILE_ROUNDS=15 LIX_RETURNING_PROFILE_OPERATIONS=insert \
+//!   cargo bench -p lix_engine_benchmarks --no-default-features \
+//!   --bench registered_entity_returning
+//! ```
+//!
+//! `LIX_RETURNING_PROFILE_ROWS`, `LIX_RETURNING_PROFILE_ROUNDS`, and
+//! `LIX_RETURNING_PROFILE_WARMUP_ROUNDS` are positive integer environment
+//! variables. `LIX_RETURNING_PROFILE_OPERATIONS` accepts a comma-separated
+//! subset of `insert,update`; each selected operation always measures both
+//! its ordinary and RETURNING forms. Set
+//! `LIX_RETURNING_PROFILE_PROJECTION=wildcard` to exercise `RETURNING *`,
+//! which includes transaction-derived audit fields and its staged postimage
+//! lookup; the default `columns` measures `RETURNING id, payload`. Set
+//! `LIX_RETURNING_PROFILE_EXPLICIT_PRESTAGED=1` to also measure one write in
+//! an explicit transaction after `LIX_RETURNING_PROFILE_ROWS` prior rows have
+//! been staged. With `projection=wildcard`, that isolates the statement
+//! checkpoint needed by staged postimage projection.
+
+use std::fmt::Write as _;
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use lix_engine::storage::Memory;
+use lix_engine::{Engine, ExecuteResult, SessionContext};
+
+const DEFAULT_ROWS: usize = 1_000;
+const DEFAULT_ROUNDS: usize = 11;
+const DEFAULT_WARMUP_ROUNDS: usize = 1;
+const ENTITY_TABLE: &str = "benchmark_returning_entity";
+const REGISTER_SCHEMA_SQL: &str = "INSERT INTO lix_registered_schema \
+    (value, lixcol_global, lixcol_untracked) VALUES (\
+    lix_json('{\"x-lix-key\":\"benchmark_returning_entity\",\
+    \"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\
+    \"properties\":{\"id\":{\"type\":\"string\"},\
+    \"payload\":{\"type\":\"string\"}},\"required\":[\"id\",\"payload\"],\
+    \"additionalProperties\":false}'), false, false)";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Operation {
+    Insert,
+    Update,
+}
+
+impl Operation {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Insert => "insert",
+            Self::Update => "update",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Case {
+    operation: Operation,
+    returning: bool,
+}
+
+const CASES: [Case; 4] = [
+    Case {
+        operation: Operation::Insert,
+        returning: false,
+    },
+    Case {
+        operation: Operation::Insert,
+        returning: true,
+    },
+    Case {
+        operation: Operation::Update,
+        returning: false,
+    },
+    Case {
+        operation: Operation::Update,
+        returning: true,
+    },
+];
+
+#[derive(Clone, Copy, Debug)]
+struct OperationSelection {
+    insert: bool,
+    update: bool,
+}
+
+impl OperationSelection {
+    fn from_env() -> Self {
+        let Some(raw) = std::env::var_os("LIX_RETURNING_PROFILE_OPERATIONS") else {
+            return Self {
+                insert: true,
+                update: true,
+            };
+        };
+
+        let raw = raw
+            .into_string()
+            .unwrap_or_else(|_| panic!("LIX_RETURNING_PROFILE_OPERATIONS must be valid UTF-8"));
+        let mut selection = Self {
+            insert: false,
+            update: false,
+        };
+        for operation in raw
+            .split(',')
+            .map(str::trim)
+            .filter(|part| !part.is_empty())
+        {
+            match operation {
+                "insert" => selection.insert = true,
+                "update" => selection.update = true,
+                _ => panic!(
+                    "LIX_RETURNING_PROFILE_OPERATIONS supports only 'insert' and 'update', got {operation:?}"
+                ),
+            }
+        }
+        assert!(
+            selection.insert || selection.update,
+            "LIX_RETURNING_PROFILE_OPERATIONS must select at least one operation"
+        );
+        selection
+    }
+
+    const fn includes(self, operation: Operation) -> bool {
+        match operation {
+            Operation::Insert => self.insert,
+            Operation::Update => self.update,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ReturningProjection {
+    Columns,
+    Wildcard,
+}
+
+impl ReturningProjection {
+    fn from_env() -> Self {
+        match std::env::var("LIX_RETURNING_PROFILE_PROJECTION") {
+            Ok(value) if value == "wildcard" => Self::Wildcard,
+            Ok(value) if value == "columns" => Self::Columns,
+            Ok(value) => panic!(
+                "LIX_RETURNING_PROFILE_PROJECTION supports only 'columns' or 'wildcard', got {value:?}"
+            ),
+            Err(std::env::VarError::NotPresent) => Self::Columns,
+            Err(std::env::VarError::NotUnicode(_)) => {
+                panic!("LIX_RETURNING_PROFILE_PROJECTION must be valid UTF-8")
+            }
+        }
+    }
+
+    const fn sql(self) -> &'static str {
+        match self {
+            Self::Columns => "id, payload",
+            Self::Wildcard => "*",
+        }
+    }
+
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Columns => "columns",
+            Self::Wildcard => "wildcard",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Config {
+    rows: usize,
+    rounds: usize,
+    warmup_rounds: usize,
+    operations: OperationSelection,
+    returning_projection: ReturningProjection,
+    explicit_pre_staged: bool,
+}
+
+impl Config {
+    fn from_env() -> Self {
+        Self {
+            rows: positive_env_usize("LIX_RETURNING_PROFILE_ROWS", DEFAULT_ROWS),
+            rounds: positive_env_usize("LIX_RETURNING_PROFILE_ROUNDS", DEFAULT_ROUNDS),
+            warmup_rounds: positive_env_usize(
+                "LIX_RETURNING_PROFILE_WARMUP_ROUNDS",
+                DEFAULT_WARMUP_ROUNDS,
+            ),
+            operations: OperationSelection::from_env(),
+            returning_projection: ReturningProjection::from_env(),
+            explicit_pre_staged: enabled_env_flag("LIX_RETURNING_PROFILE_EXPLICIT_PRESTAGED"),
+        }
+    }
+}
+
+struct SqlPlans {
+    rows: usize,
+    returning_projection: ReturningProjection,
+    insert: String,
+    insert_returning: String,
+    update: String,
+    update_returning: String,
+}
+
+impl SqlPlans {
+    fn new(rows: usize, returning_projection: ReturningProjection) -> Self {
+        let mut values = String::with_capacity(rows.saturating_mul(32));
+        for index in 0..rows {
+            if index > 0 {
+                values.push_str(", ");
+            }
+            write!(values, "('{}', 'before')", row_id(index)).expect("write benchmark INSERT row");
+        }
+
+        let insert = format!("INSERT INTO {ENTITY_TABLE} (id, payload) VALUES {values}");
+        let insert_returning = format!("{insert} RETURNING {}", returning_projection.sql());
+        let update = format!("UPDATE {ENTITY_TABLE} SET payload = 'after'");
+        let update_returning = format!("{update} RETURNING {}", returning_projection.sql());
+        Self {
+            rows,
+            returning_projection,
+            insert,
+            insert_returning,
+            update,
+            update_returning,
+        }
+    }
+
+    fn sql(&self, case: Case) -> &str {
+        match (case.operation, case.returning) {
+            (Operation::Insert, false) => &self.insert,
+            (Operation::Insert, true) => &self.insert_returning,
+            (Operation::Update, false) => &self.update,
+            (Operation::Update, true) => &self.update_returning,
+        }
+    }
+}
+
+fn main() {
+    if std::env::var_os("LIX_RETURNING_PROFILE").is_none() {
+        print_usage();
+        return;
+    }
+
+    let config = Config::from_env();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("create registered-entity RETURNING profile runtime");
+    runtime.block_on(run(config));
+}
+
+fn print_usage() {
+    println!(
+        "registered_entity_returning is opt-in; run \
+         LIX_RETURNING_PROFILE=1 cargo bench -p lix_engine_benchmarks \
+         --no-default-features --bench registered_entity_returning"
+    );
+}
+
+async fn run(config: Config) {
+    let plans = SqlPlans::new(config.rows, config.returning_projection);
+    println!(
+        "registered_entity_returning suite=registered_entity_write rows={} rounds={} \
+         warmup_rounds={} projection={} operations=insert:{},update:{}",
+        config.rows,
+        config.rounds,
+        config.warmup_rounds,
+        config.returning_projection.name(),
+        config.operations.insert,
+        config.operations.update,
+    );
+
+    for round in 0..config.warmup_rounds {
+        run_round(&plans, config.operations, round, None).await;
+    }
+
+    let mut samples: [Vec<u128>; CASES.len()] =
+        std::array::from_fn(|_| Vec::with_capacity(config.rounds));
+    for round in 0..config.rounds {
+        run_round(&plans, config.operations, round, Some(&mut samples)).await;
+    }
+
+    for (index, case) in CASES.into_iter().enumerate() {
+        let sample_set = &samples[index];
+        if sample_set.is_empty() {
+            continue;
+        }
+        let p50 = median_ns(sample_set);
+        println!(
+            "registered_entity_returning summary operation={} returning={} rows={} \
+             rounds={} p50_ns={p50} median_ns={p50} p50_ns_per_row={:.3}",
+            case.operation.name(),
+            case.returning,
+            plans.rows,
+            sample_set.len(),
+            p50 as f64 / plans.rows as f64,
+        );
+    }
+
+    print_returning_overhead(&samples, Operation::Insert, plans.rows);
+    print_returning_overhead(&samples, Operation::Update, plans.rows);
+    if config.explicit_pre_staged {
+        run_explicit_pre_staged_profile(&plans, config.rounds, config.warmup_rounds).await;
+    }
+}
+
+async fn run_round(
+    plans: &SqlPlans,
+    operations: OperationSelection,
+    round: usize,
+    mut samples: Option<&mut [Vec<u128>; CASES.len()]>,
+) {
+    for offset in 0..CASES.len() {
+        let case_index = (round + offset) % CASES.len();
+        let case = CASES[case_index];
+        if !operations.includes(case.operation) {
+            continue;
+        }
+
+        let elapsed = measure_case(plans, case).await;
+        if let Some(samples) = samples.as_deref_mut() {
+            samples[case_index].push(elapsed.as_nanos());
+            println!(
+                "registered_entity_returning sample operation={} returning={} rows={} \
+                 round={round} elapsed_ns={}",
+                case.operation.name(),
+                case.returning,
+                plans.rows,
+                elapsed.as_nanos(),
+            );
+        }
+    }
+}
+
+async fn measure_case(plans: &SqlPlans, case: Case) -> Duration {
+    let session = match case.operation {
+        Operation::Insert => new_fixture().await,
+        Operation::Update => seeded_fixture(plans).await,
+    };
+    let sql = plans.sql(case);
+    let started = Instant::now();
+    let result = session.execute(sql, &[]).await.unwrap_or_else(|error| {
+        panic!(
+            "registered-entity {} benchmark SQL failed: {error:?}\\nSQL: {sql}",
+            case.operation.name()
+        )
+    });
+    let elapsed = started.elapsed();
+
+    assert_result(case, &result, plans.rows, plans.returning_projection);
+    black_box(result);
+    elapsed
+}
+
+/// Measures the explicit-transaction path after it already owns a large
+/// staged journal. The ordinary projection skips the checkpoint because it is
+/// evaluated before stage; wildcard includes audit columns and exercises the
+/// post-stage checkpoint path.
+async fn run_explicit_pre_staged_profile(plans: &SqlPlans, rounds: usize, warmup_rounds: usize) {
+    println!(
+        "registered_entity_returning explicit_pre_staged rows={} rounds={} warmup_rounds={} \
+         projection={}",
+        plans.rows,
+        rounds,
+        warmup_rounds,
+        plans.returning_projection.name(),
+    );
+    for round in 0..warmup_rounds {
+        let returning = round % 2 == 1;
+        measure_explicit_pre_staged_case(plans, returning).await;
+    }
+
+    let mut plain = Vec::with_capacity(rounds);
+    let mut returning = Vec::with_capacity(rounds);
+    for round in 0..rounds {
+        for returning_case in [round % 2 == 1, round % 2 == 0] {
+            let elapsed = measure_explicit_pre_staged_case(plans, returning_case).await;
+            let samples = if returning_case {
+                &mut returning
+            } else {
+                &mut plain
+            };
+            samples.push(elapsed.as_nanos());
+            println!(
+                "registered_entity_returning explicit_pre_staged sample returning={} \
+                 rows={} round={round} elapsed_ns={}",
+                returning_case,
+                plans.rows,
+                elapsed.as_nanos(),
+            );
+        }
+    }
+    let plain_p50 = median_ns(&plain);
+    let returning_p50 = median_ns(&returning);
+    println!(
+        "registered_entity_returning explicit_pre_staged comparison rows={} \
+         projection={} non_returning_p50_ns={} returning_p50_ns={} \
+         returning_to_non_returning_ratio={:.3}x",
+        plans.rows,
+        plans.returning_projection.name(),
+        plain_p50,
+        returning_p50,
+        returning_p50 as f64 / plain_p50 as f64,
+    );
+}
+
+async fn measure_explicit_pre_staged_case(plans: &SqlPlans, returning: bool) -> Duration {
+    let session = new_fixture().await;
+    let mut transaction = session
+        .begin_transaction()
+        .await
+        .expect("open explicit registered-entity RETURNING benchmark transaction");
+    let seeded = transaction
+        .execute(&plans.insert, &[])
+        .await
+        .expect("seed explicit registered-entity RETURNING benchmark rows");
+    assert_eq!(
+        seeded.rows_affected(),
+        u64::try_from(plans.rows).expect("benchmark row count fits u64")
+    );
+
+    let mut sql = format!(
+        "INSERT INTO {ENTITY_TABLE} (id, payload) \
+         VALUES ('explicit-returning-checkpoint-target', 'after')"
+    );
+    if returning {
+        write!(sql, " RETURNING {}", plans.returning_projection.sql())
+            .expect("write explicit benchmark RETURNING projection");
+    }
+    let started = Instant::now();
+    let result = transaction
+        .execute(&sql, &[])
+        .await
+        .unwrap_or_else(|error| {
+            panic!(
+                "explicit registered-entity RETURNING benchmark SQL failed: {error:?}\nSQL: {sql}"
+            )
+        });
+    let elapsed = started.elapsed();
+
+    assert_eq!(result.rows_affected(), 1);
+    if returning {
+        assert_eq!(result.len(), 1);
+    } else {
+        assert!(result.is_empty());
+    }
+    black_box(result);
+    transaction
+        .rollback()
+        .await
+        .expect("rollback explicit registered-entity RETURNING benchmark transaction");
+    elapsed
+}
+
+async fn new_fixture() -> SessionContext<Memory> {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize registered-entity RETURNING benchmark storage");
+    let engine = Engine::new(storage)
+        .await
+        .expect("open registered-entity RETURNING benchmark engine");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("open registered-entity RETURNING benchmark session");
+    let registration = session
+        .execute(REGISTER_SCHEMA_SQL, &[])
+        .await
+        .expect("register benchmark entity schema");
+    assert_eq!(registration.rows_affected(), 1);
+    session
+}
+
+async fn seeded_fixture(plans: &SqlPlans) -> SessionContext<Memory> {
+    let session = new_fixture().await;
+    let seed = session
+        .execute(&plans.insert, &[])
+        .await
+        .expect("seed registered-entity UPDATE benchmark rows");
+    assert_eq!(
+        seed.rows_affected(),
+        u64::try_from(plans.rows).expect("benchmark row count fits u64")
+    );
+    session
+}
+
+fn assert_result(
+    case: Case,
+    result: &ExecuteResult,
+    rows: usize,
+    returning_projection: ReturningProjection,
+) {
+    assert_eq!(
+        result.rows_affected(),
+        u64::try_from(rows).expect("benchmark row count fits u64"),
+        "{} benchmark should affect every fixture row",
+        case.operation.name()
+    );
+    if case.returning {
+        assert_eq!(result.len(), rows);
+        match returning_projection {
+            ReturningProjection::Columns => assert_eq!(
+                result
+                    .columns()
+                    .iter()
+                    .map(String::as_str)
+                    .collect::<Vec<_>>(),
+                vec!["id", "payload"],
+                "RETURNING result should preserve its selected columns"
+            ),
+            ReturningProjection::Wildcard => {
+                assert!(result.columns().iter().any(|column| column == "id"));
+                assert!(result.columns().iter().any(|column| column == "payload"));
+                assert!(
+                    result
+                        .columns()
+                        .iter()
+                        .any(|column| column == "lixcol_commit_id"),
+                    "RETURNING * should exercise the staged audit postimage path"
+                );
+            }
+        }
+    } else {
+        assert!(result.is_empty());
+        assert!(result.columns().is_empty());
+    }
+}
+
+fn print_returning_overhead(samples: &[Vec<u128>; CASES.len()], operation: Operation, rows: usize) {
+    let plain_index = CASES
+        .iter()
+        .position(|case| case.operation == operation && !case.returning)
+        .expect("non-RETURNING case is registered");
+    let returning_index = CASES
+        .iter()
+        .position(|case| case.operation == operation && case.returning)
+        .expect("RETURNING case is registered");
+    let plain = &samples[plain_index];
+    let returning = &samples[returning_index];
+    if plain.is_empty() || returning.is_empty() {
+        return;
+    }
+
+    let plain_p50 = median_ns(plain);
+    let returning_p50 = median_ns(returning);
+    println!(
+        "registered_entity_returning comparison operation={} rows={rows} \
+         non_returning_p50_ns={plain_p50} returning_p50_ns={returning_p50} \
+         returning_to_non_returning_ratio={:.3}x",
+        operation.name(),
+        returning_p50 as f64 / plain_p50 as f64,
+    );
+}
+
+fn median_ns(samples: &[u128]) -> u128 {
+    assert!(!samples.is_empty(), "median needs at least one sample");
+    let mut sorted = samples.to_vec();
+    sorted.sort_unstable();
+    let upper = sorted[sorted.len() / 2];
+    let lower = sorted[(sorted.len() - 1) / 2];
+    lower + (upper - lower) / 2
+}
+
+fn positive_env_usize(name: &str, default: usize) -> usize {
+    let Some(value) = std::env::var_os(name) else {
+        return default;
+    };
+    let value = value
+        .into_string()
+        .unwrap_or_else(|_| panic!("{name} must be valid UTF-8"));
+    let parsed = value
+        .parse::<usize>()
+        .unwrap_or_else(|_| panic!("{name} must be a positive integer, got {value:?}"));
+    assert!(
+        parsed > 0,
+        "{name} must be a positive integer, got {value:?}"
+    );
+    parsed
+}
+
+fn enabled_env_flag(name: &str) -> bool {
+    let Some(value) = std::env::var_os(name) else {
+        return false;
+    };
+    match value.to_str() {
+        Some("1" | "true") => true,
+        Some("0" | "false") => false,
+        Some(value) => panic!("{name} must be one of '1', '0', 'true', or 'false', got {value:?}"),
+        None => panic!("{name} must be valid UTF-8"),
+    }
+}
+
+fn row_id(index: usize) -> String {
+    format!("row-{index:012}")
+}

--- a/packages/engine/src/checkpoint.rs
+++ b/packages/engine/src/checkpoint.rs
@@ -3,9 +3,9 @@ use std::collections::{HashMap, HashSet};
 use serde_json::json;
 
 use crate::LixError;
-use crate::changelog::{
-    ChangeRecordProjection, ChangelogContext, ChangelogReader, CommitId, CommitScanRequest,
-};
+use crate::changelog::{ChangeRecordProjection, CommitId};
+#[cfg(any(test, feature = "storage-benches"))]
+use crate::changelog::{ChangelogContext, ChangelogReader, CommitScanRequest};
 use crate::commit_graph::{
     CommitGraphChangeHistoryRequest, CommitGraphCommitRecord, CommitGraphReader,
 };
@@ -15,6 +15,7 @@ use crate::tracked_state::{TrackedStateKey, TrackedStateStoreReader};
 use crate::transaction::types::{TransactionJson, TransactionWriteRow};
 
 pub(crate) const CHECKPOINT_MARKER_SCHEMA_KEY: &str = "lix_checkpoint_marker";
+#[cfg(any(test, feature = "storage-benches"))]
 const CHECKPOINT_RECORD_SCAN_PAGE_SIZE: usize = 1_024;
 
 /// Record-only index used while materializing an unbounded checkpoint history.
@@ -57,6 +58,7 @@ pub(crate) fn checkpoint_marker_stage_row(branch_id: &str) -> TransactionWriteRo
 /// The SQL provider constructs this once for an unbounded checkpoint query and
 /// shares it between branch heads. Bounded `LIMIT` queries retain the smaller
 /// point-walk path below.
+#[cfg(any(test, feature = "storage-benches"))]
 pub(crate) async fn scan_checkpoint_commit_records<S>(
     store: S,
 ) -> Result<CheckpointCommitRecords, LixError>

--- a/packages/engine/src/filesystem/path_index.rs
+++ b/packages/engine/src/filesystem/path_index.rs
@@ -1187,6 +1187,16 @@ pub(crate) struct FilesystemPathIndexCache {
 }
 
 impl FilesystemPathIndexCache {
+    /// Evicts transaction-local cached views after restoring an earlier staged
+    /// write checkpoint. Rebuilding from the restored overlay is cheaper and
+    /// safer than cloning potentially large path indexes for an error path.
+    pub(crate) fn clear(&self) {
+        self.entries
+            .lock()
+            .expect("filesystem path cache lock poisoned")
+            .clear();
+    }
+
     pub(crate) fn get(
         &self,
         request: &FilesystemPathIndexRequest,

--- a/packages/engine/src/functions/deterministic.rs
+++ b/packages/engine/src/functions/deterministic.rs
@@ -1,5 +1,5 @@
 use crate::common::LixTimestamp;
-use crate::functions::FunctionProvider;
+use crate::functions::{FunctionProvider, FunctionProviderCheckpoint};
 
 const DETERMINISTIC_UUID_COUNTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
 
@@ -56,6 +56,22 @@ impl FunctionProvider for DeterministicFunctionProvider {
 
     fn deterministic_sequence_persist_highest_seen(&self) -> Option<i64> {
         self.highest_seen()
+    }
+
+    fn statement_checkpoint(&self) -> Option<FunctionProviderCheckpoint> {
+        Some(FunctionProviderCheckpoint::DeterministicSequence {
+            next_sequence: self.next_sequence,
+            highest_seen: self.highest_seen,
+        })
+    }
+
+    fn restore_statement_checkpoint(&mut self, checkpoint: FunctionProviderCheckpoint) {
+        let FunctionProviderCheckpoint::DeterministicSequence {
+            next_sequence,
+            highest_seen,
+        } = checkpoint;
+        self.next_sequence = next_sequence;
+        self.highest_seen = highest_seen;
     }
 }
 
@@ -118,5 +134,29 @@ mod tests {
             "01920000-0000-7000-8000-00000000002a"
         );
         assert_eq!(provider.highest_seen(), Some(42));
+    }
+
+    #[test]
+    fn statement_checkpoint_restores_consumed_sequence() {
+        let mut provider = DeterministicFunctionProvider::new(0, false);
+        assert_eq!(
+            provider.uuid_v7().to_string(),
+            "01920000-0000-7000-8000-000000000000"
+        );
+
+        let checkpoint = provider
+            .statement_checkpoint()
+            .expect("deterministic provider should be checkpointable");
+        assert_eq!(
+            provider.uuid_v7().to_string(),
+            "01920000-0000-7000-8000-000000000001"
+        );
+
+        provider.restore_statement_checkpoint(checkpoint);
+        assert_eq!(
+            provider.uuid_v7().to_string(),
+            "01920000-0000-7000-8000-000000000001"
+        );
+        assert_eq!(provider.highest_seen(), Some(1));
     }
 }

--- a/packages/engine/src/functions/mod.rs
+++ b/packages/engine/src/functions/mod.rs
@@ -12,7 +12,9 @@ mod types;
 
 pub(crate) use context::FunctionContext;
 pub(crate) use deterministic::DeterministicFunctionProvider;
-pub(crate) use provider::{FunctionProvider, FunctionProviderHandle, SystemFunctionProvider};
+pub(crate) use provider::{
+    FunctionProvider, FunctionProviderCheckpoint, FunctionProviderHandle, SystemFunctionProvider,
+};
 #[cfg(feature = "storage-benches")]
 pub(crate) use state::DETERMINISTIC_MODE_KEY;
 pub(crate) use state::DETERMINISTIC_SEQUENCE_KEY;

--- a/packages/engine/src/functions/provider.rs
+++ b/packages/engine/src/functions/provider.rs
@@ -3,6 +3,17 @@ use std::sync::{Arc, Mutex};
 use crate::cel::CelFunctionProvider;
 use crate::common::LixTimestamp;
 
+/// Restorable runtime-function state captured around an explicit SQL
+/// statement. Only deterministic providers have durable state that must be
+/// rewound when a post-stage statement error is rolled back.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FunctionProviderCheckpoint {
+    DeterministicSequence {
+        next_sequence: i64,
+        highest_seen: Option<i64>,
+    },
+}
+
 /// Engine-owned runtime function provider trait.
 pub(crate) trait FunctionProvider: Send {
     fn uuid_v7(&mut self) -> uuid::Uuid;
@@ -11,6 +22,12 @@ pub(crate) trait FunctionProvider: Send {
     fn deterministic_sequence_persist_highest_seen(&self) -> Option<i64> {
         None
     }
+
+    fn statement_checkpoint(&self) -> Option<FunctionProviderCheckpoint> {
+        None
+    }
+
+    fn restore_statement_checkpoint(&mut self, _checkpoint: FunctionProviderCheckpoint) {}
 }
 
 #[derive(Clone)]
@@ -46,6 +63,19 @@ impl FunctionProviderHandle {
         match self {
             Self::System => None,
             Self::Shared(provider) => provider.deterministic_sequence_persist_highest_seen(),
+        }
+    }
+
+    pub(crate) fn statement_checkpoint(&self) -> Option<FunctionProviderCheckpoint> {
+        match self {
+            Self::System => None,
+            Self::Shared(provider) => provider.statement_checkpoint(),
+        }
+    }
+
+    pub(crate) fn restore_statement_checkpoint(&self, checkpoint: FunctionProviderCheckpoint) {
+        if let Self::Shared(provider) = self {
+            provider.restore_statement_checkpoint(checkpoint);
         }
     }
 }
@@ -112,6 +142,14 @@ where
     pub(crate) fn deterministic_sequence_persist_highest_seen(&self) -> Option<i64> {
         self.with_lock(FunctionProvider::deterministic_sequence_persist_highest_seen)
     }
+
+    pub(crate) fn statement_checkpoint(&self) -> Option<FunctionProviderCheckpoint> {
+        self.with_lock(FunctionProvider::statement_checkpoint)
+    }
+
+    pub(crate) fn restore_statement_checkpoint(&self, checkpoint: FunctionProviderCheckpoint) {
+        self.with_lock_mut(|provider| provider.restore_statement_checkpoint(checkpoint));
+    }
 }
 
 impl<P> CelFunctionProvider for SharedFunctionProvider<P>
@@ -142,6 +180,14 @@ where
     fn deterministic_sequence_persist_highest_seen(&self) -> Option<i64> {
         Self::deterministic_sequence_persist_highest_seen(self)
     }
+
+    fn statement_checkpoint(&self) -> Option<FunctionProviderCheckpoint> {
+        Self::statement_checkpoint(self)
+    }
+
+    fn restore_statement_checkpoint(&mut self, checkpoint: FunctionProviderCheckpoint) {
+        Self::restore_statement_checkpoint(self, checkpoint);
+    }
 }
 
 impl<T> FunctionProvider for Box<T>
@@ -158,6 +204,14 @@ where
 
     fn deterministic_sequence_persist_highest_seen(&self) -> Option<i64> {
         (**self).deterministic_sequence_persist_highest_seen()
+    }
+
+    fn statement_checkpoint(&self) -> Option<FunctionProviderCheckpoint> {
+        (**self).statement_checkpoint()
+    }
+
+    fn restore_statement_checkpoint(&mut self, checkpoint: FunctionProviderCheckpoint) {
+        (**self).restore_statement_checkpoint(checkpoint);
     }
 }
 

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -2155,23 +2155,52 @@ where
             if is_read {
                 transaction.ensure_opening_snapshot_is_current().await?;
             }
-            let result = execute_transaction_statement(
-                transaction,
-                sql,
-                statement,
-                params,
-                options,
-                ExecuteStatementMetadata::default(),
-            )
-            .await
-            .map_err(|error| normalize_sql_surface_error(error, sql))?;
-            if is_read {
-                // The query opens its own coherent storage read. Checking on both sides
-                // ensures a concurrent tracked commit cannot leak a newer snapshot
-                // through an older explicit transaction.
-                transaction.ensure_opening_snapshot_is_current().await?;
+            // A successful explicit transaction retains its function provider
+            // until commit. Rewind deterministic runtime state whenever this
+            // statement fails, including errors before a direct RETURNING
+            // write reaches staging.
+            let function_checkpoint = transaction.functions().statement_checkpoint();
+            let result = async {
+                let result = if is_read {
+                    execute_transaction_statement(
+                        transaction,
+                        sql,
+                        statement,
+                        params,
+                        options,
+                        ExecuteStatementMetadata::default(),
+                    )
+                    .await
+                } else {
+                    execute_transaction_write_auto(
+                        transaction,
+                        sql,
+                        statement,
+                        params,
+                        options,
+                        ExecuteStatementMetadata::default(),
+                        true,
+                    )
+                    .await
+                };
+                let result = result.map_err(|error| normalize_sql_surface_error(error, sql))?;
+                if is_read {
+                    // The query opens its own coherent storage read. Checking on both sides
+                    // ensures a concurrent tracked commit cannot leak a newer snapshot
+                    // through an older explicit transaction.
+                    transaction.ensure_opening_snapshot_is_current().await?;
+                }
+                Ok(result)
             }
-            Ok(result)
+            .await;
+            if result.is_err() {
+                if let Some(function_checkpoint) = function_checkpoint {
+                    transaction
+                        .functions()
+                        .restore_statement_checkpoint(function_checkpoint);
+                }
+            }
+            result
         };
         let result = match telemetry.as_ref() {
             Some(telemetry) => telemetry.instrument(operation).await,
@@ -2381,6 +2410,7 @@ async fn execute_transaction_write_auto<StorageImpl>(
     params: &[Value],
     options: ExecuteOptions,
     metadata: ExecuteStatementMetadata,
+    checkpoint_post_stage_returning: bool,
 ) -> Result<ExecuteResult, LixError>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
@@ -2388,8 +2418,20 @@ where
     let previous_origin_key = transaction.replace_origin_key(options.origin_key);
     let result = async {
         let tx_plan = transaction.prepare_sql_write_logical_plan(sql, &statement)?;
+        let checkpoint = (checkpoint_post_stage_returning
+            && sql2::write_plan_requires_post_stage_returning_checkpoint(&tx_plan))
+        .then(|| transaction.begin_sql_statement_checkpoint())
+        .transpose()?;
         let result =
-            execute_prepared_transaction_write(transaction, tx_plan, params, &metadata).await?;
+            execute_prepared_transaction_write(transaction, tx_plan, params, &metadata).await;
+        if result.is_err() {
+            if let Some(checkpoint) = checkpoint {
+                transaction
+                    .rollback_sql_statement_checkpoint(checkpoint)
+                    .await?;
+            }
+        }
+        let result = result?;
         Ok(ExecuteResult::from_sql_write_result(result))
     }
     .await;
@@ -3301,8 +3343,16 @@ where
 {
     match sql2::bind_statement_route(&statement)? {
         sql2::BoundStatementRoute::Write => {
-            execute_transaction_write_auto(transaction, sql, statement, params, options, metadata)
-                .await
+            execute_transaction_write_auto(
+                transaction,
+                sql,
+                statement,
+                params,
+                options,
+                metadata,
+                false,
+            )
+            .await
         }
         sql2::BoundStatementRoute::Read => transaction
             .execute_read_sql_statement(sql.to_string(), statement, params.to_vec())

--- a/packages/engine/src/sql2/bind/statement.rs
+++ b/packages/engine/src/sql2/bind/statement.rs
@@ -185,6 +185,7 @@ pub(super) fn bind_update_bound(
         });
     }
     let predicate = bind_optional_predicate(&table, update.selection.as_ref(), &mut params)?;
+    let returning = bind_returning(&table, update.returning.as_ref(), &mut params, "UPDATE")?;
     let branch_scope = bind_write_branch_scope(
         &table.surface.kind,
         &BoundWriteInput::None,
@@ -198,7 +199,7 @@ pub(super) fn bind_update_bound(
         predicate,
         assignments,
         conflict: None,
-        returning: None,
+        returning,
         params: params.into_map(),
         branch_scope,
     })
@@ -214,7 +215,7 @@ pub(super) fn bind_delete_bound(
     let table = bind_delete_target(catalog, &delete.from)?;
     require_write_capability(&table.surface, BoundWriteOp::Delete)?;
     let predicate = bind_optional_predicate(&table, delete.selection.as_ref(), &mut params)?;
-    let returning = bind_delete_returning(&table, delete.returning.as_ref(), &mut params)?;
+    let returning = bind_returning(&table, delete.returning.as_ref(), &mut params, "DELETE")?;
     let branch_scope = bind_write_branch_scope(
         &table.surface.kind,
         &BoundWriteInput::None,
@@ -234,13 +235,14 @@ pub(super) fn bind_delete_bound(
     })
 }
 
-/// Bind the `RETURNING` list against the target surface itself.  It is not a
-/// nested SELECT: expressions are evaluated from the exact pre-delete row
-/// batch at execution time, before that batch is staged as tombstones.
-fn bind_delete_returning(
+/// Bind a normal DML `RETURNING` list against the target surface itself. It
+/// is not a nested SELECT: execution chooses the appropriate before/after
+/// row image for the write operation.
+fn bind_returning(
     table: &BoundTable,
     returning: Option<&Vec<SelectItem>>,
     params: &mut ParamBinder,
+    action: &str,
 ) -> Result<Option<BoundReturning>, LixError> {
     let Some(returning) = returning else {
         return Ok(None);
@@ -250,7 +252,7 @@ fn bind_delete_returning(
     for item in returning {
         match item {
             SelectItem::Wildcard(options) => {
-                reject_returning_wildcard_options(options)?;
+                reject_returning_wildcard_options(options, action)?;
                 for column in table
                     .surface
                     .columns
@@ -264,9 +266,9 @@ fn bind_delete_returning(
                 }
             }
             SelectItem::QualifiedWildcard(_, _) => {
-                return Err(super::error::unsupported(
-                    "qualified wildcards in DELETE RETURNING are not supported",
-                ));
+                return Err(super::error::unsupported(format!(
+                    "qualified wildcards in {action} RETURNING are not supported"
+                )));
             }
             SelectItem::UnnamedExpr(sql_expr) => {
                 let expr = bind_expr(table, sql_expr, params)?;
@@ -286,9 +288,9 @@ fn bind_delete_returning(
     }
 
     if items.is_empty() {
-        return Err(super::error::unsupported(
-            "DELETE RETURNING requires at least one result expression",
-        ));
+        return Err(super::error::unsupported(format!(
+            "{action} RETURNING requires at least one result expression"
+        )));
     }
 
     Ok(Some(BoundReturning { items }))
@@ -302,13 +304,12 @@ fn bind_insert_returning(
     let Some(returning) = returning else {
         return Ok(None);
     };
+
     if !matches!(
         table.surface.kind,
         PublicSurfaceKind::Revert | PublicSurfaceKind::Apply | PublicSurfaceKind::CreateCheckpoint
     ) {
-        return Err(super::error::unsupported(
-            "INSERT RETURNING is only supported for diff command sinks",
-        ));
+        return bind_returning(table, Some(returning), params, "INSERT");
     }
 
     let mut items = Vec::with_capacity(returning.len());
@@ -338,16 +339,19 @@ fn bind_insert_returning(
     Ok(Some(BoundReturning { items }))
 }
 
-fn reject_returning_wildcard_options(options: &WildcardAdditionalOptions) -> Result<(), LixError> {
+fn reject_returning_wildcard_options(
+    options: &WildcardAdditionalOptions,
+    action: &str,
+) -> Result<(), LixError> {
     if options.opt_ilike.is_some()
         || options.opt_exclude.is_some()
         || options.opt_except.is_some()
         || options.opt_replace.is_some()
         || options.opt_rename.is_some()
     {
-        return Err(super::error::unsupported(
-            "DELETE RETURNING wildcard modifiers are not supported",
-        ));
+        return Err(super::error::unsupported(format!(
+            "{action} RETURNING wildcard modifiers are not supported"
+        )));
     }
     Ok(())
 }
@@ -471,11 +475,6 @@ fn reject_unsupported_update_clauses(update: &Update) -> Result<(), LixError> {
     }
     if update.from.is_some() {
         return Err(super::error::unsupported("UPDATE FROM is not supported"));
-    }
-    if update.returning.is_some() {
-        return Err(super::error::unsupported(
-            "UPDATE RETURNING is not supported",
-        ));
     }
     if update.or.is_some() {
         return Err(super::error::unsupported(
@@ -2330,11 +2329,98 @@ mod tests {
         for sql in [
             "INSERT INTO lix_revert (diff_id) SELECT diff_id FROM lix_working_diff RETURNING diff_id",
             "INSERT INTO lix_revert (diff_id) SELECT diff_id FROM lix_working_diff RETURNING *",
-            "INSERT INTO lix_file (path) VALUES ('readme.md') RETURNING id",
         ] {
             let error = bind_statement(&parse_statement(sql), &[], "branch1")
                 .expect_err("unsupported INSERT RETURNING shape should fail");
             assert_eq!(error.code, LixError::CODE_UNSUPPORTED_SQL, "{sql}");
+        }
+    }
+
+    #[test]
+    fn bind_statement_binds_returning_for_registered_entity_writes() {
+        let schema = serde_json::json!({
+            "x-lix-key": "project_task",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "title": { "type": "string" }
+            },
+            "required": ["id", "title"],
+            "additionalProperties": false,
+        });
+        let inserted = bind_statement(
+            &parse_statement(
+                "INSERT INTO project_task (id, title) VALUES ($1, $2) \
+                 RETURNING id, title AS inserted_title",
+            ),
+            std::slice::from_ref(&schema),
+            "branch1",
+        )
+        .expect("registered entity INSERT RETURNING should bind");
+        assert_eq!(
+            inserted
+                .returning
+                .expect("INSERT RETURNING should be bound")
+                .items
+                .iter()
+                .map(|item| item.output_name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["id", "inserted_title"]
+        );
+        assert_eq!(
+            inserted.params.params.keys().copied().collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+
+        let updated = bind_statement(
+            &parse_statement(
+                "UPDATE project_task SET title = $1 WHERE id = $2 \
+                 RETURNING id, title AS updated_title, $3 AS marker",
+            ),
+            std::slice::from_ref(&schema),
+            "branch1",
+        )
+        .expect("registered entity UPDATE RETURNING should bind");
+        assert_eq!(
+            updated
+                .returning
+                .expect("UPDATE RETURNING should be bound")
+                .items
+                .iter()
+                .map(|item| item.output_name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["id", "updated_title", "marker"]
+        );
+        assert_eq!(
+            updated.params.params.keys().copied().collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+    }
+
+    #[test]
+    fn bind_statement_binds_returning_on_every_writable_surface() {
+        for sql in [
+            "INSERT INTO lix_file (path) VALUES ('readme.md') RETURNING id",
+            "INSERT INTO lix_directory (path) VALUES ('/docs/') RETURNING id",
+            "UPDATE lix_file SET name = 'readme.md' RETURNING id",
+            "INSERT INTO lix_branch (id, name) VALUES ('draft', 'Draft') RETURNING id",
+        ] {
+            let bound =
+                bind_statement(&parse_statement(sql), &[], "branch1").unwrap_or_else(|error| {
+                    panic!("writable surface RETURNING should bind for {sql}: {error:?}")
+                });
+            assert_eq!(
+                bound
+                    .returning
+                    .expect("RETURNING should be bound")
+                    .items
+                    .iter()
+                    .map(|item| item.output_name.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["id"],
+                "{sql}"
+            );
         }
     }
 

--- a/packages/engine/src/sql2/bind/write.rs
+++ b/packages/engine/src/sql2/bind/write.rs
@@ -12,10 +12,11 @@ pub(crate) struct BoundWrite {
     pub(crate) predicate: BoundPredicate,
     pub(crate) assignments: Vec<BoundAssignment>,
     pub(crate) conflict: Option<BoundInsertConflict>,
-    /// The pre-change projection requested by `DELETE … RETURNING`.
+    /// The row projection requested by a DML `RETURNING` clause.
     ///
-    /// This remains part of the bound write rather than a post-hoc read so
-    /// execution can project directly from the exact batch being deleted.
+    /// It remains part of the bound write so execution can project the exact
+    /// affected image: the pre-image for DELETE and the final post-image for
+    /// INSERT, UPDATE, and UPSERT.
     pub(crate) returning: Option<BoundReturning>,
     pub(crate) params: BoundParamMap,
     pub(crate) branch_scope: BranchScope,

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -876,6 +876,7 @@ fn fast_file_data_update_shape(
         || plan.bound.op != BoundWriteOp::Update
         || !matches!(plan.bound.input, BoundWriteInput::None)
         || plan.bound.conflict.is_some()
+        || plan.bound.returning.is_some()
         || !matches!(plan.bound.branch_scope, BranchScope::Active { .. })
         || !(1..=2).contains(&plan.bound.assignments.len())
     {
@@ -988,29 +989,23 @@ async fn execute_entity_write(
         BoundWriteOp::Insert => {
             if no_op {
                 entity_insert_batch(ctx, plan, &spec, params, active_branch_commit_id.as_ref())?;
-                return Ok(SqlWriteResult::affected(0));
+                return Ok(empty_entity_returning_result(plan));
             }
             if plan.bound.conflict.is_some() {
-                entity_upsert(ctx, plan, &spec, params, active_branch_commit_id.as_ref())
-                    .await
-                    .map(SqlWriteResult::affected)
+                entity_upsert(ctx, plan, &spec, params, active_branch_commit_id.as_ref()).await
             } else {
-                entity_insert(ctx, plan, &spec, params, active_branch_commit_id.as_ref())
-                    .await
-                    .map(SqlWriteResult::affected)
+                entity_insert(ctx, plan, &spec, params, active_branch_commit_id.as_ref()).await
             }
         }
         BoundWriteOp::Update => {
             if no_op {
-                return Ok(SqlWriteResult::affected(0));
+                return Ok(empty_entity_returning_result(plan));
             }
-            entity_update(ctx, plan, &spec, params, active_branch_commit_id.as_ref())
-                .await
-                .map(SqlWriteResult::affected)
+            entity_update(ctx, plan, &spec, params, active_branch_commit_id.as_ref()).await
         }
         BoundWriteOp::Delete => {
             if no_op {
-                return Ok(empty_entity_delete_returning_result(plan));
+                return Ok(empty_entity_returning_result(plan));
             }
             if matches!(surface, EntityWriteSurface::Base { .. })
                 && matches!(plan.bound.predicate, BoundPredicate::True)
@@ -1313,7 +1308,10 @@ fn fast_file_path_write_shape(
     plan: &LogicalWritePlan,
     surface: &FileWriteSurface,
 ) -> Option<FastFilePathWriteShape> {
-    if !matches!(surface, FileWriteSurface::Base) || plan.bound.op != BoundWriteOp::Insert {
+    if !matches!(surface, FileWriteSurface::Base)
+        || plan.bound.op != BoundWriteOp::Insert
+        || plan.bound.returning.is_some()
+    {
         return None;
     }
     let BoundWriteInput::Values(values) = &plan.bound.input else {
@@ -1542,9 +1540,18 @@ async fn entity_insert(
     spec: &EntitySurfaceSpec,
     params: &[Value],
     active_branch_commit_id: Option<&CommitId>,
-) -> Result<u64, LixError> {
+) -> Result<SqlWriteResult, LixError> {
     let write_rows = entity_insert_batch(ctx, plan, spec, params, active_branch_commit_id)?;
-    stage_rows(ctx, TransactionWriteMode::Insert, write_rows).await
+    stage_entity_rows_with_postimage_returning(
+        ctx,
+        plan,
+        spec,
+        params,
+        active_branch_commit_id,
+        TransactionWriteMode::Insert,
+        write_rows,
+    )
+    .await
 }
 
 async fn entity_upsert(
@@ -1553,7 +1560,7 @@ async fn entity_upsert(
     spec: &EntitySurfaceSpec,
     params: &[Value],
     active_branch_commit_id: Option<&CommitId>,
-) -> Result<u64, LixError> {
+) -> Result<SqlWriteResult, LixError> {
     let conflict = plan.bound.conflict.as_ref().ok_or_else(|| {
         LixError::new(
             LixError::CODE_UNSUPPORTED_SQL,
@@ -1590,7 +1597,16 @@ async fn entity_upsert(
         }
     }
 
-    stage_rows(ctx, TransactionWriteMode::Replace, write_rows).await
+    stage_entity_rows_with_postimage_returning(
+        ctx,
+        plan,
+        spec,
+        params,
+        active_branch_commit_id,
+        TransactionWriteMode::Replace,
+        write_rows,
+    )
+    .await
 }
 
 fn entity_insert_batch(
@@ -1640,7 +1656,7 @@ async fn entity_update(
     spec: &EntitySurfaceSpec,
     params: &[Value],
     active_branch_commit_id: Option<&CommitId>,
-) -> Result<u64, LixError> {
+) -> Result<SqlWriteResult, LixError> {
     let candidates = scan_entity_candidates(ctx, plan, spec, params).await?;
     let mut write_rows = RawWriteBatch::with_capacity(candidates.len());
     for candidate in candidates.iter() {
@@ -1654,7 +1670,234 @@ async fn entity_update(
             active_branch_commit_id,
         )?;
     }
-    stage_rows(ctx, TransactionWriteMode::Replace, write_rows).await
+    stage_entity_rows_with_postimage_returning(
+        ctx,
+        plan,
+        spec,
+        params,
+        active_branch_commit_id,
+        TransactionWriteMode::Replace,
+        write_rows,
+    )
+    .await
+}
+
+/// Stage entity INSERT/UPDATE rows and, when requested, retain their final
+/// write images for `RETURNING`.  The post-image is evaluated from the
+/// normalized write row rather than the input expression so schema defaults
+/// (including generated IDs) and conflict updates are visible to callers.
+///
+/// Evaluation happens before staging because staging consumes the batch, but
+/// the query result is only constructed after the write is accepted. This
+/// matches the existing DELETE path's all-or-error behavior while avoiding a
+/// second lookup through the transaction overlay.
+async fn stage_entity_rows_with_postimage_returning(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    plan: &LogicalWritePlan,
+    spec: &EntitySurfaceSpec,
+    params: &[Value],
+    active_branch_commit_id: Option<&CommitId>,
+    mode: TransactionWriteMode,
+    write_rows: RawWriteBatch,
+) -> Result<SqlWriteResult, LixError> {
+    let returning_requires_staged_postimage =
+        plan.bound.returning.as_ref().is_some_and(|returning| {
+            returning
+                .items
+                .iter()
+                .any(|item| returning_expr_requires_staged_postimage(&item.expr))
+        });
+    let returning_rows = if returning_requires_staged_postimage {
+        None
+    } else {
+        entity_postimage_returning_rows(
+            plan,
+            spec,
+            ctx,
+            params,
+            active_branch_commit_id,
+            &write_rows,
+        )?
+    };
+    // Transaction staging materializes audit fields such as the change and
+    // commit IDs. Keep the direct write rows only for projections that need
+    // those fields, then read their exact transaction-overlay post-images in
+    // source order after staging succeeds.
+    let staged_postimage_rows = returning_requires_staged_postimage.then(|| write_rows.clone());
+    let rows_affected = stage_rows(ctx, mode, write_rows).await?;
+    let returning_rows = match staged_postimage_rows {
+        Some(write_rows) => {
+            entity_staged_postimage_returning_rows(
+                plan,
+                spec,
+                ctx,
+                params,
+                active_branch_commit_id,
+                &write_rows,
+            )
+            .await?
+        }
+        None => returning_rows,
+    };
+    Ok(entity_returning_result(plan, rows_affected, returning_rows))
+}
+
+fn entity_postimage_returning_rows(
+    plan: &LogicalWritePlan,
+    spec: &EntitySurfaceSpec,
+    ctx: &mut dyn SqlWriteExecutionContext,
+    params: &[Value],
+    active_branch_commit_id: Option<&CommitId>,
+    write_rows: &RawWriteBatch,
+) -> Result<Option<Vec<Vec<Value>>>, LixError> {
+    let Some(returning) = plan.bound.returning.as_ref() else {
+        return Ok(None);
+    };
+    let mut rows = Vec::with_capacity(write_rows.len());
+    for row in write_rows.iter() {
+        // Certified parameter batches intentionally retain only canonical
+        // bytes. Decoding through `TransactionJson::value()` would panic for
+        // those rows, so materialize the normalized representation here.
+        let snapshot = row
+            .snapshot
+            .map(|snapshot| transaction_json_returning_value(snapshot, "entity post-image"))
+            .transpose()?
+            .unwrap_or(JsonValue::Null);
+        let context = EntityEvalContext::staged(&snapshot, row, spec);
+        rows.push(entity_returning_row(
+            returning,
+            &context,
+            spec,
+            ctx,
+            params,
+            active_branch_commit_id,
+        )?);
+    }
+    Ok(Some(rows))
+}
+
+fn transaction_json_returning_value(
+    value: &TransactionJson,
+    context: &str,
+) -> Result<JsonValue, LixError> {
+    serde_json::from_str(value.normalized()).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("{context} contains invalid normalized JSON: {error}"),
+        )
+    })
+}
+
+async fn entity_staged_postimage_returning_rows(
+    plan: &LogicalWritePlan,
+    spec: &EntitySurfaceSpec,
+    ctx: &mut dyn SqlWriteExecutionContext,
+    params: &[Value],
+    active_branch_commit_id: Option<&CommitId>,
+    write_rows: &RawWriteBatch,
+) -> Result<Option<Vec<Vec<Value>>>, LixError> {
+    let Some(returning) = plan.bound.returning.as_ref() else {
+        return Ok(None);
+    };
+    if write_rows.is_empty() {
+        return Ok(Some(Vec::new()));
+    }
+    let candidates = scan_entity_conflict_candidates(ctx, spec, write_rows).await?;
+    // A staged audit projection needs the transaction-visible row, but it
+    // must not look through every candidate again for every write row. Aside
+    // from making large `RETURNING *` writes quadratic, that repeated search
+    // hid the fact that the match is a stable physical identity. Index once
+    // and retain the previous ambiguity check.
+    let mut candidates_by_identity = std::collections::HashMap::with_capacity(candidates.len());
+    for candidate in candidates.iter() {
+        let identity = entity_live_returning_identity(candidate);
+        if candidates_by_identity.insert(identity, candidate).is_some() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "staged entity post-image for schema '{}' is ambiguous in the transaction overlay",
+                    spec.schema_key
+                ),
+            ));
+        }
+    }
+    let mut rows = Vec::with_capacity(write_rows.len());
+    for write_row in write_rows.iter() {
+        let identity = entity_staged_returning_identity(write_row, spec)?;
+        let candidate = candidates_by_identity.get(&identity).copied().ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "staged entity post-image for schema '{}' is missing from the transaction overlay",
+                    spec.schema_key
+                ),
+            )
+        })?;
+        let snapshot = candidate_snapshot(candidate)?.ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "staged entity post-image for schema '{}' is unexpectedly a tombstone",
+                    spec.schema_key
+                ),
+            )
+        })?;
+        let context = EntityEvalContext::live(&snapshot, candidate, spec);
+        rows.push(entity_returning_row(
+            returning,
+            &context,
+            spec,
+            ctx,
+            params,
+            active_branch_commit_id,
+        )?);
+    }
+    Ok(Some(rows))
+}
+
+type EntityReturningIdentity = (EntityPk, Option<String>, String, bool);
+
+fn entity_staged_returning_identity(
+    row: RawWriteRowRef<'_>,
+    spec: &EntitySurfaceSpec,
+) -> Result<EntityReturningIdentity, LixError> {
+    Ok((
+        insert_row_entity_pk(row, spec)?,
+        row.file_id.map(|file_id| file_id.as_str().to_owned()),
+        row.branch_id.as_str().to_owned(),
+        row.global,
+    ))
+}
+
+fn entity_live_returning_identity(row: MaterializedLiveStateRowRef<'_>) -> EntityReturningIdentity {
+    (
+        row.entity_pk().clone(),
+        row.file_id().map(ToOwned::to_owned),
+        row.branch_id().to_owned(),
+        row.global(),
+    )
+}
+
+fn entity_returning_result(
+    plan: &LogicalWritePlan,
+    rows_affected: u64,
+    rows: Option<Vec<Vec<Value>>>,
+) -> SqlWriteResult {
+    match (plan.bound.returning.as_ref(), rows) {
+        (Some(returning), Some(rows)) => SqlWriteResult::returning(
+            rows_affected,
+            crate::SqlQueryResult {
+                columns: returning
+                    .items
+                    .iter()
+                    .map(|item| item.output_name.clone())
+                    .collect(),
+                rows,
+                notices: Vec::new(),
+            },
+        ),
+        _ => SqlWriteResult::affected(rows_affected),
+    }
 }
 
 fn append_entity_update_row<'a>(
@@ -1798,24 +2041,8 @@ async fn entity_delete(
     }
 }
 
-fn empty_entity_delete_returning_result(plan: &LogicalWritePlan) -> SqlWriteResult {
-    plan.bound.returning.as_ref().map_or_else(
-        || SqlWriteResult::affected(0),
-        |returning| {
-            SqlWriteResult::returning(
-                0,
-                crate::SqlQueryResult {
-                    columns: returning
-                        .items
-                        .iter()
-                        .map(|item| item.output_name.clone())
-                        .collect(),
-                    rows: Vec::new(),
-                    notices: Vec::new(),
-                },
-            )
-        },
-    )
+fn empty_entity_returning_result(plan: &LogicalWritePlan) -> SqlWriteResult {
+    entity_returning_result(plan, 0, plan.bound.returning.as_ref().map(|_| Vec::new()))
 }
 
 fn entity_returning_row(
@@ -3535,10 +3762,101 @@ fn inherited_metadata<'a>(
 
 struct EntityEvalContext<'a> {
     snapshot: &'a JsonValue,
-    row: Option<EntityLiveRowRef<'a>>,
+    row: Option<EntityEvalRowRef<'a>>,
     excluded_snapshot: Option<&'a JsonValue>,
     excluded_row: Option<RawWriteRowRef<'a>>,
     visible_columns: &'a [EntitySurfaceColumn],
+}
+
+#[derive(Clone, Copy)]
+enum EntityEvalRowRef<'a> {
+    Live(EntityLiveRowRef<'a>),
+    Staged(RawWriteRowRef<'a>),
+}
+
+impl<'a> EntityEvalRowRef<'a> {
+    fn entity_pk(self) -> Option<&'a EntityPk> {
+        match self {
+            Self::Live(row) => Some(row.entity_pk()),
+            Self::Staged(row) => row.entity_pk,
+        }
+    }
+
+    fn schema_key(self) -> &'a str {
+        match self {
+            Self::Live(row) => row.schema_key(),
+            Self::Staged(row) => row.schema_key.as_str(),
+        }
+    }
+
+    fn file_id(self) -> Option<&'a str> {
+        match self {
+            Self::Live(row) => row.file_id(),
+            Self::Staged(row) => row.file_id.map(SharedStr::as_str),
+        }
+    }
+
+    fn metadata(self) -> Result<Option<JsonValue>, LixError> {
+        match self {
+            Self::Live(row) => row
+                .metadata()
+                .map(|metadata| parse_row_metadata_value(metadata, row.schema_key()))
+                .transpose(),
+            Self::Staged(row) => row
+                .metadata
+                .map(|metadata| transaction_json_returning_value(metadata, "entity metadata"))
+                .transpose(),
+        }
+    }
+
+    fn created_at(self) -> Option<String> {
+        match self {
+            Self::Live(row) => Some(row.created_at().to_string()),
+            Self::Staged(row) => row.created_at.map(str::to_owned),
+        }
+    }
+
+    fn updated_at(self) -> Option<String> {
+        match self {
+            Self::Live(row) => Some(row.updated_at().to_string()),
+            Self::Staged(row) => row.updated_at.map(str::to_owned),
+        }
+    }
+
+    fn change_id(self) -> Option<String> {
+        match self {
+            Self::Live(row) => row.change_id().map(|value| value.to_string()),
+            Self::Staged(row) => row.change_id.map(str::to_owned),
+        }
+    }
+
+    fn commit_id(self) -> Option<String> {
+        match self {
+            Self::Live(row) => row.commit_id().map(|value| value.to_string()),
+            Self::Staged(row) => row.commit_id.map(str::to_owned),
+        }
+    }
+
+    fn global(self) -> bool {
+        match self {
+            Self::Live(row) => row.global(),
+            Self::Staged(row) => row.global,
+        }
+    }
+
+    fn untracked(self) -> bool {
+        match self {
+            Self::Live(row) => row.untracked(),
+            Self::Staged(row) => row.untracked,
+        }
+    }
+
+    fn branch_id(self) -> &'a str {
+        match self {
+            Self::Live(row) => row.branch_id(),
+            Self::Staged(row) => row.branch_id.as_str(),
+        }
+    }
 }
 
 impl<'a> EntityEvalContext<'a> {
@@ -3559,7 +3877,21 @@ impl<'a> EntityEvalContext<'a> {
     ) -> Self {
         Self {
             snapshot,
-            row: Some(row.into()),
+            row: Some(EntityEvalRowRef::Live(row.into())),
+            excluded_snapshot: None,
+            excluded_row: None,
+            visible_columns: &spec.columns,
+        }
+    }
+
+    fn staged(
+        snapshot: &'a JsonValue,
+        row: RawWriteRowRef<'a>,
+        spec: &'a EntitySurfaceSpec,
+    ) -> Self {
+        Self {
+            snapshot,
+            row: Some(EntityEvalRowRef::Staged(row)),
             excluded_snapshot: None,
             excluded_row: None,
             visible_columns: &spec.columns,
@@ -3575,7 +3907,7 @@ impl<'a> EntityEvalContext<'a> {
     ) -> Self {
         Self {
             snapshot,
-            row: Some(row.into()),
+            row: Some(EntityEvalRowRef::Live(row.into())),
             excluded_snapshot: Some(excluded_snapshot),
             excluded_row: Some(excluded_row),
             visible_columns: &spec.columns,
@@ -4097,21 +4429,52 @@ fn validate_bound_write_supported(
             validate_expr_supported(&item.expr)?;
         }
     }
-    if plan.bound.returning.is_some() && plan.bound.op != BoundWriteOp::Delete {
-        let action = match plan.bound.op {
-            BoundWriteOp::Insert => "INSERT",
-            BoundWriteOp::Update => "UPDATE",
-            BoundWriteOp::Delete => unreachable!("DELETE RETURNING is supported"),
-        };
-        return Err(LixError::new(
-            LixError::CODE_UNSUPPORTED_SQL,
-            format!("{action} RETURNING is not supported for registered entity surfaces"),
-        )
-        .with_hint(format!(
-            "Run the {action} without RETURNING, then SELECT the row explicitly."
-        )));
-    }
     Ok(())
+}
+
+/// Whether a direct entity `RETURNING` projection is fully evaluated before
+/// staging. The explicit-transaction boundary uses this to avoid snapshotting
+/// a large journal for the common `RETURNING id, ...` case; audit fields still
+/// require a rollback checkpoint because they are populated by staging.
+pub(crate) fn entity_returning_projects_before_stage(plan: &LogicalWritePlan) -> bool {
+    if !matches!(plan.bound.target, BoundWriteTarget::Entity(_))
+        || !bound_public_write_shape_supported(plan)
+    {
+        return false;
+    }
+    match plan.bound.op {
+        // Entity DELETE captures the preimage before it stages tombstones.
+        BoundWriteOp::Delete => true,
+        BoundWriteOp::Insert | BoundWriteOp::Update => {
+            plan.bound.returning.as_ref().is_some_and(|returning| {
+                returning
+                    .items
+                    .iter()
+                    .all(|item| !returning_expr_requires_staged_postimage(&item.expr))
+            })
+        }
+    }
+}
+
+fn returning_expr_requires_staged_postimage(expr: &BoundExpr) -> bool {
+    match expr {
+        BoundExpr::Column(column)
+            if matches!(
+                column.name.as_str(),
+                "lixcol_created_at" | "lixcol_updated_at" | "lixcol_change_id" | "lixcol_commit_id"
+            ) =>
+        {
+            true
+        }
+        BoundExpr::Cast { expr, .. } => returning_expr_requires_staged_postimage(expr),
+        BoundExpr::Function { args, .. } => {
+            args.iter().any(returning_expr_requires_staged_postimage)
+        }
+        BoundExpr::Column(_)
+        | BoundExpr::ExcludedColumn(_)
+        | BoundExpr::Param(_)
+        | BoundExpr::Literal(_) => false,
+    }
 }
 
 fn bound_public_write_shape_supported(plan: &LogicalWritePlan) -> bool {
@@ -4663,8 +5026,13 @@ fn column_eval_value(
     match column_name {
         "lixcol_entity_pk" => row
             .entity_pk()
-            .as_json_array_value()
-            .map(EntityEvalValue::Json),
+            .map(EntityPk::as_json_array_value)
+            .transpose()
+            .map(|value| {
+                value
+                    .map(EntityEvalValue::Json)
+                    .unwrap_or(EntityEvalValue::SqlNull)
+            }),
         "lixcol_schema_key" => Ok(EntityEvalValue::Json(JsonValue::String(
             row.schema_key().to_string(),
         ))),
@@ -4672,25 +5040,23 @@ fn column_eval_value(
             .file_id()
             .map(|value| EntityEvalValue::Json(JsonValue::String(value.to_string())))
             .unwrap_or(EntityEvalValue::SqlNull)),
-        "lixcol_metadata" => row
-            .metadata()
-            .map(|metadata| parse_row_metadata_value(metadata, row.schema_key()))
-            .transpose()
-            .map(|metadata| {
-                metadata
-                    .map(EntityEvalValue::Json)
-                    .unwrap_or(EntityEvalValue::SqlNull)
-            }),
+        "lixcol_metadata" => row.metadata().map(|metadata| {
+            metadata
+                .map(EntityEvalValue::Json)
+                .unwrap_or(EntityEvalValue::SqlNull)
+        }),
         "lixcol_change_id" => Ok(row
             .change_id()
             .map(|value| EntityEvalValue::Json(JsonValue::String(value.to_string())))
             .unwrap_or(EntityEvalValue::SqlNull)),
-        "lixcol_created_at" => Ok(EntityEvalValue::Json(JsonValue::String(
-            row.created_at().to_string(),
-        ))),
-        "lixcol_updated_at" => Ok(EntityEvalValue::Json(JsonValue::String(
-            row.updated_at().to_string(),
-        ))),
+        "lixcol_created_at" => Ok(row
+            .created_at()
+            .map(|value| EntityEvalValue::Json(JsonValue::String(value)))
+            .unwrap_or(EntityEvalValue::SqlNull)),
+        "lixcol_updated_at" => Ok(row
+            .updated_at()
+            .map(|value| EntityEvalValue::Json(JsonValue::String(value)))
+            .unwrap_or(EntityEvalValue::SqlNull)),
         "lixcol_commit_id" => Ok(row
             .commit_id()
             .map(|value| EntityEvalValue::Json(JsonValue::String(value.to_string())))

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -957,15 +957,20 @@ pub(crate) async fn execute_datafusion_write_logical_plan(
         .map_err(datafusion_error_to_lix_error)?;
     let table_schema = table.schema();
     let state = session.state();
-    let returning = if plan.bound.op == BoundWriteOp::Delete {
-        datafusion_delete_returning(
+    // Diff command sinks own their dedicated RETURNING contract. Every
+    // registered table surface takes the normal DML path below, where a
+    // provider must explicitly capture the relevant image (pre-delete or
+    // post-insert/update) rather than silently returning only an affected
+    // count.
+    let returning = if matches!(plan.bound.target, BoundWriteTarget::DiffCommand(_)) {
+        None
+    } else {
+        datafusion_dml_returning(
             &session,
             table_schema.as_ref(),
             plan.bound.returning.as_ref(),
             params,
         )?
-    } else {
-        None
     };
 
     let exec = match plan.bound.op {
@@ -974,7 +979,7 @@ pub(crate) async fn execute_datafusion_write_logical_plan(
                 insert_input_plan(&session, std::sync::Arc::clone(&table_schema), plan, params)
                     .await?;
             if plan.bound.branch_scope == BranchScope::Empty {
-                return Ok(SqlWriteResult::affected(0));
+                return sql_write_empty_returning_result(returning.as_ref());
             }
             if let Some(conflict) = &plan.bound.conflict {
                 let target_columns: Vec<String> = conflict
@@ -1005,32 +1010,75 @@ pub(crate) async fn execute_datafusion_write_logical_plan(
                         }
                     }
                 };
-                let rows_affected = crate::sql2::providers::execute_spec_upsert(
-                    &table,
-                    &input,
-                    proposed_batches,
-                    &target_columns,
-                    &action,
-                )
-                .await?;
-                return Ok(SqlWriteResult::affected(rows_affected));
+                let rows_affected = match &returning {
+                    Some(returning) => {
+                        crate::sql2::providers::execute_spec_upsert_with_returning(
+                            &table,
+                            &input,
+                            proposed_batches,
+                            &target_columns,
+                            &action,
+                            returning.clone(),
+                        )
+                        .await?
+                    }
+                    None => {
+                        crate::sql2::providers::execute_spec_upsert(
+                            &table,
+                            &input,
+                            proposed_batches,
+                            &target_columns,
+                            &action,
+                        )
+                        .await?
+                    }
+                };
+                return match returning.as_ref() {
+                    Some(returning) => {
+                        sql_write_captured_returning_result(rows_affected, returning)
+                    }
+                    None => Ok(SqlWriteResult::affected(rows_affected)),
+                };
             }
-            table
-                .insert_into(&state, input, InsertOp::Append)
-                .await
-                .map_err(datafusion_error_to_lix_error)
+            match &returning {
+                Some(returning) => {
+                    crate::sql2::providers::execute_spec_insert_with_returning(
+                        &table,
+                        &state,
+                        input,
+                        returning.clone(),
+                    )
+                    .await
+                }
+                None => table
+                    .insert_into(&state, input, InsertOp::Append)
+                    .await
+                    .map_err(datafusion_error_to_lix_error),
+            }
         }
         BoundWriteOp::Update => {
             let assignments =
                 datafusion_assignments(&session, table_schema.as_ref(), plan, params)?;
             let filters = datafusion_write_filters(&session, table_schema.as_ref(), plan, params)?;
             if plan.bound.branch_scope == BranchScope::Empty {
-                return Ok(SqlWriteResult::affected(0));
+                return sql_write_empty_returning_result(returning.as_ref());
             }
-            table
-                .update(&state, assignments, filters)
-                .await
-                .map_err(datafusion_error_to_lix_error)
+            match &returning {
+                Some(returning) => {
+                    crate::sql2::providers::execute_spec_update_with_returning(
+                        &table,
+                        &state,
+                        assignments,
+                        filters,
+                        returning.clone(),
+                    )
+                    .await
+                }
+                None => table
+                    .update(&state, assignments, filters)
+                    .await
+                    .map_err(datafusion_error_to_lix_error),
+            }
         }
         BoundWriteOp::Delete => {
             let filters = datafusion_write_filters(&session, table_schema.as_ref(), plan, params)?;
@@ -1073,19 +1121,7 @@ pub(crate) async fn execute_datafusion_write_logical_plan(
         return SqlWriteResult::diff_command(outcome, plan.bound.returning.as_ref());
     }
     match returning {
-        Some(returning) => {
-            let batch = returning
-                .take_captured()
-                .map_err(datafusion_error_to_lix_error)?;
-            let fields = returning
-                .schema()
-                .fields()
-                .iter()
-                .map(|field| field.as_ref().clone())
-                .collect::<Vec<_>>();
-            let result = query_result_from_batches(&fields, &[batch])?;
-            Ok(SqlWriteResult::returning(rows_affected, result))
-        }
+        Some(returning) => sql_write_captured_returning_result(rows_affected, &returning),
         None => Ok(SqlWriteResult::affected(rows_affected)),
     }
 }
@@ -1421,7 +1457,7 @@ fn write_provider_selection(plan: &LogicalWritePlan, target_table_name: &str) ->
     }
 }
 
-fn datafusion_delete_returning(
+fn datafusion_dml_returning(
     session: &SessionContext,
     table_schema: &Schema,
     returning: Option<&BoundReturning>,
@@ -1495,6 +1531,23 @@ fn sql_write_empty_returning_result(
         0,
         query_result_from_batches(&fields, &[])?,
     ))
+}
+
+fn sql_write_captured_returning_result(
+    rows_affected: u64,
+    returning: &crate::sql2::providers::DmlReturning,
+) -> Result<SqlWriteResult, LixError> {
+    let batch = returning
+        .take_captured()
+        .map_err(datafusion_error_to_lix_error)?;
+    let fields = returning
+        .schema()
+        .fields()
+        .iter()
+        .map(|field| field.as_ref().clone())
+        .collect::<Vec<_>>();
+    let result = query_result_from_batches(&fields, &[batch])?;
+    Ok(SqlWriteResult::returning(rows_affected, result))
 }
 
 fn insert_field_expr(

--- a/packages/engine/src/sql2/exec/mod.rs
+++ b/packages/engine/src/sql2/exec/mod.rs
@@ -87,6 +87,7 @@ pub(crate) use write::{
     create_write_plan_template_from_parsed, diff_command_query,
     execute_write_logical_plan_parameter_batch, execute_write_logical_plan_result_with_metadata,
     execute_write_logical_plan_value_batch, parameter_record_batch,
+    write_plan_requires_post_stage_returning_checkpoint,
 };
 
 pub(crate) enum SqlLogicalPlan {

--- a/packages/engine/src/sql2/exec/write.rs
+++ b/packages/engine/src/sql2/exec/write.rs
@@ -62,6 +62,18 @@ pub(crate) fn diff_command_query(
     ))
 }
 
+/// Returns whether an explicit transaction needs a statement checkpoint
+/// before executing this `RETURNING` write. Generic providers construct their
+/// result from a staged postimage. Direct entity writes are the one fast path
+/// that can safely evaluate ordinary visible columns before staging.
+pub(crate) fn write_plan_requires_post_stage_returning_checkpoint(plan: &SqlLogicalPlan) -> bool {
+    let SqlLogicalPlan::Write(write) = plan else {
+        return false;
+    };
+    write.plan.bound.returning.is_some()
+        && !super::bound_public_write::entity_returning_projects_before_stage(&write.plan)
+}
+
 #[cfg(test)]
 pub(crate) async fn create_write_logical_plan(
     ctx: &mut dyn SqlWriteExecutionContext,

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -52,7 +52,7 @@ pub(crate) use exec::{
     execute_read_statement_in_session_from_parsed, execute_transaction_read_statement_from_parsed,
     execute_write_logical_plan_parameter_batch, execute_write_logical_plan_result_with_metadata,
     execute_write_logical_plan_value_batch, parameter_record_batch, prepare_read_session,
-    prepare_read_session_at_head,
+    prepare_read_session_at_head, write_plan_requires_post_stage_returning_checkpoint,
 };
 #[cfg(test)]
 pub(crate) use exec::{

--- a/packages/engine/src/sql2/providers/branch.rs
+++ b/packages/engine/src/sql2/providers/branch.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -38,9 +38,10 @@ use crate::transaction::types::{
 
 use super::columns::{Col, ColumnTable, ColumnTableError};
 use super::spec::{
-    PlannedDml, PlannedScan, TableSpec, projected_schema, register_spec_table, row_source,
+    DmlReturning, InsertApply, PlannedDml, PlannedScan, TableSpec, projected_schema,
+    register_spec_table, row_source, take_record_batch_rows,
 };
-use super::upsert::{StagedUpsert, UpsertSupport, materialize_omitted_column};
+use super::upsert::{StagedUpsert, UpsertReturningRow, UpsertSupport, materialize_omitted_column};
 use super::values::{required_bool_value, required_string_value};
 
 pub(super) async fn register_lix_branch_read_provider(
@@ -185,6 +186,77 @@ impl TableSpec for BranchSpec {
         Ok(count)
     }
 
+    async fn plan_insert_with_returning(
+        &self,
+        write_ctx: SqlWriteContext,
+        _input: &Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+        returning: DmlReturning,
+    ) -> Result<InsertApply> {
+        let branch_ref = Arc::clone(&self.branch_ref);
+        Ok(Arc::new(move |batches| {
+            let write_ctx = write_ctx.clone();
+            let branch_ref = Arc::clone(&branch_ref);
+            let returning = returning.clone();
+            async move {
+                let default_commit_id = branch_ref
+                    .load_head(&write_ctx.active_branch_id())
+                    .await
+                    .map_err(lix_error_to_datafusion_error)?
+                    .map(|head| head.commit_id)
+                    .ok_or_else(|| {
+                        DataFusionError::Execution(
+                            "INSERT into lix_branch could not resolve active branch head"
+                                .to_string(),
+                        )
+                    })?;
+                let row_capacity = batches
+                    .iter()
+                    .map(RecordBatch::num_rows)
+                    .sum::<usize>()
+                    .saturating_mul(2);
+                let mut stage_rows = RawWriteBatch::with_capacity(row_capacity);
+                let mut post_rows = Vec::new();
+                let mut count = 0u64;
+                for batch in batches {
+                    let branch_rows = branch_insert_rows_from_batch(&batch, &default_commit_id)?;
+                    count = count
+                        .checked_add(u64::try_from(branch_rows.len()).map_err(|_| {
+                            DataFusionError::Execution("INSERT row count overflow".to_string())
+                        })?)
+                        .ok_or_else(|| {
+                            DataFusionError::Execution("INSERT row count overflow".to_string())
+                        })?;
+                    for row in &branch_rows {
+                        push_branch_stage_rows(
+                            &mut stage_rows,
+                            row.clone(),
+                            TransactionWriteOperation::Insert,
+                            false,
+                        );
+                    }
+                    post_rows.extend(branch_rows);
+                }
+
+                if !stage_rows.is_empty() {
+                    write_ctx
+                        .stage_write(TransactionWrite::Rows {
+                            mode: TransactionWriteMode::Insert,
+                            rows: stage_rows,
+                        })
+                        .await
+                        .map_err(lix_error_to_datafusion_error)?;
+                }
+
+                let post_image = LIX_BRANCH_COLS
+                    .build(lix_branch_schema(), &post_rows)
+                    .map_err(branch_batch_error)?;
+                returning.capture(returning.project(&post_image)?);
+                Ok(count)
+            }
+            .boxed()
+        }))
+    }
+
     fn validate_update_assignments(&self, assignments: &[(String, Expr)]) -> Result<()> {
         validate_lix_branch_update_assignments(assignments)
     }
@@ -275,6 +347,60 @@ impl TableSpec for BranchSpec {
                             .map_err(lix_error_to_datafusion_error)?;
                     }
 
+                    Ok(count)
+                }
+                .boxed()
+            }),
+        })
+    }
+
+    async fn plan_update_with_returning(
+        &self,
+        write_ctx: SqlWriteContext,
+        assignments: Vec<(String, Arc<dyn PhysicalExpr>)>,
+        filters: &[Expr],
+        returning: DmlReturning,
+    ) -> Result<PlannedDml> {
+        let table_schema = lix_branch_schema();
+        Ok(PlannedDml {
+            source: self.write_row_source(filters),
+            apply: Arc::new(move |matched_batch| {
+                let write_ctx = write_ctx.clone();
+                let assignments = assignments.clone();
+                let table_schema = Arc::clone(&table_schema);
+                let returning = returning.clone();
+                async move {
+                    let branch_rows =
+                        branch_update_rows_from_batch(&matched_batch, &assignments, &table_schema)?;
+                    reject_protected_branch_updates(&branch_rows)?;
+                    let count = u64::try_from(branch_rows.len()).map_err(|_| {
+                        DataFusionError::Execution("UPDATE row count overflow".to_string())
+                    })?;
+                    let post_image = LIX_BRANCH_COLS
+                        .build(lix_branch_schema(), &branch_rows)
+                        .map_err(branch_batch_error)?;
+                    let mut rows =
+                        RawWriteBatch::with_capacity(branch_rows.len().saturating_mul(2));
+                    for row in branch_rows {
+                        push_branch_stage_rows(
+                            &mut rows,
+                            row,
+                            TransactionWriteOperation::Update,
+                            false,
+                        );
+                    }
+
+                    if !rows.is_empty() {
+                        write_ctx
+                            .stage_write(TransactionWrite::Rows {
+                                mode: TransactionWriteMode::Replace,
+                                rows,
+                            })
+                            .await
+                            .map_err(lix_error_to_datafusion_error)?;
+                    }
+
+                    returning.capture(returning.project(&post_image)?);
                     Ok(count)
                 }
                 .boxed()
@@ -380,6 +506,86 @@ impl UpsertSupport for BranchSpec {
             .map(|_| Some(default_commit_id.to_string()))
             .collect::<StringArray>();
         materialize_omitted_column(&materialized, "commit_id", Arc::new(values))
+    }
+
+    async fn materialize_returning_insert_defaults(
+        &self,
+        write_ctx: &SqlWriteContext,
+        proposed: &RecordBatch,
+    ) -> Result<RecordBatch> {
+        // Branch identity is always caller-provided. Reuse the existing
+        // excluded-default materialization so a conflict update and a fresh
+        // insert observe the same hidden/head defaults.
+        self.materialize_excluded_defaults(write_ctx, proposed)
+            .await
+    }
+
+    async fn capture_upsert_returning(
+        &self,
+        write_ctx: &SqlWriteContext,
+        affected_rows: Vec<UpsertReturningRow>,
+        returning: DmlReturning,
+    ) -> Result<()> {
+        let keys = affected_rows
+            .iter()
+            .map(|row| {
+                required_string_value(
+                    row.batch(),
+                    row.row_index(),
+                    "id",
+                    "INSERT ON CONFLICT RETURNING lix_branch",
+                )
+            })
+            .collect::<Result<Vec<_>>>()?;
+        if keys.is_empty() {
+            let empty = RecordBatch::new_empty(lix_branch_schema());
+            returning.capture(returning.project(&empty)?);
+            return Ok(());
+        }
+
+        // Build fresh readers rather than reuse the session's cached branch
+        // ref: a conflict update may have just staged a new branch head.
+        let live_state: Arc<dyn LiveStateReader> =
+            Arc::new(WriteContextLiveStateReader::new(write_ctx.clone()));
+        let branch_ref: Arc<dyn BranchRefReader> = Arc::new(
+            crate::sql2::WriteContextBranchRefReader::new(write_ctx.clone()),
+        );
+        let rows = load_branch_rows(live_state, branch_ref, BranchHeadReadStrategy::Point)
+            .await
+            .map_err(lix_error_to_datafusion_error)?;
+        let batch = LIX_BRANCH_COLS
+            .build(lix_branch_schema(), &rows)
+            .map_err(branch_batch_error)?;
+        let mut post_rows = BTreeMap::new();
+        for row_index in 0..batch.num_rows() {
+            let id = required_string_value(
+                &batch,
+                row_index,
+                "id",
+                "INSERT ON CONFLICT RETURNING lix_branch",
+            )?;
+            let index = u32::try_from(row_index).map_err(|_| {
+                DataFusionError::Execution("lix_branch RETURNING row index overflow".into())
+            })?;
+            if post_rows.insert(id.clone(), index).is_some() {
+                return Err(DataFusionError::Execution(format!(
+                    "lix_branch RETURNING post-image contains duplicate row for id '{id}'"
+                )));
+            }
+        }
+        let indices = keys
+            .iter()
+            .map(|id| {
+                post_rows.get(id).copied().ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "lix_branch RETURNING post-image is missing inserted or updated row '{id}'"
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let post_image = take_record_batch_rows(&batch, &indices)?;
+        returning.capture(returning.project(&post_image)?);
+        Ok(())
     }
 
     async fn scan_conflict_candidates(

--- a/packages/engine/src/sql2/providers/directory.rs
+++ b/packages/engine/src/sql2/providers/directory.rs
@@ -73,12 +73,12 @@ use super::file::{
     file_path_predicate_from_filters, indexed_path_matches,
 };
 use super::spec::{
-    PlannedDml, PlannedScan, RowSource, TableSpec, finish_scan_batch, projected_schema,
-    register_spec_table, row_source,
+    DmlReturning, InsertApply, PlannedDml, PlannedScan, RowSource, TableSpec, finish_scan_batch,
+    projected_schema, register_spec_table, row_source, take_record_batch_rows,
 };
 use super::upsert::{
-    StagedUpsert, UpsertConflictKind, UpsertConflictTarget, UpsertSupport,
-    materialize_omitted_column, validate_target_columns,
+    StagedUpsert, UpsertConflictKind, UpsertConflictTarget, UpsertReturningRow, UpsertSupport,
+    materialize_omitted_column, materialize_omitted_insert_default, validate_target_columns,
 };
 use crate::entity_pk::EntityPk;
 
@@ -236,6 +236,7 @@ pub(super) async fn register_active_write_provider(
     )
 }
 
+#[derive(Clone)]
 struct LixDirectorySpec {
     schema: SchemaRef,
     live_state: Arc<dyn LiveStateReader>,
@@ -243,6 +244,15 @@ struct LixDirectorySpec {
     branch_ref: Arc<dyn BranchRefReader>,
     functions: FunctionProviderHandle,
     branch_binding: BranchBinding,
+}
+
+/// Stable public identity for a directory post-image. By-branch surfaces need
+/// both components; active surfaces operate on one visible branch scope and
+/// intentionally use an empty branch discriminator.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct DirectoryReturningKey {
+    id: String,
+    branch_id: String,
 }
 
 impl LixDirectorySpec {
@@ -401,6 +411,91 @@ impl LixDirectorySpec {
                 Ok(source_batch)
             },
         )
+    }
+
+    fn returning_key_from_batch(
+        &self,
+        batch: &RecordBatch,
+        row_index: usize,
+    ) -> Result<DirectoryReturningKey> {
+        Ok(DirectoryReturningKey {
+            id: required_string_value(batch, row_index, "id")?,
+            branch_id: match self.branch_binding {
+                BranchBinding::Active { .. } => String::new(),
+                BranchBinding::Explicit => {
+                    required_string_value(batch, row_index, "lixcol_branch_id")?
+                }
+            },
+        })
+    }
+
+    fn materialize_returning_insert_defaults(&self, batch: &RecordBatch) -> Result<RecordBatch> {
+        if !insert_column_is_omitted(batch, "id") {
+            return Ok(batch.clone());
+        }
+        let ids = (0..batch.num_rows())
+            .map(|_| Some(self.functions.call_uuid_v7().to_string()))
+            .collect::<StringArray>();
+        materialize_omitted_insert_default(batch, "id", Arc::new(ids))
+    }
+
+    /// Reload the just-staged rows from the transaction overlay. Filesystem
+    /// paths and audit fields are derived during staging, so applying SQL
+    /// assignments to the pre-image would produce stale `RETURNING *` values.
+    /// Scan the complete directory graph for the relevant branch scope, then
+    /// select the requested identities in write-row order.
+    async fn returning_post_image(
+        &self,
+        write_ctx: &SqlWriteContext,
+        keys: &[DirectoryReturningKey],
+    ) -> Result<RecordBatch> {
+        if keys.is_empty() {
+            return Ok(RecordBatch::new_empty(Arc::clone(&self.schema)));
+        }
+        let mut request = lix_directory_scan_request(
+            self.branch_binding.active_branch_id(),
+            Some(self.schema.as_ref()),
+            None,
+        );
+        if matches!(self.branch_binding, BranchBinding::Explicit) {
+            request.filter.branch_ids = keys
+                .iter()
+                .map(|key| key.branch_id.clone())
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect();
+        }
+        let rows = write_ctx
+            .scan_live_state_batch(&request)
+            .await
+            .map_err(lix_error_to_datafusion_error)?;
+        let batch = lix_directory_record_batch(&self.schema, &rows)
+            .map_err(lix_error_to_datafusion_error)?;
+        let mut post_rows = BTreeMap::new();
+        for row_index in 0..batch.num_rows() {
+            let key = self.returning_key_from_batch(&batch, row_index)?;
+            let index = u32::try_from(row_index).map_err(|_| {
+                DataFusionError::Execution("lix_directory RETURNING row index overflow".into())
+            })?;
+            if post_rows.insert(key.clone(), index).is_some() {
+                return Err(DataFusionError::Execution(format!(
+                    "lix_directory RETURNING post-image contains duplicate row for id '{}'",
+                    key.id
+                )));
+            }
+        }
+        let indices = keys
+            .iter()
+            .map(|key| {
+                post_rows.get(key).copied().ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "lix_directory RETURNING post-image is missing inserted or updated row '{}'",
+                        key.id
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        take_record_batch_rows(&batch, &indices)
     }
 }
 
@@ -607,6 +702,89 @@ impl TableSpec for LixDirectorySpec {
         Ok(count)
     }
 
+    async fn plan_insert_with_returning(
+        &self,
+        write_ctx: SqlWriteContext,
+        _input: &Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+        returning: DmlReturning,
+    ) -> Result<InsertApply> {
+        let spec = self.clone();
+        Ok(Arc::new(move |batches| {
+            let write_ctx = write_ctx.clone();
+            let spec = spec.clone();
+            let returning = returning.clone();
+            async move {
+                let surface_name = lix_directory_surface_name(&spec.branch_binding);
+                let row_capacity = batches
+                    .iter()
+                    .map(RecordBatch::num_rows)
+                    .sum::<usize>()
+                    .saturating_mul(3);
+                let mut rows = RawWriteBatch::with_capacity(row_capacity);
+                let mut path_resolvers = None;
+                let mut keys = Vec::new();
+                let mut count = 0_u64;
+                for batch in batches {
+                    let batch = spec.materialize_returning_insert_defaults(&batch)?;
+                    for row_index in 0..batch.num_rows() {
+                        keys.push(spec.returning_key_from_batch(&batch, row_index)?);
+                    }
+                    if path_resolvers.is_none() {
+                        path_resolvers = Some(spec.path_resolvers_for_write(&write_ctx).await?);
+                    }
+                    count = count
+                        .checked_add(u64::try_from(batch.num_rows()).map_err(|_| {
+                            DataFusionError::Execution(
+                                "lix_directory INSERT row count overflow".into(),
+                            )
+                        })?)
+                        .ok_or_else(|| {
+                            DataFusionError::Execution(
+                                "lix_directory INSERT row count overflow".into(),
+                            )
+                        })?;
+                    if record_batch_has_non_null_column(&batch, "path")? {
+                        rows.append(lix_directory_write_rows_from_batch_with_path_resolvers(
+                            &batch,
+                            spec.branch_binding.active_branch_id(),
+                            surface_name,
+                            path_resolvers
+                                .as_mut()
+                                .expect("path resolver should be initialized"),
+                            &mut || spec.functions.call_uuid_v7().to_string(),
+                        )?);
+                    } else {
+                        rows.append(
+                            lix_directory_write_rows_from_batch_with_options_and_path_resolvers(
+                                &batch,
+                                spec.branch_binding.active_branch_id(),
+                                surface_name,
+                                true,
+                                path_resolvers.as_mut(),
+                                None,
+                            )?,
+                        );
+                    }
+                }
+
+                if !rows.is_empty() {
+                    write_ctx
+                        .stage_write(TransactionWrite::Rows {
+                            mode: TransactionWriteMode::Insert,
+                            rows,
+                        })
+                        .await
+                        .map_err(lix_error_to_datafusion_error)?;
+                }
+
+                let post_image = spec.returning_post_image(&write_ctx, &keys).await?;
+                returning.capture(returning.project(&post_image)?);
+                Ok(count)
+            }
+            .boxed()
+        }))
+    }
+
     fn validate_update_assignments(&self, assignments: &[(String, Expr)]) -> Result<()> {
         validate_lix_directory_update_assignments(&self.schema, assignments)
     }
@@ -735,6 +913,72 @@ impl TableSpec for LixDirectorySpec {
             }),
         })
     }
+
+    async fn plan_update_with_returning(
+        &self,
+        write_ctx: SqlWriteContext,
+        assignments: Vec<(String, Arc<dyn PhysicalExpr>)>,
+        filters: &[Expr],
+        returning: DmlReturning,
+    ) -> Result<PlannedDml> {
+        let request = self.dml_scan_request(filters).await?;
+        let indexed_matches = self.indexed_path_matches(&request, filters).await?;
+        let captured: Arc<Mutex<Option<RecordBatch>>> = Arc::new(Mutex::new(None));
+        let branch_binding = self.branch_binding.clone();
+        let functions = self.functions.clone();
+        let returning_spec = self.clone();
+        Ok(PlannedDml {
+            source: self.dml_source(&write_ctx, request, indexed_matches, captured),
+            apply: Arc::new(move |matched_batch| {
+                let write_ctx = write_ctx.clone();
+                let branch_binding = branch_binding.clone();
+                let functions = functions.clone();
+                let assignments = assignments.clone();
+                let returning = returning.clone();
+                let returning_spec = returning_spec.clone();
+                async move {
+                    let keys = (0..matched_batch.num_rows())
+                        .map(|row_index| {
+                            returning_spec.returning_key_from_batch(&matched_batch, row_index)
+                        })
+                        .collect::<Result<Vec<_>>>()?;
+                    let mut path_resolvers = directory_path_resolvers_from_live_state(
+                        Arc::new(WriteContextLiveStateReader::new(write_ctx.clone())),
+                        branch_binding.active_branch_id(),
+                    )
+                    .await
+                    .map_err(lix_error_to_datafusion_error)?;
+                    let write_rows = lix_directory_update_write_rows_from_batch(
+                        &matched_batch,
+                        &assignments,
+                        branch_binding.active_branch_id(),
+                        &mut path_resolvers,
+                        &mut || functions.call_uuid_v7().to_string(),
+                    )?;
+                    let count = u64::try_from(write_rows.len()).map_err(|_| {
+                        DataFusionError::Execution("lix_directory UPDATE row count overflow".into())
+                    })?;
+
+                    if count > 0 {
+                        write_ctx
+                            .stage_write(TransactionWrite::Rows {
+                                mode: TransactionWriteMode::Replace,
+                                rows: write_rows,
+                            })
+                            .await
+                            .map_err(lix_error_to_datafusion_error)?;
+                    }
+
+                    let post_image = returning_spec
+                        .returning_post_image(&write_ctx, &keys)
+                        .await?;
+                    returning.capture(returning.project(&post_image)?);
+                    Ok(count)
+                }
+                .boxed()
+            }),
+        })
+    }
 }
 
 #[async_trait]
@@ -849,6 +1093,29 @@ impl UpsertSupport for LixDirectorySpec {
             "lixcol_untracked",
             Arc::new(BooleanArray::from(vec![false; proposed.num_rows()])),
         )
+    }
+
+    async fn materialize_returning_insert_defaults(
+        &self,
+        _write_ctx: &SqlWriteContext,
+        proposed: &RecordBatch,
+    ) -> Result<RecordBatch> {
+        LixDirectorySpec::materialize_returning_insert_defaults(self, proposed)
+    }
+
+    async fn capture_upsert_returning(
+        &self,
+        write_ctx: &SqlWriteContext,
+        affected_rows: Vec<UpsertReturningRow>,
+        returning: DmlReturning,
+    ) -> Result<()> {
+        let keys = affected_rows
+            .iter()
+            .map(|row| self.returning_key_from_batch(row.batch(), row.row_index()))
+            .collect::<Result<Vec<_>>>()?;
+        let post_image = self.returning_post_image(write_ctx, &keys).await?;
+        returning.capture(returning.project(&post_image)?);
+        Ok(())
     }
 
     /// Scan the existing directories that could conflict with `proposed`,

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -106,12 +106,12 @@ use crate::transaction::types::{
 };
 
 use super::spec::{
-    DmlApply, DmlPlanOptions, InsertApply, PlannedDml, PlannedScan, RowSource, TableSpec,
-    finish_scan_batch, register_spec_table, row_source,
+    DmlApply, DmlPlanOptions, DmlReturning, InsertApply, PlannedDml, PlannedScan, RowSource,
+    TableSpec, finish_scan_batch, register_spec_table, row_source, take_record_batch_rows,
 };
 use super::upsert::{
-    StagedUpsert, UpsertConflictKind, UpsertConflictTarget, UpsertSupport,
-    materialize_omitted_column, validate_target_columns,
+    StagedUpsert, UpsertConflictKind, UpsertConflictTarget, UpsertReturningRow, UpsertSupport,
+    materialize_omitted_column, materialize_omitted_insert_default, validate_target_columns,
 };
 
 pub(super) async fn register_lix_file_active_provider(
@@ -212,6 +212,7 @@ pub(super) async fn register_active_write_provider(
     )
 }
 
+#[derive(Clone)]
 struct LixFileSpec {
     schema: SchemaRef,
     live_state: Arc<dyn LiveStateReader>,
@@ -231,6 +232,15 @@ struct LixFileDmlSourceState {
     plugin_render: Option<PluginRenderContext>,
     path_resolvers: Option<BTreeMap<String, DirectoryPathResolver>>,
     path_index: Option<FilesystemPathSelection>,
+}
+
+/// Stable public identity for a file post-image. The by-branch surface needs
+/// both components; the active surface exposes one visible branch scope and
+/// uses an empty branch discriminator.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct FileReturningKey {
+    id: String,
+    branch_id: String,
 }
 
 #[derive(Clone, Copy)]
@@ -531,6 +541,112 @@ impl LixFileSpec {
                 Ok(source_batch)
             },
         )
+    }
+
+    fn returning_key_from_batch(
+        &self,
+        batch: &RecordBatch,
+        row_index: usize,
+    ) -> Result<FileReturningKey> {
+        let id = required_string_value(batch, row_index, "id")?;
+        let branch_id = match self.branch_binding {
+            BranchBinding::Active { .. } => String::new(),
+            // This is a readback identity, not a new write context. A global
+            // row is projected into the requested explicit branch with
+            // `lixcol_global = true` and that branch in `lixcol_branch_id`.
+            // Normalizing it as a write would reject the valid projection.
+            BranchBinding::Explicit => required_string_value(batch, row_index, "lixcol_branch_id")?,
+        };
+        Ok(FileReturningKey { id, branch_id })
+    }
+
+    fn materialize_returning_insert_defaults(&self, batch: &RecordBatch) -> Result<RecordBatch> {
+        if !insert_column_is_omitted(batch, "id") {
+            return Ok(batch.clone());
+        }
+        let ids = (0..batch.num_rows())
+            .map(|row_index| {
+                let plugin_archive_id = optional_string_value(batch, row_index, "path")?
+                    .and_then(|path| plugin_key_from_archive_path(&path))
+                    .map(|plugin_key| plugin_storage_archive_file_id(&plugin_key));
+                Ok(Some(plugin_archive_id.unwrap_or_else(|| {
+                    self.functions.call_uuid_v7().to_string()
+                })))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let ids = StringArray::from(ids);
+        materialize_omitted_insert_default(batch, "id", Arc::new(ids))
+    }
+
+    /// Reload the just-staged rows from the transaction overlay. Filesystem
+    /// writes derive paths, blob references, and audit fields during staging;
+    /// projecting the pre-image with assignments applied would make
+    /// `RETURNING *` stale or incomplete.
+    async fn returning_post_image(
+        &self,
+        write_ctx: &SqlWriteContext,
+        keys: &[FileReturningKey],
+        needs_data: bool,
+    ) -> Result<RecordBatch> {
+        if keys.is_empty() {
+            return Ok(RecordBatch::new_empty(Arc::clone(&self.schema)));
+        }
+        let mut request = lix_file_scan_request(
+            self.branch_binding.active_branch_id(),
+            Some(self.schema.as_ref()),
+            None,
+        );
+        if matches!(self.branch_binding, BranchBinding::Explicit) {
+            request.filter.branch_ids = keys
+                .iter()
+                .map(|key| key.branch_id.clone())
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect();
+        }
+        let file_ids = keys
+            .iter()
+            .map(|key| key.id.clone())
+            .collect::<BTreeSet<_>>();
+        let captured: SharedLixFileDmlSourceState = Arc::new(Mutex::new(None));
+        let source = self.dml_source(
+            write_ctx,
+            request,
+            FileIdConstraint::Ids(file_ids),
+            None,
+            LixFileDmlSourceOptions {
+                needs_data,
+                needs_plugin_ownership: false,
+                capture_path_resolver_rows: false,
+            },
+            captured,
+        );
+        let batch = source().await?;
+        let mut post_rows = BTreeMap::new();
+        for row_index in 0..batch.num_rows() {
+            let key = self.returning_key_from_batch(&batch, row_index)?;
+            let index = u32::try_from(row_index).map_err(|_| {
+                DataFusionError::Execution("lix_file RETURNING row index overflow".into())
+            })?;
+            if post_rows.insert(key.clone(), index).is_some() {
+                return Err(DataFusionError::Execution(format!(
+                    "lix_file RETURNING post-image contains duplicate row for id '{}'",
+                    key.id
+                )));
+            }
+        }
+        let indices = keys
+            .iter()
+            .map(|key| {
+                post_rows.get(key).copied().ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "lix_file RETURNING post-image is missing inserted or updated row '{}'",
+                        key.id
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        take_record_batch_rows(&batch, &indices)
     }
 }
 
@@ -1191,6 +1307,116 @@ impl TableSpec for LixFileSpec {
         Ok(Some(apply))
     }
 
+    async fn plan_insert_with_returning(
+        &self,
+        write_ctx: SqlWriteContext,
+        input: &Arc<dyn ExecutionPlan>,
+        returning: DmlReturning,
+    ) -> Result<InsertApply> {
+        let insert_intents = InsertColumnIntents::from_input(input);
+        let data_is_explicit = write_ctx.explicit_insert_columns().map_or_else(
+            || {
+                insert_intents.includes_column("data")
+                    && !self.options.omitted_insert_columns.contains("data")
+            },
+            |columns| columns.contains("data"),
+        );
+        let include_data_writes = self.schema.field_with_name("data").is_ok() && data_is_explicit;
+        let spec = self.clone();
+        Ok(Arc::new(move |batches| {
+            let write_ctx = write_ctx.clone();
+            let spec = spec.clone();
+            let returning = returning.clone();
+            async move {
+                let row_capacity = batches
+                    .iter()
+                    .map(RecordBatch::num_rows)
+                    .sum::<usize>()
+                    .saturating_mul(3);
+                let mut staged = LixFileStagedBatch::with_row_capacity(row_capacity);
+                let mut path_resolvers = None;
+                let mut keys = Vec::new();
+                for batch in batches {
+                    let batch = spec.materialize_returning_insert_defaults(&batch)?;
+                    for row_index in 0..batch.num_rows() {
+                        keys.push(spec.returning_key_from_batch(&batch, row_index)?);
+                    }
+                    if path_resolvers.is_none() {
+                        path_resolvers = Some(
+                            directory_path_resolvers_from_live_state(
+                                Arc::new(WriteContextLiveStateReader::new(write_ctx.clone())),
+                                spec.branch_binding.active_branch_id(),
+                            )
+                            .await
+                            .map_err(lix_error_to_datafusion_error)?,
+                        );
+                    }
+                    if record_batch_has_non_null_column(&batch, "path")? {
+                        staged
+                            .extend(lix_file_insert_stage_from_batch_with_path_resolvers(
+                                &batch,
+                                spec.branch_binding.active_branch_id(),
+                                lix_file_surface_name(&spec.branch_binding),
+                                path_resolvers
+                                    .as_mut()
+                                    .expect("path resolver should be initialized"),
+                                &mut || spec.functions.call_uuid_v7().to_string(),
+                                include_data_writes,
+                            )?)
+                            .map_err(lix_error_to_datafusion_error)?;
+                    } else {
+                        staged
+                            .extend(
+                                lix_file_insert_stage_from_batch_with_id_generator_and_path_resolvers(
+                                    &batch,
+                                    spec.branch_binding.active_branch_id(),
+                                    lix_file_surface_name(&spec.branch_binding),
+                                    path_resolvers
+                                        .as_mut()
+                                        .expect("path resolver should be initialized"),
+                                    &mut || spec.functions.call_uuid_v7().to_string(),
+                                    include_data_writes,
+                                )?,
+                            )
+                            .map_err(lix_error_to_datafusion_error)?;
+                    }
+                }
+
+                let count = staged.count;
+                if !staged.state_rows.is_empty() || !staged.file_data_writes.is_empty() {
+                    let intent = if staged.file_data_writes.is_empty() {
+                        TransactionWrite::Rows {
+                            mode: TransactionWriteMode::Insert,
+                            rows: staged.state_rows,
+                        }
+                    } else {
+                        TransactionWrite::RowsWithFileData {
+                            mode: TransactionWriteMode::Insert,
+                            rows: staged.state_rows,
+                            file_data: staged.file_data_writes,
+                            count,
+                        }
+                    };
+                    write_ctx
+                        .stage_write(intent)
+                        .await
+                        .map_err(lix_error_to_datafusion_error)?;
+                }
+
+                let post_image = spec
+                    .returning_post_image(
+                        &write_ctx,
+                        &keys,
+                        returning.required_columns().contains("data"),
+                    )
+                    .await?;
+                returning.capture(returning.project(&post_image)?);
+                Ok(count)
+            }
+            .boxed()
+        }))
+    }
+
     fn validate_update_assignments(&self, assignments: &[(String, Expr)]) -> Result<()> {
         validate_lix_file_update_assignments(&self.schema, assignments)
     }
@@ -1287,10 +1513,37 @@ impl TableSpec for LixFileSpec {
         assignments: Vec<(String, Arc<dyn PhysicalExpr>)>,
         filters: &[Expr],
     ) -> Result<PlannedDml> {
+        self.plan_update_with_post_image(write_ctx, assignments, filters, None)
+            .await
+    }
+
+    async fn plan_update_with_returning(
+        &self,
+        write_ctx: SqlWriteContext,
+        assignments: Vec<(String, Arc<dyn PhysicalExpr>)>,
+        filters: &[Expr],
+        returning: DmlReturning,
+    ) -> Result<PlannedDml> {
+        self.plan_update_with_post_image(write_ctx, assignments, filters, Some(returning))
+            .await
+    }
+}
+
+impl LixFileSpec {
+    async fn plan_update_with_post_image(
+        &self,
+        write_ctx: SqlWriteContext,
+        assignments: Vec<(String, Arc<dyn PhysicalExpr>)>,
+        filters: &[Expr],
+        returning: Option<DmlReturning>,
+    ) -> Result<PlannedDml> {
         let needs_data = filters.iter().any(|filter| contains_column(filter, "data"))
             || assignments.iter().any(|(column_name, expr)| {
                 column_name == "path" || physical_expr_contains_column(expr, "data")
-            });
+            })
+            || returning
+                .as_ref()
+                .is_some_and(|returning| returning.required_columns().contains("data"));
         let target_file_ids = file_id_constraint_from_filters(filters)?;
         let mut request = lix_file_scan_request(self.branch_binding.active_branch_id(), None, None);
         request.filter.branch_ids = explicit_branch_ids_from_dml_filters(filters);
@@ -1326,13 +1579,26 @@ impl TableSpec for LixFileSpec {
         );
         let branch_binding = self.branch_binding.clone();
         let functions = self.functions.clone();
+        let returning_spec = self.clone();
         let apply: DmlApply = Arc::new(move |matched_batch| {
             let write_ctx = write_ctx.clone();
             let branch_binding = branch_binding.clone();
             let functions = functions.clone();
             let assignments = assignments.clone();
             let captured = Arc::clone(&captured);
+            let returning = returning.clone();
+            let returning_spec = returning_spec.clone();
             async move {
+                let keys = returning
+                    .as_ref()
+                    .map(|_| {
+                        (0..matched_batch.num_rows())
+                            .map(|row_index| {
+                                returning_spec.returning_key_from_batch(&matched_batch, row_index)
+                            })
+                            .collect::<Result<Vec<_>>>()
+                    })
+                    .transpose()?;
                 let LixFileDmlSourceState {
                     blob_ref_keys,
                     derived_file_ref_keys,
@@ -1410,6 +1676,16 @@ impl TableSpec for LixFileSpec {
                         .map_err(lix_error_to_datafusion_error)?;
                 }
 
+                if let (Some(returning), Some(keys)) = (returning, keys) {
+                    let post_image = returning_spec
+                        .returning_post_image(
+                            &write_ctx,
+                            &keys,
+                            returning.required_columns().contains("data"),
+                        )
+                        .await?;
+                    returning.capture(returning.project(&post_image)?);
+                }
                 Ok(count)
             }
             .boxed()
@@ -1559,6 +1835,35 @@ impl UpsertSupport for LixFileSpec {
             "lixcol_untracked",
             Arc::new(BooleanArray::from(vec![false; proposed.num_rows()])),
         )
+    }
+
+    async fn materialize_returning_insert_defaults(
+        &self,
+        _write_ctx: &SqlWriteContext,
+        proposed: &RecordBatch,
+    ) -> Result<RecordBatch> {
+        LixFileSpec::materialize_returning_insert_defaults(self, proposed)
+    }
+
+    async fn capture_upsert_returning(
+        &self,
+        write_ctx: &SqlWriteContext,
+        affected_rows: Vec<UpsertReturningRow>,
+        returning: DmlReturning,
+    ) -> Result<()> {
+        let keys = affected_rows
+            .iter()
+            .map(|row| self.returning_key_from_batch(row.batch(), row.row_index()))
+            .collect::<Result<Vec<_>>>()?;
+        let post_image = self
+            .returning_post_image(
+                write_ctx,
+                &keys,
+                returning.required_columns().contains("data"),
+            )
+            .await?;
+        returning.capture(returning.project(&post_image)?);
+        Ok(())
     }
 
     async fn scan_conflict_candidates(

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -85,6 +85,81 @@ pub(crate) async fn execute_spec_upsert(
         .map_err(crate::sql2::error::datafusion_error_to_lix_error)
 }
 
+/// Execute an `INSERT ... ON CONFLICT ... RETURNING` against a registered
+/// provider. The provider must capture an exact post-image; this helper does
+/// not permit a successful mutation to return only its affected count.
+pub(crate) async fn execute_spec_upsert_with_returning(
+    table: &Arc<dyn TableProvider>,
+    input: &Arc<dyn ExecutionPlan>,
+    proposed_batches: Vec<datafusion::arrow::record_batch::RecordBatch>,
+    target_columns: &[String],
+    action: &UpsertAction,
+    returning: DmlReturning,
+) -> Result<u64, LixError> {
+    let provider = table
+        .as_any()
+        .downcast_ref::<spec::SpecTableProvider>()
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_UNSUPPORTED_SQL,
+                "INSERT ON CONFLICT RETURNING is not supported on this table",
+            )
+        })?;
+    provider
+        .execute_upsert_with_returning(input, proposed_batches, target_columns, action, returning)
+        .await
+        .map_err(crate::sql2::error::datafusion_error_to_lix_error)
+}
+
+/// Plan an `INSERT ... RETURNING` against a registered table provider. The
+/// provider must explicitly implement post-image capture; this helper does
+/// not fall back to a count-only insert plan.
+pub(crate) async fn execute_spec_insert_with_returning(
+    table: &Arc<dyn TableProvider>,
+    state: &dyn datafusion::catalog::Session,
+    input: Arc<dyn ExecutionPlan>,
+    returning: DmlReturning,
+) -> Result<Arc<dyn ExecutionPlan>, LixError> {
+    let provider = table
+        .as_any()
+        .downcast_ref::<spec::SpecTableProvider>()
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_UNSUPPORTED_SQL,
+                "INSERT RETURNING is not supported on this table",
+            )
+        })?;
+    provider
+        .insert_with_returning(state, input, returning)
+        .await
+        .map_err(crate::sql2::error::datafusion_error_to_lix_error)
+}
+
+/// Plan an `UPDATE ... RETURNING` against a registered table provider. The
+/// provider must explicitly implement post-image capture; this helper does
+/// not fall back to a count-only update plan.
+pub(crate) async fn execute_spec_update_with_returning(
+    table: &Arc<dyn TableProvider>,
+    state: &dyn datafusion::catalog::Session,
+    assignments: Vec<(String, datafusion::logical_expr::Expr)>,
+    filters: Vec<datafusion::logical_expr::Expr>,
+    returning: DmlReturning,
+) -> Result<Arc<dyn ExecutionPlan>, LixError> {
+    let provider = table
+        .as_any()
+        .downcast_ref::<spec::SpecTableProvider>()
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_UNSUPPORTED_SQL,
+                "UPDATE RETURNING is not supported on this table",
+            )
+        })?;
+    provider
+        .update_with_returning(state, assignments, filters, returning)
+        .await
+        .map_err(crate::sql2::error::datafusion_error_to_lix_error)
+}
+
 /// Validate an `INSERT ... ON CONFLICT` against a registered table provider.
 pub(crate) async fn validate_spec_upsert(
     table: &Arc<dyn TableProvider>,

--- a/packages/engine/src/sql2/providers/spec.rs
+++ b/packages/engine/src/sql2/providers/spec.rs
@@ -15,8 +15,8 @@ use std::future::Future;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use datafusion::arrow::array::{ArrayRef, BooleanArray, UInt64Array};
-use datafusion::arrow::compute::{SortOptions, and, filter_record_batch};
+use datafusion::arrow::array::{ArrayRef, BooleanArray, UInt32Array, UInt64Array};
+use datafusion::arrow::compute::{SortOptions, and, filter_record_batch, take};
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::catalog::{Session, TableProvider};
@@ -71,10 +71,12 @@ where
 pub(super) type DmlApply =
     Arc<dyn Fn(RecordBatch) -> BoxFuture<'static, Result<u64>> + Send + Sync>;
 
-/// Optional pre-delete projection captured from the exact batch that will be
-/// handed to a DML apply handler.  The capture is deliberately separate from
-/// the physical DML count output: callers continue to receive an accurate
-/// affected-row count even when a delete stages additional cascade rows.
+/// Optional DML projection captured by a write handler. DELETE captures its
+/// pre-image in [`SpecDmlExec`], while INSERT and UPDATE providers capture
+/// their post-image only after the staged write has succeeded. The capture is
+/// deliberately separate from the physical DML count output: callers still
+/// receive an accurate affected-row count even when a write stages auxiliary
+/// rows (for example, filesystem descriptors or cascades).
 #[derive(Clone)]
 pub(crate) struct DmlReturning {
     schema: SchemaRef,
@@ -105,7 +107,7 @@ impl DmlReturning {
         &self.required_columns
     }
 
-    fn project(&self, batch: &RecordBatch) -> Result<RecordBatch> {
+    pub(super) fn project(&self, batch: &RecordBatch) -> Result<RecordBatch> {
         let columns = self
             .expressions
             .iter()
@@ -118,21 +120,21 @@ impl DmlReturning {
         RecordBatch::try_new(Arc::clone(&self.schema), columns).map_err(DataFusionError::from)
     }
 
-    fn capture(&self, batch: RecordBatch) {
+    pub(super) fn capture(&self, batch: RecordBatch) {
         *self
             .captured
             .lock()
-            .expect("DELETE RETURNING capture mutex poisoned") = Some(batch);
+            .expect("DML RETURNING capture mutex poisoned") = Some(batch);
     }
 
     pub(crate) fn take_captured(&self) -> Result<RecordBatch> {
         self.captured
             .lock()
-            .expect("DELETE RETURNING capture mutex poisoned")
+            .expect("DML RETURNING capture mutex poisoned")
             .take()
             .ok_or_else(|| {
                 DataFusionError::Execution(
-                    "DELETE RETURNING execution completed without a captured result".to_string(),
+                    "DML RETURNING execution completed without a captured result".to_string(),
                 )
             })
     }
@@ -262,6 +264,22 @@ pub(super) trait TableSpec: Send + Sync + 'static {
         Ok(None)
     }
 
+    /// Plan an INSERT that must produce the exact inserted post-image.  This
+    /// intentionally has no default fallback to `stage_insert`: a provider
+    /// that does not explicitly construct and capture its post-image must not
+    /// turn `INSERT ... RETURNING` into a count-only mutation.
+    async fn plan_insert_with_returning(
+        &self,
+        _write_ctx: SqlWriteContext,
+        _input: &Arc<dyn ExecutionPlan>,
+        _returning: DmlReturning,
+    ) -> Result<InsertApply> {
+        Err(DataFusionError::Execution(format!(
+            "INSERT RETURNING is not supported on {}",
+            self.table_name()
+        )))
+    }
+
     /// Plan-time validation of UPDATE assignment targets.
     fn validate_update_assignments(&self, _assignments: &[(String, Expr)]) -> Result<()> {
         Ok(())
@@ -303,6 +321,23 @@ pub(super) trait TableSpec: Send + Sync + 'static {
     ) -> Result<PlannedDml> {
         Err(DataFusionError::Execution(format!(
             "UPDATE {} is not supported",
+            self.table_name()
+        )))
+    }
+
+    /// Plan an UPDATE that must produce the exact updated post-image.  Like
+    /// [`TableSpec::plan_insert_with_returning`], this deliberately rejects by
+    /// default so a newly writable provider cannot silently report only the
+    /// affected count for `UPDATE ... RETURNING`.
+    async fn plan_update_with_returning(
+        &self,
+        _write_ctx: SqlWriteContext,
+        _assignments: Vec<(String, Arc<dyn PhysicalExpr>)>,
+        _filters: &[Expr],
+        _returning: DmlReturning,
+    ) -> Result<PlannedDml> {
+        Err(DataFusionError::Execution(format!(
+            "UPDATE RETURNING is not supported on {}",
             self.table_name()
         )))
     }
@@ -373,6 +408,29 @@ impl SpecTableProvider {
         upsert::execute_upsert(support, &write_ctx, proposed_batches, &target, action).await
     }
 
+    /// Execute an `INSERT ... ON CONFLICT ... RETURNING` through the shared
+    /// upsert driver. The driver requires provider-owned post-image capture,
+    /// so this has no count-only fallback.
+    pub(crate) async fn execute_upsert_with_returning(
+        &self,
+        input: &Arc<dyn ExecutionPlan>,
+        proposed_batches: Vec<RecordBatch>,
+        target_columns: &[String],
+        action: &upsert::UpsertAction,
+        returning: DmlReturning,
+    ) -> Result<u64> {
+        let (write_ctx, support, target) = self.validate_upsert(input, target_columns).await?;
+        upsert::execute_upsert_with_returning(
+            support,
+            &write_ctx,
+            proposed_batches,
+            &target,
+            action,
+            returning,
+        )
+        .await
+    }
+
     pub(crate) async fn validate_upsert(
         &self,
         input: &Arc<dyn ExecutionPlan>,
@@ -403,6 +461,88 @@ impl SpecTableProvider {
         returning: DmlReturning,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         self.delete_impl(state, filters, Some(returning)).await
+    }
+
+    /// Plan an INSERT whose provider captures a post-write `RETURNING`
+    /// projection. This path is separate from `TableProvider::insert_into` so
+    /// only providers that explicitly implement post-image capture can expose
+    /// the SQL surface.
+    pub(crate) async fn insert_with_returning(
+        &self,
+        _state: &dyn Session,
+        input: Arc<dyn ExecutionPlan>,
+        returning: DmlReturning,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let table = self.spec.table_name();
+        let write_ctx = self
+            .write_access
+            .require_write(&format!("INSERT into {table}"))?;
+        self.schema
+            .logically_equivalent_names_and_types(&input.schema())?;
+        let omitted_insert_columns = write_ctx.explicit_insert_columns().map_or_else(
+            || InsertColumnIntents::from_input(&input).omitted_columns(self.schema.as_ref()),
+            |explicit_columns| {
+                self.schema
+                    .fields()
+                    .iter()
+                    .filter(|field| !explicit_columns.contains(field.name().as_str()))
+                    .map(|field| field.name().clone())
+                    .collect()
+            },
+        );
+        let apply = self
+            .spec
+            .plan_insert_with_returning(write_ctx, &input, returning)
+            .await?;
+        let sink: Arc<dyn InsertSink> = Arc::new(PlannedInsertSink {
+            table: table.into(),
+            apply,
+            omitted_insert_columns,
+        });
+        Ok(Arc::new(InsertExec::new(input, sink)))
+    }
+
+    /// Plan an UPDATE whose provider captures a post-write `RETURNING`
+    /// projection. `SpecDmlExec` receives no returning projection here because
+    /// its built-in capture is intentionally the DELETE pre-image path.
+    pub(crate) async fn update_with_returning(
+        &self,
+        state: &dyn Session,
+        assignments: Vec<(String, Expr)>,
+        filters: Vec<Expr>,
+        returning: DmlReturning,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let table = self.spec.table_name();
+        let write_ctx = self
+            .write_access
+            .require_write(&format!("UPDATE {table}"))?;
+        self.spec.validate_update_assignments(&assignments)?;
+        let filters = self.spec.prepare_write_filters(filters)?;
+        let df_schema = DFSchema::try_from(Arc::clone(&self.schema))?;
+        let physical_assignments = assignments
+            .iter()
+            .map(|(column_name, expr)| {
+                Ok((
+                    column_name.clone(),
+                    create_physical_expr(expr, &df_schema, state.execution_props())?,
+                ))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let physical_filters = filters
+            .iter()
+            .map(|expr| create_physical_expr(expr, &df_schema, state.execution_props()))
+            .collect::<Result<Vec<_>>>()?;
+        let planned = self
+            .spec
+            .plan_update_with_returning(write_ctx, physical_assignments, &filters, returning)
+            .await?;
+        Ok(Arc::new(SpecDmlExec::new(
+            table.into(),
+            "UPDATE",
+            planned,
+            physical_filters,
+            None,
+        )))
     }
 
     async fn delete_impl(
@@ -928,6 +1068,20 @@ pub(super) fn filter_batch(
         return Ok(batch);
     };
     Ok(filter_record_batch(&batch, &mask)?)
+}
+
+/// Select rows from a fully materialized provider batch in a caller-defined
+/// order. `RETURNING` reloads use this after reading the transaction-visible
+/// post-image by stable provider identity, so the result still corresponds to
+/// the input write rows rather than incidental storage scan ordering.
+pub(super) fn take_record_batch_rows(batch: &RecordBatch, indices: &[u32]) -> Result<RecordBatch> {
+    let indices = UInt32Array::from(indices.to_vec());
+    let columns = batch
+        .columns()
+        .iter()
+        .map(|column| take(column.as_ref(), &indices, None))
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    RecordBatch::try_new(batch.schema(), columns).map_err(DataFusionError::from)
 }
 
 fn evaluate_filters(

--- a/packages/engine/src/sql2/providers/upsert.rs
+++ b/packages/engine/src/sql2/providers/upsert.rs
@@ -26,10 +26,13 @@ use datafusion::physical_expr::PhysicalExpr;
 
 use crate::sql2::SqlWriteContext;
 use crate::sql2::error::lix_error_to_datafusion_error;
+use crate::sql2::exec::datafusion::LIX_INSERT_COLUMN_OMITTED_METADATA_KEY;
 use crate::sql2::write_normalization::{insert_column_is_omitted, mark_omitted_insert_columns};
 use crate::transaction::types::{
     RawWriteBatch, TransactionFileData, TransactionWrite, TransactionWriteMode,
 };
+
+use super::spec::DmlReturning;
 
 /// Which `ON CONFLICT` action to take on a conflicting row.
 pub(crate) enum UpsertAction {
@@ -110,6 +113,40 @@ impl StagedUpsert {
     }
 }
 
+/// One logical row affected by an upsert, retained solely to let a provider
+/// recover its exact post-image after the shared driver has staged all writes.
+/// The row comes from the proposed input for an insert and from the existing
+/// batch for a conflict update; either way it retains the stable row identity.
+#[derive(Clone)]
+pub(super) struct UpsertReturningRow {
+    batch: RecordBatch,
+    row_index: usize,
+}
+
+impl UpsertReturningRow {
+    fn proposed(batch: &RecordBatch, row_index: usize) -> Self {
+        Self {
+            batch: batch.clone(),
+            row_index,
+        }
+    }
+
+    fn existing(batch: &RecordBatch, row_index: usize) -> Self {
+        Self {
+            batch: batch.clone(),
+            row_index,
+        }
+    }
+
+    pub(super) fn batch(&self) -> &RecordBatch {
+        &self.batch
+    }
+
+    pub(super) fn row_index(&self) -> usize {
+        self.row_index
+    }
+}
+
 /// The per-table capabilities the generic upsert driver composes. Every method
 /// reuses logic the spec already has for plain INSERT/UPDATE.
 #[async_trait]
@@ -162,6 +199,33 @@ pub(super) trait UpsertSupport: Send + Sync {
         proposed: &RecordBatch,
     ) -> Result<RecordBatch> {
         Ok(proposed.clone())
+    }
+
+    /// Materialize any generated insert identity needed to reload an upsert's
+    /// post-image. Implementations must make that value explicit to their
+    /// insert staging path. The default deliberately rejects so `RETURNING`
+    /// can never silently fall back to a count-only upsert.
+    async fn materialize_returning_insert_defaults(
+        &self,
+        _write_ctx: &SqlWriteContext,
+        _proposed: &RecordBatch,
+    ) -> Result<RecordBatch> {
+        Err(DataFusionError::Execution(
+            "INSERT ON CONFLICT RETURNING is not supported on this table".to_string(),
+        ))
+    }
+
+    /// Capture an upsert's post-image after shared staging has succeeded.
+    /// Filesystem providers reload derived and audit values from the overlay.
+    async fn capture_upsert_returning(
+        &self,
+        _write_ctx: &SqlWriteContext,
+        _affected_rows: Vec<UpsertReturningRow>,
+        _returning: DmlReturning,
+    ) -> Result<()> {
+        Err(DataFusionError::Execution(
+            "INSERT ON CONFLICT RETURNING is not supported on this table".to_string(),
+        ))
     }
 
     /// Scan existing rows whose identity matches a proposed row, returned as a
@@ -276,26 +340,152 @@ pub(super) async fn execute_upsert<S: UpsertSupport + ?Sized>(
         }
     }
 
-    if !staged.is_empty() {
-        let write = if staged.file_data.is_empty() {
-            TransactionWrite::Rows {
-                mode: TransactionWriteMode::Replace,
-                rows: staged.rows,
-            }
-        } else {
-            TransactionWrite::RowsWithFileData {
-                mode: TransactionWriteMode::Replace,
-                rows: staged.rows,
-                file_data: staged.file_data,
-                count: affected,
-            }
-        };
-        write_ctx
-            .stage_write(write)
-            .await
-            .map_err(lix_error_to_datafusion_error)?;
-    }
+    stage_upsert(write_ctx, staged, affected).await?;
     Ok(affected)
+}
+
+/// Run an upsert that must produce an exact post-image. The shared conflict
+/// algorithm retains the stable identity for every logical insert/update in
+/// input-row order, then asks the provider to reload that post-image from the
+/// transaction overlay once all staged writes are visible.
+pub(super) async fn execute_upsert_with_returning<S: UpsertSupport + ?Sized>(
+    spec: &S,
+    write_ctx: &SqlWriteContext,
+    proposed_batches: Vec<RecordBatch>,
+    target: &UpsertConflictTarget,
+    action: &UpsertAction,
+    returning: DmlReturning,
+) -> Result<u64> {
+    let conflict_columns = target.columns();
+    let mut staged = StagedUpsert::default();
+    let mut affected = 0_u64;
+    let mut returning_rows = Vec::new();
+    let mut normalized_batches = Vec::with_capacity(proposed_batches.len());
+
+    for batch in proposed_batches {
+        let batch = if let Some(explicit_columns) = write_ctx.explicit_insert_columns() {
+            let omitted_columns = batch
+                .schema()
+                .fields()
+                .iter()
+                .filter(|field| !explicit_columns.contains(field.name().as_str()))
+                .map(|field| field.name().clone())
+                .collect::<BTreeSet<_>>();
+            mark_omitted_insert_columns(batch, &omitted_columns)?
+        } else {
+            batch
+        };
+        normalized_batches.push(
+            spec.materialize_returning_insert_defaults(write_ctx, &batch)
+                .await?,
+        );
+    }
+
+    for batch in &normalized_batches {
+        spec.validate_proposed_batch(batch)?;
+        let existing = spec
+            .scan_conflict_candidates(write_ctx, batch, target)
+            .await?;
+        let existing_by_identity = index_by_identity(&existing, conflict_columns)?;
+
+        let mut matched_proposed = Vec::new();
+        let mut matched_existing = Vec::new();
+        let mut unmatched_proposed = Vec::new();
+        let mut existing_for_proposed = vec![None; batch.num_rows()];
+        for row in 0..batch.num_rows() {
+            let key = identity_key(batch, row, conflict_columns)?;
+            if let Some(existing_rows) = existing_by_identity.get(&key) {
+                for &existing_row in existing_rows {
+                    spec.validate_conflict_pair(&existing, existing_row, batch, row, target)?;
+                }
+                let existing_row = existing_rows[0];
+                existing_for_proposed[row] = Some(existing_row);
+                matched_proposed.push(row as u64);
+                matched_existing.push(existing_row as u64);
+            } else {
+                unmatched_proposed.push(row as u64);
+            }
+        }
+
+        if !unmatched_proposed.is_empty() {
+            let insert_batch = take_rows(batch, &unmatched_proposed)?;
+            staged.extend(spec.insert_staged_rows(write_ctx, &insert_batch).await?);
+            affected = affected
+                .checked_add(u64::try_from(unmatched_proposed.len()).map_err(|_| {
+                    DataFusionError::Execution("UPSERT row count overflow".to_string())
+                })?)
+                .ok_or_else(|| {
+                    DataFusionError::Execution("UPSERT row count overflow".to_string())
+                })?;
+        }
+
+        if !matched_proposed.is_empty() {
+            if let UpsertAction::DoUpdate { assignments } = action {
+                let existing_matched = take_rows(&existing, &matched_existing)?;
+                let proposed_matched = take_rows(batch, &matched_proposed)?;
+                let proposed_matched = spec
+                    .materialize_excluded_defaults(write_ctx, &proposed_matched)
+                    .await?;
+                let augmented = augment_with_excluded(&existing_matched, &proposed_matched)?;
+                staged.extend(
+                    spec.apply_conflict_update(write_ctx, &augmented, assignments)
+                        .await?,
+                );
+                affected = affected
+                    .checked_add(u64::try_from(matched_proposed.len()).map_err(|_| {
+                        DataFusionError::Execution("UPSERT row count overflow".to_string())
+                    })?)
+                    .ok_or_else(|| {
+                        DataFusionError::Execution("UPSERT row count overflow".to_string())
+                    })?;
+            }
+        }
+
+        // A conflict `DO NOTHING` emits no RETURNING row. All other rows are
+        // kept in SQL input order; the existing row owns an update identity.
+        for (row, existing_row) in existing_for_proposed.into_iter().enumerate() {
+            match (existing_row, action) {
+                (None, _) => returning_rows.push(UpsertReturningRow::proposed(batch, row)),
+                (Some(existing_row), UpsertAction::DoUpdate { .. }) => {
+                    returning_rows.push(UpsertReturningRow::existing(&existing, existing_row));
+                }
+                (Some(_), UpsertAction::DoNothing) => {}
+            }
+        }
+    }
+
+    stage_upsert(write_ctx, staged, affected).await?;
+    spec.capture_upsert_returning(write_ctx, returning_rows, returning)
+        .await?;
+    Ok(affected)
+}
+
+async fn stage_upsert(
+    write_ctx: &SqlWriteContext,
+    staged: StagedUpsert,
+    affected: u64,
+) -> Result<()> {
+    if staged.is_empty() {
+        return Ok(());
+    }
+    let write = if staged.file_data.is_empty() {
+        TransactionWrite::Rows {
+            mode: TransactionWriteMode::Replace,
+            rows: staged.rows,
+        }
+    } else {
+        TransactionWrite::RowsWithFileData {
+            mode: TransactionWriteMode::Replace,
+            rows: staged.rows,
+            file_data: staged.file_data,
+            count: affected,
+        }
+    };
+    write_ctx
+        .stage_write(write)
+        .await
+        .map_err(lix_error_to_datafusion_error)
+        .map(|_| ())
 }
 
 /// Replace one omitted INSERT placeholder with its provider-evaluated default.
@@ -318,6 +508,44 @@ where
     let mut columns = proposed.columns().to_vec();
     columns[column_index] = values;
     RecordBatch::try_new(proposed.schema(), columns).map_err(DataFusionError::from)
+}
+
+/// Materialize a provider default for a plain INSERT and make the column
+/// visible as an explicit value to the staging path. Unlike
+/// [`materialize_omitted_column`], this removes the omission marker: plain
+/// INSERT builders intentionally treat that marker as "generate later", but
+/// a `RETURNING` write needs one stable generated value it can both stage and
+/// read back by identity.
+pub(super) fn materialize_omitted_insert_default<A>(
+    proposed: &RecordBatch,
+    column_name: &str,
+    values: Arc<A>,
+) -> Result<RecordBatch>
+where
+    A: Array + 'static,
+{
+    if !insert_column_is_omitted(proposed, column_name) {
+        return Ok(proposed.clone());
+    }
+    let materialized = materialize_omitted_column(proposed, column_name, values)?;
+    let fields = materialized
+        .schema()
+        .fields()
+        .iter()
+        .map(|field| {
+            if field.name() != column_name {
+                return field.as_ref().clone();
+            }
+            let mut metadata = field.metadata().clone();
+            metadata.remove(LIX_INSERT_COLUMN_OMITTED_METADATA_KEY);
+            field.as_ref().clone().with_metadata(metadata)
+        })
+        .collect::<Vec<_>>();
+    let schema = Arc::new(Schema::new_with_metadata(
+        fields,
+        materialized.schema().metadata().clone(),
+    ));
+    RecordBatch::try_new(schema, materialized.columns().to_vec()).map_err(DataFusionError::from)
 }
 
 pub(super) fn validate_target_columns(

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -111,6 +111,7 @@ use crate::transaction::normalization::{
 use crate::transaction::schema_resolver::TransactionSchemaResolver;
 use crate::transaction::staging::{
     PreparedStateRowOverlay, PreparedWriteSet, TransactionWriteBuffer,
+    TransactionWriteBufferCheckpoint,
 };
 use crate::transaction::types::{
     PreparedRowFacts, PreparedStateBatch, PreparedTransactionWrite, RawWriteBatch, RawWriteRowRef,
@@ -414,6 +415,15 @@ pub(crate) struct Transaction<StorageImpl: Storage = Memory> {
     pending_plugin_actor_publications: Vec<PendingPluginActorPublication>,
     plugin_generation_read_guard: Option<tokio::sync::OwnedRwLockReadGuard<()>>,
     plugin_generation_upgrade_guard: Option<tokio::sync::OwnedRwLockWriteGuard<()>>,
+}
+
+/// State which must be restored when `RETURNING` evaluation fails after a
+/// write has been staged in an explicit SQL transaction.
+pub(crate) struct SqlStatementCheckpoint {
+    staged_writes: TransactionWriteBufferCheckpoint,
+    filesystem_path_index_epoch: usize,
+    pending_file_view_mutations: BTreeMap<SessionFileViewKey, SessionFileViewMutation>,
+    trust_filesystem_planner: bool,
 }
 
 #[derive(Clone)]
@@ -970,6 +980,65 @@ where
     /// rely on.
     pub(crate) async fn rollback(mut self) -> Result<(), LixError> {
         self.discard_pending_plugin_actor_publications().await;
+        Ok(())
+    }
+
+    /// Captures the mutable state an explicit SQL statement can change before
+    /// its `RETURNING` projection is evaluated.
+    ///
+    /// Most write errors occur before staging. Post-image `RETURNING` paths
+    /// intentionally stage first, though, so this checkpoint gives those paths
+    /// normal statement atomicity without adding work to the automatic-write
+    /// fast path.
+    pub(crate) fn begin_sql_statement_checkpoint(
+        &self,
+    ) -> Result<SqlStatementCheckpoint, LixError> {
+        Ok(SqlStatementCheckpoint {
+            staged_writes: self.staged_writes.checkpoint()?,
+            filesystem_path_index_epoch: self.filesystem_path_index_epoch.load(Ordering::SeqCst),
+            pending_file_view_mutations: self.pending_file_view_mutations.clone(),
+            trust_filesystem_planner: self.trust_filesystem_planner,
+        })
+    }
+
+    /// Restores an explicit transaction after a statement failed during
+    /// post-stage projection. Earlier successful statements remain staged.
+    pub(crate) async fn rollback_sql_statement_checkpoint(
+        &mut self,
+        checkpoint: SqlStatementCheckpoint,
+    ) -> Result<(), LixError> {
+        let SqlStatementCheckpoint {
+            staged_writes,
+            filesystem_path_index_epoch,
+            pending_file_view_mutations,
+            trust_filesystem_planner,
+        } = checkpoint;
+        self.staged_writes.restore(staged_writes)?;
+        self.filesystem_path_index_epoch
+            .store(filesystem_path_index_epoch, Ordering::SeqCst);
+        // The cache is derived from the discarded post-image. Evict it rather
+        // than cloning potentially large indexes solely for this error path.
+        self.filesystem_path_index_cache.clear();
+        self.pending_file_view_mutations = pending_file_view_mutations;
+        self.trust_filesystem_planner = trust_filesystem_planner;
+        // A failed statement may have chained a predecessor actor successor.
+        // Its prior document can no longer be restored byte-for-byte, so
+        // conservatively discard all unpublished actor cache work. The staged
+        // durable rows are restored above; a later read cold-opens from them.
+        let publications = std::mem::take(&mut self.pending_plugin_actor_publications);
+        let discarded_view_keys = publications
+            .iter()
+            .map(|publication| publication.session_key().clone())
+            .collect::<Vec<_>>();
+        discard_plugin_actor_publications(publications).await;
+        for key in discarded_view_keys {
+            self.pending_file_view_mutations
+                .insert(key.clone(), SessionFileViewMutation::Remove { key });
+        }
+        // Registered-schema normalization uses copy-on-write catalogs. Rebuild
+        // lazily from the restored staging overlay so failed registrations do
+        // not survive in a cached catalog while earlier ones still do.
+        self.schema_resolver.clear_cached_catalogs();
         Ok(())
     }
 
@@ -5537,6 +5606,7 @@ where
             validate_certified_fresh_plugin_file_import(&live_state, certificate).await?;
             return Ok(());
         }
+        let staged = self.staged_writes.staging_overlay()?;
         let validation_index = prepared_writes.validation_index();
         for scope in validation_index.schema_scopes() {
             #[cfg(feature = "storage-benches")]
@@ -5545,7 +5615,7 @@ where
             let live_state = self.live_state.reader(read);
             let schema_catalog = self
                 .schema_resolver
-                .catalog_for_validation(&live_state, scope)
+                .catalog_for_validation(&live_state, &staged, scope)
                 .await?;
             let mut validation_input = TransactionValidationInput::new(
                 &branch_prepared_writes,

--- a/packages/engine/src/transaction/schema_resolver.rs
+++ b/packages/engine/src/transaction/schema_resolver.rs
@@ -74,9 +74,10 @@ impl TransactionSchemaResolver {
     pub(crate) async fn catalog_for_validation(
         &mut self,
         live_state: &dyn LiveStateReader,
+        staged: &PreparedStateRowOverlay,
         domain: &Domain,
     ) -> Result<&CatalogSnapshot, LixError> {
-        self.load_catalog_for_domain(live_state, None, domain)
+        self.load_catalog_for_domain(live_state, Some(staged), domain)
             .await?;
         let domain = domain.schema_catalog_domain();
         Ok(self
@@ -95,6 +96,14 @@ impl TransactionSchemaResolver {
             domain.schema_catalog_domain(),
             TransactionCatalog::Shared(catalog),
         );
+    }
+
+    /// Drops transaction-private compiled catalogs after a statement rollback.
+    /// The next normalization or validation lazily rebuilds from the restored
+    /// staging overlay, retaining registrations from earlier successful
+    /// statements without retaining a failed statement's copy-on-write plan.
+    pub(crate) fn clear_cached_catalogs(&mut self) {
+        self.catalogs_by_domain.clear();
     }
 
     #[cfg(test)]

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -60,6 +60,22 @@ pub(crate) struct TransactionWriteBuffer {
     file_data_writes: Mutex<Vec<TransactionFileData>>,
 }
 
+/// A transaction-local statement checkpoint.
+///
+/// SQL writes coalesce rows, update their commit membership, and can attach
+/// file payloads, so a row-count marker cannot restore the previous journal.
+/// This owns the prepared-row owners and transaction control structures needed
+/// to restore an explicit transaction after a post-stage SQL error.
+pub(crate) struct TransactionWriteBufferCheckpoint {
+    rows: StagedPreparedRows,
+    commit_change_refs_by_branch: BTreeMap<String, StagedCommitChangeRefs>,
+    first_commit_parent_override_by_branch: BTreeMap<String, CommitId>,
+    checkpoint_publications: Vec<CheckpointPublication>,
+    extra_commit_parents_by_branch: BTreeMap<String, Vec<CommitId>>,
+    intermediate_commits: Vec<StagedIntermediateCommit>,
+    file_data_writes: Vec<TransactionFileData>,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct StagedIntermediateCommit {
     pub(crate) branch_id: String,
@@ -72,7 +88,7 @@ pub(crate) enum RowSlot {
     State(usize),
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 struct StagedScanFileCandidates {
     slots_by_value: HashMap<SharedStr, SmallVec<[RowSlot; 1]>>,
     null_slots: SmallVec<[RowSlot; 1]>,
@@ -82,7 +98,7 @@ struct StagedScanFileCandidates {
 /// overlay without changing the journal's identity/coalescing semantics.
 /// Branch and durability remain post-filter checks because one indexed
 /// candidate can legitimately have multiple such physical rows while staged.
-#[derive(Default)]
+#[derive(Clone, Default)]
 struct StagedScanCandidateIndex {
     slots_by_schema: HashMap<SharedStr, SmallVec<[RowSlot; 1]>>,
     slots_by_schema_and_entity: HashMap<SharedStr, HashMap<EntityPk, SmallVec<[RowSlot; 1]>>>,
@@ -233,6 +249,7 @@ impl StagedScanCandidateIndex {
 /// The normal write path is an ordered journal. It becomes an indexed overlay
 /// only if a later write overlaps it or a transaction-local read actually
 /// needs read-your-writes semantics.
+#[derive(Clone)]
 enum StagedPreparedRows {
     AppendOnly {
         rows: PreparedStateBatch,
@@ -316,7 +333,7 @@ pub(crate) struct PreparedWriteValidationIndex<'a> {
 /// stays in one contiguous parallel column so an INSERT followed by an UPDATE
 /// retains the original primary-key error surface without cloning the row's
 /// schema, file, branch, or entity identity.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct PreparedInsertSelection {
     row_count: usize,
     count: usize,
@@ -791,6 +808,144 @@ impl TransactionWriteBuffer {
             intermediate_commits: Mutex::new(Vec::new()),
             file_data_writes: Mutex::new(Vec::new()),
         }
+    }
+
+    /// Captures every mutable staging structure before a statement that may
+    /// need post-stage SQL projection. Restoring this checkpoint preserves
+    /// earlier explicit-transaction statements even when the current one
+    /// fails after it has staged rows.
+    pub(crate) fn checkpoint(&self) -> Result<TransactionWriteBufferCheckpoint, LixError> {
+        let rows = self.rows.lock().map_err(|_| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "failed to acquire transaction staged writes lock",
+            )
+        })?;
+        let file_data_writes = self.file_data_writes.lock().map_err(|_| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "failed to acquire transaction staged file data lock",
+            )
+        })?;
+        let commit_change_refs_by_branch =
+            self.commit_change_refs_by_branch.lock().map_err(|_| {
+                LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    "failed to acquire transaction staged commit change refs lock",
+                )
+            })?;
+        let extra_commit_parents_by_branch =
+            self.extra_commit_parents_by_branch.lock().map_err(|_| {
+                LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    "failed to acquire transaction staged extra commit parents lock",
+                )
+            })?;
+        let intermediate_commits = self.intermediate_commits.lock().map_err(|_| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "failed to acquire transaction staged intermediate commits lock",
+            )
+        })?;
+        let first_commit_parent_override_by_branch = self
+            .first_commit_parent_override_by_branch
+            .lock()
+            .map_err(|_| {
+                LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    "failed to acquire transaction staged first commit parent overrides lock",
+                )
+            })?;
+        let checkpoint_publications = self.checkpoint_publications.lock().map_err(|_| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "failed to acquire transaction staged checkpoint publications lock",
+            )
+        })?;
+
+        Ok(TransactionWriteBufferCheckpoint {
+            rows: rows.clone(),
+            commit_change_refs_by_branch: commit_change_refs_by_branch.clone(),
+            first_commit_parent_override_by_branch: first_commit_parent_override_by_branch.clone(),
+            checkpoint_publications: checkpoint_publications.clone(),
+            extra_commit_parents_by_branch: extra_commit_parents_by_branch.clone(),
+            intermediate_commits: intermediate_commits.clone(),
+            file_data_writes: file_data_writes.clone(),
+        })
+    }
+
+    /// Restores a complete journal checkpoint. The lock order matches
+    /// [`Self::drain`] so rollback cannot observe a partially restored write
+    /// set through another staging operation.
+    pub(crate) fn restore(
+        &self,
+        checkpoint: TransactionWriteBufferCheckpoint,
+    ) -> Result<(), LixError> {
+        let TransactionWriteBufferCheckpoint {
+            rows,
+            commit_change_refs_by_branch,
+            first_commit_parent_override_by_branch,
+            checkpoint_publications,
+            extra_commit_parents_by_branch,
+            intermediate_commits,
+            file_data_writes,
+        } = checkpoint;
+        let mut rows_guard = self.rows.lock().map_err(|_| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "failed to acquire transaction staged writes lock",
+            )
+        })?;
+        let mut file_data_guard = self.file_data_writes.lock().map_err(|_| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "failed to acquire transaction staged file data lock",
+            )
+        })?;
+        let mut commit_change_refs_guard =
+            self.commit_change_refs_by_branch.lock().map_err(|_| {
+                LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    "failed to acquire transaction staged commit change refs lock",
+                )
+            })?;
+        let mut extra_parents_guard = self.extra_commit_parents_by_branch.lock().map_err(|_| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "failed to acquire transaction staged extra commit parents lock",
+            )
+        })?;
+        let mut intermediate_commits_guard = self.intermediate_commits.lock().map_err(|_| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "failed to acquire transaction staged intermediate commits lock",
+            )
+        })?;
+        let mut first_parent_overrides_guard = self
+            .first_commit_parent_override_by_branch
+            .lock()
+            .map_err(|_| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "failed to acquire transaction staged first commit parent overrides lock",
+            )
+        })?;
+        let mut checkpoint_publications_guard =
+            self.checkpoint_publications.lock().map_err(|_| {
+                LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    "failed to acquire transaction staged checkpoint publications lock",
+                )
+            })?;
+
+        *rows_guard = rows;
+        *file_data_guard = file_data_writes;
+        *commit_change_refs_guard = commit_change_refs_by_branch;
+        *extra_parents_guard = extra_commit_parents_by_branch;
+        *intermediate_commits_guard = intermediate_commits;
+        *first_parent_overrides_guard = first_commit_parent_override_by_branch;
+        *checkpoint_publications_guard = checkpoint_publications;
+        Ok(())
     }
 
     /// Returns whether this transaction has changed the schema catalog used
@@ -1960,13 +2115,27 @@ impl PreparedStateRowOverlay {
 
         let mut rows = MaterializedLiveStateBatchBuilder::with_capacity(staged_rows.len());
         if let Some(slots) = by_candidate.slots_for_filter(&request.filter) {
-            append_matching_staged_rows(&mut rows, slots.iter().copied(), staged_rows, request);
+            // `slots_for_filter` already selected these rows by schema and,
+            // when present, entity primary key. Rechecking a large entity-PK
+            // predicate here turns a keyed transaction-overlay read into an
+            // O(candidates * entity_pks) scan. The remaining branch,
+            // retention, and file filters still need their established final
+            // matching because candidate slots intentionally retain their
+            // possible global fallbacks.
+            append_matching_staged_rows(
+                &mut rows,
+                slots.iter().copied(),
+                staged_rows,
+                request,
+                true,
+            );
         } else {
             append_matching_staged_rows(
                 &mut rows,
                 by_identity.values().copied(),
                 staged_rows,
                 request,
+                false,
             );
         }
         Ok(rows.finish())
@@ -2443,13 +2612,15 @@ fn append_matching_staged_rows(
     slots: impl IntoIterator<Item = RowSlot>,
     staged_rows: &PreparedStateBatch,
     request: &LiveStateScanRequest,
+    candidate_index_matched_schema_and_entity: bool,
 ) {
     for slot in slots {
         let RowSlot::State(index) = slot;
         let Some(row) = staged_rows.get(index) else {
             continue;
         };
-        if staged_row_identity_matches_scan(row, request) {
+        if staged_row_identity_matches_scan(row, request, candidate_index_matched_schema_and_entity)
+        {
             push_prepared_materialized(output, row);
         }
     }
@@ -2481,8 +2652,10 @@ fn push_prepared_materialized(
 fn staged_row_identity_matches_scan(
     row: PreparedStateRowRef<'_>,
     request: &LiveStateScanRequest,
+    candidate_index_matched_schema_and_entity: bool,
 ) -> bool {
-    if !request.filter.schema_keys.is_empty()
+    if !candidate_index_matched_schema_and_entity
+        && !request.filter.schema_keys.is_empty()
         && !request
             .filter
             .schema_keys
@@ -2491,7 +2664,10 @@ fn staged_row_identity_matches_scan(
     {
         return false;
     }
-    if !request.filter.entity_pks.is_empty() && !request.filter.entity_pks.contains(row.entity_pk) {
+    if !candidate_index_matched_schema_and_entity
+        && !request.filter.entity_pks.is_empty()
+        && !request.filter.entity_pks.contains(row.entity_pk)
+    {
         return false;
     }
     if !staged_branch_matches_scan(row.branch_id, request) {

--- a/packages/engine/tests/integration/sql.rs
+++ b/packages/engine/tests/integration/sql.rs
@@ -113,6 +113,7 @@ mod metadata;
 mod read_only;
 mod udfs;
 mod untracked_current_state;
+mod write_returning;
 
 use lix_engine::ExecuteResult;
 use lix_engine::Value;

--- a/packages/engine/tests/integration/sql/information_schema.rs
+++ b/packages/engine/tests/integration/sql/information_schema.rs
@@ -1257,29 +1257,52 @@ simulation_test!(
             assert_eq!(error.code, LixError::CODE_TYPE_MISMATCH);
         }
 
-        for sql in [
-            "INSERT INTO engine_excluded_typed_default (id, status) \
-             VALUES ('unsupported-returning-insert', 'x') RETURNING id",
-            "UPDATE engine_excluded_typed_default SET status = 'changed' \
-             WHERE id = 'same' RETURNING id",
-        ] {
-            let error = session
-                .execute(sql, &[])
-                .await
-                .expect_err("unsupported entity RETURNING must not be silently ignored");
-            assert_eq!(error.code, LixError::CODE_UNSUPPORTED_SQL, "{sql}");
-            assert!(error.message.contains("RETURNING"), "{error:?}");
-        }
+        let inserted_returning = session
+            .execute(
+                "INSERT INTO engine_excluded_typed_default (id, status) \
+                 VALUES ('returning-insert', 'x') \
+                 RETURNING id, status AS inserted_status",
+                &[],
+            )
+            .await
+            .expect("entity INSERT RETURNING should expose its final snapshot");
+        assert_eq!(inserted_returning.rows_affected(), 1);
+        assert_eq!(inserted_returning.columns(), ["id", "inserted_status"]);
+        assert_rows_eq(
+            inserted_returning,
+            vec![vec![
+                Value::Text("returning-insert".to_string()),
+                Value::Text("x".to_string()),
+            ]],
+        );
+
+        let updated_returning = session
+            .execute(
+                "UPDATE engine_excluded_typed_default SET status = 'changed' \
+                 WHERE id = 'same' RETURNING id, status AS updated_status",
+                &[],
+            )
+            .await
+            .expect("entity UPDATE RETURNING should expose the post-update snapshot");
+        assert_eq!(updated_returning.rows_affected(), 1);
+        assert_eq!(updated_returning.columns(), ["id", "updated_status"]);
+        assert_rows_eq(
+            updated_returning,
+            vec![vec![
+                Value::Text("same".to_string()),
+                Value::Text("changed".to_string()),
+            ]],
+        );
         assert_rows_eq(
             session
                 .execute(
                     "SELECT id FROM engine_excluded_typed_default \
-                     WHERE id = 'unsupported-returning-insert'",
+                     WHERE id = 'returning-insert'",
                     &[],
                 )
                 .await
-                .expect("rejected INSERT RETURNING must not write"),
-            vec![],
+                .expect("INSERT RETURNING must write its row"),
+            vec![vec![Value::Text("returning-insert".to_string())]],
         );
         assert_rows_eq(
             session
@@ -1288,8 +1311,8 @@ simulation_test!(
                     &[],
                 )
                 .await
-                .expect("rejected UPDATE RETURNING must not write"),
-            vec![vec![Value::Text("old".to_string())]],
+                .expect("UPDATE RETURNING must write its row"),
+            vec![vec![Value::Text("changed".to_string())]],
         );
     }
 );

--- a/packages/engine/tests/integration/sql/write_returning.rs
+++ b/packages/engine/tests/integration/sql/write_returning.rs
@@ -1,0 +1,699 @@
+use lix_engine::Value;
+
+use super::assert_rows_eq;
+
+simulation_test!(
+    registered_entity_returning_uses_generated_postimages_for_insert_update_and_upsert,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("workspace session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (\
+                 lix_json('{\"x-lix-key\":\"returning_task\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"x-lix-default\":\"lix_uuid_v7()\"},\"title\":{\"type\":\"string\"}},\"required\":[\"id\",\"title\"],\"additionalProperties\":false}'))",
+                &[],
+            )
+            .await
+            .expect("returning-task schema registration should succeed");
+
+        let inserted = session
+            .execute(
+                "INSERT INTO returning_task (title) VALUES ($1) RETURNING id, title",
+                &[Value::Text("Created through RETURNING".to_string())],
+            )
+            .await
+            .expect("registered entity INSERT RETURNING should succeed");
+        assert_eq!(inserted.rows_affected(), 1);
+        assert_eq!(inserted.columns(), ["id", "title"]);
+        let [Value::Text(id), Value::Text(title)] = inserted.rows()[0].values() else {
+            panic!("INSERT RETURNING should expose a generated text id and title")
+        };
+        assert!(!id.is_empty(), "generated id should not be empty");
+        assert_eq!(title, "Created through RETURNING");
+        let id = id.clone();
+
+        // `RETURNING *` includes transaction-derived audit fields and uses
+        // the staged postimage path. Exercise more than one row so its
+        // identity lookup remains correct for bulk writes.
+        let wildcard = session
+            .execute(
+                "INSERT INTO returning_task (title) \
+                 VALUES ('Wildcard one'), ('Wildcard two') RETURNING *",
+                &[],
+            )
+            .await
+            .expect("multi-row entity INSERT RETURNING * should succeed");
+        assert_eq!(wildcard.rows_affected(), 2);
+        assert_eq!(wildcard.rows().len(), 2);
+        assert!(
+            wildcard
+                .columns()
+                .iter()
+                .any(|column| column == "lixcol_commit_id"),
+            "wildcard should include the final audit columns"
+        );
+
+        let updated = session
+            .execute(
+                "UPDATE returning_task SET title = $1 WHERE id = $2 \
+                 RETURNING id, title, lixcol_created_at, lixcol_updated_at, \
+                 lixcol_change_id, lixcol_commit_id",
+                &[
+                    Value::Text("Updated through RETURNING".to_string()),
+                    Value::Text(id.clone()),
+                ],
+            )
+            .await
+            .expect("registered entity UPDATE RETURNING should succeed");
+        assert_eq!(updated.rows_affected(), 1);
+        assert_eq!(
+            updated.columns(),
+            [
+                "id",
+                "title",
+                "lixcol_created_at",
+                "lixcol_updated_at",
+                "lixcol_change_id",
+                "lixcol_commit_id",
+            ]
+        );
+        let [
+            Value::Text(returned_id),
+            Value::Text(updated_title),
+            Value::Text(created_at),
+            Value::Text(updated_at),
+            Value::Null,
+            Value::Text(commit_id),
+        ] = updated.rows()[0].values()
+        else {
+            panic!("UPDATE RETURNING should expose final audit fields")
+        };
+        assert_eq!(returned_id, &id);
+        assert_eq!(updated_title, "Updated through RETURNING");
+        // Addressable tracked writes intentionally hide the staged change ID
+        // from transaction-visible state. RETURNING matches SELECT and keeps
+        // it NULL until that visibility boundary exposes it.
+        for value in [created_at, updated_at, commit_id] {
+            assert!(
+                !value.is_empty(),
+                "returned audit value should not be empty"
+            );
+        }
+
+        let upserted = session
+            .execute(
+                "INSERT INTO returning_task (id, title) VALUES ($1, $2) \
+                 ON CONFLICT (id) DO UPDATE SET title = excluded.title \
+                 RETURNING id, title",
+                &[
+                    Value::Text(id.clone()),
+                    Value::Text("Upserted through RETURNING".to_string()),
+                ],
+            )
+            .await
+            .expect("entity UPSERT RETURNING should expose its postimage");
+        assert_eq!(upserted.rows_affected(), 1);
+        assert_rows_eq(
+            upserted,
+            vec![vec![
+                Value::Text(id.clone()),
+                Value::Text("Upserted through RETURNING".to_string()),
+            ]],
+        );
+
+        let no_op = session
+            .execute(
+                "INSERT INTO returning_task (id, title) VALUES ($1, $2) \
+                 ON CONFLICT (id) DO NOTHING RETURNING id, title",
+                &[
+                    Value::Text(id.clone()),
+                    Value::Text("Ignored through RETURNING".to_string()),
+                ],
+            )
+            .await
+            .expect("DO NOTHING RETURNING should succeed");
+        assert_eq!(no_op.rows_affected(), 0);
+        assert_eq!(no_op.columns(), ["id", "title"]);
+        assert!(no_op.rows().is_empty());
+
+        let by_branch = session
+            .execute(
+                "INSERT INTO returning_task_by_branch (id, title, lixcol_branch_id) \
+                 VALUES ('returning-by-branch', 'By branch', $1) \
+                 RETURNING id, title, lixcol_branch_id",
+                &[Value::Text(sim.main_branch_id().to_string())],
+            )
+            .await
+            .expect("by-branch entity INSERT RETURNING should succeed");
+        assert_rows_eq(
+            by_branch,
+            vec![vec![
+                Value::Text("returning-by-branch".to_string()),
+                Value::Text("By branch".to_string()),
+                Value::Text(sim.main_branch_id().to_string()),
+            ]],
+        );
+    }
+);
+
+simulation_test!(
+    filesystem_and_branch_surfaces_return_postimages_for_insert_update_and_upsert,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("workspace session should open"),
+            &engine,
+        );
+
+        let inserted_file = session
+            .execute(
+                "INSERT INTO lix_file (path, data) \
+                 VALUES ('/returning-file.txt', X'6265666F7265') \
+                 RETURNING id, path, data",
+                &[],
+            )
+            .await
+            .expect("file INSERT RETURNING should succeed");
+        assert_eq!(inserted_file.rows_affected(), 1);
+        let [Value::Text(file_id), Value::Text(path), Value::Blob(data)] =
+            inserted_file.rows()[0].values()
+        else {
+            panic!("file INSERT RETURNING should expose the generated id and bytes")
+        };
+        assert!(!file_id.is_empty());
+        assert_eq!(path, "/returning-file.txt");
+        assert_eq!(data.as_ref(), b"before");
+        let file_id = file_id.clone();
+
+        let updated_file = session
+            .execute(
+                "UPDATE lix_file SET data = X'6166746572' WHERE id = $1 \
+                 RETURNING id, path, data",
+                &[Value::Text(file_id.clone())],
+            )
+            .await
+            .expect("file UPDATE RETURNING should expose the postimage");
+        assert_rows_eq(
+            updated_file,
+            vec![vec![
+                Value::Text(file_id.clone()),
+                Value::Text("/returning-file.txt".to_string()),
+                Value::Blob(b"after".to_vec().into()),
+            ]],
+        );
+
+        let upserted_file = session
+            .execute(
+                "INSERT INTO lix_file (path, data) \
+                 VALUES ('/returning-file.txt', X'66696E616C') \
+                 ON CONFLICT (path) DO UPDATE SET data = excluded.data \
+                 RETURNING id, data",
+                &[],
+            )
+            .await
+            .expect("file UPSERT RETURNING should expose the updated row");
+        assert_rows_eq(
+            upserted_file,
+            vec![vec![
+                Value::Text(file_id),
+                Value::Blob(b"final".to_vec().into()),
+            ]],
+        );
+
+        let inserted_directory = session
+            .execute(
+                "INSERT INTO lix_directory (path) VALUES ('/returning-directory') \
+                 RETURNING id, path",
+                &[],
+            )
+            .await
+            .expect("directory INSERT RETURNING should succeed");
+        let [Value::Text(directory_id), Value::Text(directory_path)] =
+            inserted_directory.rows()[0].values()
+        else {
+            panic!("directory INSERT RETURNING should expose the generated id and path")
+        };
+        assert!(!directory_id.is_empty());
+        assert_eq!(directory_path, "/returning-directory");
+        let directory_id = directory_id.clone();
+
+        let updated_directory = session
+            .execute(
+                "UPDATE lix_directory SET path = '/returning-directory-renamed' \
+                 WHERE id = $1 RETURNING id, path",
+                &[Value::Text(directory_id.clone())],
+            )
+            .await
+            .expect("directory UPDATE RETURNING should expose the postimage");
+        assert_rows_eq(
+            updated_directory,
+            vec![vec![
+                Value::Text(directory_id.clone()),
+                Value::Text("/returning-directory-renamed".to_string()),
+            ]],
+        );
+
+        let upserted_directory = session
+            .execute(
+                "INSERT INTO lix_directory (id, path) \
+                 VALUES ($1, '/returning-directory-upserted') \
+                 ON CONFLICT (id) DO UPDATE SET path = excluded.path \
+                 RETURNING id, path",
+                &[Value::Text(directory_id.clone())],
+            )
+            .await
+            .expect("directory UPSERT RETURNING should expose the updated row");
+        assert_rows_eq(
+            upserted_directory,
+            vec![vec![
+                Value::Text(directory_id),
+                Value::Text("/returning-directory-upserted".to_string()),
+            ]],
+        );
+
+        let branch_id = "72657475-726e-896e-872d-6272616e6301";
+        let inserted_branch = session
+            .execute(
+                "INSERT INTO lix_branch (id, name) \
+                 VALUES ('72657475-726e-896e-872d-6272616e6301', 'Returning branch') \
+                 RETURNING id, name, hidden",
+                &[],
+            )
+            .await
+            .expect("branch INSERT RETURNING should succeed");
+        assert_rows_eq(
+            inserted_branch,
+            vec![vec![
+                Value::Text(branch_id.to_string()),
+                Value::Text("Returning branch".to_string()),
+                Value::Boolean(false),
+            ]],
+        );
+
+        let updated_branch = session
+            .execute(
+                "UPDATE lix_branch SET name = 'Updated returning branch' \
+                 WHERE id = $1 RETURNING id, name",
+                &[Value::Text(branch_id.to_string())],
+            )
+            .await
+            .expect("branch UPDATE RETURNING should expose the postimage");
+        assert_rows_eq(
+            updated_branch,
+            vec![vec![
+                Value::Text(branch_id.to_string()),
+                Value::Text("Updated returning branch".to_string()),
+            ]],
+        );
+
+        let upserted_branch = session
+            .execute(
+                "INSERT INTO lix_branch (id, name) \
+                 VALUES ($1, 'Upserted returning branch') \
+                 ON CONFLICT (id) DO UPDATE SET name = excluded.name \
+                 RETURNING id, name, hidden",
+                &[Value::Text(branch_id.to_string())],
+            )
+            .await
+            .expect("branch UPSERT RETURNING should expose the updated row");
+        assert_rows_eq(
+            upserted_branch,
+            vec![vec![
+                Value::Text(branch_id.to_string()),
+                Value::Text("Upserted returning branch".to_string()),
+                Value::Boolean(false),
+            ]],
+        );
+
+        let explicit_branch_id = sim.main_branch_id().to_string();
+        let inserted_file_by_branch = session
+            .execute(
+                "INSERT INTO lix_file_by_branch (path, data, lixcol_branch_id) \
+                 VALUES ('/returning-by-branch-file.txt', X'01', $1) \
+                 RETURNING id, path, lixcol_branch_id",
+                &[Value::Text(explicit_branch_id.clone())],
+            )
+            .await
+            .expect("by-branch file INSERT RETURNING should succeed");
+        let [
+            Value::Text(file_by_branch_id),
+            Value::Text(file_by_branch_path),
+            Value::Text(returned_branch_id),
+        ] = inserted_file_by_branch.rows()[0].values()
+        else {
+            panic!("by-branch file INSERT RETURNING should expose its postimage")
+        };
+        assert_eq!(file_by_branch_path, "/returning-by-branch-file.txt");
+        assert_eq!(returned_branch_id, &explicit_branch_id);
+        let file_by_branch_id = file_by_branch_id.clone();
+
+        let upserted_file_by_branch = session
+            .execute(
+                "INSERT INTO lix_file_by_branch (path, data, lixcol_branch_id) \
+                 VALUES ('/returning-by-branch-file.txt', X'02', $1) \
+                 ON CONFLICT (path, lixcol_branch_id) DO UPDATE SET data = excluded.data \
+                 RETURNING id, data, lixcol_branch_id",
+                &[Value::Text(explicit_branch_id.clone())],
+            )
+            .await
+            .expect("by-branch file UPSERT RETURNING should expose its postimage");
+        assert_rows_eq(
+            upserted_file_by_branch,
+            vec![vec![
+                Value::Text(file_by_branch_id),
+                Value::Blob(vec![2].into()),
+                Value::Text(explicit_branch_id.clone()),
+            ]],
+        );
+
+        let global_file_id = "72657475-726e-896e-872d-676c6f62616c";
+        session
+            .execute(
+                "INSERT INTO lix_file_by_branch \
+                 (id, path, data, lixcol_global, lixcol_branch_id) \
+                 VALUES ($1, '/returning-global-file.txt', X'01', true, \
+                         'ffffffff-ffff-7fff-bfff-ffffffffffff')",
+                &[Value::Text(global_file_id.to_string())],
+            )
+            .await
+            .expect("global file seed should succeed");
+
+        // A global file is rendered in an explicit branch with that consumer
+        // branch's id. RETURNING must preserve that readback identity rather
+        // than re-validate the rendered row as a new global write.
+        let updated_global_projection = session
+            .execute(
+                "UPDATE lix_file_by_branch SET data = X'03' \
+                 WHERE id = $1 AND lixcol_branch_id = $2 \
+                 RETURNING id, path, lixcol_branch_id, lixcol_global",
+                &[
+                    Value::Text(global_file_id.to_string()),
+                    Value::Text(explicit_branch_id.clone()),
+                ],
+            )
+            .await
+            .expect("global file projection UPDATE RETURNING should succeed");
+        assert_rows_eq(
+            updated_global_projection,
+            vec![vec![
+                Value::Text(global_file_id.to_string()),
+                Value::Text("/returning-global-file.txt".to_string()),
+                Value::Text(explicit_branch_id.clone()),
+                Value::Boolean(true),
+            ]],
+        );
+
+        let inserted_directory_by_branch = session
+            .execute(
+                "INSERT INTO lix_directory_by_branch (path, lixcol_branch_id) \
+                 VALUES ('/returning-by-branch-directory', $1) \
+                 RETURNING id, path, lixcol_branch_id",
+                &[Value::Text(explicit_branch_id.clone())],
+            )
+            .await
+            .expect("by-branch directory INSERT RETURNING should succeed");
+        let [
+            Value::Text(directory_by_branch_id),
+            Value::Text(directory_by_branch_path),
+            Value::Text(returned_branch_id),
+        ] = inserted_directory_by_branch.rows()[0].values()
+        else {
+            panic!("by-branch directory INSERT RETURNING should expose its postimage")
+        };
+        assert_eq!(directory_by_branch_path, "/returning-by-branch-directory");
+        assert_eq!(returned_branch_id, &explicit_branch_id);
+        let directory_by_branch_id = directory_by_branch_id.clone();
+
+        let upserted_directory_by_branch = session
+            .execute(
+                "INSERT INTO lix_directory_by_branch (id, path, lixcol_branch_id) \
+                 VALUES ($1, '/returning-by-branch-directory-upserted', $2) \
+                 ON CONFLICT (id) DO UPDATE SET path = excluded.path \
+                 RETURNING id, path, lixcol_branch_id",
+                &[
+                    Value::Text(directory_by_branch_id.clone()),
+                    Value::Text(explicit_branch_id.clone()),
+                ],
+            )
+            .await
+            .expect("by-branch directory UPSERT RETURNING should expose its postimage");
+        assert_rows_eq(
+            upserted_directory_by_branch,
+            vec![vec![
+                Value::Text(directory_by_branch_id),
+                Value::Text("/returning-by-branch-directory-upserted".to_string()),
+                Value::Text(explicit_branch_id),
+            ]],
+        );
+    }
+);
+
+simulation_test!(
+    explicit_transaction_returning_errors_rollback_only_the_failing_statement,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("workspace session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (\
+                 lix_json('{\"x-lix-key\":\"atomic_returning_task\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"title\":{\"type\":\"string\"}},\"required\":[\"id\",\"title\"],\"additionalProperties\":false}'))",
+                &[],
+            )
+            .await
+            .expect("atomic-returning schema registration should succeed");
+        session
+            .execute(
+                "INSERT INTO atomic_returning_task (id, title) VALUES ('task', '42')",
+                &[],
+            )
+            .await
+            .expect("atomic-returning entity seed should succeed");
+        session
+            .execute(
+                "INSERT INTO lix_file (path, data) VALUES ('/42', X'01')",
+                &[],
+            )
+            .await
+            .expect("atomic-returning file seed should succeed");
+
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("transaction should begin");
+        transaction
+            .execute(
+                "INSERT INTO lix_file (path, data) \
+                 VALUES ('/successful-before-returning-error.txt', X'02')",
+                &[],
+            )
+            .await
+            .expect("prior transaction write should stage");
+        // Keep a copy-on-write schema catalog from an earlier successful
+        // statement in this transaction. The rollback below must invalidate
+        // only the failed statement's catalog state, then rebuild this schema
+        // from the restored journal at commit.
+        transaction
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (\
+                 lix_json('{\"x-lix-key\":\"checkpoint_after_returning_error\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"title\":{\"type\":\"string\"}},\"required\":[\"id\",\"title\"],\"additionalProperties\":false}'))",
+                &[],
+            )
+            .await
+            .expect("prior transaction schema registration should stage");
+
+        // `name` is `42` before the update and `not-a-number` afterwards.
+        // A pre-stage/preimage RETURNING check would therefore succeed; the
+        // real postimage cast must fail and leave the transaction unchanged.
+        let error = transaction
+            .execute(
+                "UPDATE lix_file SET path = '/not-a-number' WHERE path = '/42' \
+                 RETURNING CAST(name AS BIGINT) AS x",
+                &[],
+            )
+            .await
+            .expect_err("postimage file RETURNING cast should fail");
+        assert_eq!(error.code, "LIX_TYPE_MISMATCH");
+        assert_rows_eq(
+            transaction
+                .execute("SELECT path FROM lix_file WHERE path = '/42'", &[])
+                .await
+                .expect("failed RETURNING should restore the file row"),
+            vec![vec![Value::Text("/42".to_string())]],
+        );
+        assert_rows_eq(
+            transaction
+                .execute(
+                    "SELECT path FROM lix_file \
+                     WHERE path = '/successful-before-returning-error.txt'",
+                    &[],
+                )
+                .await
+                .expect("failed RETURNING should retain earlier transaction writes"),
+            vec![vec![Value::Text(
+                "/successful-before-returning-error.txt".to_string(),
+            )]],
+        );
+
+        // Entity audit fields require the direct executor's staged postimage
+        // path too. Keep the same cast to prove it is rolled back by the
+        // shared statement checkpoint rather than a provider-specific guard.
+        let error = transaction
+            .execute(
+                "UPDATE atomic_returning_task SET title = 'not-a-number' \
+                 WHERE id = 'task' \
+                 RETURNING CAST(title AS BIGINT) AS x, lixcol_commit_id",
+                &[],
+            )
+            .await
+            .expect_err("staged entity RETURNING cast should fail");
+        assert_eq!(error.code, "LIX_TYPE_MISMATCH");
+        assert_rows_eq(
+            transaction
+                .execute(
+                    "SELECT id, title FROM atomic_returning_task WHERE id = 'task'",
+                    &[],
+                )
+                .await
+                .expect("failed entity RETURNING should restore the postimage"),
+            vec![vec![
+                Value::Text("task".to_string()),
+                Value::Text("42".to_string()),
+            ]],
+        );
+
+        transaction
+            .commit()
+            .await
+            .expect("transaction should commit its earlier successful write");
+        assert_rows_eq(
+            session
+                .execute("SELECT path FROM lix_file WHERE path = '/42'", &[])
+                .await
+                .expect("failed file RETURNING must not persist"),
+            vec![vec![Value::Text("/42".to_string())]],
+        );
+        assert_rows_eq(
+            session
+                .execute(
+                    "SELECT id, title FROM atomic_returning_task WHERE id = 'task'",
+                    &[],
+                )
+                .await
+                .expect("failed entity RETURNING must not persist"),
+            vec![vec![
+                Value::Text("task".to_string()),
+                Value::Text("42".to_string()),
+            ]],
+        );
+        let committed_schema = session
+            .execute(
+                "INSERT INTO checkpoint_after_returning_error (id, title) \
+                 VALUES ('checkpoint', 'retained')",
+                &[],
+            )
+            .await
+            .expect("schema staged before failed RETURNING should commit");
+        assert_eq!(committed_schema.rows_affected(), 1);
+    }
+);
+
+simulation_test!(
+    failed_explicit_returning_rewinds_deterministic_function_state,
+    options = crate::support::simulation_test::engine::SimulationOptions {
+        deterministic: false,
+    },
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("workspace session should open"),
+            &engine,
+        );
+
+        // Register before deterministic mode is enabled so the transaction
+        // below starts at a known, persisted sequence position.
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (\
+                 lix_json('{\"x-lix-key\":\"deterministic_returning_task\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"x-lix-default\":\"lix_uuid_v7()\"},\"title\":{\"type\":\"string\"}},\"required\":[\"id\",\"title\"],\"additionalProperties\":false}'))",
+                &[],
+            )
+            .await
+            .expect("deterministic-returning schema registration should succeed");
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value, lixcol_global, lixcol_untracked) \
+                 VALUES ('lix_deterministic_mode', lix_json('{\"enabled\":true}'), true, true)",
+                &[],
+            )
+            .await
+            .expect("deterministic mode should enable");
+
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("transaction should begin");
+        let error = transaction
+            .execute(
+                "INSERT INTO deterministic_returning_task (title) VALUES ('not-a-number') \
+                 RETURNING CAST(title AS BIGINT) AS x",
+                &[],
+            )
+            .await
+            .expect_err("direct deterministic RETURNING cast should fail");
+        assert_eq!(error.code, "LIX_TYPE_MISMATCH");
+
+        // Audit columns use the staged postimage path, while the cast still
+        // makes the statement fail. Both paths must restore the same runtime
+        // function sequence before the next statement executes.
+        let error = transaction
+            .execute(
+                "INSERT INTO deterministic_returning_task (title) VALUES ('not-a-number') \
+                 RETURNING CAST(title AS BIGINT) AS x, lixcol_commit_id",
+                &[],
+            )
+            .await
+            .expect_err("staged deterministic RETURNING cast should fail");
+        assert_eq!(error.code, "LIX_TYPE_MISMATCH");
+
+        let inserted = transaction
+            .execute(
+                "INSERT INTO deterministic_returning_task (title) VALUES ('restored') \
+                 RETURNING id, title",
+                &[],
+            )
+            .await
+            .expect("successful statement should reuse the failed statement sequence");
+        assert_rows_eq(
+            inserted,
+            vec![vec![
+                Value::Text("01920000-0000-7000-8000-000000000000".to_string()),
+                Value::Text("restored".to_string()),
+            ]],
+        );
+
+        transaction
+            .commit()
+            .await
+            .expect("transaction should commit the successful statement");
+    }
+);

--- a/packages/js-sdk/native/napi.rs
+++ b/packages/js-sdk/native/napi.rs
@@ -27,6 +27,19 @@ use tokio::sync::watch;
 type JsTelemetryDispatch = ThreadsafeFunction<String, (), String, Status, false>;
 type SharedJsTelemetryDispatch = Arc<JsTelemetryDispatch>;
 
+// SQL command and observation actors can compose catalog, filesystem, plugin,
+// and live-state async futures before their first suspension point. They must
+// not inherit the platform's small default thread stack for that graph.
+const NATIVE_ENGINE_ACTOR_STACK_SIZE: usize = 32 * 1024 * 1024;
+
+fn optional_telemetry_dispatch(
+    dispatch: Option<Function<'_, String, ()>>,
+) -> Result<Option<SharedJsTelemetryDispatch>> {
+    dispatch
+        .map(|dispatch| dispatch.build_threadsafe_function().build().map(Arc::new))
+        .transpose()
+}
+
 #[expect(missing_debug_implementations)]
 #[napi(js_name = "Lix")]
 pub struct NativeLix {
@@ -179,6 +192,7 @@ impl NativeLixActor {
         let actor_send_lock = Arc::clone(&actor.send_lock);
         thread::Builder::new()
             .name("lix-native".to_string())
+            .stack_size(NATIVE_ENGINE_ACTOR_STACK_SIZE)
             .spawn(move || run_lix_actor(lix, receiver, actor_closed, actor_send_lock))
             .map_err(to_napi_error)?;
         Ok(actor)
@@ -865,20 +879,22 @@ fn open_local_filesystem_native(
 impl NativeLix {
     #[napi(js_name = "openMemory")]
     pub fn open_memory(
-        telemetry_dispatch: Option<SharedJsTelemetryDispatch>,
-    ) -> AsyncTask<OpenMemoryTask> {
-        AsyncTask::new(OpenMemoryTask { telemetry_dispatch })
+        telemetry_dispatch: Option<Function<'_, String, ()>>,
+    ) -> Result<AsyncTask<OpenMemoryTask>> {
+        Ok(AsyncTask::new(OpenMemoryTask {
+            telemetry_dispatch: optional_telemetry_dispatch(telemetry_dispatch)?,
+        }))
     }
 
     #[napi(js_name = "openSQLite")]
     pub fn open_sqlite(
         path: String,
-        telemetry_dispatch: Option<SharedJsTelemetryDispatch>,
-    ) -> AsyncTask<OpenSQLiteTask> {
-        AsyncTask::new(OpenSQLiteTask {
+        telemetry_dispatch: Option<Function<'_, String, ()>>,
+    ) -> Result<AsyncTask<OpenSQLiteTask>> {
+        Ok(AsyncTask::new(OpenSQLiteTask {
             path,
-            telemetry_dispatch,
-        })
+            telemetry_dispatch: optional_telemetry_dispatch(telemetry_dispatch)?,
+        }))
     }
 
     #[napi(js_name = "openLocalFilesystem")]
@@ -886,14 +902,14 @@ impl NativeLix {
         path: String,
         lix_dir: Option<String>,
         sync_all_files: bool,
-        telemetry_dispatch: Option<SharedJsTelemetryDispatch>,
-    ) -> AsyncTask<OpenLocalFilesystemTask> {
-        AsyncTask::new(OpenLocalFilesystemTask {
+        telemetry_dispatch: Option<Function<'_, String, ()>>,
+    ) -> Result<AsyncTask<OpenLocalFilesystemTask>> {
+        Ok(AsyncTask::new(OpenLocalFilesystemTask {
             path,
             lix_dir,
             sync_all_files,
-            telemetry_dispatch,
-        })
+            telemetry_dispatch: optional_telemetry_dispatch(telemetry_dispatch)?,
+        }))
     }
 
     #[napi]
@@ -1137,6 +1153,7 @@ impl NativeObserveEvents {
         let actor_next_in_flight = Arc::clone(&next_in_flight);
         thread::Builder::new()
             .name("lix-observe-events".to_string())
+            .stack_size(NATIVE_ENGINE_ACTOR_STACK_SIZE)
             .spawn(move || {
                 run_observe_actor(
                     events,

--- a/packages/js-sdk/src/binding.node.ts
+++ b/packages/js-sdk/src/binding.node.ts
@@ -83,15 +83,26 @@ export function openLixBinding(
 					"Memory snapshots are only available in the browser binding",
 				);
 			}
-			return addon.Lix.openMemory(nativeTelemetry);
+			if (nativeTelemetry) return addon.Lix.openMemory(nativeTelemetry);
+			return addon.Lix.openMemory();
 		case "sqlite":
-			return addon.Lix.openSQLite(storage.path, nativeTelemetry);
+			if (nativeTelemetry) {
+				return addon.Lix.openSQLite(storage.path, nativeTelemetry);
+			}
+			return addon.Lix.openSQLite(storage.path);
 		case "localFilesystem":
+			if (nativeTelemetry) {
+				return addon.Lix.openLocalFilesystem(
+					storage.path,
+					storage.lixDir,
+					storage.syncAllFiles,
+					nativeTelemetry,
+				);
+			}
 			return addon.Lix.openLocalFilesystem(
 				storage.path,
 				storage.lixDir,
 				storage.syncAllFiles,
-				nativeTelemetry,
 			);
 	}
 }

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -61,6 +61,13 @@ test("openLix forwards opt-in SQL telemetry from the engine", async () => {
 	await lix.close();
 });
 
+test("openLix opens native storage without telemetry", async () => {
+	const lix = await openLix();
+	const result = await lix.execute("SELECT 1 AS value");
+	expect(get(result, "value")).toBe(1);
+	await lix.close();
+});
+
 test("openLix exposes the lix-sdk e2e flow", async () => {
 	const lix = await openLix();
 	const mainBranchId = await lix.activeBranchId();
@@ -172,6 +179,46 @@ test("createCheckpoint returns the new active head through the local worker", as
 
 	expect(checkpoint.commitId).not.toBe(before);
 	expect(checkpoint.commitId).toBe(await activeHeadCommitId(lix));
+	await lix.close();
+});
+
+test("execute and executeBatch expose registered-entity RETURNING postimages", async () => {
+	const lix = await openLix();
+	await registerCrmTaskSchema(lix);
+
+	const inserted = await lix.execute(
+		"INSERT INTO crm_task (title, done) VALUES ($1, $2) RETURNING id, title",
+		["Created through SDK RETURNING", false],
+	);
+	expect(inserted.rowsAffected).toBe(1);
+	expect(inserted.columns).toEqual(["id", "title"]);
+	expect(inserted.rows).toHaveLength(1);
+	const id = get(inserted, "id");
+	expect(typeof id).toBe("string");
+	expect(id).not.toBe("");
+	expect(get(inserted, "title")).toBe("Created through SDK RETURNING");
+	const taskId = String(id);
+
+	const updated = await lix.execute(
+		"UPDATE crm_task SET title = $1 WHERE id = $2 RETURNING id, title",
+		["Updated through SDK RETURNING", taskId],
+	);
+	expect(updated.rowsAffected).toBe(1);
+	expect(updated.columns).toEqual(["id", "title"]);
+	expect(get(updated, "id")).toBe(taskId);
+	expect(get(updated, "title")).toBe("Updated through SDK RETURNING");
+
+	const [batched] = await lix.executeBatch([
+		{
+			sql: "INSERT INTO crm_task (title, done) VALUES ($1, $2) RETURNING id, title",
+			params: ["Batched SDK RETURNING", true],
+		},
+	]);
+	expect(batched?.rowsAffected).toBe(1);
+	expect(batched?.columns).toEqual(["id", "title"]);
+	expect(get(batched!, "title")).toBe("Batched SDK RETURNING");
+	expect(typeof get(batched!, "id")).toBe("string");
+
 	await lix.close();
 });
 
@@ -1880,7 +1927,7 @@ async function registerCrmTaskSchema(lix: Lix): Promise<void> {
 		type: "object",
 		required: ["id", "title", "done"],
 		properties: {
-			id: { type: "string" },
+			id: { type: "string", "x-lix-default": "lix_uuid_v7()" },
 			title: { type: "string" },
 			done: { type: "boolean" },
 			meta: { type: "object" },


### PR DESCRIPTION
## Summary
- add SQL `RETURNING` across registered entities and writable filesystem/branch CRUD surfaces
- keep explicit transactions atomic when a staged `RETURNING` projection fails, including deterministic runtime state
- add engine/JS coverage and a focused regression benchmark
- fix a native actor stack overflow exposed by deep batch file-write execution; command and observation actors now reserve the established 32 MiB execution stack
- gate checkpoint scan-only helpers to their test/benchmark consumers so strict feature-scoped Clippy stays clean

## Validation
- `cargo test --profile test --workspace --all-features`
- 804 engine integration tests across base and tracked-state-rebuild modes
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- `cargo clippy --profile test -p lix_js_sdk --all-targets --all-features -- -D warnings`
- Node 24 native test-profile build plus `vitest run` (8 files, 133 tests)
- checkpoint record-scan regression

## Performance
- 10k `INSERT … RETURNING *` p50: 90.752 ms vs 56.191 ms without `RETURNING` (1.615×)
- profiling removed the prior quadratic staged-overlay identity lookup; `EntityPkComponents::PartialEq` is now 0.22% of samples

Closes #1035