### PR TITLE
refactor(engine): bound explicit commit admission

### DIFF
--- a/packages/engine/TRANSACTION_CONFLICT_PERFORMANCE.md
+++ b/packages/engine/TRANSACTION_CONFLICT_PERFORMANCE.md
@@ -67,6 +67,26 @@ reference format: JSON 16.201 ms p95, CSV 16.415 ms, Markdown 24.990 ms, and
 text 12.167 ms. Each run retained the exact 10% semantic-overlap workload and
 reported five resolver calls across twenty waves.
 
+## Bounded commit admission
+
+Explicit transaction commits previously contended directly on one Tokio mutex.
+That queue had no engine-owned bound, reacquired the collaboration gate for
+every transaction, and let task-local benchmark clocks start only after a task
+was polled, which could omit mutex queue time. A private FIFO coordinator now
+applies backpressure at 256 queued commits and drains at most 16 commits under
+one gate acquisition. Each transaction still revalidates, resolves, persists,
+and reports its own deterministic result; this is admission batching, not a
+change to atomicity or durability.
+
+This maintainability cut is throughput-neutral by design. On eight release
+runs of the 100-writer, 100%-overlap B3.1 stress fixture, whole-cohort p50 moved
+from 150.612 ms to 151.588 ms (+0.65%, within run variance). The corrected
+request timer now includes queue residence and reports 157.627 ms p95 for that
+pathological same-scalar workload, making the remaining serialization visible
+instead of presenting the old 1.983 ms undercount. On the practical 100-client,
+10%-overlap capacity workload, convergence p95 moved from 16.201 ms to
+16.420 ms and remains far below the 100 ms gate.
+
 ## Reproduction
 
 ```bash
@@ -78,6 +98,10 @@ cargo test -p lix_engine --release \
 
 cargo test -p lix_sdk_tests --release --test e2e \
   stale_plugin_replay_batch_benchmark_probe -- --ignored --nocapture
+
+LIX_CRDT_B3_CLIENTS=100 LIX_CRDT_SAMPLES=8 \
+cargo test -p lix_sdk_tests --release --test crdt_benchmarks_baseline \
+  crdt_benchmarks_b3_1_json_concurrent_map_sets -- --ignored --exact --nocapture
 ```
 
 The probes emit versioned machine-readable records or stable key/value output

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -25,6 +25,7 @@ use crate::storage_adapter::{
 use crate::storage_adapter::{StorageAdapter, StorageWriteSet};
 use crate::telemetry::TelemetrySink;
 use crate::tracked_state::TrackedStateContext;
+use crate::transaction::CommitCoordinator;
 use crate::wasm::WasmTransitionCounters;
 use crate::wasm::{UnsupportedWasmRuntime, WasmRuntime};
 use crate::{LixError, NullableKeyFilter};
@@ -41,6 +42,7 @@ pub struct Engine<StorageImpl: Storage = crate::storage_adapter::Memory> {
     sql_planning_cache: Arc<SqlPlanningCache<CatalogFingerprint>>,
     deterministic_runtime_gate: Arc<tokio::sync::Mutex<()>>,
     collaboration_write_gate: Arc<tokio::sync::Mutex<()>>,
+    commit_coordinator: Arc<CommitCoordinator>,
     observe_coordinator: Arc<ObserveCoordinator>,
     observe_invalidation: Arc<ObserveInvalidation>,
     plugin_host: PluginRuntimeHost,
@@ -170,6 +172,10 @@ where
         // execution-scoped SQL context, optionally wrapped by a transaction
         // overlay for writes.
 
+        let collaboration_write_gate = Arc::new(tokio::sync::Mutex::new(()));
+        let commit_coordinator = Arc::new(CommitCoordinator::new(Arc::clone(
+            &collaboration_write_gate,
+        )));
         Ok(Self {
             binary_cas: Arc::new(BinaryCasContext::new()),
             storage,
@@ -179,7 +185,8 @@ where
             catalog_context: Arc::new(CatalogContext::new()),
             sql_planning_cache: Arc::new(SqlPlanningCache::default()),
             deterministic_runtime_gate: Arc::new(tokio::sync::Mutex::new(())),
-            collaboration_write_gate: Arc::new(tokio::sync::Mutex::new(())),
+            collaboration_write_gate,
+            commit_coordinator,
             observe_coordinator: Arc::new(ObserveCoordinator::new()),
             observe_invalidation: Arc::new(ObserveInvalidation::new()),
             plugin_host,
@@ -229,6 +236,7 @@ where
             Arc::clone(&self.sql_planning_cache),
             Arc::clone(&self.deterministic_runtime_gate),
             Arc::clone(&self.collaboration_write_gate),
+            Arc::clone(&self.commit_coordinator),
             Arc::clone(&self.observe_coordinator),
             Arc::clone(&self.observe_invalidation),
             self.plugin_host.clone(),
@@ -248,6 +256,7 @@ where
             Arc::clone(&self.sql_planning_cache),
             Arc::clone(&self.deterministic_runtime_gate),
             Arc::clone(&self.collaboration_write_gate),
+            Arc::clone(&self.commit_coordinator),
             Arc::clone(&self.observe_coordinator),
             Arc::clone(&self.observe_invalidation),
             self.plugin_host.clone(),

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -40,6 +40,7 @@ use crate::tracked_state::TrackedStateContext;
 use crate::transaction::{CertifiedHistoryStoreReader, Transaction, open_transaction};
 
 use super::transaction::{SessionOperationGuard, SessionTransactionManager, SessionWriteLease};
+use crate::transaction::CommitCoordinator;
 
 pub(crate) const WORKSPACE_BRANCH_KEY: &str = "lix_workspace_branch_id";
 
@@ -142,6 +143,7 @@ pub struct SessionContext<StorageImpl: Storage = Memory> {
     pub(super) sql_planning_cache: Arc<SqlPlanningCache<CatalogFingerprint>>,
     pub(super) deterministic_runtime_gate: Arc<tokio::sync::Mutex<()>>,
     pub(super) collaboration_write_gate: Arc<tokio::sync::Mutex<()>>,
+    pub(super) commit_coordinator: Arc<CommitCoordinator>,
     pub(super) file_views: SessionFileViews,
     pub(super) observe_coordinator: Arc<ObserveCoordinator>,
     pub(super) observe_invalidation: Arc<ObserveInvalidation>,
@@ -164,6 +166,7 @@ where
         sql_planning_cache: Arc<SqlPlanningCache<CatalogFingerprint>>,
         deterministic_runtime_gate: Arc<tokio::sync::Mutex<()>>,
         collaboration_write_gate: Arc<tokio::sync::Mutex<()>>,
+        commit_coordinator: Arc<CommitCoordinator>,
         observe_coordinator: Arc<ObserveCoordinator>,
         observe_invalidation: Arc<ObserveInvalidation>,
         plugin_host: PluginRuntimeHost,
@@ -188,6 +191,7 @@ where
             sql_planning_cache,
             deterministic_runtime_gate,
             collaboration_write_gate,
+            commit_coordinator,
             observe_coordinator,
             observe_invalidation,
             plugin_host,
@@ -206,6 +210,7 @@ where
         sql_planning_cache: Arc<SqlPlanningCache<CatalogFingerprint>>,
         deterministic_runtime_gate: Arc<tokio::sync::Mutex<()>>,
         collaboration_write_gate: Arc<tokio::sync::Mutex<()>>,
+        commit_coordinator: Arc<CommitCoordinator>,
         observe_coordinator: Arc<ObserveCoordinator>,
         observe_invalidation: Arc<ObserveInvalidation>,
         plugin_host: PluginRuntimeHost,
@@ -224,6 +229,7 @@ where
             sql_planning_cache,
             deterministic_runtime_gate,
             collaboration_write_gate,
+            commit_coordinator,
             observe_coordinator,
             observe_invalidation,
             plugin_host,
@@ -242,6 +248,7 @@ where
         sql_planning_cache: Arc<SqlPlanningCache<CatalogFingerprint>>,
         deterministic_runtime_gate: Arc<tokio::sync::Mutex<()>>,
         collaboration_write_gate: Arc<tokio::sync::Mutex<()>>,
+        commit_coordinator: Arc<CommitCoordinator>,
         observe_coordinator: Arc<ObserveCoordinator>,
         observe_invalidation: Arc<ObserveInvalidation>,
         plugin_host: PluginRuntimeHost,
@@ -258,6 +265,7 @@ where
             sql_planning_cache,
             deterministic_runtime_gate,
             collaboration_write_gate,
+            commit_coordinator,
             observe_coordinator,
             observe_invalidation,
             plugin_host,
@@ -278,6 +286,7 @@ where
         sql_planning_cache: Arc<SqlPlanningCache<CatalogFingerprint>>,
         deterministic_runtime_gate: Arc<tokio::sync::Mutex<()>>,
         collaboration_write_gate: Arc<tokio::sync::Mutex<()>>,
+        commit_coordinator: Arc<CommitCoordinator>,
         observe_coordinator: Arc<ObserveCoordinator>,
         observe_invalidation: Arc<ObserveInvalidation>,
         plugin_host: PluginRuntimeHost,
@@ -296,6 +305,7 @@ where
             sql_planning_cache,
             deterministic_runtime_gate,
             collaboration_write_gate,
+            commit_coordinator,
             file_views,
             observe_coordinator,
             observe_invalidation,

--- a/packages/engine/src/session/switch_branch.rs
+++ b/packages/engine/src/session/switch_branch.rs
@@ -94,6 +94,7 @@ where
             Arc::clone(&self.sql_planning_cache),
             Arc::clone(&self.deterministic_runtime_gate),
             Arc::clone(&self.collaboration_write_gate),
+            Arc::clone(&self.commit_coordinator),
             Arc::clone(&self.observe_coordinator),
             Arc::clone(&self.observe_invalidation),
             self.plugin_host.clone(),

--- a/packages/engine/src/session/transaction.rs
+++ b/packages/engine/src/session/transaction.rs
@@ -18,6 +18,7 @@ use crate::transaction::{
 
 use super::SessionContext;
 use super::context::{SessionWriteAccess, closed_error};
+use crate::transaction::CommitCoordinator;
 
 #[expect(missing_debug_implementations)]
 pub struct SessionTransaction<StorageImpl: Storage + 'static = Memory> {
@@ -28,7 +29,7 @@ pub struct SessionTransaction<StorageImpl: Storage + 'static = Memory> {
     pub(super) sql_planning_cache: Arc<SqlPlanningCache<CatalogFingerprint>>,
     _deterministic_runtime_guard: Option<DeterministicRuntimeGuard>,
     write_access: Option<SessionWriteAccess>,
-    collaboration_write_gate: Arc<tokio::sync::Mutex<()>>,
+    commit_coordinator: Arc<CommitCoordinator>,
     pub(super) telemetry: Option<Arc<dyn TelemetrySink>>,
     pub(super) has_started_statement: bool,
 }
@@ -86,7 +87,7 @@ where
             sql_planning_cache: Arc::clone(&self.sql_planning_cache),
             _deterministic_runtime_guard: deterministic_runtime_guard,
             write_access: Some(write_access),
-            collaboration_write_gate: Arc::clone(&self.collaboration_write_gate),
+            commit_coordinator: Arc::clone(&self.commit_coordinator),
             telemetry: self.telemetry.clone(),
             has_started_statement: false,
         })
@@ -118,25 +119,22 @@ where
         // their commit-time revalidation and persistence with bounded writes.
         // Deterministic transactions already retain this gate to preserve the
         // global lock order with their deterministic-runtime guard.
-        let _collaboration_write_guard = if self
+        let already_serialized = self
             .write_access
             .as_ref()
-            .is_some_and(SessionWriteAccess::serializes_collaboration_writes)
-        {
-            None
-        } else {
-            Some(
-                Arc::clone(&self.collaboration_write_gate)
-                    .lock_owned()
-                    .await,
-            )
-        };
+            .is_some_and(SessionWriteAccess::serializes_collaboration_writes);
         let operation_guard = self.begin_session_commit_operation()?;
         let transaction = self
             .transaction
             .take()
             .ok_or_else(|| transaction_state_error("Lix transaction is closed"))?;
-        let result = transaction.commit(&self.runtime_functions).await;
+        let result = if already_serialized {
+            transaction.commit(&self.runtime_functions).await
+        } else {
+            self.commit_coordinator
+                .commit(transaction, self.runtime_functions)
+                .await
+        };
         drop(operation_guard);
         let outcome = result?;
         drop(self.write_access.take());

--- a/packages/engine/src/transaction/commit_coordinator.rs
+++ b/packages/engine/src/transaction/commit_coordinator.rs
@@ -1,0 +1,232 @@
+use std::collections::VecDeque;
+use std::future::Future;
+use std::pin::Pin;
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::{Semaphore, oneshot};
+use tracing::Instrument as _;
+
+use super::{Transaction, TransactionCommitOutcome};
+use crate::LixError;
+use crate::functions::FunctionContext;
+use crate::storage_adapter::Storage;
+
+const COMMIT_QUEUE_CAPACITY: usize = 256;
+const COMMIT_BATCH_CAPACITY: usize = 16;
+
+type CommitFuture = Pin<Box<dyn Future<Output = ()> + 'static>>;
+type CommitJob = Box<dyn FnOnce() -> CommitFuture + Send + 'static>;
+
+#[derive(Clone)]
+pub(crate) struct CommitCoordinator {
+    inner: Arc<CommitCoordinatorInner>,
+}
+
+struct CommitCoordinatorInner {
+    collaboration_write_gate: Arc<tokio::sync::Mutex<()>>,
+    capacity: Arc<Semaphore>,
+    state: Mutex<CommitCoordinatorState>,
+    #[cfg(test)]
+    stats: CommitCoordinatorStats,
+}
+
+#[derive(Default)]
+struct CommitCoordinatorState {
+    running: bool,
+    queue: VecDeque<CommitJob>,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct CommitCoordinatorStats {
+    batch_count: AtomicUsize,
+    commit_count: AtomicUsize,
+    max_batch_size: AtomicUsize,
+}
+
+impl CommitCoordinator {
+    pub(crate) fn new(collaboration_write_gate: Arc<tokio::sync::Mutex<()>>) -> Self {
+        Self {
+            inner: Arc::new(CommitCoordinatorInner {
+                collaboration_write_gate,
+                capacity: Arc::new(Semaphore::new(COMMIT_QUEUE_CAPACITY)),
+                state: Mutex::new(CommitCoordinatorState::default()),
+                #[cfg(test)]
+                stats: CommitCoordinatorStats::default(),
+            }),
+        }
+    }
+
+    pub(crate) async fn commit<StorageImpl>(
+        &self,
+        transaction: Transaction<StorageImpl>,
+        runtime_functions: FunctionContext,
+    ) -> Result<TransactionCommitOutcome, LixError>
+    where
+        StorageImpl: Storage + Clone + Send + Sync + 'static,
+    {
+        let permit = Arc::clone(&self.inner.capacity)
+            .acquire_owned()
+            .await
+            .map_err(|_| coordinator_closed())?;
+        let (result, receive) = oneshot::channel();
+        let job: CommitJob = Box::new(move || {
+            Box::pin(async move {
+                let outcome = transaction.commit(&runtime_functions).await;
+                let _ = result.send(outcome);
+                drop(permit);
+            })
+        });
+        self.enqueue(job).await;
+        receive.await.map_err(|_| coordinator_closed())?
+    }
+
+    async fn enqueue(&self, job: CommitJob) {
+        let leads = {
+            let mut state = self
+                .inner
+                .state
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            state.queue.push_back(job);
+            if state.running {
+                false
+            } else {
+                state.running = true;
+                true
+            }
+        };
+        if leads {
+            self.drive().await;
+        }
+    }
+
+    async fn drive(&self) {
+        let mut driver = CommitDriverGuard::new(&self.inner);
+        tokio::task::yield_now().await;
+        loop {
+            let batch = {
+                let mut state = self
+                    .inner
+                    .state
+                    .lock()
+                    .unwrap_or_else(|error| error.into_inner());
+                let take = state.queue.len().min(COMMIT_BATCH_CAPACITY);
+                if take == 0 {
+                    state.running = false;
+                    driver.disarm();
+                    return;
+                }
+                state.queue.drain(..take).collect::<Vec<_>>()
+            };
+            #[cfg(test)]
+            {
+                self.inner.stats.batch_count.fetch_add(1, Ordering::Relaxed);
+                self.inner
+                    .stats
+                    .commit_count
+                    .fetch_add(batch.len(), Ordering::Relaxed);
+                self.inner
+                    .stats
+                    .max_batch_size
+                    .fetch_max(batch.len(), Ordering::Relaxed);
+            }
+            let _gate = self
+                .inner
+                .collaboration_write_gate
+                .lock()
+                .instrument(tracing::debug_span!(
+                    target: "lix_transaction",
+                    "lix.transaction.commit_batch",
+                    batch_size = batch.len(),
+                ))
+                .await;
+            for job in batch {
+                job().await;
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn stats(&self) -> (usize, usize, usize) {
+        (
+            self.inner.stats.batch_count.load(Ordering::Relaxed),
+            self.inner.stats.commit_count.load(Ordering::Relaxed),
+            self.inner.stats.max_batch_size.load(Ordering::Relaxed),
+        )
+    }
+}
+
+struct CommitDriverGuard<'a> {
+    inner: &'a CommitCoordinatorInner,
+    armed: bool,
+}
+
+impl<'a> CommitDriverGuard<'a> {
+    fn new(inner: &'a CommitCoordinatorInner) -> Self {
+        Self { inner, armed: true }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for CommitDriverGuard<'_> {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let mut state = self
+            .inner
+            .state
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        state.running = false;
+        state.queue.clear();
+    }
+}
+
+fn coordinator_closed() -> LixError {
+    LixError::new(
+        LixError::CODE_INTERNAL_ERROR,
+        "transaction commit coordinator closed unexpectedly",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn concurrent_jobs_drain_in_bounded_cohorts() {
+        let coordinator = CommitCoordinator::new(Arc::new(tokio::sync::Mutex::new(())));
+        let completed = Arc::new(AtomicUsize::new(0));
+        let jobs = (0..40).map(|_| {
+            let coordinator = coordinator.clone();
+            let completed = Arc::clone(&completed);
+            async move {
+                let _permit = Arc::clone(&coordinator.inner.capacity)
+                    .acquire_owned()
+                    .await
+                    .unwrap();
+                coordinator
+                    .enqueue(Box::new(move || {
+                        Box::pin(async move {
+                            completed.fetch_add(1, Ordering::Relaxed);
+                        })
+                    }))
+                    .await;
+            }
+        });
+        futures_util::future::join_all(jobs).await;
+
+        let (batches, commits, max_batch_size) = coordinator.stats();
+        assert_eq!(completed.load(Ordering::Relaxed), 40);
+        assert_eq!(commits, 40);
+        assert!(batches >= 3);
+        assert_eq!(max_batch_size, COMMIT_BATCH_CAPACITY);
+    }
+}

--- a/packages/engine/src/transaction/mod.rs
+++ b/packages/engine/src/transaction/mod.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "storage-benches")]
 mod bench_support;
 mod commit;
+mod commit_coordinator;
 mod context;
 mod normalization;
 pub(crate) mod plugin_checkpoint;
@@ -21,12 +22,14 @@ pub(crate) use commit::take_complete_replacement_packed_current_base_publication
 pub(crate) use commit::take_complete_replacement_packed_current_base_retirements;
 #[cfg(test)]
 pub(crate) use commit::take_ordered_packed_current_base_publications;
+pub(crate) use commit_coordinator::CommitCoordinator;
 pub(crate) use context::CertifiedHistoryStoreReader;
 #[cfg(test)]
 pub(crate) use context::CommitBoundaryGuard;
 pub(crate) use context::CommitBoundaryState;
 pub(crate) use context::Transaction;
 pub(crate) use context::TransactionCommitBoundary;
+pub(crate) use context::TransactionCommitOutcome;
 pub(crate) use context::begin_commit_boundary;
 pub(crate) use context::commit_at_boundary;
 pub(crate) use context::open_transaction;

--- a/packages/rs-sdk-tests/tests/crdt_benchmarks_baseline.rs
+++ b/packages/rs-sdk-tests/tests/crdt_benchmarks_baseline.rs
@@ -143,8 +143,8 @@ async fn crdt_benchmarks_b3_1_json_concurrent_map_sets() {
             .run_until(async move {
                 let mut commits = tokio::task::JoinSet::new();
                 for transaction in transactions {
+                    let started = Instant::now();
                     commits.spawn_local(async move {
-                        let started = Instant::now();
                         let result = transaction.commit().await;
                         (started.elapsed(), result)
                     });


### PR DESCRIPTION
Stacked on #1093.

## What
- replace per-caller collaboration-gate contention with a private bounded FIFO commit coordinator
- cap queued explicit commits at 256 and drain at most 16 per gate acquisition
- preserve individual transaction revalidation, conflict resolution, commit outcomes, and deterministic lock ordering
- correct the B3.1 request timer so it includes queue residence instead of starting when a task first gets polled
- keep beginTransaction() unchanged; this adds no public API

## Benchmark evidence
- practical 100-client workload with exactly 10% semantic overlap: JSON convergence p95 16.420 ms; service p95 11.556 ms; <100 ms gate passes
- 100-client same-scalar stress, 8 rounds: whole-cohort p50 150.612 ms before vs 151.588 ms after (+0.65%, throughput-neutral)
- the newly corrected request p95 is 157.627 ms because queue time is now measured; the prior 1.983 ms number excluded that wait and was invalid

## Validation
- cargo fmt --all -- --check
- cargo test -p lix_engine --features all-simulations (802 passed, 0 failed, 2 ignored; doctests pass)
- cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings

Hard cut: no compatibility shim and no alternate commit path for ordinary explicit transactions.