### PR TITLE
perf(engine): borrow execute batch input through commit

### DIFF
--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -499,9 +499,25 @@ where
             &'tx mut Transaction<StorageImpl>,
         ) -> Pin<Box<dyn Future<Output = Result<T, LixError>> + 'tx>>,
     {
+        self.with_write_transaction_lending(async move |transaction| f(transaction).await)
+            .await
+    }
+
+    /// Runs a transaction with a lending async closure.
+    ///
+    /// Unlike the boxed compatibility entrypoint above, `AsyncFnOnce` ties
+    /// the returned future to both the transaction borrow and the closure's
+    /// captured borrows. Large callers can therefore borrow prepared input
+    /// for the duration of the transaction instead of deep-cloning it into a
+    /// `'static` closure environment.
+    pub(crate) async fn with_write_transaction_lending<T, F>(&self, f: F) -> Result<T, LixError>
+    where
+        F: for<'tx> AsyncFnOnce(&'tx mut Transaction<StorageImpl>) -> Result<T, LixError>,
+    {
         self.ensure_open()?;
         let write_access = self.begin_session_write_access().await?;
-        self.with_write_transaction_reserved(write_access, f).await
+        self.with_write_transaction_reserved_lending(write_access, f)
+            .await
     }
 
     pub(super) async fn with_write_transaction_reserved<T, F>(
@@ -513,6 +529,20 @@ where
         F: for<'tx> FnOnce(
             &'tx mut Transaction<StorageImpl>,
         ) -> Pin<Box<dyn Future<Output = Result<T, LixError>> + 'tx>>,
+    {
+        self.with_write_transaction_reserved_lending(write_access, async move |transaction| {
+            f(transaction).await
+        })
+        .await
+    }
+
+    pub(super) async fn with_write_transaction_reserved_lending<T, F>(
+        &self,
+        write_access: SessionWriteAccess,
+        f: F,
+    ) -> Result<T, LixError>
+    where
+        F: for<'tx> AsyncFnOnce(&'tx mut Transaction<StorageImpl>) -> Result<T, LixError>,
     {
         let planner_validation_is_serialized = write_access.serializes_collaboration_writes();
         // Automatic writes already hold the collaboration gate, so taking the

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -1440,10 +1440,9 @@ where
             )?;
         }
 
-        let statements = statements.to_vec();
-        match classify_execute_batch(&statements, &self.sql_planning_cache)? {
+        match classify_execute_batch(statements, &self.sql_planning_cache)? {
             ExecuteBatchExecution::ReadOnly(parsed) => {
-                self.execute_read_only_batch(&statements, parsed).await
+                self.execute_read_only_batch(statements, parsed).await
             }
             ExecuteBatchExecution::Transaction(parsed) => {
                 let contains_write = parsed.contains_write()?;
@@ -1520,140 +1519,133 @@ where
 
     async fn execute_transaction_batch(
         &self,
-        statements: Vec<ExecuteBatchStatement>,
+        statements: &[ExecuteBatchStatement],
         parsed: TransactionBatchStatements,
         options: ExecuteOptions,
         statement_metadata: Vec<ExecuteStatementMetadata>,
         idempotency: Option<ExecuteIdempotency>,
     ) -> Result<Vec<ExecuteResult>, LixError> {
         let telemetry_sink = self.telemetry.clone();
-        let statements = Arc::new(statements);
-        let transaction_statements = Arc::clone(&statements);
         let parameter_route = Arc::new(AtomicBool::new(false));
         let transaction_parameter_route = Arc::clone(&parameter_route);
         let transaction_telemetry_sink = telemetry_sink.clone();
         let result = self
-            .with_write_transaction(move |transaction| {
-                Box::pin(async move {
-                    if let Some(results) = try_execute_transaction_parameter_batch(
-                        transaction,
-                        &transaction_statements,
-                        &parsed,
-                        &options,
-                        &statement_metadata,
-                        &transaction_parameter_route,
-                    )
-                    .await?
-                    {
-                        if let Some(idempotency) = &idempotency {
-                            let receipt = ExecuteIdempotencyReceipt::batch(idempotency, &results)?;
-                            transaction.stage_execute_idempotency_receipt(idempotency, &receipt)?;
-                        }
-                        return Ok(results);
-                    }
-                    let mut results = Vec::with_capacity(transaction_statements.len());
-                    match parsed {
-                        TransactionBatchStatements::AutoParameterizedUpdate {
-                            sql,
-                            statement: parsed,
-                            parameter_batch,
-                        } => {
-                            for (statement_index, (statement, metadata)) in transaction_statements
-                                .iter()
-                                .zip(statement_metadata)
-                                .enumerate()
-                            {
-                                let params = sql2::parameter_row(&parameter_batch, statement_index)
-                                    .map_err(|error| {
-                                        with_batch_statement_index(error, statement_index)
-                                    })?;
-                                let telemetry = SqlStatementTelemetry::start(
-                                    transaction_telemetry_sink.as_ref(),
-                                    &statement.sql,
-                                    "batch",
-                                    Some(statement_index),
-                                );
-                                let operation = async {
-                                    execute_transaction_statement(
-                                        transaction,
-                                        &sql,
-                                        parsed.clone(),
-                                        &params,
-                                        options.clone(),
-                                        metadata,
-                                    )
-                                    .await
-                                    .map_err(|error| {
-                                        with_batch_statement_index(
-                                            normalize_sql_surface_error(error, &statement.sql),
-                                            statement_index,
-                                        )
-                                    })
-                                };
-                                let result = match telemetry.as_ref() {
-                                    Some(telemetry) => telemetry.instrument(operation).await,
-                                    None => operation.await,
-                                };
-                                if let Some(telemetry) = telemetry {
-                                    telemetry.finish(&result);
-                                }
-                                results.push(result?);
-                            }
-                        }
-                        parsed => {
-                            for (statement_index, ((statement, parsed), metadata)) in
-                                transaction_statements
-                                    .iter()
-                                    .zip(parsed.into_vec())
-                                    .zip(statement_metadata)
-                                    .enumerate()
-                            {
-                                let telemetry = SqlStatementTelemetry::start(
-                                    transaction_telemetry_sink.as_ref(),
-                                    &statement.sql,
-                                    "batch",
-                                    Some(statement_index),
-                                );
-                                let operation = async {
-                                    execute_transaction_statement(
-                                        transaction,
-                                        &statement.sql,
-                                        parsed,
-                                        &statement.params,
-                                        options.clone(),
-                                        metadata,
-                                    )
-                                    .await
-                                    .map_err(|error| {
-                                        with_batch_statement_index(
-                                            normalize_sql_surface_error(error, &statement.sql),
-                                            statement_index,
-                                        )
-                                    })
-                                };
-                                let result = match telemetry.as_ref() {
-                                    Some(telemetry) => telemetry.instrument(operation).await,
-                                    None => operation.await,
-                                };
-                                if let Some(telemetry) = telemetry {
-                                    telemetry.finish(&result);
-                                }
-                                results.push(result?);
-                            }
-                        }
-                    }
+            .with_write_transaction_lending(async move |transaction| {
+                if let Some(results) = try_execute_transaction_parameter_batch(
+                    transaction,
+                    statements,
+                    &parsed,
+                    &options,
+                    &statement_metadata,
+                    &transaction_parameter_route,
+                )
+                .await?
+                {
                     if let Some(idempotency) = &idempotency {
                         let receipt = ExecuteIdempotencyReceipt::batch(idempotency, &results)?;
                         transaction.stage_execute_idempotency_receipt(idempotency, &receipt)?;
                     }
-                    Ok(results)
-                })
+                    return Ok(results);
+                }
+                let mut results = Vec::with_capacity(statements.len());
+                match parsed {
+                    TransactionBatchStatements::AutoParameterizedUpdate {
+                        sql,
+                        statement: parsed,
+                        parameter_batch,
+                    } => {
+                        for (statement_index, (statement, metadata)) in
+                            statements.iter().zip(statement_metadata).enumerate()
+                        {
+                            let params = sql2::parameter_row(&parameter_batch, statement_index)
+                                .map_err(|error| {
+                                    with_batch_statement_index(error, statement_index)
+                                })?;
+                            let telemetry = SqlStatementTelemetry::start(
+                                transaction_telemetry_sink.as_ref(),
+                                &statement.sql,
+                                "batch",
+                                Some(statement_index),
+                            );
+                            let operation = async {
+                                execute_transaction_statement(
+                                    transaction,
+                                    &sql,
+                                    parsed.clone(),
+                                    &params,
+                                    options.clone(),
+                                    metadata,
+                                )
+                                .await
+                                .map_err(|error| {
+                                    with_batch_statement_index(
+                                        normalize_sql_surface_error(error, &statement.sql),
+                                        statement_index,
+                                    )
+                                })
+                            };
+                            let result = match telemetry.as_ref() {
+                                Some(telemetry) => telemetry.instrument(operation).await,
+                                None => operation.await,
+                            };
+                            if let Some(telemetry) = telemetry {
+                                telemetry.finish(&result);
+                            }
+                            results.push(result?);
+                        }
+                    }
+                    parsed => {
+                        for (statement_index, ((statement, parsed), metadata)) in statements
+                            .iter()
+                            .zip(parsed.into_vec())
+                            .zip(statement_metadata)
+                            .enumerate()
+                        {
+                            let telemetry = SqlStatementTelemetry::start(
+                                transaction_telemetry_sink.as_ref(),
+                                &statement.sql,
+                                "batch",
+                                Some(statement_index),
+                            );
+                            let operation = async {
+                                execute_transaction_statement(
+                                    transaction,
+                                    &statement.sql,
+                                    parsed,
+                                    &statement.params,
+                                    options.clone(),
+                                    metadata,
+                                )
+                                .await
+                                .map_err(|error| {
+                                    with_batch_statement_index(
+                                        normalize_sql_surface_error(error, &statement.sql),
+                                        statement_index,
+                                    )
+                                })
+                            };
+                            let result = match telemetry.as_ref() {
+                                Some(telemetry) => telemetry.instrument(operation).await,
+                                None => operation.await,
+                            };
+                            if let Some(telemetry) = telemetry {
+                                telemetry.finish(&result);
+                            }
+                            results.push(result?);
+                        }
+                    }
+                }
+                if let Some(idempotency) = &idempotency {
+                    let receipt = ExecuteIdempotencyReceipt::batch(idempotency, &results)?;
+                    transaction.stage_execute_idempotency_receipt(idempotency, &receipt)?;
+                }
+                Ok(results)
             })
             .await;
         if parameter_route.load(Ordering::Relaxed) {
             finish_parameter_batch_statement_telemetry(
                 telemetry_sink.as_ref(),
-                &statements,
+                statements,
                 &result,
             );
         }
@@ -3756,15 +3748,22 @@ fn classify_execute_batch(
             builder.append_value(value);
             builders.push(builder);
         }
+        let mut decoded_params = first
+            .params
+            .iter()
+            .map(|param| match param {
+                Value::Text(value) => String::with_capacity(value.len()),
+                _ => unreachable!("auto-parameterized string literals produce text parameters"),
+            })
+            .collect::<Vec<_>>();
         for statement in &statements[1..] {
-            let params = planning_cache
-                .update_literal_params_for_shape(&statement.sql, first.sql.as_ref())
-                .expect("the non-retaining pass certified this UPDATE shape");
-            for (builder, param) in builders.iter_mut().zip(params) {
-                let Value::Text(value) = param else {
-                    unreachable!("auto-parameterized string literals produce text parameters")
-                };
-                builder.append_value(&value);
+            assert!(
+                planning_cache
+                    .decode_certified_update_literals_into(&statement.sql, &mut decoded_params,),
+                "the non-retaining pass certified this UPDATE shape"
+            );
+            for (builder, value) in builders.iter_mut().zip(&decoded_params) {
+                builder.append_value(value);
             }
         }
         let data_type = if large_offsets {

--- a/packages/engine/src/sql2/planning_cache.rs
+++ b/packages/engine/src/sql2/planning_cache.rs
@@ -107,22 +107,6 @@ where
         })
     }
 
-    /// Extracts literal parameters when `sql` has an already validated UPDATE
-    /// shape.
-    ///
-    /// Batch classification validates and parses the first statement once.
-    /// The remaining statements only need to prove that normalization yields
-    /// the same shape; reparsing and cloning the same AST for every row would
-    /// make classification itself linear in the planner representation.
-    pub(crate) fn update_literal_params_for_shape(
-        &self,
-        sql: &str,
-        normalized_shape: &str,
-    ) -> Option<Vec<Value>> {
-        let (normalized_sql, params) = normalize_update_string_literals(sql)?;
-        (normalized_sql == normalized_shape).then_some(params)
-    }
-
     /// Checks an UPDATE template without retaining decoded literal values.
     ///
     /// Large heterogeneous batches use this as a cheap certification pass so
@@ -130,6 +114,20 @@ where
     /// memory before ordinary sequential classification resumes.
     pub(crate) fn update_literal_shape_matches(&self, sql: &str, normalized_shape: &str) -> bool {
         update_string_literals_match_shape(sql, normalized_shape)
+    }
+
+    /// Decodes a previously shape-certified UPDATE into reusable string slots.
+    ///
+    /// The batch classifier calls [`Self::update_literal_shape_matches`] for
+    /// every row before entering this path. Reusing one string per parameter
+    /// avoids allocating a transient `Vec<Value>` and owned string set for
+    /// every statement while the Arrow columns are being assembled.
+    pub(crate) fn decode_certified_update_literals_into(
+        &self,
+        sql: &str,
+        params: &mut [String],
+    ) -> bool {
+        decode_update_string_literals_into(sql, params)
     }
 
     /// Returns stable public-surface metadata for one catalog generation.
@@ -390,6 +388,54 @@ fn update_string_literals_match_shape(sql: &str, normalized_shape: &str) -> bool
     !quoted_identifier && param_count > 0 && shape.get(shape_cursor..) == Some(&bytes[copied..])
 }
 
+fn decode_update_string_literals_into(sql: &str, params: &mut [String]) -> bool {
+    params.iter_mut().for_each(String::clear);
+    let bytes = sql.as_bytes();
+    let mut cursor = 0_usize;
+    let mut param_index = 0_usize;
+    let mut quoted_identifier = false;
+    while cursor < bytes.len() {
+        match bytes[cursor] {
+            b'"' => {
+                if quoted_identifier && bytes.get(cursor + 1) == Some(&b'"') {
+                    cursor += 2;
+                    continue;
+                }
+                quoted_identifier = !quoted_identifier;
+                cursor += 1;
+            }
+            b'\'' if !quoted_identifier => {
+                let Some(value) = params.get_mut(param_index) else {
+                    return false;
+                };
+                param_index += 1;
+                cursor += 1;
+                let mut segment_start = cursor;
+                loop {
+                    let Some(quote) = bytes[cursor..]
+                        .iter()
+                        .position(|byte| *byte == b'\'')
+                        .map(|offset| cursor + offset)
+                    else {
+                        return false;
+                    };
+                    value.push_str(&sql[segment_start..quote]);
+                    if bytes.get(quote + 1) == Some(&b'\'') {
+                        value.push('\'');
+                        cursor = quote + 2;
+                        segment_start = cursor;
+                        continue;
+                    }
+                    cursor = quote + 1;
+                    break;
+                }
+            }
+            _ => cursor += 1,
+        }
+    }
+    !quoted_identifier && param_index == params.len()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -495,6 +541,24 @@ mod tests {
                 "{different_shape}"
             );
         }
+    }
+
+    #[test]
+    fn certified_literal_decoder_reuses_slots_and_unescapes_quotes() {
+        let cache = test_cache(8);
+        let mut params = vec![String::with_capacity(32), String::with_capacity(8)];
+        params[0].push_str("stale-value");
+        params[1].push_str("stale-id");
+
+        assert!(cache.decode_certified_update_literals_into(
+            "UPDATE notes SET value = lix_json('{\"text\":\"it''s fine\"}') WHERE id = 'b'",
+            &mut params,
+        ));
+        assert_eq!(params, ["{\"text\":\"it's fine\"}", "b"]);
+        assert!(!cache.decode_certified_update_literals_into(
+            "UPDATE notes SET value = 'only-one'",
+            &mut params,
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a lending `AsyncFnOnce` transaction boundary so executeBatch can borrow caller-owned statements through commit instead of deep-cloning the complete batch
- keep the existing boxed transaction entrypoints as compatibility adapters for all other write, branch, diff, and merge callers
- decode certified literal UPDATE parameters into reusable string slots while building Arrow columns, eliminating per-row transient `Vec<Value>` and `String` allocations
- preserve the existing whole-batch non-retaining shape certificate and sequential semantics for unsupported or dependent batches

## Performance

The baseline is the immediately preceding optimization PR, #1108 (`ee825ca36`).

| Backend | Rows | #1108 | This PR | Change |
| --- | ---: | ---: | ---: | ---: |
| RocksDB | 10k | 23.804 ms | 21.380 ms | -10.2% |
| SlateDB | 10k | 23.515 ms | 20.011 ms | -14.9% |
| RocksDB | 1M | 3.759 s | 3.475 s | -7.6% |
| SlateDB | 1M | 3.489 s | 3.091 s | -11.4% |

At 1M, median peak RSS falls from 2,500,896 to 2,246,652 KiB on RocksDB (-10.2%) and from 2,527,088 to 2,344,056 KiB on SlateDB (-7.2%).

Raw SQLite still takes about 1.008 s and 827,004 KiB on this fixture, so the overall 1.2x goal remains open.

## Non-regression checks

Against an exact detached #1108 build under the same machine state, 10k tracked merge preview/commit p50 changed:

- RocksDB: 17.391/2.572 ms to 18.807/2.353 ms (+1.416/-0.219 ms)
- SlateDB: 16.745/3.233 ms to 17.614/2.613 ms (+0.869/-0.620 ms)

Merge commits improve; preview movement remains below 1.5 ms and inside observed run variance. The executeBatch lending entrypoint is not used by branch/diff/merge callers.

## Validation

- `cargo test -p lix_engine --lib` (1,725 passed, 8 ignored)
- focused executeBatch suite (21 passed)
- reusable decoder test covering slot reset, escaped quotes, and parameter-count mismatch
- `cargo check -p lix_engine`
- `git diff --check`

No changenote: this is an internal performance-only change.
