### PR TITLE
perf(engine): remove million-row scan cliff

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/duckdb_public_result.mjs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/duckdb_public_result.mjs
@@ -1,0 +1,66 @@
+// Fixture-shaped DuckDB control for the 1M public-result CRUD profile.
+//
+// Run after installing the Node API without modifying the workspace:
+//   npm install --prefix /tmp/lix-duckdb --no-save @duckdb/node-api
+//   NODE_PATH=/tmp/lix-duckdb/node_modules node duckdb_public_result.mjs
+//
+// It mirrors the generated 1M `json_pointer` scale rows: a zero-padded path
+// plus a JSON object. The timed section orders the rows and materializes
+// owned path strings and parsed JSON values, matching the public result shape
+// measured by the Lix SQL-session benchmark.
+
+import { createRequire } from "node:module";
+
+// `NODE_PATH` lets this remain a standalone benchmark control instead of
+// adding a JavaScript dependency to Lix's Rust workspace.
+const require = createRequire(import.meta.url);
+const { DuckDBInstance } = require("@duckdb/node-api");
+const { version: duckdbNodeApiVersion } = require("@duckdb/node-api/package.json");
+
+const rowCount = Number.parseInt(process.env.LIX_DUCKDB_ROW_COUNT ?? "1000000", 10);
+const sampleCount = Number.parseInt(process.env.LIX_DUCKDB_SAMPLES ?? "5", 10);
+
+if (!Number.isSafeInteger(rowCount) || rowCount <= 0) {
+  throw new Error("LIX_DUCKDB_ROW_COUNT must be a positive safe integer");
+}
+if (!Number.isSafeInteger(sampleCount) || sampleCount <= 0) {
+  throw new Error("LIX_DUCKDB_SAMPLES must be a positive safe integer");
+}
+
+const db = await DuckDBInstance.create(":memory:");
+const connection = await db.connect();
+await connection.run("PRAGMA threads=1");
+await connection.run(`
+  CREATE TABLE json_pointer AS
+  SELECT
+    printf('/~lix-scale/%09d', range) AS path,
+    '{"ordinal":' || range::VARCHAR || ',"lane":"scale"}' AS value_json
+  FROM range(${rowCount})
+`);
+
+const samplesMs = [];
+for (let sample = 0; sample < sampleCount; sample += 1) {
+  const started = process.hrtime.bigint();
+  const reader = await connection.runAndReadAll(
+    "SELECT path, value_json FROM json_pointer ORDER BY path",
+  );
+  const rows = [];
+  for (const row of reader.getRows()) {
+    rows.push([String(row[0]), JSON.parse(String(row[1]))]);
+  }
+  if (rows.length !== rowCount || rows.at(-1)[1].ordinal !== rowCount - 1) {
+    throw new Error("DuckDB public-result control returned unexpected rows");
+  }
+  samplesMs.push(Number(process.hrtime.bigint() - started) / 1e6);
+}
+
+samplesMs.sort((left, right) => left - right);
+console.log(
+  JSON.stringify({
+    duckdb_node_api_version: duckdbNodeApiVersion,
+    node_version: process.version,
+    row_count: rowCount,
+    samples_ms: samplesMs,
+    median_ms: samplesMs[Math.floor(samplesMs.length / 2)],
+  }),
+);

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -79,6 +79,11 @@ const HOT_DIFF_SEGMENT_MAX_IDENTITIES: u32 = 4_096;
 // Real-repository profiling showed that smaller batches contribute negligible
 // storage amplification, so retain their allocation-free direct-key path.
 const HOT_DIFF_PACK_MIN_IDENTITIES: usize = 64;
+// Native analytical reads materialize their complete public result, so a
+// one-base payload pass may scale with that requested result. Keep the eager
+// compatibility path bounded while covering the 1M-row (about 2k-segment)
+// analytical scan target; multi-base scans retain their smaller merge bound.
+const PACKED_BROAD_SNAPSHOT_MAX_SEGMENTS: usize = 4_096;
 const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
 const CERTIFIED_ENTITY_BATCH_MAGIC_V1: &[u8; 4] = b"CEB1";
 const CERTIFIED_ENTITY_BATCH_MAGIC_V2: &[u8; 4] = b"CEB2";
@@ -2926,7 +2931,18 @@ async fn scan_packed_current_base_rows(
                     store,
                     base_ref.commit_id,
                     &request.filter.schema_keys,
-                    512,
+                    // A direct public scan over one base must return every
+                    // visible row anyway. Limiting that one-pass route by
+                    // *segment* count turned large collections into a
+                    // two-pass scan: first the identity/value plane, then a
+                    // million owned key lookups for the payloads. Keep the
+                    // resource bound for multi-base winner merges, but let
+                    // the one-base route decode every selected segment once.
+                    if single_base {
+                        PACKED_BROAD_SNAPSHOT_MAX_SEGMENTS
+                    } else {
+                        512
+                    },
                 )
                 .await?;
             if single_base {

--- a/packages/engine/src/sql2/entity_projection.rs
+++ b/packages/engine/src/sql2/entity_projection.rs
@@ -360,6 +360,15 @@ fn parse_json_value(raw: &RawValue) -> Result<JsonValue, LixError> {
 }
 
 fn raw_string_text(raw: &RawValue) -> Result<Option<String>, LixError> {
+    // String-valued entity fields dominate broad public reads. Deserializing
+    // through `serde_json::Value` first allocates the string and then clones
+    // it again in `json_value_to_string`. Decode the JSON string directly;
+    // all non-string coercions retain the established general path below.
+    if raw.get().trim_start().starts_with('"') {
+        return serde_json::from_str(raw.get())
+            .map(Some)
+            .map_err(snapshot_decode_error);
+    }
     crate::common::json_value_to_string(&parse_json_value(raw)?)
 }
 


### PR DESCRIPTION
## Summary
- Remove the 512-segment cliff for one-base, snapshot-only public scans. A 1M collection spans about 1,954 packed segments; the previous guard forced an identity/value scan followed by 1M owned payload lookups. The bounded 4,096-segment analytical route decodes those payloads once; multi-base winner merges retain the 512-segment bound.
- Decode JSON string entity fields directly in the native public result path, eliminating an intermediate JSON DOM allocation and clone. Non-string coercions retain the existing path.
- Add a standalone, fixture-shaped DuckDB public-result control that uses one thread, orders paths, owns strings, and parses JSON values.

## 1M full public result: 10 hot SQL-session reads
| Backend | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| RocksDB | 1.669971 s/op | 954.103 ms/op | 42.87% |
| SlateDB | 1.655460 s/op | 960.221 ms/op | 41.99% |

Both before and after use `LIX_TRACKED_STATE_CRUD_PROFILE_LAYER=sql_session`, `OP=read_all`, `READ_SHAPE=full_result`, 1M rows, and 10 hot repeats.

## DuckDB control and target
`packages/engine-benchmarks/benches/tracked_state_crud/duckdb_public_result.mjs` is a reproducible fixture-shaped control: one thread, 1M zero-padded paths, JSON `{ordinal,lane}`, `ORDER BY path`, owned strings, and parsed JSON output values. DuckDB Node API 1.5.5-r.3 / Node v22.23.2: 5-sample median **1.370093 s**.

Lix therefore measures **0.696×** DuckDB on RocksDB and **0.701×** on SlateDB—well inside the 1.5× goal.

Profile benefit: the old large scan performed two packed-base passes and allocated a million owned payload lookup keys; the new single-base route reads each selected segment/payload sidecar once. Direct string decoding also removes one JSON DOM and clone per string field.

## Validation
- `cargo fmt --check -p lix_engine`
- `git diff --check`
- `RUST_MIN_STACK=33554432 cargo test -p lix_engine --features all-simulations` (1,740 unit tests, 802 integration tests, 3 doc tests)
- `RUST_MIN_STACK=33554432 cargo test -p lix_engine_benchmarks --test tracked_state_crud_public_result --all-features`
- `cargo clippy -p lix_engine --all-targets` (only the existing unrelated dead-code warning in `StorageWriteSet::apply`)
- `node --check .../duckdb_public_result.mjs` and a 1M control run

Reviewed by three independent sub-agents for semantics, packed decode/memory behavior, and benchmark methodology.