### PR TITLE
perf(engine): serve exact entity counts from collection metadata

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -254,6 +254,13 @@ fn profile_operation(runtime: &tokio::runtime::Runtime, rows: &[WorkloadRow]) {
             "unknown LIX_TRACKED_STATE_CRUD_PROFILE_OP '{other}'; expected insert_all, read_all, read_one, read_many, update_all, update_one, delete_all, or delete_one"
         ),
     };
+    if sql_session_read_shape() == "aggregate_count" {
+        assert_eq!(
+            std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_LAYER").as_deref(),
+            Ok("sql_session"),
+            "LIX_TRACKED_STATE_CRUD_PROFILE_READ_SHAPE=aggregate_count requires LIX_TRACKED_STATE_CRUD_PROFILE_LAYER=sql_session"
+        );
+    }
     let read_many_pk_count = profile_read_many_pk_count(operation, rows.len());
     let sample_count = profile_sample_count();
     let hot_repeats = std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_HOT_REPEATS")
@@ -524,6 +531,16 @@ fn profile_hot_transaction_operations(
     black_box(row_count);
 }
 
+fn sql_session_read_shape() -> &'static str {
+    match std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_READ_SHAPE").as_deref() {
+        Ok("aggregate_count") => "aggregate_count",
+        Ok("full_result") | Err(_) => "full_result",
+        Ok(other) => panic!(
+            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_READ_SHAPE '{other}'; expected full_result or aggregate_count"
+        ),
+    }
+}
+
 fn profile_hot_sql_session_operations(
     runtime: &tokio::runtime::Runtime,
     rows: &[WorkloadRow],
@@ -551,7 +568,11 @@ fn profile_hot_sql_session_operations(
         row_count += runtime.block_on(run_sql_session_operation(operation, &fixture));
     }
     let elapsed = start.elapsed();
-    let profile_detail = profile_read_many_detail(operation, read_many_pk_count);
+    let profile_detail = format!(
+        "{} read_shape={}",
+        profile_read_many_detail(operation, read_many_pk_count),
+        sql_session_read_shape()
+    );
     println!(
         "tracked_state_crud hot profile: sql_session/{}/{}/{} repeats{profile_detail}: total={elapsed:?} per_operation={:?}",
         profile.name(),
@@ -888,12 +909,16 @@ fn profile_sql_session_operation(
         samples.push(start.elapsed());
         black_box(result);
     }
-    print_profile_samples(
-        &format!("sql_session/{}", profile.name()),
-        operation,
-        read_many_pk_count,
-        samples,
-    );
+    let profile_layer = if matches!(operation, TransactionBenchOp::ReadAll) {
+        format!(
+            "sql_session/{}/{}",
+            profile.name(),
+            sql_session_read_shape()
+        )
+    } else {
+        format!("sql_session/{}", profile.name())
+    };
+    print_profile_samples(&profile_layer, operation, read_many_pk_count, samples);
 }
 
 fn profile_sql_session_bound_updates(

--- a/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
@@ -216,11 +216,28 @@ impl SqlFixture {
     }
 
     pub(crate) async fn read_all(&self) -> usize {
+        if std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_READ_SHAPE").as_deref()
+            == Ok("aggregate_count")
+        {
+            return self.count_all().await;
+        }
         match self {
             Self::SQLite(fixture) => fixture.read_all().await,
             Self::RocksDB(fixture) => fixture.read_all().await,
             #[cfg(feature = "slatedb")]
             Self::SlateDB(fixture) => fixture.read_all().await,
+        }
+    }
+
+    /// Opt-in OLAP profile shape. Keeping it behind the profile selector
+    /// leaves the historical full-result CRUD benchmark unchanged while
+    /// making the exact scan-vs-aggregate boundary reproducible at 1M rows.
+    async fn count_all(&self) -> usize {
+        match self {
+            Self::SQLite(fixture) => fixture.count_all().await,
+            Self::RocksDB(fixture) => fixture.count_all().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.count_all().await,
         }
     }
 
@@ -416,6 +433,19 @@ where
         let result = std::hint::black_box(self.read_all_result().await);
         assert_eq!(result.len(), self.visible_row_count);
         result.len()
+    }
+
+    async fn count_all(&self) -> usize {
+        let result = std::hint::black_box(
+            execute(&self.session, "SELECT COUNT(*) AS count FROM json_pointer").await,
+        );
+        assert_eq!(result.columns(), ["count"]);
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result.rows()[0].get_index(0),
+            Some(&Value::Integer(self.visible_row_count as i64))
+        );
+        1
     }
 
     async fn insert_untracked_probe(&self) {

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -249,6 +249,36 @@ impl<S> LiveStateStoreReader<S>
 where
     S: StorageAdapterRead,
 {
+    /// Counts one directly-addressable entity collection from its publication
+    /// control. The direct snapshot route already proves that no global or
+    /// multi-branch visibility composition is required; retaining that proof
+    /// here makes `COUNT(*)` a metadata read rather than a million-row scan.
+    pub(crate) async fn count_direct_entity_snapshots(
+        &self,
+        request: &LiveStateScanRequest,
+    ) -> Result<Option<u64>, LixError> {
+        if !request.filter.entity_pks.is_empty() || request.limit.is_some() {
+            return Ok(None);
+        }
+        let Some((branch_id, control, schema_key)) =
+            self.direct_entity_snapshot_scope(request).await?
+        else {
+            return Ok(None);
+        };
+        self.tracked_head
+            .reader(&self.store)
+            .collection_generation(
+                &branch_id,
+                control.generation,
+                crate::collection_generation::CollectionScopeRef {
+                    schema_key: &schema_key,
+                    file_id: None,
+                },
+            )
+            .await
+            .map(|generation| Some(generation.live_count))
+    }
+
     /// Returns raw current-state snapshot bytes for one current SQL entity scan.
     ///
     /// `None` means the normal materialized visibility path remains

--- a/packages/engine/src/sql2/entity_batch.rs
+++ b/packages/engine/src/sql2/entity_batch.rs
@@ -26,6 +26,17 @@ use crate::storage_adapter::StorageAdapterRead;
 /// stronger tie order must retain the general SQL path.
 #[async_trait]
 pub(crate) trait EntitySnapshotReader: Send + Sync {
+    /// Returns the exact cardinality of a broad current-state entity scan
+    /// without materializing its snapshots. `None` preserves the normal scan
+    /// when this reader cannot prove that one collection control owns the
+    /// complete visible result.
+    async fn count_entity_snapshots(
+        &self,
+        _request: LiveStateScanRequest,
+    ) -> Result<Option<u64>, LixError> {
+        Ok(None)
+    }
+
     async fn scan_entity_snapshots(
         &self,
         request: LiveStateScanRequest,
@@ -57,6 +68,19 @@ impl<S> EntitySnapshotReader for CurrentEntitySnapshotReader<S>
 where
     S: StorageAdapterRead + Clone + Send + Sync + 'static,
 {
+    async fn count_entity_snapshots(
+        &self,
+        request: LiveStateScanRequest,
+    ) -> Result<Option<u64>, LixError> {
+        if !direct_entity_snapshot_request(&request) || !request.filter.entity_pks.is_empty() {
+            return Ok(None);
+        }
+        self.live_state
+            .reader(self.store.clone())
+            .count_direct_entity_snapshots(&request)
+            .await
+    }
+
     async fn scan_entity_snapshots(
         &self,
         request: LiveStateScanRequest,

--- a/packages/engine/src/sql2/exec/bound_public_read.rs
+++ b/packages/engine/src/sql2/exec/bound_public_read.rs
@@ -38,6 +38,45 @@ pub(crate) async fn try_execute_bound_public_read<C>(
 where
     C: SqlExecutionContext + ?Sized,
 {
+    if let Some(shape) = strict_entity_count_read(statement, params) {
+        // Validate before using publication metadata so a fast path never
+        // widens the accepted public SQL surface.
+        crate::sql2::bind_read_statement(sql, statement)?;
+        let catalog = ctx.public_catalog().await?;
+        let Some(surface) = catalog.surface(&shape.table_name) else {
+            return Ok(None);
+        };
+        let PublicSurfaceKind::EntityBase { schema_key } = &surface.kind else {
+            return Ok(None);
+        };
+        let Some(reader) = ctx.entity_snapshot_reader() else {
+            return Ok(None);
+        };
+        let request = LiveStateScanRequest {
+            filter: LiveStateFilter {
+                schema_keys: vec![schema_key.clone()],
+                branch_ids: vec![ctx.active_branch_id().to_owned()],
+                include_tombstones: false,
+                ..LiveStateFilter::default()
+            },
+            projection: LiveStateProjection::default(),
+            limit: None,
+        };
+        if let Some(count) = reader.count_entity_snapshots(request).await? {
+            let count = i64::try_from(count).map_err(|_| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "entity collection count exceeds the SQL INTEGER range",
+                )
+            })?;
+            return Ok(Some(SqlQueryResult {
+                columns: vec![shape.alias],
+                rows: vec![vec![Value::Integer(count)]],
+                notices: Vec::new(),
+            }));
+        }
+        return Ok(None);
+    }
     if let Some(shape) = strict_entity_left_join_read(statement, params) {
         crate::sql2::bind_read_statement(sql, statement)?;
         let catalog = ctx.public_catalog().await?;
@@ -530,6 +569,12 @@ struct StrictEntityBroadRead {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+struct StrictEntityCountRead {
+    table_name: String,
+    alias: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
 struct StrictEntityJoinProjection {
     table: String,
     column: String,
@@ -738,6 +783,68 @@ fn strict_entity_broad_read(
         projection: strict_projection(&select.projection)?,
         primary_key_column: canonical_ascending_order_column(query)?,
     })
+}
+
+/// Recognizes only `COUNT(*)` over one active entity table. Any predicate,
+/// grouping, distinct modifier, or expression remains with DataFusion because
+/// the collection-control cardinality is not a substitute for those SQL
+/// semantics.
+fn strict_entity_count_read(
+    statement: &DataFusionStatement,
+    params: &[Value],
+) -> Option<StrictEntityCountRead> {
+    if !params.is_empty() {
+        return None;
+    }
+    let (query, select, table_name) = strict_single_table_select(statement)?;
+    if query.order_by.is_some()
+        || query.limit_clause.is_some()
+        || query.fetch.is_some()
+        || select.selection.is_some()
+    {
+        return None;
+    }
+    let [projection] = select.projection.as_slice() else {
+        return None;
+    };
+    let (expression, alias) = match projection {
+        // Match DataFusion's public column name for an unaliased aggregate.
+        // The metadata route must not expose a different result schema.
+        SelectItem::UnnamedExpr(expression) => (expression, "count(*)".to_owned()),
+        SelectItem::ExprWithAlias { expr, alias } => (expr, strict_identifier_name(alias)),
+        _ => return None,
+    };
+    let Expr::Function(function) = expression else {
+        return None;
+    };
+    if function.name.0.len() != 1
+        || function
+            .name
+            .0
+            .first()
+            .and_then(|part| part.as_ident())
+            .is_none_or(|ident| !ident.value.eq_ignore_ascii_case("count"))
+        || function.filter.is_some()
+        || function.null_treatment.is_some()
+        || function.over.is_some()
+        || !function.within_group.is_empty()
+        || function.uses_odbc_syntax
+    {
+        return None;
+    }
+    let datafusion::sql::sqlparser::ast::FunctionArguments::List(arguments) = &function.args else {
+        return None;
+    };
+    if arguments.duplicate_treatment.is_some() || !arguments.clauses.is_empty() {
+        return None;
+    }
+    matches!(
+        arguments.args.as_slice(),
+        [datafusion::sql::sqlparser::ast::FunctionArg::Unnamed(
+            datafusion::sql::sqlparser::ast::FunctionArgExpr::Wildcard
+        )]
+    )
+    .then_some(StrictEntityCountRead { table_name, alias })
 }
 
 fn strict_single_table_select(
@@ -998,6 +1105,36 @@ mod tests {
         assert_eq!(shape.table_name, "json_pointer");
         assert_eq!(shape.projection, ["path", "value"]);
         assert_eq!(shape.primary_key_column, "path");
+    }
+
+    #[test]
+    fn recognizes_unfiltered_entity_count() {
+        let shape =
+            strict_entity_count_read(&parse("SELECT COUNT(*) AS total FROM json_pointer"), &[])
+                .expect("unfiltered entity count should use collection metadata");
+
+        assert_eq!(shape.table_name, "json_pointer");
+        assert_eq!(shape.alias, "total");
+
+        let unaliased = strict_entity_count_read(&parse("SELECT COUNT(*) FROM json_pointer"), &[])
+            .expect("unaliased entity count should use collection metadata");
+        assert_eq!(unaliased.alias, "count(*)");
+    }
+
+    #[test]
+    fn count_read_rejects_semantics_not_covered_by_collection_metadata() {
+        for sql in [
+            "SELECT COUNT(value) FROM json_pointer",
+            "SELECT COUNT(*) FROM json_pointer WHERE path = '/a'",
+            "SELECT COUNT(DISTINCT path) FROM json_pointer",
+            "SELECT COUNT(*) FROM json_pointer GROUP BY path",
+            "SELECT COUNT(*) FROM json_pointer LIMIT 1",
+        ] {
+            assert!(
+                strict_entity_count_read(&parse(sql), &[]).is_none(),
+                "query must retain DataFusion semantics: {sql}"
+            );
+        }
     }
 
     #[test]

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -2476,6 +2476,10 @@ mod tests {
         snapshots: Vec<Option<Bytes>>,
         requests: Arc<Mutex<Vec<LiveStateScanRequest>>>,
     }
+    struct CountingEntitySnapshotReader {
+        count: u64,
+        requests: Arc<Mutex<Vec<LiveStateScanRequest>>>,
+    }
     struct SchemaEntitySnapshotReader {
         snapshots: std::collections::BTreeMap<String, Vec<Option<Bytes>>>,
     }
@@ -3215,6 +3219,27 @@ mod tests {
     }
 
     #[async_trait]
+    impl EntitySnapshotReader for CountingEntitySnapshotReader {
+        async fn count_entity_snapshots(
+            &self,
+            request: LiveStateScanRequest,
+        ) -> Result<Option<u64>, LixError> {
+            self.requests
+                .lock()
+                .expect("captured count requests lock")
+                .push(request);
+            Ok(Some(self.count))
+        }
+
+        async fn scan_entity_snapshots(
+            &self,
+            _request: LiveStateScanRequest,
+        ) -> Result<Option<Vec<Option<Bytes>>>, LixError> {
+            panic!("metadata count must not materialize entity snapshots");
+        }
+    }
+
+    #[async_trait]
     impl EntitySnapshotReader for SchemaEntitySnapshotReader {
         async fn scan_entity_snapshots(
             &self,
@@ -3650,6 +3675,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn native_entity_count_reads_collection_metadata_without_scanning_rows() {
+        let sql = "SELECT COUNT(*) AS total FROM test_state_schema";
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let scans = Arc::new(AtomicUsize::new(0));
+        let ctx = DummySqlExecutionContext {
+            active_branch_id: "01920000-0000-7000-8000-0000000000a1",
+            blob_reader: Arc::new(DummyBlobReader),
+            live_state: Arc::new(CountingRowsLiveStateReader {
+                rows: Vec::new(),
+                scans: Arc::clone(&scans),
+            }),
+            entity_snapshot_reader: Some(Arc::new(CountingEntitySnapshotReader {
+                count: 1_000_000,
+                requests: Arc::clone(&requests),
+            })),
+            schema_definitions: vec![json!({
+                "x-lix-key": "test_state_schema",
+                "x-lix-primary-key": ["/id"],
+                "type": "object",
+                "properties": { "id": { "type": "string" } },
+                "required": ["id"],
+                "additionalProperties": false
+            })],
+        };
+        let statement = crate::sql2::parse_statement(sql).expect("test SQL should parse");
+
+        let result = super::super::bound_public_read::try_execute_bound_public_read(
+            &ctx,
+            sql,
+            &statement,
+            &[],
+        )
+        .await
+        .expect("metadata count should execute")
+        .expect("strict count should use the metadata route");
+
+        assert_eq!(result.columns, ["total"]);
+        assert_eq!(result.rows, vec![vec![Value::Integer(1_000_000)]]);
+        assert_eq!(scans.load(Ordering::SeqCst), 0);
+        let requests = requests.lock().expect("captured count requests lock");
+        let [request] = requests.as_slice() else {
+            panic!("native count must issue one metadata request");
+        };
+        assert_eq!(request.filter.schema_keys, ["test_state_schema"]);
+        assert_eq!(
+            request.filter.branch_ids,
+            ["01920000-0000-7000-8000-0000000000a1"]
+        );
+        assert!(request.projection.columns.is_empty());
+    }
+
+    #[tokio::test]
     async fn native_entity_left_join_preserves_matches_and_null_extension() {
         let sql = r#"SELECT "bundle"."id" AS "bundleId",
                          "message"."id" AS "messageId",
@@ -3940,6 +4017,16 @@ mod tests {
             )
             .await
             .expect("test rows should insert");
+        let initial_count = session
+            .execute("SELECT COUNT(*) AS count FROM test_state_schema", &[])
+            .await
+            .expect("collection metadata count should query after inserts");
+        assert_eq!(
+            initial_count.rows()[0]
+                .get::<i64>("count")
+                .expect("count should be numeric"),
+            3
+        );
         let before_delete = engine
             .load_branch_head_commit_id(&branch_id)
             .await
@@ -4001,6 +4088,16 @@ mod tests {
             .await
             .expect("deleted collection should remain queryable");
         assert!(rows_from_execute_result(selected).1.is_empty());
+        let deleted_count = session
+            .execute("SELECT COUNT(*) AS count FROM test_state_schema", &[])
+            .await
+            .expect("collection metadata count should query after delete");
+        assert_eq!(
+            deleted_count.rows()[0]
+                .get::<i64>("count")
+                .expect("count should be numeric"),
+            0
+        );
         session
             .create_checkpoint()
             .await
@@ -4010,6 +4107,16 @@ mod tests {
             .await
             .expect("checkpointed deleted collection should query");
         assert!(rows_from_execute_result(selected).1.is_empty());
+        let checkpointed_count = session
+            .execute("SELECT COUNT(*) AS count FROM test_state_schema", &[])
+            .await
+            .expect("collection metadata count should query after checkpoint");
+        assert_eq!(
+            checkpointed_count.rows()[0]
+                .get::<i64>("count")
+                .expect("count should be numeric"),
+            0
+        );
         let checkout = session
             .create_branch(CreateBranchOptions {
                 id: None,
@@ -4045,6 +4152,16 @@ mod tests {
                 Value::Text("a".to_string()),
                 Value::Text("A2".to_string())
             ]]
+        );
+        let recreated_count = session
+            .execute("SELECT COUNT(*) AS count FROM test_state_schema", &[])
+            .await
+            .expect("collection metadata count should query after recreation");
+        assert_eq!(
+            recreated_count.rows()[0]
+                .get::<i64>("count")
+                .expect("count should be numeric"),
+            1
         );
 
         let deleted = session


### PR DESCRIPTION
## Summary
- Serve exact `SELECT COUNT(*)` over one active entity collection from its published `live_count` control instead of materializing every entity snapshot.
- Keep the route deliberately strict: any predicate, grouping, distinct, ordering, limit, global/composed visibility, transaction reader, or unsupported shape falls back to the existing DataFusion scan.
- Make the CRUD SQL-session benchmark distinguish `read_shape=full_result` from `read_shape=aggregate_count`, and add real-engine count parity checks across insert → collection delete → checkpoint → recreate.

## Performance (1,000,000 rows, hot public SQL-session reads)
| Query | RocksDB | SlateDB |
| --- | ---: | ---: |
| Full materialized result | 1.638473 s | 1.678698 s |
| `COUNT(*)` before (DataFusion scan) | 1.704076 s | 1.694784 s |
| `COUNT(*)` after (collection metadata) | 56.52 µs | 77.762 µs |
| Improvement | 99.9967% | 99.9954% |

A same-host, one-thread DuckDB materialization control for 1M two-column fixed-payload rows was 659.518 ms. The representative full-result public scan is therefore 2.48× on RocksDB and 2.55× on SlateDB, meeting the 3× target.

Profile benefit: the fast path performs one collection-control read and avoids the DataFusion/entity-snapshot materialization path entirely.

## Validation
- `cargo fmt --check -p lix_engine -p lix_engine_benchmarks`
- `git diff --check`
- `cargo test -p lix_engine --features all-simulations` (1730 unit tests, 802 integration tests, 3 doc tests)
- Focused metadata route and lifecycle/count parity tests
- `cargo clippy -p lix_engine --all-targets` (passes with the existing unrelated dead-code warning in `StorageWriteSet::apply`; `-D warnings` is blocked by that pre-existing warning)

Reviewed by two independent sub-agents: semantics and performance/benchmark validity.