### PR TITLE
Reposition Lix around files, SQL, and version control

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://raw.githubusercontent.com/opral/lix/main/website/public/logo.svg" alt="Lix" height="60">
 </p>
 
-<h3 align="center">Embeddable version control system for every file format</h3>
+<h3 align="center">Database + filesystem + version control in one</h3>
 
 <p align="center">
   <a href="https://www.npmjs.com/package/@lix-js/sdk"><img src="https://img.shields.io/npm/dw/%40lix-js%2Fsdk?logo=npm&logoColor=red&label=npm%20downloads" alt="weekly downloads on NPM"></a>
@@ -11,22 +11,109 @@
   <a href="https://x.com/lixCCS"><img src="https://img.shields.io/badge/Follow-@lixCCS-black?logo=x&logoColor=white" alt="X (Twitter)"></a>
 </p>
 
-Lix tracks, reviews, branches, merges, and rolls back changes across Markdown, DOCX, XLSX, JSON, PDFs, and custom file formats.
+Agents and tools work with files. Applications need a database. Teams need version control.
 
-Use Lix standalone or as the change-control layer for editors, knowledge bases, AI workflows, and file-based products. Lix stores files, tracks semantic changes, exposes history through SQL, and brings version control workflows beyond source code.
+Lix combines all three: normal files for tools, SQL rows for apps, and version control for every change.
 
-- 📌 **Supports any file format.** Create drafts, branches, checkpoints, and releases for Markdown, DOCX, XLSX, JSON, PDFs, and custom formats.
-- 🔍 **Track semantic changes.** See the paragraph, cell, property, clause, or custom entity that changed.
-- 🔀 **Review and merge changes.** Build change proposals, accept/reject flows, rollback, and merge workflows around files.
-- 🤝 **Sync in real time.** Keep versions and changes in sync across users, agents, devices, and runtimes.
-- ✅ **Validate and automate.** Run checks, enforce rules, and trigger workflows when files change.
-- 🧠 **Query everything with SQL.** Ask what changed, where, when, and by whom without rereading whole files.
+## Files × database
 
-## Try a demo app
+Plugins map file parts such as paragraphs, cells, and properties to SQL rows. Your app can also define its own rows.
 
-[Flashtype](https://flashtype.ai) is a Markdown editor for Claude and Codex built on Lix. Open local Markdown files, let agents edit them, review changes as diffs, and restore previous versions from history.
+```text
+what tools see                 what your app can query
 
-[![Flashtype app preview](https://flashtype.ai/og.png)](https://flashtype.ai)
+                               entity      field      value
+/orders.csv   ── plugin ──▶   row 1001    status     shipped
+                               row 1002    status     pending
+```
+
+Apps read and write the rows with SQL. Lix tracks every change. With `LocalFilesystem`, other tools and agents keep working with the files on disk.
+
+The SDK includes plugins for Markdown and CSV. Add a plugin for other formats, such as JSON, XLSX, DOCX, or PDF.
+
+### The map: interoperability × database semantics
+
+```text
+                           database semantics
+                       (query · transact · track)
+                                  ▲
+                                  │
+       PostgreSQL / SQLite        │                 ★ Lix
+       SQL and transactions,      │          normal files and SQL rows,
+       but data lives in tables   │          with every change tracked
+                                  │
+   ───────────────────────────────┼──────────────────────────────────▶
+                                  │              file interoperability
+                                  │       (any agent or tool can read/write)
+                                  │
+                                  │             Filesystem / Git
+                                  │             normal files,
+                                  │         but no queryable rows
+```
+
+### Comparison
+
+| Capability                                 | Filesystem / Git                     | PostgreSQL / SQLite    | Lix                |
+| ------------------------------------------ | ------------------------------------ | ---------------------- | ------------------ |
+| Works with normal workspace files          | Yes                                  | No                     | Yes                |
+| Queries file content with SQL              | No                                   | Only after import      | Yes, with a plugin |
+| ACID transactions                          | No                                   | Yes                    | Yes                |
+| Change history                             | Git: blobs and lines; filesystem: no | You build audit tables | Files and rows     |
+| Branches and merging                       | Git: yes; filesystem: no             | You build them         | Yes                |
+| Reviews changes by paragraph, cell, or row | Text lines only                      | You build it           | Yes, with a plugin |
+
+## Prime use cases
+
+### Give agents safe, isolated workspaces
+
+Give each agent its own branch. The agent works with normal files while the main branch stays stable. Preview its work, then merge or discard it.
+
+```ts
+const main = await lix.activeBranchId();
+const task = await lix.createBranch({ name: "Agent task" });
+
+await lix.switchBranch({ branchId: task.id });
+// Run the agent. Its file and SQL writes are isolated to this branch.
+
+await lix.switchBranch({ branchId: main });
+const preview = await lix.mergeBranchPreview({ sourceBranchId: task.id });
+
+if (preview.conflicts.length === 0) {
+  await lix.mergeBranch({ sourceBranchId: task.id });
+}
+```
+
+[Flashtype](https://flashtype.ai) is a Markdown editor for Claude and Codex built on Lix. Agents edit local files. Users review the changes and restore earlier versions.
+
+### Build file-based apps with SQL and version control
+
+Build editors, knowledge bases, and document workflows on normal files. Use SQL for app logic and Lix for history, rollback, branches, merging, and review.
+
+Plugins define the parts Lix tracks. You can review a change to a paragraph, cell, property, or row instead of only bytes and lines.
+
+For example, when an agent updates an orders CSV, Lix can show the row field that changed:
+
+```diff
+order_id 1002 status:
+
+- pending
++ shipped
+```
+
+Query changes without reading every file:
+
+```ts
+const changes = await lix.execute(`
+  SELECT created_at, schema_key, entity_pk, snapshot_content
+  FROM lix_change
+  ORDER BY created_at DESC
+  LIMIT 20
+`);
+```
+
+Update Lix files and rows in one ACID transaction. Lix records the history automatically.
+
+[Read more about semantic changes →](https://lix.dev/docs/semantic-changes)
 
 ## Getting started
 
@@ -45,221 +132,48 @@ npm install @lix-js/sdk
 import { LocalFilesystem, openLix } from "@lix-js/sdk";
 
 const lix = await openLix({
-	storage: new LocalFilesystem({ path: "./workspace", syncAllFiles: true }),
+  storage: new LocalFilesystem({ path: "./workspace", syncAllFiles: true }),
 });
 
-await lix.execute(
-	"INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-	["/notes/status.txt", new TextEncoder().encode("draft")],
-);
-
-const main = await lix.activeBranchId();
-
-const draft = await lix.createBranch({ name: "Explore" });
-
-await lix.switchBranch({ branchId: draft.id });
-
-await lix.execute(
-	"INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-	["/notes/status.txt", new TextEncoder().encode("ready for review")],
-);
-
-await lix.switchBranch({ branchId: main });
-
-const changes = await lix.execute(
-	"SELECT schema_key, count(*) AS count FROM lix_change GROUP BY schema_key",
-);
+await lix.execute("INSERT INTO lix_file (path, data) VALUES ($1, $2)", [
+  "/notes/status.txt",
+  new TextEncoder().encode("ready"),
+]);
 ```
 
-## Why Lix?
-
-### Version control should not stop at source code.
-
-Most version control systems assume source code and text diffs. But many important products edit files where the useful change is a paragraph, spreadsheet cell, JSON property, PDF section, knowledge-base page, or custom entity.
-
-Lix is built for those files. Plugins translate file updates into semantic changes that can be queried, reviewed, branched, merged, and rolled back.
-
-[Flashtype](https://flashtype.ai), a Markdown editor for Claude and Codex, uses Lix so every local Markdown edit can be checkpointed, reviewed as a diff, and restored.
-
-[How does Lix compare to Git? →](https://lix.dev/docs/comparison-to-git)
-
-### What Lix provides
-
-#### Import as a library
-
-Import Lix and open it inside your worker, service, CLI, browser, desktop app, or server-side runtime. No daemon, no protocol.
+## Run locally or on a server
 
 ```ts
-import { LocalFilesystem, openLix } from "@lix-js/sdk";
-
 const lix = await openLix({
-	storage: new LocalFilesystem({ path: "./workspace", syncAllFiles: true }),
+  server: {
+    mode: "remote",
+    url: "https://example.com/workspaces/acme",
+  },
 });
 ```
 
-#### ACID transactions
+## Where this is going
 
-Write files, blobs, and history in one transaction.
-
-```ts
-const tx = await lix.beginTransaction();
-
-try {
-	await tx.execute(
-		"INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-		["/spec.docx", body],
-	);
-	await tx.execute(
-		"INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-		["/spec.png", image],
-	);
-	await tx.commit();
-} catch (error) {
-	await tx.rollback();
-	throw error;
-}
-```
-
-#### Parallel branches
-
-Give every draft, user, tool, or AI agent its own isolated branch.
-
-```ts
-const main = await lix.activeBranchId();
-
-const copy = await lix.createBranch({ name: "Copy draft" });
-const pricing = await lix.createBranch({ name: "Pricing draft" });
-const qa = await lix.createBranch({ name: "QA draft" });
-
-await lix.switchBranch({ branchId: copy.id });
-await lix.execute(
-	"INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-	["/landing.md", copyDraft],
-);
-
-await lix.switchBranch({ branchId: pricing.id });
-await lix.execute(
-	"INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-	["/plans.json", priceModel],
-);
-
-await lix.switchBranch({ branchId: qa.id });
-await lix.execute(
-	"INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-	["/checks/report.json", testRun],
-);
-
-await lix.switchBranch({ branchId: main });
-```
-
-#### Semantic changes
-
-Lix can track structured entities: XLSX rows, DOCX clauses, JSON properties, app records, custom entities, and more.
-
-```ts
-const changes = await lix.execute(`
-  SELECT created_at, schema_key, entity_pk, snapshot_content
-  FROM lix_change
-  ORDER BY created_at DESC
-  LIMIT 20
-`);
-```
-
-For example, a workflow edits an orders spreadsheet:
+Git makes code available to every developer tool. Lix aims to do the same for documents, spreadsheets, app data, and agent output while keeping SQL and version control.
 
 ```text
-Before:
-| order_id | product  | status  |
-| -------- | -------- | ------- |
-| 1001     | Widget A | shipped |
-| 1002     | Widget B | pending |
-
-After:
-| order_id | product  | status  |
-| -------- | -------- | ------- |
-| 1001     | Widget A | shipped |
-| 1002     | Widget B | shipped |
+ contracts.docx    pricing.xlsx      app data     agent output
+       │                │              │              │
+       └────────────────┴───────┬──────┴──────────────┘
+                                ▼
+┌─────────────────── ONE LIX REPOSITORY ───────────────────┐
+│                                                          │
+│  ┌──────────────┐     ┌──────────────┐     ┌────────────┐ │
+│  │  FILESYSTEM  │  ×  │   DATABASE   │  ×  │  VERSION   │ │
+│  │              │     │              │     │  CONTROL   │ │
+│  │ tools and    │     │ SQL queries  │     │review/merge│ │
+│  │ agents       │     │ transactions │     │ rollback   │ │
+│  └──────────────┘     └──────────────┘     └────────────┘ │
+│                                                          │
+└──────────────────────────────────────────────────────────┘
 ```
 
-A text-based diff can only tell you the file changed:
-
-```diff
--Binary files differ
-```
-
-Lix can expose the row field that changed:
-
-```diff
-order_id 1002 status:
-
-- pending
-+ shipped
-```
-
-[Read more about semantic changes →](https://lix.dev/docs/semantic-changes)
-
-#### SQL interface
-
-Answer version-control questions with SQL instead of whole-file rereads.
-
-<img src="./website/public/assets/claude-sql-question.svg" alt="Claude Code asks: Which orders changed status in this branch? Executing SQL" width="460" />
-
-```ts
-const rows = await lix.execute(`
-  SELECT created_at, schema_key, entity_pk, snapshot_content
-  FROM lix_change
-  ORDER BY created_at DESC
-  LIMIT 20
-`);
-```
-
-Every change, across every file and every branch, is a row in `lix_change`. Filter by branch, file, schema, or time without re-reading whole files.
-
-#### Portable runtimes and storage
-
-Use Lix standalone or plug it into the infrastructure your product already runs.
-
-<p><img src="https://cdn.simpleicons.org/sqlite/003B57" alt="SQLite" width="18" height="18" /> SQLite · <img src="https://cdn.simpleicons.org/postgresql/4169E1" alt="Postgres" width="18" height="18" /> Postgres · <img src="https://api.iconify.design/logos:aws-s3.svg" alt="S3" width="18" height="18" /> S3 · <img src="https://cdn.simpleicons.org/cloudflareworkers/F38020" alt="Cloudflare Workers" width="18" height="18" /> Cloudflare Workers · <img src="https://cdn.simpleicons.org/supabase/3FCF8E" alt="Supabase" width="18" height="18" /> Supabase</p>
-
-```ts
-import { LocalFilesystem, openLix } from "@lix-js/sdk";
-
-const lix = await openLix({
-	storage: new LocalFilesystem({ path: "./workspace", syncAllFiles: true }),
-});
-```
-
-Use `SQLite` when a single `.lix` SQLite file is the application document itself, for example when defining a new file format and using Lix as the application's file format.
-
-## How Lix works
-
-Lix runs in-process inside your runtime.
-
-It owns the version-control model: files, blobs, versions, history, transactions, and semantic changes. Use it standalone with `LocalFilesystem` for filesystem workspaces, use SQLite for single-file application formats, or plug it into whatever storage you need: in-memory, Postgres, S3, Cloudflare, or your own adapter.
-
-SQL is the query interface on top. Products, scripts, and agents can ask what changed without rereading whole files.
-
-```
-┌─────────────────────────────────────────────────┐
-│                  Your runtime                   │
-│       browser · desktop · server · CLI · worker  │
-│                                                 │
-│   ┌─────────────────────────────────────────┐   │
-│   │                  Lix                    │   │
-│   │  Filesystem · Versions · History · SQL  │   │
-│   └────────────────────┬────────────────────┘   │
-│                        │                        │
-└────────────────────────┼────────────────────────┘
-                         ▼
-┌─────────────────────────────────────────────────┐
-│                    Storage                      │
-│      SQLite, Postgres, S3, Cloudflare, custom   │
-└─────────────────────────────────────────────────┘
-```
-
-[Read more about Lix architecture →](https://lix.dev/docs/architecture)
-
-## Learn More
+## Learn more
 
 - **[Getting Started Guide](https://lix.dev/docs/getting-started)** - Build your first app with Lix
 - **[Documentation](https://lix.dev/docs)** - Full API reference and guides

--- a/README.md
+++ b/README.md
@@ -15,7 +15,59 @@ Agents and tools work with files. Applications need a database. Teams need versi
 
 Lix combines all three: normal files for tools, SQL rows for apps, and version control for every change.
 
-## Files × database
+- 📁 **Keep normal files.** Existing tools and agents can keep reading and writing files on disk.
+- 🧠 **Query everything with SQL.** Query file content, app data, and change history without rereading whole files.
+- 🔍 **Track semantic changes.** Review the paragraph, CSV record, property, or app row that changed.
+- 🔀 **Branch and merge safely.** Give every user or agent an isolated workspace, then review and merge its work.
+- ✅ **Use ACID transactions.** Update files and rows together while Lix records their history.
+- 🤝 **Run locally or remotely.** Embed Lix in an app or connect to a shared workspace through the server protocol.
+
+## Try a demo app
+
+[Flashtype](https://flashtype.ai) is a Markdown editor for Claude and Codex built on Lix. Open local Markdown files, let agents edit them, review changes as diffs, and restore previous versions from history.
+
+[![Flashtype app preview](https://flashtype.ai/og.png)](https://flashtype.ai)
+
+## Getting started
+
+<p>
+  <img src="https://cdn.simpleicons.org/javascript/F7DF1E" alt="JavaScript" width="18" height="18" /> JavaScript ·
+  <a href="https://github.com/opral/lix/issues/373"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" alt="Python" width="18" height="18" /> Python</a> ·
+  <a href="https://github.com/opral/lix/issues/371"><img src="https://cdn.simpleicons.org/rust/CE422B" alt="Rust" width="18" height="18" /> Rust</a> ·
+  <a href="https://github.com/opral/lix/issues/370"><img src="https://cdn.simpleicons.org/go/00ADD8" alt="Go" width="18" height="18" /> Go</a>
+</p>
+
+```bash
+npm install @lix-js/sdk
+```
+
+```ts
+import { LocalFilesystem, openLix } from "@lix-js/sdk";
+
+const lix = await openLix({
+  storage: new LocalFilesystem({ path: "./workspace", syncAllFiles: true }),
+});
+
+await lix.execute("INSERT INTO lix_file (path, data) VALUES ($1, $2)", [
+  "/notes/status.txt",
+  new TextEncoder().encode("ready"),
+]);
+```
+
+Connect to a shared Lix server with the same API:
+
+```ts
+const lix = await openLix({
+  server: {
+    mode: "remote",
+    url: "https://example.com/workspaces/acme",
+  },
+});
+```
+
+## Why Lix?
+
+### Files × database
 
 Plugins map file parts such as paragraphs, cells, and properties to SQL rows. Your app can also define its own rows.
 
@@ -62,9 +114,9 @@ The SDK includes plugins for Markdown and CSV. Add a plugin for other formats, s
 | Branches and merging                       | Git: yes; filesystem: no             | You build them         | Yes                |
 | Reviews changes by paragraph, cell, or row | Text lines only                      | You build it           | Yes, with a plugin |
 
-## Prime use cases
+### Prime use cases
 
-### Give agents safe, isolated workspaces
+#### Give agents safe, isolated workspaces
 
 Give each agent its own branch. The agent works with normal files while the main branch stays stable. Preview its work, then merge or discard it.
 
@@ -83,9 +135,7 @@ if (preview.conflicts.length === 0) {
 }
 ```
 
-[Flashtype](https://flashtype.ai) is a Markdown editor for Claude and Codex built on Lix. Agents edit local files. Users review the changes and restore earlier versions.
-
-### Build file-based apps with SQL and version control
+#### Build file-based apps with SQL and version control
 
 Build editors, knowledge bases, and document workflows on normal files. Use SQL for app logic and Lix for history, rollback, branches, merging, and review.
 
@@ -114,43 +164,6 @@ const changes = await lix.execute(`
 Update Lix files and rows in one ACID transaction. Lix records the history automatically.
 
 [Read more about semantic changes →](https://lix.dev/docs/semantic-changes)
-
-## Getting started
-
-<p>
-  <img src="https://cdn.simpleicons.org/javascript/F7DF1E" alt="JavaScript" width="18" height="18" /> JavaScript ·
-  <a href="https://github.com/opral/lix/issues/373"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" alt="Python" width="18" height="18" /> Python</a> ·
-  <a href="https://github.com/opral/lix/issues/371"><img src="https://cdn.simpleicons.org/rust/CE422B" alt="Rust" width="18" height="18" /> Rust</a> ·
-  <a href="https://github.com/opral/lix/issues/370"><img src="https://cdn.simpleicons.org/go/00ADD8" alt="Go" width="18" height="18" /> Go</a>
-</p>
-
-```bash
-npm install @lix-js/sdk
-```
-
-```ts
-import { LocalFilesystem, openLix } from "@lix-js/sdk";
-
-const lix = await openLix({
-  storage: new LocalFilesystem({ path: "./workspace", syncAllFiles: true }),
-});
-
-await lix.execute("INSERT INTO lix_file (path, data) VALUES ($1, $2)", [
-  "/notes/status.txt",
-  new TextEncoder().encode("ready"),
-]);
-```
-
-## Run locally or on a server
-
-```ts
-const lix = await openLix({
-  server: {
-    mode: "remote",
-    url: "https://example.com/workspaces/acme",
-  },
-});
-```
 
 ## Where this is going
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://raw.githubusercontent.com/opral/lix/main/website/public/logo.svg" alt="Lix" height="60">
 </p>
 
-<h3 align="center">Database + filesystem + version control in one</h3>
+<h3 align="center">Database + filesystem + version control in one system</h3>
 
 <p align="center">
   <a href="https://www.npmjs.com/package/@lix-js/sdk"><img src="https://img.shields.io/npm/dw/%40lix-js%2Fsdk?logo=npm&logoColor=red&label=npm%20downloads" alt="weekly downloads on NPM"></a>

--- a/docs/comparison-to-git.md
+++ b/docs/comparison-to-git.md
@@ -1,104 +1,72 @@
 ---
-description: Compare Git's source-code workflow with Lix's file-format version control for Markdown, DOCX, XLSX, JSON, PDFs, and custom formats.
+description: Compare Git, databases, and Lix across file access, SQL, transactions, history, branches, and semantic review.
 ---
 
 # How Lix compares to Git
 
-> **Git is optimized for source-code repositories. Lix is a version control system for every file format.**
+Git gives source code history, branches, and merge. Databases give apps SQL and transactions. Lix combines both with a filesystem that normal tools and agents can use.
 
-Use Git when developers are versioning source code. Use Lix when products, tools, agents, or teams need review, merge, rollback, and SQL-queryable history for **file formats beyond source code**: Markdown, DOCX, XLSX, CSV, JSON, PDFs, CAD files, datasets, generated reports, and custom artifacts.
+## The map: interoperability × database semantics
 
-The difference is the unit of change: Git is strongest when a line-oriented text diff explains the work. Lix is strongest when the thing you need to review is a cell, clause, property, row, record, prompt output, or parser-defined entity.
-
-|                   | Git                                             | Lix                                            |
-| :---------------- | :---------------------------------------------- | :--------------------------------------------- |
-| Primary fit       | Source-code repositories and developer workflows | File-format version control for documents, structured files, generated artifacts, and app records |
-| Integration model | External VCS, usually operated around a repo     | Runtime/library layer for products, tools, agents, services, and CLIs |
-| Artifact model    | Files and snapshots                              | Format-aware entities across files and data    |
-| Diff model        | Text-oriented by default; custom drivers possible | Semantic per-entity changes via format support |
-| Merge model       | Line merge for text; binary fallback for many formats | Entity-aware merge for supported formats       |
-| History surface   | Commit history and Git tooling                   | SQL-queryable change graph                     |
-| Driven by         | Developers, CI, and source-code tools            | Agents, services, automation, products, and users |
-
-Both can coexist: keep source code in Git, and use Lix for files and workflows where review, merge, and rollback need to happen at the level of cells, clauses, properties, records, or generated changes.
-
-## Source-code history vs semantic file history
-
-Git stores snapshots and commonly presents changes as text diffs. That works extremely well for source code, where line-oriented review is natural. For many file formats beyond source code, such as spreadsheets, rich documents, CSV datasets, CAD files, PDFs, and agent-generated outputs, a line or binary diff often loses the domain meaning users care about.
-
-Lix stores changes as data. File plugins can map formats into domain entities such as XLSX cells, DOCX clauses, CSV rows, JSON properties, PDF sections, CAD parts, or agent outputs. Format experts can add semantic versioning for the file types their products need.
-
-Product-, tool-, and agent-level questions become direct queries:
-
-- Which cells / clauses / parts changed?
-- Which prompt, tool call, user action, or service made this edit?
-- What would happen if we merged this version?
-
-Lix exposes history as queryable change data rather than only as repository history. That lets an agent ask which entities changed, who or what changed them, whether two branches touch the same entity, and what needs review before merge. See [Change History](./history.md).
-
-## What this looks like
-
-Git can be extended with custom diff drivers and textconv filters. The difference is that those semantic views usually sit beside Git, while Lix is designed to store and query structured changes as part of the version-control model.
-
-### Excel
-
-**Before:**
-
-| order_id | product  | status  |
-| -------- | -------- | ------- |
-| 1001     | Widget A | shipped |
-| 1002     | Widget B | pending |
-
-**After:**
-
-| order_id | product  | status  |
-| -------- | -------- | ------- |
-| 1001     | Widget A | shipped |
-| 1002     | Widget B | shipped |
-
-**Git default diff sees:**
-
-```diff
-Binary files differ
+```text
+                           database semantics
+                       (query · transact · track)
+                                  ▲
+                                  │
+       PostgreSQL / SQLite        │                 ★ Lix
+       SQL and transactions,      │          normal files and SQL rows,
+       but data lives in tables   │          with every change tracked
+                                  │
+   ───────────────────────────────┼──────────────────────────────────▶
+                                  │              file interoperability
+                                  │       (any agent or tool can read/write)
+                                  │
+                                  │             Filesystem / Git
+                                  │             normal files,
+                                  │         but no queryable rows
 ```
 
-**With an XLSX plugin, Lix can expose:**
+## Comparison
+
+| Capability                                 | Filesystem / Git                     | PostgreSQL / SQLite    | Lix                |
+| ------------------------------------------ | ------------------------------------ | ---------------------- | ------------------ |
+| Works with normal workspace files          | Yes                                  | No                     | Yes                |
+| Queries file content with SQL              | No                                   | Only after import      | Yes, with a plugin |
+| ACID transactions                          | No                                   | Yes                    | Yes                |
+| Change history                             | Git: blobs and lines; filesystem: no | You build audit tables | Files and rows     |
+| Branches and merging                       | Git: yes; filesystem: no             | You build them         | Yes                |
+| Reviews changes by paragraph, cell, or row | Text lines only                      | You build it           | Yes, with a plugin |
+
+Use Git for source-code repositories and developer workflows. Use Lix when a product or agent must work with normal files while the app queries their contents and history with SQL.
+
+Git and Lix can work together. Keep source code in Git. Use Lix for the files and app data your product needs to query, review, merge, and roll back.
+
+## The unit of change
+
+Git stores file snapshots and usually shows line diffs. This works well for source code.
+
+Lix stores changes as data. Plugins define the parts inside a file, such as Markdown blocks or CSV rows. Lix can query and review those parts directly.
+
+For example, an agent updates one field in an orders CSV:
 
 ```diff
 order_id 1002 status:
+
 - pending
 + shipped
 ```
 
-### JSON
+The Markdown and CSV plugins ship with the JavaScript SDK. Other formats need a plugin. For example, an XLSX plugin could define cells or rows, and a JSON plugin could define properties.
 
-Formatted JSON works reasonably well in Git. Semantic diffing helps when formatting, ordering, minification, or generated output obscures the actual field-level change.
+## SQL history
 
-**Before:**
+Lix exposes changes as rows:
 
-```json
-{ "theme": "light", "notifications": true, "language": "en" }
+```sql
+SELECT created_at, schema_key, entity_pk, snapshot_content
+FROM lix_change
+ORDER BY created_at DESC
+LIMIT 20;
 ```
 
-**After:**
-
-```json
-{ "theme": "dark", "notifications": true, "language": "en" }
-```
-
-**Git default diff on minified JSON sees:**
-
-```diff
--{ "theme": "light", "notifications": true, "language": "en" }
-+{ "theme": "dark", "notifications": true, "language": "en" }
-```
-
-**Lix sees:**
-
-```diff
-property theme:
-- light
-+ dark
-```
-
-If your product or agent workflow needs version history, review, rollback, or merge for file formats beyond source code, Lix gives it semantic primitives instead of opaque file diffs. Start with [Change History](./history.md).
+Apps and agents can ask which entities changed, which files they came from, and whether branches touch the same entity. See [Change History](./history.md).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,10 +1,10 @@
 ---
-description: Install Lix, open an in-memory repository, register a schema, write rows, and inspect a change in under 30 lines of JavaScript.
+description: Install Lix, open a file workspace, write files and SQL rows, isolate work on a branch, and merge it.
 ---
 
 # Getting Started
 
-This walks through opening Lix, registering a schema, writing a row, isolating a change in a separate version, previewing the merge, and merging.
+This guide opens a file workspace, writes a normal file, registers an app schema, writes a row, isolates a change on a branch, and merges it.
 
 ## Install
 
@@ -26,12 +26,30 @@ const lix = await openLix();
 import { LocalFilesystem, openLix } from "@lix-js/sdk";
 
 const lix = await openLix({
-	storage: new LocalFilesystem({
-		path: "./workspace",
-		syncAllFiles: true,
-	}),
+  storage: new LocalFilesystem({
+    path: "./workspace",
+    syncAllFiles: true,
+  }),
 });
 ```
+
+## Write a normal file
+
+Files are available through SQL and, with `LocalFilesystem`, on disk:
+
+```ts
+await lix.execute("INSERT INTO lix_file (path, data) VALUES ($1, $2)", [
+  "/notes/status.md",
+  new TextEncoder().encode("# Status\n\nReady"),
+]);
+
+const file = await lix.execute(
+  "SELECT path, data FROM lix_file WHERE path = $1",
+  ["/notes/status.md"],
+);
+```
+
+Tools and agents can edit `notes/status.md` as a normal file. Lix imports those edits and tracks plugin-defined entities for supported formats. The SDK includes Markdown and CSV plugins.
 
 ## Register a schema
 
@@ -39,22 +57,22 @@ Lix stores application state as typed entities. Register a schema once, then rea
 
 ```ts
 await lix.execute(
-	"INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
-	[
-		JSON.stringify({
-			$schema: "https://json-schema.org/draft/2020-12/schema",
-			"x-lix-key": "task",
-			"x-lix-primary-key": ["/id"],
-			type: "object",
-			required: ["id", "title", "done"],
-			properties: {
-				id: { type: "string" },
-				title: { type: "string" },
-				done: { type: "boolean" },
-			},
-			additionalProperties: false,
-		}),
-	],
+  "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+  [
+    JSON.stringify({
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      "x-lix-key": "task",
+      "x-lix-primary-key": ["/id"],
+      type: "object",
+      required: ["id", "title", "done"],
+      properties: {
+        id: { type: "string" },
+        title: { type: "string" },
+        done: { type: "boolean" },
+      },
+      additionalProperties: false,
+    }),
+  ],
 );
 ```
 
@@ -64,14 +82,14 @@ await lix.execute(
 
 ```ts
 await lix.execute("INSERT INTO task (id, title, done) VALUES ($1, $2, $3)", [
-	"task-1",
-	"Review agent changes",
-	false,
+  "task-1",
+  "Review agent changes",
+  false,
 ]);
 
 const result = await lix.execute(
-	"SELECT id, title, done FROM task WHERE id = $1",
-	["task-1"],
+  "SELECT id, title, done FROM task WHERE id = $1",
+  ["task-1"],
 );
 
 const row = result.rows[0]!;
@@ -90,47 +108,47 @@ Use `asBytes()` for byte content:
 
 ```ts
 const file = await lix.execute("SELECT data FROM lix_file WHERE path = $1", [
-	"/orders.xlsx",
+  "/notes/status.md",
 ]);
 const bytes = file.rows[0]!.value("data").asBytes();
 ```
 
-## Isolate a change in a version
+## Isolate a change on a branch
 
-A version is an isolated line of state. Create one for the change, switch into it, and edit:
+A branch is an isolated line of state. Create one for the change, switch into it, and edit:
 
 ```ts
-const main = await lix.activeVersionId();
+const main = await lix.activeBranchId();
 
-const draft = await lix.createVersion({ name: "Agent draft" });
-await lix.switchVersion({ versionId: draft.id });
+const draft = await lix.createBranch({ name: "Agent draft" });
+await lix.switchBranch({ branchId: draft.id });
 
 await lix.execute("UPDATE task SET done = $1 WHERE id = $2", [true, "task-1"]);
 
-await lix.switchVersion({ versionId: main });
+await lix.switchBranch({ branchId: main });
 ```
 
-The active version is now `main` again, and `task-1` is still `done = false` here. The draft change is isolated until you merge.
+The active branch is now `main` again, and `task-1` is still `done = false` here. The draft change is isolated until you merge.
 
 ## Preview and merge
 
 ```ts
-const preview = await lix.mergeVersionPreview({ sourceVersionId: draft.id });
+const preview = await lix.mergeBranchPreview({ sourceBranchId: draft.id });
 console.log(preview.outcome, preview.changeStats);
 // fastForward { total: 1, added: 0, modified: 1, removed: 0 }
 
 if (preview.conflicts.length === 0) {
-	await lix.mergeVersion({ sourceVersionId: draft.id });
+  await lix.mergeBranch({ sourceBranchId: draft.id });
 }
 ```
 
-`mergeVersionPreview()` reports the same merge decision as `mergeVersion()` without advancing refs. It returns the per-row conflict list when both sides changed the same entity. See [Versions & Merging](./versions.md).
+`mergeBranchPreview()` reports the same decision as `mergeBranch()` without changing state. It returns conflicts when both branches changed the same entity. See [Branches & Merging](./versions.md).
 
 ## The loop
 
 1. Open Lix.
 2. Register schemas for the entities you want to version.
 3. Write and read through generated tables.
-4. Create versions for isolated work.
+4. Create branches for isolated work.
 5. Preview, then merge or discard.
 6. Query [`lix_change`](./history.md) for audit and undo.

--- a/docs/js-api-reference.md
+++ b/docs/js-api-reference.md
@@ -1,12 +1,10 @@
 ---
-description: "Reference for the JavaScript SDK Lix instance, transactions, execute results, rows, and values."
+description: "Reference for opening local and remote Lix instances, running SQL, using transactions, and working with branches."
 ---
 
 # JavaScript API Reference
 
-The JavaScript SDK exports `openLix()`, `SQLite`, and `LocalFilesystem` from `@lix-js/sdk`.
-`openLix()` returns a `Lix` instance: an in-process handle to one Lix
-repository.
+The JavaScript SDK exports `openLix()`, `SQLite`, and `LocalFilesystem` from `@lix-js/sdk`. `openLix()` returns a `Lix` instance connected to a local or remote repository.
 
 ```ts
 import { openLix } from "@lix-js/sdk";
@@ -22,9 +20,24 @@ const lix = await openLix(options?);
 
 Options:
 
-| Option    | Type                         | Description                                                          |
-| --------- | ---------------------------- | -------------------------------------------------------------------- |
-| `storage` | `LocalFilesystem \| SQLite` | Optional storage implementation. Omit it for the default in-memory storage. |
+| Option    | Type                                              | Description                                                                      |
+| --------- | ------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `storage` | `LocalFilesystem \| SQLite \| LixSnapshotStorage` | Local storage. Omit it for memory.                                               |
+| `server`  | `RemoteLixServerOptions`                          | Connect to a remote Lix server. Cannot be combined with local workspace storage. |
+
+Connect to a remote server:
+
+```ts
+const lix = await openLix({
+  server: {
+    mode: "remote",
+    url: "https://example.com/workspaces/acme",
+    headers: () => ({ Authorization: `Bearer ${token}` }),
+  },
+});
+```
+
+Remote file data, SQL rows, and branches live on the server. An optional `LixSnapshotStorage` in remote mode stores only private client state. Use `headers` for authentication and `fetch` when you need a custom fetch implementation.
 
 Use `LocalFilesystem` for a filesystem workspace directory backed by RocksDB at
 `<workspace>/.lix/.internal/rocksdb`:
@@ -33,10 +46,10 @@ Use `LocalFilesystem` for a filesystem workspace directory backed by RocksDB at
 import { LocalFilesystem, openLix } from "@lix-js/sdk";
 
 const lix = await openLix({
-	storage: new LocalFilesystem({
-		path: "./workspace",
-		syncAllFiles: true,
-	}),
+  storage: new LocalFilesystem({
+    path: "./workspace",
+    syncAllFiles: true,
+  }),
 });
 ```
 
@@ -45,11 +58,11 @@ Pass `lixDir` for filesystem sync with repository metadata in an external
 
 ```ts
 const lix = await openLix({
-	storage: new LocalFilesystem({
-		path: "./workspace",
-		lixDir: "/tmp/session/.lix",
-		syncAllFiles: true,
-	}),
+  storage: new LocalFilesystem({
+    path: "./workspace",
+    lixDir: "/tmp/session/.lix",
+    syncAllFiles: true,
+  }),
 });
 ```
 
@@ -62,8 +75,8 @@ materialization; it does not filter unrelated Lix SQL state.
 
 ```ts
 const storage = new LocalFilesystem({
-	path: "./workspace",
-	syncAllFiles: false,
+  path: "./workspace",
+  syncAllFiles: false,
 });
 const lix = await openLix({ storage });
 await storage.importPaths(["notes/today.md"]);
@@ -77,7 +90,7 @@ application file format:
 import { openLix, SQLite } from "@lix-js/sdk";
 
 const lix = await openLix({
-	storage: new SQLite({ path: "app.lix" }),
+  storage: new SQLite({ path: "app.lix" }),
 });
 ```
 
@@ -104,10 +117,10 @@ Result:
 
 ```ts
 type ExecuteResult = {
-	columns: string[];
-	rows: Row[];
-	rowsAffected: number;
-	notices: LixNotice[];
+  columns: string[];
+  rows: Row[];
+  rowsAffected: number;
+  notices: LixNotice[];
 };
 ```
 
@@ -122,8 +135,8 @@ Example:
 
 ```ts
 const result = await lix.execute(
-	"SELECT path, data FROM lix_file WHERE path = $1",
-	["/hello.txt"],
+  "SELECT path, data FROM lix_file WHERE path = $1",
+  ["/hello.txt"],
 );
 
 const path = result.rows[0]?.get("path");
@@ -141,110 +154,110 @@ Starts a transaction. While it is open, execute statements on the transaction ha
 ```ts
 const tx = await lix.beginTransaction();
 try {
-	await tx.execute("INSERT INTO lix_file (path, data) VALUES (?, ?)", [
-		"/hello.txt",
-		new TextEncoder().encode("hello"),
-	]);
-	await tx.commit();
+  await tx.execute("INSERT INTO lix_file (path, data) VALUES (?, ?)", [
+    "/hello.txt",
+    new TextEncoder().encode("hello"),
+  ]);
+  await tx.commit();
 } catch (error) {
-	await tx.rollback();
-	throw error;
+  await tx.rollback();
+  throw error;
 }
 ```
 
-### activeVersionId()
+### activeBranchId()
 
 ```ts
-const versionId = await lix.activeVersionId();
+const branchId = await lix.activeBranchId();
 ```
 
-Returns the id of the version the Lix handle is currently reading and writing.
+Returns the id of the branch the Lix instance is currently reading and writing.
 
-### createVersion()
+### createBranch()
 
 ```ts
-const version = await lix.createVersion({
-	name: "Explore",
+const branch = await lix.createBranch({
+  name: "Explore",
 });
 ```
 
-Creates a version.
+Creates a branch.
 
 Options:
 
 | Option         | Type     | Description                       |
 | -------------- | -------- | --------------------------------- |
-| `name`         | `string` | Version name.                     |
-| `id`           | `string` | Optional explicit version id.     |
+| `name`         | `string` | Branch name.                      |
+| `id`           | `string` | Optional explicit branch id.      |
 | `fromCommitId` | `string` | Optional commit id to start from. |
 
 Result:
 
 ```ts
-type CreateVersionResult = {
-	id: string;
-	name: string;
-	hidden: boolean;
-	commitId: string;
+type CreateBranchReceipt = {
+  id: string;
+  name: string;
+  hidden: boolean;
+  commitId: string;
 };
 ```
 
-### switchVersion()
+### switchBranch()
 
 ```ts
-await lix.switchVersion({ versionId });
+await lix.switchBranch({ branchId });
 ```
 
-Switches the Lix handle to another version. Plain SQL tables read and write the active version.
+Switches the Lix instance to another branch. Plain SQL tables read and write the active branch.
 
-### mergeVersionPreview()
+### mergeBranchPreview()
 
 ```ts
-const preview = await lix.mergeVersionPreview({
-	sourceVersionId: draft.id,
+const preview = await lix.mergeBranchPreview({
+  sourceBranchId: draft.id,
 });
 ```
 
-Computes the merge result from `sourceVersionId` into the currently active target version without applying it.
+Computes the merge result from `sourceBranchId` into the active branch without applying it.
 
 Result:
 
 ```ts
-type MergeVersionPreviewResult = {
-	outcome: "alreadyUpToDate" | "fastForward" | "mergeCommitted";
-	targetVersionId: string;
-	sourceVersionId: string;
-	baseCommitId: string;
-	targetHeadCommitId: string;
-	sourceHeadCommitId: string;
-	changeStats: MergeChangeStats;
-	conflicts: MergeConflict[];
+type MergeBranchPreview = {
+  outcome: "alreadyUpToDate" | "fastForward" | "mergeCommitted";
+  targetBranchId: string;
+  sourceBranchId: string;
+  baseCommitId: string;
+  targetHeadCommitId: string;
+  sourceHeadCommitId: string;
+  changeStats: MergeChangeStats;
+  conflicts: MergeConflict[];
 };
 ```
 
-### mergeVersion()
+### mergeBranch()
 
 ```ts
-const merge = await lix.mergeVersion({
-	sourceVersionId: draft.id,
+const merge = await lix.mergeBranch({
+  sourceBranchId: draft.id,
 });
 ```
 
-Merges `sourceVersionId` into the currently active target version.
+Merges `sourceBranchId` into the active branch.
 
 Result:
 
 ```ts
-type MergeVersionResult = {
-	outcome: "alreadyUpToDate" | "fastForward" | "mergeCommitted";
-	targetVersionId: string;
-	sourceVersionId: string;
-	baseCommitId: string;
-	targetHeadBeforeCommitId: string;
-	sourceHeadBeforeCommitId: string;
-	targetHeadAfterCommitId: string;
-	createdMergeCommitId: string | null;
-	changeStats: MergeChangeStats;
+type MergeBranchReceipt = {
+  outcome: "alreadyUpToDate" | "fastForward" | "mergeCommitted";
+  targetBranchId: string;
+  sourceBranchId: string;
+  baseCommitId: string;
+  targetHeadBeforeCommitId: string;
+  sourceHeadBeforeCommitId: string;
+  targetHeadAfterCommitId: string;
+  createdMergeCommitId: string | null;
+  changeStats: MergeChangeStats;
 };
 ```
 
@@ -252,10 +265,10 @@ type MergeVersionResult = {
 
 ```ts
 type MergeChangeStats = {
-	total: number;
-	added: number;
-	modified: number;
-	removed: number;
+  total: number;
+  added: number;
+  modified: number;
+  removed: number;
 };
 ```
 
@@ -263,12 +276,12 @@ type MergeChangeStats = {
 
 ```ts
 type MergeConflict = {
-	kind: "sameEntityChanged";
-	schemaKey: string;
-	entityPk: string[];
-	fileId: string | null;
-	target: MergeConflictSide;
-	source: MergeConflictSide;
+  kind: "sameEntityChanged";
+  schemaKey: string;
+  entityPk: string[];
+  fileId: string | null;
+  target: MergeConflictSide;
+  source: MergeConflictSide;
 };
 ```
 
@@ -298,12 +311,12 @@ Rows are returned by `execute()`.
 const row = result.rows[0]!;
 ```
 
-| Surface                 | Return type              | Description                                                    |
-| ----------------------- | ------------------------ | -------------------------------------------------------------- |
-| `row.get(columnName)`   | `unknown`                | Native JS value for a column. Throws if the column is missing. |
-| `row.value(columnName)` | `Value`                  | Typed `Value` for a column. Throws if the column is missing.   |
-| `row.toObject()`        | `Record<string, unknown>` | Object of native JS values keyed by column name.              |
-| `row.toValueMap()`      | `Record<string, Value>`  | Object of typed values keyed by column name.                   |
+| Surface                 | Return type               | Description                                                    |
+| ----------------------- | ------------------------- | -------------------------------------------------------------- |
+| `row.get(columnName)`   | `unknown`                 | Native JS value for a column. Throws if the column is missing. |
+| `row.value(columnName)` | `Value`                   | Typed `Value` for a column. Throws if the column is missing.   |
+| `row.toObject()`        | `Record<string, unknown>` | Object of native JS values keyed by column name.               |
+| `row.toValueMap()`      | `Record<string, Value>`   | Object of typed values keyed by column name.                   |
 
 ## Value
 

--- a/docs/lix-for-ai-agents.md
+++ b/docs/lix-for-ai-agents.md
@@ -1,48 +1,72 @@
 ---
-description: Route agent writes through Lix to get isolated workspaces, previewable changes, and approve-or-discard review for every agent task.
+description: Give each agent an isolated branch, preview its changes, then merge or discard the result.
 ---
 
 # Lix for AI Agents
 
-Agent review is one of Lix's headline use cases, but the same primitives ([Versions](./versions.md), [Change History](./history.md)) power any product where end users review proposed changes. If you're building knowledge-work tools, the patterns here apply to humans drafting changes too.
+Agents make fast, useful, and sometimes wrong changes. Lix gives each agent task its own branch so a human or policy can review the work before it reaches main.
 
-Agents make fast, useful, and sometimes wrong changes. Lix gives each agent task its own isolated version of state so a human or a policy can review it before it lands.
+Agents can work through normal files with `LocalFilesystem`, through SQL, or through a hosted Lix server. All writes stay isolated on the task branch.
 
 ## The pattern
 
-1. Create a version for the agent task.
-2. Switch the agent's writes into that version.
-3. Run the agent. All writes are isolated.
-4. Preview the merge: `changeStats` for the count, `conflicts` for collisions.
-5. Approve, request changes, or discard.
+1. Create a branch for the agent task.
+2. Switch the agent to that branch.
+3. Let the agent edit files or SQL rows.
+4. Switch back to main and preview the merge.
+5. Merge, request changes, or discard the branch.
 
 ```ts
-const main = await lix.activeVersionId();
+const main = await lix.activeBranchId();
 
-const task = await lix.createVersion({ name: "Agent task 123" });
-await lix.switchVersion({ versionId: task.id });
+const task = await lix.createBranch({ name: "Agent task 123" });
+await lix.switchBranch({ branchId: task.id });
 
-// run the agent; every lix.execute is now isolated to `task`
+// Run the agent. Its file and SQL writes are isolated to `task`.
 
-await lix.switchVersion({ versionId: main });
+await lix.switchBranch({ branchId: main });
 
-const preview = await lix.mergeVersionPreview({ sourceVersionId: task.id });
+const preview = await lix.mergeBranchPreview({ sourceBranchId: task.id });
 if (preview.conflicts.length === 0) {
-  await lix.mergeVersion({ sourceVersionId: task.id });
+  await lix.mergeBranch({ sourceBranchId: task.id });
 }
 ```
 
-## Why versions matter for agents
+## Local file workspace
 
-- Run multiple agents in parallel without stepping on each other.
-- Compare proposed outcomes side by side.
-- Keep the main state stable while work is in progress.
-- Discard a bad attempt with no manual cleanup.
+Use `LocalFilesystem` when the agent works with files on disk:
 
-## Showing the work
+```ts
+import { LocalFilesystem, openLix } from "@lix-js/sdk";
 
-The point of routing agent writes through Lix is that you can ask SQL what the
-agent did. Query the typed history relation for each application schema:
+const lix = await openLix({
+  storage: new LocalFilesystem({ path: "./workspace", syncAllFiles: true }),
+});
+```
+
+## Hosted workspace
+
+Use remote mode when the workspace runs on a server:
+
+```ts
+const lix = await openLix({
+  server: {
+    mode: "remote",
+    url: "https://example.com/workspaces/acme",
+  },
+});
+```
+
+## Why branches matter
+
+- Run agents in parallel without changing main.
+- Compare proposed results side by side.
+- Review semantic changes instead of rereading every file.
+- Discard a bad attempt without manual cleanup.
+
+## Inspect the work
+
+Query typed history for each app or plugin schema:
 
 ```sql
 SELECT id, title, status, lixcol_depth,
@@ -51,19 +75,16 @@ FROM acme_task_history()
 ORDER BY lixcol_depth, id;
 ```
 
-Discover schemas through `lix_registered_schema` when the agent works across
-applications. Use `lix_change` only for workspace-global activity; it is not
-implicitly scoped to the agent's active branch. See
-[Change History](./history.md) for the scope distinction and more recipes.
+Use `lix_registered_schema` to discover available schemas. Use `lix_change` for activity across the whole workspace. It is not limited to the active branch.
 
 ## Conflicts
 
-Merge is per-entity today: two versions editing different rows merge cleanly; two versions editing the same row produce a `sameEntityChanged` conflict. Wrap `mergeVersion()` and handle the conflict in your review flow.
+Merge is per entity today. Two branches that edit different rows can merge cleanly. Two branches that edit the same row produce a `sameEntityChanged` conflict.
 
-Don't reshape your schemas around this. Conflict semantics are still evolving; design entities for how your code reads them, not around today's merge granularity. See [Versions & Merging](./versions.md#dont-shape-entities-around-merge).
+See [Branches & Merging](./versions.md) for preview results and conflict handling.
 
 ## Next
 
-- [Getting Started](./getting-started.md): the basic loop.
-- [Versions & Merging](./versions.md): preview shape, conflicts, side-by-side reads.
-- [Change History](./history.md): the SQL surface for review and undo.
+- [Getting Started](./getting-started.md): the basic setup.
+- [Branches & Merging](./versions.md): previews, conflicts, and side-by-side reads.
+- [Change History](./history.md): SQL for review and undo.

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,10 +1,29 @@
 ---
-description: Open Lix in memory for tests, persist a filesystem workspace with LocalFilesystem, or use SQLite for a single .lix application file.
+description: Run Lix in memory, in a local filesystem, in a SQLite file, or through a remote Lix server.
 ---
 
 # Persistence
 
-`openLix()` with no arguments opens an in-memory Lix that vanishes when the process exits. For anything that should survive a restart, pass a storage. For local files and directories, `LocalFilesystem` is the recommended storage.
+`openLix()` can open a local repository or connect to a remote Lix server. Local repositories use memory, `LocalFilesystem`, or SQLite. A remote server owns workspace persistence.
+
+## Remote workspace
+
+Connect to a hosted workspace with `server`:
+
+```ts
+import { openLix } from "@lix-js/sdk";
+
+const lix = await openLix({
+  server: {
+    mode: "remote",
+    url: "https://example.com/workspaces/acme",
+  },
+});
+```
+
+The client does not need a local workspace storage option. Files, SQL rows, and branches live on the server.
+
+For an S3 deployment, host Lix with the shipped Rust SlateDB storage implementation backed by an S3-compatible object store. Expose the workspace through the [Lix server protocol](https://github.com/opral/lix/blob/main/packages/server-protocol/README.md). JavaScript clients do not pass S3 directly to `openLix()`.
 
 ## In-memory (tests, demos)
 
@@ -28,10 +47,10 @@ npm install @lix-js/sdk
 import { LocalFilesystem, openLix } from "@lix-js/sdk";
 
 const lix = await openLix({
-	storage: new LocalFilesystem({
-		path: "/var/data/workspace",
-		syncAllFiles: true,
-	}),
+  storage: new LocalFilesystem({
+    path: "/var/data/workspace",
+    syncAllFiles: true,
+  }),
 });
 
 // ... use it ...
@@ -51,11 +70,11 @@ the workspace directory:
 
 ```ts
 const lix = await openLix({
-	storage: new LocalFilesystem({
-		path: "/var/data/workspace",
-		lixDir: "/tmp/session/.lix",
-		syncAllFiles: true,
-	}),
+  storage: new LocalFilesystem({
+    path: "/var/data/workspace",
+    lixDir: "/tmp/session/.lix",
+    syncAllFiles: true,
+  }),
 });
 ```
 
@@ -73,10 +92,10 @@ import path from "node:path";
 
 const dir = mkdtempSync(path.join(tmpdir(), "lix-"));
 const lix = await openLix({
-	storage: new LocalFilesystem({
-		path: path.join(dir, "workspace"),
-		syncAllFiles: true,
-	}),
+  storage: new LocalFilesystem({
+    path: path.join(dir, "workspace"),
+    syncAllFiles: true,
+  }),
 });
 ```
 
@@ -89,8 +108,8 @@ materialization; it does not filter unrelated Lix SQL state.
 
 ```ts
 const storage = new LocalFilesystem({
-	path: "/Users/me/Downloads",
-	syncAllFiles: false,
+  path: "/Users/me/Downloads",
+  syncAllFiles: false,
 });
 const lix = await openLix({ storage });
 await storage.importPaths(["notes/today.md"]);
@@ -104,7 +123,7 @@ Use `SQLite` when the `.lix` SQLite file is the application document itself. Thi
 import { openLix, SQLite } from "@lix-js/sdk";
 
 const lix = await openLix({
-	storage: new SQLite({ path: "/var/data/app.lix" }),
+  storage: new SQLite({ path: "/var/data/app.lix" }),
 });
 ```
 
@@ -116,6 +135,6 @@ Always `await lix.close()` in scripts and tests. Long-lived servers can hold a s
 
 ## Other storage targets
 
-Postgres, S3, Cloudflare D1 / Durable Objects, IndexedDB, OPFS, and other transactional key-value storage targets beyond the shipped storage implementations are not shipped by the Lix team.
+PostgreSQL, Cloudflare D1 / Durable Objects, IndexedDB, OPFS, and other storage engines require a custom storage implementation. S3-compatible object storage is available through the shipped Rust SlateDB implementation in a server deployment.
 
 The storage interface is public and small enough to implement yourself. The [Storage](./storage.md) page documents the full contract.

--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -6,7 +6,7 @@ description: Define the entity types Lix tracks for you. The x-lix-* JSON Schema
 
 Schemas describe the entities Lix tracks. You declare each entity type as a JSON Schema with a few `x-lix-*` extensions, and Lix exposes a SQL table for it.
 
-Schemas are also the foundation file-format plugins build on: a plugin parses a file format (XLSX, DOCX, CAD, ...) into entities described by a schema. You can register schemas yourself, and plugin authors can register schemas for the entities their format exposes.
+Schemas are also the foundation for file plugins. A plugin maps a file format to entities described by a schema. The SDK includes Markdown and CSV plugins. Other formats, such as XLSX, DOCX, and CAD, need a plugin.
 
 > [!NOTE]
 > **For agents.** Lix is self-documenting. When operating against a Lix repository, query `lix_registered_schema` to discover every schema currently in effect (including Lix's own internal schemas `lix_*`) rather than relying on a snapshot of these docs. The schemas you read back are authoritative and current.
@@ -33,7 +33,7 @@ INSERT INTO lix_registered_schema (value) VALUES (lix_json('{
 }'));
 ```
 
-After registration, `acme_section` is a SQL table you can `INSERT`, `SELECT`, `UPDATE`, and `DELETE` against. A sibling table `acme_section_by_version` exposes the same rows across all versions (see [Versions & Merging](./versions.md)).
+After registration, `acme_section` is a SQL table you can `INSERT`, `SELECT`, `UPDATE`, and `DELETE` against. A sibling table `acme_section_by_branch` exposes the same rows across all branches (see [Branches & Merging](./versions.md)).
 
 ## The `x-lix-*` extensions
 
@@ -144,7 +144,7 @@ Mint a new `x-lix-key`. Ship `acme_section_v2` as a separate schema, write migra
 | `figma_layer`, `figma_frame` | `layer`, `frame`  |
 
 Why it matters: a single Lix can hold many files and many schemas at once.
-App-level entities, file-format plugins (XLSX, DOCX, CAD, ...), and Lix's own
+App entities, file plugins, and Lix's own
 internal schemas all share the `lix_registered_schema` namespace. An
 unprefixed `task` collides the moment a second source registers the same name.
 The exact key `lix` and the `lix_*` prefix are reserved and enforced for
@@ -190,6 +190,6 @@ ORDER BY lixcol_entity_pk;
 
 Shape your entities the way your reads want them. Document blocks, spreadsheet cells, line items: model whatever's natural for the questions your code asks.
 
-Don't shrink rows just to avoid merge conflicts. Lix's conflict detection is row-level today (two versions editing different fields of the same row still conflict), but conflict semantics and resolution are still evolving; designs that bend around today's limitation will look strange as merge behavior matures.
+Don't shrink rows just to avoid merge conflicts. Lix's conflict detection is row-level today, so two branches that edit different fields of the same row still conflict. Conflict behavior is still evolving. Designs built around today's limitation may not make sense later.
 
 If two collaborators are likely to edit the same logical thing concurrently and your domain naturally splits it (a document into blocks, an invoice into line items), split it because the _data_ makes sense that way. Don't split a single record into ten just because a future merge might collide.

--- a/docs/semantic-changes.md
+++ b/docs/semantic-changes.md
@@ -4,7 +4,7 @@ description: Lix tracks semantic changes at the entity level, so apps and agents
 
 # Semantic Changes
 
-Semantic changes are changes to the things your app understands: rows, cells, paragraphs, clauses, nodes, tasks, symbols, or any other entity described by a Lix schema.
+Semantic changes are changes to the things your app understands: rows, paragraphs, properties, tasks, or any other entity described by a Lix schema. File plugins map file content to these entities and apply entity changes back to normal files.
 
 Text-based diffs see lines and file bytes. Lix can see structured entities.
 
@@ -39,22 +39,24 @@ ORDER BY created_at DESC
 LIMIT 20;
 ```
 
-For version-scoped reads, use the state and history surfaces documented in [SQL Surfaces](./surfaces.md) and [Change History](./history.md).
+For branch-scoped reads, use the state and history surfaces documented in [SQL Surfaces](./surfaces.md) and [Change History](./history.md).
 
 ## JSON example
+
+With a JSON plugin, Lix can track properties instead of formatting:
 
 Given a JSON file:
 
 **Before:**
 
 ```json
-{"theme":"light","notifications":true,"language":"en"}
+{ "theme": "light", "notifications": true, "language": "en" }
 ```
 
 **After:**
 
 ```json
-{"theme":"dark","notifications":true,"language":"en"}
+{ "theme": "dark", "notifications": true, "language": "en" }
 ```
 
 Text-based diff:
@@ -64,7 +66,7 @@ Text-based diff:
 +{"theme":"dark","notifications":true,"language":"en"}
 ```
 
-Lix can see:
+The plugin can expose:
 
 ```diff
 property theme:
@@ -72,9 +74,9 @@ property theme:
 + dark
 ```
 
-## Excel example
+## CSV example
 
-The same idea applies to binary formats. With an XLSX plugin, Lix can expose cell or row level changes.
+The CSV plugin ships with the JavaScript SDK. It tracks CSV records as rows.
 
 **Before:**
 
@@ -94,13 +96,14 @@ The same idea applies to binary formats. With an XLSX plugin, Lix can expose cel
 | 1002     | Widget B | shipped |
 ```
 
-Byte-level diff:
+A text diff shows the whole line:
 
 ```diff
--Binary files differ
+-1002,Widget B,pending
++1002,Widget B,shipped
 ```
 
-Lix can see:
+Lix can show the row field that changed:
 
 ```diff
 order_id 1002 status:
@@ -125,9 +128,9 @@ SELECT
 FROM lix_change AS c
 JOIN lix_file AS f
   ON f.id = c.file_id
-WHERE c.schema_key = 'xlsx_row'
-  AND f.path = '/orders.xlsx'
+WHERE c.schema_key = 'csv_v2_row'
+  AND f.path = '/orders.csv'
 ORDER BY c.created_at DESC;
 ```
 
-The result is scoped to the file and entity type the agent asked about. No spreadsheet reread required.
+The result is scoped to the file and entity type the agent asked about. No full CSV reread is required. Other formats use the same model when a plugin defines their entities. An XLSX plugin, for example, could define cells or rows.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -31,19 +31,29 @@ persists Lix's ordered keys and values is storage.
 
 ## Available implementations
 
-| Storage | Rust | JavaScript | Use for |
-| --- | --- | --- | --- |
-| `Memory` | `lix_engine` and `lix_sdk` | default when `storage` is omitted | tests, demos, and ephemeral work |
-| `SQLite` | `lix_sqlite_storage` and `lix_sdk` (`sqlite`) | `@lix-js/sdk` | a portable single-file application format |
-| `SlateDB` | `lix_slatedb_storage` | not exposed | object-storage and LSM-based deployments |
-| `RocksDB` | `lix_rocksdb_storage` | not exposed | native embedded persistence |
-| `LocalFilesystem` | `lix_sdk` (`local_filesystem`) | `@lix-js/sdk` | a local directory synchronized with Lix |
+| Storage           | Rust                                          | JavaScript                        | Use for                                   |
+| ----------------- | --------------------------------------------- | --------------------------------- | ----------------------------------------- |
+| `Memory`          | `lix_engine` and `lix_sdk`                    | default when `storage` is omitted | tests, demos, and ephemeral work          |
+| `SQLite`          | `lix_sqlite_storage` and `lix_sdk` (`sqlite`) | `@lix-js/sdk`                     | a portable single-file application format |
+| `SlateDB`         | `lix_slatedb_storage`                         | not exposed                       | object-storage and LSM-based deployments  |
+| `RocksDB`         | `lix_rocksdb_storage`                         | not exposed                       | native embedded persistence               |
+| `LocalFilesystem` | `lix_sdk` (`local_filesystem`)                | `@lix-js/sdk`                     | a local directory synchronized with Lix   |
 
 Rust applications can implement the public `Storage` traits described below.
 The JavaScript SDK currently accepts its built-in choices only: omit `storage`
 for `Memory`, or pass `SQLite` or `LocalFilesystem`. `SQLite` and
 `LocalFilesystem` require Node.js; the default `Memory` storage also works in
 browsers.
+
+### Remote clients and S3
+
+JavaScript clients do not pass S3 to `openLix()`. A server opens Lix with the Rust SlateDB storage implementation backed by an S3-compatible object store. The server exposes the workspace through the [Lix server protocol](https://github.com/opral/lix/blob/main/packages/server-protocol/README.md), and clients connect with `openLix({ server })`.
+
+```text
+JS client ── HTTP ──▶ Lix server protocol ──▶ Lix ──▶ SlateDB ──▶ S3
+```
+
+SlateDB provides the ordered, atomic storage layer above the object store. PostgreSQL and other engines require a custom Rust storage implementation.
 
 ### Memory
 
@@ -65,7 +75,7 @@ lives in one portable file.
 import { openLix, SQLite } from "@lix-js/sdk";
 
 const lix = await openLix({
-	storage: new SQLite({ path: "/var/data/app.lix" }),
+  storage: new SQLite({ path: "/var/data/app.lix" }),
 });
 ```
 
@@ -77,10 +87,10 @@ Use `LocalFilesystem` when Lix should synchronize a local directory:
 import { LocalFilesystem, openLix } from "@lix-js/sdk";
 
 const lix = await openLix({
-	storage: new LocalFilesystem({
-		path: "/var/data/workspace",
-		syncAllFiles: true,
-	}),
+  storage: new LocalFilesystem({
+    path: "/var/data/workspace",
+    syncAllFiles: true,
+  }),
 });
 ```
 

--- a/docs/table_of_contents.json
+++ b/docs/table_of_contents.json
@@ -3,12 +3,12 @@
     { "path": "./what-is-lix.md", "label": "What is Lix?" },
     { "path": "./getting-started.md", "label": "Getting Started" },
     { "path": "./lix-for-ai-agents.md", "label": "Lix for AI Agents" },
-    { "path": "./comparison-to-git.md", "label": "Comparison to Git" }
+    { "path": "./comparison-to-git.md", "label": "How Lix Fits" }
   ],
   "Concepts": [
     { "path": "./schemas.md", "label": "Schemas" },
     { "path": "./semantic-changes.md", "label": "Semantic Changes" },
-    { "path": "./versions.md", "label": "Versions & Merging" },
+    { "path": "./versions.md", "label": "Branches & Merging" },
     { "path": "./checkpoints.md", "label": "Checkpoints" },
     { "path": "./diff-commands.md", "label": "Diff Commands" },
     { "path": "./history.md", "label": "Change History" },

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -1,130 +1,111 @@
 ---
-description: Versions are isolated lines of state. Create them, switch into them, read across them with _by_version tables, and merge with conflict-aware preview.
+description: Branches are isolated lines of state. Create them, switch between them, read across them with _by_branch tables, and preview merges.
 ---
 
-# Versions & Merging
+# Branches & Merging
 
-A **version** in Lix is what Git calls a branch: an isolated line of state that can diverge from main and be merged back. Lix uses "version" because product UIs don't say "branch."
+A branch is an isolated line of state. It can change without affecting the main branch, then be merged back.
 
 ## Create and switch
 
 ```ts
-const main = await lix.activeVersionId();
+const main = await lix.activeBranchId();
 
-const draft = await lix.createVersion({ name: "Marketing edit" });
-await lix.switchVersion({ versionId: draft.id });
+const draft = await lix.createBranch({ name: "Marketing edit" });
+await lix.switchBranch({ branchId: draft.id });
 
-// writes here are isolated to `draft`
-await lix.execute(
-  "UPDATE acme_section SET title = $1 WHERE id = $2",
-  ["Sharper launch copy", "s1"],
-);
+await lix.execute("UPDATE acme_section SET title = $1 WHERE id = $2", [
+  "Sharper launch copy",
+  "s1",
+]);
 
-await lix.switchVersion({ versionId: main });
+await lix.switchBranch({ branchId: main });
 ```
 
-`createVersion()` returns `{ id, name, hidden }`. `switchVersion()` is per-Lix-instance state; it changes which version subsequent SQL goes against.
+`createBranch()` returns `{ id, name, hidden, commitId }`. `switchBranch()` changes which branch later SQL statements read and write.
 
-Use names that match your callers' vocabulary. For an end-user product that's domain language: `"Marketing edit"`, `"Q3 pricing draft"`. For a CLI or infrastructure tool, developer terms like `"feature/x"` or `"staging"` are fine; Lix doesn't prescribe.
+Use names that fit your product, such as `"Marketing edit"`, `"Q3 pricing draft"`, or `"Agent task 123"`.
 
-## Side-by-side reads with `_by_version`
+## Read branches side by side
 
-Every registered schema `X` gets a sibling table `X_by_version` with a `lixcol_version_id` column. (Files and directories have the same shape: `lix_file_by_version`, `lix_directory_by_version`. For the full surface map see [SQL Surfaces](./surfaces.md).) Use it to read or write across versions without switching:
+Every registered schema `X` gets an `X_by_branch` table with a `lixcol_branch_id` column. Files and directories have the same pattern with `lix_file_by_branch` and `lix_directory_by_branch`.
 
 ```ts
 const sideBySide = await lix.execute(
-  `SELECT v.name, s.title
-     FROM acme_section_by_version s
-     JOIN lix_version v ON v.id = s.lixcol_version_id
-    WHERE s.id = $1
-      AND s.lixcol_version_id IN ($2, $3)
-    ORDER BY v.name`,
+  `SELECT b.name, s.title
+	 FROM acme_section_by_branch s
+	 JOIN lix_branch b ON b.id = s.lixcol_branch_id
+	 WHERE s.id = $1
+	   AND s.lixcol_branch_id IN ($2, $3)
+	 ORDER BY b.name`,
   ["s1", main, draft.id],
 );
 ```
 
-Rules for `_by_version`:
+Rules for `_by_branch` tables:
 
-- `SELECT`: filter by `lixcol_version_id`, or omit the filter to scan all versions.
-- `INSERT`: must include `lixcol_version_id`.
-- `UPDATE` / `DELETE`: must include `lixcol_version_id` in the `WHERE` clause.
-- The plain (non-suffixed) table is the active-version view.
+- `SELECT` can read one or many branches.
+- `INSERT` must include `lixcol_branch_id`.
+- `UPDATE` and `DELETE` must filter by `lixcol_branch_id`.
+- The plain table reads and writes the active branch.
 
-Prefer `_by_version` for review UIs, sync, and any side-by-side rendering; it avoids the cost and risk of switching the active version.
+Use `_by_branch` tables for review UIs and side-by-side views. See [SQL Surfaces](./surfaces.md) for the full table map.
 
 ## Preview a merge
 
-`mergeVersionPreview()` reports the same merge decision as `mergeVersion()` without touching state.
+`mergeBranchPreview()` reports what `mergeBranch()` would do without changing state.
 
 ```ts
-const preview = await lix.mergeVersionPreview({ sourceVersionId: draft.id });
+const preview = await lix.mergeBranchPreview({
+  sourceBranchId: draft.id,
+});
 
-// preview shape:
 // {
 //   outcome: "alreadyUpToDate" | "fastForward" | "mergeCommitted",
-//   targetVersionId, sourceVersionId,
-//   baseCommitId, targetHeadCommitId, sourceHeadCommitId,
+//   targetBranchId,
+//   sourceBranchId,
 //   changeStats: { total, added, modified, removed },
 //   conflicts: MergeConflict[],
 // }
 ```
 
-Outcomes:
+`mergeBranch()` always merges into the active branch. Switch to the target branch before previewing or merging.
 
-- `alreadyUpToDate`: source has no commits the target lacks.
-- `fastForward`: target advances to source without a merge commit.
-- `mergeCommitted`: a new merge commit will be created.
+```ts
+await lix.switchBranch({ branchId: main });
 
-`mergeVersion()` always merges into the **active** version. If you want a different target, switch to it first.
+const preview = await lix.mergeBranchPreview({ sourceBranchId: draft.id });
+if (preview.conflicts.length === 0) {
+  await lix.mergeBranch({ sourceBranchId: draft.id });
+}
+```
 
 ## Conflicts
 
-If both versions modified the same entity since their merge base, `mergeVersionPreview()` returns them in `conflicts`, and `mergeVersion()` throws a `LixError`.
-
-Each conflict has the shape:
+If both branches changed the same entity after their merge base, the preview includes a `sameEntityChanged` conflict. `mergeBranch()` throws a `LixError` until the caller resolves it.
 
 ```ts
 {
-  kind: "sameEntityChanged",
-  schemaKey: "acme_section",
-  entityPk: ["s1"],
-  fileId: null,
-  target: { kind: "added" | "modified" | "removed", beforeChangeId, afterChangeId },
-  source: { kind: "added" | "modified" | "removed", beforeChangeId, afterChangeId },
+	kind: "sameEntityChanged",
+	schemaKey: "acme_section",
+	entityPk: ["s1"],
+	fileId: null,
+	target: { kind: "modified", beforeChangeId, afterChangeId },
+	source: { kind: "modified", beforeChangeId, afterChangeId },
 }
 ```
 
-Conflict detection is row-level today, not field-level: two versions editing different fields of the same row still conflict. Conflict semantics and resolution are still evolving. **Don't reshape your schemas to avoid this**; design entities around how your code reads them, not around today's merge granularity.
+Conflict detection is row-level today. Two branches that edit different fields of the same row still conflict. Design entities for how your app reads them, not around the current merge rule.
 
-Always wrap `mergeVersion()` when conflicts are possible:
+## Hide or delete a branch
 
-```ts
-try {
-  const result = await lix.mergeVersion({ sourceVersionId: draft.id });
-  console.log(result.outcome, result.changeStats.total);
-} catch (error) {
-  // resolve conflicts in calling code, then retry
-}
-```
-
-## Don't shape entities around merge
-
-It's tempting to split rows finely to dodge the row-level conflict rule. **Don't.** Schema design should follow how your code reads, writes, and joins data, not how today's merge engine resolves conflicts. Conflict semantics will improve; data models that work today should still work then.
-
-If a domain naturally splits (a document into blocks, an invoice into line items, a translation set into per-key messages), split it because the *reads* want it that way. If the natural shape is one row with several fields, write it that way and handle conflicts in calling code when they happen. See [Schemas](./schemas.md#design-for-querying-not-for-merging).
-
-## Hiding and deleting versions
-
-`lix_version` is a writable system table. Hide a version from the active set without deleting it:
+`lix_branch` is a writable system table:
 
 ```ts
-await lix.execute("UPDATE lix_version SET hidden = true WHERE id = $1", [draft.id]);
+await lix.execute("UPDATE lix_branch SET hidden = true WHERE id = $1", [
+  draft.id,
+]);
+await lix.execute("DELETE FROM lix_branch WHERE id = $1", [draft.id]);
 ```
 
-Delete a version with SQL:
-
-```ts
-await lix.execute("DELETE FROM lix_version WHERE id = $1", [draft.id]);
-```
-
-The engine refuses to delete the global version or the active version.
+Lix does not allow deleting the global branch or the active branch.

--- a/docs/what-is-lix.md
+++ b/docs/what-is-lix.md
@@ -1,96 +1,80 @@
 ---
-description: Lix is a version control system for every file format. It tracks semantic changes across Markdown, DOCX, XLSX, JSON, PDFs, and custom formats, exposed as SQL.
+description: Lix combines a database, filesystem, and version control. Tools work with normal files, apps use SQL, and Lix tracks every change.
 ---
 
 # What is Lix?
 
-Lix is a **version control system for every file format**. It tracks changes across Markdown, DOCX, XLSX, JSON, PDFs, CAD files, and custom formats as semantic entities: a spreadsheet cell, document clause, JSON property, PDF section, CAD part, or application row.
+Lix is a **database + filesystem + version control system in one**.
 
-Versions, branches, merge, rollback, and immutable change history are exposed through SQL, so products and tools can bring version control workflows beyond source code.
+Tools and agents work with normal files. Apps query and update SQL rows. Lix tracks every change with branches, history, review, rollback, and merge.
 
-> Lix makes version control a runtime primitive for files: products can store, query, review, sync, and merge changes without inventing a custom history system.
+## Files become queryable rows
 
-[See what a semantic diff looks like →](./comparison-to-git.md#what-this-looks-like)
+File plugins map parts of a file to rows. A row can represent a Markdown block, CSV record, spreadsheet cell, JSON property, document clause, or another entity defined by a plugin.
+
+```text
+what tools see                 what your app can query
+
+                               entity      field      value
+/orders.csv   ── plugin ──▶   row 1001    status     shipped
+                               row 1002    status     pending
+```
+
+Apps read and write these rows with SQL. Lix records their history. In filesystem mode, plugin changes are written back to normal files on disk.
+
+The JavaScript SDK includes Markdown and CSV plugins. Other formats, including JSON, XLSX, DOCX, and PDF, need a plugin.
+
+## What Lix provides
+
+```text
+filesystem      normal files for existing tools and agents
+database        SQL queries, schemas, and ACID transactions
+version control branches, history, review, rollback, and merge
+```
+
+The same model also works for app data that does not come from a file. Register a schema and Lix creates a SQL table for it. Rows in that table get the same history and branch behavior as file entities.
+
+## Prime use cases
+
+### Safe workspaces for agents
+
+Give each agent task its own branch. The agent can edit files and SQL rows without changing the main branch. Preview the result, then merge or discard it.
+
+See [Lix for AI Agents](./lix-for-ai-agents.md).
+
+### File-based apps with SQL and version control
+
+Build editors, knowledge bases, document workflows, and other file-based apps. Existing tools keep using files while your app uses SQL for queries and transactions. Lix adds history, rollback, branches, merging, and review.
+
+## Run Lix locally or remotely
+
+Run Lix inside your app with memory, `LocalFilesystem`, or SQLite:
 
 ```ts
-import { openLix } from "@lix-js/sdk";
+import { LocalFilesystem, openLix } from "@lix-js/sdk";
 
-const lix = await openLix();
-
-await lix.execute(
-  "INSERT INTO lix_file (path, data) VALUES (?, CAST(? AS BYTEA))",
-  ["/hello.txt", "hello"],
-);
-
-const changes = await lix.execute(
-  "SELECT created_at, schema_key, entity_pk FROM lix_change",
-);
+const lix = await openLix({
+  storage: new LocalFilesystem({ path: "./workspace", syncAllFiles: true }),
+});
 ```
 
-## How it works
+Or connect to a Lix server:
 
-Each file format is parsed into **entities**: cells in a spreadsheet, clauses in a document, parts in a CAD drawing. Lix versions those entities. Per-row merge and history fall out for free.
-
-## Where Lix fits
-
-The same `openLix()` powers three different shapes:
-
-**Inside an end-user product.** Lawyers redlining a contract, analysts iterating on a forecast, engineers updating a BOM, designers exploring a layout: give them drafts, review, rollback, and history inside your product UI.
-
-**Inside an AI workflow.** Every agent task gets an isolated workspace; humans or policies review the diff and merge or discard. See [Lix for AI Agents](./lix-for-ai-agents.md).
-
-**As the version-control core for file-based products.** Build a versioned filesystem, an artifact or model registry, a configuration service, a branchable database, or a domain-specific CLI. Lix is the version-control core; you ship the surface.
-
-## Why this matters
-
-Source-code version control works best when text diffs explain the change. Many products edit files where the useful diff is a domain entity instead: a cell, clause, property, section, part, record, or generated output.
-
-Lix gives those files version-control primitives directly:
-
-- **Any file format** can be represented through parser plugins or custom schemas.
-- **Semantic changes** are stored per entity instead of only as whole-file snapshots.
-- **SQL** is the query interface for application code, AI agents, and tools.
-- **Pluggable storage.** Run in-memory, sync a filesystem workspace with `LocalFilesystem`, use a `.lix` SQLite file as an application file format, or implement the [storage interface](./storage.md) to put Lix on Postgres, S3, Cloudflare, IndexedDB, OPFS, or anything transactional and key-value-shaped.
-- **ACID transactions** work across files and entities.
-
-No daemon, no protocol, no remote.
-
-## The change-first model
-
-Lix stores changes as data, not snapshots. Typed history reconstructs the
-states reachable from a branch, while the global journal records workspace
-activity:
-
-```sql
--- Which revisions of this task are reachable from the active branch?
-SELECT id, title, lixcol_depth, lixcol_is_deleted
-FROM acme_task_history()
-WHERE id = 't1'
-ORDER BY lixcol_depth;
+```ts
+const lix = await openLix({
+  server: {
+    mode: "remote",
+    url: "https://example.com/workspaces/acme",
+  },
+});
 ```
 
-Whether the entity is a spreadsheet cell, a document clause, a CAD part, or an
-application row, its registered schema supplies the typed SQL surface. Diffs,
-undo, audit, blame, and attribution are all SQL. See
-[Change History](./history.md).
-
-## Examples of what Lix versions
-
-With parser plugins, Lix can version:
-
-- DOCX contracts, with clause-level diffs and redlines
-- XLSX models, with cell-level history and conflict-aware merges
-- CAD drawings, with per-part revision tracking
-- PDFs and any other format behind a parser plugin
-
-Available today through the entity foundation:
-
-- Application state: tasks, line items, translations, CMS sections, model metadata, config keys
-- Anything you can describe with a JSON Schema
+Remote clients use the same file, SQL, branch, and observation APIs supported by the server protocol.
 
 ## Next
 
-- [Getting Started](./getting-started.md): install, register a schema, version, merge.
-- [Comparison to Git](./comparison-to-git.md): when to reach for which.
-- [Lix for AI Agents](./lix-for-ai-agents.md): one shape, in depth.
-- [Schemas](./schemas.md), [Versions & Merging](./versions.md), [Change History](./history.md), [Persistence](./persistence.md), [SQL Functions](./sql-functions.md).
+- [Getting Started](./getting-started.md): open Lix, write data, create a branch, and merge it.
+- [How Lix compares to Git](./comparison-to-git.md): files, databases, and version control side by side.
+- [Schemas](./schemas.md): define app rows and plugin entities.
+- [Semantic Changes](./semantic-changes.md): track changes inside files.
+- [Persistence](./persistence.md): choose a local or remote setup.

--- a/packages/server-protocol/README.md
+++ b/packages/server-protocol/README.md
@@ -5,6 +5,23 @@ for one workspace. A host owns authentication, workspace routing, storage
 construction, and process lifecycle. The protocol server owns the root
 `lix_sdk::Lix` handle and a bounded registry of independent remote sessions.
 
+A JavaScript client connects with `openLix({ server })`:
+
+```ts
+import { openLix } from "@lix-js/sdk";
+
+const lix = await openLix({
+  server: {
+    mode: "remote",
+    url: "https://example.com/workspaces/acme",
+  },
+});
+```
+
+The host chooses the storage. For shared S3 deployments, use the shipped
+`lix_slatedb_storage` implementation backed by an S3-compatible object store.
+The JavaScript client does not connect to S3 directly.
+
 ```rust,no_run
 use std::sync::Arc;
 use axum::Router;
@@ -22,6 +39,10 @@ protocol.close().await?;
 # Ok(())
 # }
 ```
+
+This small server example uses the default in-memory storage. Production hosts
+should construct the `Lix` instance with durable storage before passing it to
+`LixProtocolServer`.
 
 The host must retain one `LixProtocolServer` for the workspace lifetime. It
 must not reconstruct the server for each HTTP request, because the in-memory

--- a/website/public/manifest.json
+++ b/website/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "short_name": "Lix",
-  "name": "Lix - Change Control System",
+  "name": "Lix",
   "icons": [
     {
       "src": "favicon.svg",

--- a/website/src/components/landing-page.tsx
+++ b/website/src/components/landing-page.tsx
@@ -391,7 +391,7 @@ function LandingPage({
               </svg>
             </a>
             <h1 className="text-gray-900 font-bold leading-[1.1] text-4xl sm:text-5xl md:text-6xl tracking-tight">
-              Database + filesystem + version control in one
+              Database + filesystem + version control in one system
             </h1>
 
             <p className="text-gray-500 text-lg sm:text-xl max-w-4xl mx-auto mt-8">

--- a/website/src/components/landing-page.tsx
+++ b/website/src/components/landing-page.tsx
@@ -391,13 +391,12 @@ function LandingPage({
               </svg>
             </a>
             <h1 className="text-gray-900 font-bold leading-[1.1] text-4xl sm:text-5xl md:text-6xl tracking-tight">
-              Embeddable version control system for AI agents
+              Database + filesystem + version control in one
             </h1>
 
             <p className="text-gray-500 text-lg sm:text-xl max-w-4xl mx-auto mt-8">
-              Lix is a version control system that can be imported as a library.
-              Use it to, for example, enable human-in-the-loop workflows for AI
-              agents like diffs and reviews.
+              Normal files for tools and agents. SQL rows for apps. Version
+              control for every change.
             </p>
 
             {/* Trust signals */}
@@ -546,7 +545,7 @@ function LandingPage({
                   <span className="text-indigo-600">await</span>{" "}
                   <span className="text-gray-900">lix.fs.writeFile</span>
                   <span className="text-gray-900">{"("}</span>
-                  <span className="text-amber-600">"/hello.json"</span>
+                  <span className="text-amber-600">"/hello.md"</span>
                   <span className="text-gray-900">{", bytes)"}</span>
                 </div>
               </div>
@@ -588,18 +587,18 @@ function LandingPage({
                 </div>
                 <div className="text-center sm:text-left">
                   <h3 className="text-lg font-semibold text-gray-900">
-                    Fits into your tech stack
+                    Works with normal files
                   </h3>
                   <p className="text-gray-600 text-base mt-2">
-                    Import Lix and get branching, diff, and rollback without
-                    changing your architecture.
+                    Tools and agents keep reading and writing workspace files.
+                    Lix tracks the changes.
                   </p>
                 </div>
               </div>
               <div className="flex flex-col items-center sm:items-start gap-4">
                 {/* Diff illustration - semantic/field-level */}
                 <div className="w-full max-w-[220px] h-32 rounded-lg border border-gray-200 bg-white p-4">
-                  <div className="text-xs text-gray-400 mb-3">config.json</div>
+                  <div className="text-xs text-gray-400 mb-3">pricing.csv</div>
                   <div className="space-y-3 text-sm">
                     <div className="flex items-center justify-between">
                       <span className="text-gray-600">title</span>
@@ -629,11 +628,11 @@ function LandingPage({
                 </div>
                 <div className="text-center sm:text-left">
                   <h3 className="text-lg font-semibold text-gray-900">
-                    Tracks semantic changes
+                    Query file content with SQL
                   </h3>
                   <p className="text-gray-600 text-base mt-2">
-                    Lix stores semantic changes via plugins. Diffs, blame, and
-                    history are queryable via SQL.
+                    Plugins map file content to rows. Apps query current data
+                    and history with SQL.
                   </p>
                 </div>
               </div>
@@ -654,7 +653,7 @@ function LandingPage({
                       <line x1="16" y1="13" x2="8" y2="13" />
                       <line x1="16" y1="17" x2="8" y2="17" />
                     </svg>
-                    <span className="text-gray-600">edit config.json</span>
+                    <span className="text-gray-600">edit brief.md</span>
                   </div>
                   <div className="flex items-center gap-2 text-gray-400 mt-1.5">
                     <span>12:04</span>
@@ -670,7 +669,7 @@ function LandingPage({
                       <line x1="16" y1="13" x2="8" y2="13" />
                       <line x1="16" y1="17" x2="8" y2="17" />
                     </svg>
-                    <span className="text-gray-600">update data.xlsx</span>
+                    <span className="text-gray-600">update pricing.csv</span>
                   </div>
                   <div className="flex items-center gap-2 mt-1.5">
                     <span className="text-gray-400">12:05</span>
@@ -701,16 +700,16 @@ function LandingPage({
                       <line x1="16" y1="13" x2="8" y2="13" />
                       <line x1="16" y1="17" x2="8" y2="17" />
                     </svg>
-                    <span className="text-gray-600">edit report.pdf</span>
+                    <span className="text-gray-600">edit report.md</span>
                   </div>
                 </div>
                 <div className="text-center sm:text-left">
                   <h3 className="text-lg font-semibold text-gray-900">
-                    Human in the loop for agents
+                    Safe branches for agents
                   </h3>
                   <p className="text-gray-600 text-base mt-2">
-                    Agents propose changes in isolated versions. Humans review,
-                    approve, and merge.
+                    Agents work on isolated branches. Humans review, approve,
+                    and merge.
                   </p>
                 </div>
               </div>

--- a/website/src/routes/-seo-smoke.test.ts
+++ b/website/src/routes/-seo-smoke.test.ts
@@ -80,7 +80,7 @@ describe("SEO route smoke tests", () => {
       "How Lix compares to Git | Lix Documentation",
     );
     expect(findMetaContent(head.meta, "twitter:description")).toBe(
-      "Compare Git's source-code workflow with Lix's file-format version control for Markdown, DOCX, XLSX, JSON, PDFs, and custom formats.",
+      "Compare Git, databases, and Lix across file access, SQL, transactions, history, branches, and semantic review.",
     );
     expect(rendered.title).toBe("How Lix compares to Git");
     expect(rendered.body).not.toContain("<h1");

--- a/website/src/routes/index.tsx
+++ b/website/src/routes/index.tsx
@@ -14,9 +14,9 @@ export const Route = createFileRoute("/")({
     return await loadReadmeContent();
   },
   head: () => {
-    const title = "Lix | Version control system for every file format";
+    const title = "Lix | Database + filesystem + version control in one";
     const description =
-      "Lix tracks, reviews, branches, merges, and rolls back changes across Markdown, DOCX, XLSX, JSON, PDFs, and custom file formats.";
+      "Lix gives tools normal files, apps queryable SQL rows, and teams version control for every change.";
     const canonicalUrl = buildCanonicalUrl("/");
     const ogImage = resolveOgImage();
     const jsonLd = buildWebSiteJsonLd({

--- a/website/src/routes/index.tsx
+++ b/website/src/routes/index.tsx
@@ -14,7 +14,7 @@ export const Route = createFileRoute("/")({
     return await loadReadmeContent();
   },
   head: () => {
-    const title = "Lix | Database + filesystem + version control in one";
+    const title = "Lix | Database + filesystem + version control in one system";
     const description =
       "Lix gives tools normal files, apps queryable SQL rows, and teams version control for every change.";
     const canonicalUrl = buildCanonicalUrl("/");

--- a/website/src/routes/readme.tsx
+++ b/website/src/routes/readme.tsx
@@ -14,9 +14,9 @@ export const Route = createFileRoute("/readme")({
     return await loadReadmeContent();
   },
   head: () => {
-    const title = "Lix README | Version control system for every file format";
+    const title = "Lix README | Database, filesystem, and version control";
     const description =
-      "Read how Lix tracks, reviews, branches, merges, and rolls back changes across Markdown, DOCX, XLSX, JSON, PDFs, and custom file formats.";
+      "Read how Lix combines normal files, queryable SQL rows, and version control in one system.";
     const canonicalUrl = buildCanonicalUrl("/readme");
     const ogImage = resolveOgImage();
     const jsonLd = buildWebSiteJsonLd({


### PR DESCRIPTION
## Summary

- reposition Lix as database + filesystem + version control in one
- focus the README and core docs on agent workspaces and file-based apps
- add the interoperability × database semantics map and product comparison
- document local and remote `openLix` usage, including SlateDB with S3-compatible storage
- align public examples with the current branch APIs and bundled Markdown/CSV plugins
- update the website hero, metadata, and activity examples to match

## Why

The README, core docs, and website described different product categories and included stale API and deployment claims. This gives Lix one clear position while keeping the examples accurate and focused on its prime use cases.

## Verification

- `npm test` in `website`: 5 test files and 29 tests passed; TypeScript passed
- `npm run build` in `website`: production build, prerender, sitemap, and postbuild passed
- Prettier check passed for all 18 changed files
- `git diff --cached --check` passed before commit
