### PR TITLE
Admit large structured Markdown within bounded plugin memory

### DIFF
--- a/.changenotes/large-markdown-plugin-memory.md
+++ b/.changenotes/large-markdown-plugin-memory.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Large structured Markdown files no longer exhaust the default plugin memory limit.

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -87,8 +87,8 @@ impl EngineOptions {
     /// The Store limit bounds the active working set, not the number of plugin
     /// documents an atomic transaction may open. Transactions retire completed
     /// Stores and reuse their slots while preserving atomic commit.
-    /// Defaults are 128 MiB and sixteen Stores, bounding guest linear memory to
-    /// 2 GiB before host-side document state. Cached actors, active
+    /// Defaults are 192 MiB and ten Stores, bounding guest linear memory to
+    /// 1.875 GiB before host-side document state. Cached actors, active
     /// existing-document transaction leases, pending publications, cold-open
     /// candidates, and upgrade preflight Stores consume the same
     /// workspace-wide budget. Completed publications may retire their Stores

--- a/packages/engine/src/plugin/actor.rs
+++ b/packages/engine/src/plugin/actor.rs
@@ -21,7 +21,7 @@ use crate::wasm::{
 };
 use crate::{Blob, LixError};
 
-pub(crate) const DEFAULT_MAX_LIVE_PLUGIN_STORES: usize = 16;
+pub(crate) const DEFAULT_MAX_LIVE_PLUGIN_STORES: usize = 10;
 // The vscode-docs 303-path transition needs roughly 80-96 MiB to retain one
 // decoded predecessor per touched file. At 64 MiB the cache reparses 115
 // documents; 96 MiB retains the complete measured working set while remaining

--- a/packages/engine/src/plugin/component.rs
+++ b/packages/engine/src/plugin/component.rs
@@ -17,7 +17,7 @@ use super::{
 const MAX_PLUGIN_EXECUTION_TIMEOUT_MS: u64 = 60_000;
 /// Preserve enough headroom for recursive plugins and large minified text
 /// snapshots. The live-Store working set remains independently bounded.
-pub(crate) const DEFAULT_PLUGIN_MEMORY_BYTES: u64 = 128 * 1024 * 1024;
+pub(crate) const DEFAULT_PLUGIN_MEMORY_BYTES: u64 = 192 * 1024 * 1024;
 
 fn plugin_wasm_limits(max_memory_bytes: u64) -> Result<WasmLimits, LixError> {
     if max_memory_bytes == 0 {
@@ -269,11 +269,11 @@ mod tests {
         assert_eq!(WasmLimits::default().max_memory_bytes, 64 * 1024 * 1024);
         assert_eq!(
             default_plugin_wasm_limits().max_memory_bytes,
-            128 * 1024 * 1024
+            192 * 1024 * 1024
         );
         assert_eq!(
             DEFAULT_PLUGIN_MEMORY_BYTES * DEFAULT_MAX_LIVE_PLUGIN_STORES as u64,
-            2 * 1024 * 1024 * 1024
+            1_920 * 1024 * 1024
         );
         assert_eq!(
             default_plugin_wasm_limits().timeout_ms,


### PR DESCRIPTION
## Summary

- raise the production per-plugin Wasm store ceiling from 128 MiB to 192 MiB
- reduce simultaneously live plugin stores from 16 to 10
- reduce the resulting workspace-wide guest linear-memory bound from 2 GiB to 1.875 GiB
- document and test the updated resource policy

## Reproduction

The fixed 25-commit `wesnoth/wesnoth` benchmark window (`e41b98ef4187a215a6a12dc8a52bf5036339738c..9a46225df32c4d1f7d90ca90e0e51ee96962412a`) traps at commit `a964a50e8e20b274473b6755e56e70dfe558dd25` on the 991,038-byte `changelog.md` with the 128 MiB default. The Wasm backtrace ends in `rust_oom` while the Markdown plugin materializes structured inline/list payloads. The no-plugin control succeeds.

With this change, the full plugins-enabled window passes and verifies the final Git tree. The measured guest linear-memory high-water mark is **172,163,072 bytes**, below the new 192 MiB ceiling.

## Performance profile

Three complete release runs of the same 25-commit window:

- replay: 12.133 s, 12.068 s, 11.846 s (median **12.068 s**)
- end-to-end: 18.01 s, 17.97 s, 17.59 s (median **17.97 s**)
- process peak RSS: 1,364,104 / 1,374,644 / 1,332,368 KiB (median **1,364,104 KiB**)
- guest linear-memory HWM: 172,163,072 bytes in every run

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p lix_engine --features all-simulations` (1,671 unit tests, 800 integration tests, 3 doc tests passed; 8 ignored)
- `cargo clippy -p lix_engine --all-targets --all-features -- -D warnings`
- full hydrated Wesnoth replay with all bundled plugins and final-tree verification, repeated three times