### PR TITLE
perf(sdk): remove redundant native worker hop

### DIFF
--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -61,6 +61,22 @@ test("openLix forwards opt-in SQL telemetry from the engine", async () => {
 	await lix.close();
 });
 
+test("native telemetry preserves its receiver and cannot fail commands", async () => {
+	const telemetry = {
+		calls: 0,
+		onSpan() {
+			this.calls += 1;
+			throw new Error("telemetry failure");
+		},
+	};
+	const lix = await openLix({ telemetry });
+
+	await expect(lix.execute("SELECT 1 AS value")).resolves.toBeDefined();
+	await new Promise((resolve) => setTimeout(resolve, 20));
+	expect(telemetry.calls).toBeGreaterThan(0);
+	await lix.close();
+});
+
 test("openLix opens native storage without telemetry", async () => {
 	const lix = await openLix();
 	const result = await lix.execute("SELECT 1 AS value");

--- a/packages/js-sdk/src/worker/client.ts
+++ b/packages/js-sdk/src/worker/client.ts
@@ -57,7 +57,16 @@ export async function openLixWorkerBinding(
 	telemetry?: LixTelemetryOptions,
 ): Promise<LixBinding> {
 	if (openDirectLixBinding) {
-		const binding = await openDirectLixBinding(storage, telemetry?.onSpan);
+		const telemetryDispatch = telemetry
+			? (span: Parameters<LixTelemetryOptions["onSpan"]>[0]) => {
+					try {
+						telemetry.onSpan(span);
+					} catch {
+						// Telemetry is observational and must not fail engine commands.
+					}
+				}
+			: undefined;
+		const binding = await openDirectLixBinding(storage, telemetryDispatch);
 		if (!onDisposed) return binding;
 		let disposed = false;
 		return new Proxy(binding, {

--- a/packages/js-sdk/src/worker/client.ts
+++ b/packages/js-sdk/src/worker/client.ts
@@ -1,4 +1,4 @@
-import { createWorkerConnection } from "#worker-factory";
+import { createWorkerConnection, openDirectLixBinding } from "#worker-factory";
 import type {
 	LixBinding,
 	LixStorageConfig,
@@ -56,6 +56,29 @@ export async function openLixWorkerBinding(
 	onDisposed?: () => void,
 	telemetry?: LixTelemetryOptions,
 ): Promise<LixBinding> {
+	if (openDirectLixBinding) {
+		const binding = await openDirectLixBinding(storage, telemetry?.onSpan);
+		if (!onDisposed) return binding;
+		let disposed = false;
+		return new Proxy(binding, {
+			get(target, property, receiver) {
+				if (property === "close") {
+					return async () => {
+						try {
+							await target.close();
+						} finally {
+							if (!disposed) {
+								disposed = true;
+								onDisposed();
+							}
+						}
+					};
+				}
+				const value = Reflect.get(target, property, receiver) as unknown;
+				return typeof value === "function" ? value.bind(target) : value;
+			},
+		});
+	}
 	const client = await openLixWorker(storage, onDisposed, telemetry);
 	return workerBinding(client);
 }

--- a/packages/js-sdk/src/worker/factory.browser.ts
+++ b/packages/js-sdk/src/worker/factory.browser.ts
@@ -1,10 +1,21 @@
 /// <reference lib="webworker" />
 
 import type {
+	LixBinding,
+	LixStorageConfig,
+	TelemetryDispatch,
+} from "../binding-types.js";
+import type {
 	WorkerConnection,
 	WorkerInput,
 	WorkerResponse,
 } from "./protocol.js";
+
+// Browser/Wasm execution stays off the main thread.
+export const openDirectLixBinding: undefined | ((
+	storage: LixStorageConfig,
+	telemetry?: TelemetryDispatch,
+) => Promise<LixBinding>) = undefined;
 
 export function createWorkerConnection(): WorkerConnection {
 	const worker = new Worker(new URL("./entry.browser.js", import.meta.url), {

--- a/packages/js-sdk/src/worker/factory.node.ts
+++ b/packages/js-sdk/src/worker/factory.node.ts
@@ -1,4 +1,6 @@
 import { Worker } from "node:worker_threads";
+import { openLixBinding } from "../binding.node.js";
+import type { LixBinding, LixStorageConfig, TelemetryDispatch } from "../binding-types.js";
 import type {
 	WorkerConnection,
 	WorkerInput,
@@ -37,3 +39,11 @@ export function createWorkerConnection(): WorkerConnection {
 		},
 	};
 }
+
+/// Native Lix already owns a dedicated serialized engine actor. Routing it
+/// through a second JavaScript worker adds two message-port hops per query
+/// without adding isolation or concurrency.
+export const openDirectLixBinding = (
+	storage: LixStorageConfig,
+	telemetry?: TelemetryDispatch,
+): Promise<LixBinding> => openLixBinding(storage, telemetry);


### PR DESCRIPTION
## Summary
- bypass the redundant JavaScript worker for Node native bindings
- retain the native serialized engine actor as the single async isolation boundary
- keep browser/Wasm execution on its worker
- preserve local-filesystem disposal behavior for direct bindings

## Performance
In the inlang issue #1039 workload, the no-op native roundtrip drops from 0.0665 ms to 0.0237 ms (64% lower). A direct tracked point update drops from 0.1856 ms to 0.1377 ms (26% lower).

No changenote: performance-only change above the 10% threshold.

## Validation
- `npm run typecheck` in `packages/js-sdk`
- `vitest run src/open-lix.test.ts` (74 passed)
- full inlang common-operations benchmark