### PR TITLE
measure immutable revision pack lower bound

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3362,6 +3362,7 @@ dependencies = [
  "tracing-subscriber",
  "ulid",
  "xxhash-rust",
+ "zstd",
 ]
 
 [[package]]

--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -28,6 +28,7 @@ object_store = { version = "0.14", default-features = false, features = ["fs"], 
 slatedb = { version = "0.14.1", default-features = false, features = ["moka", "zstd"], optional = true }
 ulid = { version = "1.2.1", optional = true }
 rusqlite = { version = "0.32", features = ["bundled"], optional = true }
+zstd = "0.13"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 mimalloc.workspace = true
@@ -51,6 +52,11 @@ xxhash-rust = { version = "0.8", features = ["xxh3"] }
 [[example]]
 name = "storage_layout"
 path = "examples/storage_layout.rs"
+required-features = ["storage-benches", "slatedb"]
+
+[[example]]
+name = "revision_pack_oracle"
+path = "examples/revision_pack_oracle.rs"
 required-features = ["storage-benches", "slatedb"]
 
 [[test]]

--- a/packages/engine-benchmarks/benches/immutable_revision_pack_oracle_results.md
+++ b/packages/engine-benchmarks/benches/immutable_revision_pack_oracle_results.md
@@ -1,0 +1,97 @@
+# Immutable revision-pack oracle results
+
+This experiment asks whether another hard-cut binary-CAS representation can
+remove at least 10% of the complete replay databases without increasing
+payload requests. It reconstructs every CAS value through the production read
+path, then packs the identical values with Git's similarity search. Git pack
+objects are the established comparison: full objects and copy/insert deltas
+share one pack, and `--depth=1` restricts every delta to one base. See Git's
+[pack format][git-pack-format] and [pack-object selection][git-pack-objects].
+
+The oracle is deliberately engine-generic. It does not consume plugin type,
+file extension, Git/LFS status, or a text/binary storage policy. The reported
+text-like/binary split is diagnostic accounting only; all payloads enter the
+same packing experiment. Index bytes and pack headers are included.
+
+## Exhaustive lower bound
+
+The fixed, final-tree-verified SlateDB databases are the accepted semantic-root
+checkpoint artifacts: VS Code 100 commits, Brands 80, and Wesnoth 15. The
+oracle uses a 4,096-object search window, larger than every corpus, and reports
+both a one-hop pack and a hybrid which independently keeps the smaller of the
+Git-selected representation or a Zstd full anchor.
+
+| corpus | current CAS rows | one-hop pack | hybrid Zstd-9 | chained pack |
+| --- | ---: | ---: | ---: | ---: |
+| VS Code | 49,813,305 | 45,865,176 | 45,474,035 | 45,637,040 |
+| Brands | 15,553,043 | 13,888,964 | 13,780,089 | 13,888,822 |
+| Wesnoth | 3,155,642 | 1,770,466 | 1,685,711 | 1,685,350 |
+| **aggregate** | **68,521,990** | **61,524,606 (-10.21%)** | **60,939,835 (-11.06%)** | **61,211,212 (-10.67%)** |
+
+The best theoretical replacement reduces the complete 76,822,721-byte corpus
+to 69,240,566 bytes: **9.87%**, below the 10% whole-database gate. It also uses
+Zstd-9 and exhaustive search. On VS Code alone, Git's one-hop selection took
+14.6 seconds and the chained selection took 31.6 seconds, before any Lix
+transaction, checkpoint, or adapter work. Chains do not improve the aggregate
+bound and would add reconstruction CPU even if one coalesced range read hid
+their I/O depth.
+
+SlateDB already publishes immutable CAS values into segments and coalesces
+ranges from the same segment. A new adapter pack trait cannot improve this
+bound by removing requests; the missing bytes are representation savings, not
+per-object files or round trips. RocksDB's BlobDB follows the same useful
+separation—small keys in the LSM and immutable large values in blob files—so
+moving the values again does not create another universal 10% cut. See
+[RocksDB BlobDB][rocks-blobdb].
+
+## Rejected production prototypes
+
+Two production-shaped candidates were replayed with all bundled WASM plugins,
+periodic checkpoints, storage flush, and final Git-tree verification.
+
+### Generic computed replacement deltas
+
+Every ordinary replacement offered its already-known previous content hash to
+the CAS. The CAS performed format-neutral block matching, refused delta chains,
+and persisted a delta only when its exact encoding saved at least 12.5%.
+Plugins supplied no content type or Git policy.
+
+| corpus | replay before | replay candidate | physical before | physical candidate |
+| --- | ---: | ---: | ---: | ---: |
+| VS Code | 4,695.012 ms | 4,744.948 ms (+1.06%) | 56,912,396 | 56,799,638 (-0.20%) |
+| Brands | 370.679 ms | 402.252 ms (+8.52%) | 15,715,693 | 15,715,640 (flat) |
+| Wesnoth | 126.817 ms | 131.595 ms (+3.77%) | 4,194,632 | 4,090,507 (-2.48%) |
+| **aggregate** | **5,192.508 ms** | **5,278.795 ms (+1.66%)** | **76,822,721** | **76,605,785 (-0.28%)** |
+
+Brands produced only three computed deltas. Same-file replacement provenance
+therefore does not explain Git's media-corpus advantage, and the extra base
+reads and matching CPU fail the performance requirement. The prototype was
+removed.
+
+### Stronger full-anchor compression
+
+Changing only binary-CAS anchors from Zstd level 1 to level 3 kept semantic
+pages and adapter compression unchanged.
+
+| corpus | replay before | replay candidate | physical before | physical candidate |
+| --- | ---: | ---: | ---: | ---: |
+| VS Code | 4,695.012 ms | 4,775.676 ms (+1.72%) | 56,912,396 | 56,597,533 (-0.55%) |
+| Brands | 370.679 ms | 375.363 ms (+1.26%) | 15,715,693 | 15,512,065 (-1.30%) |
+| Wesnoth | 126.817 ms | 124.133 ms (-2.12%) | 4,194,632 | 3,973,270 (-5.28%) |
+| **aggregate** | **5,192.508 ms** | **5,275.172 ms (+1.59%)** | **76,822,721** | **76,082,868 (-0.96%)** |
+
+This candidate was also removed. Higher levels improve the oracle bound but
+cannot cross the whole-database gate and would increase write/checkpoint CPU.
+
+## Decision
+
+Do not add revision packs, computed binary deltas, a new immutable adapter
+trait, or stronger CAS compression for these corpora. Even an exhaustive
+offline lower bound misses the requested whole-database threshold, while both
+online approximations regress replay or save less than 1% aggregate. A future
+candidate needs a different representation with a lower bound comfortably
+past 10% before production implementation.
+
+[git-pack-format]: https://git-scm.com/docs/gitformat-pack
+[git-pack-objects]: https://git-scm.com/docs/git-pack-objects
+[rocks-blobdb]: https://github.com/facebook/rocksdb/wiki/BlobDB

--- a/packages/engine-benchmarks/examples/revision_pack_oracle.rs
+++ b/packages/engine-benchmarks/examples/revision_pack_oracle.rs
@@ -1,0 +1,237 @@
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::Instant;
+use std::{collections::HashMap, ffi::OsStr};
+
+use lix_engine::storage_adapter::{StorageAdapter, StorageReadOptions};
+use lix_engine::storage_bench::{binary_cas_payload_inventory, layout_accounting};
+use lix_slatedb_storage::SlateDB;
+
+#[tokio::main]
+async fn main() {
+    let path = std::env::args_os()
+        .nth(1)
+        .expect("usage: revision_pack_oracle <slatedb-path>");
+    let storage = StorageAdapter::new(SlateDB::open(&path).expect("open SlateDB"));
+    let read = storage
+        .begin_read(StorageReadOptions::default())
+        .await
+        .expect("open storage snapshot");
+
+    let layout = layout_accounting(&read).await;
+    let current_cas_row_bytes = layout
+        .iter()
+        .filter(|entry| entry.space.starts_with("binary_cas."))
+        .map(|entry| entry.key_bytes + entry.value_bytes)
+        .sum::<u64>();
+    let started = Instant::now();
+    let payloads = binary_cas_payload_inventory(&read)
+        .await
+        .expect("reconstruct binary CAS inventory");
+    let reconstruction_ms = started.elapsed().as_millis();
+
+    let logical_bytes = payloads
+        .iter()
+        .map(|entry| entry.bytes.len() as u64)
+        .sum::<u64>();
+    let text_bytes = payloads
+        .iter()
+        .filter(|entry| is_likely_text(&entry.bytes))
+        .map(|entry| entry.bytes.len() as u64)
+        .sum::<u64>();
+    let binary_bytes = logical_bytes - text_bytes;
+    let text_values = payloads
+        .iter()
+        .filter(|entry| is_likely_text(&entry.bytes))
+        .count();
+
+    let temporary = tempfile::tempdir().expect("create pack oracle directory");
+    run(Command::new("git")
+        .arg("init")
+        .arg("--bare")
+        .arg(temporary.path()));
+    let import_started = Instant::now();
+    import_payloads(temporary.path(), &payloads);
+    let import_ms = import_started.elapsed().as_millis();
+    let pack_started = Instant::now();
+    run(Command::new("git").arg("-C").arg(temporary.path()).args([
+        "repack",
+        "-adf",
+        "--depth=1",
+        "--window=4096",
+    ]));
+    let pack_ms = pack_started.elapsed().as_millis();
+    let (pack_data_bytes, pack_index_bytes) = pack_bytes(temporary.path());
+    let packed_bytes = pack_data_bytes + pack_index_bytes;
+    let hybrid_zstd_3_bytes = hybrid_pack_bytes(temporary.path(), &payloads, 3);
+    let hybrid_zstd_9_bytes = hybrid_pack_bytes(temporary.path(), &payloads, 9);
+    let chained_pack_started = Instant::now();
+    run(Command::new("git").arg("-C").arg(temporary.path()).args([
+        "repack",
+        "-adf",
+        "--depth=50",
+        "--window=4096",
+    ]));
+    let chained_pack_ms = chained_pack_started.elapsed().as_millis();
+    let (chained_pack_data_bytes, chained_pack_index_bytes) = pack_bytes(temporary.path());
+    let chained_packed_bytes = chained_pack_data_bytes + chained_pack_index_bytes;
+
+    println!(
+        "REVISION_PACK_ORACLE\tvalues={}\tlogical_bytes={logical_bytes}\ttext_values={text_values}\ttext_bytes={text_bytes}\tbinary_values={}\tbinary_bytes={binary_bytes}\tcurrent_cas_row_bytes={current_cas_row_bytes}\tone_hop_pack_data_bytes={pack_data_bytes}\tone_hop_pack_index_bytes={pack_index_bytes}\tone_hop_packed_bytes={packed_bytes}\thybrid_zstd_3_bytes={hybrid_zstd_3_bytes}\thybrid_zstd_9_bytes={hybrid_zstd_9_bytes}\tchained_pack_data_bytes={chained_pack_data_bytes}\tchained_pack_index_bytes={chained_pack_index_bytes}\tchained_packed_bytes={chained_packed_bytes}\treconstruction_ms={reconstruction_ms}\timport_ms={import_ms}\tone_hop_pack_ms={pack_ms}\tchained_pack_ms={chained_pack_ms}",
+        payloads.len(),
+        payloads.len() - text_values,
+    );
+}
+
+fn is_likely_text(bytes: &[u8]) -> bool {
+    !bytes.iter().take(8 * 1024).any(|byte| *byte == 0) && std::str::from_utf8(bytes).is_ok()
+}
+
+fn import_payloads(
+    repository: &Path,
+    payloads: &[lix_engine::storage_bench::BinaryCasPayloadInventoryEntry],
+) {
+    let mut child = Command::new("git")
+        .arg("-C")
+        .arg(repository)
+        .args(["fast-import", "--quiet"])
+        .stdin(Stdio::piped())
+        .spawn()
+        .expect("start git fast-import");
+    let mut input = child.stdin.take().expect("fast-import stdin");
+    for (index, payload) in payloads.iter().enumerate() {
+        writeln!(
+            input,
+            "blob\nmark :{}\ndata {}",
+            index + 1,
+            payload.bytes.len()
+        )
+        .expect("write blob header");
+        input.write_all(&payload.bytes).expect("write blob bytes");
+        input.write_all(b"\n").expect("terminate blob bytes");
+    }
+    input
+        .write_all(
+            b"commit refs/heads/oracle\ncommitter Lix Oracle <oracle@lix.dev> 0 +0000\ndata 0\n",
+        )
+        .expect("write oracle commit");
+    for (index, payload) in payloads.iter().enumerate() {
+        let class = if is_likely_text(&payload.bytes) {
+            "text"
+        } else {
+            "binary"
+        };
+        let extension = if class == "text" { "txt" } else { "bin" };
+        writeln!(
+            input,
+            "M 100644 :{} {class}/{index:08}/payload.{extension}",
+            index + 1
+        )
+        .expect("write tree entry");
+    }
+    input.write_all(b"\n").expect("finish oracle commit");
+    drop(input);
+    assert!(child.wait().expect("wait for git fast-import").success());
+}
+
+fn run(command: &mut Command) {
+    let status = command.status().expect("run git command");
+    assert!(status.success(), "git command failed with {status}");
+}
+
+fn pack_bytes(repository: &Path) -> (u64, u64) {
+    let pack_dir = repository.join("objects/pack");
+    let mut data = 0;
+    let mut index = 0;
+    for entry in fs::read_dir(pack_dir).expect("read Git pack directory") {
+        let entry = entry.expect("read Git pack entry");
+        let bytes = entry.metadata().expect("read Git pack metadata").len();
+        match entry.path().extension().and_then(|value| value.to_str()) {
+            Some("pack") => data += bytes,
+            Some("idx") => index += bytes,
+            _ => {}
+        }
+    }
+    (data, index)
+}
+
+/// Estimates a hard-cut pack that retains Git's one-hop delta choice but uses
+/// Zstd for full anchors. Each object independently keeps the smaller encoding,
+/// so already-compressed media cannot make the candidate larger.
+fn hybrid_pack_bytes(
+    repository: &Path,
+    payloads: &[lix_engine::storage_bench::BinaryCasPayloadInventoryEntry],
+    zstd_level: i32,
+) -> u64 {
+    let pack_dir = repository.join("objects/pack");
+    let index_path = fs::read_dir(&pack_dir)
+        .expect("read Git pack directory")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .find(|path| path.extension() == Some(OsStr::new("idx")))
+        .expect("Git pack index exists");
+    let tree = output(Command::new("git").arg("-C").arg(repository).args([
+        "ls-tree",
+        "-r",
+        "refs/heads/oracle",
+    ]));
+    let payload_by_git_hash = tree
+        .lines()
+        .map(|line| {
+            let (metadata, path) = line.split_once('\t').expect("Git tree row has path");
+            let hash = metadata
+                .split_whitespace()
+                .nth(2)
+                .expect("Git tree row has object hash");
+            let index = path
+                .split('/')
+                .nth(1)
+                .expect("oracle path has index")
+                .parse::<usize>()
+                .expect("oracle path index is numeric");
+            (hash, &payloads[index].bytes)
+        })
+        .collect::<HashMap<_, _>>();
+    let verify = output(
+        Command::new("git")
+            .arg("verify-pack")
+            .arg("-v")
+            .arg(&index_path),
+    );
+    let mut object_bytes = 0u64;
+    for line in verify.lines() {
+        let fields = line.split_whitespace().collect::<Vec<_>>();
+        if fields.len() != 5 && fields.len() != 7 {
+            continue;
+        }
+        let Some(payload) = payload_by_git_hash.get(fields[0]) else {
+            continue;
+        };
+        let git_object_bytes = fields[3]
+            .parse::<u64>()
+            .expect("Git packed object size is numeric");
+        if fields.len() == 7 {
+            object_bytes += git_object_bytes;
+            continue;
+        }
+        let zstd_bytes = zstd::bulk::compress(payload, zstd_level)
+            .expect("compress full oracle anchor")
+            .len() as u64
+            + 8;
+        object_bytes += git_object_bytes.min(zstd_bytes);
+    }
+    let (_, index_bytes) = pack_bytes(repository);
+    object_bytes + index_bytes + 32
+}
+
+fn output(command: &mut Command) -> String {
+    let output = command.output().expect("run Git inspection command");
+    assert!(
+        output.status.success(),
+        "git command failed: {}",
+        output.status
+    );
+    String::from_utf8(output.stdout).expect("Git inspection output is UTF-8")
+}

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -321,6 +321,16 @@ pub struct BinaryManifestLayoutAccounting {
     pub delta_manifests: u64,
 }
 
+/// One fully reconstructed binary-CAS value for offline physical-layout
+/// experiments. This stays behind `storage-benches`: production callers must
+/// address CAS values by hash instead of enumerating the repository.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BinaryCasPayloadInventoryEntry {
+    pub hash: [u8; 32],
+    pub bytes: Vec<u8>,
+    pub encoded_manifest_bytes: u64,
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct BinaryCasOwnerLayoutAccounting {
     pub owner: String,
@@ -572,6 +582,59 @@ where
         }
     }
     Ok(accounting)
+}
+
+/// Reconstructs every unique binary-CAS payload through the production read
+/// path. The bounded batches make the oracle usable for company-sized replay
+/// fixtures without turning one inventory into an unbounded point-read plan.
+pub async fn binary_cas_payload_inventory<R>(
+    read: &R,
+) -> Result<Vec<BinaryCasPayloadInventoryEntry>, crate::LixError>
+where
+    R: StorageAdapterRead,
+{
+    const BATCH_SIZE: usize = 256;
+
+    let manifests =
+        scan_layout_entries(read, crate::binary_cas::kv::BINARY_CAS_MANIFEST_SPACE).await;
+    let mut entries = Vec::with_capacity(manifests.len());
+    for batch in manifests.chunks(BATCH_SIZE) {
+        let hashes = batch
+            .iter()
+            .map(|entry| {
+                let hash: [u8; 32] = entry.key.0.as_ref().try_into().map_err(|_| {
+                    crate::LixError::new(
+                        crate::LixError::CODE_INTERNAL_ERROR,
+                        "benchmark binary CAS manifest key is not one hash",
+                    )
+                })?;
+                Ok(crate::binary_cas::BlobHash::from_bytes(hash))
+            })
+            .collect::<Result<Vec<_>, crate::LixError>>()?;
+        let payloads = crate::binary_cas::load_bytes_many(read, &hashes)
+            .await?
+            .into_vec();
+        for ((manifest, hash), payload) in batch.iter().zip(hashes).zip(payloads) {
+            let StorageProjectedValue::FullValue(encoded_manifest) = &manifest.value else {
+                unreachable!("binary CAS payload inventory requests full manifests");
+            };
+            let bytes = payload.ok_or_else(|| {
+                crate::LixError::new(
+                    crate::LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "benchmark binary CAS manifest '{}' has no payload",
+                        hash.to_hex()
+                    ),
+                )
+            })?;
+            entries.push(BinaryCasPayloadInventoryEntry {
+                hash: hash.into_bytes(),
+                bytes,
+                encoded_manifest_bytes: encoded_manifest.len() as u64,
+            });
+        }
+    }
+    Ok(entries)
 }
 
 /// Attributes every binary-CAS manifest to the durable JSON field which owns it.


### PR DESCRIPTION
## What changed

- add a benchmark-only binary CAS inventory that reconstructs every unique payload in bounded batches
- add an exhaustive Git pack oracle with one-hop, chained, and hybrid Zstd anchor accounting
- document the fixed VS Code, Brands, and Wesnoth results, including two rejected production prototypes

## Why

The next storage hard cut needed a lower bound before introducing a new physical format or adapter contract. The best exhaustive candidate removes 11.06% of CAS rows but only 9.87% of the complete SlateDB corpus, while its search takes 14.6 seconds on VS Code. Production-shaped same-file deltas and Zstd-3 anchors save only 0.28% and 0.96% aggregate respectively, with replay regressions. This PR preserves that evidence and deliberately makes no production storage change.

No plugin content type, Git/LFS status, or text/binary policy enters the engine API. The text-like/binary split exists only as benchmark accounting.

## Validation

- `cargo check -p lix_engine_benchmarks --example revision_pack_oracle --features storage-benches,slatedb`
- `cargo test -p lix_engine --features all-simulations` (1 unrelated shared-run row-count failure; isolated rerun passed)
- all six production-prototype SlateDB replays verified their final Git trees
- exhaustive oracle ran against the accepted VS Code 100, Brands 80, and Wesnoth 15 commit artifacts

No changenote: benchmark tooling and evidence only.
