### PR TITLE
Bind current plugin checkpoints to semantic roots

### DIFF
--- a/packages/engine-benchmarks/benches/current_plugin_checkpoint_results.md
+++ b/packages/engine-benchmarks/benches/current_plugin_checkpoint_results.md
@@ -3,10 +3,11 @@
 This hard cut moves rebuildable plugin checkpoints out of immutable repository
 history. A checkpoint is now one current value keyed by the raw 16-byte branch
 UUID and 16-byte file UUID. Each update overwrites that value atomically with
-the file, semantic rows, and branch head. Generation and file-blob hashes in
-the value fence stale state; malformed or mismatched cache data is ignored and
-rebuilt. Raw writes and file deletion remove the exact owner key, while branch
-deletion removes its UUID-prefixed key range.
+the file, semantic rows, and branch head. The plugin generation, file-blob
+hash, and raw 16-byte Lix semantic-root UUID fence stale state; malformed or
+mismatched cache data is ignored and rebuilt. Raw writes and file deletion
+remove the exact owner key, while branch deletion removes its UUID-prefixed key
+range.
 
 The boundary is format-neutral. The engine stores opaque runtime and authority
 bytes produced by any WASM component plugin. It contains no Git, text, binary,
@@ -33,7 +34,7 @@ This follows established database practice:
 ## Git replay corpus
 
 The baseline is `main` at `3a792c12d`; the candidate release binary SHA-256 is
-`41826a32edb748412bf4ef48246f7ce598f333c5613137025d5bf0669b4c32ec`.
+`10e9285f746800ae86ff303296a962aa7b803bbcbf7d464d453310d6576df239`.
 Every successful run used `lix exp git-replay --plugins all`, a scoped parent
 bootstrap, periodic checkpoints, explicit adapter flush, and final Git-tree
 verification. RocksDB bytes are the closed database directory. SlateDB bytes
@@ -42,13 +43,13 @@ close-timing-dependent WAL and manifest control files.
 
 | repository | adapter | replay before | replay after | time delta | bytes before | bytes after | size delta |
 | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| `microsoft/vscode-docs`, 100 commits | RocksDB | 4668.278 ms | 4496.238 ms | -3.69% | 72,622,119 | 60,044,560 | -17.32% |
-| `microsoft/vscode-docs`, 100 commits | SlateDB | 4809.890 ms | 4761.489 ms | -1.01% | 72,151,959 | 56,906,626 | -21.13% |
-| `home-assistant/brands`, 80 commits | RocksDB | 313.681 ms | 309.614 ms | -1.30% | 15,853,294 | 15,840,929 | -0.08% |
-| `home-assistant/brands`, 80 commits | SlateDB | 374.387 ms | 377.196 ms | +0.75% | 15,727,248 | 15,715,604 | -0.07% |
-| `wesnoth/wesnoth`, 15 commits | RocksDB | 121.232 ms | 124.242 ms | +2.48% | 4,345,582 | 4,233,493 | -2.58% |
-| `wesnoth/wesnoth`, 15 commits | SlateDB | 124.612 ms | 123.935 ms | -0.54% | 4,303,176 | 4,193,333 | -2.55% |
-| **aggregate** | | **10412.081 ms** | **10192.712 ms** | **-2.11%** | **185,003,378** | **156,934,545** | **-15.17%** |
+| `microsoft/vscode-docs`, 100 commits | RocksDB | 4668.278 ms | 4500.058 ms | -3.60% | 72,622,119 | 60,051,838 | -17.31% |
+| `microsoft/vscode-docs`, 100 commits | SlateDB | 4809.890 ms | 4695.012 ms | -2.39% | 72,151,959 | 56,912,396 | -21.12% |
+| `home-assistant/brands`, 80 commits | RocksDB | 313.681 ms | 311.152 ms | -0.81% | 15,853,294 | 15,841,120 | -0.08% |
+| `home-assistant/brands`, 80 commits | SlateDB | 374.387 ms | 370.679 ms | -0.99% | 15,727,248 | 15,715,693 | -0.07% |
+| `wesnoth/wesnoth`, 15 commits | RocksDB | 121.232 ms | 121.650 ms | +0.34% | 4,345,582 | 4,234,177 | -2.56% |
+| `wesnoth/wesnoth`, 15 commits | SlateDB | 124.612 ms | 126.817 ms | +1.77% | 4,303,176 | 4,194,632 | -2.52% |
+| **aggregate** | | **10412.081 ms** | **10125.368 ms** | **-2.75%** | **185,003,378** | **156,949,856** | **-15.16%** |
 
 All six final trees verified. VS Code materialized the same 97 unique Git LFS
 objects and 42,011,887 logical LFS bytes; Brands and Wesnoth materialized none.
@@ -77,11 +78,11 @@ every binary-CAS manifest to its owning hash field, and emits an explicit
 Before the hard cut, VS Code had 1,967 runtime-checkpoint manifests carrying
 17,653,016 logical bytes and 886 authority-checkpoint manifests carrying
 2,053,864 bytes. The candidate removes all 2,853 historical manifests. It
-retains 360 current checkpoint rows with 3,141,505 runtime bytes and 133,544
+retains 360 current checkpoint rows with 3,141,586 runtime bytes and 133,544
 authority bytes. All 360 runtime payloads are unique; 358 authority payloads
 are unique, and the only exact duplicates total 40 bytes. Immutable binary-CAS
 chunk values fall from 67,267,601 to 49,402,074 bytes. The current checkpoint
-space occupies 3,238,123 compressed physical bytes. All 689 encoded chunk
+space occupies 3,244,227 compressed physical bytes. All 689 encoded chunk
 values are reachable from exactly one reported owner category; none is orphaned
 or shared across categories.
 

--- a/packages/engine-benchmarks/examples/storage_layout.rs
+++ b/packages/engine-benchmarks/examples/storage_layout.rs
@@ -207,7 +207,7 @@ async fn print_binary_cas_owners(read: &impl lix_engine::storage_adapter::Storag
 async fn print_plugin_checkpoint_layout(
     read: &impl lix_engine::storage_adapter::StorageAdapterRead,
 ) {
-    const HEADER_BYTES: usize = 76;
+    const HEADER_BYTES: usize = 92;
 
     let inventory = space_inventory(read, "plugin.current_checkpoint.v1").await;
     let mut runtime_bytes = 0_u64;
@@ -216,12 +216,12 @@ async fn print_plugin_checkpoint_layout(
     let mut unique_authority = BTreeSet::new();
     for (_key, value) in &inventory {
         let runtime_len = u32::from_le_bytes(
-            value[68..72]
+            value[84..88]
                 .try_into()
                 .expect("plugin checkpoint runtime length"),
         ) as usize;
         let authority_len = u32::from_le_bytes(
-            value[72..76]
+            value[88..92]
                 .try_into()
                 .expect("plugin checkpoint authority length"),
         ) as usize;

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -243,6 +243,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
                     &write.branch_id,
                     &write.file_id,
                     &checkpoint.generation,
+                    &checkpoint.semantic_root,
                     write
                         .blob_hash()
                         .unwrap_or_else(|| crate::binary_cas::BlobHash::from_content(write.data())),

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -4125,6 +4125,7 @@ where
                                         &actor_key.branch_id,
                                         &actor_key.file_id,
                                         &actor_key.plugin_generation,
+                                        &visible_materialization.semantic_root,
                                         checkpoint_blob_hash,
                                     )
                                     .await
@@ -8099,10 +8100,10 @@ impl PluginWriteReconciliation {
     ) -> Result<(), LixError> {
         let mut checkpoints = BTreeMap::<
             (String, String),
-            (WasmDurableDocumentCheckpoint, crate::Blob, String),
+            (WasmDurableDocumentCheckpoint, crate::Blob, String, String),
         >::new();
         for publication in &self.actor_publications {
-            let Some((branch_id, file_id, generation, checkpoint, authorities)) =
+            let Some((branch_id, file_id, generation, semantic_root, checkpoint, authorities)) =
                 publication.durable_checkpoint()
             else {
                 continue;
@@ -8114,10 +8115,17 @@ impl PluginWriteReconciliation {
             };
             checkpoints.insert(
                 (branch_id.to_owned(), file_id.to_owned()),
-                (checkpoint, authority.into(), generation.to_owned()),
+                (
+                    checkpoint,
+                    authority.into(),
+                    generation.to_owned(),
+                    semantic_root.to_string(),
+                ),
             );
         }
-        for ((branch_id, file_id), (checkpoint, authority, generation)) in checkpoints {
+        for ((branch_id, file_id), (checkpoint, authority, generation, semantic_root)) in
+            checkpoints
+        {
             if self
                 .derived_materializations
                 .keys()
@@ -8136,7 +8144,7 @@ impl PluginWriteReconciliation {
                         ),
                     )
                 })?;
-            write.set_plugin_checkpoint(generation, checkpoint.bytes(), authority);
+            write.set_plugin_checkpoint(generation, semantic_root, checkpoint.bytes(), authority);
         }
         Ok(())
     }
@@ -8188,6 +8196,7 @@ enum PendingPluginActorPublication {
         key: PluginActorKey,
         view: PendingPluginActorView,
         checkpoint: Option<PluginActorStagedCheckpoint>,
+        semantic_root: Option<Arc<str>>,
         durable_checkpoint: Option<WasmDurableDocumentCheckpoint>,
         entity_authorities: PluginEntityAuthorities,
     },
@@ -8201,10 +8210,14 @@ impl PendingPluginActorPublication {
                 successor_key,
                 view,
             } => {
-                let durable_checkpoint = lease
-                    .successor_checkpoint()
-                    .and_then(|(_, _, checkpoint)| checkpoint)
+                let successor_checkpoint = lease.successor_checkpoint();
+                let durable_checkpoint = successor_checkpoint
+                    .as_ref()
+                    .and_then(|(_, _, checkpoint)| checkpoint.as_ref())
                     .and_then(|checkpoint| checkpoint.durable_checkpoint());
+                let semantic_root = successor_checkpoint
+                    .as_ref()
+                    .map(|(_, semantic_root, _)| Arc::clone(semantic_root));
                 let entity_authorities = lease
                     .successor_entity_authorities()
                     .cloned()
@@ -8220,6 +8233,7 @@ impl PendingPluginActorPublication {
                     key: successor_key,
                     view,
                     checkpoint,
+                    semantic_root,
                     durable_checkpoint,
                     entity_authorities,
                 }
@@ -8239,13 +8253,14 @@ impl PendingPluginActorPublication {
                     .as_ref()
                     .and_then(WasmDocumentCheckpoint::durable_checkpoint);
                 let staged_checkpoint =
-                    cache.stage_checkpoint(key.clone(), semantic_root, checkpoint);
+                    cache.stage_checkpoint(key.clone(), Arc::clone(&semantic_root), checkpoint);
                 let _ = store.actor_mut().drop_document(document).await;
                 let _ = store.actor_mut().retire().await;
                 Self::Uncached {
                     key,
                     view,
                     checkpoint: staged_checkpoint,
+                    semantic_root: Some(semantic_root),
                     durable_checkpoint,
                     entity_authorities,
                 }
@@ -8349,6 +8364,7 @@ impl PendingPluginActorPublication {
         &str,
         &str,
         &str,
+        Arc<str>,
         WasmDurableDocumentCheckpoint,
         &PluginEntityAuthorities,
     )> {
@@ -8357,23 +8373,26 @@ impl PendingPluginActorPublication {
                 lease,
                 successor_key,
                 ..
-            } => lease
-                .successor_checkpoint()
-                .and_then(|(_, _, checkpoint)| checkpoint)
-                .and_then(|checkpoint| checkpoint.durable_checkpoint())
-                .zip(lease.successor_entity_authorities())
-                .map(|(bytes, authorities)| {
-                    (
-                        successor_key.branch_id.as_str(),
-                        successor_key.file_id.as_str(),
-                        successor_key.plugin_generation.as_str(),
-                        bytes,
-                        authorities,
-                    )
-                }),
+            } => {
+                let (_, semantic_root, checkpoint) = lease.successor_checkpoint()?;
+                checkpoint
+                    .and_then(|checkpoint| checkpoint.durable_checkpoint())
+                    .zip(lease.successor_entity_authorities())
+                    .map(|(bytes, authorities)| {
+                        (
+                            successor_key.branch_id.as_str(),
+                            successor_key.file_id.as_str(),
+                            successor_key.plugin_generation.as_str(),
+                            semantic_root,
+                            bytes,
+                            authorities,
+                        )
+                    })
+            }
             Self::New {
                 key,
                 checkpoint,
+                semantic_root,
                 entity_authorities,
                 ..
             } => checkpoint
@@ -8384,24 +8403,29 @@ impl PendingPluginActorPublication {
                         key.branch_id.as_str(),
                         key.file_id.as_str(),
                         key.plugin_generation.as_str(),
+                        Arc::clone(semantic_root),
                         bytes,
                         entity_authorities,
                     )
                 }),
             Self::Uncached {
                 key,
+                semantic_root,
                 durable_checkpoint,
                 entity_authorities,
                 ..
-            } => durable_checkpoint.clone().map(|bytes| {
-                (
-                    key.branch_id.as_str(),
-                    key.file_id.as_str(),
-                    key.plugin_generation.as_str(),
-                    bytes,
-                    entity_authorities,
-                )
-            }),
+            } => durable_checkpoint.clone().zip(semantic_root.clone()).map(
+                |(bytes, semantic_root)| {
+                    (
+                        key.branch_id.as_str(),
+                        key.file_id.as_str(),
+                        key.plugin_generation.as_str(),
+                        semantic_root,
+                        bytes,
+                        entity_authorities,
+                    )
+                },
+            ),
         }
     }
 

--- a/packages/engine/src/transaction/plugin_checkpoint.rs
+++ b/packages/engine/src/transaction/plugin_checkpoint.rs
@@ -11,8 +11,8 @@ use crate::{Blob, LixError};
 pub(crate) const PLUGIN_CHECKPOINT_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_0026), "plugin.current_checkpoint.v1");
 
-const MAGIC: &[u8; 4] = b"LPC1";
-const HEADER_BYTES: usize = 4 + 32 + 32 + 4 + 4;
+const MAGIC: &[u8; 4] = b"LPC2";
+const HEADER_BYTES: usize = 4 + 32 + 32 + 16 + 4 + 4;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CurrentPluginCheckpoint {
@@ -25,11 +25,13 @@ pub(crate) fn stage_current_plugin_checkpoint(
     branch_id: &str,
     file_id: &str,
     generation: &str,
+    semantic_root: &str,
     blob_hash: BlobHash,
     runtime: &[u8],
     authority: &[u8],
 ) -> Result<(), LixError> {
     let generation = BlobHash::from_hex(generation)?;
+    let semantic_root = parse_semantic_root(semantic_root)?;
     let runtime_len = u32::try_from(runtime.len()).map_err(|_| checkpoint_too_large())?;
     let authority_len = u32::try_from(authority.len()).map_err(|_| checkpoint_too_large())?;
     let capacity = HEADER_BYTES
@@ -40,6 +42,7 @@ pub(crate) fn stage_current_plugin_checkpoint(
     value.extend_from_slice(MAGIC);
     value.extend_from_slice(generation.as_bytes());
     value.extend_from_slice(blob_hash.as_bytes());
+    value.extend_from_slice(semantic_root.as_bytes());
     value.extend_from_slice(&runtime_len.to_le_bytes());
     value.extend_from_slice(&authority_len.to_le_bytes());
     value.extend_from_slice(runtime);
@@ -139,9 +142,11 @@ pub(crate) async fn load_current_plugin_checkpoint(
     branch_id: &str,
     file_id: &str,
     generation: &str,
+    semantic_root: &str,
     blob_hash: BlobHash,
 ) -> Result<Option<CurrentPluginCheckpoint>, LixError> {
     let expected_generation = BlobHash::from_hex(generation)?;
+    let expected_semantic_root = parse_semantic_root(semantic_root)?;
     let values = PointReadPlan::new(
         PLUGIN_CHECKPOINT_SPACE,
         &[checkpoint_key(branch_id, file_id)?],
@@ -163,11 +168,12 @@ pub(crate) async fn load_current_plugin_checkpoint(
     if &header[..4] != MAGIC
         || header[4..36] != expected_generation.as_bytes()[..]
         || header[36..68] != blob_hash.as_bytes()[..]
+        || header[68..84] != expected_semantic_root.as_bytes()[..]
     {
         return Ok(None);
     }
-    let runtime_len = u32::from_le_bytes(header[68..72].try_into().expect("runtime length"));
-    let authority_len = u32::from_le_bytes(header[72..76].try_into().expect("authority length"));
+    let runtime_len = u32::from_le_bytes(header[84..88].try_into().expect("runtime length"));
+    let authority_len = u32::from_le_bytes(header[88..92].try_into().expect("authority length"));
     let runtime_len = runtime_len as usize;
     let authority_len = authority_len as usize;
     let runtime_end = HEADER_BYTES
@@ -183,6 +189,15 @@ pub(crate) async fn load_current_plugin_checkpoint(
         runtime: value.slice(HEADER_BYTES..runtime_end).into(),
         authority: value.slice(runtime_end..value_end).into(),
     }))
+}
+
+fn parse_semantic_root(semantic_root: &str) -> Result<uuid::Uuid, LixError> {
+    uuid::Uuid::parse_str(semantic_root).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("plugin checkpoint semantic root is not a UUID: {error}"),
+        )
+    })
 }
 
 fn checkpoint_key(branch_id: &str, file_id: &str) -> Result<StorageKey, LixError> {
@@ -219,9 +234,11 @@ mod tests {
     const BRANCH_ID: &str = "01920000-0000-7000-8000-000000000001";
     const OTHER_BRANCH_ID: &str = "01920000-0000-7000-8000-000000000003";
     const FILE_ID: &str = "01920000-0000-7000-8000-000000000002";
+    const SEMANTIC_ROOT: &str = "01920000-0000-7000-8000-000000000004";
+    const OTHER_SEMANTIC_ROOT: &str = "01920000-0000-7000-8000-000000000005";
 
     #[tokio::test]
-    async fn current_checkpoint_overwrites_and_is_bound_to_generation_and_blob() {
+    async fn current_checkpoint_overwrites_and_is_bound_to_generation_blob_and_semantic_root() {
         let storage = StorageAdapter::new(Memory::new());
         let generation = BlobHash::from_content(b"generation");
         let first_blob = BlobHash::from_content(b"first");
@@ -245,6 +262,7 @@ mod tests {
                 BRANCH_ID,
                 FILE_ID,
                 &generation.to_hex(),
+                SEMANTIC_ROOT,
                 blob_hash,
                 runtime,
                 authority,
@@ -266,6 +284,7 @@ mod tests {
                 BRANCH_ID,
                 FILE_ID,
                 &generation.to_hex(),
+                SEMANTIC_ROOT,
                 first_blob,
             )
             .await
@@ -278,6 +297,20 @@ mod tests {
                 BRANCH_ID,
                 FILE_ID,
                 &BlobHash::from_content(b"other-generation").to_hex(),
+                SEMANTIC_ROOT,
+                second_blob,
+            )
+            .await
+            .unwrap()
+            .is_none()
+        );
+        assert!(
+            load_current_plugin_checkpoint(
+                &read,
+                BRANCH_ID,
+                FILE_ID,
+                &generation.to_hex(),
+                OTHER_SEMANTIC_ROOT,
                 second_blob,
             )
             .await
@@ -289,6 +322,7 @@ mod tests {
             BRANCH_ID,
             FILE_ID,
             &generation.to_hex(),
+            SEMANTIC_ROOT,
             second_blob,
         )
         .await
@@ -310,6 +344,7 @@ mod tests {
                 branch_id,
                 FILE_ID,
                 &generation.to_hex(),
+                SEMANTIC_ROOT,
                 blob_hash,
                 b"runtime",
                 b"authority",
@@ -344,6 +379,7 @@ mod tests {
                 BRANCH_ID,
                 FILE_ID,
                 &generation.to_hex(),
+                SEMANTIC_ROOT,
                 blob_hash,
             )
             .await
@@ -356,6 +392,7 @@ mod tests {
                 OTHER_BRANCH_ID,
                 FILE_ID,
                 &generation.to_hex(),
+                SEMANTIC_ROOT,
                 blob_hash,
             )
             .await
@@ -385,6 +422,7 @@ mod tests {
                 OTHER_BRANCH_ID,
                 FILE_ID,
                 &generation.to_hex(),
+                SEMANTIC_ROOT,
                 blob_hash,
             )
             .await

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -1515,11 +1515,13 @@ impl TransactionFileData {
     pub(crate) fn set_plugin_checkpoint(
         &mut self,
         generation: String,
+        semantic_root: String,
         runtime: impl Into<crate::Blob>,
         authority: impl Into<crate::Blob>,
     ) {
         self.plugin_checkpoint = Some(PluginCheckpointWrite {
             generation,
+            semantic_root,
             runtime: runtime.into(),
             authority: authority.into(),
         });
@@ -1648,6 +1650,7 @@ impl TransactionFileData {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PluginCheckpointWrite {
     pub(crate) generation: String,
+    pub(crate) semantic_root: String,
     pub(crate) runtime: crate::Blob,
     pub(crate) authority: crate::Blob,
 }


### PR DESCRIPTION
## Summary

- fence current plugin checkpoints by the raw 16-byte Lix semantic-root UUID in addition to plugin generation and file blob
- reject stale runtime and authority state after a branch repoints to a different semantic snapshot with identical rendered bytes
- keep the boundary plugin-neutral and update physical-layout accounting for the 92-byte record header

Follow-up to #1062. No changenote: this completes the unreleased hard-cut storage format.

## Verification

- `cargo test -p lix_engine --features all-simulations`: 1,664 passed; 800 base/rebuild simulations passed
- `RUST_MIN_STACK=16777216 cargo test -p lix_engine_benchmarks --all-features --tests`: passed
- `cargo test --manifest-path plugins/text/Cargo.toml --all-features`: 12 passed
- SDK derived cold-hydration regression test passed
- all-plugin Git replay final trees verified on VS Code Docs (100 commits), Home Assistant Brands (80), and Wesnoth (15), on RocksDB and SlateDB

## Benchmark refresh

The 16-byte fence adds 15,311 physical bytes across all six replay databases. Aggregate storage remains **156,949,856 vs 185,003,378 bytes (-15.16%)**, and aggregate replay time is **10,125.368 vs 10,412.081 ms (-2.75%)**. VS Code LFS remains 97 objects / 42,011,887 logical bytes. Full before/after data and ownership accounting are in `packages/engine-benchmarks/benches/current_plugin_checkpoint_results.md`.