### PR TITLE
Store plugin checkpoints as current state

### DIFF
--- a/packages/engine-benchmarks/benches/current_plugin_checkpoint_results.md
+++ b/packages/engine-benchmarks/benches/current_plugin_checkpoint_results.md
@@ -1,0 +1,140 @@
+# Current plugin checkpoint storage results
+
+This hard cut moves rebuildable plugin checkpoints out of immutable repository
+history. A checkpoint is now one current value keyed by the raw 16-byte branch
+UUID and 16-byte file UUID. Each update overwrites that value atomically with
+the file, semantic rows, and branch head. Generation and file-blob hashes in
+the value fence stale state; malformed or mismatched cache data is ignored and
+rebuilt. Raw writes and file deletion remove the exact owner key, while branch
+deletion removes its UUID-prefixed key range.
+
+The boundary is format-neutral. The engine stores opaque runtime and authority
+bytes produced by any WASM component plugin. It contains no Git, text, binary,
+LFS, media-type, extension, or plugin-name policy. Files without a plugin
+checkpoint continue through the ordinary binary CAS, including initial Git LFS
+materialization. The repository protocol is bumped to v39 and the two old
+checkpoint-hash fields are removed from `lix_binary_blob_ref`; there is no
+migration path.
+
+This follows established database practice:
+
+- Git stores derived commit-graph metadata separately from repository objects,
+  verifies it against object identity, replaces graph layers, and expires
+  unused files. See Git's [commit-graph format][git-commit-graph-format] and
+  [commit-graph maintenance][git-commit-graph].
+- PostgreSQL materialized views persist derived query results for fast reads,
+  and `REFRESH MATERIALIZED VIEW` replaces the old contents rather than adding
+  every refresh to table history. See [materialized views][postgres-matview]
+  and [refresh semantics][postgres-refresh].
+- RocksDB provides atomic overwrite/delete operations across column families,
+  while compaction removes overwritten versions and tombstones. See the
+  [RocksDB overview][rocks-overview] and [compaction][rocks-compaction].
+
+## Git replay corpus
+
+The baseline is `main` at `3a792c12d`; the candidate release binary SHA-256 is
+`41826a32edb748412bf4ef48246f7ce598f333c5613137025d5bf0669b4c32ec`.
+Every successful run used `lix exp git-replay --plugins all`, a scoped parent
+bootstrap, periodic checkpoints, explicit adapter flush, and final Git-tree
+verification. RocksDB bytes are the closed database directory. SlateDB bytes
+are attributable SST plus immutable binary-segment bytes, excluding
+close-timing-dependent WAL and manifest control files.
+
+| repository | adapter | replay before | replay after | time delta | bytes before | bytes after | size delta |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `microsoft/vscode-docs`, 100 commits | RocksDB | 4668.278 ms | 4496.238 ms | -3.69% | 72,622,119 | 60,044,560 | -17.32% |
+| `microsoft/vscode-docs`, 100 commits | SlateDB | 4809.890 ms | 4761.489 ms | -1.01% | 72,151,959 | 56,906,626 | -21.13% |
+| `home-assistant/brands`, 80 commits | RocksDB | 313.681 ms | 309.614 ms | -1.30% | 15,853,294 | 15,840,929 | -0.08% |
+| `home-assistant/brands`, 80 commits | SlateDB | 374.387 ms | 377.196 ms | +0.75% | 15,727,248 | 15,715,604 | -0.07% |
+| `wesnoth/wesnoth`, 15 commits | RocksDB | 121.232 ms | 124.242 ms | +2.48% | 4,345,582 | 4,233,493 | -2.58% |
+| `wesnoth/wesnoth`, 15 commits | SlateDB | 124.612 ms | 123.935 ms | -0.54% | 4,303,176 | 4,193,333 | -2.55% |
+| **aggregate** | | **10412.081 ms** | **10192.712 ms** | **-2.11%** | **185,003,378** | **156,934,545** | **-15.17%** |
+
+All six final trees verified. VS Code materialized the same 97 unique Git LFS
+objects and 42,011,887 logical LFS bytes; Brands and Wesnoth materialized none.
+The media-heavy Brands control remains flat, so text checkpoint optimization
+does not trade away binary-asset layout.
+
+Increasing-batch runs cover the full 100-commit VS Code window. Brands is
+clean through 80 commits and its 100-commit attempt reaches an existing
+filesystem namespace conflict near commit 91. Wesnoth is clean through 15;
+its 50-commit attempt reaches 20 before the existing nested-Wasmtime-runtime
+panic. These are replay-tool edge cases, not storage mismatches, and do not
+invalidate the final-tree-verified windows above.
+
+## Every binary byte attributed
+
+The benchmark inventory recursively loads inline and out-of-band JSON, assigns
+every binary-CAS manifest to its owning hash field, and emits an explicit
+`unowned` category. On the final VS Code/SlateDB database it finds:
+
+| owner | references | manifests | logical bytes | chunk values | encoded chunk bytes | layout |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| file blobs | 2,193 | 2,140 | 76,563,532 | 684 | 48,247,845 | 641 single, 15 chunked, 1,484 flat deltas |
+| plugin WASM | 10 | 4 | 3,220,058 | 5 | 1,154,229 | 3 single, 1 chunked |
+| unowned or cross-owner shared | 0 | 0 | 0 | 0 | 0 | none |
+
+Before the hard cut, VS Code had 1,967 runtime-checkpoint manifests carrying
+17,653,016 logical bytes and 886 authority-checkpoint manifests carrying
+2,053,864 bytes. The candidate removes all 2,853 historical manifests. It
+retains 360 current checkpoint rows with 3,141,505 runtime bytes and 133,544
+authority bytes. All 360 runtime payloads are unique; 358 authority payloads
+are unique, and the only exact duplicates total 40 bytes. Immutable binary-CAS
+chunk values fall from 67,267,601 to 49,402,074 bytes. The current checkpoint
+space occupies 3,238,123 compressed physical bytes. All 689 encoded chunk
+values are reachable from exactly one reported owner category; none is orphaned
+or shared across categories.
+
+Wesnoth retains 40 current checkpoints with 87,381 runtime bytes and 474,696
+authority bytes; every component is unique. Brands retains eight checkpoints
+with 5,288 component bytes; every component is unique. Current divergent
+branches therefore retain distinct serving state, while superseded edits no
+longer retain checkpoint history.
+
+## Matched CRUD, merge, and cold-open benchmark
+
+The deterministic Markdown corpus is 524,721 bytes. Baseline and candidate use
+50 byte edits, 50 semantic edits, 15 unrelated-entity merges, and 30 cold
+opens. Values are medians from release builds.
+
+| operation | before | after | delta |
+| --- | ---: | ---: | ---: |
+| initial import | 32.040 ms | 32.562 ms | +1.63% |
+| hot byte edit | 1.897 ms | 1.805 ms | -4.85% |
+| semantic edit | 6.005 ms | 5.912 ms | -1.55% |
+| cold sparse edit total | 7.874 ms | 7.875 ms | +0.01% |
+| unrelated-entity merge | 7.533 ms | 7.552 ms | +0.25% |
+| cold materialized read | 0.504 ms | 0.515 ms | +2.18% |
+
+The history-live main-branch database changes from 11,163,356 to 11,226,533
+bytes (+0.57%). After 15 live divergent merge-source branches it changes from
+20,556,982 to 23,601,901 bytes (+14.81%): that delta is one distinct,
+rebuildable current accelerator per live branch, not retained edit history.
+Removing it would trade cold branch-edit performance for cache eviction, so it
+is deliberately retained and lifecycle-cleaned.
+
+An application-level Zstd prototype for certified semantic pages was rejected.
+It reduced logical page bytes by about 86%, but adapter block compression had
+already captured the redundancy: physical size regressed 0.38-0.45% on
+RocksDB and 0.20-0.21% on SlateDB, with VS Code/SlateDB replay 2.1% slower. No
+part of that prototype is retained.
+
+## Verification
+
+- `cargo test -p lix_engine --features all-simulations`: 1,664 unit tests and
+  800 base/rebuild integration simulations passed.
+- RocksDB: 15 tests passed, including storage conformance.
+- SlateDB: 58 tests passed, including storage conformance and cached storage.
+- SQLite: 2 tests passed, including storage conformance.
+- `cargo check -p lix_engine_benchmarks --all-features` passed.
+- `git_text_plugin` cold reopen passed and restored the durable checkpoint
+  without full semantic-state hydration.
+- The matched benchmark passed its byte, semantic, merge, and cold-open
+  correctness assertions.
+
+[git-commit-graph-format]: https://git-scm.com/docs/gitformat-commit-graph
+[git-commit-graph]: https://git-scm.com/docs/git-commit-graph
+[postgres-matview]: https://www.postgresql.org/docs/current/rules-materializedviews.html
+[postgres-refresh]: https://www.postgresql.org/docs/current/sql-refreshmaterializedview.html
+[rocks-overview]: https://github.com/facebook/rocksdb/wiki/RocksDB-Overview
+[rocks-compaction]: https://github.com/facebook/rocksdb/wiki/Compaction

--- a/packages/engine-benchmarks/examples/storage_layout.rs
+++ b/packages/engine-benchmarks/examples/storage_layout.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use lix_engine::storage_adapter::{StorageAdapter, StorageReadOptions};
 use lix_engine::storage_bench::{
-    binary_manifest_layout_accounting, commit_delta_layout_accounting, layout_accounting,
-    layout_space_catalog, space_inventory,
+    binary_cas_owner_layout_accounting, binary_manifest_layout_accounting,
+    commit_delta_layout_accounting, layout_accounting, layout_space_catalog, space_inventory,
 };
 use lix_slatedb_storage::SlateDB;
 use object_store::local::LocalFileSystem;
@@ -92,6 +92,8 @@ async fn main() {
     println!("SPACE\tTOTAL\tTOTAL\t{total_rows}\t{total_keys}\t{total_values}");
     print_commit_delta_inventory(&read).await;
     print_binary_manifest_layout(&read).await;
+    print_binary_cas_owners(&read).await;
+    print_plugin_checkpoint_layout(&read).await;
 
     let inventory = space_inventory(&read, HOT_SPACE).await;
     let mut groups = BTreeMap::<Vec<u8>, HotGroup>::new();
@@ -178,6 +180,69 @@ async fn main() {
     if !logical_only {
         inspect_ssts(Path::new(&path), &space_names).await;
     }
+}
+
+async fn print_binary_cas_owners(read: &impl lix_engine::storage_adapter::StorageAdapterRead) {
+    for owner in binary_cas_owner_layout_accounting(read)
+        .await
+        .expect("decode binary CAS owners")
+    {
+        println!(
+            "BINARY_OWNER\towner={}\treferences={}\tmanifests={}\tlogical_bytes={}\tencoded_manifest_bytes={}\tempty={}\tsingle_chunk={}\tchunked={}\tdelta={}\tchunk_values={}\tencoded_chunk_bytes={}",
+            owner.owner,
+            owner.references,
+            owner.manifests,
+            owner.logical_bytes,
+            owner.encoded_manifest_bytes,
+            owner.empty_manifests,
+            owner.single_chunk_manifests,
+            owner.chunked_manifests,
+            owner.delta_manifests,
+            owner.chunk_values,
+            owner.encoded_chunk_bytes,
+        );
+    }
+}
+
+async fn print_plugin_checkpoint_layout(
+    read: &impl lix_engine::storage_adapter::StorageAdapterRead,
+) {
+    const HEADER_BYTES: usize = 76;
+
+    let inventory = space_inventory(read, "plugin.current_checkpoint.v1").await;
+    let mut runtime_bytes = 0_u64;
+    let mut authority_bytes = 0_u64;
+    let mut unique_runtime = BTreeSet::new();
+    let mut unique_authority = BTreeSet::new();
+    for (_key, value) in &inventory {
+        let runtime_len = u32::from_le_bytes(
+            value[68..72]
+                .try_into()
+                .expect("plugin checkpoint runtime length"),
+        ) as usize;
+        let authority_len = u32::from_le_bytes(
+            value[72..76]
+                .try_into()
+                .expect("plugin checkpoint authority length"),
+        ) as usize;
+        let runtime_end = HEADER_BYTES + runtime_len;
+        let authority_end = runtime_end + authority_len;
+        assert_eq!(authority_end, value.len(), "plugin checkpoint value length");
+        runtime_bytes += runtime_len as u64;
+        authority_bytes += authority_len as u64;
+        unique_runtime.insert(value[HEADER_BYTES..runtime_end].to_vec());
+        unique_authority.insert(value[runtime_end..authority_end].to_vec());
+    }
+    println!(
+        "PLUGIN_CHECKPOINT\trows={}\truntime_bytes={}\tauthority_bytes={}\tunique_runtimes={}\tunique_runtime_bytes={}\tunique_authorities={}\tunique_authority_bytes={}",
+        inventory.len(),
+        runtime_bytes,
+        authority_bytes,
+        unique_runtime.len(),
+        unique_runtime.iter().map(Vec::len).sum::<usize>(),
+        unique_authority.len(),
+        unique_authority.iter().map(Vec::len).sum::<usize>(),
+    );
 }
 
 async fn print_binary_manifest_layout(read: &impl lix_engine::storage_adapter::StorageAdapterRead) {

--- a/packages/engine/src/binary_cas/mod.rs
+++ b/packages/engine/src/binary_cas/mod.rs
@@ -12,7 +12,9 @@ pub(crate) use chunking::BinaryCasChunking;
 #[cfg(all(feature = "storage-benches", test))]
 pub(crate) use codec::encode_binary_cas_manifest;
 #[cfg(feature = "storage-benches")]
-pub(crate) use codec::{BinaryCasManifest, decode_binary_cas_manifest};
+pub(crate) use codec::{
+    BinaryCasManifest, decode_binary_cas_manifest, decode_binary_cas_manifest_chunk,
+};
 pub(crate) use context::{BinaryCasContext, BlobDataReader};
 pub(crate) use kv::load_bytes_many;
 pub(crate) use types::{

--- a/packages/engine/src/binary_cas/types.rs
+++ b/packages/engine/src/binary_cas/types.rs
@@ -80,15 +80,6 @@ impl BlobPayload {
         Self { bytes, hash }
     }
 
-    pub(crate) fn from_hashed_bytes(bytes: impl Into<crate::Blob>, hash: BlobHash) -> Self {
-        let bytes = bytes.into();
-        debug_assert_eq!(BlobHash::from_content(&bytes), hash);
-        Self {
-            bytes,
-            hash: Some(hash),
-        }
-    }
-
     pub(crate) fn bytes(&self) -> &[u8] {
         &self.bytes
     }

--- a/packages/engine/src/filesystem/planner.rs
+++ b/packages/engine/src/filesystem/planner.rs
@@ -358,7 +358,6 @@ pub(crate) struct BlobRefRowInput {
     pub(crate) file_id: String,
     pub(crate) blob_hash: BlobHash,
     pub(crate) size_bytes: usize,
-    pub(crate) plugin_checkpoint_hashes: Option<(BlobHash, BlobHash)>,
     pub(crate) context: FilesystemRowContext,
 }
 
@@ -373,24 +372,11 @@ impl BlobRefRowInput {
                 ),
             )
         })?;
-        let mut snapshot = json!({
+        let snapshot = json!({
             "id": self.file_id,
             "blob_hash": self.blob_hash.to_hex(),
             "size_bytes": size_bytes,
         });
-        if let Some((state_hash, authority_hash)) = self.plugin_checkpoint_hashes {
-            let snapshot = snapshot
-                .as_object_mut()
-                .expect("blob reference snapshot is an object");
-            snapshot.insert(
-                "plugin_state_checkpoint_hash".to_owned(),
-                JsonValue::String(state_hash.to_hex()),
-            );
-            snapshot.insert(
-                "plugin_authority_checkpoint_hash".to_owned(),
-                JsonValue::String(authority_hash.to_hex()),
-            );
-        }
         let file_id = self.file_id;
         append_state_row(
             rows,
@@ -1207,7 +1193,6 @@ fn plan_parsed_file_path_write_with_fallback(
                     .blob_hash()
                     .expect("non-empty payload should have blob hash"),
                 size_bytes: file_payload.len(),
-                plugin_checkpoint_hashes: None,
                 context: FilesystemRowContext {
                     file_id: None,
                     metadata: None,
@@ -1266,7 +1251,6 @@ pub(crate) fn plan_file_descriptor_write(
                     .blob_hash()
                     .expect("non-empty payload should have blob hash"),
                 size_bytes: file_payload.len(),
-                plugin_checkpoint_hashes: None,
                 context: FilesystemRowContext {
                     file_id: None,
                     metadata: None,
@@ -2033,7 +2017,6 @@ mod tests {
             file_id: "01920000-0000-7000-8000-0000000000d2".to_string(),
             blob_hash: BlobHash::from_content(b"Hello"),
             size_bytes: 5,
-            plugin_checkpoint_hashes: None,
             context: FilesystemRowContext::active_branch("01920000-0000-7000-8000-0000000000a1"),
         })
         .expect("blob ref row should build");

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -46,7 +46,7 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"lxcd9-packed-out-of-line-binary-cas.v38";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"lxcd9-current-plugin-checkpoint.v39";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately

--- a/packages/engine/src/schema/builtin/lix_binary_blob_ref.json
+++ b/packages/engine/src/schema/builtin/lix_binary_blob_ref.json
@@ -19,14 +19,6 @@
       "type": "integer",
       "minimum": 0,
       "description": "Logical uncompressed file size in bytes for the referenced binary payload."
-    },
-    "plugin_state_checkpoint_hash": {
-      "type": "string",
-      "description": "Optional BLAKE3 CAS hash of the exact-root plugin runtime-state checkpoint."
-    },
-    "plugin_authority_checkpoint_hash": {
-      "type": "string",
-      "description": "Optional BLAKE3 CAS hash of the host-validated plugin identity authority checkpoint."
     }
   },
   "required": [

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -4442,7 +4442,6 @@ fn stage_lix_file_data_blob_ref_write(
             .blob_hash()
             .expect("non-empty payload should have blob hash"),
         size_bytes: file_data.len(),
-        plugin_checkpoint_hashes: None,
         context: FilesystemRowContext {
             file_id: None,
             metadata: None,

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -321,6 +321,21 @@ pub struct BinaryManifestLayoutAccounting {
     pub delta_manifests: u64,
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct BinaryCasOwnerLayoutAccounting {
+    pub owner: String,
+    pub references: u64,
+    pub manifests: u64,
+    pub logical_bytes: u64,
+    pub encoded_manifest_bytes: u64,
+    pub empty_manifests: u64,
+    pub single_chunk_manifests: u64,
+    pub chunked_manifests: u64,
+    pub delta_manifests: u64,
+    pub chunk_values: u64,
+    pub encoded_chunk_bytes: u64,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CommitDeltaLayoutAccounting {
     pub commit_id: String,
@@ -559,6 +574,243 @@ where
     Ok(accounting)
 }
 
+/// Attributes every binary-CAS manifest to the durable JSON field which owns it.
+///
+/// This benchmark-only inventory walks decoded commit deltas instead of raw
+/// storage values, so adapter compression and packed history do not hide CAS
+/// references. A final `unowned` row makes missing ownership explicit.
+pub async fn binary_cas_owner_layout_accounting<R>(
+    read: &R,
+) -> Result<Vec<BinaryCasOwnerLayoutAccounting>, crate::LixError>
+where
+    R: StorageAdapterRead,
+{
+    use crate::json_store::JsonSlot;
+
+    let inventory = crate::tracked_state::scan_commit_delta_inventory(read).await?;
+    let mut seen_changes = std::collections::BTreeSet::new();
+    let mut references = std::collections::BTreeMap::<String, u64>::new();
+    let mut owners = std::collections::BTreeMap::<crate::binary_cas::BlobHash, String>::new();
+    let mut json_ref_hashes = std::collections::BTreeSet::new();
+    for member in inventory
+        .commits
+        .values()
+        .flat_map(|entry| entry.members.iter())
+    {
+        if !seen_changes.insert(member.change.change_id) {
+            continue;
+        }
+        match &member.change.snapshot {
+            JsonSlot::Inline(snapshot) => {
+                if let Ok(value) = serde_json::from_str::<serde_json::Value>(snapshot) {
+                    collect_binary_cas_json_owners(&value, &mut references, &mut owners);
+                }
+            }
+            JsonSlot::Ref(json_ref) => {
+                json_ref_hashes.insert(*json_ref.as_hash_array());
+            }
+            JsonSlot::None => {}
+        }
+    }
+    let json_refs = json_ref_hashes
+        .into_iter()
+        .map(crate::json_store::JsonRef::from_hash_bytes)
+        .collect::<Vec<_>>();
+    let loaded = crate::json_store::JsonStoreContext::new()
+        .load_bytes_many(
+            read,
+            crate::json_store::JsonLoadRequestRef {
+                refs: &json_refs,
+                scope: crate::json_store::JsonReadScopeRef::OutOfBand,
+            },
+        )
+        .await?;
+    for value in loaded.into_values().into_iter().flatten() {
+        if let Ok(value) = serde_json::from_slice::<serde_json::Value>(&value) {
+            collect_binary_cas_json_owners(&value, &mut references, &mut owners);
+        }
+    }
+
+    let manifest_chunk_entries =
+        scan_layout_entries(read, crate::binary_cas::kv::BINARY_CAS_MANIFEST_CHUNK_SPACE).await;
+    let mut manifest_chunks = std::collections::BTreeMap::<
+        crate::binary_cas::BlobHash,
+        Vec<crate::binary_cas::BlobHash>,
+    >::new();
+    for entry in manifest_chunk_entries {
+        let blob_hash: [u8; 32] = entry
+            .key
+            .0
+            .get(..32)
+            .ok_or_else(|| {
+                crate::LixError::new(
+                    crate::LixError::CODE_INTERNAL_ERROR,
+                    "benchmark binary CAS manifest-chunk key is too short",
+                )
+            })?
+            .try_into()
+            .expect("manifest-chunk hash slice is 32 bytes");
+        let StorageProjectedValue::FullValue(value) = entry.value else {
+            unreachable!("binary manifest-chunk owner scan requests full values");
+        };
+        let (chunk_hash, _) = crate::binary_cas::decode_binary_cas_manifest_chunk(&value)?;
+        manifest_chunks
+            .entry(crate::binary_cas::BlobHash::from_bytes(blob_hash))
+            .or_default()
+            .push(crate::binary_cas::BlobHash::from_bytes(chunk_hash));
+    }
+
+    let entries = scan_layout_entries(read, crate::binary_cas::kv::BINARY_CAS_MANIFEST_SPACE).await;
+    let mut accounting =
+        std::collections::BTreeMap::<String, BinaryCasOwnerLayoutAccounting>::new();
+    let mut chunk_owners = std::collections::BTreeMap::<
+        crate::binary_cas::BlobHash,
+        std::collections::BTreeSet<String>,
+    >::new();
+    let mut blob_chunks = std::collections::BTreeMap::<
+        crate::binary_cas::BlobHash,
+        Vec<crate::binary_cas::BlobHash>,
+    >::new();
+    let mut delta_bases = Vec::new();
+    for entry in entries {
+        let hash_bytes: [u8; 32] = entry.key.0.as_ref().try_into().map_err(|_| {
+            crate::LixError::new(
+                crate::LixError::CODE_INTERNAL_ERROR,
+                "benchmark binary CAS manifest key is not one hash",
+            )
+        })?;
+        let owner = owners
+            .get(&crate::binary_cas::BlobHash::from_bytes(hash_bytes))
+            .cloned()
+            .unwrap_or_else(|| "unowned".to_owned());
+        let StorageProjectedValue::FullValue(value) = entry.value else {
+            unreachable!("binary manifest owner scan requests full values");
+        };
+        let manifest = crate::binary_cas::decode_binary_cas_manifest(&value)?;
+        let reference_count = references.get(&owner).copied().unwrap_or_default();
+        let row =
+            accounting
+                .entry(owner.clone())
+                .or_insert_with(|| BinaryCasOwnerLayoutAccounting {
+                    owner: owner.clone(),
+                    references: reference_count,
+                    ..Default::default()
+                });
+        row.manifests += 1;
+        row.logical_bytes += manifest.size_bytes();
+        row.encoded_manifest_bytes += value.len() as u64;
+        match manifest {
+            crate::binary_cas::BinaryCasManifest::Empty { .. } => row.empty_manifests += 1,
+            crate::binary_cas::BinaryCasManifest::SingleChunk { chunk_hash, .. } => {
+                row.single_chunk_manifests += 1;
+                let chunk_hash = crate::binary_cas::BlobHash::from_bytes(chunk_hash);
+                blob_chunks.insert(
+                    crate::binary_cas::BlobHash::from_bytes(hash_bytes),
+                    vec![chunk_hash],
+                );
+                chunk_owners.entry(chunk_hash).or_default().insert(owner);
+            }
+            crate::binary_cas::BinaryCasManifest::Chunked { .. } => {
+                row.chunked_manifests += 1;
+                let blob_hash = crate::binary_cas::BlobHash::from_bytes(hash_bytes);
+                let chunks = manifest_chunks.get(&blob_hash).cloned().unwrap_or_default();
+                for chunk_hash in &chunks {
+                    chunk_owners
+                        .entry(*chunk_hash)
+                        .or_default()
+                        .insert(owner.clone());
+                }
+                blob_chunks.insert(blob_hash, chunks);
+            }
+            crate::binary_cas::BinaryCasManifest::Delta { base_blob_hash, .. } => {
+                row.delta_manifests += 1;
+                delta_bases.push((
+                    owner,
+                    crate::binary_cas::BlobHash::from_bytes(base_blob_hash),
+                ));
+            }
+        }
+    }
+    for (owner, base_blob_hash) in delta_bases {
+        if let Some(chunks) = blob_chunks.get(&base_blob_hash) {
+            for chunk_hash in chunks {
+                chunk_owners
+                    .entry(*chunk_hash)
+                    .or_default()
+                    .insert(owner.clone());
+            }
+        }
+    }
+    let chunk_entries =
+        scan_layout_entries(read, crate::binary_cas::kv::BINARY_CAS_CHUNK_SPACE).await;
+    for entry in chunk_entries {
+        let chunk_hash: [u8; 32] = entry.key.0.as_ref().try_into().map_err(|_| {
+            crate::LixError::new(
+                crate::LixError::CODE_INTERNAL_ERROR,
+                "benchmark binary CAS chunk key is not one hash",
+            )
+        })?;
+        let StorageProjectedValue::FullValue(value) = entry.value else {
+            unreachable!("binary chunk owner scan requests full values");
+        };
+        let owners = chunk_owners.get(&crate::binary_cas::BlobHash::from_bytes(chunk_hash));
+        let owner = match owners {
+            None => "unowned_chunk".to_owned(),
+            Some(owners) if owners.len() == 1 => owners.first().expect("one chunk owner").clone(),
+            Some(owners) => format!(
+                "shared_chunk:{}",
+                owners.iter().cloned().collect::<Vec<_>>().join("+")
+            ),
+        };
+        let row =
+            accounting
+                .entry(owner.clone())
+                .or_insert_with(|| BinaryCasOwnerLayoutAccounting {
+                    owner,
+                    ..Default::default()
+                });
+        row.chunk_values += 1;
+        row.encoded_chunk_bytes += value.len() as u64;
+    }
+    Ok(accounting.into_values().collect())
+}
+
+fn collect_binary_cas_json_owners(
+    value: &serde_json::Value,
+    references: &mut std::collections::BTreeMap<String, u64>,
+    owners: &mut std::collections::BTreeMap<crate::binary_cas::BlobHash, String>,
+) {
+    match value {
+        serde_json::Value::Object(object) => {
+            for (field, value) in object {
+                if field.ends_with("hash") {
+                    if let Some(value) = value.as_str() {
+                        if let Ok(hash) = crate::binary_cas::BlobHash::from_hex(value) {
+                            let owner = match field.as_str() {
+                                "blob_hash" => "file_blob",
+                                "plugin_state_checkpoint_hash" => "plugin_runtime_checkpoint",
+                                "plugin_authority_checkpoint_hash" => "plugin_authority_checkpoint",
+                                "wasm_blob_hash" => "plugin_wasm",
+                                _ => field,
+                            }
+                            .to_owned();
+                            *references.entry(owner.clone()).or_default() += 1;
+                            owners.entry(hash).or_insert(owner);
+                        }
+                    }
+                }
+                collect_binary_cas_json_owners(value, references, owners);
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for value in values {
+                collect_binary_cas_json_owners(value, references, owners);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Per-row (key, value bytes) inventory of one space.
 ///
 /// Equivalence tests compare these inventories byte-for-byte, so the scan
@@ -610,6 +862,7 @@ fn native_storage_spaces() -> &'static [crate::storage_adapter::StorageSpace] {
         crate::live_state::CERTIFIED_ENTITY_BATCH_SPACE,
         crate::live_state::CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE,
         crate::live_state::CERTIFIED_ENTITY_BATCH_PAGE_SPACE,
+        crate::transaction::plugin_checkpoint::PLUGIN_CHECKPOINT_SPACE,
         crate::json_store::store::JSON_SPACE,
         crate::json_store::UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE,
         crate::tracked_state::TRACKED_STATE_TREE_CHUNK_SPACE,

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -185,6 +185,33 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     // shared parsed column; every later materialization stage consumes this
     // map plus canonical arena slices.
     let explicit_branch_targets = explicit_branch_head_targets(&state_rows)?;
+    let deleted_checkpoint_branches = explicit_branch_targets
+        .iter()
+        .filter_map(|(branch_id, target)| target.head_commit_id.is_none().then_some(branch_id))
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let mut deleted_checkpoint_files = state_rows
+        .iter()
+        .filter(|row| row.schema_key == "lix_binary_blob_ref" && row.snapshot.is_none())
+        .filter_map(|row| {
+            row.file_id
+                .map(|file_id| (row.branch_id.to_string(), file_id.to_string()))
+        })
+        .collect::<BTreeSet<_>>();
+    deleted_checkpoint_files.extend(
+        prepared_writes
+            .file_data_writes
+            .iter()
+            .filter(|write| write.plugin_checkpoint().is_none())
+            .map(|write| (write.branch_id.clone(), write.file_id.clone())),
+    );
+    for write in prepared_writes
+        .file_data_writes
+        .iter()
+        .filter(|write| write.plugin_checkpoint().is_some())
+    {
+        deleted_checkpoint_files.remove(&(write.branch_id.clone(), write.file_id.clone()));
+    }
     release_validated_canonical_value_columns(&mut state_rows);
     if !prepared_writes.file_data_writes.is_empty() {
         let mut blob_writer = binary_cas.writer_skipping_existing_chunks(&*read, &mut writes);
@@ -208,6 +235,40 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
                 blob_writer.stage_payload(payload).await?;
             }
         }
+        drop(blob_writer);
+        for write in &prepared_writes.file_data_writes {
+            if let Some(checkpoint) = write.plugin_checkpoint() {
+                crate::transaction::plugin_checkpoint::stage_current_plugin_checkpoint(
+                    &mut writes,
+                    &write.branch_id,
+                    &write.file_id,
+                    &checkpoint.generation,
+                    write
+                        .blob_hash()
+                        .unwrap_or_else(|| crate::binary_cas::BlobHash::from_content(write.data())),
+                    &checkpoint.runtime,
+                    &checkpoint.authority,
+                )?;
+            }
+        }
+    }
+    let deleted_checkpoint_files = deleted_checkpoint_files
+        .into_iter()
+        .filter(|(branch_id, _)| !deleted_checkpoint_branches.contains(branch_id))
+        .collect::<Vec<_>>();
+    crate::transaction::plugin_checkpoint::stage_delete_current_plugin_checkpoints(
+        &*read,
+        &mut writes,
+        &deleted_checkpoint_files,
+    )
+    .await?;
+    for branch_id in &deleted_checkpoint_branches {
+        crate::transaction::plugin_checkpoint::stage_delete_branch_plugin_checkpoints(
+            &*read,
+            &mut writes,
+            branch_id,
+        )
+        .await?;
     }
     let mut insert_selection = prepared_writes.insert_selection;
     let finalized = finalize_commit_rows(

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -4119,29 +4119,32 @@ where
                                 cache.checkpoint(&actor_key, &visible_materialization.semantic_root)
                             });
                             let mut durable_checkpoint = if decoded_checkpoint.is_none() {
-                                crate::transaction::plugin_checkpoint::load_current_plugin_checkpoint(
-                                    &read,
-                                    &actor_key.branch_id,
-                                    &actor_key.file_id,
-                                    &actor_key.plugin_generation,
-                                    checkpoint_blob_hash
-                                        .expect("durable plugin checkpoints are blob-backed"),
-                                )
-                                .await
-                                .ok()
-                                .flatten()
-                                .and_then(|checkpoint| {
-                                    Some(DecodedDurablePluginCheckpoint {
-                                        runtime: WasmDurableDocumentCheckpoint::decode(
-                                            &checkpoint.runtime,
-                                        )
-                                        .ok()?,
-                                        authorities: PluginEntityAuthorities::decode_checkpoint(
-                                            &checkpoint.authority,
-                                        )
-                                        .ok()?,
+                                if let Some(checkpoint_blob_hash) = checkpoint_blob_hash {
+                                    crate::transaction::plugin_checkpoint::load_current_plugin_checkpoint(
+                                        &read,
+                                        &actor_key.branch_id,
+                                        &actor_key.file_id,
+                                        &actor_key.plugin_generation,
+                                        checkpoint_blob_hash,
+                                    )
+                                    .await
+                                    .ok()
+                                    .flatten()
+                                    .and_then(|checkpoint| {
+                                        Some(DecodedDurablePluginCheckpoint {
+                                            runtime: WasmDurableDocumentCheckpoint::decode(
+                                                &checkpoint.runtime,
+                                            )
+                                            .ok()?,
+                                            authorities: PluginEntityAuthorities::decode_checkpoint(
+                                                &checkpoint.authority,
+                                            )
+                                            .ok()?,
+                                        })
                                     })
-                                })
+                                } else {
+                                    None
+                                }
                             } else {
                                 None
                             };

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -198,7 +198,6 @@ struct VisibleMaterialization {
 enum VisibleMaterializationBytes {
     Blob {
         hash: BlobHash,
-        plugin_checkpoint_hashes: Option<(BlobHash, BlobHash)>,
     },
     Derived {
         path: String,
@@ -273,23 +272,6 @@ fn decode_visible_materialization_parts(
             }
             VisibleMaterializationBytes::Blob {
                 hash: BlobHash::from_hex(&snapshot.blob_hash)?,
-                plugin_checkpoint_hashes: match (
-                    snapshot.plugin_state_checkpoint_hash.as_deref(),
-                    snapshot.plugin_authority_checkpoint_hash.as_deref(),
-                ) {
-                    (Some(state), Some(authority)) => {
-                        Some((BlobHash::from_hex(state)?, BlobHash::from_hex(authority)?))
-                    }
-                    (None, None) => None,
-                    _ => {
-                        return Err(LixError::new(
-                            LixError::CODE_INVALID_PLUGIN,
-                            format!(
-                                "owned component plugin file '{file_id}' has an incomplete checkpoint reference"
-                            ),
-                        ));
-                    }
-                },
             }
         }
         DERIVED_FILE_REF_SCHEMA_KEY => {
@@ -2187,7 +2169,6 @@ where
                                 .blob_hash()
                                 .unwrap_or_else(|| BlobHash::from_content(payload.data())),
                             size_bytes: payload.len(),
-                            plugin_checkpoint_hashes: payload.plugin_checkpoint_hashes(),
                             context: FilesystemRowContext {
                                 branch_id: file_key.branch_id.clone(),
                                 global: file_key.global,
@@ -2295,7 +2276,6 @@ where
                                 .blob_hash()
                                 .unwrap_or_else(|| BlobHash::from_content(payload.data())),
                             size_bytes: payload.len(),
-                            plugin_checkpoint_hashes: payload.plugin_checkpoint_hashes(),
                             context: FilesystemRowContext {
                                 branch_id: file_key.branch_id.clone(),
                                 global: file_key.global,
@@ -4042,7 +4022,7 @@ where
                             let (
                                 cold_before,
                                 checkpoint_accepted_bytes,
-                                durable_checkpoint_hashes,
+                                checkpoint_blob_hash,
                                 cold_edits,
                                 host_full_diff_bytes_compared,
                                 same_length_blob_splice,
@@ -4050,10 +4030,7 @@ where
                             ) = match (selected.materialization(), visible_materialization.bytes) {
                                 (
                                     PluginMaterialization::Blob,
-                                    VisibleMaterializationBytes::Blob {
-                                        hash,
-                                        plugin_checkpoint_hashes,
-                                    },
+                                    VisibleMaterializationBytes::Blob { hash },
                                 ) => {
                                     let before_bytes: crate::Blob =
                                         load_transaction_blob_bytes(
@@ -4103,7 +4080,7 @@ where
                                     (
                                         Some(before_source),
                                         Some(before_bytes),
-                                        plugin_checkpoint_hashes,
+                                        Some(hash),
                                         built_splices.edits,
                                         built_splices.full_diff_bytes_compared,
                                         same_length_blob_splice,
@@ -4142,42 +4119,29 @@ where
                                 cache.checkpoint(&actor_key, &visible_materialization.semantic_root)
                             });
                             let mut durable_checkpoint = if decoded_checkpoint.is_none() {
-                                if let Some((state_hash, authority_hash)) =
-                                    durable_checkpoint_hashes
-                                {
-                                    let batch = load_transaction_blob_bytes(
-                                        &self.binary_cas.reader(read.clone()),
-                                        &self.staged_writes,
-                                        &[state_hash, authority_hash],
-                                    )
-                                    .await;
-                                    batch.ok().and_then(|batch| {
-                                        let mut values = batch.into_vec().into_iter();
-                                        values
-                                            .next()
-                                            .flatten()
-                                            .zip(values.next().flatten())
-                                            .and_then(|(runtime, authority)| {
-                                                let runtime = decode_bound_plugin_checkpoint(
-                                                    &runtime,
-                                                    &actor_key.plugin_generation,
-                                                )?;
-                                                Some(DecodedDurablePluginCheckpoint {
-                                                    runtime: WasmDurableDocumentCheckpoint::decode(
-                                                        &runtime,
-                                                    )
-                                                    .ok()?,
-                                                    authorities:
-                                                        PluginEntityAuthorities::decode_checkpoint(
-                                                            &authority,
-                                                        )
-                                                        .ok()?,
-                                                })
-                                            })
+                                crate::transaction::plugin_checkpoint::load_current_plugin_checkpoint(
+                                    &read,
+                                    &actor_key.branch_id,
+                                    &actor_key.file_id,
+                                    &actor_key.plugin_generation,
+                                    checkpoint_blob_hash
+                                        .expect("durable plugin checkpoints are blob-backed"),
+                                )
+                                .await
+                                .ok()
+                                .flatten()
+                                .and_then(|checkpoint| {
+                                    Some(DecodedDurablePluginCheckpoint {
+                                        runtime: WasmDurableDocumentCheckpoint::decode(
+                                            &checkpoint.runtime,
+                                        )
+                                        .ok()?,
+                                        authorities: PluginEntityAuthorities::decode_checkpoint(
+                                            &checkpoint.authority,
+                                        )
+                                        .ok()?,
                                     })
-                                } else {
-                                    None
-                                }
+                                })
                             } else {
                                 None
                             };
@@ -8125,43 +8089,6 @@ struct DecodedDurablePluginCheckpoint {
     authorities: PluginEntityAuthorities,
 }
 
-const BOUND_PLUGIN_CHECKPOINT_MAGIC: &[u8; 8] = b"LIXDPB01";
-
-fn encode_bound_plugin_checkpoint(
-    generation: &str,
-    checkpoint: &WasmDurableDocumentCheckpoint,
-) -> Result<crate::Blob, LixError> {
-    let generation_len = u32::try_from(generation.len()).map_err(|_| {
-        LixError::new(
-            LixError::CODE_PLUGIN_RESOURCE_LIMIT,
-            "plugin generation exceeds the checkpoint format limit",
-        )
-    })?;
-    let checkpoint = checkpoint.bytes();
-    let mut encoded = Vec::with_capacity(12 + generation.len() + checkpoint.len());
-    encoded.extend_from_slice(BOUND_PLUGIN_CHECKPOINT_MAGIC);
-    encoded.extend_from_slice(&generation_len.to_le_bytes());
-    encoded.extend_from_slice(generation.as_bytes());
-    encoded.extend_from_slice(&checkpoint);
-    Ok(encoded.into())
-}
-
-fn decode_bound_plugin_checkpoint(
-    encoded: &[u8],
-    expected_generation: &str,
-) -> Option<crate::Blob> {
-    if encoded.get(..8)? != BOUND_PLUGIN_CHECKPOINT_MAGIC {
-        return None;
-    }
-    let generation_len =
-        usize::try_from(u32::from_le_bytes(encoded.get(8..12)?.try_into().ok()?)).ok()?;
-    let generation_end = 12_usize.checked_add(generation_len)?;
-    if encoded.get(12..generation_end)? != expected_generation.as_bytes() {
-        return None;
-    }
-    Some(encoded.get(generation_end..)?.to_vec().into())
-}
-
 impl PluginWriteReconciliation {
     fn attach_durable_checkpoints(
         &self,
@@ -8206,10 +8133,7 @@ impl PluginWriteReconciliation {
                         ),
                     )
                 })?;
-            let state = encode_bound_plugin_checkpoint(&generation, &checkpoint)?;
-            let state_hash = BlobHash::from_content(&state);
-            let authority_hash = BlobHash::from_content(&authority);
-            write.set_plugin_checkpoint(state, state_hash, authority, authority_hash);
+            write.set_plugin_checkpoint(generation, checkpoint.bytes(), authority);
         }
         Ok(())
     }
@@ -8709,10 +8633,6 @@ struct PluginGenerationUpgrade {
 struct PluginUpgradeBlobRefSnapshot {
     id: String,
     blob_hash: String,
-    #[serde(default)]
-    plugin_state_checkpoint_hash: Option<String>,
-    #[serde(default)]
-    plugin_authority_checkpoint_hash: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -10383,20 +10303,6 @@ mod tests {
         assert!(prepared_writes_require_filesystem_index_rebuild(
             &prepared_writes
         ));
-    }
-
-    #[test]
-    fn durable_plugin_checkpoint_is_bound_to_one_generation() {
-        let checkpoint =
-            WasmDurableDocumentCheckpoint::new(crate::Blob::from(&b"opaque-state"[..])).unwrap();
-        let encoded = encode_bound_plugin_checkpoint("generation-a", &checkpoint).unwrap();
-        let decoded = decode_bound_plugin_checkpoint(&encoded, "generation-a")
-            .expect("matching generation should restore");
-        assert_eq!(
-            WasmDurableDocumentCheckpoint::decode(&decoded).unwrap(),
-            crate::Blob::from(&b"opaque-state"[..])
-        );
-        assert!(decode_bound_plugin_checkpoint(&encoded, "generation-b").is_none());
     }
 
     #[test]

--- a/packages/engine/src/transaction/mod.rs
+++ b/packages/engine/src/transaction/mod.rs
@@ -3,6 +3,7 @@ mod bench_support;
 mod commit;
 mod context;
 mod normalization;
+pub(crate) mod plugin_checkpoint;
 mod schema_resolver;
 mod staging;
 pub(crate) mod types;

--- a/packages/engine/src/transaction/plugin_checkpoint.rs
+++ b/packages/engine/src/transaction/plugin_checkpoint.rs
@@ -1,0 +1,395 @@
+use bytes::Bytes;
+
+use crate::binary_cas::BlobHash;
+use crate::storage_adapter::{
+    PointReadPlan, ScanPlan, StorageAdapterRead, StorageCoreProjection, StorageGetOptions,
+    StorageKey, StoragePrefix, StorageProjectedValue, StorageScanOptions, StorageSpace,
+    StorageSpaceId, StorageValue, StorageWriteSet,
+};
+use crate::{Blob, LixError};
+
+pub(crate) const PLUGIN_CHECKPOINT_SPACE: StorageSpace =
+    StorageSpace::new(StorageSpaceId(0x0004_0026), "plugin.current_checkpoint.v1");
+
+const MAGIC: &[u8; 4] = b"LPC1";
+const HEADER_BYTES: usize = 4 + 32 + 32 + 4 + 4;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CurrentPluginCheckpoint {
+    pub(crate) runtime: Blob,
+    pub(crate) authority: Blob,
+}
+
+pub(crate) fn stage_current_plugin_checkpoint(
+    writes: &mut StorageWriteSet,
+    branch_id: &str,
+    file_id: &str,
+    generation: &str,
+    blob_hash: BlobHash,
+    runtime: &[u8],
+    authority: &[u8],
+) -> Result<(), LixError> {
+    let generation = BlobHash::from_hex(generation)?;
+    let runtime_len = u32::try_from(runtime.len()).map_err(|_| checkpoint_too_large())?;
+    let authority_len = u32::try_from(authority.len()).map_err(|_| checkpoint_too_large())?;
+    let capacity = HEADER_BYTES
+        .checked_add(runtime.len())
+        .and_then(|length| length.checked_add(authority.len()))
+        .ok_or_else(checkpoint_too_large)?;
+    let mut value = Vec::with_capacity(capacity);
+    value.extend_from_slice(MAGIC);
+    value.extend_from_slice(generation.as_bytes());
+    value.extend_from_slice(blob_hash.as_bytes());
+    value.extend_from_slice(&runtime_len.to_le_bytes());
+    value.extend_from_slice(&authority_len.to_le_bytes());
+    value.extend_from_slice(runtime);
+    value.extend_from_slice(authority);
+    writes.put(
+        PLUGIN_CHECKPOINT_SPACE,
+        checkpoint_key(branch_id, file_id)?,
+        StorageValue {
+            bytes: Bytes::from(value),
+        },
+    );
+    Ok(())
+}
+
+pub(crate) async fn stage_delete_current_plugin_checkpoints(
+    read: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    owners: &[(String, String)],
+) -> Result<(), LixError> {
+    let keys = owners
+        .iter()
+        .map(|(branch_id, file_id)| checkpoint_key(branch_id, file_id))
+        .collect::<Result<Vec<_>, _>>()?;
+    if keys.is_empty() {
+        return Ok(());
+    }
+    let existing = PointReadPlan::new(PLUGIN_CHECKPOINT_SPACE, &keys)
+        .materialize(
+            read,
+            StorageGetOptions {
+                projection: StorageCoreProjection::KeyOnly,
+            },
+        )
+        .await?
+        .value;
+    writes.delete_batch(
+        PLUGIN_CHECKPOINT_SPACE,
+        keys.into_iter()
+            .zip(existing)
+            .filter_map(|(key, value)| value.is_some().then_some(key)),
+    );
+    Ok(())
+}
+
+/// Deletes every derived checkpoint owned by a branch lifecycle record.
+///
+/// Checkpoints are a current-state accelerator, not repository history. Like
+/// an index maintained beside an MVCC log, their lifetime follows the current
+/// owner and a branch deletion removes the entire UUID-prefixed key range.
+pub(crate) async fn stage_delete_branch_plugin_checkpoints(
+    read: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    branch_id: &str,
+) -> Result<(), LixError> {
+    let branch_id = uuid::Uuid::parse_str(branch_id).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("plugin checkpoint branch id is not a UUID: {error}"),
+        )
+    })?;
+    let plan = ScanPlan::prefix(
+        PLUGIN_CHECKPOINT_SPACE,
+        StoragePrefix {
+            bytes: Bytes::copy_from_slice(branch_id.as_bytes()),
+        },
+    );
+    let mut resume_after = None;
+    loop {
+        let chunk = plan
+            .collect(
+                read,
+                StorageScanOptions {
+                    projection: StorageCoreProjection::KeyOnly,
+                    resume_after: resume_after.clone(),
+                    ..StorageScanOptions::default()
+                },
+            )
+            .await?
+            .value;
+        if chunk.entries.is_empty() {
+            break;
+        }
+        resume_after = chunk.entries.last().map(|entry| entry.key.clone());
+        writes.delete_batch(
+            PLUGIN_CHECKPOINT_SPACE,
+            chunk.entries.into_iter().map(|entry| entry.key),
+        );
+        if !chunk.has_more {
+            break;
+        }
+    }
+    Ok(())
+}
+
+pub(crate) async fn load_current_plugin_checkpoint(
+    read: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    file_id: &str,
+    generation: &str,
+    blob_hash: BlobHash,
+) -> Result<Option<CurrentPluginCheckpoint>, LixError> {
+    let expected_generation = BlobHash::from_hex(generation)?;
+    let values = PointReadPlan::new(
+        PLUGIN_CHECKPOINT_SPACE,
+        &[checkpoint_key(branch_id, file_id)?],
+    )
+    .materialize(
+        read,
+        StorageGetOptions {
+            projection: StorageCoreProjection::FullValue,
+        },
+    )
+    .await?
+    .value;
+    let Some(StorageProjectedValue::FullValue(value)) = values.into_iter().next().flatten() else {
+        return Ok(None);
+    };
+    let Some(header) = value.get(..HEADER_BYTES) else {
+        return Ok(None);
+    };
+    if &header[..4] != MAGIC
+        || header[4..36] != expected_generation.as_bytes()[..]
+        || header[36..68] != blob_hash.as_bytes()[..]
+    {
+        return Ok(None);
+    }
+    let runtime_len = u32::from_le_bytes(header[68..72].try_into().expect("runtime length"));
+    let authority_len = u32::from_le_bytes(header[72..76].try_into().expect("authority length"));
+    let runtime_len = runtime_len as usize;
+    let authority_len = authority_len as usize;
+    let runtime_end = HEADER_BYTES
+        .checked_add(runtime_len)
+        .filter(|end| *end <= value.len());
+    let value_end = runtime_end
+        .and_then(|end| end.checked_add(authority_len))
+        .filter(|end| *end == value.len());
+    let (Some(runtime_end), Some(value_end)) = (runtime_end, value_end) else {
+        return Ok(None);
+    };
+    Ok(Some(CurrentPluginCheckpoint {
+        runtime: value.slice(HEADER_BYTES..runtime_end).into(),
+        authority: value.slice(runtime_end..value_end).into(),
+    }))
+}
+
+fn checkpoint_key(branch_id: &str, file_id: &str) -> Result<StorageKey, LixError> {
+    let branch_id = uuid::Uuid::parse_str(branch_id).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("plugin checkpoint branch id is not a UUID: {error}"),
+        )
+    })?;
+    let file_id = uuid::Uuid::parse_str(file_id).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("plugin checkpoint file id is not a UUID: {error}"),
+        )
+    })?;
+    let mut key = Vec::with_capacity(32);
+    key.extend_from_slice(branch_id.as_bytes());
+    key.extend_from_slice(file_id.as_bytes());
+    Ok(StorageKey(Bytes::from(key)))
+}
+
+fn checkpoint_too_large() -> LixError {
+    LixError::new(
+        LixError::CODE_PLUGIN_RESOURCE_LIMIT,
+        "plugin checkpoint exceeds the current-checkpoint storage limit",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage_adapter::{Memory, StorageAdapter, StorageReadOptions, StorageWriteOptions};
+
+    const BRANCH_ID: &str = "01920000-0000-7000-8000-000000000001";
+    const OTHER_BRANCH_ID: &str = "01920000-0000-7000-8000-000000000003";
+    const FILE_ID: &str = "01920000-0000-7000-8000-000000000002";
+
+    #[tokio::test]
+    async fn current_checkpoint_overwrites_and_is_bound_to_generation_and_blob() {
+        let storage = StorageAdapter::new(Memory::new());
+        let generation = BlobHash::from_content(b"generation");
+        let first_blob = BlobHash::from_content(b"first");
+        let second_blob = BlobHash::from_content(b"second");
+
+        for (blob_hash, runtime, authority) in [
+            (
+                first_blob,
+                b"runtime-one".as_slice(),
+                b"authority-one".as_slice(),
+            ),
+            (
+                second_blob,
+                b"runtime-two".as_slice(),
+                b"authority-two".as_slice(),
+            ),
+        ] {
+            let mut writes = storage.new_write_set();
+            stage_current_plugin_checkpoint(
+                &mut writes,
+                BRANCH_ID,
+                FILE_ID,
+                &generation.to_hex(),
+                blob_hash,
+                runtime,
+                authority,
+            )
+            .unwrap();
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .unwrap();
+        }
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .unwrap();
+        assert!(
+            load_current_plugin_checkpoint(
+                &read,
+                BRANCH_ID,
+                FILE_ID,
+                &generation.to_hex(),
+                first_blob,
+            )
+            .await
+            .unwrap()
+            .is_none()
+        );
+        assert!(
+            load_current_plugin_checkpoint(
+                &read,
+                BRANCH_ID,
+                FILE_ID,
+                &BlobHash::from_content(b"other-generation").to_hex(),
+                second_blob,
+            )
+            .await
+            .unwrap()
+            .is_none()
+        );
+        let checkpoint = load_current_plugin_checkpoint(
+            &read,
+            BRANCH_ID,
+            FILE_ID,
+            &generation.to_hex(),
+            second_blob,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(checkpoint.runtime.as_ref(), b"runtime-two");
+        assert_eq!(checkpoint.authority.as_ref(), b"authority-two");
+    }
+
+    #[tokio::test]
+    async fn checkpoint_cleanup_follows_file_and_branch_lifetimes() {
+        let storage = StorageAdapter::new(Memory::new());
+        let generation = BlobHash::from_content(b"generation");
+        let blob_hash = BlobHash::from_content(b"file");
+        let mut writes = storage.new_write_set();
+        for branch_id in [BRANCH_ID, OTHER_BRANCH_ID] {
+            stage_current_plugin_checkpoint(
+                &mut writes,
+                branch_id,
+                FILE_ID,
+                &generation.to_hex(),
+                blob_hash,
+                b"runtime",
+                b"authority",
+            )
+            .unwrap();
+        }
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .unwrap();
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .unwrap();
+        let mut writes = storage.new_write_set();
+        stage_delete_branch_plugin_checkpoints(&read, &mut writes, BRANCH_ID)
+            .await
+            .unwrap();
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .unwrap();
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .unwrap();
+        assert!(
+            load_current_plugin_checkpoint(
+                &read,
+                BRANCH_ID,
+                FILE_ID,
+                &generation.to_hex(),
+                blob_hash,
+            )
+            .await
+            .unwrap()
+            .is_none()
+        );
+        assert!(
+            load_current_plugin_checkpoint(
+                &read,
+                OTHER_BRANCH_ID,
+                FILE_ID,
+                &generation.to_hex(),
+                blob_hash,
+            )
+            .await
+            .unwrap()
+            .is_some()
+        );
+
+        let mut writes = storage.new_write_set();
+        stage_delete_current_plugin_checkpoints(
+            &read,
+            &mut writes,
+            &[(OTHER_BRANCH_ID.to_owned(), FILE_ID.to_owned())],
+        )
+        .await
+        .unwrap();
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .unwrap();
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .unwrap();
+        assert!(
+            load_current_plugin_checkpoint(
+                &read,
+                OTHER_BRANCH_ID,
+                FILE_ID,
+                &generation.to_hex(),
+                blob_hash,
+            )
+            .await
+            .unwrap()
+            .is_none()
+        );
+    }
+}

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -1438,8 +1438,7 @@ pub(crate) struct TransactionFileData {
     /// Plugin installation uses this for the extracted WASM component so
     /// steady-state reads can load it directly without reopening the archive.
     auxiliary_payloads: Vec<BlobPayload>,
-    plugin_state_checkpoint_hash: Option<BlobHash>,
-    plugin_authority_checkpoint_hash: Option<BlobHash>,
+    plugin_checkpoint: Option<PluginCheckpointWrite>,
     /// Reconciliation may retain this record only as the owner of certified
     /// semantic batches after its file payload has already been materialized
     /// through the ordinary plugin path.
@@ -1473,8 +1472,7 @@ impl TransactionFileData {
             mutation_identity: None,
             payload: BlobPayload::from_bytes(data),
             auxiliary_payloads: Vec::new(),
-            plugin_state_checkpoint_hash: None,
-            plugin_authority_checkpoint_hash: None,
+            plugin_checkpoint: None,
             stage_payload_at_commit: true,
             certified_entity_batches: Vec::new(),
         }
@@ -1516,22 +1514,19 @@ impl TransactionFileData {
 
     pub(crate) fn set_plugin_checkpoint(
         &mut self,
-        state: impl Into<crate::Blob>,
-        state_hash: BlobHash,
+        generation: String,
+        runtime: impl Into<crate::Blob>,
         authority: impl Into<crate::Blob>,
-        authority_hash: BlobHash,
     ) {
-        let state = BlobPayload::from_hashed_bytes(state, state_hash);
-        let authority = BlobPayload::from_hashed_bytes(authority, authority_hash);
-        self.plugin_state_checkpoint_hash = Some(state_hash);
-        self.plugin_authority_checkpoint_hash = Some(authority_hash);
-        self.auxiliary_payloads.push(state);
-        self.auxiliary_payloads.push(authority);
+        self.plugin_checkpoint = Some(PluginCheckpointWrite {
+            generation,
+            runtime: runtime.into(),
+            authority: authority.into(),
+        });
     }
 
-    pub(crate) fn plugin_checkpoint_hashes(&self) -> Option<(BlobHash, BlobHash)> {
-        self.plugin_state_checkpoint_hash
-            .zip(self.plugin_authority_checkpoint_hash)
+    pub(crate) fn plugin_checkpoint(&self) -> Option<&PluginCheckpointWrite> {
+        self.plugin_checkpoint.as_ref()
     }
 
     pub(crate) fn set_certified_entity_batches(&mut self, batches: Vec<WasmCertifiedEntityBatch>) {
@@ -1648,6 +1643,13 @@ impl TransactionFileData {
     pub(crate) fn is_empty(&self) -> bool {
         self.payload.is_empty()
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PluginCheckpointWrite {
+    pub(crate) generation: String,
+    pub(crate) runtime: crate::Blob,
+    pub(crate) authority: crate::Blob,
 }
 
 /// One decoded write batch accepted by the transaction boundary.


### PR DESCRIPTION
## What changed

- hard-cut plugin checkpoints out of immutable CAS/history into a current-state storage space keyed by raw branch/file UUIDs
- bind every opaque WASM checkpoint to plugin generation and current file blob hash
- atomically overwrite checkpoints with file/semantic/head publication and clean them on raw writes, file deletion, and branch deletion
- remove checkpoint hashes from `lix_binary_blob_ref` and bump the repository protocol to v39
- add complete binary-CAS owner/chunk accounting and before/after evidence

The engine/API remains plugin-general: it stores opaque runtime and authority bytes and contains no Git, text, binary, LFS, extension, media-type, or plugin-name policy.

## Result

Across VS Code Docs (100 commits), Home Assistant Brands (80), and Wesnoth (15), both RocksDB and SlateDB:

- physical storage: **185,003,378 → 156,934,545 bytes (-15.17%)**
- replay time: **10,412.081 → 10,192.712 ms (-2.11%)**
- VS Code: **-17.32% RocksDB**, **-21.13% SlateDB**
- Brands media-heavy control: flat
- all final Git trees verified; 97 LFS objects / 42,011,887 logical bytes unchanged

Matched CRUD/diff/merge/cold-open medians remain within noise or improve. Full methodology, rejected prototypes, byte ownership, branch accounting, and established database references are in `packages/engine-benchmarks/benches/current_plugin_checkpoint_results.md`.

## Validation

- `cargo test -p lix_engine --features all-simulations`
- RocksDB, SlateDB, and SQLite storage conformance suites
- `cargo check -p lix_engine_benchmarks --all-features --all-targets`
- `cargo test -p lix_sdk_tests --test git_text_plugin`
- matched 524 KB Markdown CRUD/merge/cold-open benchmark
- six all-plugin Git replay runs with final-tree verification

No changenote: this is an intentional storage protocol hard cut.