### PR TITLE
feat: establish realtime collaboration capacity gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3493,6 +3493,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
+ "base64 0.22.1",
  "codspeed-criterion-compat",
  "flate2",
  "futures-core",

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -792,7 +792,7 @@ where
                 entity_pk: entry.identity.entity_pk().clone(),
             })
             .collect::<BTreeSet<_>>();
-        let candidate_indices = prepared_writes
+        let overlapping_indices = prepared_writes
             .state_rows
             .iter()
             .enumerate()
@@ -802,45 +802,44 @@ where
                     file_id: row.file_id.map(|file_id| file_id.to_string()),
                     entity_pk: row.entity_pk.clone(),
                 };
-                (concurrent_keys.contains(&key)
-                    && row.file_id.is_some()
+                concurrent_keys.contains(&key).then_some(index)
+            })
+            .collect::<Vec<_>>();
+        let candidate_indices = overlapping_indices
+            .iter()
+            .copied()
+            .filter(|&index| {
+                let row = prepared_writes.state_rows.row(index);
+                row.file_id.is_some()
                     && !matches!(
                         row.schema_key.as_str(),
                         BLOB_REF_SCHEMA_KEY | DERIVED_FILE_REF_SCHEMA_KEY
-                    ))
-                .then_some(index)
+                    )
             })
             .collect::<Vec<_>>();
-        if candidate_indices.is_empty() {
-            return Err(conflict_error());
-        }
-        let file_ids = candidate_indices
+        let file_ids = overlapping_indices
             .iter()
-            .map(|&index| {
+            .filter_map(|&index| {
                 prepared_writes
                     .state_rows
                     .row(index)
                     .file_id
-                    .expect("candidate has file id")
-                    .to_string()
+                    .map(ToString::to_string)
             })
             .collect::<BTreeSet<_>>();
-        if concurrent_keys.iter().any(|key| {
-            prepared_writes.state_rows.iter().any(|row| {
-                row.schema_key.as_str() == key.schema_key
-                    && row.file_id.map(SharedStr::as_str) == key.file_id.as_deref()
-                    && row.entity_pk == &key.entity_pk
-            }) && (!file_ids.contains(key.file_id.as_deref().unwrap_or_default())
-                || !matches!(
-                    key.schema_key.as_str(),
-                    BLOB_REF_SCHEMA_KEY | DERIVED_FILE_REF_SCHEMA_KEY
-                ) && !candidate_indices.iter().any(|&index| {
-                    let row = prepared_writes.state_rows.row(index);
-                    row.schema_key.as_str() == key.schema_key
-                        && row.file_id.map(SharedStr::as_str) == key.file_id.as_deref()
-                        && row.entity_pk == &key.entity_pk
-                }))
-        }) {
+        if file_ids.is_empty()
+            || overlapping_indices.iter().any(|&index| {
+                let row = prepared_writes.state_rows.row(index);
+                let Some(file_id) = row.file_id.map(SharedStr::as_str) else {
+                    return true;
+                };
+                !file_ids.contains(file_id)
+                    || (!matches!(
+                        row.schema_key.as_str(),
+                        BLOB_REF_SCHEMA_KEY | DERIVED_FILE_REF_SCHEMA_KEY
+                    ) && !candidate_indices.contains(&index))
+            })
+        {
             return Err(conflict_error());
         }
 
@@ -1039,6 +1038,9 @@ where
                 .saturating_add(prepared_writes.state_rows.len()),
         );
         for group in groups.values() {
+            if group.conflicts.is_empty() {
+                continue;
+            }
             let conflicts = group
                 .conflicts
                 .iter()

--- a/packages/rs-sdk-tests/CRDT_BENCHMARK_BASELINE.md
+++ b/packages/rs-sdk-tests/CRDT_BENCHMARK_BASELINE.md
@@ -57,7 +57,7 @@ The B3.1 Lix row contains 1,540 per-client service observations from one full
 cardinality run. It passes the 100-ms service gate with 78.153 ms of headroom.
 The complete test, including workspace/plugin setup, opening and staging 1,540
 transactions, committing, convergence reads, and cleanup, finished in 18.61 s.
-The 18.133-second commit batch means this implementation does **not** provide
+The 17.668-second commit batch means this implementation does **not** provide
 sub-100-ms all-client convergence when 1,540 commits arrive simultaneously;
 both numbers are retained so service latency cannot hide queueing.
 
@@ -107,3 +107,8 @@ LIX_CRDT_SAMPLES=1 cargo test -p lix_sdk_tests \
 
 `LIX_CRDT_B3_CLIENTS` overrides the default 1,540-client cardinality and
 `LIX_CRDT_SAMPLES` controls independent workspace samples.
+
+The separate [`REALTIME_COLLABORATION_CAPACITY.md`](REALTIME_COLLABORATION_CAPACITY.md)
+defines the realistic 50-100 collaborator, gradual-arrival, client-observed
+capacity gate. The 1,540-client B3.1 burst remains a saturation comparison and
+is not substituted for that real-time workload.

--- a/packages/rs-sdk-tests/Cargo.toml
+++ b/packages/rs-sdk-tests/Cargo.toml
@@ -29,7 +29,7 @@ rand = { version = "0.9", features = ["small_rng"] }
 serde_json = "1"
 sha2 = "0.10"
 tempfile = "3"
-tokio = { version = "1", features = ["rt", "macros"] }
+tokio = { version = "1", features = ["rt", "macros", "time"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["std"] }

--- a/packages/rs-sdk-tests/REALTIME_COLLABORATION_CAPACITY.md
+++ b/packages/rs-sdk-tests/REALTIME_COLLABORATION_CAPACITY.md
@@ -1,0 +1,118 @@
+# Real-time collaboration capacity
+
+Measured 2026-08-01 in optimized Rust `release` builds on the same machine as
+the CRDT baseline. The capacity gate is client-observed commit-to-convergence
+p95 below 100 ms with 50-100 active collaborators on one document.
+
+## Workload
+
+- 50 or 100 independent Lix sessions keep a live observation on one hot file.
+- The run performs one edit per collaborator in waves of five edits.
+- Waves are scheduled on one absolute clock 50 ms apart. Four same-base edits
+  commit concurrently; a fifth same-base marker edit closes the wave. A slow
+  wave cannot move later deadlines: missed-deadline lag is included in the
+  next wave's convergence latency.
+- Two writers overlap in every fourth wave. That is exactly 10% overlapping
+  operations; the other 90% target distinct semantic entities.
+- A wave converges only after every client observes the marker through its own
+  query stream. The timer begins before commits are scheduled, so it includes
+  commit queueing, stale conflict discovery, plugin reconciliation, the
+  in-memory storage commit, invalidation, query reevaluation, and observation
+  fan-out.
+- Per-commit service latency is retained as a diagnostic, but it is not the
+  capacity gate.
+- Every non-overlapping edit must survive, conflict waves must invoke the
+  owning plugin resolver, final bytes must parse, and all clients must agree.
+
+## Results
+
+Each row reports the worst value observed across the initial measurement and
+five fresh-process repetitions. This avoids selecting the fastest sample.
+
+| Adapter / format | Clients | Service p95 | Client-observed convergence p95 | p99 | Result |
+| --- | ---: | ---: | ---: | ---: | --- |
+| Local / JSON | 50 | 4.182 ms | **14.813 ms** | 14.909 ms | pass |
+| Local / JSON | 100 | 5.073 ms | **18.095 ms** | 19.462 ms | pass |
+| Local / CSV | 100 | 5.484 ms | **23.108 ms** | 23.818 ms | pass |
+| Local / Markdown | 100 | 7.952 ms | **24.780 ms** | 28.850 ms | pass |
+| Local / text | 100 | 5.520 ms | **20.922 ms** | 21.276 ms | pass |
+| Server protocol / JSON | 100 | 13.787 ms | **25.977 ms** | not recorded | pass |
+
+The server-protocol row runs 100 independent protocol sessions and 100 SSE
+streams through the canonical Axum router. It covers wire value decoding,
+transaction capability routing, response serialization, and SSE delivery, but
+uses the in-process router and therefore excludes TCP and deployment network
+RTT. Production SLOs must add measured network latency; this result must not be
+presented as a public-internet end-to-end number.
+
+Both capacity rows use Lix's canonical in-memory storage so they isolate the
+engine and transport paths. A deployment using SQLite, RocksDB, SlateDB, or a
+remote object store must run the same gate on that storage before claiming its
+own production capacity.
+
+## Profile and change
+
+The first realistic run failed before producing a latency result. Same-file
+byte edits that touched disjoint semantic entities overlapped in file-storage
+bookkeeping, and the stale transaction path classified that bookkeeping as an
+unsafe non-plugin conflict. This made the 90% disjoint workload return
+`LIX_TRANSACTION_CONFLICT`.
+
+The commit path now identifies the stable plugin-owned file from its overlapping
+bookkeeping rows, rebases the retained semantic edits through the existing
+plugin actor, keeps the final combined rendering, and commits once. Disjoint
+edits do not call the conflict resolver. Actual semantic overlaps remain
+grouped by file and invoke the resolver once for the accumulated conflict set.
+
+Across the corrected six-run matrix, worst local service p95 was 7.952 ms and
+worst local convergence p95 was 24.780 ms. Absolute-deadline schedule-lag p95
+never exceeded 2.081 ms, proving the workload sustained five edits every 50 ms
+instead of moving arrivals after convergence. The in-process server protocol's
+worst service and convergence p95 values were 13.787 ms and 25.977 ms, with
+schedule-lag p95 at or below 1.768 ms. These endpoint measurements identify
+protocol processing and fan-out as the remaining larger slices; a production
+network measurement is still required for a deployment-specific SLO.
+
+## Resource soak
+
+The ignored soak opens, stages, abandons, and closes 100 transactions and
+sessions per round. Ten rounds cover 1,000 abandoned transactions. No staged
+write becomes visible. On the measured run:
+
+- warm post-cleanup RSS: 84,520,960 bytes
+- peak RSS: 84,520,960 bytes
+- final RSS: 84,520,960 bytes
+- post-warmup growth: **0 bytes**
+- allowed post-warmup growth: 67,108,864 bytes
+
+RSS is allocator- and platform-dependent, so the bound detects unbounded
+retention rather than promising a fixed production memory footprint.
+
+## Reproduction
+
+```bash
+for format in json csv markdown text; do
+  LIX_COLLAB_CLIENTS=100 \
+  LIX_COLLAB_OPERATIONS=100 \
+  LIX_COLLAB_ARRIVAL_MS=50 \
+  LIX_COLLAB_FORMAT="$format" \
+  cargo test -p lix_sdk_tests \
+    --test realtime_collaboration_capacity --release \
+    realtime_collaboration_commit_to_convergence_capacity \
+    -- --ignored --exact --nocapture
+done
+
+LIX_COLLAB_CLIENTS=100 \
+LIX_COLLAB_SOAK_ROUNDS=10 \
+cargo test -p lix_sdk_tests \
+  --test realtime_collaboration_capacity --release \
+  abandoned_transactions_and_sessions_release_resources \
+  -- --ignored --exact --nocapture
+
+cargo test -p lix_server_protocol --release \
+  tests::remote_protocol_converges_to_one_hundred_clients_below_one_hundred_ms_p95 \
+  -- --ignored --exact --nocapture
+```
+
+`LIX_COLLAB_GATE_MS` defaults to 100. The benchmark asserts the gate rather than
+only printing it.

--- a/packages/rs-sdk-tests/tests/e2e.rs
+++ b/packages/rs-sdk-tests/tests/e2e.rs
@@ -5898,6 +5898,60 @@ async fn same_base_json_transactions_resolve_overlap_and_converge() {
 }
 
 #[tokio::test]
+async fn same_base_json_file_edits_compose_disjoint_semantics_without_resolution() {
+    let archive = build_json_plugin_archive();
+    let first = open_lix(OpenLixOptions::default()).await.unwrap();
+    install_reference_plugin_in_blank_registry(
+        &first,
+        "plugin_json",
+        &archive,
+        &["json_root", "json_object_member", "json_array_item"],
+    )
+    .await;
+    let path = "/disjoint-file-transactions.json";
+    write_file(&first, path, b"{\"a\":\"base\",\"b\":\"base\"}\n".to_vec())
+        .await
+        .unwrap();
+    let second = first.open_workspace_session().await.unwrap();
+    let mut first_transaction = first.begin_transaction().await.unwrap();
+    let mut second_transaction = second.begin_transaction().await.unwrap();
+    first_transaction
+        .execute(
+            "UPDATE lix_file SET data = $1 WHERE path = $2",
+            &[
+                Value::Blob(b"{\"a\":\"first\",\"b\":\"base\"}\n".to_vec().into()),
+                Value::Text(path.to_owned()),
+            ],
+        )
+        .await
+        .unwrap();
+    second_transaction
+        .execute(
+            "UPDATE lix_file SET data = $1 WHERE path = $2",
+            &[
+                Value::Blob(b"{\"a\":\"base\",\"b\":\"second\"}\n".to_vec().into()),
+                Value::Text(path.to_owned()),
+            ],
+        )
+        .await
+        .unwrap();
+
+    first.reset_plugin_transition_counters();
+    first_transaction.commit().await.unwrap();
+    second_transaction.commit().await.unwrap();
+    assert_eq!(
+        first.plugin_transition_counters().conflict_resolution_calls,
+        0
+    );
+    let bytes = read_file(&first, path).await.unwrap().unwrap();
+    let document: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(document, serde_json::json!({ "a": "first", "b": "second" }));
+    assert_eq!(read_file(&second, path).await.unwrap(), Some(bytes));
+    second.close().await.unwrap();
+    first.close().await.unwrap();
+}
+
+#[tokio::test]
 async fn stale_json_transaction_renders_retained_same_file_edits_with_resolutions() {
     let archive = build_json_plugin_archive();
     let stale_client = open_lix(OpenLixOptions::default()).await.unwrap();

--- a/packages/rs-sdk-tests/tests/realtime_collaboration_capacity.rs
+++ b/packages/rs-sdk-tests/tests/realtime_collaboration_capacity.rs
@@ -1,0 +1,624 @@
+//! Client-observed real-time collaboration capacity workload.
+//!
+//! The ignored release-mode benchmark models 50-100 active collaborators on
+//! one hot document. Transactions arrive in five-edit waves. Four edits commit
+//! concurrently and a fifth same-base marker edit closes the wave. Every live
+//! client must observe that marker before the wave has converged.
+
+use std::fs;
+use std::io::{Cursor, Write};
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use lix_sdk::{Lix, OpenLixOptions, Storage, Value, open_lix};
+
+const DEFAULT_CLIENTS: usize = 100;
+const WAVE_SIZE: usize = 5;
+const CONFLICT_WAVE_INTERVAL: usize = 4;
+const DEFAULT_ARRIVAL_INTERVAL: Duration = Duration::from_millis(50);
+const DEFAULT_GATE: Duration = Duration::from_millis(100);
+const OBSERVE_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_SOAK_ROUNDS: usize = 10;
+const DEFAULT_RSS_GROWTH_LIMIT_BYTES: u64 = 64 * 1024 * 1024;
+
+#[derive(Clone, Copy, Debug)]
+enum DocumentFormat {
+    Json,
+    Csv,
+    Markdown,
+    Text,
+}
+
+impl DocumentFormat {
+    fn from_env() -> Self {
+        match std::env::var("LIX_COLLAB_FORMAT")
+            .unwrap_or_else(|_| "json".to_owned())
+            .as_str()
+        {
+            "json" => Self::Json,
+            "csv" => Self::Csv,
+            "markdown" | "md" => Self::Markdown,
+            "text" | "txt" => Self::Text,
+            value => panic!("unsupported LIX_COLLAB_FORMAT {value:?}"),
+        }
+    }
+
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Json => "json",
+            Self::Csv => "csv",
+            Self::Markdown => "markdown",
+            Self::Text => "text",
+        }
+    }
+
+    const fn extension(self) -> &'static str {
+        match self {
+            Self::Json => "json",
+            Self::Csv => "csv",
+            Self::Markdown => "md",
+            Self::Text => "txt",
+        }
+    }
+
+    const fn plugin_key(self) -> &'static str {
+        match self {
+            Self::Json => "plugin_json",
+            Self::Csv => "plugin_csv",
+            Self::Markdown => "plugin_markdown",
+            Self::Text => "plugin_git_text",
+        }
+    }
+
+    fn plugin_archive(self) -> Vec<u8> {
+        match self {
+            Self::Json => build_json_plugin_archive(),
+            Self::Csv => build_csv_plugin_archive(),
+            Self::Markdown => build_markdown_plugin_archive(),
+            Self::Text => build_text_plugin_archive(),
+        }
+    }
+
+    fn base_document(self, slots: usize) -> Vec<u8> {
+        match self {
+            Self::Json => {
+                let object = (0..slots)
+                    .map(|slot| (format!("k{slot}"), serde_json::Value::String("base".into())))
+                    .collect::<serde_json::Map<_, _>>();
+                let mut bytes = serde_json::to_vec(&object).expect("serialize JSON base");
+                bytes.push(b'\n');
+                bytes
+            }
+            Self::Csv => {
+                let mut document = String::from("key,value\n");
+                for slot in 0..slots {
+                    document.push_str(&format!("k{slot},base\n"));
+                }
+                document.into_bytes()
+            }
+            Self::Markdown => {
+                let mut document = String::new();
+                for slot in 0..slots {
+                    document.push_str(&format!("## k{slot}\n\nbase\n\n"));
+                }
+                document.into_bytes()
+            }
+            Self::Text => (0..slots)
+                .map(|slot| format!("k{slot}=base\n"))
+                .collect::<String>()
+                .into_bytes(),
+        }
+    }
+
+    fn edit(self, base: &[u8], slot: usize, token: &str) -> Vec<u8> {
+        match self {
+            Self::Json => {
+                let mut object =
+                    serde_json::from_slice::<serde_json::Map<String, serde_json::Value>>(base)
+                        .expect("parse JSON wave base");
+                object.insert(format!("k{slot}"), serde_json::Value::String(token.into()));
+                let mut bytes = serde_json::to_vec(&object).expect("serialize JSON edit");
+                bytes.push(b'\n');
+                bytes
+            }
+            Self::Csv => replace_line(base, &format!("k{slot},"), &format!("k{slot},{token}")),
+            Self::Markdown => replace_markdown_value(base, slot, token),
+            Self::Text => replace_line(base, &format!("k{slot}="), &format!("k{slot}={token}")),
+        }
+    }
+}
+
+#[tokio::test]
+#[ignore = "manual release-mode 50-100 collaborator capacity gate"]
+async fn realtime_collaboration_commit_to_convergence_capacity() {
+    let clients = env_usize("LIX_COLLAB_CLIENTS", DEFAULT_CLIENTS);
+    let operations = env_usize("LIX_COLLAB_OPERATIONS", clients);
+    let gate = Duration::from_millis(env_usize(
+        "LIX_COLLAB_GATE_MS",
+        usize::try_from(DEFAULT_GATE.as_millis()).expect("gate fits usize"),
+    ) as u64);
+    let arrival_interval = Duration::from_millis(env_usize(
+        "LIX_COLLAB_ARRIVAL_MS",
+        usize::try_from(DEFAULT_ARRIVAL_INTERVAL.as_millis()).expect("arrival interval fits usize"),
+    ) as u64);
+    let format = DocumentFormat::from_env();
+    assert!(
+        (50..=100).contains(&clients),
+        "capacity gate requires 50-100 clients"
+    );
+    assert!(operations >= WAVE_SIZE && operations.is_multiple_of(WAVE_SIZE));
+
+    let lix = open_lix(OpenLixOptions::default())
+        .await
+        .expect("capacity workspace should open");
+    install_plugin(&lix, format.plugin_key(), &format.plugin_archive()).await;
+    let path = format!("/collaboration-capacity.{}", format.extension());
+    write_file(&lix, &path, &format.base_document(operations + 1)).await;
+
+    let mut peers = Vec::with_capacity(clients);
+    let mut observations = Vec::with_capacity(clients);
+    for _ in 0..clients {
+        let peer = lix
+            .open_workspace_session()
+            .await
+            .expect("collaborator session should open");
+        let mut events = peer
+            .observe(
+                "SELECT data FROM lix_file WHERE path = $1",
+                &[Value::Text(path.clone())],
+            )
+            .expect("collaborator observation should open");
+        events
+            .next()
+            .await
+            .expect("initial observation should evaluate")
+            .expect("initial observation should stay open");
+        peers.push(peer);
+        observations.push(events);
+    }
+
+    lix.reset_plugin_transition_counters();
+    let mut service_latencies = Vec::with_capacity(operations);
+    let mut convergence_latencies = Vec::with_capacity(clients * operations / WAVE_SIZE);
+    let mut wave_latencies = Vec::with_capacity(operations / WAVE_SIZE);
+    let mut schedule_lags = Vec::with_capacity(operations / WAVE_SIZE);
+    let mut expected_tokens = Vec::with_capacity(operations);
+    let run_started = Instant::now();
+    let schedule_origin = run_started + arrival_interval;
+
+    for wave in 0..operations / WAVE_SIZE {
+        let base = read_file(&lix, &path).await;
+        let mut transactions = Vec::with_capacity(WAVE_SIZE);
+        let mut marker = String::new();
+        for participant in 0..WAVE_SIZE {
+            let operation = wave * WAVE_SIZE + participant;
+            let conflict = wave.is_multiple_of(CONFLICT_WAVE_INTERVAL) && participant < 2;
+            let slot = if conflict { 0 } else { operation + 1 };
+            let token = format!("wave-{wave}-client-{operation}");
+            if !conflict {
+                expected_tokens.push(token.clone());
+            }
+            if participant == WAVE_SIZE - 1 {
+                marker.clone_from(&token);
+            }
+            let mut transaction = peers[operation % clients]
+                .begin_transaction()
+                .await
+                .expect("wave transaction should open");
+            transaction
+                .execute(
+                    "UPDATE lix_file SET data = $1 WHERE path = $2",
+                    &[
+                        Value::Blob(format.edit(&base, slot, &token).into()),
+                        Value::Text(path.clone()),
+                    ],
+                )
+                .await
+                .expect("wave edit should stage");
+            transactions.push(transaction);
+        }
+
+        let wave_started = schedule_origin
+            + arrival_interval.saturating_mul(u32::try_from(wave).expect("wave fits u32"));
+        tokio::time::sleep_until(tokio::time::Instant::from_std(wave_started)).await;
+        schedule_lags.push(wave_started.elapsed());
+        let wave_marker = marker.into_bytes();
+        let local = tokio::task::LocalSet::new();
+        let wave_result = local
+            .run_until(async move {
+                let marker_transaction = transactions
+                    .pop()
+                    .expect("wave should contain marker transaction");
+                let mut commit_tasks = tokio::task::JoinSet::new();
+                for transaction in transactions {
+                    commit_tasks.spawn_local(async move {
+                        let started = Instant::now();
+                        let result = transaction.commit().await;
+                        (started.elapsed(), result)
+                    });
+                }
+                let mut services = Vec::with_capacity(WAVE_SIZE);
+                while let Some(joined) = commit_tasks.join_next().await {
+                    let (elapsed, result) = joined.expect("commit task should not panic");
+                    result.expect("concurrent wave edit should commit");
+                    services.push(elapsed);
+                }
+                let marker_started = Instant::now();
+                marker_transaction
+                    .commit()
+                    .await
+                    .expect("same-base marker edit should commit");
+                services.push(marker_started.elapsed());
+
+                // A Lix session deliberately rejects reads while its explicit
+                // transaction is active. Start client delivery immediately
+                // after every transaction in the wave reaches a terminal
+                // state; the wall clock still begins before commit scheduling.
+                let mut observer_tasks = tokio::task::JoinSet::new();
+                for mut events in observations {
+                    let marker = wave_marker.clone();
+                    observer_tasks.spawn_local(async move {
+                        loop {
+                            let event = tokio::time::timeout(OBSERVE_TIMEOUT, events.next())
+                                .await
+                                .expect("observation timed out")
+                                .expect("observation should evaluate")
+                                .expect("observation should stay open");
+                            let data = event.rows.rows()[0]
+                                .get::<Vec<u8>>("data")
+                                .expect("observed file data should be bytes");
+                            if data.windows(marker.len()).any(|window| window == marker) {
+                                return (events, wave_started.elapsed());
+                            }
+                        }
+                    });
+                }
+                let mut next_observations = Vec::with_capacity(clients);
+                let mut convergences = Vec::with_capacity(clients);
+                while let Some(joined) = observer_tasks.join_next().await {
+                    let (events, elapsed) = joined.expect("observer task should not panic");
+                    next_observations.push(events);
+                    convergences.push(elapsed);
+                }
+                (next_observations, services, convergences)
+            })
+            .await;
+        observations = wave_result.0;
+        service_latencies.extend(wave_result.1);
+        convergence_latencies.extend(wave_result.2.iter().copied());
+        wave_latencies.push(
+            wave_result
+                .2
+                .into_iter()
+                .max()
+                .expect("wave should have convergence samples"),
+        );
+    }
+
+    let final_bytes = read_file(&lix, &path).await;
+    for token in &expected_tokens {
+        assert!(
+            final_bytes
+                .windows(token.len())
+                .any(|window| window == token.as_bytes()),
+            "non-overlapping edit {token} was not retained"
+        );
+    }
+    for peer in &peers {
+        assert_eq!(read_file(peer, &path).await, final_bytes);
+    }
+    let counters = lix.plugin_transition_counters();
+    assert!(
+        counters.conflict_resolution_calls > 0,
+        "10% overlap workload must invoke the plugin resolver"
+    );
+
+    service_latencies.sort_unstable();
+    convergence_latencies.sort_unstable();
+    wave_latencies.sort_unstable();
+    schedule_lags.sort_unstable();
+    let service_p95 = percentile(&service_latencies, 95);
+    let convergence_p50 = percentile(&convergence_latencies, 50);
+    let convergence_p95 = percentile(&convergence_latencies, 95);
+    let convergence_p99 = percentile(&convergence_latencies, 99);
+    let wave_p95 = percentile(&wave_latencies, 95);
+    let schedule_lag_p95 = percentile(&schedule_lags, 95);
+    eprintln!(
+        "realtime_collaboration_capacity format={} clients={clients} operations={operations} \
+         wave_size={WAVE_SIZE} arrival_ms={:.3} overlap_percent=10 service_p95_ms={:.3} \
+         convergence_p50_ms={:.3} convergence_p95_ms={:.3} convergence_p99_ms={:.3} \
+         wave_p95_ms={:.3} schedule_lag_p95_ms={:.3} total_ms={:.3} resolver_calls={}",
+        format.name(),
+        millis(arrival_interval),
+        millis(service_p95),
+        millis(convergence_p50),
+        millis(convergence_p95),
+        millis(convergence_p99),
+        millis(wave_p95),
+        millis(schedule_lag_p95),
+        millis(run_started.elapsed()),
+        counters.conflict_resolution_calls,
+    );
+    assert!(
+        convergence_p95 < gate,
+        "{} {clients}-client commit-to-convergence p95 {:.3} ms exceeded {:.3} ms",
+        format.name(),
+        millis(convergence_p95),
+        millis(gate),
+    );
+
+    drop(observations);
+    for peer in peers {
+        peer.close().await.expect("collaborator should close");
+    }
+    lix.close().await.expect("capacity workspace should close");
+}
+
+#[tokio::test]
+#[ignore = "manual release-mode abandoned transaction and session soak"]
+async fn abandoned_transactions_and_sessions_release_resources() {
+    let clients = env_usize("LIX_COLLAB_CLIENTS", DEFAULT_CLIENTS);
+    let rounds = env_usize("LIX_COLLAB_SOAK_ROUNDS", DEFAULT_SOAK_ROUNDS);
+    let rss_limit = env_usize(
+        "LIX_COLLAB_RSS_GROWTH_LIMIT_BYTES",
+        usize::try_from(DEFAULT_RSS_GROWTH_LIMIT_BYTES).expect("RSS limit fits usize"),
+    ) as u64;
+    assert!((50..=100).contains(&clients));
+    assert!(
+        rounds >= 2,
+        "soak needs a warmup and at least one measured round"
+    );
+
+    let lix = open_lix(OpenLixOptions::default())
+        .await
+        .expect("soak workspace should open");
+    install_plugin(&lix, "plugin_json", &build_json_plugin_archive()).await;
+    let path = "/abandoned-transaction-soak.json";
+    let base = br#"{"value":"base"}
+"#;
+    write_file(&lix, path, base).await;
+    let mut warm_rss = None;
+    let mut peak_rss = resident_set_bytes();
+
+    for round in 0..rounds {
+        let mut peers = Vec::with_capacity(clients);
+        let mut transactions = Vec::with_capacity(clients);
+        for client in 0..clients {
+            let peer = lix
+                .open_workspace_session()
+                .await
+                .expect("soak session should open");
+            let mut transaction = peer
+                .begin_transaction()
+                .await
+                .expect("soak transaction should open");
+            let edit = format!("{{\"value\":\"round-{round}-client-{client}\"}}\n");
+            transaction
+                .execute(
+                    "UPDATE lix_file SET data = $1 WHERE path = $2",
+                    &[
+                        Value::Blob(edit.into_bytes().into()),
+                        Value::Text(path.to_owned()),
+                    ],
+                )
+                .await
+                .expect("abandoned edit should stage");
+            peers.push(peer);
+            transactions.push(transaction);
+        }
+        peak_rss = peak_rss.max(resident_set_bytes());
+        drop(transactions);
+        for peer in peers {
+            peer.close().await.expect("abandoned session should close");
+        }
+        tokio::task::yield_now().await;
+        assert_eq!(read_file(&lix, path).await, base);
+        if round == 0 {
+            warm_rss = Some(resident_set_bytes());
+        }
+    }
+
+    let final_rss = resident_set_bytes();
+    let warm_rss = warm_rss.expect("warmup RSS should be captured");
+    let growth = final_rss.saturating_sub(warm_rss);
+    eprintln!(
+        "realtime_collaboration_soak clients={clients} rounds={rounds} abandoned_transactions={} \
+         warm_rss_bytes={warm_rss} peak_rss_bytes={peak_rss} final_rss_bytes={final_rss} \
+         post_warmup_growth_bytes={growth} growth_limit_bytes={rss_limit}",
+        clients * rounds,
+    );
+    assert!(
+        growth <= rss_limit,
+        "post-warmup RSS grew by {growth} bytes, above {rss_limit} bytes"
+    );
+    lix.close().await.expect("soak workspace should close");
+}
+
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .map(|value| {
+            value
+                .parse()
+                .unwrap_or_else(|_| panic!("{key} should be numeric"))
+        })
+        .unwrap_or(default)
+}
+
+fn percentile(samples: &[Duration], percentile: usize) -> Duration {
+    assert!(!samples.is_empty());
+    samples[(samples.len() * percentile).div_ceil(100).saturating_sub(1)]
+}
+
+fn millis(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}
+
+fn resident_set_bytes() -> u64 {
+    let status = fs::read_to_string("/proc/self/status").expect("Linux procfs should expose RSS");
+    let rss_kib = status
+        .lines()
+        .find_map(|line| line.strip_prefix("VmRSS:"))
+        .and_then(|value| value.split_ascii_whitespace().next())
+        .and_then(|value| value.parse::<u64>().ok())
+        .expect("VmRSS should be numeric");
+    rss_kib * 1024
+}
+
+fn replace_line(base: &[u8], prefix: &str, replacement: &str) -> Vec<u8> {
+    let source = std::str::from_utf8(base).expect("document should be UTF-8");
+    let mut found = false;
+    let mut output = String::with_capacity(source.len() + replacement.len());
+    for line in source.lines() {
+        if line.starts_with(prefix) {
+            output.push_str(replacement);
+            found = true;
+        } else {
+            output.push_str(line);
+        }
+        output.push('\n');
+    }
+    assert!(found, "slot line {prefix:?} should exist");
+    output.into_bytes()
+}
+
+fn replace_markdown_value(base: &[u8], slot: usize, token: &str) -> Vec<u8> {
+    let source = std::str::from_utf8(base).expect("Markdown should be UTF-8");
+    let heading = format!("## k{slot}\n\n");
+    let offset = source.find(&heading).expect("Markdown slot should exist") + heading.len();
+    let value_end = source[offset..]
+        .find('\n')
+        .map(|relative| offset + relative)
+        .expect("Markdown slot value should end");
+    let mut output = String::with_capacity(source.len() + token.len());
+    output.push_str(&source[..offset]);
+    output.push_str(token);
+    output.push_str(&source[value_end..]);
+    output.into_bytes()
+}
+
+async fn install_plugin<StorageImpl>(lix: &Lix<StorageImpl>, key: &str, archive: &[u8])
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    lix.execute(
+        "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+        &[
+            Value::Text(format!("/.lix/plugins/{key}.lixplugin")),
+            Value::Blob(archive.to_vec().into()),
+        ],
+    )
+    .await
+    .expect("reference plugin should install");
+}
+
+async fn write_file<StorageImpl>(lix: &Lix<StorageImpl>, path: &str, bytes: &[u8])
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    lix.execute(
+        "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+        &[
+            Value::Text(path.to_owned()),
+            Value::Blob(bytes.to_vec().into()),
+        ],
+    )
+    .await
+    .expect("capacity document should write");
+}
+
+async fn read_file<StorageImpl>(lix: &Lix<StorageImpl>, path: &str) -> Vec<u8>
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    lix.execute(
+        "SELECT data FROM lix_file WHERE path = $1",
+        &[Value::Text(path.to_owned())],
+    )
+    .await
+    .expect("capacity document should read")
+    .rows()[0]
+        .get::<Vec<u8>>("data")
+        .expect("capacity document should contain bytes")
+}
+
+fn build_json_plugin_archive() -> Vec<u8> {
+    build_plugin_archive(
+        Path::new(env!("CARGO_CDYLIB_FILE_PLUGIN_JSON_plugin_json")),
+        include_str!("../../../plugins/json/manifest.json"),
+        &[
+            (
+                "schema/json_root.json",
+                include_str!("../../../plugins/json/schema/json_root.json"),
+            ),
+            (
+                "schema/json_object_member.json",
+                include_str!("../../../plugins/json/schema/json_object_member.json"),
+            ),
+            (
+                "schema/json_array_item.json",
+                include_str!("../../../plugins/json/schema/json_array_item.json"),
+            ),
+        ],
+    )
+}
+
+fn build_csv_plugin_archive() -> Vec<u8> {
+    build_plugin_archive(
+        Path::new(env!("CARGO_CDYLIB_FILE_PLUGIN_CSV_plugin_csv")),
+        include_str!("../../../plugins/csv/manifest.json"),
+        &[
+            (
+                "schema/csv_v2_table.json",
+                include_str!("../../../plugins/csv/schema/csv_v2_table.json"),
+            ),
+            (
+                "schema/csv_v2_row.json",
+                include_str!("../../../plugins/csv/schema/csv_v2_row.json"),
+            ),
+        ],
+    )
+}
+
+fn build_markdown_plugin_archive() -> Vec<u8> {
+    build_plugin_archive(
+        Path::new(env!("CARGO_CDYLIB_FILE_PLUGIN_MARKDOWN_plugin_markdown")),
+        include_str!("../../../plugins/markdown/manifest.json"),
+        &[(
+            "schema/markdown_node_v2.json",
+            include_str!("../../../plugins/markdown/schema/markdown_node_v2.json"),
+        )],
+    )
+}
+
+fn build_text_plugin_archive() -> Vec<u8> {
+    build_plugin_archive(
+        Path::new(env!("CARGO_CDYLIB_FILE_PLUGIN_GIT_TEXT_plugin_git_text")),
+        include_str!("../../../plugins/text/manifest.json"),
+        &[(
+            "schema/git_text_line_v2.json",
+            include_str!("../../../plugins/text/schema/git_text_line_v2.json"),
+        )],
+    )
+}
+
+fn build_plugin_archive(wasm_path: &Path, manifest: &str, schemas: &[(&str, &str)]) -> Vec<u8> {
+    let wasm = fs::read(wasm_path).unwrap_or_else(|error| {
+        panic!(
+            "failed to read plugin component at {}: {error}",
+            wasm_path.display()
+        )
+    });
+    let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    writer.start_file("manifest.json", options).unwrap();
+    writer.write_all(manifest.as_bytes()).unwrap();
+    for (path, schema) in schemas {
+        writer.start_file(path, options).unwrap();
+        writer.write_all(schema.as_bytes()).unwrap();
+    }
+    writer.start_file("plugin.wasm", options).unwrap();
+    writer.write_all(&wasm).unwrap();
+    writer.finish().unwrap().into_inner()
+}

--- a/packages/server-protocol/Cargo.toml
+++ b/packages/server-protocol/Cargo.toml
@@ -35,6 +35,7 @@ sha2 = { version = "0.10", features = ["asm"] }
 
 [dev-dependencies]
 async-trait = "0.1"
+base64 = "0.22"
 criterion = { package = "codspeed-criterion-compat", version = "4" }
 flate2 = "1"
 futures-util = "0.3"

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -3541,6 +3541,7 @@ impl Drop for ObserveTaskGuard {
 mod tests {
     use super::*;
     use axum::{body::Body, http::Request};
+    use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
     use flate2::{Compression, read::GzDecoder, write::GzEncoder};
     use http_body_util::BodyExt as _;
     use lix_sdk::{
@@ -3565,6 +3566,51 @@ mod tests {
     };
 
     static TEST_IDEMPOTENCY_KEY_SEQUENCE: AtomicUsize = AtomicUsize::new(0);
+
+    struct TestSseStream {
+        body: Body,
+        buffered: Vec<u8>,
+    }
+
+    impl TestSseStream {
+        fn new(response: Response) -> Self {
+            assert_eq!(response.status(), StatusCode::OK);
+            Self {
+                body: response.into_body(),
+                buffered: Vec::new(),
+            }
+        }
+
+        async fn next(&mut self) -> JsonValue {
+            loop {
+                if let Some(end) = self
+                    .buffered
+                    .windows(2)
+                    .position(|window| window == b"\n\n")
+                {
+                    let frame = self.buffered.drain(..end + 2).collect::<Vec<_>>();
+                    let frame = std::str::from_utf8(&frame[..end]).expect("SSE event UTF-8");
+                    if !frame.starts_with("event: next\n") {
+                        continue;
+                    }
+                    let data = frame
+                        .lines()
+                        .find_map(|line| line.strip_prefix("data: "))
+                        .expect("SSE next event data");
+                    return serde_json::from_str(data).expect("SSE next event JSON");
+                }
+                let frame = tokio::time::timeout(Duration::from_secs(30), self.body.frame())
+                    .await
+                    .expect("SSE event timed out")
+                    .expect("SSE stream should stay open")
+                    .expect("SSE frame should be valid");
+                let Ok(data) = frame.into_data() else {
+                    continue;
+                };
+                self.buffered.extend_from_slice(&data);
+            }
+        }
+    }
 
     #[test]
     fn terminal_storage_responses_are_non_retryable_conflicts_and_mark_runtime_recovery() {
@@ -6632,6 +6678,221 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "manual release-mode remote commit-to-observation capacity gate"]
+    async fn remote_protocol_converges_to_one_hundred_clients_below_one_hundred_ms_p95() {
+        const CLIENTS: usize = 100;
+        const OPERATIONS: usize = 100;
+        const WAVE_SIZE: usize = 5;
+        const ARRIVAL_INTERVAL: Duration = Duration::from_millis(50);
+        const GATE: Duration = Duration::from_millis(100);
+
+        let app = app_with_options(ProtocolServerOptions {
+            max_sessions: 128,
+            ..ProtocolServerOptions::default()
+        })
+        .await;
+        let root = &app.server.inner.root;
+        root.execute(
+            "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+            &[
+                Value::Text("/.lix/plugins/plugin_json.lixplugin".to_owned()),
+                Value::Blob(build_json_plugin_archive().into()),
+            ],
+        )
+        .await
+        .expect("JSON plugin should install");
+        let path = "/remote-collaboration-capacity.json";
+        let base = (0..=OPERATIONS)
+            .map(|slot| (format!("k{slot}"), JsonValue::String("base".into())))
+            .collect::<serde_json::Map<_, _>>();
+        root.execute(
+            "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+            &[
+                Value::Text(path.to_owned()),
+                Value::Blob(serde_json::to_vec(&base).unwrap().into()),
+            ],
+        )
+        .await
+        .expect("capacity document should import");
+
+        let mut sessions = Vec::with_capacity(CLIENTS);
+        let mut observations = Vec::with_capacity(CLIENTS);
+        for _ in 0..CLIENTS {
+            let (session_id, _) = new_session(&app.router).await;
+            let response = request(
+                &app.router,
+                "POST",
+                "/lix/v1/observe",
+                Some(&session_id),
+                Some(json!({
+                    "sql": "SELECT data FROM lix_file WHERE path = $1",
+                    "params": [{ "kind": "text", "value": path }]
+                })),
+            )
+            .await;
+            let mut stream = TestSseStream::new(response);
+            let initial = stream.next().await;
+            assert_eq!(initial["sequence"].as_u64(), Some(0));
+            sessions.push(session_id);
+            observations.push(stream);
+        }
+
+        let mut convergence_latencies = Vec::with_capacity(CLIENTS * OPERATIONS / WAVE_SIZE);
+        let mut service_latencies = Vec::with_capacity(OPERATIONS);
+        let mut schedule_lags = Vec::with_capacity(OPERATIONS / WAVE_SIZE);
+        let schedule_origin = Instant::now() + ARRIVAL_INTERVAL;
+        root.reset_plugin_transition_counters();
+        for wave in 0..OPERATIONS / WAVE_SIZE {
+            let current = root
+                .execute(
+                    "SELECT data FROM lix_file WHERE path = $1",
+                    &[Value::Text(path.to_owned())],
+                )
+                .await
+                .expect("wave base should read")
+                .rows()[0]
+                .get::<Vec<u8>>("data")
+                .expect("wave base should be bytes");
+            let current = serde_json::from_slice::<serde_json::Map<String, JsonValue>>(&current)
+                .expect("wave base should parse");
+            let mut capabilities = Vec::with_capacity(WAVE_SIZE);
+            let mut marker = String::new();
+            for participant in 0..WAVE_SIZE {
+                let operation = wave * WAVE_SIZE + participant;
+                let conflict = wave.is_multiple_of(4) && participant < 2;
+                let slot = if conflict { 0 } else { operation + 1 };
+                let token = format!("wave-{wave}-client-{operation}");
+                if participant == WAVE_SIZE - 1 {
+                    marker.clone_from(&token);
+                }
+                let mut edit = current.clone();
+                edit.insert(format!("k{slot}"), JsonValue::String(token));
+                let session_id = &sessions[operation % CLIENTS];
+                let transaction_id = begin_remote_transaction(&app.router, session_id).await;
+                let staged = remote_transaction_request(
+                    &app.router,
+                    "POST",
+                    "/lix/v1/transaction/execute",
+                    session_id,
+                    &transaction_id,
+                    Some(json!({
+                        "sql": "UPDATE lix_file SET data = $1 WHERE path = $2",
+                        "params": [
+                            {
+                                "kind": "blob",
+                                "base64": BASE64_STANDARD.encode(serde_json::to_vec(&edit).unwrap())
+                            },
+                            { "kind": "text", "value": path }
+                        ]
+                    })),
+                )
+                .await;
+                assert_eq!(staged.status(), StatusCode::OK);
+                capabilities.push((session_id.clone(), transaction_id));
+            }
+
+            let wave_started = schedule_origin
+                + ARRIVAL_INTERVAL.saturating_mul(u32::try_from(wave).expect("wave fits u32"));
+            tokio::time::sleep_until(tokio::time::Instant::from_std(wave_started)).await;
+            schedule_lags.push(wave_started.elapsed());
+            let marker_capability = capabilities.pop().expect("marker capability");
+            let mut commits = tokio::task::JoinSet::new();
+            for (session_id, transaction_id) in capabilities {
+                let router = app.router.clone();
+                commits.spawn(async move {
+                    let started = Instant::now();
+                    let response = remote_transaction_request(
+                        &router,
+                        "POST",
+                        "/lix/v1/transaction/commit",
+                        &session_id,
+                        &transaction_id,
+                        None,
+                    )
+                    .await;
+                    (started.elapsed(), response.status())
+                });
+            }
+            while let Some(joined) = commits.join_next().await {
+                let (elapsed, status) = joined.expect("remote commit task should not panic");
+                assert_eq!(status, StatusCode::NO_CONTENT);
+                service_latencies.push(elapsed);
+            }
+            let marker_started = Instant::now();
+            let marker_response = remote_transaction_request(
+                &app.router,
+                "POST",
+                "/lix/v1/transaction/commit",
+                &marker_capability.0,
+                &marker_capability.1,
+                None,
+            )
+            .await;
+            assert_eq!(marker_response.status(), StatusCode::NO_CONTENT);
+            service_latencies.push(marker_started.elapsed());
+
+            let marker = marker.into_bytes();
+            let mut deliveries = tokio::task::JoinSet::new();
+            for mut stream in observations {
+                let marker = marker.clone();
+                deliveries.spawn(async move {
+                    loop {
+                        let event = stream.next().await;
+                        let encoded = event["result"]["rows"][0][0]["base64"]
+                            .as_str()
+                            .expect("observed file should be a blob");
+                        let bytes = BASE64_STANDARD
+                            .decode(encoded)
+                            .expect("observed blob should decode");
+                        if bytes.windows(marker.len()).any(|window| window == marker) {
+                            return (stream, wave_started.elapsed());
+                        }
+                    }
+                });
+            }
+            observations = Vec::with_capacity(CLIENTS);
+            while let Some(joined) = deliveries.join_next().await {
+                let (stream, elapsed) = joined.expect("delivery task should not panic");
+                observations.push(stream);
+                convergence_latencies.push(elapsed);
+            }
+        }
+
+        service_latencies.sort_unstable();
+        convergence_latencies.sort_unstable();
+        schedule_lags.sort_unstable();
+        let service_p95 = service_latencies[(service_latencies.len() * 95)
+            .div_ceil(100)
+            .saturating_sub(1)];
+        let convergence_p95 = convergence_latencies[(convergence_latencies.len() * 95)
+            .div_ceil(100)
+            .saturating_sub(1)];
+        let schedule_lag_p95 =
+            schedule_lags[(schedule_lags.len() * 95).div_ceil(100).saturating_sub(1)];
+        eprintln!(
+            "remote_collaboration_capacity clients={CLIENTS} operations={OPERATIONS} \
+             wave_size={WAVE_SIZE} arrival_ms={} overlap_percent=10 service_p95_ms={:.3} \
+             convergence_p95_ms={:.3} schedule_lag_p95_ms={:.3} resolver_calls={}",
+            ARRIVAL_INTERVAL.as_millis(),
+            service_p95.as_secs_f64() * 1_000.0,
+            convergence_p95.as_secs_f64() * 1_000.0,
+            schedule_lag_p95.as_secs_f64() * 1_000.0,
+            root.plugin_transition_counters().conflict_resolution_calls,
+        );
+        assert!(root.plugin_transition_counters().conflict_resolution_calls > 0);
+        assert!(
+            convergence_p95 < GATE,
+            "remote commit-to-convergence p95 was {:.3} ms",
+            convergence_p95.as_secs_f64() * 1_000.0
+        );
+        drop(observations);
+        app.server
+            .close()
+            .await
+            .expect("capacity server should close");
+    }
+
+    #[tokio::test]
     async fn same_base_remote_transactions_report_the_existing_commit_conflict() {
         let app = app().await;
         let (first, _) = new_session(&app.router).await;
@@ -8293,6 +8554,39 @@ mod tests {
 
         let replacement = request(&app.router, "GET", "/lix/v1", None, None).await;
         assert_eq!(replacement.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn server_shutdown_discards_abandoned_remote_transaction_and_session() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let transaction_id = begin_remote_transaction(&app.router, &session_id).await;
+        let staged = remote_transaction_request(
+            &app.router,
+            "POST",
+            "/lix/v1/transaction/execute",
+            &session_id,
+            &transaction_id,
+            Some(json!({
+                "sql": "INSERT INTO lix_key_value (key, value) VALUES ('abandoned', 'staged')"
+            })),
+        )
+        .await;
+        assert_eq!(staged.status(), StatusCode::OK);
+        let visible = app
+            .server
+            .inner
+            .root
+            .execute(
+                "SELECT COUNT(*) AS count FROM lix_key_value WHERE key = 'abandoned'",
+                &[],
+            )
+            .await
+            .expect("root should read committed state");
+        assert_eq!(visible.rows()[0].get::<i64>("count").unwrap(), 0);
+
+        app.server.close().await.expect("server should close");
+        assert!(app.server.inner.registry.lock().await.sessions.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- establish a reproducible client-observed commit-to-convergence capacity gate for 50-100 collaborators on one hot document
- fix stale same-file byte transactions so semantically disjoint edits rebase without invoking the conflict resolver
- cover JSON, CSV, Markdown, text, the server protocol, abandoned transactions, session cleanup, and bounded RSS growth

## Why

The previous B3.1 benchmark measured per-commit service time and a 1,540-client saturation burst. It did not prove the practical real-time collaboration SLO because it excluded scheduler delay from the service timer and checked convergence only after the batch.

The new workload uses five-edit waves scheduled on one absolute clock every 50 ms, exactly 10% overlapping operations, and 50 or 100 independent observers on one document. Slow waves cannot move later deadlines; missed-deadline lag is included in convergence latency. A sample ends only when every client observes the wave marker.

The first realistic run exposed that same-file bookkeeping overlaps caused disjoint semantic byte edits to return `LIX_TRANSACTION_CONFLICT`. The stale path now identifies the stable plugin-owned file, replays retained semantic edits through the existing actor, keeps the final combined rendering, and commits once. Resolver calls remain zero for disjoint edits.

## Capacity results

Worst value across the initial corrected measurement and five fresh-process repetitions:

| Adapter / format | Clients | Service p95 | Convergence p95 |
| --- | ---: | ---: | ---: |
| Local / JSON | 50 | 4.182 ms | 14.813 ms |
| Local / JSON | 100 | 5.073 ms | 18.095 ms |
| Local / CSV | 100 | 5.484 ms | 23.108 ms |
| Local / Markdown | 100 | 7.952 ms | 24.780 ms |
| Local / text | 100 | 5.520 ms | 20.922 ms |
| Server protocol / JSON | 100 | 13.787 ms | 25.977 ms |

Schedule-lag p95 never exceeded 2.081 ms locally or 1.768 ms through the server protocol, demonstrating that the workload sustains five edits per 50 ms rather than self-throttling after convergence.

The protocol result includes canonical request decoding/routing and SSE serialization/fan-out through the in-process router. It excludes TCP, deployment RTT, and production storage latency; the documentation keeps that limitation explicit.

The 1,000-transaction abandoned-session soak retained no staged writes and recorded zero post-warmup RSS growth against a 64 MiB bound.

## Validation

- `cargo test -p lix_engine --features all-simulations`
- `cargo test -p lix_server_protocol`
- `cargo test -p lix_sdk_tests --test e2e`
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- six absolute-clock release-mode capacity measurements at each documented local boundary/format
- six absolute-clock release-mode server-protocol capacity measurements
- release-mode 1,000 abandoned transaction/session soak

No public API is added or changed.
