### PR TITLE
Refactor CAS content identities

### DIFF
--- a/packages/engine/src/binary_cas/context.rs
+++ b/packages/engine/src/binary_cas/context.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use crate::LixError;
 use crate::binary_cas::BinaryCasChunking;
 use crate::binary_cas::{
-    BlobBytesBatch, BlobChunkReceipt, BlobEditSplice, BlobHash, BlobPayload, BlobRangeBytes,
+    BlobBytesBatch, BlobChunkReceipt, BlobEditSplice, BlobId, BlobPayload, BlobRangeBytes,
     BlobRangeBytesBatch, BlobSameLengthSplice, BlobWriteReceipt,
 };
 use crate::storage_adapter::{StorageAdapterRead, StorageWriteSet};
@@ -11,11 +11,11 @@ use std::collections::HashSet;
 
 #[async_trait]
 pub(crate) trait BlobDataReader: Send + Sync {
-    async fn load_bytes_many(&self, hashes: &[BlobHash]) -> Result<BlobBytesBatch, LixError>;
+    async fn load_bytes_many(&self, hashes: &[BlobId]) -> Result<BlobBytesBatch, LixError>;
 
     async fn load_ranges_many(
         &self,
-        requests: &[(BlobHash, std::ops::Range<u64>)],
+        requests: &[(BlobId, std::ops::Range<u64>)],
     ) -> Result<BlobRangeBytesBatch, LixError> {
         let hashes = requests.iter().map(|(hash, _)| *hash).collect::<Vec<_>>();
         let values = self.load_bytes_many(&hashes).await?.into_vec();
@@ -113,7 +113,7 @@ impl<S> BlobDataReader for BinaryCasStoreReader<S>
 where
     S: StorageAdapterRead + Clone + Send + Sync,
 {
-    async fn load_bytes_many(&self, hashes: &[BlobHash]) -> Result<BlobBytesBatch, LixError> {
+    async fn load_bytes_many(&self, hashes: &[BlobId]) -> Result<BlobBytesBatch, LixError> {
         let mut reader = Self {
             store: self.store.clone(),
         };
@@ -122,7 +122,7 @@ where
 
     async fn load_ranges_many(
         &self,
-        requests: &[(BlobHash, std::ops::Range<u64>)],
+        requests: &[(BlobId, std::ops::Range<u64>)],
     ) -> Result<BlobRangeBytesBatch, LixError> {
         crate::binary_cas::kv::load_ranges_many(&self.store, requests).await
     }
@@ -140,7 +140,7 @@ where
     #[expect(clippy::needless_pass_by_ref_mut)]
     pub(crate) async fn load_bytes_many(
         &mut self,
-        hashes: &[BlobHash],
+        hashes: &[BlobId],
     ) -> Result<BlobBytesBatch, LixError> {
         crate::binary_cas::kv::load_bytes_many(&self.store, hashes).await
     }

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -10,8 +10,8 @@ use crate::binary_cas::codec::{
 };
 use crate::binary_cas::{
     BinaryCasChunking, BlobBytesBatch, BlobDeltaBaseLayout, BlobDeltaSegment, BlobEditSplice,
-    BlobHash, BlobLayout, BlobMetadata, BlobMetadataBatch, BlobRangeBytes, BlobRangeBytesBatch,
-    BlobSameLengthSplice, BlobWriteReceipt,
+    BlobId, BlobLayout, BlobMetadata, BlobMetadataBatch, BlobRangeBytes, BlobRangeBytesBatch,
+    BlobSameLengthSplice, BlobWriteReceipt, ChunkHash,
 };
 #[cfg(test)]
 use crate::storage_adapter::StoragePrefix;
@@ -56,7 +56,7 @@ pub(crate) const BINARY_CAS_CHUNK_PRESENCE_SPACE: StorageSpace = StorageSpace::n
 
 #[derive(Debug)]
 struct BlobWritePlan {
-    blob_hash: BlobHash,
+    blob_hash: BlobId,
     chunk_ranges: Vec<(usize, usize)>,
     layout: BlobLayout,
     receipt: BlobWriteReceipt,
@@ -66,7 +66,7 @@ struct BlobWritePlan {
 struct PreparedChunk {
     start: usize,
     end: usize,
-    hash: BlobHash,
+    hash: ChunkHash,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -86,7 +86,7 @@ pub(crate) struct KvChunk {
 #[cfg(test)]
 async fn load_manifest(
     store: &impl StorageAdapterRead,
-    blob_hash: BlobHash,
+    blob_hash: BlobId,
 ) -> Result<Option<BinaryCasManifest>, LixError> {
     let Some(bytes) = get_one(store, BINARY_CAS_MANIFEST_SPACE, manifest_key(blob_hash)).await?
     else {
@@ -97,7 +97,7 @@ async fn load_manifest(
 
 pub(crate) fn stage_manifest(
     writes: &mut StorageWriteSet,
-    blob_hash: BlobHash,
+    blob_hash: BlobId,
     manifest: &BinaryCasManifest,
 ) {
     writes.put(
@@ -110,7 +110,7 @@ pub(crate) fn stage_manifest(
 #[cfg(test)]
 pub(crate) async fn scan_manifest_chunks(
     store: &impl StorageAdapterRead,
-    blob_hash: BlobHash,
+    blob_hash: BlobId,
 ) -> Result<Vec<KvBlobManifestChunk>, LixError> {
     scan_all_values(
         store,
@@ -138,7 +138,7 @@ pub(crate) async fn scan_manifest_chunks(
 /// rejects missing declared rows by comparing the resulting count.
 async fn load_declared_manifest_chunks(
     store: &(impl StorageAdapterRead + ?Sized),
-    blob_hash: BlobHash,
+    blob_hash: BlobId,
     chunk_count: u32,
 ) -> Result<Vec<KvBlobManifestChunk>, LixError> {
     if chunk_count == 0 {
@@ -167,7 +167,7 @@ async fn load_declared_manifest_chunks(
 
 pub(crate) fn stage_manifest_chunk(
     writes: &mut StorageWriteSet,
-    blob_hash: BlobHash,
+    blob_hash: BlobId,
     chunk_index: u64,
     chunk: &KvBlobManifestChunk,
 ) {
@@ -184,7 +184,7 @@ pub(crate) fn stage_manifest_chunk(
 #[cfg(test)]
 async fn load_chunk(
     store: &impl StorageAdapterRead,
-    chunk_hash: BlobHash,
+    chunk_hash: ChunkHash,
 ) -> Result<Option<KvChunk>, LixError> {
     let Some(bytes) = get_one(store, BINARY_CAS_CHUNK_SPACE, chunk_key(chunk_hash)).await? else {
         return Ok(None);
@@ -199,7 +199,7 @@ async fn load_chunk(
 
 pub(crate) fn stage_chunk(
     writes: &mut StorageWriteSet,
-    chunk_hash: BlobHash,
+    chunk_hash: ChunkHash,
     codec: BinaryChunkCodec,
     uncompressed_len: u64,
     payload: &[u8],
@@ -223,7 +223,7 @@ pub(crate) fn stage_chunk(
 
 fn stage_content_chunk(
     writes: &mut StorageWriteSet,
-    chunk_hash: BlobHash,
+    chunk_hash: ChunkHash,
     chunk_data: &[u8],
 ) -> Result<(), LixError> {
     stage_chunk(
@@ -251,7 +251,7 @@ pub(in crate::binary_cas) async fn stage_fixed_part_skipping_existing(
     let receipts = bytes
         .chunks(crate::binary_cas::chunking::MEDIA_CHUNK_BYTES)
         .map(|chunk| crate::binary_cas::BlobChunkReceipt {
-            hash: BlobHash::from_content(chunk),
+            hash: ChunkHash::from_content(chunk),
             size_bytes: chunk.len() as u64,
         })
         .collect::<Vec<_>>();
@@ -312,15 +312,15 @@ pub(in crate::binary_cas) fn stage_fixed_manifest(
     }
 
     let (hash, layout) = match chunks {
-        [] => (BlobHash::from_content(&[]), BlobLayout::Empty),
+        [] => (BlobId::from_content(&[]), BlobLayout::Empty),
         [chunk] => (
-            chunk.hash,
+            BlobId::from_single_chunk(chunk.hash),
             BlobLayout::SingleChunk {
                 chunk_hash: chunk.hash,
             },
         ),
         _ => (
-            BlobHash::from_chunks(
+            BlobId::from_chunks(
                 size_bytes,
                 chunks.iter().map(|chunk| (chunk.hash, chunk.size_bytes)),
             ),
@@ -433,7 +433,7 @@ async fn scan_all_values_for_plan(
 
 pub(crate) async fn load_metadata_many(
     store: &(impl StorageAdapterRead + ?Sized),
-    hashes: &[BlobHash],
+    hashes: &[BlobId],
 ) -> Result<BlobMetadataBatch, LixError> {
     if hashes.is_empty() {
         return Ok(BlobMetadataBatch::new(Vec::new()));
@@ -470,11 +470,11 @@ pub(crate) async fn load_metadata_many(
 
 pub(crate) async fn load_bytes_many(
     store: &(impl StorageAdapterRead + ?Sized),
-    hashes: &[BlobHash],
+    hashes: &[BlobId],
 ) -> Result<BlobBytesBatch, LixError> {
     let metadata = load_metadata_many(store, hashes).await?.into_vec();
-    let mut delta_bases = HashMap::<BlobHash, BlobMetadata>::new();
-    let mut delta_base_order = Vec::<BlobHash>::new();
+    let mut delta_bases = HashMap::<BlobId, BlobMetadata>::new();
+    let mut delta_base_order = Vec::<BlobId>::new();
     for entry in metadata.iter().flatten() {
         if let BlobLayout::Delta {
             base_blob_hash,
@@ -613,7 +613,7 @@ pub(crate) async fn load_bytes_many(
                             )
                         })?;
                 for manifest_chunk in manifest_chunks {
-                    let chunk_hash = BlobHash::from_bytes(manifest_chunk.chunk_hash);
+                    let chunk_hash = ChunkHash::from_bytes(manifest_chunk.chunk_hash);
                     if seen_chunks.insert(chunk_hash) {
                         requested_chunks.push(chunk_hash);
                     }
@@ -629,7 +629,7 @@ pub(crate) async fn load_bytes_many(
         .zip(chunk_rows)
         .collect::<HashMap<_, _>>();
 
-    let mut full_bytes_by_hash = HashMap::<BlobHash, Vec<u8>>::new();
+    let mut full_bytes_by_hash = HashMap::<BlobId, Vec<u8>>::new();
     for metadata in physical_metadata {
         let hash = metadata.hash;
         let bytes = assemble_blob_bytes(
@@ -677,7 +677,7 @@ pub(crate) async fn load_bytes_many(
 
 pub(crate) async fn load_ranges_many(
     store: &(impl StorageAdapterRead + ?Sized),
-    requests: &[(BlobHash, Range<u64>)],
+    requests: &[(BlobId, Range<u64>)],
 ) -> Result<BlobRangeBytesBatch, LixError> {
     let hashes = requests.iter().map(|(hash, _)| *hash).collect::<Vec<_>>();
     let metadata = load_metadata_many(store, &hashes).await?.into_vec();
@@ -757,7 +757,7 @@ async fn load_blob_range(
             }
             let hashes = selected
                 .iter()
-                .map(|(_, chunk)| BlobHash::from_bytes(chunk.chunk_hash))
+                .map(|(_, chunk)| ChunkHash::from_bytes(chunk.chunk_hash))
                 .collect::<Vec<_>>();
             let rows = load_chunk_rows(store, &hashes).await?;
             let capacity =
@@ -821,11 +821,11 @@ async fn load_blob_range(
 }
 
 fn apply_flat_delta(
-    blob_hash: BlobHash,
+    blob_hash: BlobId,
     size_bytes: u64,
-    base_blob_hash: BlobHash,
+    base_blob_hash: BlobId,
     segments: &[BlobDeltaSegment],
-    full_bytes_by_hash: &HashMap<BlobHash, Vec<u8>>,
+    full_bytes_by_hash: &HashMap<BlobId, Vec<u8>>,
 ) -> Result<Vec<u8>, LixError> {
     let expected_size = persisted_size_to_usize(size_bytes, "binary CAS delta")?;
     let Some(base) = full_bytes_by_hash.get(&base_blob_hash) else {
@@ -887,7 +887,7 @@ fn apply_flat_delta(
             ),
         ));
     }
-    if BlobHash::from_content(&out) != blob_hash {
+    if BlobId::from_content(&out) != blob_hash {
         return Err(LixError::new(
             "LIX_ERROR_UNKNOWN",
             format!(
@@ -901,7 +901,7 @@ fn apply_flat_delta(
 
 async fn load_chunk_rows(
     store: &(impl StorageAdapterRead + ?Sized),
-    hashes: &[BlobHash],
+    hashes: &[ChunkHash],
 ) -> Result<Vec<Option<Bytes>>, LixError> {
     if hashes.is_empty() {
         return Ok(Vec::new());
@@ -952,13 +952,13 @@ fn full_value(value: StorageProjectedValue) -> Option<Bytes> {
 
 fn assemble_blob_bytes(
     metadata: BlobMetadata,
-    chunk_rows_by_hash: &HashMap<BlobHash, Option<Bytes>>,
+    chunk_rows_by_hash: &HashMap<ChunkHash, Option<Bytes>>,
     chunked_manifest: Option<&Vec<KvBlobManifestChunk>>,
 ) -> Result<Vec<u8>, LixError> {
     let expected_blob_size = persisted_size_to_usize(metadata.size_bytes, "binary CAS blob")?;
     let bytes = match &metadata.layout {
         BlobLayout::Empty => {
-            if cfg!(debug_assertions) && metadata.hash != BlobHash::from_content(&[]) {
+            if cfg!(debug_assertions) && metadata.hash != BlobId::from_content(&[]) {
                 return Err(LixError::new(
                     "LIX_ERROR_UNKNOWN",
                     format!(
@@ -977,8 +977,8 @@ fn assemble_blob_bytes(
                 expected_blob_size,
             )?;
             if cfg!(debug_assertions)
-                && *chunk_hash != metadata.hash
-                && BlobHash::from_content(&chunk) != metadata.hash
+                && BlobId::from_single_chunk(*chunk_hash) != metadata.hash
+                && BlobId::from_content(&chunk) != metadata.hash
             {
                 return Err(LixError::new(
                     "LIX_ERROR_UNKNOWN",
@@ -1013,7 +1013,7 @@ fn assemble_blob_bytes(
             }
             let mut out = Vec::with_capacity(expected_blob_size);
             for manifest_chunk in manifest_chunks {
-                let chunk_hash = BlobHash::from_bytes(manifest_chunk.chunk_hash);
+                let chunk_hash = ChunkHash::from_bytes(manifest_chunk.chunk_hash);
                 let expected_chunk_size =
                     persisted_size_to_usize(manifest_chunk.chunk_size, "binary CAS chunk")?;
                 let chunk = decode_chunk_from_map(
@@ -1035,7 +1035,7 @@ fn assemble_blob_bytes(
                     ),
                 ));
             }
-            if cfg!(debug_assertions) && BlobHash::from_content(&out) != metadata.hash {
+            if cfg!(debug_assertions) && BlobId::from_content(&out) != metadata.hash {
                 return Err(LixError::new(
                     "LIX_ERROR_UNKNOWN",
                     format!(
@@ -1054,9 +1054,9 @@ fn assemble_blob_bytes(
 }
 
 fn decode_chunk_from_map(
-    chunk_rows_by_hash: &HashMap<BlobHash, Option<Bytes>>,
-    blob_hash: BlobHash,
-    chunk_hash: BlobHash,
+    chunk_rows_by_hash: &HashMap<ChunkHash, Option<Bytes>>,
+    blob_hash: BlobId,
+    chunk_hash: ChunkHash,
     expected_chunk_size: usize,
 ) -> Result<Cow<'_, [u8]>, LixError> {
     let Some(Some(chunk_bytes)) = chunk_rows_by_hash.get(&chunk_hash) else {
@@ -1075,8 +1075,8 @@ fn decode_chunk_from_map(
 fn decode_and_verify_chunk(
     chunk_bytes: &[u8],
     expected_chunk_size: usize,
-    blob_hash: BlobHash,
-    chunk_hash: BlobHash,
+    blob_hash: BlobId,
+    chunk_hash: ChunkHash,
 ) -> Result<Cow<'_, [u8]>, LixError> {
     let (codec, uncompressed_len, chunk_payload) = decode_binary_cas_chunk(chunk_bytes)?;
     decode_and_verify_payload(
@@ -1094,8 +1094,8 @@ fn decode_and_verify_payload(
     uncompressed_len: u64,
     chunk_payload: Cow<'_, [u8]>,
     expected_chunk_size: usize,
-    blob_hash: BlobHash,
-    chunk_hash: BlobHash,
+    blob_hash: BlobId,
+    chunk_hash: ChunkHash,
 ) -> Result<Cow<'_, [u8]>, LixError> {
     if expected_chunk_size > MAX_BINARY_CAS_CHUNK_BYTES
         || uncompressed_len > MAX_BINARY_CAS_CHUNK_BYTES as u64
@@ -1140,7 +1140,7 @@ fn decode_and_verify_payload(
     // The immutable sidecar and its range cache are not independently
     // authenticated. Verify raw and decoded compressed bytes against the CAS
     // key in every build before returning them.
-    if BlobHash::from_content(&decoded) != chunk_hash {
+    if ChunkHash::from_content(&decoded) != chunk_hash {
         return Err(LixError::new(
             "LIX_ERROR_UNKNOWN",
             format!(
@@ -1160,7 +1160,7 @@ pub(in crate::binary_cas) async fn stage_blob_write_skipping_existing_chunks<S>(
     blob_hashes: &mut HashSet<[u8; 32]>,
     chunk_keys: &mut HashSet<Vec<u8>>,
     bytes: &[u8],
-    precomputed_hash: Option<BlobHash>,
+    precomputed_hash: Option<BlobId>,
 ) -> Result<BlobWriteReceipt, LixError>
 where
     S: StorageAdapterRead + ?Sized,
@@ -1217,7 +1217,7 @@ pub(in crate::binary_cas) async fn try_stage_blob_write_reusing_same_length_spli
     blob_hashes: &mut HashSet<[u8; 32]>,
     chunk_keys: &mut HashSet<Vec<u8>>,
     bytes: &[u8],
-    precomputed_hash: Option<BlobHash>,
+    precomputed_hash: Option<BlobId>,
     splice: BlobSameLengthSplice,
 ) -> Result<bool, LixError>
 where
@@ -1281,9 +1281,9 @@ where
             start: cursor,
             end,
             hash: if changed {
-                BlobHash::from_content(&bytes[cursor..end])
+                ChunkHash::from_content(&bytes[cursor..end])
             } else {
-                BlobHash::from_bytes(base_chunk.chunk_hash)
+                ChunkHash::from_bytes(base_chunk.chunk_hash)
             },
         };
         if changed {
@@ -1340,7 +1340,7 @@ pub(in crate::binary_cas) async fn try_stage_blob_write_as_flat_delta<S>(
     writes: &mut StorageWriteSet,
     blob_hashes: &mut HashSet<[u8; 32]>,
     bytes: &[u8],
-    precomputed_hash: Option<BlobHash>,
+    precomputed_hash: Option<BlobId>,
     splice: BlobEditSplice,
 ) -> Result<bool, LixError>
 where
@@ -1553,12 +1553,12 @@ fn normalize_delta_segments(segments: Vec<BlobDeltaSegment>) -> Vec<BlobDeltaSeg
 fn prepare_blob_write(
     chunking: BinaryCasChunking,
     bytes: &[u8],
-    precomputed_hash: Option<BlobHash>,
+    precomputed_hash: Option<BlobId>,
 ) -> Result<BlobWritePlan, LixError> {
-    let blob_hash = precomputed_hash.unwrap_or_else(|| BlobHash::from_content(bytes));
+    let blob_hash = precomputed_hash.unwrap_or_else(|| BlobId::from_content(bytes));
     if cfg!(debug_assertions)
         && precomputed_hash.is_some()
-        && BlobHash::from_content(bytes) != blob_hash
+        && BlobId::from_content(bytes) != blob_hash
     {
         return Err(LixError::new(
             "LIX_ERROR_UNKNOWN",
@@ -1572,11 +1572,7 @@ fn prepare_blob_write(
         let layout = match chunk_ranges.as_slice() {
             [] => unreachable!("non-empty blobs always have at least one chunk"),
             [(start, end)] => BlobLayout::SingleChunk {
-                chunk_hash: if *start == 0 && *end == bytes.len() {
-                    blob_hash
-                } else {
-                    BlobHash::from_content(&bytes[*start..*end])
-                },
+                chunk_hash: ChunkHash::from_content(&bytes[*start..*end]),
             },
             _ => BlobLayout::Chunked {
                 chunk_count: u32::try_from(chunk_ranges.len()).map_err(|_| {
@@ -1614,9 +1610,9 @@ fn prepare_chunks(bytes: &[u8], plan: &BlobWritePlan) -> Vec<PreparedChunk> {
             start,
             end,
             hash: if start == 0 && end == bytes.len() {
-                plan.blob_hash
+                ChunkHash::from_content(bytes)
             } else {
-                BlobHash::from_content(&bytes[start..end])
+                ChunkHash::from_content(&bytes[start..end])
             },
         })
         .collect()
@@ -1627,7 +1623,7 @@ fn stage_prepared_blob_write(
     bytes: &[u8],
     plan: &BlobWritePlan,
     chunks: &[PreparedChunk],
-    mut should_stage_chunk: impl FnMut(BlobHash) -> Result<bool, LixError>,
+    mut should_stage_chunk: impl FnMut(ChunkHash) -> Result<bool, LixError>,
 ) -> Result<(), LixError> {
     match &plan.layout {
         BlobLayout::Empty => {
@@ -1691,8 +1687,8 @@ async fn missing_chunk_hashes(
     transaction_chunk_keys: &mut HashSet<Vec<u8>>,
     plan: &BlobWritePlan,
     chunks: &[PreparedChunk],
-) -> Result<HashSet<BlobHash>, LixError> {
-    let mut candidates = Vec::<(BlobHash, StorageKey)>::new();
+) -> Result<HashSet<ChunkHash>, LixError> {
+    let mut candidates = Vec::<(ChunkHash, StorageKey)>::new();
     match &plan.layout {
         BlobLayout::Empty => {}
         BlobLayout::SingleChunk { chunk_hash } => {
@@ -1728,8 +1724,8 @@ async fn missing_chunk_hashes_for_chunks(
     store: &(impl StorageAdapterRead + ?Sized),
     transaction_chunk_keys: &mut HashSet<Vec<u8>>,
     chunks: &[PreparedChunk],
-) -> Result<HashSet<BlobHash>, LixError> {
-    let mut candidates = Vec::<(BlobHash, StorageKey)>::new();
+) -> Result<HashSet<ChunkHash>, LixError> {
+    let mut candidates = Vec::<(ChunkHash, StorageKey)>::new();
     for chunk in chunks {
         collect_chunk_lookup_candidate(chunk.hash, transaction_chunk_keys, &mut candidates);
     }
@@ -1749,9 +1745,9 @@ async fn missing_chunk_hashes_for_chunks(
 }
 
 fn collect_chunk_lookup_candidate(
-    chunk_hash: BlobHash,
+    chunk_hash: ChunkHash,
     transaction_chunk_keys: &mut HashSet<Vec<u8>>,
-    candidates: &mut Vec<(BlobHash, StorageKey)>,
+    candidates: &mut Vec<(ChunkHash, StorageKey)>,
 ) {
     let key = chunk_key(chunk_hash);
     if !transaction_chunk_keys.insert(key.clone()) {
@@ -1790,7 +1786,7 @@ async fn chunk_keys_exist(
 }
 
 fn metadata_from_manifest(
-    hash: BlobHash,
+    hash: BlobId,
     manifest: BinaryCasManifest,
 ) -> Result<BlobMetadata, LixError> {
     let size_bytes = manifest.size_bytes();
@@ -1808,7 +1804,7 @@ fn metadata_from_manifest(
             BlobLayout::Empty
         }
         BinaryCasManifest::SingleChunk { chunk_hash, .. } => BlobLayout::SingleChunk {
-            chunk_hash: BlobHash::from_bytes(chunk_hash),
+            chunk_hash: ChunkHash::from_bytes(chunk_hash),
         },
         BinaryCasManifest::Chunked { chunk_count, .. } => BlobLayout::Chunked { chunk_count },
         BinaryCasManifest::Delta {
@@ -1820,12 +1816,12 @@ fn metadata_from_manifest(
         } => {
             validate_storage_delta_manifest(hash, size_bytes, base_size_bytes, &segments)?;
             BlobLayout::Delta {
-                base_blob_hash: BlobHash::from_bytes(base_blob_hash),
+                base_blob_hash: BlobId::from_bytes(base_blob_hash),
                 base_size_bytes,
                 base_layout: match base_layout {
                     StorageBinaryCasDeltaBaseLayout::SingleChunk { chunk_hash } => {
                         BlobDeltaBaseLayout::SingleChunk {
-                            chunk_hash: BlobHash::from_bytes(chunk_hash),
+                            chunk_hash: ChunkHash::from_bytes(chunk_hash),
                         }
                     }
                     StorageBinaryCasDeltaBaseLayout::Chunked { chunk_count } => {
@@ -1854,7 +1850,7 @@ fn metadata_from_manifest(
 }
 
 fn validate_storage_delta_manifest(
-    hash: BlobHash,
+    hash: BlobId,
     size_bytes: u64,
     base_size_bytes: u64,
     segments: &[StorageBinaryCasDeltaSegment],
@@ -1929,23 +1925,23 @@ fn validate_storage_delta_manifest(
     Ok(())
 }
 
-fn manifest_key(blob_hash: BlobHash) -> Vec<u8> {
+fn manifest_key(blob_hash: BlobId) -> Vec<u8> {
     blob_hash.as_bytes().to_vec()
 }
 
 #[cfg(test)]
-fn manifest_chunk_prefix(blob_hash: BlobHash) -> Vec<u8> {
+fn manifest_chunk_prefix(blob_hash: BlobId) -> Vec<u8> {
     blob_hash.as_bytes().to_vec()
 }
 
-fn manifest_chunk_key(blob_hash: BlobHash, chunk_index: u64) -> Vec<u8> {
+fn manifest_chunk_key(blob_hash: BlobId, chunk_index: u64) -> Vec<u8> {
     let mut out = Vec::with_capacity(40);
     out.extend_from_slice(blob_hash.as_bytes());
     out.extend_from_slice(&chunk_index.to_be_bytes());
     out
 }
 
-fn chunk_key(chunk_hash: BlobHash) -> Vec<u8> {
+fn chunk_key(chunk_hash: ChunkHash) -> Vec<u8> {
     chunk_hash.as_bytes().to_vec()
 }
 
@@ -1984,7 +1980,7 @@ mod tests {
     struct DelayedManifestScanRead<R> {
         inner: R,
         default_manifest_delay: Duration,
-        blocked_manifest: Option<(BlobHash, BlobHash)>,
+        blocked_manifest: Option<(BlobId, BlobId)>,
         blocked_manifest_release: Notify,
         active_manifest_scans: AtomicUsize,
         max_active_manifest_scans: AtomicUsize,
@@ -1993,7 +1989,7 @@ mod tests {
         chunk_get_many_calls: AtomicUsize,
         presence_get_many_calls: AtomicUsize,
         chunk_keys_requested: AtomicUsize,
-        completed_manifest_hashes: Mutex<Vec<BlobHash>>,
+        completed_manifest_hashes: Mutex<Vec<BlobId>>,
     }
 
     impl<R> DelayedManifestScanRead<R> {
@@ -2016,8 +2012,8 @@ mod tests {
 
         fn block_manifest_until(
             mut self,
-            blocked_manifest: BlobHash,
-            completed_manifest: BlobHash,
+            blocked_manifest: BlobId,
+            completed_manifest: BlobId,
         ) -> Self {
             self.blocked_manifest = Some((blocked_manifest, completed_manifest));
             self
@@ -2096,19 +2092,19 @@ mod tests {
         }
     }
 
-    fn manifest_hash_from_range(range: &StorageKeyRange) -> Option<BlobHash> {
+    fn manifest_hash_from_range(range: &StorageKeyRange) -> Option<BlobId> {
         let Bound::Included(StorageKey(bytes)) = &range.lower else {
             return None;
         };
         let hash = <[u8; 32]>::try_from(bytes.get(..32)?).ok()?;
-        Some(BlobHash::from_bytes(hash))
+        Some(BlobId::from_bytes(hash))
     }
 
-    fn stage_two_chunk_blob(writes: &mut StorageWriteSet, ordinal: usize) -> (BlobHash, Vec<u8>) {
+    fn stage_two_chunk_blob(writes: &mut StorageWriteSet, ordinal: usize) -> (BlobId, Vec<u8>) {
         let left = format!("blob-{ordinal}-left").into_bytes();
         let right = format!("blob-{ordinal}-right").into_bytes();
         let bytes = [left.as_slice(), right.as_slice()].concat();
-        let blob_hash = BlobHash::from_content(&bytes);
+        let blob_hash = BlobId::from_content(&bytes);
         let chunks = [left, right];
 
         stage_manifest(
@@ -2121,7 +2117,7 @@ mod tests {
             },
         );
         for (index, chunk) in chunks.iter().enumerate() {
-            let chunk_hash = BlobHash::from_content(chunk);
+            let chunk_hash = ChunkHash::from_content(chunk);
             stage_manifest_chunk(
                 writes,
                 blob_hash,
@@ -2146,9 +2142,9 @@ mod tests {
         writes: &mut StorageWriteSet,
         label: &[u8],
         declared_chunk_count: u32,
-    ) -> BlobHash {
-        let blob_hash = BlobHash::from_content(label);
-        let chunk_hash = BlobHash::from_content(label);
+    ) -> BlobId {
+        let blob_hash = BlobId::from_content(label);
+        let chunk_hash = BlobId::from_content(label);
         stage_manifest(
             writes,
             blob_hash,
@@ -2215,7 +2211,7 @@ mod tests {
         let storage = StorageAdapter::new(Memory::new());
         let bytes = definitely_multi_chunk_blob_bytes();
         let payload = BlobPayload::from_bytes(bytes.clone());
-        let expected_hash = BlobHash::from_content(&bytes);
+        let expected_hash = BlobId::from_content(&bytes);
 
         let mut initial = storage.new_write_set();
         let initial_receipt = stage_test_payload(&storage, &mut initial, &payload).await;
@@ -2238,9 +2234,9 @@ mod tests {
     #[tokio::test]
     async fn stores_manifest_chunks_in_scan_order() {
         let storage = StorageAdapter::new(Memory::new());
-        let blob_hash = BlobHash::from_content(b"blob-a");
-        let chunk_a_hash = BlobHash::from_content(b"chunk-a").into_bytes();
-        let chunk_b_hash = BlobHash::from_content(b"chunk-b").into_bytes();
+        let blob_hash = BlobId::from_content(b"blob-a");
+        let chunk_a_hash = BlobId::from_content(b"chunk-a").into_bytes();
+        let chunk_b_hash = BlobId::from_content(b"chunk-b").into_bytes();
 
         {
             let mut writes = storage.new_write_set();
@@ -2321,7 +2317,7 @@ mod tests {
                 fixture.0,
                 2,
                 &KvBlobManifestChunk {
-                    chunk_hash: BlobHash::from_content(b"stale manifest suffix").into_bytes(),
+                    chunk_hash: ChunkHash::from_content(b"stale manifest suffix").into_bytes(),
                     chunk_size: 1,
                 },
             );
@@ -2419,7 +2415,7 @@ mod tests {
                 .expect("chunked blob fixture should commit");
             fixture
         };
-        let missing_hash = BlobHash::from_content(b"missing duplicate fixture");
+        let missing_hash = BlobId::from_content(b"missing duplicate fixture");
 
         let store = storage
             .begin_read(StorageReadOptions::default())
@@ -2559,7 +2555,7 @@ mod tests {
             uncompressed_len: 5,
             data: b"hello".to_vec(),
         };
-        let chunk_hash = BlobHash::from_content(b"chunk-a");
+        let chunk_hash = ChunkHash::from_content(b"chunk-a");
 
         {
             let mut writes = storage.new_write_set();
@@ -2590,9 +2586,9 @@ mod tests {
 
     #[test]
     fn binary_hash_keys_are_compact_and_manifest_chunks_sort_by_index() {
-        let blob_hash = BlobHash::from_content(b"blob");
+        let blob_hash = BlobId::from_content(b"blob");
         let manifest_key = manifest_key(blob_hash);
-        let chunk_key = chunk_key(BlobHash::from_content(b"chunk"));
+        let chunk_key = chunk_key(ChunkHash::from_content(b"chunk"));
         let first = manifest_chunk_key(blob_hash, 1);
         let second = manifest_chunk_key(blob_hash, 2);
         let later = manifest_chunk_key(blob_hash, 10);
@@ -2606,15 +2602,15 @@ mod tests {
 
     #[test]
     fn delta_manifest_rejects_out_of_bounds_copy_program() {
-        let hash = BlobHash::from_content(b"invalid delta result");
+        let hash = BlobId::from_content(b"invalid delta result");
         let error = metadata_from_manifest(
             hash,
             BinaryCasManifest::Delta {
                 size_bytes: 10,
-                base_blob_hash: BlobHash::from_content(b"base").into_bytes(),
+                base_blob_hash: BlobId::from_content(b"base").into_bytes(),
                 base_size_bytes: 4,
                 base_layout: StorageBinaryCasDeltaBaseLayout::SingleChunk {
-                    chunk_hash: BlobHash::from_content(b"base").into_bytes(),
+                    chunk_hash: ChunkHash::from_content(b"base").into_bytes(),
                 },
                 segments: vec![StorageBinaryCasDeltaSegment::Copy {
                     offset: 0,
@@ -2644,7 +2640,7 @@ mod tests {
     async fn public_kv_api_roundtrips_blob_bytes() {
         let storage = StorageAdapter::new(Memory::new());
         let data = b"hello chunked kv cas";
-        let blob_hash = BlobHash::from_content(data);
+        let blob_hash = BlobId::from_content(data);
 
         {
             let mut writes = storage.new_write_set();
@@ -2697,7 +2693,7 @@ mod tests {
         let data = (0..(3 * 1024 * 1024))
             .map(|index| ((index * 131 + 17) % 251) as u8)
             .collect::<Vec<_>>();
-        let blob_hash = BlobHash::from_content(&data);
+        let blob_hash = BlobId::from_content(&data);
         {
             let mut writes = storage.new_write_set();
             stage_test_bytes(&storage, &mut writes, &data).await;
@@ -2737,7 +2733,7 @@ mod tests {
         assert!(chunk_ranges.len() > 1);
         let chunk_hashes = chunk_ranges
             .iter()
-            .map(|(start, end)| BlobHash::from_content(&data[*start..*end]))
+            .map(|(start, end)| BlobId::from_content(&data[*start..*end]))
             .collect::<HashSet<_>>();
 
         {
@@ -2801,7 +2797,7 @@ mod tests {
     async fn same_length_splice_writer_reuses_unchanged_manifest_chunks_and_roundtrips() {
         let storage = StorageAdapter::new(Memory::new());
         let before = definitely_multi_chunk_blob_bytes();
-        let base_blob_hash = BlobHash::from_content(&before);
+        let base_blob_hash = BlobId::from_content(&before);
 
         {
             let mut writes = storage.new_write_set();
@@ -2833,7 +2829,7 @@ mod tests {
         let edit_offset = changed_chunk_start + changed_chunk_len / 2;
         let mut after = before.clone();
         after[edit_offset] ^= 0xff;
-        let after_blob_hash = BlobHash::from_content(&after);
+        let after_blob_hash = BlobId::from_content(&after);
         let after_payload = BlobPayload::from_bytes(after.clone());
 
         {
@@ -2889,7 +2885,7 @@ mod tests {
     async fn flat_delta_writer_merges_edits_against_one_full_base_and_roundtrips() {
         let storage = StorageAdapter::new(Memory::new());
         let before = b"a representative text line with stable compression boundaries\n".repeat(512);
-        let full_base_hash = BlobHash::from_content(&before);
+        let full_base_hash = BlobId::from_content(&before);
         {
             let mut writes = storage.new_write_set();
             stage_test_bytes(&storage, &mut writes, &before).await;
@@ -2902,7 +2898,7 @@ mod tests {
         let first_offset = before.len() / 3;
         let mut first = before.clone();
         first[first_offset] ^= 1;
-        let first_hash = BlobHash::from_content(&first);
+        let first_hash = BlobId::from_content(&first);
         {
             let payload = BlobPayload::from_bytes(first.clone());
             let store = storage
@@ -2934,7 +2930,7 @@ mod tests {
         let second_offset = before.len() * 2 / 3;
         let mut second = first.clone();
         second[second_offset] ^= 1;
-        let second_hash = BlobHash::from_content(&second);
+        let second_hash = BlobId::from_content(&second);
         {
             let payload = BlobPayload::from_bytes(second.clone());
             let store = storage
@@ -2967,7 +2963,7 @@ mod tests {
         let inserted = b"inserted";
         let mut third = second.clone();
         third.splice(third_offset..third_offset, inserted.iter().copied());
-        let third_hash = BlobHash::from_content(&third);
+        let third_hash = BlobId::from_content(&third);
         {
             let payload = BlobPayload::from_bytes(third.clone());
             let store = storage
@@ -3030,7 +3026,7 @@ mod tests {
     async fn same_length_splice_writer_falls_back_when_result_length_changes() {
         let storage = StorageAdapter::new(Memory::new());
         let before = definitely_multi_chunk_blob_bytes();
-        let base_blob_hash = BlobHash::from_content(&before);
+        let base_blob_hash = BlobId::from_content(&before);
 
         {
             let mut writes = storage.new_write_set();
@@ -3044,7 +3040,7 @@ mod tests {
         let edit_offset = before.len() / 2;
         let mut after = before.clone();
         after.insert(edit_offset, b'!');
-        let after_blob_hash = BlobHash::from_content(&after);
+        let after_blob_hash = BlobId::from_content(&after);
         let after_payload = BlobPayload::from_bytes(after.clone());
         {
             let mut writes = storage.new_write_set();
@@ -3067,7 +3063,7 @@ mod tests {
             .expect("result read should open");
         let expected_hashes = crate::binary_cas::chunking::fastcdc_chunk_ranges(&after)
             .into_iter()
-            .map(|(start, end)| BlobHash::from_content(&after[start..end]).into_bytes())
+            .map(|(start, end)| BlobId::from_content(&after[start..end]).into_bytes())
             .collect::<Vec<_>>();
         let actual_hashes = scan_manifest_chunks(&store, after_blob_hash)
             .await
@@ -3091,8 +3087,8 @@ mod tests {
     #[test]
     fn prepared_blob_write_stages_duplicate_chunk_payload_once() {
         let data = b"abcabc";
-        let blob_hash = BlobHash::from_content(data);
-        let chunk_hash = BlobHash::from_content(b"abc");
+        let blob_hash = BlobId::from_content(data);
+        let chunk_hash = ChunkHash::from_content(b"abc");
         let plan = BlobWritePlan {
             blob_hash,
             chunk_ranges: vec![(0, 3), (3, 6)],
@@ -3174,7 +3170,7 @@ mod tests {
         let storage = StorageAdapter::new(Memory::new());
         let data = b"same length";
         let corrupted = b"SAME length";
-        let blob_hash = BlobHash::from_content(data);
+        let blob_hash = BlobId::from_content(data);
 
         {
             let mut writes = storage.new_write_set();
@@ -3189,7 +3185,7 @@ mod tests {
             let mut writes = storage.new_write_set();
             stage_chunk(
                 &mut writes,
-                blob_hash,
+                ChunkHash::from_content(data),
                 BinaryChunkCodec::Raw,
                 corrupted.len() as u64,
                 corrupted,
@@ -3218,12 +3214,17 @@ mod tests {
         let expected = vec![b'a'; 128 * 1024];
         let substituted = vec![b'b'; expected.len()];
         assert_eq!(expected.len(), substituted.len());
-        let expected_hash = BlobHash::from_content(&expected);
+        let expected_hash = BlobId::from_content(&expected);
         let row =
             encode_binary_cas_chunk(BinaryChunkCodec::Raw, expected.len() as u64, &substituted);
 
-        let error = decode_and_verify_chunk(&row, expected.len(), expected_hash, expected_hash)
-            .expect_err("raw bytes for a different hash should be rejected");
+        let error = decode_and_verify_chunk(
+            &row,
+            expected.len(),
+            expected_hash,
+            ChunkHash::from_content(&expected),
+        )
+        .expect_err("raw bytes for a different hash should be rejected");
 
         assert!(
             error
@@ -3235,11 +3236,12 @@ mod tests {
     #[test]
     fn decode_rejects_chunks_above_the_format_maximum_before_payload_validation() {
         let data = b"valid raw content".repeat(4096);
-        let chunk_hash = BlobHash::from_content(&data);
+        let chunk_hash = ChunkHash::from_content(&data);
+        let blob_hash = BlobId::from_single_chunk(chunk_hash);
         let oversized_len = MAX_BINARY_CAS_CHUNK_BYTES + 1;
         let row = encode_binary_cas_chunk(BinaryChunkCodec::Raw, oversized_len as u64, &data);
 
-        let error = decode_and_verify_chunk(&row, oversized_len, chunk_hash, chunk_hash)
+        let error = decode_and_verify_chunk(&row, oversized_len, blob_hash, chunk_hash)
             .expect_err("oversized chunk metadata should be rejected");
 
         assert!(error.message.contains("exceeds"));
@@ -3252,8 +3254,8 @@ mod tests {
         let expected = b"expected bytes";
         let substituted = b"different byte";
         assert_eq!(expected.len(), substituted.len());
-        let expected_blob_hash = BlobHash::from_content(expected);
-        let substituted_chunk_hash = BlobHash::from_content(substituted);
+        let expected_blob_hash = BlobId::from_content(expected);
+        let substituted_chunk_hash = ChunkHash::from_content(substituted);
 
         {
             let mut writes = storage.new_write_set();
@@ -3270,7 +3272,7 @@ mod tests {
                 expected_blob_hash,
                 0,
                 &KvBlobManifestChunk {
-                    chunk_hash: BlobHash::from_content(substituted).into_bytes(),
+                    chunk_hash: substituted_chunk_hash.into_bytes(),
                     chunk_size: substituted.len() as u64,
                 },
             );
@@ -3305,7 +3307,7 @@ mod tests {
     async fn public_kv_api_roundtrips_empty_blob() {
         let storage = StorageAdapter::new(Memory::new());
         let data = b"";
-        let blob_hash = BlobHash::from_content(data);
+        let blob_hash = BlobId::from_content(data);
 
         {
             let mut writes = storage.new_write_set();
@@ -3343,7 +3345,7 @@ mod tests {
     async fn public_kv_api_roundtrips_multi_chunk_blob() {
         let storage = StorageAdapter::new(Memory::new());
         let data = definitely_multi_chunk_blob_bytes();
-        let blob_hash = BlobHash::from_content(&data);
+        let blob_hash = BlobId::from_content(&data);
 
         {
             let mut writes = storage.new_write_set();

--- a/packages/engine/src/binary_cas/mod.rs
+++ b/packages/engine/src/binary_cas/mod.rs
@@ -19,6 +19,6 @@ pub(crate) use context::{BinaryCasContext, BlobDataReader};
 pub(crate) use kv::load_bytes_many;
 pub(crate) use types::{
     BlobBytesBatch, BlobChunkReceipt, BlobDeltaBaseLayout, BlobDeltaSegment, BlobEditSplice,
-    BlobHash, BlobLayout, BlobMetadata, BlobMetadataBatch, BlobPayload, BlobRangeBytes,
-    BlobRangeBytesBatch, BlobSameLengthSplice, BlobWriteReceipt,
+    BlobId, BlobLayout, BlobMetadata, BlobMetadataBatch, BlobPayload, BlobRangeBytes,
+    BlobRangeBytesBatch, BlobSameLengthSplice, BlobWriteReceipt, ChunkHash,
 };

--- a/packages/engine/src/binary_cas/stats.rs
+++ b/packages/engine/src/binary_cas/stats.rs
@@ -121,11 +121,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::binary_cas::BlobHash;
     use crate::binary_cas::codec::BinaryChunkCodec;
     use crate::binary_cas::kv::{
         KvBlobManifestChunk, stage_chunk, stage_manifest, stage_manifest_chunk,
     };
+    use crate::binary_cas::{BlobId, ChunkHash};
     use crate::storage_adapter::{Memory, StorageAdapter, StorageReadOptions, StorageWriteOptions};
 
     #[tokio::test]
@@ -134,15 +134,15 @@ mod tests {
         let storage = StorageAdapter::new(storage);
         let mut writes = storage.new_write_set();
 
-        let empty_hash = BlobHash::from_content(b"empty");
+        let empty_hash = BlobId::from_content(b"empty");
         stage_manifest(
             &mut writes,
             empty_hash,
             &BinaryCasManifest::Empty { size_bytes: 0 },
         );
 
-        let single_hash = BlobHash::from_content(b"single blob");
-        let single_chunk_hash = BlobHash::from_content(b"single");
+        let single_hash = BlobId::from_content(b"single blob");
+        let single_chunk_hash = ChunkHash::from_content(b"single");
         stage_manifest(
             &mut writes,
             single_hash,
@@ -159,7 +159,7 @@ mod tests {
             b"single",
         );
 
-        let chunked_hash = BlobHash::from_content(b"chunked blob");
+        let chunked_hash = BlobId::from_content(b"chunked blob");
         stage_manifest(
             &mut writes,
             chunked_hash,
@@ -172,7 +172,7 @@ mod tests {
             .into_iter()
             .enumerate()
         {
-            let chunk_hash = BlobHash::from_content(payload);
+            let chunk_hash = ChunkHash::from_content(payload);
             stage_manifest_chunk(
                 &mut writes,
                 chunked_hash,

--- a/packages/engine/src/binary_cas/types.rs
+++ b/packages/engine/src/binary_cas/types.rs
@@ -5,28 +5,32 @@ use crate::binary_cas::codec::{binary_blob_hash_bytes, hash_bytes_to_hex, hash_h
 use std::ops::Range;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub(crate) struct BlobHash([u8; 32]);
+pub(crate) struct BlobId([u8; 32]);
 
-impl BlobHash {
+impl BlobId {
     pub(crate) fn from_bytes(bytes: [u8; 32]) -> Self {
         Self(bytes)
     }
 
     pub(crate) fn from_content(content: &[u8]) -> Self {
         if content.len() <= MEDIA_CHUNK_BYTES {
-            return Self(binary_blob_hash_bytes(content));
+            return Self::from_single_chunk(ChunkHash::from_content(content));
         }
         let chunks = content
             .chunks(MEDIA_CHUNK_BYTES)
-            .map(|chunk| (Self(binary_blob_hash_bytes(chunk)), chunk.len() as u64));
+            .map(|chunk| (ChunkHash::from_content(chunk), chunk.len() as u64));
         Self::from_chunks(content.len() as u64, chunks)
+    }
+
+    pub(crate) fn from_single_chunk(chunk_hash: ChunkHash) -> Self {
+        Self(chunk_hash.into_bytes())
     }
 
     /// Computes the canonical identity of a fixed-chunk blob without opening
     /// its payload. Upload recovery persists precisely these bounded receipts.
     pub(crate) fn from_chunks(
         size_bytes: u64,
-        chunks: impl IntoIterator<Item = (Self, u64)>,
+        chunks: impl IntoIterator<Item = (ChunkHash, u64)>,
     ) -> Self {
         let mut hasher = blake3::Hasher::new_derive_key("lix binary cas fixed manifest v3");
         hasher.update(&size_bytes.to_le_bytes());
@@ -54,6 +58,36 @@ impl BlobHash {
     }
 }
 
+/// The raw content hash of one immutable CAS chunk.
+///
+/// A `ChunkHash` can equal a small blob's `BlobId` byte-for-byte, but it is
+/// deliberately a distinct type: chunk keys must never be accepted where a
+/// manifest identity is required.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) struct ChunkHash([u8; 32]);
+
+impl ChunkHash {
+    pub(crate) fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    pub(crate) fn from_content(content: &[u8]) -> Self {
+        Self(binary_blob_hash_bytes(content))
+    }
+
+    pub(crate) fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    pub(crate) fn into_bytes(self) -> [u8; 32] {
+        self.0
+    }
+
+    pub(crate) fn to_hex(self) -> String {
+        hash_bytes_to_hex(&self.0)
+    }
+}
+
 /// A host-verified fixed-width replacement in an already materialized blob.
 ///
 /// The ordinary SQL surface still submits complete replacement bytes. The
@@ -63,21 +97,21 @@ impl BlobHash {
 /// non-overlapping chunk instead of rechunking the complete replacement.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct BlobSameLengthSplice {
-    pub(crate) base_blob_hash: BlobHash,
+    pub(crate) base_blob_hash: BlobId,
     pub(crate) offset: usize,
     pub(crate) length: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct BlobEditSplice {
-    pub(crate) base_blob_hash: BlobHash,
+    pub(crate) base_blob_hash: BlobId,
     pub(crate) offset: usize,
     pub(crate) delete_len: usize,
     pub(crate) insert_len: usize,
 }
 
 impl BlobSameLengthSplice {
-    pub(crate) fn new(base_blob_hash: BlobHash, offset: usize, length: usize) -> Self {
+    pub(crate) fn new(base_blob_hash: BlobId, offset: usize, length: usize) -> Self {
         Self {
             base_blob_hash,
             offset,
@@ -93,13 +127,13 @@ impl BlobSameLengthSplice {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct BlobPayload {
     bytes: crate::Blob,
-    hash: Option<BlobHash>,
+    hash: Option<BlobId>,
 }
 
 impl BlobPayload {
     pub(crate) fn from_bytes(bytes: impl Into<crate::Blob>) -> Self {
         let bytes = bytes.into();
-        let hash = (!bytes.is_empty()).then(|| BlobHash::from_content(&bytes));
+        let hash = (!bytes.is_empty()).then(|| BlobId::from_content(&bytes));
         Self { bytes, hash }
     }
 
@@ -111,7 +145,7 @@ impl BlobPayload {
         self.bytes.clone()
     }
 
-    pub(crate) fn hash(&self) -> Option<BlobHash> {
+    pub(crate) fn hash(&self) -> Option<BlobId> {
         self.hash
     }
 
@@ -132,7 +166,7 @@ pub(crate) enum BlobDeltaSegment {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum BlobDeltaBaseLayout {
-    SingleChunk { chunk_hash: BlobHash },
+    SingleChunk { chunk_hash: ChunkHash },
     Chunked { chunk_count: u32 },
 }
 
@@ -140,7 +174,7 @@ pub(crate) enum BlobDeltaBaseLayout {
 pub(crate) enum BlobLayout {
     Empty,
     SingleChunk {
-        chunk_hash: BlobHash,
+        chunk_hash: ChunkHash,
     },
     Chunked {
         chunk_count: u32,
@@ -148,7 +182,7 @@ pub(crate) enum BlobLayout {
     /// One-level, flattened copy/insert program against a canonical full blob,
     /// so reads never walk a history chain.
     Delta {
-        base_blob_hash: BlobHash,
+        base_blob_hash: BlobId,
         base_size_bytes: u64,
         base_layout: BlobDeltaBaseLayout,
         segments: Vec<BlobDeltaSegment>,
@@ -157,7 +191,7 @@ pub(crate) enum BlobLayout {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct BlobMetadata {
-    pub(crate) hash: BlobHash,
+    pub(crate) hash: BlobId,
     pub(crate) size_bytes: u64,
     pub(crate) layout: BlobLayout,
 }
@@ -216,14 +250,14 @@ impl BlobBytesBatch {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct BlobWriteReceipt {
-    pub(crate) hash: BlobHash,
+    pub(crate) hash: BlobId,
     pub(crate) size_bytes: u64,
     pub(crate) layout: BlobLayout,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct BlobChunkReceipt {
-    pub(crate) hash: BlobHash,
+    pub(crate) hash: ChunkHash,
     pub(crate) size_bytes: u64,
 }
 

--- a/packages/engine/src/filesystem/path_index.rs
+++ b/packages/engine/src/filesystem/path_index.rs
@@ -11,7 +11,7 @@ use bytes::Bytes;
 use serde::Deserialize;
 
 use crate::LixError;
-use crate::binary_cas::BlobHash;
+use crate::binary_cas::BlobId;
 use crate::changelog::{ChangeId, CommitId};
 use crate::common::{LixTimestamp, compose_directory_path, compose_file_path};
 use crate::entity_pk::EntityPk;
@@ -576,7 +576,7 @@ impl FilesystemPathIndex {
         store: &impl StorageAdapterRead,
     ) -> Result<Self, LixError> {
         let mut requests =
-            BTreeMap::<String, (BlobHash, usize, Vec<Arc<FilesystemPathEntry>>)>::new();
+            BTreeMap::<String, (BlobId, usize, Vec<Arc<FilesystemPathEntry>>)>::new();
         let mut reserved_cache_bytes = 0usize;
         for entry in self.entries() {
             let Some(row) = entry.blob_ref.as_ref() else {
@@ -601,7 +601,7 @@ impl FilesystemPathIndex {
             else {
                 continue;
             };
-            let hash = BlobHash::from_hex(&snapshot.blob_hash)?;
+            let hash = BlobId::from_hex(&snapshot.blob_hash)?;
             requests
                 .entry(snapshot.blob_hash)
                 .or_insert_with(|| (hash, size_bytes, Vec::new()))
@@ -635,7 +635,7 @@ impl FilesystemPathIndex {
             let Some(data) = data else {
                 continue;
             };
-            if data.len() != size_bytes || BlobHash::from_content(&data) != hash {
+            if data.len() != size_bytes || BlobId::from_content(&data) != hash {
                 continue;
             }
             let data = crate::Blob::from(data);

--- a/packages/engine/src/filesystem/planner.rs
+++ b/packages/engine/src/filesystem/planner.rs
@@ -8,7 +8,7 @@ use serde_json::{Map as JsonMap, Value as JsonValue, json};
 
 use crate::GLOBAL_BRANCH_ID;
 use crate::LixError;
-use crate::binary_cas::BlobHash;
+use crate::binary_cas::BlobId;
 use crate::common::{LixPath, compose_file_path};
 use crate::entity_pk::EntityPk;
 use crate::live_state::{
@@ -25,7 +25,7 @@ use super::{DirectoryPathRecord, derive_directory_paths};
 #[cfg(test)]
 use crate::transaction::types::TransactionWriteRow;
 use crate::transaction::types::{
-    LogicalPrimaryKey, RawWriteBatch, TransactionFileData, TransactionJson,
+    FileContent, LogicalPrimaryKey, RawWriteBatch, TransactionFileData, TransactionJson,
     TransactionWriteOperation, TransactionWriteOrigin,
 };
 
@@ -356,7 +356,7 @@ impl FileDescriptorWriteIntent {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct BlobRefRowInput {
     pub(crate) file_id: String,
-    pub(crate) blob_hash: BlobHash,
+    pub(crate) blob_hash: BlobId,
     pub(crate) size_bytes: usize,
     pub(crate) context: FilesystemRowContext,
 }
@@ -1114,7 +1114,7 @@ pub(crate) fn plan_parsed_file_path_write_with_resolvers(
     resolvers: &mut BTreeMap<String, DirectoryPathResolver>,
     parsed: LixPath,
     id: Option<String>,
-    data: Option<crate::Blob>,
+    content: Option<FileContent>,
     context: FilesystemRowContext,
     generate_directory_id: &mut dyn FnMut() -> String,
 ) -> Result<FilesystemWritePlan, LixError> {
@@ -1125,7 +1125,7 @@ pub(crate) fn plan_parsed_file_path_write_with_resolvers(
         fallback.as_ref(),
         parsed,
         id,
-        data,
+        content,
         context,
         generate_directory_id,
     )
@@ -1136,7 +1136,7 @@ fn plan_parsed_file_path_write_with_fallback(
     fallback: Option<&DirectoryPathResolver>,
     parsed: LixPath,
     id: Option<String>,
-    data: Option<crate::Blob>,
+    content: Option<FileContent>,
     context: FilesystemRowContext,
     generate_directory_id: &mut dyn FnMut() -> String,
 ) -> Result<FilesystemWritePlan, LixError> {
@@ -1176,7 +1176,7 @@ fn plan_parsed_file_path_write_with_fallback(
     .append_to(&mut rows);
 
     let mut file_data = Vec::new();
-    if let Some(data) = data {
+    if let Some(content) = content {
         let file_payload = TransactionFileData::new(
             file_id.clone(),
             Some(file_path),
@@ -1184,7 +1184,7 @@ fn plan_parsed_file_path_write_with_fallback(
             context.branch_id.clone(),
             context.global,
             context.untracked,
-            data,
+            content,
         );
         if !file_payload.is_empty() {
             BlobRefRowInput {
@@ -1242,7 +1242,7 @@ pub(crate) fn plan_file_descriptor_write(
             input.context.branch_id.clone(),
             input.context.global,
             input.context.untracked,
-            data,
+            FileContent::inline(data),
         );
         if !file_payload.is_empty() {
             BlobRefRowInput {
@@ -1823,7 +1823,7 @@ mod tests {
     use serde_json::{Value as JsonValue, json};
 
     use crate::GLOBAL_BRANCH_ID;
-    use crate::binary_cas::BlobHash;
+    use crate::binary_cas::BlobId;
     use crate::changelog::{ChangeId, CommitId};
     use crate::common::LixTimestamp;
     use crate::filesystem::{FilesystemBlobRefKey, FilesystemDescriptorKey};
@@ -2015,7 +2015,7 @@ mod tests {
     fn blob_ref_row_builds_state_row() {
         let row = blob_ref_row(BlobRefRowInput {
             file_id: "01920000-0000-7000-8000-0000000000d2".to_string(),
-            blob_hash: BlobHash::from_content(b"Hello"),
+            blob_hash: BlobId::from_content(b"Hello"),
             size_bytes: 5,
             context: FilesystemRowContext::active_branch("01920000-0000-7000-8000-0000000000a1"),
         })
@@ -2035,7 +2035,7 @@ mod tests {
         assert_eq!(snapshot["size_bytes"], 5);
         assert_eq!(
             snapshot["blob_hash"].as_str(),
-            Some(BlobHash::from_content(b"Hello").to_hex().as_str())
+            Some(BlobId::from_content(b"Hello").to_hex().as_str())
         );
     }
 

--- a/packages/engine/src/filesystem/planner.rs
+++ b/packages/engine/src/filesystem/planner.rs
@@ -357,25 +357,16 @@ impl FileDescriptorWriteIntent {
 pub(crate) struct BlobRefRowInput {
     pub(crate) file_id: String,
     pub(crate) blob_hash: BlobId,
-    pub(crate) size_bytes: usize,
+    pub(crate) size_bytes: u64,
     pub(crate) context: FilesystemRowContext,
 }
 
 impl BlobRefRowInput {
     pub(crate) fn append_to(self, rows: &mut RawWriteBatch) -> Result<(), LixError> {
-        let size_bytes = u64::try_from(self.size_bytes).map_err(|_| {
-            LixError::new(
-                "LIX_ERROR_UNKNOWN",
-                format!(
-                    "binary blob size exceeds supported range for file '{}' branch '{}'",
-                    self.file_id, self.context.branch_id
-                ),
-            )
-        })?;
         let snapshot = json!({
             "id": self.file_id,
             "blob_hash": self.blob_hash.to_hex(),
-            "size_bytes": size_bytes,
+            "size_bytes": self.size_bytes,
         });
         let file_id = self.file_id;
         append_state_row(

--- a/packages/engine/src/plugin/archive.rs
+++ b/packages/engine/src/plugin/archive.rs
@@ -6,7 +6,7 @@ use zip::CompressionMethod;
 use zip::read::{ArchiveOffset, Config, ZipArchive};
 
 use crate::LixError;
-use crate::binary_cas::BlobHash;
+use crate::binary_cas::BlobId;
 use crate::schema::{schema_key_from_definition, validate_lix_schema_definition};
 
 #[cfg(test)]
@@ -26,7 +26,7 @@ pub(crate) struct ParsedPluginArchive {
     pub schema_keys: Vec<String>,
     pub create_schema_keys: Vec<String>,
     pub wasm_bytes: Vec<u8>,
-    pub wasm_hash: BlobHash,
+    pub wasm_hash: BlobId,
 }
 
 const KIB: u64 = 1024;
@@ -117,7 +117,7 @@ pub(crate) fn parse_plugin_archive_for_install(
     let wasm_bytes = loaded
         .wasm
         .expect("full plugin archive load should include WASM bytes");
-    let wasm_hash = BlobHash::from_content(&wasm_bytes);
+    let wasm_hash = BlobId::from_content(&wasm_bytes);
     Ok(ParsedPluginArchive {
         manifest: loaded.manifest,
         normalized_manifest_json: loaded.normalized_manifest_json,
@@ -145,7 +145,7 @@ pub(crate) fn load_installed_plugin_from_archive_bytes(
     let wasm = loaded
         .wasm
         .expect("full plugin archive load should include WASM bytes");
-    let wasm_hash = BlobHash::from_content(&wasm);
+    let wasm_hash = BlobId::from_content(&wasm);
 
     Ok(InstalledPlugin {
         key: loaded.manifest.key,
@@ -1102,7 +1102,7 @@ mod tests {
     use zip::{CompressionMethod, ZipWriter};
 
     use crate::LixError;
-    use crate::binary_cas::BlobHash;
+    use crate::binary_cas::BlobId;
 
     use super::{
         BoundedPluginArchive, PluginArchiveLimits, PluginArchiveReadKind, declared_zip_entry_count,
@@ -1209,7 +1209,7 @@ mod tests {
             assert_eq!(parsed.schemas.len(), 1);
             assert_eq!(parsed.schema_keys, ["plugin_test_note"]);
             assert_eq!(parsed.wasm_bytes, WASM);
-            assert_eq!(parsed.wasm_hash, BlobHash::from_content(WASM));
+            assert_eq!(parsed.wasm_hash, BlobId::from_content(WASM));
             assert_eq!(
                 serde_json::from_str::<serde_json::Value>(&parsed.normalized_manifest_json)
                     .expect("normalized manifest should remain JSON")["key"],
@@ -1221,7 +1221,7 @@ mod tests {
                 &archive,
             )
             .expect("canonical plugin archive should materialize");
-            assert_eq!(installed.wasm_hash, BlobHash::from_content(WASM));
+            assert_eq!(installed.wasm_hash, BlobId::from_content(WASM));
         }
     }
 

--- a/packages/engine/src/plugin/component.rs
+++ b/packages/engine/src/plugin/component.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex};
 
-use crate::binary_cas::BlobHash;
+use crate::binary_cas::BlobId;
 use crate::common::LixError;
 use crate::wasm::{WasmComponentFactory, WasmLimits, WasmRuntime, WasmTransitionCounters};
 
@@ -41,7 +41,7 @@ fn default_plugin_wasm_limits() -> WasmLimits {
 
 #[derive(Clone)]
 struct CachedPluginFactory {
-    wasm_hash: BlobHash,
+    wasm_hash: BlobId,
     factory: Arc<dyn WasmComponentFactory>,
 }
 
@@ -239,7 +239,7 @@ impl PluginRuntimeHost {
     pub(crate) fn cached_plugin_factory(
         &self,
         plugin_key: &str,
-        wasm_hash: BlobHash,
+        wasm_hash: BlobId,
     ) -> Result<Option<Arc<dyn WasmComponentFactory>>, LixError> {
         let cache = self
             .plugin_factory_cache

--- a/packages/engine/src/plugin/create_context.rs
+++ b/packages/engine/src/plugin/create_context.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use serde_json::{Value as JsonValue, json};
 
 use crate::LixError;
-use crate::binary_cas::BlobHash;
+use crate::binary_cas::BlobId;
 #[cfg(test)]
 use crate::common::LixTimestamp;
 use crate::common::MutationIdentity;
@@ -131,7 +131,7 @@ fn framed_digest(domain: &[u8], fields: &[&[u8]]) -> [u8; 32] {
         input.extend_from_slice(&u64::try_from(field.len()).unwrap_or(u64::MAX).to_be_bytes());
         input.extend_from_slice(field);
     }
-    BlobHash::from_content(&input).into_bytes()
+    BlobId::from_content(&input).into_bytes()
 }
 
 /// Result of validating generated identities in one sparse guest transition.

--- a/packages/engine/src/plugin/install.rs
+++ b/packages/engine/src/plugin/install.rs
@@ -112,7 +112,7 @@ mod tests {
     use zip::write::SimpleFileOptions;
 
     use crate::LixError;
-    use crate::binary_cas::BlobHash;
+    use crate::binary_cas::BlobId;
 
     use super::plugin_install_plan_from_archive_path;
 
@@ -146,7 +146,7 @@ mod tests {
         assert_eq!(plan.parsed.manifest.key, "plugin_test");
         assert_eq!(plan.parsed.schema_keys, ["plugin_test_note"]);
         assert_eq!(plan.parsed.wasm_bytes, WASM);
-        assert_eq!(plan.parsed.wasm_hash, BlobHash::from_content(WASM));
+        assert_eq!(plan.parsed.wasm_hash, BlobId::from_content(WASM));
         assert_eq!(plan.schema_rows.len(), 1);
         let schema_row = plan.schema_rows.row(0);
         assert_eq!(schema_row.schema_key, "lix_registered_schema");

--- a/packages/engine/src/plugin/mod.rs
+++ b/packages/engine/src/plugin/mod.rs
@@ -89,7 +89,7 @@ pub(crate) struct InstalledPlugin {
     /// Content-addressed identity computed while the component bytes are
     /// already in hand. Warm component-cache lookups must use this fixed-size
     /// value instead of rehashing or comparing the full WASM payload.
-    pub wasm_hash: crate::binary_cas::BlobHash,
+    pub wasm_hash: crate::binary_cas::BlobId,
     pub wasm: Vec<u8>,
 }
 

--- a/packages/engine/src/plugin/registry.rs
+++ b/packages/engine/src/plugin/registry.rs
@@ -14,7 +14,7 @@ use lru::LruCache;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value as JsonValue, json};
 
-use crate::binary_cas::BlobHash;
+use crate::binary_cas::BlobId;
 use crate::entity_pk::EntityPk;
 use crate::live_state::MaterializedLiveStateRow;
 use crate::tracked_state::MaterializedTrackedStateRowRef;
@@ -186,7 +186,7 @@ impl PluginRegistryEntry {
     }
 
     pub(crate) fn to_installed_plugin(&self, wasm: Vec<u8>) -> Result<InstalledPlugin, LixError> {
-        let wasm_hash = BlobHash::from_content(&wasm);
+        let wasm_hash = BlobId::from_content(&wasm);
         let actual_hash = wasm_hash.to_hex();
         if actual_hash != self.wasm_blob_hash {
             return Err(invalid_registry(format!(
@@ -1445,7 +1445,7 @@ mod tests {
             archive_file_id: plugin_storage_archive_file_id("plugin_a"),
             archive_path: plugin_storage_archive_path("plugin_a"),
             archive_blob_hash: hash('a'),
-            wasm_blob_hash: BlobHash::from_content(&wasm).to_hex(),
+            wasm_blob_hash: BlobId::from_content(&wasm).to_hex(),
         };
         let registry_entry = PluginRegistryEntry::new(input.clone()).unwrap();
         let installed = registry_entry
@@ -1453,7 +1453,7 @@ mod tests {
             .expect("matching extracted WASM should materialize");
         assert_eq!(installed.key, "plugin_a");
         assert_eq!(installed.content_type, Some(PluginContentType::Text));
-        assert_eq!(installed.wasm_hash, BlobHash::from_content(&wasm));
+        assert_eq!(installed.wasm_hash, BlobId::from_content(&wasm));
         assert_eq!(installed.wasm, wasm);
 
         input.wasm_blob_hash = hash('b');

--- a/packages/engine/src/session/media_upload.rs
+++ b/packages/engine/src/session/media_upload.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::ops::Bound;
 
-use crate::binary_cas::{BlobChunkReceipt, BlobHash, BlobLayout, BlobWriteReceipt};
+use crate::binary_cas::{BlobChunkReceipt, BlobId, BlobLayout, BlobWriteReceipt, ChunkHash};
 use crate::storage_adapter::{
     MAX_SCAN_PAGE_ROWS, Storage, StorageCoreProjection, StorageGetManyRequest, StorageGetOptions,
     StorageKey, StorageKeyRange, StorageProjectedValue, StorageReadOptions, StorageScanOptions,
@@ -204,12 +204,12 @@ impl UploadState {
     fn blob_receipt(&self) -> Result<BlobWriteReceipt, LixError> {
         let hash = self
             .complete_hash
-            .map(BlobHash::from_bytes)
+            .map(BlobId::from_bytes)
             .ok_or_else(|| invalid_upload("upload has no complete manifest"))?;
         let layout = match self.chunk_count {
             0 => BlobLayout::Empty,
             1 => BlobLayout::SingleChunk {
-                chunk_hash: BlobHash::from_bytes(
+                chunk_hash: ChunkHash::from_bytes(
                     self.first_chunk_hash
                         .ok_or_else(|| invalid_upload("upload is missing its first chunk"))?,
                 ),
@@ -387,7 +387,7 @@ async fn load_upload_chunks(
             let mut size = [0u8; 8];
             size.copy_from_slice(&value[32..]);
             receipts.push(BlobChunkReceipt {
-                hash: BlobHash::from_bytes(hash),
+                hash: ChunkHash::from_bytes(hash),
                 size_bytes: u64::from_be_bytes(size),
             });
         }

--- a/packages/engine/src/sql2/context.rs
+++ b/packages/engine/src/sql2/context.rs
@@ -7,7 +7,7 @@ use serde_json::Value as JsonValue;
 use tokio::sync::Mutex;
 
 use crate::LixError;
-use crate::binary_cas::{BlobBytesBatch, BlobDataReader, BlobHash};
+use crate::binary_cas::{BlobBytesBatch, BlobDataReader, BlobId};
 use crate::branch::{BranchHead, BranchRefReader};
 use crate::changelog::CommitId;
 use crate::commit_graph::CommitGraphReader;
@@ -166,7 +166,7 @@ pub(crate) trait SqlWriteExecutionContext: Send {
         None
     }
 
-    async fn load_bytes_many(&mut self, hashes: &[BlobHash]) -> Result<BlobBytesBatch, LixError>;
+    async fn load_bytes_many(&mut self, hashes: &[BlobId]) -> Result<BlobBytesBatch, LixError>;
 
     async fn scan_live_state_batch(
         &mut self,
@@ -350,7 +350,7 @@ impl SqlWriteContext {
 
     pub(crate) async fn load_bytes_many(
         &self,
-        hashes: &[BlobHash],
+        hashes: &[BlobId],
     ) -> Result<BlobBytesBatch, LixError> {
         let _guard = self.gate.lock().await;
         unsafe {
@@ -442,7 +442,7 @@ impl WriteContextBlobDataReader {
 
 #[async_trait]
 impl BlobDataReader for WriteContextBlobDataReader {
-    async fn load_bytes_many(&self, hashes: &[BlobHash]) -> Result<BlobBytesBatch, LixError> {
+    async fn load_bytes_many(&self, hashes: &[BlobId]) -> Result<BlobBytesBatch, LixError> {
         self.ctx.load_bytes_many(hashes).await
     }
 }

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -2693,7 +2693,7 @@ mod tests {
 
         async fn load_bytes_many(
             &mut self,
-            hashes: &[crate::binary_cas::BlobHash],
+            hashes: &[crate::binary_cas::BlobId],
         ) -> Result<crate::binary_cas::BlobBytesBatch, LixError> {
             self.blob_reader.load_bytes_many(hashes).await
         }
@@ -2780,7 +2780,7 @@ mod tests {
 
         async fn load_bytes_many(
             &mut self,
-            hashes: &[crate::binary_cas::BlobHash],
+            hashes: &[crate::binary_cas::BlobId],
         ) -> Result<crate::binary_cas::BlobBytesBatch, LixError> {
             self.inner.load_bytes_many(hashes).await
         }
@@ -3258,7 +3258,7 @@ mod tests {
     impl BlobDataReader for DummyBlobReader {
         async fn load_bytes_many(
             &self,
-            hashes: &[crate::binary_cas::BlobHash],
+            hashes: &[crate::binary_cas::BlobId],
         ) -> Result<crate::binary_cas::BlobBytesBatch, LixError> {
             Ok(crate::binary_cas::BlobBytesBatch::new(vec![
                 None;
@@ -3271,7 +3271,7 @@ mod tests {
     impl BlobDataReader for StaticBlobReader {
         async fn load_bytes_many(
             &self,
-            hashes: &[crate::binary_cas::BlobHash],
+            hashes: &[crate::binary_cas::BlobId],
         ) -> Result<crate::binary_cas::BlobBytesBatch, LixError> {
             Ok(crate::binary_cas::BlobBytesBatch::new(vec![
                 Some(
@@ -3393,7 +3393,7 @@ mod tests {
             snapshot_content: Some(
                 json!({
                     "id": entity_pk,
-                    "blob_hash": crate::binary_cas::BlobHash::from_content(bytes).to_hex(),
+                    "blob_hash": crate::binary_cas::BlobId::from_content(bytes).to_hex(),
                     "size_bytes": bytes.len()
                 })
                 .to_string()
@@ -5162,7 +5162,7 @@ mod tests {
         assert_eq!(blob_ref["size_bytes"], 3);
         assert_eq!(
             blob_ref["blob_hash"],
-            crate::binary_cas::BlobHash::from_content(b"new").to_hex()
+            crate::binary_cas::BlobId::from_content(b"new").to_hex()
         );
     }
 
@@ -6463,7 +6463,7 @@ mod tests {
         assert_eq!(snapshot["size_bytes"], 3);
         assert_eq!(
             snapshot["blob_hash"],
-            crate::binary_cas::BlobHash::from_content(b"new").to_hex()
+            crate::binary_cas::BlobId::from_content(b"new").to_hex()
         );
     }
 

--- a/packages/engine/src/sql2/providers/directory.rs
+++ b/packages/engine/src/sql2/providers/directory.rs
@@ -2589,7 +2589,7 @@ mod tests {
     impl BlobDataReader for CapturingWriteContext {
         async fn load_bytes_many(
             &self,
-            hashes: &[crate::binary_cas::BlobHash],
+            hashes: &[crate::binary_cas::BlobId],
         ) -> Result<crate::binary_cas::BlobBytesBatch, LixError> {
             Ok(crate::binary_cas::BlobBytesBatch::new(vec![
                 None;
@@ -2614,7 +2614,7 @@ mod tests {
 
         async fn load_bytes_many(
             &mut self,
-            hashes: &[crate::binary_cas::BlobHash],
+            hashes: &[crate::binary_cas::BlobId],
         ) -> Result<crate::binary_cas::BlobBytesBatch, LixError> {
             BlobDataReader::load_bytes_many(self, hashes).await
         }

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -1878,7 +1878,7 @@ mod tests {
 
         async fn load_bytes_many(
             &mut self,
-            hashes: &[crate::binary_cas::BlobHash],
+            hashes: &[crate::binary_cas::BlobId],
         ) -> Result<crate::binary_cas::BlobBytesBatch, LixError> {
             Ok(crate::binary_cas::BlobBytesBatch::new(vec![
                 None;

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -31,7 +31,7 @@ use datafusion::prelude::SessionContext;
 use futures_util::{FutureExt, future::try_join_all};
 use serde::Deserialize;
 
-use crate::binary_cas::{BlobDataReader, BlobHash, BlobRangeBytes};
+use crate::binary_cas::{BlobDataReader, BlobId, BlobRangeBytes};
 use crate::branch::BranchRefReader;
 use crate::common::{LixPath, MutationIdentity, RequestBlobSpliceProvenance, compose_file_path};
 use crate::entity_pk::EntityPk;
@@ -102,7 +102,7 @@ use crate::sql2::{
     SqlWriteContext, SqlWriteExecutionContext, WriteAccess, WriteContextLiveStateReader,
 };
 use crate::transaction::types::{
-    LogicalPrimaryKey, TransactionFileData, TransactionWrite, TransactionWriteMode,
+    FileContent, LogicalPrimaryKey, TransactionFileData, TransactionWrite, TransactionWriteMode,
     TransactionWriteOperation, TransactionWriteOrigin,
 };
 
@@ -2732,13 +2732,7 @@ pub(crate) async fn execute_fast_lix_file_path_writes(
         writes
             .into_iter()
             .map(|(path, data, metadata, splice)| {
-                (
-                    None,
-                    path,
-                    FastFileWriteData::Inline(data),
-                    metadata,
-                    splice,
-                )
+                (None, path, FileContent::inline(data), metadata, splice)
             })
             .collect(),
         conflict,
@@ -2764,7 +2758,7 @@ pub(crate) async fn execute_fast_lix_file_id_path_writes(
         writes
             .into_iter()
             .map(|(id, path, data, metadata, splice)| {
-                (id, path, FastFileWriteData::Inline(data), metadata, splice)
+                (id, path, FileContent::inline(data), metadata, splice)
             })
             .collect(),
         conflict,
@@ -2780,7 +2774,7 @@ pub(crate) async fn execute_fast_lix_file_prepared_path_write(
 ) -> Result<Option<u64>, LixError> {
     execute_fast_lix_file_id_path_writes_inner(
         ctx,
-        vec![(None, path, FastFileWriteData::Prepared(receipt), None, None)],
+        vec![(None, path, FileContent::PreparedCas(receipt), None, None)],
         FastLixFilePathWriteConflict::UpdateData,
         None,
     )
@@ -2792,7 +2786,7 @@ async fn execute_fast_lix_file_id_path_writes_inner(
     writes: Vec<(
         Option<String>,
         String,
-        FastFileWriteData,
+        FileContent,
         Option<TransactionJson>,
         Option<RequestBlobSpliceProvenance>,
     )>,
@@ -2852,13 +2846,12 @@ async fn execute_fast_lix_file_id_path_writes_inner(
     let mut staged = LixFileStagedBatch::with_row_capacity(parsed_writes.len().saturating_mul(3));
 
     for write in parsed_writes {
-        let prepared_blob = write.data.prepared().cloned();
-        let planning_data = write.data.planning_bytes();
+        let content = write.data.clone();
         if let Some(existing) = filesystem.file_entry(&write.parsed.path).cloned() {
             let base_blob_hash = existing
                 .blob_hash
                 .as_deref()
-                .and_then(|hash| BlobHash::from_hex(hash).ok());
+                .and_then(|hash| BlobId::from_hex(hash).ok());
             if conflict != FastLixFilePathWriteConflict::None {
                 validate_fast_lix_file_path_conflict_pair(
                     existing.scope.untracked,
@@ -2875,17 +2868,14 @@ async fn execute_fast_lix_file_id_path_writes_inner(
                         file_id: None,
                         metadata: write.metadata,
                     };
-                    let mut plan = plan_parsed_file_path_write_with_resolvers(
+                    let plan = plan_parsed_file_path_write_with_resolvers(
                         &mut path_resolvers,
                         write.parsed.parsed_path,
                         Some(file_id),
-                        Some(planning_data),
+                        Some(content.clone()),
                         context,
                         &mut || ctx.functions().call_uuid_v7().to_string(),
                     )?;
-                    if let Some(receipt) = prepared_blob {
-                        apply_prepared_file_data(&mut plan.rows, &mut plan.file_data, 0, receipt)?;
-                    }
                     staged.extend_filesystem_plan(plan)?;
                 }
                 FastLixFilePathWriteConflict::DoNothing
@@ -2902,7 +2892,7 @@ async fn execute_fast_lix_file_id_path_writes_inner(
                         existing.id.clone(),
                         Some(write.parsed.path),
                         Some(existing.name.clone()),
-                        planning_data,
+                        content.clone(),
                         context,
                         existing.blob_hash.is_some(),
                         existing.has_derived_file_ref,
@@ -2910,14 +2900,6 @@ async fn execute_fast_lix_file_id_path_writes_inner(
                         None,
                     )
                     .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
-                    if let Some(receipt) = prepared_blob {
-                        apply_prepared_file_data(
-                            &mut staged.state_rows,
-                            &mut staged.file_data_writes,
-                            file_data_start,
-                            receipt,
-                        )?;
-                    }
                     attach_fast_file_write_metadata(
                         &mut staged.file_data_writes[file_data_start..],
                         write.splice_provenance,
@@ -2945,7 +2927,7 @@ async fn execute_fast_lix_file_id_path_writes_inner(
                         existing.id.clone(),
                         Some(write.parsed.path),
                         Some(existing.name.clone()),
-                        planning_data,
+                        content.clone(),
                         context,
                         existing.blob_hash.is_some(),
                         existing.has_derived_file_ref,
@@ -2953,14 +2935,6 @@ async fn execute_fast_lix_file_id_path_writes_inner(
                         None,
                     )
                     .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
-                    if let Some(receipt) = prepared_blob {
-                        apply_prepared_file_data(
-                            &mut staged.state_rows,
-                            &mut staged.file_data_writes,
-                            file_data_start,
-                            receipt,
-                        )?;
-                    }
                     attach_fast_file_write_metadata(
                         &mut staged.file_data_writes[file_data_start..],
                         write.splice_provenance,
@@ -2982,13 +2956,10 @@ async fn execute_fast_lix_file_id_path_writes_inner(
                 &mut path_resolvers,
                 write.parsed.parsed_path,
                 Some(file_id.clone()),
-                Some(planning_data),
+                Some(content),
                 context,
                 &mut || ctx.functions().call_uuid_v7().to_string(),
             )?;
-            if let Some(receipt) = prepared_blob {
-                apply_prepared_file_data(&mut plan.rows, &mut plan.file_data, 0, receipt)?;
-            }
             attach_fast_file_write_metadata(
                 &mut plan.file_data,
                 write.splice_provenance,
@@ -3152,8 +3123,7 @@ async fn stage_indexed_file_path_writes(
     let mut staged = LixFileStagedBatch::with_row_capacity(writes.len().saturating_mul(3));
 
     for (write, entry) in writes.into_iter().zip(indexed.existing) {
-        let prepared_blob = write.data.prepared().cloned();
-        let planning_data = write.data.planning_bytes();
+        let content = write.data.clone();
         if let Some(entry) = entry {
             if conflict == FastLixFilePathWriteConflict::IdDoNothing {
                 continue;
@@ -3209,7 +3179,7 @@ async fn stage_indexed_file_path_writes(
                 entry.id().to_string(),
                 Some(update_path),
                 Some(entry.name.clone()),
-                planning_data,
+                content,
                 context,
                 materialization.has_blob_ref,
                 materialization.has_derived_file_ref,
@@ -3217,14 +3187,6 @@ async fn stage_indexed_file_path_writes(
                 None,
             )
             .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
-            if let Some(receipt) = prepared_blob {
-                apply_prepared_file_data(
-                    &mut staged.state_rows,
-                    &mut staged.file_data_writes,
-                    file_data_start,
-                    receipt,
-                )?;
-            }
             attach_fast_file_write_metadata(
                 &mut staged.file_data_writes[file_data_start..],
                 write.splice_provenance,
@@ -3247,13 +3209,10 @@ async fn stage_indexed_file_path_writes(
                     .expect("missing indexed path should have directory resolvers"),
                 write.parsed.parsed_path,
                 Some(file_id.clone()),
-                Some(planning_data),
+                Some(content),
                 context,
                 &mut || ctx.functions().call_uuid_v7().to_string(),
             )?;
-            if let Some(receipt) = prepared_blob {
-                apply_prepared_file_data(&mut plan.rows, &mut plan.file_data, 0, receipt)?;
-            }
             attach_fast_file_write_metadata(
                 &mut plan.file_data,
                 write.splice_provenance,
@@ -3271,7 +3230,7 @@ async fn stage_indexed_file_path_writes(
 struct ExistingFileMaterialization {
     has_blob_ref: bool,
     has_derived_file_ref: bool,
-    blob_hash: Option<BlobHash>,
+    blob_hash: Option<BlobId>,
 }
 
 async fn load_exact_existing_materializations(
@@ -3331,7 +3290,7 @@ async fn load_exact_existing_materializations(
             .map(|snapshot| snapshot.as_str())
             .and_then(|snapshot| serde_json::from_str::<BlobRefSnapshot>(snapshot).ok())
             .filter(|snapshot| snapshot.id == request.file_id.as_deref().unwrap_or_default())
-            .and_then(|snapshot| BlobHash::from_hex(&snapshot.blob_hash).ok());
+            .and_then(|snapshot| BlobId::from_hex(&snapshot.blob_hash).ok());
     }
 
     let derived_requests = unique
@@ -3493,7 +3452,7 @@ async fn execute_fast_lix_file_data_update_by_id_impl(
                 .expect("prepared lix_file descriptor should have a path");
             let base_blob_hash = blob_rows
                 .get(&blob_ref_key)
-                .and_then(|row| BlobHash::from_hex(&row.blob_hash).ok());
+                .and_then(|row| BlobId::from_hex(&row.blob_hash).ok());
             let has_blob_ref = blob_rows.contains_key(&blob_ref_key);
             let has_derived_file_ref = derived_rows.contains_key(&blob_ref_key);
             (
@@ -3552,94 +3511,16 @@ async fn execute_fast_lix_file_data_update_by_id_impl(
 struct FastLixFilePathWrite {
     id: Option<String>,
     parsed: ParsedFileWritePath,
-    data: FastFileWriteData,
+    data: FileContent,
     metadata: Option<TransactionJson>,
     splice_provenance: Option<RequestBlobSpliceProvenance>,
-}
-
-#[derive(Clone)]
-enum FastFileWriteData {
-    Inline(crate::Blob),
-    Prepared(crate::binary_cas::BlobWriteReceipt),
-}
-
-impl FastFileWriteData {
-    fn planning_bytes(&self) -> crate::Blob {
-        match self {
-            Self::Inline(data) => data.clone(),
-            // A present byte makes the ordinary planner create a blob-ref row;
-            // `apply_prepared_file_data` replaces its identity and size before
-            // transaction validation observes it.
-            Self::Prepared(_) => vec![0].into(),
-        }
-    }
-
-    fn prepared(&self) -> Option<&crate::binary_cas::BlobWriteReceipt> {
-        match self {
-            Self::Prepared(receipt) => Some(receipt),
-            Self::Inline(_) => None,
-        }
-    }
-}
-
-fn apply_prepared_file_data(
-    rows: &mut RawWriteBatch,
-    file_data: &mut [TransactionFileData],
-    start: usize,
-    receipt: crate::binary_cas::BlobWriteReceipt,
-) -> Result<(), LixError> {
-    let affected_ids = file_data[start..]
-        .iter()
-        .map(|write| write.file_id.clone())
-        .collect::<BTreeSet<_>>();
-    if affected_ids.is_empty() {
-        return Err(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            "prepared file write did not produce file data",
-        ));
-    }
-    for write in &mut file_data[start..] {
-        write.use_prepared_blob(receipt.clone());
-    }
-    let size_bytes = usize::try_from(receipt.size_bytes).map_err(|_| {
-        LixError::new(
-            LixError::CODE_INVALID_PARAM,
-            "prepared file size exceeds this platform",
-        )
-    })?;
-    for index in 0..rows.len() {
-        let row = rows.row(index);
-        if row.schema_key.as_str() != BLOB_REF_SCHEMA_KEY
-            || row
-                .file_id
-                .is_none_or(|id| !affected_ids.contains(id.as_str()))
-        {
-            continue;
-        }
-        let file_id = row
-            .file_id
-            .expect("checked prepared blob-ref file id")
-            .to_string();
-        rows.set_snapshot(
-            index,
-            Some(TransactionJson::from_value(
-                serde_json::json!({
-                    "id": file_id,
-                    "blob_hash": receipt.hash.to_hex(),
-                    "size_bytes": size_bytes,
-                }),
-                "prepared binary blob ref",
-            )?),
-        );
-    }
-    Ok(())
 }
 
 fn parse_fast_lix_file_path_writes(
     writes: Vec<(
         Option<String>,
         String,
-        FastFileWriteData,
+        FileContent,
         Option<TransactionJson>,
         Option<RequestBlobSpliceProvenance>,
     )>,
@@ -4537,7 +4418,7 @@ fn stage_lix_file_data_insert_write(
     file_id: String,
     path: Option<String>,
     filename: Option<String>,
-    data: impl Into<crate::Blob>,
+    content: impl Into<FileContent>,
     context: FilesystemRowContext,
     origin: Option<TransactionWriteOrigin>,
 ) -> Result<()> {
@@ -4548,7 +4429,7 @@ fn stage_lix_file_data_insert_write(
         context.branch_id.clone(),
         context.global,
         context.untracked,
-        data,
+        content,
     );
     if !file_payload.is_empty() {
         stage_lix_file_data_blob_ref_write(staged, &file_payload, &context, origin)?;
@@ -4562,11 +4443,11 @@ fn stage_lix_file_data_update_write(
     file_id: String,
     path: Option<String>,
     filename: Option<String>,
-    data: impl Into<crate::Blob>,
+    content: impl Into<FileContent>,
     context: FilesystemRowContext,
     has_blob_ref: bool,
     has_derived_file_ref: bool,
-    base_blob_hash: Option<BlobHash>,
+    base_blob_hash: Option<BlobId>,
     origin: Option<TransactionWriteOrigin>,
 ) -> Result<()> {
     let file_payload = TransactionFileData::new(
@@ -4576,7 +4457,7 @@ fn stage_lix_file_data_update_write(
         context.branch_id.clone(),
         context.global,
         context.untracked,
-        data,
+        content,
     )
     .with_had_blob_ref(has_blob_ref)
     .with_base_blob_hash(base_blob_hash);
@@ -5654,7 +5535,7 @@ async fn load_blob_ranges_for_files(
                     );
                 } else {
                     keys.push(key);
-                    requests.push((BlobHash::from_hex(&row.blob_hash)?, range.clone()));
+                    requests.push((BlobId::from_hex(&row.blob_hash)?, range.clone()));
                 }
             }
             *remaining += 1;
@@ -5702,7 +5583,7 @@ async fn load_blob_bytes_for_files(
                     bytes_by_key.insert(key.clone(), Some(data.clone()));
                 } else {
                     keys.push(key);
-                    hashes.push(BlobHash::from_hex(&row.blob_hash)?);
+                    hashes.push(BlobId::from_hex(&row.blob_hash)?);
                 }
             }
             *remaining += 1;
@@ -5890,7 +5771,7 @@ async fn render_derived_file_for_sql(
     });
     let limits = WasmTransitionLimits::default();
     let source = VecEntitySource::new(v2_read_host_entities(rows, limits)?, limits)?;
-    let wasm_hash = BlobHash::from_hex(plugin.wasm_blob_hash())?;
+    let wasm_hash = BlobId::from_hex(plugin.wasm_blob_hash())?;
     let factory = match plugin_render
         .host
         .cached_plugin_factory(plugin.key(), wasm_hash)?
@@ -7684,7 +7565,9 @@ mod tests {
     use datafusion::physical_expr::expressions::Literal;
     use serde_json::Value as JsonValue;
 
-    use crate::binary_cas::{BlobBytesBatch, BlobDataReader, BlobHash};
+    use crate::binary_cas::{
+        BlobBytesBatch, BlobDataReader, BlobId, BlobLayout, BlobWriteReceipt, ChunkHash,
+    };
     use crate::branch::{BranchHead, BranchRefReader};
     use crate::changelog::{ChangeId, CommitId};
     use crate::common::LixTimestamp;
@@ -8585,7 +8468,7 @@ mod tests {
                     "01920000-0000-7000-8000-0000000000d2",
                     "01920000-0000-7000-8000-0000000000b1",
                     "01920000-0000-7000-8000-0000000000d2",
-                    &BlobHash::from_content(&data).to_hex(),
+                    &BlobId::from_content(&data).to_hex(),
                     data.len(),
                 ),
             ])
@@ -8634,11 +8517,11 @@ mod tests {
     async fn lower_path_contains_scan_loads_blob_rows_only_for_the_matching_find_files_projection()
     {
         let selected_data = b"selected contents".to_vec();
-        let selected_blob_hash = BlobHash::from_content(&selected_data).to_hex();
+        let selected_blob_hash = BlobId::from_content(&selected_data).to_hex();
         let changelog_data = b"changelog contents".to_vec();
-        let changelog_blob_hash = BlobHash::from_content(&changelog_data).to_hex();
+        let changelog_blob_hash = BlobId::from_content(&changelog_data).to_hex();
         let outside_data = b"outside contents".to_vec();
-        let outside_blob_hash = BlobHash::from_content(&outside_data).to_hex();
+        let outside_blob_hash = BlobId::from_content(&outside_data).to_hex();
         let selected_change_id = ChangeId::for_test_label("selected-search-blob");
         let live_state_requests = Arc::new(Mutex::new(Vec::new()));
         let mut selected_blob = live_blob_ref_row(
@@ -8792,9 +8675,9 @@ mod tests {
     #[tokio::test]
     async fn file_directory_id_scan_uses_indexed_descriptors_and_blob_rows() {
         let data = b"docs contents".to_vec();
-        let blob_hash = BlobHash::from_content(&data).to_hex();
+        let blob_hash = BlobId::from_content(&data).to_hex();
         let other_data = b"other contents".to_vec();
-        let other_blob_hash = BlobHash::from_content(&other_data).to_hex();
+        let other_blob_hash = BlobId::from_content(&other_data).to_hex();
         let live_state_requests = Arc::new(Mutex::new(Vec::new()));
         let path_index_requests = Arc::new(AtomicUsize::new(0));
         let index = Arc::new(
@@ -8954,7 +8837,7 @@ mod tests {
             "01920000-0000-7000-8000-000000000122",
             "01920000-0000-7000-8000-0000000000b1",
             "01920000-0000-7000-8000-000000000122",
-            &BlobHash::from_content(&tracked_data).to_hex(),
+            &BlobId::from_content(&tracked_data).to_hex(),
             tracked_data.len(),
         );
         tracked_blob.change_id = Some(ChangeId::for_test_label("tracked-blob"));
@@ -8963,7 +8846,7 @@ mod tests {
             // Path-index rows are already projected into the requested branch.
             "01920000-0000-7000-8000-0000000000b1",
             "01920000-0000-7000-8000-000000000112",
-            &BlobHash::from_content(&global_data).to_hex(),
+            &BlobId::from_content(&global_data).to_hex(),
             global_data.len(),
         );
         global_blob.global = true;
@@ -8972,7 +8855,7 @@ mod tests {
             "01920000-0000-7000-8000-000000000132",
             "01920000-0000-7000-8000-0000000000b1",
             "01920000-0000-7000-8000-000000000132",
-            &BlobHash::from_content(&untracked_data).to_hex(),
+            &BlobId::from_content(&untracked_data).to_hex(),
             untracked_data.len(),
         );
         untracked_blob.untracked = true;
@@ -8983,7 +8866,7 @@ mod tests {
             "01920000-0000-7000-8000-000000000122",
             "01920000-0000-7000-8000-0000000000b1",
             "different-file-id",
-            &BlobHash::from_content(&misplaced_data).to_hex(),
+            &BlobId::from_content(&misplaced_data).to_hex(),
             misplaced_data.len(),
         );
         misplaced_blob.change_id = Some(ChangeId::for_test_label("misplaced-blob"));
@@ -9084,9 +8967,9 @@ mod tests {
     #[tokio::test]
     async fn file_root_directory_scan_uses_indexed_descriptors_and_root_blob_rows() {
         let root_data = b"root contents".to_vec();
-        let root_blob_hash = BlobHash::from_content(&root_data).to_hex();
+        let root_blob_hash = BlobId::from_content(&root_data).to_hex();
         let nested_data = b"nested contents".to_vec();
-        let nested_blob_hash = BlobHash::from_content(&nested_data).to_hex();
+        let nested_blob_hash = BlobId::from_content(&nested_data).to_hex();
         let live_state_requests = Arc::new(Mutex::new(Vec::new()));
         let path_index_requests = Arc::new(AtomicUsize::new(0));
         let index = Arc::new(
@@ -9284,7 +9167,7 @@ mod tests {
     #[derive(Default)]
     struct CapturingWriteContext {
         rows: Vec<MaterializedLiveStateRow>,
-        blob_bytes_by_hash: BTreeMap<BlobHash, Vec<u8>>,
+        blob_bytes_by_hash: BTreeMap<BlobId, Vec<u8>>,
         writes: Vec<TransactionWrite>,
         scan_count: usize,
         path_index_count: usize,
@@ -9300,12 +9183,12 @@ mod tests {
     }
 
     struct StaticBlobReader {
-        bytes_by_hash: BTreeMap<BlobHash, Vec<u8>>,
+        bytes_by_hash: BTreeMap<BlobId, Vec<u8>>,
     }
 
     struct ExactBlobReader {
-        expected_hashes: Vec<BlobHash>,
-        bytes_by_hash: BTreeMap<BlobHash, Vec<u8>>,
+        expected_hashes: Vec<BlobId>,
+        bytes_by_hash: BTreeMap<BlobId, Vec<u8>>,
     }
 
     impl StaticBlobReader {
@@ -9313,7 +9196,7 @@ mod tests {
             Self {
                 bytes_by_hash: blobs
                     .into_iter()
-                    .map(|bytes| (BlobHash::from_content(&bytes), bytes))
+                    .map(|bytes| (BlobId::from_content(&bytes), bytes))
                     .collect(),
             }
         }
@@ -9321,7 +9204,7 @@ mod tests {
 
     #[async_trait]
     impl BlobDataReader for CapturingWriteContext {
-        async fn load_bytes_many(&self, hashes: &[BlobHash]) -> Result<BlobBytesBatch, LixError> {
+        async fn load_bytes_many(&self, hashes: &[BlobId]) -> Result<BlobBytesBatch, LixError> {
             Ok(BlobBytesBatch::new(
                 hashes
                     .iter()
@@ -9333,7 +9216,7 @@ mod tests {
 
     #[async_trait]
     impl BlobDataReader for StaticBlobReader {
-        async fn load_bytes_many(&self, hashes: &[BlobHash]) -> Result<BlobBytesBatch, LixError> {
+        async fn load_bytes_many(&self, hashes: &[BlobId]) -> Result<BlobBytesBatch, LixError> {
             Ok(BlobBytesBatch::new(
                 hashes
                     .iter()
@@ -9345,7 +9228,7 @@ mod tests {
 
     #[async_trait]
     impl BlobDataReader for ExactBlobReader {
-        async fn load_bytes_many(&self, hashes: &[BlobHash]) -> Result<BlobBytesBatch, LixError> {
+        async fn load_bytes_many(&self, hashes: &[BlobId]) -> Result<BlobBytesBatch, LixError> {
             assert_eq!(hashes, self.expected_hashes.as_slice());
             Ok(BlobBytesBatch::new(
                 hashes
@@ -9370,10 +9253,7 @@ mod tests {
             Ok(Vec::new().into())
         }
 
-        async fn load_bytes_many(
-            &mut self,
-            hashes: &[BlobHash],
-        ) -> Result<BlobBytesBatch, LixError> {
+        async fn load_bytes_many(&mut self, hashes: &[BlobId]) -> Result<BlobBytesBatch, LixError> {
             BlobDataReader::load_bytes_many(self, hashes).await
         }
 
@@ -9475,10 +9355,7 @@ mod tests {
             Ok(Vec::new().into())
         }
 
-        async fn load_bytes_many(
-            &mut self,
-            hashes: &[BlobHash],
-        ) -> Result<BlobBytesBatch, LixError> {
+        async fn load_bytes_many(&mut self, hashes: &[BlobId]) -> Result<BlobBytesBatch, LixError> {
             Ok(BlobBytesBatch::new(vec![None; hashes.len()]))
         }
 
@@ -9891,8 +9768,8 @@ mod tests {
             manifest_json,
             archive_file_id: plugin_storage_archive_file_id(key),
             archive_path: plugin_storage_archive_path(key),
-            archive_blob_hash: BlobHash::from_content(format!("archive-{key}").as_bytes()).to_hex(),
-            wasm_blob_hash: BlobHash::from_content(wasm).to_hex(),
+            archive_blob_hash: BlobId::from_content(format!("archive-{key}").as_bytes()).to_hex(),
+            wasm_blob_hash: BlobId::from_content(wasm).to_hex(),
         })
         .expect("test plugin registry entry should be valid")
     }
@@ -10377,7 +10254,7 @@ mod tests {
         let file_id = "01920000-0000-7000-8000-0000000000e2";
         let branch_id = "01920000-0000-7000-8000-0000000000b1";
         let data = b"indexed contents";
-        let blob_hash = BlobHash::from_content(data);
+        let blob_hash = BlobId::from_content(data);
         let index = Arc::new(
             path_index_from_rows(vec![
                 live_file_row(
@@ -10433,8 +10310,8 @@ mod tests {
     async fn file_path_predicate_filters_before_blob_and_plugin_hydration() {
         let selected_data = b"selected".to_vec();
         let other_data = b"other".to_vec();
-        let selected_hash = BlobHash::from_content(&selected_data);
-        let other_hash = BlobHash::from_content(&other_data);
+        let selected_hash = BlobId::from_content(&selected_data);
+        let other_hash = BlobId::from_content(&other_data);
         let rows = vec![
             live_file_row(
                 "01920000-0000-7000-8000-0000000000e2",
@@ -10503,7 +10380,7 @@ mod tests {
     #[test]
     fn file_path_predicate_only_discovers_plugins_for_selected_blobless_files() {
         let blob_data = b"stored".to_vec();
-        let blob_hash = BlobHash::from_content(&blob_data);
+        let blob_hash = BlobId::from_content(&blob_data);
         let rows = vec![
             live_file_row(
                 "01920000-0000-7000-8000-000000000512",
@@ -10572,7 +10449,7 @@ mod tests {
     #[tokio::test]
     async fn file_projection_matches_blob_ref_by_descriptor_file_id() {
         let data = b"shared data".to_vec();
-        let blob_hash = BlobHash::from_content(&data).to_hex();
+        let blob_hash = BlobId::from_content(&data).to_hex();
         let blob_reader =
             Arc::new(StaticBlobReader::from_blobs(vec![data.clone()])) as Arc<dyn BlobDataReader>;
         let batch = super::lix_file_record_batch(
@@ -11618,7 +11495,7 @@ mod tests {
             snapshot["blob_hash"].as_str(),
             staged.file_data_writes[0]
                 .blob_hash()
-                .map(BlobHash::to_hex)
+                .map(BlobId::to_hex)
                 .as_deref()
         );
     }
@@ -11786,7 +11663,7 @@ mod tests {
             snapshot["blob_hash"].as_str(),
             staged.file_data_writes[0]
                 .blob_hash()
-                .map(BlobHash::to_hex)
+                .map(BlobId::to_hex)
                 .as_deref()
         );
     }
@@ -12247,7 +12124,7 @@ mod tests {
     #[tokio::test]
     async fn file_id_conflict_probe_uses_path_index_and_exact_blob_batch() {
         let data = b"hello".to_vec();
-        let blob_hash = BlobHash::from_content(&data);
+        let blob_hash = BlobId::from_content(&data);
         let rows = vec![
             live_file_row(
                 "01920000-0000-7000-8000-0000000000d2",
@@ -12312,7 +12189,7 @@ mod tests {
                 "01920000-0000-7000-8000-0000000000d2",
                 "01920000-0000-7000-8000-0000000000b1",
                 "01920000-0000-7000-8000-0000000000d2",
-                &BlobHash::from_content(old_data).to_hex(),
+                &BlobId::from_content(old_data).to_hex(),
                 old_data.len(),
             )],
             writes: Vec::new(),
@@ -12403,7 +12280,7 @@ mod tests {
                 "01920000-0000-7000-8000-0000000000d2",
                 "01920000-0000-7000-8000-0000000000b1",
                 "01920000-0000-7000-8000-0000000000d2",
-                &BlobHash::from_content(old_data).to_hex(),
+                &BlobId::from_content(old_data).to_hex(),
                 old_data.len(),
             ),
         ];
@@ -12445,7 +12322,7 @@ mod tests {
         assert!(file_data[0].had_blob_ref);
         assert_eq!(
             file_data[0].base_blob_hash(),
-            Some(BlobHash::from_content(old_data)),
+            Some(BlobId::from_content(old_data)),
             "the exact indexed blob hash should be retained for optional CAS reuse",
         );
         let descriptor = rows
@@ -12458,6 +12335,70 @@ mod tests {
                 serde_json::json!({"source": "upload"})
             ))
         );
+    }
+
+    #[tokio::test]
+    async fn prepared_cas_path_write_is_first_class_transaction_content() {
+        let old_payload = b"old media payload";
+        let rows = vec![
+            live_file_row(
+                "01920000-0000-7000-8000-0000000000d2",
+                "01920000-0000-7000-8000-0000000000b1",
+                r#"{"id":"01920000-0000-7000-8000-0000000000d2","directory_id":null,"name":"proxy.mov"}"#,
+            ),
+            live_blob_ref_row(
+                "01920000-0000-7000-8000-0000000000d2",
+                "01920000-0000-7000-8000-0000000000b1",
+                "01920000-0000-7000-8000-0000000000d2",
+                &BlobId::from_content(old_payload).to_hex(),
+                old_payload.len(),
+            ),
+        ];
+        let mut write_context = CapturingWriteContext {
+            rows,
+            ..CapturingWriteContext::default()
+        };
+        let payload = b"durable media payload";
+        let size_bytes = payload.len() as u64;
+        let chunk_hash = ChunkHash::from_content(payload);
+        let blob_id = BlobId::from_single_chunk(chunk_hash);
+        let receipt = BlobWriteReceipt {
+            hash: blob_id,
+            size_bytes,
+            layout: BlobLayout::SingleChunk { chunk_hash },
+        };
+
+        let outcome = super::execute_fast_lix_file_prepared_path_write(
+            &mut write_context,
+            "/proxy.mov".to_string(),
+            receipt,
+        )
+        .await
+        .expect("prepared path write should stage");
+
+        assert!(outcome.is_some());
+        let TransactionWrite::RowsWithFileData {
+            rows, file_data, ..
+        } = &write_context.writes[0]
+        else {
+            panic!("prepared path write should use ordinary file transaction rows");
+        };
+        assert_eq!(file_data.len(), 1);
+        assert!(file_data[0].inline_data().is_none());
+        assert_eq!(file_data[0].blob_hash(), Some(blob_id));
+        assert_eq!(file_data[0].len(), payload.len());
+        let blob_ref = rows
+            .iter()
+            .find(|row| row.schema_key == super::BLOB_REF_SCHEMA_KEY)
+            .expect("prepared path write should stage its final blob reference directly");
+        let snapshot = blob_ref
+            .snapshot
+            .as_ref()
+            .expect("prepared blob ref should have a snapshot")
+            .value();
+        let blob_id_hex = blob_id.to_hex();
+        assert_eq!(snapshot["blob_hash"].as_str(), Some(blob_id_hex.as_str()));
+        assert_eq!(snapshot["size_bytes"].as_u64(), Some(size_bytes));
     }
 
     #[tokio::test]
@@ -12490,7 +12431,7 @@ mod tests {
                 "01920000-0000-7000-8000-0000000000d2",
                 "01920000-0000-7000-8000-0000000000b1",
                 "01920000-0000-7000-8000-0000000000d2",
-                &BlobHash::from_content(old_data).to_hex(),
+                &BlobId::from_content(old_data).to_hex(),
                 old_data.len(),
             ),
         ];
@@ -12667,7 +12608,7 @@ mod tests {
             "01920000-0000-7000-8000-000000000442",
             crate::GLOBAL_BRANCH_ID,
             "01920000-0000-7000-8000-000000000442",
-            &BlobHash::from_content(b"global").to_hex(),
+            &BlobId::from_content(b"global").to_hex(),
             6,
         );
         global_fallback.global = true;
@@ -12682,7 +12623,7 @@ mod tests {
             "01920000-0000-7000-8000-000000000112",
             "01920000-0000-7000-8000-0000000000b1",
             "01920000-0000-7000-8000-000000000112",
-            &BlobHash::from_content(b"branch").to_hex(),
+            &BlobId::from_content(b"branch").to_hex(),
             6,
         );
         let mut write_context = CapturingWriteContext {
@@ -12750,7 +12691,7 @@ mod tests {
                 "01920000-0000-7000-8000-0000000000d2",
                 "01920000-0000-7000-8000-0000000000b1",
                 "01920000-0000-7000-8000-0000000000d2",
-                &BlobHash::from_content(old_data).to_hex(),
+                &BlobId::from_content(old_data).to_hex(),
                 old_data.len(),
             ),
         ];

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -12358,14 +12358,18 @@ mod tests {
             rows,
             ..CapturingWriteContext::default()
         };
-        let payload = b"durable media payload";
-        let size_bytes = payload.len() as u64;
-        let chunk_hash = ChunkHash::from_content(payload);
-        let blob_id = BlobId::from_single_chunk(chunk_hash);
+        let chunk_hash = ChunkHash::from_content(b"durable media chunk");
+        let chunk_count = 4_096;
+        let chunk_size = 1024 * 1024;
+        let size_bytes = u64::from(chunk_count) * chunk_size;
+        let blob_id = BlobId::from_chunks(
+            size_bytes,
+            (0..chunk_count).map(|_| (chunk_hash, chunk_size)),
+        );
         let receipt = BlobWriteReceipt {
             hash: blob_id,
             size_bytes,
-            layout: BlobLayout::SingleChunk { chunk_hash },
+            layout: BlobLayout::Chunked { chunk_count },
         };
 
         let outcome = super::execute_fast_lix_file_prepared_path_write(
@@ -12386,7 +12390,7 @@ mod tests {
         assert_eq!(file_data.len(), 1);
         assert!(file_data[0].inline_data().is_none());
         assert_eq!(file_data[0].blob_hash(), Some(blob_id));
-        assert_eq!(file_data[0].len(), payload.len());
+        assert_eq!(file_data[0].len(), size_bytes);
         let blob_ref = rows
             .iter()
             .find(|row| row.schema_key == super::BLOB_REF_SCHEMA_KEY)

--- a/packages/engine/src/sql2/providers/file_history.rs
+++ b/packages/engine/src/sql2/providers/file_history.rs
@@ -14,7 +14,7 @@ use tokio::sync::Mutex;
 
 use crate::LixError;
 use crate::NullableKeyFilter;
-use crate::binary_cas::{BlobDataReader, BlobHash};
+use crate::binary_cas::{BlobDataReader, BlobId};
 use crate::commit_graph::CommitGraphReader;
 use crate::common::{SharedStr, compose_file_path};
 use crate::entity_pk::EntityPk;
@@ -966,14 +966,14 @@ async fn load_file_history_blob_bytes(
     blob_reader: &Arc<dyn BlobDataReader>,
     rows: &[PreparedFileHistoryRow],
 ) -> Result<BTreeMap<String, Option<Vec<u8>>>, LixError> {
-    let mut hashes = BTreeMap::<BlobHash, BTreeSet<String>>::new();
+    let mut hashes = BTreeMap::<BlobId, BTreeSet<String>>::new();
     for hash in rows
         .iter()
         .filter(|row| row.descriptor().name.is_some())
         .filter_map(|row| row.blob_hash.as_deref())
     {
         hashes
-            .entry(BlobHash::from_hex(hash)?)
+            .entry(BlobId::from_hex(hash)?)
             .or_default()
             .insert(hash.to_string());
     }
@@ -1095,7 +1095,7 @@ async fn render_derived_file_history_bytes(
         limits,
     )?;
     let source = VecEntitySource::new(entities, limits)?;
-    let wasm_hash = BlobHash::from_hex(plugin.wasm_blob_hash())?;
+    let wasm_hash = BlobId::from_hex(plugin.wasm_blob_hash())?;
     let factory = match plugin_host.cached_plugin_factory(plugin.key(), wasm_hash)? {
         Some(factory) => factory,
         None => {
@@ -2688,7 +2688,7 @@ mod tests {
     use datafusion::logical_expr::{BinaryExpr, Expr, Operator};
 
     use crate::LixError;
-    use crate::binary_cas::{BlobBytesBatch, BlobDataReader, BlobHash};
+    use crate::binary_cas::{BlobBytesBatch, BlobDataReader, BlobId};
     use crate::changelog::{ChangeId, CommitId};
     use crate::common::SharedStr;
     use crate::entity_pk::EntityPk;
@@ -2786,7 +2786,7 @@ mod tests {
         }
     }
 
-    fn blob_record(file_id: &str, hash: BlobHash, depth: u32) -> FileHistoryBlobRecord {
+    fn blob_record(file_id: &str, hash: BlobId, depth: u32) -> FileHistoryBlobRecord {
         let mut entry = history_entry(file_id, depth, None);
         entry.change.id = format!("blob-{file_id}-{depth}");
         entry.change.schema_key = super::BLOB_REF_SCHEMA_KEY.to_string();
@@ -3014,9 +3014,9 @@ mod tests {
             manifest_json,
             archive_file_id: plugin_storage_archive_file_id(plugin_key),
             archive_path: plugin_storage_archive_path(plugin_key),
-            archive_blob_hash: BlobHash::from_content(format!("archive-{plugin_key}").as_bytes())
+            archive_blob_hash: BlobId::from_content(format!("archive-{plugin_key}").as_bytes())
                 .to_hex(),
-            wasm_blob_hash: BlobHash::from_content(wasm).to_hex(),
+            wasm_blob_hash: BlobId::from_content(wasm).to_hex(),
         })
         .expect("test plugin registry entry should be valid");
         PluginRegistry::new(vec![entry]).expect("test plugin registry should be valid")
@@ -3046,13 +3046,13 @@ mod tests {
 
     #[derive(Default)]
     struct RecordingBlobReader {
-        calls: StdMutex<Vec<Vec<BlobHash>>>,
-        values: BTreeMap<BlobHash, Option<Vec<u8>>>,
+        calls: StdMutex<Vec<Vec<BlobId>>>,
+        values: BTreeMap<BlobId, Option<Vec<u8>>>,
     }
 
     #[async_trait]
     impl BlobDataReader for RecordingBlobReader {
-        async fn load_bytes_many(&self, hashes: &[BlobHash]) -> Result<BlobBytesBatch, LixError> {
+        async fn load_bytes_many(&self, hashes: &[BlobId]) -> Result<BlobBytesBatch, LixError> {
             self.calls.lock().unwrap().push(hashes.to_vec());
             Ok(BlobBytesBatch::new(
                 hashes
@@ -3067,14 +3067,14 @@ mod tests {
 
     #[async_trait]
     impl BlobDataReader for FixedBatchBlobReader {
-        async fn load_bytes_many(&self, _hashes: &[BlobHash]) -> Result<BlobBytesBatch, LixError> {
+        async fn load_bytes_many(&self, _hashes: &[BlobId]) -> Result<BlobBytesBatch, LixError> {
             Ok(BlobBytesBatch::new(self.0.clone()))
         }
     }
 
     #[test]
     fn public_id_and_path_filters_prune_before_hydration() {
-        let hash = BlobHash::from_content(b"content");
+        let hash = BlobId::from_content(b"content");
         let live_a = descriptor("01920000-0000-7000-8000-0000000000a2", Some("a.md"), 0);
         let live_b = descriptor("01920000-0000-7000-8000-0000000000b2", Some("b.md"), 0);
         let tombstone = descriptor("file-deleted", None, 0);
@@ -3299,7 +3299,7 @@ mod tests {
         let descriptor = descriptor("01920000-0000-7000-8000-0000000000a2", Some("a.txt"), 0);
         let blob = blob_record(
             "01920000-0000-7000-8000-0000000000a2",
-            BlobHash::from_content(b"raw"),
+            BlobId::from_content(b"raw"),
             0,
         );
         let proof = derived_file_ref_record("01920000-0000-7000-8000-0000000000a2", &sha256, 3, 0);
@@ -3338,7 +3338,7 @@ mod tests {
         let descriptor = descriptor("01920000-0000-7000-8000-0000000000a2", Some("a.txt"), 0);
         let blob = blob_record(
             "01920000-0000-7000-8000-0000000000a2",
-            BlobHash::from_content(b"raw"),
+            BlobId::from_content(b"raw"),
             0,
         );
         let mut proof_tombstone = derived_file_ref_record(
@@ -3607,8 +3607,8 @@ mod tests {
 
     #[tokio::test]
     async fn blob_hydration_batches_deduplicates_and_preserves_missing_values() {
-        let present_hash = BlobHash::from_content(b"present");
-        let missing_hash = BlobHash::from_content(b"missing");
+        let present_hash = BlobId::from_content(b"present");
+        let missing_hash = BlobId::from_content(b"missing");
         let descriptor = descriptor("01920000-0000-7000-8000-0000000000a2", Some("a.md"), 0);
         let event = file_history_event_from_entry(
             "01920000-0000-7000-8000-0000000000a2".to_string(),
@@ -3618,7 +3618,7 @@ mod tests {
             [descriptor.entry.clone()],
             PluginRegistry::empty(),
         ));
-        let row = |id: &str, hash: BlobHash| PreparedFileHistoryRow {
+        let row = |id: &str, hash: BlobId| PreparedFileHistoryRow {
             id: id.to_string(),
             path: Some(format!("/{id}.md")),
             observed_state: Arc::clone(&observed_state),
@@ -3663,7 +3663,7 @@ mod tests {
             [descriptor.entry.clone()],
             PluginRegistry::empty(),
         ));
-        let row = |id: &str, hash: BlobHash| PreparedFileHistoryRow {
+        let row = |id: &str, hash: BlobId| PreparedFileHistoryRow {
             id: id.to_string(),
             path: Some(format!("/{id}.md")),
             observed_state: Arc::clone(&observed_state),
@@ -3675,11 +3675,11 @@ mod tests {
         let rows = vec![
             row(
                 "01920000-0000-7000-8000-0000000000a2",
-                BlobHash::from_content(b"first"),
+                BlobId::from_content(b"first"),
             ),
             row(
                 "01920000-0000-7000-8000-0000000000b2",
-                BlobHash::from_content(b"second"),
+                BlobId::from_content(b"second"),
             ),
         ];
 
@@ -3698,8 +3698,8 @@ mod tests {
 
     #[tokio::test]
     async fn unfiltered_bulk_history_keeps_all_rows_and_uses_one_blob_batch() {
-        let first_hash = BlobHash::from_content(b"first");
-        let second_hash = BlobHash::from_content(b"second");
+        let first_hash = BlobId::from_content(b"first");
+        let second_hash = BlobId::from_content(b"second");
         let descriptors = vec![
             descriptor("01920000-0000-7000-8000-0000000000a2", Some("a.md"), 0),
             descriptor("01920000-0000-7000-8000-0000000000b2", Some("b.md"), 0),

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -349,7 +349,7 @@ where
     StorageImpl: Storage,
 {
     let read = storage.begin_read(ReadOptions::default()).await?;
-    let hash = crate::binary_cas::BlobHash::from_hex(hash_hex)?;
+    let hash = crate::binary_cas::BlobId::from_hex(hash_hex)?;
     let mut entries = crate::binary_cas::BinaryCasContext::new()
         .reader(read)
         .load_bytes_many(&[hash])
@@ -698,7 +698,7 @@ where
                         "benchmark binary CAS manifest key is not one hash",
                     )
                 })?;
-                Ok(crate::binary_cas::BlobHash::from_bytes(hash))
+                Ok(crate::binary_cas::BlobId::from_bytes(hash))
             })
             .collect::<Result<Vec<_>, crate::LixError>>()?;
         let payloads = crate::binary_cas::load_bytes_many(read, &hashes)
@@ -772,13 +772,13 @@ where
         let Some(hash) = value.get("blob_hash").and_then(serde_json::Value::as_str) else {
             continue;
         };
-        current_file_hashes.insert(crate::binary_cas::BlobHash::from_hex(hash)?);
+        current_file_hashes.insert(crate::binary_cas::BlobId::from_hex(hash)?);
     }
 
     let payloads = binary_cas_payload_inventory(read).await?;
     let mut retained_blobs = std::collections::BTreeSet::new();
     for payload in &payloads {
-        let hash = crate::binary_cas::BlobHash::from_bytes(payload.hash);
+        let hash = crate::binary_cas::BlobId::from_bytes(payload.hash);
         let plugin_selectable = !payload.bytes.iter().take(8_000).any(|byte| *byte == 0);
         if current_file_hashes.contains(&hash) || !plugin_selectable {
             retained_blobs.insert(hash);
@@ -795,8 +795,8 @@ where
         scan_layout_entries(read, crate::binary_cas::kv::BINARY_CAS_CHUNK_PRESENCE_SPACE).await;
 
     let mut manifest_chunks = std::collections::BTreeMap::<
-        crate::binary_cas::BlobHash,
-        Vec<(crate::binary_cas::BlobHash, u64)>,
+        crate::binary_cas::BlobId,
+        Vec<(crate::binary_cas::BlobId, u64)>,
     >::new();
     for entry in &manifest_chunk_entries {
         let blob_hash = hash_from_key_prefix(&entry.key.0, "manifest chunk")?;
@@ -805,7 +805,7 @@ where
         };
         let (chunk_hash, _) = crate::binary_cas::decode_binary_cas_manifest_chunk(value)?;
         manifest_chunks.entry(blob_hash).or_default().push((
-            crate::binary_cas::BlobHash::from_bytes(chunk_hash),
+            crate::binary_cas::BlobId::from_bytes(chunk_hash),
             storage_entry_bytes(entry),
         ));
     }
@@ -825,7 +825,7 @@ where
         match crate::binary_cas::decode_binary_cas_manifest(value)? {
             crate::binary_cas::BinaryCasManifest::Empty { .. } => {}
             crate::binary_cas::BinaryCasManifest::SingleChunk { chunk_hash, .. } => {
-                retained_chunks.insert(crate::binary_cas::BlobHash::from_bytes(chunk_hash));
+                retained_chunks.insert(crate::binary_cas::BlobId::from_bytes(chunk_hash));
             }
             crate::binary_cas::BinaryCasManifest::Chunked { .. } => {
                 retained_manifest_chunk_owners.insert(blob_hash);
@@ -843,10 +843,10 @@ where
                 ..
             } => match base_layout {
                 crate::binary_cas::StorageBinaryCasDeltaBaseLayout::SingleChunk { chunk_hash } => {
-                    retained_chunks.insert(crate::binary_cas::BlobHash::from_bytes(chunk_hash));
+                    retained_chunks.insert(crate::binary_cas::BlobId::from_bytes(chunk_hash));
                 }
                 crate::binary_cas::StorageBinaryCasDeltaBaseLayout::Chunked { .. } => {
-                    let base_hash = crate::binary_cas::BlobHash::from_bytes(base_blob_hash);
+                    let base_hash = crate::binary_cas::BlobId::from_bytes(base_blob_hash);
                     retained_manifest_chunk_owners.insert(base_hash);
                     retained_chunks.extend(
                         manifest_chunks
@@ -902,7 +902,7 @@ where
 fn hash_from_key_prefix(
     key: &Bytes,
     label: &str,
-) -> Result<crate::binary_cas::BlobHash, crate::LixError> {
+) -> Result<crate::binary_cas::BlobId, crate::LixError> {
     let hash: [u8; 32] = key
         .get(..32)
         .ok_or_else(|| {
@@ -913,7 +913,7 @@ fn hash_from_key_prefix(
         })?
         .try_into()
         .expect("checked hash slice length");
-    Ok(crate::binary_cas::BlobHash::from_bytes(hash))
+    Ok(crate::binary_cas::BlobId::from_bytes(hash))
 }
 
 fn storage_entry_bytes(entry: &crate::storage_adapter::StorageReadEntry) -> u64 {
@@ -940,7 +940,7 @@ where
     let inventory = crate::tracked_state::scan_commit_delta_inventory(read).await?;
     let mut seen_changes = std::collections::BTreeSet::new();
     let mut references = std::collections::BTreeMap::<String, u64>::new();
-    let mut owners = std::collections::BTreeMap::<crate::binary_cas::BlobHash, String>::new();
+    let mut owners = std::collections::BTreeMap::<crate::binary_cas::BlobId, String>::new();
     let mut json_ref_hashes = std::collections::BTreeSet::new();
     for member in inventory
         .commits
@@ -984,8 +984,8 @@ where
     let manifest_chunk_entries =
         scan_layout_entries(read, crate::binary_cas::kv::BINARY_CAS_MANIFEST_CHUNK_SPACE).await;
     let mut manifest_chunks = std::collections::BTreeMap::<
-        crate::binary_cas::BlobHash,
-        Vec<crate::binary_cas::BlobHash>,
+        crate::binary_cas::BlobId,
+        Vec<crate::binary_cas::BlobId>,
     >::new();
     for entry in manifest_chunk_entries {
         let blob_hash: [u8; 32] = entry
@@ -1005,21 +1005,21 @@ where
         };
         let (chunk_hash, _) = crate::binary_cas::decode_binary_cas_manifest_chunk(&value)?;
         manifest_chunks
-            .entry(crate::binary_cas::BlobHash::from_bytes(blob_hash))
+            .entry(crate::binary_cas::BlobId::from_bytes(blob_hash))
             .or_default()
-            .push(crate::binary_cas::BlobHash::from_bytes(chunk_hash));
+            .push(crate::binary_cas::BlobId::from_bytes(chunk_hash));
     }
 
     let entries = scan_layout_entries(read, crate::binary_cas::kv::BINARY_CAS_MANIFEST_SPACE).await;
     let mut accounting =
         std::collections::BTreeMap::<String, BinaryCasOwnerLayoutAccounting>::new();
     let mut chunk_owners = std::collections::BTreeMap::<
-        crate::binary_cas::BlobHash,
+        crate::binary_cas::BlobId,
         std::collections::BTreeSet<String>,
     >::new();
     let mut blob_chunks = std::collections::BTreeMap::<
-        crate::binary_cas::BlobHash,
-        Vec<crate::binary_cas::BlobHash>,
+        crate::binary_cas::BlobId,
+        Vec<crate::binary_cas::BlobId>,
     >::new();
     let mut delta_bases = Vec::new();
     for entry in entries {
@@ -1030,7 +1030,7 @@ where
             )
         })?;
         let owner = owners
-            .get(&crate::binary_cas::BlobHash::from_bytes(hash_bytes))
+            .get(&crate::binary_cas::BlobId::from_bytes(hash_bytes))
             .cloned()
             .unwrap_or_else(|| "unowned".to_owned());
         let StorageProjectedValue::FullValue(value) = entry.value else {
@@ -1053,16 +1053,16 @@ where
             crate::binary_cas::BinaryCasManifest::Empty { .. } => row.empty_manifests += 1,
             crate::binary_cas::BinaryCasManifest::SingleChunk { chunk_hash, .. } => {
                 row.single_chunk_manifests += 1;
-                let chunk_hash = crate::binary_cas::BlobHash::from_bytes(chunk_hash);
+                let chunk_hash = crate::binary_cas::BlobId::from_bytes(chunk_hash);
                 blob_chunks.insert(
-                    crate::binary_cas::BlobHash::from_bytes(hash_bytes),
+                    crate::binary_cas::BlobId::from_bytes(hash_bytes),
                     vec![chunk_hash],
                 );
                 chunk_owners.entry(chunk_hash).or_default().insert(owner);
             }
             crate::binary_cas::BinaryCasManifest::Chunked { .. } => {
                 row.chunked_manifests += 1;
-                let blob_hash = crate::binary_cas::BlobHash::from_bytes(hash_bytes);
+                let blob_hash = crate::binary_cas::BlobId::from_bytes(hash_bytes);
                 let chunks = manifest_chunks.get(&blob_hash).cloned().unwrap_or_default();
                 for chunk_hash in &chunks {
                     chunk_owners
@@ -1074,10 +1074,7 @@ where
             }
             crate::binary_cas::BinaryCasManifest::Delta { base_blob_hash, .. } => {
                 row.delta_manifests += 1;
-                delta_bases.push((
-                    owner,
-                    crate::binary_cas::BlobHash::from_bytes(base_blob_hash),
-                ));
+                delta_bases.push((owner, crate::binary_cas::BlobId::from_bytes(base_blob_hash)));
             }
         }
     }
@@ -1103,7 +1100,7 @@ where
         let StorageProjectedValue::FullValue(value) = entry.value else {
             unreachable!("binary chunk owner scan requests full values");
         };
-        let owners = chunk_owners.get(&crate::binary_cas::BlobHash::from_bytes(chunk_hash));
+        let owners = chunk_owners.get(&crate::binary_cas::BlobId::from_bytes(chunk_hash));
         let owner = match owners {
             None => "unowned_chunk".to_owned(),
             Some(owners) if owners.len() == 1 => owners.first().expect("one chunk owner").clone(),
@@ -1128,14 +1125,14 @@ where
 fn collect_binary_cas_json_owners(
     value: &serde_json::Value,
     references: &mut std::collections::BTreeMap<String, u64>,
-    owners: &mut std::collections::BTreeMap<crate::binary_cas::BlobHash, String>,
+    owners: &mut std::collections::BTreeMap<crate::binary_cas::BlobId, String>,
 ) {
     match value {
         serde_json::Value::Object(object) => {
             for (field, value) in object {
                 if field.ends_with("hash") {
                     if let Some(value) = value.as_str() {
-                        if let Ok(hash) = crate::binary_cas::BlobHash::from_hex(value) {
+                        if let Ok(hash) = crate::binary_cas::BlobId::from_hex(value) {
                             let owner = match field.as_str() {
                                 "blob_hash" => "file_blob",
                                 "plugin_state_checkpoint_hash" => "plugin_runtime_checkpoint",

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -245,9 +245,12 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
                 debug_assert!(write.auxiliary_payloads().is_empty());
                 continue;
             }
+            let payload = write
+                .inline_payload()
+                .expect("only inline file content is staged during commit");
             blob_writer
                 .stage_file_payload(
-                    write.payload(),
+                    payload,
                     write.same_length_blob_splice(),
                     write.edit_blob_splice(),
                 )
@@ -269,9 +272,13 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
                     &write.file_id,
                     &checkpoint.generation,
                     &checkpoint.semantic_root,
-                    write
-                        .blob_hash()
-                        .unwrap_or_else(|| crate::binary_cas::BlobHash::from_content(write.data())),
+                    write.blob_hash().unwrap_or_else(|| {
+                        crate::binary_cas::BlobId::from_content(
+                            write
+                                .inline_data()
+                                .expect("plugin checkpoints require inline file content"),
+                        )
+                    }),
                     &checkpoint.runtime,
                     &checkpoint.authority,
                 )?;

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -19,7 +19,7 @@ use serde_json::Value as JsonValue;
 use tracing::Instrument as _;
 
 use crate::GLOBAL_BRANCH_ID;
-use crate::binary_cas::{BinaryCasContext, BlobBytesBatch, BlobDataReader, BlobHash};
+use crate::binary_cas::{BinaryCasContext, BlobBytesBatch, BlobDataReader, BlobId};
 use crate::branch::{
     BRANCH_REF_SCHEMA_KEY, BranchContext, BranchHeadControlContext, BranchLifecycle,
     BranchOperation, BranchRefReader, BranchReferenceRole, branch_ref_stage_row,
@@ -300,7 +300,7 @@ struct VisibleMaterialization {
 #[derive(Debug, Clone)]
 enum VisibleMaterializationBytes {
     Blob {
-        hash: BlobHash,
+        hash: BlobId,
     },
     Derived {
         path: String,
@@ -374,7 +374,7 @@ fn decode_visible_materialization_parts(
                 ));
             }
             VisibleMaterializationBytes::Blob {
-                hash: BlobHash::from_hex(&snapshot.blob_hash)?,
+                hash: BlobId::from_hex(&snapshot.blob_hash)?,
             }
         }
         DERIVED_FILE_REF_SCHEMA_KEY => {
@@ -2071,7 +2071,7 @@ where
         let expected_count = conflicts.len();
         let limits = conflict_resolution_limits(expected_count)?;
         let source = VecEntityConflictSource::new(conflicts, limits)?;
-        let wasm_hash = BlobHash::from_hex(plugin.wasm_blob_hash())?;
+        let wasm_hash = BlobId::from_hex(plugin.wasm_blob_hash())?;
         let factory = match self
             .plugin_host
             .cached_plugin_factory(plugin.key(), wasm_hash)?
@@ -2869,9 +2869,13 @@ where
                             })?;
                         BlobRefRowInput {
                             file_id: file_key.file_id.clone(),
-                            blob_hash: payload
-                                .blob_hash()
-                                .unwrap_or_else(|| BlobHash::from_content(payload.data())),
+                            blob_hash: payload.blob_hash().unwrap_or_else(|| {
+                                BlobId::from_content(
+                                    payload.inline_data().expect(
+                                        "plugin materializations require inline file content",
+                                    ),
+                                )
+                            }),
                             size_bytes: payload.len(),
                             context: FilesystemRowContext {
                                 branch_id: file_key.branch_id.clone(),
@@ -2976,9 +2980,13 @@ where
                             })?;
                         BlobRefRowInput {
                             file_id: file_key.file_id.clone(),
-                            blob_hash: payload
-                                .blob_hash()
-                                .unwrap_or_else(|| BlobHash::from_content(payload.data())),
+                            blob_hash: payload.blob_hash().unwrap_or_else(|| {
+                                BlobId::from_content(
+                                    payload.inline_data().expect(
+                                        "plugin materializations require inline file content",
+                                    ),
+                                )
+                            }),
                             size_bytes: payload.len(),
                             context: FilesystemRowContext {
                                 branch_id: file_key.branch_id.clone(),
@@ -3113,13 +3121,25 @@ where
         let mut lifecycle_schema_rows = RawWriteBatch::new();
         let mut current_install_schema_definitions =
             BTreeMap::<PluginLifecycleKey, BTreeMap<String, JsonValue>>::new();
-        let mut current_install_wasm = BTreeMap::<BlobHash, Vec<u8>>::new();
+        let mut current_install_wasm = BTreeMap::<BlobId, Vec<u8>>::new();
         let mut branch_ids = BTreeSet::<String>::new();
 
         // Parse each archive exactly once. The original ZIP remains the file
         // payload; the extracted component is staged as a second CAS payload.
         for write in file_data.iter_mut() {
             let Some(path) = write.path.as_deref() else {
+                continue;
+            };
+            let Some(data) = write.inline_data() else {
+                if is_plugin_storage_path(path) {
+                    return Err(LixError::new(
+                        LixError::CODE_CONSTRAINT_VIOLATION,
+                        "prepared CAS content cannot install a plugin archive",
+                    ));
+                }
+                if !write.global && !write.untracked {
+                    branch_ids.insert(write.branch_id.clone());
+                }
                 continue;
             };
             if !is_plugin_storage_path(path) {
@@ -3130,7 +3150,7 @@ where
             }
             let plan = plugin_install_plan_from_archive_path(
                 path,
-                write.data(),
+                data,
                 &write.branch_id,
                 write.global,
                 write.untracked,
@@ -3596,6 +3616,9 @@ where
             {
                 continue;
             }
+            if write.inline_data().is_none() {
+                continue;
+            }
             candidate_file_keys.insert(PluginFileWriteKey::from(write));
         }
         for key in deleted_file_keys.keys() {
@@ -3871,6 +3894,9 @@ where
             {
                 continue;
             }
+            let Some(write_data) = write.inline_data() else {
+                continue;
+            };
             let file_key = PluginFileWriteKey::from(write);
             let catalog = catalogs
                 .get(&write.branch_id)
@@ -3905,14 +3931,14 @@ where
                         write.splice_provenance().is_some_and(|provenance| {
                             observation.bytes_sha256().is_some_and(|digest| {
                                 digest.matches_lower_hex(provenance.base_sha256())
-                            }) && transport_splice_preserves_utf8(write.data(), provenance)
+                            }) && transport_splice_preserves_utf8(write_data, provenance)
                         })
                     }
                     Some(PluginContentType::GitText) => {
                         write.splice_provenance().is_some_and(|provenance| {
                             observation.bytes_sha256().is_some_and(|digest| {
                                 digest.matches_lower_hex(provenance.base_sha256())
-                            }) && transport_splice_preserves_git_text(write.data(), provenance)
+                            }) && transport_splice_preserves_git_text(write_data, provenance)
                         })
                     }
                     Some(PluginContentType::Binary) => false,
@@ -3921,7 +3947,7 @@ where
             });
 
             let (plugin, classified_bytes) = warm_owned_plugin.map_or_else(
-                || catalog.select_for_bytes_with_classification_work(path, write.data()),
+                || catalog.select_for_bytes_with_classification_work(path, write_data),
                 |plugin| (Some(plugin), 0),
             );
             if classified_bytes != 0 {
@@ -4096,7 +4122,7 @@ where
             BTreeMap::<PluginBranchEntryKey, Arc<dyn WasmComponentFactory>>::new();
         let mut cold_entries = BTreeMap::<PluginBranchEntryKey, PluginRegistryEntry>::new();
         for (key, entry) in selected_entries {
-            let hash = BlobHash::from_hex(entry.wasm_blob_hash())?;
+            let hash = BlobId::from_hex(entry.wasm_blob_hash())?;
             let cached_factory = self.plugin_host.cached_plugin_factory(entry.key(), hash)?;
             if let Some(factory) = cached_factory {
                 component_factories.insert(key, factory);
@@ -4106,9 +4132,9 @@ where
         }
 
         let mut wasm_by_hash = current_install_wasm;
-        let mut missing_hashes = Vec::<BlobHash>::new();
+        let mut missing_hashes = Vec::<BlobId>::new();
         for entry in cold_entries.values() {
-            let hash = BlobHash::from_hex(entry.wasm_blob_hash())?;
+            let hash = BlobId::from_hex(entry.wasm_blob_hash())?;
             if !wasm_by_hash.contains_key(&hash) && !missing_hashes.contains(&hash) {
                 missing_hashes.push(hash);
             }
@@ -4136,7 +4162,7 @@ where
             }
         }
         for (key, entry) in cold_entries {
-            let hash = BlobHash::from_hex(entry.wasm_blob_hash())?;
+            let hash = BlobId::from_hex(entry.wasm_blob_hash())?;
             let wasm = wasm_by_hash.get(&hash).cloned().ok_or_else(|| {
                 LixError::new(
                     LixError::CODE_INVALID_PLUGIN,
@@ -4252,7 +4278,10 @@ where
                 });
                 let create_context = BoundCreateContext::bind(mutation_identity, &actor_key)?;
                 let materialization_version = self.functions.call_uuid_v7().to_string();
-                let submitted_bytes = write.payload().shared_bytes();
+                let submitted_bytes = write
+                    .inline_payload()
+                    .expect("selected plugin writes require inline content")
+                    .shared_bytes();
                 let cold_limits = WasmTransitionLimits::for_cold_file_bytes(
                     u64::try_from(submitted_bytes.len()).unwrap_or(u64::MAX),
                 );
@@ -4659,7 +4688,10 @@ where
                     }
                 };
             let materialization_version = self.functions.call_uuid_v7().to_string();
-            let submitted_bytes = write.payload().shared_bytes();
+            let submitted_bytes = write
+                .inline_payload()
+                .expect("selected plugin writes require inline content")
+                .shared_bytes();
             let limits = WasmTransitionLimits::for_file_bytes(
                 u64::try_from(submitted_bytes.len()).unwrap_or(u64::MAX),
             );
@@ -4766,7 +4798,9 @@ where
                                         build_file_update_splices(
                                             &before_bytes,
                                             Some(FileBytesSha256::compute(&before_bytes)),
-                                            write.data(),
+                                            write.inline_data().expect(
+                                                "selected plugin writes require inline content",
+                                            ),
                                             write.splice_provenance(),
                                             cold_limits,
                                         )
@@ -5213,7 +5247,9 @@ where
                         build_file_update_splices(
                             &observed_bytes,
                             lease.observed_bytes_sha256(),
-                            write.data(),
+                            write
+                                .inline_data()
+                                .expect("selected plugin writes require inline content"),
                             write.splice_provenance(),
                             limits,
                         )
@@ -5582,7 +5618,11 @@ where
             }
             match selected.materialization() {
                 PluginMaterialization::Blob => {
-                    if materialized_bytes.as_ref() != write.data() {
+                    if materialized_bytes.as_ref()
+                        != write
+                            .inline_data()
+                            .expect("selected plugin writes require inline content")
+                    {
                         write.replace_data(materialized_bytes);
                     } else {
                         if let Some((visible_base_blob_hash, offset, length)) =
@@ -7211,7 +7251,7 @@ struct TransactionBlobDataReader {
 
 #[async_trait]
 impl BlobDataReader for TransactionBlobDataReader {
-    async fn load_bytes_many(&self, hashes: &[BlobHash]) -> Result<BlobBytesBatch, LixError> {
+    async fn load_bytes_many(&self, hashes: &[BlobId]) -> Result<BlobBytesBatch, LixError> {
         load_transaction_blob_bytes(self.base.as_ref(), &self.staged_writes, hashes).await
     }
 }
@@ -7219,7 +7259,7 @@ impl BlobDataReader for TransactionBlobDataReader {
 async fn load_transaction_blob_bytes(
     base: &dyn BlobDataReader,
     staged_writes: &TransactionWriteBuffer,
-    hashes: &[BlobHash],
+    hashes: &[BlobId],
 ) -> Result<BlobBytesBatch, LixError> {
     let mut entries = staged_writes
         .load_staged_file_bytes_many(hashes)?
@@ -7634,7 +7674,7 @@ where
         None
     }
 
-    async fn load_bytes_many(&mut self, hashes: &[BlobHash]) -> Result<BlobBytesBatch, LixError> {
+    async fn load_bytes_many(&mut self, hashes: &[BlobId]) -> Result<BlobBytesBatch, LixError> {
         let read = SharedStorageAdapterRead::new(
             self.storage
                 .begin_read(StorageReadOptions::default())
@@ -9179,7 +9219,7 @@ fn semantic_rendered_file_data(
     path: String,
     filename: String,
     branch_id: String,
-    base_blob_hash: BlobHash,
+    base_blob_hash: BlobId,
     rendered_bytes: crate::Blob,
     same_length_output_splice: Option<ValidatedSameLengthOutputSplice>,
 ) -> TransactionFileData {
@@ -9969,7 +10009,7 @@ async fn preflight_owned_generation_upgrades(
     base_blob_reader: &dyn BlobDataReader,
     staged_writes: &TransactionWriteBuffer,
     upgrades: &[PluginGenerationUpgrade],
-    install_wasm: &BTreeMap<BlobHash, Vec<u8>>,
+    install_wasm: &BTreeMap<BlobId, Vec<u8>>,
     install_schema_definitions: &BTreeMap<PluginLifecycleKey, BTreeMap<String, JsonValue>>,
 ) -> Result<(), LixError> {
     let branch_ids = upgrades
@@ -10270,7 +10310,7 @@ async fn preflight_owned_generation_upgrades(
             },
         )
         .await?;
-        let mut materialized_hash_by_file = BTreeMap::<String, BlobHash>::new();
+        let mut materialized_hash_by_file = BTreeMap::<String, BlobId>::new();
         for row in blob_rows.iter() {
             let Some(file_id) = row.file_id() else {
                 continue;
@@ -10302,7 +10342,7 @@ async fn preflight_owned_generation_upgrades(
                     ),
                 ));
             }
-            let hash = BlobHash::from_hex(&snapshot.blob_hash)
+            let hash = BlobId::from_hex(&snapshot.blob_hash)
                 .map_err(|error| plugin_upgrade_error(upgrade, file_id, error))?;
             if materialized_hash_by_file
                 .insert(file_id.to_string(), hash)
@@ -10348,7 +10388,7 @@ async fn preflight_owned_generation_upgrades(
             ));
         }
 
-        let wasm_hash = BlobHash::from_hex(upgrade.replacement.wasm_blob_hash())?;
+        let wasm_hash = BlobId::from_hex(upgrade.replacement.wasm_blob_hash())?;
         let wasm = install_wasm.get(&wasm_hash).cloned().ok_or_else(|| {
             LixError::new(
                 LixError::CODE_INVALID_PLUGIN,
@@ -11059,7 +11099,7 @@ mod tests {
 
     #[test]
     fn visible_materialization_requires_a_matching_blob_ref_identity() {
-        let blob_hash = BlobHash::from_content(b"base");
+        let blob_hash = BlobId::from_content(b"base");
         let row = |snapshot_id: &str| MaterializedLiveStateRow {
             entity_pk: EntityPk::single("01920000-0000-7000-8000-0000000000a2"),
             schema_key: BLOB_REF_SCHEMA_KEY.to_string(),
@@ -11102,7 +11142,7 @@ mod tests {
 
     #[test]
     fn semantic_renderer_splice_provenance_is_bound_to_its_visible_blob() {
-        let base_blob_hash = BlobHash::from_content(b"abcdef");
+        let base_blob_hash = BlobId::from_content(b"abcdef");
         let rendered = semantic_rendered_file_data(
             "01920000-0000-7000-8000-0000000000a2".to_string(),
             "/document.md".to_string(),

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -1540,7 +1540,7 @@ where
         let large_files = prepared_writes
             .file_data_writes
             .iter()
-            .filter(|write| write.len() > MAX_RETAINED_IMPORT_BYTES)
+            .filter(|write| write.len() > MAX_RETAINED_IMPORT_BYTES as u64)
             .map(|write| (write.branch_id.as_str(), write.file_id.as_str()))
             .collect::<BTreeSet<_>>();
         if large_files.is_empty() {

--- a/packages/engine/src/transaction/plugin_checkpoint.rs
+++ b/packages/engine/src/transaction/plugin_checkpoint.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 
-use crate::binary_cas::BlobHash;
+use crate::binary_cas::BlobId;
 use crate::storage_adapter::{
     PointReadPlan, ScanPlan, StorageAdapterRead, StorageCoreProjection, StorageGetOptions,
     StorageKey, StoragePrefix, StorageProjectedValue, StorageScanOptions, StorageSpace,
@@ -26,11 +26,11 @@ pub(crate) fn stage_current_plugin_checkpoint(
     file_id: &str,
     generation: &str,
     semantic_root: &str,
-    blob_hash: BlobHash,
+    blob_hash: BlobId,
     runtime: &[u8],
     authority: &[u8],
 ) -> Result<(), LixError> {
-    let generation = BlobHash::from_hex(generation)?;
+    let generation = BlobId::from_hex(generation)?;
     let semantic_root = parse_semantic_root(semantic_root)?;
     let runtime_len = u32::try_from(runtime.len()).map_err(|_| checkpoint_too_large())?;
     let authority_len = u32::try_from(authority.len()).map_err(|_| checkpoint_too_large())?;
@@ -143,9 +143,9 @@ pub(crate) async fn load_current_plugin_checkpoint(
     file_id: &str,
     generation: &str,
     semantic_root: &str,
-    blob_hash: BlobHash,
+    blob_hash: BlobId,
 ) -> Result<Option<CurrentPluginCheckpoint>, LixError> {
-    let expected_generation = BlobHash::from_hex(generation)?;
+    let expected_generation = BlobId::from_hex(generation)?;
     let expected_semantic_root = parse_semantic_root(semantic_root)?;
     let values = PointReadPlan::new(
         PLUGIN_CHECKPOINT_SPACE,
@@ -240,9 +240,9 @@ mod tests {
     #[tokio::test]
     async fn current_checkpoint_overwrites_and_is_bound_to_generation_blob_and_semantic_root() {
         let storage = StorageAdapter::new(Memory::new());
-        let generation = BlobHash::from_content(b"generation");
-        let first_blob = BlobHash::from_content(b"first");
-        let second_blob = BlobHash::from_content(b"second");
+        let generation = BlobId::from_content(b"generation");
+        let first_blob = BlobId::from_content(b"first");
+        let second_blob = BlobId::from_content(b"second");
 
         for (blob_hash, runtime, authority) in [
             (
@@ -296,7 +296,7 @@ mod tests {
                 &read,
                 BRANCH_ID,
                 FILE_ID,
-                &BlobHash::from_content(b"other-generation").to_hex(),
+                &BlobId::from_content(b"other-generation").to_hex(),
                 SEMANTIC_ROOT,
                 second_blob,
             )
@@ -335,8 +335,8 @@ mod tests {
     #[tokio::test]
     async fn checkpoint_cleanup_follows_file_and_branch_lifetimes() {
         let storage = StorageAdapter::new(Memory::new());
-        let generation = BlobHash::from_content(b"generation");
-        let blob_hash = BlobHash::from_content(b"file");
+        let generation = BlobId::from_content(b"generation");
+        let blob_hash = BlobId::from_content(b"file");
         let mut writes = storage.new_write_set();
         for branch_id in [BRANCH_ID, OTHER_BRANCH_ID] {
             stage_current_plugin_checkpoint(

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -15,7 +15,7 @@ use std::sync::{Arc, Mutex};
 use smallvec::SmallVec;
 
 use crate::GLOBAL_BRANCH_ID;
-use crate::binary_cas::{BlobBytesBatch, BlobHash};
+use crate::binary_cas::{BlobBytesBatch, BlobId};
 use crate::catalog::SchemaPlanId;
 use crate::changelog::{ChangeId, CommitId};
 use crate::common::SharedStr;
@@ -1702,7 +1702,7 @@ impl TransactionWriteBuffer {
     /// staged file payloads that commit will later write.
     pub(crate) fn load_staged_file_bytes_many(
         &self,
-        hashes: &[BlobHash],
+        hashes: &[BlobId],
     ) -> Result<BlobBytesBatch, LixError> {
         if hashes.is_empty() {
             return Ok(BlobBytesBatch::new(Vec::new()));
@@ -1717,16 +1717,21 @@ impl TransactionWriteBuffer {
             .iter()
             .copied()
             .map(|hash| (hash, None))
-            .collect::<BTreeMap<BlobHash, Option<&[u8]>>>();
+            .collect::<BTreeMap<BlobId, Option<&[u8]>>>();
         let mut remaining = requested.len();
         'writes: for write in file_data_guard.iter() {
+            let Some(data) = write.inline_data() else {
+                // Prepared CAS content is already durable. Leaving its slot
+                // unresolved lets the transaction reader fall through to CAS.
+                continue;
+            };
             let hash = write
                 .blob_hash()
-                .unwrap_or_else(|| BlobHash::from_content(write.data()));
+                .unwrap_or_else(|| BlobId::from_content(data));
             if let Some(bytes) = requested.get_mut(&hash)
                 && bytes.is_none()
             {
-                *bytes = Some(write.data());
+                *bytes = Some(data);
                 remaining -= 1;
                 if remaining == 0 {
                     break 'writes;
@@ -1735,7 +1740,7 @@ impl TransactionWriteBuffer {
             for payload in write.auxiliary_payloads() {
                 let hash = payload
                     .hash()
-                    .unwrap_or_else(|| BlobHash::from_content(payload.bytes()));
+                    .unwrap_or_else(|| BlobId::from_content(payload.bytes()));
                 if let Some(bytes) = requested.get_mut(&hash)
                     && bytes.is_none()
                 {
@@ -4094,9 +4099,9 @@ mod tests {
             })
             .expect("file payloads should stage");
 
-        let auxiliary_hash = BlobHash::from_content(b"requested-auxiliary");
-        let missing_hash = BlobHash::from_content(b"missing");
-        let main_hash = BlobHash::from_content(b"requested-main");
+        let auxiliary_hash = BlobId::from_content(b"requested-auxiliary");
+        let missing_hash = BlobId::from_content(b"missing");
+        let main_hash = BlobId::from_content(b"requested-main");
         let loaded = staged_writes
             .load_staged_file_bytes_many(&[auxiliary_hash, missing_hash, main_hash, auxiliary_hash])
             .expect("staged payload lookup should succeed")

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -1501,10 +1501,10 @@ impl FileContent {
         }
     }
 
-    pub(crate) fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> u64 {
         match self {
-            Self::Inline(payload) => payload.len(),
-            Self::PreparedCas(receipt) => usize::try_from(receipt.size_bytes).unwrap_or(usize::MAX),
+            Self::Inline(payload) => payload.len() as u64,
+            Self::PreparedCas(receipt) => receipt.size_bytes,
         }
     }
 
@@ -1727,7 +1727,7 @@ impl TransactionFileData {
         if length == 0
             || offset
                 .checked_add(length)
-                .is_none_or(|end| end > self.content.len())
+                .is_none_or(|end| end as u64 > self.content.len())
         {
             return;
         }
@@ -1749,7 +1749,7 @@ impl TransactionFileData {
             || (delete_len == 0 && insert_len == 0)
             || offset
                 .checked_add(insert_len)
-                .is_none_or(|end| end > self.content.len())
+                .is_none_or(|end| end as u64 > self.content.len())
         {
             return;
         }
@@ -1765,7 +1765,7 @@ impl TransactionFileData {
         self.content.blob_id()
     }
 
-    pub(crate) fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> u64 {
         self.content.len()
     }
 

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -7,7 +7,9 @@ use std::{
 };
 
 use crate::LixError;
-use crate::binary_cas::{BlobEditSplice, BlobHash, BlobPayload, BlobSameLengthSplice};
+use crate::binary_cas::{
+    BlobEditSplice, BlobId, BlobPayload, BlobSameLengthSplice, BlobWriteReceipt,
+};
 use crate::catalog::SchemaPlanId;
 use crate::changelog::{ChangeId, CommitId};
 use crate::common::{LixTimestamp, MutationIdentity, RequestBlobSpliceProvenance, SharedStr};
@@ -1476,7 +1478,68 @@ where
         .map(|primary_key| primary_key.map(Arc::new))
 }
 
-/// Incoming file payload paired with transaction write rows.
+/// File content accepted by the ordinary transaction write abstraction.
+///
+/// Prepared CAS content is already durable; publishing it is a metadata-only
+/// transaction operation. Keeping that state in the content enum prevents a
+/// prepared blob from masquerading as an empty inline payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum FileContent {
+    Inline(BlobPayload),
+    PreparedCas(BlobWriteReceipt),
+}
+
+impl FileContent {
+    pub(crate) fn inline(data: impl Into<crate::Blob>) -> Self {
+        Self::Inline(BlobPayload::from_bytes(data))
+    }
+
+    pub(crate) fn blob_id(&self) -> Option<BlobId> {
+        match self {
+            Self::Inline(payload) => payload.hash(),
+            Self::PreparedCas(receipt) => Some(receipt.hash),
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            Self::Inline(payload) => payload.len(),
+            Self::PreparedCas(receipt) => usize::try_from(receipt.size_bytes).unwrap_or(usize::MAX),
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        match self {
+            Self::Inline(payload) => payload.is_empty(),
+            Self::PreparedCas(receipt) => receipt.size_bytes == 0,
+        }
+    }
+
+    pub(crate) fn inline_payload(&self) -> Option<&BlobPayload> {
+        match self {
+            Self::Inline(payload) => Some(payload),
+            Self::PreparedCas(_) => None,
+        }
+    }
+
+    pub(crate) fn inline_bytes(&self) -> Option<&[u8]> {
+        self.inline_payload().map(BlobPayload::bytes)
+    }
+}
+
+impl From<crate::Blob> for FileContent {
+    fn from(data: crate::Blob) -> Self {
+        Self::inline(data)
+    }
+}
+
+impl From<Vec<u8>> for FileContent {
+    fn from(data: Vec<u8>) -> Self {
+        Self::inline(data)
+    }
+}
+
+/// Incoming file content paired with transaction write rows.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TransactionFileData {
     pub(crate) file_id: String,
@@ -1496,7 +1559,7 @@ pub(crate) struct TransactionFileData {
     /// available without an additional read. This is transient write
     /// provenance only; it lets a verified v2 same-length edit reuse durable
     /// CAS chunk references at commit.
-    base_blob_hash: Option<BlobHash>,
+    base_blob_hash: Option<BlobId>,
     /// A fixed-width replacement proven by the v2 transition against the
     /// exact accepted document. The complete output bytes remain authoritative;
     /// this only permits an internal CAS staging fast path.
@@ -1512,12 +1575,7 @@ pub(crate) struct TransactionFileData {
     /// durable plugin state. The current HTTP protocol does not expose replay
     /// identity.
     mutation_identity: Option<MutationIdentity>,
-    payload: BlobPayload,
-    /// A complete CAS object whose chunks and manifest were durably staged by
-    /// the resumable transfer path before this history transaction began.
-    /// The file row still publishes through the ordinary transaction path;
-    /// it simply does not retain the multi-gigabyte payload again.
-    prepared_blob: Option<crate::binary_cas::BlobWriteReceipt>,
+    content: FileContent,
     /// Content-addressed payloads produced while validating this file write.
     /// Plugin installation uses this for the extracted WASM component so
     /// steady-state reads can load it directly without reopening the archive.
@@ -1539,7 +1597,7 @@ impl TransactionFileData {
         branch_id: String,
         global: bool,
         untracked: bool,
-        data: impl Into<crate::Blob>,
+        content: impl Into<FileContent>,
     ) -> Self {
         Self {
             file_id,
@@ -1554,8 +1612,7 @@ impl TransactionFileData {
             edit_blob_splice: None,
             splice_provenance: None,
             mutation_identity: None,
-            payload: BlobPayload::from_bytes(data),
-            prepared_blob: None,
+            content: content.into(),
             auxiliary_payloads: Vec::new(),
             plugin_checkpoint: None,
             stage_payload_at_commit: true,
@@ -1568,7 +1625,7 @@ impl TransactionFileData {
         self
     }
 
-    pub(crate) fn with_base_blob_hash(mut self, base_blob_hash: Option<BlobHash>) -> Self {
+    pub(crate) fn with_base_blob_hash(mut self, base_blob_hash: Option<BlobId>) -> Self {
         self.had_blob_ref |= base_blob_hash.is_some();
         self.base_blob_hash = base_blob_hash;
         self
@@ -1628,27 +1685,22 @@ impl TransactionFileData {
         self.stage_payload_at_commit = false;
     }
 
-    pub(crate) fn use_prepared_blob(&mut self, receipt: crate::binary_cas::BlobWriteReceipt) {
-        self.payload = BlobPayload::from_bytes(Vec::new());
-        self.prepared_blob = Some(receipt);
-        self.stage_payload_at_commit = false;
-        self.splice_provenance = None;
-        self.base_blob_hash = None;
-        self.same_length_blob_splice = None;
-        self.edit_blob_splice = None;
-    }
-
     pub(crate) fn stage_payload_at_commit(&self) -> bool {
-        self.stage_payload_at_commit
+        self.stage_payload_at_commit && matches!(self.content, FileContent::Inline(_))
     }
 
+    pub(crate) fn inline_data(&self) -> Option<&[u8]> {
+        self.content.inline_bytes()
+    }
+
+    #[cfg(test)]
     pub(crate) fn data(&self) -> &[u8] {
-        self.payload.bytes()
+        self.inline_data()
+            .expect("test fixture expected inline file content")
     }
 
     pub(crate) fn replace_data(&mut self, data: impl Into<crate::Blob>) {
-        self.payload = BlobPayload::from_bytes(data);
-        self.prepared_blob = None;
+        self.content = FileContent::inline(data);
         // Transport provenance describes the replaced request payload. Once a
         // plugin renderer materializes merged bytes, it no longer applies.
         self.splice_provenance = None;
@@ -1662,7 +1714,7 @@ impl TransactionFileData {
     /// leaves this unset so CAS staging follows the normal full path.
     pub(crate) fn set_verified_same_length_blob_splice(
         &mut self,
-        visible_base_blob_hash: BlobHash,
+        visible_base_blob_hash: BlobId,
         offset: usize,
         length: usize,
     ) {
@@ -1675,7 +1727,7 @@ impl TransactionFileData {
         if length == 0
             || offset
                 .checked_add(length)
-                .is_none_or(|end| end > self.payload.len())
+                .is_none_or(|end| end > self.content.len())
         {
             return;
         }
@@ -1685,7 +1737,7 @@ impl TransactionFileData {
 
     pub(crate) fn set_verified_blob_edit_splice(
         &mut self,
-        visible_base_blob_hash: BlobHash,
+        visible_base_blob_hash: BlobId,
         offset: usize,
         delete_len: usize,
         insert_len: usize,
@@ -1697,7 +1749,7 @@ impl TransactionFileData {
             || (delete_len == 0 && insert_len == 0)
             || offset
                 .checked_add(insert_len)
-                .is_none_or(|end| end > self.payload.len())
+                .is_none_or(|end| end > self.content.len())
         {
             return;
         }
@@ -1709,22 +1761,16 @@ impl TransactionFileData {
         });
     }
 
-    pub(crate) fn blob_hash(&self) -> Option<BlobHash> {
-        self.prepared_blob
-            .as_ref()
-            .map(|receipt| receipt.hash)
-            .or_else(|| self.payload.hash())
+    pub(crate) fn blob_hash(&self) -> Option<BlobId> {
+        self.content.blob_id()
     }
 
     pub(crate) fn len(&self) -> usize {
-        self.prepared_blob.as_ref().map_or_else(
-            || self.payload.len(),
-            |receipt| usize::try_from(receipt.size_bytes).unwrap_or(usize::MAX),
-        )
+        self.content.len()
     }
 
-    pub(crate) fn payload(&self) -> &BlobPayload {
-        &self.payload
+    pub(crate) fn inline_payload(&self) -> Option<&BlobPayload> {
+        self.content.inline_payload()
     }
 
     pub(crate) fn same_length_blob_splice(&self) -> Option<BlobSameLengthSplice> {
@@ -1736,7 +1782,7 @@ impl TransactionFileData {
     }
 
     #[cfg(test)]
-    pub(crate) fn base_blob_hash(&self) -> Option<BlobHash> {
+    pub(crate) fn base_blob_hash(&self) -> Option<BlobId> {
         self.base_blob_hash
     }
 
@@ -1745,10 +1791,7 @@ impl TransactionFileData {
     }
 
     pub(crate) fn is_empty(&self) -> bool {
-        self.prepared_blob.as_ref().map_or_else(
-            || self.payload.is_empty(),
-            |receipt| receipt.size_bytes == 0,
-        )
+        self.content.is_empty()
     }
 }
 
@@ -4637,8 +4680,8 @@ mod tests {
 
     #[test]
     fn verified_same_length_splice_requires_the_visible_blob_base() {
-        let base = BlobHash::from_content(b"before");
-        let wrong_base = BlobHash::from_content(b"other!");
+        let base = BlobId::from_content(b"before");
+        let wrong_base = BlobId::from_content(b"other!");
         let mut write = TransactionFileData::new(
             "file".to_string(),
             None,
@@ -4666,8 +4709,8 @@ mod tests {
 
     #[test]
     fn verified_edit_splice_is_format_neutral_and_cleared_by_rematerialization() {
-        let base = BlobHash::from_content(b"before");
-        let wrong_base = BlobHash::from_content(b"other!");
+        let base = BlobId::from_content(b"before");
+        let wrong_base = BlobId::from_content(b"other!");
         let mut write = TransactionFileData::new(
             "file".to_string(),
             None,


### PR DESCRIPTION
## Summary

- make prepared CAS receipts first-class file transaction content instead of lowering placeholder bytes and rewriting staged rows
- separate whole-blob `BlobId` from raw `ChunkHash` throughout the CAS, storage, filesystem, and plugin paths
- keep the clean-cut raw chunk format from #1084; this intentionally adds no legacy Zstd decode path

## Validation

- `cargo test -p lix_engine --features all-simulations`
- `cargo test -p lix_rocksdb_storage`
- `cargo test -p lix_slatedb_storage`
- `cargo test -p lix_sqlite_storage`
- `cargo test -p lix_engine_benchmarks --all-features --test movie_workspace_qualification`
- `cargo test -p lix_engine_benchmarks --all-features --no-run`
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`