### PR TITLE
perf(engine): index stale commit overlaps

### DIFF
--- a/packages/engine/src/plugin/conflict.rs
+++ b/packages/engine/src/plugin/conflict.rs
@@ -1,0 +1,43 @@
+use crate::changelog::ChangeId;
+use crate::common::LixTimestamp;
+
+/// Host-owned ordering key for the two non-base sides of a semantic conflict.
+///
+/// Branch merges and stale transaction reconciliation must present identical
+/// changes to plugins in the same `a`/`b` order. Keeping that contract in one
+/// typed key prevents either path from silently inventing a different tie
+/// breaker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct ConflictRank {
+    updated_at: LixTimestamp,
+    change_id: ChangeId,
+}
+
+impl ConflictRank {
+    pub(crate) const fn new(updated_at: LixTimestamp, change_id: ChangeId) -> Self {
+        Self {
+            updated_at,
+            change_id,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ConflictRank;
+    use crate::changelog::ChangeId;
+    use crate::common::LixTimestamp;
+
+    #[test]
+    fn timestamp_precedes_change_id_in_durable_conflict_order() {
+        let early = ConflictRank::new(
+            LixTimestamp::from_unix_millis_utc_lossy(1),
+            ChangeId::for_test_label("later-id"),
+        );
+        let late = ConflictRank::new(
+            LixTimestamp::from_unix_millis_utc_lossy(2),
+            ChangeId::for_test_label("earlier-id"),
+        );
+        assert!(early < late);
+    }
+}

--- a/packages/engine/src/plugin/mod.rs
+++ b/packages/engine/src/plugin/mod.rs
@@ -7,6 +7,7 @@
 mod actor;
 mod archive;
 mod component;
+mod conflict;
 mod create_context;
 mod incremental;
 mod install;
@@ -22,6 +23,7 @@ pub(crate) use actor::{
 };
 pub(crate) use archive::{ParsedPluginArchive, parse_plugin_archive_for_install};
 pub(crate) use component::{DEFAULT_PLUGIN_MEMORY_BYTES, PluginRuntimeHost};
+pub(crate) use conflict::ConflictRank;
 pub(crate) use create_context::{
     BoundCreateContext, is_reservation_key, local_mutation_identity, materialize_keyless_creates,
     require_existing_id_authorities, reservation_tombstone_row, reserve_create_row,

--- a/packages/engine/src/session/merge/branch.rs
+++ b/packages/engine/src/session/merge/branch.rs
@@ -11,8 +11,8 @@ use crate::changelog::ChangeRecordProjection;
 use crate::entity_pk::EntityPk;
 use crate::filesystem::DERIVED_FILE_REF_SCHEMA_KEY;
 use crate::plugin::{
-    PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY, PluginFileOwner, PluginRegistry, PluginRegistryEntry,
-    inferred_media_type_for_path,
+    ConflictRank, PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY, PluginFileOwner, PluginRegistry,
+    PluginRegistryEntry, inferred_media_type_for_path,
 };
 use crate::storage_adapter::Storage;
 #[cfg(test)]
@@ -1402,10 +1402,9 @@ fn canonical_conflict_variants_ref<'a>(
             "merge conflict source side omitted its resulting row",
         )
     })?;
-    let ordering = target_after
-        .updated_at
-        .cmp(&source_after.updated_at)
-        .then_with(|| target_after.change_id.cmp(&source_after.change_id));
+    let ordering = ConflictRank::new(target_after.updated_at, target_after.change_id).cmp(
+        &ConflictRank::new(source_after.updated_at, source_after.change_id),
+    );
     if ordering.is_eq() {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,

--- a/packages/engine/src/tracked_state/diff.rs
+++ b/packages/engine/src/tracked_state/diff.rs
@@ -1011,6 +1011,14 @@ impl TrackedStateDiffIdentity {
         self.batch.schema_key(self.ordinal)
     }
 
+    pub(crate) fn as_key_ref(&self) -> TrackedStateKeyRef<'_> {
+        TrackedStateKeyRef {
+            schema_key: self.schema_key(),
+            file_id: self.file_id(),
+            entity_pk: self.entity_pk(),
+        }
+    }
+
     /// Clones the shared schema owner without allocating decoded text.
     ///
     /// Downstream typed batches use this when re-dictionary-encoding an

--- a/packages/engine/src/tracked_state/types.rs
+++ b/packages/engine/src/tracked_state/types.rs
@@ -29,7 +29,7 @@ pub(crate) struct TrackedStateKey {
 }
 
 /// Zero-copy view of primary tracked-state key.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct TrackedStateKeyRef<'a> {
     pub(crate) schema_key: &'a str,
     pub(crate) file_id: Option<&'a str>,

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -61,7 +61,7 @@ use crate::live_state::{
     overlay_load_exact_batch, overlay_scan_batch,
 };
 use crate::plugin::{
-    ArcByteSource, BoundCreateContext, CompiledPluginCatalog, FileBytesSha256,
+    ArcByteSource, BoundCreateContext, CompiledPluginCatalog, ConflictRank, FileBytesSha256,
     LiveBatchEntitySource, PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY, PluginActorCache,
     PluginActorColdInstall, PluginActorColdOpen, PluginActorKey, PluginActorLease,
     PluginActorStagedCheckpoint, PluginActorStore, PluginActorStorePermit,
@@ -112,6 +112,9 @@ use crate::transaction::schema_resolver::TransactionSchemaResolver;
 use crate::transaction::staging::{
     PreparedStateRowOverlay, PreparedWriteSet, TransactionWriteBuffer,
     TransactionWriteBufferCheckpoint,
+};
+use crate::transaction::stale_commit::{
+    StaleCommitPlan, StalePluginReconciliationPlan, classify_stale_commit,
 };
 use crate::transaction::types::{
     PreparedRowFacts, PreparedStateBatch, PreparedTransactionWrite, RawWriteBatch, RawWriteRowRef,
@@ -723,40 +726,22 @@ where
                 &TrackedStateDiffRequest::default(),
             )
             .await?;
-        let overlapping_row_indices = prepared_writes
-            .state_rows
-            .iter()
-            .enumerate()
-            .filter_map(|(index, row)| {
-                concurrent
-                    .entries
-                    .iter()
-                    .any(|entry| {
-                        row.schema_key.as_str() == entry.identity.schema_key()
-                            && row.file_id.map(SharedStr::as_str) == entry.identity.file_id()
-                            && row.entity_pk == entry.identity.entity_pk()
-                    })
-                    .then_some(index)
-            })
-            .collect::<Vec<_>>();
-        if !overlapping_row_indices.is_empty() {
-            // Ordinary INSERT races keep their established constraint surface:
-            // commit-time validation reports the exact UNIQUE/statement-index
-            // error from the current snapshot. Updates and file-scoped semantic
-            // rows cannot safely use that absence-check lane.
-            let ordinary_insert_race = overlapping_row_indices.iter().all(|&index| {
-                prepared_writes.insert_selection.contains(index)
-                    && prepared_writes.state_rows.row(index).file_id.is_none()
-            });
-            if !ordinary_insert_race {
-                self.resolve_stale_plugin_overlaps(
+        match classify_stale_commit(prepared_writes, &concurrent) {
+            StaleCommitPlan::Direct | StaleCommitPlan::RevalidateOrdinaryInsert => {}
+            StaleCommitPlan::ReconcilePlugin(plan) => {
+                self.reconcile_stale_plugin_writes(
                     read,
                     prepared_writes,
-                    &concurrent,
+                    plan,
                     opening_head,
                     current_head,
                 )
                 .await?;
+            }
+            StaleCommitPlan::Unsafe => {
+                return Err(conflict(
+                    "concurrent transaction changed an overlapping entity outside a stable plugin-owned file",
+                ));
             }
         }
 
@@ -765,11 +750,11 @@ where
         Ok(())
     }
 
-    async fn resolve_stale_plugin_overlaps<S>(
+    async fn reconcile_stale_plugin_writes<S>(
         &mut self,
         read: &S,
         prepared_writes: &mut PreparedWriteSet,
-        concurrent: &crate::tracked_state::TrackedStateDiff,
+        plan: StalePluginReconciliationPlan,
         opening_head: CommitId,
         current_head: CommitId,
     ) -> Result<(), LixError>
@@ -783,65 +768,10 @@ where
             )
             .with_hint("Retry the transaction against the latest committed state.")
         };
-        let concurrent_keys = concurrent
-            .entries
-            .iter()
-            .map(|entry| TrackedStateKey {
-                schema_key: entry.identity.schema_key().to_owned(),
-                file_id: entry.identity.file_id().map(str::to_owned),
-                entity_pk: entry.identity.entity_pk().clone(),
-            })
-            .collect::<BTreeSet<_>>();
-        let overlapping_indices = prepared_writes
-            .state_rows
-            .iter()
-            .enumerate()
-            .filter_map(|(index, row)| {
-                let key = TrackedStateKey {
-                    schema_key: row.schema_key.to_string(),
-                    file_id: row.file_id.map(|file_id| file_id.to_string()),
-                    entity_pk: row.entity_pk.clone(),
-                };
-                concurrent_keys.contains(&key).then_some(index)
-            })
-            .collect::<Vec<_>>();
-        let candidate_indices = overlapping_indices
-            .iter()
-            .copied()
-            .filter(|&index| {
-                let row = prepared_writes.state_rows.row(index);
-                row.file_id.is_some()
-                    && !matches!(
-                        row.schema_key.as_str(),
-                        BLOB_REF_SCHEMA_KEY | DERIVED_FILE_REF_SCHEMA_KEY
-                    )
-            })
-            .collect::<Vec<_>>();
-        let file_ids = overlapping_indices
-            .iter()
-            .filter_map(|&index| {
-                prepared_writes
-                    .state_rows
-                    .row(index)
-                    .file_id
-                    .map(ToString::to_string)
-            })
-            .collect::<BTreeSet<_>>();
-        if file_ids.is_empty()
-            || overlapping_indices.iter().any(|&index| {
-                let row = prepared_writes.state_rows.row(index);
-                let Some(file_id) = row.file_id.map(SharedStr::as_str) else {
-                    return true;
-                };
-                !file_ids.contains(file_id)
-                    || (!matches!(
-                        row.schema_key.as_str(),
-                        BLOB_REF_SCHEMA_KEY | DERIVED_FILE_REF_SCHEMA_KEY
-                    ) && !candidate_indices.contains(&index))
-            })
-        {
-            return Err(conflict_error());
-        }
+        let StalePluginReconciliationPlan {
+            semantic_conflict_indices: candidate_indices,
+            file_ids,
+        } = plan;
 
         let owner_keys = file_ids
             .iter()
@@ -1004,9 +934,10 @@ where
                     "staged tracked plugin row is missing change_id",
                 )
             })?;
-            let source_order = (source.updated_at, source_change_id);
-            let target_order = target.map(|row| (row.updated_at(), row.change_id()));
-            let (a, b) = if target_order.is_some_and(|order| order < source_order) {
+            let source_rank = ConflictRank::new(source.updated_at, source_change_id);
+            let target_rank =
+                target.map(|row| ConflictRank::new(row.updated_at(), row.change_id()));
+            let (a, b) = if target_rank.is_some_and(|rank| rank < source_rank) {
                 (target_payload, source_payload)
             } else {
                 (source_payload, target_payload)

--- a/packages/engine/src/transaction/mod.rs
+++ b/packages/engine/src/transaction/mod.rs
@@ -6,6 +6,7 @@ mod normalization;
 pub(crate) mod plugin_checkpoint;
 mod schema_resolver;
 mod staging;
+mod stale_commit;
 pub(crate) mod types;
 mod validation;
 

--- a/packages/engine/src/transaction/stale_commit.rs
+++ b/packages/engine/src/transaction/stale_commit.rs
@@ -1,0 +1,226 @@
+use std::collections::{BTreeSet, HashSet};
+
+use crate::common::SharedStr;
+use crate::filesystem::DERIVED_FILE_REF_SCHEMA_KEY;
+use crate::tracked_state::{TrackedStateDiff, TrackedStateKeyRef};
+
+use super::staging::PreparedWriteSet;
+
+const BLOB_REF_SCHEMA_KEY: &str = "lix_binary_blob_ref";
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum StaleCommitPlan {
+    Direct,
+    RevalidateOrdinaryInsert,
+    ReconcilePlugin(StalePluginReconciliationPlan),
+    Unsafe,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct StalePluginReconciliationPlan {
+    pub(super) semantic_conflict_indices: Vec<usize>,
+    pub(super) file_ids: BTreeSet<String>,
+}
+
+pub(super) fn classify_stale_commit(
+    prepared_writes: &PreparedWriteSet,
+    concurrent: &TrackedStateDiff,
+) -> StaleCommitPlan {
+    let overlapping_indices = indexed_overlap_indices(
+        prepared_writes
+            .state_rows
+            .iter()
+            .enumerate()
+            .map(|(index, row)| {
+                (
+                    index,
+                    TrackedStateKeyRef {
+                        schema_key: row.schema_key.as_str(),
+                        file_id: row.file_id.map(SharedStr::as_str),
+                        entity_pk: row.entity_pk,
+                    },
+                )
+            }),
+        concurrent
+            .entries
+            .iter()
+            .map(|entry| entry.identity.as_key_ref()),
+    );
+    if overlapping_indices.is_empty() {
+        return StaleCommitPlan::Direct;
+    }
+
+    // Ordinary INSERT races keep their established constraint surface:
+    // commit-time validation reports the exact UNIQUE/statement-index error
+    // from the current snapshot.
+    if overlapping_indices.iter().all(|&index| {
+        prepared_writes.insert_selection.contains(index)
+            && prepared_writes.state_rows.row(index).file_id.is_none()
+    }) {
+        return StaleCommitPlan::RevalidateOrdinaryInsert;
+    }
+
+    let file_ids = overlapping_indices
+        .iter()
+        .filter_map(|&index| {
+            prepared_writes
+                .state_rows
+                .row(index)
+                .file_id
+                .map(ToString::to_string)
+        })
+        .collect::<BTreeSet<_>>();
+    if file_ids.is_empty()
+        || overlapping_indices
+            .iter()
+            .any(|&index| prepared_writes.state_rows.row(index).file_id.is_none())
+    {
+        return StaleCommitPlan::Unsafe;
+    }
+
+    let semantic_conflict_indices = overlapping_indices
+        .iter()
+        .copied()
+        .filter(|&index| {
+            !matches!(
+                prepared_writes.state_rows.row(index).schema_key.as_str(),
+                BLOB_REF_SCHEMA_KEY | DERIVED_FILE_REF_SCHEMA_KEY
+            )
+        })
+        .collect();
+    StaleCommitPlan::ReconcilePlugin(StalePluginReconciliationPlan {
+        semantic_conflict_indices,
+        file_ids,
+    })
+}
+
+fn indexed_overlap_indices<'a>(
+    prepared: impl Iterator<Item = (usize, TrackedStateKeyRef<'a>)>,
+    concurrent: impl Iterator<Item = TrackedStateKeyRef<'a>>,
+) -> Vec<usize> {
+    let concurrent_keys = concurrent.collect::<HashSet<_>>();
+    prepared
+        .filter_map(|(index, key)| concurrent_keys.contains(&key).then_some(index))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use super::*;
+    use crate::entity_pk::EntityPk;
+    use crate::tracked_state::TrackedStateKey;
+
+    fn test_key_ref(key: &TrackedStateKey) -> TrackedStateKeyRef<'_> {
+        TrackedStateKeyRef {
+            schema_key: &key.schema_key,
+            file_id: key.file_id.as_deref(),
+            entity_pk: &key.entity_pk,
+        }
+    }
+
+    fn overlap_fixture(rows: usize) -> (Vec<TrackedStateKey>, Vec<TrackedStateKey>) {
+        let prepared = (0..rows)
+            .map(|index| TrackedStateKey {
+                schema_key: "plugin_entity".to_owned(),
+                file_id: Some("hot-file".to_owned()),
+                entity_pk: EntityPk::single(format!("row-{index}")),
+            })
+            .collect::<Vec<_>>();
+        let concurrent = (0..rows)
+            .map(|index| TrackedStateKey {
+                schema_key: "plugin_entity".to_owned(),
+                file_id: Some("hot-file".to_owned()),
+                entity_pk: EntityPk::single(if index.is_multiple_of(2) {
+                    format!("row-{index}")
+                } else {
+                    format!("other-{index}")
+                }),
+            })
+            .collect::<Vec<_>>();
+        (prepared, concurrent)
+    }
+
+    fn legacy_nested_overlap_indices(
+        prepared: &[TrackedStateKey],
+        concurrent: &[TrackedStateKey],
+    ) -> Vec<usize> {
+        prepared
+            .iter()
+            .enumerate()
+            .filter_map(|(index, key)| concurrent.iter().any(|other| other == key).then_some(index))
+            .collect()
+    }
+
+    #[test]
+    fn indexed_overlap_discovery_matches_legacy_order_and_membership() {
+        let (prepared, concurrent) = overlap_fixture(257);
+        let indexed = indexed_overlap_indices(
+            prepared
+                .iter()
+                .enumerate()
+                .map(|(index, key)| (index, test_key_ref(key))),
+            concurrent.iter().map(test_key_ref),
+        );
+        assert_eq!(
+            indexed,
+            legacy_nested_overlap_indices(&prepared, &concurrent)
+        );
+    }
+
+    #[test]
+    #[ignore = "release-only stale overlap discovery benchmark probe"]
+    fn stale_overlap_discovery_benchmark_probe() {
+        let rows = std::env::var("LIX_STALE_OVERLAP_BENCH_ROWS")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(5_000);
+        let rounds = std::env::var("LIX_STALE_OVERLAP_BENCH_ROUNDS")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(8);
+        let (prepared, concurrent) = overlap_fixture(rows);
+        let expected = legacy_nested_overlap_indices(&prepared, &concurrent);
+
+        let mut legacy_samples = Vec::with_capacity(rounds);
+        let mut indexed_samples = Vec::with_capacity(rounds);
+        for _ in 0..rounds {
+            let started = Instant::now();
+            let legacy = std::hint::black_box(legacy_nested_overlap_indices(
+                std::hint::black_box(&prepared),
+                std::hint::black_box(&concurrent),
+            ));
+            legacy_samples.push(started.elapsed());
+            assert_eq!(legacy, expected);
+
+            let started = Instant::now();
+            let indexed = std::hint::black_box(indexed_overlap_indices(
+                prepared
+                    .iter()
+                    .enumerate()
+                    .map(|(index, key)| (index, test_key_ref(key))),
+                concurrent.iter().map(test_key_ref),
+            ));
+            indexed_samples.push(started.elapsed());
+            assert_eq!(indexed, expected);
+        }
+        legacy_samples.sort_unstable();
+        indexed_samples.sort_unstable();
+        let p50 = |samples: &[std::time::Duration]| samples[(samples.len() - 1) / 2];
+        let legacy_p50 = p50(&legacy_samples);
+        let indexed_p50 = p50(&indexed_samples);
+        println!(
+            "stale_overlap_discovery rows={rows} overlaps={} rounds={rounds} \
+             legacy_p50_us={} indexed_p50_us={} speedup={:.2}",
+            expected.len(),
+            legacy_p50.as_micros(),
+            indexed_p50.as_micros(),
+            legacy_p50.as_secs_f64() / indexed_p50.as_secs_f64(),
+        );
+        assert!(
+            indexed_p50 < legacy_p50,
+            "indexed overlap discovery should beat the nested legacy scan"
+        );
+    }
+}


### PR DESCRIPTION
## What changed

- classify stale commits once into direct, ordinary-insert revalidation, plugin reconciliation, or unsafe conflict plans
- replace the nested prepared-write × concurrent-change scan and duplicate overlap reconstruction with one hash-indexed discovery pass
- move stale-commit planning out of the transaction context into a focused internal module
- use one typed durable conflict rank for stale transactions and branch merges
- retain the removed nested algorithm only inside an ignored release benchmark for direct before/after measurement

## Why

Stale commit reconciliation performed an O(P × C) overlap scan for P prepared rows and C concurrent changes, then allocated and searched the same key set again inside plugin reconciliation. The transaction context also mixed discovery, policy classification, resolution, replay, and persistence concerns.

This is a hard internal cut: the old production scan and `resolve_stale_plugin_overlaps` path are removed. The public transaction API is unchanged.

## Performance

Release probe, 5,000 prepared keys, 5,000 concurrent keys, 2,500 overlaps, 8 rounds:

- before nested scan p50: 112,658 µs
- after indexed scan p50: 698 µs
- speedup: 161.30×

The probe asserts identical overlap membership and prepared-row order before timing.

## Validation

- `cargo test -p lix_engine --features all-simulations` (1,705 unit tests, 802 integration simulations, doctests)
- `cargo test -p lix_sdk_tests --test e2e same_base_ -- --nocapture`
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p lix_engine --release stale_overlap_discovery_benchmark_probe --lib -- --ignored --nocapture`

Stack 1 of the transaction/conflict-resolution performance and maintainability series.
