### PR TITLE
perf(engine): stream certified update materialization

### DIFF
--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -5018,6 +5018,134 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn certified_replacement_batch_revalidates_after_staged_schema_amendment() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "x-lix-key": "amended_parameter_update_probe",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" },
+                "value": {
+                    "type": [
+                        "object", "array", "string", "number", "integer", "boolean", "null"
+                    ]
+                }
+            },
+            "required": ["path", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+        session
+            .execute(
+                "INSERT INTO amended_parameter_update_probe (path, value) VALUES ('a', lix_json('\"old-a\"')), ('b', lix_json('\"old-b\"'))",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let amended_schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "x-lix-key": "amended_parameter_update_probe",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" },
+                "value": {
+                    "type": [
+                        "object", "array", "string", "number", "integer", "boolean", "null"
+                    ]
+                },
+                "source": { "type": "string", "default": "amended-plan" }
+            },
+            "required": ["path", "value"],
+            "additionalProperties": false
+        });
+        let mut transaction = session.begin_transaction().await.unwrap();
+        transaction
+            .execute(
+                "UPDATE lix_registered_schema SET value = $1 \
+                 WHERE lixcol_entity_pk = lix_json('[\"amended_parameter_update_probe\"]')",
+                &[Value::Json(amended_schema)],
+            )
+            .await
+            .expect("compatible schema amendment should stage");
+
+        let sql = "UPDATE amended_parameter_update_probe SET value = lix_json($1) WHERE path = $2";
+        let statements = [
+            ExecuteBatchStatement {
+                sql: sql.to_string(),
+                params: vec![
+                    Value::Text("\"updated-a\"".to_string()),
+                    Value::Text("a".to_string()),
+                ],
+            },
+            ExecuteBatchStatement {
+                sql: sql.to_string(),
+                params: vec![
+                    Value::Text("\"updated-b\"".to_string()),
+                    Value::Text("b".to_string()),
+                ],
+            },
+        ];
+        let parsed = TransactionBatchStatements::Shared {
+            statement: sql2::parse_statement(sql).unwrap(),
+            len: statements.len(),
+        };
+        sql2::take_certified_replacement_parameter_batch_executions();
+        let staged = try_execute_transaction_parameter_batch(
+            transaction.transaction_mut().unwrap(),
+            &statements,
+            &parsed,
+            &ExecuteOptions::default(),
+            &vec![ExecuteStatementMetadata::default(); statements.len()],
+            &AtomicBool::new(false),
+        )
+        .await
+        .expect("replacement batch should be revalidated");
+        assert!(
+            staged.is_some(),
+            "the UPDATE batch should retain its typed parameter route"
+        );
+        assert_eq!(
+            sql2::take_certified_replacement_parameter_batch_executions(),
+            1,
+            "the UPDATE batch must reach the certified replacement subroute"
+        );
+        transaction.commit().await.unwrap();
+
+        let rows = session
+            .execute(
+                "SELECT path, value, source FROM amended_parameter_update_probe ORDER BY path",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(
+            rows.rows()[0].get::<serde_json::Value>("value").unwrap(),
+            serde_json::json!("updated-a")
+        );
+        assert_eq!(
+            rows.rows()[1].get::<serde_json::Value>("value").unwrap(),
+            serde_json::json!("updated-b")
+        );
+        assert!(
+            rows.rows()
+                .iter()
+                .all(|row| row.get::<String>("source").unwrap() == "amended-plan"),
+            "replacement normalization must apply the staged schema's default"
+        );
+    }
+
+    #[tokio::test]
     async fn certified_empty_batch_rechecks_concurrent_insert_at_commit_snapshot() {
         let storage = Memory::default();
         Engine::initialize(storage.clone())

--- a/packages/engine/src/sql2/context.rs
+++ b/packages/engine/src/sql2/context.rs
@@ -25,7 +25,8 @@ use crate::plugin::PluginRuntimeHost;
 use crate::storage_adapter::StorageAdapterRead;
 use crate::tracked_state::TrackedStateScanRequest;
 use crate::transaction::types::{
-    RawWriteBatch, TransactionWrite, TransactionWriteMode, TransactionWriteOutcome,
+    CertifiedParameterReplacementBatch, RawWriteBatch, TransactionWrite, TransactionWriteMode,
+    TransactionWriteOutcome,
 };
 use crate::wasm::UnsupportedWasmRuntime;
 
@@ -231,6 +232,13 @@ pub(crate) trait SqlWriteExecutionContext: Send {
             rows,
         })
         .await
+    }
+
+    async fn stage_certified_parameter_batch_replace(
+        &mut self,
+        rows: CertifiedParameterReplacementBatch,
+    ) -> Result<TransactionWriteOutcome, LixError> {
+        self.stage_parameter_batch_replace(rows.into_raw()?).await
     }
 
     async fn execute_diff_command(

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -31,8 +31,8 @@ use crate::sql2::plan::predicate::{BoundPredicate, FilterSet};
 use crate::sql2::read_only::reject_read_only_entity_surface;
 use crate::sql2::value_contract::{json_bigint_value, json_double_value};
 use crate::transaction::types::{
-    CertifiedRawWriteBatchPreparation, PreparedRowFacts, RawWriteBatch, RawWriteRowRef,
-    TransactionJson, TransactionWrite, TransactionWriteMode,
+    CertifiedParameterReplacementBatch, CertifiedRawWriteBatchPreparation, PreparedRowFacts,
+    RawWriteBatch, RawWriteRowRef, TransactionJson, TransactionWrite, TransactionWriteMode,
 };
 use crate::wasm::WasmEntityKey;
 use crate::{LixError, NullableKeyFilter, Value, parse_row_metadata_value};
@@ -840,7 +840,6 @@ async fn try_execute_direct_path_value_replacement_batch(
         .as_deref()
         .unwrap_or(entity_pks.as_slice());
     let unique_row_count = unique_entity_pks.len();
-
     let active_branch_id = ctx.active_branch_id().to_owned();
     let scope = crate::collection_generation::CollectionScopeRef {
         schema_key: &spec.schema_key,
@@ -1023,11 +1022,10 @@ async fn try_execute_direct_path_value_replacement_batch(
             candidate_index += 1;
         }
     }
-
     if !replacement_entity_pks.is_empty() {
         let snapshots =
             TransactionJson::from_certified_row_content_arena(normalized, snapshot_offsets)?;
-        let rows = RawWriteBatch::from_certified_parameter_replacement(
+        let rows = CertifiedParameterReplacementBatch::new(
             replacement_entity_pks,
             snapshots,
             spec.schema_key.as_str().into(),
@@ -1042,7 +1040,7 @@ async fn try_execute_direct_path_value_replacement_batch(
                 complete_collection_replacement,
             },
         )?;
-        ctx.stage_parameter_batch_replace(rows)
+        ctx.stage_certified_parameter_batch_replace(rows)
             .instrument(tracing::debug_span!(
                 target: "lix_perf",
                 "lix.perf.entity_update_value_batch.stage_rows",

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -5157,33 +5157,36 @@ mod tests {
 
     #[tokio::test]
     async fn dense_ordered_parent_merge_is_canonical_and_reads_staged_parent_chunks() {
+        const PARENT_ROW_COUNT: usize = 8_194;
+        const UPDATED_ROW_COUNT: usize = 4_097;
+        const NEW_ROW_COUNT: usize = 4_097;
         let bulk_storage = StorageAdapter::new(Memory::new());
         let generic_storage = StorageAdapter::new(Memory::new());
         let tracked_state = TrackedStateContext::new();
         let parent_commit_id = CommitId::for_test_label("dense-parent").to_string();
         let child_commit_id = CommitId::for_test_label("dense-child").to_string();
 
-        let parent_rows = (0..192)
+        let parent_rows = (0..PARENT_ROW_COUNT)
             .map(|index| {
                 row(
-                    &format!("entity-{index:03}"),
-                    &format!("change-parent-{index:03}"),
+                    &format!("entity-{index:05}"),
+                    &format!("change-parent-{index:05}"),
                     "dense-parent",
                 )
             })
             .collect::<Vec<_>>();
-        let mut child_rows = (0..96)
+        let mut child_rows = (0..UPDATED_ROW_COUNT)
             .map(|index| {
                 row(
-                    &format!("entity-{index:03}"),
-                    &format!("change-child-{index:03}"),
+                    &format!("entity-{index:05}"),
+                    &format!("change-child-{index:05}"),
                     "dense-child",
                 )
             })
-            .chain((0..96).map(|index| {
+            .chain((0..NEW_ROW_COUNT).map(|index| {
                 row(
-                    &format!("entity-{index:03}-new"),
-                    &format!("change-child-new-{index:03}"),
+                    &format!("entity-{index:05}-new"),
+                    &format!("change-child-new-{index:05}"),
                     "dense-child",
                 )
             }))
@@ -5302,7 +5305,7 @@ mod tests {
                 &TrackedStateKey {
                     schema_key: "test_schema".to_string(),
                     file_id: None,
-                    entity_pk: EntityPk::single("entity-000"),
+                    entity_pk: EntityPk::single("entity-00000"),
                 },
             )
             .await

--- a/packages/engine/src/tracked_state/tree.rs
+++ b/packages/engine/src/tracked_state/tree.rs
@@ -470,8 +470,8 @@ impl TrackedStateTree {
         I: IntoIterator<Item = Result<TrackedStateRootMutationRef<'a>, LixError>>,
     {
         let mut parent_entries = OrderedLeafCursor::new(*root_id.as_bytes());
-        let mut mutations = collect_pending_root_mutations(mutation_count, mutations)?;
-        let mut next_mutation = mutations.pop_front();
+        let mut mutations = PendingRootMutationCursor::new(mutations.into_iter());
+        let mut next_mutation = mutations.next_pending()?;
         let mut assembler = OrderedTreeAssembler::new(&self.options, mutation_count);
         let mut cascaded_rows = 0usize;
 
@@ -489,7 +489,7 @@ impl TrackedStateTree {
                 std::cmp::Ordering::Less => {
                     let created_at = mutation.delta.created_at;
                     assembler.push_mutation(mutation, created_at)?;
-                    next_mutation = mutations.pop_front();
+                    next_mutation = mutations.next_pending()?;
                     next_parent_entry = Some(parent_entry);
                 }
                 std::cmp::Ordering::Equal => {
@@ -498,7 +498,7 @@ impl TrackedStateTree {
                         return Err(duplicate_root_insert_error(&mutation.delta));
                     }
                     assembler.push_mutation(mutation, parent_value.created_at())?;
-                    next_mutation = mutations.pop_front();
+                    next_mutation = mutations.next_pending()?;
                     next_parent_entry = parent_entries.next(self, store, overlay).await?;
                 }
                 std::cmp::Ordering::Greater => {
@@ -515,7 +515,7 @@ impl TrackedStateTree {
         while let Some(mutation) = next_mutation {
             let created_at = mutation.delta.created_at;
             assembler.push_mutation(mutation, created_at)?;
-            next_mutation = mutations.pop_front();
+            next_mutation = mutations.next_pending()?;
         }
 
         let built = assembler.finish(self)?;
@@ -2356,39 +2356,61 @@ fn cascade_parent_entry(
     Ok((entry, true))
 }
 
-fn collect_pending_root_mutations<'a, I>(
-    mutation_count: usize,
-    mutations: I,
-) -> Result<VecDeque<PendingRootMutation<'a>>, LixError>
+const PENDING_ROOT_MUTATION_WINDOW: usize = 4096;
+
+struct PendingRootMutationCursor<'a, I> {
+    source: Box<I>,
+    pending: VecDeque<PendingRootMutation<'a>>,
+}
+
+impl<'a, I> PendingRootMutationCursor<'a, I>
 where
-    I: IntoIterator<Item = Result<TrackedStateRootMutationRef<'a>, LixError>>,
+    I: Iterator<Item = Result<TrackedStateRootMutationRef<'a>, LixError>>,
 {
-    let mut key_arena = Vec::with_capacity(mutation_count.saturating_mul(96));
-    let mut pending = Vec::with_capacity(mutation_count);
-    for mutation in mutations {
-        let mutation = mutation?;
-        let delta = mutation.delta;
-        let encoded_key = encode_key_ref_into(
-            &mut key_arena,
-            TrackedStateKeyRef {
-                schema_key: delta.schema_key,
-                file_id: delta.file_id,
-                entity_pk: delta.entity_pk,
-            },
-        );
-        pending.push((delta, mutation.require_absence, encoded_key));
+    fn new(source: I) -> Self {
+        Self {
+            source: Box::new(source),
+            pending: VecDeque::new(),
+        }
     }
-    let key_arena = Bytes::from(key_arena);
-    Ok(pending
-        .into_iter()
-        .map(
-            |(delta, require_absence, encoded_key)| PendingRootMutation {
-                delta,
-                require_absence,
-                encoded_key: key_arena.slice(encoded_key),
-            },
-        )
-        .collect())
+
+    fn next_pending(&mut self) -> Result<Option<PendingRootMutation<'a>>, LixError> {
+        if let Some(mutation) = self.pending.pop_front() {
+            return Ok(Some(mutation));
+        }
+        let mut key_arena = Vec::with_capacity(PENDING_ROOT_MUTATION_WINDOW * 96);
+        let mut pending = Vec::with_capacity(PENDING_ROOT_MUTATION_WINDOW);
+        for _ in 0..PENDING_ROOT_MUTATION_WINDOW {
+            let Some(mutation) = self.source.next() else {
+                break;
+            };
+            let mutation = mutation?;
+            let delta = mutation.delta;
+            let encoded_key = encode_key_ref_into(
+                &mut key_arena,
+                TrackedStateKeyRef {
+                    schema_key: delta.schema_key,
+                    file_id: delta.file_id,
+                    entity_pk: delta.entity_pk,
+                },
+            );
+            pending.push((delta, mutation.require_absence, encoded_key));
+        }
+        if pending.is_empty() {
+            return Ok(None);
+        }
+        let key_arena = Bytes::from(key_arena);
+        self.pending.extend(
+            pending.into_iter().map(
+                |(delta, require_absence, encoded_key)| PendingRootMutation {
+                    delta,
+                    require_absence,
+                    encoded_key: key_arena.slice(encoded_key),
+                },
+            ),
+        );
+        Ok(self.pending.pop_front())
+    }
 }
 
 fn duplicate_root_insert_error(delta: &TrackedStateDeltaRef<'_>) -> LixError {
@@ -2453,9 +2475,7 @@ impl<'a> OrderedTreeAssembler<'a> {
             options,
             current_leaf: OrderedLeafAccumulator::default(),
             leaf_summaries: Vec::new(),
-            chunks: PendingChunkBatchBuilder::with_data_capacity(
-                mutation_count.saturating_mul(128),
-            ),
+            chunks: PendingChunkBatchBuilder::with_data_capacity(mutation_count.saturating_mul(64)),
         }
     }
 

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -118,9 +118,10 @@ use crate::transaction::stale_commit::{
     StaleCommitPlan, StalePluginReconciliationPlan, classify_stale_commit,
 };
 use crate::transaction::types::{
-    PreparedRowFacts, PreparedStateBatch, PreparedTransactionWrite, RawWriteBatch, RawWriteRowRef,
-    StagedCommitChangeBatch, StagedCommitChangeBatchBuilder, TransactionFileData, TransactionJson,
-    TransactionWrite, TransactionWriteMode, TransactionWriteOperation, TransactionWriteOrigin,
+    CertifiedParameterReplacementBatch, PreparedRowFacts, PreparedStateBatch,
+    PreparedTransactionWrite, RawWriteBatch, RawWriteRowRef, StagedCommitChangeBatch,
+    StagedCommitChangeBatchBuilder, TransactionFileData, TransactionJson, TransactionWrite,
+    TransactionWriteMode, TransactionWriteOperation, TransactionWriteOrigin,
     TransactionWriteOutcome, TransactionWriteRow, canonicalize_transaction_json_batch,
     stage_json_from_value,
 };
@@ -8197,6 +8198,51 @@ where
             },
         )
         .await
+    }
+
+    async fn stage_certified_parameter_batch_replace(
+        &mut self,
+        rows: CertifiedParameterReplacementBatch,
+    ) -> Result<TransactionWriteOutcome, LixError> {
+        let row_count = rows.len();
+        if row_count == 0 {
+            return Ok(TransactionWriteOutcome { count: 0 });
+        }
+        self.ensure_plugin_generation_read_guard().await;
+        #[cfg(feature = "storage-benches")]
+        {
+            crate::storage_bench::record_transaction_rows_staged(row_count);
+            crate::storage_bench::record_transaction_untracked_rows(0);
+        }
+        let domain = Domain::schema_catalog(rows.schema_scope_branch_id().to_string(), false);
+        let prepared = if self
+            .staged_writes
+            .has_staged_schema_catalog_change(&domain)?
+        {
+            self.prepare_transaction_rows(rows.into_raw()?)
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.transaction_prepare_rows"
+                ))
+                .await?
+        } else {
+            rows.into_prepared(self.origin_key.as_ref(), self.functions.call_timestamp())?
+        };
+        if prepared.len() != row_count {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "certified replacement preparation changed row cardinality",
+            ));
+        }
+        tracing::debug_span!(target: "lix_perf", "lix.perf.transaction_buffer_stage").in_scope(
+            || {
+                self.staged_writes
+                    .stage_write(PreparedTransactionWrite::Rows {
+                        mode: TransactionWriteMode::Replace,
+                        rows: prepared,
+                    })
+            },
+        )
     }
 
     async fn execute_diff_command(

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -487,6 +487,157 @@ pub(crate) struct CertifiedRawWriteBatchPreparation {
     pub(crate) complete_collection_replacement: bool,
 }
 
+/// Dense, typed replacement columns produced by the certified SQL batch path.
+///
+/// Keeping this transport separate from [`RawWriteBatch`] avoids allocating
+/// raw nullable/system columns only for transaction preparation to dismantle
+/// them immediately. The transaction either lowers these columns directly or
+/// explicitly converts them to raw rows when a transaction-local schema
+/// change invalidates the certificate.
+pub(crate) struct CertifiedParameterReplacementBatch {
+    entity_pks: Vec<EntityPk>,
+    snapshots: Vec<TransactionJson>,
+    schema_key: SharedStr,
+    branch_id: SharedStr,
+    certificate: CertifiedRawWriteBatchPreparation,
+}
+
+impl CertifiedParameterReplacementBatch {
+    pub(crate) fn new(
+        entity_pks: Vec<EntityPk>,
+        snapshots: Vec<TransactionJson>,
+        schema_key: SharedStr,
+        branch_id: SharedStr,
+        certificate: CertifiedRawWriteBatchPreparation,
+    ) -> Result<Self, LixError> {
+        if entity_pks.len() != snapshots.len() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "certified replacement columns are not aligned",
+            ));
+        }
+        if entity_pks.len() >= RAW_WRITE_NONE as usize {
+            return Err(LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                "certified replacement row count exceeds u32",
+            ));
+        }
+        Ok(Self {
+            entity_pks,
+            snapshots,
+            schema_key,
+            branch_id,
+            certificate,
+        })
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.entity_pks.len()
+    }
+
+    pub(crate) fn schema_scope_branch_id(&self) -> &str {
+        self.branch_id.as_str()
+    }
+
+    pub(crate) fn into_raw(self) -> Result<RawWriteBatch, LixError> {
+        RawWriteBatch::from_certified_parameter_replacement(
+            self.entity_pks,
+            self.snapshots,
+            self.schema_key,
+            self.branch_id,
+            self.certificate,
+        )
+    }
+
+    pub(crate) fn into_prepared(
+        self,
+        origin_key: Option<&SharedStr>,
+        timestamp: LixTimestamp,
+    ) -> Result<PreparedStateBatch, LixError> {
+        let Self {
+            entity_pks,
+            snapshots,
+            schema_key,
+            branch_id,
+            certificate,
+        } = self;
+        let row_count = entity_pks.len();
+        let (mut strings, schema_key_ordinal, branch_id_ordinal) = if schema_key == branch_id {
+            (vec![schema_key], 0_u32, 0_u32)
+        } else {
+            (vec![schema_key, branch_id], 0_u32, 1_u32)
+        };
+        let origin_key = origin_key.map(|value| {
+            if let Some(ordinal) = strings.iter().position(|candidate| candidate == value) {
+                return u32::try_from(ordinal)
+                    .expect("certified replacement string dictionary must fit u32");
+            }
+            let ordinal = u32::try_from(strings.len())
+                .expect("certified replacement string dictionary must fit u32");
+            strings.push(value.clone());
+            ordinal
+        });
+        let mut prepared_slots = Vec::with_capacity(row_count);
+        let mut json = Vec::with_capacity(row_count);
+        for (row_index, snapshot) in snapshots.into_iter().enumerate() {
+            json.push(stage_json_from_value(
+                snapshot,
+                "certified replacement snapshot_content",
+            )?);
+            prepared_slots.push(PreparedStateSlot {
+                schema_plan_id: certificate.schema_plan_id,
+                facts: certificate.facts,
+                entity_pk: u32::try_from(row_index)
+                    .expect("certified replacement row ordinal must fit u32"),
+                schema_key: schema_key_ordinal,
+                file_id: None,
+                snapshot: Some(
+                    u32::try_from(row_index)
+                        .expect("certified replacement JSON ordinal must fit u32"),
+                ),
+                metadata: None,
+                origin: None,
+                origin_key,
+                created_at: timestamp,
+                updated_at: timestamp,
+                global: false,
+                change_id: Some(ChangeId::default()),
+                addressable_change_id: true,
+                commit_id: None,
+                untracked: false,
+                branch_id: branch_id_ordinal,
+                durable_predecessor: None,
+            });
+        }
+        let string_index = strings
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(ordinal, value)| {
+                (
+                    value,
+                    u32::try_from(ordinal)
+                        .expect("certified replacement string dictionary must fit u32"),
+                )
+            })
+            .collect();
+        Ok(PreparedStateBatch {
+            slots: prepared_slots,
+            entity_pks,
+            strings,
+            string_index,
+            json,
+            durable_predecessors: Vec::new(),
+            origins: Vec::new(),
+            origin_index: HashMap::new(),
+            origin_column_sets: Vec::new(),
+            origin_column_index: HashMap::new(),
+            certified_ordered_insert: certificate.tracked_keys_strictly_ordered,
+            certified_complete_collection_replacement: certificate.complete_collection_replacement,
+        })
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct RawWriteRowRef<'a> {
     pub(crate) entity_pk: Option<&'a EntityPk>,


### PR DESCRIPTION
## What changed

- lower certified path/value UPDATE batches directly into prepared transaction columns instead of constructing generic nullable/system write columns
- preserve schema-change correctness by explicitly falling back to raw normalization when the transaction-local catalog changed
- stream dense tracked-root mutation keys through bounded 4,096-row arenas and right-size output allocation
- add UPDATE-specific schema revalidation and multi-window canonical-root coverage

## Why

At 1M rows, certified UPDATE still retained large intermediate columns and dense root assembly reserved full-workload key/output arenas. Those allocations dominated peak RSS and amplified materialization latency.

## Performance

Baseline is the previous optimization PR merged as 38dd06b85 (#1111), using alternating cold 1M fixtures:

| Adapter | UPDATE baseline | UPDATE head | Delta | RSS baseline | RSS head | Delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| RocksDB | 2.423 s | 1.964 s | -18.9% | 1,394,484 KiB | 1,142,760 KiB | -18.1% |
| SlateDB | 2.927 s | 1.723 s | -41.1% | 1,477,180 KiB | 1,200,084 KiB | -18.8% |

At 10k rows, UPDATE also improves without regression:

- RocksDB: 26.675 ms to 25.404 ms
- SlateDB: 23.896 ms to 23.365 ms

The tracked-root format is unchanged, and the new >4,096-row test proves the streamed dense root is byte-canonically identical to the generic builder. Diff, merge, and branch semantics therefore retain the same roots.

## Validation

- cargo fmt --check
- git diff --check
- cargo clippy -p lix_engine --lib -- -D warnings
- RUST_MIN_STACK=8388608 cargo test -p lix_engine: 1,741 unit tests; 435 integration tests passed, 2 ignored; 3 doctests passed
- focused certified UPDATE schema-amendment fallback test
- focused 8,194-mutation dense-root canonical equivalence test

The larger test stack works around a stack overflow reproducible on unchanged 38dd06b85 in file_delete_roundtrips_exact_tracked_dependency_closure.

No changenote.