### PR TITLE
perf(engine): remove bulk update materialization copies

### DIFF
--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -2784,25 +2784,16 @@ async fn load_packed_current_base_exact_entries(
         return Ok((0..keys.len()).map(|_| None).collect());
     }
     if let [base_ref] = base_refs.as_slice() {
-        let requests = keys
-            .iter()
-            .map(|key| {
-                (
-                    base_ref.commit_id,
-                    TrackedStateKey {
-                        schema_key: key.schema_key.to_owned(),
-                        file_id: key.file_id.map(str::to_owned),
-                        entity_pk: key.entity_pk.clone(),
-                    },
-                )
-            })
-            .collect::<Vec<_>>();
         return Ok(
-            crate::tracked_state::load_owned_commit_delta_entries(store, &requests)
-                .await?
-                .into_iter()
-                .map(|entry| entry.map(|entry| (entry.value, entry.change_record)))
-                .collect(),
+            crate::tracked_state::load_owned_commit_delta_entries_one_ordered_ref(
+                store,
+                base_ref.commit_id,
+                keys,
+            )
+            .await?
+            .into_iter()
+            .map(|entry| entry.map(|entry| (entry.value, entry.change_record)))
+            .collect(),
         );
     }
     let owned_keys = keys
@@ -2901,9 +2892,15 @@ fn compare_materialized_live_identity_refs(
 /// Merge two identity-ordered materialized batches without expanding their
 /// dictionary and payload columns into row-owned DTOs.
 fn merge_ordered_live_batches(
-    left: &MaterializedLiveStateBatch,
-    right: &MaterializedLiveStateBatch,
+    left: MaterializedLiveStateBatch,
+    right: MaterializedLiveStateBatch,
 ) -> MaterializedLiveStateBatch {
+    if left.is_empty() {
+        return right;
+    }
+    if right.is_empty() {
+        return left;
+    }
     let mut merged =
         MaterializedLiveStateBatchBuilder::with_capacity(left.len().saturating_add(right.len()));
     let mut left_index = 0usize;
@@ -3323,8 +3320,8 @@ where
                 None,
             )
         };
-        let combined = merge_ordered_live_batches(&rows, &packed_rows);
-        let rows = merge_ordered_live_batches(&combined, &certified_rows);
+        let combined = merge_ordered_live_batches(rows, packed_rows);
+        let rows = merge_ordered_live_batches(combined, certified_rows);
         if request.filter.include_tombstones
             && request.limit.is_none()
             && replaced_generation.is_none()

--- a/packages/engine/src/live_state/visibility.rs
+++ b/packages/engine/src/live_state/visibility.rs
@@ -84,6 +84,23 @@ pub(crate) fn resolve_visible_batch(
     request: &VisibilityRequest,
 ) -> MaterializedLiveStateBatch {
     let requested_branch_ids = requested_branch_ids(&request.branch_scope);
+    if staged_rows.is_empty()
+        && request.limit.is_none_or(|limit| base_rows.len() <= limit)
+        && base_rows.iter().all(|row| {
+            (request.include_tombstones || !row.deleted())
+                && (requested_branch_ids.is_empty()
+                    || (!row.global()
+                        && requested_branch_ids
+                            .iter()
+                            .any(|branch_id| branch_id == row.branch_id())))
+        })
+        && base_rows
+            .iter()
+            .map(materialized_row_identity)
+            .is_sorted_by(|left, right| left < right)
+    {
+        return base_rows;
+    }
     resolve_live_state_batch(
         &base_rows,
         &staged_rows,
@@ -91,6 +108,15 @@ pub(crate) fn resolve_visible_batch(
         request.include_tombstones,
         request.limit,
     )
+}
+
+fn materialized_row_identity(row: MaterializedLiveStateRowRef<'_>) -> LiveStateRowIdentityRef<'_> {
+    LiveStateRowIdentityRef {
+        branch_id: row.branch_id(),
+        schema_key: row.schema_key(),
+        entity_pk: row.entity_pk(),
+        file_id: row.file_id(),
+    }
 }
 
 pub(crate) async fn overlay_scan_batch<S>(
@@ -315,9 +341,7 @@ impl<'a> OverlayCandidate<'a> {
     fn identity(self) -> LiveStateRowIdentityRef<'a> {
         LiveStateRowIdentityRef {
             branch_id: self.branch_id,
-            schema_key: self.row.schema_key(),
-            entity_pk: self.row.entity_pk(),
-            file_id: self.row.file_id(),
+            ..materialized_row_identity(self.row)
         }
     }
 }
@@ -512,8 +536,10 @@ mod tests {
                 branch_id: branch_id.into(),
             })
             .collect();
+        let source = MaterializedLiveStateBatch::from_rows(rows);
+        let source_entity_column = source.entity_column_ptr();
         let batch = resolve_visible_batch(
-            MaterializedLiveStateBatch::from_rows(rows),
+            source,
             MaterializedLiveStateBatch::default(),
             &VisibilityRequest {
                 branch_scope: VisibilityBranchScope::BranchIds {
@@ -525,6 +551,7 @@ mod tests {
         );
 
         assert_eq!(batch.len(), 10_000);
+        assert_eq!(batch.entity_column_ptr(), source_entity_column);
         assert_eq!(batch.dictionary_entry_count(), 3);
         assert_eq!(batch.row(0).schema_key(), batch.row(9_999).schema_key());
         assert_eq!(

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -426,27 +426,45 @@ pub(crate) async fn try_execute_entity_update_parameter_batch(
     let direct_primary_key_param =
         bound_single_text_primary_key_param(&spec, &plan.bound.predicate);
     let direct_replacement = direct_path_value_replacement(&spec, plan, direct_primary_key_param);
+    let borrowed_direct_parameters = direct_replacement.as_ref().and_then(|replacement| {
+        direct_replacement_text_columns(
+            parameter_batch,
+            direct_primary_key_param?,
+            replacement.value_param_index,
+        )
+    });
     let mut parameter_rows = Vec::with_capacity(parameter_batch.num_rows());
     let mut entity_pks = Vec::<EntityPk>::with_capacity(parameter_batch.num_rows());
     let mut entity_pks_strictly_ordered = true;
     for row_index in 0..parameter_batch.num_rows() {
-        let params = super::write::parameter_row(parameter_batch, row_index)
-            .map_err(|error| with_parameter_batch_statement_index(error, row_index))?;
-        let entity_pk = if let Some(param_index) = direct_primary_key_param {
-            let Some(Value::Text(value)) = params.get(param_index) else {
-                return Ok(None);
-            };
-            EntityPk::single(value.clone())
-        } else {
-            let Some(mut row_entity_pks) =
-                bound_entity_pks_from_primary_key_predicate(&spec, &plan.bound.predicate, &params)
-            else {
-                return Ok(None);
-            };
-            if row_entity_pks.len() != 1 {
+        let entity_pk = if let Some(columns) = borrowed_direct_parameters {
+            if columns.primary_keys.is_null(row_index) {
                 return Ok(None);
             }
-            row_entity_pks.pop().expect("one point-update identity")
+            EntityPk::single(columns.primary_keys.value(row_index).to_owned())
+        } else {
+            let params = super::write::parameter_row(parameter_batch, row_index)
+                .map_err(|error| with_parameter_batch_statement_index(error, row_index))?;
+            let entity_pk = if let Some(param_index) = direct_primary_key_param {
+                let Some(Value::Text(value)) = params.get(param_index) else {
+                    return Ok(None);
+                };
+                EntityPk::single(value.clone())
+            } else {
+                let Some(mut row_entity_pks) = bound_entity_pks_from_primary_key_predicate(
+                    &spec,
+                    &plan.bound.predicate,
+                    &params,
+                ) else {
+                    return Ok(None);
+                };
+                if row_entity_pks.len() != 1 {
+                    return Ok(None);
+                }
+                row_entity_pks.pop().expect("one point-update identity")
+            };
+            parameter_rows.push(params);
+            entity_pk
         };
         if let Some(previous) = entity_pks.last() {
             match previous.cmp(&entity_pk) {
@@ -459,7 +477,6 @@ pub(crate) async fn try_execute_entity_update_parameter_batch(
                 Ordering::Greater => entity_pks_strictly_ordered = false,
             }
         }
-        parameter_rows.push(params);
         entity_pks.push(entity_pk);
     }
     if !entity_pks_strictly_ordered {
@@ -469,6 +486,14 @@ pub(crate) async fn try_execute_entity_update_parameter_batch(
             .any(|entity_pk| !unique_entity_pks.insert(entity_pk))
         {
             return Ok(None);
+        }
+    }
+    if borrowed_direct_parameters.is_some() && !entity_pks_strictly_ordered {
+        for row_index in 0..parameter_batch.num_rows() {
+            parameter_rows.push(
+                super::write::parameter_row(parameter_batch, row_index)
+                    .map_err(|error| with_parameter_batch_statement_index(error, row_index))?,
+            );
         }
     }
 
@@ -508,10 +533,22 @@ pub(crate) async fn try_execute_entity_update_parameter_batch(
         let mut normalized = Vec::with_capacity(parameter_rows.len().saturating_mul(64));
         let mut offsets = Vec::with_capacity(parameter_rows.len());
         let mut matched_candidates = Vec::with_capacity(parameter_rows.len());
-        for (row_index, params) in parameter_rows.iter().enumerate() {
-            let expected_entity_pk = match params.get(primary_key_param_index) {
-                Some(Value::Text(value)) => value,
-                _ => unreachable!("direct replacement primary key was validated as text"),
+        for row_index in 0..parameter_batch.num_rows() {
+            let (expected_entity_pk, borrowed_value, params) = if let Some(columns) =
+                borrowed_direct_parameters
+            {
+                (
+                    columns.primary_keys.value(row_index),
+                    (!columns.values.is_null(row_index)).then(|| columns.values.value(row_index)),
+                    None,
+                )
+            } else {
+                let params = &parameter_rows[row_index];
+                let expected_entity_pk = match params.get(primary_key_param_index) {
+                    Some(Value::Text(value)) => value.as_str(),
+                    _ => unreachable!("direct replacement primary key was validated as text"),
+                };
+                (expected_entity_pk, None, Some(params.as_slice()))
             };
             let mut affected = 0;
             while let Some(candidate) = candidates.peek().copied() {
@@ -529,13 +566,21 @@ pub(crate) async fn try_execute_entity_update_parameter_batch(
                         .expect("peeked exact entity candidate remains available"),
                 );
                 let start = normalized.len();
-                append_direct_path_value_replacement_json(
-                    &mut normalized,
-                    candidate,
-                    params,
-                    replacement,
-                )
-                .map_err(|error| with_parameter_batch_statement_index(error, row_index))?;
+                let result = if borrowed_direct_parameters.is_some() {
+                    append_direct_path_value_replacement_json_text(
+                        &mut normalized,
+                        candidate,
+                        borrowed_value,
+                    )
+                } else {
+                    append_direct_path_value_replacement_json(
+                        &mut normalized,
+                        candidate,
+                        params.expect("owned direct replacement has one parameter row"),
+                        replacement,
+                    )
+                };
+                result.map_err(|error| with_parameter_batch_statement_index(error, row_index))?;
                 offsets.push((start, normalized.len()));
                 matched_candidates.push((row_index, candidate));
                 affected += 1;
@@ -614,6 +659,32 @@ pub(crate) async fn try_execute_entity_update_parameter_batch(
 
 struct DirectPathValueReplacement {
     value_param_index: usize,
+}
+
+#[derive(Clone, Copy)]
+struct DirectReplacementTextColumns<'a> {
+    primary_keys: &'a StringArray,
+    values: &'a StringArray,
+}
+
+fn direct_replacement_text_columns<'a>(
+    batch: &'a RecordBatch,
+    primary_key_param_index: usize,
+    value_param_index: usize,
+) -> Option<DirectReplacementTextColumns<'a>> {
+    if crate::sql2::result_metadata::field_is_json(batch.schema().field(value_param_index)) {
+        return None;
+    }
+    Some(DirectReplacementTextColumns {
+        primary_keys: batch
+            .column(primary_key_param_index)
+            .as_any()
+            .downcast_ref::<StringArray>()?,
+        values: batch
+            .column(value_param_index)
+            .as_any()
+            .downcast_ref::<StringArray>()?,
+    })
 }
 
 #[derive(Clone, Copy)]
@@ -790,14 +861,9 @@ fn append_direct_path_value_replacement_json(
     params: &[Value],
     replacement: &DirectPathValueReplacement,
 ) -> Result<(), LixError> {
-    let value = match params.get(replacement.value_param_index) {
-        Some(Value::Null) => JsonValue::Null,
-        Some(Value::Text(raw)) => serde_json::from_str(raw).map_err(|error| {
-            LixError::new(
-                LixError::CODE_TYPE_MISMATCH,
-                format!("lix_json argument is not valid JSON: {error}"),
-            )
-        })?,
+    let raw = match params.get(replacement.value_param_index) {
+        Some(Value::Null) => None,
+        Some(Value::Text(raw)) => Some(raw.as_str()),
         Some(_) => {
             return Err(LixError::new(
                 LixError::CODE_TYPE_MISMATCH,
@@ -813,6 +879,23 @@ fn append_direct_path_value_replacement_json(
                 ),
             ));
         }
+    };
+    append_direct_path_value_replacement_json_text(normalized, candidate, raw)
+}
+
+fn append_direct_path_value_replacement_json_text(
+    normalized: &mut Vec<u8>,
+    candidate: EntityLiveRowRef<'_>,
+    raw: Option<&str>,
+) -> Result<(), LixError> {
+    let value = match raw {
+        None => JsonValue::Null,
+        Some(raw) => serde_json::from_str(raw).map_err(|error| {
+            LixError::new(
+                LixError::CODE_TYPE_MISMATCH,
+                format!("lix_json argument is not valid JSON: {error}"),
+            )
+        })?,
     };
     normalized.extend_from_slice(br#"{"path":"#);
     append_canonical_json_string(normalized, candidate.entity_pk().as_single_string()?)?;

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -34,11 +34,12 @@ pub(crate) use storage::{
     direct_change_locator, load_change_record_by_id, load_commit_delta_change_records,
     load_commit_delta_members_with_payloads, load_commit_delta_members_with_payloads_for_schemas,
     load_commit_delta_selection_certificate, load_owned_commit_delta_entries,
-    scan_change_records_from_commit_deltas, scan_commit_delta_inventory, scan_commit_delta_values,
-    selected_change_selection_fingerprint, stage_addressable_commit_deltas,
-    stage_addressable_commit_deltas_with_selected_source, stage_change_locators,
-    stage_commit_deltas, stage_delete_change_locators, stage_delete_commit_delta_inventory_entry,
-    stage_delete_commit_roots, stage_ordered_addressable_commit_deltas,
+    load_owned_commit_delta_entries_one_ordered_ref, scan_change_records_from_commit_deltas,
+    scan_commit_delta_inventory, scan_commit_delta_values, selected_change_selection_fingerprint,
+    stage_addressable_commit_deltas, stage_addressable_commit_deltas_with_selected_source,
+    stage_change_locators, stage_commit_deltas, stage_delete_change_locators,
+    stage_delete_commit_delta_inventory_entry, stage_delete_commit_roots,
+    stage_ordered_addressable_commit_deltas,
 };
 #[cfg(feature = "storage-benches")]
 pub(crate) use storage::{

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -19,7 +19,8 @@ use crate::storage_adapter::{
 use crate::tracked_state::codec::{
     DecodedLeafNodeRef, DecodedNodeRef, EncodedLeafEntry, PendingChunkBatch,
     TrackedStateMutationBatchBuilder, decode_key, decode_key_shared, decode_node_ref, decode_value,
-    encode_key_ref, encode_leaf_node, encode_schema_key_prefix, encode_value_ref,
+    encode_key_ref, encode_key_ref_into, encode_leaf_node, encode_schema_key_prefix,
+    encode_value_ref,
 };
 use crate::tracked_state::types::{
     TRACKED_STATE_HASH_BYTES, TrackedStateCommitDeltaRef, TrackedStateCommitRoot,
@@ -2509,6 +2510,45 @@ pub(crate) async fn load_owned_commit_delta_entries(
     Ok(output)
 }
 
+/// Loads one ordered exact-key batch without first owning a second copy of
+/// every identity. Dense current-state reads have this shape and normally
+/// resolve every key from the physical owner; unusual selected-source or
+/// missing-key cases fall back to the general loader.
+pub(crate) async fn load_owned_commit_delta_entries_one_ordered_ref(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+    keys: &[TrackedStateKeyRef<'_>],
+) -> Result<Vec<Option<LoadedCommitDeltaEntry>>, LixError> {
+    if keys.is_empty() {
+        return Ok(Vec::new());
+    }
+    let strictly_ordered = keys.windows(2).all(|pair| {
+        (pair[0].schema_key, pair[0].file_id, pair[0].entity_pk)
+            < (pair[1].schema_key, pair[1].file_id, pair[1].entity_pk)
+    });
+    if strictly_ordered {
+        let output =
+            load_local_owned_commit_delta_entries_one_ordered(store, commit_id, keys).await?;
+        if output.iter().all(Option::is_some) {
+            return Ok(output);
+        }
+    }
+    let requests = keys
+        .iter()
+        .map(|key| {
+            (
+                commit_id,
+                TrackedStateKey {
+                    schema_key: key.schema_key.to_owned(),
+                    file_id: key.file_id.map(str::to_owned),
+                    entity_pk: key.entity_pk.clone(),
+                },
+            )
+        })
+        .collect::<Vec<_>>();
+    load_owned_commit_delta_entries(store, &requests).await
+}
+
 async fn load_local_owned_commit_delta_entries(
     store: &(impl StorageAdapterRead + ?Sized),
     requests: &[(CommitId, TrackedStateKey)],
@@ -2520,8 +2560,18 @@ async fn load_local_owned_commit_delta_entries(
         .windows(2)
         .all(|pair| pair[0].0 == pair[1].0 && pair[0].1 < pair[1].1)
     {
+        let keys = requests
+            .iter()
+            .map(|(_, key)| TrackedStateKeyRef {
+                schema_key: &key.schema_key,
+                file_id: key.file_id.as_deref(),
+                entity_pk: &key.entity_pk,
+            })
+            .collect::<Vec<_>>();
         return Box::pin(load_local_owned_commit_delta_entries_one_ordered(
-            store, requests,
+            store,
+            requests[0].0,
+            &keys,
         ))
         .await;
     }
@@ -2646,9 +2696,9 @@ async fn load_local_owned_commit_delta_entries(
 /// commit map, a segment B-tree, and one lookup vector per segment.
 async fn load_local_owned_commit_delta_entries_one_ordered(
     store: &(impl StorageAdapterRead + ?Sized),
-    requests: &[(CommitId, TrackedStateKey)],
+    commit_id: CommitId,
+    keys: &[TrackedStateKeyRef<'_>],
 ) -> Result<Vec<Option<LoadedCommitDeltaEntry>>, LixError> {
-    let commit_id = requests[0].0;
     let manifest_key = StorageKey(Bytes::from(commit_delta_manifest_key(commit_id)));
     let manifest_values = PointReadPlan::new(
         TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
@@ -2663,14 +2713,14 @@ async fn load_local_owned_commit_delta_entries_one_ordered(
         .flatten()
         .and_then(full_value_bytes)
     else {
-        return Ok((0..requests.len()).map(|_| None).collect());
+        return Ok((0..keys.len()).map(|_| None).collect());
     };
     let manifest = decode_commit_delta_manifest(&bytes)?;
-    let mut output = (0..requests.len()).map(|_| None).collect::<Vec<_>>();
+    let mut output = (0..keys.len()).map(|_| None).collect::<Vec<_>>();
     if let Some(inline_segment) = manifest.inline_segment() {
         let (leaf, payloads) = decode_commit_delta_with_payloads(inline_segment, None)?;
-        for (request_index, (_, key)) in requests.iter().enumerate() {
-            let encoded_key = encoded_commit_delta_lookup_key(key);
+        for (request_index, &key) in keys.iter().enumerate() {
+            let encoded_key = encode_key_ref(key);
             output[request_index] =
                 find_loaded_commit_delta_entry(&leaf, &payloads, &encoded_key, commit_id)?;
         }
@@ -2678,11 +2728,14 @@ async fn load_local_owned_commit_delta_entries_one_ordered(
         return Ok(output);
     }
 
-    let mut routed = Vec::<(usize, usize, Vec<u8>)>::with_capacity(requests.len());
+    let mut encoded_keys = Vec::new();
+    let mut routed = Vec::<(usize, usize, Range<usize>)>::with_capacity(keys.len());
     let mut segment_indices = Vec::new();
-    for (request_index, (_, key)) in requests.iter().enumerate() {
-        let encoded_key = encoded_commit_delta_lookup_key(key);
-        let Some(segment_index) = commit_delta_segment_for_key(&manifest, &encoded_key) else {
+    for (request_index, &key) in keys.iter().enumerate() {
+        let encoded_key = encode_key_ref_into(&mut encoded_keys, key);
+        let Some(segment_index) =
+            commit_delta_segment_for_key(&manifest, &encoded_keys[encoded_key.clone()])
+        else {
             continue;
         };
         if segment_indices.last().copied() != Some(segment_index) {
@@ -2726,6 +2779,7 @@ async fn load_local_owned_commit_delta_entries_one_ordered(
             )
         })?;
         let (leaf, payloads) = decode_commit_delta_with_payloads(&bytes, Some(bounds))?;
+        let mut leaf_index = 0usize;
         while routed
             .peek()
             .is_some_and(|(_, routed_segment, _)| *routed_segment == segment_index)
@@ -2733,8 +2787,26 @@ async fn load_local_owned_commit_delta_entries_one_ordered(
             let (request_index, _, encoded_key) = routed
                 .next()
                 .expect("peeked routed lookup remains available");
-            output[request_index] =
-                find_loaded_commit_delta_entry(&leaf, &payloads, &encoded_key, commit_id)?;
+            let encoded_key = &encoded_keys[encoded_key];
+            while leaf_index < leaf.len()
+                && leaf.key(leaf_index)?.ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "tracked_state packed commit_delta leaf has a missing key",
+                    )
+                })? < encoded_key
+            {
+                leaf_index += 1;
+            }
+            let Some(leaf_key) = leaf.key(leaf_index)? else {
+                continue;
+            };
+            if leaf_key == encoded_key {
+                output[request_index] = Some(load_commit_delta_entry_at_index(
+                    &leaf, &payloads, leaf_index, commit_id,
+                )?);
+                leaf_index += 1;
+            }
         }
     }
     hydrate_selected_loaded_entries(store, &mut output).await?;
@@ -4374,6 +4446,20 @@ fn find_loaded_commit_delta_entry(
     let Some(index) = find_commit_delta_entry_index(leaf, target_key)? else {
         return Ok(None);
     };
+    Ok(Some(load_commit_delta_entry_at_index(
+        leaf,
+        payloads,
+        index,
+        expected_commit_id,
+    )?))
+}
+
+fn load_commit_delta_entry_at_index(
+    leaf: &DecodedLeafNodeRef,
+    payloads: &CommitDeltaPayloadIndexRef<'_>,
+    index: usize,
+    expected_commit_id: CommitId,
+) -> Result<LoadedCommitDeltaEntry, LixError> {
     let entry = leaf.entry(index)?.ok_or_else(|| {
         LixError::new(
             LixError::CODE_INTERNAL_ERROR,
@@ -4430,13 +4516,13 @@ fn find_loaded_commit_delta_entry(
         created_at: value.updated_at,
         origin_key,
     };
-    Ok(Some(LoadedCommitDeltaEntry {
+    Ok(LoadedCommitDeltaEntry {
         value,
         change_record,
         selected_ref,
         certified_ref,
         owner_commit_id: expected_commit_id,
-    }))
+    })
 }
 
 fn find_commit_delta_entry_index(


### PR DESCRIPTION
## What changed

- borrow ordered bound `UPDATE` primary keys and JSON values directly from Arrow arrays
- return owned visibility and tracked-head batches directly when no overlay work is required
- replace per-key packed-delta allocations and binary searches with one encoded arena and a monotonic merge cursor
- retain the general materializing paths for unordered batches, missing keys, selected-source commits, tombstones, limits, and overlays

## Why

The public bound bulk-update path copied the same 10k identities and values through Arrow row materialization, packed-base requests, visibility resolution, and tracked-head merging. Profiling showed those copies dominated the remaining planning latency even after predecessor rereads were removed in #1061.

## Performance

All comparisons use the exact immediately preceding PR head, `21347942a`, never a pre-stack baseline.

| Adapter / scale | Previous PR | This PR | Change |
| --- | ---: | ---: | ---: |
| RocksDB UPDATE, 10k (25 samples) | 79.276 ms | 72.391 ms | **-8.69%** |
| SlateDB UPDATE, 10k (25 samples) | 68.333 ms | 57.616 ms | **-15.68%** |
| RocksDB UPDATE, 1M (3 samples) | 13.710 s | 11.103 s | **-19.02%** |
| SlateDB UPDATE, 1M (3 samples) | 16.211 s | 12.477 s | **-23.03%** |
| RocksDB peak RSS, 1M | 4,290,180 KiB | 4,272,396 KiB | **-0.41%** |
| SlateDB peak RSS, 1M | 4,298,072 KiB | 4,269,516 KiB | **-0.66%** |

The 10k RocksDB result uses the explicitly accepted allocation-removal exception to the usual 10% stacked-PR threshold.

Representative non-regression p50 checks against the same exact parent:

- working diff: +2.6% RocksDB, +2.8% SlateDB
- merge preview: -1.5% RocksDB, +4.4% SlateDB
- merge commit: -0.6% RocksDB, +6.3% SlateDB

## Validation

- `cargo test -p lix_engine --quiet` (2,090 passed, 9 ignored)
- `cargo test -p lix_engine_benchmarks --test tracked_state_crud_public_result --features storage-benches,slatedb --quiet` (4 passed)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

No changenote is included.
