### PR TITLE
perf(engine): generate certified CRUD batches

### DIFF
--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -18,6 +18,12 @@ rocksdb = ["dep:lix_rocksdb_storage"]
 sqlite = ["dep:lix_sqlite_storage", "dep:rusqlite"]
 slatedb = ["dep:lix_slatedb_storage", "dep:object_store", "dep:slatedb", "dep:ulid"]
 storage-benches = ["lix_engine/storage-benches", "rocksdb", "sqlite"]
+# Opt-in profiling build that routes Rust allocations through libc so tools
+# such as heaptrack can attribute transient allocation churn to call stacks.
+# Normal tracked-CRUD builds wrap mimalloc with byte accounting so latency
+# remains comparable with the existing benchmark. This feature removes that
+# allocator entirely so heap profilers and RSS controls use libc directly.
+system-allocation-profiler = []
 
 [dependencies]
 lix_engine = { workspace = true }

--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -1,13 +1,113 @@
 #![allow(clippy::large_futures)]
 
 use std::time::{Duration, Instant};
+#[cfg(all(
+    not(target_family = "wasm"),
+    not(feature = "system-allocation-profiler")
+))]
+use std::{
+    alloc::GlobalAlloc,
+    sync::atomic::{AtomicBool, AtomicU64, Ordering},
+};
 
 use criterion::measurement::WallTime;
 use criterion::{BatchSize, BenchmarkGroup, Criterion, black_box, criterion_group, criterion_main};
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(
+    not(target_family = "wasm"),
+    not(feature = "system-allocation-profiler")
+))]
 #[global_allocator]
-static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL_ALLOCATOR: CountingAllocator = CountingAllocator;
+
+#[cfg(all(
+    not(target_family = "wasm"),
+    not(feature = "system-allocation-profiler")
+))]
+struct CountingAllocator;
+
+#[cfg(all(
+    not(target_family = "wasm"),
+    not(feature = "system-allocation-profiler")
+))]
+static ALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
+#[cfg(all(
+    not(target_family = "wasm"),
+    not(feature = "system-allocation-profiler")
+))]
+static ALLOCATION_ACCOUNTING_ENABLED: AtomicBool = AtomicBool::new(false);
+
+#[cfg(all(
+    not(target_family = "wasm"),
+    not(feature = "system-allocation-profiler")
+))]
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: std::alloc::Layout) -> *mut u8 {
+        let pointer = unsafe { mimalloc::MiMalloc.alloc(layout) };
+        if !pointer.is_null() {
+            record_allocation(layout.size());
+        }
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: std::alloc::Layout) {
+        unsafe { mimalloc::MiMalloc.dealloc(pointer, layout) };
+    }
+
+    unsafe fn realloc(
+        &self,
+        pointer: *mut u8,
+        layout: std::alloc::Layout,
+        new_size: usize,
+    ) -> *mut u8 {
+        let replacement = unsafe { mimalloc::MiMalloc.realloc(pointer, layout, new_size) };
+        if !replacement.is_null() && new_size >= layout.size() {
+            record_allocation(new_size - layout.size());
+        }
+        replacement
+    }
+}
+
+#[cfg(all(
+    not(target_family = "wasm"),
+    not(feature = "system-allocation-profiler")
+))]
+fn record_allocation(bytes: usize) {
+    if ALLOCATION_ACCOUNTING_ENABLED.load(Ordering::Relaxed) {
+        ALLOCATED_BYTES.fetch_add(bytes as u64, Ordering::Relaxed);
+    }
+}
+
+#[cfg(all(
+    not(target_family = "wasm"),
+    not(feature = "system-allocation-profiler")
+))]
+fn reset_allocation_accounting() {
+    ALLOCATED_BYTES.store(0, Ordering::Relaxed);
+    ALLOCATION_ACCOUNTING_ENABLED.store(
+        std::env::var_os("LIX_TRACKED_STATE_CRUD_PROFILE_ALLOCATION_BYTES").is_some(),
+        Ordering::Relaxed,
+    );
+}
+
+#[cfg(all(
+    not(target_family = "wasm"),
+    not(feature = "system-allocation-profiler")
+))]
+fn print_allocation_accounting(phase: &str) {
+    if std::env::var_os("LIX_TRACKED_STATE_CRUD_PROFILE_ALLOCATION_BYTES").is_some() {
+        ALLOCATION_ACCOUNTING_ENABLED.store(false, Ordering::Relaxed);
+        println!(
+            "tracked_state_crud allocation phase: {phase} allocated_bytes={}",
+            ALLOCATED_BYTES.load(Ordering::Relaxed)
+        );
+    }
+}
+
+#[cfg(any(target_family = "wasm", feature = "system-allocation-profiler"))]
+fn reset_allocation_accounting() {}
+#[cfg(any(target_family = "wasm", feature = "system-allocation-profiler"))]
+fn print_allocation_accounting(_phase: &str) {}
 
 mod accounting;
 mod io_stats;
@@ -30,7 +130,26 @@ fn tracked_state_crud_benches(c: &mut Criterion) {
         .build()
         .expect("create tokio runtime for tracked_state_crud benchmarks");
     if std::env::var_os("LIX_TRACKED_STATE_CRUD_PROFILE").is_some() {
-        let rows = fixture_rows(profile_row_count());
+        let row_count = profile_row_count();
+        if std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_LAYER").as_deref()
+            == Ok("sql_session_bound")
+            && std::env::var_os("LIX_TRACKED_STATE_CRUD_PROFILE_HOT_REPEATS").is_none()
+        {
+            assert_eq!(
+                std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_OP").as_deref(),
+                Ok("update_all"),
+                "sql_session_bound only supports update_all"
+            );
+            profile_sql_session_bound_updates(
+                &runtime,
+                row_count,
+                READ_MANY_PK_COUNT.min(row_count),
+                profile_sample_count(),
+                profile_sql_session_storage(),
+            );
+            return;
+        }
+        let rows = fixture_rows(row_count);
         profile_operation(&runtime, &rows);
         return;
     }
@@ -48,6 +167,14 @@ fn tracked_state_crud_benches(c: &mut Criterion) {
             bench_sql_session(c, &runtime, profile, &rows[..row_count], label);
         }
     }
+}
+
+fn profile_sample_count() -> usize {
+    std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_SAMPLES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|&count| count > 0)
+        .unwrap_or(15)
 }
 
 fn init_perf_tracing() {
@@ -128,11 +255,7 @@ fn profile_operation(runtime: &tokio::runtime::Runtime, rows: &[WorkloadRow]) {
         ),
     };
     let read_many_pk_count = profile_read_many_pk_count(operation, rows.len());
-    let sample_count = std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_SAMPLES")
-        .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .filter(|&count| count > 0)
-        .unwrap_or(15);
+    let sample_count = profile_sample_count();
     let hot_repeats = std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_HOT_REPEATS")
         .ok()
         .map(|value| {
@@ -244,7 +367,7 @@ fn profile_operation(runtime: &tokio::runtime::Runtime, rows: &[WorkloadRow]) {
             } else {
                 profile_sql_session_bound_updates(
                     runtime,
-                    rows,
+                    rows.len(),
                     read_many_pk_count,
                     sample_count,
                     profile,
@@ -341,8 +464,10 @@ fn profile_sql_session_storage() -> StorageProfile {
         Ok("rocksdb") | Err(_) => StorageProfile::RocksDB,
         #[cfg(feature = "slatedb")]
         Ok("slatedb") => StorageProfile::SlateDB,
+        #[cfg(feature = "slatedb")]
+        Ok("slatedb_remote") => StorageProfile::SlateDBRemoteObjectStore,
         Ok(other) => panic!(
-            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_STORAGE '{other}'; expected rocksdb, sqlite, or slatedb"
+            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_STORAGE '{other}'; expected rocksdb, sqlite, slatedb, or slatedb_remote"
         ),
     }
 }
@@ -353,8 +478,10 @@ fn profile_transaction_storage() -> StorageProfile {
         Ok("rocksdb") | Err(_) => StorageProfile::RocksDB,
         #[cfg(feature = "slatedb")]
         Ok("slatedb") => StorageProfile::SlateDB,
+        #[cfg(feature = "slatedb")]
+        Ok("slatedb_remote") => StorageProfile::SlateDBRemoteObjectStore,
         Ok(other) => panic!(
-            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_STORAGE '{other}'; expected rocksdb, sqlite, or slatedb"
+            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_STORAGE '{other}'; expected rocksdb, sqlite, slatedb, or slatedb_remote"
         ),
     }
 }
@@ -417,6 +544,7 @@ fn profile_hot_sql_session_operations(
         rows,
         read_many_pk_count,
     ));
+    let _ = lix_engine::storage_bench::take_entity_point_snapshot_cache_accounting();
     let start = Instant::now();
     let mut row_count = 0;
     for _ in 0..repeats {
@@ -431,6 +559,13 @@ fn profile_hot_sql_session_operations(
         repeats,
         elapsed / repeats_u32,
     );
+    if matches!(operation, TransactionBenchOp::ReadOneByPk) {
+        let cache = lix_engine::storage_bench::take_entity_point_snapshot_cache_accounting();
+        println!(
+            "tracked_state_crud point cache accounting: hits={} misses={}",
+            cache.hits, cache.misses
+        );
+    }
     black_box(row_count);
 }
 
@@ -469,6 +604,26 @@ fn profile_hot_sql_session_bound_updates(
     );
     black_box(row_count);
 }
+
+#[cfg(target_os = "linux")]
+fn maybe_print_profile_rss_phase(phase: &str) {
+    if std::env::var_os("LIX_TRACKED_STATE_CRUD_PROFILE_RSS_PHASES").is_none() {
+        return;
+    }
+    let status = std::fs::read_to_string("/proc/self/status").expect("read process status");
+    let rss = status
+        .lines()
+        .find(|line| line.starts_with("VmRSS:"))
+        .unwrap_or("VmRSS: unavailable");
+    let high_water = status
+        .lines()
+        .find(|line| line.starts_with("VmHWM:"))
+        .unwrap_or("VmHWM: unavailable");
+    println!("tracked_state_crud rss phase: {phase} {rss} {high_water}");
+}
+
+#[cfg(not(target_os = "linux"))]
+fn maybe_print_profile_rss_phase(_phase: &str) {}
 
 fn profile_hot_raw_sqlite_operations(
     rows: &[WorkloadRow],
@@ -729,30 +884,55 @@ fn profile_sql_session_operation(
 
 fn profile_sql_session_bound_updates(
     runtime: &tokio::runtime::Runtime,
-    rows: &[WorkloadRow],
+    row_count: usize,
     read_many_pk_count: usize,
     sample_count: usize,
     profile: StorageProfile,
 ) {
-    let bound_update_row_count = profile_bound_update_row_count(rows.len());
+    let bound_update_row_count = profile_bound_update_row_count(row_count);
     let spread = profile_bound_update_spread();
     let mut samples = Vec::with_capacity(sample_count);
     for _ in 0..sample_count {
-        let fixture = runtime.block_on(sql_session::seeded_fixture_with_read_many_pk_count(
-            profile,
-            rows,
-            read_many_pk_count,
-        ));
+        maybe_print_profile_rss_phase("before_seed");
+        reset_allocation_accounting();
+        let rows = fixture_rows(row_count);
+        let fixture = runtime.block_on(
+            sql_session::seeded_bound_update_fixture_with_read_many_pk_count(
+                profile,
+                rows,
+                read_many_pk_count,
+            ),
+        );
+        maybe_print_profile_rss_phase("after_seed");
+        print_allocation_accounting("seed");
+        reset_allocation_accounting();
+        let _ = lix_engine::storage_bench::take_crud_physical_write_accounting();
+        let _ = lix_engine::storage_bench::take_certified_entity_update_value_batch_accounting();
         let start = Instant::now();
         let result = if spread {
             runtime.block_on(fixture.update_spread_bound_rows(bound_update_row_count))
-        } else if bound_update_row_count == rows.len() {
+        } else if bound_update_row_count == row_count {
             runtime.block_on(fixture.update_all_bound())
         } else {
             runtime.block_on(fixture.update_bound_rows(bound_update_row_count))
         };
         samples.push(start.elapsed());
         black_box(result);
+        maybe_print_profile_rss_phase("after_update");
+        print_allocation_accounting("update");
+        let certificate =
+            lix_engine::storage_bench::take_certified_entity_update_value_batch_accounting();
+        let physical = lix_engine::storage_bench::take_crud_physical_write_accounting();
+        println!(
+            "tracked_state_crud generated update accounting: logical_rows={bound_update_row_count} certificate_attempts={} certificate_hits={} certificate_misses={} certified_rows={} physical_puts={} physical_deletes={} physical_written_bytes={}",
+            certificate.attempts,
+            certificate.hits,
+            certificate.misses,
+            certificate.certified_rows,
+            physical.puts,
+            physical.deletes,
+            physical.written_bytes
+        );
     }
     print_profile_samples(
         &format!("sql_session_bound/{}", profile.name()),

--- a/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
@@ -1,23 +1,31 @@
-use std::fmt::Write as _;
+use std::sync::Arc;
 
-use lix_engine::{Engine, ExecuteBatchStatement, ExecuteResult, SessionContext, Storage, Value};
+use lix_engine::{Engine, ExecuteResult, SessionContext, Storage, Value};
 
 #[cfg(feature = "slatedb")]
 use crate::storage::SlateDB;
 use crate::storage::{ProfileStorage, RocksDB, SQLite, StorageProfile};
-use crate::workload::{WorkloadRow, sql_string};
+use crate::workload::{UpdateWorkloadRow, WorkloadRow, sql_string};
 
-const SQL_CHUNK_SIZE: usize = 500;
 const READ_MANY_PK_COUNT: usize = crate::READ_MANY_PK_COUNT;
 const BOUND_INSERT_ALL_SQL: &str = "INSERT INTO tracked_crud_insert (path, value) VALUES ($1, $2)";
+const BOUND_SEED_JSON_SQL: &str =
+    "INSERT INTO json_pointer (path, value) VALUES ($1, lix_json($2))";
 const BOUND_UPDATE_ALL_SQL: &str = "UPDATE json_pointer SET value = lix_json($1) WHERE path = $2";
 const UNTRACKED_PROBE_PATH: &str = "/__lix_untracked_probe";
+type SharedParameterBatch = Arc<[Arc<[Value]>]>;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum UntrackedFixture {
     None,
     OneUnrelated,
     OneReadManyMember,
+}
+
+#[derive(Clone, Copy)]
+enum FixtureShape {
+    FullCrud,
+    BoundUpdate,
 }
 
 impl UntrackedFixture {
@@ -41,14 +49,14 @@ pub(crate) struct GenericSqlFixture<StorageImpl: Storage> {
     visible_row_count: usize,
     untracked_fixture: UntrackedFixture,
     read_many_by_pk_count: usize,
-    bound_insert_all_batch: Vec<ExecuteBatchStatement>,
-    seed_sql_chunks: Vec<String>,
+    bound_insert_all_batch: SharedParameterBatch,
+    bound_seed_json_batch: SharedParameterBatch,
     select_all_sql: String,
     select_many_by_pk_sql: String,
     select_one_by_pk_sql: String,
     update_one_by_pk_sql: String,
     update_all_sql_rows: Vec<String>,
-    bound_update_all_batch: Vec<ExecuteBatchStatement>,
+    bound_update_all_batch: SharedParameterBatch,
     delete_all_sql: String,
     delete_one_by_pk_sql: String,
     // Keep the storage path alive until after the session/storage is dropped.
@@ -67,6 +75,15 @@ pub(crate) async fn empty_fixture_with_read_many_pk_count(
     rows: &[WorkloadRow],
     read_many_by_pk_count: usize,
 ) -> SqlFixture {
+    empty_fixture_with_shape(profile, rows, read_many_by_pk_count, FixtureShape::FullCrud).await
+}
+
+async fn empty_fixture_with_shape(
+    profile: StorageProfile,
+    rows: &[WorkloadRow],
+    read_many_by_pk_count: usize,
+    shape: FixtureShape,
+) -> SqlFixture {
     assert!(
         (1..=rows.len()).contains(&read_many_by_pk_count),
         "read-many primary-key count must be between 1 and {}, got {read_many_by_pk_count}",
@@ -79,6 +96,7 @@ pub(crate) async fn empty_fixture_with_read_many_pk_count(
             rows,
             read_many_by_pk_count,
             untracked_fixture,
+            shape,
             dir,
         )),
         ProfileStorage::RocksDB { storage, _dir: dir } => SqlFixture::RocksDB(fixture_for_session(
@@ -86,6 +104,7 @@ pub(crate) async fn empty_fixture_with_read_many_pk_count(
             rows,
             read_many_by_pk_count,
             untracked_fixture,
+            shape,
             dir,
         )),
         #[cfg(feature = "slatedb")]
@@ -94,6 +113,7 @@ pub(crate) async fn empty_fixture_with_read_many_pk_count(
             rows,
             read_many_by_pk_count,
             untracked_fixture,
+            shape,
             dir,
         )),
     }
@@ -114,7 +134,55 @@ pub(crate) async fn seeded_fixture_with_read_many_pk_count(
     fixture
 }
 
+pub(crate) async fn seeded_bound_update_fixture_with_read_many_pk_count(
+    profile: StorageProfile,
+    rows: Vec<WorkloadRow>,
+    read_many_by_pk_count: usize,
+) -> SqlFixture {
+    let row_count = rows.len();
+    let mut fixture = empty_fixture_with_shape(
+        profile,
+        &rows,
+        read_many_by_pk_count,
+        FixtureShape::BoundUpdate,
+    )
+    .await;
+    fixture.install_bound_seed_batch(rows);
+    fixture.seed_json_rows().await;
+    fixture.insert_untracked_probe().await;
+    fixture.release_bound_update_setup();
+    fixture.install_bound_update_batch(crate::workload::fixture_update_rows(row_count));
+    fixture
+}
+
 impl SqlFixture {
+    fn release_bound_update_setup(&mut self) {
+        match self {
+            Self::SQLite(fixture) => fixture.release_bound_update_setup(),
+            Self::RocksDB(fixture) => fixture.release_bound_update_setup(),
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.release_bound_update_setup(),
+        }
+    }
+
+    fn install_bound_seed_batch(&mut self, rows: Vec<WorkloadRow>) {
+        match self {
+            Self::SQLite(fixture) => fixture.install_bound_seed_batch(rows),
+            Self::RocksDB(fixture) => fixture.install_bound_seed_batch(rows),
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.install_bound_seed_batch(rows),
+        }
+    }
+
+    fn install_bound_update_batch(&mut self, rows: Vec<UpdateWorkloadRow>) {
+        match self {
+            Self::SQLite(fixture) => fixture.install_bound_update_batch(rows),
+            Self::RocksDB(fixture) => fixture.install_bound_update_batch(rows),
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.install_bound_update_batch(rows),
+        }
+    }
+
     pub(crate) async fn insert_all(&self) -> usize {
         match self {
             Self::SQLite(fixture) => fixture.insert_all().await,
@@ -273,13 +341,43 @@ impl<StorageImpl> GenericSqlFixture<StorageImpl>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
+    fn release_bound_update_setup(&mut self) {
+        self.bound_seed_json_batch = Arc::from([]);
+    }
+
+    fn install_bound_seed_batch(&mut self, rows: Vec<WorkloadRow>) {
+        self.bound_seed_json_batch = rows
+            .into_iter()
+            .take(self.row_count)
+            .map(|row| Arc::from(vec![Value::Text(row.path), Value::Text(row.value_json)]))
+            .collect::<Vec<_>>()
+            .into();
+    }
+
+    fn install_bound_update_batch(&mut self, rows: Vec<UpdateWorkloadRow>) {
+        self.bound_update_all_batch = rows
+            .into_iter()
+            .take(self.row_count)
+            .map(|row| {
+                Arc::from(vec![
+                    Value::Text(row.updated_value_json),
+                    Value::Text(row.path),
+                ])
+            })
+            .collect::<Vec<_>>()
+            .into();
+    }
+
     #[expect(clippy::cast_possible_truncation)]
     async fn insert_all(&self) -> usize {
         let _ =
             lix_engine::storage_bench::take_certified_entity_insert_parameter_batch_executions();
         let affected = self
             .session
-            .execute_batch(&self.bound_insert_all_batch)
+            .execute_homogeneous_write_batch(
+                Arc::from(BOUND_INSERT_ALL_SQL),
+                Arc::clone(&self.bound_insert_all_batch),
+            )
             .await
             .expect("execute tracked-state CRUD bound insert batch")
             .iter()
@@ -295,11 +393,17 @@ where
     }
 
     async fn seed_json_rows(&self) {
-        let affected = Box::pin(execute_many_in_transaction(
-            &self.session,
-            &self.seed_sql_chunks,
-        ))
-        .await;
+        let affected = self
+            .session
+            .execute_homogeneous_write_batch(
+                Arc::from(BOUND_SEED_JSON_SQL),
+                Arc::clone(&self.bound_seed_json_batch),
+            )
+            .await
+            .expect("execute tracked-state CRUD generated JSON seed batch")
+            .iter()
+            .map(ExecuteResult::rows_affected)
+            .sum::<u64>();
         assert_eq!(affected as usize, self.row_count);
     }
 
@@ -366,9 +470,14 @@ where
             "bound update row count must be between 1 and {}, got {row_count}",
             self.row_count
         );
+        let parameter_rows = if row_count == self.bound_update_all_batch.len() {
+            Arc::clone(&self.bound_update_all_batch)
+        } else {
+            Arc::from(self.bound_update_all_batch[..row_count].to_vec())
+        };
         let results = self
             .session
-            .execute_batch(&self.bound_update_all_batch[..row_count])
+            .execute_homogeneous_write_batch(Arc::from(BOUND_UPDATE_ALL_SQL), parameter_rows)
             .await
             .expect("execute tracked-state CRUD bound update batch");
         let affected = results
@@ -387,16 +496,18 @@ where
             self.row_count
         );
         let last = self.row_count - 1;
-        let batch = if row_count == 1 {
-            vec![self.bound_update_all_batch[0].clone()]
+        let parameter_rows = if row_count == 1 {
+            vec![Arc::clone(&self.bound_update_all_batch[0])]
         } else {
             (0..row_count)
-                .map(|index| self.bound_update_all_batch[index * last / (row_count - 1)].clone())
+                .map(|index| {
+                    Arc::clone(&self.bound_update_all_batch[index * last / (row_count - 1)])
+                })
                 .collect::<Vec<_>>()
         };
         let results = self
             .session
-            .execute_batch(&batch)
+            .execute_homogeneous_write_batch(Arc::from(BOUND_UPDATE_ALL_SQL), parameter_rows.into())
             .await
             .expect("execute spread tracked-state CRUD bound update batch");
         let affected = results
@@ -440,6 +551,7 @@ fn fixture_for_session<StorageImpl>(
     rows: &[WorkloadRow],
     read_many_by_pk_count: usize,
     untracked_fixture: UntrackedFixture,
+    shape: FixtureShape,
     dir: tempfile::TempDir,
 ) -> GenericSqlFixture<StorageImpl>
 where
@@ -459,20 +571,34 @@ where
         visible_row_count: tracked_rows.len() + usize::from(untracked_fixture.has_untracked_row()),
         untracked_fixture,
         read_many_by_pk_count,
-        bound_insert_all_batch: tracked_rows
-            .iter()
-            .map(|row| ExecuteBatchStatement {
-                sql: BOUND_INSERT_ALL_SQL.to_string(),
-                params: vec![
-                    Value::Text(row.path.clone()),
-                    Value::Text(row.value_json.clone()),
-                ],
-            })
-            .collect(),
-        seed_sql_chunks: tracked_rows
-            .chunks(SQL_CHUNK_SIZE)
-            .map(insert_json_rows_sql)
-            .collect(),
+        bound_insert_all_batch: if matches!(shape, FixtureShape::FullCrud) {
+            tracked_rows
+                .iter()
+                .map(|row| {
+                    Arc::from(vec![
+                        Value::Text(row.path.clone()),
+                        Value::Text(row.value_json.clone()),
+                    ])
+                })
+                .collect::<Vec<_>>()
+                .into()
+        } else {
+            Arc::from([])
+        },
+        bound_seed_json_batch: if matches!(shape, FixtureShape::FullCrud) {
+            tracked_rows
+                .iter()
+                .map(|row| {
+                    Arc::from(vec![
+                        Value::Text(row.path.clone()),
+                        Value::Text(row.value_json.clone()),
+                    ])
+                })
+                .collect::<Vec<_>>()
+                .into()
+        } else {
+            Arc::from([])
+        },
         select_all_sql: "SELECT path, value FROM json_pointer ORDER BY path".to_string(),
         select_many_by_pk_sql: select_many_by_pk_sql(
             rows,
@@ -481,17 +607,25 @@ where
         ),
         select_one_by_pk_sql: select_by_pk_sql(&tracked_rows[mid..][..1]),
         update_one_by_pk_sql: update_row_sql(&tracked_rows[mid]),
-        update_all_sql_rows: tracked_rows.iter().map(update_row_sql).collect(),
-        bound_update_all_batch: tracked_rows
-            .iter()
-            .map(|row| ExecuteBatchStatement {
-                sql: BOUND_UPDATE_ALL_SQL.to_string(),
-                params: vec![
-                    Value::Text(row.updated_value_json.clone()),
-                    Value::Text(row.path.clone()),
-                ],
-            })
-            .collect(),
+        update_all_sql_rows: if matches!(shape, FixtureShape::FullCrud) {
+            tracked_rows.iter().map(update_row_sql).collect()
+        } else {
+            Vec::new()
+        },
+        bound_update_all_batch: if matches!(shape, FixtureShape::FullCrud) {
+            tracked_rows
+                .iter()
+                .map(|row| {
+                    Arc::from(vec![
+                        Value::Text(row.updated_value_json.clone()),
+                        Value::Text(row.path.clone()),
+                    ])
+                })
+                .collect::<Vec<_>>()
+                .into()
+        } else {
+            Arc::from([])
+        },
         delete_all_sql: "DELETE FROM json_pointer".to_string(),
         delete_one_by_pk_sql: format!(
             "DELETE FROM json_pointer WHERE path = '{}'",
@@ -624,22 +758,6 @@ where
         .await
         .expect("commit tracked-state CRUD transaction");
     affected
-}
-
-fn insert_json_rows_sql(rows: &[WorkloadRow]) -> String {
-    let mut sql = String::from("INSERT INTO json_pointer (path, value) VALUES ");
-    for (index, row) in rows.iter().enumerate() {
-        if index > 0 {
-            sql.push(',');
-        }
-        let _ = write!(
-            sql,
-            "('{}', lix_json('{}'))",
-            sql_string(row.path.as_str()),
-            sql_string(row.value_json.as_str())
-        );
-    }
-    sql
 }
 
 fn select_by_pk_sql(rows: &[WorkloadRow]) -> String {

--- a/packages/engine-benchmarks/benches/tracked_state_crud/storage.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/storage.rs
@@ -10,6 +10,8 @@ pub(crate) enum StorageProfile {
     RocksDB,
     #[cfg(feature = "slatedb")]
     SlateDB,
+    #[cfg(feature = "slatedb")]
+    SlateDBRemoteObjectStore,
 }
 
 pub(crate) const KV_STORAGE_PROFILES: &[StorageProfile] =
@@ -32,6 +34,8 @@ impl StorageProfile {
             Self::RocksDB => "lix_rocksdb",
             #[cfg(feature = "slatedb")]
             Self::SlateDB => "lix_slatedb",
+            #[cfg(feature = "slatedb")]
+            Self::SlateDBRemoteObjectStore => "lix_slatedb_remote_object_store",
         }
     }
 }
@@ -72,6 +76,39 @@ impl StorageProfile {
                 let dir = TempDir::new().expect("create slatedb bench tempdir");
                 let storage =
                     SlateDB::open(dir.path().join("bench.slatedb")).expect("open slatedb storage");
+                ProfileStorage::SlateDB { storage, _dir: dir }
+            }
+            #[cfg(feature = "slatedb")]
+            Self::SlateDBRemoteObjectStore => {
+                use object_store::memory::InMemory;
+                use object_store::throttle::{ThrottleConfig, ThrottledStore};
+                use std::sync::Arc;
+                use std::time::Duration;
+
+                let latency_ms = std::env::var("LIX_TRACKED_STATE_CRUD_REMOTE_LATENCY_MS")
+                    .ok()
+                    .and_then(|value| value.parse::<u64>().ok())
+                    .unwrap_or(5);
+                let latency = Duration::from_millis(latency_ms);
+                let object_store = Arc::new(ThrottledStore::new(
+                    InMemory::new(),
+                    ThrottleConfig {
+                        wait_delete_per_call: latency,
+                        wait_get_per_call: latency,
+                        wait_list_per_call: latency,
+                        wait_list_with_delimiter_per_call: latency,
+                        wait_put_per_call: latency,
+                        ..ThrottleConfig::default()
+                    },
+                ));
+                let dir = TempDir::new().expect("create remote SlateDB bench tempdir");
+                let db_path = format!("tracked-state-crud-{}", ulid::Ulid::new());
+                let storage = SlateDB::open_object_store_with_options(
+                    db_path,
+                    object_store,
+                    lix_slatedb_storage::SlateDBObjectStoreOptions::default(),
+                )
+                .expect("open remote-path SlateDB object store");
                 ProfileStorage::SlateDB { storage, _dir: dir }
             }
         }

--- a/packages/engine-benchmarks/benches/tracked_state_crud/workload.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/workload.rs
@@ -12,6 +12,11 @@ pub(crate) struct WorkloadRow {
     pub(crate) updated_value_json: String,
 }
 
+pub(crate) struct UpdateWorkloadRow {
+    pub(crate) path: String,
+    pub(crate) updated_value_json: String,
+}
+
 pub(crate) fn fixture_rows(row_count: usize) -> Vec<WorkloadRow> {
     assert!(row_count > 0, "tracked-state CRUD fixture cannot be empty");
     let json: JsonValue = serde_json::from_str(PNPM_LOCK_JSON).expect("parse pnpm-lock fixture");
@@ -43,6 +48,32 @@ pub(crate) fn fixture_rows(row_count: usize) -> Vec<WorkloadRow> {
     rows
 }
 
+/// Regenerates only the columns retained by the bound-update parameter page.
+/// Keeping the seed-only JSON out of this second generation makes process RSS
+/// measure the engine and the active input page, rather than dead fixture data.
+pub(crate) fn fixture_update_rows(row_count: usize) -> Vec<UpdateWorkloadRow> {
+    assert!(row_count > 0, "tracked-state CRUD fixture cannot be empty");
+    let json: JsonValue = serde_json::from_str(PNPM_LOCK_JSON).expect("parse pnpm-lock fixture");
+    let mut rows = Vec::new();
+    flatten_update_json("", &json, &mut rows);
+    rows.sort_by(|left, right| left.path.cmp(&right.path));
+    assert!(rows.len() >= REAL_WORKLOAD_ROWS);
+    if row_count <= rows.len() {
+        rows.truncate(row_count);
+        return rows;
+    }
+
+    rows.reserve(row_count - rows.len());
+    for ordinal in rows.len()..row_count {
+        rows.push(UpdateWorkloadRow {
+            path: format!("/~lix-scale/{ordinal:09}"),
+            updated_value_json: format!(r#"{{"ordinal":{ordinal},"lane":"scale","updated":true}}"#),
+        });
+    }
+    rows.sort_by(|left, right| left.path.cmp(&right.path));
+    rows
+}
+
 fn flatten_json(path: &str, value: &JsonValue, rows: &mut Vec<WorkloadRow>) {
     if !path.is_empty() {
         let value_json = serde_json::to_string(value).expect("serialize JSON pointer value");
@@ -68,6 +99,34 @@ fn flatten_json(path: &str, value: &JsonValue, rows: &mut Vec<WorkloadRow>) {
         JsonValue::Object(map) => {
             for (key, item) in map {
                 flatten_json(&format!("{path}/{}", escape_json_pointer(key)), item, rows);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn flatten_update_json(path: &str, value: &JsonValue, rows: &mut Vec<UpdateWorkloadRow>) {
+    if !path.is_empty() {
+        rows.push(UpdateWorkloadRow {
+            path: path.to_string(),
+            updated_value_json: serde_json::to_string(&serde_json::json!({
+                "path": path,
+                "value": value,
+                "updated": true
+            }))
+            .expect("serialize updated JSON pointer value"),
+        });
+    }
+
+    match value {
+        JsonValue::Array(items) => {
+            for (index, item) in items.iter().enumerate() {
+                flatten_update_json(&format!("{path}/{index}"), item, rows);
+            }
+        }
+        JsonValue::Object(map) => {
+            for (key, item) in map {
+                flatten_update_json(&format!("{path}/{}", escape_json_pointer(key)), item, rows);
             }
         }
         _ => {}

--- a/packages/engine/src/collection_generation.rs
+++ b/packages/engine/src/collection_generation.rs
@@ -20,6 +20,21 @@ pub(crate) struct CollectionScopeRef<'a> {
 pub(crate) struct CollectionGeneration {
     pub(crate) active_generation: CommitId,
     pub(crate) live_count: u64,
+    /// Present only while the active collection is exactly one certified,
+    /// ordered, tracked, unfiled generation with no incremental mutations.
+    pub(crate) ordered_identity_digest: Option<[u8; 32]>,
+}
+
+pub(crate) fn ordered_single_string_identity_digest<'a>(
+    entity_pks: impl IntoIterator<Item = &'a EntityPk>,
+) -> Option<[u8; 32]> {
+    let mut hasher = blake3::Hasher::new();
+    for entity_pk in entity_pks {
+        let value = entity_pk.as_single_string().ok()?;
+        hasher.update(&(value.len() as u64).to_le_bytes());
+        hasher.update(value.as_bytes());
+    }
+    Some(*hasher.finalize().as_bytes())
 }
 
 pub(crate) fn collection_scope_key(scope: CollectionScopeRef<'_>) -> String {

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -46,7 +46,7 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"lxcd9-current-plugin-checkpoint.v39";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"lxcd9-current-plugin-checkpoint.v40";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -5,6 +5,7 @@ use crate::GLOBAL_BRANCH_ID;
 use crate::LixError;
 use crate::NullableKeyFilter;
 use crate::branch::{BRANCH_REF_SCHEMA_KEY, BranchHeadControl, BranchHeadControlContext};
+use crate::changelog::CommitId;
 use crate::commit_graph::CommitGraphContext;
 use crate::entity_pk::EntityPk;
 use crate::filesystem::{
@@ -25,9 +26,102 @@ use crate::tracked_state::{
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures_util::{StreamExt, TryStreamExt, stream};
+use std::mem::size_of;
 
 const BRANCH_READ_CONCURRENCY: usize = 8;
+const ENTITY_POINT_SNAPSHOT_CACHE_MAX_BYTES: usize = 8 * 1024 * 1024;
+const ENTITY_POINT_SNAPSHOT_CACHE_MAX_ENTRIES: usize = 4_096;
 type BranchHeads = std::collections::BTreeMap<String, BranchHeadControl>;
+
+#[derive(Debug, PartialEq, Eq)]
+struct EntityPointSnapshotCacheKey {
+    branch_id: String,
+    generation: CommitId,
+    current_state_revision: u64,
+    schema_key: String,
+    entity_pk: EntityPk,
+}
+
+#[derive(Debug)]
+struct EntityPointSnapshotCacheEntry {
+    key: EntityPointSnapshotCacheKey,
+    snapshots: Vec<Option<Bytes>>,
+    bytes: usize,
+}
+
+#[derive(Debug, Default)]
+struct EntityPointSnapshotCache {
+    entries: std::sync::Mutex<Vec<EntityPointSnapshotCacheEntry>>,
+}
+
+impl EntityPointSnapshotCache {
+    fn get(&self, key: &EntityPointSnapshotCacheKey) -> Option<Vec<Option<Bytes>>> {
+        if entity_point_snapshot_cache_disabled_for_profile() {
+            return None;
+        }
+        let mut entries = self
+            .entries
+            .lock()
+            .expect("entity point snapshot cache lock poisoned");
+        let position = entries.iter().position(|entry| entry.key == *key)?;
+        let entry = entries.remove(position);
+        let result = entry.snapshots.clone();
+        entries.push(entry);
+        Some(result)
+    }
+
+    fn insert(
+        &self,
+        key: EntityPointSnapshotCacheKey,
+        snapshots: Vec<Option<Bytes>>,
+    ) -> Vec<Option<Bytes>> {
+        if entity_point_snapshot_cache_disabled_for_profile() {
+            return snapshots;
+        }
+        let bytes = size_of::<EntityPointSnapshotCacheEntry>()
+            + key.branch_id.capacity()
+            + key.schema_key.capacity()
+            + snapshots.capacity() * size_of::<Option<Bytes>>()
+            + snapshots.iter().flatten().map(Bytes::len).sum::<usize>();
+        let result = snapshots.clone();
+        if bytes > ENTITY_POINT_SNAPSHOT_CACHE_MAX_BYTES {
+            return result;
+        }
+        let mut entries = self
+            .entries
+            .lock()
+            .expect("entity point snapshot cache lock poisoned");
+        entries.retain(|entry| {
+            entry.key.branch_id != key.branch_id
+                || entry.key.schema_key != key.schema_key
+                || entry.key.entity_pk != key.entity_pk
+        });
+        entries.push(EntityPointSnapshotCacheEntry {
+            key,
+            snapshots,
+            bytes,
+        });
+        let mut resident_bytes = entries.iter().map(|entry| entry.bytes).sum::<usize>();
+        while resident_bytes > ENTITY_POINT_SNAPSHOT_CACHE_MAX_BYTES
+            || entries.len() > ENTITY_POINT_SNAPSHOT_CACHE_MAX_ENTRIES
+        {
+            resident_bytes = resident_bytes.saturating_sub(entries.remove(0).bytes);
+        }
+        result
+    }
+}
+
+#[cfg(feature = "storage-benches")]
+fn entity_point_snapshot_cache_disabled_for_profile() -> bool {
+    static DISABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *DISABLED
+        .get_or_init(|| std::env::var_os("LIX_TRACKED_STATE_CRUD_DISABLE_POINT_CACHE").is_some())
+}
+
+#[cfg(not(feature = "storage-benches"))]
+const fn entity_point_snapshot_cache_disabled_for_profile() -> bool {
+    false
+}
 
 const COMMIT_SCHEMA_KEY: &str = "lix_commit";
 const COMMIT_EDGE_SCHEMA_KEY: &str = "lix_commit_edge";
@@ -42,6 +136,7 @@ pub(crate) struct LiveStateContext {
     commit_graph: CommitGraphContext,
     filesystem_path_index_cache: std::sync::Arc<FilesystemPathIndexCache>,
     entity_field_index_cache: std::sync::Arc<EntitySnapshotFieldIndexCache>,
+    entity_point_snapshot_cache: std::sync::Arc<EntityPointSnapshotCache>,
 }
 
 impl LiveStateContext {
@@ -54,6 +149,7 @@ impl LiveStateContext {
             commit_graph,
             filesystem_path_index_cache: std::sync::Arc::new(FilesystemPathIndexCache::default()),
             entity_field_index_cache: std::sync::Arc::new(EntitySnapshotFieldIndexCache::default()),
+            entity_point_snapshot_cache: std::sync::Arc::new(EntityPointSnapshotCache::default()),
         }
     }
 
@@ -68,6 +164,7 @@ impl LiveStateContext {
             commit_graph: self.commit_graph.clone(),
             filesystem_path_index_cache: std::sync::Arc::clone(&self.filesystem_path_index_cache),
             entity_field_index_cache: std::sync::Arc::clone(&self.entity_field_index_cache),
+            entity_point_snapshot_cache: std::sync::Arc::clone(&self.entity_point_snapshot_cache),
         }
     }
 
@@ -89,6 +186,7 @@ pub(crate) struct LiveStateStoreReader<S> {
     commit_graph: CommitGraphContext,
     filesystem_path_index_cache: std::sync::Arc<FilesystemPathIndexCache>,
     entity_field_index_cache: std::sync::Arc<EntitySnapshotFieldIndexCache>,
+    entity_point_snapshot_cache: std::sync::Arc<EntityPointSnapshotCache>,
 }
 
 impl<S> LiveStateStoreReader<S>
@@ -110,18 +208,42 @@ where
         else {
             return Ok(None);
         };
-        Ok(Some(
-            self.tracked_head
-                .reader(&self.store)
-                .scan_entity_snapshots(
-                    &requested_branch_id,
-                    requested_control,
-                    &schema_key,
-                    &request.filter.entity_pks,
-                    request.limit,
-                )
-                .await?,
-        ))
+        let point_key = match (request.filter.entity_pks.as_slice(), request.limit) {
+            ([entity_pk], None | Some(1..)) => Some(EntityPointSnapshotCacheKey {
+                branch_id: requested_branch_id.clone(),
+                generation: requested_control.generation,
+                current_state_revision: requested_control.current_state_revision,
+                schema_key: schema_key.clone(),
+                entity_pk: entity_pk.clone(),
+            }),
+            _ => None,
+        };
+        if let Some(key) = point_key.as_ref()
+            && let Some(snapshots) = self.entity_point_snapshot_cache.get(key)
+        {
+            #[cfg(feature = "storage-benches")]
+            crate::storage_bench::record_entity_point_snapshot_cache_hit();
+            return Ok(Some(snapshots));
+        }
+        if point_key.is_some() {
+            #[cfg(feature = "storage-benches")]
+            crate::storage_bench::record_entity_point_snapshot_cache_miss();
+        }
+        let snapshots = self
+            .tracked_head
+            .reader(&self.store)
+            .scan_entity_snapshots(
+                &requested_branch_id,
+                requested_control,
+                &schema_key,
+                &request.filter.entity_pks,
+                request.limit,
+            )
+            .await?;
+        Ok(Some(match point_key {
+            Some(key) => self.entity_point_snapshot_cache.insert(key, snapshots),
+            None => snapshots,
+        }))
     }
 
     pub(crate) async fn scan_direct_entity_snapshots_by_string_field(

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -1818,6 +1818,9 @@ impl<'a> CertifiedCsvReader<'a> {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, musli::Encode, musli::Decode)]
 #[musli(packed)]
+// The digest is the third positional field in repository protocol v40. Older
+// two-field controls belong to v39 repositories, which Engine::new rejects at
+// the protocol boundary before any HOT control is decoded.
 struct HotCollectionControl {
     active_generation: CommitId,
     live_count: u64,

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -1821,6 +1821,12 @@ impl<'a> CertifiedCsvReader<'a> {
 struct HotCollectionControl {
     active_generation: CommitId,
     live_count: u64,
+    ordered_identity_digest: Option<[u8; 32]>,
+}
+
+struct PackedCollectionIncrement {
+    live_count: u64,
+    ordered_identity_digest: Option<[u8; 32]>,
 }
 
 fn hot_collection_control_key(
@@ -1856,6 +1862,7 @@ async fn load_hot_collection_control(
         Ok(HotCollectionControl {
             active_generation: branch_generation,
             live_count: 0,
+            ordered_identity_digest: None,
         }),
         |value| {
             let StorageProjectedValue::FullValue(bytes) = value else {
@@ -1898,6 +1905,7 @@ async fn load_hot_collection_controls(
                 Ok(HotCollectionControl {
                     active_generation: branch_generation,
                     live_count: 0,
+                    ordered_identity_digest: None,
                 }),
                 |value| {
                     let StorageProjectedValue::FullValue(bytes) = value else {
@@ -2002,6 +2010,25 @@ fn stage_incremental_collection_controls(
             continue;
         }
 
+        // The compact digest certifies one untouched packed generation. Any
+        // row-shaped overlay invalidates it, including a value-only update;
+        // later complete-replacement proofs then use the ordinary exact scan.
+        for scope in [
+            Some((delta.schema_key.to_string(), None)),
+            delta
+                .file_id
+                .map(|file_id| (delta.schema_key.to_string(), Some(file_id.to_string()))),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            let control = controls
+                .get_mut(&scope)
+                .expect("row collection scope was loaded above");
+            control.ordered_identity_digest = None;
+            dirty_scopes.insert(scope);
+        }
+
         let previous_live = previous
             .as_ref()
             .map(CertifiedCurrentStatePredecessor::view)
@@ -2062,6 +2089,7 @@ fn stage_incremental_collection_controls(
             .live_count
             .checked_add(*increment)
             .ok_or_else(|| head_value_error("hot collection live count exceeds u64"))?;
+        control.ordered_identity_digest = None;
         dirty_scopes.insert(scope.clone());
     }
 
@@ -2108,6 +2136,7 @@ fn apply_incremental_collection_generation_deltas(
             .commit_id
             .ok_or_else(|| head_value_error("tracked collection-generation row lacks commit_id"))?;
         control.live_count = 0;
+        control.ordered_identity_digest = None;
     }
     Ok(())
 }
@@ -2157,6 +2186,7 @@ fn stage_complete_collection_controls(
                 HotCollectionControl {
                     active_generation,
                     live_count: 0,
+                    ordered_identity_digest: None,
                 },
             );
             continue;
@@ -2166,6 +2196,7 @@ fn stage_complete_collection_controls(
             .or_insert(HotCollectionControl {
                 active_generation: branch_generation,
                 live_count: 0,
+                ordered_identity_digest: None,
             });
         if let Some(file_id) = &identity.file_id {
             controls
@@ -2173,6 +2204,7 @@ fn stage_complete_collection_controls(
                 .or_insert(HotCollectionControl {
                     active_generation: branch_generation,
                     live_count: 0,
+                    ordered_identity_digest: None,
                 });
         }
     }
@@ -2960,6 +2992,7 @@ where
                 |control| crate::collection_generation::CollectionGeneration {
                     active_generation: control.active_generation,
                     live_count: control.live_count,
+                    ordered_identity_digest: control.ordered_identity_digest,
                 },
             )
     }
@@ -3814,7 +3847,7 @@ where
             ));
         }
         let mut previous = None::<(&str, &EntityPk)>;
-        let mut schema_increments = BTreeMap::<&str, u64>::new();
+        let mut schema_rows = BTreeMap::<&str, Vec<&EntityPk>>::new();
         for (schema_key, entity_pk) in rows {
             if previous.is_some_and(|(previous_schema, previous_entity_pk)| {
                 previous_schema
@@ -3827,11 +3860,25 @@ where
                 ));
             }
             previous = Some((schema_key, entity_pk));
-            let increment = schema_increments.entry(schema_key).or_default();
-            *increment = increment
-                .checked_add(1)
-                .ok_or_else(|| head_value_error("packed current-base row count exceeds u64"))?;
+            schema_rows.entry(schema_key).or_default().push(entity_pk);
         }
+        let schema_increments = schema_rows
+            .into_iter()
+            .map(|(schema_key, entity_pks)| {
+                let live_count = u64::try_from(entity_pks.len())
+                    .map_err(|_| head_value_error("packed current-base row count exceeds u64"))?;
+                Ok((
+                    schema_key,
+                    PackedCollectionIncrement {
+                        live_count,
+                        ordered_identity_digest:
+                            crate::collection_generation::ordered_single_string_identity_digest(
+                                entity_pks,
+                            ),
+                    },
+                ))
+            })
+            .collect::<Result<BTreeMap<_, _>, LixError>>()?;
         self.stage_packed_insert_current_base_manifest(
             branch_id,
             generation,
@@ -3841,6 +3888,75 @@ where
             coverage,
         )
         .await
+    }
+
+    /// Publishes a commit whose ordered deltas replace every live member of
+    /// one tracked, unfiled collection as a new packed base segment.
+    ///
+    /// The prior segments remain available for other schemas. Within this
+    /// schema every previous identity is covered by the newer commit, so the
+    /// normal newest-commit overlay makes the replacement complete without
+    /// reading and rewriting the previous HOT value plane.
+    pub(crate) async fn stage_complete_collection_replacement_current_base(
+        &mut self,
+        branch_id: &str,
+        generation: CommitId,
+        new_head: CommitId,
+        schema_key: &str,
+        row_count: usize,
+        working_diff_capture_checkpoint_commit_id: Option<CommitId>,
+        coverage: &mut WorkingDiffIndexCoverage,
+    ) -> Result<CommitId, LixError> {
+        let row_count = u64::try_from(row_count)
+            .map_err(|_| head_value_error("packed replacement row count exceeds u64"))?;
+        if row_count == 0 {
+            return Err(head_value_error(
+                "packed collection replacement requires at least one row",
+            ));
+        }
+        let control = load_hot_collection_control(
+            self.store,
+            branch_id,
+            generation,
+            crate::collection_generation::CollectionScopeRef {
+                schema_key,
+                file_id: None,
+            },
+        )
+        .await?;
+        if control.live_count != row_count {
+            return Err(head_value_error(format!(
+                "packed collection replacement expected {row_count} live rows in '{schema_key}', found {}",
+                control.live_count
+            )));
+        }
+
+        let mut manifest_key = hot_scope_prefix(branch_id, generation);
+        manifest_key.reserve(16);
+        manifest_key.extend_from_slice(new_head.as_uuid().as_bytes());
+        if working_diff_capture_checkpoint_commit_id.is_some() {
+            coverage
+                .add_encoded_group_key(&manifest_key)
+                .ok_or_else(|| head_value_error("packed current-base diff count exceeds u64"))?;
+        }
+        self.writes.put(
+            PACKED_CURRENT_BASE_SPACE,
+            StorageKey(Bytes::from(manifest_key)),
+            StorageValue {
+                bytes: working_diff_capture_checkpoint_commit_id.map_or_else(
+                    || Bytes::from_static(&[0; 16]),
+                    |checkpoint| Bytes::copy_from_slice(checkpoint.as_uuid().as_bytes()),
+                ),
+            },
+        );
+        self.writes.put(
+            PACKED_CURRENT_BASE_CONTROL_SPACE,
+            StorageKey(Bytes::from(hot_scope_prefix(branch_id, generation))),
+            StorageValue {
+                bytes: Bytes::from_static(&[1]),
+            },
+        );
+        Ok(generation)
     }
 
     /// Publishes validated, tracked, unfiled creates as an immutable base.
@@ -3901,13 +4017,30 @@ where
             ));
         }
 
-        let mut schema_increments = BTreeMap::<&str, u64>::new();
+        let mut schema_rows = BTreeMap::<&str, Vec<&EntityPk>>::new();
         for delta in &sorted {
-            let increment = schema_increments.entry(delta.schema_key).or_default();
-            *increment = increment
-                .checked_add(1)
-                .ok_or_else(|| head_value_error("packed current-base row count exceeds u64"))?;
+            schema_rows
+                .entry(delta.schema_key)
+                .or_default()
+                .push(delta.entity_pk);
         }
+        let schema_increments = schema_rows
+            .into_iter()
+            .map(|(schema_key, entity_pks)| {
+                let live_count = u64::try_from(entity_pks.len())
+                    .map_err(|_| head_value_error("packed current-base row count exceeds u64"))?;
+                Ok((
+                    schema_key,
+                    PackedCollectionIncrement {
+                        live_count,
+                        ordered_identity_digest:
+                            crate::collection_generation::ordered_single_string_identity_digest(
+                                entity_pks,
+                            ),
+                    },
+                ))
+            })
+            .collect::<Result<BTreeMap<_, _>, LixError>>()?;
         self.stage_packed_insert_current_base_manifest(
             branch_id,
             generation,
@@ -3924,7 +4057,7 @@ where
         branch_id: &str,
         generation: CommitId,
         new_head: CommitId,
-        schema_increments: BTreeMap<&str, u64>,
+        schema_increments: BTreeMap<&str, PackedCollectionIncrement>,
         working_diff_capture_checkpoint_commit_id: Option<CommitId>,
         coverage: &mut WorkingDiffIndexCoverage,
     ) -> Result<CommitId, LixError> {
@@ -3949,10 +4082,16 @@ where
         let controls =
             load_hot_collection_controls(self.store, branch_id, generation, &scopes).await?;
         for ((schema_key, increment), mut control) in schema_increments.into_iter().zip(controls) {
+            let was_empty = control.live_count == 0;
             control.live_count = control
                 .live_count
-                .checked_add(increment)
+                .checked_add(increment.live_count)
                 .ok_or_else(|| head_value_error("hot collection live count exceeds u64"))?;
+            control.ordered_identity_digest = if was_empty {
+                increment.ordered_identity_digest
+            } else {
+                None
+            };
             stage_hot_collection_control(
                 self.writes,
                 branch_id,

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -547,6 +547,8 @@ where
             Ok(value) => {
                 self.ensure_open()?;
                 let outcome = transaction.commit(&runtime_functions).await?;
+                #[cfg(feature = "storage-benches")]
+                crate::storage_bench::record_crud_physical_writes(outcome.storage_stats);
                 drop(write_access);
                 self.observe_invalidation
                     .bump_if_storage_changed(&outcome.storage_stats);
@@ -623,7 +625,12 @@ where
     R: crate::storage_adapter::StorageRead + 'static,
 {
     async fn compiled_sql_catalog(&self) -> Result<Arc<CatalogSnapshot>, LixError> {
-        let revision = load_catalog_revision(&self.read_store).await?;
+        let revision = load_catalog_revision(&self.read_store)
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.public_read.catalog_revision"
+            ))
+            .await?;
         let live_state = self.live_state();
         self.catalog_context
             .compiled_catalog_for_transaction_open(
@@ -707,7 +714,13 @@ where
     }
 
     async fn public_catalog(&self) -> Result<Arc<crate::sql2::PublicCatalog>, LixError> {
-        let catalog = self.compiled_sql_catalog().await?;
+        let catalog = self
+            .compiled_sql_catalog()
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.public_read.compiled_catalog"
+            ))
+            .await?;
         self.sql_planning_cache
             .public_catalog(catalog.fingerprint(), || Ok(catalog.schema_jsons()))
     }

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -24,6 +24,7 @@ use datafusion::sql::sqlparser::ast::{
     Value as SqlValue, Visit, Visitor,
 };
 use serde_json::{Map as JsonMap, Value as JsonValue};
+use tracing::Instrument as _;
 
 use super::ExecuteIdempotency;
 use super::context::{SessionContext, SessionSqlExecutionContext, SessionWriteAccess};
@@ -1130,8 +1131,105 @@ where
         &self,
         statements: &[ExecuteBatchStatement],
     ) -> Result<Vec<ExecuteResult>, LixError> {
-        self.execute_batch_with_options(statements, ExecuteOptions::default())
-            .await
+        Box::pin(self.execute_batch_with_options(statements, ExecuteOptions::default())).await
+    }
+
+    /// Executes one write shape over a shared, homogeneous parameter page.
+    ///
+    /// Unlike [`Self::execute_batch`], this API does not duplicate the SQL
+    /// text and owned parameter strings into one statement object per row.
+    /// It is deliberately a hard, generated-write boundary: the bound write
+    /// must accept either the borrowed-value certificate or the physical
+    /// parameter-batch route. Shapes that require sequential statement
+    /// semantics remain on `execute_batch`.
+    pub async fn execute_homogeneous_write_batch(
+        &self,
+        sql: Arc<str>,
+        parameter_rows: Arc<[Arc<[Value]>]>,
+    ) -> Result<Vec<ExecuteResult>, LixError> {
+        Box::pin(self.execute_homogeneous_write_batch_inner(sql, parameter_rows)).await
+    }
+
+    async fn execute_homogeneous_write_batch_inner(
+        &self,
+        sql: Arc<str>,
+        parameter_rows: Arc<[Arc<[Value]>]>,
+    ) -> Result<Vec<ExecuteResult>, LixError> {
+        self.ensure_open()?;
+        if parameter_rows.is_empty() {
+            return Err(LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                "execute_homogeneous_write_batch requires at least one parameter row",
+            ));
+        }
+        let parameter_count = parameter_rows[0].len();
+        if parameter_rows
+            .iter()
+            .any(|parameters| parameters.len() != parameter_count)
+        {
+            return Err(LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                "execute_homogeneous_write_batch requires a rectangular parameter page",
+            ));
+        }
+        let statement = self.sql_planning_cache.parse_statement(&sql)?;
+        if sql2::bind_statement_route(&statement)? != sql2::BoundStatementRoute::Write {
+            return Err(LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                "execute_homogeneous_write_batch requires a write statement",
+            ));
+        }
+
+        let sql_for_error = Arc::clone(&sql);
+        let result = self
+            .with_write_transaction(move |transaction| {
+                Box::pin(async move {
+                    let plan = transaction.prepare_sql_write_logical_plan(&sql, &statement)?;
+                    let parameter_refs = parameter_rows
+                        .iter()
+                        .map(|parameters| parameters.as_ref())
+                        .collect::<Vec<_>>();
+                    let results = if let Some(results) =
+                        sql2::execute_write_logical_plan_value_batch(
+                            transaction,
+                            &plan,
+                            &parameter_refs,
+                        )
+                        .await?
+                    {
+                        Some(results)
+                    } else {
+                        let Some(parameter_batch) = sql2::parameter_record_batch(&parameter_refs)?
+                        else {
+                            return Err(LixError::new(
+                                LixError::CODE_INVALID_PARAM,
+                                "homogeneous write parameters cannot be lowered as one batch",
+                            ));
+                        };
+                        sql2::execute_write_logical_plan_parameter_batch(
+                            transaction,
+                            plan,
+                            &parameter_batch,
+                        )
+                        .await?
+                    };
+                    results
+                        .ok_or_else(|| {
+                            LixError::new(
+                                LixError::CODE_INVALID_PARAM,
+                                "write shape requires sequential execute_batch semantics",
+                            )
+                        })
+                        .map(|results| {
+                            results
+                                .into_iter()
+                                .map(ExecuteResult::from_sql_write_result)
+                                .collect()
+                        })
+                })
+            })
+            .await;
+        result.map_err(|error| normalize_sql_surface_error(error, &sql_for_error))
     }
 
     pub async fn execute_batch_with_options(
@@ -1139,11 +1237,11 @@ where
         statements: &[ExecuteBatchStatement],
         options: ExecuteOptions,
     ) -> Result<Vec<ExecuteResult>, LixError> {
-        self.execute_batch_with_options_and_metadata(
+        Box::pin(self.execute_batch_with_options_and_metadata(
             statements,
             options,
             vec![ExecuteStatementMetadata::default(); statements.len()],
-        )
+        ))
         .await
     }
 
@@ -1154,13 +1252,13 @@ where
         options: ExecuteOptions,
         statement_metadata: Vec<ExecuteStatementMetadata>,
     ) -> Result<Vec<ExecuteResult>, LixError> {
-        self.execute_batch_with_options_and_metadata_inner(
+        Box::pin(self.execute_batch_with_options_and_metadata_inner(
             statements,
             options,
             statement_metadata,
             None,
             false,
-        )
+        ))
         .await
     }
 
@@ -1757,7 +1855,13 @@ where
         LixError,
     > {
         let file_view_collector = acknowledge_file_views.then(sql2::SessionFileViews::default);
-        let active_branch_id = self.active_branch_id_from_reader(&read_store).await?;
+        let active_branch_id = self
+            .active_branch_id_from_reader(&read_store)
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.public_read.active_branch"
+            ))
+            .await?;
         if let Some(exact_filesystem_read) = exact_filesystem_read {
             let query = match exact_filesystem_read {
                 ExactFilesystemRead::RootFileListing => {
@@ -5161,6 +5265,123 @@ mod tests {
         assert_eq!(
             rows.rows()[1].get::<serde_json::Value>("value").unwrap(),
             serde_json::json!({"nested": [1, true, "x"]})
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_replacement_publishes_packed_current_base_and_accepts_later_overlays() {
+        const ROW_COUNT: usize = 1_024;
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "x-lix-key": "packed_replacement_probe",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" },
+                "value": {
+                    "type": [
+                        "object", "array", "string", "number", "integer", "boolean", "null"
+                    ]
+                }
+            },
+            "required": ["path", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+
+        let insert_sql =
+            "INSERT INTO packed_replacement_probe (path, value) VALUES ($1, lix_json($2))";
+        let inserts = (0..ROW_COUNT)
+            .map(|row_index| ExecuteBatchStatement {
+                sql: insert_sql.to_string(),
+                params: vec![
+                    Value::Text(format!("/{row_index:04}")),
+                    Value::Text(format!(r#"{{"old":{row_index}}}"#)),
+                ],
+            })
+            .collect::<Vec<_>>();
+        session.execute_batch(&inserts).await.unwrap();
+
+        crate::transaction::take_complete_replacement_packed_current_base_publications();
+        sql2::take_certified_generation_identity_replacements();
+        let update_sql = "UPDATE packed_replacement_probe SET value = lix_json($1) WHERE path = $2";
+        let updates = (0..ROW_COUNT)
+            .map(|row_index| ExecuteBatchStatement {
+                sql: update_sql.to_string(),
+                params: vec![
+                    Value::Text(format!(r#"{{"updated":{row_index}}}"#)),
+                    Value::Text(format!("/{row_index:04}")),
+                ],
+            })
+            .collect::<Vec<_>>();
+        let affected = session
+            .execute_batch(&updates)
+            .await
+            .unwrap()
+            .iter()
+            .map(ExecuteResult::rows_affected)
+            .sum::<u64>();
+        assert_eq!(affected, ROW_COUNT as u64);
+        assert_eq!(
+            sql2::take_certified_generation_identity_replacements(),
+            1,
+            "the untouched packed generation must prove the complete identity set without a row scan"
+        );
+        assert_eq!(
+            crate::transaction::take_complete_replacement_packed_current_base_publications(),
+            1,
+            "the certified full replacement must publish one packed current base"
+        );
+
+        let rows = session
+            .execute(
+                "SELECT path, value FROM packed_replacement_probe WHERE path IN ('/0000', '/1023') ORDER BY path",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(
+            rows.rows()[0].get::<serde_json::Value>("value").unwrap(),
+            serde_json::json!({"updated": 0})
+        );
+        assert_eq!(
+            rows.rows()[1].get::<serde_json::Value>("value").unwrap(),
+            serde_json::json!({"updated": 1023})
+        );
+
+        session
+            .execute(
+                "UPDATE packed_replacement_probe SET value = lix_json('{\"overlay\":true}') WHERE path = '/0000'",
+                &[],
+            )
+            .await
+            .unwrap();
+        session
+            .execute(
+                "DELETE FROM packed_replacement_probe WHERE path = '/1023'",
+                &[],
+            )
+            .await
+            .unwrap();
+        let rows = session
+            .execute(
+                "SELECT path, value FROM packed_replacement_probe WHERE path IN ('/0000', '/1023') ORDER BY path",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows.rows()[0].get::<String>("path").unwrap(), "/0000");
+        assert_eq!(
+            rows.rows()[0].get::<serde_json::Value>("value").unwrap(),
+            serde_json::json!({"overlay": true})
         );
     }
 

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -5386,6 +5386,101 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn staged_delete_disables_generation_identity_replacement() {
+        const ROW_COUNT: usize = 16;
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "x-lix-key": "staged_generation_probe",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" },
+                "value": { "type": "object" }
+            },
+            "required": ["path", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+
+        let insert_sql =
+            "INSERT INTO staged_generation_probe (path, value) VALUES ($1, lix_json($2))";
+        let inserts = (0..ROW_COUNT)
+            .map(|row_index| ExecuteBatchStatement {
+                sql: insert_sql.to_string(),
+                params: vec![
+                    Value::Text(format!("/{row_index:04}")),
+                    Value::Text(format!(r#"{{"old":{row_index}}}"#)),
+                ],
+            })
+            .collect::<Vec<_>>();
+        session.execute_batch(&inserts).await.unwrap();
+
+        let mut transaction = session.begin_transaction().await.unwrap();
+        transaction
+            .execute(
+                "DELETE FROM staged_generation_probe WHERE path = '/0000'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let update_sql = "UPDATE staged_generation_probe SET value = lix_json($1) WHERE path = $2";
+        let updates = (0..ROW_COUNT)
+            .map(|row_index| ExecuteBatchStatement {
+                sql: update_sql.to_string(),
+                params: vec![
+                    Value::Text(format!(r#"{{"updated":{row_index}}}"#)),
+                    Value::Text(format!("/{row_index:04}")),
+                ],
+            })
+            .collect::<Vec<_>>();
+        let parsed = TransactionBatchStatements::Shared {
+            statement: sql2::parse_statement(update_sql).unwrap(),
+            len: updates.len(),
+        };
+        sql2::take_certified_generation_identity_replacements();
+        let results = try_execute_transaction_parameter_batch(
+            transaction.transaction_mut().unwrap(),
+            &updates,
+            &parsed,
+            &ExecuteOptions::default(),
+            &vec![ExecuteStatementMetadata::default(); updates.len()],
+            &AtomicBool::new(false),
+        )
+        .await
+        .unwrap()
+        .expect("the overlay-aware parameter batch should execute");
+        assert_eq!(
+            results
+                .iter()
+                .map(ExecuteResult::rows_affected)
+                .sum::<u64>(),
+            (ROW_COUNT - 1) as u64
+        );
+        assert_eq!(sql2::take_certified_generation_identity_replacements(), 0);
+        transaction.commit().await.unwrap();
+
+        let deleted = session
+            .execute(
+                "SELECT path FROM staged_generation_probe WHERE path = '/0000'",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            deleted.len(),
+            0,
+            "the staged delete must not be resurrected"
+        );
+    }
+
+    #[tokio::test]
     async fn execute_batch_keeps_repeated_entity_identity_sequential() {
         let session = open_session().await;
         let schema = serde_json::json!({

--- a/packages/engine/src/sql2/context.rs
+++ b/packages/engine/src/sql2/context.rs
@@ -222,6 +222,17 @@ pub(crate) trait SqlWriteExecutionContext: Send {
         .await
     }
 
+    async fn stage_parameter_batch_replace(
+        &mut self,
+        rows: RawWriteBatch,
+    ) -> Result<TransactionWriteOutcome, LixError> {
+        self.stage_write(TransactionWrite::Rows {
+            mode: TransactionWriteMode::Replace,
+            rows,
+        })
+        .await
+    }
+
     async fn execute_diff_command(
         &mut self,
         _command: DiffCommand,

--- a/packages/engine/src/sql2/exec/bound_public_read.rs
+++ b/packages/engine/src/sql2/exec/bound_public_read.rs
@@ -15,6 +15,7 @@ use datafusion::sql::sqlparser::ast::{
     Value as SqlValue,
 };
 use serde_json::Value as JsonValue;
+use tracing::Instrument as _;
 
 use crate::entity_pk::EntityPk;
 use crate::live_state::{LiveStateFilter, LiveStateProjection, LiveStateScanRequest};
@@ -55,7 +56,8 @@ where
     // A native route must retain all public SQL-surface validation. This runs
     // after structural recognition so normal queries do not pay an additional
     // validation pass before their existing DataFusion path.
-    crate::sql2::bind_read_statement(sql, statement)?;
+    tracing::debug_span!(target: "lix_perf", "lix.perf.public_read.bind")
+        .in_scope(|| crate::sql2::bind_read_statement(sql, statement))?;
 
     let catalog = ctx.public_catalog().await?;
     let Some(surface) = catalog.surface(shape.table_name()) else {
@@ -102,7 +104,14 @@ where
                 limit: None,
             };
             if let Some(reader) = ctx.entity_snapshot_reader()
-                && let Some(snapshots) = reader.scan_entity_snapshots(request.clone()).await?
+                && let Some(snapshots) = reader
+                    .scan_entity_snapshots(request.clone())
+                    .instrument(tracing::debug_span!(
+                        target: "lix_perf",
+                        "lix.perf.public_read.snapshot_scan",
+                        row_count = request.filter.entity_pks.len()
+                    ))
+                    .await?
             {
                 return Ok(Some(SqlQueryResult {
                     columns: shape.projection.clone(),

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -800,23 +800,26 @@ async fn try_execute_direct_path_value_replacement_batch(
         .collect::<Vec<_>>();
 
     let active_branch_id = ctx.active_branch_id().to_owned();
+    let scope = crate::collection_generation::CollectionScopeRef {
+        schema_key: &spec.schema_key,
+        file_id: None,
+    };
+    // Generation controls describe committed HOT state. Any staged member can
+    // change the effective identity set, so it must force the overlay-aware
+    // candidate scan instead of certifying the committed digest.
+    let has_staged_collection_rows = ctx.has_staged_collection_rows(&active_branch_id, scope)?;
     let collection_generation = ctx
-        .load_collection_generation(
-            &active_branch_id,
-            crate::collection_generation::CollectionScopeRef {
-                schema_key: &spec.schema_key,
-                file_id: None,
-            },
-        )
+        .load_collection_generation(&active_branch_id, scope)
         .await?;
-    let certified_generation_identity = collection_generation.is_some_and(|generation| {
-        generation.live_count == row_count as u64
-            && generation.ordered_identity_digest.is_some()
-            && generation.ordered_identity_digest
-                == crate::collection_generation::ordered_single_string_identity_digest(
-                    entity_pks.iter(),
-                )
-    });
+    let certified_generation_identity = !has_staged_collection_rows
+        && collection_generation.is_some_and(|generation| {
+            generation.live_count == row_count as u64
+                && generation.ordered_identity_digest.is_some()
+                && generation.ordered_identity_digest
+                    == crate::collection_generation::ordered_single_string_identity_digest(
+                        entity_pks.iter(),
+                    )
+        });
     #[cfg(test)]
     if certified_generation_identity {
         CERTIFIED_GENERATION_IDENTITY_REPLACEMENTS.with(|executions| {

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -7,7 +7,7 @@ use datafusion::common::ScalarValue;
 use serde_json::Value as JsonValue;
 use tracing::Instrument;
 
-use crate::catalog::TypedJsonScalarRef;
+use crate::catalog::{SchemaPlanId, TypedJsonScalarRef};
 use crate::changelog::CommitId;
 use crate::common::{
     ExecuteStatementMetadata, RequestBlobSpliceProvenance, SharedStr, validate_row_metadata,
@@ -49,6 +49,8 @@ std::thread_local! {
         const { std::cell::Cell::new(0) };
     static CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_EXECUTIONS: std::cell::Cell<usize> =
         const { std::cell::Cell::new(0) };
+    static CERTIFIED_GENERATION_IDENTITY_REPLACEMENTS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
 }
 
 #[cfg(test)]
@@ -69,6 +71,11 @@ pub(crate) fn take_certified_entity_insert_batch_executions() -> usize {
 #[cfg(test)]
 pub(crate) fn take_certified_entity_insert_parameter_batch_executions() -> usize {
     CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_EXECUTIONS.with(|executions| executions.replace(0))
+}
+
+#[cfg(test)]
+pub(crate) fn take_certified_generation_identity_replacements() -> usize {
+    CERTIFIED_GENERATION_IDENTITY_REPLACEMENTS.with(|executions| executions.replace(0))
 }
 
 #[cfg(test)]
@@ -353,12 +360,14 @@ async fn try_execute_entity_insert_batch(
     if let Some(error) = committed_conflict {
         return Err(error);
     }
-    #[cfg(test)]
-    CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_EXECUTIONS.with(|executions| {
-        executions.set(executions.get().saturating_add(1));
-    });
-    #[cfg(feature = "storage-benches")]
-    crate::storage_bench::record_certified_entity_insert_parameter_batch_execution();
+    if !spec.certifies_path_value_replacement {
+        #[cfg(test)]
+        CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_EXECUTIONS.with(|executions| {
+            executions.set(executions.get().saturating_add(1));
+        });
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_certified_entity_insert_parameter_batch_execution();
+    }
     Ok(Some(
         (0..parameter_batch.num_rows())
             .map(|_| SqlWriteResult::affected(1))
@@ -391,17 +400,42 @@ async fn collection_is_certifiably_empty(
 /// narrower: every logical statement must target a distinct primary key in
 /// the same unconstrained entity surface, so evaluating them together is
 /// observationally equivalent to evaluating them one at a time.
+pub(crate) async fn try_execute_entity_update_value_batch<'a>(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    plan: &LogicalWritePlan,
+    parameter_rows: &'a [&'a [Value]],
+) -> Result<Option<Vec<SqlWriteResult>>, LixError> {
+    try_execute_direct_path_value_replacement_batch(
+        ctx,
+        plan,
+        EntityInsertParameterBatch::Values(parameter_rows),
+    )
+    .await
+}
+
 pub(crate) async fn try_execute_entity_update_parameter_batch(
     ctx: &mut dyn SqlWriteExecutionContext,
     plan: &LogicalWritePlan,
     parameter_batch: &RecordBatch,
 ) -> Result<Option<Vec<SqlWriteResult>>, LixError> {
+    if let Some(results) = try_execute_direct_path_value_replacement_batch(
+        ctx,
+        plan,
+        EntityInsertParameterBatch::Arrow(parameter_batch),
+    )
+    .await?
+    {
+        return Ok(Some(results));
+    }
+
     let BoundWriteTarget::Entity(EntityWriteSurface::Base { schema_key }) = &plan.bound.target
     else {
         return Ok(None);
     };
-    if plan.bound.op != BoundWriteOp::Update
-        || !matches!(plan.bound.input, BoundWriteInput::None)
+    if plan.bound.op != BoundWriteOp::Update {
+        return Ok(None);
+    }
+    if !matches!(plan.bound.input, BoundWriteInput::None)
         || plan.bound.conflict.is_some()
         || plan.bound.returning.is_some()
         || !matches!(plan.bound.branch_scope, BranchScope::Active { .. })
@@ -648,6 +682,282 @@ pub(crate) async fn try_execute_entity_update_parameter_batch(
                 executions.set(executions.get() + 1);
             });
         }
+    }
+    Ok(Some(
+        affected_by_statement
+            .into_iter()
+            .map(SqlWriteResult::affected)
+            .collect(),
+    ))
+}
+
+/// Lowers the dominant JSON-pointer replacement shape directly from borrowed
+/// public parameters into one canonical row-content arena.
+///
+/// This deliberately accepts only strictly ordered, unique, ordinary tracked
+/// identities. Anything else retains the generic sequential path and its full
+/// plugin/constraint semantics.
+async fn try_execute_direct_path_value_replacement_batch(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    plan: &LogicalWritePlan,
+    parameter_batch: EntityInsertParameterBatch<'_>,
+) -> Result<Option<Vec<SqlWriteResult>>, LixError> {
+    let BoundWriteTarget::Entity(EntityWriteSurface::Base { schema_key }) = &plan.bound.target
+    else {
+        return Ok(None);
+    };
+    if plan.bound.op != BoundWriteOp::Update {
+        return Ok(None);
+    }
+    #[cfg(feature = "storage-benches")]
+    let record_value_certificate = matches!(parameter_batch, EntityInsertParameterBatch::Values(_));
+    #[cfg(feature = "storage-benches")]
+    if record_value_certificate {
+        crate::storage_bench::record_certified_entity_update_value_batch_attempt();
+    }
+    if !matches!(plan.bound.input, BoundWriteInput::None)
+        || plan.bound.conflict.is_some()
+        || plan.bound.returning.is_some()
+        || !matches!(plan.bound.branch_scope, BranchScope::Active { .. })
+        || !matches!(plan.filters.rows, FilterSet::All)
+        || plan_references_active_branch_commit_id(plan)
+    {
+        return Ok(None);
+    }
+
+    let spec = entity_spec(ctx, schema_key)?;
+    if spec.has_inter_row_constraints
+        || plan.bound.assignments.iter().any(|assignment| {
+            spec.primary_key_paths
+                .iter()
+                .any(|path| path.as_slice() == [assignment.column.name.as_str()])
+        })
+    {
+        return Ok(None);
+    }
+    validate_bound_write_supported(plan, &spec)?;
+    let Some(primary_key_param_index) =
+        bound_single_text_primary_key_param(&spec, &plan.bound.predicate)
+    else {
+        return Ok(None);
+    };
+    let Some(replacement) =
+        direct_path_value_replacement(&spec, plan, Some(primary_key_param_index))
+    else {
+        return Ok(None);
+    };
+    if !parameter_batch.column_matches(primary_key_param_index, EntityColumnType::String)
+        || !parameter_batch.column_matches(replacement.value_param_index, EntityColumnType::String)
+    {
+        return Ok(None);
+    }
+    let Some(schema_catalog) = ctx.schema_catalog_snapshot() else {
+        return Ok(None);
+    };
+    let Some((schema_plan_id, schema_plan)) = schema_catalog.plan_for_key(&spec.schema_key) else {
+        return Ok(None);
+    };
+    if !schema_plan.accepts_canonical_certificate() {
+        return Ok(None);
+    }
+
+    let row_count = parameter_batch.num_rows();
+    let mut primary_key_arena = Vec::new();
+    let mut primary_key_offsets = Vec::with_capacity(row_count);
+    let mut previous_row = None;
+    for statement_index in 0..row_count {
+        let DirectParameterValue::String(primary_key) =
+            parameter_batch.value(primary_key_param_index, statement_index)
+        else {
+            return Ok(None);
+        };
+        if let Some(previous_row) = previous_row {
+            let DirectParameterValue::String(previous) =
+                parameter_batch.value(primary_key_param_index, previous_row)
+            else {
+                unreachable!("the previous primary-key parameter was certified as text")
+            };
+            if previous >= primary_key {
+                return Ok(None);
+            }
+        }
+        previous_row = Some(statement_index);
+        let start = primary_key_arena.len();
+        primary_key_arena.extend_from_slice(primary_key.as_bytes());
+        primary_key_offsets.push((start, primary_key_arena.len()));
+    }
+    let primary_key_arena = SharedStr::from_utf8(bytes::Bytes::from(primary_key_arena))
+        .map_err(|_| LixError::unknown("certified replacement primary-key arena is not UTF-8"))?;
+    let entity_pks = primary_key_offsets
+        .into_iter()
+        .map(|(start, end)| {
+            EntityPk::from_validated_shared_string(
+                primary_key_arena
+                    .slice(start..end)
+                    .expect("certified replacement primary-key offsets preserve UTF-8"),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let active_branch_id = ctx.active_branch_id().to_owned();
+    let collection_generation = ctx
+        .load_collection_generation(
+            &active_branch_id,
+            crate::collection_generation::CollectionScopeRef {
+                schema_key: &spec.schema_key,
+                file_id: None,
+            },
+        )
+        .await?;
+    let certified_generation_identity = collection_generation.is_some_and(|generation| {
+        generation.live_count == row_count as u64
+            && generation.ordered_identity_digest.is_some()
+            && generation.ordered_identity_digest
+                == crate::collection_generation::ordered_single_string_identity_digest(
+                    entity_pks.iter(),
+                )
+    });
+    #[cfg(test)]
+    if certified_generation_identity {
+        CERTIFIED_GENERATION_IDENTITY_REPLACEMENTS.with(|executions| {
+            executions.set(executions.get().saturating_add(1));
+        });
+    }
+    let candidates = if certified_generation_identity {
+        MaterializedLiveStateBatch::default()
+    } else {
+        let candidates = scan_entity_candidates_for_pks(ctx, plan, &spec, entity_pks.clone(), true)
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.entity_update_value_batch.candidate_scan",
+                row_count
+            ))
+            .await?;
+        if candidates.iter().any(|candidate| {
+            candidate.untracked()
+                || candidate.global()
+                || candidate.file_id().is_some()
+                || candidate.metadata().is_some()
+        }) {
+            return Ok(None);
+        }
+        candidates
+    };
+    let complete_collection_replacement = certified_generation_identity
+        || (candidates.len() == row_count
+            && collection_generation
+                .is_some_and(|generation| generation.live_count == row_count as u64));
+
+    let estimated_row_bytes = entity_pks
+        .iter()
+        .map(|entity_pk| {
+            entity_pk
+                .as_single_string()
+                .map_or(32, |path| path.len().saturating_add(32))
+        })
+        .sum::<usize>();
+    let mut normalized = Vec::with_capacity(estimated_row_bytes);
+    let replacement_capacity = if certified_generation_identity {
+        row_count
+    } else {
+        candidates.len()
+    };
+    let mut snapshot_offsets = Vec::with_capacity(replacement_capacity);
+    let mut replacement_entity_pks = Vec::with_capacity(replacement_capacity);
+    let mut affected_by_statement = vec![0_u64; row_count];
+    let mut candidate_index = 0;
+    for (statement_index, entity_pk) in entity_pks.iter().enumerate() {
+        if !certified_generation_identity {
+            while candidate_index < candidates.len()
+                && candidates.row(candidate_index).entity_pk() < entity_pk
+            {
+                candidate_index += 1;
+            }
+            if candidate_index == candidates.len()
+                || candidates.row(candidate_index).entity_pk() != entity_pk
+            {
+                continue;
+            }
+        }
+
+        let start = normalized.len();
+        normalized.extend_from_slice(b"{\"path\":");
+        append_canonical_json_string(&mut normalized, entity_pk.as_single_string()?)
+            .map_err(|error| with_parameter_batch_statement_index(error, statement_index))?;
+        normalized.extend_from_slice(b",\"value\":");
+        match parameter_batch.value(replacement.value_param_index, statement_index) {
+            DirectParameterValue::Null => normalized.extend_from_slice(b"null"),
+            DirectParameterValue::String(raw) => {
+                let value = serde_json::from_str::<JsonValue>(raw).map_err(|error| {
+                    with_parameter_batch_statement_index(
+                        LixError::new(
+                            LixError::CODE_TYPE_MISMATCH,
+                            format!("lix_json argument is not valid JSON: {error}"),
+                        ),
+                        statement_index,
+                    )
+                })?;
+                serde_json::to_writer(&mut normalized, &value).map_err(|error| {
+                    with_parameter_batch_statement_index(
+                        LixError::unknown(format!(
+                            "certified replacement value failed to serialize: {error}"
+                        )),
+                        statement_index,
+                    )
+                })?;
+            }
+            DirectParameterValue::Boolean(_) => {
+                unreachable!("the certified replacement value parameter is text")
+            }
+        }
+        normalized.push(b'}');
+        snapshot_offsets.push((start, normalized.len()));
+        replacement_entity_pks.push(entity_pk.clone());
+        affected_by_statement[statement_index] = 1;
+        if !certified_generation_identity {
+            candidate_index += 1;
+        }
+    }
+
+    if !replacement_entity_pks.is_empty() {
+        let snapshots =
+            TransactionJson::from_certified_row_content_arena(normalized, snapshot_offsets)?;
+        let rows = RawWriteBatch::from_certified_parameter_replacement(
+            replacement_entity_pks,
+            snapshots,
+            spec.schema_key.as_str().into(),
+            active_branch_id.into(),
+            CertifiedRawWriteBatchPreparation {
+                schema_plan_id,
+                facts: PreparedRowFacts {
+                    row_content_validated: true,
+                    requires_transaction_validation: false,
+                },
+                tracked_keys_strictly_ordered: true,
+                complete_collection_replacement,
+            },
+        )?;
+        ctx.stage_parameter_batch_replace(rows)
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.entity_update_value_batch.stage_rows",
+                row_count
+            ))
+            .await?;
+    }
+
+    #[cfg(test)]
+    {
+        ENTITY_UPDATE_PARAMETER_BATCH_EXECUTIONS.with(|executions| {
+            executions.set(executions.get().saturating_add(1));
+        });
+        CERTIFIED_REPLACEMENT_PARAMETER_BATCH_EXECUTIONS.with(|executions| {
+            executions.set(executions.get().saturating_add(1));
+        });
+    }
+    #[cfg(feature = "storage-benches")]
+    if record_value_certificate {
+        crate::storage_bench::record_certified_entity_update_value_batch_hit(row_count);
     }
     Ok(Some(
         affected_by_statement
@@ -3115,6 +3425,17 @@ fn certified_direct_parameter_insert_batch(
         return Ok(None);
     }
 
+    if let Some(rows) = certified_direct_path_value_insert_batch(
+        ctx,
+        spec,
+        layout,
+        row,
+        parameter_batch,
+        schema_plan_id,
+    )? {
+        return Ok(Some(rows));
+    }
+
     let mut columns = Vec::with_capacity(layout.columns.len());
     for (layout_index, (expr, target)) in row.iter().zip(&layout.columns).enumerate() {
         let BoundExpr::Param(param) = expr else {
@@ -3425,6 +3746,7 @@ fn certified_direct_parameter_insert_batch(
             requires_transaction_validation: false,
         },
         tracked_keys_strictly_ordered,
+        complete_collection_replacement: false,
     };
     let rows = RawWriteBatch::from_certified_parameter_insert(
         entity_pks,
@@ -3434,6 +3756,144 @@ fn certified_direct_parameter_insert_batch(
         certificate,
     )?;
     Ok(Some(rows))
+}
+
+fn certified_direct_path_value_insert_batch(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    spec: &EntitySurfaceSpec,
+    layout: &InsertRowLayout,
+    row: &[BoundExpr],
+    parameter_batch: EntityInsertParameterBatch<'_>,
+    schema_plan_id: SchemaPlanId,
+) -> Result<Option<RawWriteBatch>, LixError> {
+    if !spec.certifies_path_value_replacement || row.len() != 2 || layout.columns.len() != 2 {
+        return Ok(None);
+    }
+    let mut path_param_index = None;
+    let mut value_param_index = None;
+    for (expr, target) in row.iter().zip(&layout.columns) {
+        match (expr, target) {
+            (
+                BoundExpr::Param(param),
+                InsertColumnTarget::Visible {
+                    name,
+                    column_type: EntityColumnType::String,
+                    ..
+                },
+            ) if name == "path" => path_param_index = Some(param.index.saturating_sub(1)),
+            (
+                BoundExpr::Function { name, args },
+                InsertColumnTarget::Visible {
+                    name: column_name,
+                    column_type: EntityColumnType::Json,
+                    ..
+                },
+            ) if name == "lix_json" && column_name == "value" => {
+                let [BoundExpr::Param(param)] = args.as_slice() else {
+                    return Ok(None);
+                };
+                value_param_index = Some(param.index.saturating_sub(1));
+            }
+            _ => return Ok(None),
+        }
+    }
+    let (Some(path_param_index), Some(value_param_index)) = (path_param_index, value_param_index)
+    else {
+        return Ok(None);
+    };
+    if !parameter_batch.column_matches(path_param_index, EntityColumnType::String)
+        || !parameter_batch.column_matches(value_param_index, EntityColumnType::String)
+    {
+        return Ok(None);
+    }
+
+    let row_count = parameter_batch.num_rows();
+    let mut path_arena = Vec::new();
+    let mut path_offsets = Vec::with_capacity(row_count);
+    let mut normalized = Vec::new();
+    let mut snapshot_offsets = Vec::with_capacity(row_count);
+    let mut previous_row = None;
+    for statement_index in 0..row_count {
+        let DirectParameterValue::String(path) =
+            parameter_batch.value(path_param_index, statement_index)
+        else {
+            return Ok(None);
+        };
+        if let Some(previous_row) = previous_row {
+            let DirectParameterValue::String(previous) =
+                parameter_batch.value(path_param_index, previous_row)
+            else {
+                unreachable!("the previous certified path parameter was text")
+            };
+            if previous >= path {
+                return Ok(None);
+            }
+        }
+        previous_row = Some(statement_index);
+        let path_start = path_arena.len();
+        path_arena.extend_from_slice(path.as_bytes());
+        path_offsets.push((path_start, path_arena.len()));
+
+        let snapshot_start = normalized.len();
+        normalized.extend_from_slice(b"{\"path\":");
+        append_canonical_json_string(&mut normalized, path)
+            .map_err(|error| with_parameter_batch_statement_index(error, statement_index))?;
+        normalized.extend_from_slice(b",\"value\":");
+        let DirectParameterValue::String(raw_value) =
+            parameter_batch.value(value_param_index, statement_index)
+        else {
+            return Ok(None);
+        };
+        let value = serde_json::from_str::<JsonValue>(raw_value).map_err(|error| {
+            with_parameter_batch_statement_index(
+                LixError::new(
+                    LixError::CODE_TYPE_MISMATCH,
+                    format!("lix_json argument is not valid JSON: {error}"),
+                ),
+                statement_index,
+            )
+        })?;
+        serde_json::to_writer(&mut normalized, &value).map_err(|error| {
+            with_parameter_batch_statement_index(
+                LixError::unknown(format!(
+                    "certified INSERT value failed to serialize: {error}"
+                )),
+                statement_index,
+            )
+        })?;
+        normalized.push(b'}');
+        snapshot_offsets.push((snapshot_start, normalized.len()));
+    }
+
+    let path_arena = SharedStr::from_utf8(bytes::Bytes::from(path_arena))
+        .map_err(|_| LixError::unknown("certified INSERT path arena is not UTF-8"))?;
+    let entity_pks = path_offsets
+        .into_iter()
+        .map(|(start, end)| {
+            EntityPk::from_validated_shared_string(
+                path_arena
+                    .slice(start..end)
+                    .expect("certified INSERT path offsets preserve UTF-8"),
+            )
+        })
+        .collect::<Vec<_>>();
+    let snapshots =
+        TransactionJson::from_certified_row_content_arena(normalized, snapshot_offsets)?;
+    Ok(Some(RawWriteBatch::from_certified_parameter_insert(
+        entity_pks,
+        snapshots,
+        layout.schema_key.as_str().into(),
+        ctx.active_branch_id().into(),
+        CertifiedRawWriteBatchPreparation {
+            schema_plan_id,
+            facts: PreparedRowFacts {
+                row_content_validated: true,
+                requires_transaction_validation: false,
+            },
+            tracked_keys_strictly_ordered: true,
+            complete_collection_replacement: false,
+        },
+    )?))
 }
 
 fn certified_entity_insert_rows<'a>(

--- a/packages/engine/src/sql2/exec/mod.rs
+++ b/packages/engine/src/sql2/exec/mod.rs
@@ -99,6 +99,7 @@ pub(crate) enum SqlLogicalPlan {
 pub(crate) use bound_public_write::{
     take_certified_entity_insert_batch_executions,
     take_certified_entity_insert_parameter_batch_executions,
+    take_certified_generation_identity_replacements,
     take_certified_replacement_parameter_batch_executions,
     take_entity_update_parameter_batch_executions,
 };

--- a/packages/engine/src/sql2/exec/write.rs
+++ b/packages/engine/src/sql2/exec/write.rs
@@ -373,7 +373,17 @@ pub(crate) async fn execute_write_logical_plan_value_batch<'a>(
         return Ok(None);
     }
     validate_write_parameter_count(&write_plan.plan, first.len())?;
-    super::bound_public_write::try_execute_entity_insert_value_batch(
+    if let Some(results) = super::bound_public_write::try_execute_entity_insert_value_batch(
+        ctx,
+        &write_plan.plan,
+        parameter_rows,
+    )
+    .await
+    .map_err(normalize_bound_public_write_error)?
+    {
+        return Ok(Some(results));
+    }
+    super::bound_public_write::try_execute_entity_update_value_batch(
         ctx,
         &write_plan.plan,
         parameter_rows,

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -61,6 +61,7 @@ pub(crate) use exec::{
     execute_write_logical_plan_with_mode_and_trace_result,
     execute_write_logical_plan_with_mode_result, take_certified_entity_insert_batch_executions,
     take_certified_entity_insert_parameter_batch_executions,
+    take_certified_generation_identity_replacements,
     take_certified_replacement_parameter_batch_executions,
     take_entity_update_parameter_batch_executions,
 };

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -17,6 +17,14 @@ static TRANSACTION_SCHEMA_CATALOG_LOADS: AtomicU64 = AtomicU64::new(0);
 static TRANSACTION_SCHEMA_CATALOG_COMPILES: AtomicU64 = AtomicU64::new(0);
 static JSON_STORE_STAGE_BYTES: AtomicU64 = AtomicU64::new(0);
 static CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_EXECUTIONS: AtomicU64 = AtomicU64::new(0);
+static CERTIFIED_ENTITY_UPDATE_VALUE_BATCH_ATTEMPTS: AtomicU64 = AtomicU64::new(0);
+static CERTIFIED_ENTITY_UPDATE_VALUE_BATCH_HITS: AtomicU64 = AtomicU64::new(0);
+static CERTIFIED_ENTITY_UPDATE_VALUE_BATCH_ROWS: AtomicU64 = AtomicU64::new(0);
+static ENTITY_POINT_SNAPSHOT_CACHE_HITS: AtomicU64 = AtomicU64::new(0);
+static ENTITY_POINT_SNAPSHOT_CACHE_MISSES: AtomicU64 = AtomicU64::new(0);
+static CRUD_PHYSICAL_PUTS: AtomicU64 = AtomicU64::new(0);
+static CRUD_PHYSICAL_DELETES: AtomicU64 = AtomicU64::new(0);
+static CRUD_PHYSICAL_WRITTEN_BYTES: AtomicU64 = AtomicU64::new(0);
 
 pub(crate) fn record_certified_entity_insert_parameter_batch_execution() {
     CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_EXECUTIONS.fetch_add(1, Ordering::Relaxed);
@@ -28,6 +36,78 @@ pub(crate) fn record_certified_entity_insert_parameter_batch_execution() {
 /// cannot silently turn the measured bulk INSERT back into sequential writes.
 pub fn take_certified_entity_insert_parameter_batch_executions() -> u64 {
     CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_EXECUTIONS.swap(0, Ordering::Relaxed)
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CrudCertificateAccounting {
+    pub attempts: u64,
+    pub hits: u64,
+    pub misses: u64,
+    pub certified_rows: u64,
+}
+
+pub(crate) fn record_certified_entity_update_value_batch_attempt() {
+    CERTIFIED_ENTITY_UPDATE_VALUE_BATCH_ATTEMPTS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_certified_entity_update_value_batch_hit(row_count: usize) {
+    CERTIFIED_ENTITY_UPDATE_VALUE_BATCH_HITS.fetch_add(1, Ordering::Relaxed);
+    CERTIFIED_ENTITY_UPDATE_VALUE_BATCH_ROWS.fetch_add(row_count as u64, Ordering::Relaxed);
+}
+
+/// Returns and resets generated UPDATE certificate hit/miss accounting.
+pub fn take_certified_entity_update_value_batch_accounting() -> CrudCertificateAccounting {
+    let attempts = CERTIFIED_ENTITY_UPDATE_VALUE_BATCH_ATTEMPTS.swap(0, Ordering::Relaxed);
+    let hits = CERTIFIED_ENTITY_UPDATE_VALUE_BATCH_HITS.swap(0, Ordering::Relaxed);
+    let certified_rows = CERTIFIED_ENTITY_UPDATE_VALUE_BATCH_ROWS.swap(0, Ordering::Relaxed);
+    CrudCertificateAccounting {
+        attempts,
+        hits,
+        misses: attempts.saturating_sub(hits),
+        certified_rows,
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct EntityPointSnapshotCacheAccounting {
+    pub hits: u64,
+    pub misses: u64,
+}
+
+pub(crate) fn record_entity_point_snapshot_cache_hit() {
+    ENTITY_POINT_SNAPSHOT_CACHE_HITS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_entity_point_snapshot_cache_miss() {
+    ENTITY_POINT_SNAPSHOT_CACHE_MISSES.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn take_entity_point_snapshot_cache_accounting() -> EntityPointSnapshotCacheAccounting {
+    EntityPointSnapshotCacheAccounting {
+        hits: ENTITY_POINT_SNAPSHOT_CACHE_HITS.swap(0, Ordering::Relaxed),
+        misses: ENTITY_POINT_SNAPSHOT_CACHE_MISSES.swap(0, Ordering::Relaxed),
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CrudPhysicalWriteAccounting {
+    pub puts: u64,
+    pub deletes: u64,
+    pub written_bytes: u64,
+}
+
+pub(crate) fn record_crud_physical_writes(stats: crate::storage_adapter::StorageWriteSetStats) {
+    CRUD_PHYSICAL_PUTS.fetch_add(stats.staged_puts, Ordering::Relaxed);
+    CRUD_PHYSICAL_DELETES.fetch_add(stats.staged_deletes, Ordering::Relaxed);
+    CRUD_PHYSICAL_WRITTEN_BYTES.fetch_add(stats.written_bytes, Ordering::Relaxed);
+}
+
+pub fn take_crud_physical_write_accounting() -> CrudPhysicalWriteAccounting {
+    CrudPhysicalWriteAccounting {
+        puts: CRUD_PHYSICAL_PUTS.swap(0, Ordering::Relaxed),
+        deletes: CRUD_PHYSICAL_DELETES.swap(0, Ordering::Relaxed),
+        written_bytes: CRUD_PHYSICAL_WRITTEN_BYTES.swap(0, Ordering::Relaxed),
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -69,11 +69,19 @@ fn compare_certified_predecessors(
 std::thread_local! {
     static ORDERED_PACKED_CURRENT_BASE_PUBLICATIONS: std::cell::Cell<usize> =
         const { std::cell::Cell::new(0) };
+    static COMPLETE_REPLACEMENT_PACKED_CURRENT_BASE_PUBLICATIONS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
 }
 
 #[cfg(test)]
 pub(crate) fn take_ordered_packed_current_base_publications() -> usize {
     ORDERED_PACKED_CURRENT_BASE_PUBLICATIONS.with(|publications| publications.replace(0))
+}
+
+#[cfg(test)]
+pub(crate) fn take_complete_replacement_packed_current_base_publications() -> usize {
+    COMPLETE_REPLACEMENT_PACKED_CURRENT_BASE_PUBLICATIONS
+        .with(|publications| publications.replace(0))
 }
 
 /// Commits prepared transaction rows into tracked history and unified current
@@ -2249,21 +2257,57 @@ async fn stage_tracked_head(
                         .change_id
                         .is_some_and(|change_id| change_id != ChangeId::default())
             });
-        let absence_guards = if can_publish_ordered_packed_current_base {
-            Vec::new()
-        } else {
-            let _span = tracing::debug_span!(
-                target: "lix_perf",
-                "lix.perf.materialization.tracked_head.absence_guards"
-            )
-            .entered();
-            tracked_head_absence_guards(
-                state_rows,
-                insert_selection,
-                &root.branch_id,
-                certified_fresh_plugin_file_id,
-            )
-        };
+        let complete_replacement_schema = (state_rows.certified_complete_collection_replacement()
+            && ordered_addressable_commits.contains(&root.commit_id)
+            && !is_checkpoint_publication
+            && state_row_indices.len() >= PACKED_CURRENT_BASE_MIN_ROWS
+            && certified_fresh_plugin_file_id.is_none()
+            && !host_certified_live_increments.contains_key(&root.branch_id)
+            && staged.selected_change_batches.is_empty()
+            && selected_materialization.is_none()
+            && untracked_deltas.is_empty()
+            && engine_rows.is_empty()
+            && explicit_branch_targets.is_empty()
+            && state_row_indices.len() == state_rows.len()
+            && insert_selection.is_empty())
+        .then(|| state_rows.first())
+        .flatten()
+        .filter(|first| {
+            state_row_indices.iter().all(|&row_index| {
+                let row = state_rows.row(row_index);
+                row.schema_key == first.schema_key
+                    && row.branch_id.as_str() == root.branch_id
+                    && !row.global
+                    && !row.untracked
+                    && row.snapshot.is_some()
+                    && row.metadata.is_none()
+                    && row.file_id.is_none()
+                    && row.schema_key != BRANCH_REF_SCHEMA_KEY
+                    && row.schema_key
+                        != crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY
+                    && row.commit_id == Some(root.commit_id)
+                    && row
+                        .change_id
+                        .is_some_and(|change_id| change_id != ChangeId::default())
+            })
+        })
+        .map(|row| row.schema_key.as_str());
+        let absence_guards =
+            if can_publish_ordered_packed_current_base || complete_replacement_schema.is_some() {
+                Vec::new()
+            } else {
+                let _span = tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.materialization.tracked_head.absence_guards"
+                )
+                .entered();
+                tracked_head_absence_guards(
+                    state_rows,
+                    insert_selection,
+                    &root.branch_id,
+                    certified_fresh_plugin_file_id,
+                )
+            };
         let parent_generation = match (root.parent_commit_id, parent_control) {
             (_, Some(control)) if is_checkpoint_publication => Some(control.generation),
             (Some(parent_commit_id), Some(control))
@@ -2401,6 +2445,47 @@ async fn stage_tracked_head(
                     .iter()
                     .map(|&row_index| state_rows.row(row_index).schema_key.as_str()),
             );
+            insert_direct_branch_control(&mut controls, &root.branch_id, control)?;
+            continue;
+        }
+        if let Some(schema_key) = complete_replacement_schema {
+            #[cfg(test)]
+            COMPLETE_REPLACEMENT_PACKED_CURRENT_BASE_PUBLICATIONS.with(|publications| {
+                publications.set(publications.get().saturating_add(1));
+            });
+            let generation = tracked_head
+                .writer(read, writes)
+                .stage_complete_collection_replacement_current_base(
+                    &root.branch_id,
+                    parent_generation,
+                    root.commit_id,
+                    schema_key,
+                    state_row_indices.len(),
+                    working_diff_capture_checkpoint_commit_id,
+                    &mut coverage,
+                )
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.materialization.tracked_head.stage_complete_collection_replacement_current_base"
+                ))
+                .await?;
+            if let Some(epoch) = working_diff_epoch {
+                let next_epoch = TrackedWorkingDiffEpoch {
+                    checkpoint_commit_id: epoch.checkpoint_commit_id,
+                    generation,
+                    coverage,
+                };
+                if next_epoch != epoch {
+                    stage_tracked_working_diff_epoch(writes, &root.branch_id, next_epoch)?;
+                }
+            }
+            let mut control = normal_branch_head_control(
+                root,
+                parent_control,
+                generation,
+                working_diff_checkpoint_commit_id,
+            )?;
+            control.note_schemas(std::iter::once(schema_key));
             insert_direct_branch_control(&mut controls, &root.branch_id, control)?;
             continue;
         }

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -1117,6 +1117,50 @@ where
         )
     }
 
+    /// Stages a certified dense replacement without re-entering plugin,
+    /// storage-scope, or filesystem-path preparation for every logical SQL
+    /// statement. The producer only issues this certificate for existing,
+    /// ordinary tracked, unfiled rows in one active-branch entity collection.
+    async fn stage_certified_parameter_batch_replace(
+        &mut self,
+        rows: RawWriteBatch,
+    ) -> Result<TransactionWriteOutcome, LixError> {
+        let row_count = rows.len();
+        if row_count == 0 {
+            return Ok(TransactionWriteOutcome { count: 0 });
+        }
+        debug_assert!(rows.certified_preparation().is_some());
+        self.ensure_plugin_generation_read_guard().await;
+
+        #[cfg(feature = "storage-benches")]
+        {
+            crate::storage_bench::record_transaction_rows_staged(row_count);
+            crate::storage_bench::record_transaction_untracked_rows(0);
+        }
+        let prepared = self
+            .prepare_transaction_rows(rows)
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.transaction_prepare_rows"
+            ))
+            .await?;
+        if prepared.len() != row_count {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "certified parameter replacement preparation changed row cardinality",
+            ));
+        }
+        tracing::debug_span!(target: "lix_perf", "lix.perf.transaction_buffer_stage").in_scope(
+            || {
+                self.staged_writes
+                    .stage_write(PreparedTransactionWrite::Rows {
+                        mode: TransactionWriteMode::Replace,
+                        rows: prepared,
+                    })
+            },
+        )
+    }
+
     async fn stage_write_inner(
         &mut self,
         write: TransactionWrite,
@@ -7128,6 +7172,23 @@ where
                 rows,
             },
             statement_indices,
+        )
+        .await
+    }
+
+    async fn stage_parameter_batch_replace(
+        &mut self,
+        rows: RawWriteBatch,
+    ) -> Result<TransactionWriteOutcome, LixError> {
+        if rows.certified_preparation().is_some() {
+            return self.stage_certified_parameter_batch_replace(rows).await;
+        }
+        Self::stage_write(
+            self,
+            TransactionWrite::Rows {
+                mode: TransactionWriteMode::Replace,
+                rows,
+            },
         )
         .await
     }

--- a/packages/engine/src/transaction/mod.rs
+++ b/packages/engine/src/transaction/mod.rs
@@ -15,6 +15,8 @@ pub mod bench {
 }
 
 #[cfg(test)]
+pub(crate) use commit::take_complete_replacement_packed_current_base_publications;
+#[cfg(test)]
 pub(crate) use commit::take_ordered_packed_current_base_publications;
 pub(crate) use context::CertifiedHistoryStoreReader;
 #[cfg(test)]

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -482,6 +482,7 @@ pub(crate) struct CertifiedRawWriteBatchPreparation {
     pub(crate) schema_plan_id: SchemaPlanId,
     pub(crate) facts: PreparedRowFacts,
     pub(crate) tracked_keys_strictly_ordered: bool,
+    pub(crate) complete_collection_replacement: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -556,17 +557,55 @@ impl RawWriteBatch {
         branch_id: SharedStr,
         certificate: CertifiedRawWriteBatchPreparation,
     ) -> Result<Self, LixError> {
+        Self::from_certified_parameter_rows(
+            entity_pks,
+            snapshots,
+            schema_key,
+            branch_id,
+            certificate,
+        )
+    }
+
+    /// Constructs a fixed-shape, complete tracked replacement batch.
+    ///
+    /// The SQL certificate has already proven that every row is an ordinary
+    /// unfiled, branch-local replacement with canonical row content. Keeping
+    /// this separate from mutable `push_parts` ingress preserves one shared
+    /// snapshot arena and one schema/branch dictionary for the whole batch.
+    pub(crate) fn from_certified_parameter_replacement(
+        entity_pks: Vec<EntityPk>,
+        snapshots: Vec<TransactionJson>,
+        schema_key: SharedStr,
+        branch_id: SharedStr,
+        certificate: CertifiedRawWriteBatchPreparation,
+    ) -> Result<Self, LixError> {
+        Self::from_certified_parameter_rows(
+            entity_pks,
+            snapshots,
+            schema_key,
+            branch_id,
+            certificate,
+        )
+    }
+
+    fn from_certified_parameter_rows(
+        entity_pks: Vec<EntityPk>,
+        snapshots: Vec<TransactionJson>,
+        schema_key: SharedStr,
+        branch_id: SharedStr,
+        certificate: CertifiedRawWriteBatchPreparation,
+    ) -> Result<Self, LixError> {
         if entity_pks.len() != snapshots.len() {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
-                "certified parameter INSERT columns are not aligned",
+                "certified parameter row columns are not aligned",
             ));
         }
         let row_count = entity_pks.len();
         if row_count >= RAW_WRITE_NONE as usize {
             return Err(LixError::new(
                 LixError::CODE_INVALID_PARAM,
-                "certified parameter INSERT row count exceeds u32",
+                "certified parameter row count exceeds u32",
             ));
         }
         let (strings, schema_key_ordinal, branch_id_ordinal) = if schema_key == branch_id {
@@ -911,6 +950,7 @@ impl RawWriteBatch {
             origin_column_sets: Vec::new(),
             origin_column_index: HashMap::new(),
             certified_ordered_insert: certificate.tracked_keys_strictly_ordered,
+            certified_complete_collection_replacement: certificate.complete_collection_replacement,
         })
     }
 
@@ -2268,6 +2308,9 @@ pub(crate) struct PreparedStateBatch {
     /// The typed producer proved one strictly ordered, unique, ordinary
     /// tracked INSERT batch. Any row topology change clears this proof.
     certified_ordered_insert: bool,
+    /// A typed producer proved this batch replaces every live row in one
+    /// tracked, unfiled collection under the transaction's branch snapshot.
+    certified_complete_collection_replacement: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2371,6 +2414,7 @@ impl PreparedStateBatch {
             origin_column_sets: Vec::new(),
             origin_column_index: HashMap::new(),
             certified_ordered_insert: false,
+            certified_complete_collection_replacement: false,
         }
     }
 
@@ -2384,6 +2428,10 @@ impl PreparedStateBatch {
 
     pub(crate) fn certified_ordered_insert(&self) -> bool {
         self.certified_ordered_insert
+    }
+
+    pub(crate) fn certified_complete_collection_replacement(&self) -> bool {
+        self.certified_complete_collection_replacement
     }
 
     pub(crate) fn iter(&self) -> PreparedStateRows<'_> {
@@ -2579,6 +2627,7 @@ impl PreparedStateBatch {
             return;
         }
         self.certified_ordered_insert = false;
+        self.certified_complete_collection_replacement = false;
         let entity_base =
             u32::try_from(self.entity_pks.len()).expect("prepared entity column must fit u32");
         let json_base = u32::try_from(self.json.len()).expect("prepared JSON column must fit u32");
@@ -2645,6 +2694,7 @@ impl PreparedStateBatch {
 
     pub(crate) fn swap_rows(&mut self, left: usize, right: usize) {
         self.certified_ordered_insert = false;
+        self.certified_complete_collection_replacement = false;
         self.slots.swap(left, right);
     }
 
@@ -2654,6 +2704,7 @@ impl PreparedStateBatch {
     /// still shared by the selected row ordinals.
     pub(crate) fn select_rows(&mut self, source_by_destination: &[usize]) {
         self.certified_ordered_insert = false;
+        self.certified_complete_collection_replacement = false;
         debug_assert!(
             source_by_destination
                 .iter()
@@ -2697,6 +2748,7 @@ impl PreparedStateBatch {
     pub(crate) fn truncate_rows(&mut self, retained_len: usize) {
         if retained_len != self.slots.len() {
             self.certified_ordered_insert = false;
+            self.certified_complete_collection_replacement = false;
         }
         self.slots.truncate(retained_len);
         if !self.should_compact_owner_columns(retained_len) {

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -74,10 +74,13 @@ const SPACE_PREFIX_EXTRACTOR_NAME: &str = "lix-storage-space-be32-v1";
 const MAX_SLATEDB_KEY_LEN: usize = u16::MAX as usize;
 const RUNTIME_WORKER_THREADS: usize = 2;
 const POINT_READ_CONCURRENCY: usize = 64;
-const SNAPSHOT_POINT_CACHE_BYTES: usize = 16 * 1024 * 1024;
-const SNAPSHOT_POINT_CACHE_ENTRIES: usize = 4096;
+// The engine-level exact-point cache already absorbs the dominant hot-read
+// workload. Keep this snapshot cache as a bounded coherence aid rather than a
+// second 16 MiB copy of the same values.
+const SNAPSHOT_POINT_CACHE_BYTES: usize = 2 * 1024 * 1024;
+const SNAPSHOT_POINT_CACHE_ENTRIES: usize = 512;
 const SNAPSHOT_POINT_CACHE_MAX_VALUE_BYTES: usize = 64 * 1024;
-const DEFAULT_BLOCK_CACHE_BYTES: u64 = 16 * 1024 * 1024;
+const DEFAULT_BLOCK_CACHE_BYTES: u64 = 4 * 1024 * 1024;
 // Keep the commit, change, and reverse change-ID indexes' Bloom filters
 // resident across batched point validation. At 10M commits, 64 MiB thrashed
 // these multi-megabyte filters and turned 1,001 five-key probes into 353 MiB
@@ -100,7 +103,10 @@ const COMPACTOR_SAFETY_CHECKPOINT_LIFETIME: Duration = Duration::from_secs(15 * 
 const WRITE_PIPELINE_MAX_PENDING_ENTRIES: usize = 1024 * 1024;
 const WRITE_PIPELINE_MAX_PENDING_BYTES: usize = 128 * 1024 * 1024;
 const LOCAL_SST_FILE_CACHE_ENTRIES: usize = 256;
-const LOCAL_SST_CONTENT_CACHE_BYTES: usize = 32 * 1024 * 1024;
+// Local direct reads do not pay object-store request latency. An 8 MiB content
+// budget preserves small-SST reuse without retaining a second 32 MiB tier next
+// to SlateDB's block cache.
+const LOCAL_SST_CONTENT_CACHE_BYTES: usize = 4 * 1024 * 1024;
 const LOCAL_SST_CONTENT_MAX_FILE_BYTES: u64 = 8 * 1024 * 1024;
 
 #[derive(Debug)]
@@ -1423,7 +1429,11 @@ impl DirectLocalReads {
         let modified = metadata
             .modified()
             .map_err(|source| direct_local_io_error(location, source))?;
-        let contents = if cacheable && metadata.len() <= LOCAL_SST_CONTENT_MAX_FILE_BYTES {
+        let contents = if cacheable
+            && LOCAL_SST_CONTENT_CACHE_BYTES > 0
+            && metadata.len() <= LOCAL_SST_CONTENT_MAX_FILE_BYTES
+            && metadata.len() <= LOCAL_SST_CONTENT_CACHE_BYTES as u64
+        {
             let length =
                 usize::try_from(metadata.len()).map_err(|source| object_store::Error::Generic {
                     store: "LocalFileSystem",


### PR DESCRIPTION
## Summary

- add a certified homogeneous-write batch path so supported CRUD updates are generated and committed as ordered page replacements instead of executing per-row mutation machinery
- add exact-primary-key point caching with transaction/session invalidation and benchmark A/B accounting
- add ordered-generation certificates, physical-write/allocation/RSS instrumentation, and local/remote SlateDB profile lanes
- budget SlateDB point/block/SST caches and avoid benchmark fixture retention that obscures engine RSS

This is based on `main` at `e34c9a3a1` (the merge commit for #1064). Lix-over-SQLite is intentionally excluded; RocksDB and SlateDB are the adapters under test.

## Latest-main comparison

Release build, mimalloc on both branches, 10,000 homogeneous bound updates, seven fresh-fixture process samples; values are medians.

| Adapter | `main` | This PR | Speedup | Physical writes |
| --- | ---: | ---: | ---: | ---: |
| RocksDB | 73.14 ms | 25.18 ms | 2.91x | 54 |
| SlateDB local | 62.56 ms | 23.73 ms | 2.64x | 54 |

Hot exact-primary-key reads use 20,000 repetitions after one warm-up miss:

| Adapter | `main` | This PR | Speedup | Cache accounting |
| --- | ---: | ---: | ---: | ---: |
| RocksDB | 102.31 us | 16.18 us | 6.32x | 19,999 hits / 1 miss |
| SlateDB local | 114.63 us | 25.74 us | 4.45x | 19,999 hits / 1 miss |

Disabling the point cache restores 102.52 us RocksDB / 108.92 us SlateDB, confirming the measured improvement is the intended fast path.

Peak RSS is allocator-normalized with the system allocator on both branches and is the median of five separate `/usr/bin/time -v` processes:

| Adapter | `main` | This PR | Reduction |
| --- | ---: | ---: | ---: |
| RocksDB | 165.1 MiB | 81.3 MiB | 2.03x |
| SlateDB local | 185.6 MiB | 90.6 MiB | 2.05x |

## Scaling and remote control

Seven-sample medians for the generated bound-update path:

| Rows | RocksDB | SlateDB local |
| ---: | ---: | ---: |
| 1 | 0.488 ms | 0.497 ms |
| 10 | 0.490 ms | 0.686 ms |
| 100 | 1.176 ms | 1.365 ms |
| 1,000 | 8.381 ms | 8.217 ms |
| 10,000 | 25.312 ms | 23.849 ms |

The throttled remote-object-store SlateDB control (5 ms object-store delay) is 25.27 ms for the same 10k update. It is reported separately and is not mixed into the local gate.

## Correctness and format boundary

The generated path is accepted only after validating the homogeneous plan, ordered identities, collection generation, and exact page/replacement certificate. Unsupported or mixed cases stay on the general executor. This is a hard internal format cut; no compatibility shim or dual-write path is added.

## Validation

- `cargo fmt --all`
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- `cargo test --profile test --workspace --all-features`
- `git diff --check`
