### PR TITLE
measure current materialization image bound

### DIFF
--- a/packages/engine-benchmarks/benches/current_materialization_image_oracle_results.md
+++ b/packages/engine-benchmarks/benches/current_materialization_image_oracle_results.md
@@ -1,0 +1,50 @@
+# Current materialization-image oracle results
+
+This experiment tests a Neon-style split between immutable semantic history
+and exact current materialization images. Plugin-selectable content would keep
+only its current file image in binary CAS; historical bytes would be rendered
+from the semantic authority. Binary, unclassified, and plugin-WASM payloads
+remain ordinary CAS values. The shape follows Neon's separation of delta
+layers from image layers and its reconstruction of a page at a requested LSN.
+See Neon's [pageserver storage model][neon-storage] and [GetPage@LSN][neon-lsn].
+
+The benchmark is intentionally optimistic. Every payload without a NUL byte
+in its first 8 KiB is treated as plugin-selectable, so an actual plugin
+selection boundary can only retain more data. It then traverses the production
+CAS manifests and retains every dependency needed by a surviving single,
+chunked, or one-hop delta value. Shared chunks, base layouts, manifest pages,
+and chunk-presence rows are included.
+
+## Exact reachable-row bound
+
+The accepted SlateDB replay databases are unchanged: VS Code 100 commits,
+Brands 80, and Wesnoth 15. `current CAS rows` and `reclaimable CAS rows` include
+the physical four-byte space prefix on every logical storage row.
+
+| corpus | complete database | current images | current CAS rows | retained CAS rows | reclaimable CAS rows | optimistic complete cut |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| VS Code | 56,912,396 | 495 | 49,813,305 | 48,798,448 | 1,014,857 | 1.78% |
+| Brands | 15,715,693 | 258 | 15,553,043 | 15,550,778 | 2,265 | 0.01% |
+| Wesnoth | 4,194,632 | 46 | 3,155,642 | 3,023,749 | 131,893 | 3.14% |
+| **aggregate** | **76,822,721** | **799** | **68,521,990** | **67,372,975** | **1,149,015** | **1.50%** |
+
+VS Code removes 1,640 historical manifests, but their retained one-hop delta
+representation is already small. Brands removes only ten manifests because
+almost all storage is unique current media. Wesnoth removes 43 manifests, yet
+their complete reachable footprint is only 132 KiB.
+
+## Decision
+
+Do not add a current-image materialization mode or historical render fallback.
+The most permissive lower bound misses the requested 20% complete-database
+gate by more than an order of magnitude. Production support would add a second
+historical file-read path, proof validation, image lifecycle management, and
+failure recovery while reclaiming at most 1.50% on this corpus.
+
+The result also narrows the remaining search space: historical file CAS is not
+the large duplicate. A future radical candidate must change the encoding of
+semantic history/current-state rows themselves, or demonstrate a combined
+representation bound above 20%, before production implementation.
+
+[neon-storage]: https://github.com/neondatabase/neon/blob/main/docs/pageserver-storage.md
+[neon-lsn]: https://neon.com/blog/get-page-at-lsn

--- a/packages/engine-benchmarks/examples/revision_pack_oracle.rs
+++ b/packages/engine-benchmarks/examples/revision_pack_oracle.rs
@@ -6,11 +6,16 @@ use std::time::Instant;
 use std::{collections::HashMap, ffi::OsStr};
 
 use lix_engine::storage_adapter::{StorageAdapter, StorageReadOptions};
-use lix_engine::storage_bench::{binary_cas_payload_inventory, layout_accounting};
+use lix_engine::storage_bench::{
+    binary_cas_payload_inventory, current_image_cas_oracle_accounting, layout_accounting,
+};
 use lix_slatedb_storage::SlateDB;
 
 #[tokio::main]
 async fn main() {
+    let current_image_only = std::env::args_os()
+        .nth(2)
+        .is_some_and(|argument| argument == "--current-image-only");
     let path = std::env::args_os()
         .nth(1)
         .expect("usage: revision_pack_oracle <slatedb-path>");
@@ -31,6 +36,21 @@ async fn main() {
         .await
         .expect("reconstruct binary CAS inventory");
     let reconstruction_ms = started.elapsed().as_millis();
+    let current_image = current_image_cas_oracle_accounting(&read)
+        .await
+        .expect("compute current-image CAS oracle");
+    println!(
+        "CURRENT_IMAGE_ORACLE\tcurrent_file_images={}\tretained_manifests={}\tremoved_manifests={}\tcurrent_cas_row_bytes={}\tretained_cas_row_bytes={}\treclaimable_cas_row_bytes={}",
+        current_image.current_file_images,
+        current_image.retained_manifests,
+        current_image.removed_manifests,
+        current_image.current_cas_row_bytes,
+        current_image.retained_cas_row_bytes,
+        current_image.reclaimable_cas_row_bytes,
+    );
+    if current_image_only {
+        return;
+    }
 
     let logical_bytes = payloads
         .iter()

--- a/packages/engine/src/binary_cas/mod.rs
+++ b/packages/engine/src/binary_cas/mod.rs
@@ -13,7 +13,8 @@ pub(crate) use chunking::BinaryCasChunking;
 pub(crate) use codec::encode_binary_cas_manifest;
 #[cfg(feature = "storage-benches")]
 pub(crate) use codec::{
-    BinaryCasManifest, decode_binary_cas_manifest, decode_binary_cas_manifest_chunk,
+    BinaryCasManifest, StorageBinaryCasDeltaBaseLayout, decode_binary_cas_manifest,
+    decode_binary_cas_manifest_chunk,
 };
 pub(crate) use context::{BinaryCasContext, BlobDataReader};
 pub(crate) use kv::load_bytes_many;

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -331,6 +331,16 @@ pub struct BinaryCasPayloadInventoryEntry {
     pub encoded_manifest_bytes: u64,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CurrentImageCasOracleAccounting {
+    pub current_file_images: u64,
+    pub retained_manifests: u64,
+    pub removed_manifests: u64,
+    pub current_cas_row_bytes: u64,
+    pub retained_cas_row_bytes: u64,
+    pub reclaimable_cas_row_bytes: u64,
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct BinaryCasOwnerLayoutAccounting {
     pub owner: String,
@@ -635,6 +645,203 @@ where
         }
     }
     Ok(entries)
+}
+
+/// Computes the exact logical CAS rows required by a current-image layout.
+///
+/// Current file images and binary/unclassified values remain ordinary CAS
+/// payloads. Superseded payloads eligible for the catch-all WASM text plugin
+/// are reconstructible from semantic history and may be removed. Dependency
+/// traversal retains shared chunks, chunk manifests, delta bases, and presence
+/// rows, so the result does not count unreachable manifest bytes as payload
+/// savings.
+pub async fn current_image_cas_oracle_accounting<R>(
+    read: &R,
+) -> Result<CurrentImageCasOracleAccounting, crate::LixError>
+where
+    R: StorageAdapterRead,
+{
+    use crate::live_state::LiveStateScanRequest;
+
+    let live_state = crate::live_state::LiveStateContext::new(
+        crate::tracked_state::TrackedStateContext::new(),
+        crate::commit_graph::CommitGraphContext::new(),
+    );
+    let current_rows = live_state
+        .reader(read)
+        .scan_batch(&LiveStateScanRequest {
+            filter: crate::live_state::LiveStateFilter {
+                schema_keys: vec!["lix_binary_blob_ref".to_owned()],
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .await?;
+    let mut current_file_hashes = std::collections::BTreeSet::new();
+    for row in current_rows.iter() {
+        let Some(snapshot) = row.snapshot_content() else {
+            continue;
+        };
+        let value: serde_json::Value =
+            serde_json::from_str(snapshot.as_str()).map_err(|error| {
+                crate::LixError::new(
+                    crate::LixError::CODE_INTERNAL_ERROR,
+                    format!("current-image oracle found invalid blob reference: {error}"),
+                )
+            })?;
+        let Some(hash) = value.get("blob_hash").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        current_file_hashes.insert(crate::binary_cas::BlobHash::from_hex(hash)?);
+    }
+
+    let payloads = binary_cas_payload_inventory(read).await?;
+    let mut retained_blobs = std::collections::BTreeSet::new();
+    for payload in &payloads {
+        let hash = crate::binary_cas::BlobHash::from_bytes(payload.hash);
+        let plugin_selectable = !payload.bytes.iter().take(8_000).any(|byte| *byte == 0);
+        if current_file_hashes.contains(&hash) || !plugin_selectable {
+            retained_blobs.insert(hash);
+        }
+    }
+
+    let manifest_entries =
+        scan_layout_entries(read, crate::binary_cas::kv::BINARY_CAS_MANIFEST_SPACE).await;
+    let manifest_chunk_entries =
+        scan_layout_entries(read, crate::binary_cas::kv::BINARY_CAS_MANIFEST_CHUNK_SPACE).await;
+    let chunk_entries =
+        scan_layout_entries(read, crate::binary_cas::kv::BINARY_CAS_CHUNK_SPACE).await;
+    let presence_entries =
+        scan_layout_entries(read, crate::binary_cas::kv::BINARY_CAS_CHUNK_PRESENCE_SPACE).await;
+
+    let mut manifest_chunks = std::collections::BTreeMap::<
+        crate::binary_cas::BlobHash,
+        Vec<(crate::binary_cas::BlobHash, u64)>,
+    >::new();
+    for entry in &manifest_chunk_entries {
+        let blob_hash = hash_from_key_prefix(&entry.key.0, "manifest chunk")?;
+        let StorageProjectedValue::FullValue(value) = &entry.value else {
+            unreachable!("current-image oracle requests full manifest chunks");
+        };
+        let (chunk_hash, _) = crate::binary_cas::decode_binary_cas_manifest_chunk(value)?;
+        manifest_chunks.entry(blob_hash).or_default().push((
+            crate::binary_cas::BlobHash::from_bytes(chunk_hash),
+            storage_entry_bytes(entry),
+        ));
+    }
+
+    let mut retained_chunks = std::collections::BTreeSet::new();
+    let mut retained_manifest_chunk_owners = std::collections::BTreeSet::new();
+    let mut retained_manifest_bytes = 0u64;
+    for entry in &manifest_entries {
+        let blob_hash = hash_from_key_prefix(&entry.key.0, "manifest")?;
+        if !retained_blobs.contains(&blob_hash) {
+            continue;
+        }
+        retained_manifest_bytes += storage_entry_bytes(entry);
+        let StorageProjectedValue::FullValue(value) = &entry.value else {
+            unreachable!("current-image oracle requests full manifests");
+        };
+        match crate::binary_cas::decode_binary_cas_manifest(value)? {
+            crate::binary_cas::BinaryCasManifest::Empty { .. } => {}
+            crate::binary_cas::BinaryCasManifest::SingleChunk { chunk_hash, .. } => {
+                retained_chunks.insert(crate::binary_cas::BlobHash::from_bytes(chunk_hash));
+            }
+            crate::binary_cas::BinaryCasManifest::Chunked { .. } => {
+                retained_manifest_chunk_owners.insert(blob_hash);
+                retained_chunks.extend(
+                    manifest_chunks
+                        .get(&blob_hash)
+                        .into_iter()
+                        .flatten()
+                        .map(|(hash, _)| *hash),
+                );
+            }
+            crate::binary_cas::BinaryCasManifest::Delta {
+                base_blob_hash,
+                base_layout,
+                ..
+            } => match base_layout {
+                crate::binary_cas::StorageBinaryCasDeltaBaseLayout::SingleChunk { chunk_hash } => {
+                    retained_chunks.insert(crate::binary_cas::BlobHash::from_bytes(chunk_hash));
+                }
+                crate::binary_cas::StorageBinaryCasDeltaBaseLayout::Chunked { .. } => {
+                    let base_hash = crate::binary_cas::BlobHash::from_bytes(base_blob_hash);
+                    retained_manifest_chunk_owners.insert(base_hash);
+                    retained_chunks.extend(
+                        manifest_chunks
+                            .get(&base_hash)
+                            .into_iter()
+                            .flatten()
+                            .map(|(hash, _)| *hash),
+                    );
+                }
+            },
+        }
+    }
+    let retained_manifest_chunk_bytes = retained_manifest_chunk_owners
+        .iter()
+        .flat_map(|hash| manifest_chunks.get(hash).into_iter().flatten())
+        .map(|(_, bytes)| *bytes)
+        .sum::<u64>();
+    let mut retained_chunk_bytes = 0u64;
+    for entry in &chunk_entries {
+        let hash = hash_from_key_prefix(&entry.key.0, "chunk")?;
+        if retained_chunks.contains(&hash) {
+            retained_chunk_bytes += storage_entry_bytes(entry);
+        }
+    }
+    let mut retained_presence_bytes = 0u64;
+    for entry in &presence_entries {
+        let hash = hash_from_key_prefix(&entry.key.0, "chunk presence")?;
+        if retained_chunks.contains(&hash) {
+            retained_presence_bytes += storage_entry_bytes(entry);
+        }
+    }
+    let current_cas_row_bytes = manifest_entries
+        .iter()
+        .chain(manifest_chunk_entries.iter())
+        .chain(chunk_entries.iter())
+        .chain(presence_entries.iter())
+        .map(storage_entry_bytes)
+        .sum::<u64>();
+    let retained_cas_row_bytes = retained_manifest_bytes
+        + retained_manifest_chunk_bytes
+        + retained_chunk_bytes
+        + retained_presence_bytes;
+    Ok(CurrentImageCasOracleAccounting {
+        current_file_images: current_file_hashes.len() as u64,
+        retained_manifests: retained_blobs.len() as u64,
+        removed_manifests: payloads.len().saturating_sub(retained_blobs.len()) as u64,
+        current_cas_row_bytes,
+        retained_cas_row_bytes,
+        reclaimable_cas_row_bytes: current_cas_row_bytes.saturating_sub(retained_cas_row_bytes),
+    })
+}
+
+fn hash_from_key_prefix(
+    key: &Bytes,
+    label: &str,
+) -> Result<crate::binary_cas::BlobHash, crate::LixError> {
+    let hash: [u8; 32] = key
+        .get(..32)
+        .ok_or_else(|| {
+            crate::LixError::new(
+                crate::LixError::CODE_INTERNAL_ERROR,
+                format!("current-image oracle {label} key is shorter than one hash"),
+            )
+        })?
+        .try_into()
+        .expect("checked hash slice length");
+    Ok(crate::binary_cas::BlobHash::from_bytes(hash))
+}
+
+fn storage_entry_bytes(entry: &crate::storage_adapter::StorageReadEntry) -> u64 {
+    4 + entry.key.0.len() as u64
+        + match &entry.value {
+            StorageProjectedValue::FullValue(value) => value.len() as u64,
+            StorageProjectedValue::KeyOnly => 0,
+        }
 }
 
 /// Attributes every binary-CAS manifest to the durable JSON field which owns it.


### PR DESCRIPTION
## What changed

- add an exact benchmark-only reachability oracle for a current-materialization-image layout
- retain all current file images plus binary, unclassified, plugin-WASM, and transitive CAS dependencies
- add a fast `--current-image-only` mode to the revision-pack oracle
- record the three-corpus before/after bound and reject the production layout

## Result

The deliberately optimistic policy reclaims 1,149,015 logical CAS row bytes across the accepted 76,822,721-byte replay corpus (1.50%). VS Code saves 1.78%, Brands 0.01%, and Wesnoth 3.14%. This misses the requested >20% gate by more than an order of magnitude, so this PR makes no production storage, plugin, or API change.

This PR is stacked on #1065 because it extends that benchmark oracle.

## Validation

- `cargo fmt --check`
- `cargo clippy -p lix_engine_benchmarks --example revision_pack_oracle --features storage-benches,slatedb -- -D warnings`
- `cargo test -p lix_engine --features storage-benches storage_bench --lib`
- current-image oracle against the accepted VS Code docs, Home Assistant Brands, and Wesnoth SlateDB replay artifacts