### PR TITLE
perf(engine): bound descriptor undo closure

### DIFF
--- a/.changenotes/descriptor-dependency-closure.md
+++ b/.changenotes/descriptor-dependency-closure.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Kept file and directory undo work proportional to the affected tracked dependency closure instead of the whole repository.

--- a/packages/engine-benchmarks/benches/undo_redo.rs
+++ b/packages/engine-benchmarks/benches/undo_redo.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, Instant};
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use lix_engine::{Engine, ExecuteBatchStatement, Memory};
+use lix_engine::{Blob, Engine, ExecuteBatchStatement, Memory};
 
 fn seeded_storage(runtime: &tokio::runtime::Runtime, history_depth: usize) -> Vec<u8> {
     runtime.block_on(async move {
@@ -173,6 +173,53 @@ fn seeded_wide_transition_storage(
     })
 }
 
+fn seeded_descriptor_unrelated_width_storage(
+    runtime: &tokio::runtime::Runtime,
+    unrelated_width: usize,
+) -> Vec<u8> {
+    runtime.block_on(async move {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("benchmark storage initializes");
+        let engine = Engine::new(storage.clone())
+            .await
+            .expect("benchmark engine opens");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("benchmark session opens");
+        session
+            .upsert_file_data(
+                "/descriptor-target.txt".into(),
+                Blob::from("target".as_bytes()),
+            )
+            .await
+            .expect("target file creates");
+        let values = (0..unrelated_width)
+            .map(|index| format!("('descriptor-noise-{index}', '{index}')"))
+            .collect::<Vec<_>>()
+            .join(",");
+        session
+            .execute(
+                &format!("INSERT INTO lix_key_value (key, value) VALUES {values}"),
+                &[],
+            )
+            .await
+            .expect("unrelated repository rows write");
+        session
+            .execute(
+                "DELETE FROM lix_file WHERE path = '/descriptor-target.txt'",
+                &[],
+            )
+            .await
+            .expect("target file deletes");
+        storage
+            .export_snapshot()
+            .expect("benchmark storage snapshot exports")
+    })
+}
+
 fn open_session(
     runtime: &tokio::runtime::Runtime,
     storage: Memory,
@@ -270,6 +317,34 @@ fn benchmark_undo_redo(criterion: &mut Criterion) {
                         runtime
                             .block_on(session.redo())
                             .expect("benchmarked redo succeeds");
+                        elapsed += started.elapsed();
+                    }
+                    elapsed
+                });
+            },
+        );
+    }
+    group.finish();
+
+    let mut group = criterion.benchmark_group("undo_descriptor_unrelated_repository_width");
+    for unrelated_width in [1_usize, 1_000, 10_000] {
+        let snapshot = seeded_descriptor_unrelated_width_storage(&runtime, unrelated_width);
+        group.bench_with_input(
+            BenchmarkId::new("undo_file_delete", unrelated_width),
+            &unrelated_width,
+            |benchmark, _| {
+                benchmark.iter_custom(|iterations| {
+                    let mut elapsed = Duration::ZERO;
+                    for _ in 0..iterations {
+                        let session = open_session(
+                            &runtime,
+                            Memory::from_snapshot(&snapshot)
+                                .expect("descriptor benchmark snapshot restores"),
+                        );
+                        let started = Instant::now();
+                        runtime
+                            .block_on(session.undo())
+                            .expect("benchmarked descriptor undo succeeds");
                         elapsed += started.elapsed();
                     }
                     elapsed

--- a/packages/engine/src/session/undo_redo.rs
+++ b/packages/engine/src/session/undo_redo.rs
@@ -5,7 +5,9 @@ use crate::commit_graph::CommitGraphReader;
 use crate::entity_pk::EntityPk;
 use crate::sql2::SqlWriteExecutionContext;
 use crate::storage_adapter::Storage;
-use crate::tracked_state::{TrackedStateDiffRequest, TrackedStateIndexValue, TrackedStateKey};
+use crate::tracked_state::{
+    TrackedStateIndexValue, TrackedStateKey, descriptor_dependency_cascade_file_ids,
+};
 use crate::transaction::Transaction;
 use crate::transaction::types::{RawWriteBatch, TransactionWrite, TransactionWriteMode};
 use crate::undo_redo::{
@@ -467,21 +469,33 @@ where
 {
     reject_untracked_descriptor_cascade(transaction, target_delta, desired_is_target, target)
         .await?;
-    if target_delta.iter().any(|(key, _)| {
-        matches!(
-            key.schema_key.as_str(),
-            "lix_file_descriptor" | "lix_directory_descriptor"
-        )
-    }) {
-        return apply_generic_state_diff(transaction, current, desired).await;
-    }
-    let keys = target_delta
-        .iter()
-        .filter(|(key, _)| {
+    let cascade_file_ids = descriptor_dependency_cascade_file_ids(target_delta)?;
+    let keys = if cascade_file_ids.is_empty() {
+        target_delta
+            .iter()
+            .map(|(key, _)| key.clone())
+            .collect::<Vec<_>>()
+    } else {
+        let visible_schema_keys = transaction.visible_schema_keys()?;
+        let dependency_commit = if desired_is_target { current } else { desired };
+        let mut tracked = transaction.tracked_state_reader().await;
+        tracked
+            .descriptor_dependency_closure(
+                &current.to_string(),
+                &desired.to_string(),
+                &dependency_commit.to_string(),
+                target_delta,
+                &cascade_file_ids,
+                &visible_schema_keys,
+            )
+            .await?
+    };
+    let keys = keys
+        .into_iter()
+        .filter(|key| {
             key.schema_key != CHECKPOINT_MARKER_SCHEMA_KEY
                 && key.schema_key != UNDO_REDO_MARKER_SCHEMA_KEY
         })
-        .map(|(key, _)| key.clone())
         .collect::<Vec<_>>();
     transaction
         .execute_tracked_state_transition(current, desired, keys)
@@ -536,45 +550,6 @@ where
         ));
     }
     Ok(())
-}
-
-async fn apply_generic_state_diff<S>(
-    transaction: &mut Transaction<S>,
-    current: CommitId,
-    desired: CommitId,
-) -> Result<crate::sql2::DiffCommandOutcome, LixError>
-where
-    S: Storage + Clone + Send + Sync + 'static,
-{
-    let diff = {
-        let mut tracked = transaction.tracked_state_reader().await;
-        tracked
-            .diff_commits(
-                &current.to_string(),
-                &desired.to_string(),
-                &TrackedStateDiffRequest {
-                    retain_payloads: false,
-                    ..TrackedStateDiffRequest::default()
-                },
-            )
-            .await?
-    };
-    let keys = diff
-        .entries
-        .into_iter()
-        .filter(|entry| {
-            entry.identity.schema_key() != CHECKPOINT_MARKER_SCHEMA_KEY
-                && entry.identity.schema_key() != UNDO_REDO_MARKER_SCHEMA_KEY
-        })
-        .map(|entry| TrackedStateKey {
-            schema_key: entry.identity.schema_key().to_owned(),
-            file_id: entry.identity.file_id().map(str::to_owned),
-            entity_pk: entry.identity.entity_pk().clone(),
-        })
-        .collect::<Vec<_>>();
-    transaction
-        .execute_tracked_state_transition(current, desired, keys)
-        .await
 }
 
 async fn stage_marker<S>(
@@ -979,12 +954,51 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn file_delete_roundtrips_through_the_cascade_fallback() {
+    async fn file_delete_roundtrips_exact_tracked_dependency_closure() {
         let session = setup().await;
         session
             .upsert_file_data("/deleted.txt".into(), Blob::from("restored".as_bytes()))
             .await
             .expect("file creates");
+        session
+            .upsert_file_data("/unrelated.txt".into(), Blob::from("untouched".as_bytes()))
+            .await
+            .expect("unrelated file creates");
+        let files = session
+            .execute(
+                "SELECT id, path FROM lix_file WHERE path IN ('/deleted.txt', '/unrelated.txt')",
+                &[],
+            )
+            .await
+            .expect("file identities read");
+        let file_id = |path: &str| {
+            files
+                .rows()
+                .iter()
+                .find(|row| row.get::<String>("path").ok().as_deref() == Some(path))
+                .and_then(|row| row.get::<String>("id").ok())
+                .expect("file identity exists")
+        };
+        let deleted_file_id = file_id("/deleted.txt");
+        let unrelated_file_id = file_id("/unrelated.txt");
+        session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    sql: "INSERT INTO lix_key_value (key, value, lixcol_file_id) VALUES ('deleted-state', 'restore-me', $1)".to_string(),
+                    params: vec![Value::Text(deleted_file_id)],
+                },
+                ExecuteBatchStatement {
+                    sql: "INSERT INTO lix_key_value (key, value, lixcol_file_id) VALUES ('unrelated-state', 'keep-me', $1)".to_string(),
+                    params: vec![Value::Text(unrelated_file_id)],
+                },
+                ExecuteBatchStatement {
+                    sql: "INSERT INTO lix_key_value (key, value) VALUES ('global-state', 'keep-me')"
+                        .to_string(),
+                    params: vec![],
+                },
+            ])
+            .await
+            .expect("tracked dependency rows write");
         session
             .execute("DELETE FROM lix_file WHERE path = '/deleted.txt'", &[])
             .await
@@ -995,6 +1009,15 @@ mod tests {
                 .await
                 .expect("deleted file reads"),
             None
+        );
+        assert_eq!(value(&session, "deleted-state").await, None);
+        assert_eq!(
+            value(&session, "unrelated-state").await.as_deref(),
+            Some("keep-me")
+        );
+        assert_eq!(
+            value(&session, "global-state").await.as_deref(),
+            Some("keep-me")
         );
 
         session.undo().await.expect("file deletion undoes");
@@ -1008,6 +1031,18 @@ mod tests {
                 .as_ref(),
             b"restored"
         );
+        assert_eq!(
+            value(&session, "deleted-state").await.as_deref(),
+            Some("restore-me")
+        );
+        assert_eq!(
+            value(&session, "unrelated-state").await.as_deref(),
+            Some("keep-me")
+        );
+        assert_eq!(
+            value(&session, "global-state").await.as_deref(),
+            Some("keep-me")
+        );
         session.redo().await.expect("file deletion redoes");
         assert_eq!(
             session
@@ -1015,6 +1050,15 @@ mod tests {
                 .await
                 .expect("redeleted file reads"),
             None
+        );
+        assert_eq!(value(&session, "deleted-state").await, None);
+        assert_eq!(
+            value(&session, "unrelated-state").await.as_deref(),
+            Some("keep-me")
+        );
+        assert_eq!(
+            value(&session, "global-state").await.as_deref(),
+            Some("keep-me")
         );
     }
 

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -55,6 +55,7 @@ use bytes::Bytes;
 use xxhash_rust::xxh3::xxh3_64;
 
 const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
+const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 // A right-edge probe is worthwhile for a real append batch, but would add a
 // second tree traversal to sparse non-append writes that already use point
 // reads. Keep those latency-sensitive writes on the unchanged generic path.
@@ -1264,6 +1265,102 @@ where
         request: &TrackedStateDiffRequest,
     ) -> Result<TrackedStateDiff, LixError> {
         diff_commits(self, left_commit_id, right_commit_id, request).await
+    }
+
+    /// Resolves the exact tracked identities affected by descriptor cascades.
+    ///
+    /// File-descriptor tombstones implicitly delete every tracked row owned by
+    /// that file, but those cascade members are not authored commit-delta
+    /// rows. Historical keys are ordered by schema before file ID, so a
+    /// file-only scan would still walk the whole root. Build the schema
+    /// inventory from the visible schema catalog and scan only the resulting
+    /// `(schema_key, file_id)` prefixes at the endpoint where the file is
+    /// live. If the target changes the catalog, also include both historical
+    /// endpoint inventories.
+    pub(crate) async fn descriptor_dependency_closure(
+        &mut self,
+        current_commit_id: &str,
+        desired_commit_id: &str,
+        dependency_commit_id: &str,
+        target_delta: &[(TrackedStateKey, TrackedStateIndexValue)],
+        file_ids: &[String],
+        visible_schema_keys: &[String],
+    ) -> Result<Vec<TrackedStateKey>, LixError> {
+        let mut keys = target_delta
+            .iter()
+            .map(|(key, _)| key.clone())
+            .collect::<BTreeSet<_>>();
+
+        let mut schema_keys = visible_schema_keys.iter().cloned().collect::<BTreeSet<_>>();
+        if target_delta
+            .iter()
+            .any(|(key, _)| key.schema_key == REGISTERED_SCHEMA_KEY)
+        {
+            schema_keys.extend(
+                self.registered_schema_keys_at_commit(desired_commit_id)
+                    .await?,
+            );
+            schema_keys.extend(
+                self.registered_schema_keys_at_commit(current_commit_id)
+                    .await?,
+            );
+        }
+        let request = TrackedStateScanRequest {
+            filter: crate::tracked_state::TrackedStateFilter {
+                schema_keys: schema_keys.into_iter().collect(),
+                file_ids: file_ids
+                    .iter()
+                    .cloned()
+                    .map(NullableKeyFilter::Value)
+                    .collect(),
+                ..crate::tracked_state::TrackedStateFilter::default()
+            },
+            read_columns: crate::tracked_state::TrackedStateReadColumns {
+                columns: vec!["change_id".to_string()],
+            },
+            limit: None,
+        };
+        let rows = self
+            .scan_batch_at_commit(dependency_commit_id, &request)
+            .await?;
+        keys.extend(rows.iter().map(|row| TrackedStateKey {
+            schema_key: row.schema_key().to_owned(),
+            file_id: row.file_id().map(str::to_owned),
+            entity_pk: row.entity_pk().clone(),
+        }));
+        Ok(keys.into_iter().collect())
+    }
+
+    async fn registered_schema_keys_at_commit(
+        &mut self,
+        commit_id: &str,
+    ) -> Result<BTreeSet<String>, LixError> {
+        let rows = self
+            .scan_batch_at_commit(
+                commit_id,
+                &TrackedStateScanRequest {
+                    filter: crate::tracked_state::TrackedStateFilter {
+                        schema_keys: vec![REGISTERED_SCHEMA_KEY.to_string()],
+                        file_ids: vec![NullableKeyFilter::Null],
+                        ..crate::tracked_state::TrackedStateFilter::default()
+                    },
+                    read_columns: crate::tracked_state::TrackedStateReadColumns {
+                        columns: vec!["change_id".to_string()],
+                    },
+                    limit: None,
+                },
+            )
+            .await?;
+        rows.iter()
+            .map(|row| {
+                row.entity_pk().as_single_string_owned().map_err(|error| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!("registered schema dependency identity is invalid: {error}"),
+                    )
+                })
+            })
+            .collect()
     }
 
     /// Loads the identities and index values authored or selected by exactly
@@ -3929,6 +4026,18 @@ fn file_delete_cascade(
         },
         value,
     )
+}
+
+pub(crate) fn descriptor_dependency_cascade_file_ids(
+    target_delta: &[(TrackedStateKey, TrackedStateIndexValue)],
+) -> Result<Vec<String>, LixError> {
+    let mut file_ids = BTreeSet::new();
+    for (key, value) in target_delta {
+        if let Some(file_id) = file_delete_cascade(key, value)? {
+            file_ids.insert(file_id);
+        }
+    }
+    Ok(file_ids.into_iter().collect())
 }
 
 fn file_delete_cascade_ref(

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -12,7 +12,9 @@ mod tree;
 mod types;
 
 pub(crate) use codec::encode_key_ref;
-pub(crate) use context::{TrackedStateContext, TrackedStateStoreReader};
+pub(crate) use context::{
+    TrackedStateContext, TrackedStateStoreReader, descriptor_dependency_cascade_file_ids,
+};
 pub(crate) use diff::{
     TrackedStateDiff, TrackedStateDiffEntry, TrackedStateDiffIdentity, TrackedStateDiffKind,
     TrackedStateDiffRequest, TrackedStateDiffRow, TrackedStatePayloadBatch, TrackedStatePayloadRef,

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -6697,6 +6697,14 @@ where
         self.sql_schema_snapshot.schema_jsons()
     }
 
+    pub(crate) fn visible_schema_keys(&self) -> Result<Vec<String>, LixError> {
+        self.sql_visible_schemas()
+            .iter()
+            .map(crate::schema::schema_key_from_definition)
+            .map(|result| result.map(|key| key.schema_key))
+            .collect()
+    }
+
     /// Advances a branch ref without staging tracked rows.
     ///
     /// Fast-forward merges use this path because the commit graph already


### PR DESCRIPTION
## Summary

- replace descriptor undo's full-database historical diff fallback with an exact dependency closure
- scan only the live endpoint's schema × affected-file prefixes with identity-only projection
- keep ordinary non-descriptor undo on the direct target-delta path
- add isolation coverage and a repository-width benchmark

## Performance

Criterion comparison against latest `main` for undoing one file deletion with unrelated tracked rows:

| Unrelated rows | `main` | This PR | Change |
| ---: | ---: | ---: | ---: |
| 1 | 2.590 ms | 2.660 ms | +2.7% |
| 1,000 | 3.180 ms | 2.997 ms | -5.7% |
| 10,000 | 9.062 ms | 5.991 ms | -33.9% |

The one-row delta is about 0.07 ms; the repository-width performance cliff is removed as width grows.

## Validation

- `cargo test -p lix_engine --features all-simulations -- --test-threads=1`
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- focused undo/redo tests after the final rebase
- correctness, performance, and test-coverage reviews by three independent sub-agents
