### PR TITLE
perf(engine): columnarize literal update parameters

### DIFF
--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -19,6 +19,9 @@ use crate::storage_adapter::{
 use crate::telemetry::TelemetrySpanKind;
 use crate::transaction::{begin_commit_boundary, commit_at_boundary};
 use crate::{Blob, LixError, LixNotice, SqlQueryResult, Value};
+use datafusion::arrow::array::{ArrayRef, LargeStringBuilder, StringBuilder};
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::sql::parser::Statement as DataFusionStatement;
 use datafusion::sql::sqlparser::ast::{
     BinaryOperator, Expr, GroupByExpr, Ident, LimitClause, OrderByKind, Query, Select,
@@ -32,6 +35,40 @@ use super::ExecuteIdempotency;
 use super::context::{SessionContext, SessionSqlExecutionContext, SessionWriteAccess};
 use super::idempotency::{ExecuteIdempotencyReceipt, load_receipt};
 use super::transaction::SessionTransaction;
+
+const MAX_INITIAL_LITERAL_COLUMN_BYTES: usize = 64 * 1024 * 1024;
+
+enum LiteralParameterBuilder {
+    Utf8(StringBuilder),
+    LargeUtf8(LargeStringBuilder),
+}
+
+impl LiteralParameterBuilder {
+    fn with_capacity(large_offsets: bool, item_capacity: usize, data_capacity: usize) -> Self {
+        if large_offsets {
+            Self::LargeUtf8(LargeStringBuilder::with_capacity(
+                item_capacity,
+                data_capacity,
+            ))
+        } else {
+            Self::Utf8(StringBuilder::with_capacity(item_capacity, data_capacity))
+        }
+    }
+
+    fn append_value(&mut self, value: &str) {
+        match self {
+            Self::Utf8(builder) => builder.append_value(value),
+            Self::LargeUtf8(builder) => builder.append_value(value),
+        }
+    }
+
+    fn finish(&mut self) -> ArrayRef {
+        match self {
+            Self::Utf8(builder) => Arc::new(builder.finish()),
+            Self::LargeUtf8(builder) => Arc::new(builder.finish()),
+        }
+    }
+}
 
 /// Result of executing one SQL statement through engine.
 ///
@@ -477,7 +514,7 @@ enum TransactionBatchStatements {
     AutoParameterizedUpdate {
         sql: Arc<str>,
         statement: datafusion::sql::parser::Statement,
-        parameter_rows: Vec<Vec<Value>>,
+        parameter_batch: RecordBatch,
     },
     Distinct(Vec<datafusion::sql::parser::Statement>),
 }
@@ -486,7 +523,9 @@ impl TransactionBatchStatements {
     fn len(&self) -> usize {
         match self {
             Self::Shared { len, .. } => *len,
-            Self::AutoParameterizedUpdate { parameter_rows, .. } => parameter_rows.len(),
+            Self::AutoParameterizedUpdate {
+                parameter_batch, ..
+            } => parameter_batch.num_rows(),
             Self::Distinct(statements) => statements.len(),
         }
     }
@@ -514,9 +553,9 @@ impl TransactionBatchStatements {
             Self::Shared { statement, len } => vec![statement; len],
             Self::AutoParameterizedUpdate {
                 statement,
-                parameter_rows,
+                parameter_batch,
                 ..
-            } => vec![statement; parameter_rows.len()],
+            } => vec![statement; parameter_batch.num_rows()],
             Self::Distinct(statements) => statements,
         }
     }
@@ -1517,15 +1556,17 @@ where
                         TransactionBatchStatements::AutoParameterizedUpdate {
                             sql,
                             statement: parsed,
-                            parameter_rows,
+                            parameter_batch,
                         } => {
-                            for (statement_index, ((statement, params), metadata)) in
-                                transaction_statements
-                                    .iter()
-                                    .zip(parameter_rows)
-                                    .zip(statement_metadata)
-                                    .enumerate()
+                            for (statement_index, (statement, metadata)) in transaction_statements
+                                .iter()
+                                .zip(statement_metadata)
+                                .enumerate()
                             {
+                                let params = sql2::parameter_row(&parameter_batch, statement_index)
+                                    .map_err(|error| {
+                                        with_batch_statement_index(error, statement_index)
+                                    })?;
                                 let telemetry = SqlStatementTelemetry::start(
                                     transaction_telemetry_sink.as_ref(),
                                     &statement.sql,
@@ -2644,15 +2685,9 @@ where
     }
 
     let (planning_sql, parsed_statement, parameter_rows) = match parsed {
-        TransactionBatchStatements::AutoParameterizedUpdate {
-            sql,
-            statement,
-            parameter_rows,
-        } => (
-            sql.as_ref(),
-            statement,
-            parameter_rows.iter().map(Vec::as_slice).collect::<Vec<_>>(),
-        ),
+        TransactionBatchStatements::AutoParameterizedUpdate { sql, statement, .. } => {
+            (sql.as_ref(), statement, None)
+        }
         TransactionBatchStatements::Shared { statement, .. }
             if statements
                 .iter()
@@ -2661,10 +2696,12 @@ where
             (
                 first_statement.sql.as_str(),
                 statement,
-                statements
-                    .iter()
-                    .map(|statement| statement.params.as_slice())
-                    .collect::<Vec<_>>(),
+                Some(
+                    statements
+                        .iter()
+                        .map(|statement| statement.params.as_slice())
+                        .collect::<Vec<_>>(),
+                ),
             )
         }
         TransactionBatchStatements::Shared { .. } | TransactionBatchStatements::Distinct(_) => {
@@ -2678,13 +2715,26 @@ where
     let previous_origin_key = transaction.replace_origin_key(options.origin_key.clone());
     let execution = async {
         let plan = transaction.prepare_sql_write_logical_plan(planning_sql, parsed_statement)?;
+        if let TransactionBatchStatements::AutoParameterizedUpdate {
+            parameter_batch, ..
+        } = parsed
+        {
+            return sql2::execute_write_logical_plan_parameter_batch(
+                transaction,
+                plan,
+                parameter_batch,
+            )
+            .await;
+        }
+        let parameter_rows = parameter_rows
+            .as_ref()
+            .expect("shared parameter execution retains borrowed rows");
         if let Some(results) =
-            sql2::execute_write_logical_plan_value_batch(transaction, &plan, &parameter_rows)
-                .await?
+            sql2::execute_write_logical_plan_value_batch(transaction, &plan, parameter_rows).await?
         {
             return Ok(Some(results));
         }
-        let Some(parameter_batch) = sql2::parameter_record_batch(&parameter_rows)? else {
+        let Some(parameter_batch) = sql2::parameter_record_batch(parameter_rows)? else {
             return Ok(None);
         };
         sql2::execute_write_logical_plan_parameter_batch(transaction, plan, &parameter_batch).await
@@ -3679,28 +3729,69 @@ fn classify_execute_batch(
             .iter()
             .all(|statement| statement.params.is_empty())
         && let Some(first) = planning_cache.auto_parameterized_update(&statements[0].sql)
+        && statements[1..].iter().all(|statement| {
+            planning_cache.update_literal_shape_matches(&statement.sql, first.sql.as_ref())
+        })
     {
-        let mut parameter_rows = Vec::with_capacity(statements.len());
-        parameter_rows.push(first.params);
-        let mut same_shape = true;
-        for statement in &statements[1..] {
-            let Some(params) =
-                planning_cache.update_literal_params_for_shape(&statement.sql, first.sql.as_ref())
-            else {
-                same_shape = false;
-                break;
+        let mut builders = Vec::with_capacity(first.params.len());
+        // Every decoded literal is a substring of its source SQL (doubled
+        // quotes only shrink it), so total SQL bytes are a conservative proof
+        // that every parameter column fits Arrow's 32-bit Utf8 offsets.
+        let large_offsets = statements.iter().fold(0_usize, |total, statement| {
+            total.saturating_add(statement.sql.len())
+        }) > i32::MAX as usize;
+        let per_column_byte_cap = MAX_INITIAL_LITERAL_COLUMN_BYTES / first.params.len().max(1);
+        for param in &first.params {
+            let Value::Text(value) = param else {
+                unreachable!("auto-parameterized string literals produce text parameters")
             };
-            parameter_rows.push(params);
+            let mut builder = LiteralParameterBuilder::with_capacity(
+                large_offsets,
+                statements.len(),
+                value
+                    .len()
+                    .saturating_mul(statements.len())
+                    .min(per_column_byte_cap),
+            );
+            builder.append_value(value);
+            builders.push(builder);
         }
-        if same_shape {
-            return Ok(ExecuteBatchExecution::Transaction(
-                TransactionBatchStatements::AutoParameterizedUpdate {
-                    sql: first.sql,
-                    statement: first.statement,
-                    parameter_rows,
-                },
-            ));
+        for statement in &statements[1..] {
+            let params = planning_cache
+                .update_literal_params_for_shape(&statement.sql, first.sql.as_ref())
+                .expect("the non-retaining pass certified this UPDATE shape");
+            for (builder, param) in builders.iter_mut().zip(params) {
+                let Value::Text(value) = param else {
+                    unreachable!("auto-parameterized string literals produce text parameters")
+                };
+                builder.append_value(&value);
+            }
         }
+        let data_type = if large_offsets {
+            DataType::LargeUtf8
+        } else {
+            DataType::Utf8
+        };
+        let fields = (0..builders.len())
+            .map(|index| Field::new(format!("${}", index + 1), data_type.clone(), false))
+            .collect::<Vec<_>>();
+        let columns = builders
+            .iter_mut()
+            .map(LiteralParameterBuilder::finish)
+            .collect::<Vec<_>>();
+        let parameter_batch = RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
+            .map_err(|error| {
+                LixError::unknown(format!(
+                    "failed to construct literal UPDATE parameter batch: {error}"
+                ))
+            })?;
+        return Ok(ExecuteBatchExecution::Transaction(
+            TransactionBatchStatements::AutoParameterizedUpdate {
+                sql: first.sql,
+                statement: first.statement,
+                parameter_batch,
+            },
+        ));
     }
 
     let mut parsed = Vec::with_capacity(statements.len());
@@ -4337,7 +4428,7 @@ mod tests {
         let ExecuteBatchExecution::Transaction(
             TransactionBatchStatements::AutoParameterizedUpdate {
                 sql,
-                parameter_rows,
+                parameter_batch,
                 ..
             },
         ) = classify_execute_batch(&statements, &cache).unwrap()
@@ -4345,6 +4436,9 @@ mod tests {
             panic!("literal UPDATE statements should share one parameterized shape");
         };
         assert_eq!(sql.as_ref(), "UPDATE notes SET value = $1 WHERE id = $2");
+        let parameter_rows = (0..parameter_batch.num_rows())
+            .map(|row_index| sql2::parameter_row(&parameter_batch, row_index).unwrap())
+            .collect::<Vec<_>>();
         assert_eq!(
             parameter_rows,
             [
@@ -4358,6 +4452,22 @@ mod tests {
                 ],
             ]
         );
+    }
+
+    #[test]
+    fn execute_batch_declines_a_late_literal_shape_mismatch() {
+        let cache = sql2::SqlPlanningCache::default();
+        let statements = [
+            batch_statement("UPDATE notes SET value = 'first' WHERE id = 'a'"),
+            batch_statement("UPDATE notes SET value = 'second' WHERE id = 'b'"),
+            batch_statement("UPDATE notes SET other = 'third' WHERE id = 'c'"),
+        ];
+        let ExecuteBatchExecution::Transaction(TransactionBatchStatements::Distinct(parsed)) =
+            classify_execute_batch(&statements, &cache).unwrap()
+        else {
+            panic!("a heterogeneous batch must retain sequential classification");
+        };
+        assert_eq!(parsed.len(), statements.len());
     }
 
     #[tokio::test]

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use datafusion::arrow::array::{Array, BooleanArray, StringArray};
+use datafusion::arrow::array::{Array, BooleanArray, LargeStringArray, StringArray};
 use datafusion::arrow::datatypes::DataType;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::ScalarValue;
@@ -142,7 +142,10 @@ impl<'a> EntityInsertParameterBatch<'a> {
                     return false;
                 }
                 match column_type {
-                    EntityColumnType::String => array.as_any().is::<StringArray>(),
+                    EntityColumnType::String => {
+                        array.as_any().is::<StringArray>()
+                            || array.as_any().is::<LargeStringArray>()
+                    }
                     EntityColumnType::Boolean => array.as_any().is::<BooleanArray>(),
                     _ => false,
                 }
@@ -168,6 +171,8 @@ impl<'a> EntityInsertParameterBatch<'a> {
                     return DirectParameterValue::Null;
                 }
                 if let Some(array) = array.as_any().downcast_ref::<StringArray>() {
+                    DirectParameterValue::String(array.value(row_index))
+                } else if let Some(array) = array.as_any().downcast_ref::<LargeStringArray>() {
                     DirectParameterValue::String(array.value(row_index))
                 } else if let Some(array) = array.as_any().downcast_ref::<BooleanArray>() {
                     DirectParameterValue::Boolean(array.value(row_index))
@@ -819,7 +824,7 @@ async fn try_execute_direct_path_value_replacement_batch(
         });
         Some(ordinals)
     };
-    let unique_entity_pks = if let Some(ordinals) = &sorted_statement_ordinals {
+    let deduplicated_entity_pks = if let Some(ordinals) = &sorted_statement_ordinals {
         let mut unique = Vec::with_capacity(row_count);
         for &statement_index in ordinals {
             let entity_pk = &entity_pks[statement_index];
@@ -827,10 +832,13 @@ async fn try_execute_direct_path_value_replacement_batch(
                 unique.push(entity_pk.clone());
             }
         }
-        unique
+        Some(unique)
     } else {
-        entity_pks.clone()
+        None
     };
+    let unique_entity_pks = deduplicated_entity_pks
+        .as_deref()
+        .unwrap_or(entity_pks.as_slice());
     let unique_row_count = unique_entity_pks.len();
 
     let active_branch_id = ctx.active_branch_id().to_owned();
@@ -864,7 +872,7 @@ async fn try_execute_direct_path_value_replacement_batch(
         MaterializedLiveStateBatch::default()
     } else {
         let candidates =
-            scan_entity_candidates_for_pks(ctx, plan, &spec, unique_entity_pks.clone(), true)
+            scan_entity_candidates_for_pks(ctx, plan, &spec, unique_entity_pks.to_vec(), true)
                 .instrument(tracing::debug_span!(
                     target: "lix_perf",
                     "lix.perf.entity_update_value_batch.candidate_scan",
@@ -1070,8 +1078,41 @@ struct DirectPathValueReplacement {
 
 #[derive(Clone, Copy)]
 struct DirectReplacementTextColumns<'a> {
-    primary_keys: &'a StringArray,
-    values: &'a StringArray,
+    primary_keys: DirectTextColumn<'a>,
+    values: DirectTextColumn<'a>,
+}
+
+#[derive(Clone, Copy)]
+enum DirectTextColumn<'a> {
+    Utf8(&'a StringArray),
+    LargeUtf8(&'a LargeStringArray),
+}
+
+impl<'a> DirectTextColumn<'a> {
+    fn is_null(self, row_index: usize) -> bool {
+        match self {
+            Self::Utf8(array) => array.is_null(row_index),
+            Self::LargeUtf8(array) => array.is_null(row_index),
+        }
+    }
+
+    fn value(self, row_index: usize) -> &'a str {
+        match self {
+            Self::Utf8(array) => array.value(row_index),
+            Self::LargeUtf8(array) => array.value(row_index),
+        }
+    }
+}
+
+fn direct_text_column<'a>(array: &'a dyn Array) -> Option<DirectTextColumn<'a>> {
+    if let Some(array) = array.as_any().downcast_ref::<StringArray>() {
+        Some(DirectTextColumn::Utf8(array))
+    } else {
+        array
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .map(DirectTextColumn::LargeUtf8)
+    }
 }
 
 fn direct_replacement_text_columns<'a>(
@@ -1083,14 +1124,8 @@ fn direct_replacement_text_columns<'a>(
         return None;
     }
     Some(DirectReplacementTextColumns {
-        primary_keys: batch
-            .column(primary_key_param_index)
-            .as_any()
-            .downcast_ref::<StringArray>()?,
-        values: batch
-            .column(value_param_index)
-            .as_any()
-            .downcast_ref::<StringArray>()?,
+        primary_keys: direct_text_column(batch.column(primary_key_param_index).as_ref())?,
+        values: direct_text_column(batch.column(value_param_index).as_ref())?,
     })
 }
 

--- a/packages/engine/src/sql2/exec/mod.rs
+++ b/packages/engine/src/sql2/exec/mod.rs
@@ -86,7 +86,7 @@ pub(crate) use write::{
     WriteLogicalPlan as SqlWriteLogicalPlan, create_write_logical_plan_from_template,
     create_write_plan_template_from_parsed, diff_command_query,
     execute_write_logical_plan_parameter_batch, execute_write_logical_plan_result_with_metadata,
-    execute_write_logical_plan_value_batch, parameter_record_batch,
+    execute_write_logical_plan_value_batch, parameter_record_batch, parameter_row,
     write_plan_requires_post_stage_returning_checkpoint,
 };
 

--- a/packages/engine/src/sql2/exec/write.rs
+++ b/packages/engine/src/sql2/exec/write.rs
@@ -221,7 +221,7 @@ pub(crate) fn parameter_record_batch(rows: &[&[Value]]) -> Result<Option<RecordB
         })
 }
 
-pub(super) fn parameter_row(batch: &RecordBatch, row_index: usize) -> Result<Vec<Value>, LixError> {
+pub(crate) fn parameter_row(batch: &RecordBatch, row_index: usize) -> Result<Vec<Value>, LixError> {
     if row_index >= batch.num_rows() {
         return Err(LixError::unknown(format!(
             "SQL parameter row {row_index} is outside a {} row batch",
@@ -313,11 +313,20 @@ fn scalar_parameter_value(scalar: ScalarValue, is_json: bool) -> Result<Value, L
                 ))
             }),
         ScalarValue::Utf8(Some(value)) => Ok(Value::Text(value)),
+        ScalarValue::LargeUtf8(Some(value)) if is_json => serde_json::from_str(&value)
+            .map(Value::Json)
+            .map_err(|error| {
+                LixError::unknown(format!(
+                    "invalid JSON value in SQL parameter batch: {error}"
+                ))
+            }),
+        ScalarValue::LargeUtf8(Some(value)) => Ok(Value::Text(value)),
         ScalarValue::LargeBinary(Some(value)) => Ok(Value::Blob(value.into())),
         ScalarValue::Boolean(None)
         | ScalarValue::Int64(None)
         | ScalarValue::Float64(None)
         | ScalarValue::Utf8(None)
+        | ScalarValue::LargeUtf8(None)
         | ScalarValue::LargeBinary(None)
         | ScalarValue::Null => Ok(Value::Null),
         value => Err(LixError::unknown(format!(

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -51,8 +51,9 @@ pub(crate) use exec::{
     create_write_plan_template_from_parsed, diff_command_query, execute_read_statement_from_parsed,
     execute_read_statement_in_session_from_parsed, execute_transaction_read_statement_from_parsed,
     execute_write_logical_plan_parameter_batch, execute_write_logical_plan_result_with_metadata,
-    execute_write_logical_plan_value_batch, parameter_record_batch, prepare_read_session,
-    prepare_read_session_at_head, write_plan_requires_post_stage_returning_checkpoint,
+    execute_write_logical_plan_value_batch, parameter_record_batch, parameter_row,
+    prepare_read_session, prepare_read_session_at_head,
+    write_plan_requires_post_stage_returning_checkpoint,
 };
 #[cfg(test)]
 pub(crate) use exec::{

--- a/packages/engine/src/sql2/planning_cache.rs
+++ b/packages/engine/src/sql2/planning_cache.rs
@@ -123,6 +123,15 @@ where
         (normalized_sql == normalized_shape).then_some(params)
     }
 
+    /// Checks an UPDATE template without retaining decoded literal values.
+    ///
+    /// Large heterogeneous batches use this as a cheap certification pass so
+    /// a late shape mismatch cannot leave almost an entire parameter batch in
+    /// memory before ordinary sequential classification resumes.
+    pub(crate) fn update_literal_shape_matches(&self, sql: &str, normalized_shape: &str) -> bool {
+        update_string_literals_match_shape(sql, normalized_shape)
+    }
+
     /// Returns stable public-surface metadata for one catalog generation.
     ///
     /// Callers are responsible for using a key that changes whenever any
@@ -288,6 +297,99 @@ fn normalize_update_string_literals(sql: &str) -> Option<(String, Vec<Value>)> {
     Some((normalized, params))
 }
 
+fn update_string_literals_match_shape(sql: &str, normalized_shape: &str) -> bool {
+    let trimmed = sql.trim_start();
+    let Some(update) = trimmed.get(.."UPDATE".len()) else {
+        return false;
+    };
+    if !update.eq_ignore_ascii_case("UPDATE")
+        || !trimmed
+            .as_bytes()
+            .get("UPDATE".len())
+            .is_some_and(u8::is_ascii_whitespace)
+    {
+        return false;
+    }
+
+    let bytes = sql.as_bytes();
+    let shape = normalized_shape.as_bytes();
+    let mut cursor = 0;
+    let mut copied = 0;
+    let mut shape_cursor = 0;
+    let mut param_count = 0_usize;
+    let mut quoted_identifier = false;
+    while cursor < bytes.len() {
+        match bytes[cursor] {
+            b'"' => {
+                if quoted_identifier && bytes.get(cursor + 1) == Some(&b'"') {
+                    cursor += 2;
+                    continue;
+                }
+                quoted_identifier = !quoted_identifier;
+                cursor += 1;
+            }
+            b'-' if !quoted_identifier && bytes.get(cursor + 1) == Some(&b'-') => return false,
+            b'/' if !quoted_identifier && bytes.get(cursor + 1) == Some(&b'*') => return false,
+            b'?' | b'$' if !quoted_identifier => return false,
+            b'\'' if !quoted_identifier => {
+                if bytes[..cursor]
+                    .iter()
+                    .rposition(|byte| !byte.is_ascii_whitespace())
+                    .is_some_and(|index| {
+                        matches!(bytes[index], b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_')
+                    })
+                {
+                    return false;
+                }
+                let outside = &bytes[copied..cursor];
+                if !shape
+                    .get(shape_cursor..)
+                    .is_some_and(|remaining| remaining.starts_with(outside))
+                {
+                    return false;
+                }
+                shape_cursor += outside.len();
+                if shape.get(shape_cursor) != Some(&b'$') {
+                    return false;
+                }
+                shape_cursor += 1;
+                let digit_start = shape_cursor;
+                let mut parameter_number = 0_usize;
+                while let Some(digit @ b'0'..=b'9') = shape.get(shape_cursor) {
+                    parameter_number = parameter_number
+                        .saturating_mul(10)
+                        .saturating_add(usize::from(*digit - b'0'));
+                    shape_cursor += 1;
+                }
+                if shape_cursor == digit_start || parameter_number != param_count + 1 {
+                    return false;
+                }
+                param_count += 1;
+
+                cursor += 1;
+                loop {
+                    let Some(quote) = bytes[cursor..]
+                        .iter()
+                        .position(|byte| *byte == b'\'')
+                        .map(|offset| cursor + offset)
+                    else {
+                        return false;
+                    };
+                    if bytes.get(quote + 1) == Some(&b'\'') {
+                        cursor = quote + 2;
+                        continue;
+                    }
+                    cursor = quote + 1;
+                    copied = cursor;
+                    break;
+                }
+            }
+            _ => cursor += 1,
+        }
+    }
+    !quoted_identifier && param_count > 0 && shape.get(shape_cursor..) == Some(&bytes[copied..])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -367,6 +469,32 @@ mod tests {
             ]
         );
         assert_eq!(lock_or_recover(&cache.parsed_statements).len(), 1);
+    }
+
+    #[test]
+    fn literal_update_shape_matcher_streams_without_decoding_values() {
+        let cache = test_cache(8);
+        let template = cache
+            .auto_parameterized_update(
+                "UPDATE \"notes\" SET value = lix_json('{\"text\":\"first\"}') WHERE id = 'a'",
+            )
+            .unwrap();
+
+        assert!(cache.update_literal_shape_matches(
+            "UPDATE \"notes\" SET value = lix_json('{\"text\":\"it''''s fine\"}') WHERE id = 'b'",
+            &template.sql,
+        ));
+        for different_shape in [
+            "UPDATE \"notes\" SET value = lix_json('{}') WHERE other_id = 'b'",
+            "UPDATE notes SET value = lix_json('{}') WHERE id = 'b'",
+            "UPDATE \"notes\" SET value = lix_json('{}') WHERE id = 'b' -- comment",
+            "UPDATE \"notes\" SET value = lix_json('{}') WHERE id = $1",
+        ] {
+            assert!(
+                !cache.update_literal_shape_matches(different_shape, &template.sql),
+                "{different_shape}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- certify auto-parameterized literal UPDATE shapes without retaining one parameter vector per statement
- materialize literal parameters directly as contiguous Arrow UTF-8 columns, switching to LargeUtf8 when the SQL input can exceed 32-bit offsets
- cap speculative string reservation at 64 MiB across all columns
- borrow already ordered entity identities instead of cloning a second 1M-row identity vector
- preserve the certified columnar executor and sequential fallback semantics for unsupported or dependent batches

## Performance

Baseline is the immediately preceding merged PR (`03d0d34c1`, #1106), as required.

| Backend | Rows | Baseline | This PR | Change |
| --- | ---: | ---: | ---: | ---: |
| RocksDB | 1M | 4.343 s | 3.759 s | -13.5% |
| SlateDB | 1M | 4.314 s | 3.489 s | -19.1% |
| RocksDB | 10k | 22.33 ms | 23.80 ms | +6.6% |
| SlateDB | 10k | 23.77 ms | 23.52 ms | -1.1% |

Peak RSS at 1M falls from 2,707,556 to 2,500,896 KiB on RocksDB (-7.6%) and from 2,760,680 to 2,527,088 KiB on SlateDB (-8.5%). The 10k results remain within sub-millisecond run variance.

The remaining distance to raw SQLite is explicit: the same 1M UPDATE fixture takes 1.008 s and 827,004 KiB in SQLite. This PR is one bounded cut, not a claim that the overall 1.2x goal is complete.

## Non-regression checks

Compared with the same parent, 10k tracked merge preview/commit p50 changed:

- RocksDB: 17.139/2.125 ms to 17.380/2.143 ms (+1.4%/+0.8%)
- SlateDB: 16.910/3.149 ms to 17.826/2.726 ms (+5.4%/-13.4%)

The implementation does not alter diff, merge, or branch execution paths.

## Validation

- `cargo test -p lix_engine --lib` (1,716 passed, 8 ignored)
- focused execute-batch suite (21 passed)
- shape-matcher coverage for escaped quotes, quoted identifiers, comments, placeholders, and late heterogeneous statements
- three independent reviews covering SQL semantics, performance architecture, and regression risk; no blockers remained after fixing aggregate reservation and LargeUtf8 handling

No changenote: this is an internal performance-only change.
