### PR TITLE
perf(engine): reuse certified bulk update predecessors

### DIFF
--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -17,7 +17,8 @@ pub(crate) use tracked_head::TrackedHeadDeltaRef;
 #[allow(unused_imports)]
 pub(crate) use tracked_head::{
     CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE, CERTIFIED_ENTITY_BATCH_PAGE_SPACE,
-    CERTIFIED_ENTITY_BATCH_SPACE, CertifiedEntityBatchFileRef, CurrentStateDeltaRef,
+    CERTIFIED_ENTITY_BATCH_SPACE, CertifiedCurrentStatePredecessor,
+    CertifiedCurrentStatePredecessorRef, CertifiedEntityBatchFileRef, CurrentStateDeltaRef,
     DeferredFreshHotPlan, DeferredFreshHotRowRef, DeferredFreshHotRows, HOT_DIFF_SPACE,
     HOT_FILE_SPACE, HOT_ROW_SPACE, HotTrackedSnapshot, PACKED_CURRENT_BASE_CONTROL_SPACE,
     PACKED_CURRENT_BASE_SPACE, TRACKED_WORKING_DIFF_MARKER_SPACE, TrackedHeadContext,

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -38,7 +38,7 @@ use crate::json_store::{
 };
 use crate::live_state::{
     MaterializedLiveStateBatch, MaterializedLiveStateBatchBuilder, MaterializedLiveStateExactBatch,
-    MaterializedLiveStateRow,
+    MaterializedLiveStateRow, MaterializedLiveStateRowRef,
 };
 use crate::storage_adapter::{
     PointReadPlan, ScanPlan, StorageAdapterRead, StorageCoreProjection, StorageGetOptions,
@@ -311,6 +311,35 @@ pub(crate) struct CurrentStateDeltaRef<'a> {
     pub(crate) updated_at: LixTimestamp,
     pub(crate) snapshot: JsonSlotRef<'a>,
     pub(crate) metadata: JsonSlotRef<'a>,
+}
+
+/// Durable exact-read evidence aligned with a transaction delta.
+///
+/// The branch-control CAS protects this predecessor through publication. A
+/// writer may therefore reuse its encoded HOT value instead of issuing the
+/// same primary and packed-base reads again during commit materialization.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CertifiedCurrentStatePredecessorRef<'a> {
+    pub(crate) schema_key: &'a str,
+    pub(crate) file_id: Option<&'a str>,
+    pub(crate) entity_pk: &'a EntityPk,
+    pub(crate) value: &'a CertifiedCurrentStatePredecessor,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum CertifiedCurrentStatePredecessor {
+    Encoded(Bytes),
+    Packed(PackedHeadValue),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PackedHeadValue {
+    change_id: ChangeId,
+    commit_id: CommitId,
+    deleted: bool,
+    created_at: LixTimestamp,
+    updated_at: LixTimestamp,
+    checkpoint_commit_id: Option<CommitId>,
 }
 
 impl<'a> CurrentStateDeltaRef<'a> {
@@ -1298,6 +1327,33 @@ struct HeadValueView<'a> {
     working_diff_baseline: WorkingDiffBaseline,
 }
 
+impl CertifiedCurrentStatePredecessor {
+    fn view(&self) -> Result<HeadValueView<'_>, LixError> {
+        match self {
+            Self::Encoded(bytes) => decode_head_value(bytes),
+            Self::Packed(value) => Ok(HeadValueView {
+                change_id: Some(value.change_id),
+                commit_id: Some(value.commit_id),
+                untracked: false,
+                deleted: value.deleted,
+                created_at: value.created_at,
+                updated_at: value.updated_at,
+                // Packed current bases are immutable post-checkpoint inserts.
+                // Their active-epoch before image is therefore absent; no
+                // payload fingerprint is needed to preserve that baseline.
+                snapshot: HeadSlotView::None,
+                metadata: HeadSlotView::None,
+                working_diff_baseline: value.checkpoint_commit_id.map_or(
+                    WorkingDiffBaseline::Disabled,
+                    |checkpoint_commit_id| WorkingDiffBaseline::BeforeAbsent {
+                        checkpoint_commit_id,
+                    },
+                ),
+            }),
+        }
+    }
+}
+
 impl HeadValueView<'_> {
     fn working_diff_version(self) -> Option<WorkingDiffVersion> {
         Some(WorkingDiffVersion {
@@ -1968,6 +2024,7 @@ where
             value.untracked,
             branch_id,
         );
+        rows.set_durable_predecessor(row_index, CertifiedCurrentStatePredecessor::Encoded(bytes));
     }
     if json_refs.is_empty() {
         return Ok(rows.finish());

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -1987,7 +1987,7 @@ fn stage_incremental_collection_controls(
     branch_id: &str,
     branch_generation: CommitId,
     deltas: &[&CurrentStateDeltaRef<'_>],
-    previous_values: &[Option<Bytes>],
+    previous_values: &[Option<CertifiedCurrentStatePredecessor>],
     mut controls: BTreeMap<(String, Option<String>), HotCollectionControl>,
     certified_live_increments: &BTreeMap<(String, Option<String>), u64>,
 ) -> Result<(), LixError> {
@@ -2003,8 +2003,8 @@ fn stage_incremental_collection_controls(
         }
 
         let previous_live = previous
-            .as_deref()
-            .map(decode_head_value)
+            .as_ref()
+            .map(CertifiedCurrentStatePredecessor::view)
             .transpose()?
             .is_some_and(|value| {
                 !value.deleted
@@ -2663,6 +2663,7 @@ async fn load_packed_current_base_exact(
     store: &(impl StorageAdapterRead + ?Sized),
     branch_id: &str,
     generation: CommitId,
+    active_checkpoint_commit_id: Option<CommitId>,
     keys: &[TrackedStateKeyRef<'_>],
     projection: ChangeRecordProjection,
 ) -> Result<MaterializedLiveStateExactBatch, LixError> {
@@ -2690,6 +2691,14 @@ async fn load_packed_current_base_exact(
             continue;
         }
         let row_index = rows.len();
+        let durable_predecessor = CertifiedCurrentStatePredecessor::Packed(PackedHeadValue {
+            change_id: value.change_id,
+            commit_id: value.commit_id,
+            deleted: false,
+            created_at: value.created_at,
+            updated_at: value.updated_at,
+            checkpoint_commit_id: active_checkpoint_commit_id,
+        });
         let snapshot = materialize_packed_slot(
             projection.snapshot_content,
             change_record.snapshot,
@@ -2724,6 +2733,7 @@ async fn load_packed_current_base_exact(
             false,
             branch_id,
         );
+        rows.set_durable_predecessor(row_index, durable_predecessor);
     }
     if !json_refs.is_empty() {
         let mut json_values = JsonStoreContext::new()
@@ -2835,6 +2845,7 @@ async fn load_packed_current_base_exact_entries(
     Ok(winners)
 }
 
+#[cfg(test)]
 fn compare_materialized_live_identities(
     left: &MaterializedLiveStateRow,
     right: &MaterializedLiveStateRow,
@@ -2845,6 +2856,7 @@ fn compare_materialized_live_identities(
         .then_with(|| left.file_id.cmp(&right.file_id))
 }
 
+#[cfg(test)]
 fn merge_ordered_live_rows(
     left: Vec<MaterializedLiveStateRow>,
     right: Vec<MaterializedLiveStateRow>,
@@ -2874,6 +2886,60 @@ fn merge_ordered_live_rows(
     merged.extend(left);
     merged.extend(right);
     merged
+}
+
+fn compare_materialized_live_identity_refs(
+    left: MaterializedLiveStateRowRef<'_>,
+    right: MaterializedLiveStateRowRef<'_>,
+) -> Ordering {
+    left.schema_key()
+        .cmp(right.schema_key())
+        .then_with(|| left.entity_pk().cmp(right.entity_pk()))
+        .then_with(|| left.file_id().cmp(&right.file_id()))
+}
+
+/// Merge two identity-ordered materialized batches without expanding their
+/// dictionary and payload columns into row-owned DTOs.
+fn merge_ordered_live_batches(
+    left: &MaterializedLiveStateBatch,
+    right: &MaterializedLiveStateBatch,
+) -> MaterializedLiveStateBatch {
+    let mut merged =
+        MaterializedLiveStateBatchBuilder::with_capacity(left.len().saturating_add(right.len()));
+    let mut left_index = 0usize;
+    let mut right_index = 0usize;
+    while left_index < left.len() && right_index < right.len() {
+        let left_row = left.row(left_index);
+        let right_row = right.row(right_index);
+        match compare_materialized_live_identity_refs(left_row, right_row) {
+            Ordering::Less => {
+                merged.push_ref(left_row, None);
+                left_index += 1;
+            }
+            Ordering::Greater => {
+                merged.push_ref(right_row, None);
+                right_index += 1;
+            }
+            Ordering::Equal => {
+                if left_row.commit_id() < right_row.commit_id() {
+                    merged.push_ref(right_row, None);
+                } else {
+                    merged.push_ref(left_row, None);
+                }
+                left_index += 1;
+                right_index += 1;
+            }
+        }
+    }
+    while left_index < left.len() {
+        merged.push_ref(left.row(left_index), None);
+        left_index += 1;
+    }
+    while right_index < right.len() {
+        merged.push_ref(right.row(right_index), None);
+        right_index += 1;
+    }
+    merged.finish()
 }
 
 /// Direct reader for one published hot generation.
@@ -3131,6 +3197,7 @@ where
                 &self.store,
                 branch_id,
                 generation,
+                active_checkpoint_commit_id,
                 &key_refs,
                 projection,
             )
@@ -3256,9 +3323,8 @@ where
                 None,
             )
         };
-        let combined = merge_ordered_live_rows(rows.into_rows(), packed_rows.into_rows());
-        let combined = merge_ordered_live_rows(combined, certified_rows.into_rows());
-        let rows = MaterializedLiveStateBatch::from_rows(combined);
+        let combined = merge_ordered_live_batches(&rows, &packed_rows);
+        let rows = merge_ordered_live_batches(&combined, &certified_rows);
         if request.filter.include_tombstones
             && request.limit.is_none()
             && replaced_generation.is_none()
@@ -3425,9 +3491,15 @@ where
         // proving that a keyed update or foreign-key target already exists.
         // Decode the matching segment rows only when the ordinary point-read
         // index misses, then preserve the original request alignment.
-        let packed =
-            load_packed_current_base_exact(&self.store, branch_id, generation, keys, *projection)
-                .await?;
+        let packed = load_packed_current_base_exact(
+            &self.store,
+            branch_id,
+            generation,
+            active_checkpoint_commit_id,
+            keys,
+            *projection,
+        )
+        .await?;
         let mut resolved = Vec::with_capacity(keys.len());
         for (index, slot) in slots.into_iter().enumerate() {
             let mut row = slot.and_then(|slot| rows.get(slot as usize));
@@ -3996,6 +4068,41 @@ where
             parent_generation,
             new_head,
             deltas,
+            &[],
+            absence_guards,
+            parent_rows,
+            preserved_untracked_rows,
+            working_diff_capture_checkpoint_commit_id,
+            coverage,
+            false,
+            None,
+            None,
+            false,
+            &BTreeMap::new(),
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn stage_current_state_with_certified_predecessors(
+        &mut self,
+        branch_id: &str,
+        parent_generation: Option<CommitId>,
+        new_head: CommitId,
+        deltas: &[CurrentStateDeltaRef<'_>],
+        durable_predecessors: &[CertifiedCurrentStatePredecessorRef<'_>],
+        absence_guards: &BTreeSet<TrackedStateKey>,
+        parent_rows: Option<Vec<MaterializedTrackedStateRow>>,
+        preserved_untracked_rows: Option<Vec<MaterializedLiveStateRow>>,
+        working_diff_capture_checkpoint_commit_id: Option<CommitId>,
+        coverage: &mut WorkingDiffIndexCoverage,
+    ) -> Result<CommitId, LixError> {
+        self.stage_current_state_with_working_diff_inner(
+            branch_id,
+            parent_generation,
+            new_head,
+            deltas,
+            durable_predecessors,
             absence_guards,
             parent_rows,
             preserved_untracked_rows,
@@ -4027,6 +4134,7 @@ where
             parent_generation,
             new_head,
             deltas,
+            &[],
             absence_guards,
             None,
             None,
@@ -4063,6 +4171,7 @@ where
                 Some(generation),
                 new_head,
                 deltas,
+                &[],
                 absence_guards,
                 None,
                 None,
@@ -4114,6 +4223,7 @@ where
                     parent_generation,
                     new_head,
                     deltas,
+                    &[],
                     &owned_guards,
                     parent_rows,
                     preserved_untracked_rows,
@@ -4133,6 +4243,7 @@ where
             parent_generation,
             new_head,
             deltas,
+            &[],
             &no_owned_guards,
             parent_rows,
             preserved_untracked_rows,
@@ -4154,6 +4265,7 @@ where
         parent_generation: Option<CommitId>,
         new_head: CommitId,
         deltas: &[CurrentStateDeltaRef<'_>],
+        durable_predecessors: &[CertifiedCurrentStatePredecessorRef<'_>],
         absence_guards: &BTreeSet<TrackedStateKey>,
         parent_rows: Option<Vec<MaterializedTrackedStateRow>>,
         preserved_untracked_rows: Option<Vec<MaterializedLiveStateRow>>,
@@ -4200,7 +4312,46 @@ where
             sorted
         };
 
+        let durable_previous_values = {
+            let mut predecessor_index = 0usize;
+            let mut aligned = Vec::with_capacity(sorted.len());
+            for delta in &sorted {
+                let predecessor = durable_predecessors.get(predecessor_index);
+                match predecessor
+                    .map(|predecessor| compare_certified_predecessor_to_delta(predecessor, delta))
+                {
+                    Some(Ordering::Less) => {
+                        return Err(head_value_error(
+                            "certified predecessor does not belong to a staged delta",
+                        ));
+                    }
+                    Some(Ordering::Equal) => {
+                        let value = durable_predecessors[predecessor_index].value.view()?;
+                        if value.untracked || value.deleted {
+                            return Err(head_value_error(
+                                "certified predecessor must be a live tracked row",
+                            ));
+                        }
+                        aligned.push(Some(durable_predecessors[predecessor_index].value.clone()));
+                        predecessor_index += 1;
+                    }
+                    Some(Ordering::Greater) | None => aligned.push(None),
+                }
+            }
+            if predecessor_index != durable_predecessors.len() {
+                return Err(head_value_error(
+                    "certified predecessor does not belong to a staged delta",
+                ));
+            }
+            aligned
+        };
+
         if parent_generation.is_none() {
+            if !durable_predecessors.is_empty() {
+                return Err(head_value_error(
+                    "bootstrap publication cannot carry durable predecessors",
+                ));
+            }
             stage_hot_bootstrap(
                 self.writes,
                 branch_id,
@@ -4230,6 +4381,7 @@ where
             self.store,
             &identities,
             &sorted,
+            &durable_previous_values,
             absence_guards_validated,
             validated_absent_file_id,
         )
@@ -4241,13 +4393,16 @@ where
         let mut loaded_previous_values = loaded_previous_values.into_iter();
         let mut previous_values = sorted
             .iter()
-            .map(|delta| {
+            .zip(durable_previous_values.iter())
+            .map(|(delta, durable_predecessor)| {
                 if hot_delta_is_guarded_by_absent_file(
                     delta,
                     absence_guards_validated,
                     validated_absent_file_id,
                 ) {
                     None
+                } else if let Some(durable_predecessor) = durable_predecessor {
+                    Some(durable_predecessor.clone())
                 } else {
                     loaded_previous_values
                         .next()
@@ -4257,27 +4412,39 @@ where
             .collect::<Vec<_>>();
         let mut previous_from_packed = vec![false; previous_values.len()];
         debug_assert_eq!(loaded_previous_values.len(), 0);
-        let previous_keys = sorted
+        let packed_previous_indices = durable_previous_values
             .iter()
-            .map(|delta| TrackedStateKeyRef {
-                schema_key: delta.schema_key,
-                entity_pk: delta.entity_pk,
-                file_id: delta.file_id,
+            .enumerate()
+            .filter_map(|(index, predecessor)| predecessor.is_none().then_some(index))
+            .collect::<Vec<_>>();
+        let packed_previous_keys = packed_previous_indices
+            .iter()
+            .map(|&index| {
+                let delta = sorted[index];
+                TrackedStateKeyRef {
+                    schema_key: delta.schema_key,
+                    entity_pk: delta.entity_pk,
+                    file_id: delta.file_id,
+                }
             })
             .collect::<Vec<_>>();
         let packed_previous = Box::pin(load_packed_current_base_exact_entries(
             self.store,
             branch_id,
             generation,
-            &previous_keys,
+            &packed_previous_keys,
         ))
         .await?;
-        for (index, previous) in previous_values.iter_mut().enumerate() {
-            let Some((packed_value, packed_change)) = &packed_previous[index] else {
+        for (index, packed_previous) in packed_previous_indices.into_iter().zip(packed_previous) {
+            let previous = &mut previous_values[index];
+            let Some((packed_value, _)) = &packed_previous else {
                 continue;
             };
             let packed_is_newer = match (
-                previous.as_deref().map(decode_head_value).transpose()?,
+                previous
+                    .as_ref()
+                    .map(CertifiedCurrentStatePredecessor::view)
+                    .transpose()?,
                 Some(packed_value.commit_id),
             ) {
                 (None, Some(_)) => true,
@@ -4290,30 +4457,14 @@ where
                 continue;
             }
             previous_from_packed[index] = true;
-            *previous = Some(Bytes::from(encode_head_value(&HeadValueRef {
-                change_id: Some(packed_value.change_id),
-                commit_id: Some(packed_value.commit_id),
-                untracked: false,
+            *previous = Some(CertifiedCurrentStatePredecessor::Packed(PackedHeadValue {
+                change_id: packed_value.change_id,
+                commit_id: packed_value.commit_id,
                 deleted: packed_value.deleted,
                 created_at: packed_value.created_at,
                 updated_at: packed_value.updated_at,
-                snapshot: packed_change.snapshot.as_ref_slot(),
-                metadata: packed_change.metadata.as_ref_slot(),
-                working_diff_baseline: if let Some(checkpoint_commit_id) =
-                    working_diff_capture_checkpoint_commit_id
-                {
-                    // Checkpoints publish complete HOT rows. Therefore a
-                    // packed base in an active checkpoint generation was
-                    // created after that checkpoint and has an absent before
-                    // image; its O(1) manifest already owns the dirty-key
-                    // coverage.
-                    WorkingDiffBaseline::BeforeAbsent {
-                        checkpoint_commit_id,
-                    }
-                } else {
-                    WorkingDiffBaseline::Disabled
-                },
-            })?));
+                checkpoint_commit_id: working_diff_capture_checkpoint_commit_id,
+            }));
         }
         let mut collection_controls =
             load_incremental_collection_controls(self.store, branch_id, generation, &sorted)
@@ -4359,8 +4510,8 @@ where
                 continue;
             }
             let belongs_to_retired_generation = previous
-                .as_deref()
-                .map(decode_head_value)
+                .as_ref()
+                .map(CertifiedCurrentStatePredecessor::view)
                 .transpose()?
                 .is_some_and(|value| {
                     !row_belongs_to_active_collection_generation(
@@ -4382,7 +4533,7 @@ where
                 created_ats.push(delta.created_at);
                 continue;
             };
-            let existing = decode_head_value(previous)?;
+            let existing = previous.view()?;
             if let Some(borrowed_absence_guards) = borrowed_absence_guards {
                 reject_borrowed_guarded_live_member(borrowed_absence_guards, delta, existing)?;
             } else {
@@ -4430,8 +4581,8 @@ where
                     && delta.schema_key
                         != crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY
                     && previous
-                        .as_deref()
-                        .map(decode_head_value)
+                        .as_ref()
+                        .map(CertifiedCurrentStatePredecessor::view)
                         .transpose()?
                         .is_some_and(|value| {
                             value.change_id == delta.change_id
@@ -4529,7 +4680,10 @@ where
                 {
                     (WorkingDiffBaseline::Clean, false)
                 } else if working_diff_capture_checkpoint_commit_id.is_some() && !delta.untracked {
-                    let previous = previous.as_deref().map(decode_head_value).transpose()?;
+                    let previous = previous
+                        .as_ref()
+                        .map(CertifiedCurrentStatePredecessor::view)
+                        .transpose()?;
                     next_hot_working_diff_baseline(
                         working_diff_capture_checkpoint_commit_id,
                         delta,
@@ -5287,6 +5441,17 @@ fn compare_hot_deltas(
         .then_with(|| left.file_id.cmp(&right.file_id))
 }
 
+fn compare_certified_predecessor_to_delta(
+    predecessor: &CertifiedCurrentStatePredecessorRef<'_>,
+    delta: &CurrentStateDeltaRef<'_>,
+) -> Ordering {
+    predecessor
+        .schema_key
+        .cmp(delta.schema_key)
+        .then_with(|| predecessor.entity_pk.cmp(delta.entity_pk))
+        .then_with(|| predecessor.file_id.cmp(&delta.file_id))
+}
+
 fn hot_identity(
     branch_id: &str,
     generation: CommitId,
@@ -5380,22 +5545,30 @@ async fn hot_load_primary_mutation_identity_refs(
     store: &(impl StorageAdapterRead + ?Sized),
     identities: &EncodedHotMutationIdentities,
     deltas: &[&CurrentStateDeltaRef<'_>],
+    durable_predecessors: &[Option<CertifiedCurrentStatePredecessor>],
     absence_guards_validated: bool,
     validated_absent_file_id: Option<&str>,
-) -> Result<Vec<Option<Bytes>>, LixError> {
+) -> Result<Vec<Option<CertifiedCurrentStatePredecessor>>, LixError> {
     assert_eq!(
         identities.key_ranges.len(),
         deltas.len(),
         "every hot mutation identity must have one source delta"
     );
+    assert_eq!(
+        durable_predecessors.len(),
+        deltas.len(),
+        "every hot mutation identity must have one predecessor slot"
+    );
     let read_count = deltas
         .iter()
-        .filter(|delta| {
-            !hot_delta_is_guarded_by_absent_file(
-                delta,
-                absence_guards_validated,
-                validated_absent_file_id,
-            )
+        .zip(durable_predecessors)
+        .filter(|(delta, durable_predecessor)| {
+            durable_predecessor.is_none()
+                && !hot_delta_is_guarded_by_absent_file(
+                    delta,
+                    absence_guards_validated,
+                    validated_absent_file_id,
+                )
         })
         .count();
     if read_count == 0 {
@@ -5404,15 +5577,25 @@ async fn hot_load_primary_mutation_identity_refs(
     if read_count == deltas.len()
         && let Some(values) = hot_scan_dense_mutation_identity_range(store, identities).await?
     {
-        return Ok(values);
+        return Ok(values
+            .into_iter()
+            .map(|value| value.map(CertifiedCurrentStatePredecessor::Encoded))
+            .collect());
     }
     let mut keys = Vec::with_capacity(read_count);
-    for (identity, delta) in identities.key_ranges.iter().zip(deltas) {
-        if hot_delta_is_guarded_by_absent_file(
-            delta,
-            absence_guards_validated,
-            validated_absent_file_id,
-        ) {
+    for ((identity, delta), durable_predecessor) in identities
+        .key_ranges
+        .iter()
+        .zip(deltas)
+        .zip(durable_predecessors)
+    {
+        if durable_predecessor.is_some()
+            || hot_delta_is_guarded_by_absent_file(
+                delta,
+                absence_guards_validated,
+                validated_absent_file_id,
+            )
+        {
             continue;
         }
         let start = identity.row_key.offset();
@@ -5427,7 +5610,12 @@ async fn hot_load_primary_mutation_identity_refs(
         .await?
         .value
         .into_iter()
-        .map(|value| value.map(full_value_bytes).transpose())
+        .map(|value| {
+            value
+                .map(full_value_bytes)
+                .transpose()
+                .map(|value| value.map(CertifiedCurrentStatePredecessor::Encoded))
+        })
         .collect()
 }
 

--- a/packages/engine/src/live_state/types.rs
+++ b/packages/engine/src/live_state/types.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use ahash::RandomState;
 use bytes::Bytes;
 
+use super::tracked_head::CertifiedCurrentStatePredecessor;
 use crate::changelog::{ChangeId, CommitId};
 use crate::common::{LixTimestamp, SharedStr};
 use crate::entity_pk::EntityPk;
@@ -112,6 +113,12 @@ pub(crate) struct MaterializedLiveStateBatch {
     change_id: Vec<Option<ChangeId>>,
     commit_id: Vec<Option<CommitId>>,
     untracked: Vec<bool>,
+    /// Encoded authoritative HOT predecessor resolved by a durable exact read.
+    ///
+    /// This is intentionally internal transaction evidence, not a public
+    /// projection column. SQL UPDATE can carry it into commit materialization
+    /// and avoid reading the same current row a second time.
+    durable_predecessor: Vec<Option<CertifiedCurrentStatePredecessor>>,
 }
 
 impl MaterializedLiveStateBatch {
@@ -355,6 +362,10 @@ impl<'a> MaterializedLiveStateRowRef<'a> {
 
     pub(crate) fn untracked(self) -> bool {
         self.batch.untracked[self.index]
+    }
+
+    pub(crate) fn durable_predecessor(self) -> Option<&'a CertifiedCurrentStatePredecessor> {
+        self.batch.durable_predecessor[self.index].as_ref()
     }
 
     pub(crate) fn branch_id(self) -> &'a str {
@@ -813,6 +824,7 @@ pub(crate) struct MaterializedLiveStateBatchBuilder {
     change_id: Vec<Option<ChangeId>>,
     commit_id: Vec<Option<CommitId>>,
     untracked: Vec<bool>,
+    durable_predecessor: Vec<Option<CertifiedCurrentStatePredecessor>>,
 }
 
 impl MaterializedLiveStateBatchBuilder {
@@ -864,6 +876,7 @@ impl MaterializedLiveStateBatchBuilder {
             change_id: Vec::with_capacity(capacity),
             commit_id: Vec::with_capacity(capacity),
             untracked: Vec::with_capacity(capacity),
+            durable_predecessor: Vec::with_capacity(capacity),
         }
     }
 
@@ -1007,6 +1020,10 @@ impl MaterializedLiveStateBatchBuilder {
             row.commit_id(),
             row.untracked(),
         );
+        self.durable_predecessor
+            .last_mut()
+            .expect("pushed live-state row has a predecessor slot")
+            .clone_from(&row.durable_predecessor().cloned());
         ordinal
     }
 
@@ -1040,6 +1057,7 @@ impl MaterializedLiveStateBatchBuilder {
         self.change_id.push(change_id);
         self.commit_id.push(commit_id);
         self.untracked.push(untracked);
+        self.durable_predecessor.push(None);
     }
 
     pub(crate) fn set_snapshot_content(&mut self, row: usize, value: SharedStr) {
@@ -1048,6 +1066,14 @@ impl MaterializedLiveStateBatchBuilder {
 
     pub(crate) fn set_metadata(&mut self, row: usize, value: SharedStr) {
         self.metadata[row] = Some(value);
+    }
+
+    pub(crate) fn set_durable_predecessor(
+        &mut self,
+        row: usize,
+        value: CertifiedCurrentStatePredecessor,
+    ) {
+        self.durable_predecessor[row] = Some(value);
     }
 
     pub(crate) fn finish(self) -> MaterializedLiveStateBatch {
@@ -1066,6 +1092,7 @@ impl MaterializedLiveStateBatchBuilder {
             change_id: self.change_id,
             commit_id: self.commit_id,
             untracked: self.untracked,
+            durable_predecessor: self.durable_predecessor,
         }
     }
 }

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -5084,7 +5084,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn execute_batch_certifies_complete_path_value_replacements() {
+    async fn execute_batch_certifies_out_of_order_complete_path_value_replacements() {
         let session = open_session().await;
         let schema = serde_json::json!({
             "x-lix-key": "certified_replacement_probe",
@@ -5124,15 +5124,15 @@ mod tests {
                 ExecuteBatchStatement {
                     sql: sql.to_string(),
                     params: vec![
-                        Value::Text("null".to_string()),
-                        Value::Text("/a".to_string()),
+                        Value::Text(r#"{"nested":[1,true,"x"]}"#.to_string()),
+                        Value::Text("/b".to_string()),
                     ],
                 },
                 ExecuteBatchStatement {
                     sql: sql.to_string(),
                     params: vec![
-                        Value::Text(r#"{"nested":[1,true,"x"]}"#.to_string()),
-                        Value::Text("/b".to_string()),
+                        Value::Text("null".to_string()),
+                        Value::Text("/a".to_string()),
                     ],
                 },
             ])

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -505,6 +505,9 @@ pub(crate) async fn try_execute_entity_update_parameter_batch(
         let mut candidates = candidates.iter().peekable();
         let primary_key_param_index = direct_primary_key_param
             .expect("ordered direct replacement has one primary-key parameter");
+        let mut normalized = Vec::with_capacity(parameter_rows.len().saturating_mul(64));
+        let mut offsets = Vec::with_capacity(parameter_rows.len());
+        let mut matched_candidates = Vec::with_capacity(parameter_rows.len());
         for (row_index, params) in parameter_rows.iter().enumerate() {
             let expected_entity_pk = match params.get(primary_key_param_index) {
                 Some(Value::Text(value)) => value,
@@ -520,20 +523,34 @@ pub(crate) async fn try_execute_entity_update_parameter_batch(
                 {
                     break;
                 }
-                let candidate = candidates
-                    .next()
-                    .expect("peeked exact entity candidate remains available");
-                append_direct_path_value_replacement_row(
-                    &mut write_rows,
-                    &spec,
+                let candidate = EntityLiveRowRef::from(
+                    candidates
+                        .next()
+                        .expect("peeked exact entity candidate remains available"),
+                );
+                let start = normalized.len();
+                append_direct_path_value_replacement_json(
+                    &mut normalized,
                     candidate,
                     params,
                     replacement,
                 )
                 .map_err(|error| with_parameter_batch_statement_index(error, row_index))?;
+                offsets.push((start, normalized.len()));
+                matched_candidates.push((row_index, candidate));
                 affected += 1;
             }
             affected_by_statement.push(affected);
+        }
+        let snapshots = TransactionJson::from_certified_row_content_arena(normalized, offsets)?;
+        for ((row_index, candidate), snapshot) in matched_candidates.into_iter().zip(snapshots) {
+            append_direct_path_value_replacement_prepared_row(
+                &mut write_rows,
+                &spec,
+                candidate,
+                snapshot,
+            )
+            .map_err(|error| with_parameter_batch_statement_index(error, row_index))?;
         }
     } else {
         let mut candidates_by_pk = std::collections::BTreeMap::<EntityPk, Vec<_>>::new();
@@ -683,6 +700,15 @@ impl<'a> EntityLiveRowRef<'a> {
         }
     }
 
+    fn durable_predecessor(
+        self,
+    ) -> Option<&'a crate::live_state::CertifiedCurrentStatePredecessor> {
+        match self {
+            Self::Owned(_) => None,
+            Self::Batch(row) => row.durable_predecessor(),
+        }
+    }
+
     fn branch_id(self) -> &'a str {
         match self {
             Self::Owned(row) => row.branch_id.as_ref(),
@@ -742,6 +768,28 @@ fn append_direct_path_value_replacement_row<'a>(
     replacement: &DirectPathValueReplacement,
 ) -> Result<(), LixError> {
     let candidate = candidate.into();
+    let mut normalized = Vec::new();
+    append_direct_path_value_replacement_json(&mut normalized, candidate, params, replacement)?;
+    let normalized = SharedStr::from_utf8(bytes::Bytes::from(normalized)).map_err(|error| {
+        LixError::new(
+            LixError::CODE_UNKNOWN,
+            format!("certified replacement row is not UTF-8: {error}"),
+        )
+    })?;
+    append_direct_path_value_replacement_prepared_row(
+        rows,
+        spec,
+        candidate,
+        TransactionJson::from_certified_shared_normalized_row_content(normalized),
+    )
+}
+
+fn append_direct_path_value_replacement_json(
+    normalized: &mut Vec<u8>,
+    candidate: EntityLiveRowRef<'_>,
+    params: &[Value],
+    replacement: &DirectPathValueReplacement,
+) -> Result<(), LixError> {
     let value = match params.get(replacement.value_param_index) {
         Some(Value::Null) => JsonValue::Null,
         Some(Value::Text(raw)) => serde_json::from_str(raw).map_err(|error| {
@@ -766,28 +814,31 @@ fn append_direct_path_value_replacement_row<'a>(
             ));
         }
     };
-    let value = serde_json::to_string(&value).map_err(|error| {
+    normalized.extend_from_slice(br#"{"path":"#);
+    append_canonical_json_string(normalized, candidate.entity_pk().as_single_string()?)?;
+    normalized.extend_from_slice(br#","value":"#);
+    serde_json::to_writer(&mut *normalized, &value).map_err(|error| {
         LixError::new(
             LixError::CODE_UNKNOWN,
             format!("certified replacement value failed to serialize: {error}"),
         )
     })?;
-    let path =
-        serde_json::to_string(candidate.entity_pk().as_single_string()?).map_err(|error| {
-            LixError::new(
-                LixError::CODE_UNKNOWN,
-                format!("certified replacement identity failed to serialize: {error}"),
-            )
-        })?;
-    let normalized = format!(r#"{{"path":{path},"value":{value}}}"#);
+    normalized.push(b'}');
+    Ok(())
+}
+
+fn append_direct_path_value_replacement_prepared_row(
+    rows: &mut RawWriteBatch,
+    spec: &EntitySurfaceSpec,
+    candidate: EntityLiveRowRef<'_>,
+    snapshot: TransactionJson,
+) -> Result<(), LixError> {
     let metadata = inherited_metadata(candidate, spec)?;
     rows.push_parts(
         Some(candidate.entity_pk().clone()),
         spec.schema_key.as_str().into(),
         candidate.file_id().map(Into::into),
-        Some(TransactionJson::from_certified_normalized_row_content(
-            normalized.into(),
-        )),
+        Some(snapshot),
         metadata,
         None,
         None,
@@ -802,6 +853,8 @@ fn append_direct_path_value_replacement_row<'a>(
             candidate.branch_id().into()
         },
     );
+    let row_index = rows.len() - 1;
+    rows.set_durable_predecessor(row_index, candidate.durable_predecessor().cloned());
     Ok(())
 }
 

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -55,6 +55,16 @@ type RowIndex = usize;
 // amplification dominates the cost of retaining one immutable manifest.
 const PACKED_CURRENT_BASE_MIN_ROWS: usize = 1_024;
 
+fn compare_certified_predecessors(
+    left: &crate::live_state::CertifiedCurrentStatePredecessorRef<'_>,
+    right: &crate::live_state::CertifiedCurrentStatePredecessorRef<'_>,
+) -> std::cmp::Ordering {
+    left.schema_key
+        .cmp(right.schema_key)
+        .then_with(|| left.entity_pk.cmp(right.entity_pk))
+        .then_with(|| left.file_id.cmp(&right.file_id))
+}
+
 #[cfg(test)]
 std::thread_local! {
     static ORDERED_PACKED_CURRENT_BASE_PUBLICATIONS: std::cell::Cell<usize> =
@@ -2442,12 +2452,12 @@ async fn stage_tracked_head(
                 })
             })
             .collect::<Vec<_>>();
-        durable_predecessors.sort_unstable_by(|left, right| {
-            left.schema_key
-                .cmp(right.schema_key)
-                .then_with(|| left.entity_pk.cmp(right.entity_pk))
-                .then_with(|| left.file_id.cmp(&right.file_id))
-        });
+        if !durable_predecessors
+            .windows(2)
+            .all(|pair| compare_certified_predecessors(&pair[0], &pair[1]).is_lt())
+        {
+            durable_predecessors.sort_unstable_by(compare_certified_predecessors);
+        }
         let packed_schema_keys = tracked_deltas
             .iter()
             .map(|delta| delta.schema_key)

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -2419,7 +2419,7 @@ async fn stage_tracked_head(
                     }),
             );
         }
-        let durable_predecessors = state_row_indices
+        let mut durable_predecessors = state_row_indices
             .iter()
             .filter_map(|&row_index| {
                 let row = state_rows.row(row_index);
@@ -2442,6 +2442,12 @@ async fn stage_tracked_head(
                 })
             })
             .collect::<Vec<_>>();
+        durable_predecessors.sort_unstable_by(|left, right| {
+            left.schema_key
+                .cmp(right.schema_key)
+                .then_with(|| left.entity_pk.cmp(right.entity_pk))
+                .then_with(|| left.file_id.cmp(&right.file_id))
+        });
         let packed_schema_keys = tracked_deltas
             .iter()
             .map(|delta| delta.schema_key)

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -2419,6 +2419,29 @@ async fn stage_tracked_head(
                     }),
             );
         }
+        let durable_predecessors = state_row_indices
+            .iter()
+            .filter_map(|&row_index| {
+                let row = state_rows.row(row_index);
+                (!host_certified_batch_owns_live_row(
+                    row,
+                    &root.branch_id,
+                    root.commit_id,
+                    host_certified_file_schemas,
+                ))
+                .then_some(row)
+            })
+            .filter_map(|row| {
+                row.durable_predecessor.map(|value| {
+                    crate::live_state::CertifiedCurrentStatePredecessorRef {
+                        schema_key: row.schema_key.as_str(),
+                        file_id: row.file_id.map(crate::common::SharedStr::as_str),
+                        entity_pk: row.entity_pk,
+                        value,
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
         let packed_schema_keys = tracked_deltas
             .iter()
             .map(|delta| delta.schema_key)
@@ -2455,6 +2478,7 @@ async fn stage_tracked_head(
             has_certified_file = certified_fresh_plugin_file_id.is_some(),
             has_certified_counts = host_certified_live_increments.contains_key(&root.branch_id),
             has_selected_batches = !staged.selected_change_batches.is_empty(),
+            durable_predecessor_count = durable_predecessors.len(),
             "packed current-base route decision"
         );
         let mut deltas = tracked_deltas.clone();
@@ -2562,23 +2586,23 @@ async fn stage_tracked_head(
                 .await?
         } else {
             let owned_absence_guards = owned_absence_guards(&absence_guards);
-            writer
-                .stage_current_state_with_working_diff(
-                    &root.branch_id,
-                    Some(parent_generation),
-                    root.commit_id,
-                    &deltas,
-                    &owned_absence_guards,
-                    None,
-                    None,
-                    working_diff_capture_checkpoint_commit_id,
-                    &mut coverage,
-                )
-                .instrument(tracing::debug_span!(
-                    target: "lix_perf",
-                    "lix.perf.materialization.tracked_head.stage_current_state"
-                ))
-                .await?
+            Box::pin(writer.stage_current_state_with_certified_predecessors(
+                &root.branch_id,
+                Some(parent_generation),
+                root.commit_id,
+                &deltas,
+                &durable_predecessors,
+                &owned_absence_guards,
+                None,
+                None,
+                working_diff_capture_checkpoint_commit_id,
+                &mut coverage,
+            ))
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.materialization.tracked_head.stage_current_state"
+            ))
+            .await?
         };
         if let Some(epoch) = working_diff_epoch {
             let next_epoch = TrackedWorkingDiffEpoch {

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -1059,7 +1059,7 @@ where
         &mut self,
         write: TransactionWrite,
     ) -> Result<TransactionWriteOutcome, LixError> {
-        self.stage_write_inner(write, None).await
+        Box::pin(self.stage_write_inner(write, None)).await
     }
 
     async fn stage_parameter_batch_insert(
@@ -1067,7 +1067,7 @@ where
         write: TransactionWrite,
         statement_indices: Vec<u32>,
     ) -> Result<TransactionWriteOutcome, LixError> {
-        self.stage_write_inner(write, Some(statement_indices)).await
+        Box::pin(self.stage_write_inner(write, Some(statement_indices))).await
     }
 
     /// Stages the fixed-shape public parameter INSERT proof without routing it
@@ -6764,6 +6764,7 @@ fn push_prepared_state_row_from_planned_parts(
     scalar: PreparedScalarRow,
     origin_key: Option<&SharedStr>,
 ) -> Result<(), LixError> {
+    let durable_predecessor = rows.take_durable_predecessor(row_index);
     let row = rows.row(row_index);
     let schema_key = row.schema_key.clone();
     let file_id = row.file_id.cloned();
@@ -6804,6 +6805,7 @@ fn push_prepared_state_row_from_planned_parts(
         untracked,
         branch_id,
     );
+    prepared.set_durable_predecessor(prepared.len() - 1, durable_predecessor);
     Ok(())
 }
 
@@ -7088,7 +7090,7 @@ where
         rows: RawWriteBatch,
     ) -> Result<TransactionWriteOutcome, LixError> {
         if rows.certified_preparation().is_some() {
-            return self.stage_certified_parameter_batch_insert(rows).await;
+            return Box::pin(self.stage_certified_parameter_batch_insert(rows)).await;
         }
         let statement_indices = (0..rows.len())
             .map(|index| {

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -13,9 +13,10 @@ use crate::changelog::{ChangeId, CommitId};
 use crate::common::{LixTimestamp, MutationIdentity, RequestBlobSpliceProvenance, SharedStr};
 use crate::entity_pk::EntityPk;
 use crate::json_store::JsonRef;
-use crate::live_state::MaterializedLiveStateRow;
+use crate::live_state::{CertifiedCurrentStatePredecessor, MaterializedLiveStateRow};
 use crate::tracked_state::TrackedStateDiffIdentity;
 use crate::wasm::{WasmCanonicalJson, WasmCanonicalJsonCertificateRef, WasmCertifiedEntityBatch};
+use bytes::Bytes;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value as JsonValue;
 
@@ -30,6 +31,7 @@ enum TransactionJsonStorage {
         value: Arc<JsonValue>,
         normalized: OnceLock<Arc<str>>,
     },
+    #[cfg_attr(not(test), allow(dead_code))]
     Certified {
         normalized: Arc<str>,
     },
@@ -102,6 +104,7 @@ impl TransactionJson {
     /// placement only consume canonical bytes. Callers may issue this
     /// certificate only for complete replacement rows whose unchanged
     /// identity and row-local schema constraints were already established.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn from_certified_normalized_row_content(normalized: Arc<str>) -> Self {
         Self {
             storage: TransactionJsonStorage::Certified { normalized },
@@ -133,7 +136,7 @@ impl TransactionJson {
         offsets: Vec<(usize, usize)>,
     ) -> Result<Vec<Self>, LixError> {
         let invalid_arena = |message| LixError::new(LixError::CODE_INVALID_PARAM, message);
-        let arena = SharedStr::from_utf8(bytes::Bytes::from(normalized))
+        let arena = SharedStr::from_utf8(Bytes::from(normalized))
             .map_err(|_| invalid_arena("certified transaction JSON arena is not UTF-8"))?;
         let arena_len = u32::try_from(arena.len())
             .map_err(|_| invalid_arena("certified transaction JSON arena exceeds u32"))?;
@@ -458,6 +461,7 @@ pub(crate) struct RawWriteBatch {
     entity_pks: Vec<Option<EntityPk>>,
     snapshots: Vec<Option<TransactionJson>>,
     metadata: Vec<Option<TransactionJson>>,
+    durable_predecessors: Vec<Option<CertifiedCurrentStatePredecessor>>,
     strings: Vec<SharedStr>,
     string_index: Option<HashMap<SharedStr, u32>>,
     expected_rows: usize,
@@ -523,6 +527,7 @@ impl RawWriteBatch {
             entity_pks: Vec::with_capacity(row_capacity),
             snapshots: Vec::with_capacity(row_capacity),
             metadata: Vec::with_capacity(row_capacity),
+            durable_predecessors: Vec::with_capacity(row_capacity),
             // File ids are the only commonly row-cardinal strings. Schema,
             // branch, timestamp, and origin metadata normally collapse to a
             // handful of dictionary entries.
@@ -583,6 +588,7 @@ impl RawWriteBatch {
             entity_pks: entity_pks.into_iter().map(Some).collect(),
             snapshots: snapshots.into_iter().map(Some).collect(),
             metadata: std::iter::repeat_with(|| None).take(row_count).collect(),
+            durable_predecessors: std::iter::repeat_with(|| None).take(row_count).collect(),
             strings,
             string_index: None,
             expected_rows: row_count,
@@ -709,6 +715,7 @@ impl RawWriteBatch {
         self.entity_pks.push(entity_pk);
         self.snapshots.push(snapshot);
         self.metadata.push(metadata);
+        self.durable_predecessors.push(None);
         self.debug_assert_aligned();
     }
 
@@ -759,6 +766,7 @@ impl RawWriteBatch {
             entity_pks,
             snapshots,
             metadata,
+            durable_predecessors,
             mut strings,
             string_index: _,
             expected_rows: _,
@@ -774,6 +782,7 @@ impl RawWriteBatch {
         if entity_pks.len() != row_count
             || snapshots.len() != row_count
             || metadata.len() != row_count
+            || durable_predecessors.len() != row_count
         {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
@@ -784,6 +793,12 @@ impl RawWriteBatch {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 "certified transaction batch unexpectedly contains logical origins",
+            ));
+        }
+        if durable_predecessors.iter().any(Option::is_some) {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "certified INSERT batch unexpectedly contains durable predecessors",
             ));
         }
 
@@ -868,6 +883,7 @@ impl RawWriteBatch {
                 commit_id: None,
                 untracked: false,
                 branch_id: slot.branch_id,
+                durable_predecessor: None,
             });
         }
         Ok(PreparedStateBatch {
@@ -876,6 +892,7 @@ impl RawWriteBatch {
             strings,
             string_index,
             json,
+            durable_predecessors: Vec::new(),
             origins: Vec::new(),
             origin_index: HashMap::new(),
             origin_column_sets: Vec::new(),
@@ -904,6 +921,7 @@ impl RawWriteBatch {
         self.entity_pks.reserve(additional);
         self.snapshots.reserve(additional);
         self.metadata.reserve(additional);
+        self.durable_predecessors.reserve(additional);
         if let Some(index) = &mut self.string_index {
             // One row-cardinal file id plus the inline schema/branch/timestamp
             // set is the bulk-write happy path. Preserve headroom for those
@@ -941,6 +959,21 @@ impl RawWriteBatch {
 
     pub(crate) fn take_metadata(&mut self, index: usize) -> Option<TransactionJson> {
         self.metadata[index].take()
+    }
+
+    pub(crate) fn take_durable_predecessor(
+        &mut self,
+        index: usize,
+    ) -> Option<CertifiedCurrentStatePredecessor> {
+        self.durable_predecessors[index].take()
+    }
+
+    pub(crate) fn set_durable_predecessor(
+        &mut self,
+        index: usize,
+        value: Option<CertifiedCurrentStatePredecessor>,
+    ) {
+        self.durable_predecessors[index] = value;
     }
 
     pub(crate) fn snapshot_slots_mut(
@@ -989,6 +1022,7 @@ impl RawWriteBatch {
                 self.entity_pks.swap(destination, source);
                 self.snapshots.swap(destination, source);
                 self.metadata.swap(destination, source);
+                self.durable_predecessors.swap(destination, source);
             }
             destination += 1;
         }
@@ -996,6 +1030,7 @@ impl RawWriteBatch {
         self.entity_pks.truncate(destination);
         self.snapshots.truncate(destination);
         self.metadata.truncate(destination);
+        self.durable_predecessors.truncate(destination);
         self.debug_assert_aligned();
     }
 
@@ -1052,6 +1087,7 @@ impl RawWriteBatch {
 
     fn move_row_into(&mut self, index: usize, destination: &mut Self) {
         let slot = self.slots[index];
+        let durable_predecessor = self.durable_predecessors[index].take();
         destination.push_parts(
             self.entity_pks[index].take(),
             self.strings[slot.schema_key as usize].clone(),
@@ -1067,6 +1103,8 @@ impl RawWriteBatch {
             slot.flags & RAW_WRITE_UNTRACKED != 0,
             self.strings[slot.branch_id as usize].clone(),
         );
+        let destination_index = destination.len() - 1;
+        destination.set_durable_predecessor(destination_index, durable_predecessor);
     }
 
     fn intern_optional_string(&mut self, value: Option<SharedStr>) -> u32 {
@@ -1183,6 +1221,7 @@ impl RawWriteBatch {
         debug_assert_eq!(self.entity_pks.len(), self.slots.len());
         debug_assert_eq!(self.snapshots.len(), self.slots.len());
         debug_assert_eq!(self.metadata.len(), self.slots.len());
+        debug_assert_eq!(self.durable_predecessors.len(), self.slots.len());
     }
 
     #[cfg(test)]
@@ -2150,6 +2189,7 @@ impl TestPreparedStateRow {
             commit_id: self.commit_id,
             untracked: self.untracked,
             branch_id: &self.branch_id,
+            durable_predecessor: None,
         }
     }
 }
@@ -2168,6 +2208,7 @@ pub(crate) struct PreparedStateBatch {
     strings: Vec<SharedStr>,
     string_index: HashMap<SharedStr, u32>,
     json: Vec<StageJson>,
+    durable_predecessors: Vec<CertifiedCurrentStatePredecessor>,
     origins: Vec<TransactionWriteOrigin>,
     origin_index: HashMap<TransactionWriteOrigin, u32>,
     origin_column_sets: Vec<Arc<[String]>>,
@@ -2198,6 +2239,7 @@ struct PreparedStateSlot {
     commit_id: Option<CommitId>,
     untracked: bool,
     branch_id: u32,
+    durable_predecessor: Option<u32>,
 }
 
 /// Borrowed row projection over a [`PreparedStateBatch`].
@@ -2223,6 +2265,7 @@ pub(crate) struct PreparedStateRowRef<'a> {
     pub(crate) commit_id: Option<CommitId>,
     pub(crate) untracked: bool,
     pub(crate) branch_id: &'a SharedStr,
+    pub(crate) durable_predecessor: Option<&'a CertifiedCurrentStatePredecessor>,
 }
 
 pub(crate) struct PreparedStateRows<'a> {
@@ -2267,6 +2310,7 @@ impl PreparedStateBatch {
             strings: Vec::with_capacity(string_capacity),
             string_index: HashMap::with_capacity(string_capacity),
             json: Vec::with_capacity(json_capacity),
+            durable_predecessors: Vec::new(),
             // Origin dictionaries are absent for ordinary SQL/direct writes
             // and typically contain only a few shared descriptors. Allocate
             // them lazily instead of paying two N-sized buffers up front.
@@ -2322,6 +2366,9 @@ impl PreparedStateBatch {
             commit_id: slot.commit_id,
             untracked: slot.untracked,
             branch_id: &self.strings[slot.branch_id as usize],
+            durable_predecessor: slot
+                .durable_predecessor
+                .map(|index| &self.durable_predecessors[index as usize]),
         })
     }
 
@@ -2453,6 +2500,20 @@ impl PreparedStateBatch {
             commit_id,
             untracked,
             branch_id,
+            durable_predecessor: None,
+        });
+    }
+
+    pub(crate) fn set_durable_predecessor(
+        &mut self,
+        row: usize,
+        value: Option<CertifiedCurrentStatePredecessor>,
+    ) {
+        self.slots[row].durable_predecessor = value.map(|value| {
+            let index = u32::try_from(self.durable_predecessors.len())
+                .expect("prepared durable predecessor column must fit u32");
+            self.durable_predecessors.push(value);
+            index
         });
     }
 
@@ -2469,9 +2530,13 @@ impl PreparedStateBatch {
         let entity_base =
             u32::try_from(self.entity_pks.len()).expect("prepared entity column must fit u32");
         let json_base = u32::try_from(self.json.len()).expect("prepared JSON column must fit u32");
+        let predecessor_base = u32::try_from(self.durable_predecessors.len())
+            .expect("prepared predecessor column must fit u32");
         self.slots.reserve(other.slots.len());
         self.entity_pks.reserve(other.entity_pks.len());
         self.json.reserve(other.json.len());
+        self.durable_predecessors
+            .reserve(other.durable_predecessors.len());
         self.strings.reserve(other.strings.len());
         self.string_index.reserve(other.strings.len());
         self.origins.reserve(other.origins.len());
@@ -2492,6 +2557,8 @@ impl PreparedStateBatch {
             .collect::<Vec<_>>();
         self.entity_pks.append(&mut other.entity_pks);
         self.json.append(&mut other.json);
+        self.durable_predecessors
+            .append(&mut other.durable_predecessors);
         self.slots.extend(other.slots.into_iter().map(|slot| {
             let remap_string = |index: u32| string_remap[index as usize];
             PreparedStateSlot {
@@ -2510,6 +2577,11 @@ impl PreparedStateBatch {
                     index
                         .checked_add(json_base)
                         .expect("prepared JSON ordinal overflowed")
+                }),
+                durable_predecessor: slot.durable_predecessor.map(|index| {
+                    index
+                        .checked_add(predecessor_base)
+                        .expect("prepared predecessor ordinal overflowed")
                 }),
                 origin: slot.origin.map(|index| origin_remap[index as usize]),
                 origin_key: slot.origin_key.map(remap_string),
@@ -2679,7 +2751,7 @@ impl PreparedStateBatch {
             for (_, value) in &normalized {
                 arena.extend_from_slice(value.as_bytes());
             }
-            let arena = SharedStr::from_utf8(bytes::Bytes::from(arena))
+            let arena = SharedStr::from_utf8(Bytes::from(arena))
                 .expect("validated canonical JSON arena remains UTF-8");
             let mut offset = 0usize;
             for (_, value) in &mut normalized {
@@ -2818,6 +2890,8 @@ impl PreparedStateBatch {
             row.untracked,
             row.branch_id.clone(),
         );
+        let index = self.len() - 1;
+        self.set_durable_predecessor(index, row.durable_predecessor.cloned());
     }
 }
 


### PR DESCRIPTION
## What changed

- Carry authoritative exact-read predecessor evidence from direct ordered public UPDATE planning into commit materialization.
- Reuse certified HOT or packed-current-base predecessors after validating their identity against the sorted mutation deltas, avoiding a second primary/packed read and decode of the same rows.
- Preserve predecessor evidence through columnar live-state merges and transaction batch moves.
- Build canonical replacement snapshots in one shared UTF-8 arena instead of allocating a JSON value, string, and shared owner per row.
- Keep the existing read path as the fallback for mixed, staged, or uncertified mutations.

## Why

Profiling the 10k public SQL UPDATE path showed that planning already exact-resolved every current row, but commit materialization discarded that authoritative result and reread/redecoded all 10k predecessors. Snapshot construction also paid row-cardinal temporary allocations.

The branch-control compare-and-swap protects the exact-read evidence through publication, so commit can validate and reuse it safely.

## Performance

Baseline is the immediately preceding stacked PR, #1054, at exact head `d83184d268d9c89dbbce0e0fa8a65f54e9164860`. It is not pre-stack `main`.

Public SQL benchmark:

```sql
UPDATE json_pointer SET value = lix_json($1) WHERE path = $2
```

| Adapter | Rows | #1054 parent | This PR | Change |
| --- | ---: | ---: | ---: | ---: |
| RocksDB | 10k | 96.148 ms | 79.828 ms | 16.97% faster |
| SlateDB | 10k | 85.512 ms | 69.140 ms | 19.15% faster |
| RocksDB | 1M | 14.535 s | 10.301 s | 29.13% faster |
| SlateDB | 1M | 15.158 s | 11.677 s | 22.96% faster |

10k values are medians of 25 samples for this PR and 15 locked samples for the exact parent. The 1M values are one measured run per adapter.

Peak RSS at 1M:

| Adapter | #1054 parent | This PR | Change |
| --- | ---: | ---: | ---: |
| RocksDB | 4,867,904 KiB | 4,292,608 KiB | 11.82% lower |
| SlateDB | 4,216,268 KiB | 4,242,828 KiB | 0.63% higher |

The SlateDB RSS delta is a single-run 0.63% movement; the 22.96% latency reduction is the material result.

## Validation

- `cargo test -p lix_engine --quiet` — 2,093 passed, 8 ignored
- `cargo test -p lix_rocksdb_storage --quiet` — 15 passed
- `cargo test -p lix_slatedb_storage --quiet` — 58 passed
- `cargo test -p lix_engine_benchmarks --test tracked_state_crud_public_result --features storage-benches,slatedb` — 4 passed, including SQLite result parity for every Lix adapter
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
