### PR TITLE
Scale semantic conflict resolution limits

### DIFF
--- a/.changenotes/scale-semantic-conflict-resolution.md
+++ b/.changenotes/scale-semantic-conflict-resolution.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Semantic merges now resolve large conflict sets without hitting small-transition page and attachment limits.

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -1382,8 +1382,8 @@ where
         conflicts: Vec<WasmEntityConflict<WasmHostBytes>>,
     ) -> Result<ValidatedConflictTransition, LixError> {
         self.ensure_plugin_generation_read_guard().await;
-        let limits = WasmTransitionLimits::default();
         let expected_count = conflicts.len();
+        let limits = conflict_resolution_limits(expected_count)?;
         let source = VecEntityConflictSource::new(conflicts, limits)?;
         let wasm_hash = BlobHash::from_hex(plugin.wasm_blob_hash())?;
         let factory = match self
@@ -6349,6 +6349,27 @@ where
     }
 }
 
+fn conflict_resolution_limits(conflict_count: usize) -> Result<WasmTransitionLimits, LixError> {
+    let conflict_count = u32::try_from(conflict_count).map_err(|_| {
+        LixError::new(
+            LixError::CODE_INVALID_PARAM,
+            "semantic conflict count exceeds the component protocol ordinal range",
+        )
+    })?;
+    let mut limits = WasmTransitionLimits::default();
+    // Each conflict can reference base, A, and B snapshots. These are
+    // host-owned attachments from an already admitted finite batch, so bound
+    // the source by its actual worst-case reference count instead of the
+    // small-transition default.
+    limits.max_attachment_refs = limits
+        .max_attachment_refs
+        .max(conflict_count.saturating_mul(3));
+    // A resolver may emit one bounded replacement page per conflict. Keep the
+    // independent aggregate byte and deadline limits unchanged.
+    limits.max_pages = limits.max_pages.max(conflict_count.saturating_add(1));
+    Ok(limits)
+}
+
 fn required_diff_change<'a>(
     records: &'a HashMap<ChangeId, ChangeRecord>,
     change_id: ChangeId,
@@ -10193,6 +10214,22 @@ mod tests {
     }
 
     const SCHEMA_FIXTURE_COMMIT_ID: &str = "01920000-0000-7000-8000-0000000000f1";
+
+    #[test]
+    fn semantic_conflict_limits_scale_host_owned_records_but_not_bytes_or_deadline() {
+        let defaults = WasmTransitionLimits::default();
+        let limits = conflict_resolution_limits(5_000).expect("conflict count should fit");
+
+        assert_eq!(limits.max_attachment_refs, 15_000);
+        assert_eq!(limits.max_pages, 5_001);
+        assert_eq!(limits.max_record_bytes, defaults.max_record_bytes);
+        assert_eq!(limits.max_page_bytes, defaults.max_page_bytes);
+        assert_eq!(limits.max_total_bytes, defaults.max_total_bytes);
+        assert_eq!(
+            limits.total_deadline_nanoseconds,
+            defaults.total_deadline_nanoseconds
+        );
+    }
 
     #[test]
     fn cold_successor_deadline_scales_with_submitted_file_size() {

--- a/packages/rs-sdk/tests/semantic_merge.rs
+++ b/packages/rs-sdk/tests/semantic_merge.rs
@@ -11,6 +11,7 @@ async fn plugin_resolved_rows_are_included_in_semantic_merge_change_stats() {
     let lix = open_lix(OpenLixOptions::default()).await.unwrap();
     install_csv_plugin(&lix).await;
     write_file(&lix, "/semantic-merge.csv", b"quick,dog\n").await;
+
     let main_branch_id = lix.active_branch_id().await.unwrap();
     let source = lix
         .create_branch(CreateBranchOptions {
@@ -58,6 +59,58 @@ async fn plugin_resolved_rows_are_included_in_semantic_merge_change_stats() {
         b"very quick,sleepy dog\n"
     );
     lix.close().await.unwrap();
+}
+
+const CONFLICT_COUNT: usize = 1_500;
+
+#[tokio::test]
+async fn semantic_merge_resolves_more_conflicts_than_default_transition_caps() {
+    let lix = open_lix(OpenLixOptions::default()).await.unwrap();
+    install_csv_plugin(&lix).await;
+    let base = csv_rows(|index| format!("left-{index:04},right-{index:04}"));
+    write_file(&lix, "/large-semantic-merge.csv", &base).await;
+    let main_branch_id = lix.active_branch_id().await.unwrap();
+    let source = lix
+        .create_branch(CreateBranchOptions {
+            id: None,
+            name: "Large semantic source".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .unwrap();
+
+    lix.switch_branch(SwitchBranchOptions {
+        branch_id: source.id.clone(),
+    })
+    .await
+    .unwrap();
+    let source_bytes = csv_rows(|index| format!("source-{index:04},right-{index:04}"));
+    write_file(&lix, "/large-semantic-merge.csv", &source_bytes).await;
+    lix.switch_branch(SwitchBranchOptions {
+        branch_id: main_branch_id,
+    })
+    .await
+    .unwrap();
+    let target_bytes = csv_rows(|index| format!("left-{index:04},target-{index:04}"));
+    write_file(&lix, "/large-semantic-merge.csv", &target_bytes).await;
+
+    lix.merge_branch(MergeBranchOptions {
+        source_branch_id: source.id,
+    })
+    .await
+    .unwrap();
+    let expected = csv_rows(|index| format!("source-{index:04},target-{index:04}"));
+    assert_eq!(read_file(&lix, "/large-semantic-merge.csv").await, expected);
+    lix.close().await.unwrap();
+}
+
+fn csv_rows(row: impl Fn(usize) -> String) -> Vec<u8> {
+    let mut csv = String::new();
+    for index in 0..CONFLICT_COUNT {
+        csv.push_str(&row(index));
+        csv.push('\n');
+    }
+    csv.into_bytes()
 }
 
 async fn install_csv_plugin<StorageImpl>(lix: &Lix<StorageImpl>)


### PR DESCRIPTION
## Summary

- derive semantic conflict transition page and attachment-reference caps from the finite host-owned conflict batch
- retain the existing per-record, per-page, aggregate-byte, and deadline limits
- add a Rust SDK integration test using the real compiled CSV plugin with 1,500 semantic conflicts

## Why

Large semantic merges failed before invoking the resolver because the generic small-transition defaults allow only 1,024 pages and 4,096 attachment references. A three-way conflict can expose base, source, and target snapshots, so valid finite batches crossed those defaults.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p lix_sdk --test semantic_merge`
- `cargo test -p lix_engine --features all-simulations` (1,670 unit tests, 800 integration tests, 3 doc tests passed; 8 ignored)

## Performance profile

Five warm end-to-end runs of the 1,500-conflict Rust SDK regression test (including Cargo test process overhead): median **1.40 s**, median peak RSS **127,012 KiB**. Samples: 1.90/1.36/1.40/1.40/1.37 s and 126,592/126,756/127,220/127,292/127,012 KiB. Before this fix the same workload deterministically failed with `component packet source exceeds max_attachment_refs`.