### PR TITLE
perf(engine): execute typed undo transitions

### DIFF
--- a/.changenotes/typed-state-transition-executor.md
+++ b/.changenotes/typed-state-transition-executor.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Reduced undo and redo work by applying typed tracked-state transitions directly instead of round-tripping through public diff identifiers.

--- a/packages/engine-benchmarks/benches/undo_redo.rs
+++ b/packages/engine-benchmarks/benches/undo_redo.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, Instant};
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use lix_engine::{Engine, Memory};
+use lix_engine::{Engine, ExecuteBatchStatement, Memory};
 
 fn seeded_storage(runtime: &tokio::runtime::Runtime, history_depth: usize) -> Vec<u8> {
     runtime.block_on(async move {
@@ -126,6 +126,53 @@ fn seeded_wide_parent_storage(runtime: &tokio::runtime::Runtime, parent_width: u
     })
 }
 
+fn seeded_wide_transition_storage(
+    runtime: &tokio::runtime::Runtime,
+    transition_width: usize,
+) -> Vec<u8> {
+    runtime.block_on(async move {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("benchmark storage initializes");
+        let engine = Engine::new(storage.clone())
+            .await
+            .expect("benchmark engine opens");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("benchmark session opens");
+        let before = "b".repeat(256);
+        let values = (0..transition_width)
+            .map(|index| format!("('transition-{index}', '{before}')"))
+            .collect::<Vec<_>>()
+            .join(",");
+        session
+            .execute(
+                &format!("INSERT INTO lix_key_value (key, value) VALUES {values}"),
+                &[],
+            )
+            .await
+            .expect("transition rows start");
+        let after = "a".repeat(256);
+        let updates = (0..transition_width)
+            .map(|index| ExecuteBatchStatement {
+                sql: format!(
+                    "UPDATE lix_key_value SET value = '{after}' WHERE key = 'transition-{index}'"
+                ),
+                params: vec![],
+            })
+            .collect::<Vec<_>>();
+        session
+            .execute_batch(&updates)
+            .await
+            .expect("wide transition commit succeeds");
+        storage
+            .export_snapshot()
+            .expect("benchmark storage snapshot exports")
+    })
+}
+
 fn open_session(
     runtime: &tokio::runtime::Runtime,
     storage: Memory,
@@ -223,6 +270,34 @@ fn benchmark_undo_redo(criterion: &mut Criterion) {
                         runtime
                             .block_on(session.redo())
                             .expect("benchmarked redo succeeds");
+                        elapsed += started.elapsed();
+                    }
+                    elapsed
+                });
+            },
+        );
+    }
+    group.finish();
+
+    let mut group = criterion.benchmark_group("undo_transition_width");
+    for transition_width in [1_usize, 100, 1_000] {
+        let snapshot = seeded_wide_transition_storage(&runtime, transition_width);
+        group.bench_with_input(
+            BenchmarkId::new("undo", transition_width),
+            &transition_width,
+            |benchmark, _| {
+                benchmark.iter_custom(|iterations| {
+                    let mut elapsed = Duration::ZERO;
+                    for _ in 0..iterations {
+                        let session = open_session(
+                            &runtime,
+                            Memory::from_snapshot(&snapshot)
+                                .expect("wide-transition benchmark snapshot restores"),
+                        );
+                        let started = Instant::now();
+                        runtime
+                            .block_on(session.undo())
+                            .expect("benchmarked wide-transition undo succeeds");
                         elapsed += started.elapsed();
                     }
                     elapsed

--- a/packages/engine/src/changelog/materialization.rs
+++ b/packages/engine/src/changelog/materialization.rs
@@ -29,6 +29,14 @@ impl ChangeRecordProjection {
         }
     }
 
+    /// Loads identity and revision columns without hydrating JSON payloads.
+    pub(crate) fn identity_only() -> Self {
+        Self {
+            snapshot_content: false,
+            metadata: false,
+        }
+    }
+
     pub(crate) fn from_columns(columns: &[String]) -> Self {
         if columns.is_empty() {
             return Self::full();

--- a/packages/engine/src/session/undo_redo.rs
+++ b/packages/engine/src/session/undo_redo.rs
@@ -3,12 +3,9 @@ use crate::changelog::{ChangeRecordProjection, CommitId};
 use crate::checkpoint::CHECKPOINT_MARKER_SCHEMA_KEY;
 use crate::commit_graph::CommitGraphReader;
 use crate::entity_pk::EntityPk;
-use crate::sql2::DiffCommand;
 use crate::sql2::SqlWriteExecutionContext;
 use crate::storage_adapter::Storage;
-use crate::tracked_state::{
-    TrackedStateDiffRequest, TrackedStateIndexValue, TrackedStateKey, encode_diff_id,
-};
+use crate::tracked_state::{TrackedStateDiffRequest, TrackedStateIndexValue, TrackedStateKey};
 use crate::transaction::Transaction;
 use crate::transaction::types::{RawWriteBatch, TransactionWrite, TransactionWriteMode};
 use crate::undo_redo::{
@@ -486,31 +483,9 @@ where
         })
         .map(|(key, _)| key.clone())
         .collect::<Vec<_>>();
-    let projection = ChangeRecordProjection::from_columns(&[]);
-    let (current_rows, desired_rows) = {
-        let mut tracked = transaction.tracked_state_reader().await;
-        let current_rows = tracked
-            .load_projected_batch_at_commit(&current.to_string(), &keys, &projection)
-            .await?;
-        let desired_rows = tracked
-            .load_projected_batch_at_commit(&desired.to_string(), &keys, &projection)
-            .await?;
-        (current_rows, desired_rows)
-    };
-    let diff_ids = (0..keys.len())
-        .filter_map(|index| {
-            let before = current_rows
-                .row(index)
-                .filter(|row| !row.deleted())
-                .map(|row| row.change_id());
-            let after = desired_rows
-                .row(index)
-                .filter(|row| !row.deleted())
-                .map(|row| row.change_id());
-            (before != after).then_some(encode_diff_id(before, after))
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    apply_diff_ids(transaction, current, desired, diff_ids).await
+    transaction
+        .execute_tracked_state_transition(current, desired, keys)
+        .await
 }
 
 async fn reject_untracked_descriptor_cascade<S>(
@@ -584,40 +559,21 @@ where
             )
             .await?
     };
-    let diff_ids = diff
+    let keys = diff
         .entries
         .into_iter()
         .filter(|entry| {
             entry.identity.schema_key() != CHECKPOINT_MARKER_SCHEMA_KEY
                 && entry.identity.schema_key() != UNDO_REDO_MARKER_SCHEMA_KEY
         })
-        .map(|entry| {
-            encode_diff_id(
-                entry.before.as_ref().map(|row| row.change_id),
-                entry.after.as_ref().map(|row| row.change_id),
-            )
+        .map(|entry| TrackedStateKey {
+            schema_key: entry.identity.schema_key().to_owned(),
+            file_id: entry.identity.file_id().map(str::to_owned),
+            entity_pk: entry.identity.entity_pk().clone(),
         })
-        .collect::<Result<Vec<_>, _>>()?;
-    apply_diff_ids(transaction, current, desired, diff_ids).await
-}
-
-async fn apply_diff_ids<S>(
-    transaction: &mut Transaction<S>,
-    current: CommitId,
-    desired: CommitId,
-    diff_ids: Vec<String>,
-) -> Result<crate::sql2::DiffCommandOutcome, LixError>
-where
-    S: Storage + Clone + Send + Sync + 'static,
-{
-    if diff_ids.is_empty() {
-        return Err(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!("undo/redo state transition from '{current}' to '{desired}' is empty"),
-        ));
-    }
+        .collect::<Vec<_>>();
     transaction
-        .execute_diff_command(DiffCommand::Apply, diff_ids)
+        .execute_tracked_state_transition(current, desired, keys)
         .await
 }
 
@@ -643,6 +599,8 @@ where
 mod tests {
     use serde_json::Value as JsonValue;
 
+    use super::{load_commit_delta, load_commit_record, only_parent};
+    use crate::sql2::SqlWriteExecutionContext;
     use crate::storage::Memory;
     use crate::{
         Blob, CreateBranchOptions, Engine, ExecuteBatchStatement, LixError, MergeBranchOptions,
@@ -712,6 +670,77 @@ mod tests {
         assert_eq!(value(&session, "theme").await.as_deref(), Some("light"));
         session.redo().await.expect("update redoes");
         assert_eq!(value(&session, "theme").await.as_deref(), Some("dark"));
+    }
+
+    #[tokio::test]
+    async fn typed_transition_rejects_duplicate_keys_and_non_head_sources() {
+        let session = setup().await;
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('typed', 'before')",
+                &[],
+            )
+            .await
+            .expect("insert commits");
+        session
+            .execute(
+                "UPDATE lix_key_value SET value = 'after' WHERE key = 'typed'",
+                &[],
+            )
+            .await
+            .expect("update commits");
+
+        let duplicate = session
+            .with_write_transaction(|transaction| {
+                Box::pin(async move {
+                    let branch_id = transaction.active_branch_id().to_string();
+                    let head = transaction
+                        .load_branch_head(&branch_id)
+                        .await?
+                        .expect("branch has a head");
+                    let record = load_commit_record(transaction, head).await?;
+                    let parent = only_parent(&record.parent_commit_ids, head, "test")?;
+                    let key = load_commit_delta(transaction, head)
+                        .await?
+                        .into_iter()
+                        .find(|(key, _)| key.schema_key == "lix_key_value")
+                        .expect("update delta contains the key-value row")
+                        .0;
+                    transaction
+                        .execute_tracked_state_transition(head, parent, vec![key.clone(), key])
+                        .await
+                })
+            })
+            .await
+            .expect_err("duplicate transition identities are rejected");
+        assert_eq!(duplicate.code, LixError::CODE_CONSTRAINT_VIOLATION);
+        assert_eq!(value(&session, "typed").await.as_deref(), Some("after"));
+
+        let stale = session
+            .with_write_transaction(|transaction| {
+                Box::pin(async move {
+                    let branch_id = transaction.active_branch_id().to_string();
+                    let head = transaction
+                        .load_branch_head(&branch_id)
+                        .await?
+                        .expect("branch has a head");
+                    let record = load_commit_record(transaction, head).await?;
+                    let parent = only_parent(&record.parent_commit_ids, head, "test")?;
+                    let key = load_commit_delta(transaction, head)
+                        .await?
+                        .into_iter()
+                        .find(|(key, _)| key.schema_key == "lix_key_value")
+                        .expect("update delta contains the key-value row")
+                        .0;
+                    transaction
+                        .execute_tracked_state_transition(parent, head, vec![key])
+                        .await
+                })
+            })
+            .await
+            .expect_err("non-head transition sources are rejected");
+        assert_eq!(stale.code, LixError::CODE_CONSTRAINT_VIOLATION);
+        assert_eq!(value(&session, "typed").await.as_deref(), Some("after"));
     }
 
     #[tokio::test]

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -521,6 +521,21 @@ pub(crate) struct Transaction<StorageImpl: Storage + 'static = Memory> {
     plugin_generation_upgrade_guard: Option<tokio::sync::OwnedRwLockWriteGuard<()>>,
 }
 
+/// One already-resolved tracked-state transition. The expected side is
+/// certified by the active branch head and its immutable historical root;
+/// target payloads come from an exact read of the desired root.
+struct TypedStateTransition {
+    identity: TrackedStateKey,
+    expected_change_id: Option<ChangeId>,
+    target: Option<TypedStateTransitionTarget>,
+}
+
+struct TypedStateTransitionTarget {
+    change_id: ChangeId,
+    snapshot_content: Option<SharedStr>,
+    metadata: Option<SharedStr>,
+}
+
 /// State which must be restored when `RETURNING` evaluation fails after a
 /// write has been staged in an explicit SQL transaction.
 pub(crate) struct SqlStatementCheckpoint {
@@ -6763,6 +6778,162 @@ where
         CommitGraphContext::new().reader(SharedStorageAdapterRead::new(read))
     }
 
+    /// Applies a tracked-state transition resolved from two immutable commits.
+    ///
+    /// This is the internal counterpart to the public diff command. The
+    /// caller supplies typed identities instead of user-facing `diff_id`
+    /// strings. The transaction's coherent opening head certifies the current
+    /// side, so undo/redo does not need to reload visible live state after it
+    /// has already read that exact historical root.
+    pub(crate) async fn execute_tracked_state_transition(
+        &mut self,
+        current_commit_id: CommitId,
+        desired_commit_id: CommitId,
+        keys: Vec<TrackedStateKey>,
+    ) -> Result<crate::sql2::DiffCommandOutcome, LixError> {
+        let branch_id = self.active_branch_id.clone();
+        if self.opening_active_branch_head != Some(current_commit_id) {
+            return Err(LixError::new(
+                LixError::CODE_CONSTRAINT_VIOLATION,
+                "tracked-state transition source is no longer the active branch head",
+            ));
+        }
+        if self
+            .staged_writes
+            .commit_id_for_branch(&branch_id)?
+            .is_some()
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "typed tracked-state transitions require a clean branch transaction",
+            ));
+        }
+        if keys.is_empty() {
+            return Err(empty_state_transition(current_commit_id, desired_commit_id));
+        }
+        let unique = keys.iter().collect::<BTreeSet<_>>();
+        if unique.len() != keys.len() {
+            return Err(LixError::new(
+                LixError::CODE_CONSTRAINT_VIOLATION,
+                "typed tracked-state transition contains more than one row for the same entity",
+            ));
+        }
+
+        let (current_rows, desired_rows) = {
+            let mut tracked = self.tracked_state_reader().await;
+            let current_rows = tracked
+                .load_projected_batch_at_commit(
+                    &current_commit_id.to_string(),
+                    &keys,
+                    &ChangeRecordProjection::identity_only(),
+                )
+                .await?;
+            let desired_rows = tracked
+                .load_projected_batch_at_commit(
+                    &desired_commit_id.to_string(),
+                    &keys,
+                    &ChangeRecordProjection::full(),
+                )
+                .await?;
+            (current_rows, desired_rows)
+        };
+        let mut transitions = Vec::with_capacity(keys.len());
+        for (index, identity) in keys.into_iter().enumerate() {
+            let current = current_rows.row(index).filter(|row| !row.deleted());
+            let desired = desired_rows.row(index).filter(|row| !row.deleted());
+            for row in [current, desired].into_iter().flatten() {
+                if row.schema_key() != identity.schema_key
+                    || row.file_id() != identity.file_id.as_deref()
+                    || row.entity_pk() != &identity.entity_pk
+                {
+                    return Err(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "historical exact read returned a mismatched transition identity",
+                    ));
+                }
+            }
+            let expected_change_id = current.map(|row| row.change_id());
+            let target = desired.map(|row| TypedStateTransitionTarget {
+                change_id: row.change_id(),
+                snapshot_content: row.snapshot_content().cloned(),
+                metadata: row.metadata().cloned(),
+            });
+            if expected_change_id != target.as_ref().map(|target| target.change_id) {
+                transitions.push(TypedStateTransition {
+                    identity,
+                    expected_change_id,
+                    target,
+                });
+            }
+        }
+        self.execute_typed_state_transitions(current_commit_id, desired_commit_id, transitions)
+            .await
+    }
+
+    async fn execute_typed_state_transitions(
+        &mut self,
+        current_commit_id: CommitId,
+        desired_commit_id: CommitId,
+        transitions: Vec<TypedStateTransition>,
+    ) -> Result<crate::sql2::DiffCommandOutcome, LixError> {
+        if transitions.is_empty() {
+            return Err(empty_state_transition(current_commit_id, desired_commit_id));
+        }
+        let branch_id = self.active_branch_id.clone();
+        let rows_affected = transitions.len() as u64;
+        let mut rows = RawWriteBatch::with_capacity(transitions.len());
+        for transition in transitions {
+            if transition.expected_change_id
+                == transition.target.as_ref().map(|target| target.change_id)
+            {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "typed tracked-state transition contains an unchanged row",
+                ));
+            }
+            let (snapshot, metadata) = match transition.target {
+                Some(target) => (
+                    parse_materialized_diff_json(
+                        target.snapshot_content,
+                        "typed state transition target",
+                    )?,
+                    parse_materialized_diff_json(
+                        target.metadata,
+                        "typed state transition target metadata",
+                    )?,
+                ),
+                None => (None, None),
+            };
+            rows.push(TransactionWriteRow {
+                entity_pk: Some(transition.identity.entity_pk),
+                schema_key: transition.identity.schema_key.into(),
+                file_id: transition.identity.file_id.map(Into::into),
+                snapshot,
+                metadata,
+                origin: None,
+                created_at: None,
+                updated_at: None,
+                global: false,
+                change_id: None,
+                commit_id: None,
+                untracked: false,
+                branch_id: branch_id.clone().into(),
+            });
+        }
+        self.stage_write(TransactionWrite::Rows {
+            mode: TransactionWriteMode::Replace,
+            rows,
+        })
+        .await?;
+        Ok(crate::sql2::DiffCommandOutcome {
+            rows_affected,
+            commit_id: self
+                .staged_writes
+                .commit_id_for_branch(&branch_id)?
+                .map(|commit_id| commit_id.to_string()),
+        })
+    }
+
     async fn execute_apply_or_revert(
         &mut self,
         command: DiffCommand,
@@ -7183,6 +7354,13 @@ fn stale_or_unknown_diff_id() -> LixError {
     LixError::new(
         LixError::CODE_CONSTRAINT_VIOLATION,
         "stale or unknown diff_id; re-evaluate the source diff and retry",
+    )
+}
+
+fn empty_state_transition(current: CommitId, desired: CommitId) -> LixError {
+    LixError::new(
+        LixError::CODE_INTERNAL_ERROR,
+        format!("tracked-state transition from '{current}' to '{desired}' is empty"),
     )
 }
 


### PR DESCRIPTION
## Summary

- add an internal typed tracked-state transition executor for undo/redo
- load only source identities/change IDs and hydrate target payloads once
- preserve the public string `diff_id` SQL boundary while removing undo/redo's encode/parse/resolve/reload round trip
- add stale-source and duplicate-identity regression coverage plus a width-scaling benchmark

## Performance

Criterion comparison against the same `origin/main` fixture and storage snapshot:

| Changed rows | Before | After | Change |
| ---: | ---: | ---: | ---: |
| 1 | 2.4188 ms | 2.2978 ms | 5.0% faster |
| 100 | 5.6445 ms | 3.2908 ms | 41.7% faster |
| 1,000 | 40.940 ms | 10.121 ms | 75.3% faster |

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p lix_engine --features all-simulations`
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- independent correctness and performance reviews: no blockers
