### PR TITLE
Optimize durable media storage flow

### DIFF
--- a/.changenotes/media-storage-domains.md
+++ b/.changenotes/media-storage-domains.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Media file transfers now use durable atomic publication, raw immutable SlateDB payload segments, bounded HTTP response bodies, and ordinal CAS range reads without duplicating temporary upload metadata.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3533,7 +3533,6 @@ dependencies = [
  "slatedb-common",
  "tempfile",
  "tokio",
- "zstd",
 ]
 
 [[package]]

--- a/packages/engine-benchmarks/MOVIE_WORKSPACE.md
+++ b/packages/engine-benchmarks/MOVIE_WORKSPACE.md
@@ -1,0 +1,27 @@
+# Movie workspace qualification
+
+The release qualification models the 1 TiB media-inclusive happy path with
+resumable ingest, two concurrent 100 Mbit/s proxy readers, 5,000 project
+history commits, and concurrent project saves. Run the local SlateDB profile
+with:
+
+```sh
+cargo test -p lix_engine_benchmarks \
+  --features 'storage-benches slatedb' \
+  --test movie_workspace_qualification \
+  slatedb_movie_workspace_interference \
+  --release -- --ignored --nocapture
+```
+
+On 2026-08-01, the raw-only immutable-payload build measured the following on
+the local filesystem-backed SlateDB fixture:
+
+| CAS chunk | Save p95 | Late proxy reads | Ingest |
+| --- | ---: | ---: | ---: |
+| 1 MiB | 103.126 ms | 0 / 0 | 153.1 MiB/s |
+| 4 MiB | 103.470 ms | 0 / 0 | 153.1 MiB/s |
+
+SlateDB coalesces sequential immutable chunks into 64 MiB sidecar segments in
+this workload, so the larger CAS unit did not improve ingest and slightly
+regressed save p95. The engine therefore retains 1 MiB chunks; remote
+object-store latency profiles may justify revisiting the choice.

--- a/packages/engine/src/binary_cas/chunking.rs
+++ b/packages/engine/src/binary_cas/chunking.rs
@@ -1,5 +1,9 @@
 pub(super) const SINGLE_CHUNK_FAST_PATH_MAX_BYTES: usize = 64 * 1024;
 pub(super) const MAX_BINARY_CAS_CHUNK_BYTES: usize = 4096 * 1024;
+// SlateDB packs sequential immutable payloads into 64 MiB sidecar segments.
+// The local mixed movie profile in engine-benchmarks/MOVIE_WORKSPACE.md was
+// showed no ingest gain at 4 MiB and a slightly worse save p95; retain the
+// smaller seek unit until a remote profile demonstrates a material win.
 pub(crate) const MEDIA_CHUNK_BYTES: usize = 1024 * 1024;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/packages/engine/src/binary_cas/context.rs
+++ b/packages/engine/src/binary_cas/context.rs
@@ -84,6 +84,14 @@ impl BinaryCasContext {
         }
     }
 
+    pub(crate) fn prepared_manifest_is_staged(
+        &self,
+        writes: &StorageWriteSet,
+        blob_id: BlobId,
+    ) -> bool {
+        writes.contains_put(super::kv::BINARY_CAS_MANIFEST_SPACE, blob_id.as_bytes())
+    }
+
     /// Creates a Binary CAS reader over any storage reader.
     ///
     /// The reader can be a read transaction or the active write transaction

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -165,6 +165,39 @@ async fn load_declared_manifest_chunks(
         .collect()
 }
 
+/// Loads one ordinal interval from a fixed-size media manifest.
+async fn load_declared_manifest_chunk_range(
+    store: &(impl StorageAdapterRead + ?Sized),
+    blob_hash: BlobId,
+    start_index: u64,
+    end_index: u64,
+) -> Result<Vec<KvBlobManifestChunk>, LixError> {
+    if start_index >= end_index {
+        return Ok(Vec::new());
+    }
+    let range = StorageKeyRange {
+        lower: Bound::Included(StorageKey(Bytes::from(manifest_chunk_key(
+            blob_hash,
+            start_index,
+        )))),
+        upper: Bound::Excluded(StorageKey(Bytes::from(manifest_chunk_key(
+            blob_hash, end_index,
+        )))),
+    };
+    let plan = ScanPlan::range(BINARY_CAS_MANIFEST_CHUNK_SPACE, range);
+    scan_all_values_for_plan(store, &plan)
+        .await?
+        .into_iter()
+        .map(|value| {
+            let (chunk_hash, chunk_size) = decode_binary_cas_manifest_chunk(&value)?;
+            Ok(KvBlobManifestChunk {
+                chunk_hash,
+                chunk_size,
+            })
+        })
+        .collect()
+}
+
 pub(crate) fn stage_manifest_chunk(
     writes: &mut StorageWriteSet,
     blob_hash: BlobId,
@@ -728,32 +761,75 @@ async fn load_blob_range(
             decoded[start..end].to_vec()
         }
         BlobLayout::Chunked { chunk_count } => {
-            let manifest =
-                load_declared_manifest_chunks(store, metadata.hash, *chunk_count).await?;
-            if manifest.len() != *chunk_count as usize {
+            let fixed_chunk_bytes = crate::binary_cas::chunking::MEDIA_CHUNK_BYTES as u64;
+            let first_chunk_index = range.start / fixed_chunk_bytes;
+            let end_chunk_index = range
+                .end
+                .div_ceil(fixed_chunk_bytes)
+                .min(u64::from(*chunk_count));
+            let manifest = load_declared_manifest_chunk_range(
+                store,
+                metadata.hash,
+                first_chunk_index,
+                end_chunk_index,
+            )
+            .await?;
+            let expected_manifest_len = usize::try_from(end_chunk_index - first_chunk_index)
+                .map_err(|_| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "binary CAS selected manifest range exceeds this runtime",
+                    )
+                })?;
+            if manifest.len() != expected_manifest_len {
                 return Err(LixError::new(
                     "LIX_ERROR_UNKNOWN",
                     format!(
-                        "binary CAS blob '{}' expected {} chunks, found {}",
+                        "binary CAS blob '{}' expected {} selected chunks, found {}",
                         metadata.hash.to_hex(),
-                        chunk_count,
+                        expected_manifest_len,
                         manifest.len()
                     ),
                 ));
             }
-            let mut selected = Vec::new();
-            let mut offset = 0u64;
-            for chunk in manifest {
-                let chunk_end = offset.checked_add(chunk.chunk_size).ok_or_else(|| {
+            let mut selected = Vec::with_capacity(manifest.len());
+            for (selected_index, chunk) in manifest.into_iter().enumerate() {
+                let chunk_index = first_chunk_index
+                    + u64::try_from(selected_index).map_err(|_| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            "binary CAS selected chunk index exceeds u64",
+                        )
+                    })?;
+                let chunk_start = chunk_index.checked_mul(fixed_chunk_bytes).ok_or_else(|| {
                     LixError::new("LIX_ERROR_UNKNOWN", "binary CAS chunk offsets overflow u64")
                 })?;
-                if offset < range.end && chunk_end > range.start {
-                    selected.push((offset, chunk));
+                let expected_chunk_size = if chunk_index + 1 == u64::from(*chunk_count) {
+                    metadata
+                        .size_bytes
+                        .checked_sub(chunk_start)
+                        .ok_or_else(|| {
+                            LixError::new(
+                                "LIX_ERROR_UNKNOWN",
+                                "binary CAS final chunk starts beyond the declared blob size",
+                            )
+                        })?
+                } else {
+                    fixed_chunk_bytes
+                };
+                if chunk.chunk_size != expected_chunk_size {
+                    return Err(LixError::new(
+                        "LIX_ERROR_UNKNOWN",
+                        format!(
+                            "binary CAS blob '{}' chunk {} has size {}, expected {}",
+                            metadata.hash.to_hex(),
+                            chunk_index,
+                            chunk.chunk_size,
+                            expected_chunk_size,
+                        ),
+                    ));
                 }
-                offset = chunk_end;
-                if offset >= range.end {
-                    break;
-                }
+                selected.push((chunk_start, chunk));
             }
             let hashes = selected
                 .iter()
@@ -2720,6 +2796,31 @@ mod tests {
         assert_eq!(actual.range, requested.clone());
         assert_eq!(
             actual.bytes,
+            data[requested.start as usize..requested.end as usize]
+        );
+
+        let mut writes = storage.new_write_set();
+        writes.delete(
+            BINARY_CAS_MANIFEST_CHUNK_SPACE,
+            manifest_chunk_key(blob_hash, 2),
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("remove manifest row outside selected range");
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("second ranged read should open");
+        let selected = load_ranges_many(&store, &[(blob_hash, requested.clone())])
+            .await
+            .expect("range read must not visit unselected manifest rows")
+            .into_vec()
+            .pop()
+            .flatten()
+            .expect("selected range should exist");
+        assert_eq!(
+            selected.bytes,
             data[requested.start as usize..requested.end as usize]
         );
     }

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -5,6 +5,7 @@ use std::ops::Range;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 
+use crate::binary_cas::BlobId;
 use crate::branch::BranchRefReader;
 use crate::common::ExecuteStatementMetadata;
 use crate::functions::{FunctionContext, FunctionProviderHandle};
@@ -84,6 +85,7 @@ pub struct FileRead {
     data: Blob,
     total_size: u64,
     range: Range<u64>,
+    content_identity: String,
 }
 
 impl FileRead {
@@ -101,6 +103,10 @@ impl FileRead {
 
     pub fn range(&self) -> Range<u64> {
         self.range.clone()
+    }
+
+    pub fn content_identity(&self) -> &str {
+        &self.content_identity
     }
 }
 
@@ -2074,7 +2080,16 @@ fn native_file_read_from_exact_result(
             .map(|data| materialize_file_read(data, None))
             .transpose();
     }
-    if result.columns.as_slice() != ["path", "data", "total_size", "range_start", "range_end"] {
+    if result.columns.as_slice()
+        != [
+            "path",
+            "data",
+            "total_size",
+            "range_start",
+            "range_end",
+            "content_identity",
+        ]
+    {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
             "native ranged file read returned an unexpected result schema",
@@ -2096,6 +2111,7 @@ fn native_file_read_from_exact_result(
         Value::Integer(total_size),
         Value::Integer(range_start),
         Value::Integer(range_end),
+        Value::Text(content_identity),
     ] = row.as_mut_slice()
     else {
         return Err(LixError::new(
@@ -2140,6 +2156,7 @@ fn native_file_read_from_exact_result(
         data,
         total_size,
         range: range_start..range_end,
+        content_identity: std::mem::take(content_identity),
     }))
 }
 
@@ -2201,6 +2218,7 @@ fn materialize_file_read(
             "native file size does not fit the public 64-bit range",
         )
     })?;
+    let content_identity = BlobId::from_content(data.as_ref()).to_hex();
     let range = match requested_range {
         None => 0..total_size,
         Some(range) => {
@@ -2227,6 +2245,7 @@ fn materialize_file_read(
         data,
         total_size,
         range,
+        content_identity,
     })
 }
 

--- a/packages/engine/src/session/media_upload.rs
+++ b/packages/engine/src/session/media_upload.rs
@@ -2,11 +2,11 @@ use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::ops::Bound;
 
-use crate::binary_cas::{BlobChunkReceipt, BlobId, BlobLayout, BlobWriteReceipt, ChunkHash};
+use crate::binary_cas::{BlobChunkReceipt, ChunkHash};
 use crate::storage_adapter::{
     MAX_SCAN_PAGE_ROWS, Storage, StorageCoreProjection, StorageGetManyRequest, StorageGetOptions,
-    StorageKey, StorageKeyRange, StorageProjectedValue, StorageReadOptions, StorageScanOptions,
-    StorageSpace, StorageSpaceId, StorageValue, StorageWriteOptions,
+    StorageKey, StorageKeyRange, StoragePrecondition, StorageProjectedValue, StorageReadOptions,
+    StorageScanOptions, StorageSpace, StorageSpaceId, StorageValue, StorageWriteOptions,
 };
 use crate::transaction::{begin_commit_boundary, commit_at_boundary};
 use crate::{Blob, LixError};
@@ -28,15 +28,25 @@ pub struct FileUploadProgress {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct UploadState {
-    version: u8,
+#[serde(tag = "state", rename_all = "snake_case")]
+enum UploadState {
+    Open(UploadOpen),
+    Complete(UploadComplete),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct UploadOpen {
     path: String,
     total_size: u64,
     next_offset: u64,
     chunk_count: u32,
-    first_chunk_hash: Option<[u8; 32]>,
-    complete_hash: Option<[u8; 32]>,
-    published: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct UploadComplete {
+    path: String,
+    total_size: u64,
+    blob_id: [u8; 32],
 }
 
 impl<StorageImpl> SessionContext<StorageImpl>
@@ -65,18 +75,44 @@ where
             .storage
             .begin_read(StorageReadOptions::default())
             .await?;
-        let mut state = load_upload_state(&read, &state_key)
-            .await?
-            .unwrap_or(UploadState {
-                version: 1,
-                path: path.clone(),
-                total_size,
-                next_offset: 0,
-                chunk_count: 0,
-                first_chunk_hash: None,
-                complete_hash: None,
-                published: false,
-            });
+        let loaded_state = load_upload_state(&read, &state_key).await?;
+        let (mut state, state_precondition) = match loaded_state {
+            Some(UploadState::Complete(complete)) => {
+                if complete.path != path || complete.total_size != total_size {
+                    return Err(invalid_upload(
+                        "upload id is already bound to a different path or size",
+                    ));
+                }
+                return Ok(FileUploadProgress {
+                    next_offset: complete.total_size,
+                    total_size: complete.total_size,
+                    finalized: true,
+                });
+            }
+            Some(UploadState::Open(state)) => {
+                let expected = encode_upload_state(&UploadState::Open(state.clone()))?;
+                (
+                    state,
+                    StoragePrecondition::KeyValueEquals {
+                        space: UPLOAD_STATE_SPACE.id,
+                        key: state_key.clone(),
+                        expected: Bytes::from(expected),
+                    },
+                )
+            }
+            None => (
+                UploadOpen {
+                    path: path.clone(),
+                    total_size,
+                    next_offset: 0,
+                    chunk_count: 0,
+                },
+                StoragePrecondition::KeyAbsent {
+                    space: UPLOAD_STATE_SPACE.id,
+                    key: state_key.clone(),
+                },
+            ),
+        };
         if state.path != path || state.total_size != total_size {
             return Err(invalid_upload(
                 "upload id is already bound to a different path or size",
@@ -84,7 +120,9 @@ where
         }
         if start < state.next_offset {
             drop(write_access);
-            return self.publish_completed_upload(state_key, state).await;
+            return self
+                .publish_completed_upload(upload_id, state_key, state)
+                .await;
         }
         if start != state.next_offset {
             return Err(invalid_upload(
@@ -104,9 +142,6 @@ where
         drop(writer);
         let part_chunk_start = state.chunk_count;
         for (part_index, receipt) in part_receipts.iter().enumerate() {
-            if state.first_chunk_hash.is_none() {
-                state.first_chunk_hash = Some(receipt.hash.into_bytes());
-            }
             let index = part_chunk_start
                 .checked_add(
                     u32::try_from(part_index)
@@ -126,21 +161,23 @@ where
             .next_offset
             .checked_add(data.len() as u64)
             .ok_or_else(|| invalid_upload("upload offset exceeds u64"))?;
-        if state.next_offset == state.total_size {
-            let mut receipts = load_upload_chunks(&read, &upload_id, part_chunk_start).await?;
-            receipts.extend(part_receipts);
-            let mut writer = self
-                .binary_cas
-                .writer_skipping_existing_chunks(&read, &mut writes);
-            let receipt = writer.stage_fixed_manifest(&receipts)?;
-            state.complete_hash = Some(receipt.hash.into_bytes());
-        }
-        stage_upload_state(&mut writes, state_key.clone(), &state)?;
+        stage_upload_state(
+            &mut writes,
+            state_key.clone(),
+            &UploadState::Open(state.clone()),
+        )?;
         let commit_boundary = self.transaction_commit_boundary();
         let _commit_guard = begin_commit_boundary(Some(&commit_boundary));
         let prepared = self
             .storage
-            .prepare_write_set(writes, StorageWriteOptions::default())
+            .prepare_write_set(
+                writes,
+                StorageWriteOptions {
+                    preconditions: vec![state_precondition],
+                    await_durable: true,
+                    ..StorageWriteOptions::default()
+                },
+            )
             .await?;
         let stats = commit_at_boundary(Some(&commit_boundary), || async move {
             let (_, stats) = prepared.commit().await?;
@@ -149,27 +186,66 @@ where
         .await?;
         self.observe_invalidation.bump_if_storage_changed(&stats);
         drop(write_access);
-        self.publish_completed_upload(state_key, state).await
+        self.publish_completed_upload(upload_id, state_key, state)
+            .await
     }
 
     async fn publish_completed_upload(
         &self,
+        upload_id: String,
         state_key: StorageKey,
-        mut state: UploadState,
+        state: UploadOpen,
     ) -> Result<FileUploadProgress, LixError> {
-        if state.complete_hash.is_none() || state.published {
+        if state.next_offset != state.total_size {
             return Ok(FileUploadProgress {
                 next_offset: state.next_offset,
                 total_size: state.total_size,
-                finalized: state.published,
+                finalized: false,
             });
         }
-        let receipt = state.blob_receipt()?;
+        let read = self
+            .storage
+            .begin_read(StorageReadOptions::default())
+            .await?;
+        let receipts = load_upload_chunks(&read, &upload_id, state.chunk_count).await?;
+        let mut finalization_writes = self.storage.new_write_set();
+        finalization_writes
+            .delete_range_exclusive(UPLOAD_CHUNK_SPACE, upload_chunk_range(&upload_id)?)
+            .map_err(LixError::from)?;
+        let receipt = self
+            .binary_cas
+            .writer_skipping_existing_chunks(&read, &mut finalization_writes)
+            .stage_fixed_manifest(&receipts)?;
+        let complete = UploadState::Complete(UploadComplete {
+            path: state.path.clone(),
+            total_size: state.total_size,
+            blob_id: receipt.hash.into_bytes(),
+        });
+        let publication_blob_id = receipt.hash;
+        let expected_blob_id = receipt.hash.into_bytes();
+        stage_upload_state(&mut finalization_writes, state_key.clone(), &complete)?;
+        let expected_open = encode_upload_state(&UploadState::Open(state.clone()))?;
+        let finalization_preconditions = vec![StoragePrecondition::KeyValueEquals {
+            space: UPLOAD_STATE_SPACE.id,
+            key: state_key,
+            expected: Bytes::from(expected_open),
+        }];
+        drop(read);
         let path = state.path.clone();
         let write_access = self.begin_session_write_access().await?;
-        self.with_write_transaction_reserved(write_access, |transaction| {
-            Box::pin(async move {
-                crate::sql2::execute_fast_lix_file_prepared_path_write(transaction, path, receipt)
+        let publish_result = self
+            .with_write_transaction_reserved(write_access, |transaction| {
+                Box::pin(async move {
+                    transaction.stage_atomic_cas_publication(
+                        finalization_writes,
+                        finalization_preconditions,
+                        publication_blob_id,
+                    )?;
+                    crate::sql2::execute_fast_lix_file_prepared_path_write(
+                        transaction,
+                        path,
+                        receipt,
+                    )
                     .await?
                     .ok_or_else(|| {
                         LixError::new(
@@ -177,49 +253,33 @@ where
                             "resumable file publication requires an unambiguous filesystem layout",
                         )
                     })
+                })
             })
-        })
-        .await?;
-
-        state.published = true;
-        let write_access = self.begin_session_write_access().await?;
-        let mut writes = self.storage.new_write_set();
-        stage_upload_state(&mut writes, state_key, &state)?;
-        let prepared = self
-            .storage
-            .prepare_write_set(writes, StorageWriteOptions::default())
-            .await?;
-        let (_, stats) = prepared.commit().await?;
-        self.observe_invalidation.bump_if_storage_changed(&stats);
-        drop(write_access);
+            .await;
+        if let Err(error) = publish_result {
+            let read = self
+                .storage
+                .begin_read(StorageReadOptions::default())
+                .await?;
+            if matches!(
+                load_upload_state(&read, &upload_state_key(&upload_id)?).await?,
+                Some(UploadState::Complete(complete))
+                    if complete.path == state.path
+                        && complete.total_size == state.total_size
+                        && complete.blob_id == expected_blob_id
+            ) {
+                return Ok(FileUploadProgress {
+                    next_offset: state.total_size,
+                    total_size: state.total_size,
+                    finalized: true,
+                });
+            }
+            return Err(error);
+        }
         Ok(FileUploadProgress {
             next_offset: state.next_offset,
             total_size: state.total_size,
             finalized: true,
-        })
-    }
-}
-
-impl UploadState {
-    fn blob_receipt(&self) -> Result<BlobWriteReceipt, LixError> {
-        let hash = self
-            .complete_hash
-            .map(BlobId::from_bytes)
-            .ok_or_else(|| invalid_upload("upload has no complete manifest"))?;
-        let layout = match self.chunk_count {
-            0 => BlobLayout::Empty,
-            1 => BlobLayout::SingleChunk {
-                chunk_hash: ChunkHash::from_bytes(
-                    self.first_chunk_hash
-                        .ok_or_else(|| invalid_upload("upload is missing its first chunk"))?,
-                ),
-            },
-            chunk_count => BlobLayout::Chunked { chunk_count },
-        };
-        Ok(BlobWriteReceipt {
-            hash,
-            size_bytes: self.total_size,
-            layout,
         })
     }
 }
@@ -297,12 +357,7 @@ fn stage_upload_state(
     key: StorageKey,
     state: &UploadState,
 ) -> Result<(), LixError> {
-    let value = serde_json::to_vec(state).map_err(|error| {
-        LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!("encode file upload state: {error}"),
-        )
-    })?;
+    let value = encode_upload_state(state)?;
     writes.put(
         UPLOAD_STATE_SPACE,
         key,
@@ -311,6 +366,15 @@ fn stage_upload_state(
         },
     );
     Ok(())
+}
+
+fn encode_upload_state(state: &UploadState) -> Result<Vec<u8>, LixError> {
+    serde_json::to_vec(state).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("encode file upload state: {error}"),
+        )
+    })
 }
 
 fn upload_chunk_prefix(upload_id: &str) -> Result<Vec<u8>, LixError> {
@@ -348,13 +412,7 @@ async fn load_upload_chunks(
     upload_id: &str,
     expected_count: u32,
 ) -> Result<Vec<BlobChunkReceipt>, LixError> {
-    let prefix = upload_chunk_prefix(upload_id)?;
-    let mut upper = prefix.clone();
-    upper.push(0xff);
-    let range = StorageKeyRange {
-        lower: Bound::Included(StorageKey(Bytes::from(prefix))),
-        upper: Bound::Excluded(StorageKey(Bytes::from(upper))),
-    };
+    let range = upload_chunk_range(upload_id)?;
     let mut receipts = Vec::with_capacity(expected_count as usize);
     let mut resume_after = None;
     loop {
@@ -414,6 +472,16 @@ async fn load_upload_chunks(
         ));
     }
     Ok(receipts)
+}
+
+fn upload_chunk_range(upload_id: &str) -> Result<StorageKeyRange, LixError> {
+    let prefix = upload_chunk_prefix(upload_id)?;
+    let mut upper = prefix.clone();
+    upper.push(0xff);
+    Ok(StorageKeyRange {
+        lower: Bound::Included(StorageKey(Bytes::from(prefix))),
+        upper: Bound::Excluded(StorageKey(Bytes::from(upper))),
+    })
 }
 
 fn invalid_upload(message: &'static str) -> LixError {
@@ -494,6 +562,35 @@ mod tests {
             boundary.data().as_ref(),
             [vec![0x31; 4], vec![0x72; 4]].concat().as_slice()
         );
+        let adapter = StorageAdapter::new(storage.clone());
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open upload cleanup read");
+        let temporary_receipts = read
+            .scan(
+                UPLOAD_CHUNK_SPACE.id,
+                upload_chunk_range("movie-proxy-1").expect("upload receipt range"),
+                StorageScanOptions {
+                    projection: StorageCoreProjection::KeyOnly,
+                    limit_rows: MAX_SCAN_PAGE_ROWS,
+                    resume_after: None,
+                },
+            )
+            .await
+            .expect("scan temporary upload receipts");
+        assert!(
+            temporary_receipts.entries.is_empty(),
+            "publication must atomically remove temporary chunk receipts",
+        );
+        drop(read);
+        let published_commit_id = resumed_session
+            .execute("SELECT lix_active_branch_commit_id() AS commit_id", &[])
+            .await
+            .expect("published branch head")
+            .rows()[0]
+            .get::<String>("commit_id")
+            .expect("published commit id");
 
         let replay = resumed_session
             .upsert_file_data_part(
@@ -507,6 +604,17 @@ mod tests {
             .expect("replay final part");
         assert!(replay.finalized);
         assert_eq!(replay.next_offset, total);
+        let replayed_commit_id = resumed_session
+            .execute("SELECT lix_active_branch_commit_id() AS commit_id", &[])
+            .await
+            .expect("replayed branch head")
+            .rows()[0]
+            .get::<String>("commit_id")
+            .expect("replayed commit id");
+        assert_eq!(
+            replayed_commit_id, published_commit_id,
+            "a completed upload replay must not publish duplicate history",
+        );
 
         resumed_session
             .upsert_file_data_part(

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -895,6 +895,7 @@ pub(crate) async fn execute_exact_lix_file_batch_read(
             "total_size".to_string(),
             "range_start".to_string(),
             "range_end".to_string(),
+            "content_identity".to_string(),
         ]
     } else {
         vec!["path".to_string(), "data".to_string()]
@@ -5384,6 +5385,21 @@ async fn exact_path_data_rows_from_prepared(
             .expect("prepared lix_file descriptor should have a path");
         let blob_key = file.blob_ref_key(&live_rows);
         if let Some(range) = data_range {
+            let content_identity = blob_rows
+                .get(&blob_key)
+                .map(|blob_ref| blob_ref.blob_hash.clone())
+                .or_else(|| {
+                    derived_rows
+                        .get(&blob_key)
+                        .map(|derived| derived.sha256.clone())
+                })
+                .or_else(|| {
+                    live_rows
+                        .row(file.live)
+                        .change_id()
+                        .map(|change_id| change_id.to_string())
+                })
+                .unwrap_or_else(|| file.id.clone());
             let selected = match blob_ranges.take(&blob_key) {
                 Some(data) => data,
                 None => match rendered_plugin_bytes.remove(&key) {
@@ -5404,6 +5420,7 @@ async fn exact_path_data_rows_from_prepared(
                     Value::Null,
                     Value::Null,
                     Value::Null,
+                    Value::Null,
                 ]);
                 continue;
             };
@@ -5419,6 +5436,7 @@ async fn exact_path_data_rows_from_prepared(
                 Value::Integer(i64::try_from(selected.range.end).map_err(|_| {
                     LixError::new(LixError::CODE_INTERNAL_ERROR, "file range exceeds SQL i64")
                 })?),
+                Value::Text(content_identity),
             ]);
         } else {
             let data = match blob_bytes.take(&blob_key) {
@@ -5447,6 +5465,16 @@ async fn exact_path_data_rows_from_prepared(
 fn materialize_vec_range(data: Vec<u8>, requested: Range<u64>) -> Result<BlobRangeBytes, LixError> {
     let total_size = u64::try_from(data.len())
         .map_err(|_| LixError::new(LixError::CODE_INTERNAL_ERROR, "file size exceeds u64"))?;
+    // A zero-width result is the metadata-bearing representation of a
+    // present empty file. It lets bounded download callers distinguish that
+    // file from a missing path without materializing an unbounded read first.
+    if total_size == 0 && requested.start == 0 {
+        return Ok(BlobRangeBytes {
+            bytes: Vec::new(),
+            total_size,
+            range: 0..0,
+        });
+    }
     if requested.start >= requested.end || requested.start >= total_size {
         return Err(LixError::new(
             LixError::CODE_INVALID_PARAM,

--- a/packages/engine/src/storage/types.rs
+++ b/packages/engine/src/storage/types.rs
@@ -321,6 +321,9 @@ pub enum ReadConsistency {
 pub struct WriteOptions {
     pub base_snapshot: Option<SnapshotRef>,
     pub idempotency_key: Option<Bytes>,
+    /// Do not acknowledge the commit until the backend has crossed its
+    /// durable persistence boundary.
+    pub await_durable: bool,
     /// Conditions evaluated atomically against the state immediately before
     /// this write becomes visible.
     pub preconditions: Vec<Precondition>,

--- a/packages/engine/src/storage_adapter/write_set.rs
+++ b/packages/engine/src/storage_adapter/write_set.rs
@@ -2,8 +2,8 @@ use std::collections::{HashMap, HashSet};
 use std::fmt;
 
 use crate::storage::{
-    BufferRange, CommitResult, EncodedMutationBatch, Key, PutBatch, PutEntry, SpaceId, Storage,
-    StorageError, StorageWrite, StoredValue, WriteOptions,
+    BufferRange, CommitResult, EncodedMutationBatch, Key, KeyRange, PutBatch, PutEntry, SpaceId,
+    Storage, StorageError, StorageWrite, StoredValue, WriteOptions,
 };
 use crate::storage_adapter::{StorageSpace, StorageWriteSetStats};
 use ahash::RandomState;
@@ -73,6 +73,7 @@ impl IntoStorageValue for &[u8] {
 pub struct StorageWriteSet {
     groups: Vec<StorageWriteGroup>,
     group_index: HashMap<SpaceId, usize, FastHashBuilder>,
+    exclusive_range_deletes: Vec<(StorageSpace, KeyRange)>,
     deferred_final_puts: Vec<Box<dyn DeferredFinalPutSource>>,
     stats: StorageWriteSetStats,
     // Domain stores can seal a write lane after planning a destructive sweep.
@@ -87,6 +88,7 @@ impl fmt::Debug for StorageWriteSet {
         formatter
             .debug_struct("StorageWriteSet")
             .field("groups", &self.groups)
+            .field("exclusive_range_deletes", &self.exclusive_range_deletes)
             .field(
                 "deferred_final_put_sources",
                 &self.deferred_final_puts.len(),
@@ -244,6 +246,7 @@ impl StorageWriteSet {
                 expected_spaces,
                 FastHashBuilder::with_seeds(0, 0, 0, 0),
             ),
+            exclusive_range_deletes: Vec::new(),
             deferred_final_puts: Vec::new(),
             stats: StorageWriteSetStats::default(),
             changelog_gc_sealed: false,
@@ -252,6 +255,7 @@ impl StorageWriteSet {
 
     pub fn is_empty(&self) -> bool {
         self.deferred_final_puts.is_empty()
+            && self.exclusive_range_deletes.is_empty()
             && self
                 .groups
                 .iter()
@@ -522,6 +526,41 @@ impl StorageWriteSet {
         self.stage_encoded_batch(space.into_storage_space(), batch);
     }
 
+    /// Stages one storage-native range deletion for a space with no other
+    /// mutations in this write set. Keeping the lane exclusive makes its
+    /// ordering and duplicate semantics unambiguous while avoiding millions
+    /// of materialized point-delete keys for temporary upload metadata.
+    pub(crate) fn delete_range_exclusive(
+        &mut self,
+        space: StorageSpace,
+        range: KeyRange,
+    ) -> Result<(), StorageWriteSetError> {
+        let has_points = self
+            .group_index
+            .get(&space.id)
+            .and_then(|index| self.groups.get(*index))
+            .is_some_and(|group| !group.puts.is_empty() || !group.deletes.is_empty());
+        let has_range = self
+            .exclusive_range_deletes
+            .iter()
+            .any(|(existing, _)| existing.id == space.id);
+        let has_deferred = self.deferred_final_puts.iter().any(|source| {
+            source
+                .target_spaces()
+                .iter()
+                .any(|target| target.id == space.id)
+        });
+        if has_points || has_range || has_deferred {
+            return Err(StorageWriteSetError::DuplicateMutation {
+                space,
+                key: Key(Bytes::new()),
+            });
+        }
+        self.stats.touched_spaces += 1;
+        self.exclusive_range_deletes.push((space, range));
+        Ok(())
+    }
+
     /// Reserves capacity for a storage space's grouped puts and deletes.
     ///
     /// This is most useful with canonical construction, where domain stores can
@@ -556,6 +595,7 @@ impl StorageWriteSet {
     pub fn extend(&mut self, other: Self) {
         let Self {
             groups,
+            exclusive_range_deletes,
             deferred_final_puts,
             stats,
             changelog_gc_sealed,
@@ -566,6 +606,10 @@ impl StorageWriteSet {
             let space = group.space;
             let target = self.group_mut(space);
             target.append(group);
+        }
+        for (space, range) in exclusive_range_deletes {
+            self.delete_range_exclusive(space, range)
+                .expect("extended exclusive range-delete spaces remain exclusive");
         }
         for source in deferred_final_puts {
             for &space in source.target_spaces() {
@@ -645,6 +689,7 @@ impl StorageWriteSet {
     /// This performs the full duplicate/conflicting-declaration scan before
     /// lowering so the storage never receives ambiguous final mutations.
     pub fn validate(&self) -> Result<(), StorageWriteSetError> {
+        self.validate_exclusive_range_deletes()?;
         for group in &self.groups {
             if let Some(incoming) = group.conflicting_declarations.first() {
                 return Err(StorageWriteSetError::ConflictingSpaceDeclaration {
@@ -698,6 +743,7 @@ impl StorageWriteSet {
     /// duplicate by adjacent/merge comparison without cloning the keys or
     /// allocating a second full-workload hash table.
     fn validate_and_sort(&mut self) -> Result<(), StorageWriteSetError> {
+        self.validate_exclusive_range_deletes()?;
         for group in &self.groups {
             if let Some(incoming) = group.conflicting_declarations.first() {
                 return Err(StorageWriteSetError::ConflictingSpaceDeclaration {
@@ -740,10 +786,20 @@ impl StorageWriteSet {
     {
         let Self {
             groups,
+            exclusive_range_deletes,
             mut deferred_final_puts,
             mut stats,
             ..
         } = self;
+
+        for (space, range) in exclusive_range_deletes {
+            stats.delete_batches += 1;
+            stats.storage_calls += 1;
+            write
+                .delete_range(space.id, range)
+                .await
+                .map_err(StorageWriteSetError::Storage)?;
+        }
 
         for group in groups {
             #[cfg(feature = "storage-benches")]
@@ -858,6 +914,32 @@ impl StorageWriteSet {
         }
         group
     }
+
+    fn validate_exclusive_range_deletes(&self) -> Result<(), StorageWriteSetError> {
+        for (index, (space, _)) in self.exclusive_range_deletes.iter().enumerate() {
+            let conflicts_with_points = self
+                .group_index
+                .get(&space.id)
+                .and_then(|group_index| self.groups.get(*group_index))
+                .is_some_and(|group| !group.puts.is_empty() || !group.deletes.is_empty());
+            let conflicts_with_range = self.exclusive_range_deletes[index + 1..]
+                .iter()
+                .any(|(other, _)| other.id == space.id);
+            let conflicts_with_deferred = self.deferred_final_puts.iter().any(|source| {
+                source
+                    .target_spaces()
+                    .iter()
+                    .any(|target| target.id == space.id)
+            });
+            if conflicts_with_points || conflicts_with_range || conflicts_with_deferred {
+                return Err(StorageWriteSetError::DuplicateMutation {
+                    space: *space,
+                    key: Key(Bytes::new()),
+                });
+            }
+        }
+        Ok(())
+    }
 }
 
 fn validate_sorted_group(group: &StorageWriteGroup) -> Result<(), StorageWriteSetError> {
@@ -906,6 +988,7 @@ impl Default for StorageWriteSet {
         Self {
             groups: Vec::new(),
             group_index: HashMap::with_hasher(FastHashBuilder::with_seeds(0, 0, 0, 0)),
+            exclusive_range_deletes: Vec::new(),
             deferred_final_puts: Vec::new(),
             stats: StorageWriteSetStats::default(),
             changelog_gc_sealed: false,

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -94,7 +94,8 @@ use crate::sql2::{
 use crate::sql2::{SqlPlanningCache, SqlWriteExecutionContext};
 use crate::storage_adapter::Storage;
 use crate::storage_adapter::{
-    Memory, StoragePrecondition, StorageReadOptions, StorageWriteOptions, StorageWriteSetStats,
+    Memory, StoragePrecondition, StorageReadOptions, StorageWriteOptions, StorageWriteSet,
+    StorageWriteSetStats,
 };
 use crate::storage_adapter::{
     SharedStorageAdapterRead, StorageAdapter, StorageAdapterRead, StorageAdapterReadScope,
@@ -504,6 +505,12 @@ pub(crate) struct Transaction<StorageImpl: Storage + 'static = Memory> {
     trust_filesystem_planner: bool,
     origin_key: Option<SharedStr>,
     idempotency_receipt: Option<(crate::storage_adapter::StorageKey, Vec<u8>)>,
+    /// Storage-native metadata that must publish in the same backend commit as
+    /// this transaction's file rows and history. Resumable media finalization
+    /// uses this lane for its completed manifest and upload receipt.
+    atomic_metadata_writes: Option<StorageWriteSet>,
+    atomic_metadata_preconditions: Vec<StoragePrecondition>,
+    await_durable_commit: bool,
     session_file_views: SessionFileViews,
     pending_file_view_mutations: BTreeMap<SessionFileViewKey, SessionFileViewMutation>,
     pending_plugin_actor_publications: Vec<PendingPluginActorPublication>,
@@ -643,6 +650,33 @@ impl<StorageImpl> Transaction<StorageImpl>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
+    pub(crate) fn stage_atomic_cas_publication(
+        &mut self,
+        writes: StorageWriteSet,
+        preconditions: Vec<StoragePrecondition>,
+        blob_id: BlobId,
+    ) -> Result<(), LixError> {
+        if self.atomic_metadata_writes.is_some() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "atomic transaction metadata was staged more than once",
+            ));
+        }
+        if !self
+            .binary_cas
+            .prepared_manifest_is_staged(&writes, blob_id)
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "atomic CAS publication is missing its prepared manifest",
+            ));
+        }
+        self.atomic_metadata_writes = Some(writes);
+        self.atomic_metadata_preconditions.extend(preconditions);
+        self.await_durable_commit = true;
+        Ok(())
+    }
+
     fn opening_read(&self) -> SharedStorageAdapterRead<StorageImpl::Read<'static>> {
         self.opening_read.clone()
     }
@@ -1281,6 +1315,9 @@ where
                 trust_filesystem_planner: false,
                 origin_key: None,
                 idempotency_receipt: None,
+                atomic_metadata_writes: None,
+                atomic_metadata_preconditions: Vec::new(),
+                await_durable_commit: false,
                 session_file_views,
                 pending_file_view_mutations: BTreeMap::new(),
                 pending_plugin_actor_publications: Vec::new(),
@@ -1439,10 +1476,17 @@ where
         if tracked_state_changed {
             StorageAdapter::<StorageImpl>::stage_tracked_mutation_revision(&mut writes);
         }
+        if let Some(metadata_writes) = transaction.atomic_metadata_writes.take() {
+            writes.extend(metadata_writes);
+        }
         let mut write_options = StorageWriteOptions::default();
+        write_options.await_durable = transaction.await_durable_commit;
         write_options
             .preconditions
             .extend(materialization_preconditions);
+        write_options
+            .preconditions
+            .append(&mut transaction.atomic_metadata_preconditions);
         if requires_tracked_snapshot_fence {
             write_options.preconditions.push(
                 StorageAdapter::<StorageImpl>::tracked_mutation_revision_precondition(

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -32,6 +32,7 @@ use std::{
     collections::{HashMap, HashSet, VecDeque},
     convert::Infallible,
     future::Future,
+    io,
     mem::size_of,
     sync::{
         Arc, Mutex, Once,
@@ -101,6 +102,8 @@ const MAX_REQUEST_BLOB_CACHE_BYTES: usize = 16 * 1024 * 1024;
 /// blob retry path; request correctness never depends on cache admission.
 pub const DEFAULT_MAX_REQUEST_BLOB_CACHE_BYTES: usize = 128 * 1024 * 1024;
 const BLOB_BASE_MISSING_CODE: &str = "LIX_REMOTE_BLOB_BASE_MISSING";
+/// Maximum bytes held by one raw file-download response body at a time.
+const FILE_READ_STREAM_WINDOW_BYTES: u64 = 4 * 1024 * 1024;
 
 const SESSION_TOKEN_BYTES: usize = 32;
 const SESSION_TOKEN_HEX_LEN: usize = SESSION_TOKEN_BYTES * 2;
@@ -2128,24 +2131,82 @@ where
     let path = required_non_empty(request.path, "path")?;
     let requested_range = parse_single_file_range(&headers)?;
     let partial = requested_range.is_some();
+    let first_requested_range = requested_range
+        .as_ref()
+        .map(|range| {
+            range.start
+                ..range
+                    .end
+                    .min(range.start.saturating_add(FILE_READ_STREAM_WINDOW_BYTES))
+        })
+        .unwrap_or(0..FILE_READ_STREAM_WINDOW_BYTES);
+    let first_path = path.clone();
     let data = lease
-        .run_cancellable_read(
-            move |lix| async move { lix.read_file_data(path, requested_range).await },
-        )
+        .run_cancellable_read(move |lix| async move {
+            lix.read_file_data(first_path, Some(first_requested_range))
+                .await
+        })
         .await?;
-    let (found, body, file_range) = data.map_or_else(
-        || ("false", Bytes::new(), None),
-        |read| {
-            let range = read.range();
+    let (found, body, file_range) = match data {
+        None => ("false", axum::body::Body::empty(), None),
+        Some(read) => {
+            let first_range = read.range();
             let total_size = read.total_size();
-            (
-                "true",
-                read.into_data().into_bytes(),
-                Some((range, total_size)),
-            )
-        },
-    );
-    let mut response = Response::new(axum::body::Body::from(body));
+            let content_identity = read.content_identity().to_owned();
+            if partial && total_size == 0 {
+                return Err(ApiError::bad_request("file read range is not satisfiable"));
+            }
+            let response_range = requested_range
+                .as_ref()
+                .map(|range| range.start..range.end.min(total_size))
+                .unwrap_or(0..total_size);
+            let next_offset = first_range.end;
+            let end_offset = response_range.end;
+            let first = read.into_data().into_bytes();
+            let body_stream = async_stream::stream! {
+                yield Ok::<Bytes, io::Error>(first);
+                let mut next_offset = next_offset;
+                while next_offset < end_offset {
+                    let next_end = end_offset.min(
+                        next_offset.saturating_add(FILE_READ_STREAM_WINDOW_BYTES),
+                    );
+                    let read_path = path.clone();
+                    let read = match lease
+                        .run_cancellable_read(move |lix| async move {
+                            lix.read_file_data(read_path, Some(next_offset..next_end))
+                                .await
+                        })
+                        .await {
+                            Ok(Some(read)) => read,
+                            Ok(None) => {
+                                yield Err(io::Error::new(
+                                    io::ErrorKind::NotFound,
+                                    "file disappeared while its response was streaming",
+                                ));
+                                break;
+                            }
+                            Err(error) => {
+                                yield Err(file_stream_error(error));
+                                break;
+                            }
+                        };
+                    let actual_range = read.range();
+                    if read.content_identity() != content_identity {
+                        yield Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "file changed while its response was streaming",
+                        ));
+                        break;
+                    }
+                    next_offset = actual_range.end;
+                    yield Ok(read.into_data().into_bytes());
+                }
+            };
+            let body = axum::body::Body::from_stream(body_stream);
+            ("true", body, Some((response_range, total_size)))
+        }
+    };
+    let mut response = Response::new(body);
     if partial && file_range.is_some() {
         *response.status_mut() = StatusCode::PARTIAL_CONTENT;
     }
@@ -2185,6 +2246,10 @@ where
         }
     }
     Ok(response)
+}
+
+fn file_stream_error(error: LixError) -> io::Error {
+    io::Error::other(error.to_string())
 }
 
 /// Parses the common single, forward byte range. Multipart and suffix ranges
@@ -6075,7 +6140,9 @@ mod tests {
     async fn binary_file_read_returns_raw_bytes_and_distinguishes_empty_and_missing() {
         let app = app().await;
         let (session_id, _) = new_session(&app.router).await;
-        let payload = vec![0, 1, 2, 3, 255];
+        let payload = (0..FILE_READ_STREAM_WINDOW_BYTES as usize + 17)
+            .map(|index| (index % 251) as u8)
+            .collect::<Vec<_>>();
         let inserted = app
             .router
             .clone()
@@ -6152,7 +6219,10 @@ mod tests {
         );
         assert_eq!(
             ranged.headers().get(CONTENT_RANGE),
-            Some(&axum::http::HeaderValue::from_static("bytes 1-3/5"))
+            Some(
+                &axum::http::HeaderValue::from_str(&format!("bytes 1-3/{}", payload.len()))
+                    .expect("content range header")
+            )
         );
         assert_eq!(
             ranged
@@ -6164,6 +6234,51 @@ mod tests {
                 .as_ref(),
             &payload[1..4]
         );
+
+        let concurrent = app
+            .router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/lix/v1/file?path=%2Fpayload.bin")
+                    .header(SESSION_ID_HEADER, &session_id)
+                    .body(Body::empty())
+                    .expect("concurrent binary file read request"),
+            )
+            .await
+            .expect("concurrent binary file read response");
+        let mut concurrent_body = concurrent.into_body();
+        let first_frame = concurrent_body
+            .frame()
+            .await
+            .expect("first stream frame")
+            .expect("first stream frame should succeed")
+            .into_data()
+            .expect("first stream frame should contain data");
+        assert_eq!(first_frame.len(), FILE_READ_STREAM_WINDOW_BYTES as usize);
+
+        let replacement = vec![0xee; payload.len()];
+        let replaced = app
+            .router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/lix/v1/file/upsert?path=%2Fpayload.bin")
+                    .header(SESSION_ID_HEADER, &session_id)
+                    .body(Body::from(replacement))
+                    .expect("concurrent binary file replacement request"),
+            )
+            .await
+            .expect("concurrent binary file replacement response");
+        assert_eq!(replaced.status(), StatusCode::OK);
+        let stream_error = concurrent_body
+            .frame()
+            .await
+            .expect("changed stream should produce a terminal frame")
+            .expect_err("changed stream must not mix file versions");
+        assert!(stream_error.to_string().contains("file changed"));
 
         let emptied = app
             .router
@@ -6208,6 +6323,21 @@ mod tests {
                 .to_bytes()
                 .is_empty()
         );
+        let empty_range = app
+            .router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/lix/v1/file?path=%2Fpayload.bin")
+                    .header(SESSION_ID_HEADER, &session_id)
+                    .header(RANGE, "bytes=0-")
+                    .body(Body::empty())
+                    .expect("empty ranged binary file read request"),
+            )
+            .await
+            .expect("empty ranged read response");
+        assert_eq!(empty_range.status(), StatusCode::BAD_REQUEST);
 
         let missing = app
             .router

--- a/packages/slatedb-storage/Cargo.toml
+++ b/packages/slatedb-storage/Cargo.toml
@@ -28,4 +28,3 @@ slatedb = { version = "0.14.1", default-features = false, features = ["moka", "z
 slatedb-common = "0.14.1"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
-zstd = "0.13"

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -56,15 +56,11 @@ use std::io::{Read, Seek, SeekFrom};
 
 const DB_PATH: &str = "db";
 const SEGMENTED_FORMAT_PATH: &str = "lix-space-segments-v2";
-const IMMUTABLE_BINARY_CAS_CHUNK_PATH: &str = "lix-immutable-binary-cas-segment-v4";
-const IMMUTABLE_BINARY_CAS_CACHE_PATH: &str = "lix-immutable-binary-cas-segment-v4";
+const IMMUTABLE_BINARY_CAS_CHUNK_PATH: &str = "lix-immutable-binary-cas-segment-v5";
+const IMMUTABLE_BINARY_CAS_CACHE_PATH: &str = "lix-immutable-binary-cas-segment-v5";
 const IMMUTABLE_CACHE_VALUE_MAGIC: &[u8; 8] = b"LIXICV5\0";
-const IMMUTABLE_VALUE_MAGIC: &[u8; 8] = b"LIXICV3\0";
-const IMMUTABLE_VALUE_RAW: u8 = 0;
-const IMMUTABLE_VALUE_ZSTD: u8 = 1;
+const IMMUTABLE_VALUE_MAGIC: &[u8; 8] = b"LIXICV6\0";
 const IMMUTABLE_LOCATOR_MAGIC: &[u8; 8] = b"LIXILV4\0";
-const IMMUTABLE_VALUE_ZSTD_LEVEL: i32 = 3;
-const IMMUTABLE_VALUE_MIN_SAVINGS_BYTES: usize = 128;
 const IMMUTABLE_VALUE_MAX_ENCODED_BYTES: usize = 4 * 1024 * 1024 + 1024;
 const IMMUTABLE_SEGMENT_MAX_BYTES: usize = 64 * 1024 * 1024;
 const BINARY_CAS_CHUNK_SPACE_ID: SpaceId = SpaceId(0x0005_0003);
@@ -703,33 +699,19 @@ fn encode_immutable_value(value: Bytes) -> Result<Bytes, StorageError> {
             IMMUTABLE_VALUE_MAX_ENCODED_BYTES
         )));
     }
-    let uncompressed_len = u64::try_from(value.len()).map_err(|_| {
+    let value_len = u64::try_from(value.len()).map_err(|_| {
         StorageError::Io("immutable value exceeds the u64 storage limit".to_string())
     })?;
-    let compressed = zstd::bulk::compress(&value, IMMUTABLE_VALUE_ZSTD_LEVEL)
-        .map_err(|error| StorageError::Io(format!("immutable value compression: {error}")))?;
-    let header_bytes = IMMUTABLE_VALUE_MAGIC
-        .len()
-        .saturating_add(size_of::<u8>())
-        .saturating_add(size_of::<u64>());
-    let compressed_envelope_bytes = header_bytes.saturating_add(compressed.len());
-    let (encoding, payload) = if value.len().saturating_sub(compressed_envelope_bytes)
-        >= IMMUTABLE_VALUE_MIN_SAVINGS_BYTES
-    {
-        (IMMUTABLE_VALUE_ZSTD, compressed.as_slice())
-    } else {
-        (IMMUTABLE_VALUE_RAW, value.as_ref())
-    };
-    let mut envelope = Vec::with_capacity(header_bytes.saturating_add(payload.len()));
+    let header_bytes = IMMUTABLE_VALUE_MAGIC.len().saturating_add(size_of::<u64>());
+    let mut envelope = Vec::with_capacity(header_bytes.saturating_add(value.len()));
     envelope.extend_from_slice(IMMUTABLE_VALUE_MAGIC);
-    envelope.push(encoding);
-    envelope.extend_from_slice(&uncompressed_len.to_le_bytes());
-    envelope.extend_from_slice(payload);
+    envelope.extend_from_slice(&value_len.to_le_bytes());
+    envelope.extend_from_slice(&value);
     Ok(Bytes::from(envelope))
 }
 
 fn decode_immutable_value(value: Bytes) -> Result<Bytes, StorageError> {
-    let header_len = IMMUTABLE_VALUE_MAGIC.len() + size_of::<u8>() + size_of::<u64>();
+    let header_len = IMMUTABLE_VALUE_MAGIC.len() + size_of::<u64>();
     if value.len() < header_len {
         return Err(StorageError::Corruption(
             "immutable value envelope is truncated".to_string(),
@@ -740,44 +722,29 @@ fn decode_immutable_value(value: Bytes) -> Result<Bytes, StorageError> {
             "immutable value envelope magic is invalid".to_string(),
         ));
     }
-    let encoding = value[IMMUTABLE_VALUE_MAGIC.len()];
-    let length_start = IMMUTABLE_VALUE_MAGIC.len() + size_of::<u8>();
-    let uncompressed_len = u64::from_le_bytes(
+    let length_start = IMMUTABLE_VALUE_MAGIC.len();
+    let value_len = u64::from_le_bytes(
         value[length_start..header_len]
             .try_into()
             .expect("fixed immutable value length header"),
     );
-    let uncompressed_len = usize::try_from(uncompressed_len).map_err(|_| {
-        StorageError::Corruption(
-            "immutable value uncompressed length exceeds this platform".to_string(),
-        )
+    let value_len = usize::try_from(value_len).map_err(|_| {
+        StorageError::Corruption("immutable value length exceeds this platform".to_string())
     })?;
-    if uncompressed_len > IMMUTABLE_VALUE_MAX_ENCODED_BYTES {
+    if value_len > IMMUTABLE_VALUE_MAX_ENCODED_BYTES {
         return Err(StorageError::Corruption(format!(
             "immutable value exceeds the {} byte format maximum",
             IMMUTABLE_VALUE_MAX_ENCODED_BYTES
         )));
     }
-    match encoding {
-        IMMUTABLE_VALUE_RAW => {
-            let payload = value.slice(header_len..);
-            if payload.len() != uncompressed_len {
-                return Err(StorageError::Corruption(format!(
-                    "immutable raw value length {} does not match declared length {uncompressed_len}",
-                    payload.len()
-                )));
-            }
-            Ok(payload)
-        }
-        IMMUTABLE_VALUE_ZSTD => zstd::bulk::decompress(&value[header_len..], uncompressed_len)
-            .map(Bytes::from)
-            .map_err(|error| {
-                StorageError::Corruption(format!("immutable value decompression failed: {error}"))
-            }),
-        other => Err(StorageError::Corruption(format!(
-            "immutable value encoding {other} is unknown"
-        ))),
+    let payload = value.slice(header_len..);
+    if payload.len() != value_len {
+        return Err(StorageError::Corruption(format!(
+            "immutable raw value length {} does not match declared length {value_len}",
+            payload.len()
+        )));
     }
+    Ok(payload)
 }
 
 #[derive(Clone)]
@@ -2368,7 +2335,7 @@ impl Storage for SlateDB {
                 // The engine sets this only for the atomic mutation plus
                 // idempotency-receipt commit. Its replay contract requires a
                 // durable receipt before the request can be acknowledged.
-                await_durable: opts.idempotency_key.is_some(),
+                await_durable: opts.await_durable || opts.idempotency_key.is_some(),
                 base: None,
                 overlay: BTreeMap::new(),
                 immutable_values: BTreeMap::new(),
@@ -4469,27 +4436,20 @@ mod tests {
     }
 
     #[test]
-    fn immutable_value_envelope_roundtrips_and_rejects_oversized_lengths() {
-        let compressible = Bytes::from(vec![0x44; 1024 * 1024]);
-        let encoded = encode_immutable_value(compressible.clone()).expect("encode immutable value");
+    fn immutable_value_envelope_is_raw_and_rejects_oversized_lengths() {
+        let payload = Bytes::from(vec![0x44; 1024 * 1024]);
+        let encoded = encode_immutable_value(payload.clone()).expect("encode immutable value");
         assert!(encoded.starts_with(IMMUTABLE_VALUE_MAGIC));
-        assert_eq!(encoded[IMMUTABLE_VALUE_MAGIC.len()], IMMUTABLE_VALUE_ZSTD);
+        assert_eq!(
+            encoded.len(),
+            IMMUTABLE_VALUE_MAGIC.len() + size_of::<u64>() + payload.len()
+        );
         assert_eq!(
             decode_immutable_value(encoded).expect("decode immutable value"),
-            compressible
-        );
-
-        let raw = Bytes::from_static(b"LIXICV3\0already compact bytes");
-        let encoded = encode_immutable_value(raw.clone()).expect("encode compact immutable value");
-        assert!(encoded.starts_with(IMMUTABLE_VALUE_MAGIC));
-        assert_eq!(encoded[IMMUTABLE_VALUE_MAGIC.len()], IMMUTABLE_VALUE_RAW);
-        assert_eq!(
-            decode_immutable_value(encoded).expect("decode compact immutable value"),
-            raw
+            payload
         );
 
         let mut oversized = Vec::from(IMMUTABLE_VALUE_MAGIC.as_slice());
-        oversized.push(IMMUTABLE_VALUE_ZSTD);
         oversized
             .extend_from_slice(&((IMMUTABLE_VALUE_MAX_ENCODED_BYTES as u64) + 1).to_le_bytes());
         oversized.push(0);
@@ -4866,10 +4826,9 @@ mod tests {
         let stored_bytes = std::fs::read(&stored_path).expect("read immutable chunk object");
         assert!(stored_bytes.starts_with(IMMUTABLE_VALUE_MAGIC));
         assert_eq!(
-            stored_bytes[IMMUTABLE_VALUE_MAGIC.len()],
-            IMMUTABLE_VALUE_ZSTD
+            stored_bytes.len(),
+            IMMUTABLE_VALUE_MAGIC.len() + size_of::<u64>() + value.len()
         );
-        assert!(stored_bytes.len() < value.len());
         assert_eq!(
             std::fs::read_dir(&immutable_directory)
                 .expect("list immutable segments")
@@ -6272,6 +6231,54 @@ mod tests {
             .values,
             vec![Some(ProjectedValue::FullValue(value))]
         );
+    }
+
+    #[test]
+    fn await_durable_write_does_not_acknowledge_a_blocked_wal_upload() {
+        let store = Arc::new(BlockingStore::new(Arc::new(InMemory::new())));
+        let storage = SlateDB::open_object_store_with_options(
+            "test-await-durable-write",
+            store.clone(),
+            SlateDBObjectStoreOptions::default(),
+        )
+        .expect("open await-durable storage");
+        let blocked_write = store.block_next_write();
+        let committer_storage = storage.clone();
+        let (commit_tx, commit_rx) = mpsc::channel();
+        let committer = std::thread::spawn(move || {
+            let mut write = block_on(committer_storage.begin_write(WriteOptions {
+                await_durable: true,
+                ..WriteOptions::default()
+            }))
+            .expect("begin await-durable write");
+            block_on(write.put_many(
+                SpaceId(8),
+                PutBatch {
+                    entries: vec![PutEntry {
+                        key: Key(Bytes::from_static(b"durable-before-ack")),
+                        value: StoredValue {
+                            bytes: Bytes::from_static(b"value"),
+                        },
+                    }],
+                },
+            ))
+            .expect("stage await-durable row");
+            commit_tx
+                .send(block_on(write.commit()))
+                .expect("send await-durable result");
+        });
+
+        blocked_write.wait_for_entries(1, "await-durable SlateDB WAL write");
+        assert!(
+            commit_rx.recv_timeout(Duration::from_millis(100)).is_err(),
+            "durable write must not acknowledge before its WAL upload completes",
+        );
+        drop(blocked_write);
+        commit_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("durable write should finish after WAL upload")
+            .expect("await-durable commit");
+        committer.join().expect("join await-durable committer");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- publish resumable CAS manifests, file/history metadata, completion receipts, and temporary-receipt cleanup in one durable commit
- keep media payloads in RocksDB BlobDB / SlateDB immutable sidecar domains and remove SlateDB per-chunk Zstd trials with a clean format break
- stream HTTP file bodies in bounded 4 MiB windows, reject cross-version mixing, and read only intersecting manifest ordinals
- retain 1 MiB CAS chunks after the durable mixed SlateDB profile showed no ingest gain at 4 MiB

No backward compatibility is included for the removed SlateDB immutable-value envelope or upload-state format.

## Validation
- cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
- RUST_MIN_STACK=8388608 cargo test --profile test --workspace --all-features -q
- RocksDB and SlateDB resumable upload restart tests
- SlateDB blocked-WAL durable acknowledgement test
- mixed SlateDB movie qualification: save p95 103.126 ms, zero late proxy reads, ingest 153.1 MiB/s
- three independent final code reviews with no remaining scoped findings