### PR TITLE
perf(engine): use generation write sets for stale commits

### DIFF
--- a/packages/engine/TRANSACTION_CONFLICT_PERFORMANCE.md
+++ b/packages/engine/TRANSACTION_CONFLICT_PERFORMANCE.md
@@ -1,0 +1,57 @@
+# Transaction conflict-resolution performance
+
+Release-mode microbenchmarks isolate stale-commit discovery work from plugin
+execution, storage commit latency, and observation delivery. End-to-end
+capacity results remain in
+`packages/rs-sdk-tests/REALTIME_COLLABORATION_CAPACITY.md`.
+
+## Indexed overlap discovery
+
+The removed production path compared every prepared key with every concurrent
+key and then rebuilt the overlap set inside reconciliation. The replacement
+hashes concurrent identities once and preserves prepared-row order.
+
+| Prepared keys | Concurrent keys | Overlaps | Before p50 | After p50 | Speedup |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 5,000 | 5,000 | 2,500 | 112,658 µs | 698 µs | 161.30× |
+
+The benchmark executes both algorithms over identical typed keys and asserts
+identical membership and order before accepting a sample.
+
+## Committed-generation write set
+
+Normal commits already persist compact, immutable per-generation identity
+deltas. Stale transaction admission now unions those write sets directly for
+a first-parent interval. It no longer performs endpoint reconstruction,
+ancestor point reads, or payload hydration merely to discover touched keys.
+Non-first-parent and non-journal histories retain the general diff fallback.
+
+| Touched identities | Before: general diff p50 | After: generation write set p50 | Speedup |
+| ---: | ---: | ---: | ---: |
+| 5,000 | 19,136 µs | 1,946 µs | 9.83× |
+
+The write set is deliberately conservative: an identity touched and then
+restored to its opening payload remains present. This prevents stale admission
+from treating intervening writes as if they never happened. Duplicate touches
+across generations are returned once.
+
+The optimization targets large stale intervals, not the five-write capacity
+wave. Five fresh-process 100-client JSON capacity repetitions after this cut
+had a worst convergence p95 of 16.062 ms, versus the established pre-series
+six-process worst of 18.095 ms. The real-time path therefore remains flat
+within run-to-run variance and far below the 100 ms gate while high-cardinality
+discovery improves by an order of magnitude.
+
+## Reproduction
+
+```bash
+cargo test -p lix_engine --release \
+  stale_overlap_discovery_benchmark_probe --lib -- --ignored --nocapture
+
+cargo test -p lix_engine --release \
+  generation_write_set_benchmark_probe --lib -- --ignored --nocapture
+```
+
+Both probes emit versioned machine-readable records or stable key/value output
+and assert that the optimized path beats its exact predecessor on the same
+fixture.

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -26,9 +26,9 @@ use crate::tracked_state::codec::{
     decode_key_shared, encode_key, encode_key_ref_into, encode_value_ref,
 };
 use crate::tracked_state::diff::{
-    TrackedStateDiff, TrackedStateDiffRequest, TrackedStateDiffRow, TrackedStatePayloadBatch,
-    TrackedStateTreeDiffBatch, TrackedStateTreeDiffBatchBuilder, TrackedStateTreeDiffRowRef,
-    diff_commits,
+    TrackedStateDiff, TrackedStateDiffIdentity, TrackedStateDiffRequest, TrackedStateDiffRow,
+    TrackedStatePayloadBatch, TrackedStateTreeDiffBatch, TrackedStateTreeDiffBatchBuilder,
+    TrackedStateTreeDiffRowRef, diff_commits,
 };
 #[cfg(test)]
 use crate::tracked_state::merge::{self, TrackedStateMergePlan};
@@ -2276,6 +2276,59 @@ where
         entries.finish()
     }
 
+    /// Returns the compact write-set union for an ancestor/descendant
+    /// first-parent interval.
+    ///
+    /// Stale transaction admission needs to know whether a prepared identity
+    /// was touched, not the endpoint payload or before value. Reading the
+    /// immutable per-commit delta generations directly avoids tree diffing,
+    /// ancestor point reads, and changelog payload hydration. `None` means the
+    /// pair is not representable by the rootless first-parent journal and the
+    /// caller must use the general commit diff.
+    pub(crate) async fn changed_identities_in_first_parent_interval(
+        &mut self,
+        ancestor_commit_id: &str,
+        descendant_commit_id: &str,
+    ) -> Result<Option<Vec<TrackedStateDiffIdentity>>, LixError> {
+        let Some(interval) = self
+            .first_parent_interval_between(ancestor_commit_id, descendant_commit_id)
+            .await?
+        else {
+            return Ok(None);
+        };
+        let mut batches = Vec::with_capacity(interval.len());
+        for commit_id in interval {
+            batches.push(
+                self.scan_replayed_commit_delta_values(commit_id, &[])
+                    .await?,
+            );
+        }
+        let row_count = batches
+            .iter()
+            .try_fold(0usize, |count, batch| count.checked_add(batch.len()))
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "first-parent write-set row count overflows usize",
+                )
+            })?;
+        let mut seen = HashSet::with_capacity(row_count);
+        let mut keys = Vec::with_capacity(row_count);
+        for batch in &batches {
+            for row in batch.iter() {
+                let key = row.key_ref();
+                if seen.insert(key) {
+                    keys.push(key);
+                }
+            }
+        }
+        keys.sort_unstable();
+        Ok(Some(TrackedStateDiffIdentity::from_key_refs(
+            keys.len(),
+            |index| keys[index],
+        )?))
+    }
+
     /// Diffs an ancestor/descendant pair from immutable per-commit deltas.
     ///
     /// Merge always compares its merge base with each head. Walking only that
@@ -4057,6 +4110,8 @@ fn nullable_key_filter_allows(filters: &[NullableKeyFilter<String>], value: Opti
 
 #[cfg(test)]
 mod tests {
+    use std::time::Instant;
+
     use super::*;
     use crate::NullableKeyFilter;
     use crate::branch::BranchHeadControl;
@@ -6802,6 +6857,151 @@ mod tests {
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
             .expect("rootless commit should commit");
+    }
+
+    #[tokio::test]
+    async fn first_parent_generation_write_set_deduplicates_touched_identities() {
+        let storage = StorageAdapter::new(Memory::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_for_test(
+            &storage,
+            &tracked_state,
+            "base",
+            None,
+            &[row_with_value("entity-a", "base-a", "base", "base")],
+        )
+        .await
+        .expect("base root should write");
+        write_rootless_commit_for_test(
+            &storage,
+            "generation-1",
+            "base",
+            &[
+                row_with_value("entity-a", "generation-1-a", "generation-1", "middle"),
+                row_with_value("entity-b", "generation-1-b", "generation-1", "created"),
+            ],
+        )
+        .await;
+        write_rootless_commit_for_test(
+            &storage,
+            "generation-2",
+            "generation-1",
+            &[
+                // The endpoint payload returns to the base value, but stale
+                // admission must still know that this identity was touched.
+                row_with_value("entity-a", "generation-2-a", "generation-2", "base"),
+                row_with_value("entity-c", "generation-2-c", "generation-2", "created"),
+            ],
+        )
+        .await;
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("write-set read should open");
+        let identities = tracked_state
+            .reader(read)
+            .changed_identities_in_first_parent_interval("base", "generation-2")
+            .await
+            .expect("generation write set should load")
+            .expect("rootless first-parent interval should be supported");
+        assert_eq!(
+            identities
+                .iter()
+                .map(|identity| { identity.entity_pk().as_single_string().unwrap().to_owned() })
+                .collect::<Vec<_>>(),
+            ["entity-a", "entity-b", "entity-c"]
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "release-only generation write-set benchmark probe"]
+    async fn generation_write_set_benchmark_probe() {
+        let rows = std::env::var("LIX_GENERATION_WRITE_SET_BENCH_ROWS")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(5_000);
+        let rounds = std::env::var("LIX_GENERATION_WRITE_SET_BENCH_ROUNDS")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(8);
+        let storage = StorageAdapter::new(Memory::new());
+        let tracked_state = TrackedStateContext::new();
+        let base_rows = (0..rows)
+            .map(|index| {
+                row_with_value(
+                    &format!("entity-{index:05}"),
+                    &format!("base-change-{index:05}"),
+                    "base",
+                    "base",
+                )
+            })
+            .collect::<Vec<_>>();
+        write_root_for_test(&storage, &tracked_state, "base", None, &base_rows)
+            .await
+            .expect("benchmark base should write");
+        let changed_rows = (0..rows)
+            .map(|index| {
+                row_with_value(
+                    &format!("entity-{index:05}"),
+                    &format!("changed-{index:05}"),
+                    "after",
+                    "after",
+                )
+            })
+            .collect::<Vec<_>>();
+        write_rootless_commit_for_test(&storage, "after", "base", &changed_rows).await;
+
+        let mut write_set_samples = Vec::with_capacity(rounds);
+        let mut diff_samples = Vec::with_capacity(rounds);
+        for _ in 0..rounds {
+            let read = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("write-set benchmark read should open");
+            let started = Instant::now();
+            let identities = tracked_state
+                .reader(read)
+                .changed_identities_in_first_parent_interval("base", "after")
+                .await
+                .expect("generation write set should load")
+                .expect("benchmark interval should be rootless");
+            write_set_samples.push(started.elapsed());
+            assert_eq!(identities.len(), rows);
+
+            let read = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("diff benchmark read should open");
+            let started = Instant::now();
+            let diff = tracked_state
+                .reader(read)
+                .diff_commits("base", "after", &TrackedStateDiffRequest::default())
+                .await
+                .expect("general diff should load");
+            diff_samples.push(started.elapsed());
+            assert_eq!(diff.entries.len(), rows);
+        }
+        write_set_samples.sort_unstable();
+        diff_samples.sort_unstable();
+        let p50 = |samples: &[std::time::Duration]| samples[(samples.len() - 1) / 2];
+        let write_set_p50 = p50(&write_set_samples);
+        let diff_p50 = p50(&diff_samples);
+        println!(
+            "{}",
+            serde_json::json!({
+                "schema": "lix.generation-write-set.v1",
+                "rows": rows,
+                "rounds": rounds,
+                "general_diff_p50_us": diff_p50.as_micros(),
+                "generation_write_set_p50_us": write_set_p50.as_micros(),
+                "speedup": diff_p50.as_secs_f64() / write_set_p50.as_secs_f64(),
+            })
+        );
+        assert!(
+            write_set_p50 < diff_p50,
+            "generation write-set discovery should beat general endpoint diffing"
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -832,8 +832,8 @@ impl DecodedCommitDeltaBatch {
     }
 }
 
-impl DecodedCommitDeltaRowRef<'_> {
-    pub(crate) fn key_ref(&self) -> TrackedStateKeyRef<'_> {
+impl<'a> DecodedCommitDeltaRowRef<'a> {
+    pub(crate) fn key_ref(self) -> TrackedStateKeyRef<'a> {
         let row = &self.batch.rows[self.ordinal];
         TrackedStateKeyRef {
             schema_key: self.batch.schema_keys[row.schema_key_ordinal as usize].as_str(),
@@ -843,7 +843,7 @@ impl DecodedCommitDeltaRowRef<'_> {
         }
     }
 
-    pub(crate) fn value(&self) -> &TrackedStateIndexValue {
+    pub(crate) fn value(self) -> &'a TrackedStateIndexValue {
         &self.batch.values[self.ordinal]
     }
 

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -719,30 +719,71 @@ where
         };
 
         let mut tracked = self.tracked_state.reader(read);
-        let concurrent = tracked
-            .diff_commits(
-                &opening_head.to_string(),
-                &current_head.to_string(),
-                &TrackedStateDiffRequest::default(),
-            )
+        let opening_head_text = opening_head.to_string();
+        let current_head_text = current_head.to_string();
+        let generation_write_set = tracked
+            .changed_identities_in_first_parent_interval(&opening_head_text, &current_head_text)
             .instrument(tracing::debug_span!(
                 target: "lix_transaction",
-                "lix.transaction.stale.diff"
+                "lix.transaction.stale.generation_write_set"
             ))
             .await?;
-        let plan = {
-            let span = tracing::debug_span!(
-                target: "lix_transaction",
-                "lix.transaction.stale.classify",
-                prepared_rows = prepared_writes.state_rows.len(),
-                concurrent_changes = concurrent.entries.len(),
-            );
-            let _entered = span.enter();
-            classify_stale_commit(prepared_writes, &concurrent)
+        let (plan, concurrent_change_count, discovery) = match generation_write_set {
+            Some(identities) => {
+                let count = identities.len();
+                let plan = {
+                    let span = tracing::debug_span!(
+                        target: "lix_transaction",
+                        "lix.transaction.stale.classify",
+                        prepared_rows = prepared_writes.state_rows.len(),
+                        concurrent_changes = count,
+                    );
+                    let _entered = span.enter();
+                    classify_stale_commit(
+                        prepared_writes,
+                        identities.iter().map(|identity| identity.as_key_ref()),
+                    )
+                };
+                (plan, count, "generation_write_set")
+            }
+            None => {
+                let concurrent = tracked
+                    .diff_commits(
+                        &opening_head_text,
+                        &current_head_text,
+                        &TrackedStateDiffRequest::default(),
+                    )
+                    .instrument(tracing::debug_span!(
+                        target: "lix_transaction",
+                        "lix.transaction.stale.general_diff"
+                    ))
+                    .await?;
+                let count = concurrent.entries.len();
+                let plan = {
+                    let span = tracing::debug_span!(
+                        target: "lix_transaction",
+                        "lix.transaction.stale.classify",
+                        prepared_rows = prepared_writes.state_rows.len(),
+                        concurrent_changes = count,
+                    );
+                    let _entered = span.enter();
+                    classify_stale_commit(
+                        prepared_writes,
+                        concurrent
+                            .entries
+                            .iter()
+                            .map(|entry| entry.identity.as_key_ref()),
+                    )
+                };
+                (plan, count, "general_diff")
+            }
         };
         tracing::debug!(
             target: "lix_transaction",
             plan = plan.kind(),
+            discovery,
+            prepared_rows = prepared_writes.state_rows.len(),
+            concurrent_changes = concurrent_change_count,
             "classified stale transaction commit"
         );
         match plan {

--- a/packages/engine/src/transaction/stale_commit.rs
+++ b/packages/engine/src/transaction/stale_commit.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeSet, HashSet};
 
 use crate::common::SharedStr;
 use crate::filesystem::DERIVED_FILE_REF_SCHEMA_KEY;
-use crate::tracked_state::{TrackedStateDiff, TrackedStateKeyRef};
+use crate::tracked_state::TrackedStateKeyRef;
 
 use super::staging::PreparedWriteSet;
 
@@ -33,9 +33,9 @@ pub(super) struct StalePluginReconciliationPlan {
     pub(super) file_ids: BTreeSet<String>,
 }
 
-pub(super) fn classify_stale_commit(
-    prepared_writes: &PreparedWriteSet,
-    concurrent: &TrackedStateDiff,
+pub(super) fn classify_stale_commit<'a>(
+    prepared_writes: &'a PreparedWriteSet,
+    concurrent: impl Iterator<Item = TrackedStateKeyRef<'a>>,
 ) -> StaleCommitPlan {
     let overlapping_indices = indexed_overlap_indices(
         prepared_writes
@@ -52,10 +52,7 @@ pub(super) fn classify_stale_commit(
                     },
                 )
             }),
-        concurrent
-            .entries
-            .iter()
-            .map(|entry| entry.identity.as_key_ref()),
+        concurrent,
     );
     if overlapping_indices.is_empty() {
         return StaleCommitPlan::Direct;


### PR DESCRIPTION
## Summary

- reuse the existing immutable per-commit delta journal as a committed-generation write index
- classify stale transaction overlap from the union of touched identities on rootless first-parent history
- preserve the general commit diff only for nonlinear or unsupported history
- keep touch-then-revert identities in the write set conservatively and deduplicate repeated touches
- add tracing for generation-index versus general-diff discovery and document reproducible before/after results

This is Stack 3, based on #1091. It is an internal hard cut with no public API or protocol additions and no compatibility shim.

## Performance

Release benchmark, 5,000 touched identities, 8 rounds:

| Path | p50 |
| --- | ---: |
| Before: general endpoint diff | 19,136 µs |
| After: generation write set | 1,946 µs |

Speedup: **9.83×**.

Five fresh-process 100-client local capacity repetitions produced a worst convergence p95 of **16.062 ms**, compared with the established pre-series worst of **18.095 ms**. This remains far below the 100 ms target.

## Validation

- `cargo test -p lix_engine --features all-simulations`
- `cargo test -p lix_sdk_tests --test e2e same_base_ -- --nocapture`
- `cargo test -p lix_engine --release generation_write_set_benchmark_probe --lib -- --ignored --nocapture`
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
