### PR TITLE
perf(engine): batch distinct literal updates

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use lix_engine::{Engine, ExecuteResult, SessionContext, Storage, Value};
+use lix_engine::{Engine, ExecuteBatchStatement, ExecuteResult, SessionContext, Storage, Value};
 
 #[cfg(feature = "slatedb")]
 use crate::storage::SlateDB;
@@ -26,6 +26,11 @@ enum UntrackedFixture {
 enum FixtureShape {
     FullCrud,
     BoundUpdate,
+}
+
+enum LiteralUpdateWorkload {
+    Transaction(Vec<String>),
+    ExecuteBatch(Vec<ExecuteBatchStatement>),
 }
 
 impl UntrackedFixture {
@@ -55,7 +60,7 @@ pub(crate) struct GenericSqlFixture<StorageImpl: Storage> {
     select_many_by_pk_sql: String,
     select_one_by_pk_sql: String,
     update_one_by_pk_sql: String,
-    update_all_sql_rows: Vec<String>,
+    update_all_workload: LiteralUpdateWorkload,
     bound_update_all_batch: SharedParameterBatch,
     delete_all_sql: String,
     delete_one_by_pk_sql: String,
@@ -450,11 +455,19 @@ where
 
     #[expect(clippy::cast_possible_truncation)]
     async fn update_all(&self) -> usize {
-        let affected = Box::pin(execute_many_in_transaction(
-            &self.session,
-            &self.update_all_sql_rows,
-        ))
-        .await;
+        let affected = match &self.update_all_workload {
+            LiteralUpdateWorkload::Transaction(statements) => {
+                Box::pin(execute_many_in_transaction(&self.session, statements)).await
+            }
+            LiteralUpdateWorkload::ExecuteBatch(statements) => self
+                .session
+                .execute_batch(statements)
+                .await
+                .expect("execute tracked-state CRUD SQL batch")
+                .into_iter()
+                .map(|result| result.rows_affected())
+                .sum(),
+        };
         assert_eq!(affected as usize, self.row_count);
         affected as usize
     }
@@ -607,11 +620,7 @@ where
         ),
         select_one_by_pk_sql: select_by_pk_sql(&tracked_rows[mid..][..1]),
         update_one_by_pk_sql: update_row_sql(&tracked_rows[mid]),
-        update_all_sql_rows: if matches!(shape, FixtureShape::FullCrud) {
-            tracked_rows.iter().map(update_row_sql).collect()
-        } else {
-            Vec::new()
-        },
+        update_all_workload: literal_update_workload(shape, tracked_rows),
         bound_update_all_batch: if matches!(shape, FixtureShape::FullCrud) {
             tracked_rows
                 .iter()
@@ -632,6 +641,26 @@ where
             sql_string(tracked_rows[mid].path.as_str())
         ),
         _dir: dir,
+    }
+}
+
+fn literal_update_workload(shape: FixtureShape, rows: &[WorkloadRow]) -> LiteralUpdateWorkload {
+    if !matches!(shape, FixtureShape::FullCrud) {
+        return LiteralUpdateWorkload::Transaction(Vec::new());
+    }
+    match std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_UPDATE_API").as_deref() {
+        Ok("execute_batch") => LiteralUpdateWorkload::ExecuteBatch(
+            rows.iter()
+                .map(|row| ExecuteBatchStatement {
+                    sql: update_row_sql(row),
+                    params: Vec::new(),
+                })
+                .collect(),
+        ),
+        Ok(other) => panic!(
+            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_UPDATE_API '{other}'; expected execute_batch"
+        ),
+        Err(_) => LiteralUpdateWorkload::Transaction(rows.iter().map(update_row_sql).collect()),
     }
 }
 

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -474,6 +474,11 @@ enum TransactionBatchStatements {
         statement: datafusion::sql::parser::Statement,
         len: usize,
     },
+    AutoParameterizedUpdate {
+        sql: Arc<str>,
+        statement: datafusion::sql::parser::Statement,
+        parameter_rows: Vec<Vec<Value>>,
+    },
     Distinct(Vec<datafusion::sql::parser::Statement>),
 }
 
@@ -481,14 +486,8 @@ impl TransactionBatchStatements {
     fn len(&self) -> usize {
         match self {
             Self::Shared { len, .. } => *len,
+            Self::AutoParameterizedUpdate { parameter_rows, .. } => parameter_rows.len(),
             Self::Distinct(statements) => statements.len(),
-        }
-    }
-
-    fn first(&self) -> Option<&datafusion::sql::parser::Statement> {
-        match self {
-            Self::Shared { statement, len } => (*len > 0).then_some(statement),
-            Self::Distinct(statements) => statements.first(),
         }
     }
 
@@ -497,6 +496,7 @@ impl TransactionBatchStatements {
             Self::Shared { statement, .. } => {
                 Ok(sql2::bind_statement_route(statement)? == sql2::BoundStatementRoute::Write)
             }
+            Self::AutoParameterizedUpdate { .. } => Ok(true),
             Self::Distinct(statements) => {
                 statements
                     .iter()
@@ -512,6 +512,11 @@ impl TransactionBatchStatements {
     fn into_vec(self) -> Vec<datafusion::sql::parser::Statement> {
         match self {
             Self::Shared { statement, len } => vec![statement; len],
+            Self::AutoParameterizedUpdate {
+                statement,
+                parameter_rows,
+                ..
+            } => vec![statement; parameter_rows.len()],
             Self::Distinct(statements) => statements,
         }
     }
@@ -1508,44 +1513,93 @@ where
                         return Ok(results);
                     }
                     let mut results = Vec::with_capacity(transaction_statements.len());
-                    let parsed = parsed.into_vec();
-                    for (statement_index, ((statement, parsed), metadata)) in transaction_statements
-                        .iter()
-                        .zip(parsed)
-                        .zip(statement_metadata)
-                        .enumerate()
-                    {
-                        let telemetry = SqlStatementTelemetry::start(
-                            transaction_telemetry_sink.as_ref(),
-                            &statement.sql,
-                            "batch",
-                            Some(statement_index),
-                        );
-                        let operation = async {
-                            execute_transaction_statement(
-                                transaction,
-                                &statement.sql,
-                                parsed,
-                                &statement.params,
-                                options.clone(),
-                                metadata,
-                            )
-                            .await
-                            .map_err(|error| {
-                                with_batch_statement_index(
-                                    normalize_sql_surface_error(error, &statement.sql),
-                                    statement_index,
-                                )
-                            })
-                        };
-                        let result = match telemetry.as_ref() {
-                            Some(telemetry) => telemetry.instrument(operation).await,
-                            None => operation.await,
-                        };
-                        if let Some(telemetry) = telemetry {
-                            telemetry.finish(&result);
+                    match parsed {
+                        TransactionBatchStatements::AutoParameterizedUpdate {
+                            sql,
+                            statement: parsed,
+                            parameter_rows,
+                        } => {
+                            for (statement_index, ((statement, params), metadata)) in
+                                transaction_statements
+                                    .iter()
+                                    .zip(parameter_rows)
+                                    .zip(statement_metadata)
+                                    .enumerate()
+                            {
+                                let telemetry = SqlStatementTelemetry::start(
+                                    transaction_telemetry_sink.as_ref(),
+                                    &statement.sql,
+                                    "batch",
+                                    Some(statement_index),
+                                );
+                                let operation = async {
+                                    execute_transaction_statement(
+                                        transaction,
+                                        &sql,
+                                        parsed.clone(),
+                                        &params,
+                                        options.clone(),
+                                        metadata,
+                                    )
+                                    .await
+                                    .map_err(|error| {
+                                        with_batch_statement_index(
+                                            normalize_sql_surface_error(error, &statement.sql),
+                                            statement_index,
+                                        )
+                                    })
+                                };
+                                let result = match telemetry.as_ref() {
+                                    Some(telemetry) => telemetry.instrument(operation).await,
+                                    None => operation.await,
+                                };
+                                if let Some(telemetry) = telemetry {
+                                    telemetry.finish(&result);
+                                }
+                                results.push(result?);
+                            }
                         }
-                        results.push(result?);
+                        parsed => {
+                            for (statement_index, ((statement, parsed), metadata)) in
+                                transaction_statements
+                                    .iter()
+                                    .zip(parsed.into_vec())
+                                    .zip(statement_metadata)
+                                    .enumerate()
+                            {
+                                let telemetry = SqlStatementTelemetry::start(
+                                    transaction_telemetry_sink.as_ref(),
+                                    &statement.sql,
+                                    "batch",
+                                    Some(statement_index),
+                                );
+                                let operation = async {
+                                    execute_transaction_statement(
+                                        transaction,
+                                        &statement.sql,
+                                        parsed,
+                                        &statement.params,
+                                        options.clone(),
+                                        metadata,
+                                    )
+                                    .await
+                                    .map_err(|error| {
+                                        with_batch_statement_index(
+                                            normalize_sql_surface_error(error, &statement.sql),
+                                            statement_index,
+                                        )
+                                    })
+                                };
+                                let result = match telemetry.as_ref() {
+                                    Some(telemetry) => telemetry.instrument(operation).await,
+                                    None => operation.await,
+                                };
+                                if let Some(telemetry) = telemetry {
+                                    telemetry.finish(&result);
+                                }
+                                results.push(result?);
+                            }
+                        }
                     }
                     if let Some(idempotency) = &idempotency {
                         let receipt = ExecuteIdempotencyReceipt::batch(idempotency, &results)?;
@@ -2582,34 +2636,48 @@ where
     if statements.len() < 2
         || parsed.len() != statements.len()
         || statement_metadata.len() != statements.len()
-        || statements
-            .iter()
-            .any(|statement| statement.sql != first_statement.sql)
         || statement_metadata
             .iter()
             .any(|metadata| metadata != &ExecuteStatementMetadata::default())
-        || sql2::bind_statement_route(
-            parsed
-                .first()
-                .expect("non-empty transaction batch has a parsed statement"),
-        )? != sql2::BoundStatementRoute::Write
     {
         return Ok(None);
     }
 
-    let parameter_rows = statements
-        .iter()
-        .map(|statement| statement.params.as_slice())
-        .collect::<Vec<_>>();
+    let (planning_sql, parsed_statement, parameter_rows) = match parsed {
+        TransactionBatchStatements::AutoParameterizedUpdate {
+            sql,
+            statement,
+            parameter_rows,
+        } => (
+            sql.as_ref(),
+            statement,
+            parameter_rows.iter().map(Vec::as_slice).collect::<Vec<_>>(),
+        ),
+        TransactionBatchStatements::Shared { statement, .. }
+            if statements
+                .iter()
+                .all(|candidate| candidate.sql == first_statement.sql) =>
+        {
+            (
+                first_statement.sql.as_str(),
+                statement,
+                statements
+                    .iter()
+                    .map(|statement| statement.params.as_slice())
+                    .collect::<Vec<_>>(),
+            )
+        }
+        TransactionBatchStatements::Shared { .. } | TransactionBatchStatements::Distinct(_) => {
+            return Ok(None);
+        }
+    };
+    if sql2::bind_statement_route(parsed_statement)? != sql2::BoundStatementRoute::Write {
+        return Ok(None);
+    }
 
     let previous_origin_key = transaction.replace_origin_key(options.origin_key.clone());
     let execution = async {
-        let plan = transaction.prepare_sql_write_logical_plan(
-            &first_statement.sql,
-            parsed
-                .first()
-                .expect("non-empty transaction batch has a parsed statement"),
-        )?;
+        let plan = transaction.prepare_sql_write_logical_plan(planning_sql, parsed_statement)?;
         if let Some(results) =
             sql2::execute_write_logical_plan_value_batch(transaction, &plan, &parameter_rows)
                 .await?
@@ -2634,7 +2702,7 @@ where
             })
         })
         .map_err(|error| {
-            let error = normalize_sql_surface_error(error, &first_statement.sql);
+            let error = normalize_sql_surface_error(error, planning_sql);
             if batch_statement_index(&error).is_some() {
                 error
             } else {
@@ -3600,6 +3668,41 @@ fn classify_execute_batch(
         };
     }
 
+    // Distinct literal UPDATE statements have the same execution shape as a
+    // homogeneous bound batch. Explicit transactions already normalize this
+    // narrow SQL subset one statement at a time; recognize the complete batch
+    // here so the ordered mutation kernel can fold repeated identities and use
+    // the certified columnar route. Shapes that have not yet been lowered into
+    // that mutation program retain their original sequential execution.
+    if statements.len() >= 2
+        && statements
+            .iter()
+            .all(|statement| statement.params.is_empty())
+        && let Some(first) = planning_cache.auto_parameterized_update(&statements[0].sql)
+    {
+        let mut parameter_rows = Vec::with_capacity(statements.len());
+        parameter_rows.push(first.params);
+        let mut same_shape = true;
+        for statement in &statements[1..] {
+            let Some(params) =
+                planning_cache.update_literal_params_for_shape(&statement.sql, first.sql.as_ref())
+            else {
+                same_shape = false;
+                break;
+            };
+            parameter_rows.push(params);
+        }
+        if same_shape {
+            return Ok(ExecuteBatchExecution::Transaction(
+                TransactionBatchStatements::AutoParameterizedUpdate {
+                    sql: first.sql,
+                    statement: first.statement,
+                    parameter_rows,
+                },
+            ));
+        }
+    }
+
     let mut parsed = Vec::with_capacity(statements.len());
     let mut is_read_only = true;
     for (statement_index, statement) in statements.iter().enumerate() {
@@ -4222,6 +4325,39 @@ mod tests {
             panic!("homogeneous durable statements should share one parsed statement");
         };
         assert_eq!(len, statements.len());
+    }
+
+    #[test]
+    fn execute_batch_auto_parameterizes_distinct_literal_update_shapes() {
+        let cache = sql2::SqlPlanningCache::default();
+        let statements = [
+            batch_statement("UPDATE notes SET value = 'first' WHERE id = 'a'"),
+            batch_statement("UPDATE notes SET value = 'second' WHERE id = 'b'"),
+        ];
+        let ExecuteBatchExecution::Transaction(
+            TransactionBatchStatements::AutoParameterizedUpdate {
+                sql,
+                parameter_rows,
+                ..
+            },
+        ) = classify_execute_batch(&statements, &cache).unwrap()
+        else {
+            panic!("literal UPDATE statements should share one parameterized shape");
+        };
+        assert_eq!(sql.as_ref(), "UPDATE notes SET value = $1 WHERE id = $2");
+        assert_eq!(
+            parameter_rows,
+            [
+                vec![
+                    Value::Text("first".to_string()),
+                    Value::Text("a".to_string())
+                ],
+                vec![
+                    Value::Text("second".to_string()),
+                    Value::Text("b".to_string())
+                ],
+            ]
+        );
     }
 
     #[tokio::test]
@@ -5370,6 +5506,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_batch_lowers_distinct_literal_entity_updates_once() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "x-lix-key": "literal_parameter_batch_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": { "type": "string" }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+        session
+            .execute(
+                "INSERT INTO literal_parameter_batch_probe (id, value) VALUES \
+                 ('a', 'old-a'), ('b', 'old-b')",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sql2::take_entity_update_parameter_batch_executions();
+        let results = session
+            .execute_batch(&[
+                batch_statement(
+                    "UPDATE literal_parameter_batch_probe SET value = 'new-a' WHERE id = 'a'",
+                ),
+                batch_statement(
+                    "UPDATE literal_parameter_batch_probe SET value = 'new-b' WHERE id = 'b'",
+                ),
+            ])
+            .await
+            .unwrap();
+
+        assert_eq!(sql2::take_entity_update_parameter_batch_executions(), 1);
+        assert_eq!(
+            results
+                .iter()
+                .map(ExecuteResult::rows_affected)
+                .collect::<Vec<_>>(),
+            vec![1, 1]
+        );
+        let rows = session
+            .execute(
+                "SELECT id, value FROM literal_parameter_batch_probe ORDER BY id",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(rows.rows()[0].get::<String>("value").unwrap(), "new-a");
+        assert_eq!(rows.rows()[1].get::<String>("value").unwrap(), "new-b");
+    }
+
+    #[tokio::test]
     async fn entity_insert_values_use_one_certified_canonical_batch() {
         let session = open_session().await;
         let schema = serde_json::json!({
@@ -5559,8 +5757,29 @@ mod tests {
                 ExecuteBatchStatement {
                     sql: sql.to_string(),
                     params: vec![
+                        Value::Text(r#"{"missing":1}"#.to_string()),
+                        Value::Text("/missing".to_string()),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
                         Value::Text("null".to_string()),
                         Value::Text("/a".to_string()),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text(r#"{"final":"b"}"#.to_string()),
+                        Value::Text("/b".to_string()),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text(r#"{"missing":2}"#.to_string()),
+                        Value::Text("/missing".to_string()),
                     ],
                 },
             ])
@@ -5576,7 +5795,7 @@ mod tests {
                 .iter()
                 .map(ExecuteResult::rows_affected)
                 .collect::<Vec<_>>(),
-            vec![1, 1]
+            vec![1, 0, 1, 1, 0]
         );
         let rows = session
             .execute(
@@ -5588,7 +5807,7 @@ mod tests {
         assert_eq!(rows.rows()[0].value("value").unwrap(), &Value::Null);
         assert_eq!(
             rows.rows()[1].get::<serde_json::Value>("value").unwrap(),
-            serde_json::json!({"nested": [1, true, "x"]})
+            serde_json::json!({"final": "b"})
         );
     }
 
@@ -5805,7 +6024,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn execute_batch_keeps_repeated_entity_identity_sequential() {
+    async fn execute_batch_keeps_repeated_generic_entity_identity_sequential() {
         let session = open_session().await;
         let schema = serde_json::json!({
             "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -5894,7 +6113,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn execute_batch_keeps_parameterless_updates_sequential() {
+    async fn execute_batch_keeps_unsupported_parameterless_updates_sequential() {
         let session = open_session().await;
         let schema = serde_json::json!({
             "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -5924,17 +6143,14 @@ mod tests {
             .unwrap();
 
         sql2::take_entity_update_parameter_batch_executions();
-        let sql = "UPDATE parameterless_batch_probe SET value = 'new' WHERE id = 'a'";
         let results = session
             .execute_batch(&[
-                ExecuteBatchStatement {
-                    sql: sql.to_string(),
-                    params: Vec::new(),
-                },
-                ExecuteBatchStatement {
-                    sql: sql.to_string(),
-                    params: Vec::new(),
-                },
+                batch_statement(
+                    "UPDATE parameterless_batch_probe SET value = 'first' WHERE id = 'a'",
+                ),
+                batch_statement(
+                    "UPDATE parameterless_batch_probe SET value = 'second' WHERE id = 'a'",
+                ),
             ])
             .await
             .unwrap();
@@ -5955,7 +6171,7 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(row.rows()[0].get::<String>("value").unwrap(), "new");
+        assert_eq!(row.rows()[0].get::<String>("value").unwrap(), "second");
     }
 
     #[tokio::test]

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -400,13 +400,12 @@ async fn collection_is_certifiably_empty(
         .is_some_and(|generation| generation.live_count == 0))
 }
 
-/// Executes a certified run of independent point updates as one physical
+/// Executes a certified ordered run of point updates as one physical
 /// scan/stage operation.
 ///
-/// `executeBatch` remains sequential at its public boundary. This route is
-/// narrower: every logical statement must target a distinct primary key in
-/// the same unconstrained entity surface, so evaluating them together is
-/// observationally equivalent to evaluating them one at a time.
+/// `executeBatch` remains ordered at its public boundary. This route folds
+/// repeated identities in statement order and lowers the resulting unique,
+/// identity-sorted replacements in one physical scan/stage operation.
 pub(crate) async fn try_execute_entity_update_value_batch<'a>(
     ctx: &mut dyn SqlWriteExecutionContext,
     plan: &LogicalWritePlan,
@@ -701,9 +700,10 @@ pub(crate) async fn try_execute_entity_update_parameter_batch(
 /// Lowers the dominant JSON-pointer replacement shape directly from borrowed
 /// public parameters into one canonical row-content arena.
 ///
-/// This deliberately accepts only strictly ordered, unique, ordinary tracked
-/// identities. Anything else retains the generic sequential path and its full
-/// plugin/constraint semantics.
+/// Statement order is preserved even when identities repeat or arrive out of
+/// order: each live identity reports every matching statement as affected and
+/// the last statement supplies the staged replacement. The canonical write
+/// batch itself remains identity-sorted and contains one row per identity.
 async fn try_execute_direct_path_value_replacement_batch(
     ctx: &mut dyn SqlWriteExecutionContext,
     plan: &LogicalWritePlan,
@@ -772,6 +772,7 @@ async fn try_execute_direct_path_value_replacement_batch(
     let mut primary_key_arena = Vec::new();
     let mut primary_key_offsets = Vec::with_capacity(row_count);
     let mut previous_row = None;
+    let mut primary_keys_strictly_ordered = true;
     for statement_index in 0..row_count {
         let DirectParameterValue::String(primary_key) =
             parameter_batch.value(primary_key_param_index, statement_index)
@@ -784,9 +785,7 @@ async fn try_execute_direct_path_value_replacement_batch(
             else {
                 unreachable!("the previous primary-key parameter was certified as text")
             };
-            if previous >= primary_key {
-                return Ok(None);
-            }
+            primary_keys_strictly_ordered &= previous < primary_key;
         }
         previous_row = Some(statement_index);
         let start = primary_key_arena.len();
@@ -806,6 +805,34 @@ async fn try_execute_direct_path_value_replacement_batch(
         })
         .collect::<Vec<_>>();
 
+    // Keep the already-sorted case allocation-free. Otherwise sort statement
+    // ordinals by identity and then ordinal so equal-identity groups retain
+    // SQL's sequential last-write-wins semantics.
+    let sorted_statement_ordinals = if primary_keys_strictly_ordered {
+        None
+    } else {
+        let mut ordinals = (0..row_count).collect::<Vec<_>>();
+        ordinals.sort_unstable_by(|left, right| {
+            entity_pks[*left]
+                .cmp(&entity_pks[*right])
+                .then_with(|| left.cmp(right))
+        });
+        Some(ordinals)
+    };
+    let unique_entity_pks = if let Some(ordinals) = &sorted_statement_ordinals {
+        let mut unique = Vec::with_capacity(row_count);
+        for &statement_index in ordinals {
+            let entity_pk = &entity_pks[statement_index];
+            if unique.last() != Some(entity_pk) {
+                unique.push(entity_pk.clone());
+            }
+        }
+        unique
+    } else {
+        entity_pks.clone()
+    };
+    let unique_row_count = unique_entity_pks.len();
+
     let active_branch_id = ctx.active_branch_id().to_owned();
     let scope = crate::collection_generation::CollectionScopeRef {
         schema_key: &spec.schema_key,
@@ -820,11 +847,11 @@ async fn try_execute_direct_path_value_replacement_batch(
         .await?;
     let certified_generation_identity = !has_staged_collection_rows
         && collection_generation.is_some_and(|generation| {
-            generation.live_count == row_count as u64
+            generation.live_count == unique_row_count as u64
                 && generation.ordered_identity_digest.is_some()
                 && generation.ordered_identity_digest
                     == crate::collection_generation::ordered_single_string_identity_digest(
-                        entity_pks.iter(),
+                        unique_entity_pks.iter(),
                     )
         });
     #[cfg(test)]
@@ -836,13 +863,15 @@ async fn try_execute_direct_path_value_replacement_batch(
     let candidates = if certified_generation_identity {
         MaterializedLiveStateBatch::default()
     } else {
-        let candidates = scan_entity_candidates_for_pks(ctx, plan, &spec, entity_pks.clone(), true)
-            .instrument(tracing::debug_span!(
-                target: "lix_perf",
-                "lix.perf.entity_update_value_batch.candidate_scan",
-                row_count
-            ))
-            .await?;
+        let candidates =
+            scan_entity_candidates_for_pks(ctx, plan, &spec, unique_entity_pks.clone(), true)
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.entity_update_value_batch.candidate_scan",
+                    row_count,
+                    unique_row_count
+                ))
+                .await?;
         if candidates.iter().any(|candidate| {
             candidate.untracked()
                 || candidate.global()
@@ -854,11 +883,11 @@ async fn try_execute_direct_path_value_replacement_batch(
         candidates
     };
     let complete_collection_replacement = certified_generation_identity
-        || (candidates.len() == row_count
+        || (candidates.len() == unique_row_count
             && collection_generation
-                .is_some_and(|generation| generation.live_count == row_count as u64));
+                .is_some_and(|generation| generation.live_count == unique_row_count as u64));
 
-    let estimated_row_bytes = entity_pks
+    let estimated_row_bytes = unique_entity_pks
         .iter()
         .map(|entity_pk| {
             entity_pk
@@ -868,7 +897,7 @@ async fn try_execute_direct_path_value_replacement_batch(
         .sum::<usize>();
     let mut normalized = Vec::with_capacity(estimated_row_bytes);
     let replacement_capacity = if certified_generation_identity {
-        row_count
+        unique_row_count
     } else {
         candidates.len()
     };
@@ -876,7 +905,20 @@ async fn try_execute_direct_path_value_replacement_batch(
     let mut replacement_entity_pks = Vec::with_capacity(replacement_capacity);
     let mut affected_by_statement = vec![0_u64; row_count];
     let mut candidate_index = 0;
-    for (statement_index, entity_pk) in entity_pks.iter().enumerate() {
+    let mut ordinal_index = 0;
+    for (identity_index, entity_pk) in unique_entity_pks.iter().enumerate() {
+        let (first_statement_index, last_statement_index) =
+            if let Some(ordinals) = &sorted_statement_ordinals {
+                let first = ordinal_index;
+                while ordinal_index < ordinals.len()
+                    && entity_pks[ordinals[ordinal_index]] == *entity_pk
+                {
+                    ordinal_index += 1;
+                }
+                (first, ordinal_index - 1)
+            } else {
+                (identity_index, identity_index)
+            };
         if !certified_generation_identity {
             while candidate_index < candidates.len()
                 && candidates.row(candidate_index).entity_pk() < entity_pk
@@ -889,6 +931,12 @@ async fn try_execute_direct_path_value_replacement_batch(
                 continue;
             }
         }
+
+        let statement_index = sorted_statement_ordinals
+            .as_ref()
+            .map_or(last_statement_index, |ordinals| {
+                ordinals[last_statement_index]
+            });
 
         let start = normalized.len();
         normalized.extend_from_slice(b"{\"path\":");
@@ -909,7 +957,13 @@ async fn try_execute_direct_path_value_replacement_batch(
         normalized.push(b'}');
         snapshot_offsets.push((start, normalized.len()));
         replacement_entity_pks.push(entity_pk.clone());
-        affected_by_statement[statement_index] = 1;
+        if let Some(ordinals) = &sorted_statement_ordinals {
+            for &affected_statement in &ordinals[first_statement_index..=last_statement_index] {
+                affected_by_statement[affected_statement] = 1;
+            }
+        } else {
+            affected_by_statement[statement_index] = 1;
+        }
         if !certified_generation_identity {
             candidate_index += 1;
         }

--- a/packages/engine/src/sql2/planning_cache.rs
+++ b/packages/engine/src/sql2/planning_cache.rs
@@ -107,6 +107,22 @@ where
         })
     }
 
+    /// Extracts literal parameters when `sql` has an already validated UPDATE
+    /// shape.
+    ///
+    /// Batch classification validates and parses the first statement once.
+    /// The remaining statements only need to prove that normalization yields
+    /// the same shape; reparsing and cloning the same AST for every row would
+    /// make classification itself linear in the planner representation.
+    pub(crate) fn update_literal_params_for_shape(
+        &self,
+        sql: &str,
+        normalized_shape: &str,
+    ) -> Option<Vec<Value>> {
+        let (normalized_sql, params) = normalize_update_string_literals(sql)?;
+        (normalized_sql == normalized_shape).then_some(params)
+    }
+
     /// Returns stable public-surface metadata for one catalog generation.
     ///
     /// Callers are responsible for using a key that changes whenever any


### PR DESCRIPTION
## What changed

- recognize distinct literal `UPDATE` statements in `executeBatch` as one normalized prepared shape
- extract literal values into one parameter batch and route it through the existing certified mutation executor
- preserve statement order for repeated and out-of-order identities with an identity/ordinal fold
- scan each unique identity once and stage only its final replacement
- retain sequential semantics for SQL shapes that have not yet been lowered into the ordered mutation program
- add an opt-in tracked CRUD benchmark selector for the distinct-literal `executeBatch` surface

## Why

The previous implementation parsed, planned, and staged every distinct literal statement separately. At 1M rows this duplicated enough planner and row state that the benchmark was killed by the memory limit before completing. The physical mutation is one ordered replacement batch, so the row-at-a-time planning path was unnecessary.

## Performance

Exact stacked baseline: `5e183cc81` (#1100). Three setup-excluded samples unless noted.

| Adapter | Rows | #1100 median | This PR median | Change |
| --- | ---: | ---: | ---: | ---: |
| RocksDB | 10k | 424.85 ms | 23.12 ms | -94.6% |
| SlateDB | 10k | 369.01 ms | 22.31 ms | -94.0% |
| RocksDB | 1M | OOM | 3.85 s | completes |
| SlateDB | 1M | OOM | 3.97 s | completes |

At 1M RocksDB, the #1100 process reached 8.80 GB RSS before SIGKILL. This PR completes at 2.77 GB RSS (at least 68.5% lower peak RSS). SlateDB completes at 2.78 GB RSS.

## Validation

- `cargo test -p lix_engine --lib`: 1,709 passed, 8 ignored
- focused `executeBatch` suite: 20 passed
- repeated, out-of-order, and missing identities preserve per-statement affected counts and last-write-wins behavior
- tracked merge-preview and merge-commit benchmarks on RocksDB and SlateDB remain within run noise of #1100
- `cargo check -p lix_engine_benchmarks --bench tracked_state_crud --features storage-benches,slatedb`
- no changenote
