### PR TITLE
fix(engine): preserve ordered batch update errors

### DIFF
--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -5743,8 +5743,77 @@ mod tests {
             .await
             .unwrap();
 
-        sql2::take_certified_replacement_parameter_batch_executions();
         let sql = "UPDATE certified_replacement_probe SET value = lix_json($1) WHERE path = $2";
+        let missing_results = session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("invalid-missing-1".to_string()),
+                        Value::Text("/missing".to_string()),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("invalid-missing-2".to_string()),
+                        Value::Text("/missing".to_string()),
+                    ],
+                },
+            ])
+            .await
+            .expect("missing rows must not evaluate their replacement expression");
+        assert_eq!(
+            missing_results
+                .iter()
+                .map(ExecuteResult::rows_affected)
+                .collect::<Vec<_>>(),
+            vec![0, 0]
+        );
+
+        let error = session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("not-json".to_string()),
+                        Value::Text("/b".to_string()),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text(r#"{"later":"valid"}"#.to_string()),
+                        Value::Text("/b".to_string()),
+                    ],
+                },
+            ])
+            .await
+            .expect_err("a later replacement must not hide earlier invalid JSON");
+        assert_eq!(error.details.unwrap()["statementIndex"], 0);
+
+        let error = session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("invalid-b".to_string()),
+                        Value::Text("/b".to_string()),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    sql: sql.to_string(),
+                    params: vec![
+                        Value::Text("invalid-a".to_string()),
+                        Value::Text("/a".to_string()),
+                    ],
+                },
+            ])
+            .await
+            .expect_err("errors must retain statement order when identities are sorted");
+        assert_eq!(error.details.unwrap()["statementIndex"], 0);
+
+        sql2::take_certified_replacement_parameter_batch_executions();
         let results = session
             .execute_batch(&[
                 ExecuteBatchStatement {

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -882,6 +882,53 @@ async fn try_execute_direct_path_value_replacement_batch(
         }
         candidates
     };
+    // Sorting identities changes expression evaluation order. Once this route
+    // is fully certified, validate JSON arguments for live rows in original
+    // statement order so a later replacement cannot hide an earlier error.
+    // Missing-row UPDATEs do not evaluate SET expressions, so first derive
+    // liveness from the certified generation or the exact candidate scan.
+    if !primary_keys_strictly_ordered {
+        let live_unique_identities = if certified_generation_identity {
+            None
+        } else {
+            let mut live = vec![false; unique_row_count];
+            let mut candidate_index = 0;
+            for (identity_index, entity_pk) in unique_entity_pks.iter().enumerate() {
+                while candidate_index < candidates.len()
+                    && candidates.row(candidate_index).entity_pk() < entity_pk
+                {
+                    candidate_index += 1;
+                }
+                live[identity_index] = candidate_index < candidates.len()
+                    && candidates.row(candidate_index).entity_pk() == entity_pk;
+            }
+            Some(live)
+        };
+        let mut scratch = Vec::new();
+        for (statement_index, entity_pk) in entity_pks.iter().enumerate() {
+            let identity_index = unique_entity_pks
+                .binary_search(entity_pk)
+                .expect("every statement identity belongs to the unique identity set");
+            if live_unique_identities
+                .as_ref()
+                .is_some_and(|live| !live[identity_index])
+            {
+                continue;
+            }
+            match parameter_batch.value(replacement.value_param_index, statement_index) {
+                DirectParameterValue::Null => {}
+                DirectParameterValue::String(raw) => {
+                    scratch.clear();
+                    append_canonical_json_parameter(&mut scratch, raw).map_err(|error| {
+                        with_parameter_batch_statement_index(error, statement_index)
+                    })?;
+                }
+                DirectParameterValue::Boolean(_) => {
+                    unreachable!("the certified replacement value parameter is text")
+                }
+            }
+        }
+    }
     let complete_collection_replacement = certified_generation_identity
         || (candidates.len() == unique_row_count
             && collection_generation


### PR DESCRIPTION
## What changed

- validate live direct-replacement expressions in original `executeBatch` statement order before identity sorting and last-write folding
- skip validation for missing-row updates, matching SQL's rule that `SET` expressions are not evaluated when no row matches
- cover repeated identities, out-of-order identities, missing identities, and statement-index attribution

## Root cause

The ordered mutation fold introduced in #1104 selected the final replacement for each identity before canonicalizing its JSON value. A later valid replacement could therefore hide an earlier invalid value for the same identity. Sorting identities could also report an invalid later statement before an invalid earlier statement.

## Validation

- `cargo test -p lix_engine --lib`: 1,714 passed, 8 ignored
- focused `execute_batch_` suite: 20 passed
- reviewed independently by three parallel reviewers
- no changenote
