### PR TITLE
perf(engine): stream certified insert materialization

### DIFF
--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -4916,6 +4916,9 @@ mod tests {
 
     #[tokio::test]
     async fn certified_parameter_batch_revalidates_after_staged_schema_amendment() {
+        // Keep this at the production typed-transport boundary. A separate
+        // route-selection unit test pins the threshold itself.
+        const ROW_COUNT: usize = 32 * 1024;
         let session = open_session().await;
         let schema = serde_json::json!({
             "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -4961,22 +4964,15 @@ mod tests {
             .expect("compatible schema amendment should stage");
 
         let sql = "INSERT INTO amended_parameter_insert_probe (id, value) VALUES ($1, $2)";
-        let statements = [
-            ExecuteBatchStatement {
+        let statements = (0..ROW_COUNT)
+            .map(|index| ExecuteBatchStatement {
                 sql: sql.to_string(),
                 params: vec![
-                    Value::Text("a".to_string()),
-                    Value::Text("first".to_string()),
+                    Value::Text(format!("entity-{index:05}")),
+                    Value::Text(format!("value-{index:05}")),
                 ],
-            },
-            ExecuteBatchStatement {
-                sql: sql.to_string(),
-                params: vec![
-                    Value::Text("b".to_string()),
-                    Value::Text("second".to_string()),
-                ],
-            },
-        ];
+            })
+            .collect::<Vec<_>>();
         let parsed = TransactionBatchStatements::Shared {
             statement: sql2::parse_statement(sql).unwrap(),
             len: statements.len(),
@@ -5003,16 +4999,15 @@ mod tests {
 
         let rows = session
             .execute(
-                "SELECT id, source FROM amended_parameter_insert_probe ORDER BY id",
+                "SELECT COUNT(*) AS entries FROM amended_parameter_insert_probe \
+                 WHERE source = 'amended-plan'",
                 &[],
             )
             .await
             .unwrap();
-        assert_eq!(rows.len(), 2);
-        assert!(
-            rows.rows()
-                .iter()
-                .all(|row| row.get::<String>("source").unwrap() == "amended-plan"),
+        assert_eq!(
+            rows.rows()[0].get::<i64>("entries").unwrap(),
+            ROW_COUNT as i64,
             "transaction normalization must apply the staged schema's default"
         );
     }

--- a/packages/engine/src/sql2/context.rs
+++ b/packages/engine/src/sql2/context.rs
@@ -25,8 +25,8 @@ use crate::plugin::PluginRuntimeHost;
 use crate::storage_adapter::StorageAdapterRead;
 use crate::tracked_state::TrackedStateScanRequest;
 use crate::transaction::types::{
-    CertifiedParameterReplacementBatch, RawWriteBatch, TransactionWrite, TransactionWriteMode,
-    TransactionWriteOutcome,
+    CertifiedParameterInsertBatch, CertifiedParameterReplacementBatch, RawWriteBatch,
+    TransactionWrite, TransactionWriteMode, TransactionWriteOutcome,
 };
 use crate::wasm::UnsupportedWasmRuntime;
 
@@ -221,6 +221,13 @@ pub(crate) trait SqlWriteExecutionContext: Send {
             rows,
         })
         .await
+    }
+
+    async fn stage_certified_parameter_batch_insert(
+        &mut self,
+        rows: CertifiedParameterInsertBatch,
+    ) -> Result<TransactionWriteOutcome, LixError> {
+        self.stage_parameter_batch_insert(rows.into_raw()?).await
     }
 
     async fn stage_parameter_batch_replace(

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -31,8 +31,9 @@ use crate::sql2::plan::predicate::{BoundPredicate, FilterSet};
 use crate::sql2::read_only::reject_read_only_entity_surface;
 use crate::sql2::value_contract::{json_bigint_value, json_double_value};
 use crate::transaction::types::{
-    CertifiedParameterReplacementBatch, CertifiedRawWriteBatchPreparation, PreparedRowFacts,
-    RawWriteBatch, RawWriteRowRef, TransactionJson, TransactionWrite, TransactionWriteMode,
+    CertifiedParameterInsertBatch, CertifiedParameterReplacementBatch,
+    CertifiedRawWriteBatchPreparation, PreparedRowFacts, RawWriteBatch, RawWriteRowRef,
+    TransactionJson, TransactionWrite, TransactionWriteMode,
 };
 use crate::wasm::WasmEntityKey;
 use crate::{LixError, NullableKeyFilter, Value, parse_row_metadata_value};
@@ -106,6 +107,26 @@ pub(crate) enum BoundPublicWriteExecution {
 enum EntityInsertParameterBatch<'a> {
     Arrow(&'a RecordBatch),
     Values(&'a [&'a [Value]]),
+}
+
+enum CertifiedEntityInsertParameterBatch {
+    Typed(CertifiedParameterInsertBatch),
+    Raw(RawWriteBatch),
+}
+
+const TYPED_CERTIFIED_INSERT_MIN_ROWS: usize = 32 * 1024;
+
+fn use_typed_certified_insert(row_count: usize) -> bool {
+    row_count >= TYPED_CERTIFIED_INSERT_MIN_ROWS
+}
+
+impl CertifiedEntityInsertParameterBatch {
+    fn into_raw(self) -> Result<RawWriteBatch, LixError> {
+        match self {
+            Self::Typed(rows) => rows.into_raw(),
+            Self::Raw(rows) => Ok(rows),
+        }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -267,7 +288,7 @@ async fn try_execute_entity_insert_batch(
         "lix.perf.entity_insert_parameter_batch.certify"
     )
     .entered();
-    let Some(write_rows) = certified_entity_insert_parameter_batch(
+    let Some(mut write_rows) = certified_entity_insert_parameter_batch(
         ctx,
         plan,
         &spec,
@@ -281,24 +302,22 @@ async fn try_execute_entity_insert_batch(
         return Ok(None);
     };
     drop(certification_span);
-    let committed = if collection_is_certifiably_empty(ctx, &spec.schema_key).await? {
-        MaterializedLiveStateBatch::default()
+    let collection_empty = collection_is_certifiably_empty(ctx, &spec.schema_key).await?;
+    let committed_conflict = if collection_empty {
+        None
     } else {
-        scan_entity_conflict_candidates(ctx, &spec, &write_rows)
+        let raw_rows = write_rows.into_raw()?;
+        let committed = scan_entity_conflict_candidates(ctx, &spec, &raw_rows)
             .instrument(tracing::debug_span!(
                 target: "lix_perf",
                 "lix.perf.entity_insert_parameter_batch.conflict_scan"
             ))
-            .await?
-    };
-    let conflict_attribution_span = tracing::debug_span!(
-        target: "lix_perf",
-        "lix.perf.entity_insert_parameter_batch.conflict_attribution"
-    )
-    .entered();
-    let committed_conflict = if committed.is_empty() {
-        None
-    } else {
+            .await?;
+        let conflict_attribution_span = tracing::debug_span!(
+            target: "lix_perf",
+            "lix.perf.entity_insert_parameter_batch.conflict_attribution"
+        )
+        .entered();
         let committed_identities = committed
             .iter()
             .map(|row| {
@@ -314,7 +333,7 @@ async fn try_execute_entity_insert_batch(
             })
             .collect::<std::collections::HashMap<_, _>>();
         let mut conflict = None;
-        for (row_index, row) in write_rows.iter().enumerate() {
+        for (row_index, row) in raw_rows.iter().enumerate() {
             let entity_pk = row
                 .entity_pk
                 .expect("certified parameter INSERT rows have explicit identities");
@@ -359,16 +378,29 @@ async fn try_execute_entity_insert_batch(
             conflict = Some(with_parameter_batch_statement_index(error, row_index));
             break;
         }
+        drop(conflict_attribution_span);
+        drop(committed);
+        write_rows = CertifiedEntityInsertParameterBatch::Raw(raw_rows);
         conflict
     };
-    drop(conflict_attribution_span);
-    drop(committed);
-    ctx.stage_parameter_batch_insert(write_rows)
-        .instrument(tracing::debug_span!(
-            target: "lix_perf",
-            "lix.perf.entity_insert_parameter_batch.stage_rows"
-        ))
-        .await?;
+    match write_rows {
+        CertifiedEntityInsertParameterBatch::Typed(rows) => {
+            ctx.stage_certified_parameter_batch_insert(rows)
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.entity_insert_parameter_batch.stage_rows"
+                ))
+                .await?;
+        }
+        CertifiedEntityInsertParameterBatch::Raw(rows) => {
+            ctx.stage_parameter_batch_insert(rows)
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.entity_insert_parameter_batch.stage_rows"
+                ))
+                .await?;
+        }
+    }
     if let Some(error) = committed_conflict {
         return Err(error);
     }
@@ -3922,14 +3954,18 @@ fn certified_entity_insert_parameter_batch(
     parameter_batch: EntityInsertParameterBatch<'_>,
     allow_generic_fallback: bool,
     active_branch_commit_id: Option<&CommitId>,
-) -> Result<Option<RawWriteBatch>, LixError> {
+) -> Result<Option<CertifiedEntityInsertParameterBatch>, LixError> {
     let [row] = values.rows.as_slice() else {
         return Ok(None);
     };
     if let Some(rows) =
         certified_direct_parameter_insert_batch(ctx, plan, spec, layout, row, parameter_batch)?
     {
-        return Ok(Some(rows));
+        return Ok(Some(if use_typed_certified_insert(rows.len()) {
+            CertifiedEntityInsertParameterBatch::Typed(rows)
+        } else {
+            CertifiedEntityInsertParameterBatch::Raw(rows.into_raw()?)
+        }));
     }
     if !allow_generic_fallback {
         return Ok(None);
@@ -3954,6 +3990,7 @@ fn certified_entity_insert_parameter_batch(
         }),
         active_branch_commit_id,
     )
+    .map(|rows| rows.map(CertifiedEntityInsertParameterBatch::Raw))
 }
 
 struct DirectParameterInsertColumn {
@@ -3990,7 +4027,7 @@ fn certified_direct_parameter_insert_batch(
     layout: &InsertRowLayout,
     row: &[BoundExpr],
     parameter_batch: EntityInsertParameterBatch<'_>,
-) -> Result<Option<RawWriteBatch>, LixError> {
+) -> Result<Option<CertifiedParameterInsertBatch>, LixError> {
     if plan.bound.conflict.is_some()
         || !spec.defaults.is_empty()
         || row.len() != layout.columns.len()
@@ -4331,7 +4368,7 @@ fn certified_direct_parameter_insert_batch(
         tracked_keys_strictly_ordered,
         complete_collection_replacement: false,
     };
-    let rows = RawWriteBatch::from_certified_parameter_insert(
+    let rows = CertifiedParameterInsertBatch::new(
         entity_pks,
         snapshots,
         schema_key,
@@ -4348,7 +4385,7 @@ fn certified_direct_path_value_insert_batch(
     row: &[BoundExpr],
     parameter_batch: EntityInsertParameterBatch<'_>,
     schema_plan_id: SchemaPlanId,
-) -> Result<Option<RawWriteBatch>, LixError> {
+) -> Result<Option<CertifiedParameterInsertBatch>, LixError> {
     if !spec.certifies_path_value_replacement || row.len() != 2 || layout.columns.len() != 2 {
         return Ok(None);
     }
@@ -4462,7 +4499,7 @@ fn certified_direct_path_value_insert_batch(
         .collect::<Vec<_>>();
     let snapshots =
         TransactionJson::from_certified_row_content_arena(normalized, snapshot_offsets)?;
-    Ok(Some(RawWriteBatch::from_certified_parameter_insert(
+    Ok(Some(CertifiedParameterInsertBatch::new(
         entity_pks,
         snapshots,
         layout.schema_key.as_str().into(),
@@ -6624,6 +6661,14 @@ fn entity_action(op: &BoundWriteOp) -> &'static str {
 mod primary_key_route_tests {
     use super::*;
     use crate::sql2::bind::expr::{BoundColumnRef, BoundParamRef};
+
+    #[test]
+    fn typed_certified_insert_is_reserved_for_allocation_material_batches() {
+        assert!(!use_typed_certified_insert(
+            TYPED_CERTIFIED_INSERT_MIN_ROWS - 1
+        ));
+        assert!(use_typed_certified_insert(TYPED_CERTIFIED_INSERT_MIN_ROWS));
+    }
 
     #[test]
     fn canonical_string_fast_path_matches_serde_for_safe_and_escaped_utf8() {

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -60,6 +60,8 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 // second tree traversal to sparse non-append writes that already use point
 // reads. Keep those latency-sensitive writes on the unchanged generic path.
 const ORDERED_APPEND_BATCH_MIN_ROWS: usize = 64;
+const STREAMING_DOMINANT_APPEND_MIN_ROWS: usize = 32 * 1024;
+const STREAMING_DOMINANT_APPEND_PARENT_RATIO: u64 = 16;
 // Retain the point cache for latency-sensitive descriptor/registry probes.
 // Above this boundary, per-key cache ownership and duplicate adapters dominate
 // and the arena-backed encoded replay is the intended bulk path.
@@ -68,6 +70,13 @@ const NO_FIRST_PARENT_ORDINAL: u32 = u32::MAX;
 const NO_ROOTLESS_REPLAY_ORDINAL: u32 = u32::MAX;
 const SMALL_FILE_ID_DICTIONARY_CAPACITY: usize = 64;
 const ESTIMATED_FILE_ID_BYTES: usize = 36;
+
+#[cfg(test)]
+thread_local! {
+    static STREAMING_DOMINANT_APPEND_EXECUTIONS: std::cell::Cell<usize> = const {
+        std::cell::Cell::new(0)
+    };
+}
 
 #[derive(Clone, Copy)]
 enum FirstParentDiffKeySource {
@@ -3869,8 +3878,27 @@ where
             }
             None => false,
         };
-        let use_borrowed_batch =
-            parent_metadata.is_none() || (append_only && file_delete_cascades.is_empty());
+        // The right-spine patcher is ideal while the durable parent is a
+        // meaningful fraction of the output. For a production-sized append at
+        // least 16x the parent, rebuilding bounds extra parent work to 6.25%
+        // while avoiding mutation arenas and a second owned descriptor vector.
+        let dominant_append = mutation_count >= STREAMING_DOMINANT_APPEND_MIN_ROWS
+            && append_only
+            && file_delete_cascades.is_empty()
+            && parent_metadata.as_ref().is_some_and(|parent_metadata| {
+                mutation_count_u64
+                    >= parent_metadata
+                        .row_count_estimate
+                        .saturating_mul(STREAMING_DOMINANT_APPEND_PARENT_RATIO)
+            });
+        #[cfg(test)]
+        if dominant_append {
+            STREAMING_DOMINANT_APPEND_EXECUTIONS.with(|executions| {
+                executions.set(executions.get().saturating_add(1));
+            });
+        }
+        let use_borrowed_batch = parent_metadata.is_none()
+            || (append_only && file_delete_cascades.is_empty() && !dominant_append);
         // Match the existing full-rebuild threshold for overlapping roots. A
         // parentless batch needs no reads, while an append-only batch is already
         // the patcher's cheapest case and can skip point reads at any batch
@@ -5517,6 +5545,216 @@ mod tests {
                 .await
                 .expect("appended row should load")
                 .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn dominant_ordered_append_uses_bounded_parent_merge() {
+        const PARENT_ROWS: usize = 64;
+        const APPENDED_ROWS: usize = STREAMING_DOMINANT_APPEND_MIN_ROWS + 1;
+        STREAMING_DOMINANT_APPEND_EXECUTIONS.with(|executions| executions.set(0));
+
+        let storage = StorageAdapter::new(Memory::new());
+        let tracked_state = TrackedStateContext::new();
+        let parent_commit_id = CommitId::for_test_label("dominant-append-parent").to_string();
+        let child_commit_id = CommitId::for_test_label("dominant-append-child").to_string();
+        let parent_rows = (0..PARENT_ROWS)
+            .map(|index| {
+                row(
+                    &format!("entity-{index:05}"),
+                    &format!("change-parent-{index:05}"),
+                    "dominant-append-parent",
+                )
+            })
+            .collect::<Vec<_>>();
+        let child_rows = (0..APPENDED_ROWS)
+            .map(|index| {
+                row(
+                    &format!("entity-1{index:05}"),
+                    &format!("change-child-{index:05}"),
+                    "dominant-append-child",
+                )
+            })
+            .collect::<Vec<_>>();
+        let first_child_key = encoded_key_from_materialized_row(&child_rows[0]);
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let mut writes = storage.new_write_set();
+        let mut writer = tracked_state.writer(&read, &mut writes);
+        writer
+            .stage_commit_root(
+                &parent_commit_id,
+                None,
+                parent_rows.iter().map(delta_from_materialized_row),
+            )
+            .await
+            .expect("parent root should stage");
+        for (claimed_count, actual_count) in [
+            (APPENDED_ROWS, APPENDED_ROWS - 1),
+            (APPENDED_ROWS - 1, APPENDED_ROWS),
+        ] {
+            let error = writer
+                .try_stage_bulk_parent_root_from_ordered_mutations(
+                    &child_commit_id,
+                    Some(&parent_commit_id),
+                    claimed_count,
+                    &first_child_key,
+                    &BTreeMap::new(),
+                    child_rows.iter().take(actual_count).map(|row| {
+                        Ok(TrackedStateRootMutationRef {
+                            delta: delta_from_materialized_row(row),
+                            require_absence: true,
+                        })
+                    }),
+                )
+                .await
+                .expect_err("dominant append must validate its declared mutation count");
+            assert_eq!(error.code, LixError::CODE_INTERNAL_ERROR);
+            assert!(error.message.contains("mutation count mismatch"));
+        }
+        let child_report = writer
+            .try_stage_bulk_parent_root_from_ordered_mutations(
+                &child_commit_id,
+                Some(&parent_commit_id),
+                child_rows.len(),
+                &first_child_key,
+                &BTreeMap::new(),
+                child_rows.iter().map(|row| {
+                    Ok(TrackedStateRootMutationRef {
+                        delta: delta_from_materialized_row(row),
+                        require_absence: true,
+                    })
+                }),
+            )
+            .await
+            .expect("dominant append root should stage")
+            .expect("dominant append should use the ordered bulk path");
+        assert_eq!(child_report.changed_rows, APPENDED_ROWS);
+        STREAMING_DOMINANT_APPEND_EXECUTIONS.with(|executions| {
+            assert_eq!(
+                executions.get(),
+                3,
+                "production-sized dominant appends must use the bounded parent merger"
+            );
+        });
+        drop(writer);
+
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("dominant append root should commit");
+        let committed = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("committed dominant append root should open");
+        for expected in [
+            parent_rows.first().expect("parent fixture has rows"),
+            child_rows.last().expect("append fixture has rows"),
+        ] {
+            assert!(
+                TrackedStateTree::new()
+                    .get(
+                        &committed,
+                        &child_report.root_id,
+                        &TrackedStateKey {
+                            schema_key: expected.schema_key.clone(),
+                            file_id: expected.file_id.clone(),
+                            entity_pk: expected.entity_pk.clone(),
+                        },
+                    )
+                    .await
+                    .expect("merged row should load")
+                    .is_some()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn substantial_parent_append_preserves_parent_chunks() {
+        const PARENT_ROWS: usize = 4_096;
+        const APPENDED_ROWS: usize = STREAMING_DOMINANT_APPEND_MIN_ROWS;
+        STREAMING_DOMINANT_APPEND_EXECUTIONS.with(|executions| executions.set(0));
+
+        let storage = StorageAdapter::new(Memory::new());
+        let tracked_state = TrackedStateContext::new();
+        let parent_commit_id = CommitId::for_test_label("substantial-append-parent").to_string();
+        let child_commit_id = CommitId::for_test_label("substantial-append-child").to_string();
+        let rebuild_commit_id = CommitId::for_test_label("substantial-append-rebuild").to_string();
+        let parent_rows = (0..PARENT_ROWS)
+            .map(|index| {
+                row(
+                    &format!("entity-{index:05}"),
+                    &format!("change-parent-{index:05}"),
+                    "substantial-append-parent",
+                )
+            })
+            .collect::<Vec<_>>();
+        let child_rows = (0..APPENDED_ROWS)
+            .map(|index| {
+                row(
+                    &format!("entity-1{index:05}"),
+                    &format!("change-child-{index:05}"),
+                    "substantial-append-child",
+                )
+            })
+            .collect::<Vec<_>>();
+        let first_child_key = encoded_key_from_materialized_row(&child_rows[0]);
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let mut writes = storage.new_write_set();
+        let mut writer = tracked_state.writer(&read, &mut writes);
+        let _parent_report = writer
+            .stage_commit_root(
+                &parent_commit_id,
+                None,
+                parent_rows.iter().map(delta_from_materialized_row),
+            )
+            .await
+            .expect("parent root should stage");
+        let child_report = writer
+            .try_stage_bulk_parent_root_from_ordered_mutations(
+                &child_commit_id,
+                Some(&parent_commit_id),
+                child_rows.len(),
+                &first_child_key,
+                &BTreeMap::new(),
+                child_rows.iter().map(|row| {
+                    Ok(TrackedStateRootMutationRef {
+                        delta: delta_from_materialized_row(row),
+                        require_absence: true,
+                    })
+                }),
+            )
+            .await
+            .expect("append root should stage")
+            .expect("append should use the ordered bulk path");
+        STREAMING_DOMINANT_APPEND_EXECUTIONS.with(|executions| {
+            assert_eq!(
+                executions.get(),
+                0,
+                "an append below the parent ratio must retain right-spine reuse"
+            );
+        });
+        let rebuild_report = writer
+            .stage_commit_root(
+                &rebuild_commit_id,
+                None,
+                parent_rows
+                    .iter()
+                    .chain(child_rows.iter())
+                    .map(delta_from_materialized_row),
+            )
+            .await
+            .expect("canonical full rebuild should stage");
+        assert!(
+            child_report.primary_chunk_puts < rebuild_report.primary_chunk_puts,
+            "right-spine append should stage fewer chunks than a full output rebuild"
         );
     }
 

--- a/packages/engine/src/tracked_state/tree.rs
+++ b/packages/engine/src/tracked_state/tree.rs
@@ -517,6 +517,15 @@ impl TrackedStateTree {
             assembler.push_mutation(mutation, created_at)?;
             next_mutation = mutations.next_pending()?;
         }
+        let actual_mutation_count = mutations.consumed_count();
+        if actual_mutation_count != mutation_count {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "tracked-state ordered bulk mutation count mismatch: expected {mutation_count}, received {actual_mutation_count}"
+                ),
+            ));
+        }
 
         let built = assembler.finish(self)?;
         let result = self
@@ -2361,6 +2370,7 @@ const PENDING_ROOT_MUTATION_WINDOW: usize = 4096;
 struct PendingRootMutationCursor<'a, I> {
     source: Box<I>,
     pending: VecDeque<PendingRootMutation<'a>>,
+    consumed_count: usize,
 }
 
 impl<'a, I> PendingRootMutationCursor<'a, I>
@@ -2371,11 +2381,13 @@ where
         Self {
             source: Box::new(source),
             pending: VecDeque::new(),
+            consumed_count: 0,
         }
     }
 
     fn next_pending(&mut self) -> Result<Option<PendingRootMutation<'a>>, LixError> {
         if let Some(mutation) = self.pending.pop_front() {
+            self.consumed_count = self.consumed_count.saturating_add(1);
             return Ok(Some(mutation));
         }
         let mut key_arena = Vec::with_capacity(PENDING_ROOT_MUTATION_WINDOW * 96);
@@ -2409,7 +2421,15 @@ where
                 },
             ),
         );
-        Ok(self.pending.pop_front())
+        let mutation = self.pending.pop_front();
+        self.consumed_count = self
+            .consumed_count
+            .saturating_add(usize::from(mutation.is_some()));
+        Ok(mutation)
+    }
+
+    fn consumed_count(&self) -> usize {
+        self.consumed_count
     }
 }
 

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -118,10 +118,10 @@ use crate::transaction::stale_commit::{
     StaleCommitPlan, StalePluginReconciliationPlan, classify_stale_commit,
 };
 use crate::transaction::types::{
-    CertifiedParameterReplacementBatch, PreparedRowFacts, PreparedStateBatch,
-    PreparedTransactionWrite, RawWriteBatch, RawWriteRowRef, StagedCommitChangeBatch,
-    StagedCommitChangeBatchBuilder, TransactionFileData, TransactionJson, TransactionWrite,
-    TransactionWriteMode, TransactionWriteOperation, TransactionWriteOrigin,
+    CertifiedParameterInsertBatch, CertifiedParameterReplacementBatch, PreparedRowFacts,
+    PreparedStateBatch, PreparedTransactionWrite, RawWriteBatch, RawWriteRowRef,
+    StagedCommitChangeBatch, StagedCommitChangeBatchBuilder, TransactionFileData, TransactionJson,
+    TransactionWrite, TransactionWriteMode, TransactionWriteOperation, TransactionWriteOrigin,
     TransactionWriteOutcome, TransactionWriteRow, canonicalize_transaction_json_batch,
     stage_json_from_value,
 };
@@ -1848,7 +1848,7 @@ where
     /// preflight. The producer certificate excludes every system column those
     /// generic passes inspect; committed and transaction-local INSERT
     /// collision checks remain in the normal prepared journal.
-    async fn stage_certified_parameter_batch_insert(
+    async fn stage_certified_raw_parameter_batch_insert(
         &mut self,
         rows: RawWriteBatch,
     ) -> Result<TransactionWriteOutcome, LixError> {
@@ -8160,7 +8160,7 @@ where
         rows: RawWriteBatch,
     ) -> Result<TransactionWriteOutcome, LixError> {
         if rows.certified_preparation().is_some() {
-            return Box::pin(self.stage_certified_parameter_batch_insert(rows)).await;
+            return Box::pin(self.stage_certified_raw_parameter_batch_insert(rows)).await;
         }
         let statement_indices = (0..rows.len())
             .map(|index| {
@@ -8181,6 +8181,66 @@ where
             statement_indices,
         )
         .await
+    }
+
+    async fn stage_certified_parameter_batch_insert(
+        &mut self,
+        rows: CertifiedParameterInsertBatch,
+    ) -> Result<TransactionWriteOutcome, LixError> {
+        let row_count = rows.len();
+        if row_count == 0 {
+            return Ok(TransactionWriteOutcome { count: 0 });
+        }
+        self.ensure_plugin_generation_read_guard().await;
+
+        let branch_id = rows.schema_scope_branch_id().to_owned();
+        let schema_key = rows.schema_key().to_owned();
+        let staged = self.staged_writes.staging_overlay()?;
+        if StagedLiveStateRows::collection_replaced(&staged, &branch_id, &schema_key, None)? {
+            return Err(LixError::new(
+                LixError::CODE_CONSTRAINT_VIOLATION,
+                format!("collection '{schema_key}' was deleted earlier in this transaction"),
+            )
+            .with_hint(
+                "Commit the collection deletion before recreating rows in its next generation.",
+            ));
+        }
+
+        #[cfg(feature = "storage-benches")]
+        {
+            crate::storage_bench::record_transaction_rows_staged(row_count);
+            crate::storage_bench::record_transaction_untracked_rows(0);
+        }
+        let domain = Domain::schema_catalog(branch_id, false);
+        let prepared = if self
+            .staged_writes
+            .has_staged_schema_catalog_change(&domain)?
+        {
+            self.prepare_transaction_rows(rows.into_raw()?)
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.transaction_prepare_rows"
+                ))
+                .await?
+        } else {
+            rows.into_prepared(self.origin_key.as_ref(), self.functions.call_timestamp())?
+        };
+        if prepared.len() != row_count {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "certified parameter INSERT preparation changed row cardinality",
+            ));
+        }
+        tracing::debug_span!(target: "lix_perf", "lix.perf.transaction_buffer_stage").in_scope(
+            || {
+                self.staged_writes.stage_certified_parameter_batch_insert(
+                    PreparedTransactionWrite::Rows {
+                        mode: TransactionWriteMode::Insert,
+                        rows: prepared,
+                    },
+                )
+            },
+        )
     }
 
     async fn stage_parameter_batch_replace(

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -487,14 +487,14 @@ pub(crate) struct CertifiedRawWriteBatchPreparation {
     pub(crate) complete_collection_replacement: bool,
 }
 
-/// Dense, typed replacement columns produced by the certified SQL batch path.
+/// Dense, typed columns produced by certified SQL parameter-batch paths.
 ///
 /// Keeping this transport separate from [`RawWriteBatch`] avoids allocating
 /// raw nullable/system columns only for transaction preparation to dismantle
 /// them immediately. The transaction either lowers these columns directly or
 /// explicitly converts them to raw rows when a transaction-local schema
 /// change invalidates the certificate.
-pub(crate) struct CertifiedParameterReplacementBatch {
+pub(crate) struct CertifiedParameterBatch {
     entity_pks: Vec<EntityPk>,
     snapshots: Vec<TransactionJson>,
     schema_key: SharedStr,
@@ -502,7 +502,7 @@ pub(crate) struct CertifiedParameterReplacementBatch {
     certificate: CertifiedRawWriteBatchPreparation,
 }
 
-impl CertifiedParameterReplacementBatch {
+impl CertifiedParameterBatch {
     pub(crate) fn new(
         entity_pks: Vec<EntityPk>,
         snapshots: Vec<TransactionJson>,
@@ -539,8 +539,12 @@ impl CertifiedParameterReplacementBatch {
         self.branch_id.as_str()
     }
 
+    pub(crate) fn schema_key(&self) -> &str {
+        self.schema_key.as_str()
+    }
+
     pub(crate) fn into_raw(self) -> Result<RawWriteBatch, LixError> {
-        RawWriteBatch::from_certified_parameter_replacement(
+        RawWriteBatch::from_certified_parameter_rows(
             self.entity_pks,
             self.snapshots,
             self.schema_key,
@@ -638,6 +642,9 @@ impl CertifiedParameterReplacementBatch {
     }
 }
 
+pub(crate) type CertifiedParameterInsertBatch = CertifiedParameterBatch;
+pub(crate) type CertifiedParameterReplacementBatch = CertifiedParameterBatch;
+
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct RawWriteRowRef<'a> {
     pub(crate) entity_pk: Option<&'a EntityPk>,
@@ -698,25 +705,6 @@ impl RawWriteBatch {
             #[cfg(test)]
             origin_promotions: 0,
         }
-    }
-
-    /// Constructs the fixed-shape public INSERT ingress batch without
-    /// interning the same schema/branch pair and appending seven null system
-    /// columns once per row.
-    pub(crate) fn from_certified_parameter_insert(
-        entity_pks: Vec<EntityPk>,
-        snapshots: Vec<TransactionJson>,
-        schema_key: SharedStr,
-        branch_id: SharedStr,
-        certificate: CertifiedRawWriteBatchPreparation,
-    ) -> Result<Self, LixError> {
-        Self::from_certified_parameter_rows(
-            entity_pks,
-            snapshots,
-            schema_key,
-            branch_id,
-            certificate,
-        )
     }
 
     /// Constructs a fixed-shape, complete tracked replacement batch.


### PR DESCRIPTION
## What changed

- carry certified bulk INSERTs through transaction staging as dense typed identity/snapshot columns instead of expanding million-row nullable raw-write columns
- lower explicitly back to the generic raw path when conflict attribution or a transaction-local schema change requires revalidation
- route production-sized append runs through the bounded ordered parent merger only when the append is at least 16x the parent
- keep small and substantial-parent appends on the existing right-spine patcher to preserve latency and chunk reuse
- validate the bounded merger's consumed mutation cardinality before staging tree chunks or root metadata

## Why

At 1M rows, INSERT still allocated the raw transport envelope and then materialized the append mutation into large key/value arenas plus a second owned descriptor vector. Those transient structures dominated latency and peak RSS even though the SQL executor had already certified the batch shape and ordering.

The 32k row and 16:1 parent-ratio cuts keep low-latency small batches and meaningful existing parents on the current patcher. The rebuilding route is limited to shapes where parent work is at most 6.25% of the appended rows.

## Performance

Release SQL-session benchmark, alternating exact previous-PR/main (`f8d17c59f`) and this commit, 1M rows:

| Adapter | Previous | This PR | Latency | Peak RSS |
| --- | ---: | ---: | ---: | ---: |
| RocksDB | 3.363 s | 2.679 s | **-20.3%** | **-10.7%** |
| SlateDB | 3.234 s | 2.635 s | **-18.5%** | -8.9% |

The 31-sample 10k control remains effectively flat: RocksDB +1.0%, SlateDB +1.3%.

## Validation

- `RUST_MIN_STACK=8388608 cargo test -p lix_engine`
- `cargo clippy -p lix_engine --lib -- -D warnings`
- production-threshold typed INSERT schema-amendment revalidation test
- dominant append canonical lookup plus under/over-count rejection tests
- below-ratio append chunk-reuse comparison against a canonical full rebuild
- independent correctness review, including conflict attribution, staged collection replacement, schema fallback, and historical-root routing

No changenote: this is an internal performance-only change.
