### PR TITLE
perf(engine): cache transaction serving metadata

### DIFF
--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -12,7 +12,7 @@ use crate::filesystem::{
     FilesystemPathIndex, FilesystemPathIndexCache, FilesystemPathIndexReader,
     FilesystemPathIndexRequest, build_path_index, load_path_index_revision,
 };
-use crate::live_state::tracked_head::TrackedHeadContext;
+use crate::live_state::tracked_head::{HotStateTransactionCache, TrackedHeadContext};
 use crate::live_state::{
     LiveStateExactBatchRequest, LiveStateReader, LiveStateRowFilter, LiveStateRowRequest,
     LiveStateScanRequest, MaterializedLiveStateBatch, MaterializedLiveStateBatchBuilder,
@@ -45,6 +45,7 @@ type BranchHeads = std::collections::BTreeMap<String, BranchHeadControl>;
 #[derive(Default)]
 pub(crate) struct BranchHeadControlCache {
     controls: StdMutex<std::collections::BTreeMap<String, Option<BranchHeadControl>>>,
+    hot_state: std::sync::Arc<HotStateTransactionCache>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -545,9 +546,14 @@ where
             return Ok(Some(MaterializedLiveStateBatch::default()));
         }
         let tracked_request = tracked_scan_request_from_live(request);
-        let rows_by_branch = self
-            .tracked_head
-            .reader(&self.store)
+        let tracked_head = self.branch_head_control_cache.as_ref().map_or_else(
+            || self.tracked_head.reader(&self.store),
+            |cache| {
+                self.tracked_head
+                    .transaction_reader(&self.store, std::sync::Arc::clone(&cache.hot_state))
+            },
+        );
+        let rows_by_branch = tracked_head
             .scan_live_batches_for_controls(&controls, &tracked_request)
             .await?;
         let rows = concat_live_state_batches(

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -27,11 +27,25 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures_util::{StreamExt, TryStreamExt, stream};
 use std::mem::size_of;
+use std::sync::Mutex as StdMutex;
 
 const BRANCH_READ_CONCURRENCY: usize = 8;
 const ENTITY_POINT_SNAPSHOT_CACHE_MAX_BYTES: usize = 8 * 1024 * 1024;
 const ENTITY_POINT_SNAPSHOT_CACHE_MAX_ENTRIES: usize = 4_096;
+const TRANSACTION_BRANCH_HEAD_CONTROL_CACHE_MAX_ENTRIES: usize = 64;
 type BranchHeads = std::collections::BTreeMap<String, BranchHeadControl>;
+
+/// Transaction-local branch publication controls.
+///
+/// A transaction is fenced by the tracked mutation revision observed when it
+/// opens, so repeatedly loading the same immutable generation selector only
+/// adds storage round trips. Missing controls are cached as well: branch
+/// creation rotates that revision and therefore conflicts with the pinned
+/// transaction before commit.
+#[derive(Default)]
+pub(crate) struct BranchHeadControlCache {
+    controls: StdMutex<std::collections::BTreeMap<String, Option<BranchHeadControl>>>,
+}
 
 #[derive(Debug, PartialEq, Eq)]
 struct EntityPointSnapshotCacheKey {
@@ -165,6 +179,28 @@ impl LiveStateContext {
             filesystem_path_index_cache: std::sync::Arc::clone(&self.filesystem_path_index_cache),
             entity_field_index_cache: std::sync::Arc::clone(&self.entity_field_index_cache),
             entity_point_snapshot_cache: std::sync::Arc::clone(&self.entity_point_snapshot_cache),
+            branch_head_control_cache: None,
+        }
+    }
+
+    /// Creates a reader whose branch generation selectors are pinned to one
+    /// transaction-local cache.
+    pub(crate) fn transaction_reader<S>(
+        &self,
+        store: S,
+        branch_head_control_cache: std::sync::Arc<BranchHeadControlCache>,
+    ) -> LiveStateStoreReader<S>
+    where
+        S: StorageAdapterRead,
+    {
+        LiveStateStoreReader {
+            store,
+            tracked_head: self.tracked_head,
+            commit_graph: self.commit_graph.clone(),
+            filesystem_path_index_cache: std::sync::Arc::clone(&self.filesystem_path_index_cache),
+            entity_field_index_cache: std::sync::Arc::clone(&self.entity_field_index_cache),
+            entity_point_snapshot_cache: std::sync::Arc::clone(&self.entity_point_snapshot_cache),
+            branch_head_control_cache: Some(branch_head_control_cache),
         }
     }
 
@@ -187,6 +223,7 @@ pub(crate) struct LiveStateStoreReader<S> {
     filesystem_path_index_cache: std::sync::Arc<FilesystemPathIndexCache>,
     entity_field_index_cache: std::sync::Arc<EntitySnapshotFieldIndexCache>,
     entity_point_snapshot_cache: std::sync::Arc<EntityPointSnapshotCache>,
+    branch_head_control_cache: Option<std::sync::Arc<BranchHeadControlCache>>,
 }
 
 impl<S> LiveStateStoreReader<S>
@@ -317,7 +354,13 @@ where
         let [schema_key] = request.filter.schema_keys.as_slice() else {
             return Ok(None);
         };
-        let scope = scan_scope(&self.store, request, true).await?;
+        let scope = scan_scope(
+            &self.store,
+            request,
+            true,
+            self.branch_head_control_cache.as_deref(),
+        )
+        .await?;
         let [requested_branch_id] = scope.projection_branch_ids.as_slice() else {
             return Ok(None);
         };
@@ -361,7 +404,13 @@ where
     ) -> Result<MaterializedLiveStateBatch, LixError> {
         let store = &self.store;
         let reads_tracked = !is_commit_derived_only_request(request);
-        let scope = scan_scope(store, request, reads_tracked).await?;
+        let scope = scan_scope(
+            store,
+            request,
+            reads_tracked,
+            self.branch_head_control_cache.as_deref(),
+        )
+        .await?;
         if skip_proven_empty_schema && !scope_may_have_schema_rows(request, &scope) {
             return Ok(MaterializedLiveStateBatch::default());
         }
@@ -478,9 +527,23 @@ where
                     .map(|control| (branch_id.clone(), control))
             })
             .collect::<Option<Vec<_>>>();
-        let Some(controls) = controls else {
+        let Some(mut controls) = controls else {
             return Ok(None);
         };
+        // Branch-head schema membership is an atomic, no-false-negative
+        // publication filter. Apply it per generation before a finite PK
+        // lookup so an absent global schema does not pay the complete hot,
+        // packed, and certified point-read stack for every active-branch row.
+        controls.retain(|(_, control)| {
+            request
+                .filter
+                .schema_keys
+                .iter()
+                .any(|schema_key| control.may_have_schema(schema_key))
+        });
+        if controls.is_empty() {
+            return Ok(Some(MaterializedLiveStateBatch::default()));
+        }
         let tracked_request = tracked_scan_request_from_live(request);
         let rows_by_branch = self
             .tracked_head
@@ -581,7 +644,13 @@ where
         // controls that select the active generation; treating that request
         // as "not tracked" used to skip the controls entirely and made the
         // workspace selector (an untracked row) invisible after hot-index init.
-        let scope = scan_scope(&self.store, &scope_request, true).await?;
+        let scope = scan_scope(
+            &self.store,
+            &scope_request,
+            true,
+            self.branch_head_control_cache.as_deref(),
+        )
+        .await?;
         let visible_branch_ids = scope
             .projection_branch_ids
             .iter()
@@ -739,7 +808,13 @@ where
     ) -> Result<MaterializedLiveStateBatch, LixError> {
         let store = &self.store;
         let reads_tracked = !is_commit_derived_only_request(request);
-        let scope = scan_scope(store, request, reads_tracked).await?;
+        let scope = scan_scope(
+            store,
+            request,
+            reads_tracked,
+            self.branch_head_control_cache.as_deref(),
+        )
+        .await?;
         if skip_proven_empty_schema && !scope_may_have_schema_rows(request, &scope) {
             return Ok(MaterializedLiveStateBatch::default());
         }
@@ -862,7 +937,12 @@ where
         branch_id: &str,
         scope: crate::collection_generation::CollectionScopeRef<'_>,
     ) -> Result<Option<crate::collection_generation::CollectionGeneration>, LixError> {
-        let controls = load_branch_head_controls(&self.store, &[branch_id.to_owned()]).await?;
+        let controls = load_branch_head_controls(
+            &self.store,
+            &[branch_id.to_owned()],
+            self.branch_head_control_cache.as_deref(),
+        )
+        .await?;
         let Some(control) = controls.get(branch_id).copied() else {
             return Ok(None);
         };
@@ -1305,10 +1385,11 @@ async fn scan_scope(
     store: &(impl StorageAdapterRead + ?Sized),
     request: &LiveStateScanRequest,
     resolve_branch_heads: bool,
+    branch_head_control_cache: Option<&BranchHeadControlCache>,
 ) -> Result<LiveStateScanScope, LixError> {
     if request.filter.branch_ids.is_empty() {
         if resolve_branch_heads {
-            let branch_heads = load_branch_head_controls(store, &[]).await?;
+            let branch_heads = load_branch_head_controls(store, &[], None).await?;
             return Ok(LiveStateScanScope {
                 storage_branch_ids: branch_heads.keys().cloned().collect(),
                 projection_branch_ids: Vec::new(),
@@ -1324,7 +1405,9 @@ async fn scan_scope(
 
     if resolve_branch_heads {
         let candidate_branch_ids = expanded_branch_ids(&request.filter.branch_ids);
-        let branch_heads = load_branch_head_controls(store, &candidate_branch_ids).await?;
+        let branch_heads =
+            load_branch_head_controls(store, &candidate_branch_ids, branch_head_control_cache)
+                .await?;
         let projection_branch_ids = request
             .filter
             .branch_ids
@@ -1366,17 +1449,66 @@ async fn scan_scope(
 async fn load_branch_head_controls(
     store: &(impl StorageAdapterRead + ?Sized),
     branch_ids: &[String],
+    cache: Option<&BranchHeadControlCache>,
 ) -> Result<BranchHeads, LixError> {
     let reader = BranchHeadControlContext::new().reader(store);
     if branch_ids.is_empty() {
         return Ok(reader.scan().await?.into_iter().collect());
     }
-    let controls = reader.load_many(branch_ids).await?;
+    let Some(cache) = cache else {
+        let controls = reader.load_many(branch_ids).await?;
+        return Ok(branch_ids
+            .iter()
+            .cloned()
+            .zip(controls)
+            .filter_map(|(branch_id, control)| control.map(|control| (branch_id, control)))
+            .collect());
+    };
+    let missing = {
+        let controls = cache.controls.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "transaction branch-head control cache lock is poisoned",
+            )
+        })?;
+        branch_ids
+            .iter()
+            .filter(|branch_id| !controls.contains_key(*branch_id))
+            .cloned()
+            .collect::<Vec<_>>()
+    };
+    let mut loaded_by_branch = std::collections::BTreeMap::new();
+    if !missing.is_empty() {
+        let loaded = reader.load_many(&missing).await?;
+        let mut controls = cache.controls.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "transaction branch-head control cache lock is poisoned",
+            )
+        })?;
+        for (branch_id, control) in missing.into_iter().zip(loaded) {
+            if controls.len() < TRANSACTION_BRANCH_HEAD_CONTROL_CACHE_MAX_ENTRIES {
+                controls.entry(branch_id.clone()).or_insert(control);
+            }
+            loaded_by_branch.insert(branch_id, control);
+        }
+    }
+    let controls = cache.controls.lock().map_err(|_| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "transaction branch-head control cache lock is poisoned",
+        )
+    })?;
     Ok(branch_ids
         .iter()
-        .cloned()
-        .zip(controls)
-        .filter_map(|(branch_id, control)| control.map(|control| (branch_id, control)))
+        .filter_map(|branch_id| {
+            controls
+                .get(branch_id)
+                .copied()
+                .or_else(|| loaded_by_branch.get(branch_id).copied())
+                .flatten()
+                .map(|control| (branch_id.clone(), control))
+        })
         .collect())
 }
 
@@ -1585,11 +1717,97 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("open direct hot-state scan read");
-        let scope = scan_scope(&read, request, true).await?;
+        let scope = scan_scope(&read, request, true, None).await?;
         live_state
             .reader(read)
             .scan_direct_entity_pk_rows(request, &scope)
             .await
+    }
+
+    #[tokio::test]
+    async fn transaction_branch_head_control_cache_pins_loaded_generation() {
+        let storage = StorageAdapter::new(Memory::new());
+        let branch_id = "ffffffff-ffff-7fff-bfff-ffffffffffff";
+        let entity_pk = EntityPk::single("cached-control-row");
+        stage_direct_entity_head(
+            &storage,
+            branch_id,
+            CommitId::for_test_label("cached-control-head"),
+            "schema",
+            &entity_pk,
+            r#"{"value":"one"}"#,
+        )
+        .await;
+
+        let cache = BranchHeadControlCache::default();
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open first branch-control read");
+        let first = load_branch_head_controls(&read, &[branch_id.to_string()], Some(&cache))
+            .await
+            .expect("first branch control should load")[branch_id];
+        drop(read);
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open branch-control update read");
+        let mut current = BranchHeadControlContext::new()
+            .reader(&read)
+            .load(branch_id)
+            .await
+            .expect("branch control should load")
+            .expect("branch control should exist");
+        current.current_state_revision += 1;
+        let mut writes = StorageWriteSet::new();
+        crate::branch::stage_branch_head_control(&mut writes, branch_id, current)
+            .expect("updated branch control should stage");
+        drop(read);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("updated branch control should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open repeated branch-control read");
+        let pinned = load_branch_head_controls(&read, &[branch_id.to_string()], Some(&cache))
+            .await
+            .expect("cached branch control should load")[branch_id];
+        let uncached = load_branch_head_controls(&read, &[branch_id.to_string()], None)
+            .await
+            .expect("uncached branch control should load")[branch_id];
+        assert_eq!(pinned, first);
+        assert_eq!(uncached, current);
+        assert_ne!(
+            pinned.current_state_revision,
+            uncached.current_state_revision
+        );
+
+        let full_cache = BranchHeadControlCache::default();
+        {
+            let mut controls = full_cache
+                .controls
+                .lock()
+                .expect("branch-control cache lock should not be poisoned");
+            for index in 0..TRANSACTION_BRANCH_HEAD_CONTROL_CACHE_MAX_ENTRIES {
+                controls.insert(format!("uncached-branch-{index}"), None);
+            }
+        }
+        let overflow =
+            load_branch_head_controls(&read, &[branch_id.to_string()], Some(&full_cache))
+                .await
+                .expect("control beyond the cache capacity should still load")[branch_id];
+        assert_eq!(overflow, current);
+        assert!(
+            !full_cache
+                .controls
+                .lock()
+                .expect("branch-control cache lock should not be poisoned")
+                .contains_key(branch_id)
+        );
     }
 
     async fn scan_rows_for_test(

--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -6,7 +6,7 @@ mod types;
 pub(crate) mod visibility;
 
 #[allow(unused_imports)]
-pub(crate) use context::{LiveStateContext, LiveStateStoreReader};
+pub(crate) use context::{BranchHeadControlCache, LiveStateContext, LiveStateStoreReader};
 pub(crate) use entity_field_index::EntitySnapshotFieldIndexCache;
 #[allow(unused_imports)]
 pub(crate) use reader::LiveStateReader;

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -13,13 +13,12 @@ pub(crate) use hot::{
     CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE, CERTIFIED_ENTITY_BATCH_PAGE_SPACE,
     CERTIFIED_ENTITY_BATCH_SPACE, CertifiedEntityBatchFileRef, DeferredFreshHotPlan,
     DeferredFreshHotRowRef, DeferredFreshHotRows, HOT_DIFF_SPACE, HOT_FILE_SPACE, HOT_ROW_SPACE,
-    HotTrackedSnapshot, PACKED_CURRENT_BASE_CONTROL_SPACE, PACKED_CURRENT_BASE_SPACE,
-    PACKED_CURRENT_EXCLUSIVE_SCHEMA_BASE_SPACE, scan_certified_history_rows,
-    stage_certified_entity_batches,
+    HotStateTransactionCache, HotTrackedSnapshot, PACKED_CURRENT_BASE_CONTROL_SPACE,
+    PACKED_CURRENT_BASE_SPACE, PACKED_CURRENT_EXCLUSIVE_SCHEMA_BASE_SPACE,
+    scan_certified_history_rows, stage_certified_entity_batches,
 };
 
 use std::collections::{BTreeMap, BTreeSet};
-#[cfg(test)]
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -411,7 +410,25 @@ impl TrackedHeadContext {
     where
         S: StorageAdapterRead,
     {
-        hot::HotStateStoreReader { store }
+        hot::HotStateStoreReader {
+            store,
+            transaction_cache: None,
+        }
+    }
+
+    #[expect(clippy::unused_self)]
+    pub(crate) fn transaction_reader<S>(
+        &self,
+        store: S,
+        cache: Arc<HotStateTransactionCache>,
+    ) -> hot::HotStateStoreReader<S>
+    where
+        S: StorageAdapterRead,
+    {
+        hot::HotStateStoreReader {
+            store,
+            transaction_cache: Some(cache),
+        }
     }
 
     #[expect(clippy::unused_self)]

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -11,6 +11,7 @@ use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::ops::Range;
 use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
 
 use crate::wasm::WasmCreateContext;
 use base64::Engine as _;
@@ -942,6 +943,7 @@ async fn scan_certified_entity_batch_rows(
     generation: CommitId,
     request: &TrackedStateScanRequest,
     limit: Option<usize>,
+    transaction_cache: Option<&HotStateTransactionCache>,
 ) -> Result<MaterializedLiveStateBatch, LixError> {
     if matches!(limit, Some(0)) {
         return Ok(MaterializedLiveStateBatch::default());
@@ -963,8 +965,14 @@ async fn scan_certified_entity_batch_rows(
             })
             .collect::<BTreeSet<_>>()
     });
+    if exact_file_ids.is_none()
+        && let Some(cache) = transaction_cache
+        && cache.certified_generation_absent(generation)?
+    {
+        return Ok(MaterializedLiveStateBatch::default());
+    }
     let mut manifest_entries = Vec::new();
-    if let Some(file_ids) = exact_file_ids {
+    if let Some(file_ids) = exact_file_ids.as_ref() {
         for file_id in file_ids {
             let mut prefix = generation.as_uuid().as_bytes().to_vec();
             append_batch_text(&mut prefix, file_id)?;
@@ -988,6 +996,12 @@ async fn scan_certified_entity_batch_rows(
         .collect(store, StorageScanOptions::default())
         .await?;
         manifest_entries = manifests.value.entries;
+    }
+    if exact_file_ids.is_none() && manifest_entries.is_empty() {
+        if let Some(cache) = transaction_cache {
+            cache.remember_certified_generation_absent(generation)?;
+        }
+        return Ok(MaterializedLiveStateBatch::default());
     }
     let content_keys = manifest_entries
         .into_iter()
@@ -1834,6 +1848,78 @@ struct HotCollectionControl {
     active_generation: CommitId,
     live_count: u64,
     ordered_identity_digest: Option<[u8; 32]>,
+}
+
+const TRANSACTION_HOT_STATE_CACHE_MAX_ENTRIES: usize = 64;
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct HotCollectionCacheKey {
+    branch_id: String,
+    generation: CommitId,
+    schema_key: String,
+    file_id: Option<String>,
+}
+
+/// Bounded serving metadata retained for one transaction snapshot.
+#[derive(Default)]
+pub(crate) struct HotStateTransactionCache {
+    collection_controls: StdMutex<BTreeMap<HotCollectionCacheKey, HotCollectionControl>>,
+    certified_absent_generations: StdMutex<BTreeSet<CommitId>>,
+}
+
+impl HotStateTransactionCache {
+    fn collection_control(
+        &self,
+        key: &HotCollectionCacheKey,
+    ) -> Result<Option<HotCollectionControl>, LixError> {
+        Ok(self
+            .collection_controls
+            .lock()
+            .map_err(|_| hot_state_cache_lock_error())?
+            .get(key)
+            .copied())
+    }
+
+    fn remember_collection_control(
+        &self,
+        key: HotCollectionCacheKey,
+        control: HotCollectionControl,
+    ) -> Result<(), LixError> {
+        let mut entries = self
+            .collection_controls
+            .lock()
+            .map_err(|_| hot_state_cache_lock_error())?;
+        if entries.len() < TRANSACTION_HOT_STATE_CACHE_MAX_ENTRIES {
+            entries.entry(key).or_insert(control);
+        }
+        Ok(())
+    }
+
+    fn certified_generation_absent(&self, generation: CommitId) -> Result<bool, LixError> {
+        Ok(self
+            .certified_absent_generations
+            .lock()
+            .map_err(|_| hot_state_cache_lock_error())?
+            .contains(&generation))
+    }
+
+    fn remember_certified_generation_absent(&self, generation: CommitId) -> Result<(), LixError> {
+        let mut entries = self
+            .certified_absent_generations
+            .lock()
+            .map_err(|_| hot_state_cache_lock_error())?;
+        if entries.len() < TRANSACTION_HOT_STATE_CACHE_MAX_ENTRIES {
+            entries.insert(generation);
+        }
+        Ok(())
+    }
+}
+
+fn hot_state_cache_lock_error() -> LixError {
+    LixError::new(
+        LixError::CODE_INTERNAL_ERROR,
+        "transaction hot-state metadata cache lock is poisoned",
+    )
 }
 
 struct PackedCollectionIncrement {
@@ -3104,19 +3190,45 @@ fn merge_ordered_live_batches(
 /// Direct reader for one published hot generation.
 pub(crate) struct HotStateStoreReader<S> {
     pub(super) store: S,
+    pub(super) transaction_cache: Option<Arc<HotStateTransactionCache>>,
 }
 
 impl<S> HotStateStoreReader<S>
 where
     S: StorageAdapterRead,
 {
+    async fn collection_control(
+        &self,
+        branch_id: &str,
+        generation: CommitId,
+        scope: crate::collection_generation::CollectionScopeRef<'_>,
+    ) -> Result<HotCollectionControl, LixError> {
+        let key = HotCollectionCacheKey {
+            branch_id: branch_id.to_owned(),
+            generation,
+            schema_key: scope.schema_key.to_owned(),
+            file_id: scope.file_id.map(str::to_owned),
+        };
+        if let Some(cache) = self.transaction_cache.as_deref()
+            && let Some(control) = cache.collection_control(&key)?
+        {
+            return Ok(control);
+        }
+        let control =
+            load_hot_collection_control(&self.store, branch_id, generation, scope).await?;
+        if let Some(cache) = self.transaction_cache.as_deref() {
+            cache.remember_collection_control(key, control)?;
+        }
+        Ok(control)
+    }
+
     pub(crate) async fn collection_generation(
         &self,
         branch_id: &str,
         branch_generation: CommitId,
         scope: crate::collection_generation::CollectionScopeRef<'_>,
     ) -> Result<crate::collection_generation::CollectionGeneration, LixError> {
-        load_hot_collection_control(&self.store, branch_id, branch_generation, scope)
+        self.collection_control(branch_id, branch_generation, scope)
             .await
             .map(
                 |control| crate::collection_generation::CollectionGeneration {
@@ -3217,6 +3329,7 @@ where
                 limit: Some(1),
             },
             Some(1),
+            self.transaction_cache.as_deref(),
         )
         .await?;
         Ok(!certified.is_empty())
@@ -3281,8 +3394,7 @@ where
                 if schema_key != crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY =>
             {
                 Some(
-                    load_hot_collection_control(
-                        &self.store,
+                    self.collection_control(
                         branch_id,
                         generation,
                         crate::collection_generation::CollectionScopeRef {
@@ -3443,6 +3555,7 @@ where
                 } else {
                     None
                 },
+                self.transaction_cache.as_deref(),
             )
             .await?
             .filter(
@@ -3728,6 +3841,7 @@ where
                 generation,
                 &certified_request,
                 None,
+                self.transaction_cache.as_deref(),
             )
             .await?
         };
@@ -8750,9 +8864,147 @@ mod tests {
         StorageWriteOptions,
     };
 
+    #[test]
+    fn transaction_hot_state_cache_is_bounded_per_metadata_lane() {
+        let cache = HotStateTransactionCache::default();
+        for index in 0..=TRANSACTION_HOT_STATE_CACHE_MAX_ENTRIES {
+            let generation = CommitId::for_test_label(&format!("cache-generation-{index}"));
+            cache
+                .remember_collection_control(
+                    HotCollectionCacheKey {
+                        branch_id: "cache-branch".to_owned(),
+                        generation,
+                        schema_key: format!("schema-{index}"),
+                        file_id: None,
+                    },
+                    HotCollectionControl {
+                        active_generation: generation,
+                        live_count: index as u64,
+                        ordered_identity_digest: None,
+                    },
+                )
+                .expect("remember collection control");
+            cache
+                .remember_certified_generation_absent(generation)
+                .expect("remember absent certified generation");
+        }
+        assert_eq!(
+            cache.collection_controls.lock().unwrap().len(),
+            TRANSACTION_HOT_STATE_CACHE_MAX_ENTRIES
+        );
+        assert_eq!(
+            cache.certified_absent_generations.lock().unwrap().len(),
+            TRANSACTION_HOT_STATE_CACHE_MAX_ENTRIES
+        );
+    }
+
+    #[tokio::test]
+    async fn transaction_reader_reuses_collection_control_point_read() {
+        const BRANCH_ID: &str = "collection-control-cache-branch";
+        const SCHEMA_KEY: &str = "collection_control_cache_schema";
+        let storage = StorageAdapter::new(Memory::new());
+        let generation = CommitId::for_test_label("collection-control-cache-generation");
+        let mut writes = StorageWriteSet::new();
+        stage_hot_collection_control(
+            &mut writes,
+            BRANCH_ID,
+            generation,
+            crate::collection_generation::CollectionScopeRef {
+                schema_key: SCHEMA_KEY,
+                file_id: None,
+            },
+            HotCollectionControl {
+                active_generation: generation,
+                live_count: 7,
+                ordered_identity_digest: Some([3; 32]),
+            },
+        )
+        .expect("stage collection control fixture");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("publish collection control fixture");
+
+        let get_many_calls = Arc::new(AtomicUsize::new(0));
+        let reader = HotStateStoreReader {
+            store: CountingRead {
+                inner: storage
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .expect("open collection control fixture read"),
+                get_many_calls: Arc::clone(&get_many_calls),
+                scan_calls: None,
+            },
+            transaction_cache: Some(Arc::new(HotStateTransactionCache::default())),
+        };
+        for _ in 0..2 {
+            let control = reader
+                .collection_generation(
+                    BRANCH_ID,
+                    generation,
+                    crate::collection_generation::CollectionScopeRef {
+                        schema_key: SCHEMA_KEY,
+                        file_id: None,
+                    },
+                )
+                .await
+                .expect("load cached collection control");
+            assert_eq!(control.live_count, 7);
+            assert_eq!(control.ordered_identity_digest, Some([3; 32]));
+        }
+        assert_eq!(
+            get_many_calls.load(Ordering::Relaxed),
+            1,
+            "the immutable transaction snapshot should point-read a control once"
+        );
+    }
+
+    #[tokio::test]
+    async fn transaction_cache_reuses_absent_certified_manifest_scan() {
+        const BRANCH_ID: &str = "absent-certified-cache-branch";
+        let storage = StorageAdapter::new(Memory::new());
+        let generation = CommitId::for_test_label("absent-certified-cache-generation");
+        let scan_calls = Arc::new(AtomicUsize::new(0));
+        let read = CountingRead {
+            inner: storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("open absent certified fixture read"),
+            get_many_calls: Arc::new(AtomicUsize::new(0)),
+            scan_calls: Some(Arc::clone(&scan_calls)),
+        };
+        let cache = HotStateTransactionCache::default();
+        let request = TrackedStateScanRequest {
+            filter: TrackedStateFilter {
+                schema_keys: vec!["plugin_row".to_owned()],
+                ..TrackedStateFilter::default()
+            },
+            ..TrackedStateScanRequest::default()
+        };
+        for _ in 0..2 {
+            let rows = scan_certified_entity_batch_rows(
+                &read,
+                BRANCH_ID,
+                generation,
+                &request,
+                None,
+                Some(&cache),
+            )
+            .await
+            .expect("scan absent certified generation");
+            assert!(rows.is_empty());
+        }
+        assert_eq!(
+            scan_calls.load(Ordering::Relaxed),
+            1,
+            "an immutable generation without manifests should be scanned once"
+        );
+    }
+
     struct CountingRead<R> {
         inner: R,
         get_many_calls: Arc<AtomicUsize>,
+        scan_calls: Option<Arc<AtomicUsize>>,
     }
 
     impl<R: StorageAdapterRead> StorageAdapterRead for CountingRead<R> {
@@ -8774,6 +9026,9 @@ mod tests {
             range: StorageKeyRange,
             opts: StorageScanOptions,
         ) -> Result<StorageScanChunk, crate::storage_adapter::StorageError> {
+            if let Some(scan_calls) = &self.scan_calls {
+                scan_calls.fetch_add(1, Ordering::Relaxed);
+            }
             self.inner.scan(space, range, opts).await
         }
     }
@@ -8945,7 +9200,10 @@ mod tests {
             "mutation predecessor lookup must not read large JSON payloads"
         );
 
-        let reader = HotStateStoreReader { store: read };
+        let reader = HotStateStoreReader {
+            store: read,
+            transaction_cache: None,
+        };
         let control = BranchHeadControl {
             head_commit_id: generation,
             generation,
@@ -9615,6 +9873,7 @@ mod tests {
                 ..TrackedStateScanRequest::default()
             },
             None,
+            None,
         )
         .await
         .expect("exact-file scan must not decode unrelated certified content");
@@ -9684,6 +9943,7 @@ mod tests {
                 .begin_read(StorageReadOptions::default())
                 .await
                 .expect("open exact HOT read"),
+            transaction_cache: None,
         };
         let result = reader
             .load_projected_live_batch_for_generation_refs(
@@ -9882,6 +10142,7 @@ mod tests {
         let read = CountingRead {
             inner: read,
             get_many_calls: Arc::clone(&get_many_calls),
+            scan_calls: None,
         };
         let rows = scan_certified_entity_batch_rows(
             &read,
@@ -9897,6 +10158,7 @@ mod tests {
                 },
                 limit: None,
             },
+            None,
             None,
         )
         .await

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -54,8 +54,8 @@ use crate::gc::{
 #[cfg(test)]
 use crate::live_state::LiveStateRowRequest;
 use crate::live_state::{
-    LiveStateContext, LiveStateExactBatchRequest, LiveStateExactRowRequest, LiveStateFilter,
-    LiveStateProjection, LiveStateScanRequest, MaterializedLiveStateBatch,
+    BranchHeadControlCache, LiveStateContext, LiveStateExactBatchRequest, LiveStateExactRowRequest,
+    LiveStateFilter, LiveStateProjection, LiveStateScanRequest, MaterializedLiveStateBatch,
     MaterializedLiveStateBatchBuilder, MaterializedLiveStateExactBatch, MaterializedLiveStateRow,
     MaterializedLiveStateRowRef, StagedLiveStateRows, TrackedHeadContext, TrackedWorkingDiff,
     overlay_load_exact_batch, overlay_scan_batch,
@@ -382,6 +382,7 @@ pub(crate) struct Transaction<StorageImpl: Storage = Memory> {
     staged_writes: Arc<TransactionWriteBuffer>,
     filesystem_path_index_cache: Arc<FilesystemPathIndexCache>,
     filesystem_path_index_epoch: Arc<AtomicUsize>,
+    branch_head_control_cache: Arc<BranchHeadControlCache>,
     storage: StorageAdapter<StorageImpl>,
     functions: FunctionProviderHandle,
     /// Tracked-state revision observed by the coherent transaction-open read.
@@ -644,6 +645,7 @@ where
                 staged_writes,
                 filesystem_path_index_cache: Arc::new(FilesystemPathIndexCache::default()),
                 filesystem_path_index_epoch: Arc::new(AtomicUsize::new(0)),
+                branch_head_control_cache: Arc::new(BranchHeadControlCache::default()),
                 storage,
                 functions,
                 opening_tracked_mutation_revision,
@@ -1513,7 +1515,9 @@ where
                 .begin_read(StorageReadOptions::default())
                 .await?,
         );
-        let base = self.live_state.reader(read);
+        let base = self
+            .live_state
+            .transaction_reader(read, Arc::clone(&self.branch_head_control_cache));
         overlay_scan_batch(&base, &staged, request).await
     }
 
@@ -1890,7 +1894,9 @@ where
                 .begin_read(StorageReadOptions::default())
                 .await?,
         );
-        let base = self.live_state.reader(read);
+        let base = self
+            .live_state
+            .transaction_reader(read, Arc::clone(&self.branch_head_control_cache));
         overlay_load_exact_batch(&base, &staged, request).await
     }
 
@@ -5800,6 +5806,7 @@ where
         let staged_writes = Arc::clone(&self.staged_writes);
         let filesystem_path_index_cache = Arc::clone(&self.filesystem_path_index_cache);
         let filesystem_path_index_epoch = Arc::clone(&self.filesystem_path_index_epoch);
+        let branch_head_control_cache = Arc::clone(&self.branch_head_control_cache);
         let plugin_host = self.plugin_host.clone();
 
         with_static_transaction_sql_read::<StorageImpl, _, _>(read, |read_store| async move {
@@ -5815,6 +5822,7 @@ where
                 staged_writes,
                 filesystem_path_index_cache,
                 filesystem_path_index_epoch,
+                branch_head_control_cache,
                 plugin_host,
             };
             let result = crate::sql2::execute_transaction_read_statement_from_parsed(
@@ -6462,6 +6470,7 @@ pub(crate) struct TransactionSqlReadExecutionContext<R: crate::storage_adapter::
     staged_writes: Arc<TransactionWriteBuffer>,
     filesystem_path_index_cache: Arc<FilesystemPathIndexCache>,
     filesystem_path_index_epoch: Arc<AtomicUsize>,
+    branch_head_control_cache: Arc<BranchHeadControlCache>,
     plugin_host: PluginRuntimeHost,
 }
 
@@ -6478,7 +6487,10 @@ where
 
     fn live_state(&self) -> Arc<dyn crate::live_state::LiveStateReader> {
         Arc::new(TransactionReadLiveStateReader {
-            base: self.live_state.reader(self.read_store.clone()),
+            base: self.live_state.transaction_reader(
+                self.read_store.clone(),
+                Arc::clone(&self.branch_head_control_cache),
+            ),
             read_store: self.read_store.clone(),
             staged: self.staged.clone(),
             filesystem_path_index_cache: Arc::clone(&self.filesystem_path_index_cache),
@@ -6488,7 +6500,10 @@ where
 
     fn filesystem_path_index(&self) -> Arc<dyn FilesystemPathIndexReader> {
         Arc::new(TransactionReadLiveStateReader {
-            base: self.live_state.reader(self.read_store.clone()),
+            base: self.live_state.transaction_reader(
+                self.read_store.clone(),
+                Arc::clone(&self.branch_head_control_cache),
+            ),
             read_store: self.read_store.clone(),
             staged: self.staged.clone(),
             filesystem_path_index_cache: Arc::clone(&self.filesystem_path_index_cache),


### PR DESCRIPTION
## Summary

Stacked on #1077.

- retain immutable HOT serving metadata for the lifetime of one transaction snapshot
- reuse collection-generation control point reads across repeated CRUD scans
- remember generation-wide absence of certified entity manifests
- bound each metadata lane to 64 entries; no row payloads are cached

The measured bottleneck was repeated storage metadata I/O during literal point updates inside one transaction. The cache shares the existing transaction branch-head-control lifetime, so entries cannot outlive the coherent storage snapshot they describe.

## Performance

Immediate baseline: #1077 commit `1a059dea3`.

### 10k literal SQL updates, 15 samples

| Adapter | #1077 p50 | Candidate p50 | Change |
| --- | ---: | ---: | ---: |
| RocksDB | 677.645 ms | 605.131 ms | **-10.7%** |
| SlateDB | 750.814 ms | 703.414 ms | -6.3% |

### 1M literal SQL updates and peak RSS

| Adapter | #1077 latency | Candidate latency | Latency | #1077 RSS | Candidate RSS | RSS |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| RocksDB | 166.54 s | 163.33 s | -1.9% | 4,241,416 KiB | 4,227,660 KiB | -0.32% |
| SlateDB | 182.41 s | 172.96 s | -5.2% | 4,285,944 KiB | 4,262,228 KiB | -0.55% |

### Non-CRUD guards versus exact #1077 binary

| Guard | RocksDB | SlateDB |
| --- | ---: | ---: |
| Working diff p50 | 3.589 → 3.183 ms (-11.3%) | 6.597 → 6.491 ms (-1.6%) |
| Merge preview p50 | 127.305 → 120.673 ms (-5.2%) | 128.438 → 121.984 ms (-5.0%) |
| Merge commit p50 | 16.440 → 15.458 ms (-6.0%) | 20.343 → 17.348 ms (-14.7%) |

## Validation

- `cargo fmt --check`
- `cargo clippy --profile test -p lix_engine --all-targets --all-features -- -D warnings`
- engine unit tests: 1,675 passed, 6 ignored
- engine integration tests: 433 passed, 2 ignored
- focused tests cover cache bounds, collection-control reuse, and absent-manifest scan reuse
- no changenote added
