### PR TITLE
perf(engine): certify constraint-neutral updates

### DIFF
--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -1641,10 +1641,11 @@ async fn entity_update(
     params: &[Value],
     active_branch_commit_id: Option<&CommitId>,
 ) -> Result<u64, LixError> {
+    let constraints_unchanged = update_assignments_preserve_constraints(ctx, plan, spec);
     let candidates = scan_entity_candidates(ctx, plan, spec, params).await?;
     let mut write_rows = RawWriteBatch::with_capacity(candidates.len());
     for candidate in candidates.iter() {
-        append_entity_update_row(
+        let appended = append_entity_update_row(
             &mut write_rows,
             ctx,
             plan,
@@ -1653,8 +1654,61 @@ async fn entity_update(
             params,
             active_branch_commit_id,
         )?;
+        if appended && constraints_unchanged {
+            write_rows.mark_last_constraints_unchanged();
+        }
     }
     stage_rows(ctx, TransactionWriteMode::Replace, write_rows).await
+}
+
+fn update_assignments_preserve_constraints(
+    ctx: &dyn SqlWriteExecutionContext,
+    plan: &LogicalWritePlan,
+    spec: &EntitySurfaceSpec,
+) -> bool {
+    let Some(schema_catalog) = ctx.schema_catalog_snapshot() else {
+        return false;
+    };
+    let Some((_, schema_plan)) = schema_catalog.plan_for_key(&spec.schema_key) else {
+        return false;
+    };
+    let assigned = plan
+        .bound
+        .assignments
+        .iter()
+        .map(|assignment| assignment.column.name.as_str())
+        .collect::<std::collections::HashSet<_>>();
+    assigned_columns_preserve_constraints(schema_plan, &assigned)
+}
+
+fn assigned_columns_preserve_constraints(
+    schema_plan: &crate::catalog::SchemaPlan,
+    assigned: &std::collections::HashSet<&str>,
+) -> bool {
+    let touches = |path: &[String]| {
+        path.first()
+            .is_some_and(|property| assigned.contains(property.as_str()))
+    };
+    !schema_plan
+        .primary_key
+        .iter()
+        .flatten()
+        .any(|path| touches(path))
+        && !schema_plan
+            .uniques
+            .iter()
+            .flatten()
+            .any(|path| touches(path))
+        && !schema_plan
+            .foreign_keys
+            .iter()
+            .flat_map(|foreign_key| &foreign_key.local_properties)
+            .any(|path| touches(path))
+        && !schema_plan.state_foreign_keys.iter().any(|foreign_key| {
+            touches(&foreign_key.entity_pk_property)
+                || touches(&foreign_key.schema_key_property)
+                || touches(&foreign_key.file_id_property)
+        })
 }
 
 fn append_entity_update_row<'a>(
@@ -5133,6 +5187,53 @@ mod primary_key_route_tests {
                 .expect("identity predicate should be complete")
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn only_constraint_source_assignments_require_commit_validation() {
+        let catalog = crate::catalog::CatalogSnapshot::from_visible_schemas(&[
+            serde_json::json!({
+                "x-lix-key": "parent",
+                "x-lix-primary-key": ["/id"],
+                "type": "object",
+                "properties": { "id": { "type": "string" } },
+                "required": ["id"],
+                "additionalProperties": false
+            }),
+            serde_json::json!({
+                "x-lix-key": "child",
+                "x-lix-primary-key": ["/id"],
+                "x-lix-unique": [["/slug"]],
+                "x-lix-foreign-keys": [{
+                    "properties": ["/parent_id"],
+                    "references": { "schemaKey": "parent", "properties": ["/id"] }
+                }],
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string" },
+                    "parent_id": { "type": "string" },
+                    "slug": { "type": "string" },
+                    "value": { "type": "string" }
+                },
+                "required": ["id", "parent_id", "slug", "value"],
+                "additionalProperties": false
+            }),
+        ])
+        .expect("constraint schemas should compile");
+        let (_, plan) = catalog
+            .plan_for_key("child")
+            .expect("child schema plan should exist");
+
+        assert!(assigned_columns_preserve_constraints(
+            plan,
+            &std::collections::HashSet::from(["value"]),
+        ));
+        for constrained in ["id", "slug", "parent_id"] {
+            assert!(!assigned_columns_preserve_constraints(
+                plan,
+                &std::collections::HashSet::from([constrained]),
+            ));
+        }
     }
 
     fn equals(left: BoundExpr, right: BoundExpr) -> BoundPredicate {

--- a/packages/engine/src/transaction/normalization.rs
+++ b/packages/engine/src/transaction/normalization.rs
@@ -196,7 +196,7 @@ pub(crate) fn normalize_raw_write_row_in_place(
             .snapshot()
             .delete_plan_for_key(&row.schema_key)
             .has_committed_checks()
-    };
+    } && !row.constraints_unchanged;
 
     if row.schema_key == REGISTERED_SCHEMA_KEY {
         if row.file_id.is_some() {

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -1845,6 +1845,7 @@ impl TransactionWriteBuffer {
             let row = rows.row(source_index);
             let is_insert = row_is_insert(mode, row);
             let existing_slot = by_identity.get(&identity).copied();
+            let mut requires_transaction_validation = row.facts.requires_transaction_validation;
             if let Some(RowSlot::State(index)) = existing_slot {
                 let previous = if let Some(previous_source) =
                     latest_incoming_source_by_destination.get(&index)
@@ -1853,8 +1854,13 @@ impl TransactionWriteBuffer {
                 } else {
                     staged_rows.row(index)
                 };
+                requires_transaction_validation |= previous.facts.requires_transaction_validation;
                 remove_row_from_commit_change_refs(&mut commit_change_refs_guard, previous);
             }
+            if requires_transaction_validation != row.facts.requires_transaction_validation {
+                rows.set_requires_transaction_validation(source_index, true);
+            }
+            let row = rows.row(source_index);
             let commit_id =
                 add_row_to_commit_change_refs(&mut commit_change_refs_guard, row, &self.functions);
             let identity = PreparedStateRowIdentity::from(row);
@@ -3344,6 +3350,33 @@ mod tests {
                 && row.snapshot.as_ref().map(|snapshot| snapshot.normalized())
                     == Some("{\"key\":\"sql2-key-b\",\"value\":\"only\"}")
         }));
+    }
+
+    #[tokio::test]
+    async fn coalesced_replacement_preserves_prior_validation_requirement() {
+        let staged_writes = test_staged_writes();
+        let mut first = prepared_rows![state_row("validation-key", "constraint-change")];
+        first.set_requires_transaction_validation(0, true);
+        staged_writes
+            .stage_write(PreparedTransactionWrite::Rows {
+                mode: TransactionWriteMode::Replace,
+                rows: first,
+            })
+            .expect("constraint-changing row should stage");
+        staged_writes
+            .stage_write(PreparedTransactionWrite::Rows {
+                mode: TransactionWriteMode::Replace,
+                rows: prepared_rows![state_row("validation-key", "unrelated-change")],
+            })
+            .expect("later replacement should stage");
+
+        let drained = staged_writes.drain().expect("drain should succeed");
+        assert_eq!(drained.state_rows.len(), 1);
+        let row = drained.state_rows.row(0);
+        assert!(
+            row.facts.requires_transaction_validation,
+            "a later neutral replacement must not erase an earlier validation requirement"
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -2724,7 +2724,6 @@ impl PreparedStateBatch {
         self.origins.len()
     }
 
-    #[cfg(test)]
     pub(crate) fn set_requires_transaction_validation(
         &mut self,
         index: usize,

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -426,6 +426,7 @@ pub(crate) struct TransactionWriteRow {
 const RAW_WRITE_NONE: u32 = u32::MAX;
 const RAW_WRITE_GLOBAL: u8 = 1;
 const RAW_WRITE_UNTRACKED: u8 = 1 << 1;
+const RAW_WRITE_CONSTRAINTS_UNCHANGED: u8 = 1 << 2;
 
 /// Compact row topology for an incoming transaction write batch.
 ///
@@ -493,6 +494,7 @@ pub(crate) struct RawWriteRowRef<'a> {
     pub(crate) change_id: Option<&'a str>,
     pub(crate) commit_id: Option<&'a str>,
     pub(crate) untracked: bool,
+    pub(crate) constraints_unchanged: bool,
     pub(crate) branch_id: &'a SharedStr,
 }
 
@@ -633,6 +635,7 @@ impl RawWriteBatch {
             change_id: self.optional_string(slot.change_id).map(SharedStr::as_str),
             commit_id: self.optional_string(slot.commit_id).map(SharedStr::as_str),
             untracked: slot.flags & RAW_WRITE_UNTRACKED != 0,
+            constraints_unchanged: slot.flags & RAW_WRITE_CONSTRAINTS_UNCHANGED != 0,
             branch_id: &self.strings[slot.branch_id as usize],
         })
     }
@@ -661,6 +664,16 @@ impl RawWriteBatch {
             row.untracked,
             row.branch_id,
         );
+    }
+
+    /// Certifies that the row just appended is a replacement whose primary
+    /// key, unique-key, and foreign-key source properties are unchanged.
+    pub(crate) fn mark_last_constraints_unchanged(&mut self) {
+        let slot = self
+            .slots
+            .last_mut()
+            .expect("constraint certificate requires an appended row");
+        slot.flags |= RAW_WRITE_CONSTRAINTS_UNCHANGED;
     }
 
     #[expect(clippy::too_many_arguments)]
@@ -1300,6 +1313,7 @@ impl PartialEq for RawWriteRowRef<'_> {
             && self.change_id == other.change_id
             && self.commit_id == other.commit_id
             && self.untracked == other.untracked
+            && self.constraints_unchanged == other.constraints_unchanged
             && self.branch_id == other.branch_id
     }
 }


### PR DESCRIPTION
Updates that leave primary, unique, and foreign-key source columns unchanged now carry a narrow preparation certificate through normalization. Commit validation still validates row shape/content, while skipping the redundant committed constraint scan for non-relational field updates.

Measured on the inlang Sherlock point-update benchmark: the direct Lix update path fell from ~0.36 ms to ~0.22 ms (about 40%).

No changenote: internal performance optimization.