### PR TITLE
perf(engine): batch stale plugin reconciliation

### DIFF
--- a/packages/engine/TRANSACTION_CONFLICT_PERFORMANCE.md
+++ b/packages/engine/TRANSACTION_CONFLICT_PERFORMANCE.md
@@ -42,6 +42,31 @@ six-process worst of 18.095 ms. The real-time path therefore remains flat
 within run-to-run variance and far below the 100 ms gate while high-cardinality
 discovery improves by an order of magnitude.
 
+## Batched conflict replay
+
+Conflict resolution was already invoked once per file, but its resolved and
+retained rows were replayed through one plugin transition at a time. The hard
+cut groups those rows by file and sends one semantic batch through the existing
+plugin boundary. JSON now accepts multiple independent existing-scalar edits;
+CSV, Markdown, and text already accepted multi-entity updates. Every reference
+plugin is covered by a multi-entity same-base convergence test that asserts one
+resolver call and one render transition.
+
+| Conflicts in one JSON file | Before p50 | After p50 | Before guest exports | After guest exports | Speedup |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 64 | 41,065 µs | 5,099 µs | 66 | 3 | 8.05× |
+
+Eight release-mode rounds measured stale `commit()` only after both
+transactions were staged and the winning commit completed. The before probe
+uses the same batch-capable plugin and fixture with only the engine replay loop
+restored, isolating the effect of replay cardinality. Its p95 falls from
+43,041 µs to 5,251 µs (8.20×).
+
+The 100-client capacity regression remained below the 100 ms gate in every
+reference format: JSON 16.201 ms p95, CSV 16.415 ms, Markdown 24.990 ms, and
+text 12.167 ms. Each run retained the exact 10% semantic-overlap workload and
+reported five resolver calls across twenty waves.
+
 ## Reproduction
 
 ```bash
@@ -50,8 +75,11 @@ cargo test -p lix_engine --release \
 
 cargo test -p lix_engine --release \
   generation_write_set_benchmark_probe --lib -- --ignored --nocapture
+
+cargo test -p lix_sdk_tests --release --test e2e \
+  stale_plugin_replay_batch_benchmark_probe -- --ignored --nocapture
 ```
 
-Both probes emit versioned machine-readable records or stable key/value output
+The probes emit versioned machine-readable records or stable key/value output
 and assert that the optimized path beats its exact predecessor on the same
 fixture.

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -1031,12 +1031,8 @@ where
         self.pending_file_view_mutations
             .retain(|key, _| !file_ids.contains(&key.file_id));
 
-        let mut reconciliation_batches = Vec::<RawWriteBatch>::with_capacity(
-            candidate_indices
-                .len()
-                .saturating_add(prepared_writes.state_rows.len()),
-        );
-        for group in groups.values() {
+        let mut reconciliation_batches = BTreeMap::<String, RawWriteBatch>::new();
+        for (file_id, group) in &groups {
             if group.conflicts.is_empty() {
                 continue;
             }
@@ -1071,15 +1067,11 @@ where
                     conflict_count = group.conflicts.len(),
                 ))
                 .await?;
+            let rows = reconciliation_batches
+                .entry(file_id.clone())
+                .or_insert_with(|| RawWriteBatch::with_capacity(group.conflicts.len()));
             for (conflict, resolution) in group.conflicts.iter().zip(resolutions.resolutions) {
-                let mut rows = RawWriteBatch::with_capacity(1);
-                push_stale_conflict_resolution(
-                    &mut rows,
-                    conflict,
-                    resolution,
-                    &self.active_branch_id,
-                )?;
-                reconciliation_batches.push(rows);
+                push_stale_conflict_resolution(rows, conflict, resolution, &self.active_branch_id)?;
             }
         }
         let conflict_row_indices = candidate_indices.iter().copied().collect::<BTreeSet<_>>();
@@ -1101,38 +1093,40 @@ where
             {
                 continue;
             }
-            let mut rows = RawWriteBatch::with_capacity(1);
-            rows.push_parts(
-                Some(row.entity_pk.clone()),
-                row.schema_key.clone(),
-                row.file_id.cloned(),
-                row.snapshot.map(|snapshot| {
-                    TransactionJson::from_unvalidated_shared_normalized_content(
-                        snapshot.materialize_shared(),
-                    )
-                }),
-                row.metadata.map(|metadata| {
-                    TransactionJson::from_unvalidated_shared_normalized_content(
-                        metadata.materialize_shared(),
-                    )
-                }),
-                row.origin.cloned(),
-                Some(row.created_at.to_string().into()),
-                Some(row.updated_at.to_string().into()),
-                row.global,
-                row.change_id.map(|change_id| change_id.to_string().into()),
-                None,
-                row.untracked,
-                row.branch_id.clone(),
-            );
-            reconciliation_batches.push(rows);
+            reconciliation_batches
+                .entry(file_id.to_owned())
+                .or_insert_with(RawWriteBatch::new)
+                .push_parts(
+                    Some(row.entity_pk.clone()),
+                    row.schema_key.clone(),
+                    row.file_id.cloned(),
+                    row.snapshot.map(|snapshot| {
+                        TransactionJson::from_unvalidated_shared_normalized_content(
+                            snapshot.materialize_shared(),
+                        )
+                    }),
+                    row.metadata.map(|metadata| {
+                        TransactionJson::from_unvalidated_shared_normalized_content(
+                            metadata.materialize_shared(),
+                        )
+                    }),
+                    row.origin.cloned(),
+                    Some(row.created_at.to_string().into()),
+                    Some(row.updated_at.to_string().into()),
+                    row.global,
+                    row.change_id.map(|change_id| change_id.to_string().into()),
+                    None,
+                    row.untracked,
+                    row.branch_id.clone(),
+                );
         }
-        // Plugins may deliberately accept only one semantic edit per warm
-        // transition. Preserve the accumulated conflict decision while
-        // replaying its resolved and retained edits through one actor in order.
+        // Conflict discovery and resolution already operate per file. Replay
+        // the complete resolved write set through the same boundary so each
+        // file performs one semantic transition and one render, independent
+        // of how many conflicts and retained edits it contains.
         let replay_batch_count = reconciliation_batches.len();
         async {
-            for rows in reconciliation_batches {
+            for rows in reconciliation_batches.into_values() {
                 self.stage_write(TransactionWrite::Rows {
                     mode: TransactionWriteMode::Replace,
                     rows,

--- a/packages/rs-sdk-tests/tests/e2e.rs
+++ b/packages/rs-sdk-tests/tests/e2e.rs
@@ -2702,7 +2702,7 @@ async fn v2_json_scalar_lww_composes_and_stale_structure_does_not_resurrect_node
     assert!(
         direct_structure_error
             .message
-            .contains("one existing scalar value only")
+            .contains("existing scalar values only")
     );
     assert_eq!(read_file(&lix, path).await.unwrap(), Some(lww));
     lix.execute(
@@ -2721,27 +2721,23 @@ async fn v2_json_scalar_lww_composes_and_stale_structure_does_not_resurrect_node
         read_file(&lix, path).await.unwrap(),
         Some(scalar_after_direct_reject.clone())
     );
-    let direct_batch_error = lix
-        .execute(
-            "UPDATE json_object_member SET scalar_json = $1 \
+    lix.execute(
+        "UPDATE json_object_member SET scalar_json = $1 \
              WHERE parent_id = 'root' AND lixcol_file_id = $2",
-            &[
-                Value::Text(r#""BULK""#.to_owned()),
-                Value::Text(file_id.clone()),
-            ],
-        )
-        .await
-        .expect_err("a direct JSON semantic transition must contain one scalar change");
-    assert_eq!(direct_batch_error.code, LixError::CODE_INVALID_PLUGIN);
-    assert!(
-        direct_batch_error
-            .message
-            .contains("one existing scalar value only")
-    );
+        &[
+            Value::Text(r#""BULK""#.to_owned()),
+            Value::Text(file_id.clone()),
+        ],
+    )
+    .await
+    .expect("a direct JSON semantic transition accepts an existing-scalar batch");
     assert_eq!(
         read_file(&lix, path).await.unwrap(),
-        Some(scalar_after_direct_reject.clone())
+        Some(b"{\"left\":\"BULK\",\"right\":\"BULK\",\"gone\":\"BULK\"}".to_vec())
     );
+    write_file(&lix, path, scalar_after_direct_reject.clone())
+        .await
+        .unwrap();
 
     // Structure is byte-owned. A stale scalar delta is not allowed to
     // recreate an entity after another writer removes its containing slot.
@@ -2767,7 +2763,7 @@ async fn v2_json_scalar_lww_composes_and_stale_structure_does_not_resurrect_node
     .await
     .expect_err("a stale scalar must not resurrect a byte-deleted JSON node");
     assert_eq!(error.code, LixError::CODE_INVALID_PLUGIN);
-    assert!(error.message.contains("one existing scalar value only"));
+    assert!(error.message.contains("existing scalar values only"));
     assert_eq!(
         read_file(&lix, path).await.unwrap(),
         Some(without_gone.clone())

--- a/packages/rs-sdk-tests/tests/e2e.rs
+++ b/packages/rs-sdk-tests/tests/e2e.rs
@@ -6004,19 +6004,174 @@ async fn stale_json_transaction_renders_retained_same_file_edits_with_resolution
 
     stale_client.reset_plugin_transition_counters();
     winner.commit().await.unwrap();
+    stale_client.reset_plugin_transition_counters();
     stale.commit().await.unwrap();
-    assert_eq!(
-        stale_client
-            .plugin_transition_counters()
-            .conflict_resolution_calls,
-        1
-    );
+    let counters = stale_client.plugin_transition_counters();
+    assert_eq!(counters.conflict_resolution_calls, 1);
+    assert_eq!(counters.conflict_resolution_records, 1);
+    assert_eq!(counters.guest_export_calls, 3);
+    assert_eq!(counters.durable_semantic_changes, 2);
     let bytes = read_file(&stale_client, path).await.unwrap().unwrap();
     let rendered: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
     assert_eq!(rendered["retained"], "stale");
     assert_eq!(read_file(&winner_client, path).await.unwrap(), Some(bytes));
     winner_client.close().await.unwrap();
     stale_client.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn stale_json_transaction_batches_conflicts_into_one_render_transition() {
+    const CONFLICTS: usize = 32;
+    let archive = build_json_plugin_archive();
+    let stale_client = open_lix(OpenLixOptions::default()).await.unwrap();
+    install_reference_plugin_in_blank_registry(
+        &stale_client,
+        "plugin_json",
+        &archive,
+        &["json_root", "json_object_member", "json_array_item"],
+    )
+    .await;
+    let path = "/batched-transaction-conflict.json";
+    let base = serde_json::Value::Object(
+        (0..CONFLICTS)
+            .map(|index| (format!("key-{index:02}"), serde_json::json!("base")))
+            .collect(),
+    );
+    write_file(
+        &stale_client,
+        path,
+        serde_json::to_vec(&base).expect("base JSON should encode"),
+    )
+    .await
+    .unwrap();
+    let winner_client = stale_client.open_workspace_session().await.unwrap();
+    let mut stale = stale_client.begin_transaction().await.unwrap();
+    let mut winner = winner_client.begin_transaction().await.unwrap();
+    for (transaction, value) in [(&mut stale, "stale"), (&mut winner, "winner")] {
+        let changed = serde_json::Value::Object(
+            (0..CONFLICTS)
+                .map(|index| (format!("key-{index:02}"), serde_json::json!(value)))
+                .collect(),
+        );
+        transaction
+            .execute(
+                "UPDATE lix_file SET data = $1 WHERE path = $2",
+                &[
+                    Value::Blob(
+                        serde_json::to_vec(&changed)
+                            .expect("changed JSON should encode")
+                            .into(),
+                    ),
+                    Value::Text(path.to_owned()),
+                ],
+            )
+            .await
+            .unwrap();
+    }
+
+    winner.commit().await.unwrap();
+    stale_client.reset_plugin_transition_counters();
+    stale.commit().await.unwrap();
+    let counters = stale_client.plugin_transition_counters();
+    assert_eq!(counters.conflict_resolution_calls, 1);
+    assert_eq!(counters.conflict_resolution_records, CONFLICTS as u64);
+    assert_eq!(counters.guest_export_calls, 3);
+    assert_eq!(counters.durable_semantic_changes, CONFLICTS as u64);
+    assert_eq!(
+        read_file(&stale_client, path).await.unwrap(),
+        read_file(&winner_client, path).await.unwrap()
+    );
+    winner_client.close().await.unwrap();
+    stale_client.close().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "release-only stale plugin replay benchmark"]
+async fn stale_plugin_replay_batch_benchmark_probe() {
+    let conflicts = std::env::var("LIX_STALE_REPLAY_BENCH_CONFLICTS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(64);
+    let rounds = std::env::var("LIX_STALE_REPLAY_BENCH_ROUNDS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(8);
+    let archive = build_json_plugin_archive();
+    let mut samples = Vec::with_capacity(rounds);
+    let mut guest_export_calls = Vec::with_capacity(rounds);
+    for round in 0..rounds {
+        let stale_client = open_lix(OpenLixOptions::default()).await.unwrap();
+        install_reference_plugin_in_blank_registry(
+            &stale_client,
+            "plugin_json",
+            &archive,
+            &["json_root", "json_object_member", "json_array_item"],
+        )
+        .await;
+        let path = format!("/batched-transaction-conflict-{round}.json");
+        let document = |value: &str| {
+            serde_json::Value::Object(
+                (0..conflicts)
+                    .map(|index| (format!("key-{index:04}"), serde_json::json!(value)))
+                    .collect(),
+            )
+        };
+        write_file(
+            &stale_client,
+            &path,
+            serde_json::to_vec(&document("base")).unwrap(),
+        )
+        .await
+        .unwrap();
+        let winner_client = stale_client.open_workspace_session().await.unwrap();
+        let mut stale = stale_client.begin_transaction().await.unwrap();
+        let mut winner = winner_client.begin_transaction().await.unwrap();
+        for (transaction, value) in [(&mut stale, "stale"), (&mut winner, "winner")] {
+            transaction
+                .execute(
+                    "UPDATE lix_file SET data = $1 WHERE path = $2",
+                    &[
+                        Value::Blob(serde_json::to_vec(&document(value)).unwrap().into()),
+                        Value::Text(path.clone()),
+                    ],
+                )
+                .await
+                .unwrap();
+        }
+        winner.commit().await.unwrap();
+        stale_client.reset_plugin_transition_counters();
+        let started = Instant::now();
+        stale.commit().await.unwrap();
+        samples.push(started.elapsed());
+        let counters = stale_client.plugin_transition_counters();
+        assert_eq!(counters.conflict_resolution_calls, 1);
+        assert_eq!(counters.conflict_resolution_records, conflicts as u64);
+        assert_eq!(counters.durable_semantic_changes, conflicts as u64);
+        guest_export_calls.push(counters.guest_export_calls);
+        assert_eq!(
+            read_file(&stale_client, &path).await.unwrap(),
+            read_file(&winner_client, &path).await.unwrap()
+        );
+        winner_client.close().await.unwrap();
+        stale_client.close().await.unwrap();
+    }
+    samples.sort_unstable();
+    guest_export_calls.sort_unstable();
+    let percentile = |values: &[Duration], percentile: usize| {
+        values[(values.len() - 1).saturating_mul(percentile) / 100]
+    };
+    println!(
+        "{}",
+        serde_json::json!({
+            "schema": "lix.stale-plugin-replay.v1",
+            "conflicts": conflicts,
+            "rounds": rounds,
+            "commit_p50_us": percentile(&samples, 50).as_micros(),
+            "commit_p95_us": percentile(&samples, 95).as_micros(),
+            "guest_export_calls_min": guest_export_calls[0],
+            "guest_export_calls_max": guest_export_calls[guest_export_calls.len() - 1],
+        })
+    );
 }
 
 #[tokio::test]
@@ -6027,36 +6182,36 @@ async fn same_base_transactions_resolve_reference_plugin_file_overlaps() {
             "plugin_json",
             build_json_plugin_archive(),
             vec!["json_root", "json_object_member", "json_array_item"],
-            b"{\"value\":\"base\"}\n".to_vec(),
-            b"{\"value\":\"first\"}\n".to_vec(),
-            b"{\"value\":\"second\"}\n".to_vec(),
+            b"{\"a\":\"base\",\"b\":\"base\"}\n".to_vec(),
+            b"{\"a\":\"first\",\"b\":\"first\"}\n".to_vec(),
+            b"{\"a\":\"second\",\"b\":\"second\"}\n".to_vec(),
         ),
         (
             "csv",
             "plugin_csv",
             build_csv_plugin_archive(),
             vec!["csv_v2_table", "csv_v2_row"],
-            b"name,value\nitem,base\n".to_vec(),
-            b"name,value\nitem,first\n".to_vec(),
-            b"name,value\nitem,second\n".to_vec(),
+            b"name,value\nitem,base\nother,base\n".to_vec(),
+            b"name,value\nitem,first\nother,first\n".to_vec(),
+            b"name,value\nitem,second\nother,second\n".to_vec(),
         ),
         (
             "markdown",
             "plugin_markdown",
             build_markdown_plugin_archive(),
             vec!["markdown_node_v2"],
-            b"# Base\n".to_vec(),
-            b"# First\n".to_vec(),
-            b"# Second\n".to_vec(),
+            b"# Base\n\nBase paragraph\n".to_vec(),
+            b"# First\n\nFirst paragraph\n".to_vec(),
+            b"# Second\n\nSecond paragraph\n".to_vec(),
         ),
         (
             "text",
             "plugin_git_text",
             build_text_plugin_archive(),
             vec!["git_text_line_v2"],
-            b"base\n".to_vec(),
-            b"first\n".to_vec(),
-            b"second\n".to_vec(),
+            b"base one\nbase two\n".to_vec(),
+            b"first one\nfirst two\n".to_vec(),
+            b"second one\nsecond two\n".to_vec(),
         ),
     ];
 
@@ -6083,6 +6238,7 @@ async fn same_base_transactions_resolve_reference_plugin_file_overlaps() {
 
         first.reset_plugin_transition_counters();
         first_transaction.commit().await.unwrap();
+        first.reset_plugin_transition_counters();
         second_transaction
             .commit()
             .await
@@ -6091,6 +6247,14 @@ async fn same_base_transactions_resolve_reference_plugin_file_overlaps() {
         assert!(
             counters.conflict_resolution_calls > 0,
             "{extension} must invoke its conflict resolver"
+        );
+        assert!(
+            counters.conflict_resolution_records >= 2,
+            "{extension} must resolve the multi-entity fixture as one batch"
+        );
+        assert_eq!(
+            counters.guest_export_calls, 3,
+            "{extension} must use one resolver and one render transition"
         );
         let first_bytes = read_file(&first, &path).await.unwrap().unwrap();
         let second_bytes = read_file(&second, &path).await.unwrap().unwrap();

--- a/plugins/json/src/core.rs
+++ b/plugins/json/src/core.rs
@@ -12,7 +12,7 @@ pub const ARRAY_ITEM_SCHEMA_KEY: &str = "json_array_item";
 const ROOT_ID: &str = "root";
 const OBJECT_CONTAINER_DOMAIN: &[u8] = b"lix-json-object-container-v2\0";
 const NODES_PER_SPAN_CHUNK: usize = 512;
-const SCALAR_ONLY_SEMANTIC_WRITE: &str = "JSON semantic writes support one existing scalar value only; use a file byte write for additions, deletions, containers, moves, ordering, or layout changes";
+const SCALAR_ONLY_SEMANTIC_WRITE: &str = "JSON semantic writes support existing scalar values only; use a file byte write for additions, deletions, containers, moves, ordering, or layout changes";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct IdNamespace(pub [u8; 16]);
@@ -1575,20 +1575,40 @@ impl Document {
         if changes.is_empty() {
             return Ok((self.clone(), Vec::new()));
         }
-        if changes.len() != 1 {
-            return Err(SCALAR_ONLY_SEMANTIC_WRITE.to_owned());
+        let mut edits = Vec::with_capacity(changes.len());
+        for change in changes {
+            if let Some(edit) = self.scalar_entity_edit(change)? {
+                edits.push(edit);
+            }
         }
-        self.single_scalar_entity_changed(&changes[0])?
-            .ok_or_else(|| SCALAR_ONLY_SEMANTIC_WRITE.to_owned())
+        edits.sort_unstable_by_key(|edit| edit.offset);
+        if edits.windows(2).any(|pair| {
+            pair[0]
+                .offset
+                .checked_add(pair[0].delete_len)
+                .is_none_or(|end| end > pair[1].offset)
+        }) {
+            return Err("JSON semantic write batch contains overlapping scalar edits".to_owned());
+        }
+        if edits.is_empty() {
+            return Ok((self.clone(), edits));
+        }
+        let splices = edits
+            .iter()
+            .map(|edit| InputSplice {
+                offset: edit.offset,
+                delete_len: edit.delete_len,
+                insert: edit.insert.as_slice(),
+            })
+            .collect::<Vec<_>>();
+        let (after, _) = self.file_changed(&splices, IdNamespace([0; 16]))?;
+        Ok((after, edits))
     }
 
-    fn single_scalar_entity_changed(
-        &self,
-        change: &EntityChange,
-    ) -> Result<Option<(Self, Vec<ByteEdit>)>, String> {
+    fn scalar_entity_edit(&self, change: &EntityChange) -> Result<Option<ByteEdit>, String> {
         let identity = EntityIdentity::from_parts(&change.schema_key, &change.entity_pk)?;
         let Some(&node_index) = self.0.lookup.get(&identity_fingerprint(&identity)) else {
-            return Ok(None);
+            return Err(SCALAR_ONLY_SEMANTIC_WRITE.to_owned());
         };
         let node_index = usize::try_from(node_index).expect("u32 fits usize");
         let node = &self.0.nodes[node_index];
@@ -1596,10 +1616,10 @@ impl Document {
             return Err("JSON entity identity fingerprint collision".to_owned());
         }
         if node.kind.is_container() {
-            return Ok(None);
+            return Err(SCALAR_ONLY_SEMANTIC_WRITE.to_owned());
         }
         let Some(snapshot) = &change.snapshot else {
-            return Ok(None);
+            return Err(SCALAR_ONLY_SEMANTIC_WRITE.to_owned());
         };
         let mut strings = HashSet::new();
         let entity = SemanticEntity::parse(
@@ -1611,7 +1631,7 @@ impl Document {
             &mut strings,
         )?;
         if entity.identity() != identity || entity.kind().is_container() {
-            return Ok(None);
+            return Err(SCALAR_ONLY_SEMANTIC_WRITE.to_owned());
         }
         let current = SemanticEntity::parse(
             EntityRecord {
@@ -1622,7 +1642,7 @@ impl Document {
             &mut strings,
         )?;
         if !entity.same_location(&current) {
-            return Ok(None);
+            return Err(SCALAR_ONLY_SEMANTIC_WRITE.to_owned());
         }
         let scalar = entity
             .scalar_json()
@@ -1643,23 +1663,13 @@ impl Document {
                 .ok_or_else(|| "JSON scalar range overflow".to_owned())?,
         )?;
         if before == scalar.as_bytes() {
-            return Ok(Some((self.clone(), Vec::new())));
+            return Ok(None);
         }
-        let splice = InputSplice {
+        Ok(Some(ByteEdit {
             offset: u64::from(value_start),
             delete_len: u64::from(value_len),
-            insert: scalar.as_bytes(),
-        };
-        let (after, _) = self.file_changed(&[splice], IdNamespace([0; 16]))?;
-        let insert = Arc::new(scalar.as_bytes().to_vec());
-        Ok(Some((
-            after,
-            vec![ByteEdit {
-                offset: u64::from(value_start),
-                delete_len: u64::from(value_len),
-                insert,
-            }],
-        )))
+            insert: Arc::new(scalar.as_bytes().to_vec()),
+        }))
     }
 
     pub fn open_entities(entities: Vec<EntityRecord>) -> Result<(Self, ByteEdit), String> {


### PR DESCRIPTION
## Summary

- group resolved and retained stale semantic rows by file before replay
- invoke each file's existing semantic transition/render boundary once per accumulated batch
- hard-cut the JSON reference plugin from one-scalar-only input to sorted, non-overlapping multi-scalar edits applied in one parse/render transition
- retain the existing `beginTransaction()` API and plugin API; no public surface or compatibility shim is added
- strengthen JSON, CSV, Markdown, and text same-base tests to require multi-entity conflict batches, one resolver call, one render transition, and convergence

This is Stack 4, based on #1092.

## Performance

Release benchmark, 64 conflicts in one JSON file, 8 rounds; timing covers stale `commit()` after staging and the winning commit:

| Path | p50 | p95 | Guest exports |
| --- | ---: | ---: | ---: |
| Before: one replay per row | 41,065 µs | 43,041 µs | 66 |
| After: one replay per file | 5,099 µs | 5,251 µs | 3 |

This is **8.05× faster at p50** and **8.20× at p95**. The before probe retained the same batch-capable JSON plugin and fixture, changing only the engine replay loop.

100-client convergence p95 after the cut:

- JSON: 16.201 ms
- CSV: 16.415 ms
- Markdown: 24.990 ms
- text: 12.167 ms

All remain below the 100 ms gate with exact 10% semantic overlap.

## Validation

- `cargo test -p lix_engine --features all-simulations`
- `cargo test -p plugin_json`
- targeted multi-conflict JSON and four-plugin same-base E2E tests
- four-format 100-client release capacity matrix
- `cargo test -p lix_sdk_tests --release --test e2e stale_plugin_replay_batch_benchmark_probe -- --ignored --nocapture`
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
