### PR TITLE
perf(engine): certify single point replacements

### DIFF
--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -6732,6 +6732,92 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn explicit_transaction_certified_json_pointer_updates_observe_staged_rows() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "x-lix-key": "json_pointer",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "required": ["path", "value"],
+            "properties": {
+                "path": { "type": "string" },
+                "value": {
+                    "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+                }
+            },
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .expect("json pointer schema should register");
+        session
+            .execute(
+                "INSERT INTO json_pointer (path, value) VALUES ($1, lix_json($2))",
+                &[
+                    Value::Text("/certified".to_string()),
+                    Value::Text("{\"step\":0}".to_string()),
+                ],
+            )
+            .await
+            .expect("json pointer seed should commit");
+
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("transaction should begin");
+        assert_eq!(sql2::take_certified_single_path_value_replacements(), 0);
+        let sql = "UPDATE json_pointer SET value = lix_json($1) WHERE path = $2";
+        for step in [1, 2] {
+            let result = transaction
+                .execute(
+                    sql,
+                    &[
+                        Value::Text(format!("{{\"step\":{step}}}")),
+                        Value::Text("/certified".to_string()),
+                    ],
+                )
+                .await
+                .expect("certified replacement should stage");
+            assert_eq!(result.rows_affected(), 1);
+        }
+        let missing = transaction
+            .execute(
+                sql,
+                &[
+                    Value::Text("{\"step\":3}".to_string()),
+                    Value::Text("/missing".to_string()),
+                ],
+            )
+            .await
+            .expect("missing certified replacement should succeed");
+        assert_eq!(missing.rows_affected(), 0);
+        assert_eq!(sql2::take_certified_single_path_value_replacements(), 2);
+        transaction
+            .commit()
+            .await
+            .expect("certified replacements should commit atomically");
+
+        let result = session
+            .execute(
+                "SELECT value FROM json_pointer WHERE path = $1",
+                &[Value::Text("/certified".to_string())],
+            )
+            .await
+            .expect("committed json pointer should be visible");
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result.rows()[0]
+                .get::<serde_json::Value>("value")
+                .expect("JSON value should decode"),
+            serde_json::json!({"step": 2})
+        );
+    }
+
+    #[tokio::test]
     async fn explicit_transaction_origin_key_survives_addressable_change_assignment() {
         let session = open_session().await;
         session

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -2248,9 +2248,28 @@ where
     ) -> Result<ExecuteResult, LixError> {
         let telemetry =
             SqlStatementTelemetry::start(self.telemetry.as_ref(), sql, "transaction", None);
+        let may_reuse_literal_shape = self.has_started_statement;
+        self.has_started_statement = true;
         let operation = async {
             let _operation_guard = self.begin_session_operation()?;
-            let statement = self.sql_planning_cache.parse_statement(sql)?;
+            let auto_parameterized = (may_reuse_literal_shape && params.is_empty())
+                .then(|| self.sql_planning_cache.auto_parameterized_update(sql))
+                .flatten();
+            let (planning_sql, statement, auto_params) =
+                if let Some(auto_parameterized) = auto_parameterized {
+                    (
+                        auto_parameterized.sql,
+                        auto_parameterized.statement,
+                        Some(auto_parameterized.params),
+                    )
+                } else {
+                    (
+                        Arc::from(sql),
+                        self.sql_planning_cache.parse_statement(sql)?,
+                        None,
+                    )
+                };
+            let params = auto_params.as_deref().unwrap_or(params);
             let transaction = self.transaction_mut()?;
             let is_read = matches!(
                 sql2::bind_statement_route(&statement)?,
@@ -2278,7 +2297,7 @@ where
                 } else {
                     execute_transaction_write_auto(
                         transaction,
-                        sql,
+                        &planning_sql,
                         statement,
                         params,
                         options,
@@ -6651,6 +6670,65 @@ mod tests {
             .rollback()
             .await
             .expect("transaction should roll back");
+    }
+
+    #[tokio::test]
+    async fn explicit_transaction_literal_updates_preserve_escaped_string_values() {
+        let session = open_session().await;
+        for (key, value) in [("auto'one", "seed one"), ("auto'two", "seed two")] {
+            session
+                .execute(
+                    "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
+                    &[Value::Text(key.to_string()), Value::Text(value.to_string())],
+                )
+                .await
+                .expect("seed row should commit");
+        }
+
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("transaction should begin");
+        let first = transaction
+            .execute(
+                "UPDATE lix_key_value SET value = 'first''s value' WHERE key = 'auto''one'",
+                &[],
+            )
+            .await
+            .expect("first literal update should stage");
+        let second = transaction
+            .execute(
+                "UPDATE lix_key_value SET value = 'second''s value' WHERE key = 'auto''two'",
+                &[],
+            )
+            .await
+            .expect("second literal update should reuse the statement shape");
+        assert_eq!(first.rows_affected(), 1);
+        assert_eq!(second.rows_affected(), 1);
+        transaction
+            .commit()
+            .await
+            .expect("literal updates should commit atomically");
+
+        let values = session
+            .execute(
+                "SELECT key, value FROM lix_key_value WHERE key IN ($1, $2) ORDER BY key",
+                &[
+                    Value::Text("auto'one".to_string()),
+                    Value::Text("auto'two".to_string()),
+                ],
+            )
+            .await
+            .expect("updated rows should be readable");
+        assert_eq!(values.len(), 2);
+        assert_eq!(
+            values.rows()[0].get::<serde_json::Value>("value").unwrap(),
+            serde_json::json!("first's value")
+        );
+        assert_eq!(
+            values.rows()[1].get::<serde_json::Value>("value").unwrap(),
+            serde_json::json!("second's value")
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/session/transaction.rs
+++ b/packages/engine/src/session/transaction.rs
@@ -30,6 +30,7 @@ pub struct SessionTransaction<StorageImpl: Storage = Memory> {
     write_access: Option<SessionWriteAccess>,
     collaboration_write_gate: Arc<tokio::sync::Mutex<()>>,
     pub(super) telemetry: Option<Arc<dyn TelemetrySink>>,
+    pub(super) has_started_statement: bool,
 }
 
 impl<StorageImpl> SessionContext<StorageImpl>
@@ -87,6 +88,7 @@ where
             write_access: Some(write_access),
             collaboration_write_gate: Arc::clone(&self.collaboration_write_gate),
             telemetry: self.telemetry.clone(),
+            has_started_statement: false,
         })
     }
 }

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -51,6 +51,8 @@ std::thread_local! {
         const { std::cell::Cell::new(0) };
     static CERTIFIED_GENERATION_IDENTITY_REPLACEMENTS: std::cell::Cell<usize> =
         const { std::cell::Cell::new(0) };
+    static CERTIFIED_SINGLE_PATH_VALUE_REPLACEMENTS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
 }
 
 #[cfg(test)]
@@ -76,6 +78,11 @@ pub(crate) fn take_certified_entity_insert_parameter_batch_executions() -> usize
 #[cfg(test)]
 pub(crate) fn take_certified_generation_identity_replacements() -> usize {
     CERTIFIED_GENERATION_IDENTITY_REPLACEMENTS.with(|executions| executions.replace(0))
+}
+
+#[cfg(test)]
+pub(crate) fn take_certified_single_path_value_replacements() -> usize {
+    CERTIFIED_SINGLE_PATH_VALUE_REPLACEMENTS.with(|executions| executions.replace(0))
 }
 
 #[cfg(test)]
@@ -2168,6 +2175,10 @@ async fn entity_update(
     params: &[Value],
     active_branch_commit_id: Option<&CommitId>,
 ) -> Result<SqlWriteResult, LixError> {
+    if let Some(result) = try_execute_direct_path_value_replacement(ctx, plan, spec, params).await?
+    {
+        return Ok(result);
+    }
     let constraints_unchanged = update_assignments_preserve_constraints(ctx, plan, spec);
     let candidates = scan_entity_candidates(ctx, plan, spec, params).await?;
     let mut write_rows = RawWriteBatch::with_capacity(candidates.len());
@@ -2195,6 +2206,131 @@ async fn entity_update(
         write_rows,
     )
     .await
+}
+
+/// Stages one ordinary `json_pointer(path, value)` point replacement through
+/// the same canonical certificate used by dense parameter batches.
+///
+/// Explicit SQL transactions commonly issue one UPDATE per row because each
+/// call must report its affected-row count immediately. The generic entity
+/// route re-enters plugin reconciliation, schema normalization, and constraint
+/// preparation for every such call even though this exact schema and plan
+/// prove those passes redundant. A visible-row lookup still preserves
+/// statement ordering and transaction-overlay semantics; only ordinary
+/// tracked, branch-local, unfiled rows without metadata take the certificate.
+async fn try_execute_direct_path_value_replacement(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    plan: &LogicalWritePlan,
+    spec: &EntitySurfaceSpec,
+    params: &[Value],
+) -> Result<Option<SqlWriteResult>, LixError> {
+    if spec.has_inter_row_constraints
+        || !matches!(plan.bound.input, BoundWriteInput::None)
+        || plan.bound.conflict.is_some()
+        || plan.bound.returning.is_some()
+        || !matches!(plan.bound.branch_scope, BranchScope::Active { .. })
+        || !matches!(plan.filters.rows, FilterSet::All)
+        || plan_references_active_branch_commit_id(plan)
+        || plan.bound.assignments.iter().any(|assignment| {
+            spec.primary_key_paths
+                .iter()
+                .any(|path| path.as_slice() == [assignment.column.name.as_str()])
+        })
+    {
+        return Ok(None);
+    }
+    let Some(primary_key_param_index) =
+        bound_single_text_primary_key_param(spec, &plan.bound.predicate)
+    else {
+        return Ok(None);
+    };
+    let Some(replacement) =
+        direct_path_value_replacement(spec, plan, Some(primary_key_param_index))
+    else {
+        return Ok(None);
+    };
+    let Some(Value::Text(primary_key)) = params.get(primary_key_param_index) else {
+        return Ok(None);
+    };
+    let replacement_value = match params.get(replacement.value_param_index) {
+        Some(Value::Text(value)) => Some(value.as_str()),
+        Some(Value::Null) => None,
+        _ => return Ok(None),
+    };
+    let Some(schema_catalog) = ctx.schema_catalog_snapshot() else {
+        return Ok(None);
+    };
+    let Some((schema_plan_id, schema_plan)) = schema_catalog.plan_for_key(&spec.schema_key) else {
+        return Ok(None);
+    };
+    if !schema_plan.accepts_canonical_certificate() {
+        return Ok(None);
+    }
+
+    let candidates = scan_entity_candidates(ctx, plan, spec, params).await?;
+    if candidates.is_empty() {
+        return Ok(Some(SqlWriteResult::affected(0)));
+    }
+    if candidates.len() != 1 {
+        return Ok(None);
+    }
+    let candidate = candidates.row(0);
+    if candidate.untracked()
+        || candidate.global()
+        || candidate.file_id().is_some()
+        || candidate.metadata().is_some()
+        || candidate.branch_id() != ctx.active_branch_id()
+    {
+        return Ok(None);
+    }
+
+    let mut normalized = Vec::with_capacity(primary_key.len().saturating_add(32));
+    normalized.extend_from_slice(b"{\"path\":");
+    append_canonical_json_string(&mut normalized, primary_key)?;
+    normalized.extend_from_slice(b",\"value\":");
+    match replacement_value {
+        None => normalized.extend_from_slice(b"null"),
+        Some(raw) => {
+            let value = serde_json::from_str::<JsonValue>(raw).map_err(|error| {
+                LixError::new(
+                    LixError::CODE_TYPE_MISMATCH,
+                    format!("lix_json argument is not valid JSON: {error}"),
+                )
+            })?;
+            serde_json::to_writer(&mut normalized, &value).map_err(|error| {
+                LixError::unknown(format!(
+                    "certified replacement value failed to serialize: {error}"
+                ))
+            })?;
+        }
+    }
+    normalized.push(b'}');
+    let normalized_len = normalized.len();
+    let snapshot =
+        TransactionJson::from_certified_row_content_arena(normalized, vec![(0, normalized_len)])?
+            .pop()
+            .expect("one certified replacement snapshot");
+    let rows = RawWriteBatch::from_certified_parameter_replacement(
+        vec![EntityPk::single(primary_key.clone())],
+        vec![snapshot],
+        spec.schema_key.as_str().into(),
+        ctx.active_branch_id().into(),
+        CertifiedRawWriteBatchPreparation {
+            schema_plan_id,
+            facts: PreparedRowFacts {
+                row_content_validated: true,
+                requires_transaction_validation: false,
+            },
+            tracked_keys_strictly_ordered: true,
+            complete_collection_replacement: false,
+        },
+    )?;
+    ctx.stage_parameter_batch_replace(rows).await?;
+    #[cfg(test)]
+    CERTIFIED_SINGLE_PATH_VALUE_REPLACEMENTS.with(|executions| {
+        executions.set(executions.get().saturating_add(1));
+    });
+    Ok(Some(SqlWriteResult::affected(1)))
 }
 
 /// Stage entity INSERT/UPDATE rows and, when requested, retain their final

--- a/packages/engine/src/sql2/exec/mod.rs
+++ b/packages/engine/src/sql2/exec/mod.rs
@@ -101,5 +101,5 @@ pub(crate) use bound_public_write::{
     take_certified_entity_insert_parameter_batch_executions,
     take_certified_generation_identity_replacements,
     take_certified_replacement_parameter_batch_executions,
-    take_entity_update_parameter_batch_executions,
+    take_certified_single_path_value_replacements, take_entity_update_parameter_batch_executions,
 };

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -63,7 +63,7 @@ pub(crate) use exec::{
     take_certified_entity_insert_parameter_batch_executions,
     take_certified_generation_identity_replacements,
     take_certified_replacement_parameter_batch_executions,
-    take_entity_update_parameter_batch_executions,
+    take_certified_single_path_value_replacements, take_entity_update_parameter_batch_executions,
 };
 pub(crate) use file_view::{
     SessionFileViewKey, SessionFileViewMutation, SessionFileViews, SessionPluginFileView,

--- a/packages/engine/src/sql2/planning_cache.rs
+++ b/packages/engine/src/sql2/planning_cache.rs
@@ -2,15 +2,27 @@ use std::hash::Hash;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex, MutexGuard};
 
-use crate::LixError;
 use crate::sql2::catalog::PublicCatalog;
 use crate::sql2::plan::LogicalWritePlan;
+use crate::{LixError, Value};
 use datafusion::sql::parser::Statement as DataFusionStatement;
 use lru::LruCache;
 
 const PARSED_STATEMENT_CAPACITY: usize = 256;
 const PUBLIC_CATALOG_CAPACITY: usize = 16;
 const WRITE_PLAN_CAPACITY: usize = 256;
+
+/// One conservative auto-parameterization of a literal UPDATE statement.
+///
+/// The normalized SQL is suitable as a planning-cache key while `params`
+/// preserves the values from the caller's original statement. Keeping this
+/// representation private to SQL execution avoids making automatic
+/// parameterization part of the public API contract.
+pub(crate) struct AutoParameterizedUpdate {
+    pub(crate) sql: Arc<str>,
+    pub(crate) statement: DataFusionStatement,
+    pub(crate) params: Vec<Value>,
+}
 
 /// Bounded, engine-owned cache for snapshot-independent SQL planning templates.
 ///
@@ -75,6 +87,24 @@ where
         }
         statements.put(Arc::from(sql), Arc::new(parsed.clone()));
         Ok(parsed)
+    }
+
+    /// Reuses one parsed template for UPDATE statements that differ only in
+    /// ordinary string literals.
+    ///
+    /// This intentionally accepts a narrow, unambiguous SQL subset. Existing
+    /// placeholders, comments, prefixed string forms, and malformed literals
+    /// fall back to exact parsing. The fallback keeps the full SQL surface and
+    /// its existing diagnostics authoritative while the common literal CRUD
+    /// shape avoids churning the bounded exact-text caches.
+    pub(crate) fn auto_parameterized_update(&self, sql: &str) -> Option<AutoParameterizedUpdate> {
+        let (normalized_sql, params) = normalize_update_string_literals(sql)?;
+        let statement = self.parse_statement(&normalized_sql).ok()?;
+        Some(AutoParameterizedUpdate {
+            sql: Arc::from(normalized_sql),
+            statement,
+            params,
+        })
     }
 
     /// Returns stable public-surface metadata for one catalog generation.
@@ -162,6 +192,86 @@ fn lock_or_recover<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
         .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
+fn normalize_update_string_literals(sql: &str) -> Option<(String, Vec<Value>)> {
+    let trimmed = sql.trim_start();
+    let update = trimmed.get(.."UPDATE".len())?;
+    if !update.eq_ignore_ascii_case("UPDATE")
+        || !trimmed
+            .as_bytes()
+            .get("UPDATE".len())
+            .is_some_and(u8::is_ascii_whitespace)
+    {
+        return None;
+    }
+
+    let bytes = sql.as_bytes();
+    let mut normalized = String::with_capacity(sql.len());
+    let mut params = Vec::new();
+    let mut cursor = 0;
+    let mut copied = 0;
+    let mut quoted_identifier = false;
+
+    while cursor < bytes.len() {
+        match bytes[cursor] {
+            b'"' => {
+                if quoted_identifier && bytes.get(cursor + 1) == Some(&b'"') {
+                    cursor += 2;
+                    continue;
+                }
+                quoted_identifier = !quoted_identifier;
+                cursor += 1;
+            }
+            b'-' if !quoted_identifier && bytes.get(cursor + 1) == Some(&b'-') => return None,
+            b'/' if !quoted_identifier && bytes.get(cursor + 1) == Some(&b'*') => return None,
+            b'?' | b'$' if !quoted_identifier => return None,
+            b'\'' if !quoted_identifier => {
+                if bytes[..cursor]
+                    .iter()
+                    .rposition(|byte| !byte.is_ascii_whitespace())
+                    .is_some_and(|index| {
+                        matches!(bytes[index], b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_')
+                    })
+                {
+                    return None;
+                }
+                normalized.push_str(&sql[copied..cursor]);
+                normalized.push('$');
+                normalized.push_str(&(params.len() + 1).to_string());
+
+                cursor += 1;
+                let mut value = String::new();
+                let value_start = cursor;
+                let mut segment_start = cursor;
+                loop {
+                    let quote = bytes[cursor..]
+                        .iter()
+                        .position(|byte| *byte == b'\'')
+                        .map(|offset| cursor + offset)?;
+                    value.push_str(&sql[segment_start..quote]);
+                    if bytes.get(quote + 1) == Some(&b'\'') {
+                        value.push('\'');
+                        cursor = quote + 2;
+                        segment_start = cursor;
+                        continue;
+                    }
+                    cursor = quote + 1;
+                    copied = cursor;
+                    break;
+                }
+                debug_assert!(cursor > value_start);
+                params.push(Value::Text(value));
+            }
+            _ => cursor += 1,
+        }
+    }
+
+    if quoted_identifier || params.is_empty() {
+        return None;
+    }
+    normalized.push_str(&sql[copied..]);
+    Some((normalized, params))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -206,6 +316,54 @@ mod tests {
 
         assert!(cache.parse_statement("SELECT (").is_err());
         assert!(lock_or_recover(&cache.parsed_statements).is_empty());
+    }
+
+    #[test]
+    fn literal_updates_share_one_parameterized_parse_template() {
+        let cache = test_cache(8);
+        let first = cache
+            .auto_parameterized_update(
+                "UPDATE notes SET value = lix_json('{\"text\":\"first\"}') WHERE id = 'a'",
+            )
+            .expect("literal update auto-parameterizes");
+        let second = cache
+            .auto_parameterized_update(
+                "UPDATE notes SET value = lix_json('{\"text\":\"second\"}') WHERE id = 'b'",
+            )
+            .expect("case-equivalent literal update auto-parameterizes");
+
+        assert_eq!(
+            first.sql.as_ref(),
+            "UPDATE notes SET value = lix_json($1) WHERE id = $2"
+        );
+        assert_eq!(
+            first.params,
+            [
+                Value::Text("{\"text\":\"first\"}".to_string()),
+                Value::Text("a".to_string())
+            ]
+        );
+        assert_eq!(
+            second.params,
+            [
+                Value::Text("{\"text\":\"second\"}".to_string()),
+                Value::Text("b".to_string())
+            ]
+        );
+        assert_eq!(lock_or_recover(&cache.parsed_statements).len(), 1);
+    }
+
+    #[test]
+    fn ambiguous_literal_updates_keep_exact_sql_path() {
+        let cache = test_cache(8);
+        for sql in [
+            "UPDATE notes SET value = $1 WHERE id = 'a'",
+            "UPDATE notes SET value = DATE '2026-08-01' WHERE id = 'a'",
+            "UPDATE notes SET value = 'a' -- comment",
+            "SELECT 'not an update'",
+        ] {
+            assert!(cache.auto_parameterized_update(sql).is_none(), "{sql}");
+        }
     }
 
     #[test]

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -964,15 +964,33 @@ impl TransactionWriteBuffer {
                 "failed to acquire transaction staged writes lock",
             )
         })?;
-        let rows = match &*rows {
-            StagedPreparedRows::AppendOnly { rows, .. }
-            | StagedPreparedRows::Indexed { rows, .. } => rows,
+        let registered_schema_key = crate::transaction::normalization::REGISTERED_SCHEMA_KEY;
+        let (rows, candidate_slots) = match &*rows {
+            StagedPreparedRows::AppendOnly { rows, .. } => (rows, None),
+            StagedPreparedRows::Indexed {
+                rows, by_candidate, ..
+            } => (
+                rows,
+                Some(
+                    by_candidate
+                        .slots_by_schema
+                        .get(registered_schema_key)
+                        .map(SmallVec::as_slice)
+                        .unwrap_or(&[]),
+                ),
+            ),
         };
-        Ok(rows.iter().any(|row| {
-            row.schema_key.as_str() == crate::transaction::normalization::REGISTERED_SCHEMA_KEY
+        let matches_domain = |row: PreparedStateRowRef<'_>| {
+            row.schema_key.as_str() == registered_schema_key
                 && row.branch_id.as_str() == domain.branch_id()
                 && (row.untracked == domain.untracked() || (domain.untracked() && !row.untracked))
-        }))
+        };
+        Ok(match candidate_slots {
+            Some(slots) => slots.iter().any(|slot| match slot {
+                RowSlot::State(index) => matches_domain(rows.row(*index)),
+            }),
+            None => rows.iter().any(matches_domain),
+        })
     }
 
     /// Promotes the compact ordered journal into the existing identity overlay
@@ -2988,6 +3006,62 @@ mod tests {
         assert!(
             staged_writes.uses_identity_index_for_tests(),
             "reads keep the single materialized index rather than rebuilding it"
+        );
+    }
+
+    #[test]
+    fn indexed_schema_catalog_probe_uses_schema_candidates_and_preserves_domains() {
+        let branch_id = "01920000-0000-7000-8000-0000000000a1";
+        let staged_writes = test_staged_writes();
+        staged_writes
+            .stage_write(PreparedTransactionWrite::Rows {
+                mode: TransactionWriteMode::Replace,
+                rows: prepared_rows![tracked_append_row("entity-a", "ordinary")],
+            })
+            .expect("ordinary row should stage");
+        let overlay = staged_writes
+            .staging_overlay()
+            .expect("overlay should build");
+        assert!(
+            overlay
+                .load_exact(&exact_request_for_branch_key(branch_id, "entity-a"))
+                .is_some()
+        );
+        assert!(staged_writes.uses_identity_index_for_tests());
+
+        let tracked_domain = Domain::schema_catalog(branch_id, false);
+        assert!(
+            !staged_writes
+                .has_staged_schema_catalog_change(&tracked_domain)
+                .expect("indexed catalog probe should succeed")
+        );
+
+        let mut schema_row = tracked_append_row("schema-a", "schema");
+        schema_row.schema_key = crate::transaction::normalization::REGISTERED_SCHEMA_KEY.into();
+        staged_writes
+            .stage_write(PreparedTransactionWrite::Rows {
+                mode: TransactionWriteMode::Replace,
+                rows: prepared_rows![schema_row],
+            })
+            .expect("registered schema row should stage into the index");
+
+        assert!(
+            staged_writes
+                .has_staged_schema_catalog_change(&tracked_domain)
+                .expect("tracked catalog change should be detected")
+        );
+        assert!(
+            staged_writes
+                .has_staged_schema_catalog_change(&Domain::schema_catalog(branch_id, true))
+                .expect("untracked catalog includes tracked schema definitions")
+        );
+        assert!(
+            !staged_writes
+                .has_staged_schema_catalog_change(&Domain::schema_catalog(
+                    "01920000-0000-7000-8000-0000000000b1",
+                    false,
+                ))
+                .expect("other branch should remain independent")
         );
     }
 


### PR DESCRIPTION
## What changed

- Route one ordinary tracked `json_pointer(path, value)` point replacement through the existing canonical replacement certificate.
- Preserve immediate statement semantics by retaining the transaction-visible candidate lookup before certification.
- Keep global, untracked, file-owned, metadata-bearing, constrained, `RETURNING`, and ambiguous rows on the generic path.
- Use the transaction overlay's schema candidate index when checking whether a staged schema change invalidates a certificate, replacing the previous O(staged rows) scan.

## Why

After #1079 removed repeated literal parsing/planning, profiling a 10k explicit transaction showed final commit materialization was only about 44 ms. The remaining dominant work was repeated entity candidate lookup plus re-entering generic plugin reconciliation, normalization, and constraint preparation for a schema shape the catalog already certifies.

The first singleton-certificate prototype regressed because certificate validity scanned every staged row for every statement. Indexing that check removes the superlinear scan and makes the narrow certificate profitable while keeping fallback semantics intact.

## Performance

Immediate parent: #1079 (`codex/auto-parameterize-literal-updates`). Back-to-back release runs, 15 samples at 10k rows:

| Storage | #1079 UPDATE | This PR | Change |
| --- | ---: | ---: | ---: |
| RocksDB | 451.58 ms | 378.32 ms | **-16.2%** |
| SlateDB | 509.04 ms | 413.98 ms | **-18.7%** |

1M-row setup-excluded runs:

| Storage | #1079 UPDATE | This PR | Change | Candidate max RSS |
| --- | ---: | ---: | ---: | ---: |
| RocksDB | 141.05 s | 126.55 s | **-10.3%** | 3,600,176 KiB |
| SlateDB | 144.68 s | 130.46 s | **-9.8%** | 3,105,736 KiB |

Unaffected 10k controls remained inside the 10% guard. Three 101-sample rounds put RocksDB point UPDATE at 909.39 -> 899.69 us and SlateDB at 1,008.03 -> 986.65 us (median of round medians). DELETE medians were +6.6% RocksDB and -6.8% SlateDB. Dense bound UPDATE was +5.4% RocksDB and +7.7% SlateDB.

Non-CRUD guards against the same parent:

- Working diff: paired 101-sample distributions overlap on the same fixtures.
- Merge preview, 20k rows / 10k source changes: RocksDB 161.89 -> 158.21 ms; SlateDB 177.11 -> 174.42 ms.
- Merge commit, three 101-cycle rounds: median-of-round p50 was 2.124 -> 2.127 ms RocksDB and 3.349 -> 3.347 ms SlateDB.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p lix_engine --all-targets --features storage-benches -- -D warnings`
- `cargo test -p lix_engine --features storage-benches --quiet`
  - 1,690 unit tests passed; 6 ignored
  - 435 integration tests passed; 2 ignored
  - 3 doctests passed
- `git diff --check`

No changenote is included.
