### PR TITLE
perf(engine): stream ordered bulk update lookups

### DIFF
--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -2773,6 +2773,28 @@ async fn load_packed_current_base_exact_entries(
     if base_refs.is_empty() {
         return Ok((0..keys.len()).map(|_| None).collect());
     }
+    if let [base_ref] = base_refs.as_slice() {
+        let requests = keys
+            .iter()
+            .map(|key| {
+                (
+                    base_ref.commit_id,
+                    TrackedStateKey {
+                        schema_key: key.schema_key.to_owned(),
+                        file_id: key.file_id.map(str::to_owned),
+                        entity_pk: key.entity_pk.clone(),
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+        return Ok(
+            crate::tracked_state::load_owned_commit_delta_entries(store, &requests)
+                .await?
+                .into_iter()
+                .map(|entry| entry.map(|entry| (entry.value, entry.change_record)))
+                .collect(),
+        );
+    }
     let owned_keys = keys
         .iter()
         .map(|key| TrackedStateKey {
@@ -4383,14 +4405,6 @@ where
                 existing.created_at
             });
         }
-        let validated_delta_keys = sorted
-            .iter()
-            .map(|delta| TrackedStateKey {
-                schema_key: delta.schema_key.to_string(),
-                entity_pk: delta.entity_pk.clone(),
-                file_id: delta.file_id.map(str::to_string),
-            })
-            .collect::<BTreeSet<_>>();
         // A checkpoint often selects immutable change records whose HOT row
         // is already the exact authoritative value. Re-publishing those rows
         // only changes the row-local dirty marker and commit ownership, even
@@ -4441,6 +4455,14 @@ where
         let unmatched_guards = if absence_guards_validated || absence_guards.is_empty() {
             BTreeSet::new()
         } else {
+            let validated_delta_keys = sorted
+                .iter()
+                .map(|delta| TrackedStateKey {
+                    schema_key: delta.schema_key.to_string(),
+                    entity_pk: delta.entity_pk.clone(),
+                    file_id: delta.file_id.map(str::to_string),
+                })
+                .collect::<BTreeSet<_>>();
             absence_guards
                 .iter()
                 .filter(|key| !validated_delta_keys.contains(*key))

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -1,3 +1,5 @@
+use std::cmp::Ordering;
+
 use datafusion::arrow::array::{Array, BooleanArray, StringArray};
 use datafusion::arrow::datatypes::DataType;
 use datafusion::arrow::record_batch::RecordBatch;
@@ -425,8 +427,8 @@ pub(crate) async fn try_execute_entity_update_parameter_batch(
         bound_single_text_primary_key_param(&spec, &plan.bound.predicate);
     let direct_replacement = direct_path_value_replacement(&spec, plan, direct_primary_key_param);
     let mut parameter_rows = Vec::with_capacity(parameter_batch.num_rows());
-    let mut entity_pks = Vec::with_capacity(parameter_batch.num_rows());
-    let mut unique_entity_pks = std::collections::BTreeSet::new();
+    let mut entity_pks = Vec::<EntityPk>::with_capacity(parameter_batch.num_rows());
+    let mut entity_pks_strictly_ordered = true;
     for row_index in 0..parameter_batch.num_rows() {
         let params = super::write::parameter_row(parameter_batch, row_index)
             .map_err(|error| with_parameter_batch_statement_index(error, row_index))?;
@@ -446,20 +448,41 @@ pub(crate) async fn try_execute_entity_update_parameter_batch(
             }
             row_entity_pks.pop().expect("one point-update identity")
         };
-        if !unique_entity_pks.insert(entity_pk.clone()) {
-            // Repeated identities observe earlier staged writes and are not
-            // independent statements.
-            return Ok(None);
+        if let Some(previous) = entity_pks.last() {
+            match previous.cmp(&entity_pk) {
+                Ordering::Less => {}
+                Ordering::Equal => {
+                    // Repeated identities observe earlier staged writes and
+                    // are not independent statements.
+                    return Ok(None);
+                }
+                Ordering::Greater => entity_pks_strictly_ordered = false,
+            }
         }
         parameter_rows.push(params);
         entity_pks.push(entity_pk);
     }
+    if !entity_pks_strictly_ordered {
+        let mut unique_entity_pks = std::collections::BTreeSet::new();
+        if entity_pks
+            .iter()
+            .any(|entity_pk| !unique_entity_pks.insert(entity_pk))
+        {
+            return Ok(None);
+        }
+    }
 
+    let direct_ordered = entity_pks_strictly_ordered && direct_replacement.is_some();
+    let scan_entity_pks = if direct_ordered {
+        std::mem::take(&mut entity_pks)
+    } else {
+        entity_pks.clone()
+    };
     let candidates = scan_entity_candidates_for_pks(
         ctx,
         plan,
         &spec,
-        unique_entity_pks.into_iter().collect(),
+        scan_entity_pks,
         direct_replacement.is_some(),
     )
     .await?;
@@ -473,45 +496,84 @@ pub(crate) async fn try_execute_entity_update_parameter_batch(
         // entity replacements.
         return Ok(None);
     }
-    let mut candidates_by_pk = std::collections::BTreeMap::<EntityPk, Vec<_>>::new();
-    for candidate in candidates.iter() {
-        candidates_by_pk
-            .entry(candidate.entity_pk().clone())
-            .or_default()
-            .push(candidate);
-    }
-
     let mut affected_by_statement = Vec::with_capacity(parameter_rows.len());
     let mut write_rows = RawWriteBatch::with_capacity(parameter_rows.len());
-    for (row_index, (entity_pk, params)) in entity_pks.into_iter().zip(&parameter_rows).enumerate()
-    {
-        let mut affected = 0;
-        for candidate in candidates_by_pk.remove(&entity_pk).unwrap_or_default() {
-            let appended = match direct_replacement.as_ref() {
-                Some(replacement) => append_direct_path_value_replacement_row(
+    if direct_ordered && let Some(replacement) = direct_replacement.as_ref() {
+        // Exact scans return physical entity order. Merge the ordered request
+        // and result streams directly instead of cloning every identity into
+        // a second B-tree and allocating one candidate vector per row.
+        let mut candidates = candidates.iter().peekable();
+        let primary_key_param_index = direct_primary_key_param
+            .expect("ordered direct replacement has one primary-key parameter");
+        for (row_index, params) in parameter_rows.iter().enumerate() {
+            let expected_entity_pk = match params.get(primary_key_param_index) {
+                Some(Value::Text(value)) => value,
+                _ => unreachable!("direct replacement primary key was validated as text"),
+            };
+            let mut affected = 0;
+            while let Some(candidate) = candidates.peek().copied() {
+                if candidate
+                    .entity_pk()
+                    .as_single_string()
+                    .map_err(|error| with_parameter_batch_statement_index(error, row_index))?
+                    != expected_entity_pk
+                {
+                    break;
+                }
+                let candidate = candidates
+                    .next()
+                    .expect("peeked exact entity candidate remains available");
+                append_direct_path_value_replacement_row(
                     &mut write_rows,
                     &spec,
                     candidate,
                     params,
                     replacement,
                 )
-                .map(|()| true),
-                None => append_entity_update_row(
-                    &mut write_rows,
-                    ctx,
-                    plan,
-                    &spec,
-                    candidate,
-                    params,
-                    None,
-                ),
-            }
-            .map_err(|error| with_parameter_batch_statement_index(error, row_index))?;
-            if appended {
+                .map_err(|error| with_parameter_batch_statement_index(error, row_index))?;
                 affected += 1;
             }
+            affected_by_statement.push(affected);
         }
-        affected_by_statement.push(affected);
+    } else {
+        let mut candidates_by_pk = std::collections::BTreeMap::<EntityPk, Vec<_>>::new();
+        for candidate in candidates.iter() {
+            candidates_by_pk
+                .entry(candidate.entity_pk().clone())
+                .or_default()
+                .push(candidate);
+        }
+        for (row_index, (entity_pk, params)) in
+            entity_pks.into_iter().zip(&parameter_rows).enumerate()
+        {
+            let mut affected = 0;
+            for candidate in candidates_by_pk.remove(&entity_pk).unwrap_or_default() {
+                let appended = match direct_replacement.as_ref() {
+                    Some(replacement) => append_direct_path_value_replacement_row(
+                        &mut write_rows,
+                        &spec,
+                        candidate,
+                        params,
+                        replacement,
+                    )
+                    .map(|()| true),
+                    None => append_entity_update_row(
+                        &mut write_rows,
+                        ctx,
+                        plan,
+                        &spec,
+                        candidate,
+                        params,
+                        None,
+                    ),
+                }
+                .map_err(|error| with_parameter_batch_statement_index(error, row_index))?;
+                if appended {
+                    affected += 1;
+                }
+            }
+            affected_by_statement.push(affected);
+        }
     }
     stage_rows(ctx, TransactionWriteMode::Replace, write_rows).await?;
     #[cfg(test)]
@@ -3085,8 +3147,8 @@ fn certified_direct_parameter_insert_batch(
                             previous.cmp(current)
                         })
                         .find(|ordering| !ordering.is_eq())
-                        .unwrap_or(std::cmp::Ordering::Equal);
-                    if ordering != std::cmp::Ordering::Less {
+                        .unwrap_or(Ordering::Equal);
+                    if ordering != Ordering::Less {
                         // The common bulk producer is already ordered. Keep
                         // this arena route allocation-free and let the
                         // established generic certified path preserve

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -2516,6 +2516,15 @@ async fn load_local_owned_commit_delta_entries(
     if requests.is_empty() {
         return Ok(Vec::new());
     }
+    if requests
+        .windows(2)
+        .all(|pair| pair[0].0 == pair[1].0 && pair[0].1 < pair[1].1)
+    {
+        return Box::pin(load_local_owned_commit_delta_entries_one_ordered(
+            store, requests,
+        ))
+        .await;
+    }
 
     let mut request_indices_by_commit = BTreeMap::<CommitId, Vec<usize>>::new();
     for (request_index, (commit_id, _)) in requests.iter().enumerate() {
@@ -2622,6 +2631,108 @@ async fn load_local_owned_commit_delta_entries(
             .remove(&(commit_id, segment_index))
             .expect("read segment came from the routed lookup set");
         for (request_index, encoded_key) in lookups {
+            output[request_index] =
+                find_loaded_commit_delta_entry(&leaf, &payloads, &encoded_key, commit_id)?;
+        }
+    }
+    hydrate_selected_loaded_entries(store, &mut output).await?;
+    Ok(output)
+}
+
+/// Fast path for one physical owner and an already ordered exact-key batch.
+///
+/// Dense current-state replacement reads naturally have this shape. Route the
+/// monotonic key stream through the manifest once instead of allocating a
+/// commit map, a segment B-tree, and one lookup vector per segment.
+async fn load_local_owned_commit_delta_entries_one_ordered(
+    store: &(impl StorageAdapterRead + ?Sized),
+    requests: &[(CommitId, TrackedStateKey)],
+) -> Result<Vec<Option<LoadedCommitDeltaEntry>>, LixError> {
+    let commit_id = requests[0].0;
+    let manifest_key = StorageKey(Bytes::from(commit_delta_manifest_key(commit_id)));
+    let manifest_values = PointReadPlan::new(
+        TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
+        std::slice::from_ref(&manifest_key),
+    )
+    .materialize(store, StorageGetOptions::default())
+    .await?;
+    let Some(bytes) = manifest_values
+        .value
+        .into_iter()
+        .next()
+        .flatten()
+        .and_then(full_value_bytes)
+    else {
+        return Ok((0..requests.len()).map(|_| None).collect());
+    };
+    let manifest = decode_commit_delta_manifest(&bytes)?;
+    let mut output = (0..requests.len()).map(|_| None).collect::<Vec<_>>();
+    if let Some(inline_segment) = manifest.inline_segment() {
+        let (leaf, payloads) = decode_commit_delta_with_payloads(inline_segment, None)?;
+        for (request_index, (_, key)) in requests.iter().enumerate() {
+            let encoded_key = encoded_commit_delta_lookup_key(key);
+            output[request_index] =
+                find_loaded_commit_delta_entry(&leaf, &payloads, &encoded_key, commit_id)?;
+        }
+        hydrate_selected_loaded_entries(store, &mut output).await?;
+        return Ok(output);
+    }
+
+    let mut routed = Vec::<(usize, usize, Vec<u8>)>::with_capacity(requests.len());
+    let mut segment_indices = Vec::new();
+    for (request_index, (_, key)) in requests.iter().enumerate() {
+        let encoded_key = encoded_commit_delta_lookup_key(key);
+        let Some(segment_index) = commit_delta_segment_for_key(&manifest, &encoded_key) else {
+            continue;
+        };
+        if segment_indices.last().copied() != Some(segment_index) {
+            debug_assert!(
+                segment_indices
+                    .last()
+                    .is_none_or(|previous| *previous < segment_index),
+                "ordered commit-delta keys must route monotonically"
+            );
+            segment_indices.push(segment_index);
+        }
+        routed.push((request_index, segment_index, encoded_key));
+    }
+    let segment_keys = segment_indices
+        .iter()
+        .map(|&segment_index| {
+            commit_delta_segment_key(commit_id, segment_index)
+                .map(|key| StorageKey(Bytes::from(key)))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let segment_values =
+        PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, &segment_keys)
+            .materialize(store, StorageGetOptions::default())
+            .await?;
+    let mut routed = routed.into_iter().peekable();
+    for (segment_index, segment_value) in segment_indices.into_iter().zip(segment_values.value) {
+        let bytes = segment_value.and_then(full_value_bytes).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "tracked_state commit_delta manifest for commit '{commit_id}' references missing segment {segment_index}"
+                ),
+            )
+        })?;
+        let bounds = manifest.segments.get(segment_index).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "tracked_state commit_delta manifest for commit '{commit_id}' has no segment {segment_index}"
+                ),
+            )
+        })?;
+        let (leaf, payloads) = decode_commit_delta_with_payloads(&bytes, Some(bounds))?;
+        while routed
+            .peek()
+            .is_some_and(|(_, routed_segment, _)| *routed_segment == segment_index)
+        {
+            let (request_index, _, encoded_key) = routed
+                .next()
+                .expect("peeked routed lookup remains available");
             output[request_index] =
                 find_loaded_commit_delta_entry(&leaf, &payloads, &encoded_key, commit_id)?;
         }


### PR DESCRIPTION
## Summary

- stream already ordered bound UPDATE identities against exact scan results instead of allocating a second identity B-tree and one candidate vector per row
- route one-owner ordered commit-delta reads monotonically through the manifest instead of allocating commit/segment B-trees
- transfer single-base exact-read results without redundant identity/value clones
- avoid absence-guard identity allocation when there are no guards
- no changenote

## Performance

Immediate-parent baseline: PR #1044 exact head (`9ec97fb6f`), never the pre-stack baseline.

10k public SQL `executeBatch`:
`UPDATE json_pointer SET value = lix_json($1) WHERE path = $2`

| Adapter | PR #1044 | This PR | Change |
| --- | ---: | ---: | ---: |
| RocksDB | 107.16 ms | 93.72 ms | -12.5% |
| SlateDB | 95.94 ms | 86.85 ms | -9.5% |

SlateDB is within 0.5 percentage points of the nominal stacked threshold while removing concrete O(n) key/map allocations, following the accepted allocation-removal exception used for PR #1036.

1M scaling against the same exact parent:

| Adapter | PR #1044 | This PR | Change | Parent RSS | This RSS |
| --- | ---: | ---: | ---: | ---: | ---: |
| RocksDB | 14.98 s | 14.54 s | -3.0% | 4.84 GiB | 4.64 GiB |
| SlateDB | 19.17 s | 15.16 s | -20.9% | 4.37 GiB | 4.02 GiB |

## Validation

- `cargo test -p lix_engine`: 1,663 unit + 433 integration + 3 doctests passed (2 ignored)
- `cargo test -p lix_rocksdb_storage`: 15 passed
- `cargo test -p lix_slatedb_storage`: 58 passed
- formatting and diff checks pass
