### PR TITLE
perf(engine): compact certified insert staging

### DIFF
--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -31,15 +31,16 @@ pub(crate) use row_materialization::{
 };
 pub(crate) use storage::{
     CommitDeltaChangeLocator, CommitDeltaMember, CommitDeltaPointReadCache,
-    commit_delta_contains_schema, direct_change_locator, load_change_record_by_id,
-    load_commit_delta_change_records, load_commit_delta_members_with_payloads,
-    load_commit_delta_members_with_payloads_for_schemas, load_commit_delta_selection_certificate,
-    load_owned_commit_delta_entries, load_owned_commit_delta_entries_one_ordered_ref,
-    scan_change_records_from_commit_deltas, scan_commit_delta_inventory, scan_commit_delta_values,
-    selected_change_selection_fingerprint, stage_addressable_commit_deltas,
-    stage_addressable_commit_deltas_with_selected_source, stage_change_locators,
-    stage_commit_deltas, stage_delete_change_locators, stage_delete_commit_delta_inventory_entry,
-    stage_delete_commit_roots, stage_ordered_addressable_commit_deltas,
+    OrderedAddressableCommitDeltaStage, commit_delta_contains_schema, direct_change_locator,
+    load_change_record_by_id, load_commit_delta_change_records,
+    load_commit_delta_members_with_payloads, load_commit_delta_members_with_payloads_for_schemas,
+    load_commit_delta_selection_certificate, load_owned_commit_delta_entries,
+    load_owned_commit_delta_entries_one_ordered_ref, scan_change_records_from_commit_deltas,
+    scan_commit_delta_inventory, scan_commit_delta_values, selected_change_selection_fingerprint,
+    stage_addressable_commit_deltas, stage_addressable_commit_deltas_with_selected_source,
+    stage_change_locators, stage_commit_deltas, stage_delete_change_locators,
+    stage_delete_commit_delta_inventory_entry, stage_delete_commit_roots,
+    stage_ordered_addressable_commit_deltas,
 };
 #[cfg(feature = "storage-benches")]
 pub(crate) use storage::{

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -405,33 +405,58 @@ pub(crate) struct AddressableCommitDeltaStage {
 
 /// Compact assignment map for an already ordered, fully addressable commit.
 ///
-/// Segment lengths reconstruct every direct change id in source order. This
-/// avoids retaining one UUID per row while the prepared batch and backend
+/// Full 512-row segments derive their direct addresses from the row ordinal.
+/// Byte-limited irregular segments retain one packed u32 address per row. Both
+/// shapes avoid retaining one UUID per row while the prepared batch and backend
 /// write batch are simultaneously live.
+#[derive(Debug, Clone)]
 pub(crate) struct OrderedAddressableCommitDeltaStage {
     commit_id: CommitId,
-    segment_row_counts: Vec<u16>,
+    change_addresses: OrderedChangeAddresses,
     row_count: usize,
+}
+
+#[derive(Debug, Clone)]
+enum OrderedChangeAddresses {
+    Dense,
+    Packed(Vec<u32>),
 }
 
 impl OrderedAddressableCommitDeltaStage {
     pub(crate) fn assigned_change_ids(
         &self,
     ) -> impl Iterator<Item = crate::changelog::ChangeId> + '_ {
-        let commit_id = self.commit_id;
-        self.segment_row_counts
-            .iter()
-            .enumerate()
-            .flat_map(move |(segment_index, &row_count)| {
-                (0..row_count).map(move |ordinal| {
-                    addressable_change_id(commit_id, segment_index, usize::from(ordinal))
-                        .expect("staged ordered address is inside the direct change-id space")
-                })
-            })
+        (0..self.row_count).map(|row_index| {
+            self.change_id_at(row_index)
+                .expect("ordered change assignment covers every row")
+        })
     }
 
     pub(crate) fn row_count(&self) -> usize {
         self.row_count
+    }
+
+    pub(crate) fn change_id_at(&self, row_index: usize) -> Option<crate::changelog::ChangeId> {
+        if row_index >= self.row_count {
+            return None;
+        }
+        let packed = match &self.change_addresses {
+            OrderedChangeAddresses::Dense => u32::try_from(row_index)
+                .expect("ordered commit-delta row index fits direct address space")
+                .checked_add(1)
+                .expect("ordered commit-delta address fits direct address space"),
+            OrderedChangeAddresses::Packed(addresses) => addresses[row_index],
+        };
+        Some(change_id_from_packed_address(self.commit_id, packed))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test_dense(commit_id: CommitId, row_count: usize) -> Self {
+        Self {
+            commit_id,
+            change_addresses: OrderedChangeAddresses::Dense,
+            row_count,
+        }
     }
 }
 
@@ -1222,7 +1247,7 @@ where
     let Some(first) = probe.next().transpose()? else {
         return Ok(Some(OrderedAddressableCommitDeltaStage {
             commit_id: CommitId::default(),
-            segment_row_counts: Vec::new(),
+            change_addresses: OrderedChangeAddresses::Dense,
             row_count: 0,
         }));
     };
@@ -1354,9 +1379,35 @@ where
         key(commit_delta_manifest_key(commit_id)),
         value(encode_commit_delta_manifest(&manifest)?),
     );
+    let dense_addresses = segment_row_counts
+        .iter()
+        .take(segment_row_counts.len().saturating_sub(1))
+        .all(|&count| usize::from(count) == COMMIT_DELTA_SEGMENT_MAX_ROWS);
+    let change_addresses = if dense_addresses {
+        OrderedChangeAddresses::Dense
+    } else {
+        let mut packed = Vec::with_capacity(row_count);
+        for (segment_index, &segment_rows) in segment_row_counts.iter().enumerate() {
+            let segment_base = u32::try_from(segment_index)
+                .expect("ordered commit-delta segment index fits u32")
+                .checked_mul(
+                    u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS)
+                        .expect("segment row limit fits u32"),
+                )
+                .expect("ordered commit-delta segment base fits direct address space");
+            packed.extend((0..segment_rows).map(|ordinal| {
+                segment_base
+                    .checked_add(u32::from(ordinal))
+                    .and_then(|address| address.checked_add(1))
+                    .expect("ordered commit-delta address fits u32")
+            }));
+        }
+        debug_assert_eq!(packed.len(), row_count);
+        OrderedChangeAddresses::Packed(packed)
+    };
     Ok(Some(OrderedAddressableCommitDeltaStage {
         commit_id,
-        segment_row_counts,
+        change_addresses,
         row_count,
     }))
 }
@@ -1696,11 +1747,13 @@ fn addressable_change_id(
                 "tracked_state commit_delta address exceeds u32",
             )
         })?;
+    Ok(change_id_from_packed_address(commit_id, packed))
+}
+
+fn change_id_from_packed_address(commit_id: CommitId, packed: u32) -> crate::changelog::ChangeId {
     let mut bytes = *commit_id.as_uuid().as_bytes();
     bytes[12..].copy_from_slice(&packed.to_be_bytes());
-    Ok(crate::changelog::ChangeId::new(uuid::Uuid::from_bytes(
-        bytes,
-    )))
+    crate::changelog::ChangeId::new(uuid::Uuid::from_bytes(bytes))
 }
 
 fn commit_delta_change_locators(
@@ -6068,6 +6121,106 @@ mod tests {
             assert_eq!(generic_loaded.created_at, loaded.created_at);
             assert_eq!(generic_loaded.origin_key, loaded.origin_key);
         }
+    }
+
+    #[tokio::test]
+    async fn irregular_ordered_segment_addresses_match_the_manifest() {
+        use std::fmt::Write as _;
+
+        const ROW_COUNT: usize = 700;
+        let storage = StorageAdapter::new(Memory::new());
+        let commit_id = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x0192_0000_0000_7000_8000_9876_0000_0000,
+        ));
+        let fixtures = (0..ROW_COUNT)
+            .map(|index| CommitDeltaFixture {
+                schema_key: "irregular".to_string(),
+                file_id: None,
+                entity_pk: EntityPk::single(format!("entity-{index:04}")),
+                change_id: ChangeId::for_test_label(&format!("irregular-change-{index}")),
+                deleted: false,
+                created_at: LixTimestamp::from_unix_millis_utc_lossy(index as i64),
+                updated_at: LixTimestamp::from_unix_millis_utc_lossy(index as i64 + 1),
+            })
+            .collect::<Vec<_>>();
+        let snapshots = (0..ROW_COUNT)
+            .map(|index| {
+                let mut state = (index as u64 + 1).wrapping_mul(0x9e37_79b9_7f4a_7c15);
+                let mut payload = String::with_capacity(1_024);
+                for _ in 0..64 {
+                    state ^= state << 13;
+                    state ^= state >> 7;
+                    state ^= state << 17;
+                    write!(&mut payload, "{state:016x}").expect("write deterministic payload");
+                }
+                format!(r#"{{"payload":"{payload}"}}"#)
+            })
+            .collect::<Vec<_>>();
+        let deltas = fixtures
+            .iter()
+            .zip(&snapshots)
+            .map(|(fixture, snapshot)| {
+                commit_delta_ref(
+                    commit_id,
+                    fixture,
+                    crate::json_store::JsonSlotRef::Inline(snapshot),
+                    crate::json_store::JsonSlotRef::None,
+                    None,
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut writes = storage.new_write_set();
+        let staged = super::stage_ordered_addressable_commit_deltas(
+            &mut writes,
+            deltas.iter().copied().map(Ok::<_, LixError>),
+            true,
+        )
+        .expect("irregular ordered deltas should stage")
+        .expect("certified ordered deltas should use the streaming route");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("irregular ordered deltas should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("irregular ordered read should open");
+        let certificate = super::load_commit_delta_selection_certificate(&read, commit_id)
+            .await
+            .expect("irregular selection certificate should load")
+            .expect("irregular ordered commit should have a certificate");
+        assert!(
+            certificate
+                .direct_segment_row_counts
+                .iter()
+                .take(certificate.direct_segment_row_counts.len() - 1)
+                .any(|&count| usize::from(count) < super::COMMIT_DELTA_SEGMENT_MAX_ROWS),
+            "payload bytes should force a non-final segment below the row limit"
+        );
+        let assigned = staged.assigned_change_ids().collect::<Vec<_>>();
+        assert_eq!(assigned.len(), ROW_COUNT);
+        assert_eq!(staged.change_id_at(ROW_COUNT), None);
+
+        let mut row_start = 0usize;
+        for (segment_index, &segment_rows) in
+            certificate.direct_segment_row_counts.iter().enumerate()
+        {
+            for row_index in [row_start, row_start + usize::from(segment_rows) - 1] {
+                assert_eq!(staged.change_id_at(row_index), Some(assigned[row_index]));
+                let locator = super::direct_change_locator(assigned[row_index])
+                    .expect("assigned id should carry a direct locator");
+                assert_eq!(locator.segment_index, segment_index as u32);
+                assert_eq!(locator.ordinal as usize, row_index - row_start);
+                let loaded = load_change_record_by_id(&read, assigned[row_index])
+                    .await
+                    .expect("irregular direct address should read")
+                    .expect("irregular direct address should resolve");
+                assert_eq!(loaded.entity_pk, fixtures[row_index].entity_pk);
+            }
+            row_start += usize::from(segment_rows);
+        }
+        assert_eq!(row_start, ROW_COUNT);
     }
 
     #[tokio::test]

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -1648,18 +1648,7 @@ async fn stage_tracked_commit_delta_index(
                 stage_ordered_addressable_commit_deltas(writes, deltas, order_certified)?
             };
             if let Some(ordered_stage) = ordered_stage {
-                if ordered_stage.row_count() != state_row_indices.len() {
-                    return Err(LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        "ordered commit-delta assignment count changed during staging",
-                    ));
-                }
-                for (&row_index, change_id) in state_row_indices
-                    .iter()
-                    .zip(ordered_stage.assigned_change_ids())
-                {
-                    state_rows.set_change_id(row_index, Some(change_id));
-                }
+                state_rows.set_ordered_addressable_change_ids(state_row_indices, ordered_stage)?;
                 ordered_addressable_commits.insert(root.commit_id);
                 continue;
             }

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -8247,7 +8247,10 @@ where
                 ))
                 .await?
         } else {
-            rows.into_prepared(self.origin_key.as_ref(), self.functions.call_timestamp())?
+            rows.into_dense_insert_prepared(
+                self.origin_key.as_ref(),
+                self.functions.call_timestamp(),
+            )?
         };
         if prepared.len() != row_count {
             return Err(LixError::new(

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -365,7 +365,7 @@ impl PreparedInsertSelection {
             row_count: 0,
             count: 0,
             bits: Vec::with_capacity(row_capacity.div_ceil(Self::WORD_BITS)),
-            origins: Vec::with_capacity(row_capacity),
+            origins: Vec::new(),
             statement_indices: Vec::new(),
             statement_indices_are_row_ordinals: false,
         }
@@ -392,7 +392,7 @@ impl PreparedInsertSelection {
 
     pub(crate) fn origin(&self, row_index: usize) -> Option<&TransactionWriteOrigin> {
         self.contains(row_index)
-            .then(|| self.origins[row_index].as_ref())
+            .then(|| self.origins.get(row_index).and_then(Option::as_ref))
             .flatten()
     }
 
@@ -405,7 +405,7 @@ impl PreparedInsertSelection {
             .map(|row_index| PreparedInsertRef {
                 row_index,
                 row: rows.row(row_index),
-                origin: self.origins[row_index].as_ref(),
+                origin: self.origins.get(row_index).and_then(Option::as_ref),
                 statement_index: self.statement_index(row_index),
             })
     }
@@ -433,8 +433,14 @@ impl PreparedInsertSelection {
         {
             *last = (1_u64 << (row_count % Self::WORD_BITS)) - 1;
         }
-        self.origins.resize(row_count, None);
         self.statement_indices_are_row_ordinals = true;
+    }
+
+    pub(crate) fn is_complete_ordinal_selection(&self, row_count: usize) -> bool {
+        self.row_count == row_count
+            && self.count == row_count
+            && self.statement_indices_are_row_ordinals
+            && self.origins.is_empty()
     }
 
     fn push_not_insert(&mut self) {
@@ -445,10 +451,7 @@ impl PreparedInsertSelection {
         if !may_insert && self.is_empty() {
             return;
         }
-        if self.origins.is_empty() {
-            self.origins
-                .reserve(self.row_count.saturating_add(additional));
-        } else {
+        if !self.origins.is_empty() {
             self.origins.reserve(additional);
         }
         let final_words = self
@@ -488,12 +491,18 @@ impl PreparedInsertSelection {
         if self.bits.is_empty() {
             self.bits
                 .resize(self.row_count.div_ceil(Self::WORD_BITS), 0);
-            self.origins.resize(self.row_count, None);
         }
         if self.bits[word] & mask == 0 {
             self.bits[word] |= mask;
             self.count += 1;
-            self.origins[row_index] = origin.cloned();
+            if let Some(origin) = origin {
+                if self.origins.is_empty() {
+                    self.origins.resize(self.row_count, None);
+                }
+                self.origins[row_index] = Some(origin.clone());
+            } else if !self.origins.is_empty() {
+                self.origins[row_index] = None;
+            }
         }
         if let Some(statement_index) = statement_index {
             let statement_index =
@@ -534,7 +543,10 @@ impl PreparedInsertSelection {
         let mut selected = Self::with_row_capacity(source_by_destination.len());
         for &source in source_by_destination {
             if self.contains(source) {
-                selected.push(self.origins[source].as_ref(), self.statement_index(source));
+                selected.push(
+                    self.origins.get(source).and_then(Option::as_ref),
+                    self.statement_index(source),
+                );
             } else {
                 selected.push_not_insert();
             }
@@ -548,7 +560,7 @@ impl PreparedInsertSelection {
         for row_index in 0..other_rows {
             if other.contains(row_index) {
                 self.push(
-                    other.origins[row_index].as_ref(),
+                    other.origins.get(row_index).and_then(Option::as_ref),
                     other.statement_index(row_index),
                 );
             } else {
@@ -3092,8 +3104,12 @@ mod tests {
     fn generic_insert_after_certified_batch_does_not_inherit_statement_index() {
         let mut selection = PreparedInsertSelection::new();
         selection.push_certified_ordinal_inserts(2);
+        assert!(selection.is_complete_ordinal_selection(2));
+        assert!(selection.origins.is_empty());
         selection.push(None, None);
 
+        assert!(!selection.is_complete_ordinal_selection(3));
+        assert!(selection.origins.is_empty());
         assert_eq!(selection.statement_index(0), Some(0));
         assert_eq!(selection.statement_index(1), Some(1));
         assert_eq!(selection.statement_index(2), None);
@@ -5005,7 +5021,7 @@ mod tests {
     }
 
     #[test]
-    fn ten_thousand_inserts_use_two_dense_buffers_and_no_identity_copies() {
+    fn ten_thousand_inserts_use_one_dense_buffer_and_no_identity_copies() {
         const ROW_COUNT: usize = 10_000;
         let staged_writes = test_staged_writes();
         let mut rows = PreparedStateBatch::with_capacity(ROW_COUNT);
@@ -5028,7 +5044,7 @@ mod tests {
             .drain()
             .expect("10k INSERT batch should drain");
         assert_eq!(drained.insert_selection.len(), ROW_COUNT);
-        assert_eq!(drained.insert_selection.large_buffer_count(), 2);
+        assert_eq!(drained.insert_selection.large_buffer_count(), 1);
         assert_eq!(drained.insert_selection.identity_copy_count(), 0);
         assert!(
             (0..ROW_COUNT).all(|row_index| drained.insert_selection.contains(row_index)),

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -16,7 +16,7 @@ use crate::common::{LixTimestamp, MutationIdentity, RequestBlobSpliceProvenance,
 use crate::entity_pk::EntityPk;
 use crate::json_store::JsonRef;
 use crate::live_state::{CertifiedCurrentStatePredecessor, MaterializedLiveStateRow};
-use crate::tracked_state::TrackedStateDiffIdentity;
+use crate::tracked_state::{OrderedAddressableCommitDeltaStage, TrackedStateDiffIdentity};
 use crate::wasm::{WasmCanonicalJson, WasmCanonicalJsonCertificateRef, WasmCertifiedEntityBatch};
 use bytes::Bytes;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -553,6 +553,80 @@ impl CertifiedParameterBatch {
         )
     }
 
+    pub(crate) fn into_dense_insert_prepared(
+        self,
+        origin_key: Option<&SharedStr>,
+        timestamp: LixTimestamp,
+    ) -> Result<PreparedStateBatch, LixError> {
+        let Self {
+            entity_pks,
+            snapshots,
+            schema_key,
+            branch_id,
+            certificate,
+        } = self;
+        let row_count = entity_pks.len();
+        let (mut strings, schema_key_ordinal, branch_id_ordinal) = if schema_key == branch_id {
+            (vec![schema_key], 0_u32, 0_u32)
+        } else {
+            (vec![schema_key, branch_id], 0_u32, 1_u32)
+        };
+        let origin_key = origin_key.map(|value| {
+            if let Some(ordinal) = strings.iter().position(|candidate| candidate == value) {
+                return u32::try_from(ordinal)
+                    .expect("certified replacement string dictionary must fit u32");
+            }
+            let ordinal = u32::try_from(strings.len())
+                .expect("certified replacement string dictionary must fit u32");
+            strings.push(value.clone());
+            ordinal
+        });
+        let mut json = Vec::with_capacity(row_count);
+        for snapshot in snapshots {
+            json.push(stage_json_from_value(
+                snapshot,
+                "certified parameter snapshot_content",
+            )?);
+        }
+        let string_index = strings
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(ordinal, value)| {
+                (
+                    value,
+                    u32::try_from(ordinal)
+                        .expect("certified replacement string dictionary must fit u32"),
+                )
+            })
+            .collect();
+        Ok(PreparedStateBatch {
+            slots: Vec::new(),
+            dense_certified_insert: Some(DenseCertifiedInsertSlots {
+                len: row_count,
+                schema_plan_id: certificate.schema_plan_id,
+                facts: certificate.facts,
+                schema_key: schema_key_ordinal,
+                origin_key,
+                timestamp,
+                commit_id: None,
+                branch_id: branch_id_ordinal,
+                direct_change_ids: None,
+            }),
+            entity_pks,
+            strings,
+            string_index,
+            json,
+            durable_predecessors: Vec::new(),
+            origins: Vec::new(),
+            origin_index: HashMap::new(),
+            origin_column_sets: Vec::new(),
+            origin_column_index: HashMap::new(),
+            certified_ordered_insert: certificate.tracked_keys_strictly_ordered,
+            certified_complete_collection_replacement: certificate.complete_collection_replacement,
+        })
+    }
+
     pub(crate) fn into_prepared(
         self,
         origin_key: Option<&SharedStr>,
@@ -588,17 +662,15 @@ impl CertifiedParameterBatch {
                 snapshot,
                 "certified replacement snapshot_content",
             )?);
+            let ordinal =
+                u32::try_from(row_index).expect("certified replacement row ordinal must fit u32");
             prepared_slots.push(PreparedStateSlot {
                 schema_plan_id: certificate.schema_plan_id,
                 facts: certificate.facts,
-                entity_pk: u32::try_from(row_index)
-                    .expect("certified replacement row ordinal must fit u32"),
+                entity_pk: ordinal,
                 schema_key: schema_key_ordinal,
                 file_id: None,
-                snapshot: Some(
-                    u32::try_from(row_index)
-                        .expect("certified replacement JSON ordinal must fit u32"),
-                ),
+                snapshot: Some(ordinal),
                 metadata: None,
                 origin: None,
                 origin_key,
@@ -627,6 +699,7 @@ impl CertifiedParameterBatch {
             .collect();
         Ok(PreparedStateBatch {
             slots: prepared_slots,
+            dense_certified_insert: None,
             entity_pks,
             strings,
             string_index,
@@ -1081,6 +1154,7 @@ impl RawWriteBatch {
         }
         Ok(PreparedStateBatch {
             slots: prepared_slots,
+            dense_certified_insert: None,
             entity_pks: prepared_entity_pks,
             strings,
             string_index,
@@ -2504,6 +2578,10 @@ impl TestPreparedStateRow {
 #[derive(Debug, Clone)]
 pub(crate) struct PreparedStateBatch {
     slots: Vec<PreparedStateSlot>,
+    /// Fixed-shape certified INSERTs keep batch-common facts once and derive
+    /// identity/JSON ordinals from the row position. Any operation that needs
+    /// row-local topology expands this representation into `slots`.
+    dense_certified_insert: Option<DenseCertifiedInsertSlots>,
     entity_pks: Vec<EntityPk>,
     strings: Vec<SharedStr>,
     string_index: HashMap<SharedStr, u32>,
@@ -2543,6 +2621,21 @@ struct PreparedStateSlot {
     untracked: bool,
     branch_id: u32,
     durable_predecessor: Option<u32>,
+}
+
+#[derive(Debug, Clone)]
+struct DenseCertifiedInsertSlots {
+    len: usize,
+    schema_plan_id: SchemaPlanId,
+    facts: PreparedRowFacts,
+    schema_key: u32,
+    origin_key: Option<u32>,
+    timestamp: LixTimestamp,
+    commit_id: Option<CommitId>,
+    branch_id: u32,
+    /// Absent until commit-delta publication assigns direct addresses. The
+    /// compact segment map derives every UUID without a million-row column.
+    direct_change_ids: Option<OrderedAddressableCommitDeltaStage>,
 }
 
 /// Borrowed row projection over a [`PreparedStateBatch`].
@@ -2604,6 +2697,7 @@ impl PreparedStateBatch {
     ) -> Self {
         Self {
             slots: Vec::with_capacity(row_capacity),
+            dense_certified_insert: None,
             entity_pks: Vec::with_capacity(row_capacity),
             // Most bulk batches share schema, branch, and origin descriptors;
             // file ids are the only commonly row-cardinal string. Reserving
@@ -2627,11 +2721,13 @@ impl PreparedStateBatch {
     }
 
     pub(crate) fn len(&self) -> usize {
-        self.slots.len()
+        self.dense_certified_insert
+            .as_ref()
+            .map_or_else(|| self.slots.len(), |dense| dense.len)
     }
 
     pub(crate) fn is_empty(&self) -> bool {
-        self.slots.is_empty()
+        self.len() == 0
     }
 
     pub(crate) fn certified_ordered_insert(&self) -> bool {
@@ -2655,6 +2751,38 @@ impl PreparedStateBatch {
     }
 
     pub(crate) fn get(&self, index: usize) -> Option<PreparedStateRowRef<'_>> {
+        if let Some(dense) = &self.dense_certified_insert {
+            if index >= dense.len {
+                return None;
+            }
+            return Some(PreparedStateRowRef {
+                schema_plan_id: dense.schema_plan_id,
+                facts: dense.facts,
+                entity_pk: &self.entity_pks[index],
+                schema_key: &self.strings[dense.schema_key as usize],
+                file_id: None,
+                snapshot: Some(&self.json[index]),
+                metadata: None,
+                origin: None,
+                origin_key: dense.origin_key.map(|index| &self.strings[index as usize]),
+                created_at: dense.timestamp,
+                updated_at: dense.timestamp,
+                global: false,
+                change_id: Some(dense.direct_change_ids.as_ref().map_or_else(
+                    ChangeId::default,
+                    |assignment| {
+                        assignment
+                            .change_id_at(index)
+                            .expect("dense direct change assignment covers every row")
+                    },
+                )),
+                addressable_change_id: true,
+                commit_id: dense.commit_id,
+                untracked: false,
+                branch_id: &self.strings[dense.branch_id as usize],
+                durable_predecessor: None,
+            });
+        }
         let slot = *self.slots.get(index)?;
         Some(PreparedStateRowRef {
             schema_plan_id: slot.schema_plan_id,
@@ -2782,6 +2910,7 @@ impl PreparedStateBatch {
         untracked: bool,
         branch_id: SharedStr,
     ) {
+        self.expand_dense_certified_insert();
         let entity_pk = self.push_entity_pk(entity_pk);
         let schema_key = self.intern_string(schema_key);
         let file_id = file_id.map(|value| self.intern_string(value));
@@ -2812,11 +2941,53 @@ impl PreparedStateBatch {
         });
     }
 
+    fn expand_dense_certified_insert(&mut self) {
+        let Some(dense) = self.dense_certified_insert.take() else {
+            return;
+        };
+        debug_assert!(self.slots.is_empty());
+        debug_assert_eq!(self.entity_pks.len(), dense.len);
+        debug_assert_eq!(self.json.len(), dense.len);
+        self.slots.reserve(dense.len);
+        for row_index in 0..dense.len {
+            let ordinal =
+                u32::try_from(row_index).expect("dense certified INSERT row ordinal must fit u32");
+            self.slots.push(PreparedStateSlot {
+                schema_plan_id: dense.schema_plan_id,
+                facts: dense.facts,
+                entity_pk: ordinal,
+                schema_key: dense.schema_key,
+                file_id: None,
+                snapshot: Some(ordinal),
+                metadata: None,
+                origin: None,
+                origin_key: dense.origin_key,
+                created_at: dense.timestamp,
+                updated_at: dense.timestamp,
+                global: false,
+                change_id: Some(dense.direct_change_ids.as_ref().map_or_else(
+                    ChangeId::default,
+                    |assignment| {
+                        assignment
+                            .change_id_at(row_index)
+                            .expect("dense direct change assignment covers every row")
+                    },
+                )),
+                addressable_change_id: true,
+                commit_id: dense.commit_id,
+                untracked: false,
+                branch_id: dense.branch_id,
+                durable_predecessor: None,
+            });
+        }
+    }
+
     pub(crate) fn set_durable_predecessor(
         &mut self,
         row: usize,
         value: Option<CertifiedCurrentStatePredecessor>,
     ) {
+        self.expand_dense_certified_insert();
         self.slots[row].durable_predecessor = value.map(|value| {
             let index = u32::try_from(self.durable_predecessors.len())
                 .expect("prepared durable predecessor column must fit u32");
@@ -2834,6 +3005,8 @@ impl PreparedStateBatch {
             *self = other;
             return;
         }
+        self.expand_dense_certified_insert();
+        other.expand_dense_certified_insert();
         self.certified_ordered_insert = false;
         self.certified_complete_collection_replacement = false;
         let entity_base =
@@ -2901,6 +3074,7 @@ impl PreparedStateBatch {
     }
 
     pub(crate) fn swap_rows(&mut self, left: usize, right: usize) {
+        self.expand_dense_certified_insert();
         self.certified_ordered_insert = false;
         self.certified_complete_collection_replacement = false;
         self.slots.swap(left, right);
@@ -2911,6 +3085,16 @@ impl PreparedStateBatch {
     /// Only compact slots move; typed owner columns remain stable and are
     /// still shared by the selected row ordinals.
     pub(crate) fn select_rows(&mut self, source_by_destination: &[usize]) {
+        if self.dense_certified_insert.is_some()
+            && source_by_destination.len() == self.len()
+            && source_by_destination
+                .iter()
+                .enumerate()
+                .all(|(destination, &source)| destination == source)
+        {
+            return;
+        }
+        self.expand_dense_certified_insert();
         self.certified_ordered_insert = false;
         self.certified_complete_collection_replacement = false;
         debug_assert!(
@@ -2954,6 +3138,10 @@ impl PreparedStateBatch {
     /// Unlike `select_rows`, this path allocates no O(live_rows) permutation
     /// buffers. Generic staging uses it for sparse point replacements.
     pub(crate) fn truncate_rows(&mut self, retained_len: usize) {
+        if self.dense_certified_insert.is_some() && retained_len == self.len() {
+            return;
+        }
+        self.expand_dense_certified_insert();
         if retained_len != self.slots.len() {
             self.certified_ordered_insert = false;
             self.certified_complete_collection_replacement = false;
@@ -2970,58 +3158,97 @@ impl PreparedStateBatch {
     }
 
     pub(crate) fn set_commit_id(&mut self, index: usize, commit_id: Option<CommitId>) {
+        self.expand_dense_certified_insert();
         self.slots[index].commit_id = commit_id;
     }
 
     pub(crate) fn set_commit_id_all(&mut self, commit_id: CommitId) {
+        if let Some(dense) = &mut self.dense_certified_insert {
+            dense.commit_id = Some(commit_id);
+            return;
+        }
         for slot in &mut self.slots {
             slot.commit_id = Some(commit_id);
         }
     }
 
     pub(crate) fn set_change_id(&mut self, index: usize, change_id: Option<ChangeId>) {
+        self.expand_dense_certified_insert();
         self.slots[index].change_id = change_id;
     }
 
+    pub(crate) fn set_ordered_addressable_change_ids(
+        &mut self,
+        row_indices: &[usize],
+        assignment: OrderedAddressableCommitDeltaStage,
+    ) -> Result<(), LixError> {
+        if assignment.row_count() != row_indices.len() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "ordered commit-delta assignment count changed during staging",
+            ));
+        }
+        if let Some(dense) = &mut self.dense_certified_insert
+            && row_indices.len() == dense.len
+            && row_indices
+                .iter()
+                .enumerate()
+                .all(|(index, &row_index)| index == row_index)
+        {
+            dense.direct_change_ids = Some(assignment);
+            return Ok(());
+        }
+        for (&row_index, change_id) in row_indices.iter().zip(assignment.assigned_change_ids()) {
+            self.set_change_id(row_index, Some(change_id));
+        }
+        Ok(())
+    }
+
     pub(crate) fn release_validated_canonical_value_columns(&mut self) {
-        let live_json_count = self
-            .slots
-            .iter()
-            .map(|slot| usize::from(slot.snapshot.is_some()) + usize::from(slot.metadata.is_some()))
-            .sum::<usize>();
-        #[cfg(debug_assertions)]
-        if live_json_count == self.json.len() {
-            let mut referenced = vec![false; self.json.len()];
-            for ordinal in self
+        if let Some(dense) = &self.dense_certified_insert {
+            debug_assert_eq!(dense.len, self.json.len());
+        } else {
+            let live_json_count = self
                 .slots
                 .iter()
-                .flat_map(|slot| [slot.snapshot, slot.metadata].into_iter().flatten())
-            {
-                assert!(
-                    !std::mem::replace(&mut referenced[ordinal as usize], true),
-                    "prepared JSON ordinals must remain unique"
-                );
-            }
-        }
-        if live_json_count != self.json.len() {
-            let old_json = std::mem::take(&mut self.json);
-            let mut ordinal_remap = vec![u32::MAX; old_json.len()];
-            let mut live_json = Vec::with_capacity(live_json_count);
-            for slot in &mut self.slots {
-                for ordinal in [&mut slot.snapshot, &mut slot.metadata] {
-                    let Some(old_ordinal) = *ordinal else {
-                        continue;
-                    };
-                    let remapped = &mut ordinal_remap[old_ordinal as usize];
-                    if *remapped == u32::MAX {
-                        *remapped = u32::try_from(live_json.len())
-                            .expect("prepared live JSON ordinal must fit u32");
-                        live_json.push(old_json[old_ordinal as usize].clone());
-                    }
-                    *ordinal = Some(*remapped);
+                .map(|slot| {
+                    usize::from(slot.snapshot.is_some()) + usize::from(slot.metadata.is_some())
+                })
+                .sum::<usize>();
+            #[cfg(debug_assertions)]
+            if live_json_count == self.json.len() {
+                let mut referenced = vec![false; self.json.len()];
+                for ordinal in self
+                    .slots
+                    .iter()
+                    .flat_map(|slot| [slot.snapshot, slot.metadata].into_iter().flatten())
+                {
+                    assert!(
+                        !std::mem::replace(&mut referenced[ordinal as usize], true),
+                        "prepared JSON ordinals must remain unique"
+                    );
                 }
             }
-            self.json = live_json;
+            if live_json_count != self.json.len() {
+                let old_json = std::mem::take(&mut self.json);
+                let mut ordinal_remap = vec![u32::MAX; old_json.len()];
+                let mut live_json = Vec::with_capacity(live_json_count);
+                for slot in &mut self.slots {
+                    for ordinal in [&mut slot.snapshot, &mut slot.metadata] {
+                        let Some(old_ordinal) = *ordinal else {
+                            continue;
+                        };
+                        let remapped = &mut ordinal_remap[old_ordinal as usize];
+                        if *remapped == u32::MAX {
+                            *remapped = u32::try_from(live_json.len())
+                                .expect("prepared live JSON ordinal must fit u32");
+                            live_json.push(old_json[old_ordinal as usize].clone());
+                        }
+                        *ordinal = Some(*remapped);
+                    }
+                }
+                self.json = live_json;
+            }
         }
         if self.json.is_empty() {
             return;
@@ -3084,6 +3311,20 @@ impl PreparedStateBatch {
         self.slots.as_ptr().cast()
     }
 
+    pub(crate) fn dense_certified_insert_summary(&self) -> Option<(PreparedRowFacts, &str, &str)> {
+        let dense = self.dense_certified_insert.as_ref()?;
+        Some((
+            dense.facts,
+            self.strings[dense.schema_key as usize].as_str(),
+            self.strings[dense.branch_id as usize].as_str(),
+        ))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_dense_certified_insert(&self) -> bool {
+        self.dense_certified_insert.is_some()
+    }
+
     #[cfg(test)]
     pub(crate) fn shared_string_count(&self) -> usize {
         self.strings.len()
@@ -3099,6 +3340,7 @@ impl PreparedStateBatch {
         index: usize,
         requires_transaction_validation: bool,
     ) {
+        self.expand_dense_certified_insert();
         self.slots[index].facts.requires_transaction_validation = requires_transaction_validation;
     }
 
@@ -3705,6 +3947,81 @@ impl StagedCommitChangeRefs {
 mod tests {
     use super::*;
     use crate::tracked_state::{TrackedStateDiffIdentity, TrackedStateKey};
+
+    #[test]
+    fn certified_parameter_rows_keep_batch_common_prepared_facts_dense() {
+        let entity_pks = vec![EntityPk::single("a"), EntityPk::single("b")];
+        let snapshots = [r#"{"id":"a"}"#, r#"{"id":"b"}"#]
+            .into_iter()
+            .map(|value| {
+                TransactionJson::from_certified_shared_normalized_row_content(value.into())
+            })
+            .collect::<Vec<_>>();
+        let certificate = CertifiedRawWriteBatchPreparation {
+            schema_plan_id: SchemaPlanId::for_test(7),
+            facts: PreparedRowFacts {
+                row_content_validated: true,
+                requires_transaction_validation: false,
+            },
+            tracked_keys_strictly_ordered: true,
+            complete_collection_replacement: false,
+        };
+        let timestamp = LixTimestamp::expect_parse("timestamp", "2026-08-02T00:00:00.000Z");
+        let mut prepared = CertifiedParameterInsertBatch::new(
+            entity_pks,
+            snapshots,
+            "dense_probe".into(),
+            "main".into(),
+            certificate,
+        )
+        .expect("certified rows should construct")
+        .into_dense_insert_prepared(None, timestamp)
+        .expect("certified rows should prepare");
+
+        assert!(prepared.is_dense_certified_insert());
+        assert!(prepared.slots.is_empty());
+        assert_eq!(prepared.len(), 2);
+        assert_eq!(prepared.first().unwrap().entity_pk, &EntityPk::single("a"));
+        assert_eq!(
+            prepared.last().unwrap().snapshot.unwrap().normalized(),
+            r#"{"id":"b"}"#
+        );
+        assert!(prepared.iter().all(|row| {
+            row.schema_key.as_str() == "dense_probe"
+                && row.branch_id.as_str() == "main"
+                && row.created_at == timestamp
+                && row.updated_at == timestamp
+                && row.change_id == Some(ChangeId::default())
+                && row.addressable_change_id
+        }));
+
+        let commit_id = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x0192_0000_0000_7000_8000_2468_0000_0000,
+        ));
+        prepared.set_commit_id_all(commit_id);
+        assert!(prepared.iter().all(|row| row.commit_id == Some(commit_id)));
+        let assignment = OrderedAddressableCommitDeltaStage::for_test_dense(commit_id, 2);
+        let assigned = assignment.assigned_change_ids().collect::<Vec<_>>();
+        prepared
+            .set_ordered_addressable_change_ids(&[0, 1], assignment)
+            .expect("dense direct addresses should assign");
+        assert_eq!(
+            prepared
+                .iter()
+                .map(|row| row.change_id.unwrap())
+                .collect::<Vec<_>>(),
+            assigned
+        );
+
+        prepared.set_requires_transaction_validation(0, true);
+        assert!(!prepared.is_dense_certified_insert());
+        assert_eq!(prepared.slots.len(), 2);
+        assert!(prepared.row(0).facts.requires_transaction_validation);
+        assert!(!prepared.row(1).facts.requires_transaction_validation);
+        assert_eq!(prepared.row(1).commit_id, Some(commit_id));
+        assert_eq!(prepared.row(0).change_id, Some(assigned[0]));
+        assert_eq!(prepared.row(1).change_id, Some(assigned[1]));
+    }
 
     #[test]
     fn ten_thousand_selected_changes_retain_one_shared_typed_batch() {

--- a/packages/engine/src/transaction/validation.rs
+++ b/packages/engine/src/transaction/validation.rs
@@ -449,6 +449,18 @@ fn row_local_certificates_cover_validation(staged_rows: &[PreparedValidationRow<
 /// and BTreeMap entry per row only to discover every schema scope can skip
 /// validation independently.
 pub(crate) fn prepared_tracked_rows_have_row_local_certificates(rows: &PreparedStateBatch) -> bool {
+    if let Some((facts, schema_key, _branch_id)) = rows.dense_certified_insert_summary() {
+        return !rows.is_empty()
+            && facts.row_content_validated
+            && !facts.requires_transaction_validation
+            && !matches!(
+                schema_key,
+                REGISTERED_SCHEMA_KEY
+                    | DIRECTORY_DESCRIPTOR_SCHEMA_KEY
+                    | FILE_DESCRIPTOR_SCHEMA_KEY
+                    | BRANCH_REF_SCHEMA_KEY
+            );
+    }
     !rows.is_empty()
         && rows.iter().all(|row| {
             row.facts.row_content_validated
@@ -1374,6 +1386,24 @@ pub(crate) async fn validate_certified_tracked_insert_identities(
     live_state: &dyn LiveStateReader,
     prepared_writes: &PreparedWriteSet,
 ) -> Result<(), LixError> {
+    if let Some((_facts, schema_key, branch_id)) =
+        prepared_writes.state_rows.dense_certified_insert_summary()
+        && prepared_writes
+            .insert_selection
+            .is_complete_ordinal_selection(prepared_writes.state_rows.len())
+    {
+        let scope = crate::collection_generation::CollectionScopeRef {
+            schema_key,
+            file_id: None,
+        };
+        if live_state
+            .collection_generation(branch_id, scope)
+            .await?
+            .is_some_and(|generation| generation.live_count == 0)
+        {
+            return Ok(());
+        }
+    }
     let mut inserts = prepared_writes
         .insert_selection
         .iter(&prepared_writes.state_rows);


### PR DESCRIPTION
## What changed

- represent large certified INSERT batches with one dense batch header instead of one ~128-byte prepared slot per row
- derive entity/snapshot ordinals and uniform row facts from the dense representation
- assign ordered direct change IDs through an O(1) hybrid address map: no row map for full 512-row segments, packed u32 addresses for byte-limited irregular segments
- keep the insert-origin column lazy when every origin is absent
- use dense/common-scope proofs to skip row-wide certificate and empty-collection validation scans
- explicitly expand to the generic representation for topology mutations, dependent/fallback batches, and per-row facts
- leave typed replacement/UPDATE, durable storage format, scan execution, packed-base decoding, diff, merge, and branch paths unchanged

No changenote.

## Why

After #1116, profiling a 1M-row public SQL INSERT still showed substantial CPU and RSS in typed-to-prepared staging, repeated prepared-row sweeps, and an all-None insert-origin column. The old prepared representation repeated batch-common facts per row and then wrote a UUID-sized change ID into every slot.

This cut keeps the dominant certified INSERT shape columnar/dense until a fallback genuinely needs row-local topology.

## Performance

Baseline is the immediately previous CRUD PR, #1116, using its exact benchmark binary.

Fresh-process protocol: one sample per process, discarded warmups, seven AB/BA pairs, same TMPDIR/filesystem, no tracing. Values below are median pairwise changes at 1M rows:

| Adapter | INSERT latency | Peak RSS |
| --- | ---: | ---: |
| RocksDB | **-14.0%** | -9.6% |
| SlateDB | **-21.3%** | -9.4% |

10k-row 31-sample controls:

| Adapter | #1116 | This PR | Change |
| --- | ---: | ---: | ---: |
| RocksDB | 25.39 ms | 23.82 ms | -6.2% |
| SlateDB | 22.24 ms | 22.13 ms | -0.5% |

After rebasing onto current main (#1117/#1118), a rebuilt 1M smoke pair remained faster: RocksDB 2.344 → 1.693 s and SlateDB 2.152 → 1.696 s.

## Correctness

- irregular byte-limited commit-delta segment test verifies packed addresses at every segment boundary against the encoded manifest and real point reads
- dense assignment followed by forced genericization preserves change IDs, commit ID, schema, snapshots, and validation facts
- replacement/UPDATE stays on the existing generic representation
- independent review found no correctness blocker in fallback, validation-proof, address-mapping, or diff/merge/branch behavior

## Validation

- `cargo test -p lix_engine --lib`: 1741 passed, 8 ignored
- `cargo test -p lix_engine --doc`: 3 passed
- `cargo clippy -p lix_engine --lib -- -D warnings`
- focused certified INSERT, certified replacement, irregular segment, selection, and executeBatch tests
