### PR TITLE
perf(engine): index commits by generation for merge-base

### DIFF
--- a/packages/engine/src/changelog/bench_support.rs
+++ b/packages/engine/src/changelog/bench_support.rs
@@ -231,6 +231,7 @@ pub fn append_ordered_commits(
         append.commits.push(CommitRecord {
             format_version: 1,
             commit_id: CommitId::new(ordered_bench_uuid(commit_index, 0)),
+            generation: 0,
             parent_commit_ids: Vec::new(),
             tracked_state_rootless: false,
             change_id: ChangeId::new(ordered_bench_uuid(commit_index, 1)),
@@ -591,6 +592,7 @@ fn direct_append_with_shape(
         append.commits.push(CommitRecord {
             format_version: 1,
             commit_id: typed_commit_id,
+            generation: 0,
             parent_commit_ids: Vec::new(),
             tracked_state_rootless: false,
             change_id: ChangeId::for_test_label(&commit_change_id),

--- a/packages/engine/src/changelog/context.rs
+++ b/packages/engine/src/changelog/context.rs
@@ -743,23 +743,67 @@ where
         append: &ChangelogAppend,
         append_commit_ids: &HashSet<CommitId>,
     ) -> Result<(), LixError> {
-        let parent_ids = append
+        let mut parent_ids = append
             .commits
             .iter()
             .flat_map(|commit| commit.parent_commit_ids.iter().copied())
             .filter(|parent_id| !append_commit_ids.contains(parent_id))
-            .collect::<HashSet<_>>();
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        parent_ids.sort_unstable();
         let keys = parent_ids
             .iter()
             .map(|id| commit_key(*id))
             .collect::<Vec<_>>();
+        let mut parent_generations = HashMap::<CommitId, u64>::new();
         for (parent_id, found) in parent_ids
             .iter()
             .zip(get_many(self.store, COMMIT_SPACE, keys).await?)
         {
-            if found.is_none() && !self.staged_commits.contains_key(parent_id) {
+            let generation = match found {
+                Some(bytes) => {
+                    let record: CommitRecord = storage_codec::decode("commit record", &bytes)?;
+                    record.generation
+                }
+                None => self
+                    .staged_commits
+                    .get(parent_id)
+                    .map(|commit| commit.generation)
+                    .ok_or_else(|| {
+                        LixError::unknown(format!(
+                            "changelog parent commit '{parent_id}' does not exist"
+                        ))
+                    })?,
+            };
+            parent_generations.insert(*parent_id, generation);
+        }
+        let append_generations = append
+            .commits
+            .iter()
+            .map(|commit| (commit.commit_id, commit.generation))
+            .collect::<HashMap<_, _>>();
+        for commit in &append.commits {
+            let expected_generation = commit
+                .parent_commit_ids
+                .iter()
+                .map(|parent_id| {
+                    append_generations
+                        .get(parent_id)
+                        .or_else(|| parent_generations.get(parent_id))
+                        .copied()
+                        .expect("every parent generation was resolved")
+                })
+                .max()
+                .map_or(Ok(0), |generation| {
+                    generation
+                        .checked_add(1)
+                        .ok_or_else(|| LixError::unknown("commit generation exceeds u64"))
+                })?;
+            if commit.generation != expected_generation {
                 return Err(LixError::unknown(format!(
-                    "changelog parent commit '{parent_id}' does not exist"
+                    "changelog commit '{}' has generation {}, expected {expected_generation}",
+                    commit.commit_id, commit.generation
                 )));
             }
         }

--- a/packages/engine/src/changelog/types.rs
+++ b/packages/engine/src/changelog/types.rs
@@ -314,6 +314,9 @@ pub(crate) struct ChangelogAppend {
 pub(crate) struct CommitRecord {
     pub(crate) format_version: u32,
     pub(crate) commit_id: CommitId,
+    /// Longest-path distance from a graph root. Every parent has a strictly
+    /// smaller generation, enabling bounded priority graph walks.
+    pub(crate) generation: u64,
     pub(crate) parent_commit_ids: Vec<CommitId>,
     /// Normal serial tracked commits carry all required state in the
     /// changelog/delta index and intentionally omit an immutable root. Root

--- a/packages/engine/src/checkpoint.rs
+++ b/packages/engine/src/checkpoint.rs
@@ -82,6 +82,7 @@ where
                 record.commit_id,
                 CommitGraphCommitRecord {
                     commit_id: record.commit_id,
+                    generation: record.generation,
                     parent_commit_ids: record.parent_commit_ids,
                     created_at: record.created_at,
                 },
@@ -426,10 +427,11 @@ mod tests {
         LixTimestamp::expect_parse("checkpoint scan timestamp", "2026-07-24T00:00:00Z")
     }
 
-    fn commit_record(id: CommitId, parent: Option<CommitId>) -> CommitRecord {
+    fn commit_record(id: CommitId, generation: u64, parent: Option<CommitId>) -> CommitRecord {
         CommitRecord {
             format_version: 1,
             commit_id: id,
+            generation,
             parent_commit_ids: parent.into_iter().collect(),
             tracked_state_rootless: false,
             change_id: ChangeId::for_test_label(&format!("{id}-change")),
@@ -454,7 +456,9 @@ mod tests {
         // the map-backed depth calculation too.
         for index in 0..1_025 {
             let commit_id = CommitId::for_test_label(&format!("checkpoint-{index}"));
-            append.commits.push(commit_record(commit_id, parent));
+            append
+                .commits
+                .push(commit_record(commit_id, index as u64, parent));
             parent = Some(commit_id);
         }
         let latest_checkpoint = parent.expect("fixture should create checkpoints");
@@ -462,10 +466,10 @@ mod tests {
         let second_auto = CommitId::for_test_label("checkpoint-auto-2");
         append
             .commits
-            .push(commit_record(first_auto, Some(latest_checkpoint)));
+            .push(commit_record(first_auto, 1_025, Some(latest_checkpoint)));
         append
             .commits
-            .push(commit_record(second_auto, Some(first_auto)));
+            .push(commit_record(second_auto, 1_026, Some(first_auto)));
 
         ChangelogContext::new()
             .writer(&mut read, &mut writes)

--- a/packages/engine/src/commit_graph/context.rs
+++ b/packages/engine/src/commit_graph/context.rs
@@ -392,6 +392,7 @@ fn commit_graph_change_from_change_record(change: ChangeRecord) -> CommitGraphCh
 fn commit_graph_commit_record_from_commit_record(record: CommitRecord) -> CommitGraphCommitRecord {
     CommitGraphCommitRecord {
         commit_id: record.commit_id,
+        generation: record.generation,
         parent_commit_ids: record.parent_commit_ids,
         created_at: record.created_at,
     }
@@ -467,6 +468,7 @@ fn commit_graph_commit_from_commit_record(
         canonical_change: change.clone(),
         change,
         commit_id: record.commit_id,
+        generation: record.generation,
         change_ids,
         author_account_ids: record.author_account_ids,
         parent_commit_ids: record.parent_commit_ids,
@@ -1041,6 +1043,7 @@ mod tests {
         let mut writer = changelog.writer(&mut read, &mut writes);
         let mut append = ChangelogAppend::default();
         let mut commit_members = Vec::<(CommitId, Vec<ChangeRecord>)>::new();
+        let mut generations = BTreeMap::<CommitId, u64>::new();
         for change in changes.iter().filter(|change| change.is_commit()) {
             let commit_label = change
                 .change
@@ -1052,6 +1055,7 @@ mod tests {
                 canonical_change: change.change.clone(),
                 change: change.change.clone(),
                 commit_id: CommitId::for_test_label(&commit_label),
+                generation: 0,
                 change_ids: change.commit_change_ids.clone(),
                 author_account_ids: change.author_account_ids.clone(),
                 parent_commit_ids: change.parent_commit_ids.clone(),
@@ -1061,8 +1065,17 @@ mod tests {
                     && staged_commit_ids.insert(*parent_commit_id)
                 {
                     append_empty_commit(&mut append, *parent_commit_id);
+                    generations.insert(*parent_commit_id, 0);
                 }
             }
+            let generation = commit
+                .parent_commit_ids
+                .iter()
+                .filter_map(|parent| generations.get(parent).copied())
+                .max()
+                .map_or(0, |parent_generation| parent_generation + 1);
+            let mut commit = commit;
+            commit.generation = generation;
             let mut members = Vec::new();
             for change_id in &commit.change_ids {
                 if let Some(change) = changes_by_id.get(change_id) {
@@ -1073,6 +1086,7 @@ mod tests {
             append.commits.push(CommitRecord {
                 format_version: 1,
                 commit_id: commit.commit_id,
+                generation: commit.generation,
                 parent_commit_ids: commit.parent_commit_ids.clone(),
                 tracked_state_rootless: false,
                 change_id: commit.canonical_change.id,
@@ -1081,6 +1095,7 @@ mod tests {
             });
             commit_members.push((commit.commit_id, members));
             staged_commit_ids.insert(commit.commit_id);
+            generations.insert(commit.commit_id, generation);
         }
         writer
             .stage_append(append)
@@ -1121,6 +1136,7 @@ mod tests {
         append.commits.push(CommitRecord {
             format_version: 1,
             commit_id,
+            generation: 0,
             parent_commit_ids: Vec::new(),
             tracked_state_rootless: false,
             change_id: ChangeId::for_test_label(&change_id),
@@ -1170,6 +1186,7 @@ mod tests {
             canonical_change: change.clone(),
             change,
             commit_id,
+            generation: 0,
             change_ids: change_ids
                 .iter()
                 .map(|change_id| ChangeId::for_test_label(change_id))

--- a/packages/engine/src/commit_graph/types.rs
+++ b/packages/engine/src/commit_graph/types.rs
@@ -26,6 +26,7 @@ pub(crate) struct CommitGraphCommit {
     pub(crate) canonical_change: CommitGraphChange,
     pub(crate) change: CommitGraphChange,
     pub(crate) commit_id: CommitId,
+    pub(crate) generation: u64,
     pub(crate) change_ids: Vec<ChangeId>,
     pub(crate) author_account_ids: Vec<String>,
     pub(crate) parent_commit_ids: Vec<CommitId>,
@@ -35,6 +36,7 @@ pub(crate) struct CommitGraphCommit {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CommitGraphCommitRecord {
     pub(crate) commit_id: CommitId,
+    pub(crate) generation: u64,
     pub(crate) parent_commit_ids: Vec<CommitId>,
     pub(crate) created_at: LixTimestamp,
 }
@@ -97,6 +99,7 @@ pub(crate) trait CommitGraphReader: Send + Sync {
             .await?
             .map(|commit| CommitGraphCommitRecord {
                 commit_id: commit.commit_id,
+                generation: commit.generation,
                 parent_commit_ids: commit.parent_commit_ids,
                 created_at: commit.canonical_change.created_at,
             }))

--- a/packages/engine/src/commit_graph/walker.rs
+++ b/packages/engine/src/commit_graph/walker.rs
@@ -54,50 +54,10 @@ pub(crate) async fn best_common_ancestors<S>(
 where
     S: StorageAdapterRead,
 {
-    // Merge-base graph math only needs parent links. Loading full commits also
-    // decodes every tracked delta payload, multiplying history traversal by
-    // unrelated commit width. Share one lightweight record loader across both
-    // sides and hydrate only the final best candidates.
     let mut loader = CommitRecordTraversalLoader::new(reader);
-    let left_reachable = loader.walk(left_commit_id).await?;
-    let right_reachable = loader.walk(right_commit_id).await?;
-    let right_ids = right_reachable
-        .iter()
-        .map(|reachable| reachable.commit.commit_id)
-        .collect::<BTreeSet<_>>();
-    let common_ids = left_reachable
-        .iter()
-        .filter(|reachable| right_ids.contains(&reachable.commit.commit_id))
-        .map(|reachable| reachable.commit.commit_id)
-        .collect::<BTreeSet<_>>();
-
-    // The intersection of two ancestor sets is ancestor-closed: every parent
-    // of a common ancestor is itself a common ancestor. Therefore a common
-    // commit is "best" exactly when it is not a direct parent of another
-    // common commit. Marking those direct parents avoids the previous
-    // per-candidate graph walk, which made merge-base discovery quadratic in
-    // the length of ordinary shared history.
-    let mut superseded = BTreeSet::new();
-    for reachable in &left_reachable {
-        if !common_ids.contains(&reachable.commit.commit_id) {
-            continue;
-        }
-        for parent_commit_id in &reachable.commit.parent_commit_ids {
-            if common_ids.contains(parent_commit_id) {
-                superseded.insert(*parent_commit_id);
-            }
-        }
-    }
-
-    let mut best = left_reachable
-        .into_iter()
-        .filter(|reachable| {
-            common_ids.contains(&reachable.commit.commit_id)
-                && !superseded.contains(&reachable.commit.commit_id)
-        })
-        .map(|reachable| reachable.commit.commit_id)
-        .collect::<Vec<_>>();
-    best.sort_unstable();
+    let best = loader
+        .best_common_ids(*left_commit_id, *right_commit_id)
+        .await?;
     drop(loader);
     let mut hydrated = Vec::with_capacity(best.len());
     for commit_id in best {
@@ -110,11 +70,6 @@ where
         hydrated.push(commit);
     }
     Ok(hydrated)
-}
-
-struct ReachableCommitRecord {
-    commit: CommitGraphCommitRecord,
-    depth: u32,
 }
 
 struct CommitRecordTraversalLoader<'a, S>
@@ -136,82 +91,67 @@ where
         }
     }
 
-    async fn walk(
+    async fn best_common_ids(
         &mut self,
-        head_commit_id: &CommitId,
-    ) -> Result<Vec<ReachableCommitRecord>, LixError> {
-        let mut visiting = BTreeSet::new();
-        let mut nearest_depths = BTreeMap::new();
-        self.walk_commit(head_commit_id, 0, &mut visiting, &mut nearest_depths)
-            .await?;
-        let mut commits = nearest_depths
-            .into_iter()
-            .map(|(commit_id, depth)| ReachableCommitRecord {
-                commit: self
-                    .loaded
-                    .get(&commit_id)
-                    .expect("visited commit record should be cached")
-                    .clone(),
-                depth,
-            })
-            .collect::<Vec<_>>();
-        commits.sort_by(|left, right| {
-            left.depth
-                .cmp(&right.depth)
-                .then_with(|| left.commit.commit_id.cmp(&right.commit.commit_id))
-        });
-        Ok(commits)
-    }
+        left_commit_id: CommitId,
+        right_commit_id: CommitId,
+    ) -> Result<Vec<CommitId>, LixError> {
+        const LEFT: u8 = 1;
+        const RIGHT: u8 = 2;
+        const BOTH: u8 = LEFT | RIGHT;
+        const STALE: u8 = 4;
 
-    async fn walk_commit(
-        &mut self,
-        commit_id: &CommitId,
-        depth: u32,
-        visiting: &mut BTreeSet<CommitId>,
-        nearest_depths: &mut BTreeMap<CommitId, u32>,
-    ) -> Result<(), LixError> {
-        let mut stack = vec![TraversalFrame {
-            commit_id: *commit_id,
-            depth,
-            expanded: false,
-        }];
-        while let Some(frame) = stack.pop() {
-            if frame.expanded {
-                visiting.remove(&frame.commit_id);
-                continue;
+        let left = self.load_commit_record(&left_commit_id).await?;
+        let right = self.load_commit_record(&right_commit_id).await?;
+        let mut colors = BTreeMap::from([(left_commit_id, LEFT), (right_commit_id, RIGHT)]);
+        if left_commit_id == right_commit_id {
+            colors.insert(left_commit_id, BOTH);
+        }
+        let mut queue = BTreeSet::from([
+            (left.generation, left_commit_id),
+            (right.generation, right_commit_id),
+        ]);
+        let mut non_stale_queued = BTreeSet::from([left_commit_id, right_commit_id]);
+        let mut best = Vec::new();
+
+        while !queue.is_empty() {
+            if !best.is_empty() && non_stale_queued.is_empty() {
+                break;
             }
-            if visiting.contains(&frame.commit_id) {
-                return Err(LixError::new(
-                    "LIX_ERROR_UNKNOWN",
-                    format!(
-                        "commit_graph cycle detected at commit '{}'",
-                        frame.commit_id
-                    ),
-                ));
+            let (generation, commit_id) = queue.pop_last().expect("queue is not empty");
+            non_stale_queued.remove(&commit_id);
+            let commit = self.load_commit_record(&commit_id).await?;
+            if commit.generation != generation {
+                return Err(LixError::unknown(format!(
+                    "commit '{commit_id}' generation changed during graph walk"
+                )));
             }
-            if nearest_depths
-                .get(&frame.commit_id)
-                .is_some_and(|previous_depth| *previous_depth <= frame.depth)
-            {
-                continue;
+            let mut color = colors[&commit_id];
+            if color & STALE == 0 && color & BOTH == BOTH {
+                best.push(commit_id);
+                color |= STALE;
+                colors.insert(commit_id, color);
             }
-            let commit = self.load_commit_record(&frame.commit_id).await?;
-            nearest_depths.insert(frame.commit_id, frame.depth);
-            visiting.insert(frame.commit_id);
-            stack.push(TraversalFrame {
-                commit_id: frame.commit_id,
-                depth: frame.depth,
-                expanded: true,
-            });
-            for parent_commit_id in commit.parent_commit_ids.iter().rev() {
-                stack.push(TraversalFrame {
-                    commit_id: *parent_commit_id,
-                    depth: frame.depth + 1,
-                    expanded: false,
-                });
+            for parent_commit_id in commit.parent_commit_ids {
+                let parent = self.load_commit_record(&parent_commit_id).await?;
+                if parent.generation >= generation {
+                    return Err(LixError::unknown(format!(
+                        "commit '{commit_id}' parent '{parent_commit_id}' does not have a lower generation"
+                    )));
+                }
+                let parent_color = colors.entry(parent_commit_id).or_default();
+                *parent_color |= color;
+                queue.insert((parent.generation, parent_commit_id));
+                if *parent_color & STALE == 0 {
+                    non_stale_queued.insert(parent_commit_id);
+                } else {
+                    non_stale_queued.remove(&parent_commit_id);
+                }
             }
         }
-        Ok(())
+        best.sort_unstable();
+        best.dedup();
+        Ok(best)
     }
 
     async fn load_commit_record(
@@ -356,6 +296,7 @@ struct TraversalFrame {
 
 #[cfg(test)]
 mod tests {
+    use bytes::Bytes;
     use serde_json::json;
 
     use crate::LixError;
@@ -365,7 +306,7 @@ mod tests {
     use crate::commit_graph::CommitGraphChange;
     use crate::commit_graph::CommitGraphContext;
     use crate::storage_adapter::StorageAdapter;
-    use crate::storage_adapter::{Memory, StorageReadOptions, StorageWriteOptions};
+    use crate::storage_adapter::{Memory, StorageKey, StorageReadOptions, StorageWriteOptions};
 
     fn ts(value: &str) -> crate::common::LixTimestamp {
         crate::common::LixTimestamp::expect_parse("timestamp", value)
@@ -463,14 +404,29 @@ mod tests {
     #[tokio::test]
     async fn reachable_commits_errors_on_cycle() {
         let storage = StorageAdapter::new(Memory::new());
-        append_changes(
-            &storage,
-            &[
-                commit_change("commit-a-change", "commit-a", &[], &["commit-b"]),
-                commit_change("commit-b-change", "commit-b", &[], &["commit-a"]),
-            ],
-        )
-        .await;
+        let mut writes = storage.new_write_set();
+        for (label, parent) in [("commit-a", "commit-b"), ("commit-b", "commit-a")] {
+            let commit_id = commit_id(label);
+            writes.put(
+                crate::changelog::COMMIT_SPACE,
+                StorageKey(Bytes::copy_from_slice(commit_id.as_uuid().as_bytes())),
+                crate::changelog::encode_commit_record(&CommitRecord {
+                    format_version: 1,
+                    commit_id,
+                    generation: 1,
+                    parent_commit_ids: commit_ids([parent]),
+                    tracked_state_rootless: false,
+                    change_id: ChangeId::for_test_label(&format!("{label}-change")),
+                    author_account_ids: Vec::new(),
+                    created_at: ts("2026-01-01T00:00:00Z"),
+                })
+                .expect("cycle commit should encode"),
+            );
+        }
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("corrupt cycle should persist");
 
         let graph = CommitGraphContext::new();
         let read = storage
@@ -675,6 +631,101 @@ mod tests {
                 .collect::<Vec<_>>(),
             commit_ids(["commit-b"])
         );
+    }
+
+    #[tokio::test]
+    async fn best_common_ancestors_does_not_walk_the_shared_history_below_the_frontier() {
+        let storage = StorageAdapter::new(Memory::new());
+        append_changes(
+            &storage,
+            &[
+                commit_change("commit-root-change", "commit-root", &[], &[]),
+                commit_change(
+                    "commit-parent-change",
+                    "commit-parent",
+                    &[],
+                    &["commit-root"],
+                ),
+                commit_change("commit-base-change", "commit-base", &[], &["commit-parent"]),
+                commit_change("commit-left-change", "commit-left", &[], &["commit-base"]),
+                commit_change("commit-right-change", "commit-right", &[], &["commit-base"]),
+            ],
+        )
+        .await;
+        let root = commit_id("commit-root");
+        let mut writes = storage.new_write_set();
+        writes.delete(
+            crate::changelog::COMMIT_SPACE,
+            StorageKey(Bytes::copy_from_slice(root.as_uuid().as_bytes())),
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("old shared history corruption should stage");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let mut reader = CommitGraphContext::new().reader(read);
+        let ancestors = reader
+            .best_common_ancestors(&commit_id("commit-left"), &commit_id("commit-right"))
+            .await
+            .expect("merge base should stop at the shared frontier");
+
+        assert_eq!(
+            ancestors
+                .into_iter()
+                .map(|commit| commit.commit_id)
+                .collect::<Vec<_>>(),
+            commit_ids(["commit-base"])
+        );
+    }
+
+    #[tokio::test]
+    async fn best_common_ancestors_rejects_non_decreasing_parent_generation() {
+        let storage = StorageAdapter::new(Memory::new());
+        append_changes(
+            &storage,
+            &[
+                commit_change("commit-root-change", "commit-root", &[], &[]),
+                commit_change("commit-child-change", "commit-child", &[], &["commit-root"]),
+            ],
+        )
+        .await;
+        let child = commit_id("commit-child");
+        let mut writes = storage.new_write_set();
+        writes.put(
+            crate::changelog::COMMIT_SPACE,
+            StorageKey(Bytes::copy_from_slice(child.as_uuid().as_bytes())),
+            crate::changelog::encode_commit_record(&CommitRecord {
+                format_version: 1,
+                commit_id: child,
+                generation: 0,
+                parent_commit_ids: commit_ids(["commit-root"]),
+                tracked_state_rootless: false,
+                change_id: ChangeId::for_test_label("commit-child-change"),
+                author_account_ids: Vec::new(),
+                created_at: ts("2026-01-01T00:00:00Z"),
+            })
+            .expect("corrupt commit should encode"),
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("corrupt commit should persist");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let mut reader = CommitGraphContext::new().reader(read);
+        let error = reader
+            .best_common_ancestors(&child, &commit_id("commit-root"))
+            .await
+            .expect_err("invalid generations should fail the graph walk");
+
+        assert!(error.message.contains("does not have a lower generation"));
     }
 
     #[tokio::test]
@@ -953,6 +1004,7 @@ mod tests {
             .expect("read should open");
         let mut writes = storage.new_write_set();
         let mut append = ChangelogAppend::default();
+        let mut generations = std::collections::BTreeMap::<CommitId, u64>::new();
         for change in changes {
             let commit_id = change
                 .change
@@ -960,15 +1012,24 @@ mod tests {
                 .as_single_string()
                 .expect("commit fixture should have single id")
                 .to_string();
+            let parent_commit_ids = change.parent_commit_ids.iter().copied().collect::<Vec<_>>();
+            let generation = parent_commit_ids
+                .iter()
+                .filter_map(|parent| generations.get(parent).copied())
+                .max()
+                .map_or(0, |parent_generation| parent_generation + 1);
+            let typed_commit_id = CommitId::for_test_label(&commit_id);
             append.commits.push(CommitRecord {
                 format_version: 1,
-                commit_id: CommitId::for_test_label(&commit_id),
-                parent_commit_ids: change.parent_commit_ids.iter().copied().collect(),
+                commit_id: typed_commit_id,
+                generation,
+                parent_commit_ids,
                 tracked_state_rootless: false,
                 change_id: change.change.id,
                 author_account_ids: Vec::new(),
                 created_at: change.change.created_at,
             });
+            generations.insert(typed_commit_id, generation);
         }
         ChangelogContext::new()
             .writer(&mut read, &mut writes)

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -1360,6 +1360,7 @@ mod tests {
             CommitRecord {
                 format_version: 1,
                 commit_id: source_commit,
+                generation: 0,
                 parent_commit_ids: Vec::new(),
                 tracked_state_rootless: true,
                 change_id: ChangeId::for_test_label("gc-tombstone-alias-source-header"),
@@ -1369,6 +1370,7 @@ mod tests {
             CommitRecord {
                 format_version: 1,
                 commit_id: alias_commit,
+                generation: 0,
                 parent_commit_ids: Vec::new(),
                 tracked_state_rootless: true,
                 change_id: ChangeId::for_test_label("gc-tombstone-alias-live-header"),
@@ -1378,6 +1380,7 @@ mod tests {
             CommitRecord {
                 format_version: 1,
                 commit_id: authority_commit,
+                generation: 0,
                 parent_commit_ids: Vec::new(),
                 tracked_state_rootless: true,
                 change_id: ChangeId::for_test_label("gc-tombstone-alias-authority-header"),
@@ -1387,6 +1390,7 @@ mod tests {
             CommitRecord {
                 format_version: 1,
                 commit_id: live_head,
+                generation: 1,
                 parent_commit_ids: vec![alias_commit, authority_commit],
                 tracked_state_rootless: true,
                 change_id: ChangeId::for_test_label("gc-tombstone-alias-head-header"),
@@ -1517,6 +1521,7 @@ mod tests {
             CommitRecord {
                 format_version: 1,
                 commit_id: live_parent,
+                generation: 0,
                 parent_commit_ids: Vec::new(),
                 tracked_state_rootless: true,
                 change_id: ChangeId::for_test_label("authority-gc-live-parent-header"),
@@ -1526,6 +1531,7 @@ mod tests {
             CommitRecord {
                 format_version: 1,
                 commit_id: live_head,
+                generation: 1,
                 parent_commit_ids: vec![live_parent],
                 tracked_state_rootless: true,
                 change_id: ChangeId::for_test_label("authority-gc-live-head-header"),
@@ -1535,6 +1541,7 @@ mod tests {
             CommitRecord {
                 format_version: 1,
                 commit_id: dead_commit,
+                generation: 0,
                 parent_commit_ids: Vec::new(),
                 tracked_state_rootless: true,
                 change_id: ChangeId::for_test_label("authority-gc-dead-header"),

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -46,7 +46,7 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::mutable(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"lxcd9-root-backed-branches.v42";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"lxcd9-generation-indexed-commits.v43";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately
@@ -545,6 +545,7 @@ async fn stage_init_changelog_commit(
     let commit = CommitRecord {
         format_version: 1,
         commit_id: plan.commit.id,
+        generation: 0,
         parent_commit_ids: plan.commit.parent_ids.clone(),
         tracked_state_rootless: false,
         change_id: plan.commit.change_id,

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -1605,7 +1605,10 @@ async fn load_branch_head_control_ids(
 mod tests {
     use super::*;
     use crate::NullableKeyFilter;
-    use crate::changelog::{ChangeId, ChangeRecord, ChangelogAppend, CommitId};
+    use crate::changelog::{
+        ChangeId, ChangeRecord, ChangelogAppend, ChangelogContext, ChangelogReader, CommitId,
+        CommitLoadRequest,
+    };
     use crate::entity_pk::EntityPk;
     use crate::json_store::{JsonRef, JsonStoreContext, JsonWritePlacementRef, NormalizedJsonRef};
     use crate::live_state::{
@@ -2684,6 +2687,7 @@ mod tests {
             append.commits.push(crate::changelog::CommitRecord {
                 format_version: 1,
                 commit_id: CommitId::for_test_label(&commit_id_text),
+                generation: 0,
                 parent_commit_ids: Vec::new(),
                 tracked_state_rootless: false,
                 change_id: ChangeId::for_test_label(&commit_change_id),
@@ -2692,8 +2696,7 @@ mod tests {
             });
         }
         let mut changelog_read = read;
-        let mut writer =
-            crate::changelog::ChangelogContext::new().writer(&mut changelog_read, &mut writes);
+        let mut writer = ChangelogContext::new().writer(&mut changelog_read, &mut writes);
         crate::changelog::ChangelogWriter::stage_append(&mut writer, append)
             .await
             .expect("empty changelog commits should stage");
@@ -2760,6 +2763,7 @@ mod tests {
             }
         }
 
+        let mut generations = std::collections::BTreeMap::<String, u64>::new();
         for (commit_id, rows) in tracked_rows_by_commit {
             let parent_commit_id = parent_by_commit.remove(&commit_id).flatten();
             let parent_ids = parent_commit_id
@@ -2771,10 +2775,38 @@ mod tests {
                 .map(|(change, _, _)| change.created_at)
                 .unwrap_or_else(|| ts("1970-01-01T00:00:00.000Z"));
             let commit_change_id = format!("{commit_id}:commit");
+            let generation = if let Some(parent) = parent_ids.first() {
+                let parent_generation = if let Some(generation) = generations.get(parent) {
+                    *generation
+                } else {
+                    let typed_parent = CommitId::for_test_label(parent);
+                    let mut changelog_read = store;
+                    ChangelogContext::new()
+                        .reader(&mut changelog_read)
+                        .load_commits(CommitLoadRequest {
+                            commit_ids: &[typed_parent],
+                        })
+                        .await?
+                        .entries
+                        .into_iter()
+                        .next()
+                        .flatten()
+                        .ok_or_else(|| {
+                            LixError::unknown("test changelog parent commit is missing")
+                        })?
+                        .generation
+                };
+                parent_generation
+                    .checked_add(1)
+                    .ok_or_else(|| LixError::unknown("test commit generation exceeds u64"))?
+            } else {
+                0
+            };
             let mut append = ChangelogAppend::default();
             append.commits.push(crate::changelog::CommitRecord {
                 format_version: 1,
                 commit_id: CommitId::for_test_label(&commit_id),
+                generation,
                 parent_commit_ids: parent_ids
                     .iter()
                     .map(|id| CommitId::for_test_label(id))
@@ -2785,10 +2817,10 @@ mod tests {
                 created_at: commit_created_at,
             });
             let mut changelog_read = store;
-            let mut writer =
-                crate::changelog::ChangelogContext::new().writer(&mut changelog_read, writes);
+            let mut writer = ChangelogContext::new().writer(&mut changelog_read, writes);
             crate::changelog::ChangelogWriter::stage_append(&mut writer, append).await?;
             drop(writer);
+            generations.insert(commit_id.clone(), generation);
             let typed_commit_id = CommitId::for_test_label(&commit_id);
             let root_deltas = rows
                 .iter()

--- a/packages/engine/src/sql2/history_route.rs
+++ b/packages/engine/src/sql2/history_route.rs
@@ -1062,6 +1062,7 @@ mod tests {
                     canonical_change: change.clone(),
                     change,
                     commit_id: self.start_commit_id,
+                    generation: 0,
                     change_ids: vec![ChangeId::for_test_label("entity-change")],
                     author_account_ids: Vec::new(),
                     parent_commit_ids: Vec::new(),

--- a/packages/engine/src/test_support.rs
+++ b/packages/engine/src/test_support.rs
@@ -1,6 +1,7 @@
 use crate::changelog::CommitId;
 use crate::changelog::{
-    ChangeId, ChangeRecord, ChangelogAppend, ChangelogContext, ChangelogWriter, CommitRecord,
+    ChangeId, ChangeRecord, ChangelogAppend, ChangelogContext, ChangelogReader, ChangelogWriter,
+    CommitLoadRequest, CommitRecord,
 };
 use crate::json_store::{JsonRef, JsonStoreContext, JsonWritePlacementRef, NormalizedJsonRef};
 #[cfg(test)]
@@ -544,6 +545,28 @@ async fn stage_test_changelog_commit(
         .map(|parent| test_commit_id(parent))
         .collect::<Vec<_>>();
     let typed_commit_change_id = test_change_id(commit_change_id);
+    let parent_records = ChangelogContext::new()
+        .reader(&mut *read)
+        .load_commits(CommitLoadRequest {
+            commit_ids: &typed_parent_ids,
+        })
+        .await?;
+    let generation = parent_records
+        .entries
+        .into_iter()
+        .map(|record| {
+            record
+                .map(|record| record.generation)
+                .ok_or_else(|| crate::LixError::unknown("test changelog parent commit is missing"))
+        })
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .max()
+        .map_or(Ok(0), |generation| {
+            generation
+                .checked_add(1)
+                .ok_or_else(|| crate::LixError::unknown("test commit generation exceeds u64"))
+        })?;
     let winner_indices = final_state_row_winner_indices(rows)?;
     let mut append = ChangelogAppend::default();
     let mut change_commit_ids = Vec::new();
@@ -566,6 +589,7 @@ async fn stage_test_changelog_commit(
     append.commits.push(CommitRecord {
         format_version: 1,
         commit_id: typed_commit_id,
+        generation,
         parent_commit_ids: typed_parent_ids,
         tracked_state_rootless,
         change_id: typed_commit_change_id,

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -6239,6 +6239,7 @@ mod tests {
                 crate::changelog::encode_commit_record(&CommitRecord {
                     format_version: 1,
                     commit_id: commit_a,
+                    generation: 1,
                     parent_commit_ids: vec![commit_b],
                     tracked_state_rootless: false,
                     change_id: ChangeId::for_test_label("commit-a:commit"),

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -890,6 +890,95 @@ async fn stage_changelog_commits(
     certified_packet_root_rows: &BTreeMap<CommitId, Vec<MaterializedLiveStateRow>>,
 ) -> Result<BTreeMap<CommitId, StagedChangelogCommit>, LixError> {
     let mut commits = Vec::with_capacity(commit_rows.len());
+    let staged_commit_ids = commit_rows
+        .iter()
+        .map(|commit| commit.commit_id)
+        .collect::<BTreeSet<_>>();
+    if staged_commit_ids.len() != commit_rows.len() {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "transaction contains duplicate staged commit ids",
+        ));
+    }
+    let external_parent_ids = commit_rows
+        .iter()
+        .flat_map(|commit| commit.parent_commit_ids.iter().copied())
+        .filter(|parent| !staged_commit_ids.contains(parent))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let external_parent_records = ChangelogContext::new()
+        .reader(&mut *read)
+        .load_commits(ChangelogCommitLoadRequest {
+            commit_ids: &external_parent_ids,
+        })
+        .await?;
+    let mut generations = external_parent_ids
+        .into_iter()
+        .zip(external_parent_records.entries)
+        .map(|(commit_id, record)| {
+            record
+                .map(|record| (commit_id, record.generation))
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!("commit '{commit_id}' has a missing parent"),
+                    )
+                })
+        })
+        .collect::<Result<BTreeMap<_, _>, _>>()?;
+    let mut staged_parent_count = BTreeMap::<CommitId, usize>::new();
+    let mut children = BTreeMap::<CommitId, Vec<CommitId>>::new();
+    for commit in commit_rows {
+        let mut count = 0;
+        for parent in &commit.parent_commit_ids {
+            if staged_commit_ids.contains(parent) {
+                count += 1;
+                children.entry(*parent).or_default().push(commit.commit_id);
+            }
+        }
+        staged_parent_count.insert(commit.commit_id, count);
+    }
+    let mut ready = staged_parent_count
+        .iter()
+        .filter_map(|(commit_id, count)| (*count == 0).then_some(*commit_id))
+        .collect::<BTreeSet<_>>();
+    let commit_rows_by_id = commit_rows
+        .iter()
+        .map(|commit| (commit.commit_id, commit))
+        .collect::<BTreeMap<_, _>>();
+    while let Some(commit_id) = ready.pop_first() {
+        let commit = commit_rows_by_id[&commit_id];
+        let generation = commit
+            .parent_commit_ids
+            .iter()
+            .filter_map(|parent| generations.get(parent).copied())
+            .max()
+            .map_or(Ok(0), |generation| {
+                generation
+                    .checked_add(1)
+                    .ok_or_else(|| LixError::unknown("commit generation exceeds u64"))
+            })?;
+        generations.insert(commit_id, generation);
+        for child in children.get(&commit_id).into_iter().flatten() {
+            let remaining = staged_parent_count
+                .get_mut(child)
+                .expect("staged child has a parent count");
+            *remaining -= 1;
+            if *remaining == 0 {
+                ready.insert(*child);
+            }
+        }
+    }
+    if staged_commit_ids
+        .iter()
+        .any(|commit_id| !generations.contains_key(commit_id))
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "staged commit graph contains a parent cycle",
+        ));
+    }
     let changes = state_rows
         .iter()
         // Ordinary untracked members are intentionally current-state only in
@@ -908,6 +997,7 @@ async fn stage_changelog_commits(
         .collect::<Result<Vec<_>, _>>()?;
     let mut staged = BTreeMap::<CommitId, StagedChangelogCommit>::new();
     for commit_row in commit_rows {
+        let generation = generations[&commit_row.commit_id];
         let state_row_indices = tracked_row_indices_by_commit
             .get(&commit_row.commit_id)
             .map(Vec::as_slice)
@@ -930,6 +1020,7 @@ async fn stage_changelog_commits(
         commits.push(CommitRecord {
             format_version: 1,
             commit_id: commit_row.commit_id,
+            generation,
             parent_commit_ids: commit_row.parent_commit_ids.clone(),
             tracked_state_rootless: false,
             change_id: commit_row.change_id,
@@ -6925,6 +7016,8 @@ mod tests {
             .await
             .expect("commits should load");
         assert!(commits.entries.iter().all(Option::is_some));
+        assert_eq!(commits.entries[0].as_ref().unwrap().generation, 0);
+        assert_eq!(commits.entries[1].as_ref().unwrap().generation, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- persist an exact commit generation (`max(parent generation) + 1`) and validate it at the changelog write boundary
- resolve best common ancestors with a generation-priority paint-down walk that stops at the shared frontier
- hydrate only winning merge-base commits; retain ordinary reachable-history behavior unchanged
- bump the repository protocol for the hard-cut commit-record format

## Before / after versus #1115 (same host, 10k shared commits)
- 10 divergent commits/side: preview merge-base 38.50 -> 0.24 ms; preview 39.73 -> 1.80 ms; merge 58.20 -> 7.86 ms; preview allocations 26.76 -> 1.59 MB; preview incremental RSS 0.34 -> 0.23 MB
- 100 divergent commits/side: preview merge-base 55.79 -> 0.92 ms; preview 58.13 -> 3.01 ms; merge 62.72 -> 10.67 ms; preview allocations 28.03 -> 2.84 MB; preview incremental RSS 1.43 -> 0.36 MB
- merge incremental RSS: 2.19 -> 1.75 MB (10 divergent), 1.32 -> 1.33 MB (100 divergent)
- every row-model correctness gate passed

## All-plugin file qualification
Cold-reopen text, Markdown, JSON, CSV, and Excalidraw merge:
- preview 10.46 ms; merge 19.64 ms
- merge-base 0.21 ms preview / 0.20 ms merge
- preview incremental RSS 0.46 MB; merge incremental RSS 2.97 MB
- every semantic, resolver, isolation, idempotence, and non-rewrite gate passed

## Qualification
- full engine suite: 1735 unit passed, 802 integration passed, 3 doctests passed
- focused commit-graph suite: 16 passed
- clippy all targets passes (allowing one pre-existing test-only dead-code warning)
- independent graph/complexity re-review: no remaining blocker
