### PR TITLE
Use verified WASM edits for CAS deltas

### DIFF
--- a/packages/engine-benchmarks/benches/flat_text_cas_delta_results.md
+++ b/packages/engine-benchmarks/benches/flat_text_cas_delta_results.md
@@ -1,0 +1,115 @@
+# Verified-edit CAS delta results
+
+This change connects the format-neutral WASM edit stream to the binary CAS's
+bounded copy/insert representation. The interface contains no file-format,
+content-type, Git, or LFS policy. The format is a hard cut; existing databases
+are not migrated.
+
+Git packfiles establish the core representation: a deltified object names a
+base and reconstructs its result with copy-from-base and inline-insert
+instructions. Lix uses the same primitives but deliberately flattens every
+edit onto one full base, avoiding Git's delta-chain read amplification. The
+manifest embeds the base's physical layout, so a cold delta read needs no
+dependent base-manifest lookup. See Git's [pack format][git-pack].
+
+The surrounding layout follows RocksDB's key/value-separation guidance:
+compact manifests live apart from immutable content chunks, and related
+metadata is kept away from bulky values. RocksDB documents both the reduction
+in compaction write amplification from immutable blob files and the benefit of
+separating file metadata from file-block data in the key space. See
+[BlobDB][rocks-blobdb] and [key layout][rocks-key-layout].
+
+## Policy
+
+- Any WASM component plugin with blob materialization can participate. Its
+  transition must produce one host-verified coalesced edit against the exact
+  accepted document. Full output bytes and their BLAKE3 hash remain
+  authoritative.
+- There is no plugin manifest flag and no text/binary branch in the CAS API.
+  Derived materializations do not use the binary CAS; raw or initial writes
+  without a verified base edit use the normal full-blob path.
+- Files smaller than 512 bytes use the normal full-blob path.
+- A delta has at most 32 segments and at most the smaller of 64 KiB or 12.5%
+  of the resulting file in inserted bytes.
+- Editing a delta composes its piece table against the same canonical full
+  base. A delta never references another delta. Crossing a bound writes a new
+  full blob, which becomes the next base.
+- Every inserted content chunk and every reconstructed delta is verified
+  against its content-addressed key.
+
+Fine-grained FastCDC policies at 8 KiB and 64 KiB were rejected. The 8 KiB
+policy made the microbenchmark 30.5% faster but regressed Wesnoth/SlateDB
+replay by 3.4%; the 64 KiB policy made the microbenchmark 23.7% faster but
+regressed aggregate replay by 1.9%. The retained verified-edit policy is
+neutral in aggregate replay time and lets any plugin benefit when it can prove
+the same format-independent edit contract.
+
+## Git replay corpus
+
+The baseline is `main` at `b51aacaf7` with the RocksDB Zstd and final
+point-write changes. The candidate release binary SHA-256 is
+`6c0b5b5f8ce420c98adf22c731dda57c74fcaa71f850afdbfa5e82981257e095`.
+Every run used `lix exp git-replay --plugins all`, scoped parent bootstrap,
+explicit checkpoints, storage flush, and final Git-tree verification. Database
+bytes are `du -sb` after close.
+
+| repository | adapter | replay before | replay after | time delta | bytes before | bytes after | size delta |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `microsoft/vscode-docs`, 100 commits | RocksDB | 4624.477 ms | 4668.278 ms | +0.95% | 79,633,004 | 72,622,119 | -8.80% |
+| `microsoft/vscode-docs`, 100 commits | SlateDB | 4857.188 ms | 4809.890 ms | -0.97% | 79,760,567 | 72,545,795 | -9.05% |
+| `home-assistant/brands`, 80 commits | RocksDB | 313.514 ms | 313.681 ms | +0.05% | 15,854,439 | 15,853,294 | -0.01% |
+| `home-assistant/brands`, 80 commits | SlateDB | 374.780 ms | 374.387 ms | -0.10% | 15,898,061 | 15,893,791 | -0.03% |
+| `wesnoth/wesnoth`, 15 commits | RocksDB | 125.481 ms | 121.232 ms | -3.39% | 4,487,302 | 4,345,582 | -3.16% |
+| `wesnoth/wesnoth`, 15 commits | SlateDB | 125.817 ms | 124.612 ms | -0.96% | 4,484,039 | 4,340,966 | -3.19% |
+| **aggregate** | | **10421.257 ms** | **10412.081 ms** | **-0.09%** | **200,117,412** | **185,601,547** | **-7.25%** |
+
+All final-tree checks passed. VS Code materialized 97 unique LFS objects with
+42,011,887 logical payload bytes before and after; Brands and Wesnoth
+materialized none. LFS payload is a replay accounting category, not a CAS or
+plugin API concept. These were initial materializations without a verified
+base edit and therefore used the normal full-blob path. The table is the
+complete Lix database footprint and includes Lix's physical representation of
+those payloads.
+
+On VS Code/SlateDB, delta manifests replace 1,484 whole-file chunks. Immutable
+chunk value bytes fall from 74,441,216 to 67,267,601 while encoded manifest
+bytes rise from 194,970 to 391,995. Wesnoth replaces 25 whole-file chunks;
+immutable chunk value bytes fall from 3,485,355 to 3,339,981. Brands is the
+media-heavy control and stays flat.
+
+## Matched Git and hot-path benchmark
+
+The deterministic Markdown corpus is 524,721 bytes. Before and after use the
+same public SQL writes and release configuration. Duration rows are medians;
+the unprofiled hot loop uses 500 edits.
+
+| operation | before | after | delta | Git after |
+| --- | ---: | ---: | ---: | ---: |
+| hot byte edit | 3.231 ms | 2.187 ms | -32.31% | 5.751 ms matched edit median |
+| cold materialized read | 0.722 ms | 0.573 ms | -20.64% | 1.260 ms |
+| semantic edit | 6.052 ms | 5.932 ms | -1.98% | 5.751 ms |
+| unrelated-entity merge | 6.744 ms | 6.714 ms | -0.44% | 10.326 ms |
+| initial import | 32.534 ms | 31.944 ms | -1.81% | 5.552 ms |
+
+The byte-edit path is 3.10x faster than Git and the cold materialized read is
+2.20x faster. This is a material improvement but does not claim the broader
+10x target: initial import remains 5.75x slower than Git, semantic edits are
+3.1% slower, and the Wesnoth storage window remains above the requested 2x
+Git footprint.
+
+The before Samply profile is
+`bench-artifacts/git-comparison/profiles/markdown-byte-write-before.json.gz`;
+the after profile is
+`bench-artifacts/piece-table-cas-delta-512/profiles/markdown-byte-write-after.json.gz`.
+The before profile attributed about 43% of sampled hot-path time to Zstd
+compressing the repeatedly rewritten whole CAS chunk. The after loop is
+2.211 ms/edit under sampling and stores only the bounded delta manifest.
+
+Both RocksDB and SlateDB passed the eight-operation tracked-state CRUD smoke
+matrix (insert/read/update/delete, bulk and keyed). The local Codspeed
+compatibility runner reports correctness but not statistically useful timing;
+replay and the matched benchmark above are the performance checks.
+
+[git-pack]: https://git-scm.com/docs/gitformat-pack
+[rocks-blobdb]: https://github.com/facebook/rocksdb/wiki/BlobDB
+[rocks-key-layout]: https://github.com/facebook/rocksdb/wiki/Basic-Operations#key-layout

--- a/packages/engine-benchmarks/benches/verified_edit_cas_delta_results.md
+++ b/packages/engine-benchmarks/benches/verified_edit_cas_delta_results.md
@@ -1,6 +1,6 @@
 # Verified-edit CAS delta results
 
-This change connects the format-neutral WASM edit stream to the binary CAS's
+The follow-up connects the format-neutral WASM edit stream to the binary CAS's
 bounded copy/insert representation. The interface contains no file-format,
 content-type, Git, or LFS policy. The format is a hard cut; existing databases
 are not migrated.

--- a/packages/engine/src/plugin/incremental.rs
+++ b/packages/engine/src/plugin/incremental.rs
@@ -280,10 +280,12 @@ pub(crate) struct BuiltInputSplices {
 }
 
 impl BuiltInputSplices {
-    /// Returns the one fixed-width base-relative replacement, if this update
-    /// can retain its prior binary-CAS chunk boundaries. This is private host
-    /// staging information; the WIT input remains the ordinary splice vector.
-    pub(crate) fn same_length_replacement(&self) -> Option<(usize, usize)> {
+    /// Returns one host-verified base-relative replacement for storage reuse.
+    ///
+    /// This is format-neutral transition evidence. The WIT input remains the
+    /// ordinary splice vector, and callers still retain the complete accepted
+    /// output bytes as authority.
+    pub(crate) fn replacement(&self) -> Option<(usize, usize, usize)> {
         let [splice] = self.edits.as_slice() else {
             return None;
         };
@@ -291,8 +293,18 @@ impl BuiltInputSplices {
             WasmInputBytes::Inline(bytes) => bytes.len(),
             WasmInputBytes::AfterRange(range) => usize::try_from(range.length).ok()?,
         };
-        let offset = usize::try_from(splice.offset).ok()?;
-        let delete_len = usize::try_from(splice.delete_len).ok()?;
+        Some((
+            usize::try_from(splice.offset).ok()?,
+            usize::try_from(splice.delete_len).ok()?,
+            insert_len,
+        ))
+    }
+
+    /// Returns the one fixed-width base-relative replacement, if this update
+    /// can retain its prior binary-CAS chunk boundaries. This is private host
+    /// staging information; the WIT input remains the ordinary splice vector.
+    pub(crate) fn same_length_replacement(&self) -> Option<(usize, usize)> {
+        let (offset, delete_len, insert_len) = self.replacement()?;
         (delete_len == insert_len && delete_len != 0).then_some((offset, delete_len))
     }
 }
@@ -3465,6 +3477,7 @@ mod tests {
         assert!(from_transport.used_transport_provenance);
         assert_eq!(from_transport.full_diff_bytes_compared, 0);
         assert_eq!(from_transport.after_sha256, Some(after_sha256));
+        assert_eq!(from_transport.replacement(), Some((2, 2, 2)));
         assert_eq!(from_transport.same_length_replacement(), Some((2, 2)));
         assert_eq!(
             from_transport.edits,
@@ -3528,6 +3541,7 @@ mod tests {
         )
         .expect("length-changing splice should still build");
         assert_eq!(length_changing.same_length_replacement(), None);
+        assert_eq!(length_changing.replacement(), Some((2, 2, 3)));
     }
 
     #[test]

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -194,7 +194,11 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
                 continue;
             }
             blob_writer
-                .stage_file_payload(write.payload(), write.same_length_blob_splice(), None)
+                .stage_file_payload(
+                    write.payload(),
+                    write.same_length_blob_splice(),
+                    write.edit_blob_splice(),
+                )
                 .instrument(tracing::debug_span!(
                     target: "lix_perf",
                     "lix.perf.binary_cas_stage_payload"

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -3911,6 +3911,7 @@ where
                 u64::try_from(submitted_bytes.len()).unwrap_or(u64::MAX),
             );
             let mut verified_same_length_blob_splice = None;
+            let mut verified_blob_edit_splice = None;
 
             let (changes, publication, materialized_bytes, create_rows) = if same_plugin_owner {
                 'same_owner: {
@@ -3976,6 +3977,7 @@ where
                                 cold_edits,
                                 host_full_diff_bytes_compared,
                                 same_length_blob_splice,
+                                blob_edit_splice,
                             ) = match (selected.materialization(), visible_materialization.bytes) {
                                 (
                                     PluginMaterialization::Blob,
@@ -4022,6 +4024,11 @@ where
                                     let same_length_blob_splice = built_splices
                                         .same_length_replacement()
                                         .map(|(offset, length)| (hash, offset, length));
+                                    let blob_edit_splice = built_splices.replacement().map(
+                                        |(offset, delete_len, insert_len)| {
+                                            (hash, offset, delete_len, insert_len)
+                                        },
+                                    );
                                     let before_source: Arc<dyn crate::wasm::WasmByteSource> =
                                         Arc::new(ArcByteSource::new(before_bytes.clone()));
                                     (
@@ -4031,6 +4038,7 @@ where
                                         built_splices.edits,
                                         built_splices.full_diff_bytes_compared,
                                         same_length_blob_splice,
+                                        blob_edit_splice,
                                     )
                                 }
                                 (
@@ -4048,7 +4056,7 @@ where
                                             ),
                                         ));
                                     }
-                                    (None, None, None, Vec::new(), 0, None)
+                                    (None, None, None, Vec::new(), 0, None, None)
                                 }
                                 _ => {
                                     return Err(LixError::new(
@@ -4358,6 +4366,7 @@ where
                                     .saturating_add(certified_row_count);
                             self.plugin_host.record_transition_counters(counters);
                             verified_same_length_blob_splice = same_length_blob_splice;
+                            verified_blob_edit_splice = blob_edit_splice;
                             drop(cold_open_guard);
                             break 'same_owner (
                                 changes,
@@ -4471,6 +4480,7 @@ where
                     let submitted_bytes_sha256 = built_splices.after_sha256;
                     let host_full_diff_bytes_compared = built_splices.full_diff_bytes_compared;
                     let same_length_blob_splice = built_splices.same_length_replacement();
+                    let blob_edit_splice = built_splices.replacement();
                     let observed_source = ArcByteSource::new(observed_bytes.clone());
                     let submitted_source = ArcByteSource::new(submitted_bytes.clone());
                     let observed_document = lease.observed_document();
@@ -4593,11 +4603,19 @@ where
                             // validated file successor is therefore already the
                             // exact merge result; rendering the same sparse change
                             // onto the same base would only repeat guest work.
-                            verified_same_length_blob_splice = match visible_materialization.bytes {
+                            verified_same_length_blob_splice = match &visible_materialization.bytes
+                            {
                                 VisibleMaterializationBytes::Blob { hash, .. } => {
                                     same_length_blob_splice
-                                        .map(|(offset, length)| (hash, offset, length))
+                                        .map(|(offset, length)| (*hash, offset, length))
                                 }
+                                VisibleMaterializationBytes::Derived { .. } => None,
+                            };
+                            verified_blob_edit_splice = match &visible_materialization.bytes {
+                                VisibleMaterializationBytes::Blob { hash, .. } => blob_edit_splice
+                                    .map(|(offset, delete_len, insert_len)| {
+                                        (*hash, offset, delete_len, insert_len)
+                                    }),
                                 VisibleMaterializationBytes::Derived { .. } => None,
                             };
                             (
@@ -4825,14 +4843,26 @@ where
                 PluginMaterialization::Blob => {
                     if materialized_bytes.as_ref() != write.data() {
                         write.replace_data(materialized_bytes);
-                    } else if let Some((visible_base_blob_hash, offset, length)) =
-                        verified_same_length_blob_splice
-                    {
-                        write.set_verified_same_length_blob_splice(
-                            visible_base_blob_hash,
-                            offset,
-                            length,
-                        );
+                    } else {
+                        if let Some((visible_base_blob_hash, offset, length)) =
+                            verified_same_length_blob_splice
+                        {
+                            write.set_verified_same_length_blob_splice(
+                                visible_base_blob_hash,
+                                offset,
+                                length,
+                            );
+                        }
+                        if let Some((visible_base_blob_hash, offset, delete_len, insert_len)) =
+                            verified_blob_edit_splice
+                        {
+                            write.set_verified_blob_edit_splice(
+                                visible_base_blob_hash,
+                                offset,
+                                delete_len,
+                                insert_len,
+                            );
+                        }
                     }
                     reconciliation
                         .materialized_file_keys

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crate::LixError;
-use crate::binary_cas::{BlobHash, BlobPayload, BlobSameLengthSplice};
+use crate::binary_cas::{BlobEditSplice, BlobHash, BlobPayload, BlobSameLengthSplice};
 use crate::catalog::SchemaPlanId;
 use crate::changelog::{ChangeId, CommitId};
 use crate::common::{LixTimestamp, MutationIdentity, RequestBlobSpliceProvenance, SharedStr};
@@ -1408,6 +1408,7 @@ pub(crate) struct TransactionFileData {
     /// exact accepted document. The complete output bytes remain authoritative;
     /// this only permits an internal CAS staging fast path.
     same_length_blob_splice: Option<BlobSameLengthSplice>,
+    edit_blob_splice: Option<BlobEditSplice>,
     /// Validated transport splice that produced `payload`, when the ordinary
     /// SQL blob parameter arrived through the remote splice optimization.
     /// This is transient execution provenance and is never persisted as file
@@ -1453,6 +1454,7 @@ impl TransactionFileData {
             had_blob_ref: false,
             base_blob_hash: None,
             same_length_blob_splice: None,
+            edit_blob_splice: None,
             splice_provenance: None,
             mutation_identity: None,
             payload: BlobPayload::from_bytes(data),
@@ -1545,6 +1547,7 @@ impl TransactionFileData {
         self.splice_provenance = None;
         self.base_blob_hash = None;
         self.same_length_blob_splice = None;
+        self.edit_blob_splice = None;
     }
 
     /// Marks a single fixed-width replacement that was independently verified
@@ -1573,6 +1576,32 @@ impl TransactionFileData {
             Some(BlobSameLengthSplice::new(base_blob_hash, offset, length));
     }
 
+    pub(crate) fn set_verified_blob_edit_splice(
+        &mut self,
+        visible_base_blob_hash: BlobHash,
+        offset: usize,
+        delete_len: usize,
+        insert_len: usize,
+    ) {
+        let Some(base_blob_hash) = self.base_blob_hash else {
+            return;
+        };
+        if base_blob_hash != visible_base_blob_hash
+            || (delete_len == 0 && insert_len == 0)
+            || offset
+                .checked_add(insert_len)
+                .is_none_or(|end| end > self.payload.len())
+        {
+            return;
+        }
+        self.edit_blob_splice = Some(BlobEditSplice {
+            base_blob_hash,
+            offset,
+            delete_len,
+            insert_len,
+        });
+    }
+
     pub(crate) fn blob_hash(&self) -> Option<BlobHash> {
         self.payload.hash()
     }
@@ -1587,6 +1616,10 @@ impl TransactionFileData {
 
     pub(crate) fn same_length_blob_splice(&self) -> Option<BlobSameLengthSplice> {
         self.same_length_blob_splice
+    }
+
+    pub(crate) fn edit_blob_splice(&self) -> Option<BlobEditSplice> {
+        self.edit_blob_splice
     }
 
     #[cfg(test)]
@@ -4458,6 +4491,43 @@ mod tests {
         assert_eq!(
             write.same_length_blob_splice(),
             Some(BlobSameLengthSplice::new(base, 2, 1))
+        );
+    }
+
+    #[test]
+    fn verified_edit_splice_is_format_neutral_and_cleared_by_rematerialization() {
+        let base = BlobHash::from_content(b"before");
+        let wrong_base = BlobHash::from_content(b"other!");
+        let mut write = TransactionFileData::new(
+            "file".to_string(),
+            None,
+            None,
+            "main".to_string(),
+            false,
+            false,
+            b"after-more".to_vec(),
+        )
+        .with_base_blob_hash(Some(base));
+
+        write.set_verified_blob_edit_splice(wrong_base, 2, 1, 5);
+        assert_eq!(write.edit_blob_splice(), None);
+
+        write.set_verified_blob_edit_splice(base, 2, 1, 5);
+        assert_eq!(
+            write.edit_blob_splice(),
+            Some(BlobEditSplice {
+                base_blob_hash: base,
+                offset: 2,
+                delete_len: 1,
+                insert_len: 5,
+            })
+        );
+
+        write.replace_data(b"plugin-rendered".to_vec());
+        assert_eq!(
+            write.edit_blob_splice(),
+            None,
+            "a plugin-rendered replacement invalidates the submitted-byte proof"
         );
     }
 }


### PR DESCRIPTION
## Summary
- bridge the existing format-neutral WASM transition splice to the binary CAS verified-edit input
- make the bridge available to every blob-materializing component plugin without content-type, file-format, Git, or LFS branches
- retain complete accepted bytes and their content hash as authority; a rematerialized plugin output clears the hint
- support both fixed-width and length-changing single edits
- include all-plugin replay, LFS accounting, matched Git, CRUD, and profile evidence
- no changenote

## Results
- 524,721-byte hot edit: 3.231 ms -> 2.187 ms (-32.3%)
- cold materialized read: 0.722 ms -> 0.573 ms (-20.6%)
- six-lane all-plugin replay aggregate: -0.09% time, -7.25% physical bytes
- VS Code storage: -8.8% RocksDB / -9.0% SlateDB
- Wesnoth storage: -3.2%; Brands media-heavy control: flat
- VS Code replay accounting: 97 LFS objects / 42,011,887 logical payload bytes unchanged; LFS is not represented in either API

All currently bundled component plugins use blob materialization, so removing the former Text/GitText eligibility branch preserves the measured behavior while making the bridge work for future binary and structured plugins.

## Validation
- `cargo test -p lix_engine --features all-simulations`
- focused plugin incremental tests: 34 passed
- focused binary CAS tests in the parent: 39 passed
- RocksDB and SlateDB tracked-state CRUD smoke matrices: all 16 operations passed
- final Git tree verified in all six replay lanes
- release matched Git/Lix benchmark and 500-edit Samply profile