### PR TITLE
Fix Git comparison benchmark branch IDs

### DIFF
--- a/packages/rs-sdk-tests/tests/markdown_git_benchmark.rs
+++ b/packages/rs-sdk-tests/tests/markdown_git_benchmark.rs
@@ -231,7 +231,7 @@ async fn markdown_git_semantic_entities_benchmark() {
     for sample in 0..merge_samples {
         let source = lix
             .create_branch(CreateBranchOptions {
-                id: Some(format!("markdown-merge-source-{sample}")),
+                id: Some(format!("01920000-0000-7000-8000-{:012x}", 0x600 + sample)),
                 name: format!("Markdown merge source {sample}"),
                 from_commit_id: None,
             })


### PR DESCRIPTION
## Summary
- generate schema-valid UUIDv7 branch IDs in the matched Git/Lix merge benchmark
- keep deterministic IDs across benchmark runs

## Validation
- `markdown_git_semantic_entities_benchmark` passes in release mode
- no changenote: benchmark-only fix