### PR TITLE
Fix semantic merge change statistics

### DIFF
--- a/.changenotes/semantic-merge-change-stats.md
+++ b/.changenotes/semantic-merge-change-stats.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Semantic merge previews and receipts now include plugin-resolved changes in their change statistics.

--- a/packages/engine/src/session/merge/branch.rs
+++ b/packages/engine/src/session/merge/branch.rs
@@ -194,12 +194,38 @@ where
                         .await?
                 };
 
+                let plugin_resolution_stats = if analysis.outcome == MergeOutcome::MergeCommitted {
+                    let plugin_conflict_groups = {
+                        let mut reader = transaction.tracked_state_reader().await;
+                        plugin_merge_conflict_groups(
+                            &mut reader,
+                            &analysis,
+                            &derived_blob_files,
+                            &resolvable_plugin_conflicts,
+                        )
+                        .await?
+                    };
+                    let semantic_branch_id = SharedStr::from(active_branch_id.as_str());
+                    let resolved_plugin_rows = resolve_plugin_merge_conflict_groups(
+                        transaction,
+                        plugin_conflict_groups,
+                        &semantic_branch_id,
+                    )
+                    .await?;
+                    let mut reader = transaction.tracked_state_reader().await;
+                    plugin_resolution_change_stats(&mut reader, &analysis, &resolved_plugin_rows)
+                        .await?
+                } else {
+                    MergeChangeStats::default()
+                };
+
                 preview_from_analysis(
                     &active_branch_id,
                     &source_branch_id,
                     &analysis,
                     &derived_blob_files,
                     &resolvable_plugin_conflicts,
+                    &plugin_resolution_stats,
                 )
             })
         })
@@ -385,6 +411,17 @@ where
                 ))
                 .await?;
 
+                let plugin_resolution_stats = async {
+                    let mut reader = transaction.tracked_state_reader().await;
+                    plugin_resolution_change_stats(&mut reader, &analysis, &resolved_plugin_rows)
+                        .await
+                }
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.merge_plugin_resolution_stats"
+                ))
+                .await?;
+
                 let semantic_rows = async {
                     let mut reader = transaction.tracked_state_reader().await;
                     materialized_plugin_merge_rows(
@@ -449,7 +486,10 @@ where
                     target_head_before_commit_id: analysis.commits.target_commit_id.to_string(),
                     source_head_before_commit_id: analysis.commits.source_commit_id.to_string(),
                     created_merge_commit_id: Some(created_merge_commit_id),
-                    change_stats: merge_change_stats_from_analysis(&analysis.stats),
+                    change_stats: merge_change_stats_with_plugin_resolutions(
+                        &analysis.stats,
+                        &plugin_resolution_stats,
+                    ),
                 })
             })
         })
@@ -1740,12 +1780,104 @@ where
     Ok(rows)
 }
 
+async fn plugin_resolution_change_stats<S>(
+    reader: &mut TrackedStateStoreReader<S>,
+    analysis: &super::analysis::MergeAnalysis,
+    resolved_rows: &RawWriteBatch,
+) -> Result<MergeChangeStats, LixError>
+where
+    S: crate::storage_adapter::StorageAdapterRead,
+{
+    if resolved_rows.is_empty() {
+        return Ok(MergeChangeStats::default());
+    }
+    let keys = resolved_rows
+        .iter()
+        .map(|row| {
+            Ok(TrackedStateKeyRef {
+                schema_key: row.schema_key.as_str(),
+                file_id: row.file_id.map(SharedStr::as_str),
+                entity_pk: row.entity_pk.ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "plugin resolution row omitted its entity identity",
+                    )
+                })?,
+            })
+        })
+        .collect::<Result<Vec<_>, LixError>>()?;
+    let target_rows = reader
+        .load_projected_batch_at_commit_refs(
+            &analysis.commits.target_commit_id.to_string(),
+            &keys,
+            &ChangeRecordProjection::full(),
+        )
+        .await?;
+    let mut stats = MergeChangeStats::default();
+    for (index, resolved) in resolved_rows.iter().enumerate() {
+        let target = target_rows.row(index).filter(|row| !row.deleted());
+        let target_snapshot = target
+            .map(|row| {
+                row.snapshot_content().ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "live plugin target row omitted its snapshot",
+                    )
+                })
+            })
+            .transpose()?;
+        match classify_plugin_resolution(
+            target_snapshot.map(SharedStr::as_str),
+            target
+                .and_then(MaterializedTrackedStateRowRef::metadata)
+                .map(SharedStr::as_str),
+            resolved.snapshot.map(TransactionJson::normalized),
+            resolved.metadata.map(TransactionJson::normalized),
+        ) {
+            Some(PluginResolutionChange::Added) => stats.added += 1,
+            Some(PluginResolutionChange::Modified) => stats.modified += 1,
+            Some(PluginResolutionChange::Removed) => stats.removed += 1,
+            None => {}
+        }
+    }
+    stats.total = stats.added + stats.modified + stats.removed;
+    Ok(stats)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PluginResolutionChange {
+    Added,
+    Modified,
+    Removed,
+}
+
+fn classify_plugin_resolution(
+    target_snapshot: Option<&str>,
+    target_metadata: Option<&str>,
+    resolved_snapshot: Option<&str>,
+    resolved_metadata: Option<&str>,
+) -> Option<PluginResolutionChange> {
+    match (target_snapshot, resolved_snapshot) {
+        (None, None) => None,
+        (None, Some(_)) => Some(PluginResolutionChange::Added),
+        (Some(_), None) => Some(PluginResolutionChange::Removed),
+        (Some(target), Some(resolved)) => {
+            if target == resolved && target_metadata == resolved_metadata {
+                None
+            } else {
+                Some(PluginResolutionChange::Modified)
+            }
+        }
+    }
+}
+
 fn preview_from_analysis(
     target_branch_id: &str,
     source_branch_id: &str,
     analysis: &super::analysis::MergeAnalysis,
     derived_blob_files: &BTreeMap<String, PluginFileOwner>,
     resolvable_plugin_conflicts: &BTreeSet<TrackedStateDiffIdentity>,
+    plugin_resolution_stats: &MergeChangeStats,
 ) -> Result<MergeBranchPreview, LixError> {
     let conflicts = analysis
         .conflict_batch()
@@ -1771,7 +1903,10 @@ fn preview_from_analysis(
         base_commit_id: analysis.commits.base_commit_id.to_string(),
         target_head_commit_id: analysis.commits.target_commit_id.to_string(),
         source_head_commit_id: analysis.commits.source_commit_id.to_string(),
-        change_stats: merge_change_stats_from_analysis(&analysis.stats),
+        change_stats: merge_change_stats_with_plugin_resolutions(
+            &analysis.stats,
+            plugin_resolution_stats,
+        ),
         conflicts,
     })
 }
@@ -1790,6 +1925,18 @@ fn merge_change_stats_from_analysis(stats: &MergeStats) -> MergeChangeStats {
         added: stats.added,
         modified: stats.modified,
         removed: stats.removed,
+    }
+}
+
+fn merge_change_stats_with_plugin_resolutions(
+    stats: &MergeStats,
+    plugin_resolution_stats: &MergeChangeStats,
+) -> MergeChangeStats {
+    MergeChangeStats {
+        total: stats.total + plugin_resolution_stats.total,
+        added: stats.added + plugin_resolution_stats.added,
+        modified: stats.modified + plugin_resolution_stats.modified,
+        removed: stats.removed + plugin_resolution_stats.removed,
     }
 }
 
@@ -1894,6 +2041,38 @@ mod tests {
             change_id: ChangeId::for_test_label("descriptor-change"),
             commit_id: CommitId::for_test_label("descriptor-commit"),
         }
+    }
+
+    #[test]
+    fn plugin_resolution_stats_follow_actual_target_delta() {
+        assert_eq!(
+            classify_plugin_resolution(Some("target"), None, Some("target"), None),
+            None,
+            "taking the target is not a change"
+        );
+        assert_eq!(
+            classify_plugin_resolution(Some("target"), None, None, None),
+            Some(PluginResolutionChange::Removed),
+            "deleting a modified source row is a removal from the target"
+        );
+        assert_eq!(
+            classify_plugin_resolution(None, None, Some("replacement"), None),
+            Some(PluginResolutionChange::Added)
+        );
+        assert_eq!(
+            classify_plugin_resolution(
+                Some("target"),
+                Some("target-meta"),
+                Some("replacement"),
+                None,
+            ),
+            Some(PluginResolutionChange::Modified)
+        );
+        assert_eq!(
+            classify_plugin_resolution(Some("target"), Some("target-meta"), Some("target"), None,),
+            Some(PluginResolutionChange::Modified),
+            "metadata-only resolver effects remain visible"
+        );
     }
 
     fn owner_row(file_id: &str, incarnation: &str) -> MaterializedTrackedStateRow {

--- a/packages/rs-sdk/tests/semantic_merge.rs
+++ b/packages/rs-sdk/tests/semantic_merge.rs
@@ -104,8 +104,7 @@ where
 }
 
 fn csv_plugin_archive() -> Vec<u8> {
-    let wasm_path = option_env!("CARGO_CDYLIB_FILE_PLUGIN_CSV_plugin_csv")
-        .expect("Cargo must provide the CSV plugin artifact for rs-sdk tests");
+    let wasm_path = env!("CARGO_CDYLIB_FILE_PLUGIN_CSV_plugin_csv");
     let wasm = std::fs::read(Path::new(wasm_path)).expect("read CSV plugin wasm");
     let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
     let options =

--- a/packages/rs-sdk/tests/semantic_merge.rs
+++ b/packages/rs-sdk/tests/semantic_merge.rs
@@ -1,0 +1,132 @@
+use std::io::{Cursor, Write as _};
+use std::path::Path;
+
+use lix_sdk::{
+    CreateBranchOptions, Lix, MergeBranchOptions, OpenLixOptions, Storage, SwitchBranchOptions,
+    Value, open_lix,
+};
+
+#[tokio::test]
+async fn plugin_resolved_rows_are_included_in_semantic_merge_change_stats() {
+    let lix = open_lix(OpenLixOptions::default()).await.unwrap();
+    install_csv_plugin(&lix).await;
+    write_file(&lix, "/semantic-merge.csv", b"quick,dog\n").await;
+    let main_branch_id = lix.active_branch_id().await.unwrap();
+    let source = lix
+        .create_branch(CreateBranchOptions {
+            id: None,
+            name: "Semantic source".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .unwrap();
+
+    lix.switch_branch(SwitchBranchOptions {
+        branch_id: source.id.clone(),
+    })
+    .await
+    .unwrap();
+    write_file(&lix, "/semantic-merge.csv", b"very quick,dog\n").await;
+    lix.switch_branch(SwitchBranchOptions {
+        branch_id: main_branch_id,
+    })
+    .await
+    .unwrap();
+    write_file(&lix, "/semantic-merge.csv", b"quick,sleepy dog\n").await;
+
+    let preview = lix
+        .merge_branch_preview(lix_sdk::MergeBranchPreviewOptions {
+            source_branch_id: source.id.clone(),
+        })
+        .await
+        .unwrap();
+    assert!(preview.conflicts.is_empty());
+    assert_eq!(preview.change_stats.total, 1);
+    assert_eq!(preview.change_stats.added, 0);
+    assert_eq!(preview.change_stats.modified, 1);
+    assert_eq!(preview.change_stats.removed, 0);
+
+    let receipt = lix
+        .merge_branch(MergeBranchOptions {
+            source_branch_id: source.id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(receipt.change_stats, preview.change_stats);
+    assert_eq!(
+        read_file(&lix, "/semantic-merge.csv").await,
+        b"very quick,sleepy dog\n"
+    );
+    lix.close().await.unwrap();
+}
+
+async fn install_csv_plugin<StorageImpl>(lix: &Lix<StorageImpl>)
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    write_file(
+        lix,
+        "/.lix/plugins/plugin_csv.lixplugin",
+        &csv_plugin_archive(),
+    )
+    .await;
+}
+
+async fn write_file<StorageImpl>(lix: &Lix<StorageImpl>, path: &str, data: &[u8])
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    lix.execute(
+        "INSERT INTO lix_file (path, data) VALUES ($1, $2) \
+         ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+        &[
+            Value::Text(path.to_string()),
+            Value::Blob(data.to_vec().into()),
+        ],
+    )
+    .await
+    .unwrap();
+}
+
+async fn read_file<StorageImpl>(lix: &Lix<StorageImpl>, path: &str) -> Vec<u8>
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    lix.execute(
+        "SELECT data FROM lix_file WHERE path = $1",
+        &[Value::Text(path.to_string())],
+    )
+    .await
+    .unwrap()
+    .rows()[0]
+        .get::<Vec<u8>>("data")
+        .unwrap()
+}
+
+fn csv_plugin_archive() -> Vec<u8> {
+    let wasm_path = option_env!("CARGO_CDYLIB_FILE_PLUGIN_CSV_plugin_csv")
+        .expect("Cargo must provide the CSV plugin artifact for rs-sdk tests");
+    let wasm = std::fs::read(Path::new(wasm_path)).expect("read CSV plugin wasm");
+    let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    for (path, bytes) in [
+        (
+            "manifest.json",
+            include_str!("../../../plugins/csv/manifest.json").as_bytes(),
+        ),
+        (
+            "schema/csv_v2_table.json",
+            include_str!("../../../plugins/csv/schema/csv_v2_table.json").as_bytes(),
+        ),
+        (
+            "schema/csv_v2_row.json",
+            include_str!("../../../plugins/csv/schema/csv_v2_row.json").as_bytes(),
+        ),
+        ("plugin.wasm", wasm.as_slice()),
+    ] {
+        writer.start_file(path, options).unwrap();
+        writer.write_all(bytes).unwrap();
+    }
+    writer.finish().unwrap().into_inner()
+}


### PR DESCRIPTION
## What changed

- derive semantic merge statistics from the resolver's actual output relative to the target state
- execute the resolver during preview so preview and receipt report the same exact target delta
- batch target-state reads and classify resolved rows in one aligned pass
- cover take-target, delete, replacement, metadata-only, fast-forward, and real CSV-plugin behavior in engine/Rust SDK tests
- add a dedicated performance trace span and patch changenote

## Why

Semantic merges could produce changed file content while returning `{ total: 0, added: 0, modified: 0, removed: 0 }`. Merge analysis counted only conflict-free source picks; plugin-resolved conflicts were omitted.

The initial fix inferred categories from `source_diff`. Review correctly identified that this misclassified `Delete`, counted `Take(target)` as a change, and rescanned the source diff once per conflict. The revised implementation compares the resolver's exact output with an aligned batch of target rows.

## Impact

Callers now receive exact added/modified/removed statistics for semantic merges. Preview intentionally executes the resolver to make its prediction exact; this adds the resolver cost to semantic previews.

## Performance profile

Release native SDK, bundled Markdown plugin, local in-memory Lix, repeated hydrated semantic conflicts:

| Conflicts | Repetitions | Median preview | Median merge |
|---:|---:|---:|---:|
| 100 | 3 | 5.48 ms | 10.89 ms |
| 1,000 | 5 | 47.04 ms | 143.06 ms |

The 1,000-conflict `perf stat` run (five complete setup/preview/merge samples) used 3.20 s task-clock, 9.53B cycles, 32.51B instructions, 37.46M cache misses, and 275 MB process peak RSS. Statistics were exact in every sample (`1,000 modified`) and preview equaled receipt.

The removed implementation required 50,005,000 source-identity checks for 10,000 ordered conflicts. The revised accounting uses one batched historical target read and one O(n) aligned classification pass. Full semantic resolution currently reaches existing component packet/page limits above roughly 1,000 conflicts; that separately discovered scalability bug is intentionally excluded from this PR and is being fixed in an isolated follow-up.

## Validation

- `cargo test -p lix_engine --features all-simulations` (1,660 unit tests + 800 integration simulations passed; existing manual probes ignored)
- `cargo test -p lix_sdk --test semantic_merge`
- `cargo fmt --check`
- `git diff --check`