### PR TITLE
Define the regular-file filesystem sync contract

### DIFF
--- a/.changenotes/diagnose-unsupported-filesystem-entries.md
+++ b/.changenotes/diagnose-unsupported-filesystem-entries.md
@@ -4,4 +4,4 @@ type: patch
 
 Filesystem sync now reports symlinks and other unsupported entries that block a regular Lix file instead of silently leaving Lix and disk out of sync.
 
-Lix file paths remain literal UTF-8, and experimental Git replay now rejects non-UTF-8 paths, symbolic links, and gitlinks rather than encoding or representing them as regular files.
+The engine now owns and enforces the literal UTF-8 logical-path contract, including descriptor names and NUL rejection. Experimental Git replay rejects non-UTF-8 paths, symbolic links, and gitlinks rather than encoding or representing them as regular files.

--- a/.changenotes/diagnose-unsupported-filesystem-entries.md
+++ b/.changenotes/diagnose-unsupported-filesystem-entries.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Filesystem sync now reports symlinks and other unsupported entries that block a regular Lix file instead of silently leaving Lix and disk out of sync.
+
+Lix file paths remain literal UTF-8, and experimental Git replay now rejects non-UTF-8 paths, symbolic links, and gitlinks rather than encoding or representing them as regular files.

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -59,6 +59,14 @@ await lix.close();
 
 Reopening the same path resumes existing RocksDB filesystem storage state. Lix stores its private repository data in `<workspace>/.lix/.internal/rocksdb` and syncs workspace files through Lix.
 
+Filesystem sync imports, watches, materializes, and deletes regular files. It
+does not follow or import symbolic links or other special filesystem entries.
+Those entries may coexist at unrelated paths, but if one blocks a path that
+Lix needs to materialize, the write reports
+`LIX_FILESYSTEM_UNSUPPORTED_ENTRY` instead of silently leaving disk and Lix in
+different states. Executable and other permission bits are currently outside
+the sync contract.
+
 Older SQLite filesystem storage metadata is not migrated. If Lix detects the
 old SQLite metadata files in `<workspace>/.lix/.internal` before a RocksDB store
 exists, it clears `.lix/.internal` and initializes a fresh RocksDB storage.

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -28,6 +28,13 @@ links, device nodes, sockets, and other non-regular filesystem entries are not
 represented as `lix_file` rows. Executable and other permission bits are not
 part of the current file contract.
 
+The engine defines a Lix logical path as an absolute `/`-separated sequence of
+literal UTF-8 segments. Empty segments, `.`, `..`, `/` within a segment, NUL,
+and a trailing slash are invalid; `/` itself is only the root directory. All
+other segment text is preserved exactly: the engine does not URL-decode,
+case-fold, or Unicode-normalize paths. Filesystem adapters diagnose names that
+the target host cannot represent.
+
 The checkpoint and diff relations are read-only. Their `diff_id` rows can feed
 the `lix_revert`, `lix_apply`, and `lix_create_checkpoint` command sinks. See
 [Checkpoints](./checkpoints.md) and [Diff commands](./diff-commands.md).

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -20,6 +20,14 @@ Lix exposes logical application data through typed SQL relations:
 shared workspace metadata, and `lix_change` provides workspace-wide activity.
 There is no generic `lix_state*` SQL family.
 
+`lix_file` represents regular file contents only. Its public shape remains
+`id`, `path`, and `data` (plus the standard `lixcol_*` bookkeeping columns):
+`path` is an absolute, literal UTF-8 path and `data` is the file's bytes. Path
+characters such as spaces, `%`, `#`, `?`, and `@` are not URL-encoded. Symbolic
+links, device nodes, sockets, and other non-regular filesystem entries are not
+represented as `lix_file` rows. Executable and other permission bits are not
+part of the current file contract.
+
 The checkpoint and diff relations are read-only. Their `diff_id` rows can feed
 the `lix_revert`, `lix_apply`, and `lix_create_checkpoint` command sinks. See
 [Checkpoints](./checkpoints.md) and [Diff commands](./diff-commands.md).

--- a/packages/cli/src/commands/exp/git_replay.rs
+++ b/packages/cli/src/commands/exp/git_replay.rs
@@ -46,8 +46,8 @@ struct Change {
 }
 
 impl Change {
-    fn new_is_blob(&self) -> bool {
-        mode_is_blob(&self.new_mode)
+    fn new_is_regular_file(&self) -> bool {
+        mode_is_regular_file(&self.new_mode)
     }
 }
 
@@ -57,8 +57,8 @@ struct ReplayCommit {
     first_parent: Option<String>,
 }
 
-/// A Git pathname is bytes, not Unicode. Keep that identity byte-exact and
-/// encode it only at the Lix filesystem boundary.
+/// `lix_file.path` is literal UTF-8. Reject Git's non-UTF-8 pathnames instead
+/// of inventing an encoded path with different identity.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct GitPath(Vec<u8>);
 
@@ -72,11 +72,18 @@ impl GitPath {
                 "malformed git diff-tree output: Git path must be relative",
             ));
         }
+        std::str::from_utf8(token).map_err(|_| {
+            CliError::msg(
+                "unsupported Git path: lix_file paths must be valid UTF-8 and are stored literally",
+            )
+        })?;
         Ok(Self(token.to_vec()))
     }
 
     fn relative_lix_path(&self) -> String {
-        encode_git_path_bytes(&self.0)
+        std::str::from_utf8(&self.0)
+            .expect("GitPath construction validates UTF-8")
+            .to_string()
     }
 
     fn lix_path(&self) -> String {
@@ -940,11 +947,10 @@ fn read_tree_snapshot_changes(repo_path: &Path, commit_sha: &str) -> Result<Vec<
                 "malformed git ls-tree record: {header}"
             )));
         }
-        let is_blob = fields[1] == "blob" && mode_is_blob(fields[0]);
-        let is_gitlink = fields[1] == "commit" && mode_is_gitlink(fields[0]);
-        if !is_blob && !is_gitlink {
+        let is_regular_file = fields[1] == "blob" && mode_is_regular_file(fields[0]);
+        if !is_regular_file {
             return Err(CliError::msg(format!(
-                "unsupported git ls-tree entry {header}; expected blob or gitlink"
+                "unsupported Git tree entry {header}; lix_file stores regular file contents only"
             )));
         }
         changes.push(Change {
@@ -1659,7 +1665,7 @@ fn git_process_error(
 fn collect_wanted_blob_ids(changes: &[Change]) -> Vec<String> {
     let mut wanted_blob_ids = BTreeSet::<String>::new();
     for change in changes {
-        if change.new_path.is_none() || !change.new_is_blob() {
+        if change.new_path.is_none() || !change.new_is_regular_file() {
             continue;
         }
         if !change.new_oid.is_empty() && !is_null_git_oid(&change.new_oid) {
@@ -1681,6 +1687,9 @@ fn prepare_commit_changes(
     for change in changes {
         let status = normalize_status(change.status);
 
+        reject_unsupported_git_mode(&change.old_mode, change.old_path.as_ref())?;
+        reject_unsupported_git_mode(&change.new_mode, change.new_path.as_ref())?;
+
         if should_delete_old_entry(change, status) {
             if let Some(deleted_id) = resolve_delete_path(state, change) {
                 delete_ids.insert(deleted_id.clone());
@@ -1693,7 +1702,7 @@ fn prepare_commit_changes(
             continue;
         }
 
-        if !mode_is_replay_file(&change.new_mode) {
+        if !mode_is_regular_file(&change.new_mode) {
             return Err(CliError::msg(format!(
                 "unsupported Git file mode {} for replayed path {}",
                 change.new_mode,
@@ -1710,23 +1719,19 @@ fn prepare_commit_changes(
         };
 
         let target = resolve_write_target(state, change)?;
-        let data = if change.new_is_blob() {
-            Some(
-                blob_by_oid
-                    .get(&change.new_oid)
-                    .ok_or_else(|| {
-                        CliError::msg(format!(
-                            "missing blob {} while applying {} {}",
-                            change.new_oid,
-                            status,
-                            new_path.lix_path()
-                        ))
-                    })?
-                    .clone(),
-            )
-        } else {
-            None
-        };
+        let data = Some(
+            blob_by_oid
+                .get(&change.new_oid)
+                .ok_or_else(|| {
+                    CliError::msg(format!(
+                        "missing blob {} while applying {} {}",
+                        change.new_oid,
+                        status,
+                        new_path.lix_path()
+                    ))
+                })?
+                .clone(),
+        );
 
         let row = WriteRow {
             id: target.id.clone(),
@@ -1763,7 +1768,7 @@ fn prepare_commit_changes(
 }
 
 fn should_delete_old_entry(change: &Change, status: char) -> bool {
-    if change.old_path.is_none() || !mode_is_replay_file(&change.old_mode) {
+    if change.old_path.is_none() || !mode_is_regular_file(&change.old_mode) {
         return false;
     }
 
@@ -1774,7 +1779,7 @@ fn should_delete_old_entry(change: &Change, status: char) -> bool {
         // in the same atomic replay revision.
         'D' | 'R' => true,
         'A' | 'C' => false,
-        _ => !mode_is_replay_file(&change.new_mode),
+        _ => !mode_is_regular_file(&change.new_mode),
     }
 }
 
@@ -1934,16 +1939,12 @@ where
                 .as_ref()
                 .ok_or_else(|| CliError::msg("Git tree snapshot entry has no path"))?
                 .lix_path();
-            let data = if change.new_is_blob() {
-                Some(blob_by_oid.get(&change.new_oid).ok_or_else(|| {
-                    CliError::msg(format!(
-                        "Git tree blob {} was not returned for {path}",
-                        change.new_oid
-                    ))
-                })?)
-            } else {
-                None
-            };
+            let data = Some(blob_by_oid.get(&change.new_oid).ok_or_else(|| {
+                CliError::msg(format!(
+                    "Git tree blob {} was not returned for {path}",
+                    change.new_oid
+                ))
+            })?);
             if expected_by_path.contains_key(&path) {
                 return Err(CliError::msg(format!(
                     "Git tree snapshot contains duplicate path {path}"
@@ -2056,24 +2057,16 @@ fn verify_file_manifest_entry(
     expected: &ExpectedFile,
     commit_sha: &str,
 ) -> Result<(), CliError> {
-    if mode_is_gitlink(&expected.git_mode) {
-        if data.is_some_and(|bytes| !bytes.is_empty()) {
-            return Err(CliError::msg(format!(
-                "state mismatch at {commit_sha}: gitlink {path} has non-empty synthetic payload"
-            )));
-        }
-    } else {
-        if expected.size_bytes != data.map(<[u8]>::len) {
-            return Err(CliError::msg(format!(
-                "state mismatch at {commit_sha}: byte length differs for path {path}"
-            )));
-        }
-        let hash = data.map(sha256_hex);
-        if expected.sha256 != hash {
-            return Err(CliError::msg(format!(
-                "state mismatch at {commit_sha}: hash differs for path {path}"
-            )));
-        }
+    if expected.size_bytes != data.map(<[u8]>::len) {
+        return Err(CliError::msg(format!(
+            "state mismatch at {commit_sha}: byte length differs for path {path}"
+        )));
+    }
+    let hash = data.map(sha256_hex);
+    if expected.sha256 != hash {
+        return Err(CliError::msg(format!(
+            "state mismatch at {commit_sha}: hash differs for path {path}"
+        )));
     }
     if metadata.get("git_mode").and_then(serde_json::Value::as_str) != Some(&expected.git_mode)
         || metadata.get("git_oid").and_then(serde_json::Value::as_str) != Some(&expected.git_oid)
@@ -2133,14 +2126,6 @@ fn hex_digit_lower(value: u8) -> char {
     }
 }
 
-fn hex_digit_upper(value: u8) -> char {
-    match value {
-        0..=9 => (b'0' + value) as char,
-        10..=15 => (b'A' + (value - 10)) as char,
-        _ => '0',
-    }
-}
-
 fn normalize_status(value: char) -> char {
     value.to_ascii_uppercase()
 }
@@ -2154,36 +2139,24 @@ fn stable_file_id(path: &GitPath) -> String {
     .to_string()
 }
 
-fn encode_git_path_bytes(path: &[u8]) -> String {
-    let mut encoded = String::new();
-    for byte in path {
-        if *byte == b'/' {
-            encoded.push('/');
-            continue;
-        }
-        let is_alpha_num = byte.is_ascii_alphanumeric();
-        let is_safe = matches!(*byte, b'.' | b'_' | b'~' | b'-');
-        if is_alpha_num || is_safe {
-            encoded.push(*byte as char);
-        } else {
-            encoded.push('%');
-            encoded.push(hex_digit_upper(byte >> 4));
-            encoded.push(hex_digit_upper(byte & 0x0f));
-        }
+fn reject_unsupported_git_mode(mode: &str, path: Option<&GitPath>) -> Result<(), CliError> {
+    if mode == "000000" || mode_is_regular_file(mode) {
+        return Ok(());
     }
-    encoded
+    let kind = match mode {
+        "120000" => "symbolic link",
+        "160000" => "gitlink/submodule",
+        _ => "non-regular entry",
+    };
+    Err(CliError::msg(format!(
+        "unsupported Git {kind} mode {mode} at {}; lix_file stores regular file contents only",
+        path.map(GitPath::lix_path)
+            .unwrap_or_else(|| "<missing path>".to_string())
+    )))
 }
 
-fn mode_is_blob(mode: &str) -> bool {
-    matches!(mode, "100644" | "100755" | "120000")
-}
-
-fn mode_is_gitlink(mode: &str) -> bool {
-    mode == "160000"
-}
-
-fn mode_is_replay_file(mode: &str) -> bool {
-    mode_is_blob(mode) || mode_is_gitlink(mode)
+fn mode_is_regular_file(mode: &str) -> bool {
+    matches!(mode, "100644" | "100755")
 }
 
 fn is_null_git_oid(oid: &str) -> bool {
@@ -2728,7 +2701,7 @@ mod tests {
     }
 
     #[test]
-    fn collect_wanted_blob_ids_skips_gitlink_oids() {
+    fn collect_wanted_blob_ids_only_includes_regular_files() {
         let changes = vec![
             Change {
                 status: 'A',
@@ -2832,7 +2805,7 @@ mod tests {
     }
 
     #[test]
-    fn prepare_commit_changes_typechange_blob_to_gitlink_preserves_file_identity() {
+    fn prepare_commit_changes_rejects_gitlinks() {
         let path = git_path(b"artifact/spa-prerender-repro");
         let file_id = stable_file_id(&path);
         let mut state = ReplayState::default();
@@ -2848,19 +2821,11 @@ mod tests {
             new_path: Some(git_path(b"artifact/spa-prerender-repro")),
         }];
 
-        let prepared = prepare_commit_changes(&mut state, &changes, &HashMap::new())
-            .expect("gitlink typechange should not error");
+        let error = prepare_commit_changes(&mut state, &changes, &HashMap::new())
+            .expect_err("gitlink typechange should be rejected");
 
-        assert!(prepared.deletes.is_empty());
-        assert!(prepared.inserts.is_empty());
-        assert_eq!(prepared.updates.len(), 1);
-        assert_eq!(prepared.updates[0].data, None);
-        assert_eq!(prepared.updates[0].git_mode, "160000");
-        assert!(
-            state
-                .path_to_file_id
-                .contains_key(&git_path(b"artifact/spa-prerender-repro"))
-        );
+        assert!(error.to_string().contains("gitlink/submodule"));
+        assert!(error.to_string().contains("regular file contents only"));
     }
 
     #[test]
@@ -3072,7 +3037,7 @@ mod tests {
                 id: "/src/new.ts".to_string(),
                 path: "/src/new.ts".to_string(),
                 data: Some(b"hello".to_vec()),
-                git_mode: "120000".to_string(),
+                git_mode: "100644".to_string(),
                 git_oid: "b".repeat(40),
             }],
             updates: Vec::new(),
@@ -3096,47 +3061,43 @@ mod tests {
                 Value::Text("/src/new.ts".to_string()),
                 Value::Text("/src/new.ts".to_string()),
                 Value::Blob(b"hello".to_vec().into()),
-                Value::Json(json!({"git_mode": "120000", "git_oid": "b".repeat(40)})),
+                Value::Json(json!({"git_mode": "100644", "git_oid": "b".repeat(40)})),
             ]
         );
     }
 
     #[test]
-    fn gitlink_rows_use_empty_binary_payload_and_preserve_reference_metadata() {
-        let batch = PreparedBatch {
-            deletes: Vec::new(),
-            inserts: vec![WriteRow {
-                id: "/vendor/submodule".to_string(),
-                path: "/vendor/submodule".to_string(),
-                data: None,
-                git_mode: "160000".to_string(),
-                git_oid: "c".repeat(40),
-            }],
-            updates: Vec::new(),
-        };
+    fn prepare_commit_changes_rejects_symbolic_links() {
+        let changes = vec![Change {
+            status: 'A',
+            old_mode: "000000".to_string(),
+            new_mode: "120000".to_string(),
+            new_oid: "c".repeat(40),
+            old_path: None,
+            new_path: Some(git_path(b"link.txt")),
+        }];
 
-        let statements = build_replay_commit_statements(&batch, DEFAULT_INSERT_BATCH_ROWS);
+        let error = prepare_commit_changes(&mut ReplayState::default(), &changes, &HashMap::new())
+            .expect_err("symbolic links should be rejected");
 
-        assert_eq!(statements.len(), 1);
-        assert_eq!(statements[0].params[2], Value::Blob(Vec::new().into()));
-        assert_eq!(
-            statements[0].params[3],
-            Value::Json(json!({"git_mode": "160000", "git_oid": "c".repeat(40)}))
-        );
+        assert!(error.to_string().contains("symbolic link"));
+        assert!(error.to_string().contains("/link.txt"));
     }
 
     #[test]
-    fn raw_diff_parser_preserves_non_utf8_git_path_bytes() {
+    fn raw_diff_parser_rejects_non_utf8_git_paths() {
         let raw = b":100644 100755 1111111111111111111111111111111111111111 2222222222222222222222222222222222222222 M\0dir/\xff name\0";
-        let changes = parse_raw_diff_tree(raw).expect("raw diff should parse");
+        let error = parse_raw_diff_tree(raw).expect_err("non-UTF-8 path should fail");
 
-        assert_eq!(changes.len(), 1);
-        let path = changes[0]
-            .new_path
-            .as_ref()
-            .expect("modified entry should have new path");
-        assert_eq!(path.0, b"dir/\xff name");
-        assert_eq!(path.lix_path(), "/dir/%FF%20name");
+        assert!(error.to_string().contains("valid UTF-8"));
+    }
+
+    #[test]
+    fn git_paths_are_literal_utf8() {
+        let path = GitPath::from_diff_token("docs/100% @2x/日本語.txt".as_bytes())
+            .expect("UTF-8 Git path should be accepted");
+
+        assert_eq!(path.lix_path(), "/docs/100% @2x/日本語.txt");
     }
 
     #[test]

--- a/packages/cli/src/commands/exp/git_replay.rs
+++ b/packages/cli/src/commands/exp/git_replay.rs
@@ -857,15 +857,7 @@ fn seed_parent_tree<StorageImpl>(
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
-    let changes = read_tree_snapshot_changes(repo_path, parent_commit)?
-        .into_iter()
-        .filter(|change| {
-            change
-                .new_path
-                .as_ref()
-                .is_some_and(|path| replay_scope.contains(path))
-        })
-        .collect::<Vec<_>>();
+    let changes = read_scoped_tree_snapshot_changes(repo_path, parent_commit, replay_scope)?;
     let mut pending = PreparedBatch::default();
     let mut result = SeedResult::default();
     for change_batch in changes.chunks(TREE_BLOB_READ_BATCH_ROWS) {
@@ -947,12 +939,6 @@ fn read_tree_snapshot_changes(repo_path: &Path, commit_sha: &str) -> Result<Vec<
                 "malformed git ls-tree record: {header}"
             )));
         }
-        let is_regular_file = fields[1] == "blob" && mode_is_regular_file(fields[0]);
-        if !is_regular_file {
-            return Err(CliError::msg(format!(
-                "unsupported Git tree entry {header}; lix_file stores regular file contents only"
-            )));
-        }
         changes.push(Change {
             status: 'A',
             old_mode: "000000".to_string(),
@@ -962,6 +948,28 @@ fn read_tree_snapshot_changes(repo_path: &Path, commit_sha: &str) -> Result<Vec<
             new_path: Some(GitPath::from_diff_token(path)?),
         });
     }
+    Ok(changes)
+}
+
+fn read_scoped_tree_snapshot_changes(
+    repo_path: &Path,
+    commit_sha: &str,
+    replay_scope: &HashSet<GitPath>,
+) -> Result<Vec<Change>, CliError> {
+    let changes = read_tree_snapshot_changes(repo_path, commit_sha)?
+        .into_iter()
+        .filter(|change| {
+            change
+                .new_path
+                .as_ref()
+                .is_some_and(|path| replay_scope.contains(path))
+        })
+        .collect::<Vec<_>>();
+
+    for change in &changes {
+        reject_unsupported_git_mode(&change.new_mode, change.new_path.as_ref())?;
+    }
+
     Ok(changes)
 }
 
@@ -1921,15 +1929,7 @@ fn verify_final_git_tree<StorageImpl>(
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
-    let tree_changes = read_tree_snapshot_changes(repo_path, commit_sha)?
-        .into_iter()
-        .filter(|change| {
-            change
-                .new_path
-                .as_ref()
-                .is_some_and(|path| replay_scope.contains(path))
-        })
-        .collect::<Vec<_>>();
+    let tree_changes = read_scoped_tree_snapshot_changes(repo_path, commit_sha, replay_scope)?;
     let mut expected_by_path = HashMap::<String, ExpectedFile>::with_capacity(tree_changes.len());
     for change_batch in tree_changes.chunks(TREE_BLOB_READ_BATCH_ROWS) {
         let blob_by_oid = blob_reader.read_blobs(&collect_wanted_blob_ids(change_batch))?;
@@ -2778,6 +2778,39 @@ mod tests {
         extend_replay_scope_with_tree(&repo, parent, &mut scope)
             .expect("full parent tree should extend scope");
         assert!(scope.contains(&git_path(b"untouched.txt")));
+        fs::remove_dir_all(&fixture).expect("fixture directory should be removable");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn scoped_tree_snapshot_ignores_unrelated_symbolic_links() {
+        use std::os::unix::fs::symlink;
+
+        let fixture = unique_temp_dir();
+        let repo = fixture.join("repo");
+        fs::create_dir_all(&repo).expect("fixture repository should be created");
+        git_ok(&repo, &["init", "-q", "-b", "main"]);
+        git_ok(&repo, &["config", "user.email", "replay@example.test"]);
+        git_ok(&repo, &["config", "user.name", "Replay Test"]);
+        fs::write(repo.join("selected.txt"), b"selected\n").expect("fixture should write");
+        symlink("selected.txt", repo.join("unrelated-link")).expect("fixture should link");
+        git_ok(&repo, &["add", "-A"]);
+        git_ok(&repo, &["commit", "-qm", "root"]);
+        let commit = run_git_text(&repo, &["rev-parse".to_string(), "HEAD".to_string()], None)
+            .expect("fixture commit should resolve");
+
+        let window_scope = HashSet::from([git_path(b"selected.txt")]);
+        let changes = read_scoped_tree_snapshot_changes(&repo, commit.trim(), &window_scope)
+            .expect("an unrelated symbolic link should not fail window scope");
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].new_path, Some(git_path(b"selected.txt")));
+
+        let full_scope = HashSet::from([git_path(b"selected.txt"), git_path(b"unrelated-link")]);
+        let error = read_scoped_tree_snapshot_changes(&repo, commit.trim(), &full_scope)
+            .expect_err("a symbolic link inside replay scope should be rejected");
+        assert!(error.to_string().contains("symbolic link"));
+        assert!(error.to_string().contains("/unrelated-link"));
+
         fs::remove_dir_all(&fixture).expect("fixture directory should be removable");
     }
 

--- a/packages/engine/src/common/lix_path.rs
+++ b/packages/engine/src/common/lix_path.rs
@@ -13,7 +13,10 @@
 //! - Empty, `.`, and `..` segments are rejected because they do not name stable
 //!   Lix filesystem entries.
 //! - `/` is only a separator, so a standalone segment cannot contain `/`.
+//! - NUL is rejected because it cannot be represented by host filesystem APIs.
 //! - Root is represented as the directory path `/`.
+//! - Segment text is otherwise preserved literally: paths are not URL-decoded,
+//!   case-folded, or Unicode-normalized.
 //!
 //! Runtime strategy:
 //!
@@ -34,17 +37,26 @@
     clippy::semicolon_if_nothing_returned
 )]
 
+use std::fmt;
+
 use crate::LixError;
 
 type PathResult<T> = Result<T, PathError>;
 
+/// A validated absolute Lix logical filesystem path.
+///
+/// Construct paths with [`LixPath::try_from_file_path`] or
+/// [`LixPath::try_from_directory_path`].
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct LixPath {
-    segments: String,
+pub struct LixPath {
+    path: String,
 }
 
 impl LixPath {
-    pub(crate) fn try_from_file_path(path: &str) -> Result<Self, LixError> {
+    /// Parses an absolute logical file path.
+    ///
+    /// The root path `/` is rejected because it names a directory.
+    pub fn try_from_file_path(path: &str) -> Result<Self, LixError> {
         let Some(path) = path.strip_prefix('/') else {
             return Err(PathError::MissingLeadingSlash.into_lix_error());
         };
@@ -58,11 +70,12 @@ impl LixPath {
             .try_for_each(validate_segment)
             .map_err(PathError::into_lix_error)?;
         Ok(Self {
-            segments: path.to_owned(),
+            path: format!("/{path}"),
         })
     }
 
-    pub(crate) fn try_from_directory_path(path: &str) -> Result<Self, LixError> {
+    /// Parses an absolute logical directory path, including root `/`.
+    pub fn try_from_directory_path(path: &str) -> Result<Self, LixError> {
         let Some(path) = path.strip_prefix('/') else {
             return Err(PathError::MissingLeadingSlash.into_lix_error());
         };
@@ -75,15 +88,34 @@ impl LixPath {
                 .map_err(PathError::into_lix_error)?;
         }
         Ok(Self {
-            segments: path.to_owned(),
+            path: format!("/{path}"),
         })
     }
 
-    pub(crate) fn segments(&self) -> impl Iterator<Item = &str> {
-        (!self.segments.is_empty())
-            .then_some(&self.segments)
+    /// Returns the canonical absolute logical path text.
+    pub fn as_str(&self) -> &str {
+        &self.path
+    }
+
+    /// Returns the literal path segments without the structural `/` separators.
+    pub fn segments(&self) -> impl Iterator<Item = &str> {
+        let segments = self.path.strip_prefix('/').unwrap_or(&self.path);
+        (!segments.is_empty())
+            .then_some(segments)
             .into_iter()
             .flat_map(|segments| segments.split('/'))
+    }
+}
+
+impl AsRef<str> for LixPath {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for LixPath {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
     }
 }
 
@@ -94,7 +126,12 @@ fn validate_segment(segment: &str) -> PathResult<()> {
     if segment == "." || segment == ".." {
         return Err(PathError::DotSegment);
     }
-    debug_assert!(!segment.contains('/'));
+    if segment.contains('\0') {
+        return Err(PathError::Nul);
+    }
+    if segment.contains('/') {
+        return Err(PathError::SlashInSegment);
+    }
     Ok(())
 }
 
@@ -104,6 +141,7 @@ enum PathError {
     UnexpectedTrailingSlash,
     EmptySegment,
     DotSegment,
+    Nul,
     SlashInSegment,
     InvalidRootUsage,
     InvalidDirectoryParentPath,
@@ -132,6 +170,11 @@ impl PathError {
                 "path segment cannot be '.' or '..'",
                 Some("use a real segment name instead of '.' or '..'"),
             ),
+            Self::Nul => (
+                "LIX_ERROR_PATH_NUL",
+                "path segment cannot contain NUL",
+                Some("remove the NUL character from the path segment"),
+            ),
             Self::SlashInSegment => (
                 "LIX_ERROR_PATH_SLASH_IN_SEGMENT",
                 "path segment must not contain '/'",
@@ -158,16 +201,19 @@ impl PathError {
 }
 
 fn renderable_segment_text(segment: &str) -> PathResult<&str> {
-    if segment.is_empty() {
-        return Err(PathError::EmptySegment);
-    }
-    if segment == "." || segment == ".." {
-        return Err(PathError::DotSegment);
-    }
-    if segment.contains('/') {
-        return Err(PathError::SlashInSegment);
-    }
+    validate_segment(segment)?;
     Ok(segment)
+}
+
+/// Validates one literal segment of a Lix logical filesystem path.
+///
+/// Valid segments are non-empty UTF-8 strings other than `.` and `..` and do
+/// not contain `/` or NUL. No URL decoding, case folding, or Unicode
+/// normalization is performed.
+pub fn validate_lix_path_segment(segment: &str) -> Result<(), LixError> {
+    renderable_segment_text(segment)
+        .map(|_| ())
+        .map_err(PathError::into_lix_error)
 }
 
 pub(crate) fn compose_file_path(
@@ -197,5 +243,38 @@ pub(crate) fn compose_directory_path(
         Ok(format!("{parent_path}/{name_text}"))
     } else {
         Err(PathError::InvalidDirectoryParentPath.into_lix_error())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn logical_paths_preserve_literal_utf8_segments() {
+        let path = LixPath::try_from_file_path("/docs/100% @2x/日本語.txt").unwrap();
+
+        assert_eq!(
+            path.segments().collect::<Vec<_>>(),
+            vec!["docs", "100% @2x", "日本語.txt"]
+        );
+        assert_eq!(path.as_str(), "/docs/100% @2x/日本語.txt");
+    }
+
+    #[test]
+    fn logical_paths_do_not_normalize_unicode() {
+        let composed = LixPath::try_from_file_path("/caf\u{e9}.txt").unwrap();
+        let decomposed = LixPath::try_from_file_path("/cafe\u{301}.txt").unwrap();
+
+        assert_ne!(composed, decomposed);
+    }
+
+    #[test]
+    fn logical_paths_reject_structural_segments_and_nul() {
+        for path in ["relative", "/", "/a/", "/a//b", "/a/./b", "/a/../b"] {
+            assert!(LixPath::try_from_file_path(path).is_err(), "{path:?}");
+        }
+        let error = LixPath::try_from_file_path("/nul\0name").unwrap_err();
+        assert_eq!(error.code, "LIX_ERROR_PATH_NUL");
     }
 }

--- a/packages/engine/src/common/mod.rs
+++ b/packages/engine/src/common/mod.rs
@@ -15,7 +15,8 @@ pub use execution_metadata::{
 pub use identity::{BranchId, CanonicalPluginKey, CanonicalSchemaKey, EntityPk, FileId};
 pub(crate) use identity::{json_pointer_get, validate_non_empty_identity_value};
 pub(crate) use json_pointer::{format_json_pointer, parse_json_pointer, top_level_property_name};
-pub(crate) use lix_path::{LixPath, compose_directory_path, compose_file_path};
+pub use lix_path::{LixPath, validate_lix_path_segment};
+pub(crate) use lix_path::{compose_directory_path, compose_file_path};
 pub(crate) use metadata::{
     parse_row_metadata, parse_row_metadata_value, serialize_row_metadata, validate_row_metadata,
 };

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -81,6 +81,7 @@ pub use schema::{
 pub use common::LixError;
 pub use common::{Blob, LixNotice, NullableKeyFilter, SharedStr, SqlQueryResult, Value};
 pub use common::{BranchId, CanonicalPluginKey, CanonicalSchemaKey, EntityPk, FileId};
+pub use common::{LixPath, validate_lix_path_segment};
 pub use common::{WireQueryResult, WireValue};
 pub(crate) use common::{parse_row_metadata, parse_row_metadata_value, serialize_row_metadata};
 pub use engine::{Engine, EngineOptions};

--- a/packages/engine/src/schema/builtin/lix_directory_descriptor.json
+++ b/packages/engine/src/schema/builtin/lix_directory_descriptor.json
@@ -37,6 +37,7 @@
     },
     "name": {
       "type": "string",
+      "format": "lix-path-segment",
       "pattern": "^(?!\\.{1,2}$)[^/]+$"
     }
   },

--- a/packages/engine/src/schema/builtin/lix_file_descriptor.json
+++ b/packages/engine/src/schema/builtin/lix_file_descriptor.json
@@ -37,6 +37,7 @@
     },
     "name": {
       "type": "string",
+      "format": "lix-path-segment",
       "pattern": "^(?!\\.{1,2}$)[^/]+$"
     }
   },

--- a/packages/engine/src/schema/definition.rs
+++ b/packages/engine/src/schema/definition.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeSet;
 use std::sync::OnceLock;
 
 use crate::LixError;
-use crate::common::parse_json_pointer;
+use crate::common::{parse_json_pointer, validate_lix_path_segment};
 
 static LIX_SCHEMA_DEFINITION: OnceLock<JsonValue> = OnceLock::new();
 static LIX_SCHEMA_VALIDATOR: OnceLock<Result<JSONSchema, LixError>> = OnceLock::new();
@@ -288,6 +288,7 @@ pub(crate) fn compile_lix_schema(schema: &JsonValue) -> Result<JSONSchema, LixEr
     options.should_validate_formats(true);
     options.with_format("json-pointer", is_json_pointer);
     options.with_format("cel", is_cel_expression);
+    options.with_format("lix-path-segment", is_lix_path_segment);
 
     options.compile(schema).map_err(|err| LixError {
         code: LixError::CODE_SCHEMA_DEFINITION.to_string(),
@@ -310,6 +311,10 @@ fn is_json_pointer(value: &str) -> bool {
 
 fn is_cel_expression(value: &str) -> bool {
     Program::compile(value).is_ok()
+}
+
+fn is_lix_path_segment(value: &str) -> bool {
+    validate_lix_path_segment(value).is_ok()
 }
 
 fn assert_primary_key_pointers(schema: &JsonValue) -> Result<(), LixError> {

--- a/packages/engine/src/schema/tests.rs
+++ b/packages/engine/src/schema/tests.rs
@@ -1,5 +1,6 @@
+use crate::schema::seed_schema_definition;
 use crate::{validate_lix_schema, validate_lix_schema_definition};
-use serde_json::json;
+use serde_json::{Value as JsonValue, json};
 
 #[test]
 fn validate_lix_schema_definition_passes_for_valid_schema() {
@@ -97,6 +98,35 @@ fn validate_lix_schema_validates_both_schema_and_data_successfully() {
     });
 
     assert!(validate_lix_schema(&schema, &valid_data).is_ok());
+}
+
+#[test]
+fn filesystem_descriptor_schemas_assert_the_engine_path_segment_format() {
+    for (schema_key, parent_field) in [
+        ("lix_file_descriptor", "directory_id"),
+        ("lix_directory_descriptor", "parent_id"),
+    ] {
+        let schema = seed_schema_definition(schema_key)
+            .unwrap_or_else(|| panic!("builtin {schema_key} schema should exist"));
+        let mut valid = json!({
+            "id": "01920000-0000-7000-8000-000000000001",
+            "name": "100% @2x 日本語.txt"
+        });
+        valid[parent_field] = JsonValue::Null;
+        assert!(validate_lix_schema(schema, &valid).is_ok());
+
+        for name in ["", ".", "..", "a/b", "nul\0name"] {
+            let mut invalid = json!({
+                "id": "01920000-0000-7000-8000-000000000001",
+                "name": name
+            });
+            invalid[parent_field] = JsonValue::Null;
+            assert!(
+                validate_lix_schema(schema, &invalid).is_err(),
+                "{schema_key} name {name:?} should be rejected"
+            );
+        }
+    }
 }
 
 #[test]

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -1053,7 +1053,7 @@ test("fs storage with a fresh external lixDir reimports disk state without old l
 });
 
 test.skipIf(process.platform === "win32")(
-	"fs storage ignores symlinks",
+	"fs storage ignores unrelated symlinks and diagnoses materialization collisions",
 	async () => {
 		const dir = tempFsDir();
 		mkdirSync(join(dir, "docs"), { recursive: true });
@@ -1076,6 +1076,15 @@ test.skipIf(process.platform === "win32")(
 			["/docs", "/linked-docs"],
 		);
 		expect(directories.rows.map((row) => row.get("path"))).toEqual(["/docs"]);
+
+		await expect(
+			lix.execute("INSERT INTO lix_file (path, data) VALUES ($1, $2)", [
+				"/link.txt",
+				new TextEncoder().encode("replacement"),
+			]),
+		).rejects.toThrow("LIX_FILESYSTEM_UNSUPPORTED_ENTRY");
+		expect(readFileSync(join(dir, "target.txt"), "utf8")).toBe("target");
+		expect(readFileSync(join(dir, "link.txt"), "utf8")).toBe("target");
 		await lix.close();
 	},
 );

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -14,8 +14,8 @@ use std::time::Duration;
 
 use lix_engine::wasm::WasmRuntime;
 use lix_engine::{
-    CommitResult, Engine, Key, KeyRange, LixError, PutBatch, ReadOptions, SessionContext, SpaceId,
-    Storage, StorageError, StorageWrite, Value, WriteOptions,
+    CommitResult, Engine, Key, KeyRange, LixError, LixPath, PutBatch, ReadOptions, SessionContext,
+    SpaceId, Storage, StorageError, StorageWrite, Value, WriteOptions,
 };
 use notify_debouncer_full::notify::{Config, RecommendedWatcher, RecursiveMode};
 use notify_debouncer_full::{DebounceEventResult, Debouncer, RecommendedCache, new_debouncer_opt};
@@ -2023,7 +2023,7 @@ fn normalize_filter_file_path(path: &str) -> Result<String, LixError> {
 }
 
 fn validate_lix_path(path: &str) -> Result<(), LixError> {
-    let _ = lix_path_to_local_path(Path::new("/"), path)?;
+    let _ = LixPath::try_from_file_path(path)?;
     Ok(())
 }
 
@@ -2064,29 +2064,15 @@ fn insert_parent_lix_directories(path: &str, snapshot: &mut Snapshot) {
 }
 
 fn lix_path_to_local_path(root: &Path, path: &str) -> Result<PathBuf, LixError> {
-    if path == "/" {
-        return Ok(root.to_path_buf());
-    }
-    let body = path
-        .strip_prefix('/')
-        .ok_or_else(|| filesystem_error(format!("Lix path {path:?} is not absolute")))?;
-    if body.is_empty() {
-        return Ok(root.to_path_buf());
-    }
+    let parsed = LixPath::try_from_directory_path(path)?;
     let mut local = root.to_path_buf();
-    for segment in body.split('/') {
+    for segment in parsed.segments() {
         push_lix_path_segment(&mut local, segment, path)?;
     }
     Ok(local)
 }
 
 fn push_lix_path_segment(local: &mut PathBuf, segment: &str, path: &str) -> Result<(), LixError> {
-    if segment.is_empty() || segment == "." || segment == ".." {
-        return Err(filesystem_error(format!(
-            "Lix path {path:?} contains unsupported segment {segment:?}"
-        )));
-    }
-
     let mut components = Path::new(segment).components();
     match (components.next(), components.next()) {
         (Some(Component::Normal(component)), None) => {
@@ -2660,9 +2646,15 @@ mod tests {
     fn lix_paths_reject_structurally_unsafe_segments() {
         let root = Path::new("root");
 
-        for path in ["relative", "/a//b", "/./b", "/../b"] {
+        for (path, expected_code) in [
+            ("relative", "LIX_ERROR_PATH_MISSING_LEADING_SLASH"),
+            ("/a//b", "LIX_ERROR_PATH_EMPTY_SEGMENT"),
+            ("/./b", "LIX_ERROR_PATH_DOT_SEGMENT"),
+            ("/../b", "LIX_ERROR_PATH_DOT_SEGMENT"),
+            ("/nul\0name", "LIX_ERROR_PATH_NUL"),
+        ] {
             let error = lix_path_to_local_path(root, path).expect_err("path should fail");
-            assert_eq!(error.code, "LIX_FILESYSTEM_ERROR");
+            assert_eq!(error.code, expected_code);
         }
     }
 

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -1843,7 +1843,7 @@ fn create_materialized_directory(layout: &FilesystemLayout, path: &str) -> Resul
         return Ok(());
     };
     if path_contains_unmanaged_entry(layout, &local_path)? {
-        return Ok(());
+        return Err(unsupported_materialization_entry(path, &local_path));
     }
     std::fs::create_dir_all(&local_path)
         .map_err(|error| io_error("create filesystem directory", &local_path, error))
@@ -1861,20 +1861,20 @@ fn write_materialized_file(
         return Ok(());
     };
     if path_contains_unmanaged_entry(layout, &local_path)? {
-        return Ok(());
+        return Err(unsupported_materialization_entry(path, &local_path));
     }
     if let Some(parent) = local_path.parent() {
         if path_contains_unmanaged_entry(layout, parent)? {
-            return Ok(());
+            return Err(unsupported_materialization_entry(path, &local_path));
         }
         std::fs::create_dir_all(parent)
             .map_err(|error| io_error("create filesystem file parent", parent, error))?;
         if path_contains_unmanaged_entry(layout, parent)? {
-            return Ok(());
+            return Err(unsupported_materialization_entry(path, &local_path));
         }
     }
     if path_contains_unmanaged_entry(layout, &local_path)? {
-        return Ok(());
+        return Err(unsupported_materialization_entry(path, &local_path));
     }
     std::fs::write(&local_path, data)
         .map_err(|error| io_error("write filesystem file", &local_path, error))
@@ -2214,6 +2214,16 @@ fn filesystem_sync_storage_error(error: LixError) -> StorageError {
 
 fn filesystem_error(message: impl Into<String>) -> LixError {
     LixError::new("LIX_FILESYSTEM_ERROR", message)
+}
+
+fn unsupported_materialization_entry(path: &str, local_path: &Path) -> LixError {
+    LixError::new(
+        "LIX_FILESYSTEM_UNSUPPORTED_ENTRY",
+        format!(
+            "cannot materialize regular Lix path {path} at {}: the path is blocked by a symlink or another unsupported filesystem entry",
+            local_path.display()
+        ),
+    )
 }
 
 #[cfg(feature = "local_filesystem")]
@@ -2615,6 +2625,34 @@ mod tests {
         assert_eq!(
             lix_path_to_local_path(root, "/#hash?.txt").unwrap(),
             root.join("#hash?.txt")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn materializing_a_regular_file_reports_symlink_collisions() {
+        use std::os::unix::fs::symlink;
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = tempdir.path().join("workspace");
+        let lix_dir = root.join(".lix");
+        std::fs::create_dir_all(&lix_dir).unwrap();
+        std::fs::write(root.join("target.txt"), b"target").unwrap();
+        symlink("target.txt", root.join("link.txt")).unwrap();
+        let layout = FilesystemLayout {
+            root,
+            lix_dir,
+            lix_dir_is_default: true,
+        };
+
+        let error = write_materialized_file(&layout, "/link.txt", b"replacement")
+            .expect_err("a symlink collision must be reported");
+
+        assert_eq!(error.code, "LIX_FILESYSTEM_UNSUPPORTED_ENTRY");
+        assert!(error.message.contains("/link.txt"));
+        assert_eq!(
+            std::fs::read(layout.root.join("target.txt")).unwrap(),
+            b"target"
         );
     }
 

--- a/packages/rs-sdk/src/lib.rs
+++ b/packages/rs-sdk/src/lib.rs
@@ -41,8 +41,8 @@ pub use lix_engine::{
     CreateCheckpointReceipt as CreateCheckpointResult, ExecuteBatchStatement, ExecuteIdempotency,
     ExecuteOptions, ExecuteResult, ExecuteStatementMetadata, ExecutionDisposition,
     FILE_UPLOAD_PART_BYTES, FileRead, FileUploadProgress, GLOBAL_BRANCH_ID, GetManyRequest,
-    GetManyResult, GetOptions, Key, KeyRange, LixError, LixNotice, MAX_SCAN_PAGE_ROWS, Memory,
-    MemoryRead, MemoryWrite, MergeBranchOptions, MergeBranchOutcome, MergeBranchPreview,
+    GetManyResult, GetOptions, Key, KeyRange, LixError, LixNotice, LixPath, MAX_SCAN_PAGE_ROWS,
+    Memory, MemoryRead, MemoryWrite, MergeBranchOptions, MergeBranchOutcome, MergeBranchPreview,
     MergeBranchPreviewOptions, MergeBranchReceipt, MergeBranchReceipt as MergeBranchResult,
     MergeChangeStats, MergeConflict, MergeConflictChangeKind, MergeConflictKind, MergeConflictSide,
     MutationIdentity, ObserveEvent, ObserveEvents, ProjectedValue, PutBatch, ReadDurability,
@@ -52,7 +52,7 @@ pub use lix_engine::{
     StorageFactory, StorageFixture, StorageRead, StorageTestConfig, StorageWrite, StoredValue,
     SwitchBranchOptions, SwitchBranchReceipt, SwitchBranchReceipt as SwitchBranchResult,
     TryFromValue, UndoReceipt, Value, VerifiedRequestBlob, WireValue, WriteOptions, WriteStats,
-    parse_sql_script, run_storage_conformance,
+    parse_sql_script, run_storage_conformance, validate_lix_path_segment,
 };
 #[cfg(feature = "sqlite")]
 pub use sqlite::{SQLITE_FORMAT_VERSION, SQLite, SQLiteFactory, SQLiteFixture, SQLiteOptions};

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -86,6 +86,12 @@ async fn rs_sdk_native_file_upsert_creates_updates_and_keeps_empty_file() {
         .await
         .expect_err("relative native file path should be rejected");
     assert_eq!(error.code, "LIX_ERROR_PATH_MISSING_LEADING_SLASH");
+
+    let error = lix
+        .upsert_file_data("/nul\0name.bin", b"invalid".as_slice())
+        .await
+        .expect_err("NUL in a native file path should be rejected by the engine");
+    assert_eq!(error.code, "LIX_ERROR_PATH_NUL");
 }
 
 #[tokio::test]

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -1682,7 +1682,7 @@ async fn filesystem_watcher_ignores_symlinks_created_after_open() {
 
 #[tokio::test]
 #[cfg(all(unix, feature = "local_filesystem"))]
-async fn filesystem_materialization_skips_symlink_collisions() {
+async fn filesystem_materialization_reports_symlink_collisions() {
     use std::os::unix::fs::symlink;
 
     let tempdir = tempfile::tempdir().unwrap();
@@ -1696,12 +1696,22 @@ async fn filesystem_materialization_skips_symlink_collisions() {
     symlink(outside.path(), tempdir.path().join("blocked-dir")).unwrap();
 
     let lix = open_lix_with_filesystem(tempdir.path()).await;
-    write_file(&lix, "/blocked.txt", b"lix".to_vec())
+    let file_error = write_file(&lix, "/blocked.txt", b"lix".to_vec())
         .await
-        .unwrap();
-    write_file(&lix, "/blocked-dir/file.txt", b"nested".to_vec())
+        .expect_err("a symlink collision must be reported");
+    assert!(
+        file_error
+            .message
+            .contains("LIX_FILESYSTEM_UNSUPPORTED_ENTRY")
+    );
+    let directory_error = write_file(&lix, "/blocked-dir/file.txt", b"nested".to_vec())
         .await
-        .unwrap();
+        .expect_err("a symlink ancestor must be reported");
+    assert!(
+        directory_error
+            .message
+            .contains("LIX_FILESYSTEM_UNSUPPORTED_ENTRY")
+    );
 
     assert_eq!(
         read_file(&lix, "/blocked.txt").await.unwrap().as_deref(),
@@ -1749,7 +1759,7 @@ async fn filesystem_materialization_skips_symlink_collisions() {
 
 #[tokio::test]
 #[cfg(all(unix, feature = "local_filesystem"))]
-async fn filesystem_materialization_skips_special_file_collisions() {
+async fn filesystem_materialization_reports_special_file_collisions() {
     use std::os::unix::fs::FileTypeExt;
     use std::os::unix::net::UnixListener;
 
@@ -1758,7 +1768,10 @@ async fn filesystem_materialization_skips_special_file_collisions() {
     let listener = UnixListener::bind(&socket_path).unwrap();
 
     let lix = open_lix_with_filesystem(tempdir.path()).await;
-    write_file(&lix, "/socket", b"lix".to_vec()).await.unwrap();
+    let error = write_file(&lix, "/socket", b"lix".to_vec())
+        .await
+        .expect_err("a socket collision must be reported");
+    assert!(error.message.contains("LIX_FILESYSTEM_UNSUPPORTED_ENTRY"));
 
     assert_eq!(
         read_file(&lix, "/socket").await.unwrap().as_deref(),


### PR DESCRIPTION
## Summary

Addresses the 90% regular-file path from #1072 without expanding `lix_file` or promising permission fidelity.

- define `lix_file` as regular file contents at literal UTF-8 logical paths
- make the engine's public `LixPath` type and `lix-path-segment` schema format the single path-validation contract
- reject empty, dot, slash-bearing, and NUL descriptor segments while preserving all other UTF-8 literally (no URL decoding, case folding, or Unicode normalization)
- route filesystem sync through the engine validator
- keep ordinary filesystem import, materialization, and deletion behavior
- report `LIX_FILESYSTEM_UNSUPPORTED_ENTRY` when a symlink or special entry blocks materialization instead of silently diverging
- reject non-UTF-8 Git paths, symlinks, and gitlinks in experimental Git replay instead of encoding or synthesizing them as regular files
- document executable and other permission bits as out of scope for the current contract

## Validation

- `cargo test -p lix_engine --features all-simulations`
- `cargo test -p lix_sdk --features local_filesystem`
- `cargo test -p lix_cli git_replay`
- `cargo clippy --profile test -p lix_engine -p lix_sdk --all-targets --all-features -- -D warnings`
- `npx vitest run src/open-lix.test.ts -t "fs storage ignores unrelated symlinks"`
- `cargo fmt --all -- --check`
- `git diff --check`
