### PR TITLE
feat(cli): allow full parent-tree git replay

### DIFF
--- a/.changenotes/git-replay-full-parent-tree.md
+++ b/.changenotes/git-replay-full-parent-tree.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Git replay can now seed the complete parent tree for a bounded commit window.
+
+Use `--parent-tree full` when untouched parent files must remain available in current and historical snapshots; the default window-scoped mode remains unchanged.

--- a/packages/cli/src/cli/exp.rs
+++ b/packages/cli/src/cli/exp.rs
@@ -43,6 +43,14 @@ impl GitReplayPlugins {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum GitReplayParentTree {
+    /// Seed only parent-tree paths touched by the selected commit window.
+    Window,
+    /// Seed the complete parent tree before replaying the selected window.
+    Full,
+}
+
 #[derive(Debug, Args)]
 pub struct ExpGitReplayArgs {
     /// Path to the git repository to replay.
@@ -65,10 +73,13 @@ pub struct ExpGitReplayArgs {
     #[arg(long, default_value = "main")]
     pub branch: String,
 
-    /// Start replay from this commit (inclusive). Before timed replay, seed only parent-tree
-    /// paths touched by the selected commit window; untouched parent files are omitted.
+    /// Start replay from this commit (inclusive).
     #[arg(long)]
     pub from_commit: Option<String>,
+
+    /// Parent-tree paths seeded before timed replay.
+    #[arg(long, value_enum, default_value_t = GitReplayParentTree::Window)]
+    pub parent_tree: GitReplayParentTree,
 
     /// Maximum number of commits to replay (after applying --from-commit, if set).
     #[arg(long, value_parser = value_parser!(u32).range(1..))]

--- a/packages/cli/src/commands/exp/git_replay.rs
+++ b/packages/cli/src/commands/exp/git_replay.rs
@@ -1,4 +1,4 @@
-use crate::cli::exp::{ExpGitReplayArgs, GitReplayPlugins, GitReplayStorage};
+use crate::cli::exp::{ExpGitReplayArgs, GitReplayParentTree, GitReplayPlugins, GitReplayStorage};
 use crate::db;
 use crate::error::CliError;
 use lix_rocksdb_storage::RocksDB;
@@ -337,12 +337,22 @@ fn run_with_storage<StorageImpl>(
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
-    let replay_scope = collect_replay_scope(&repo_path, &commits)?;
+    let baseline_seed_parent = commits
+        .first()
+        .and_then(|commit| commit.first_parent.clone());
+    let mut replay_scope = collect_replay_scope(&repo_path, &commits)?;
+    if args.parent_tree == GitReplayParentTree::Full
+        && let Some(parent) = baseline_seed_parent.as_deref()
+    {
+        extend_replay_scope_with_tree(&repo_path, parent, &mut replay_scope)?;
+    }
     let history_scope = if commits
         .first()
         .is_some_and(|commit| commit.first_parent.is_none())
     {
         "complete"
+    } else if args.parent_tree == GitReplayParentTree::Full {
+        "full-parent-window"
     } else {
         "window"
     };
@@ -362,9 +372,6 @@ where
     let plugin_install_ms = duration_to_ms(plugin_install_started.elapsed());
 
     let mut state = ReplayState::default();
-    let baseline_seed_parent = commits
-        .first()
-        .and_then(|commit| commit.first_parent.clone());
     let mut baseline_seed_ms = 0.0;
     let mut baseline_seed_files = 0usize;
     let mut baseline_seed_batches = 0usize;
@@ -817,6 +824,19 @@ fn collect_replay_scope(
     }
     reader.finish()?;
     Ok(scope)
+}
+
+fn extend_replay_scope_with_tree(
+    repo_path: &Path,
+    commit: &str,
+    scope: &mut HashSet<GitPath>,
+) -> Result<(), CliError> {
+    for change in read_tree_snapshot_changes(repo_path, commit)? {
+        if let Some(path) = change.new_path {
+            scope.insert(path);
+        }
+    }
+    Ok(())
 }
 
 fn seed_parent_tree<StorageImpl>(
@@ -2641,6 +2661,7 @@ mod tests {
             plugins: GitReplayPlugins::None,
             branch: "main".to_string(),
             from_commit: None,
+            parent_tree: GitReplayParentTree::Window,
             num_commits: None,
             checkpoint_every: None,
             force: false,
@@ -2743,7 +2764,7 @@ mod tests {
     }
 
     #[test]
-    fn replay_scope_contains_rename_history_but_not_untouched_parent_paths() {
+    fn full_parent_tree_extends_window_scope_with_untouched_paths() {
         let fixture = unique_temp_dir();
         let repo = fixture.join("repo");
         fs::create_dir_all(&repo).expect("fixture repository should be created");
@@ -2767,7 +2788,7 @@ mod tests {
                 .expect("rename commit should resolve");
         let commits = list_linear_commits(&repo, "main", Some(rename_commit.trim()), None)
             .expect("rename window should select");
-        let scope = collect_replay_scope(&repo, &commits).expect("scope should collect");
+        let mut scope = collect_replay_scope(&repo, &commits).expect("scope should collect");
 
         assert_eq!(
             scope,
@@ -2777,6 +2798,13 @@ mod tests {
             ])
         );
         assert!(!scope.contains(&git_path(b"untouched.txt")));
+        let parent = commits[0]
+            .first_parent
+            .as_deref()
+            .expect("rename window should have a parent");
+        extend_replay_scope_with_tree(&repo, parent, &mut scope)
+            .expect("full parent tree should extend scope");
+        assert!(scope.contains(&git_path(b"untouched.txt")));
         fs::remove_dir_all(&fixture).expect("fixture directory should be removable");
     }
 
@@ -2968,6 +2996,7 @@ mod tests {
             plugins: GitReplayPlugins::All,
             branch: "missing-ref".to_string(),
             from_commit: None,
+            parent_tree: GitReplayParentTree::Window,
             num_commits: None,
             checkpoint_every: None,
             force: true,
@@ -3270,6 +3299,7 @@ mod tests {
             plugins: GitReplayPlugins::All,
             branch: "main".to_string(),
             from_commit: None,
+            parent_tree: GitReplayParentTree::Window,
             num_commits: None,
             checkpoint_every: Some(1),
             force: false,
@@ -3385,6 +3415,7 @@ mod tests {
                     plugins,
                     branch: "main".to_string(),
                     from_commit: None,
+                    parent_tree: GitReplayParentTree::Window,
                     num_commits: Some(1),
                     checkpoint_every: None,
                     force: false,
@@ -3486,6 +3517,7 @@ mod tests {
             plugins: GitReplayPlugins::All,
             branch: "main".to_string(),
             from_commit: None,
+            parent_tree: GitReplayParentTree::Window,
             num_commits: Some(100),
             checkpoint_every: None,
             force: false,
@@ -3632,6 +3664,7 @@ mod tests {
             plugins: GitReplayPlugins::All,
             branch: "main".to_string(),
             from_commit: None,
+            parent_tree: GitReplayParentTree::Window,
             num_commits: Some(2),
             checkpoint_every: None,
             force: false,


### PR DESCRIPTION
## Summary
- add `--parent-tree full` to seed the complete parent tree before a bounded Git replay window
- preserve the existing window-scoped behavior as the default
- identify full-parent bounded profiles as `full-parent-window`
- cover untouched parent paths with a focused CLI regression test

This removes API friction found while building an equivalent Git/P4/Lix benchmark: window-scoped replay could not represent the same hydrated baseline tree as Git and P4.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p lix_cli full_parent_tree_extends_window_scope_with_untouched_paths`
- `cargo clippy -p lix_cli --all-targets -- -D warnings`