### PR TITLE
perf(engine): cache packed point addresses

### DIFF
--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -1851,6 +1851,7 @@ struct HotCollectionControl {
 }
 
 const TRANSACTION_HOT_STATE_CACHE_MAX_ENTRIES: usize = 64;
+const TRANSACTION_PACKED_POINT_CACHE_MIN_OBSERVATIONS: u8 = 16;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct HotCollectionCacheKey {
@@ -1865,9 +1866,61 @@ struct HotCollectionCacheKey {
 pub(crate) struct HotStateTransactionCache {
     collection_controls: StdMutex<BTreeMap<HotCollectionCacheKey, HotCollectionControl>>,
     certified_absent_generations: StdMutex<BTreeSet<CommitId>>,
+    packed_point_generation_observations: StdMutex<SmallVec<[(CommitId, u8); 4]>>,
+    packed_current_base_refs: StdMutex<BTreeMap<(String, CommitId), Vec<PackedCurrentBaseRef>>>,
+    commit_delta_points: crate::tracked_state::CommitDeltaPointReadCache,
 }
 
 impl HotStateTransactionCache {
+    fn should_reuse_packed_points(&self, generation: CommitId) -> Result<bool, LixError> {
+        let mut generations = self
+            .packed_point_generation_observations
+            .lock()
+            .map_err(|_| hot_state_cache_lock_error())?;
+        if let Some((_, observations)) = generations
+            .iter_mut()
+            .find(|(candidate, _)| *candidate == generation)
+        {
+            *observations = observations.saturating_add(1);
+            return Ok(*observations >= TRANSACTION_PACKED_POINT_CACHE_MIN_OBSERVATIONS);
+        }
+        if generations.len() < TRANSACTION_HOT_STATE_CACHE_MAX_ENTRIES {
+            generations.push((generation, 1));
+        }
+        Ok(false)
+    }
+
+    fn packed_current_base_refs(
+        &self,
+        branch_id: &str,
+        generation: CommitId,
+    ) -> Result<Option<Vec<PackedCurrentBaseRef>>, LixError> {
+        Ok(self
+            .packed_current_base_refs
+            .lock()
+            .map_err(|_| hot_state_cache_lock_error())?
+            .get(&(branch_id.to_owned(), generation))
+            .cloned())
+    }
+
+    fn remember_packed_current_base_refs(
+        &self,
+        branch_id: &str,
+        generation: CommitId,
+        refs: &[PackedCurrentBaseRef],
+    ) -> Result<(), LixError> {
+        let mut entries = self
+            .packed_current_base_refs
+            .lock()
+            .map_err(|_| hot_state_cache_lock_error())?;
+        if entries.len() < TRANSACTION_HOT_STATE_CACHE_MAX_ENTRIES {
+            entries
+                .entry((branch_id.to_owned(), generation))
+                .or_insert_with(|| refs.to_vec());
+        }
+        Ok(())
+    }
+
     fn collection_control(
         &self,
         key: &HotCollectionCacheKey,
@@ -2365,6 +2418,7 @@ fn stage_complete_collection_controls(
     Ok(())
 }
 
+#[derive(Clone)]
 struct PackedCurrentBaseRef {
     commit_id: CommitId,
     checkpoint_commit_id: Option<CommitId>,
@@ -2914,6 +2968,7 @@ async fn load_packed_current_base_exact(
     active_checkpoint_commit_id: Option<CommitId>,
     keys: &[TrackedStateKeyRef<'_>],
     projection: ChangeRecordProjection,
+    transaction_cache: Option<&HotStateTransactionCache>,
 ) -> Result<MaterializedLiveStateExactBatch, LixError> {
     if keys.is_empty() {
         return MaterializedLiveStateExactBatch::new(
@@ -2921,8 +2976,14 @@ async fn load_packed_current_base_exact(
             Vec::new(),
         );
     }
-    let winners =
-        load_packed_current_base_exact_entries(store, branch_id, generation, keys).await?;
+    let winners = load_packed_current_base_exact_entries(
+        store,
+        branch_id,
+        generation,
+        keys,
+        transaction_cache,
+    )
+    .await?;
 
     let mut rows = MaterializedLiveStateBatchBuilder::with_capacity(keys.len());
     let mut slots = Vec::with_capacity(keys.len());
@@ -3015,6 +3076,7 @@ async fn load_packed_current_base_exact_entries(
     branch_id: &str,
     generation: CommitId,
     keys: &[TrackedStateKeyRef<'_>],
+    transaction_cache: Option<&HotStateTransactionCache>,
 ) -> Result<
     Vec<
         Option<(
@@ -3027,7 +3089,24 @@ async fn load_packed_current_base_exact_entries(
     if keys.is_empty() {
         return Ok(Vec::new());
     }
-    let base_refs = packed_current_base_refs(store, branch_id, generation).await?;
+    let transaction_cache = match transaction_cache {
+        Some(cache) if cache.should_reuse_packed_points(generation)? => Some(cache),
+        Some(_) | None => None,
+    };
+    let base_refs = match transaction_cache
+        .map(|cache| cache.packed_current_base_refs(branch_id, generation))
+        .transpose()?
+        .flatten()
+    {
+        Some(refs) => refs,
+        None => {
+            let refs = packed_current_base_refs(store, branch_id, generation).await?;
+            if let Some(cache) = transaction_cache {
+                cache.remember_packed_current_base_refs(branch_id, generation, &refs)?;
+            }
+            refs
+        }
+    };
     if base_refs.is_empty() {
         return Ok((0..keys.len()).map(|_| None).collect());
     }
@@ -3037,6 +3116,7 @@ async fn load_packed_current_base_exact_entries(
                 store,
                 base_ref.commit_id,
                 keys,
+                transaction_cache.map(|cache| &cache.commit_delta_points),
             )
             .await?
             .into_iter()
@@ -3053,7 +3133,7 @@ async fn load_packed_current_base_exact_entries(
         })
         .collect::<Vec<_>>();
     let mut requests = Vec::with_capacity(base_refs.len().saturating_mul(keys.len()));
-    for base_ref in &base_refs {
+    for base_ref in base_refs.iter() {
         requests.extend(
             owned_keys
                 .iter()
@@ -3472,6 +3552,7 @@ where
                 active_checkpoint_commit_id,
                 &key_refs,
                 projection,
+                self.transaction_cache.as_deref(),
             )
             .await?
             .into_present_batch()
@@ -3771,6 +3852,7 @@ where
             active_checkpoint_commit_id,
             keys,
             *projection,
+            self.transaction_cache.as_deref(),
         )
         .await?;
         let mut resolved = Vec::with_capacity(keys.len());
@@ -4894,6 +4976,7 @@ where
             branch_id,
             generation,
             &packed_previous_keys,
+            None,
         ))
         .await?;
         for (index, packed_previous) in packed_previous_indices.into_iter().zip(packed_previous) {
@@ -8887,6 +8970,31 @@ mod tests {
             cache
                 .remember_certified_generation_absent(generation)
                 .expect("remember absent certified generation");
+            cache
+                .remember_packed_current_base_refs(
+                    &format!("packed-branch-{index}"),
+                    generation,
+                    &[PackedCurrentBaseRef {
+                        commit_id: generation,
+                        checkpoint_commit_id: None,
+                        coverage_key: Bytes::new(),
+                    }],
+                )
+                .expect("remember packed current-base refs");
+            assert!(
+                !cache
+                    .should_reuse_packed_points(generation)
+                    .expect("observe first packed point scope")
+            );
+            for observation in 2..=TRANSACTION_PACKED_POINT_CACHE_MIN_OBSERVATIONS {
+                assert_eq!(
+                    cache
+                        .should_reuse_packed_points(generation)
+                        .expect("observe packed point scope"),
+                    index < TRANSACTION_HOT_STATE_CACHE_MAX_ENTRIES
+                        && observation == TRANSACTION_PACKED_POINT_CACHE_MIN_OBSERVATIONS,
+                );
+            }
         }
         assert_eq!(
             cache.collection_controls.lock().unwrap().len(),
@@ -8894,6 +9002,18 @@ mod tests {
         );
         assert_eq!(
             cache.certified_absent_generations.lock().unwrap().len(),
+            TRANSACTION_HOT_STATE_CACHE_MAX_ENTRIES
+        );
+        assert_eq!(
+            cache.packed_current_base_refs.lock().unwrap().len(),
+            TRANSACTION_HOT_STATE_CACHE_MAX_ENTRIES
+        );
+        assert_eq!(
+            cache
+                .packed_point_generation_observations
+                .lock()
+                .unwrap()
+                .len(),
             TRANSACTION_HOT_STATE_CACHE_MAX_ENTRIES
         );
     }
@@ -9170,25 +9290,78 @@ mod tests {
             .expect("publish packed system-schema fixture");
 
         let json_get_many_calls = Arc::new(AtomicUsize::new(0));
+        let get_many_calls = Arc::new(AtomicUsize::new(0));
+        let scan_calls = Arc::new(AtomicUsize::new(0));
         let read = JsonCountingRead {
-            inner: storage
-                .begin_read(StorageReadOptions::default())
-                .await
-                .expect("open packed fixture read"),
+            inner: CountingRead {
+                inner: storage
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .expect("open packed fixture read"),
+                get_many_calls: Arc::clone(&get_many_calls),
+                scan_calls: Some(Arc::clone(&scan_calls)),
+            },
             json_get_many_calls: Arc::clone(&json_get_many_calls),
         };
+        let transaction_cache = Arc::new(HotStateTransactionCache::default());
+        let request_keys = [TrackedStateKeyRef {
+            schema_key: "lix_key_value",
+            entity_pk: &entity_pk,
+            file_id: None,
+        }];
         let entries = load_packed_current_base_exact_entries(
             &read,
             crate::GLOBAL_BRANCH_ID,
             generation,
-            &[TrackedStateKeyRef {
-                schema_key: "lix_key_value",
-                entity_pk: &entity_pk,
-                file_id: None,
-            }],
+            &request_keys,
+            Some(transaction_cache.as_ref()),
         )
         .await
         .expect("load packed mutation predecessor");
+        for _ in 2..=TRANSACTION_PACKED_POINT_CACHE_MIN_OBSERVATIONS {
+            let observed = load_packed_current_base_exact_entries(
+                &read,
+                crate::GLOBAL_BRANCH_ID,
+                generation,
+                &request_keys,
+                Some(transaction_cache.as_ref()),
+            )
+            .await
+            .expect("observe repeated packed mutation predecessor");
+            assert!(observed[0].is_some());
+        }
+        let admitted = load_packed_current_base_exact_entries(
+            &read,
+            crate::GLOBAL_BRANCH_ID,
+            generation,
+            &request_keys,
+            Some(transaction_cache.as_ref()),
+        )
+        .await
+        .expect("admit repeated packed mutation predecessor");
+        assert!(admitted[0].is_some());
+        let admitted_read_counts = (
+            get_many_calls.load(Ordering::Relaxed),
+            scan_calls.load(Ordering::Relaxed),
+        );
+        let reused = load_packed_current_base_exact_entries(
+            &read,
+            crate::GLOBAL_BRANCH_ID,
+            generation,
+            &request_keys,
+            Some(transaction_cache.as_ref()),
+        )
+        .await
+        .expect("reuse admitted packed mutation predecessor");
+        assert!(reused[0].is_some());
+        assert_eq!(
+            (
+                get_many_calls.load(Ordering::Relaxed),
+                scan_calls.load(Ordering::Relaxed),
+            ),
+            admitted_read_counts,
+            "a transaction snapshot must reuse an admitted packed segment by immutable address"
+        );
         let (_, change) = entries[0].as_ref().expect("packed predecessor exists");
         assert!(
             matches!(change.snapshot, JsonSlot::Ref(_)),
@@ -9202,7 +9375,7 @@ mod tests {
 
         let reader = HotStateStoreReader {
             store: read,
-            transaction_cache: None,
+            transaction_cache: Some(transaction_cache),
         };
         let control = BranchHeadControl {
             head_commit_id: generation,

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -30,16 +30,16 @@ pub(crate) use row_materialization::{
 #[cfg(test)]
 pub(crate) use storage::load_commit_delta_change_ids;
 pub(crate) use storage::{
-    CommitDeltaChangeLocator, CommitDeltaMember, commit_delta_contains_schema,
-    direct_change_locator, load_change_record_by_id, load_commit_delta_change_records,
-    load_commit_delta_members_with_payloads, load_commit_delta_members_with_payloads_for_schemas,
-    load_commit_delta_selection_certificate, load_owned_commit_delta_entries,
-    load_owned_commit_delta_entries_one_ordered_ref, scan_change_records_from_commit_deltas,
-    scan_commit_delta_inventory, scan_commit_delta_values, selected_change_selection_fingerprint,
-    stage_addressable_commit_deltas, stage_addressable_commit_deltas_with_selected_source,
-    stage_change_locators, stage_commit_deltas, stage_delete_change_locators,
-    stage_delete_commit_delta_inventory_entry, stage_delete_commit_roots,
-    stage_ordered_addressable_commit_deltas,
+    CommitDeltaChangeLocator, CommitDeltaMember, CommitDeltaPointReadCache,
+    commit_delta_contains_schema, direct_change_locator, load_change_record_by_id,
+    load_commit_delta_change_records, load_commit_delta_members_with_payloads,
+    load_commit_delta_members_with_payloads_for_schemas, load_commit_delta_selection_certificate,
+    load_owned_commit_delta_entries, load_owned_commit_delta_entries_one_ordered_ref,
+    scan_change_records_from_commit_deltas, scan_commit_delta_inventory, scan_commit_delta_values,
+    selected_change_selection_fingerprint, stage_addressable_commit_deltas,
+    stage_addressable_commit_deltas_with_selected_source, stage_change_locators,
+    stage_commit_deltas, stage_delete_change_locators, stage_delete_commit_delta_inventory_entry,
+    stage_delete_commit_roots, stage_ordered_addressable_commit_deltas,
 };
 #[cfg(feature = "storage-benches")]
 pub(crate) use storage::{

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -6,7 +6,7 @@
 
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
-use std::ops::{Bound, Range};
+use std::ops::{Bound, Deref, Range};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::changelog::CommitId;
@@ -88,6 +88,8 @@ const DECODED_COMMIT_DELTA_CACHE_MAX_BYTES: usize = 8 * 1024 * 1024;
 const DECODED_COMMIT_DELTA_CACHE_MAX_ENTRIES: usize = 8;
 const DECODED_COMMIT_DELTA_CACHE_ADMISSION_ENTRIES: usize = 32;
 const DECODED_COMMIT_DELTA_CACHE_MAX_POINT_KEYS: usize = 16;
+const TRANSACTION_COMMIT_DELTA_POINT_CACHE_MAX_BYTES: usize = 2 * 1024 * 1024;
+const TRANSACTION_COMMIT_DELTA_POINT_CACHE_MAX_ENTRIES: usize = 2;
 
 enum CommitDeltaSegmentEncodeError {
     SidecarTooLarge,
@@ -575,6 +577,193 @@ impl DecodedCommitDeltaCache {
 fn decoded_commit_delta_cache() -> &'static Mutex<DecodedCommitDeltaCache> {
     static CACHE: OnceLock<Mutex<DecodedCommitDeltaCache>> = OnceLock::new();
     CACHE.get_or_init(|| Mutex::new(DecodedCommitDeltaCache::default()))
+}
+
+/// Bounded immutable-address cache for repeated point reads in one storage
+/// snapshot. Unlike the process-wide content cache, this may trust
+/// `(commit_id, segment_index)` because a transaction cannot cross repositories
+/// or observe a rewritten value at that address.
+#[derive(Default)]
+pub(crate) struct CommitDeltaPointReadCache {
+    inner: Mutex<CommitDeltaPointReadCacheInner>,
+}
+
+#[derive(Default)]
+struct CommitDeltaPointReadCacheInner {
+    manifests: VecDeque<(CommitId, Arc<CommitDeltaManifest>)>,
+    segments: VecDeque<((CommitId, usize), Arc<DecodedCommitDeltaSegment>)>,
+    recent_segment_misses: VecDeque<(CommitId, usize)>,
+    segment_resident_bytes: usize,
+}
+
+impl CommitDeltaPointReadCache {
+    fn should_admit_segment(
+        &self,
+        commit_id: CommitId,
+        segment_index: usize,
+    ) -> Result<bool, LixError> {
+        let address = (commit_id, segment_index);
+        let mut cache = self.inner.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "transaction commit-delta point cache lock is poisoned",
+            )
+        })?;
+        if let Some(position) = cache
+            .recent_segment_misses
+            .iter()
+            .position(|candidate| *candidate == address)
+        {
+            cache.recent_segment_misses.remove(position);
+            return Ok(true);
+        }
+        cache.recent_segment_misses.push_back(address);
+        while cache.recent_segment_misses.len() > DECODED_COMMIT_DELTA_CACHE_ADMISSION_ENTRIES {
+            cache.recent_segment_misses.pop_front();
+        }
+        Ok(false)
+    }
+
+    fn manifest(&self, commit_id: CommitId) -> Result<Option<Arc<CommitDeltaManifest>>, LixError> {
+        let mut cache = self.inner.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "transaction commit-delta point cache lock is poisoned",
+            )
+        })?;
+        let Some(position) = cache
+            .manifests
+            .iter()
+            .position(|(cached_commit_id, _)| *cached_commit_id == commit_id)
+        else {
+            return Ok(None);
+        };
+        let entry = cache
+            .manifests
+            .remove(position)
+            .expect("located transaction commit-delta manifest cache entry");
+        let manifest = Arc::clone(&entry.1);
+        cache.manifests.push_back(entry);
+        Ok(Some(manifest))
+    }
+
+    fn remember_manifest(
+        &self,
+        commit_id: CommitId,
+        manifest: Arc<CommitDeltaManifest>,
+    ) -> Result<(), LixError> {
+        let mut cache = self.inner.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "transaction commit-delta point cache lock is poisoned",
+            )
+        })?;
+        if let Some(position) = cache
+            .manifests
+            .iter()
+            .position(|(cached_commit_id, _)| *cached_commit_id == commit_id)
+        {
+            cache.manifests.remove(position);
+        }
+        cache.manifests.push_back((commit_id, manifest));
+        while cache.manifests.len() > DECODED_COMMIT_DELTA_CACHE_MAX_ENTRIES {
+            cache.manifests.pop_front();
+        }
+        Ok(())
+    }
+
+    fn segment(
+        &self,
+        commit_id: CommitId,
+        segment_index: usize,
+        expected_bounds: Option<&CommitDeltaSegmentBounds>,
+    ) -> Result<Option<Arc<DecodedCommitDeltaSegment>>, LixError> {
+        let mut cache = self.inner.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "transaction commit-delta point cache lock is poisoned",
+            )
+        })?;
+        let Some(position) = cache
+            .segments
+            .iter()
+            .position(|(address, _)| *address == (commit_id, segment_index))
+        else {
+            return Ok(None);
+        };
+        validate_decoded_commit_delta_bounds(&cache.segments[position].1.leaf, expected_bounds)?;
+        let entry = cache
+            .segments
+            .remove(position)
+            .expect("located transaction commit-delta segment cache entry");
+        let decoded = Arc::clone(&entry.1);
+        cache.segments.push_back(entry);
+        Ok(Some(decoded))
+    }
+
+    fn remember_segment(
+        &self,
+        commit_id: CommitId,
+        segment_index: usize,
+        decoded: Arc<DecodedCommitDeltaSegment>,
+    ) -> Result<(), LixError> {
+        if decoded.resident_bytes > TRANSACTION_COMMIT_DELTA_POINT_CACHE_MAX_BYTES {
+            return Ok(());
+        }
+        let mut cache = self.inner.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "transaction commit-delta point cache lock is poisoned",
+            )
+        })?;
+        if let Some(position) = cache
+            .segments
+            .iter()
+            .position(|(address, _)| *address == (commit_id, segment_index))
+        {
+            let previous = cache
+                .segments
+                .remove(position)
+                .expect("located transaction commit-delta segment cache entry");
+            cache.segment_resident_bytes = cache
+                .segment_resident_bytes
+                .saturating_sub(previous.1.resident_bytes);
+        }
+        cache.segment_resident_bytes = cache
+            .segment_resident_bytes
+            .saturating_add(decoded.resident_bytes);
+        cache
+            .segments
+            .push_back(((commit_id, segment_index), decoded));
+        while cache.segment_resident_bytes > TRANSACTION_COMMIT_DELTA_POINT_CACHE_MAX_BYTES
+            || cache.segments.len() > TRANSACTION_COMMIT_DELTA_POINT_CACHE_MAX_ENTRIES
+        {
+            let evicted = cache
+                .segments
+                .pop_front()
+                .expect("over-budget transaction commit-delta cache is non-empty");
+            cache.segment_resident_bytes = cache
+                .segment_resident_bytes
+                .saturating_sub(evicted.1.resident_bytes);
+        }
+        Ok(())
+    }
+}
+
+enum PointReadCommitDeltaManifest {
+    Owned(CommitDeltaManifest),
+    Cached(Arc<CommitDeltaManifest>),
+}
+
+impl Deref for PointReadCommitDeltaManifest {
+    type Target = CommitDeltaManifest;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Owned(manifest) => manifest,
+            Self::Cached(manifest) => manifest,
+        }
+    }
 }
 
 const COMMIT_DELTA_SMALL_STRING_DICTIONARY_LIMIT: usize = 32;
@@ -2662,6 +2851,7 @@ pub(crate) async fn load_owned_commit_delta_entries_one_ordered_ref(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
     keys: &[TrackedStateKeyRef<'_>],
+    point_cache: Option<&CommitDeltaPointReadCache>,
 ) -> Result<Vec<Option<LoadedCommitDeltaEntry>>, LixError> {
     if keys.is_empty() {
         return Ok(Vec::new());
@@ -2672,7 +2862,8 @@ pub(crate) async fn load_owned_commit_delta_entries_one_ordered_ref(
     });
     if strictly_ordered {
         let output =
-            load_local_owned_commit_delta_entries_one_ordered(store, commit_id, keys).await?;
+            load_local_owned_commit_delta_entries_one_ordered(store, commit_id, keys, point_cache)
+                .await?;
         if output.iter().all(Option::is_some) {
             return Ok(output);
         }
@@ -2716,6 +2907,7 @@ async fn load_local_owned_commit_delta_entries(
             store,
             requests[0].0,
             &keys,
+            None,
         ))
         .await;
     }
@@ -2842,26 +3034,82 @@ async fn load_local_owned_commit_delta_entries_one_ordered(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
     keys: &[TrackedStateKeyRef<'_>],
+    point_cache: Option<&CommitDeltaPointReadCache>,
 ) -> Result<Vec<Option<LoadedCommitDeltaEntry>>, LixError> {
-    let manifest_key = StorageKey(Bytes::from(commit_delta_manifest_key(commit_id)));
-    let manifest_values = PointReadPlan::new(
-        TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
-        std::slice::from_ref(&manifest_key),
-    )
-    .materialize(store, StorageGetOptions::default())
-    .await?;
-    let Some(bytes) = manifest_values
-        .value
-        .into_iter()
-        .next()
+    let manifest = match point_cache
+        .map(|cache| cache.manifest(commit_id))
+        .transpose()?
         .flatten()
-        .and_then(full_value_bytes)
-    else {
-        return Ok((0..keys.len()).map(|_| None).collect());
+    {
+        Some(manifest) => PointReadCommitDeltaManifest::Cached(manifest),
+        None => {
+            let manifest_key = StorageKey(Bytes::from(commit_delta_manifest_key(commit_id)));
+            let manifest_values = PointReadPlan::new(
+                TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
+                std::slice::from_ref(&manifest_key),
+            )
+            .materialize(store, StorageGetOptions::default())
+            .await?;
+            let Some(bytes) = manifest_values
+                .value
+                .into_iter()
+                .next()
+                .flatten()
+                .and_then(full_value_bytes)
+            else {
+                return Ok((0..keys.len()).map(|_| None).collect());
+            };
+            let manifest = decode_commit_delta_manifest(&bytes)?;
+            match point_cache {
+                Some(cache) => {
+                    let manifest = Arc::new(manifest);
+                    cache.remember_manifest(commit_id, Arc::clone(&manifest))?;
+                    PointReadCommitDeltaManifest::Cached(manifest)
+                }
+                None => PointReadCommitDeltaManifest::Owned(manifest),
+            }
+        }
     };
-    let manifest = decode_commit_delta_manifest(&bytes)?;
     let mut output = (0..keys.len()).map(|_| None).collect::<Vec<_>>();
     if let Some(inline_segment) = manifest.inline_segment() {
+        if keys.len() <= DECODED_COMMIT_DELTA_CACHE_MAX_POINT_KEYS
+            && let Some(cache) = point_cache
+        {
+            let decoded = match cache.segment(commit_id, 0, None)? {
+                Some(decoded) => decoded,
+                None => {
+                    if !cache.should_admit_segment(commit_id, 0)? {
+                        let (leaf, payloads) =
+                            decode_commit_delta_with_payloads(inline_segment, None)?;
+                        for (request_index, &key) in keys.iter().enumerate() {
+                            let encoded_key = encode_key_ref(key);
+                            output[request_index] = find_loaded_commit_delta_entry(
+                                &leaf,
+                                &payloads,
+                                &encoded_key,
+                                commit_id,
+                            )?;
+                        }
+                        hydrate_selected_loaded_entries(store, &mut output).await?;
+                        return Ok(output);
+                    }
+                    let decoded = decode_owned_commit_delta_segment(inline_segment, None)?;
+                    cache.remember_segment(commit_id, 0, Arc::clone(&decoded))?;
+                    decoded
+                }
+            };
+            for (request_index, &key) in keys.iter().enumerate() {
+                let encoded_key = encode_key_ref(key);
+                output[request_index] = find_loaded_commit_delta_entry(
+                    &decoded.leaf,
+                    &decoded.payloads,
+                    &encoded_key,
+                    commit_id,
+                )?;
+            }
+            hydrate_selected_loaded_entries(store, &mut output).await?;
+            return Ok(output);
+        }
         if keys.len() <= DECODED_COMMIT_DELTA_CACHE_MAX_POINT_KEYS {
             if let Some(decoded) = decode_commit_delta_with_payloads_cached(inline_segment, None)? {
                 for (request_index, &key) in keys.iter().enumerate() {
@@ -2915,6 +3163,106 @@ async fn load_local_owned_commit_delta_entries_one_ordered(
             segment_indices.push(segment_index);
         }
         routed.push((request_index, segment_index, encoded_key));
+    }
+    if keys.len() <= DECODED_COMMIT_DELTA_CACHE_MAX_POINT_KEYS
+        && let Some(cache) = point_cache
+    {
+        let mut decoded_segments = Vec::with_capacity(segment_indices.len());
+        let mut missing_indices = Vec::new();
+        let mut missing_keys = Vec::new();
+        for &segment_index in &segment_indices {
+            let bounds = manifest.segments.get(segment_index).ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "tracked_state commit_delta manifest for commit '{commit_id}' has no segment {segment_index}"
+                    ),
+                )
+            })?;
+            match cache.segment(commit_id, segment_index, Some(bounds))? {
+                Some(decoded) => decoded_segments.push(Some(decoded)),
+                None => {
+                    decoded_segments.push(None);
+                    missing_indices.push(segment_index);
+                    missing_keys.push(StorageKey(Bytes::from(commit_delta_segment_key(
+                        commit_id,
+                        segment_index,
+                    )?)));
+                }
+            }
+        }
+        let missing_values =
+            PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, &missing_keys)
+                .materialize(store, StorageGetOptions::default())
+                .await?;
+        let mut missing = missing_indices.into_iter().zip(missing_values.value);
+        let mut routed = routed.into_iter().peekable();
+        for (segment_position, segment_index) in segment_indices.into_iter().enumerate() {
+            let decoded = match decoded_segments[segment_position].take() {
+                Some(decoded) => decoded,
+                None => {
+                    let (missing_index, value) = missing
+                        .next()
+                        .expect("every uncached commit-delta segment has a point-read result");
+                    debug_assert_eq!(missing_index, segment_index);
+                    let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            format!(
+                                "tracked_state commit_delta manifest for commit '{commit_id}' references missing segment {segment_index}"
+                            ),
+                        )
+                    })?;
+                    let bounds = manifest.segments.get(segment_index).ok_or_else(|| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            format!(
+                                "tracked_state commit_delta manifest for commit '{commit_id}' has no segment {segment_index}"
+                            ),
+                        )
+                    })?;
+                    if !cache.should_admit_segment(commit_id, segment_index)? {
+                        let (leaf, payloads) =
+                            decode_commit_delta_with_payloads(&bytes, Some(bounds))?;
+                        while routed
+                            .peek()
+                            .is_some_and(|(_, routed_segment, _)| *routed_segment == segment_index)
+                        {
+                            let (request_index, _, encoded_key) = routed
+                                .next()
+                                .expect("peeked routed lookup remains available");
+                            output[request_index] = find_loaded_commit_delta_entry(
+                                &leaf,
+                                &payloads,
+                                &encoded_keys[encoded_key],
+                                commit_id,
+                            )?;
+                        }
+                        continue;
+                    }
+                    let decoded = decode_owned_commit_delta_segment(&bytes, Some(bounds))?;
+                    cache.remember_segment(commit_id, segment_index, Arc::clone(&decoded))?;
+                    decoded
+                }
+            };
+            while routed
+                .peek()
+                .is_some_and(|(_, routed_segment, _)| *routed_segment == segment_index)
+            {
+                let (request_index, _, encoded_key) = routed
+                    .next()
+                    .expect("peeked routed lookup remains available");
+                output[request_index] = find_loaded_commit_delta_entry(
+                    &decoded.leaf,
+                    &decoded.payloads,
+                    &encoded_keys[encoded_key],
+                    commit_id,
+                )?;
+            }
+        }
+        debug_assert!(missing.next().is_none());
+        hydrate_selected_loaded_entries(store, &mut output).await?;
+        return Ok(output);
     }
     let segment_keys = segment_indices
         .iter()
@@ -4624,20 +4972,27 @@ fn decode_commit_delta_with_payloads_cached(
         return Ok(None);
     }
 
-    let (leaf, payloads) = decode_commit_delta_with_payloads(bytes, expected_bounds)?;
-    let payloads = payloads.into_owned();
-    let resident_bytes =
-        size_of::<DecodedCommitDeltaSegment>() + leaf.resident_bytes() + payloads.resident_bytes();
-    let decoded = Arc::new(DecodedCommitDeltaSegment {
-        leaf,
-        payloads,
-        resident_bytes,
-    });
+    let decoded = decode_owned_commit_delta_segment(bytes, expected_bounds)?;
     decoded_commit_delta_cache()
         .lock()
         .expect("decoded commit-delta cache lock poisoned")
         .insert(digest, Bytes::copy_from_slice(bytes), Arc::clone(&decoded));
     Ok(Some(decoded))
+}
+
+fn decode_owned_commit_delta_segment(
+    bytes: &[u8],
+    expected_bounds: Option<&CommitDeltaSegmentBounds>,
+) -> Result<Arc<DecodedCommitDeltaSegment>, LixError> {
+    let (leaf, payloads) = decode_commit_delta_with_payloads(bytes, expected_bounds)?;
+    let payloads = payloads.into_owned();
+    let resident_bytes =
+        size_of::<DecodedCommitDeltaSegment>() + leaf.resident_bytes() + payloads.resident_bytes();
+    Ok(Arc::new(DecodedCommitDeltaSegment {
+        leaf,
+        payloads,
+        resident_bytes,
+    }))
 }
 
 fn decode_commit_delta_segment(
@@ -5174,6 +5529,26 @@ mod tests {
         assert_eq!(cache.entries.len(), 1);
         assert!(cache.resident_bytes > 0);
         assert!(cache.resident_bytes <= super::DECODED_COMMIT_DELTA_CACHE_MAX_BYTES);
+
+        let transaction_cache = super::CommitDeltaPointReadCache::default();
+        for index in 0..=super::TRANSACTION_COMMIT_DELTA_POINT_CACHE_MAX_ENTRIES {
+            transaction_cache
+                .remember_segment(
+                    CommitId::for_test_label(&format!("transaction-point-cache-{index}")),
+                    index,
+                    std::sync::Arc::clone(&decoded),
+                )
+                .expect("remember transaction-addressed decoded segment");
+        }
+        let transaction_cache = transaction_cache.inner.lock().unwrap();
+        assert!(
+            transaction_cache.segments.len()
+                <= super::TRANSACTION_COMMIT_DELTA_POINT_CACHE_MAX_ENTRIES
+        );
+        assert!(
+            transaction_cache.segment_resident_bytes
+                <= super::TRANSACTION_COMMIT_DELTA_POINT_CACHE_MAX_BYTES
+        );
     }
 
     #[derive(Clone)]


### PR DESCRIPTION
## Stack

Base: #1080 (`codex/certify-single-path-value-updates`). All performance comparisons use that immediate previous PR, not main.

## What changed

Profiled 10k RocksDB UPDATE showed packed current-base exact lookup consuming 182 ms of 208 ms in tracked-head serving. Repeated point replacements were re-reading and decoding the same immutable packed addresses inside one transaction.

This cut adds a transaction-scoped cache for:

- packed current-base refs by `(branch_id, generation)`
- decoded commit-delta manifests by commit id
- decoded segments by `(commit_id, segment_index)`

The cache admits only dense workloads after 16 observations of one generation, then admits segments on their second address observation. This preserves the old allocation-free path for one-shot and small-batch transactions. Retained decoded segments are bounded to 2 MiB and two entries.

## Exact previous-PR benchmarks

SQL-session `UPDATE ...` through Lix, setup excluded:

| Rows | Backend | #1080 | This PR | Change |
|---:|---|---:|---:|---:|
| 10k | RocksDB | 373.671 ms | 213.700 ms | **-42.8%** |
| 10k | SlateDB | 439.196 ms | 231.934 ms | **-47.2%** |
| 1M | RocksDB | 126.551 s | 30.320 s | **-76.0%** |
| 1M | SlateDB | 130.461 s | 36.039 s | **-72.4%** |

1M peak RSS:

| Backend | #1080 | This PR | Change |
|---|---:|---:|---:|
| RocksDB | 3,600,176 KiB | 3,609,180 KiB | +0.25% |
| SlateDB | 3,105,736 KiB | 3,133,620 KiB | +0.90% |

Paired 10k INSERT/SELECT/DELETE guards stayed within noise or improved (largest observed slowdown +3.5%).

## Non-CRUD guards

Median of paired-round p50s:

| Workload | RocksDB | SlateDB |
|---|---:|---:|
| working diff | 0.502→0.492 ms (-2.0%) | 0.527→0.527 ms (flat) |
| merge preview | 141.646→145.236 ms (+2.5%) | 171.231→175.292 ms (+2.4%) |
| merge commit | 1.968→1.978 ms (+0.5%) | 3.839→3.243 ms (-15.5%) |

Merge-commit runs create 101 branches each; branch behavior is also covered by the full integration suite.

## Validation

- `cargo fmt --all`
- `cargo check -p lix_engine --lib`
- `cargo clippy -p lix_engine --lib -- -D warnings`
- `cargo test -p lix_engine`
  - 1,686 unit tests
  - 433 integration tests
  - 3 doctests
- exact release 10k/1M UPDATE latency and RSS
- paired working-diff, merge-preview, and merge-commit guards

No changenote.