### PR TITLE
perf(engine): avoid full parent delta scans in undo

### DIFF
--- a/.changenotes/undo-semantic-point-reads.md
+++ b/.changenotes/undo-semantic-point-reads.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Reduced undo history classification to commit-delta schema bounds and one exact operation-marker read. Inspecting an undo target no longer scans its parent commit's full delta.

--- a/packages/engine-benchmarks/benches/undo_redo.rs
+++ b/packages/engine-benchmarks/benches/undo_redo.rs
@@ -82,6 +82,50 @@ fn seeded_sparse_gap_storage(runtime: &tokio::runtime::Runtime, history_depth: u
     })
 }
 
+fn seeded_wide_parent_storage(runtime: &tokio::runtime::Runtime, parent_width: usize) -> Vec<u8> {
+    runtime.block_on(async move {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("benchmark storage initializes");
+        let engine = Engine::new(storage.clone())
+            .await
+            .expect("benchmark engine opens");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("benchmark session opens");
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('target-key', 'before')",
+                &[],
+            )
+            .await
+            .expect("benchmark target starts");
+        let values = (0..parent_width)
+            .map(|index| format!("('noise-{index}', '{index}')"))
+            .collect::<Vec<_>>()
+            .join(",");
+        session
+            .execute(
+                &format!("INSERT INTO lix_key_value (key, value) VALUES {values}"),
+                &[],
+            )
+            .await
+            .expect("wide parent commit succeeds");
+        session
+            .execute(
+                "UPDATE lix_key_value SET value = 'after' WHERE key = 'target-key'",
+                &[],
+            )
+            .await
+            .expect("benchmark target update succeeds");
+        storage
+            .export_snapshot()
+            .expect("benchmark storage snapshot exports")
+    })
+}
+
 fn open_session(
     runtime: &tokio::runtime::Runtime,
     storage: Memory,
@@ -179,6 +223,34 @@ fn benchmark_undo_redo(criterion: &mut Criterion) {
                         runtime
                             .block_on(session.redo())
                             .expect("benchmarked redo succeeds");
+                        elapsed += started.elapsed();
+                    }
+                    elapsed
+                });
+            },
+        );
+    }
+    group.finish();
+
+    let mut group = criterion.benchmark_group("undo_wide_parent_delta");
+    for parent_width in [10_usize, 1_000] {
+        let snapshot = seeded_wide_parent_storage(&runtime, parent_width);
+        group.bench_with_input(
+            BenchmarkId::new("undo", parent_width),
+            &parent_width,
+            |benchmark, _| {
+                benchmark.iter_custom(|iterations| {
+                    let mut elapsed = Duration::ZERO;
+                    for _ in 0..iterations {
+                        let session = open_session(
+                            &runtime,
+                            Memory::from_snapshot(&snapshot)
+                                .expect("wide-parent benchmark snapshot restores"),
+                        );
+                        let started = Instant::now();
+                        runtime
+                            .block_on(session.undo())
+                            .expect("benchmarked wide-parent undo succeeds");
                         elapsed += started.elapsed();
                     }
                     elapsed

--- a/packages/engine/src/session/undo_redo.rs
+++ b/packages/engine/src/session/undo_redo.rs
@@ -187,9 +187,70 @@ where
     S: Storage + Clone + Send + Sync + 'static,
 {
     let record = load_commit_record(transaction, commit_id).await?;
-    semantic_state_for_record(transaction, branch_id, commit_id, &record)
-        .await
-        .map(|(state, _)| state)
+    if record.parent_commit_ids.len() != 1 {
+        return Ok(SemanticState::default());
+    }
+    let keys = semantic_keys(branch_id)?;
+    let marker_schemas = [
+        CHECKPOINT_MARKER_SCHEMA_KEY.to_string(),
+        UNDO_REDO_MARKER_SCHEMA_KEY.to_string(),
+    ];
+    let marker_delta = {
+        let mut tracked = transaction.tracked_state_reader().await;
+        tracked
+            .commit_delta_values_for_schemas(commit_id, &marker_schemas)
+            .await?
+    };
+    let mut has_checkpoint = false;
+    let mut has_foreign_operation = false;
+    let mut has_local_operation = false;
+    for row in marker_delta.iter().filter(|row| !row.value().deleted) {
+        let key = row.key_ref();
+        match key.schema_key {
+            CHECKPOINT_MARKER_SCHEMA_KEY => has_checkpoint = true,
+            UNDO_REDO_MARKER_SCHEMA_KEY if key.entity_pk == &keys[1].entity_pk => {
+                has_local_operation = true;
+            }
+            UNDO_REDO_MARKER_SCHEMA_KEY => has_foreign_operation = true,
+            _ => {}
+        }
+    }
+    if has_checkpoint || has_foreign_operation {
+        return Ok(SemanticState::default());
+    }
+    if !has_local_operation {
+        return Ok(SemanticState {
+            undo_top: Some(commit_id),
+            redo_top: None,
+            redo_target: None,
+            redo_next: None,
+        });
+    }
+    let marker = operation_marker_at(transaction, branch_id, commit_id)
+        .await?
+        .ok_or_else(|| missing_operation_marker(commit_id))?;
+    Ok(semantic_state_from_marker(marker, commit_id))
+}
+
+fn semantic_keys(branch_id: &str) -> Result<[TrackedStateKey; 2], LixError> {
+    let branch_pk = EntityPk::uuid_from_canonical(branch_id).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INVALID_PARAM,
+            format!("undo branch id must be a canonical UUID: {error}"),
+        )
+    })?;
+    Ok([
+        TrackedStateKey {
+            schema_key: CHECKPOINT_MARKER_SCHEMA_KEY.to_string(),
+            file_id: None,
+            entity_pk: branch_pk.clone(),
+        },
+        TrackedStateKey {
+            schema_key: UNDO_REDO_MARKER_SCHEMA_KEY.to_string(),
+            file_id: None,
+            entity_pk: branch_pk,
+        },
+    ])
 }
 
 async fn semantic_state_for_record<S>(
@@ -211,24 +272,7 @@ where
         return Ok((SemanticState::default(), Vec::new()));
     }
 
-    let branch_pk = EntityPk::uuid_from_canonical(branch_id).map_err(|error| {
-        LixError::new(
-            LixError::CODE_INVALID_PARAM,
-            format!("undo branch id must be a canonical UUID: {error}"),
-        )
-    })?;
-    let keys = [
-        TrackedStateKey {
-            schema_key: CHECKPOINT_MARKER_SCHEMA_KEY.to_string(),
-            file_id: None,
-            entity_pk: branch_pk.clone(),
-        },
-        TrackedStateKey {
-            schema_key: UNDO_REDO_MARKER_SCHEMA_KEY.to_string(),
-            file_id: None,
-            entity_pk: branch_pk,
-        },
-    ];
+    let keys = semantic_keys(branch_id)?;
     let delta = load_commit_delta(transaction, commit_id).await?;
     if delta
         .iter()
@@ -273,7 +317,12 @@ where
         return Err(missing_operation_marker(commit_id));
     }
     let marker = parse_marker(row.snapshot_content(), commit_id)?;
-    let state = match marker.kind {
+    let state = semantic_state_from_marker(marker, commit_id);
+    Ok((state, delta))
+}
+
+fn semantic_state_from_marker(marker: UndoRedoMarker, commit_id: CommitId) -> SemanticState {
+    match marker.kind {
         UndoRedoKind::Undo => SemanticState {
             undo_top: marker.undo_target_after,
             redo_top: Some(commit_id),
@@ -286,8 +335,7 @@ where
             redo_target: None,
             redo_next: None,
         },
-    };
-    Ok((state, delta))
+    }
 }
 
 async fn operation_marker_at<S>(

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -1240,6 +1240,17 @@ where
         storage::scan_commit_delta_members(&self.store, commit_id).await
     }
 
+    /// Loads only the requested schema ranges from one commit delta. Semantic
+    /// classification uses this to avoid hydrating unrelated commit members.
+    pub(crate) async fn commit_delta_values_for_schemas(
+        &mut self,
+        commit_id: CommitId,
+        schema_keys: &[String],
+    ) -> Result<storage::DecodedCommitDeltaBatch, LixError> {
+        self.scan_replayed_commit_delta_values(commit_id, schema_keys)
+            .await
+    }
+
     /// True only for the sparse immutable checkpoints. A false result does
     /// not mean the commit is unreadable: ordinary v4 commits replay their
     /// first-parent changelog interval on the cold historical path.


### PR DESCRIPTION
## Summary

- classify undo history from the checkpoint and undo/redo marker schema ranges instead of hydrating the parent commit's entire delta
- retain the full head-delta load only on the path that applies an undo
- add a benchmark covering narrow and wide parent commits

This is the performance follow-up to #1085. That PR is merged, so this branch is based directly on `main`.

## Performance

`undo_wide_parent_delta/undo` (Criterion, in-memory snapshot restored per iteration):

| Parent delta members | Before | After | Result |
| ---: | ---: | ---: | ---: |
| 10 | 2.41 ms | 2.43 ms | within noise |
| 1,000 | 2.89 ms | 2.47 ms | 14.9% faster |

The optimization avoids work proportional to unrelated values in the parent commit without adding storage metadata or changing the persisted format.

## Verification

- `cargo test -p lix_engine --features all-simulations`
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- targeted undo/redo tests: checkpoint and merge floors, redo invalidation, branch-fork reset, untracked descriptor protection, and persistence across sessions
- persisted CLI smoke: commit → undo → redo; undo → new commit → redo rejected; multiple operations; reopen between operations; explicit `--branch`
- persisted JS SDK smoke: the equivalent reopen, redo invalidation, multiple-operation, and branch-isolation workflows
