### PR TITLE
perf(sql): project direct primary-key scans

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/duckdb_public_result.mjs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/duckdb_public_result.mjs
@@ -19,12 +19,26 @@ const { version: duckdbNodeApiVersion } = require("@duckdb/node-api/package.json
 
 const rowCount = Number.parseInt(process.env.LIX_DUCKDB_ROW_COUNT ?? "1000000", 10);
 const sampleCount = Number.parseInt(process.env.LIX_DUCKDB_SAMPLES ?? "5", 10);
+const shape = process.env.LIX_DUCKDB_SHAPE ?? "full_result";
 
 if (!Number.isSafeInteger(rowCount) || rowCount <= 0) {
   throw new Error("LIX_DUCKDB_ROW_COUNT must be a positive safe integer");
 }
 if (!Number.isSafeInteger(sampleCount) || sampleCount <= 0) {
   throw new Error("LIX_DUCKDB_SAMPLES must be a positive safe integer");
+}
+
+const query = {
+  full_result: "SELECT path, value_json FROM json_pointer ORDER BY path",
+  general_filter_sort:
+    "SELECT path, value_json FROM json_pointer WHERE path IS NOT NULL ORDER BY value_json, path",
+  general_aggregate:
+    "SELECT COUNT(*) AS rows, MIN(path) AS first_path, MAX(path) AS last_path FROM json_pointer WHERE path IS NOT NULL",
+}[shape];
+if (query === undefined) {
+  throw new Error(
+    "LIX_DUCKDB_SHAPE must be full_result, general_filter_sort, or general_aggregate",
+  );
 }
 
 const db = await DuckDBInstance.create(":memory:");
@@ -41,14 +55,22 @@ await connection.run(`
 const samplesMs = [];
 for (let sample = 0; sample < sampleCount; sample += 1) {
   const started = process.hrtime.bigint();
-  const reader = await connection.runAndReadAll(
-    "SELECT path, value_json FROM json_pointer ORDER BY path",
-  );
+  const reader = await connection.runAndReadAll(query);
   const rows = [];
   for (const row of reader.getRows()) {
-    rows.push([String(row[0]), JSON.parse(String(row[1]))]);
+    rows.push(
+      shape === "general_aggregate"
+        ? [Number(row[0]), String(row[1]), String(row[2])]
+        : [String(row[0]), JSON.parse(String(row[1]))],
+    );
   }
-  if (rows.length !== rowCount || rows.at(-1)[1].ordinal !== rowCount - 1) {
+  const expectedRows = shape === "general_aggregate" ? 1 : rowCount;
+  if (
+    rows.length !== expectedRows ||
+    (shape === "general_aggregate"
+      ? rows[0][0] !== rowCount
+      : rows.at(-1)[1].ordinal !== rowCount - 1)
+  ) {
     throw new Error("DuckDB public-result control returned unexpected rows");
   }
   samplesMs.push(Number(process.hrtime.bigint() - started) / 1e6);
@@ -59,6 +81,7 @@ console.log(
   JSON.stringify({
     duckdb_node_api_version: duckdbNodeApiVersion,
     node_version: process.version,
+    shape,
     row_count: rowCount,
     samples_ms: samplesMs,
     median_ms: samplesMs[Math.floor(samplesMs.length / 2)],

--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -254,11 +254,11 @@ fn profile_operation(runtime: &tokio::runtime::Runtime, rows: &[WorkloadRow]) {
             "unknown LIX_TRACKED_STATE_CRUD_PROFILE_OP '{other}'; expected insert_all, read_all, read_one, read_many, update_all, update_one, delete_all, or delete_one"
         ),
     };
-    if sql_session_read_shape() == "aggregate_count" {
+    if sql_session_read_shape() != "full_result" {
         assert_eq!(
             std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_LAYER").as_deref(),
             Ok("sql_session"),
-            "LIX_TRACKED_STATE_CRUD_PROFILE_READ_SHAPE=aggregate_count requires LIX_TRACKED_STATE_CRUD_PROFILE_LAYER=sql_session"
+            "non-default LIX_TRACKED_STATE_CRUD_PROFILE_READ_SHAPE values require LIX_TRACKED_STATE_CRUD_PROFILE_LAYER=sql_session"
         );
     }
     let read_many_pk_count = profile_read_many_pk_count(operation, rows.len());
@@ -534,9 +534,11 @@ fn profile_hot_transaction_operations(
 fn sql_session_read_shape() -> &'static str {
     match std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_READ_SHAPE").as_deref() {
         Ok("aggregate_count") => "aggregate_count",
+        Ok("general_filter_sort") => "general_filter_sort",
+        Ok("general_aggregate") => "general_aggregate",
         Ok("full_result") | Err(_) => "full_result",
         Ok(other) => panic!(
-            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_READ_SHAPE '{other}'; expected full_result or aggregate_count"
+            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_READ_SHAPE '{other}'; expected full_result, aggregate_count, general_filter_sort, or general_aggregate"
         ),
     }
 }

--- a/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
@@ -13,6 +13,13 @@ const BOUND_SEED_JSON_SQL: &str =
     "INSERT INTO json_pointer (path, value) VALUES ($1, lix_json($2))";
 const BOUND_UPDATE_ALL_SQL: &str = "UPDATE json_pointer SET value = lix_json($1) WHERE path = $2";
 const UNTRACKED_PROBE_PATH: &str = "/__lix_untracked_probe";
+// These deliberately miss the native entity-read recognizer so profile mode
+// can measure the general DataFusion execution path rather than a specialized
+// public CRUD fast path.
+const GENERAL_FILTER_SORT_SQL: &str =
+    "SELECT path, value FROM json_pointer WHERE path IS NOT NULL ORDER BY value, path";
+const GENERAL_AGGREGATE_SQL: &str = "SELECT COUNT(*) AS rows, MIN(path) AS first_path, MAX(path) AS last_path \
+    FROM json_pointer WHERE path IS NOT NULL";
 type SharedParameterBatch = Arc<[Arc<[Value]>]>;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -216,10 +223,14 @@ impl SqlFixture {
     }
 
     pub(crate) async fn read_all(&self) -> usize {
-        if std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_READ_SHAPE").as_deref()
-            == Ok("aggregate_count")
-        {
-            return self.count_all().await;
+        match std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_READ_SHAPE").as_deref() {
+            Ok("aggregate_count") => return self.count_all().await,
+            Ok("general_filter_sort") => return self.general_filter_sort_all().await,
+            Ok("general_aggregate") => return self.general_aggregate().await,
+            Ok("full_result") | Err(_) => {}
+            Ok(other) => panic!(
+                "unknown LIX_TRACKED_STATE_CRUD_PROFILE_READ_SHAPE '{other}'; expected full_result, aggregate_count, general_filter_sort, or general_aggregate"
+            ),
         }
         match self {
             Self::SQLite(fixture) => fixture.read_all().await,
@@ -238,6 +249,24 @@ impl SqlFixture {
             Self::RocksDB(fixture) => fixture.count_all().await,
             #[cfg(feature = "slatedb")]
             Self::SlateDB(fixture) => fixture.count_all().await,
+        }
+    }
+
+    async fn general_filter_sort_all(&self) -> usize {
+        match self {
+            Self::SQLite(fixture) => fixture.general_filter_sort_all().await,
+            Self::RocksDB(fixture) => fixture.general_filter_sort_all().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.general_filter_sort_all().await,
+        }
+    }
+
+    async fn general_aggregate(&self) -> usize {
+        match self {
+            Self::SQLite(fixture) => fixture.general_aggregate().await,
+            Self::RocksDB(fixture) => fixture.general_aggregate().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.general_aggregate().await,
         }
     }
 
@@ -440,6 +469,23 @@ where
             execute(&self.session, "SELECT COUNT(*) AS count FROM json_pointer").await,
         );
         assert_eq!(result.columns(), ["count"]);
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result.rows()[0].get_index(0),
+            Some(&Value::Integer(self.visible_row_count as i64))
+        );
+        1
+    }
+
+    async fn general_filter_sort_all(&self) -> usize {
+        let result = std::hint::black_box(execute(&self.session, GENERAL_FILTER_SORT_SQL).await);
+        assert_eq!(result.len(), self.visible_row_count);
+        result.len()
+    }
+
+    async fn general_aggregate(&self) -> usize {
+        let result = std::hint::black_box(execute(&self.session, GENERAL_AGGREGATE_SQL).await);
+        assert_eq!(result.columns(), ["rows", "first_path", "last_path"]);
         assert_eq!(result.len(), 1);
         assert_eq!(
             result.rows()[0].get_index(0),

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -337,6 +337,32 @@ where
         }))
     }
 
+    /// Returns committed entity identities under the same narrow visibility
+    /// proof as [`Self::scan_direct_entity_snapshots`].  The packed reader
+    /// still resolves the authoritative current rows; callers may avoid JSON
+    /// decoding only when their projected SQL fields are exact key components.
+    pub(crate) async fn scan_direct_entity_primary_keys(
+        &self,
+        request: &LiveStateScanRequest,
+    ) -> Result<Option<Vec<EntityPk>>, LixError> {
+        let Some((branch_id, control, schema_key)) =
+            self.direct_entity_snapshot_scope(request).await?
+        else {
+            return Ok(None);
+        };
+        self.tracked_head
+            .reader(&self.store)
+            .scan_entity_primary_keys(
+                &branch_id,
+                control,
+                &schema_key,
+                &request.filter.entity_pks,
+                request.limit,
+            )
+            .await
+            .map(Some)
+    }
+
     pub(crate) async fn scan_direct_entity_snapshots_by_string_field(
         &self,
         request: &LiveStateScanRequest,

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -4248,6 +4248,43 @@ where
         .await
     }
 
+    pub(crate) async fn scan_entity_primary_keys(
+        &self,
+        branch_id: &str,
+        control: BranchHeadControl,
+        schema_key: &str,
+        entity_pks: &[EntityPk],
+        limit: Option<usize>,
+    ) -> Result<Vec<EntityPk>, LixError> {
+        if matches!(limit, Some(0)) {
+            return Ok(Vec::new());
+        }
+        let rows = self
+            .scan_live_batch_for_generation(
+                branch_id,
+                control.generation,
+                control.working_diff_checkpoint_commit_id,
+                &TrackedStateScanRequest {
+                    filter: TrackedStateFilter {
+                        schema_keys: vec![schema_key.to_owned()],
+                        entity_pks: entity_pks.to_vec(),
+                        include_tombstones: false,
+                        ..TrackedStateFilter::default()
+                    },
+                    // Retain the packed broad-scan route, which resolves the
+                    // same committed winners as snapshot scans. The provider
+                    // drops these bytes before Arrow conversion because only
+                    // the identity columns were requested.
+                    read_columns: TrackedStateReadColumns {
+                        columns: vec!["snapshot_content".to_owned()],
+                    },
+                    limit,
+                },
+            )
+            .await?;
+        Ok(rows.into_identity_ordered_primary_keys())
+    }
+
     #[cfg(test)]
     pub(crate) async fn scan_live_rows_if_current(
         &self,

--- a/packages/engine/src/live_state/types.rs
+++ b/packages/engine/src/live_state/types.rs
@@ -233,6 +233,28 @@ impl MaterializedLiveStateBatch {
             .collect()
     }
 
+    /// Consumes the batch into entity keys ordered by their logical primary
+    /// key.  The direct SQL provider uses this when its entire visible
+    /// projection is primary-key columns, so no snapshot JSON needs decoding.
+    pub(crate) fn into_identity_ordered_primary_keys(mut self) -> Vec<EntityPk> {
+        if let Some(singleton) = self.singleton.take() {
+            return vec![singleton.row.entity_pk];
+        }
+        let mut ordinals = (0..self.len()).collect::<Vec<_>>();
+        if !ordinals.is_sorted_by(|left, right| self.entity_pks[*left] <= self.entity_pks[*right]) {
+            ordinals.sort_unstable_by(|left, right| {
+                self.entity_pks[*left].cmp(&self.entity_pks[*right])
+            });
+        }
+        if ordinals.iter().copied().eq(0..self.len()) {
+            return self.entity_pks;
+        }
+        ordinals
+            .into_iter()
+            .map(|index| self.entity_pks[index].clone())
+            .collect()
+    }
+
     fn terminal_branch_owners(&self) -> Vec<Option<Arc<str>>> {
         if let Some(singleton) = &self.singleton {
             return vec![Some(Arc::clone(&singleton.row.branch_id))];

--- a/packages/engine/src/sql2/entity_batch.rs
+++ b/packages/engine/src/sql2/entity_batch.rs
@@ -12,6 +12,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 
 use crate::LixError;
+use crate::entity_pk::EntityPk;
 use crate::live_state::{LiveStateContext, LiveStateRowFilter, LiveStateScanRequest};
 use crate::storage_adapter::StorageAdapterRead;
 
@@ -41,6 +42,17 @@ pub(crate) trait EntitySnapshotReader: Send + Sync {
         &self,
         request: LiveStateScanRequest,
     ) -> Result<Option<Vec<Option<Bytes>>>, LixError>;
+
+    /// Returns primary keys from the same committed direct-scan proof as raw
+    /// snapshots. Providers use this only when every projected SQL field is
+    /// an exact primary-key component, avoiding a redundant JSON decode while
+    /// leaving all relational operators to DataFusion.
+    async fn scan_entity_primary_keys(
+        &self,
+        _request: LiveStateScanRequest,
+    ) -> Result<Option<Vec<EntityPk>>, LixError> {
+        Ok(None)
+    }
 
     async fn scan_entity_snapshots_by_string_field(
         &self,
@@ -91,6 +103,19 @@ where
         self.live_state
             .reader(self.store.clone())
             .scan_direct_entity_snapshots(&request)
+            .await
+    }
+
+    async fn scan_entity_primary_keys(
+        &self,
+        request: LiveStateScanRequest,
+    ) -> Result<Option<Vec<EntityPk>>, LixError> {
+        if !direct_entity_snapshot_request(&request) {
+            return Ok(None);
+        }
+        self.live_state
+            .reader(self.store.clone())
+            .scan_direct_entity_primary_keys(&request)
             .await
     }
 

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -337,6 +337,8 @@ impl TableSpec for EntitySpec {
         let direct_entity_snapshot = direct_entity_batch_eligible(&schema, &request, &row_filters)
             .then(|| self.entity_snapshot_reader.clone())
             .flatten();
+        let direct_primary_key_projection =
+            direct_primary_key_projection_eligible(&self.spec, &schema, &request, &row_filters);
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
             ordering: None,
@@ -349,6 +351,7 @@ impl TableSpec for EntitySpec {
                     row_filters,
                     batch_projection,
                     direct_entity_snapshot,
+                    direct_primary_key_projection,
                 ),
                 |(
                     spec,
@@ -358,7 +361,17 @@ impl TableSpec for EntitySpec {
                     row_filters,
                     batch_projection,
                     direct_entity_snapshot,
+                    direct_primary_key_projection,
                 )| async move {
+                    if direct_primary_key_projection
+                        && let Some(direct_entity_snapshot) = direct_entity_snapshot.as_ref()
+                        && let Some(entity_pks) = direct_entity_snapshot
+                            .scan_entity_primary_keys(request.clone())
+                            .await
+                            .map_err(lix_error_to_datafusion_error)?
+                    {
+                        return entity_primary_key_record_batch(&spec, schema, entity_pks);
+                    }
                     if let Some(direct_entity_snapshot) = direct_entity_snapshot
                         && let Some(rows) = direct_entity_snapshot
                             .scan_entity_snapshots(request.clone())
@@ -1463,6 +1476,41 @@ fn direct_entity_batch_eligible(
             .all(|field| !field.name().starts_with("lixcol_"))
 }
 
+/// A provider-level physical projection: all requested columns are simple
+/// string primary-key components stored verbatim in the current-state key.
+/// DataFusion still plans and executes every relational operator above this
+/// scan; the provider merely avoids JSON decoding to reproduce identity data.
+fn direct_primary_key_projection_eligible(
+    spec: &EntitySurfaceSpec,
+    schema: &Schema,
+    request: &LiveStateScanRequest,
+    row_filters: &[EntityRowFilter],
+) -> bool {
+    direct_entity_batch_eligible(schema, request, row_filters)
+        // Exact key reads retain the established point-snapshot cache. This
+        // broad-scan projection is an OLAP lane, not a replacement for OLTP
+        // point serving.
+        && request.filter.entity_pks.is_empty()
+        && !schema.fields().is_empty()
+        && schema
+            .fields()
+            .iter()
+            .all(|field| simple_string_primary_key_index(spec, field.name()).is_some())
+}
+
+fn simple_string_primary_key_index(spec: &EntitySurfaceSpec, column_name: &str) -> Option<usize> {
+    spec.primary_key_paths
+        .iter()
+        .position(|path| matches!(path.as_slice(), [name] if name == column_name))
+        .filter(|index| {
+            spec.primary_key_component_types.get(*index)
+                == Some(&crate::entity_pk::EntityPkComponentType::String)
+                && spec
+                    .visible_column(column_name)
+                    .is_some_and(|column| column.column_type == EntityColumnType::String)
+        })
+}
+
 /// Selects the snapshot-to-Arrow implementation once per provider batch.
 ///
 /// Exact primary-key scans retain their established serde-value fallback when
@@ -1527,6 +1575,38 @@ fn entity_record_batch_with_parsed(
             entity_record_batch_from_snapshots(spec, schema, rows)
         }
     }
+}
+
+fn entity_primary_key_record_batch(
+    spec: &EntitySurfaceSpec,
+    schema: SchemaRef,
+    entity_pks: Vec<EntityPk>,
+) -> Result<RecordBatch> {
+    let columns = schema
+        .fields()
+        .iter()
+        .map(|field| {
+            let component_index = simple_string_primary_key_index(spec, field.name()).ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "entity primary-key projection cannot serve column '{}' for schema '{}'",
+                    field.name(), spec.schema_key
+                ))
+            })?;
+            let values = entity_pks
+                .iter()
+                .map(|entity_pk| match entity_pk.components.as_slice().get(component_index) {
+                    Some(crate::entity_pk::EntityPkComponent::String(value)) => Ok(Some(value.as_ref())),
+                    _ => Err(DataFusionError::Execution(format!(
+                        "entity primary-key projection found an invalid key component for schema '{}' column '{}'",
+                        spec.schema_key, field.name()
+                    ))),
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let array: ArrayRef = Arc::new(StringArray::from(values));
+            Ok(array)
+        })
+        .collect::<Result<Vec<_>>>()?;
+    RecordBatch::try_new(schema, columns).map_err(DataFusionError::from)
 }
 
 fn entity_record_batch_from_snapshots(
@@ -1797,7 +1877,7 @@ mod tests {
     use std::sync::Arc;
 
     use async_trait::async_trait;
-    use datafusion::arrow::array::{Float64Array, Int64Array};
+    use datafusion::arrow::array::{Float64Array, Int64Array, StringArray};
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::arrow::record_batch::RecordBatch;
     use datafusion::catalog::TableProvider;
@@ -2082,6 +2162,52 @@ mod tests {
                 column_type: EntityColumnType::String,
                 value: super::EntityFilterValue::String("hello".to_string()),
             }]
+        ));
+    }
+
+    #[test]
+    fn direct_primary_key_projection_uses_identity_columns_without_snapshot_decode() {
+        let spec = entity_insert_spec_with_primary_key();
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Utf8, false)]));
+        let request = LiveStateScanRequest::default();
+        assert!(super::direct_primary_key_projection_eligible(
+            &spec,
+            schema.as_ref(),
+            &request,
+            &[]
+        ));
+
+        let batch = super::entity_primary_key_record_batch(
+            &spec,
+            Arc::clone(&schema),
+            vec![crate::entity_pk::EntityPk::single("identity-1")],
+        )
+        .expect("identity projection should build an Arrow batch");
+        let values = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("identity column should be utf8");
+        assert_eq!(values.value(0), "identity-1");
+
+        let payload_schema = Schema::new(vec![Field::new("body", DataType::Utf8, true)]);
+        assert!(!super::direct_primary_key_projection_eligible(
+            &spec,
+            &payload_schema,
+            &request,
+            &[]
+        ));
+
+        let mut exact_request = request.clone();
+        exact_request
+            .filter
+            .entity_pks
+            .push(crate::entity_pk::EntityPk::single("identity-1"));
+        assert!(!super::direct_primary_key_projection_eligible(
+            &spec,
+            schema.as_ref(),
+            &exact_request,
+            &[]
         ));
     }
 

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -1877,7 +1877,7 @@ mod tests {
     use std::sync::Arc;
 
     use async_trait::async_trait;
-    use datafusion::arrow::array::{Float64Array, Int64Array, StringArray};
+    use datafusion::arrow::array::{Float64Array, Int64Array};
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::arrow::record_batch::RecordBatch;
     use datafusion::catalog::TableProvider;
@@ -2186,7 +2186,7 @@ mod tests {
         let values = batch
             .column(0)
             .as_any()
-            .downcast_ref::<StringArray>()
+            .downcast_ref::<datafusion::arrow::array::StringArray>()
             .expect("identity column should be utf8");
         assert_eq!(values.value(0), "identity-1");
 


### PR DESCRIPTION
## What changed

- Adds forced-general DataFusion scan and aggregate benchmark shapes with matched DuckDB controls.
- Projects broad top-level string primary-key scans from the committed packed identity plane, avoiding redundant JSON-to-Arrow decoding.
- Retains cached exact point reads and all payload/system projections on the established paths.

## Why

A 1M-row general DataFusion aggregate was dominated by snapshot JSON decode before DataFusion could aggregate. This physical projection keeps DataFusion responsible for the predicate and aggregate while using the exact stored primary key.

## Performance

1M rows, hot SQL-session profile, forced-general `WHERE path IS NOT NULL` + `COUNT/MIN/MAX`, 3 repeats:

- RocksDB: 763.6 ms → 625.3 ms (18.1% faster)
- SlateDB: 838.0 ms → 620.3 ms (26.0% faster)
- Matched DuckDB control: 10.3 ms median; this PR is intentionally a bridge, not the 1.5× solution.

## Validation

- `cargo test -p lix_engine sql2::providers::entity::tests --lib --no-fail-fast` (29 passed)
- `cargo check -p lix_engine_benchmarks --bench tracked_state_crud --features storage-benches,rocksdb,slatedb`
- `node --check packages/engine-benchmarks/benches/tracked_state_crud/duckdb_public_result.mjs`
- Sub-agent architecture and semantic review completed.