### PR TITLE
perf(engine): index certified packet identity filters

### DIFF
--- a/.changenotes/index-certified-packet-identity-filters.md
+++ b/.changenotes/index-certified-packet-identity-filters.md
@@ -1,5 +1,5 @@
 ---
-"@lix-js/sdk": patch
+type: patch
 ---
 
 Speed up historical semantic-state queries by indexing requested entity identities instead of rescanning the complete filter for every certified packet row.

--- a/.changenotes/index-certified-packet-identity-filters.md
+++ b/.changenotes/index-certified-packet-identity-filters.md
@@ -1,0 +1,5 @@
+---
+"@lix-js/sdk": patch
+---
+
+Speed up historical semantic-state queries by indexing requested entity identities instead of rescanning the complete filter for every certified packet row.

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -1035,12 +1035,14 @@ async fn scan_certified_entity_batch_rows(
     let mut builder = MaterializedLiveStateBatchBuilder::with_capacity(
         limit.unwrap_or_else(|| decode_inputs.len().saturating_mul(1024)),
     );
+    let selected_packet_entity_pks = packet_entity_pk_index(request);
     for (value, external_pages) in decode_inputs {
         decode_certified_entity_batch_rows(
             &value,
             external_pages.as_deref(),
             branch_id,
             request,
+            selected_packet_entity_pks.as_ref(),
             needs_snapshot,
             decode_limit,
             &mut builder,
@@ -1092,6 +1094,7 @@ pub(crate) async fn scan_certified_history_rows(
         .columns
         .iter()
         .any(|column| column == "snapshot_content");
+    let selected_packet_entity_pks = packet_entity_pk_index(request);
     let mut builder = MaterializedLiveStateBatchBuilder::with_capacity(commit_ids.len() * 1024);
     for commit_id in commit_ids {
         let plan = ScanPlan::prefix(
@@ -1145,6 +1148,7 @@ pub(crate) async fn scan_certified_history_rows(
                     external_pages.as_deref(),
                     "",
                     request,
+                    selected_packet_entity_pks.as_ref(),
                     needs_snapshot,
                     None,
                     &mut builder,
@@ -1176,11 +1180,20 @@ fn certified_batch_commit_id(bytes: &[u8]) -> Result<CommitId, LixError> {
     ))
 }
 
+fn packet_entity_pk_index(request: &TrackedStateScanRequest) -> Option<HashSet<EntityPk>> {
+    // Packet identities are arbitrary component tuples, so they cannot use the
+    // compact local-reference optimization available to certified CSV pages.
+    // Build one request-scoped index and share it across every decoded batch.
+    (!request.filter.entity_pks.is_empty())
+        .then(|| request.filter.entity_pks.iter().cloned().collect())
+}
+
 fn decode_certified_entity_batch_rows(
     bytes: &[u8],
     external_pages: Option<&[(u32, Bytes)]>,
     branch_id: &str,
     request: &TrackedStateScanRequest,
+    selected_packet_entity_pks: Option<&HashSet<EntityPk>>,
     needs_snapshot: bool,
     limit: Option<usize>,
     builder: &mut MaterializedLiveStateBatchBuilder,
@@ -1241,18 +1254,6 @@ fn decode_certified_entity_batch_rows(
                     _ => None,
                 })
                 .collect::<BTreeSet<_>>()
-        });
-    // Packet identities are arbitrary component tuples, so they cannot use the
-    // compact local-reference optimization above. Index the requested keys once
-    // instead of rescanning the entire filter for every decoded packet row.
-    let selected_packet_entity_pks =
-        (format != 1 && !request.filter.entity_pks.is_empty()).then(|| {
-            request
-                .filter
-                .entity_pks
-                .iter()
-                .cloned()
-                .collect::<HashSet<_>>()
         });
     let page_count = input.u32()?;
     if !request.filter.schema_keys.is_empty()
@@ -1323,7 +1324,7 @@ fn decode_certified_entity_batch_rows(
                 branch_id,
                 file_id,
                 request,
-                selected_packet_entity_pks.as_ref(),
+                selected_packet_entity_pks,
                 needs_snapshot,
                 limit,
                 decoded_rows,

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -831,6 +831,7 @@ fn certified_external_page_plan(
     bytes: &[u8],
     content_key: &[u8],
     request: &TrackedStateScanRequest,
+    filter_index: &CertifiedScanFilterIndex,
 ) -> Result<Option<Vec<(u32, StorageKey)>>, LixError> {
     let mut input = CertifiedBatchReader::new(bytes)?;
     if !input.external_pages {
@@ -842,26 +843,10 @@ fn certified_external_page_plan(
         schema_keys.push(input.text()?);
     }
     let file_id = input.text()?;
-    if !request.filter.schema_keys.is_empty()
-        && !request
-            .filter
-            .schema_keys
-            .iter()
-            .any(|candidate| schema_keys.contains(&candidate.as_str()))
-    {
+    if !filter_index.includes_any_schema(&schema_keys) {
         return Ok(Some(Vec::new()));
     }
-    if !request.filter.file_ids.is_empty()
-        && !request
-            .filter
-            .file_ids
-            .iter()
-            .any(|candidate| match candidate {
-                NullableKeyFilter::Any => true,
-                NullableKeyFilter::Null => false,
-                NullableKeyFilter::Value(candidate) => candidate == file_id,
-            })
-    {
+    if !filter_index.includes_file(file_id) {
         return Ok(Some(Vec::new()));
     }
     let _commit_id = input.bytes(16)?;
@@ -996,6 +981,7 @@ async fn scan_certified_entity_batch_rows(
             .columns
             .iter()
             .any(|column| column == "snapshot_content");
+    let filter_index = CertifiedScanFilterIndex::new(request);
     let mut decode_inputs = Vec::with_capacity(content_keys.len());
     let mut page_routes = Vec::new();
     let mut page_keys = Vec::new();
@@ -1004,7 +990,8 @@ async fn scan_certified_entity_batch_rows(
             continue;
         };
         let value = full_value_bytes(value)?;
-        let external_plan = certified_external_page_plan(&value, content_key.0.as_ref(), request)?;
+        let external_plan =
+            certified_external_page_plan(&value, content_key.0.as_ref(), request, &filter_index)?;
         let input_index = decode_inputs.len();
         let external_pages = external_plan
             .as_ref()
@@ -1035,14 +1022,13 @@ async fn scan_certified_entity_batch_rows(
     let mut builder = MaterializedLiveStateBatchBuilder::with_capacity(
         limit.unwrap_or_else(|| decode_inputs.len().saturating_mul(1024)),
     );
-    let selected_packet_entity_pks = packet_entity_pk_index(request);
     for (value, external_pages) in decode_inputs {
         decode_certified_entity_batch_rows(
             &value,
             external_pages.as_deref(),
             branch_id,
             request,
-            selected_packet_entity_pks.as_ref(),
+            &filter_index,
             needs_snapshot,
             decode_limit,
             &mut builder,
@@ -1094,7 +1080,7 @@ pub(crate) async fn scan_certified_history_rows(
         .columns
         .iter()
         .any(|column| column == "snapshot_content");
-    let selected_packet_entity_pks = packet_entity_pk_index(request);
+    let filter_index = CertifiedScanFilterIndex::new(request);
     let mut builder = MaterializedLiveStateBatchBuilder::with_capacity(commit_ids.len() * 1024);
     for commit_id in commit_ids {
         let plan = ScanPlan::prefix(
@@ -1121,8 +1107,12 @@ pub(crate) async fn scan_certified_history_rows(
                 if certified_batch_commit_id(&value)? != *commit_id {
                     continue;
                 }
-                let external_plan =
-                    certified_external_page_plan(&value, entry.key.0.as_ref(), request)?;
+                let external_plan = certified_external_page_plan(
+                    &value,
+                    entry.key.0.as_ref(),
+                    request,
+                    &filter_index,
+                )?;
                 let external_pages = if let Some(plan) = &external_plan {
                     let keys = plan.iter().map(|(_, key)| key.clone()).collect::<Vec<_>>();
                     let values = PointReadPlan::new(CERTIFIED_ENTITY_BATCH_PAGE_SPACE, &keys)
@@ -1148,7 +1138,7 @@ pub(crate) async fn scan_certified_history_rows(
                     external_pages.as_deref(),
                     "",
                     request,
-                    selected_packet_entity_pks.as_ref(),
+                    &filter_index,
                     needs_snapshot,
                     None,
                     &mut builder,
@@ -1180,12 +1170,69 @@ fn certified_batch_commit_id(bytes: &[u8]) -> Result<CommitId, LixError> {
     ))
 }
 
-fn packet_entity_pk_index(request: &TrackedStateScanRequest) -> Option<HashSet<EntityPk>> {
-    // Packet identities are arbitrary component tuples, so they cannot use the
-    // compact local-reference optimization available to certified CSV pages.
-    // Build one request-scoped index and share it across every decoded batch.
-    (!request.filter.entity_pks.is_empty())
-        .then(|| request.filter.entity_pks.iter().cloned().collect())
+struct CertifiedScanFilterIndex {
+    schema_keys: Option<HashSet<String>>,
+    file_ids: Option<HashSet<String>>,
+    entity_pks: Option<HashSet<EntityPk>>,
+}
+
+impl CertifiedScanFilterIndex {
+    fn new(request: &TrackedStateScanRequest) -> Self {
+        let file_ids = if request.filter.file_ids.is_empty()
+            || request
+                .filter
+                .file_ids
+                .iter()
+                .any(|file_id| matches!(file_id, NullableKeyFilter::Any))
+        {
+            None
+        } else {
+            Some(
+                request
+                    .filter
+                    .file_ids
+                    .iter()
+                    .filter_map(|file_id| match file_id {
+                        NullableKeyFilter::Value(file_id) => Some(file_id.clone()),
+                        NullableKeyFilter::Any | NullableKeyFilter::Null => None,
+                    })
+                    .collect(),
+            )
+        };
+        Self {
+            schema_keys: (!request.filter.schema_keys.is_empty())
+                .then(|| request.filter.schema_keys.iter().cloned().collect()),
+            file_ids,
+            entity_pks: (!request.filter.entity_pks.is_empty())
+                .then(|| request.filter.entity_pks.iter().cloned().collect()),
+        }
+    }
+
+    fn includes_any_schema(&self, schema_keys: &[&str]) -> bool {
+        self.schema_keys.as_ref().is_none_or(|selected| {
+            schema_keys
+                .iter()
+                .any(|schema_key| selected.contains(*schema_key))
+        })
+    }
+
+    fn includes_schema(&self, schema_key: &str) -> bool {
+        self.schema_keys
+            .as_ref()
+            .is_none_or(|selected| selected.contains(schema_key))
+    }
+
+    fn includes_file(&self, file_id: &str) -> bool {
+        self.file_ids
+            .as_ref()
+            .is_none_or(|selected| selected.contains(file_id))
+    }
+
+    fn includes_entity(&self, entity_pk: &EntityPk) -> bool {
+        self.entity_pks
+            .as_ref()
+            .is_none_or(|selected| selected.contains(entity_pk))
+    }
 }
 
 fn decode_certified_entity_batch_rows(
@@ -1193,7 +1240,7 @@ fn decode_certified_entity_batch_rows(
     external_pages: Option<&[(u32, Bytes)]>,
     branch_id: &str,
     request: &TrackedStateScanRequest,
-    selected_packet_entity_pks: Option<&HashSet<EntityPk>>,
+    filter_index: &CertifiedScanFilterIndex,
     needs_snapshot: bool,
     limit: Option<usize>,
     builder: &mut MaterializedLiveStateBatchBuilder,
@@ -1256,26 +1303,10 @@ fn decode_certified_entity_batch_rows(
                 .collect::<BTreeSet<_>>()
         });
     let page_count = input.u32()?;
-    if !request.filter.schema_keys.is_empty()
-        && !request
-            .filter
-            .schema_keys
-            .iter()
-            .any(|candidate| schema_keys.contains(&candidate.as_str()))
-    {
+    if !filter_index.includes_any_schema(&schema_keys) {
         return Ok(());
     }
-    if !request.filter.file_ids.is_empty()
-        && !request
-            .filter
-            .file_ids
-            .iter()
-            .any(|candidate| match candidate {
-                NullableKeyFilter::Any => true,
-                NullableKeyFilter::Null => false,
-                NullableKeyFilter::Value(candidate) => candidate == file_id,
-            })
-    {
+    if !filter_index.includes_file(file_id) {
         return Ok(());
     }
 
@@ -1323,8 +1354,7 @@ fn decode_certified_entity_batch_rows(
                 timestamp,
                 branch_id,
                 file_id,
-                request,
-                selected_packet_entity_pks,
+                filter_index,
                 needs_snapshot,
                 limit,
                 decoded_rows,
@@ -1465,8 +1495,7 @@ fn decode_certified_packet_rows(
     timestamp: LixTimestamp,
     branch_id: &str,
     file_id: &str,
-    request: &TrackedStateScanRequest,
-    selected_entity_pks: Option<&HashSet<EntityPk>>,
+    filter_index: &CertifiedScanFilterIndex,
     needs_snapshot: bool,
     limit: Option<usize>,
     base_ordinal: u64,
@@ -1540,13 +1569,8 @@ fn decode_certified_packet_rows(
             ));
         }
         decoded = decoded.saturating_add(1);
-        let selected = (request.filter.schema_keys.is_empty()
-            || request
-                .filter
-                .schema_keys
-                .iter()
-                .any(|candidate| candidate == schema_key))
-            && selected_entity_pks.is_none_or(|selected| selected.contains(&entity_pk));
+        let selected =
+            filter_index.includes_schema(schema_key) && filter_index.includes_entity(&entity_pk);
         if !selected {
             continue;
         }

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -8,7 +8,7 @@
 //! file-first row index.
 
 use std::cmp::Ordering;
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
 use std::ops::Range;
 use std::sync::Arc;
 
@@ -1242,6 +1242,18 @@ fn decode_certified_entity_batch_rows(
                 })
                 .collect::<BTreeSet<_>>()
         });
+    // Packet identities are arbitrary component tuples, so they cannot use the
+    // compact local-reference optimization above. Index the requested keys once
+    // instead of rescanning the entire filter for every decoded packet row.
+    let selected_packet_entity_pks =
+        (format != 1 && !request.filter.entity_pks.is_empty()).then(|| {
+            request
+                .filter
+                .entity_pks
+                .iter()
+                .cloned()
+                .collect::<HashSet<_>>()
+        });
     let page_count = input.u32()?;
     if !request.filter.schema_keys.is_empty()
         && !request
@@ -1311,6 +1323,7 @@ fn decode_certified_entity_batch_rows(
                 branch_id,
                 file_id,
                 request,
+                selected_packet_entity_pks.as_ref(),
                 needs_snapshot,
                 limit,
                 decoded_rows,
@@ -1452,6 +1465,7 @@ fn decode_certified_packet_rows(
     branch_id: &str,
     file_id: &str,
     request: &TrackedStateScanRequest,
+    selected_entity_pks: Option<&HashSet<EntityPk>>,
     needs_snapshot: bool,
     limit: Option<usize>,
     base_ordinal: u64,
@@ -1531,12 +1545,7 @@ fn decode_certified_packet_rows(
                 .schema_keys
                 .iter()
                 .any(|candidate| candidate == schema_key))
-            && (request.filter.entity_pks.is_empty()
-                || request
-                    .filter
-                    .entity_pks
-                    .iter()
-                    .any(|candidate| candidate == &entity_pk));
+            && selected_entity_pks.is_none_or(|selected| selected.contains(&entity_pk));
         if !selected {
             continue;
         }


### PR DESCRIPTION
## Summary

- index requested semantic entity identities once per certified packet batch
- replace the per-row linear filter scan with constant-time membership checks
- document the historical-query performance improvement in the changelog

## Profile and cause

A 10-second `perf` sample while activating a historical Wesnoth branch attributed 87.16% of samples to `EntityPkComponents::eq` and 10.82% to `decode_certified_packet_rows`. The request contained tens of thousands of entity identities, and the decoder linearly rescanned that complete filter for every packet row.

This changes the work from O(packet rows × requested identities) equality checks to O(requested identities) index construction plus O(packet rows) lookups.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p lix_engine --features all-simulations` (1,674 tests across simulations plus doctests)
- `cargo clippy -p lix_engine --all-targets --features all-simulations -- -D warnings` reaches an unrelated pre-existing `dead_code` failure for `StorageWriteSet::apply`; no warning is introduced by this patch

The end-to-end benchmark rerun will be attached after exercising this commit together with the two other isolated benchmark fixes.
