### PR TITLE
perf(engine): reuse literal update plans

### DIFF
--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -12,7 +12,7 @@ use crate::filesystem::{
     FilesystemPathIndex, FilesystemPathIndexCache, FilesystemPathIndexReader,
     FilesystemPathIndexRequest, build_path_index, load_path_index_revision,
 };
-use crate::live_state::tracked_head::TrackedHeadContext;
+use crate::live_state::tracked_head::{HotStateTransactionCache, TrackedHeadContext};
 use crate::live_state::{
     LiveStateExactBatchRequest, LiveStateReader, LiveStateRowFilter, LiveStateRowRequest,
     LiveStateScanRequest, MaterializedLiveStateBatch, MaterializedLiveStateBatchBuilder,
@@ -45,6 +45,7 @@ type BranchHeads = std::collections::BTreeMap<String, BranchHeadControl>;
 #[derive(Default)]
 pub(crate) struct BranchHeadControlCache {
     controls: StdMutex<std::collections::BTreeMap<String, Option<BranchHeadControl>>>,
+    hot_state: std::sync::Arc<HotStateTransactionCache>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -545,9 +546,14 @@ where
             return Ok(Some(MaterializedLiveStateBatch::default()));
         }
         let tracked_request = tracked_scan_request_from_live(request);
-        let rows_by_branch = self
-            .tracked_head
-            .reader(&self.store)
+        let tracked_head = self.branch_head_control_cache.as_ref().map_or_else(
+            || self.tracked_head.reader(&self.store),
+            |cache| {
+                self.tracked_head
+                    .transaction_reader(&self.store, std::sync::Arc::clone(&cache.hot_state))
+            },
+        );
+        let rows_by_branch = tracked_head
             .scan_live_batches_for_controls(&controls, &tracked_request)
             .await?;
         let rows = concat_live_state_batches(

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -13,13 +13,12 @@ pub(crate) use hot::{
     CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE, CERTIFIED_ENTITY_BATCH_PAGE_SPACE,
     CERTIFIED_ENTITY_BATCH_SPACE, CertifiedEntityBatchFileRef, DeferredFreshHotPlan,
     DeferredFreshHotRowRef, DeferredFreshHotRows, HOT_DIFF_SPACE, HOT_FILE_SPACE, HOT_ROW_SPACE,
-    HotTrackedSnapshot, PACKED_CURRENT_BASE_CONTROL_SPACE, PACKED_CURRENT_BASE_SPACE,
-    PACKED_CURRENT_EXCLUSIVE_SCHEMA_BASE_SPACE, scan_certified_history_rows,
-    stage_certified_entity_batches,
+    HotStateTransactionCache, HotTrackedSnapshot, PACKED_CURRENT_BASE_CONTROL_SPACE,
+    PACKED_CURRENT_BASE_SPACE, PACKED_CURRENT_EXCLUSIVE_SCHEMA_BASE_SPACE,
+    scan_certified_history_rows, stage_certified_entity_batches,
 };
 
 use std::collections::{BTreeMap, BTreeSet};
-#[cfg(test)]
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -411,7 +410,25 @@ impl TrackedHeadContext {
     where
         S: StorageAdapterRead,
     {
-        hot::HotStateStoreReader { store }
+        hot::HotStateStoreReader {
+            store,
+            transaction_cache: None,
+        }
+    }
+
+    #[expect(clippy::unused_self)]
+    pub(crate) fn transaction_reader<S>(
+        &self,
+        store: S,
+        cache: Arc<HotStateTransactionCache>,
+    ) -> hot::HotStateStoreReader<S>
+    where
+        S: StorageAdapterRead,
+    {
+        hot::HotStateStoreReader {
+            store,
+            transaction_cache: Some(cache),
+        }
     }
 
     #[expect(clippy::unused_self)]

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -11,6 +11,7 @@ use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::ops::Range;
 use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
 
 use crate::wasm::WasmCreateContext;
 use base64::Engine as _;
@@ -942,6 +943,7 @@ async fn scan_certified_entity_batch_rows(
     generation: CommitId,
     request: &TrackedStateScanRequest,
     limit: Option<usize>,
+    transaction_cache: Option<&HotStateTransactionCache>,
 ) -> Result<MaterializedLiveStateBatch, LixError> {
     if matches!(limit, Some(0)) {
         return Ok(MaterializedLiveStateBatch::default());
@@ -963,8 +965,14 @@ async fn scan_certified_entity_batch_rows(
             })
             .collect::<BTreeSet<_>>()
     });
+    if exact_file_ids.is_none()
+        && let Some(cache) = transaction_cache
+        && cache.certified_generation_absent(generation)?
+    {
+        return Ok(MaterializedLiveStateBatch::default());
+    }
     let mut manifest_entries = Vec::new();
-    if let Some(file_ids) = exact_file_ids {
+    if let Some(file_ids) = exact_file_ids.as_ref() {
         for file_id in file_ids {
             let mut prefix = generation.as_uuid().as_bytes().to_vec();
             append_batch_text(&mut prefix, file_id)?;
@@ -988,6 +996,12 @@ async fn scan_certified_entity_batch_rows(
         .collect(store, StorageScanOptions::default())
         .await?;
         manifest_entries = manifests.value.entries;
+    }
+    if exact_file_ids.is_none() && manifest_entries.is_empty() {
+        if let Some(cache) = transaction_cache {
+            cache.remember_certified_generation_absent(generation)?;
+        }
+        return Ok(MaterializedLiveStateBatch::default());
     }
     let content_keys = manifest_entries
         .into_iter()
@@ -1834,6 +1848,78 @@ struct HotCollectionControl {
     active_generation: CommitId,
     live_count: u64,
     ordered_identity_digest: Option<[u8; 32]>,
+}
+
+const TRANSACTION_HOT_STATE_CACHE_MAX_ENTRIES: usize = 64;
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct HotCollectionCacheKey {
+    branch_id: String,
+    generation: CommitId,
+    schema_key: String,
+    file_id: Option<String>,
+}
+
+/// Bounded serving metadata retained for one transaction snapshot.
+#[derive(Default)]
+pub(crate) struct HotStateTransactionCache {
+    collection_controls: StdMutex<BTreeMap<HotCollectionCacheKey, HotCollectionControl>>,
+    certified_absent_generations: StdMutex<BTreeSet<CommitId>>,
+}
+
+impl HotStateTransactionCache {
+    fn collection_control(
+        &self,
+        key: &HotCollectionCacheKey,
+    ) -> Result<Option<HotCollectionControl>, LixError> {
+        Ok(self
+            .collection_controls
+            .lock()
+            .map_err(|_| hot_state_cache_lock_error())?
+            .get(key)
+            .copied())
+    }
+
+    fn remember_collection_control(
+        &self,
+        key: HotCollectionCacheKey,
+        control: HotCollectionControl,
+    ) -> Result<(), LixError> {
+        let mut entries = self
+            .collection_controls
+            .lock()
+            .map_err(|_| hot_state_cache_lock_error())?;
+        if entries.len() < TRANSACTION_HOT_STATE_CACHE_MAX_ENTRIES {
+            entries.entry(key).or_insert(control);
+        }
+        Ok(())
+    }
+
+    fn certified_generation_absent(&self, generation: CommitId) -> Result<bool, LixError> {
+        Ok(self
+            .certified_absent_generations
+            .lock()
+            .map_err(|_| hot_state_cache_lock_error())?
+            .contains(&generation))
+    }
+
+    fn remember_certified_generation_absent(&self, generation: CommitId) -> Result<(), LixError> {
+        let mut entries = self
+            .certified_absent_generations
+            .lock()
+            .map_err(|_| hot_state_cache_lock_error())?;
+        if entries.len() < TRANSACTION_HOT_STATE_CACHE_MAX_ENTRIES {
+            entries.insert(generation);
+        }
+        Ok(())
+    }
+}
+
+fn hot_state_cache_lock_error() -> LixError {
+    LixError::new(
+        LixError::CODE_INTERNAL_ERROR,
+        "transaction hot-state metadata cache lock is poisoned",
+    )
 }
 
 struct PackedCollectionIncrement {
@@ -3104,19 +3190,45 @@ fn merge_ordered_live_batches(
 /// Direct reader for one published hot generation.
 pub(crate) struct HotStateStoreReader<S> {
     pub(super) store: S,
+    pub(super) transaction_cache: Option<Arc<HotStateTransactionCache>>,
 }
 
 impl<S> HotStateStoreReader<S>
 where
     S: StorageAdapterRead,
 {
+    async fn collection_control(
+        &self,
+        branch_id: &str,
+        generation: CommitId,
+        scope: crate::collection_generation::CollectionScopeRef<'_>,
+    ) -> Result<HotCollectionControl, LixError> {
+        let key = HotCollectionCacheKey {
+            branch_id: branch_id.to_owned(),
+            generation,
+            schema_key: scope.schema_key.to_owned(),
+            file_id: scope.file_id.map(str::to_owned),
+        };
+        if let Some(cache) = self.transaction_cache.as_deref()
+            && let Some(control) = cache.collection_control(&key)?
+        {
+            return Ok(control);
+        }
+        let control =
+            load_hot_collection_control(&self.store, branch_id, generation, scope).await?;
+        if let Some(cache) = self.transaction_cache.as_deref() {
+            cache.remember_collection_control(key, control)?;
+        }
+        Ok(control)
+    }
+
     pub(crate) async fn collection_generation(
         &self,
         branch_id: &str,
         branch_generation: CommitId,
         scope: crate::collection_generation::CollectionScopeRef<'_>,
     ) -> Result<crate::collection_generation::CollectionGeneration, LixError> {
-        load_hot_collection_control(&self.store, branch_id, branch_generation, scope)
+        self.collection_control(branch_id, branch_generation, scope)
             .await
             .map(
                 |control| crate::collection_generation::CollectionGeneration {
@@ -3217,6 +3329,7 @@ where
                 limit: Some(1),
             },
             Some(1),
+            self.transaction_cache.as_deref(),
         )
         .await?;
         Ok(!certified.is_empty())
@@ -3281,8 +3394,7 @@ where
                 if schema_key != crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY =>
             {
                 Some(
-                    load_hot_collection_control(
-                        &self.store,
+                    self.collection_control(
                         branch_id,
                         generation,
                         crate::collection_generation::CollectionScopeRef {
@@ -3443,6 +3555,7 @@ where
                 } else {
                     None
                 },
+                self.transaction_cache.as_deref(),
             )
             .await?
             .filter(
@@ -3728,6 +3841,7 @@ where
                 generation,
                 &certified_request,
                 None,
+                self.transaction_cache.as_deref(),
             )
             .await?
         };
@@ -8750,9 +8864,147 @@ mod tests {
         StorageWriteOptions,
     };
 
+    #[test]
+    fn transaction_hot_state_cache_is_bounded_per_metadata_lane() {
+        let cache = HotStateTransactionCache::default();
+        for index in 0..=TRANSACTION_HOT_STATE_CACHE_MAX_ENTRIES {
+            let generation = CommitId::for_test_label(&format!("cache-generation-{index}"));
+            cache
+                .remember_collection_control(
+                    HotCollectionCacheKey {
+                        branch_id: "cache-branch".to_owned(),
+                        generation,
+                        schema_key: format!("schema-{index}"),
+                        file_id: None,
+                    },
+                    HotCollectionControl {
+                        active_generation: generation,
+                        live_count: index as u64,
+                        ordered_identity_digest: None,
+                    },
+                )
+                .expect("remember collection control");
+            cache
+                .remember_certified_generation_absent(generation)
+                .expect("remember absent certified generation");
+        }
+        assert_eq!(
+            cache.collection_controls.lock().unwrap().len(),
+            TRANSACTION_HOT_STATE_CACHE_MAX_ENTRIES
+        );
+        assert_eq!(
+            cache.certified_absent_generations.lock().unwrap().len(),
+            TRANSACTION_HOT_STATE_CACHE_MAX_ENTRIES
+        );
+    }
+
+    #[tokio::test]
+    async fn transaction_reader_reuses_collection_control_point_read() {
+        const BRANCH_ID: &str = "collection-control-cache-branch";
+        const SCHEMA_KEY: &str = "collection_control_cache_schema";
+        let storage = StorageAdapter::new(Memory::new());
+        let generation = CommitId::for_test_label("collection-control-cache-generation");
+        let mut writes = StorageWriteSet::new();
+        stage_hot_collection_control(
+            &mut writes,
+            BRANCH_ID,
+            generation,
+            crate::collection_generation::CollectionScopeRef {
+                schema_key: SCHEMA_KEY,
+                file_id: None,
+            },
+            HotCollectionControl {
+                active_generation: generation,
+                live_count: 7,
+                ordered_identity_digest: Some([3; 32]),
+            },
+        )
+        .expect("stage collection control fixture");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("publish collection control fixture");
+
+        let get_many_calls = Arc::new(AtomicUsize::new(0));
+        let reader = HotStateStoreReader {
+            store: CountingRead {
+                inner: storage
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .expect("open collection control fixture read"),
+                get_many_calls: Arc::clone(&get_many_calls),
+                scan_calls: None,
+            },
+            transaction_cache: Some(Arc::new(HotStateTransactionCache::default())),
+        };
+        for _ in 0..2 {
+            let control = reader
+                .collection_generation(
+                    BRANCH_ID,
+                    generation,
+                    crate::collection_generation::CollectionScopeRef {
+                        schema_key: SCHEMA_KEY,
+                        file_id: None,
+                    },
+                )
+                .await
+                .expect("load cached collection control");
+            assert_eq!(control.live_count, 7);
+            assert_eq!(control.ordered_identity_digest, Some([3; 32]));
+        }
+        assert_eq!(
+            get_many_calls.load(Ordering::Relaxed),
+            1,
+            "the immutable transaction snapshot should point-read a control once"
+        );
+    }
+
+    #[tokio::test]
+    async fn transaction_cache_reuses_absent_certified_manifest_scan() {
+        const BRANCH_ID: &str = "absent-certified-cache-branch";
+        let storage = StorageAdapter::new(Memory::new());
+        let generation = CommitId::for_test_label("absent-certified-cache-generation");
+        let scan_calls = Arc::new(AtomicUsize::new(0));
+        let read = CountingRead {
+            inner: storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("open absent certified fixture read"),
+            get_many_calls: Arc::new(AtomicUsize::new(0)),
+            scan_calls: Some(Arc::clone(&scan_calls)),
+        };
+        let cache = HotStateTransactionCache::default();
+        let request = TrackedStateScanRequest {
+            filter: TrackedStateFilter {
+                schema_keys: vec!["plugin_row".to_owned()],
+                ..TrackedStateFilter::default()
+            },
+            ..TrackedStateScanRequest::default()
+        };
+        for _ in 0..2 {
+            let rows = scan_certified_entity_batch_rows(
+                &read,
+                BRANCH_ID,
+                generation,
+                &request,
+                None,
+                Some(&cache),
+            )
+            .await
+            .expect("scan absent certified generation");
+            assert!(rows.is_empty());
+        }
+        assert_eq!(
+            scan_calls.load(Ordering::Relaxed),
+            1,
+            "an immutable generation without manifests should be scanned once"
+        );
+    }
+
     struct CountingRead<R> {
         inner: R,
         get_many_calls: Arc<AtomicUsize>,
+        scan_calls: Option<Arc<AtomicUsize>>,
     }
 
     impl<R: StorageAdapterRead> StorageAdapterRead for CountingRead<R> {
@@ -8774,6 +9026,9 @@ mod tests {
             range: StorageKeyRange,
             opts: StorageScanOptions,
         ) -> Result<StorageScanChunk, crate::storage_adapter::StorageError> {
+            if let Some(scan_calls) = &self.scan_calls {
+                scan_calls.fetch_add(1, Ordering::Relaxed);
+            }
             self.inner.scan(space, range, opts).await
         }
     }
@@ -8945,7 +9200,10 @@ mod tests {
             "mutation predecessor lookup must not read large JSON payloads"
         );
 
-        let reader = HotStateStoreReader { store: read };
+        let reader = HotStateStoreReader {
+            store: read,
+            transaction_cache: None,
+        };
         let control = BranchHeadControl {
             head_commit_id: generation,
             generation,
@@ -9615,6 +9873,7 @@ mod tests {
                 ..TrackedStateScanRequest::default()
             },
             None,
+            None,
         )
         .await
         .expect("exact-file scan must not decode unrelated certified content");
@@ -9684,6 +9943,7 @@ mod tests {
                 .begin_read(StorageReadOptions::default())
                 .await
                 .expect("open exact HOT read"),
+            transaction_cache: None,
         };
         let result = reader
             .load_projected_live_batch_for_generation_refs(
@@ -9882,6 +10142,7 @@ mod tests {
         let read = CountingRead {
             inner: read,
             get_many_calls: Arc::clone(&get_many_calls),
+            scan_calls: None,
         };
         let rows = scan_certified_entity_batch_rows(
             &read,
@@ -9897,6 +10158,7 @@ mod tests {
                 },
                 limit: None,
             },
+            None,
             None,
         )
         .await

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -2248,9 +2248,28 @@ where
     ) -> Result<ExecuteResult, LixError> {
         let telemetry =
             SqlStatementTelemetry::start(self.telemetry.as_ref(), sql, "transaction", None);
+        let may_reuse_literal_shape = self.has_started_statement;
+        self.has_started_statement = true;
         let operation = async {
             let _operation_guard = self.begin_session_operation()?;
-            let statement = self.sql_planning_cache.parse_statement(sql)?;
+            let auto_parameterized = (may_reuse_literal_shape && params.is_empty())
+                .then(|| self.sql_planning_cache.auto_parameterized_update(sql))
+                .flatten();
+            let (planning_sql, statement, auto_params) =
+                if let Some(auto_parameterized) = auto_parameterized {
+                    (
+                        auto_parameterized.sql,
+                        auto_parameterized.statement,
+                        Some(auto_parameterized.params),
+                    )
+                } else {
+                    (
+                        Arc::from(sql),
+                        self.sql_planning_cache.parse_statement(sql)?,
+                        None,
+                    )
+                };
+            let params = auto_params.as_deref().unwrap_or(params);
             let transaction = self.transaction_mut()?;
             let is_read = matches!(
                 sql2::bind_statement_route(&statement)?,
@@ -2278,7 +2297,7 @@ where
                 } else {
                     execute_transaction_write_auto(
                         transaction,
-                        sql,
+                        &planning_sql,
                         statement,
                         params,
                         options,
@@ -6651,6 +6670,65 @@ mod tests {
             .rollback()
             .await
             .expect("transaction should roll back");
+    }
+
+    #[tokio::test]
+    async fn explicit_transaction_literal_updates_preserve_escaped_string_values() {
+        let session = open_session().await;
+        for (key, value) in [("auto'one", "seed one"), ("auto'two", "seed two")] {
+            session
+                .execute(
+                    "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
+                    &[Value::Text(key.to_string()), Value::Text(value.to_string())],
+                )
+                .await
+                .expect("seed row should commit");
+        }
+
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("transaction should begin");
+        let first = transaction
+            .execute(
+                "UPDATE lix_key_value SET value = 'first''s value' WHERE key = 'auto''one'",
+                &[],
+            )
+            .await
+            .expect("first literal update should stage");
+        let second = transaction
+            .execute(
+                "UPDATE lix_key_value SET value = 'second''s value' WHERE key = 'auto''two'",
+                &[],
+            )
+            .await
+            .expect("second literal update should reuse the statement shape");
+        assert_eq!(first.rows_affected(), 1);
+        assert_eq!(second.rows_affected(), 1);
+        transaction
+            .commit()
+            .await
+            .expect("literal updates should commit atomically");
+
+        let values = session
+            .execute(
+                "SELECT key, value FROM lix_key_value WHERE key IN ($1, $2) ORDER BY key",
+                &[
+                    Value::Text("auto'one".to_string()),
+                    Value::Text("auto'two".to_string()),
+                ],
+            )
+            .await
+            .expect("updated rows should be readable");
+        assert_eq!(values.len(), 2);
+        assert_eq!(
+            values.rows()[0].get::<serde_json::Value>("value").unwrap(),
+            serde_json::json!("first's value")
+        );
+        assert_eq!(
+            values.rows()[1].get::<serde_json::Value>("value").unwrap(),
+            serde_json::json!("second's value")
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/session/transaction.rs
+++ b/packages/engine/src/session/transaction.rs
@@ -30,6 +30,7 @@ pub struct SessionTransaction<StorageImpl: Storage = Memory> {
     write_access: Option<SessionWriteAccess>,
     collaboration_write_gate: Arc<tokio::sync::Mutex<()>>,
     pub(super) telemetry: Option<Arc<dyn TelemetrySink>>,
+    pub(super) has_started_statement: bool,
 }
 
 impl<StorageImpl> SessionContext<StorageImpl>
@@ -87,6 +88,7 @@ where
             write_access: Some(write_access),
             collaboration_write_gate: Arc::clone(&self.collaboration_write_gate),
             telemetry: self.telemetry.clone(),
+            has_started_statement: false,
         })
     }
 }

--- a/packages/engine/src/sql2/planning_cache.rs
+++ b/packages/engine/src/sql2/planning_cache.rs
@@ -2,15 +2,27 @@ use std::hash::Hash;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex, MutexGuard};
 
-use crate::LixError;
 use crate::sql2::catalog::PublicCatalog;
 use crate::sql2::plan::LogicalWritePlan;
+use crate::{LixError, Value};
 use datafusion::sql::parser::Statement as DataFusionStatement;
 use lru::LruCache;
 
 const PARSED_STATEMENT_CAPACITY: usize = 256;
 const PUBLIC_CATALOG_CAPACITY: usize = 16;
 const WRITE_PLAN_CAPACITY: usize = 256;
+
+/// One conservative auto-parameterization of a literal UPDATE statement.
+///
+/// The normalized SQL is suitable as a planning-cache key while `params`
+/// preserves the values from the caller's original statement. Keeping this
+/// representation private to SQL execution avoids making automatic
+/// parameterization part of the public API contract.
+pub(crate) struct AutoParameterizedUpdate {
+    pub(crate) sql: Arc<str>,
+    pub(crate) statement: DataFusionStatement,
+    pub(crate) params: Vec<Value>,
+}
 
 /// Bounded, engine-owned cache for snapshot-independent SQL planning templates.
 ///
@@ -75,6 +87,24 @@ where
         }
         statements.put(Arc::from(sql), Arc::new(parsed.clone()));
         Ok(parsed)
+    }
+
+    /// Reuses one parsed template for UPDATE statements that differ only in
+    /// ordinary string literals.
+    ///
+    /// This intentionally accepts a narrow, unambiguous SQL subset. Existing
+    /// placeholders, comments, prefixed string forms, and malformed literals
+    /// fall back to exact parsing. The fallback keeps the full SQL surface and
+    /// its existing diagnostics authoritative while the common literal CRUD
+    /// shape avoids churning the bounded exact-text caches.
+    pub(crate) fn auto_parameterized_update(&self, sql: &str) -> Option<AutoParameterizedUpdate> {
+        let (normalized_sql, params) = normalize_update_string_literals(sql)?;
+        let statement = self.parse_statement(&normalized_sql).ok()?;
+        Some(AutoParameterizedUpdate {
+            sql: Arc::from(normalized_sql),
+            statement,
+            params,
+        })
     }
 
     /// Returns stable public-surface metadata for one catalog generation.
@@ -162,6 +192,86 @@ fn lock_or_recover<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
         .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
+fn normalize_update_string_literals(sql: &str) -> Option<(String, Vec<Value>)> {
+    let trimmed = sql.trim_start();
+    let update = trimmed.get(.."UPDATE".len())?;
+    if !update.eq_ignore_ascii_case("UPDATE")
+        || !trimmed
+            .as_bytes()
+            .get("UPDATE".len())
+            .is_some_and(u8::is_ascii_whitespace)
+    {
+        return None;
+    }
+
+    let bytes = sql.as_bytes();
+    let mut normalized = String::with_capacity(sql.len());
+    let mut params = Vec::new();
+    let mut cursor = 0;
+    let mut copied = 0;
+    let mut quoted_identifier = false;
+
+    while cursor < bytes.len() {
+        match bytes[cursor] {
+            b'"' => {
+                if quoted_identifier && bytes.get(cursor + 1) == Some(&b'"') {
+                    cursor += 2;
+                    continue;
+                }
+                quoted_identifier = !quoted_identifier;
+                cursor += 1;
+            }
+            b'-' if !quoted_identifier && bytes.get(cursor + 1) == Some(&b'-') => return None,
+            b'/' if !quoted_identifier && bytes.get(cursor + 1) == Some(&b'*') => return None,
+            b'?' | b'$' if !quoted_identifier => return None,
+            b'\'' if !quoted_identifier => {
+                if bytes[..cursor]
+                    .iter()
+                    .rposition(|byte| !byte.is_ascii_whitespace())
+                    .is_some_and(|index| {
+                        matches!(bytes[index], b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_')
+                    })
+                {
+                    return None;
+                }
+                normalized.push_str(&sql[copied..cursor]);
+                normalized.push('$');
+                normalized.push_str(&(params.len() + 1).to_string());
+
+                cursor += 1;
+                let mut value = String::new();
+                let value_start = cursor;
+                let mut segment_start = cursor;
+                loop {
+                    let quote = bytes[cursor..]
+                        .iter()
+                        .position(|byte| *byte == b'\'')
+                        .map(|offset| cursor + offset)?;
+                    value.push_str(&sql[segment_start..quote]);
+                    if bytes.get(quote + 1) == Some(&b'\'') {
+                        value.push('\'');
+                        cursor = quote + 2;
+                        segment_start = cursor;
+                        continue;
+                    }
+                    cursor = quote + 1;
+                    copied = cursor;
+                    break;
+                }
+                debug_assert!(cursor > value_start);
+                params.push(Value::Text(value));
+            }
+            _ => cursor += 1,
+        }
+    }
+
+    if quoted_identifier || params.is_empty() {
+        return None;
+    }
+    normalized.push_str(&sql[copied..]);
+    Some((normalized, params))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -206,6 +316,54 @@ mod tests {
 
         assert!(cache.parse_statement("SELECT (").is_err());
         assert!(lock_or_recover(&cache.parsed_statements).is_empty());
+    }
+
+    #[test]
+    fn literal_updates_share_one_parameterized_parse_template() {
+        let cache = test_cache(8);
+        let first = cache
+            .auto_parameterized_update(
+                "UPDATE notes SET value = lix_json('{\"text\":\"first\"}') WHERE id = 'a'",
+            )
+            .expect("literal update auto-parameterizes");
+        let second = cache
+            .auto_parameterized_update(
+                "UPDATE notes SET value = lix_json('{\"text\":\"second\"}') WHERE id = 'b'",
+            )
+            .expect("case-equivalent literal update auto-parameterizes");
+
+        assert_eq!(
+            first.sql.as_ref(),
+            "UPDATE notes SET value = lix_json($1) WHERE id = $2"
+        );
+        assert_eq!(
+            first.params,
+            [
+                Value::Text("{\"text\":\"first\"}".to_string()),
+                Value::Text("a".to_string())
+            ]
+        );
+        assert_eq!(
+            second.params,
+            [
+                Value::Text("{\"text\":\"second\"}".to_string()),
+                Value::Text("b".to_string())
+            ]
+        );
+        assert_eq!(lock_or_recover(&cache.parsed_statements).len(), 1);
+    }
+
+    #[test]
+    fn ambiguous_literal_updates_keep_exact_sql_path() {
+        let cache = test_cache(8);
+        for sql in [
+            "UPDATE notes SET value = $1 WHERE id = 'a'",
+            "UPDATE notes SET value = DATE '2026-08-01' WHERE id = 'a'",
+            "UPDATE notes SET value = 'a' -- comment",
+            "SELECT 'not an update'",
+        ] {
+            assert!(cache.auto_parameterized_update(sql).is_none(), "{sql}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- conservatively auto-parameterize ordinary string literals in repeated explicit-transaction `UPDATE` statements
- reuse one parsed and bound write-plan shape instead of churning exact-text caches for every distinct literal statement
- keep caller-parameterized, commented, typed/prefixed-literal, malformed, and single-statement transactions on the existing exact SQL path
- preserve per-statement execution/results and transaction semantics
- add focused cache/fallback and escaped-string execution coverage

## Why

At 10k rows, the bound update control took about 25 ms while 10k distinct literal statements took 639–736 ms. Profiling isolated repeated SQL parse/plan/dispatch as the largest remaining 10k bottleneck. This applies prepared-plan reuse transparently after the first statement in an explicit transaction.

## Performance versus immediate parent (#1078)

Literal SQL update, 15 samples:

| Adapter | Rows | #1078 | This PR | Delta |
| --- | ---: | ---: | ---: | ---: |
| RocksDB | 10k | 674.23 ms | 469.46 ms | -30.4% |
| SlateDB | 10k | 735.90 ms | 550.46 ms | -25.2% |
| RocksDB | 1M | 163.33 s | 141.05 s | -13.6% |
| SlateDB | 1M | 172.96 s | 144.68 s | -16.3% |

1M peak RSS:

- RocksDB: 4,227,660 -> 4,222,636 KiB (-0.12%)
- SlateDB: 4,262,228 -> 4,247,820 KiB (-0.34%)

Single-row literal updates stay on the exact path and were slightly faster in the back-to-back control (about -2% on both adapters).

Unaffected 10k insert/select/delete and bound-update controls remained within noise. Exact-parent back-to-back guards showed working diff, merge preview, and merge commit flat or faster; a 101-branch lifecycle control was flat in latency and median RSS.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p lix_engine --all-targets --features storage-benches -- -D warnings`
- `cargo test -p lix_engine --features storage-benches --quiet`
  - 1,688 unit tests passed, 6 ignored
  - 435 integration tests passed, 2 ignored
  - 3 doc tests passed
- exact #1078 vs candidate 10k/1M RocksDB and SlateDB benchmarks
- exact #1078 vs candidate working-diff, merge-preview, merge-commit, and branch-heavy controls

No changenote.