### PR TITLE
feat: reconcile concurrent plugin transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3504,6 +3504,7 @@ dependencies = [
  "lix_sdk",
  "lix_slatedb_storage",
  "object_store 0.14.0",
+ "plugin_json",
  "serde",
  "serde_json",
  "sha2",
@@ -3513,6 +3514,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "zip",
  "zstd",
 ]
 

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -168,6 +168,23 @@ impl LiveStateContext {
         }
     }
 
+    /// Creates a reader whose derived indexes are private to one retained
+    /// storage snapshot. Process-wide caches intentionally advance with live
+    /// commits and therefore cannot serve an older explicit transaction.
+    pub(crate) fn snapshot_reader<S>(&self, store: S) -> LiveStateStoreReader<S>
+    where
+        S: StorageAdapterRead,
+    {
+        LiveStateStoreReader {
+            store,
+            tracked_head: self.tracked_head,
+            commit_graph: self.commit_graph.clone(),
+            filesystem_path_index_cache: std::sync::Arc::new(FilesystemPathIndexCache::default()),
+            entity_field_index_cache: std::sync::Arc::new(EntitySnapshotFieldIndexCache::default()),
+            entity_point_snapshot_cache: std::sync::Arc::new(EntityPointSnapshotCache::default()),
+        }
+    }
+
     pub(crate) fn advance_filesystem_path_indexes(
         &self,
         previous_revision: Option<&[u8]>,

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -1035,32 +1035,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn close_rejects_active_transaction_read_blocked_in_storage_read() {
-        let (session, gate) = open_blocking_read_session().await;
+    async fn explicit_transaction_reads_reuse_the_opening_storage_snapshot() {
+        let (session, _gate) = open_blocking_read_session().await;
         let mut transaction = session
             .begin_transaction()
             .await
             .expect("transaction should begin");
 
-        gate.block_next();
-        let reader = thread::spawn(move || {
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .build()
-                .expect("test runtime should build");
-            runtime.block_on(async move { transaction.execute("SELECT 1", &[]).await })
-        });
-        gate.wait_until_blocked();
+        let result = transaction
+            .execute("SELECT 1", &[])
+            .await
+            .expect("transaction read should use the retained opening snapshot");
+        assert_eq!(result.len(), 1);
 
         let close_error = session
             .close()
             .await
-            .expect_err("close should reject an active explicit transaction read");
+            .expect_err("close should reject an active explicit transaction");
         assert_eq!(close_error.code, "LIX_INVALID_TRANSACTION_STATE");
-
-        gate.release();
-        let result = join_thread(reader, "blocked transaction reader")
-            .expect("in-flight transaction read should finish after rejected close");
-        assert_eq!(result.len(), 1);
+        transaction
+            .rollback()
+            .await
+            .expect("transaction should roll back");
+        session.close().await.expect("session should close");
     }
 
     #[tokio::test]

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -2256,9 +2256,6 @@ where
                 sql2::bind_statement_route(&statement)?,
                 sql2::BoundStatementRoute::Read
             );
-            if is_read {
-                transaction.ensure_opening_snapshot_is_current().await?;
-            }
             // A successful explicit transaction retains its function provider
             // until commit. Rewind deterministic runtime state whenever this
             // statement fails, including errors before a direct RETURNING
@@ -2288,11 +2285,8 @@ where
                     .await
                 };
                 let result = result.map_err(|error| normalize_sql_surface_error(error, sql))?;
-                if is_read {
-                    // The query opens its own coherent storage read. Checking on both sides
-                    // ensures a concurrent tracked commit cannot leak a newer snapshot
-                    // through an older explicit transaction.
-                    transaction.ensure_opening_snapshot_is_current().await?;
+                if !is_read {
+                    transaction.release_pending_plugin_actor_leases().await;
                 }
                 Ok(result)
             }

--- a/packages/engine/src/session/merge/branch.rs
+++ b/packages/engine/src/session/merge/branch.rs
@@ -188,11 +188,8 @@ where
                     derived_plugin_blob_conflicts(&mut reader, &analysis).await?
                 };
 
-                let resolvable_plugin_conflicts = {
-                    let mut reader = transaction.tracked_state_reader().await;
-                    resolvable_plugin_conflict_keys(&mut reader, &analysis, &derived_blob_files)
-                        .await?
-                };
+                let resolvable_plugin_conflicts =
+                    resolvable_plugin_conflict_keys(&analysis, &derived_blob_files);
 
                 let plugin_resolution_stats = if analysis.outcome == MergeOutcome::MergeCommitted {
                     let plugin_conflict_groups = {
@@ -353,28 +350,25 @@ where
                 // conflicts before constructing a Component Store. A merge
                 // with an unrelated unresolved row must not pay for (or be
                 // masked by) a plugin resolver invocation.
-                let resolvable_plugin_conflicts = async {
-                    let mut reader = transaction.tracked_state_reader().await;
-                    resolvable_plugin_conflict_keys(&mut reader, &analysis, &derived_blob_files)
-                        .await
-                }
-                .instrument(tracing::debug_span!(
-                    target: "lix_perf",
-                    "lix.perf.merge_plugin_conflict_preflight"
-                ))
-                .await?;
-                let effective_conflicts = analysis
-                    .conflict_batch()
-                    .expect("mergeCommitted analysis should include a conflict batch")
-                    .iter()
-                    .filter(|conflict| {
-                        !is_derived_blob_conflict(conflict.tracked(), &derived_blob_files)
-                            && !is_resolvable_plugin_semantic_conflict(
-                                conflict.tracked(),
-                                &resolvable_plugin_conflicts,
-                            )
-                    })
-                    .collect::<Vec<_>>();
+                let resolvable_plugin_conflicts =
+                    resolvable_plugin_conflict_keys(&analysis, &derived_blob_files);
+                let effective_conflicts = if resolvable_plugin_conflicts
+                    .covers_all_with_derived_blobs(merge_plan.conflicts.len(), &derived_blob_files)
+                {
+                    Vec::new()
+                } else {
+                    analysis
+                        .conflict_batch()
+                        .expect("mergeCommitted analysis should include a conflict batch")
+                        .iter()
+                        .enumerate()
+                        .filter(|(index, conflict)| {
+                            !is_derived_blob_conflict(conflict.tracked(), &derived_blob_files)
+                                && !resolvable_plugin_conflicts.contains_index(*index)
+                        })
+                        .map(|(_, conflict)| conflict)
+                        .collect::<Vec<_>>()
+                };
                 if !effective_conflicts.is_empty() {
                     return Err(merge_conflict_error(
                         &effective_conflicts
@@ -505,10 +499,45 @@ const BLOB_REF_SCHEMA_KEY: &str = "lix_binary_blob_ref";
 const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
 const DIRECTORY_DESCRIPTOR_SCHEMA_KEY: &str = "lix_directory_descriptor";
 
+#[derive(Debug, Clone)]
+struct DerivedPluginFileConflict {
+    plugin: PluginRegistryEntry,
+    descriptor: WasmFileDescriptor,
+    conflict_indices: Vec<usize>,
+    derived_blob_conflict_count: usize,
+}
+
+#[derive(Debug, Clone, Default)]
+struct DerivedPluginConflictIndex {
+    owners: BTreeMap<String, PluginFileOwner>,
+    files: BTreeMap<String, DerivedPluginFileConflict>,
+}
+
+impl DerivedPluginConflictIndex {
+    fn context(&self, file_id: &str) -> Option<&DerivedPluginFileConflict> {
+        self.files.get(file_id)
+    }
+
+    fn owner(&self, file_id: &str) -> Option<&PluginFileOwner> {
+        self.owners.get(file_id)
+    }
+
+    fn contains_file(&self, file_id: &str) -> bool {
+        self.owners.contains_key(file_id)
+    }
+
+    fn derived_blob_conflict_count(&self) -> usize {
+        self.files
+            .values()
+            .map(|context| context.derived_blob_conflict_count)
+            .sum()
+    }
+}
+
 async fn derived_plugin_blob_conflicts<S>(
     reader: &mut TrackedStateStoreReader<S>,
     analysis: &super::analysis::MergeAnalysis,
-) -> Result<BTreeMap<String, PluginFileOwner>, LixError>
+) -> Result<DerivedPluginConflictIndex, LixError>
 where
     S: crate::storage_adapter::StorageAdapterRead,
 {
@@ -522,14 +551,24 @@ where
     // row with a deleted file owner. Keep the whole conflict visible until a
     // first-class lifecycle conflict model exists.
     let Some(conflicts) = analysis.conflict_batch() else {
-        return Ok(BTreeMap::new());
+        return Ok(DerivedPluginConflictIndex::default());
     };
-    let file_ids = conflicts
-        .iter()
-        .filter_map(|conflict| conflict.file_id().map(str::to_owned))
+    let mut conflict_indices_by_file = BTreeMap::<String, Vec<usize>>::new();
+    for (index, conflict) in conflicts.iter().enumerate() {
+        let Some(file_id) = conflict.file_id() else {
+            continue;
+        };
+        conflict_indices_by_file
+            .entry(file_id.to_owned())
+            .or_default()
+            .push(index);
+    }
+    let file_ids = conflict_indices_by_file
+        .keys()
+        .cloned()
         .collect::<BTreeSet<_>>();
     if file_ids.is_empty() {
-        return Ok(BTreeMap::new());
+        return Ok(DerivedPluginConflictIndex::default());
     }
 
     let owner_keys = file_ids
@@ -574,7 +613,7 @@ where
         common_owners.insert(file_id, owner);
     }
     if common_owners.is_empty() {
-        return Ok(BTreeMap::new());
+        return Ok(DerivedPluginConflictIndex::default());
     }
 
     // Semantic resolution regenerates the derived blob through the target
@@ -614,23 +653,58 @@ where
     .await?;
 
     let mut derived = BTreeMap::new();
+    let mut derived_owners = BTreeMap::new();
     for (file_id, owner) in common_owners {
-        if common_descriptors
-            .get(&file_id)
-            .is_some_and(|(path, _)| path.is_some())
-            && pinned_conflict_plugin_entry(
-                &owner,
-                &base_registry,
-                &target_registry,
-                &source_registry,
-                &file_id,
-            )
-            .is_ok()
-        {
-            derived.insert(file_id, owner);
-        }
+        let Some((path @ Some(_), media_type)) = common_descriptors.get(&file_id).cloned() else {
+            continue;
+        };
+        let Ok(plugin) = pinned_conflict_plugin_entry(
+            &owner,
+            &base_registry,
+            &target_registry,
+            &source_registry,
+            &file_id,
+        ) else {
+            continue;
+        };
+        let descriptor = WasmFileDescriptor {
+            path,
+            media_type,
+            plugin: WasmPluginSelection {
+                plugin_key: plugin.key().to_owned(),
+                generation: plugin.archive_blob_hash().to_owned(),
+            },
+        };
+        let conflict_indices = conflict_indices_by_file
+            .remove(&file_id)
+            .unwrap_or_default();
+        let merge_plan = analysis
+            .merge_plan()
+            .expect("derived plugin conflicts require a merge plan");
+        let derived_blob_conflict_count = conflict_indices
+            .iter()
+            .filter(|&&index| {
+                matches!(
+                    merge_plan.conflicts[index].identity.schema_key(),
+                    BLOB_REF_SCHEMA_KEY | DERIVED_FILE_REF_SCHEMA_KEY
+                )
+            })
+            .count();
+        derived.insert(
+            file_id.clone(),
+            DerivedPluginFileConflict {
+                plugin,
+                descriptor,
+                conflict_indices,
+                derived_blob_conflict_count,
+            },
+        );
+        derived_owners.insert(file_id, owner);
     }
-    Ok(derived)
+    Ok(DerivedPluginConflictIndex {
+        owners: derived_owners,
+        files: derived,
+    })
 }
 
 fn common_live_plugin_owner_ref(
@@ -705,7 +779,7 @@ fn common_live_plugin_owner(
 
 fn is_derived_blob_conflict(
     conflict: &TrackedStateMergeConflict,
-    derived_blob_files: &BTreeMap<String, PluginFileOwner>,
+    derived_blob_files: &DerivedPluginConflictIndex,
 ) -> bool {
     matches!(
         conflict.identity.schema_key(),
@@ -713,17 +787,17 @@ fn is_derived_blob_conflict(
     ) && conflict
         .identity
         .file_id()
-        .is_some_and(|file_id| derived_blob_files.contains_key(file_id))
+        .is_some_and(|file_id| derived_blob_files.contains_file(file_id))
 }
 
 fn pick_is_derived_plugin_state(
     pick: &TrackedStateMergePick,
-    derived_blob_files: &BTreeMap<String, PluginFileOwner>,
+    derived_blob_files: &DerivedPluginConflictIndex,
 ) -> bool {
     let Some(file_id) = pick.selected_row.file_id() else {
         return false;
     };
-    let Some(owner) = derived_blob_files.get(file_id) else {
+    let Some(owner) = derived_blob_files.owner(file_id) else {
         return false;
     };
     matches!(
@@ -785,104 +859,67 @@ struct PluginMergeConflictGroup {
     conflicts: PluginMergeConflictBatch,
 }
 
-fn is_resolvable_plugin_semantic_conflict(
-    conflict: &TrackedStateMergeConflict,
-    resolvable_plugin_conflicts: &BTreeSet<TrackedStateDiffIdentity>,
-) -> bool {
-    resolvable_plugin_conflicts.contains(&conflict.identity)
+#[derive(Debug, Clone, Default)]
+struct ResolvablePluginConflicts {
+    indices: Vec<usize>,
+}
+
+impl ResolvablePluginConflicts {
+    fn contains_index(&self, index: usize) -> bool {
+        self.indices.binary_search(&index).is_ok()
+    }
+
+    fn covers_all_with_derived_blobs(
+        &self,
+        conflict_count: usize,
+        derived: &DerivedPluginConflictIndex,
+    ) -> bool {
+        self.indices
+            .len()
+            .checked_add(derived.derived_blob_conflict_count())
+            == Some(conflict_count)
+    }
 }
 
 /// Returns exactly the semantic conflict identities that can be handed to a
 /// static resolver. This deliberately does not execute Wasm: callers use it
 /// both to make merge preview honest and to reject ordinary conflicts before
 /// allocating a Component Store.
-async fn resolvable_plugin_conflict_keys<S>(
-    reader: &mut TrackedStateStoreReader<S>,
+fn resolvable_plugin_conflict_keys(
     analysis: &super::analysis::MergeAnalysis,
-    derived_blob_files: &BTreeMap<String, PluginFileOwner>,
-) -> Result<BTreeSet<TrackedStateDiffIdentity>, LixError>
-where
-    S: crate::storage_adapter::StorageAdapterRead,
-{
+    derived_blob_files: &DerivedPluginConflictIndex,
+) -> ResolvablePluginConflicts {
     let Some(merge_plan) = analysis.merge_plan() else {
-        return Ok(BTreeSet::new());
+        return ResolvablePluginConflicts::default();
     };
-    let semantic_conflicts = merge_plan
-        .conflicts
-        .iter()
-        .filter(|conflict| {
-            let Some(file_id) = conflict.identity.file_id() else {
-                return false;
-            };
-            derived_blob_files.get(file_id).is_some_and(|owner| {
-                owner
-                    .schema_keys()
-                    .iter()
-                    .any(|schema_key| schema_key == conflict.identity.schema_key())
-            })
-        })
-        .collect::<Vec<_>>();
-    if semantic_conflicts.is_empty() {
-        return Ok(BTreeSet::new());
-    }
-
-    let registry_key = TrackedStateKey {
-        schema_key: "lix_key_value".to_owned(),
-        file_id: None,
-        entity_pk: EntityPk::single(PLUGIN_REGISTRY_KEY),
-    };
-    let base_registry = load_historical_plugin_registry(
-        reader,
-        &analysis.commits.base_commit_id.to_string(),
-        &registry_key,
-    )
-    .await?;
-    let target_registry = load_historical_plugin_registry(
-        reader,
-        &analysis.commits.target_commit_id.to_string(),
-        &registry_key,
-    )
-    .await?;
-    let source_registry = load_historical_plugin_registry(
-        reader,
-        &analysis.commits.source_commit_id.to_string(),
-        &registry_key,
-    )
-    .await?;
-
-    let mut eligible = BTreeSet::new();
-    for conflict in semantic_conflicts {
-        let file_id = conflict
-            .identity
-            .file_id()
-            .expect("semantic plugin conflicts have a file id");
+    let mut eligible = ResolvablePluginConflicts::default();
+    for (file_id, context) in &derived_blob_files.files {
         let owner = derived_blob_files
-            .get(file_id)
-            .expect("semantic plugin conflicts have a derived owner");
-        // An unavailable, mismatched, or upgraded historical entry is not a
-        // fatal preflight error. Leave that row visible as an ordinary merge
-        // conflict in both preview and merge instead of claiming it was
-        // resolved. Corrupt registry snapshots were rejected while loading.
-        if pinned_conflict_plugin_entry(
-            owner,
-            &base_registry,
-            &target_registry,
-            &source_registry,
-            file_id,
-        )
-        .is_ok()
-        {
-            eligible.insert(conflict.identity.clone());
+            .owner(file_id)
+            .expect("derived plugin context has an owner");
+        for &index in &context.conflict_indices {
+            let conflict = &merge_plan.conflicts[index];
+            if !matches!(
+                conflict.identity.schema_key(),
+                BLOB_REF_SCHEMA_KEY | DERIVED_FILE_REF_SCHEMA_KEY
+            ) && owner
+                .schema_keys()
+                .iter()
+                .any(|schema_key| schema_key == conflict.identity.schema_key())
+            {
+                eligible.indices.push(index);
+            }
         }
     }
-    Ok(eligible)
+    eligible.indices.sort_unstable();
+    eligible
 }
 
 async fn plugin_merge_conflict_groups<S>(
     reader: &mut TrackedStateStoreReader<S>,
     analysis: &super::analysis::MergeAnalysis,
-    derived_blob_files: &BTreeMap<String, PluginFileOwner>,
-    resolvable_plugin_conflicts: &BTreeSet<TrackedStateDiffIdentity>,
+    derived_blob_files: &DerivedPluginConflictIndex,
+    resolvable_plugin_conflicts: &ResolvablePluginConflicts,
 ) -> Result<Vec<PluginMergeConflictGroup>, LixError>
 where
     S: crate::storage_adapter::StorageAdapterRead,
@@ -890,45 +927,14 @@ where
     let merge_plan = analysis
         .merge_plan()
         .expect("plugin conflict resolution requires a merge plan");
-    let semantic_conflicts = merge_plan
-        .conflicts
+    let semantic_conflicts = resolvable_plugin_conflicts
+        .indices
         .iter()
-        .filter(|conflict| resolvable_plugin_conflicts.contains(&conflict.identity))
+        .map(|&index| &merge_plan.conflicts[index])
         .collect::<Vec<_>>();
     if semantic_conflicts.is_empty() {
         return Ok(Vec::new());
     }
-
-    let semantic_file_ids = semantic_conflicts
-        .iter()
-        .filter_map(|conflict| conflict.identity.file_id().map(str::to_owned))
-        .collect::<BTreeSet<_>>();
-    let historical_descriptors =
-        historical_conflict_file_descriptors(reader, analysis, &semantic_file_ids).await?;
-
-    let registry_key = TrackedStateKey {
-        schema_key: "lix_key_value".to_owned(),
-        file_id: None,
-        entity_pk: EntityPk::single(PLUGIN_REGISTRY_KEY),
-    };
-    let base_registry = load_historical_plugin_registry(
-        reader,
-        &analysis.commits.base_commit_id.to_string(),
-        &registry_key,
-    )
-    .await?;
-    let target_registry = load_historical_plugin_registry(
-        reader,
-        &analysis.commits.target_commit_id.to_string(),
-        &registry_key,
-    )
-    .await?;
-    let source_registry = load_historical_plugin_registry(
-        reader,
-        &analysis.commits.source_commit_id.to_string(),
-        &registry_key,
-    )
-    .await?;
 
     let keys = semantic_conflicts
         .iter()
@@ -970,16 +976,10 @@ where
             .file_id()
             .expect("semantic plugin conflicts have a file id")
             .to_owned();
-        let owner = derived_blob_files
-            .get(&file_id)
+        let context = derived_blob_files
+            .context(&file_id)
             .expect("semantic plugin conflicts have a derived owner");
-        let plugin = pinned_conflict_plugin_entry(
-            owner,
-            &base_registry,
-            &target_registry,
-            &source_registry,
-            &file_id,
-        )?;
+        let plugin = context.plugin.clone();
         verify_historical_conflict_row_ref(base, conflict.target.before.as_ref(), "base")?;
         verify_historical_conflict_row_ref(target, conflict.target.after.as_ref(), "target")?;
         verify_historical_conflict_row_ref(source, conflict.source.after.as_ref(), "source")?;
@@ -991,22 +991,7 @@ where
             a: historical_live_payload_ref(a)?,
             b: historical_live_payload_ref(b)?,
         };
-        let (path, media_type) = historical_descriptors
-            .get(&file_id)
-            .cloned()
-            .unwrap_or((None, None));
-        let descriptor = WasmFileDescriptor {
-            // The historical file descriptor is not resolver authority, but
-            // a common path/media identity lets one plugin support multiple
-            // formats without guessing from a semantic row. Rename-divergent
-            // or unavailable descriptors deliberately remain `None`.
-            path,
-            media_type,
-            plugin: WasmPluginSelection {
-                plugin_key: plugin.key().to_owned(),
-                generation: plugin.archive_blob_hash().to_owned(),
-            },
-        };
+        let descriptor = context.descriptor.clone();
         match groups.get_mut(&file_id) {
             Some(group) => {
                 if group.plugin != plugin || group.descriptor != descriptor {
@@ -1706,7 +1691,7 @@ fn push_transaction_row_from_tracked_row_ref(
 async fn materialized_plugin_merge_rows<S>(
     reader: &mut TrackedStateStoreReader<S>,
     analysis: &super::analysis::MergeAnalysis,
-    derived_blob_files: &BTreeMap<String, PluginFileOwner>,
+    derived_blob_files: &DerivedPluginConflictIndex,
     target_branch_id: &SharedStr,
     resolved_plugin_rows: RawWriteBatch,
 ) -> Result<RawWriteBatch, LixError>
@@ -1721,7 +1706,7 @@ where
         .iter()
         .filter(|pick| {
             pick.selected_row.file_id().is_some_and(|file_id| {
-                derived_blob_files.get(file_id).is_some_and(|owner| {
+                derived_blob_files.owner(file_id).is_some_and(|owner| {
                     owner
                         .schema_keys()
                         .iter()
@@ -1735,7 +1720,7 @@ where
         let Some(file_id) = pick.selected_row.file_id() else {
             continue;
         };
-        if !derived_blob_files.get(file_id).is_some_and(|owner| {
+        if !derived_blob_files.owner(file_id).is_some_and(|owner| {
             owner
                 .schema_keys()
                 .iter()
@@ -1875,27 +1860,34 @@ fn preview_from_analysis(
     target_branch_id: &str,
     source_branch_id: &str,
     analysis: &super::analysis::MergeAnalysis,
-    derived_blob_files: &BTreeMap<String, PluginFileOwner>,
-    resolvable_plugin_conflicts: &BTreeSet<TrackedStateDiffIdentity>,
+    derived_blob_files: &DerivedPluginConflictIndex,
+    resolvable_plugin_conflicts: &ResolvablePluginConflicts,
     plugin_resolution_stats: &MergeChangeStats,
 ) -> Result<MergeBranchPreview, LixError> {
-    let conflicts = analysis
-        .conflict_batch()
-        .map(|batch| {
-            batch
-                .iter()
-                .filter(|conflict| {
-                    !is_derived_blob_conflict(conflict.tracked(), derived_blob_files)
-                        && !is_resolvable_plugin_semantic_conflict(
-                            conflict.tracked(),
-                            resolvable_plugin_conflicts,
-                        )
-                })
-                .map(merge_conflict_from_analysis)
-                .collect::<Result<Vec<_>, LixError>>()
-        })
-        .transpose()?
-        .unwrap_or_default();
+    let conflicts = match analysis.merge_plan() {
+        Some(plan)
+            if resolvable_plugin_conflicts
+                .covers_all_with_derived_blobs(plan.conflicts.len(), derived_blob_files) =>
+        {
+            Vec::new()
+        }
+        _ => analysis
+            .conflict_batch()
+            .map(|batch| {
+                batch
+                    .iter()
+                    .enumerate()
+                    .filter(|(index, conflict)| {
+                        !is_derived_blob_conflict(conflict.tracked(), derived_blob_files)
+                            && !resolvable_plugin_conflicts.contains_index(*index)
+                    })
+                    .map(|(_, conflict)| conflict)
+                    .map(merge_conflict_from_analysis)
+                    .collect::<Result<Vec<_>, LixError>>()
+            })
+            .transpose()?
+            .unwrap_or_default(),
+    };
     Ok(MergeBranchPreview {
         outcome: merge_branch_outcome_from_analysis(analysis.outcome),
         target_branch_id: target_branch_id.to_string(),
@@ -2183,12 +2175,15 @@ mod tests {
         }
     }
 
-    fn derived_file_owner(file_id: &str) -> BTreeMap<String, PluginFileOwner> {
-        BTreeMap::from([(
-            file_id.to_owned(),
-            PluginFileOwner::new(file_id, "plugin_git_text", vec!["git_text_line".to_owned()])
-                .unwrap(),
-        )])
+    fn derived_file_owner(file_id: &str) -> DerivedPluginConflictIndex {
+        DerivedPluginConflictIndex {
+            owners: BTreeMap::from([(
+                file_id.to_owned(),
+                PluginFileOwner::new(file_id, "plugin_git_text", vec!["git_text_line".to_owned()])
+                    .unwrap(),
+            )]),
+            files: BTreeMap::new(),
+        }
     }
 
     #[test]

--- a/packages/engine/src/session/transaction.rs
+++ b/packages/engine/src/session/transaction.rs
@@ -20,7 +20,7 @@ use super::SessionContext;
 use super::context::{SessionWriteAccess, closed_error};
 
 #[expect(missing_debug_implementations)]
-pub struct SessionTransaction<StorageImpl: Storage = Memory> {
+pub struct SessionTransaction<StorageImpl: Storage + 'static = Memory> {
     pub(super) transaction: Option<Transaction<StorageImpl>>,
     pub(super) runtime_functions: FunctionContext,
     transaction_manager: SessionTransactionManager,

--- a/packages/engine/src/storage_adapter/context.rs
+++ b/packages/engine/src/storage_adapter/context.rs
@@ -202,13 +202,6 @@ where
             }))
     }
 
-    pub(crate) async fn load_tracked_mutation_revision(
-        &self,
-    ) -> Result<Option<Bytes>, StorageError> {
-        let read = self.storage.begin_read(ReadOptions::default()).await?;
-        Self::load_tracked_mutation_revision_from_read(&StorageAdapterReadScope::new(read)).await
-    }
-
     pub async fn delete_range(
         &self,
         space: StorageSpace,

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -100,8 +100,8 @@ use crate::storage_adapter::{
     SharedStorageAdapterRead, StorageAdapter, StorageAdapterRead, StorageAdapterReadScope,
 };
 use crate::tracked_state::{
-    TrackedStateContext, TrackedStateDiffKind, TrackedStateDiffRequest, TrackedStateScanRequest,
-    TrackedStateStoreReader,
+    TrackedStateContext, TrackedStateDiffKind, TrackedStateDiffRequest, TrackedStateKey,
+    TrackedStateScanRequest, TrackedStateStoreReader,
 };
 use crate::transaction::commit;
 use crate::transaction::normalization::{
@@ -171,17 +171,120 @@ use crate::transaction::validation::{
 };
 use crate::wasm::{
     WasmCertifiedEntityBatch, WasmChangeEffect, WasmColdFileUpdate, WasmComponentActor,
-    WasmComponentFactory, WasmConflictUpdate, WasmDocumentCheckpoint, WasmDocumentHandle,
-    WasmDurableDocumentCheckpoint, WasmEntityChange, WasmEntityConflict, WasmEntityKey,
-    WasmEntityUpdate, WasmFileDescriptor, WasmFileUpdate, WasmHostBytes, WasmHostEntity,
-    WasmHostEntityChanges, WasmOpenEntitiesInput, WasmOpenFileInput, WasmPluginSelection,
-    WasmTransitionLimits,
+    WasmComponentFactory, WasmConflictResolution, WasmConflictTake, WasmConflictUpdate,
+    WasmDocumentCheckpoint, WasmDocumentHandle, WasmDurableDocumentCheckpoint, WasmEntityChange,
+    WasmEntityConflict, WasmEntityKey, WasmEntityUpdate, WasmFileDescriptor, WasmFileUpdate,
+    WasmHostBytes, WasmHostEntity, WasmHostEntityChanges, WasmOpenEntitiesInput, WasmOpenFileInput,
+    WasmPluginSelection, WasmTransitionLimits,
 };
 use crate::{LixError, NullableKeyFilter, SqlQueryResult, Value};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub(crate) struct TransactionCommitOutcome {
     pub(crate) storage_stats: StorageWriteSetStats,
+}
+
+#[derive(Clone)]
+struct StaleConflictPayload {
+    snapshot: SharedStr,
+    metadata: Option<SharedStr>,
+}
+
+struct StaleSemanticConflict {
+    key: TrackedStateKey,
+    base: Option<StaleConflictPayload>,
+    a: Option<StaleConflictPayload>,
+    b: Option<StaleConflictPayload>,
+}
+
+struct StalePluginConflictGroup {
+    plugin: PluginRegistryEntry,
+    descriptor: WasmFileDescriptor,
+    conflicts: Vec<StaleSemanticConflict>,
+}
+
+fn stale_payload_from_tracked(
+    row: Option<crate::tracked_state::MaterializedTrackedStateRowRef<'_>>,
+) -> Option<StaleConflictPayload> {
+    row.filter(|row| !row.deleted()).and_then(|row| {
+        Some(StaleConflictPayload {
+            snapshot: row.snapshot_content()?.clone(),
+            metadata: row.metadata().cloned(),
+        })
+    })
+}
+
+fn stale_conflict_bytes(payload: Option<&StaleConflictPayload>) -> Option<WasmHostBytes> {
+    payload
+        .map(|payload| WasmHostBytes::Inline(Bytes::copy_from_slice(payload.snapshot.as_bytes())))
+}
+
+fn push_stale_conflict_resolution(
+    rows: &mut RawWriteBatch,
+    conflict: &StaleSemanticConflict,
+    resolution: WasmConflictResolution<WasmHostBytes>,
+    branch_id: &str,
+) -> Result<(), LixError> {
+    let (snapshot, metadata) = match resolution {
+        WasmConflictResolution::Take(side) => {
+            let selected = match side {
+                WasmConflictTake::Base => conflict.base.as_ref(),
+                WasmConflictTake::A => conflict.a.as_ref(),
+                WasmConflictTake::B => conflict.b.as_ref(),
+            }
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INVALID_PLUGIN,
+                    "plugin conflict resolver selected an absent value; use delete for a tombstone",
+                )
+            })?;
+            (
+                Some(TransactionJson::from_unvalidated_shared_normalized_content(
+                    selected.snapshot.clone(),
+                )),
+                selected
+                    .metadata
+                    .clone()
+                    .map(TransactionJson::from_unvalidated_shared_normalized_content),
+            )
+        }
+        WasmConflictResolution::Delete => (None, None),
+        WasmConflictResolution::Replace {
+            snapshot_content,
+            effect,
+        } => {
+            let WasmHostBytes::CanonicalJson(snapshot) = snapshot_content else {
+                return Err(LixError::new(
+                    LixError::CODE_INVALID_PLUGIN,
+                    "validated conflict replacement is not canonical JSON",
+                ));
+            };
+            let metadata = match effect {
+                WasmChangeEffect::Content => None,
+                WasmChangeEffect::FormatOnly => Some(v2_format_only_metadata()),
+            };
+            (
+                Some(TransactionJson::from_canonical_batch(snapshot)),
+                metadata,
+            )
+        }
+    };
+    rows.push_parts(
+        Some(conflict.key.entity_pk.clone()),
+        SharedStr::from(conflict.key.schema_key.as_str()),
+        conflict.key.file_id.as_deref().map(SharedStr::from),
+        snapshot,
+        metadata,
+        None,
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        SharedStr::from(branch_id),
+    );
+    Ok(())
 }
 
 /// The durable identity and byte proof of one plugin materialization.
@@ -366,7 +469,7 @@ fn record_transaction_path_index_build(descriptor_rows: usize) {
 /// that may write. Write-relevant reads must be exposed from this transaction,
 /// after the storage write transaction has begun, rather than from session-level
 /// helpers.
-pub(crate) struct Transaction<StorageImpl: Storage = Memory> {
+pub(crate) struct Transaction<StorageImpl: Storage + 'static = Memory> {
     active_branch_id: String,
     live_state: Arc<LiveStateContext>,
     tracked_state: Arc<TrackedStateContext>,
@@ -382,12 +485,20 @@ pub(crate) struct Transaction<StorageImpl: Storage = Memory> {
     staged_writes: Arc<TransactionWriteBuffer>,
     filesystem_path_index_cache: Arc<FilesystemPathIndexCache>,
     filesystem_path_index_epoch: Arc<AtomicUsize>,
-    storage: StorageAdapter<StorageImpl>,
+    /// Coherent storage snapshot retained for explicit transaction reads.
+    /// This field is declared before `storage` so it is dropped first.
+    opening_read: SharedStorageAdapterRead<StorageImpl::Read<'static>>,
+    storage: Arc<StorageAdapter<StorageImpl>>,
     functions: FunctionProviderHandle,
     /// Tracked-state revision observed by the coherent transaction-open read.
     /// Durable tracked publication must still be based on this revision;
     /// untracked current-state writes do not invalidate the tracked snapshot.
     opening_tracked_mutation_revision: Option<Bytes>,
+    /// Branch roots captured by the same coherent opening read. They let an
+    /// explicit transaction distinguish a disjoint concurrent commit from an
+    /// overlapping semantic write without creating a temporary branch.
+    opening_active_branch_head: Option<CommitId>,
+    opening_global_branch_head: Option<CommitId>,
     commit_boundary: Option<TransactionCommitBoundary>,
     trust_filesystem_planner: bool,
     origin_key: Option<SharedStr>,
@@ -531,22 +642,516 @@ impl<StorageImpl> Transaction<StorageImpl>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
-    pub(crate) fn ensure_opening_snapshot_is_current(
-        &self,
-    ) -> impl Future<Output = Result<(), LixError>> + Send + 'static {
-        let storage = self.storage.clone();
-        let opening_revision = self.opening_tracked_mutation_revision.clone();
-        async move {
-            let current = storage.load_tracked_mutation_revision().await?;
-            if current == opening_revision {
-                return Ok(());
-            }
-            Err(LixError::new(
-                LixError::CODE_TRANSACTION_CONFLICT,
-                "transaction snapshot is stale because tracked state changed after it opened",
-            )
-            .with_hint("Retry the transaction against the latest committed state."))
+    fn opening_read(&self) -> SharedStorageAdapterRead<StorageImpl::Read<'static>> {
+        self.opening_read.clone()
+    }
+
+    async fn reconcile_stale_disjoint_writes<S>(
+        &mut self,
+        read: &S,
+        prepared_writes: &mut PreparedWriteSet,
+    ) -> Result<(), LixError>
+    where
+        S: StorageAdapterRead,
+    {
+        let current_revision =
+            StorageAdapter::<StorageImpl>::load_tracked_mutation_revision_from_read(read).await?;
+        if current_revision == self.opening_tracked_mutation_revision {
+            return Ok(());
         }
+
+        let conflict = |message: &'static str| {
+            LixError::new(LixError::CODE_TRANSACTION_CONFLICT, message)
+                .with_hint("Retry the transaction against the latest committed state.")
+        };
+        if prepared_writes.state_rows.iter().any(|row| {
+            row.untracked || row.global || row.branch_id.as_str() != self.active_branch_id
+        }) || !prepared_writes.extra_commit_parents_by_branch.is_empty()
+            || !prepared_writes
+                .first_commit_parent_override_by_branch
+                .is_empty()
+            || !prepared_writes.intermediate_commits.is_empty()
+            || !prepared_writes.checkpoint_publications.is_empty()
+            || prepared_writes
+                .commit_change_refs_by_branch
+                .keys()
+                .any(|branch_id| branch_id != &self.active_branch_id)
+        {
+            return Err(conflict(
+                "transaction snapshot is stale and contains writes outside the supported semantic reconciliation lane",
+            ));
+        }
+
+        let branch_reader = self.branch_ctx.ref_reader(read);
+        let current_global_head = branch_reader.load_head_commit_id(GLOBAL_BRANCH_ID).await?;
+        let current_active_head = branch_reader
+            .load_head_commit_id(&self.active_branch_id)
+            .await?;
+        if self.opening_active_branch_head.is_some() && current_active_head.is_none() {
+            return Err(LixError::new(
+                LixError::CODE_BRANCH_NOT_FOUND,
+                format!("branch '{}' does not exist", self.active_branch_id),
+            ));
+        }
+        if current_global_head != self.opening_global_branch_head {
+            return Err(conflict(
+                "transaction snapshot is stale because global schemas or plugin state changed after it opened",
+            ));
+        }
+        if current_active_head == self.opening_active_branch_head {
+            self.opening_tracked_mutation_revision = current_revision;
+            return Ok(());
+        }
+        let Some(opening_head) = self.opening_active_branch_head else {
+            return Err(conflict(
+                "transaction snapshot is stale because its branch lifecycle changed after it opened",
+            ));
+        };
+        let Some(current_head) = current_active_head else {
+            return Err(LixError::new(
+                LixError::CODE_BRANCH_NOT_FOUND,
+                format!("branch '{}' does not exist", self.active_branch_id),
+            ));
+        };
+
+        let mut tracked = self.tracked_state.reader(read);
+        let concurrent = tracked
+            .diff_commits(
+                &opening_head.to_string(),
+                &current_head.to_string(),
+                &TrackedStateDiffRequest::default(),
+            )
+            .await?;
+        let overlapping_row_indices = prepared_writes
+            .state_rows
+            .iter()
+            .enumerate()
+            .filter_map(|(index, row)| {
+                concurrent
+                    .entries
+                    .iter()
+                    .any(|entry| {
+                        row.schema_key.as_str() == entry.identity.schema_key()
+                            && row.file_id.map(SharedStr::as_str) == entry.identity.file_id()
+                            && row.entity_pk == entry.identity.entity_pk()
+                    })
+                    .then_some(index)
+            })
+            .collect::<Vec<_>>();
+        if !overlapping_row_indices.is_empty() {
+            // Ordinary INSERT races keep their established constraint surface:
+            // commit-time validation reports the exact UNIQUE/statement-index
+            // error from the current snapshot. Updates and file-scoped semantic
+            // rows cannot safely use that absence-check lane.
+            let ordinary_insert_race = overlapping_row_indices.iter().all(|&index| {
+                prepared_writes.insert_selection.contains(index)
+                    && prepared_writes.state_rows.row(index).file_id.is_none()
+            });
+            if !ordinary_insert_race {
+                self.resolve_stale_plugin_overlaps(
+                    read,
+                    prepared_writes,
+                    &concurrent,
+                    opening_head,
+                    current_head,
+                )
+                .await?;
+            }
+        }
+
+        self.opening_active_branch_head = Some(current_head);
+        self.opening_tracked_mutation_revision = current_revision;
+        Ok(())
+    }
+
+    async fn resolve_stale_plugin_overlaps<S>(
+        &mut self,
+        read: &S,
+        prepared_writes: &mut PreparedWriteSet,
+        concurrent: &crate::tracked_state::TrackedStateDiff,
+        opening_head: CommitId,
+        current_head: CommitId,
+    ) -> Result<(), LixError>
+    where
+        S: StorageAdapterRead,
+    {
+        let conflict_error = || {
+            LixError::new(
+                LixError::CODE_TRANSACTION_CONFLICT,
+                "concurrent transaction changed an overlapping entity outside a stable plugin-owned file",
+            )
+            .with_hint("Retry the transaction against the latest committed state.")
+        };
+        let concurrent_keys = concurrent
+            .entries
+            .iter()
+            .map(|entry| TrackedStateKey {
+                schema_key: entry.identity.schema_key().to_owned(),
+                file_id: entry.identity.file_id().map(str::to_owned),
+                entity_pk: entry.identity.entity_pk().clone(),
+            })
+            .collect::<BTreeSet<_>>();
+        let candidate_indices = prepared_writes
+            .state_rows
+            .iter()
+            .enumerate()
+            .filter_map(|(index, row)| {
+                let key = TrackedStateKey {
+                    schema_key: row.schema_key.to_string(),
+                    file_id: row.file_id.map(|file_id| file_id.to_string()),
+                    entity_pk: row.entity_pk.clone(),
+                };
+                (concurrent_keys.contains(&key)
+                    && row.file_id.is_some()
+                    && !matches!(
+                        row.schema_key.as_str(),
+                        BLOB_REF_SCHEMA_KEY | DERIVED_FILE_REF_SCHEMA_KEY
+                    ))
+                .then_some(index)
+            })
+            .collect::<Vec<_>>();
+        if candidate_indices.is_empty() {
+            return Err(conflict_error());
+        }
+        let file_ids = candidate_indices
+            .iter()
+            .map(|&index| {
+                prepared_writes
+                    .state_rows
+                    .row(index)
+                    .file_id
+                    .expect("candidate has file id")
+                    .to_string()
+            })
+            .collect::<BTreeSet<_>>();
+        if concurrent_keys.iter().any(|key| {
+            prepared_writes.state_rows.iter().any(|row| {
+                row.schema_key.as_str() == key.schema_key
+                    && row.file_id.map(SharedStr::as_str) == key.file_id.as_deref()
+                    && row.entity_pk == &key.entity_pk
+            }) && (!file_ids.contains(key.file_id.as_deref().unwrap_or_default())
+                || !matches!(
+                    key.schema_key.as_str(),
+                    BLOB_REF_SCHEMA_KEY | DERIVED_FILE_REF_SCHEMA_KEY
+                ) && !candidate_indices.iter().any(|&index| {
+                    let row = prepared_writes.state_rows.row(index);
+                    row.schema_key.as_str() == key.schema_key
+                        && row.file_id.map(SharedStr::as_str) == key.file_id.as_deref()
+                        && row.entity_pk == &key.entity_pk
+                }))
+        }) {
+            return Err(conflict_error());
+        }
+
+        let owner_keys = file_ids
+            .iter()
+            .map(|file_id| TrackedStateKey {
+                schema_key: KEY_VALUE_SCHEMA_KEY.to_owned(),
+                file_id: Some(file_id.clone()),
+                entity_pk: EntityPk::single(PLUGIN_OWNER_KEY),
+            })
+            .collect::<Vec<_>>();
+        let registry_key = TrackedStateKey {
+            schema_key: KEY_VALUE_SCHEMA_KEY.to_owned(),
+            file_id: None,
+            entity_pk: EntityPk::single(PLUGIN_REGISTRY_KEY),
+        };
+        let mut tracked = self.tracked_state.reader(read);
+        let base_owners = tracked
+            .load_projected_batch_at_commit(
+                &opening_head.to_string(),
+                &owner_keys,
+                &ChangeRecordProjection::full(),
+            )
+            .await?;
+        let current_owners = tracked
+            .load_projected_batch_at_commit(
+                &current_head.to_string(),
+                &owner_keys,
+                &ChangeRecordProjection::full(),
+            )
+            .await?;
+        let base_registry = tracked
+            .load_projected_batch_at_commit(
+                &opening_head.to_string(),
+                std::slice::from_ref(&registry_key),
+                &ChangeRecordProjection::full(),
+            )
+            .await?;
+        let current_registry = tracked
+            .load_projected_batch_at_commit(
+                &current_head.to_string(),
+                std::slice::from_ref(&registry_key),
+                &ChangeRecordProjection::full(),
+            )
+            .await?;
+        let base_registry_row = base_registry.row(0);
+        let current_registry_row = current_registry.row(0);
+        if base_registry_row.map(|row| row.change_id())
+            != current_registry_row.map(|row| row.change_id())
+        {
+            return Err(conflict_error());
+        }
+        let registry_snapshot = current_registry_row
+            .filter(|row| !row.deleted())
+            .and_then(|row| row.snapshot_content())
+            .map(|snapshot| serde_json::from_str(snapshot.as_str()))
+            .transpose()
+            .map_err(|error| {
+                LixError::new(
+                    LixError::CODE_INVALID_PLUGIN,
+                    format!("plugin registry snapshot is invalid JSON: {error}"),
+                )
+            })?;
+        let registry = PluginRegistry::from_optional_snapshot(registry_snapshot.as_ref())?;
+
+        let path_index = self
+            .filesystem_path_index(&FilesystemPathIndexRequest::new(vec![
+                self.active_branch_id.clone(),
+            ]))
+            .await?;
+        let mut groups = BTreeMap::<String, StalePluginConflictGroup>::new();
+        for (owner_index, file_id) in file_ids.iter().enumerate() {
+            let base_owner_row = base_owners.row(owner_index);
+            let current_owner_row = current_owners.row(owner_index);
+            if base_owner_row.map(|row| row.change_id())
+                != current_owner_row.map(|row| row.change_id())
+            {
+                return Err(conflict_error());
+            }
+            let owner = current_owner_row
+                .filter(|row| !row.deleted())
+                .map(PluginFileOwner::from_tracked_state_row_ref)
+                .transpose()?
+                .flatten()
+                .ok_or_else(conflict_error)?;
+            let plugin = registry
+                .plugin(owner.plugin_key())
+                .filter(|plugin| plugin.schema_keys() == owner.schema_keys())
+                .cloned()
+                .ok_or_else(conflict_error)?;
+            let paths = path_index.exact_file_id_entries(file_id);
+            let path = paths
+                .iter()
+                .find(|entry| entry.key.branch_id() == self.active_branch_id)
+                .map(|entry| entry.path.clone())
+                .ok_or_else(conflict_error)?;
+            groups.insert(
+                file_id.clone(),
+                StalePluginConflictGroup {
+                    descriptor: WasmFileDescriptor {
+                        path: Some(path.clone()),
+                        media_type: inferred_media_type_for_path(Some(&path)).map(str::to_owned),
+                        plugin: WasmPluginSelection {
+                            plugin_key: plugin.key().to_owned(),
+                            generation: plugin.archive_blob_hash().to_owned(),
+                        },
+                    },
+                    plugin,
+                    conflicts: Vec::new(),
+                },
+            );
+        }
+
+        let candidate_keys = candidate_indices
+            .iter()
+            .map(|&index| {
+                let row = prepared_writes.state_rows.row(index);
+                TrackedStateKey {
+                    schema_key: row.schema_key.to_string(),
+                    file_id: row.file_id.map(|file_id| file_id.to_string()),
+                    entity_pk: row.entity_pk.clone(),
+                }
+            })
+            .collect::<Vec<_>>();
+        let base_rows = tracked
+            .load_projected_batch_at_commit(
+                &opening_head.to_string(),
+                &candidate_keys,
+                &ChangeRecordProjection::full(),
+            )
+            .await?;
+        let current_rows = tracked
+            .load_projected_batch_at_commit(
+                &current_head.to_string(),
+                &candidate_keys,
+                &ChangeRecordProjection::full(),
+            )
+            .await?;
+        for (slot, &row_index) in candidate_indices.iter().enumerate() {
+            let source = prepared_writes.state_rows.row(row_index);
+            let file_id = source.file_id.expect("candidate has file id").to_string();
+            let group = groups.get_mut(&file_id).ok_or_else(conflict_error)?;
+            if !group
+                .plugin
+                .schema_keys()
+                .iter()
+                .any(|schema_key| schema_key == source.schema_key.as_str())
+            {
+                return Err(conflict_error());
+            }
+            let target = current_rows.row(slot);
+            let source_payload = source.snapshot.map(|snapshot| StaleConflictPayload {
+                snapshot: snapshot.materialize_shared(),
+                metadata: source
+                    .metadata
+                    .map(|metadata| metadata.materialize_shared()),
+            });
+            let target_payload = stale_payload_from_tracked(target);
+            let source_change_id = source.change_id.ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "staged tracked plugin row is missing change_id",
+                )
+            })?;
+            let source_order = (source.updated_at, source_change_id);
+            let target_order = target.map(|row| (row.updated_at(), row.change_id()));
+            let (a, b) = if target_order.is_some_and(|order| order < source_order) {
+                (target_payload, source_payload)
+            } else {
+                (source_payload, target_payload)
+            };
+            group.conflicts.push(StaleSemanticConflict {
+                key: candidate_keys[slot].clone(),
+                base: stale_payload_from_tracked(base_rows.row(slot)),
+                a,
+                b,
+            });
+        }
+
+        // Staging the original stale semantic update retained a successor
+        // actor. Retire it before admitting the short-lived static resolver;
+        // otherwise two same-base transactions can exhaust the bounded Store
+        // pool while one waits for capacity held by its own superseded work.
+        let (superseded, retained): (Vec<_>, Vec<_>) =
+            std::mem::take(&mut self.pending_plugin_actor_publications)
+                .into_iter()
+                .partition(|publication| file_ids.contains(&publication.session_key().file_id));
+        self.pending_plugin_actor_publications = retained;
+        discard_plugin_actor_publications(superseded).await;
+        self.pending_file_view_mutations
+            .retain(|key, _| !file_ids.contains(&key.file_id));
+
+        let mut reconciliation_batches = Vec::<RawWriteBatch>::with_capacity(
+            candidate_indices
+                .len()
+                .saturating_add(prepared_writes.state_rows.len()),
+        );
+        for group in groups.values() {
+            let conflicts = group
+                .conflicts
+                .iter()
+                .enumerate()
+                .map(|(ordinal, conflict)| {
+                    Ok(WasmEntityConflict {
+                        ordinal: u32::try_from(ordinal).map_err(|_| {
+                            LixError::new(
+                                LixError::CODE_INVALID_PLUGIN,
+                                "plugin conflict batch exceeds the u32 ordinal limit",
+                            )
+                        })?,
+                        key: WasmEntityKey::from_owned_parts(
+                            conflict.key.schema_key.clone(),
+                            conflict.key.entity_pk.clone().into_parts(),
+                        ),
+                        base: stale_conflict_bytes(conflict.base.as_ref()),
+                        a: stale_conflict_bytes(conflict.a.as_ref()),
+                        b: stale_conflict_bytes(conflict.b.as_ref()),
+                    })
+                })
+                .collect::<Result<Vec<_>, LixError>>()?;
+            let resolutions = self
+                .resolve_plugin_conflicts(&group.plugin, group.descriptor.clone(), conflicts)
+                .await?;
+            for (conflict, resolution) in group.conflicts.iter().zip(resolutions.resolutions) {
+                let mut rows = RawWriteBatch::with_capacity(1);
+                push_stale_conflict_resolution(
+                    &mut rows,
+                    conflict,
+                    resolution,
+                    &self.active_branch_id,
+                )?;
+                reconciliation_batches.push(rows);
+            }
+        }
+        let conflict_row_indices = candidate_indices.iter().copied().collect::<BTreeSet<_>>();
+        for (index, row) in prepared_writes.state_rows.iter().enumerate() {
+            if conflict_row_indices.contains(&index) {
+                continue;
+            }
+            let Some(file_id) = row.file_id.map(SharedStr::as_str) else {
+                continue;
+            };
+            let Some(group) = groups.get(file_id) else {
+                continue;
+            };
+            if !group
+                .plugin
+                .schema_keys()
+                .iter()
+                .any(|schema_key| schema_key == row.schema_key.as_str())
+            {
+                continue;
+            }
+            let mut rows = RawWriteBatch::with_capacity(1);
+            rows.push_parts(
+                Some(row.entity_pk.clone()),
+                row.schema_key.clone(),
+                row.file_id.cloned(),
+                row.snapshot.map(|snapshot| {
+                    TransactionJson::from_unvalidated_shared_normalized_content(
+                        snapshot.materialize_shared(),
+                    )
+                }),
+                row.metadata.map(|metadata| {
+                    TransactionJson::from_unvalidated_shared_normalized_content(
+                        metadata.materialize_shared(),
+                    )
+                }),
+                row.origin.cloned(),
+                Some(row.created_at.to_string().into()),
+                Some(row.updated_at.to_string().into()),
+                row.global,
+                row.change_id.map(|change_id| change_id.to_string().into()),
+                None,
+                row.untracked,
+                row.branch_id.clone(),
+            );
+            reconciliation_batches.push(rows);
+        }
+        // Plugins may deliberately accept only one semantic edit per warm
+        // transition. Preserve the accumulated conflict decision while
+        // replaying its resolved and retained edits through one actor in order.
+        for rows in reconciliation_batches {
+            self.stage_write(TransactionWrite::Rows {
+                mode: TransactionWriteMode::Replace,
+                rows,
+            })
+            .await?;
+        }
+        let mut replacement = self.staged_writes.drain()?;
+        let mut latest_file_data = BTreeMap::new();
+        for write in replacement.file_data_writes.drain(..) {
+            latest_file_data.insert((write.branch_id.clone(), write.file_id.clone()), write);
+        }
+        replacement
+            .file_data_writes
+            .extend(latest_file_data.into_values());
+        let commit_id = prepared_writes
+            .commit_change_refs_by_branch
+            .get(&self.active_branch_id)
+            .map(|change_refs| change_refs.commit_id)
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "stale semantic transaction is missing its staged commit identity",
+                )
+            })?;
+        for index in 0..replacement.state_rows.len() {
+            replacement.state_rows.set_commit_id(index, Some(commit_id));
+        }
+        prepared_writes.replace_reconciled_file_writes(replacement, &file_ids);
+        Ok(())
     }
 
     /// Opens an execution-scoped staging area for SQL/provider hooks.
@@ -562,8 +1167,14 @@ where
         sql_planning_cache: Arc<SqlPlanningCache<CatalogFingerprint>>,
         session_file_views: SessionFileViews,
     ) -> Result<OpenTransaction<StorageImpl>, LixError> {
-        let read =
-            SharedStorageAdapterRead::new(storage.begin_read(StorageReadOptions::default()).await?);
+        let storage = Arc::new(storage);
+        let read = storage.begin_read(StorageReadOptions::default()).await?;
+        // SAFETY: `storage` is retained in the transaction behind an `Arc` and
+        // `opening_read` is declared before it, so the widened read is always
+        // dropped before the storage value that produced it.
+        let read = unsafe { assume_static_storage_read::<StorageImpl>(read) };
+        let opening_read = SharedStorageAdapterRead::new(read);
+        let read = opening_read.clone();
         let setup_result = async {
             let active_branch_id =
                 resolve_active_branch_id(mode, live_state.as_ref(), branch_ctx.as_ref(), &read)
@@ -596,6 +1207,14 @@ where
             let opening_tracked_mutation_revision =
                 StorageAdapter::<StorageImpl>::load_tracked_mutation_revision_from_read(&read)
                     .await?;
+            let branch_reader = branch_ctx.ref_reader(&read);
+            let opening_active_branch_head =
+                branch_reader.load_head_commit_id(&active_branch_id).await?;
+            let opening_global_branch_head = if active_branch_id == GLOBAL_BRANCH_ID {
+                opening_active_branch_head
+            } else {
+                branch_reader.load_head_commit_id(GLOBAL_BRANCH_ID).await?
+            };
             Ok::<_, LixError>((
                 active_branch_id,
                 runtime_functions,
@@ -603,6 +1222,8 @@ where
                 sql_schema_catalog,
                 tracked_schema_catalog,
                 opening_tracked_mutation_revision,
+                opening_active_branch_head,
+                opening_global_branch_head,
             ))
         }
         .await;
@@ -613,6 +1234,8 @@ where
             sql_schema_catalog,
             tracked_schema_catalog,
             opening_tracked_mutation_revision,
+            opening_active_branch_head,
+            opening_global_branch_head,
         ) = match setup_result {
             Ok(result) => result,
             Err(error) => {
@@ -644,9 +1267,12 @@ where
                 staged_writes,
                 filesystem_path_index_cache: Arc::new(FilesystemPathIndexCache::default()),
                 filesystem_path_index_epoch: Arc::new(AtomicUsize::new(0)),
+                opening_read,
                 storage,
                 functions,
                 opening_tracked_mutation_revision,
+                opening_active_branch_head,
+                opening_global_branch_head,
                 commit_boundary: None,
                 trust_filesystem_planner: false,
                 origin_key: None,
@@ -672,7 +1298,7 @@ where
     ) -> Result<TransactionCommitOutcome, LixError> {
         let mut transaction = self;
         let commit_boundary = transaction.commit_boundary.clone();
-        let prepared_writes = match transaction.staged_writes.drain() {
+        let mut prepared_writes = match transaction.staged_writes.drain() {
             Ok(prepared_writes) => prepared_writes,
             Err(error) => {
                 transaction
@@ -705,11 +1331,30 @@ where
         // final write's tracked-state precondition fences the decisions made
         // here, including plugin-produced prepared rows.
         let commit_read_storage = transaction.storage.clone();
-        let mut read = SharedStorageAdapterRead::new(
-            commit_read_storage
-                .begin_read(StorageReadOptions::default())
-                .await?,
-        );
+        let commit_read = commit_read_storage
+            .begin_read(StorageReadOptions::default())
+            .await?;
+        // SAFETY: `commit_read_storage` is an `Arc` retained through commit,
+        // and the transaction drops this read before its storage field.
+        let commit_read = unsafe { assume_static_storage_read::<StorageImpl>(commit_read) };
+        let mut read = SharedStorageAdapterRead::new(commit_read);
+        // Commit-time reconciliation and validation must all observe this
+        // current coherent snapshot, while user statements above observed the
+        // snapshot retained from transaction open.
+        transaction.opening_read = read.clone();
+        if let Err(error) = transaction
+            .reconcile_stale_disjoint_writes(&read, &mut prepared_writes)
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.transaction_reconcile_stale"
+            ))
+            .await
+        {
+            transaction
+                .discard_pending_plugin_actor_publications()
+                .await;
+            return Err(error);
+        }
         let commit_parent_heads = match commit::resolve_prepared_commit_parent_heads(
             transaction.branch_ctx.as_ref(),
             &read,
@@ -1029,6 +1674,21 @@ where
             &mut self.pending_plugin_actor_publications,
         ))
         .await;
+    }
+
+    /// Releases private plugin actor leases after an explicit write statement.
+    ///
+    /// The durable semantic rows and checkpoints remain staged in this
+    /// transaction. Keeping the live actor leased until commit would serialize
+    /// another same-base transaction that edits the same file, so explicit
+    /// transactions retain only the cold-open marker between statements.
+    pub(crate) async fn release_pending_plugin_actor_leases(&mut self) {
+        let publications = std::mem::take(&mut self.pending_plugin_actor_publications);
+        let mut uncached = Vec::with_capacity(publications.len());
+        for publication in publications {
+            uncached.push(publication.into_uncached().await);
+        }
+        self.pending_plugin_actor_publications = uncached;
     }
 
     /// Stages one decoded write batch into this transaction.
@@ -1382,12 +2042,8 @@ where
             staged: staged.clone(),
             rows: prospective_rows,
         };
-        let read = SharedStorageAdapterRead::new(
-            self.storage
-                .begin_read(StorageReadOptions::default())
-                .await?,
-        );
-        let base = self.live_state.reader(read);
+        let read = self.opening_read();
+        let base = self.live_state.snapshot_reader(read);
         preflight_derived_path_stability(&base, &staged, &prospective, &prospective.rows).await
     }
 
@@ -1508,12 +2164,8 @@ where
         request: &LiveStateScanRequest,
     ) -> Result<MaterializedLiveStateBatch, LixError> {
         let staged = self.staged_writes.staging_overlay()?;
-        let read = SharedStorageAdapterRead::new(
-            self.storage
-                .begin_read(StorageReadOptions::default())
-                .await?,
-        );
-        let base = self.live_state.reader(read);
+        let read = self.opening_read();
+        let base = self.live_state.snapshot_reader(read);
         overlay_scan_batch(&base, &staged, request).await
     }
 
@@ -5788,8 +6440,7 @@ where
         statement: DataFusionStatement,
         params: Vec<Value>,
     ) -> Result<SqlQueryResult, LixError> {
-        let storage = self.storage.clone();
-        let read = storage.begin_read(StorageReadOptions::default()).await?;
+        let read_store = self.opening_read();
         let active_branch_id = self.active_branch_id.clone();
         let live_state = Arc::clone(&self.live_state);
         let binary_cas = Arc::clone(&self.binary_cas);
@@ -5802,28 +6453,23 @@ where
         let filesystem_path_index_epoch = Arc::clone(&self.filesystem_path_index_epoch);
         let plugin_host = self.plugin_host.clone();
 
-        with_static_transaction_sql_read::<StorageImpl, _, _>(read, |read_store| async move {
-            let read_ctx = TransactionSqlReadExecutionContext {
-                active_branch_id,
-                read_store,
-                live_state,
-                binary_cas,
-                branch_ctx,
-                visible_schemas,
-                functions,
-                staged,
-                staged_writes,
-                filesystem_path_index_cache,
-                filesystem_path_index_epoch,
-                plugin_host,
-            };
-            let result = crate::sql2::execute_transaction_read_statement_from_parsed(
-                &read_ctx, self, &sql, statement, &params,
-            )
-            .await;
-            drop(read_ctx);
-            result
-        })
+        let read_ctx = TransactionSqlReadExecutionContext {
+            active_branch_id,
+            read_store,
+            live_state,
+            binary_cas,
+            branch_ctx,
+            visible_schemas,
+            functions,
+            staged,
+            staged_writes,
+            filesystem_path_index_cache,
+            filesystem_path_index_epoch,
+            plugin_host,
+        };
+        crate::sql2::execute_transaction_read_statement_from_parsed(
+            &read_ctx, self, &sql, statement, &params,
+        )
         .await
     }
 
@@ -5940,11 +6586,7 @@ where
         head_commit_id: CommitId,
         request: &TrackedStateDiffRequest,
     ) -> Result<Option<TrackedWorkingDiff>, LixError> {
-        let read = SharedStorageAdapterRead::new(
-            self.storage
-                .begin_read(StorageReadOptions::default())
-                .await?,
-        );
+        let read = self.opening_read();
         let Some(control) = BranchHeadControlContext::new()
             .reader(read.clone())
             .load(branch_id)
@@ -6478,7 +7120,7 @@ where
 
     fn live_state(&self) -> Arc<dyn crate::live_state::LiveStateReader> {
         Arc::new(TransactionReadLiveStateReader {
-            base: self.live_state.reader(self.read_store.clone()),
+            base: self.live_state.snapshot_reader(self.read_store.clone()),
             read_store: self.read_store.clone(),
             staged: self.staged.clone(),
             filesystem_path_index_cache: Arc::clone(&self.filesystem_path_index_cache),
@@ -6488,7 +7130,7 @@ where
 
     fn filesystem_path_index(&self) -> Arc<dyn FilesystemPathIndexReader> {
         Arc::new(TransactionReadLiveStateReader {
-            base: self.live_state.reader(self.read_store.clone()),
+            base: self.live_state.snapshot_reader(self.read_store.clone()),
             read_store: self.read_store.clone(),
             staged: self.staged.clone(),
             filesystem_path_index_cache: Arc::clone(&self.filesystem_path_index_cache),
@@ -6663,42 +7305,12 @@ where
     }
 }
 
-/// Runs one transaction SQL read using a widened storage-read lifetime.
-///
-/// DataFusion requires provider state to be `'static`, but transaction reads
-/// are scoped to the current storage snapshot. Keep this bridge private to
-/// transaction SQL execution so no crate-level API can receive the widened
-/// storage read handle.
-async fn with_static_transaction_sql_read<StorageImpl, F, Fut>(
-    read: StorageAdapterReadScope<StorageImpl::Read<'_>>,
-    f: F,
-) -> Result<SqlQueryResult, LixError>
-where
-    StorageImpl: Storage + 'static,
-    F: FnOnce(SharedStorageAdapterRead<StorageImpl::Read<'static>>) -> Fut,
-    Fut: Future<Output = Result<SqlQueryResult, LixError>>,
-{
-    // SAFETY: the widened read is wrapped immediately in `SharedStorageAdapterRead`,
-    // only passed into this private SQL execution closure, and explicitly
-    // dropped before returning. Escaped clones are detected by `finish()`.
-    let read = unsafe { assume_static_storage_read::<StorageImpl>(read) };
-    let read = SharedStorageAdapterRead::new(read);
-    let finish = read.clone();
-    let result = f(read).await;
-    let finish_result = finish.finish().map_err(LixError::from);
-    match (result, finish_result) {
-        (Ok(value), Ok(())) => Ok(value),
-        (Err(error), Ok(())) => Err(error),
-        (_, Err(finish_error)) => Err(finish_error),
-    }
-}
-
 /// Erases the storage borrow lifetime for scoped transaction SQL execution.
 ///
 /// # Safety
 ///
 /// The returned read scope must not outlive the storage value that produced
-/// `read`, and it must be dropped before the enclosing SQL execution returns.
+/// `read`, and it must be dropped before that value.
 unsafe fn assume_static_storage_read<StorageImpl>(
     read: StorageAdapterReadScope<StorageImpl::Read<'_>>,
 ) -> StorageAdapterReadScope<StorageImpl::Read<'static>>
@@ -6934,7 +7546,7 @@ fn prepared_writes_require_filesystem_index_rebuild(prepared_writes: &PreparedWr
         })
 }
 
-pub(crate) struct OpenTransaction<StorageImpl: Storage = Memory> {
+pub(crate) struct OpenTransaction<StorageImpl: Storage + 'static = Memory> {
     pub(crate) transaction: Transaction<StorageImpl>,
     pub(crate) runtime_functions: FunctionContext,
 }
@@ -7033,14 +7645,14 @@ where
         &mut self,
         request: &FilesystemPathIndexRequest,
     ) -> Result<Arc<FilesystemPathIndex>, LixError> {
-        let read = SharedStorageAdapterRead::new(
-            self.storage
-                .begin_read(StorageReadOptions::default())
-                .await?,
-        );
+        let read = self.opening_read();
         let descriptor_epoch = self.filesystem_path_index_epoch.load(Ordering::SeqCst);
         if descriptor_epoch == 0 {
-            return self.live_state.reader(read).path_index(request).await;
+            return self
+                .live_state
+                .snapshot_reader(read)
+                .path_index(request)
+                .await;
         }
         // The revision probe is only a cache-freshness optimization. Preserve the
         // pre-cache overlay behavior if a storage fault affects that single key.
@@ -7056,7 +7668,7 @@ where
             return Ok(index);
         }
         let staged = self.staged_writes.staging_overlay()?;
-        let base = self.live_state.reader(read);
+        let base = self.live_state.snapshot_reader(read);
         let rows = overlay_scan_batch(&base, &staged, &request.live_state_request()).await?;
         #[cfg(test)]
         record_transaction_path_index_build(rows.len());
@@ -7071,11 +7683,7 @@ where
     }
 
     async fn load_branch_head(&mut self, branch_id: &str) -> Result<Option<CommitId>, LixError> {
-        let read = SharedStorageAdapterRead::new(
-            self.storage
-                .begin_read(StorageReadOptions::default())
-                .await?,
-        );
+        let read = self.opening_read();
 
         self.branch_ctx
             .ref_reader(read)

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -9,7 +9,7 @@
 )]
 
 use std::borrow::Cow;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::{Arc, Mutex};
 
 use smallvec::SmallVec;
@@ -715,6 +715,46 @@ impl<'a> PreparedWriteValidationSet<'a> {
 }
 
 impl PreparedWriteSet {
+    pub(crate) fn replace_reconciled_file_writes(
+        &mut self,
+        mut replacement: PreparedWriteSet,
+        file_ids: &BTreeSet<String>,
+    ) {
+        let replacement_keys = replacement
+            .state_rows
+            .iter()
+            .map(PreparedStateRowIdentity::from)
+            .collect::<BTreeSet<_>>();
+        let retained = self
+            .state_rows
+            .iter()
+            .enumerate()
+            .filter_map(|(index, row)| {
+                (!replacement_keys.contains(&PreparedStateRowIdentity::from(row))).then_some(index)
+            })
+            .collect::<Vec<_>>();
+        self.insert_selection.select_rows(&retained);
+        self.state_rows.select_rows(&retained);
+        let replacement_count = replacement.state_rows.len();
+        self.state_rows.append(replacement.state_rows);
+        self.insert_selection
+            .resize_rows(self.state_rows.len().saturating_sub(replacement_count));
+        for _ in 0..replacement_count {
+            self.insert_selection.push_not_insert();
+        }
+        self.file_data_writes
+            .retain(|write| !file_ids.contains(&write.file_id));
+        self.file_data_writes
+            .append(&mut replacement.file_data_writes);
+        for change_refs in self.commit_change_refs_by_branch.values_mut() {
+            change_refs.tracked_change_count = self
+                .state_rows
+                .iter()
+                .filter(|row| !row.untracked && row.branch_id.as_str() != GLOBAL_BRANCH_ID)
+                .count();
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn validation_rows(&self) -> impl Iterator<Item = PreparedValidationRow<'_>> + '_ {
         self.state_rows.iter().map(PreparedValidationRow::State)

--- a/packages/engine/tests/integration/sql/lix_file.rs
+++ b/packages/engine/tests/integration/sql/lix_file.rs
@@ -3935,7 +3935,7 @@ simulation_test!(
 );
 
 simulation_test!(
-    lix_file_transaction_path_index_cache_rejects_stale_other_session_snapshot,
+    lix_file_transaction_path_index_cache_retains_other_session_snapshot,
     options = crate::support::simulation_test::engine::SimulationOptions {
         deterministic: false,
     },
@@ -3987,14 +3987,14 @@ simulation_test!(
             .await
             .expect("other session file should commit");
 
-        let error = transaction
+        let still_missing = transaction
             .execute(
                 "SELECT id, path FROM lix_file WHERE path = '/other-session.md'",
                 &[],
             )
             .await
-            .expect_err("stale transaction lookup should reject the newer committed revision");
-        assert_eq!(error.code, LixError::CODE_TRANSACTION_CONFLICT);
+            .expect("transaction lookup should retain its opening snapshot");
+        assert_eq!(still_missing.len(), 0);
 
         transaction
             .rollback()
@@ -4028,7 +4028,7 @@ simulation_test!(
 );
 
 simulation_test!(
-    lix_file_transaction_path_index_cache_rejects_stale_merge_snapshot,
+    lix_file_transaction_path_index_cache_retains_pre_merge_snapshot,
     options = crate::support::simulation_test::engine::SimulationOptions {
         deterministic: false,
     },
@@ -4105,14 +4105,14 @@ simulation_test!(
             .expect("merge should succeed");
         assert_eq!(receipt.outcome, MergeBranchOutcome::MergeCommitted);
 
-        let error = transaction
+        let still_missing = transaction
             .execute(
                 "SELECT id, path FROM lix_file WHERE path = '/merged.md'",
                 &[],
             )
             .await
-            .expect_err("stale transaction lookup should reject merged reachable descriptors");
-        assert_eq!(error.code, LixError::CODE_TRANSACTION_CONFLICT);
+            .expect("transaction lookup should retain its pre-merge snapshot");
+        assert_eq!(still_missing.len(), 0);
 
         transaction
             .rollback()

--- a/packages/engine/tests/integration/transaction.rs
+++ b/packages/engine/tests/integration/transaction.rs
@@ -48,7 +48,7 @@ where
 }
 
 #[tokio::test]
-async fn stale_transaction_cannot_publish_over_newer_commit() {
+async fn stale_transaction_composes_disjoint_semantic_writes() {
     let storage = Memory::new();
     Engine::initialize(storage.clone())
         .await
@@ -85,17 +85,10 @@ async fn stale_transaction_cannot_publish_over_newer_commit() {
         .await
         .expect("newer transaction should commit");
 
-    let read_error = stale
-        .execute("SELECT key FROM lix_key_value", &[])
-        .await
-        .expect_err("stale transaction must not observe a newer snapshot");
-    assert_eq!(read_error.code, "LIX_TRANSACTION_CONFLICT");
-
-    let error = stale
+    stale
         .commit()
         .await
-        .expect_err("stale transaction must not publish");
-    assert_eq!(error.code, "LIX_TRANSACTION_CONFLICT");
+        .expect("disjoint stale transaction should compose onto the current head");
 
     let result = winner_session
         .execute(
@@ -105,8 +98,134 @@ async fn stale_transaction_cannot_publish_over_newer_commit() {
         )
         .await
         .expect("committed state should remain readable");
+    assert_eq!(result.rows().len(), 2);
+    assert_eq!(result.rows()[0].get::<String>("key").unwrap(), "stale-key");
+    assert_eq!(result.rows()[1].get::<String>("key").unwrap(), "winner-key");
+}
+
+#[tokio::test]
+async fn stale_transaction_reports_overlapping_ordinary_insert_atomically() {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new(storage)
+        .await
+        .expect("initialized storage should create an engine");
+    let stale_session = engine
+        .open_workspace_session()
+        .await
+        .expect("stale session should open");
+    let winner_session = engine
+        .open_workspace_session()
+        .await
+        .expect("winner session should open");
+
+    let mut stale = stale_session
+        .begin_transaction()
+        .await
+        .expect("stale transaction should begin");
+    stale
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('same-key', 'stale')",
+            &[],
+        )
+        .await
+        .expect("stale transaction should stage its write");
+    winner_session
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('same-key', 'winner')",
+            &[],
+        )
+        .await
+        .expect("winner transaction should commit");
+
+    let error = stale
+        .commit()
+        .await
+        .expect_err("overlapping ordinary rows must remain conservative");
+    assert_eq!(error.code, "LIX_ERROR_UNIQUE");
+    let result = winner_session
+        .execute(
+            "SELECT value FROM lix_key_value WHERE key = 'same-key'",
+            &[],
+        )
+        .await
+        .expect("winner state should remain readable");
     assert_eq!(result.rows().len(), 1);
-    assert_eq!(result.rows()[0].get::<String>("key").unwrap(), "winner-key");
+    assert_eq!(
+        result.rows()[0].get::<serde_json::Value>("value").unwrap(),
+        serde_json::json!("winner")
+    );
+}
+
+#[tokio::test]
+async fn explicit_transaction_reads_stable_snapshot_and_own_writes() {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new(storage).await.expect("engine should open");
+    let transaction_session = engine.open_workspace_session().await.unwrap();
+    let concurrent_session = engine.open_workspace_session().await.unwrap();
+    concurrent_session
+        .execute(
+            "INSERT INTO lix_key_value (key, value, lixcol_untracked) \
+             VALUES ('snapshot-key', 'base', false)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let mut transaction = transaction_session.begin_transaction().await.unwrap();
+    let opening = transaction
+        .execute(
+            "SELECT value FROM lix_key_value WHERE key = 'snapshot-key'",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        opening.rows()[0].get::<serde_json::Value>("value").unwrap(),
+        serde_json::json!("base")
+    );
+    concurrent_session
+        .execute(
+            "INSERT INTO lix_key_value (key, value, lixcol_untracked) \
+             VALUES ('snapshot-key', 'concurrent', false) \
+             ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let stable = transaction
+        .execute(
+            "SELECT value FROM lix_key_value WHERE key = 'snapshot-key'",
+            &[],
+        )
+        .await
+        .expect("concurrent commits must not invalidate transaction reads");
+    assert_eq!(
+        stable.rows()[0].get::<serde_json::Value>("value").unwrap(),
+        serde_json::json!("base")
+    );
+    transaction
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('own-key', 'own')",
+            &[],
+        )
+        .await
+        .unwrap();
+    let own = transaction
+        .execute("SELECT value FROM lix_key_value WHERE key = 'own-key'", &[])
+        .await
+        .unwrap();
+    assert_eq!(
+        own.rows()[0].get::<serde_json::Value>("value").unwrap(),
+        serde_json::json!("own")
+    );
+    transaction.rollback().await.unwrap();
 }
 
 #[tokio::test]

--- a/packages/js-sdk/src/remote/client.test.ts
+++ b/packages/js-sdk/src/remote/client.test.ts
@@ -988,6 +988,95 @@ test("remote responses reject malformed rows and non-JSON HTTP errors", async ()
 	await lix.close();
 });
 
+test("remote beginTransaction uses one capability-bound server lifecycle", async () => {
+	const requests: Array<{
+		method: string;
+		path: string;
+		transactionId?: string;
+		body?: unknown;
+	}> = [];
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/workspace",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const path = new URL(request.url).pathname;
+				requests.push({
+					method: request.method,
+					path,
+					...(request.headers.get("Lix-Transaction-Id") === null
+						? {}
+						: {
+								transactionId: request.headers.get("Lix-Transaction-Id")!,
+							}),
+					...(request.body === null ? {} : { body: await requestJson(request) }),
+				});
+				if (path.endsWith("/lix/v1/")) {
+					return Response.json({
+						protocolVersion: 1,
+						activeBranchId: "main-id",
+						sessionId: "session-1",
+					});
+				}
+				if (path.endsWith("/transaction/begin")) {
+					return Response.json({ transactionId: "transaction-1" });
+				}
+				if (path.endsWith("/transaction/execute")) {
+					return Response.json({
+						columns: ["value"],
+						rows: [[{ kind: "int", value: 7 }]],
+						rowsAffected: 0,
+						notices: [],
+					});
+				}
+				return new Response(null, { status: 204 });
+			},
+		},
+	});
+
+	const transaction = await lix.beginTransaction();
+	const result = await transaction.execute("SELECT $1 AS value", [7], {
+		originKey: "remote-transaction-test",
+	});
+	expect(result.rows[0]?.get("value")).toBe(7);
+	await transaction.commit();
+	await expect(transaction.execute("SELECT 1")).rejects.toMatchObject({
+		code: "LIX_INVALID_TRANSACTION_STATE",
+	});
+
+	const rolledBack = await lix.beginTransaction();
+	await rolledBack.rollback();
+	await lix.close();
+
+	expect(requests).toEqual([
+		{ method: "GET", path: "/@acme/workspace/lix/v1/" },
+		{ method: "POST", path: "/@acme/workspace/lix/v1/transaction/begin" },
+		{
+			method: "POST",
+			path: "/@acme/workspace/lix/v1/transaction/execute",
+			transactionId: "transaction-1",
+			body: {
+				sql: "SELECT $1 AS value",
+				params: [{ kind: "int", value: 7 }],
+				options: { originKey: "remote-transaction-test" },
+			},
+		},
+		{
+			method: "POST",
+			path: "/@acme/workspace/lix/v1/transaction/commit",
+			transactionId: "transaction-1",
+		},
+		{ method: "POST", path: "/@acme/workspace/lix/v1/transaction/begin" },
+		{
+			method: "POST",
+			path: "/@acme/workspace/lix/v1/transaction/rollback",
+			transactionId: "transaction-1",
+		},
+		{ method: "DELETE", path: "/@acme/workspace/lix/v1/session" },
+	]);
+});
+
 test("remote mode rejects unsupported local-only operations honestly", async () => {
 	const lix = await openLix({
 		server: {
@@ -1002,9 +1091,6 @@ test("remote mode rejects unsupported local-only operations honestly", async () 
 		},
 	});
 
-	await expect(lix.beginTransaction()).rejects.toMatchObject({
-		code: "LIX_UNSUPPORTED_REMOTE_OPERATION",
-	});
 	await expect(
 		lix.mergeBranch({ sourceBranchId: "source" }),
 	).rejects.toMatchObject({ code: "LIX_UNSUPPORTED_REMOTE_OPERATION" });

--- a/packages/js-sdk/src/remote/client.ts
+++ b/packages/js-sdk/src/remote/client.ts
@@ -41,6 +41,7 @@ import { readSseEvents } from "./sse.js";
 const OBSERVE_RETRY_BASE_MS = 100;
 const OBSERVE_RETRY_MAX_MS = 5_000;
 const REMOTE_SESSION_HEADER = "Lix-Session-Id";
+const REMOTE_TRANSACTION_HEADER = "Lix-Transaction-Id";
 const IDEMPOTENCY_KEY_HEADER = "Idempotency-Key";
 const REQUEST_BLOB_DELTA_MIN_BYTES = 32 * 1024;
 const REQUEST_BLOB_DELTA_MIN_WIRE_RATIO = 0.9;
@@ -246,7 +247,78 @@ class RemoteLixBinding implements LixBinding {
 
 	async beginTransaction(): Promise<LixTransactionBinding> {
 		this.#assertOpen();
-		throw unsupportedRemoteOperation("beginTransaction");
+		return this.#enqueue(async () => {
+			const begun = record(
+				await this.#requestJson("transaction/begin", { method: "POST" }),
+				"begin transaction response",
+			);
+			if (typeof begun.transactionId !== "string") {
+				throw protocolError(
+					"begin transaction response.transactionId must be a string",
+				);
+			}
+			const transactionId = begun.transactionId;
+			let active = true;
+			const assertActive = () => {
+				if (!active) {
+					throw remoteError(
+						"LIX_INVALID_TRANSACTION_STATE",
+						"Lix transaction is closed",
+					);
+				}
+			};
+			return {
+				execute: async (sql, params, options) => {
+					assertActive();
+					const snapshot = snapshotParams(params);
+					const requestOptions = remoteExecuteOptions(options);
+					return this.#enqueue(async () => {
+						const value = await this.#requestJson("transaction/execute", {
+							method: "POST",
+							headers: { [REMOTE_TRANSACTION_HEADER]: transactionId },
+							body: JSON.stringify({
+								sql,
+								params: snapshot.map(encodeWireValue),
+								...(requestOptions === undefined
+									? {}
+									: { options: requestOptions }),
+							}),
+						});
+						return decodeExecuteResult(value);
+					});
+				},
+				commit: async () => {
+					assertActive();
+					return this.#enqueue(async () => {
+						assertActive();
+						await this.#requestJson(
+							"transaction/commit",
+							{
+								method: "POST",
+								headers: { [REMOTE_TRANSACTION_HEADER]: transactionId },
+							},
+							"empty",
+						);
+						active = false;
+					});
+				},
+				rollback: async () => {
+					assertActive();
+					return this.#enqueue(async () => {
+						assertActive();
+						await this.#requestJson(
+							"transaction/rollback",
+							{
+								method: "POST",
+								headers: { [REMOTE_TRANSACTION_HEADER]: transactionId },
+							},
+							"empty",
+						);
+						active = false;
+					});
+				},
+			};
+		});
 	}
 
 	async activeBranchId(): Promise<string> {

--- a/packages/rs-sdk-tests/CRDT_BENCHMARK_BASELINE.md
+++ b/packages/rs-sdk-tests/CRDT_BENCHMARK_BASELINE.md
@@ -1,0 +1,109 @@
+# CRDT benchmark baseline
+
+Measured 2026-08-01 against the latest
+[`dmonad/crdt-benchmarks`](https://github.com/dmonad/crdt-benchmarks) `main`
+workloads, with `N = 6000`. Every external package was upgraded to its npm
+`latest` dist-tag before measurement. Breaking Ywasm and Loro API changes were
+adapted without changing the B2.1 or B3.1 workload.
+
+## Corrected API model
+
+The earlier adapter created one branch per simulated client and merged those
+branches sequentially. That measured the branch merge API, not database
+transactions, and was removed.
+
+The replacement uses the existing public API only:
+
+1. Open multiple Lix clients against one database.
+2. Call `begin_transaction()` on every client before any client commits.
+3. Stage overlapping semantic edits from the common opening snapshot.
+4. Commit concurrently, allow the owning plugin to resolve stale semantic
+   overlaps, and verify that every client reads the same final bytes.
+
+Remote clients exercise the same engine transaction through an internal wire
+capability. No branch or merge API and no new public transaction API is part of
+the benchmark.
+
+## Acceptance assertions
+
+- Ordinary concurrent `execute()` calls serialize normally and produce zero
+  plugin conflict-resolver calls.
+- Same-base explicit transactions produce resolver calls, all clients
+  converge, and per-client durable commit service p95 is below 100 ms.
+
+The per-commit service timer starts when each commit future is first polled and
+stops when that client's durable commit returns. A separate commit-batch timer
+starts before any commit future is scheduled and stops after all 1,540 commits
+return. The service p95 is the real-time request-processing gate; the batch
+timer exposes scheduler queueing and total convergence throughput.
+
+## Same-machine results
+
+External values are medians of five suite invocations and rounded to whole
+milliseconds. Lix values are optimized release builds on the same machine.
+Lower is better within a column, but the Lix B3.1 cell reports both durable
+per-commit service p95 and the total commit batch window.
+
+| System | B2.1: two length-6000 Markdown prefix inserts | B3.1: 1,540 concurrent JSON map sets |
+| --- | ---: | ---: |
+| Ywasm 0.27.3 | 1 ms | 45 ms total |
+| Yjs 13.6.31 | 2 ms | 64 ms total |
+| Diamond Types 1.0.2 | 3 ms | unsupported |
+| Loro 1.13.8 | 6 ms | 40 ms total |
+| Automerge 3.4.0 | 47 ms | 1,412 ms total |
+| Lix transactions + plugin resolver | **38.039 ms p50 / 39.436 ms p95** | **23.546 ms service p95; 17,668.298 ms commit batch** |
+
+The B3.1 Lix row contains 1,540 per-client service observations from one full
+cardinality run. It passes the 100-ms service gate with 78.153 ms of headroom.
+The complete test, including workspace/plugin setup, opening and staging 1,540
+transactions, committing, convergence reads, and cleanup, finished in 18.61 s.
+The 18.133-second commit batch means this implementation does **not** provide
+sub-100-ms all-client convergence when 1,540 commits arrive simultaneously;
+both numbers are retained so service latency cannot hide queueing.
+
+## Before/after
+
+| 100-client JSON adapter | Before: synthetic branch merges | After: same-base transactions |
+| --- | ---: | ---: |
+| API operations | 100 branches + 100 sequential merges | 100 existing `begin_transaction()` calls + concurrent commits |
+| Resolver scheduling | conflict discovery and plugin resolution once per merge | stale conflicts discovered at commit; one batched plugin call per affected file |
+| Measured latency | 598.560 ms total merge region | 14.703 ms commit p95 in an unoptimized diagnostic build |
+| Client convergence | inferred from one branch head | asserted from every client |
+
+At the exact upstream B3.1 cardinality, the old 1,540-branch run did not finish
+within two minutes. The corrected transaction run completes and records a
+23.546 ms release service p95. The algorithm still must inspect each conflicting
+semantic record—arbitrary exact resolution has an Ω(N) lower bound—but it no
+longer creates and merges a synthetic branch for every client. Within each
+transaction, conflicts are indexed once, grouped by owning file, passed to that
+plugin in one accumulated batch, and committed atomically.
+
+## Environment
+
+- AMD EPYC-Genoa, 16 cores, one hardware thread per core
+- Linux 7.0.0-22-generic x86-64
+- Node v22.22.1 (the benchmark declares Node 20; this is a comparability caveat)
+- Rust 1.97.0-nightly (`nightly-2026-05-21`)
+- optimized Rust `release` profile
+
+## Reproduction
+
+The CRDT workloads are ignored profiling tests so normal CI remains fast. The
+ordinary-execute correctness assertion is part of the normal test run.
+
+```bash
+cargo test -p lix_sdk_tests --test crdt_benchmarks_baseline \
+  ordinary_concurrent_execute_serializes_without_plugin_resolution -- --exact
+
+cargo test -p lix_sdk_tests --test crdt_benchmarks_baseline --release \
+  crdt_benchmarks_b2_1_markdown_concurrent_prefix_inserts \
+  -- --ignored --exact --nocapture
+
+LIX_CRDT_SAMPLES=1 cargo test -p lix_sdk_tests \
+  --test crdt_benchmarks_baseline --release \
+  crdt_benchmarks_b3_1_json_concurrent_map_sets \
+  -- --ignored --exact --nocapture
+```
+
+`LIX_CRDT_B3_CLIENTS` overrides the default 1,540-client cardinality and
+`LIX_CRDT_SAMPLES` controls independent workspace samples.

--- a/packages/rs-sdk-tests/PLUGIN_RUNTIME_PROFILE.md
+++ b/packages/rs-sdk-tests/PLUGIN_RUNTIME_PROFILE.md
@@ -4,6 +4,30 @@ Profiled on Linux x86-64 with Rust nightly 1.97.0. The release benchmarks were
 verified against `origin/main` at `c082f5f14`. The exact VS Code Docs replay
 uses commit `d5badf95f8ab16c4deb91199dc696f2293d93554`.
 
+## Conflict-resolution scaling
+
+The Component-v2 resolver has two materially different format paths. JSON and
+Git text use the API's canonical `b`-or-delete default without reading snapshot
+bytes. CSV reads each conflicting row and may compose disjoint cell edits;
+Markdown does the same for disjoint inline spans. CSV and Markdown therefore
+have an information-theoretic lower bound of one decision per semantic
+conflict. Returning an exact aligned result for every arbitrary conflict is
+also Ω(conflicts), so sublinear total resolution is not a valid correctness
+target.
+
+The avoidable scaling was in host routing around that required resolver pass.
+For a successful all-plugin merge, the old path scanned the complete conflict
+batch four times: derived-file discovery, resolver eligibility, unresolved-row
+rejection, and resolver input construction. It also loaded the same base,
+target, and source plugin registries twice and reconstructed the same common
+file descriptors twice. The merge now builds one file-to-conflict index while
+discovering derived files, retains the pinned plugin generation and descriptor,
+and routes later stages by eligible indices. The successful path is one O(N)
+classification pass plus O(K) resolver preparation for K plugin conflicts;
+the unresolved-error path alone rescans N rows to construct public details.
+Point membership remains O(log K), and the plugin is still invoked once per
+file rather than once per conflict.
+
 ## Results
 
 | Workload | Time | Host allocation | Peak live host allocation | Process peak RSS |

--- a/packages/rs-sdk-tests/tests/crdt_benchmarks_baseline.rs
+++ b/packages/rs-sdk-tests/tests/crdt_benchmarks_baseline.rs
@@ -1,0 +1,370 @@
+//! Transactional slices comparable to dmonad/crdt-benchmarks.
+//!
+//! These are deliberately ignored profiling workloads. The upstream suite
+//! measures synchronous in-memory CRDT update exchange; Lix measures durable
+//! commit-to-convergence across same-base clients. These workloads use only the
+//! existing `begin_transaction()` API and never create synthetic branches.
+
+use std::fs;
+use std::io::{Cursor, Write};
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use lix_sdk::{Lix, OpenLixOptions, Storage, Value, open_lix};
+
+const N: usize = 6_000;
+const CONCURRENT_CLIENTS: usize = 1_540;
+const SAMPLES: usize = 5;
+
+#[tokio::test]
+#[ignore = "dmonad/crdt-benchmarks B2.1 durable Lix baseline"]
+async fn crdt_benchmarks_b2_1_markdown_concurrent_prefix_inserts() {
+    let mut samples = Vec::with_capacity(SAMPLES);
+    for _sample in 0..SAMPLES {
+        let lix = open_lix(OpenLixOptions::default())
+            .await
+            .expect("B2.1 workspace should open");
+        install_plugin(&lix, "plugin_markdown", &build_markdown_plugin_archive()).await;
+
+        let path = "/b2-1.md";
+        let base = format!("{}\n", "x".repeat(100));
+        write_file(&lix, path, base.as_bytes()).await;
+        let target = format!("{}{}", "a".repeat(N), base);
+        let source_text = format!("{}{}", "b".repeat(N), base);
+        let peer = lix
+            .open_workspace_session()
+            .await
+            .expect("peer session should open");
+        let mut target_transaction = lix.begin_transaction().await.expect("target transaction");
+        let mut source_transaction = peer.begin_transaction().await.expect("peer transaction");
+        for (transaction, bytes) in [
+            (&mut target_transaction, target.as_bytes()),
+            (&mut source_transaction, source_text.as_bytes()),
+        ] {
+            transaction
+                .execute(
+                    "UPDATE lix_file SET data = $1 WHERE path = $2",
+                    &[
+                        Value::Blob(bytes.to_vec().into()),
+                        Value::Text(path.to_owned()),
+                    ],
+                )
+                .await
+                .expect("same-base Markdown edit should stage");
+        }
+
+        lix.reset_plugin_transition_counters();
+        let started = Instant::now();
+        target_transaction
+            .commit()
+            .await
+            .expect("target should commit");
+        source_transaction
+            .commit()
+            .await
+            .expect("same-position Markdown inserts should resolve");
+        samples.push(started.elapsed());
+
+        let merged = read_file(&lix, path).await;
+        let expected_ab = format!("{}{}{}", "a".repeat(N), "b".repeat(N), base);
+        let expected_ba = format!("{}{}{}", "b".repeat(N), "a".repeat(N), base);
+        assert!(merged == expected_ab.as_bytes() || merged == expected_ba.as_bytes());
+        let counters = lix.plugin_transition_counters();
+        assert_eq!(counters.conflict_resolution_calls, 1);
+        assert_eq!(counters.conflict_resolution_records, 1);
+        assert_eq!(read_file(&peer, path).await, merged);
+        peer.close().await.expect("peer should close");
+        lix.close().await.expect("B2.1 workspace should close");
+    }
+
+    report("B2.1", "markdown", &mut samples);
+}
+
+#[tokio::test]
+#[ignore = "dmonad/crdt-benchmarks B3.1 durable Lix baseline"]
+async fn crdt_benchmarks_b3_1_json_concurrent_map_sets() {
+    let clients = std::env::var("LIX_CRDT_B3_CLIENTS")
+        .ok()
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .expect("client count should be numeric")
+        })
+        .unwrap_or(CONCURRENT_CLIENTS);
+    let samples = std::env::var("LIX_CRDT_SAMPLES")
+        .ok()
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .expect("sample count should be numeric")
+        })
+        .unwrap_or(SAMPLES);
+    assert!(clients >= 2, "B3.1 needs at least two clients");
+    assert!(samples > 0, "B3.1 needs at least one sample");
+    let mut all_latencies = Vec::with_capacity(samples * clients);
+    let mut batch_latencies = Vec::with_capacity(samples);
+    for sample in 0..samples {
+        let lix = open_lix(OpenLixOptions::default())
+            .await
+            .expect("B3.1 workspace should open");
+        install_plugin(&lix, "plugin_json", &build_json_plugin_archive()).await;
+        let path = format!("/b3-1-{sample}.json");
+        write_file(&lix, &path, br#"{"v":-1}"#).await;
+        let file_id = file_id(&lix, &path).await;
+        let mut peers = Vec::with_capacity(clients);
+        let mut transactions = Vec::with_capacity(clients);
+        for client in 0..clients {
+            let peer = lix
+                .open_workspace_session()
+                .await
+                .expect("peer session should open");
+            let mut transaction = peer
+                .begin_transaction()
+                .await
+                .expect("same-base transaction should open");
+            transaction
+                .execute(
+                    "UPDATE json_object_member SET scalar_json = $1 \
+                     WHERE parent_id = 'root' AND key = 'v' AND lixcol_file_id = $2",
+                    &[
+                        Value::Text(client.to_string()),
+                        Value::Text(file_id.clone()),
+                    ],
+                )
+                .await
+                .expect("same-base JSON update should stage");
+            peers.push(peer);
+            transactions.push(transaction);
+        }
+
+        lix.reset_plugin_transition_counters();
+        let batch_started = Instant::now();
+        let commit_results = tokio::task::LocalSet::new()
+            .run_until(async move {
+                let mut commits = tokio::task::JoinSet::new();
+                for transaction in transactions {
+                    commits.spawn_local(async move {
+                        let started = Instant::now();
+                        let result = transaction.commit().await;
+                        (started.elapsed(), result)
+                    });
+                }
+                let mut results = Vec::new();
+                while let Some(joined) = commits.join_next().await {
+                    results.push(joined.expect("commit task should not panic"));
+                }
+                results
+            })
+            .await;
+        batch_latencies.push(batch_started.elapsed());
+        for (elapsed, result) in commit_results {
+            result.expect("same-base JSON update should resolve");
+            all_latencies.push(elapsed);
+        }
+
+        let counters = lix.plugin_transition_counters();
+        assert!(counters.conflict_resolution_calls > 0);
+        assert_eq!(counters.conflict_resolution_records, (clients - 1) as u64);
+        let converged = read_file(&lix, &path).await;
+        let merged: serde_json::Value =
+            serde_json::from_slice(&converged).expect("merged JSON should parse");
+        assert!(merged["v"].is_number());
+        for peer in &peers {
+            assert_eq!(read_file(peer, &path).await, converged);
+        }
+        for peer in peers {
+            peer.close().await.expect("peer should close");
+        }
+        lix.close().await.expect("B3.1 workspace should close");
+    }
+
+    all_latencies.sort_unstable();
+    let p95_index = (all_latencies.len() * 95).div_ceil(100).saturating_sub(1);
+    let p95 = all_latencies[p95_index];
+    eprintln!(
+        "crdt_benchmarks_baseline workload=B3.1 format=json clients={clients} \
+         samples={} p95_ms={:.3} commit_batch_ms={:?}",
+        all_latencies.len(),
+        p95.as_secs_f64() * 1_000.0,
+        batch_latencies
+            .iter()
+            .map(|elapsed| elapsed.as_secs_f64() * 1_000.0)
+            .collect::<Vec<_>>(),
+    );
+    assert!(
+        p95 < Duration::from_millis(100),
+        "same-base durable commit service p95 was {:.3} ms",
+        p95.as_secs_f64() * 1_000.0
+    );
+}
+
+#[tokio::test]
+async fn ordinary_concurrent_execute_serializes_without_plugin_resolution() {
+    let lix = open_lix(OpenLixOptions::default()).await.unwrap();
+    let first = lix.open_workspace_session().await.unwrap();
+    let second = lix.open_workspace_session().await.unwrap();
+    lix.reset_plugin_transition_counters();
+    let first_write = async {
+        first
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('ordinary', $1) \
+                 ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+                &[Value::Text("first".to_owned())],
+            )
+            .await
+    };
+    let second_write = async {
+        second
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('ordinary', $1) \
+                 ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+                &[Value::Text("second".to_owned())],
+            )
+            .await
+    };
+    let (first_result, second_result) = tokio::join!(first_write, second_write);
+    first_result.unwrap();
+    second_result.unwrap();
+    assert_eq!(
+        lix.plugin_transition_counters().conflict_resolution_calls,
+        0
+    );
+    let result = lix
+        .execute(
+            "SELECT value FROM lix_key_value WHERE key = 'ordinary'",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.len(), 1);
+    lix.close().await.unwrap();
+}
+
+fn report(workload: &str, format: &str, samples: &mut [Duration]) {
+    samples.sort_unstable();
+    let p50 = samples[samples.len() / 2].as_secs_f64() * 1_000.0;
+    let p95_index = (samples.len() * 95).div_ceil(100).saturating_sub(1);
+    let p95 = samples[p95_index].as_secs_f64() * 1_000.0;
+    let raw = samples
+        .iter()
+        .map(|sample| format!("{:.3}", sample.as_secs_f64() * 1_000.0))
+        .collect::<Vec<_>>();
+    eprintln!(
+        "crdt_benchmarks_baseline workload={workload} format={format} n={N} \
+         samples_ms={raw:?} p50_ms={p50:.3} p95_ms={p95:.3}"
+    );
+}
+
+async fn install_plugin<StorageImpl>(lix: &Lix<StorageImpl>, key: &str, archive: &[u8])
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    lix.execute(
+        "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+        &[
+            Value::Text(format!("/.lix/plugins/{key}.lixplugin")),
+            Value::Blob(archive.to_vec().into()),
+        ],
+    )
+    .await
+    .expect("reference plugin should install");
+}
+
+async fn write_file<StorageImpl>(lix: &Lix<StorageImpl>, path: &str, bytes: &[u8])
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    lix.execute(
+        "INSERT INTO lix_file (path, data) VALUES ($1, $2) \
+         ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+        &[
+            Value::Text(path.to_owned()),
+            Value::Blob(bytes.to_vec().into()),
+        ],
+    )
+    .await
+    .expect("benchmark file should write");
+}
+
+async fn read_file<StorageImpl>(lix: &Lix<StorageImpl>, path: &str) -> Vec<u8>
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    lix.execute(
+        "SELECT data FROM lix_file WHERE path = $1",
+        &[Value::Text(path.to_owned())],
+    )
+    .await
+    .expect("benchmark file should read")
+    .rows()[0]
+        .get::<Vec<u8>>("data")
+        .expect("benchmark file data should be bytes")
+}
+
+async fn file_id<StorageImpl>(lix: &Lix<StorageImpl>, path: &str) -> String
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    lix.execute(
+        "SELECT id FROM lix_file WHERE path = $1",
+        &[Value::Text(path.to_owned())],
+    )
+    .await
+    .expect("benchmark file id should query")
+    .rows()[0]
+        .get::<String>("id")
+        .expect("benchmark file id should be text")
+}
+
+fn build_markdown_plugin_archive() -> Vec<u8> {
+    build_plugin_archive(
+        Path::new(env!("CARGO_CDYLIB_FILE_PLUGIN_MARKDOWN_plugin_markdown")),
+        include_str!("../../../plugins/markdown/manifest.json"),
+        &[(
+            "schema/markdown_node_v2.json",
+            include_str!("../../../plugins/markdown/schema/markdown_node_v2.json"),
+        )],
+    )
+}
+
+fn build_json_plugin_archive() -> Vec<u8> {
+    build_plugin_archive(
+        Path::new(env!("CARGO_CDYLIB_FILE_PLUGIN_JSON_plugin_json")),
+        include_str!("../../../plugins/json/manifest.json"),
+        &[
+            (
+                "schema/json_root.json",
+                include_str!("../../../plugins/json/schema/json_root.json"),
+            ),
+            (
+                "schema/json_object_member.json",
+                include_str!("../../../plugins/json/schema/json_object_member.json"),
+            ),
+            (
+                "schema/json_array_item.json",
+                include_str!("../../../plugins/json/schema/json_array_item.json"),
+            ),
+        ],
+    )
+}
+
+fn build_plugin_archive(wasm_path: &Path, manifest: &str, schemas: &[(&str, &str)]) -> Vec<u8> {
+    let wasm = fs::read(wasm_path).unwrap_or_else(|error| {
+        panic!(
+            "failed to read plugin component at {}: {error}",
+            wasm_path.display()
+        )
+    });
+    let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    writer.start_file("manifest.json", options).unwrap();
+    writer.write_all(manifest.as_bytes()).unwrap();
+    for (path, schema) in schemas {
+        writer.start_file(path, options).unwrap();
+        writer.write_all(schema.as_bytes()).unwrap();
+    }
+    writer.start_file("plugin.wasm", options).unwrap();
+    writer.write_all(&wasm).unwrap();
+    writer.finish().unwrap().into_inner()
+}

--- a/packages/rs-sdk-tests/tests/e2e.rs
+++ b/packages/rs-sdk-tests/tests/e2e.rs
@@ -5848,6 +5848,209 @@ async fn v2_json_entity_write_rollback_keeps_original_bytes_and_actor() {
 }
 
 #[tokio::test]
+async fn same_base_json_transactions_resolve_overlap_and_converge() {
+    let archive = build_json_plugin_archive();
+    let first = open_lix(OpenLixOptions::default()).await.unwrap();
+    install_reference_plugin_in_blank_registry(
+        &first,
+        "plugin_json",
+        &archive,
+        &["json_root", "json_object_member", "json_array_item"],
+    )
+    .await;
+    let path = "/transaction-conflict.json";
+    write_file(&first, path, b"{\"value\":\"base\"}\n".to_vec())
+        .await
+        .unwrap();
+    let file_id = file_id_at_path(&first, path).await;
+    let second = first.open_workspace_session().await.unwrap();
+    let mut first_transaction = first.begin_transaction().await.unwrap();
+    let mut second_transaction = second.begin_transaction().await.unwrap();
+    for (transaction, value) in [
+        (&mut first_transaction, r#""first""#),
+        (&mut second_transaction, r#""second""#),
+    ] {
+        transaction
+            .execute(
+                "UPDATE json_object_member SET scalar_json = $1 \
+                 WHERE parent_id = 'root' AND key = 'value' AND lixcol_file_id = $2",
+                &[Value::Text(value.to_owned()), Value::Text(file_id.clone())],
+            )
+            .await
+            .unwrap();
+    }
+
+    first.reset_plugin_transition_counters();
+    first_transaction.commit().await.unwrap();
+    second_transaction
+        .commit()
+        .await
+        .expect("stale plugin overlap should resolve at commit");
+    let counters = first.plugin_transition_counters();
+    assert_eq!(counters.conflict_resolution_calls, 1);
+    assert_eq!(counters.conflict_resolution_records, 1);
+    let first_bytes = read_file(&first, path).await.unwrap().unwrap();
+    let second_bytes = read_file(&second, path).await.unwrap().unwrap();
+    assert_eq!(first_bytes, second_bytes);
+    assert_ne!(first_bytes, b"{\"value\":\"base\"}\n");
+    second.close().await.unwrap();
+    first.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn stale_json_transaction_renders_retained_same_file_edits_with_resolutions() {
+    let archive = build_json_plugin_archive();
+    let stale_client = open_lix(OpenLixOptions::default()).await.unwrap();
+    install_reference_plugin_in_blank_registry(
+        &stale_client,
+        "plugin_json",
+        &archive,
+        &["json_root", "json_object_member", "json_array_item"],
+    )
+    .await;
+    let path = "/partial-transaction-conflict.json";
+    write_file(
+        &stale_client,
+        path,
+        b"{\"overlap\":\"base\",\"retained\":\"base\"}\n".to_vec(),
+    )
+    .await
+    .unwrap();
+    let winner_client = stale_client.open_workspace_session().await.unwrap();
+    let mut stale = stale_client.begin_transaction().await.unwrap();
+    let mut winner = winner_client.begin_transaction().await.unwrap();
+    stale
+        .execute(
+            "UPDATE lix_file SET data = $1 WHERE path = $2",
+            &[
+                Value::Blob(
+                    b"{\"overlap\":\"stale\",\"retained\":\"stale\"}\n"
+                        .to_vec()
+                        .into(),
+                ),
+                Value::Text(path.to_owned()),
+            ],
+        )
+        .await
+        .unwrap();
+    winner
+        .execute(
+            "UPDATE lix_file SET data = $1 WHERE path = $2",
+            &[
+                Value::Blob(
+                    b"{\"overlap\":\"winner\",\"retained\":\"base\"}\n"
+                        .to_vec()
+                        .into(),
+                ),
+                Value::Text(path.to_owned()),
+            ],
+        )
+        .await
+        .unwrap();
+
+    stale_client.reset_plugin_transition_counters();
+    winner.commit().await.unwrap();
+    stale.commit().await.unwrap();
+    assert_eq!(
+        stale_client
+            .plugin_transition_counters()
+            .conflict_resolution_calls,
+        1
+    );
+    let bytes = read_file(&stale_client, path).await.unwrap().unwrap();
+    let rendered: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(rendered["retained"], "stale");
+    assert_eq!(read_file(&winner_client, path).await.unwrap(), Some(bytes));
+    winner_client.close().await.unwrap();
+    stale_client.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn same_base_transactions_resolve_reference_plugin_file_overlaps() {
+    let cases = [
+        (
+            "json",
+            "plugin_json",
+            build_json_plugin_archive(),
+            vec!["json_root", "json_object_member", "json_array_item"],
+            b"{\"value\":\"base\"}\n".to_vec(),
+            b"{\"value\":\"first\"}\n".to_vec(),
+            b"{\"value\":\"second\"}\n".to_vec(),
+        ),
+        (
+            "csv",
+            "plugin_csv",
+            build_csv_plugin_archive(),
+            vec!["csv_v2_table", "csv_v2_row"],
+            b"name,value\nitem,base\n".to_vec(),
+            b"name,value\nitem,first\n".to_vec(),
+            b"name,value\nitem,second\n".to_vec(),
+        ),
+        (
+            "markdown",
+            "plugin_markdown",
+            build_markdown_plugin_archive(),
+            vec!["markdown_node_v2"],
+            b"# Base\n".to_vec(),
+            b"# First\n".to_vec(),
+            b"# Second\n".to_vec(),
+        ),
+        (
+            "text",
+            "plugin_git_text",
+            build_text_plugin_archive(),
+            vec!["git_text_line_v2"],
+            b"base\n".to_vec(),
+            b"first\n".to_vec(),
+            b"second\n".to_vec(),
+        ),
+    ];
+
+    for (extension, plugin_key, archive, schemas, base, first_edit, second_edit) in cases {
+        let first = open_lix(OpenLixOptions::default()).await.unwrap();
+        install_reference_plugin_in_blank_registry(&first, plugin_key, &archive, &schemas).await;
+        let path = format!("/transaction-conflict.{extension}");
+        write_file(&first, &path, base.clone()).await.unwrap();
+        let second = first.open_workspace_session().await.unwrap();
+        let mut first_transaction = first.begin_transaction().await.unwrap();
+        let mut second_transaction = second.begin_transaction().await.unwrap();
+        for (transaction, bytes) in [
+            (&mut first_transaction, first_edit),
+            (&mut second_transaction, second_edit),
+        ] {
+            transaction
+                .execute(
+                    "UPDATE lix_file SET data = $1 WHERE path = $2",
+                    &[Value::Blob(bytes.into()), Value::Text(path.clone())],
+                )
+                .await
+                .unwrap();
+        }
+
+        first.reset_plugin_transition_counters();
+        first_transaction.commit().await.unwrap();
+        second_transaction
+            .commit()
+            .await
+            .unwrap_or_else(|error| panic!("{extension} overlap should resolve: {error}"));
+        let counters = first.plugin_transition_counters();
+        assert!(
+            counters.conflict_resolution_calls > 0,
+            "{extension} must invoke its conflict resolver"
+        );
+        let first_bytes = read_file(&first, &path).await.unwrap().unwrap();
+        let second_bytes = read_file(&second, &path).await.unwrap().unwrap();
+        assert_eq!(
+            first_bytes, second_bytes,
+            "{extension} clients must converge"
+        );
+        assert_ne!(first_bytes, base, "{extension} must commit a resolved edit");
+        second.close().await.unwrap();
+        first.close().await.unwrap();
+    }
+}
+
+#[tokio::test]
 async fn v2_json_rejects_mixed_byte_and_entity_transitions_in_one_transaction() {
     let archive = build_json_plugin_archive();
     let lix = open_lix(OpenLixOptions::default()).await.unwrap();
@@ -7832,6 +8035,34 @@ fn build_markdown_plugin_archive() -> Vec<u8> {
         (
             "schema/markdown_node_v2.json",
             include_str!("../../../plugins/markdown/schema/markdown_node_v2.json").as_bytes(),
+        ),
+        ("plugin.wasm", wasm.as_slice()),
+    ] {
+        writer.start_file(path, options).unwrap();
+        writer.write_all(bytes).unwrap();
+    }
+    writer.finish().unwrap().into_inner()
+}
+
+fn build_text_plugin_archive() -> Vec<u8> {
+    let wasm_path = Path::new(env!("CARGO_CDYLIB_FILE_PLUGIN_GIT_TEXT_plugin_git_text"));
+    let wasm = std::fs::read(wasm_path).unwrap_or_else(|error| {
+        panic!(
+            "failed to read bindep-built text v3 wasm at {}: {error}",
+            wasm_path.display()
+        )
+    });
+    let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    for (path, bytes) in [
+        (
+            "manifest.json",
+            include_str!("../../../plugins/text/manifest.json").as_bytes(),
+        ),
+        (
+            "schema/git_text_line_v2.json",
+            include_str!("../../../plugins/text/schema/git_text_line_v2.json").as_bytes(),
         ),
         ("plugin.wasm", wasm.as_slice()),
     ] {

--- a/packages/rs-sdk-tests/tests/git_text_plugin.rs
+++ b/packages/rs-sdk-tests/tests/git_text_plugin.rs
@@ -18,6 +18,67 @@ struct GitTextLine {
 }
 
 #[tokio::test]
+async fn git_text_same_line_branch_conflict_uses_static_canonical_resolver() {
+    let lix = open_lix(OpenLixOptions::new(lix_sdk::Memory::new()))
+        .await
+        .expect("workspace should open");
+    install_plugin(&lix, &build_plugin_archive())
+        .await
+        .expect("Git text plugin should install");
+
+    let path = "/same-line.txt";
+    write_file(&lix, path, b"base\n")
+        .await
+        .expect("base line should import");
+    let target_branch_id = lix.active_branch_id().await.expect("target branch");
+    let source = lix
+        .create_branch(CreateBranchOptions {
+            id: Some("01920000-0000-7000-8000-000000000507".to_owned()),
+            name: "Git text conflict source".to_owned(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("source branch should create");
+
+    write_file(&lix, path, b"target\n")
+        .await
+        .expect("target line should change");
+    lix.switch_branch(SwitchBranchOptions {
+        branch_id: source.id.clone(),
+    })
+    .await
+    .expect("source branch should activate");
+    write_file(&lix, path, b"source\n")
+        .await
+        .expect("source line should change");
+    lix.switch_branch(SwitchBranchOptions {
+        branch_id: target_branch_id,
+    })
+    .await
+    .expect("target branch should reactivate");
+
+    lix.reset_plugin_transition_counters();
+    lix.merge_branch(MergeBranchOptions {
+        source_branch_id: source.id,
+    })
+    .await
+    .expect("the default static resolver should resolve the line conflict");
+    let merged = read_file(&lix, path)
+        .await
+        .expect("merged file should exist");
+    assert!(
+        matches!(merged.as_slice(), b"target\n" | b"source\n"),
+        "canonical resolution must select one complete side"
+    );
+    let counters = lix.plugin_transition_counters();
+    assert_eq!(counters.conflict_resolution_calls, 1);
+    assert_eq!(counters.conflict_resolution_records, 1);
+    assert_eq!(counters.conflict_resolution_takes, 1);
+
+    lix.close().await.expect("workspace should close");
+}
+
+#[tokio::test]
 async fn git_text_plugin_persists_lossless_line_rows_and_leaves_binary_raw() {
     let storage = lix_sdk::Memory::new();
     let lix = open_lix(OpenLixOptions::new(storage.clone()))

--- a/packages/server-protocol/Cargo.toml
+++ b/packages/server-protocol/Cargo.toml
@@ -22,7 +22,7 @@ async-stream = "0.3"
 axum = "0.8"
 futures-core = "0.3"
 getrandom = "0.3"
-lix_sdk = { path = "../rs-sdk", version = "0.9.0", default-features = false }
+lix_sdk = { path = "../rs-sdk", version = "0.9.0", default-features = false, features = ["default_wasm_runtime"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
@@ -43,10 +43,12 @@ hyper = { version = "1", features = ["client", "http1"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "http1", "tokio"] }
 lix_slatedb_storage = { workspace = true }
 object_store = { version = "0.14", default-features = false }
+plugin_json = { path = "../../plugins/json", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "time"] }
 tracing-subscriber = "0.3"
+zip = { version = "8", default-features = false }
 zstd = "0.13"
 
 [[bench]]

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -17,8 +17,9 @@ use axum::{
 };
 use lix_sdk::{
     Blob, CreateBranchOptions, ExecuteBatchStatement, ExecuteIdempotency, ExecuteOptions,
-    ExecuteResult, ExecuteStatementMetadata, ExecutionDisposition, Lix, LixError, ObserveEvent,
-    ObserveEvents, Storage, SwitchBranchOptions, Value, VerifiedRequestBlob, WireValue,
+    ExecuteResult, ExecuteStatementMetadata, ExecutionDisposition, Lix, LixError, LixTransaction,
+    ObserveEvent, ObserveEvents, Storage, SwitchBranchOptions, Value, VerifiedRequestBlob,
+    WireValue,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
@@ -58,6 +59,8 @@ pub const PROTOCOL_VERSION: u32 = 1;
 pub const SESSION_ID_HEADER: &str = "lix-session-id";
 /// Standard request identity for replay-safe SQL mutations.
 pub const IDEMPOTENCY_KEY_HEADER: &str = "idempotency-key";
+/// Internal capability binding requests to one remote transaction lifecycle.
+pub const TRANSACTION_ID_HEADER: &str = "lix-transaction-id";
 /// Header distinguishing a missing file from a present empty file on the raw
 /// binary file-read endpoint.
 pub const FILE_FOUND_HEADER: &str = "lix-file-found";
@@ -94,6 +97,7 @@ const BLOB_BASE_MISSING_CODE: &str = "LIX_REMOTE_BLOB_BASE_MISSING";
 
 const SESSION_TOKEN_BYTES: usize = 32;
 const SESSION_TOKEN_HEX_LEN: usize = SESSION_TOKEN_BYTES * 2;
+const MAX_COMPLETED_REMOTE_TRANSACTIONS: usize = 8;
 const MAX_IDEMPOTENCY_COMPONENT_BYTES: usize = 255;
 const SESSION_OPEN_GATE_CLOSING: usize = 1 << (usize::BITS - 1);
 const SESSION_OPEN_GATE_COUNT_MASK: usize = !SESSION_OPEN_GATE_CLOSING;
@@ -276,10 +280,52 @@ where
     S: Storage + Clone + Send + Sync + 'static,
 {
     lix: Arc<AsyncRwLock<Arc<Lix<S>>>>,
+    transactions: AsyncMutex<RemoteTransactionRegistry<S>>,
     last_used: Mutex<Instant>,
     leases: AtomicUsize,
+    transaction_active: std::sync::atomic::AtomicBool,
     request_blobs: Mutex<RequestBlobCache>,
     max_reconstructed_request_blob_bytes: usize,
+}
+
+struct RemoteTransactionRegistry<S>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    active: Option<ActiveRemoteTransaction<S>>,
+    completed: VecDeque<CompletedRemoteTransaction>,
+}
+
+struct ActiveRemoteTransaction<S>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    id: String,
+    transaction: LixTransaction<S>,
+}
+
+#[derive(Clone)]
+struct CompletedRemoteTransaction {
+    id: String,
+    result: Result<RemoteTransactionOutcome, LixError>,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum RemoteTransactionOutcome {
+    Committed,
+    RolledBack,
+}
+
+impl<S> Default for RemoteTransactionRegistry<S>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    fn default() -> Self {
+        Self {
+            active: None,
+            completed: VecDeque::new(),
+        }
+    }
 }
 
 struct RequestBlobCacheBudget {
@@ -440,8 +486,10 @@ where
     ) -> Self {
         Self {
             lix: Arc::new(AsyncRwLock::new(Arc::new(lix))),
+            transactions: AsyncMutex::new(RemoteTransactionRegistry::default()),
             last_used: Mutex::new(now),
             leases: AtomicUsize::new(0),
+            transaction_active: std::sync::atomic::AtomicBool::new(false),
             request_blobs: Mutex::new(RequestBlobCache::new(request_blob_budget)),
             max_reconstructed_request_blob_bytes,
         }
@@ -476,7 +524,9 @@ where
     }
 
     fn is_idle_expired(&self, now: Instant, timeout: Duration) -> bool {
-        self.lease_count() == 0 && now.saturating_duration_since(self.last_used()) >= timeout
+        self.lease_count() == 0
+            && !self.transaction_active.load(Ordering::Acquire)
+            && now.saturating_duration_since(self.last_used()) >= timeout
     }
 
     fn request_blob(&self, sha256: &str) -> Option<VerifiedRequestBlob> {
@@ -710,6 +760,128 @@ where
         }
     }
 
+    async fn begin_transaction(&self) -> Result<String, LixError> {
+        let mut transactions = self.record.transactions.lock().await;
+        if transactions.active.is_some() {
+            return Err(remote_transaction_state_error(
+                "Lix session already has an active transaction",
+            ));
+        }
+        let lix = Arc::clone(&*self.record.lix.read().await);
+        let id = generate_capability_id()?;
+        transactions.active = Some(ActiveRemoteTransaction {
+            id: id.clone(),
+            transaction: lix.begin_transaction().await?,
+        });
+        self.record
+            .transaction_active
+            .store(true, Ordering::Release);
+        Ok(id)
+    }
+
+    async fn transaction_execute(
+        &self,
+        transaction_id: String,
+        sql: String,
+        params: Vec<Value>,
+        options: ExecuteOptions,
+    ) -> Result<ExecuteResult, LixError> {
+        let mut transactions = self.record.transactions.lock().await;
+        let mut active = transactions.active.take().ok_or_else(|| {
+            completed_transaction_error(&transactions, &transaction_id).unwrap_or_else(|| {
+                remote_transaction_state_error("Lix session has no active transaction")
+            })
+        })?;
+        if active.id != transaction_id {
+            transactions.active = Some(active);
+            return Err(remote_transaction_state_error(
+                "remote transaction capability does not match the active transaction",
+            ));
+        }
+        let runtime = Handle::try_current().map_err(|error| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("access Lix server runtime: {error}"),
+            )
+        })?;
+        let operation_lease = self.clone();
+        let parent = tracing::Span::current();
+        let dispatch = tracing::dispatcher::get_default(Clone::clone);
+        let joined = tokio::task::spawn_blocking(move || {
+            let _operation_lease = operation_lease;
+            let result = tracing::dispatcher::with_default(&dispatch, || {
+                parent.in_scope(|| {
+                    runtime.block_on(async {
+                        active
+                            .transaction
+                            .execute_with_options(&sql, &params, options)
+                            .await
+                    })
+                })
+            });
+            (active, result)
+        })
+        .await
+        .map_err(|error| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("join Lix server transaction operation: {error}"),
+            )
+        })?;
+        transactions.active = Some(joined.0);
+        joined.1
+    }
+
+    async fn commit_transaction(&self, transaction_id: String) -> Result<(), LixError> {
+        self.finish_transaction(transaction_id, RemoteTransactionOutcome::Committed)
+            .await
+    }
+
+    async fn rollback_transaction(&self, transaction_id: String) -> Result<(), LixError> {
+        self.finish_transaction(transaction_id, RemoteTransactionOutcome::RolledBack)
+            .await
+    }
+
+    async fn finish_transaction(
+        &self,
+        transaction_id: String,
+        requested: RemoteTransactionOutcome,
+    ) -> Result<(), LixError> {
+        let mut transactions = self.record.transactions.lock().await;
+        let Some(active) = transactions.active.take() else {
+            return completed_transaction_result(&transactions, &transaction_id, requested);
+        };
+        if active.id != transaction_id {
+            transactions.active = Some(active);
+            return Err(remote_transaction_state_error(
+                "remote transaction capability does not match the active transaction",
+            ));
+        }
+        let result = match requested {
+            RemoteTransactionOutcome::Committed => self
+                .run(move |_| async move { active.transaction.commit().await })
+                .await
+                .map(|()| RemoteTransactionOutcome::Committed),
+            RemoteTransactionOutcome::RolledBack => self
+                .run(move |_| async move { active.transaction.rollback().await })
+                .await
+                .map(|()| RemoteTransactionOutcome::RolledBack),
+        };
+        transactions
+            .completed
+            .push_back(CompletedRemoteTransaction {
+                id: transaction_id,
+                result: result.clone(),
+            });
+        while transactions.completed.len() > MAX_COMPLETED_REMOTE_TRANSACTIONS {
+            transactions.completed.pop_front();
+        }
+        self.record
+            .transaction_active
+            .store(false, Ordering::Release);
+        result.map(|_| ())
+    }
+
     async fn switch_branch(
         &self,
         options: SwitchBranchOptions,
@@ -762,6 +934,46 @@ where
             events: Arc::new(Mutex::new(lix.observe(sql, params)?)),
             terminal_sender,
         })
+    }
+}
+
+fn remote_transaction_state_error(message: impl Into<String>) -> LixError {
+    LixError::new("LIX_INVALID_TRANSACTION_STATE", message)
+}
+
+fn completed_transaction_error<S>(
+    transactions: &RemoteTransactionRegistry<S>,
+    transaction_id: &str,
+) -> Option<LixError>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    transactions
+        .completed
+        .iter()
+        .any(|completed| completed.id == transaction_id)
+        .then(|| remote_transaction_state_error("Lix transaction is closed"))
+}
+
+fn completed_transaction_result<S>(
+    transactions: &RemoteTransactionRegistry<S>,
+    transaction_id: &str,
+    requested: RemoteTransactionOutcome,
+) -> Result<(), LixError>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let completed = transactions
+        .completed
+        .iter()
+        .find(|completed| completed.id == transaction_id)
+        .ok_or_else(|| remote_transaction_state_error("Lix session has no such transaction"))?;
+    match &completed.result {
+        Ok(actual) if *actual == requested => Ok(()),
+        Ok(_) => Err(remote_transaction_state_error(
+            "Lix transaction already completed with a different outcome",
+        )),
+        Err(error) => Err(error.clone()),
     }
 }
 
@@ -951,6 +1163,16 @@ where
         let protected = Router::new()
             .route("/lix/v1/execute", post(execute::<S>))
             .route("/lix/v1/execute-batch", post(execute_batch::<S>))
+            .route("/lix/v1/transaction/begin", post(begin_transaction::<S>))
+            .route(
+                "/lix/v1/transaction/execute",
+                post(transaction_execute::<S>),
+            )
+            .route("/lix/v1/transaction/commit", post(commit_transaction::<S>))
+            .route(
+                "/lix/v1/transaction/rollback",
+                post(rollback_transaction::<S>),
+            )
             .route("/lix/v1/file", get(read_file_data::<S>))
             .route("/lix/v1/file/upsert", post(upsert_file_data::<S>))
             .route(
@@ -1145,7 +1367,9 @@ where
             let lru_idle_id = registry
                 .sessions
                 .iter()
-                .filter(|(_, record)| record.lease_count() == 0)
+                .filter(|(_, record)| {
+                    record.lease_count() == 0 && !record.transaction_active.load(Ordering::Acquire)
+                })
                 .min_by_key(|(_, record)| record.last_used())
                 .map(|(session_id, _)| session_id.clone());
             let Some(lru_idle_id) = lru_idle_id else {
@@ -1225,8 +1449,14 @@ async fn close_session_record<S>(record: &SessionRecord<S>) -> Result<(), LixErr
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
+    let rollback_result = match record.transactions.lock().await.active.take() {
+        Some(active) => active.transaction.rollback().await,
+        None => Ok(()),
+    };
+    record.transaction_active.store(false, Ordering::Release);
     let lix = record.lix.write().await;
-    lix.close().await
+    let close_result = lix.close().await;
+    rollback_result.and(close_result)
 }
 
 async fn close_removed_session<S>(record: Arc<SessionRecord<S>>)
@@ -1256,12 +1486,16 @@ where
 }
 
 fn generate_session_id() -> Result<String, ApiError> {
+    generate_capability_id().map_err(ApiError::from)
+}
+
+fn generate_capability_id() -> Result<String, LixError> {
     let mut bytes = [0_u8; SESSION_TOKEN_BYTES];
     getrandom::fill(&mut bytes).map_err(|error| {
-        ApiError::from(LixError::new(
+        LixError::new(
             LixError::CODE_INTERNAL_ERROR,
             format!("generate Lix protocol session identifier: {error}"),
-        ))
+        )
     })?;
     let mut encoded = String::with_capacity(SESSION_TOKEN_HEX_LEN);
     for byte in bytes {
@@ -1306,6 +1540,35 @@ fn optional_session_id(headers: &HeaderMap) -> Result<Option<String>, ApiError> 
 
 fn required_session_id(headers: &HeaderMap) -> Result<String, ApiError> {
     optional_session_id(headers)?.ok_or_else(ApiError::session_required)
+}
+
+fn required_transaction_id(headers: &HeaderMap) -> Result<String, ApiError> {
+    let mut values = headers.get_all(TRANSACTION_ID_HEADER).iter();
+    let value = values.next().ok_or_else(|| {
+        ApiError::from(remote_transaction_state_error(
+            "Lix-Transaction-Id is required",
+        ))
+    })?;
+    if values.next().is_some() {
+        return Err(ApiError::from(remote_transaction_state_error(
+            "Lix-Transaction-Id must be sent exactly once",
+        )));
+    }
+    let value = value.to_str().map_err(|_| {
+        ApiError::from(remote_transaction_state_error(
+            "Lix-Transaction-Id must contain visible ASCII",
+        ))
+    })?;
+    if value.len() != SESSION_TOKEN_HEX_LEN
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(ApiError::from(remote_transaction_state_error(
+            "Lix-Transaction-Id has an invalid format",
+        )));
+    }
+    Ok(value.to_owned())
 }
 
 async fn require_session<S>(
@@ -1508,6 +1771,77 @@ where
             .map(ExecuteResponse::try_from)
             .collect::<Result<Vec<_>, _>>()?,
     ))
+}
+
+async fn begin_transaction<S>(
+    Extension(lease): Extension<SessionLease<S>>,
+) -> Result<Json<BeginTransactionResponse>, ApiError>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    Ok(Json(BeginTransactionResponse {
+        transaction_id: lease.begin_transaction().await?,
+    }))
+}
+
+async fn transaction_execute<S>(
+    Extension(lease): Extension<SessionLease<S>>,
+    headers: HeaderMap,
+    Json(request): Json<ExecuteRequest>,
+) -> Result<Json<ExecuteResponse>, ApiError>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let sql = required_non_empty(request.sql, "sql")?;
+    let reconstructed_bytes_limit = lease.record.max_reconstructed_request_blob_bytes;
+    let mut reconstructed_bytes_remaining = reconstructed_bytes_limit;
+    let mut cache_candidate_bytes_remaining = 0;
+    let mut cache_candidates = Vec::new();
+    let decoded = decode_request_params(
+        request.params,
+        None,
+        false,
+        reconstructed_bytes_limit,
+        &mut reconstructed_bytes_remaining,
+        &mut cache_candidate_bytes_remaining,
+        &mut cache_candidates,
+        |sha256| lease.record.request_blob(sha256),
+    )?;
+    let result = lease
+        .transaction_execute(
+            required_transaction_id(&headers)?,
+            sql,
+            decoded.values,
+            request.options.into(),
+        )
+        .await?;
+    Ok(Json(ExecuteResponse::try_from(result)?))
+}
+
+async fn commit_transaction<S>(
+    Extension(lease): Extension<SessionLease<S>>,
+    headers: HeaderMap,
+) -> Result<StatusCode, ApiError>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    lease
+        .commit_transaction(required_transaction_id(&headers)?)
+        .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn rollback_transaction<S>(
+    Extension(lease): Extension<SessionLease<S>>,
+    headers: HeaderMap,
+) -> Result<StatusCode, ApiError>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    lease
+        .rollback_transaction(required_transaction_id(&headers)?)
+        .await?;
+    Ok(StatusCode::NO_CONTENT)
 }
 
 /// Upserts one file from an octet-stream body.
@@ -2552,6 +2886,12 @@ struct HandshakeResponse {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+struct BeginTransactionResponse {
+    transaction_id: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 // These are independently negotiated wire capabilities; grouping them would
 // change the flat handshake response without reducing protocol complexity.
 #[allow(clippy::struct_excessive_bools)]
@@ -3212,7 +3552,8 @@ mod tests {
     use object_store::memory::InMemory as ObjectStoreMemory;
     use serde_json::{Value as JsonValue, json};
     use std::{
-        io::{Read as _, Write as _},
+        io::{Cursor, Read as _, Write as _},
+        path::Path,
         sync::{Arc, Mutex, atomic::AtomicBool},
     };
     use tower::ServiceExt as _;
@@ -4721,6 +5062,72 @@ mod tests {
         request_with_headers(app, method, uri, session_id, &idempotency_headers, body).await
     }
 
+    async fn begin_remote_transaction(app: &Router, session_id: &str) -> String {
+        let response = request(
+            app,
+            "POST",
+            "/lix/v1/transaction/begin",
+            Some(session_id),
+            None,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        response_json(response).await["transactionId"]
+            .as_str()
+            .expect("transaction ID")
+            .to_owned()
+    }
+
+    async fn remote_transaction_request(
+        app: &Router,
+        method: &str,
+        uri: &str,
+        session_id: &str,
+        transaction_id: &str,
+        body: Option<JsonValue>,
+    ) -> Response {
+        request_with_headers(
+            app,
+            method,
+            uri,
+            Some(session_id),
+            &[(TRANSACTION_ID_HEADER, transaction_id)],
+            body,
+        )
+        .await
+    }
+
+    fn build_json_plugin_archive() -> Vec<u8> {
+        let wasm_path = Path::new(env!("CARGO_CDYLIB_FILE_PLUGIN_JSON_plugin_json"));
+        let wasm = std::fs::read(wasm_path).expect("JSON plugin component should be built");
+        let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Stored);
+        for (path, bytes) in [
+            (
+                "manifest.json",
+                include_str!("../../../plugins/json/manifest.json").as_bytes(),
+            ),
+            (
+                "schema/json_root.json",
+                include_str!("../../../plugins/json/schema/json_root.json").as_bytes(),
+            ),
+            (
+                "schema/json_object_member.json",
+                include_str!("../../../plugins/json/schema/json_object_member.json").as_bytes(),
+            ),
+            (
+                "schema/json_array_item.json",
+                include_str!("../../../plugins/json/schema/json_array_item.json").as_bytes(),
+            ),
+            ("plugin.wasm", wasm.as_slice()),
+        ] {
+            writer.start_file(path, options).expect("archive entry");
+            writer.write_all(bytes).expect("archive bytes");
+        }
+        writer.finish().expect("JSON plugin archive").into_inner()
+    }
+
     async fn request_with_headers(
         app: &Router,
         method: &str,
@@ -5984,6 +6391,296 @@ mod tests {
         assert_eq!(body.as_array().map(Vec::len), Some(2));
         assert_eq!(body[0]["rows"][0][0], json!({ "kind": "int", "value": 1 }));
         assert_eq!(body[1]["rows"][0][0], json!({ "kind": "int", "value": 2 }));
+    }
+
+    #[tokio::test]
+    async fn remote_transaction_commit_and_rollback_preserve_one_session_snapshot() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+
+        let transaction_id = begin_remote_transaction(&app.router, &session_id).await;
+        let staged = remote_transaction_request(
+            &app.router,
+            "POST",
+            "/lix/v1/transaction/execute",
+            &session_id,
+            &transaction_id,
+            Some(json!({
+                "sql": "INSERT INTO lix_key_value (key, value) VALUES ('remote-tx', 'committed')"
+            })),
+        )
+        .await;
+        assert_eq!(staged.status(), StatusCode::OK);
+        let outside = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({ "sql": "SELECT 1" })),
+        )
+        .await;
+        assert_eq!(outside.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            response_json(outside).await["error"]["code"],
+            "LIX_INVALID_TRANSACTION_STATE"
+        );
+        let committed = remote_transaction_request(
+            &app.router,
+            "POST",
+            "/lix/v1/transaction/commit",
+            &session_id,
+            &transaction_id,
+            None,
+        )
+        .await;
+        assert_eq!(committed.status(), StatusCode::NO_CONTENT);
+        let replayed_commit = remote_transaction_request(
+            &app.router,
+            "POST",
+            "/lix/v1/transaction/commit",
+            &session_id,
+            &transaction_id,
+            None,
+        )
+        .await;
+        assert_eq!(replayed_commit.status(), StatusCode::NO_CONTENT);
+
+        let transaction_id = begin_remote_transaction(&app.router, &session_id).await;
+        let staged = remote_transaction_request(
+            &app.router,
+            "POST",
+            "/lix/v1/transaction/execute",
+            &session_id,
+            &transaction_id,
+            Some(json!({
+                "sql": "INSERT INTO lix_key_value (key, value) VALUES ('remote-rollback', 'discarded')"
+            })),
+        )
+        .await;
+        assert_eq!(staged.status(), StatusCode::OK);
+        let rolled_back = remote_transaction_request(
+            &app.router,
+            "POST",
+            "/lix/v1/transaction/rollback",
+            &session_id,
+            &transaction_id,
+            None,
+        )
+        .await;
+        assert_eq!(rolled_back.status(), StatusCode::NO_CONTENT);
+
+        let visible = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT key FROM lix_key_value WHERE key IN ('remote-tx', 'remote-rollback') ORDER BY key"
+            })),
+        )
+        .await;
+        assert_eq!(visible.status(), StatusCode::OK);
+        assert_eq!(
+            response_json(visible).await["rows"],
+            json!([[{ "kind": "text", "value": "remote-tx" }]])
+        );
+    }
+
+    #[tokio::test]
+    async fn same_base_remote_transactions_compose_disjoint_semantic_writes() {
+        let app = app().await;
+        let (first, _) = new_session(&app.router).await;
+        let (second, _) = new_session(&app.router).await;
+        let first_transaction = begin_remote_transaction(&app.router, &first).await;
+        let second_transaction = begin_remote_transaction(&app.router, &second).await;
+        for (session_id, transaction_id, key) in [
+            (&first, &first_transaction, "first-disjoint"),
+            (&second, &second_transaction, "second-disjoint"),
+        ] {
+            let staged = remote_transaction_request(
+                &app.router,
+                "POST",
+                "/lix/v1/transaction/execute",
+                session_id,
+                transaction_id,
+                Some(json!({
+                    "sql": "INSERT INTO lix_key_value (key, value) VALUES ($1, $1)",
+                    "params": [{ "kind": "text", "value": key }]
+                })),
+            )
+            .await;
+            assert_eq!(staged.status(), StatusCode::OK);
+        }
+        for (session_id, transaction_id) in
+            [(&first, &first_transaction), (&second, &second_transaction)]
+        {
+            let committed = remote_transaction_request(
+                &app.router,
+                "POST",
+                "/lix/v1/transaction/commit",
+                session_id,
+                transaction_id,
+                None,
+            )
+            .await;
+            assert_eq!(committed.status(), StatusCode::NO_CONTENT);
+        }
+
+        let visible = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&first),
+            Some(json!({
+                "sql": "SELECT key FROM lix_key_value WHERE key LIKE '%-disjoint' ORDER BY key"
+            })),
+        )
+        .await;
+        assert_eq!(visible.status(), StatusCode::OK);
+        assert_eq!(
+            response_json(visible).await["rows"]
+                .as_array()
+                .map(Vec::len),
+            Some(2)
+        );
+    }
+
+    #[tokio::test]
+    async fn same_base_remote_plugin_writes_resolve_and_converge() {
+        let app = app().await;
+        let root = &app.server.inner.root;
+        root.execute(
+            "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+            &[
+                Value::Text("/.lix/plugins/plugin_json.lixplugin".to_owned()),
+                Value::Blob(build_json_plugin_archive().into()),
+            ],
+        )
+        .await
+        .expect("JSON plugin should install");
+        root.execute(
+            "INSERT INTO lix_file (path, data) VALUES ('/remote-conflict.json', $1)",
+            &[Value::Blob(
+                br#"{"value":"base"}
+"#
+                .to_vec()
+                .into(),
+            )],
+        )
+        .await
+        .expect("base JSON file should import");
+
+        let (first, _) = new_session(&app.router).await;
+        let (second, _) = new_session(&app.router).await;
+        let first_transaction = begin_remote_transaction(&app.router, &first).await;
+        let second_transaction = begin_remote_transaction(&app.router, &second).await;
+        for (session_id, transaction_id, base64) in [
+            (&first, &first_transaction, "eyJ2YWx1ZSI6ImZpcnN0In0K"),
+            (&second, &second_transaction, "eyJ2YWx1ZSI6InNlY29uZCJ9Cg=="),
+        ] {
+            let staged = remote_transaction_request(
+                &app.router,
+                "POST",
+                "/lix/v1/transaction/execute",
+                session_id,
+                transaction_id,
+                Some(json!({
+                    "sql": "UPDATE lix_file SET data = $1 WHERE path = '/remote-conflict.json'",
+                    "params": [{
+                        "kind": "blob",
+                        "base64": base64
+                    }]
+                })),
+            )
+            .await;
+            assert_eq!(staged.status(), StatusCode::OK);
+        }
+
+        root.reset_plugin_transition_counters();
+        for (session_id, transaction_id) in
+            [(&first, &first_transaction), (&second, &second_transaction)]
+        {
+            let committed = remote_transaction_request(
+                &app.router,
+                "POST",
+                "/lix/v1/transaction/commit",
+                session_id,
+                transaction_id,
+                None,
+            )
+            .await;
+            assert_eq!(committed.status(), StatusCode::NO_CONTENT);
+        }
+        assert!(root.plugin_transition_counters().conflict_resolution_calls > 0);
+
+        let mut converged_rows = Vec::new();
+        for session_id in [&first, &second] {
+            let visible = request(
+                &app.router,
+                "POST",
+                "/lix/v1/execute",
+                Some(session_id),
+                Some(json!({
+                    "sql": "SELECT data FROM lix_file WHERE path = '/remote-conflict.json'"
+                })),
+            )
+            .await;
+            assert_eq!(visible.status(), StatusCode::OK);
+            converged_rows.push(response_json(visible).await["rows"].clone());
+        }
+        assert_eq!(converged_rows[0], converged_rows[1]);
+    }
+
+    #[tokio::test]
+    async fn same_base_remote_transactions_report_the_existing_commit_conflict() {
+        let app = app().await;
+        let (first, _) = new_session(&app.router).await;
+        let (second, _) = new_session(&app.router).await;
+        let first_transaction = begin_remote_transaction(&app.router, &first).await;
+        let second_transaction = begin_remote_transaction(&app.router, &second).await;
+        for (session_id, transaction_id, value) in [
+            (&first, &first_transaction, "first"),
+            (&second, &second_transaction, "second"),
+        ] {
+            let staged = remote_transaction_request(
+                &app.router,
+                "POST",
+                "/lix/v1/transaction/execute",
+                session_id,
+                transaction_id,
+                Some(json!({
+                    "sql": "INSERT INTO lix_key_value (key, value) VALUES ('same-base', $1)",
+                    "params": [{ "kind": "text", "value": value }]
+                })),
+            )
+            .await;
+            assert_eq!(staged.status(), StatusCode::OK);
+        }
+
+        let first_commit = remote_transaction_request(
+            &app.router,
+            "POST",
+            "/lix/v1/transaction/commit",
+            &first,
+            &first_transaction,
+            None,
+        )
+        .await;
+        assert_eq!(first_commit.status(), StatusCode::NO_CONTENT);
+        let second_commit = remote_transaction_request(
+            &app.router,
+            "POST",
+            "/lix/v1/transaction/commit",
+            &second,
+            &second_transaction,
+            None,
+        )
+        .await;
+        assert_eq!(second_commit.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            response_json(second_commit).await["error"]["code"],
+            LixError::CODE_UNIQUE
+        );
     }
 
     #[tokio::test]
@@ -7551,6 +8248,49 @@ mod tests {
         );
 
         drop(observe_response);
+        let replacement = request(&app.router, "GET", "/lix/v1", None, None).await;
+        assert_eq!(replacement.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn active_remote_transaction_pins_session_until_terminal_request() {
+        let app = app_with_options(ProtocolServerOptions {
+            max_sessions: 1,
+            session_idle_timeout: Duration::from_mins(1),
+            ..ProtocolServerOptions::default()
+        })
+        .await;
+        let (session_id, _) = new_session(&app.router).await;
+        let transaction_id = begin_remote_transaction(&app.router, &session_id).await;
+        let record = app
+            .server
+            .inner
+            .registry
+            .lock()
+            .await
+            .sessions
+            .get(&session_id)
+            .cloned()
+            .expect("transaction session should remain registered");
+        *record
+            .last_used
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            Instant::now() - Duration::from_mins(2);
+
+        let at_capacity = request(&app.router, "GET", "/lix/v1", None, None).await;
+        assert_eq!(at_capacity.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let rolled_back = remote_transaction_request(
+            &app.router,
+            "POST",
+            "/lix/v1/transaction/rollback",
+            &session_id,
+            &transaction_id,
+            None,
+        )
+        .await;
+        assert_eq!(rolled_back.status(), StatusCode::NO_CONTENT);
+
         let replacement = request(&app.router, "GET", "/lix/v1", None, None).await;
         assert_eq!(replacement.status(), StatusCode::OK);
     }


### PR DESCRIPTION
## Summary

- retain a stable storage snapshot for explicit transactions while preserving read-your-own-writes
- reconcile stale disjoint commits and route overlapping plugin-owned JSON, CSV, Markdown, and text changes through the existing resolver at commit
- back the existing `beginTransaction()` API in remote mode with an internal capability header and replay-safe commit/rollback receipts; no new public API
- replace the branch-based CRDT adapter with same-base transaction workloads and document latest-package baselines

## Semantics

- ordinary concurrent `execute()` calls serialize with zero resolver calls
- disjoint same-base transaction writes compose
- ordinary overlapping inserts fail atomically with their existing UNIQUE error surface
- plugin-owned overlaps are grouped per file, resolved once for the accumulated file batch, committed atomically, and converge across clients
- branch/plugin lifecycle changes outside the safe lane remain conflicts

## Performance

Latest full-cardinality B3.1 run (`1,540` clients, release):

- durable per-commit service p95: **21.847 ms** (passes the `<100 ms` service gate)
- total commit batch window: **18,133.399 ms**

The report keeps both boundaries explicit: this does not yet provide sub-100-ms all-client convergence for 1,540 simultaneous commits.

External packages were upgraded to current npm latest before measurement: Yjs 13.6.31, Ywasm 0.27.3, Loro 1.13.8, Automerge 3.4.0, and Diamond Types 1.0.2.

## Verification

- `cargo test -p lix_engine --features all-simulations`
- `cargo test -p lix_server_protocol`
- local JSON overlap/convergence test
- JSON/CSV/Markdown/text overlap/convergence test
- remote protocol JSON overlap/resolver/convergence test
- ordinary concurrent execute resolver-zero test
- full-cardinality release B3.1 benchmark
- JS SDK TypeScript build and test suite (135 tests)