### PR TITLE
perf(engine): bound certified history hydration by commit

### DIFF
--- a/.changenotes/group-certified-hydration-by-commit.md
+++ b/.changenotes/group-certified-hydration-by-commit.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Bound historical semantic payload hydration by querying certified rows one commit at a time instead of materializing cross-commit filter matches together.

--- a/.changenotes/group-certified-hydration-by-commit.md
+++ b/.changenotes/group-certified-hydration-by-commit.md
@@ -2,4 +2,4 @@
 type: patch
 ---
 
-Bound historical semantic payload hydration by querying certified rows one commit at a time instead of materializing cross-commit filter matches together.
+Bound historical semantic payload hydration by querying certified rows one commit and file at a time instead of materializing broad cross-commit matches together.

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -2309,85 +2309,94 @@ async fn hydrate_certified_members(
     if pending.is_empty() {
         return Ok(());
     }
-    let commit_ids = pending
-        .iter()
-        .map(|(_, commit_id, _, _)| *commit_id)
-        .collect::<BTreeSet<_>>();
-    let request = crate::tracked_state::TrackedStateScanRequest {
-        filter: crate::tracked_state::TrackedStateFilter {
-            schema_keys: pending
-                .iter()
-                .map(|(_, _, _, key)| key.schema_key.clone())
-                .collect(),
-            entity_pks: pending
-                .iter()
-                .map(|(_, _, _, key)| key.entity_pk.clone())
-                .collect(),
-            file_ids: pending
-                .iter()
-                .map(|(_, _, _, key)| {
-                    key.file_id.clone().map_or(
-                        crate::NullableKeyFilter::Null,
-                        crate::NullableKeyFilter::Value,
-                    )
-                })
-                .collect(),
-            include_tombstones: true,
-        },
-        read_columns: crate::tracked_state::TrackedStateReadColumns {
-            columns: vec!["snapshot_content".to_owned(), "metadata".to_owned()],
-        },
-        limit: None,
-    };
-    let rows = crate::live_state::scan_certified_history_rows(store, &commit_ids, &request).await?;
-    let mut payloads = BTreeMap::new();
-    for row in rows {
-        let Some(commit_id) = row.commit_id else {
-            continue;
-        };
-        payloads.insert(
-            (commit_id, row.schema_key, row.file_id, row.entity_pk),
-            (
-                row.snapshot_content
-                    .map_or(crate::json_store::JsonSlot::None, |json| {
-                        crate::json_store::JsonSlot::Inline(json.as_str().into())
-                    }),
-                row.metadata
-                    .map_or(crate::json_store::JsonSlot::None, |json| {
-                        crate::json_store::JsonSlot::Inline(json.as_str().into())
-                    }),
-            ),
-        );
+    let mut pending_by_commit = BTreeMap::<CommitId, Vec<usize>>::new();
+    for (pending_index, (_, commit_id, _, _)) in pending.iter().enumerate() {
+        pending_by_commit
+            .entry(*commit_id)
+            .or_default()
+            .push(pending_index);
     }
-    for (index, commit_id, change_id, key) in pending {
-        let lookup = (
-            commit_id,
-            key.schema_key.clone(),
-            key.file_id.clone(),
-            key.entity_pk.clone(),
-        );
-        let Some((snapshot, metadata)) = payloads.remove(&lookup) else {
-            let candidates = payloads
-                .keys()
-                .filter(|(candidate_commit, schema_key, file_id, _)| {
-                    *candidate_commit == commit_id
-                        && schema_key == &key.schema_key
-                        && file_id == &key.file_id
-                })
-                .take(5)
-                .map(|(_, _, _, entity_pk)| format!("{entity_pk:?}"))
-                .collect::<Vec<_>>()
-                .join(", ");
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "tracked_state certified change '{change_id}' has no certified payload at commit '{commit_id}' for schema '{}' file {:?} entity {:?}; candidates: {candidates}",
-                    key.schema_key, key.file_id, key.entity_pk
-                ),
-            ));
+    for (commit_id, pending_indexes) in pending_by_commit {
+        let keys = pending_indexes
+            .iter()
+            .map(|pending_index| &pending[*pending_index].3)
+            .collect::<Vec<_>>();
+        let request = crate::tracked_state::TrackedStateScanRequest {
+            filter: crate::tracked_state::TrackedStateFilter {
+                schema_keys: keys.iter().map(|key| key.schema_key.clone()).collect(),
+                entity_pks: keys.iter().map(|key| key.entity_pk.clone()).collect(),
+                file_ids: keys
+                    .iter()
+                    .map(|key| {
+                        key.file_id.clone().map_or(
+                            crate::NullableKeyFilter::Null,
+                            crate::NullableKeyFilter::Value,
+                        )
+                    })
+                    .collect(),
+                include_tombstones: true,
+            },
+            read_columns: crate::tracked_state::TrackedStateReadColumns {
+                columns: vec!["snapshot_content".to_owned(), "metadata".to_owned()],
+            },
+            limit: None,
         };
-        members[index].change.snapshot = snapshot;
-        members[index].change.metadata = metadata;
+        let rows = crate::live_state::scan_certified_history_rows(
+            store,
+            &BTreeSet::from([commit_id]),
+            &request,
+        )
+        .await?;
+        let mut payloads = BTreeMap::new();
+        for row in rows {
+            let Some(row_commit_id) = row.commit_id else {
+                continue;
+            };
+            payloads.insert(
+                (row_commit_id, row.schema_key, row.file_id, row.entity_pk),
+                (
+                    row.snapshot_content
+                        .map_or(crate::json_store::JsonSlot::None, |json| {
+                            crate::json_store::JsonSlot::Inline(json.as_str().into())
+                        }),
+                    row.metadata
+                        .map_or(crate::json_store::JsonSlot::None, |json| {
+                            crate::json_store::JsonSlot::Inline(json.as_str().into())
+                        }),
+                ),
+            );
+        }
+        for pending_index in pending_indexes {
+            let (member_index, _, change_id, key) = &pending[pending_index];
+            let lookup = (
+                commit_id,
+                key.schema_key.clone(),
+                key.file_id.clone(),
+                key.entity_pk.clone(),
+            );
+            let Some((snapshot, metadata)) = payloads.remove(&lookup) else {
+                let candidates = payloads
+                    .keys()
+                    .filter(|(candidate_commit, schema_key, file_id, _)| {
+                        *candidate_commit == commit_id
+                            && schema_key == &key.schema_key
+                            && file_id == &key.file_id
+                    })
+                    .take(5)
+                    .map(|(_, _, _, entity_pk)| format!("{entity_pk:?}"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "tracked_state certified change '{change_id}' has no certified payload at commit '{commit_id}' for schema '{}' file {:?} entity {:?}; candidates: {candidates}",
+                        key.schema_key, key.file_id, key.entity_pk
+                    ),
+                ));
+            };
+            members[*member_index].change.snapshot = snapshot;
+            members[*member_index].change.metadata = metadata;
+        }
     }
     Ok(())
 }

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -2309,14 +2309,14 @@ async fn hydrate_certified_members(
     if pending.is_empty() {
         return Ok(());
     }
-    let mut pending_by_commit = BTreeMap::<CommitId, Vec<usize>>::new();
-    for (pending_index, (_, commit_id, _, _)) in pending.iter().enumerate() {
-        pending_by_commit
-            .entry(*commit_id)
+    let mut pending_by_commit_file = BTreeMap::<(CommitId, Option<String>), Vec<usize>>::new();
+    for (pending_index, (_, commit_id, _, key)) in pending.iter().enumerate() {
+        pending_by_commit_file
+            .entry((*commit_id, key.file_id.clone()))
             .or_default()
             .push(pending_index);
     }
-    for (commit_id, pending_indexes) in pending_by_commit {
+    for ((commit_id, file_id), pending_indexes) in pending_by_commit_file {
         let keys = pending_indexes
             .iter()
             .map(|pending_index| &pending[*pending_index].3)
@@ -2325,15 +2325,10 @@ async fn hydrate_certified_members(
             filter: crate::tracked_state::TrackedStateFilter {
                 schema_keys: keys.iter().map(|key| key.schema_key.clone()).collect(),
                 entity_pks: keys.iter().map(|key| key.entity_pk.clone()).collect(),
-                file_ids: keys
-                    .iter()
-                    .map(|key| {
-                        key.file_id.clone().map_or(
-                            crate::NullableKeyFilter::Null,
-                            crate::NullableKeyFilter::Value,
-                        )
-                    })
-                    .collect(),
+                file_ids: vec![file_id.map_or(
+                    crate::NullableKeyFilter::Null,
+                    crate::NullableKeyFilter::Value,
+                )],
                 include_tombstones: true,
             },
             read_columns: crate::tracked_state::TrackedStateReadColumns {


### PR DESCRIPTION
## Summary

- group pending certified payload references by their owning commit
- scan and consume one commit's certified rows at a time
- avoid materializing union-filter matches from every requested commit simultaneously

## Why

Historical branch activation can request certified semantic payloads spanning many commits. The previous code formed one union of every schema, entity, and file key and scanned all commit batches into one `rows` vector before selecting exact `(commit, schema, file, entity)` payloads. On the 28,873-file Wesnoth benchmark this all-plugin path reproducibly reached about 18.9 GB RSS and exited 137, while no-plugin history succeeded.

Grouping by commit preserves the exact lookup and error behavior while bounding both the scan request and temporary payload map to one commit.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p lix_engine --features all-simulations` (1,674 tests across simulations plus doctests)

An end-to-end historical Wesnoth profile against the isolated integration build will be added after CI/build validation.
