### PR TITLE
perf(engine): point-load derived commits for branch creation

### DIFF
--- a/packages/engine/src/checkpoint.rs
+++ b/packages/engine/src/checkpoint.rs
@@ -82,6 +82,7 @@ where
                 record.commit_id,
                 CommitGraphCommitRecord {
                     commit_id: record.commit_id,
+                    change_id: record.change_id,
                     generation: record.generation,
                     parent_commit_ids: record.parent_commit_ids,
                     created_at: record.created_at,

--- a/packages/engine/src/commit_graph/context.rs
+++ b/packages/engine/src/commit_graph/context.rs
@@ -72,7 +72,7 @@ where
         self.load_changelog_commit(commit_id).await
     }
 
-    async fn load_commit_records(
+    pub(crate) async fn load_commit_records(
         &mut self,
         commit_ids: &[CommitId],
     ) -> Result<Vec<Option<CommitGraphCommitRecord>>, LixError> {
@@ -392,6 +392,7 @@ fn commit_graph_change_from_change_record(change: ChangeRecord) -> CommitGraphCh
 fn commit_graph_commit_record_from_commit_record(record: CommitRecord) -> CommitGraphCommitRecord {
     CommitGraphCommitRecord {
         commit_id: record.commit_id,
+        change_id: record.change_id,
         generation: record.generation,
         parent_commit_ids: record.parent_commit_ids,
         created_at: record.created_at,

--- a/packages/engine/src/commit_graph/types.rs
+++ b/packages/engine/src/commit_graph/types.rs
@@ -36,6 +36,7 @@ pub(crate) struct CommitGraphCommit {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CommitGraphCommitRecord {
     pub(crate) commit_id: CommitId,
+    pub(crate) change_id: ChangeId,
     pub(crate) generation: u64,
     pub(crate) parent_commit_ids: Vec<CommitId>,
     pub(crate) created_at: LixTimestamp,
@@ -99,6 +100,7 @@ pub(crate) trait CommitGraphReader: Send + Sync {
             .await?
             .map(|commit| CommitGraphCommitRecord {
                 commit_id: commit.commit_id,
+                change_id: commit.canonical_change.id,
                 generation: commit.generation,
                 parent_commit_ids: commit.parent_commit_ids,
                 created_at: commit.canonical_change.created_at,

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -6,7 +6,7 @@ use crate::LixError;
 use crate::NullableKeyFilter;
 use crate::branch::{BRANCH_REF_SCHEMA_KEY, BranchHeadControl, BranchHeadControlContext};
 use crate::changelog::CommitId;
-use crate::commit_graph::CommitGraphContext;
+use crate::commit_graph::{CommitGraphCommitRecord, CommitGraphContext};
 use crate::entity_pk::EntityPk;
 use crate::filesystem::{
     FilesystemPathIndex, FilesystemPathIndexCache, FilesystemPathIndexReader,
@@ -28,6 +28,7 @@ use bytes::Bytes;
 use futures_util::{StreamExt, TryStreamExt, stream};
 use std::mem::size_of;
 use std::sync::Mutex as StdMutex;
+use tracing::Instrument;
 
 const BRANCH_READ_CONCURRENCY: usize = 8;
 const ENTITY_POINT_SNAPSHOT_CACHE_MAX_BYTES: usize = 8 * 1024 * 1024;
@@ -1069,11 +1070,70 @@ async fn scan_commit_derived_rows(
         scope.projection_branch_ids.clone()
     };
     let mut graph = commit_graph.reader(store);
-    let commits = graph.all_commits().await?;
     let include_commit = schema_filter_allows(&request.filter.schema_keys, COMMIT_SCHEMA_KEY);
     let include_commit_edge =
         schema_filter_allows(&request.filter.schema_keys, COMMIT_EDGE_SCHEMA_KEY);
 
+    if include_commit
+        && !request.filter.entity_pks.is_empty()
+        && request.filter.entity_pks.iter().all(|entity_pk| {
+            matches!(
+                entity_pk.components.as_slice(),
+                [crate::entity_pk::EntityPkComponent::Uuid(_)]
+            )
+        })
+    {
+        let commit_ids = request
+            .filter
+            .entity_pks
+            .iter()
+            .filter_map(|entity_pk| match entity_pk.components.as_slice() {
+                [crate::entity_pk::EntityPkComponent::Uuid(bytes)] => {
+                    Some(CommitId::new(uuid::Uuid::from_bytes(*bytes)))
+                }
+                _ => None,
+            })
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let records = graph
+            .load_commit_records(&commit_ids)
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.commit_derived.point"
+            ))
+            .await?;
+        let mut rows = Vec::with_capacity(records.len() * branch_ids.len());
+        for branch_id in &branch_ids {
+            for (requested_commit_id, record) in commit_ids.iter().zip(&records) {
+                let Some(record) = record else {
+                    continue;
+                };
+                if record.commit_id != *requested_commit_id {
+                    return Err(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!(
+                            "commit point lookup for {requested_commit_id} decoded record {}",
+                            record.commit_id
+                        ),
+                    ));
+                }
+                rows.push(commit_record_row(record, branch_id)?);
+            }
+        }
+        rows.retain(|row| {
+            request.filter.entity_pks.contains(&row.entity_pk)
+                && (request.filter.branch_ids.is_empty()
+                    || request
+                        .filter
+                        .branch_ids
+                        .iter()
+                        .any(|branch_id| branch_id == row.branch_id.as_ref()))
+        });
+        return Ok(rows);
+    }
+
+    let commits = graph.all_commits().await?;
     let mut rows = Vec::new();
     for branch_id in &branch_ids {
         if include_commit {
@@ -1257,6 +1317,43 @@ fn commit_row(
         updated_at: commit.change.created_at,
         global: true,
         change_id: Some(commit.change.id),
+        commit_id: Some(commit.commit_id),
+        untracked: false,
+        branch_id: branch_id.into(),
+    })
+}
+
+fn commit_record_row(
+    commit: &CommitGraphCommitRecord,
+    branch_id: &str,
+) -> Result<MaterializedLiveStateRow, LixError> {
+    let snapshot_content = serde_json::to_string(&serde_json::json!({
+        "id": commit.commit_id,
+    }))
+    .map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("failed to encode derived lix_commit snapshot: {error}"),
+        )
+    })?;
+    Ok(MaterializedLiveStateRow {
+        entity_pk: EntityPk::uuid_from_canonical(&commit.commit_id.to_string()).map_err(
+            |error| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("derived commit id is not a canonical UUID: {error}"),
+                )
+            },
+        )?,
+        schema_key: COMMIT_SCHEMA_KEY.to_string(),
+        file_id: None,
+        snapshot_content: Some(snapshot_content.into()),
+        metadata: None,
+        deleted: false,
+        created_at: commit.created_at,
+        updated_at: commit.created_at,
+        global: true,
+        change_id: Some(commit.change_id),
         commit_id: Some(commit.commit_id),
         untracked: false,
         branch_id: branch_id.into(),
@@ -2713,6 +2810,59 @@ mod tests {
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
             .expect("empty commits should commit");
+    }
+
+    #[tokio::test]
+    async fn commit_point_scan_preserves_typed_identity_and_missing_semantics() {
+        let storage = StorageAdapter::new(Memory::new());
+        let existing = CommitId::for_test_label("commit-point-existing");
+        let missing = CommitId::for_test_label("commit-point-missing");
+        let setup_read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("setup read should open");
+        write_empty_commits_to_store(&storage, &setup_read, &[&existing.to_string()]).await;
+        drop(setup_read);
+
+        let scope = LiveStateScanScope {
+            storage_branch_ids: Vec::new(),
+            projection_branch_ids: vec!["test-branch".to_string()],
+            branch_heads: BranchHeads::default(),
+        };
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("point scan read should open");
+        let typed_request = finite_pk_scan_request(
+            "test-branch",
+            COMMIT_SCHEMA_KEY,
+            vec![
+                EntityPk::uuid_from_bytes(*existing.as_uuid().as_bytes()),
+                EntityPk::uuid_from_bytes(*existing.as_uuid().as_bytes()),
+                EntityPk::uuid_from_bytes(*missing.as_uuid().as_bytes()),
+            ],
+        );
+        let rows =
+            scan_commit_derived_rows(&read, &CommitGraphContext::new(), &typed_request, &scope)
+                .await
+                .expect("typed point scan should succeed");
+        assert_eq!(rows.len(), 1, "duplicates and missing keys must flatten");
+        assert_eq!(rows[0].entity_pk, typed_request.filter.entity_pks[0]);
+        assert_eq!(rows[0].commit_id, Some(existing));
+
+        let string_request = finite_pk_scan_request(
+            "test-branch",
+            COMMIT_SCHEMA_KEY,
+            vec![EntityPk::single(existing.to_string())],
+        );
+        let rows =
+            scan_commit_derived_rows(&read, &CommitGraphContext::new(), &string_request, &scope)
+                .await
+                .expect("string-typed point scan should succeed");
+        assert!(
+            rows.is_empty(),
+            "a string component must not match the UUID primary key"
+        );
     }
 
     async fn stage_materialized_live_rows(

--- a/packages/rs-sdk-tests/examples/branch_merge_benchmark.rs
+++ b/packages/rs-sdk-tests/examples/branch_merge_benchmark.rs
@@ -662,6 +662,7 @@ async fn run_row_case(cfg: Config, collector: PerfSpanCollector) {
     let setup_reopen_ms = elapsed_ms(setup_reopen_started);
     let main_branch_id = lix.active_branch_id().await.expect("main branch id");
 
+    collector.clear();
     let branch_measure = measure_async(|| async {
         let mut per_branch_ms = Vec::with_capacity(cfg.branches);
         for index in 0..cfg.branches.saturating_sub(1) {
@@ -688,6 +689,7 @@ async fn run_row_case(cfg: Config, collector: PerfSpanCollector) {
         (receipt, per_branch_ms)
     })
     .await;
+    let branch_phases = collector.take_ms();
     let (source_receipt, per_branch_ms) = &branch_measure.value;
     let mut sorted_branch_ms = per_branch_ms.clone();
     sorted_branch_ms.sort_by(f64::total_cmp);
@@ -1012,7 +1014,12 @@ async fn run_row_case(cfg: Config, collector: PerfSpanCollector) {
             "storage_before": storage_bytes_before, "storage_after": storage_bytes_after,
             "storage_growth": signed_delta(storage_bytes_after, storage_bytes_before),
         },
-        "phase_ms": { "setup": setup_phases, "preview": preview_phases, "merge": merge_phases },
+        "phase_ms": {
+            "setup": setup_phases,
+            "create_branches": branch_phases,
+            "preview": preview_phases,
+            "merge": merge_phases,
+        },
         "correctness": {
             "independent_three_way_model": true,
             "preview_non_mutating": true,


### PR DESCRIPTION
Branch creation validates its tracked branch descriptor against lix_commit. The derived provider previously materialized every historical commit before applying the exact UUID filter, making branch creation linear in repository history. This change routes finite UUID identities through lightweight commit-record point reads, preserves typed primary-key semantics, validates decoded identity, and retains the full scan for commit-edge or mixed-key queries.

Benchmark, RocksDB release, 10k rows / 100 changed rows / 1 divergent commit / 2 branches:
- Previous PR at 10k shared commits: about 33-37 ms, 100.1 MB allocated, about 12-13 MB incremental RSS.
- This PR at 0 shared commits: 6.74 ms, 14.586 MB allocated, 0.70 MB incremental RSS.
- This PR at 10k shared commits: 8.20 ms, 14.586 MB allocated, 0.97 MB incremental RSS.
- All-plugin cold-reopen merge: all correctness gates pass; preview 8.45 ms, merge 14.90 ms.

Validation:
- RUST_MIN_STACK=8388608 cargo test -p lix_engine --features all-simulations (1747 unit, 802 integration, 3 doctests)
- cargo test -p lix_engine --features all-simulations --test integration sql::lix_commit -q
- cargo clippy -p lix_engine --features all-simulations --all-targets -- -D warnings -A dead-code
- Independent agent review: no blockers

No changenote: internal performance optimization with no user-facing behavior change.