### PR TITLE
refactor(engine): generalize derived live-state access paths

### DIFF
--- a/packages/engine/src/commit_graph/context.rs
+++ b/packages/engine/src/commit_graph/context.rs
@@ -16,8 +16,7 @@ use crate::changelog::{
 use crate::commit_graph::walker::{best_common_ancestors, walk_reachable_commits};
 use crate::commit_graph::{
     CommitGraphChange, CommitGraphChangeHistoryEntry, CommitGraphChangeHistoryRequest,
-    CommitGraphCommit, CommitGraphCommitRecord, CommitGraphEdge, CommitGraphReader,
-    ReachableCommitGraphCommit,
+    CommitGraphCommit, CommitGraphCommitRecord, CommitGraphReader, ReachableCommitGraphCommit,
 };
 use crate::entity_pk::EntityPk;
 use crate::storage_adapter::StorageAdapterRead;
@@ -202,22 +201,6 @@ where
                     .collect(),
             )),
         }
-    }
-
-    /// Derives parent/child edges from parsed commits.
-    pub(crate) fn commit_edges(&self, commits: &[CommitGraphCommit]) -> Vec<CommitGraphEdge> {
-        commits
-            .iter()
-            .flat_map(|commit| {
-                commit.parent_commit_ids.iter().enumerate().map(
-                    |(parent_order, parent_commit_id)| CommitGraphEdge {
-                        parent_commit_id: *parent_commit_id,
-                        child_commit_id: commit.commit_id,
-                        parent_order: parent_order as u32,
-                    },
-                )
-            })
-            .collect()
     }
 
     /// Returns canonical changes reachable from `start_commit_id`.
@@ -662,22 +645,15 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn commit_edges_are_derived_from_parent_commit_ids() {
-        let graph = CommitGraphContext::new();
-        let storage = StorageAdapter::new(Memory::new());
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("read should open");
-        let reader = graph.reader(read);
+    #[test]
+    fn commit_edges_are_derived_from_parent_commit_ids() {
         let commits = vec![parsed_commit(
             "commit-head",
             &[],
             &["commit-left", "commit-right"],
         )];
 
-        let edges = reader.commit_edges(&commits);
+        let edges = crate::commit_graph::commit_edges(&commits);
 
         assert_eq!(
             edges

--- a/packages/engine/src/commit_graph/mod.rs
+++ b/packages/engine/src/commit_graph/mod.rs
@@ -6,5 +6,5 @@ pub(crate) use context::{CommitGraphContext, CommitGraphStoreReader};
 pub(crate) use types::{
     CommitGraphChange, CommitGraphChangeHistoryEntry, CommitGraphChangeHistoryRequest,
     CommitGraphCommit, CommitGraphCommitRecord, CommitGraphEdge, CommitGraphReader,
-    ReachableCommitGraphCommit,
+    ReachableCommitGraphCommit, commit_edges,
 };

--- a/packages/engine/src/commit_graph/types.rs
+++ b/packages/engine/src/commit_graph/types.rs
@@ -57,6 +57,23 @@ pub(crate) struct CommitGraphEdge {
     pub(crate) parent_order: u32,
 }
 
+pub(crate) fn commit_edges(commits: &[CommitGraphCommit]) -> Vec<CommitGraphEdge> {
+    commits
+        .iter()
+        .flat_map(|commit| {
+            commit
+                .parent_commit_ids
+                .iter()
+                .enumerate()
+                .map(|(parent_order, parent_commit_id)| CommitGraphEdge {
+                    parent_commit_id: *parent_commit_id,
+                    child_commit_id: commit.commit_id,
+                    parent_order: parent_order as u32,
+                })
+        })
+        .collect()
+}
+
 /// Filter for canonical change history from a chosen traversal start commit.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct CommitGraphChangeHistoryRequest {

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -3,10 +3,11 @@
 use super::EntitySnapshotFieldIndexCache;
 use crate::GLOBAL_BRANCH_ID;
 use crate::LixError;
-use crate::NullableKeyFilter;
-use crate::branch::{BRANCH_REF_SCHEMA_KEY, BranchHeadControl, BranchHeadControlContext};
+#[cfg(test)]
+use crate::branch::BRANCH_REF_SCHEMA_KEY;
+use crate::branch::{BranchHeadControl, BranchHeadControlContext};
 use crate::changelog::CommitId;
-use crate::commit_graph::{CommitGraphCommitRecord, CommitGraphContext};
+use crate::commit_graph::CommitGraphContext;
 use crate::entity_pk::EntityPk;
 use crate::filesystem::{
     FilesystemPathIndex, FilesystemPathIndexCache, FilesystemPathIndexReader,
@@ -28,7 +29,10 @@ use bytes::Bytes;
 use futures_util::{StreamExt, TryStreamExt, stream};
 use std::mem::size_of;
 use std::sync::Mutex as StdMutex;
-use tracing::Instrument;
+
+use super::derived::{
+    is_derived_only_request, is_derived_schema, request_may_include_derived, scan_derived_rows,
+};
 
 const BRANCH_READ_CONCURRENCY: usize = 8;
 const ENTITY_POINT_SNAPSHOT_CACHE_MAX_BYTES: usize = 8 * 1024 * 1024;
@@ -138,9 +142,6 @@ fn entity_point_snapshot_cache_disabled_for_profile() -> bool {
 const fn entity_point_snapshot_cache_disabled_for_profile() -> bool {
     false
 }
-
-const COMMIT_SCHEMA_KEY: &str = "lix_commit";
-const COMMIT_EDGE_SCHEMA_KEY: &str = "lix_commit_edge";
 
 /// Serving facade for visible live-state reads.
 ///
@@ -395,14 +396,7 @@ where
     ) -> Result<Option<(String, BranchHeadControl, String)>, LixError> {
         // The hot index carries tracked and untracked rows in one serving
         // plane, so this route never probes a separate retention index.
-        if request.filter.untracked.is_some()
-            || request_may_include_commit_derived(request)
-            || request
-                .filter
-                .schema_keys
-                .iter()
-                .any(|schema_key| schema_key == BRANCH_REF_SCHEMA_KEY)
-        {
+        if request.filter.untracked.is_some() || request_may_include_derived(request) {
             return Ok(None);
         }
         let [schema_key] = request.filter.schema_keys.as_slice() else {
@@ -457,7 +451,7 @@ where
         skip_proven_empty_schema: bool,
     ) -> Result<MaterializedLiveStateBatch, LixError> {
         let store = &self.store;
-        let reads_tracked = !is_commit_derived_only_request(request);
+        let reads_tracked = !is_derived_only_request(request);
         let scope = scan_scope(
             store,
             request,
@@ -471,28 +465,22 @@ where
         if let Some(rows) = self.scan_direct_entity_pk_batch(request, &scope).await? {
             return Ok(rows);
         }
-        let commit_derived_rows = if request.filter.untracked != Some(true) {
-            MaterializedLiveStateBatch::from_rows(
-                scan_commit_derived_rows(store, &self.commit_graph, request, &scope).await?,
+        let derived_rows = MaterializedLiveStateBatch::from_rows(
+            scan_derived_rows(
+                store,
+                &self.commit_graph,
+                request,
+                &scope.projection_branch_ids,
+                &scope.storage_branch_ids,
+                request.filter.untracked,
             )
-        } else {
-            MaterializedLiveStateBatch::default()
-        };
-        let mut hot_branch_rows = if !is_commit_derived_only_request(request) {
+            .await?,
+        );
+        let mut hot_branch_rows = if !is_derived_only_request(request) {
             self.scan_hot_branch_rows(request, &scope).await?
         } else {
             Vec::new()
         };
-        if request.filter.untracked != Some(false) {
-            let branch_ref_rows = scan_direct_branch_ref_rows(store, request, &scope).await?;
-            if !branch_ref_rows.is_empty() {
-                hot_branch_rows.push(HotBranchRows {
-                    branch_id: GLOBAL_BRANCH_ID.to_string(),
-                    rows: MaterializedLiveStateBatch::from_rows(branch_ref_rows),
-                    ordered_unique: false,
-                });
-            }
-        }
         // The ordered single-branch route bypasses the generic visibility
         // resolver, so apply the retention predicate before taking that fast
         // path. Otherwise `untracked = Some(..)` accidentally returned both
@@ -505,7 +493,7 @@ where
                 );
             }
         }
-        if commit_derived_rows.is_empty()
+        if derived_rows.is_empty()
             && let Some(index) =
                 ordered_unique_branch_row_index(&hot_branch_rows, &scope.projection_branch_ids)
         {
@@ -516,7 +504,7 @@ where
             ));
         }
         let rows = concat_live_state_batches(
-            std::iter::once(commit_derived_rows).chain(
+            std::iter::once(derived_rows).chain(
                 hot_branch_rows
                     .into_iter()
                     .map(|branch_rows| branch_rows.rows),
@@ -561,12 +549,7 @@ where
             || request.filter.entity_pks.is_empty()
             || !request.filter.file_ids.is_empty()
             || !request.filter.constraints.is_empty()
-            || request_may_include_commit_derived(request)
-            || request
-                .filter
-                .schema_keys
-                .iter()
-                .any(|schema_key| schema_key == BRANCH_REF_SCHEMA_KEY)
+            || request_may_include_derived(request)
         {
             return Ok(None);
         }
@@ -655,15 +638,14 @@ where
         if request.rows.is_empty() {
             return Ok(MaterializedLiveStateExactBatch::default());
         }
-        // Commit-derived rows are synthesized rather than stored under the
+        // Derived rows are synthesized rather than stored under the
         // requested identity. Preserve their exact scan semantics without
         // widening the optimized durable-state batch.
-        if request.rows.iter().any(|row| {
-            matches!(
-                row.schema_key.as_str(),
-                COMMIT_SCHEMA_KEY | COMMIT_EDGE_SCHEMA_KEY | BRANCH_REF_SCHEMA_KEY
-            )
-        }) {
+        if request
+            .rows
+            .iter()
+            .any(|row| is_derived_schema(&row.schema_key))
+        {
             let mut builder = MaterializedLiveStateBatchBuilder::with_capacity(request.rows.len());
             let mut slots = Vec::with_capacity(request.rows.len());
             for row in &request.rows {
@@ -866,7 +848,7 @@ where
         skip_proven_empty_schema: bool,
     ) -> Result<MaterializedLiveStateBatch, LixError> {
         let store = &self.store;
-        let reads_tracked = !is_commit_derived_only_request(request);
+        let reads_tracked = !is_derived_only_request(request);
         let scope = scan_scope(
             store,
             request,
@@ -877,10 +859,18 @@ where
         if skip_proven_empty_schema && !scope_may_have_schema_rows(request, &scope) {
             return Ok(MaterializedLiveStateBatch::default());
         }
-        let commit_derived_rows = MaterializedLiveStateBatch::from_rows(
-            scan_commit_derived_rows(store, &self.commit_graph, request, &scope).await?,
+        let derived_rows = MaterializedLiveStateBatch::from_rows(
+            scan_derived_rows(
+                store,
+                &self.commit_graph,
+                request,
+                &scope.projection_branch_ids,
+                &scope.storage_branch_ids,
+                Some(false),
+            )
+            .await?,
         );
-        let mut hot_branch_rows = if !is_commit_derived_only_request(request) {
+        let mut hot_branch_rows = if !is_derived_only_request(request) {
             self.scan_hot_branch_rows(request, &scope).await?
         } else {
             Vec::new()
@@ -889,7 +879,7 @@ where
             branch_rows.rows =
                 filter_current_row_retention(std::mem::take(&mut branch_rows.rows), Some(false));
         }
-        if commit_derived_rows.is_empty()
+        if derived_rows.is_empty()
             && let Some(index) =
                 ordered_unique_branch_row_index(&hot_branch_rows, &scope.projection_branch_ids)
         {
@@ -900,7 +890,7 @@ where
             ));
         }
         let rows = concat_live_state_batches(
-            std::iter::once(commit_derived_rows).chain(
+            std::iter::once(derived_rows).chain(
                 hot_branch_rows
                     .into_iter()
                     .map(|branch_rows| branch_rows.rows),
@@ -1051,351 +1041,6 @@ where
     }
 }
 
-async fn scan_commit_derived_rows(
-    store: &(impl StorageAdapterRead + ?Sized),
-    commit_graph: &CommitGraphContext,
-    request: &LiveStateScanRequest,
-    scope: &LiveStateScanScope,
-) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-    if request.filter.untracked == Some(true) || !request_may_include_commit_derived(request) {
-        return Ok(Vec::new());
-    }
-    if !file_filter_allows_null(&request.filter.file_ids) {
-        return Ok(Vec::new());
-    }
-
-    let branch_ids = if scope.projection_branch_ids.is_empty() {
-        vec![GLOBAL_BRANCH_ID.to_string()]
-    } else {
-        scope.projection_branch_ids.clone()
-    };
-    let mut graph = commit_graph.reader(store);
-    let include_commit = schema_filter_allows(&request.filter.schema_keys, COMMIT_SCHEMA_KEY);
-    let include_commit_edge =
-        schema_filter_allows(&request.filter.schema_keys, COMMIT_EDGE_SCHEMA_KEY);
-
-    if include_commit
-        && !request.filter.entity_pks.is_empty()
-        && request.filter.entity_pks.iter().all(|entity_pk| {
-            matches!(
-                entity_pk.components.as_slice(),
-                [crate::entity_pk::EntityPkComponent::Uuid(_)]
-            )
-        })
-    {
-        let commit_ids = request
-            .filter
-            .entity_pks
-            .iter()
-            .filter_map(|entity_pk| match entity_pk.components.as_slice() {
-                [crate::entity_pk::EntityPkComponent::Uuid(bytes)] => {
-                    Some(CommitId::new(uuid::Uuid::from_bytes(*bytes)))
-                }
-                _ => None,
-            })
-            .collect::<std::collections::BTreeSet<_>>()
-            .into_iter()
-            .collect::<Vec<_>>();
-        let records = graph
-            .load_commit_records(&commit_ids)
-            .instrument(tracing::debug_span!(
-                target: "lix_perf",
-                "lix.perf.commit_derived.point"
-            ))
-            .await?;
-        let mut rows = Vec::with_capacity(records.len() * branch_ids.len());
-        for branch_id in &branch_ids {
-            for (requested_commit_id, record) in commit_ids.iter().zip(&records) {
-                let Some(record) = record else {
-                    continue;
-                };
-                if record.commit_id != *requested_commit_id {
-                    return Err(LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        format!(
-                            "commit point lookup for {requested_commit_id} decoded record {}",
-                            record.commit_id
-                        ),
-                    ));
-                }
-                rows.push(commit_record_row(record, branch_id)?);
-            }
-        }
-        rows.retain(|row| {
-            request.filter.entity_pks.contains(&row.entity_pk)
-                && (request.filter.branch_ids.is_empty()
-                    || request
-                        .filter
-                        .branch_ids
-                        .iter()
-                        .any(|branch_id| branch_id == row.branch_id.as_ref()))
-        });
-        return Ok(rows);
-    }
-
-    let commits = graph.all_commits().await?;
-    let mut rows = Vec::new();
-    for branch_id in &branch_ids {
-        if include_commit {
-            for commit in &commits {
-                rows.push(commit_row(commit, branch_id)?);
-            }
-        }
-        if include_commit_edge {
-            for edge in graph.commit_edges(&commits) {
-                rows.push(commit_edge_row(&edge, branch_id)?);
-            }
-        }
-    }
-
-    rows.retain(|row| {
-        (request.filter.entity_pks.is_empty() || request.filter.entity_pks.contains(&row.entity_pk))
-            && (request.filter.branch_ids.is_empty()
-                || request
-                    .filter
-                    .branch_ids
-                    .iter()
-                    .any(|branch_id| branch_id == row.branch_id.as_ref()))
-    });
-    Ok(rows)
-}
-
-/// Synthesizes the public `lix_branch_ref` metadata entity from authoritative
-/// branch-head controls. The mutable live-state projection is intentionally
-/// filtered out at the caller so SQL/entity consumers keep seeing exactly one
-/// current ref per branch while lifecycle operations retain their validated
-/// changelog fact.
-async fn scan_direct_branch_ref_rows(
-    store: &(impl StorageAdapterRead + ?Sized),
-    request: &LiveStateScanRequest,
-    scope: &LiveStateScanScope,
-) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-    if !schema_filter_allows(&request.filter.schema_keys, BRANCH_REF_SCHEMA_KEY)
-        || !file_filter_allows_null(&request.filter.file_ids)
-        || !scope
-            .storage_branch_ids
-            .iter()
-            .any(|branch_id| branch_id == GLOBAL_BRANCH_ID)
-    {
-        return Ok(Vec::new());
-    }
-
-    let requested_branch_ids = if request.filter.entity_pks.is_empty() {
-        Vec::new()
-    } else {
-        request
-            .filter
-            .entity_pks
-            .iter()
-            .filter_map(|entity_pk| entity_pk.as_single_string_owned().ok())
-            .collect::<Vec<_>>()
-    };
-    if !request.filter.entity_pks.is_empty()
-        && requested_branch_ids.len() != request.filter.entity_pks.len()
-    {
-        return Ok(Vec::new());
-    }
-    let controls = BranchHeadControlContext::new().reader(store);
-    let entries = if requested_branch_ids.is_empty() {
-        controls.scan().await?
-    } else {
-        controls
-            .load_many(&requested_branch_ids)
-            .await?
-            .into_iter()
-            .zip(requested_branch_ids)
-            .filter_map(|(control, branch_id)| control.map(|control| (branch_id, control)))
-            .collect()
-    };
-    entries
-        .into_iter()
-        .map(|(branch_id, control)| direct_branch_ref_row(&branch_id, control))
-        .collect()
-}
-
-fn direct_branch_ref_row(
-    branch_id: &str,
-    control: BranchHeadControl,
-) -> Result<MaterializedLiveStateRow, LixError> {
-    let snapshot_content = serde_json::to_string(&serde_json::json!({
-        "id": branch_id,
-        "commit_id": control.head_commit_id.to_string(),
-    }))
-    .map_err(|error| {
-        LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!("failed to encode direct branch-ref snapshot: {error}"),
-        )
-    })?;
-    Ok(MaterializedLiveStateRow {
-        entity_pk: EntityPk::uuid_from_canonical(branch_id).map_err(|error| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("direct branch-ref id is not a canonical UUID: {error}"),
-            )
-        })?,
-        schema_key: BRANCH_REF_SCHEMA_KEY.to_string(),
-        file_id: None,
-        snapshot_content: Some(snapshot_content.into()),
-        metadata: None,
-        deleted: false,
-        // These read-only columns are part of every public entity surface.
-        // Preserve the same replacement semantics the old flat current row
-        // had: creation time is stable, while each ref publication gets an
-        // updated timestamp and distinct change id.
-        created_at: control.created_at,
-        updated_at: control.updated_at,
-        global: true,
-        change_id: Some(control.ref_change_id),
-        commit_id: None,
-        untracked: true,
-        branch_id: GLOBAL_BRANCH_ID.into(),
-    })
-}
-
-fn request_may_include_commit_derived(request: &LiveStateScanRequest) -> bool {
-    request.filter.schema_keys.is_empty()
-        || request
-            .filter
-            .schema_keys
-            .iter()
-            .any(|schema_key| is_commit_derived_schema(schema_key))
-}
-
-fn is_commit_derived_only_request(request: &LiveStateScanRequest) -> bool {
-    !request.filter.schema_keys.is_empty()
-        && request
-            .filter
-            .schema_keys
-            .iter()
-            .all(|schema_key| is_commit_derived_schema(schema_key))
-}
-
-fn is_commit_derived_schema(schema_key: &str) -> bool {
-    matches!(schema_key, COMMIT_SCHEMA_KEY | COMMIT_EDGE_SCHEMA_KEY)
-}
-
-fn schema_filter_allows(schema_keys: &[String], schema_key: &str) -> bool {
-    schema_keys.is_empty() || schema_keys.iter().any(|candidate| candidate == schema_key)
-}
-
-fn file_filter_allows_null(file_ids: &[NullableKeyFilter<String>]) -> bool {
-    file_ids.is_empty()
-        || file_ids
-            .iter()
-            .any(|file_id| matches!(file_id, NullableKeyFilter::Any | NullableKeyFilter::Null))
-}
-
-fn commit_row(
-    commit: &crate::commit_graph::CommitGraphCommit,
-    branch_id: &str,
-) -> Result<MaterializedLiveStateRow, LixError> {
-    let snapshot_content = serde_json::to_string(&serde_json::json!({
-        "id": commit.commit_id,
-    }))
-    .map_err(|error| {
-        LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!("failed to encode derived lix_commit snapshot: {error}"),
-        )
-    })?;
-    Ok(MaterializedLiveStateRow {
-        entity_pk: EntityPk::uuid_from_canonical(&commit.commit_id.to_string()).map_err(
-            |error| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!("derived commit id is not a canonical UUID: {error}"),
-                )
-            },
-        )?,
-        schema_key: COMMIT_SCHEMA_KEY.to_string(),
-        file_id: None,
-        snapshot_content: Some(snapshot_content.into()),
-        metadata: None,
-        deleted: false,
-        created_at: commit.change.created_at,
-        updated_at: commit.change.created_at,
-        global: true,
-        change_id: Some(commit.change.id),
-        commit_id: Some(commit.commit_id),
-        untracked: false,
-        branch_id: branch_id.into(),
-    })
-}
-
-fn commit_record_row(
-    commit: &CommitGraphCommitRecord,
-    branch_id: &str,
-) -> Result<MaterializedLiveStateRow, LixError> {
-    let snapshot_content = serde_json::to_string(&serde_json::json!({
-        "id": commit.commit_id,
-    }))
-    .map_err(|error| {
-        LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!("failed to encode derived lix_commit snapshot: {error}"),
-        )
-    })?;
-    Ok(MaterializedLiveStateRow {
-        entity_pk: EntityPk::uuid_from_canonical(&commit.commit_id.to_string()).map_err(
-            |error| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!("derived commit id is not a canonical UUID: {error}"),
-                )
-            },
-        )?,
-        schema_key: COMMIT_SCHEMA_KEY.to_string(),
-        file_id: None,
-        snapshot_content: Some(snapshot_content.into()),
-        metadata: None,
-        deleted: false,
-        created_at: commit.created_at,
-        updated_at: commit.created_at,
-        global: true,
-        change_id: Some(commit.change_id),
-        commit_id: Some(commit.commit_id),
-        untracked: false,
-        branch_id: branch_id.into(),
-    })
-}
-
-fn commit_edge_row(
-    edge: &crate::commit_graph::CommitGraphEdge,
-    branch_id: &str,
-) -> Result<MaterializedLiveStateRow, LixError> {
-    let snapshot_content = serde_json::to_string(&serde_json::json!({
-        "parent_id": edge.parent_commit_id,
-        "child_id": edge.child_commit_id,
-        "parent_order": edge.parent_order,
-    }))
-    .map_err(|error| {
-        LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!("failed to encode derived lix_commit_edge snapshot: {error}"),
-        )
-    })?;
-    Ok(MaterializedLiveStateRow {
-        entity_pk: EntityPk::from_components(smallvec::smallvec![
-            crate::entity_pk::EntityPkComponent::Uuid(*edge.child_commit_id.as_uuid().as_bytes()),
-            crate::entity_pk::EntityPkComponent::Integer(i64::from(edge.parent_order)),
-        ])
-        .expect("commit edge primary key has two components"),
-        schema_key: COMMIT_EDGE_SCHEMA_KEY.to_string(),
-        file_id: None,
-        snapshot_content: Some(snapshot_content.into()),
-        metadata: None,
-        deleted: false,
-        created_at: crate::common::LixTimestamp::from_unix_millis_utc_lossy(0),
-        updated_at: crate::common::LixTimestamp::from_unix_millis_utc_lossy(0),
-        global: true,
-        change_id: None,
-        commit_id: Some(edge.child_commit_id),
-        untracked: false,
-        branch_id: branch_id.into(),
-    })
-}
-
 fn tracked_scan_request_from_live(request: &LiveStateScanRequest) -> TrackedStateScanRequest {
     TrackedStateScanRequest {
         filter: TrackedStateFilter {
@@ -1525,7 +1170,7 @@ fn scope_may_have_schema_rows(request: &LiveStateScanRequest, scope: &LiveStateS
     let [schema_key] = request.filter.schema_keys.as_slice() else {
         return true;
     };
-    if schema_key == BRANCH_REF_SCHEMA_KEY || request_may_include_commit_derived(request) {
+    if is_derived_schema(schema_key) {
         return true;
     }
     scope.storage_branch_ids.iter().any(|branch_id| {
@@ -2842,10 +2487,16 @@ mod tests {
                 EntityPk::uuid_from_bytes(*missing.as_uuid().as_bytes()),
             ],
         );
-        let rows =
-            scan_commit_derived_rows(&read, &CommitGraphContext::new(), &typed_request, &scope)
-                .await
-                .expect("typed point scan should succeed");
+        let rows = scan_derived_rows(
+            &read,
+            &CommitGraphContext::new(),
+            &typed_request,
+            &scope.projection_branch_ids,
+            &scope.storage_branch_ids,
+            Some(false),
+        )
+        .await
+        .expect("typed point scan should succeed");
         assert_eq!(rows.len(), 1, "duplicates and missing keys must flatten");
         assert_eq!(rows[0].entity_pk, typed_request.filter.entity_pks[0]);
         assert_eq!(rows[0].commit_id, Some(existing));
@@ -2855,13 +2506,199 @@ mod tests {
             COMMIT_SCHEMA_KEY,
             vec![EntityPk::single(existing.to_string())],
         );
-        let rows =
-            scan_commit_derived_rows(&read, &CommitGraphContext::new(), &string_request, &scope)
-                .await
-                .expect("string-typed point scan should succeed");
+        let rows = scan_derived_rows(
+            &read,
+            &CommitGraphContext::new(),
+            &string_request,
+            &scope.projection_branch_ids,
+            &scope.storage_branch_ids,
+            Some(false),
+        )
+        .await
+        .expect("string-typed point scan should succeed");
         assert!(
             rows.is_empty(),
             "a string component must not match the UUID primary key"
+        );
+    }
+
+    #[tokio::test]
+    async fn derived_scan_honors_proven_empty_row_filter() {
+        let storage = StorageAdapter::new(Memory::new());
+        let existing = CommitId::for_test_label("derived-empty-filter-existing");
+        let setup_read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("setup read should open");
+        write_empty_commits_to_store(&storage, &setup_read, &[&existing.to_string()]).await;
+        drop(setup_read);
+
+        let scope = LiveStateScanScope {
+            storage_branch_ids: Vec::new(),
+            projection_branch_ids: vec!["test-branch".to_string()],
+            branch_heads: BranchHeads::default(),
+        };
+        let request = LiveStateScanRequest {
+            filter: LiveStateFilter {
+                rows: LiveStateRowFilter::None,
+                schema_keys: vec![COMMIT_SCHEMA_KEY.to_string()],
+                branch_ids: vec!["test-branch".to_string()],
+                ..LiveStateFilter::default()
+            },
+            ..LiveStateScanRequest::default()
+        };
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("empty-filter scan read should open");
+        let rows = scan_derived_rows(
+            &read,
+            &CommitGraphContext::new(),
+            &request,
+            &scope.projection_branch_ids,
+            &scope.storage_branch_ids,
+            Some(false),
+        )
+        .await
+        .expect("proven-empty derived scan should succeed");
+        assert!(rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn derived_provider_point_access_preserves_branch_ref_uuid_identity() {
+        let storage = StorageAdapter::new(Memory::new());
+        let branch_id = "01920000-0000-7000-8000-0000000000d1";
+        stage_direct_tracked_head_rows(
+            &storage,
+            branch_id,
+            CommitId::for_test_label("derived-branch-ref-head"),
+            &[],
+        )
+        .await;
+        let scope = LiveStateScanScope {
+            storage_branch_ids: vec![GLOBAL_BRANCH_ID.to_string(), branch_id.to_string()],
+            projection_branch_ids: vec![branch_id.to_string()],
+            branch_heads: BranchHeads::default(),
+        };
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("branch-ref point read should open");
+        let typed_request = finite_pk_scan_request(
+            branch_id,
+            BRANCH_REF_SCHEMA_KEY,
+            vec![EntityPk::uuid_from_canonical(branch_id).expect("valid branch UUID")],
+        );
+        let rows = scan_derived_rows(
+            &read,
+            &CommitGraphContext::new(),
+            &typed_request,
+            &scope.projection_branch_ids,
+            &scope.storage_branch_ids,
+            Some(true),
+        )
+        .await
+        .expect("typed branch-ref point scan should succeed");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].entity_pk, typed_request.filter.entity_pks[0]);
+
+        let string_request = finite_pk_scan_request(
+            branch_id,
+            BRANCH_REF_SCHEMA_KEY,
+            vec![EntityPk::single(branch_id)],
+        );
+        let rows = scan_derived_rows(
+            &read,
+            &CommitGraphContext::new(),
+            &string_request,
+            &scope.projection_branch_ids,
+            &scope.storage_branch_ids,
+            Some(true),
+        )
+        .await
+        .expect("string branch-ref point scan should succeed");
+        assert!(rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn mixed_derived_identities_choose_access_per_provider() {
+        let storage = StorageAdapter::new(Memory::new());
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("mixed derived setup read should open");
+        let parent = CommitId::for_test_label("mixed-derived-parent");
+        let child = CommitId::for_test_label("mixed-derived-child");
+        let mut writes = storage.new_write_set();
+        crate::init::stage_repository_protocol(&mut writes);
+        let mut append = ChangelogAppend::default();
+        for (commit_id, generation, parents) in [(parent, 0, Vec::new()), (child, 1, vec![parent])]
+        {
+            append.commits.push(crate::changelog::CommitRecord {
+                format_version: 1,
+                commit_id,
+                generation,
+                parent_commit_ids: parents,
+                tracked_state_rootless: false,
+                change_id: ChangeId::for_test_label(&format!("{commit_id}:change")),
+                author_account_ids: Vec::new(),
+                created_at: ts("1970-01-01T00:00:00.000Z"),
+            });
+        }
+        let mut changelog_read = &read;
+        let mut writer = ChangelogContext::new().writer(&mut changelog_read, &mut writes);
+        crate::changelog::ChangelogWriter::stage_append(&mut writer, append)
+            .await
+            .expect("mixed derived commits should stage");
+        drop(writer);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("mixed derived commits should commit");
+        drop(read);
+
+        let branch_id = "test-branch";
+        let scope = LiveStateScanScope {
+            storage_branch_ids: Vec::new(),
+            projection_branch_ids: vec![branch_id.to_string()],
+            branch_heads: BranchHeads::default(),
+        };
+        let edge_pk = EntityPk::from_components(smallvec::smallvec![
+            crate::entity_pk::EntityPkComponent::Uuid(*child.as_uuid().as_bytes()),
+            crate::entity_pk::EntityPkComponent::Integer(0),
+        ])
+        .expect("valid edge identity");
+        let request = LiveStateScanRequest {
+            filter: LiveStateFilter {
+                schema_keys: vec!["lix_commit".to_string(), "lix_commit_edge".to_string()],
+                entity_pks: vec![
+                    EntityPk::uuid_from_bytes(*child.as_uuid().as_bytes()),
+                    edge_pk.clone(),
+                ],
+                branch_ids: vec![branch_id.to_string()],
+                ..LiveStateFilter::default()
+            },
+            ..LiveStateScanRequest::default()
+        };
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("mixed derived scan read should open");
+        let rows = scan_derived_rows(
+            &read,
+            &CommitGraphContext::new(),
+            &request,
+            &scope.projection_branch_ids,
+            &scope.storage_branch_ids,
+            Some(false),
+        )
+        .await
+        .expect("mixed derived scan should succeed");
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().any(|row| row.schema_key == "lix_commit"));
+        assert!(
+            rows.iter()
+                .any(|row| row.schema_key == "lix_commit_edge" && row.entity_pk == edge_pk)
         );
     }
 

--- a/packages/engine/src/live_state/derived.rs
+++ b/packages/engine/src/live_state/derived.rs
@@ -1,0 +1,633 @@
+//! Typed serving contract for live relations derived from authoritative stores.
+//!
+//! Access-path selection is centralized here. Providers declare capabilities;
+//! they never inspect a query and opportunistically switch from a scan to a
+//! point lookup themselves. Adding a derived relation therefore requires an
+//! explicit schema, retention, file-identity, and access-path declaration.
+
+use async_trait::async_trait;
+use tracing::Instrument;
+
+use crate::branch::{BRANCH_REF_SCHEMA_KEY, BranchHeadControl, BranchHeadControlContext};
+use crate::changelog::{ChangeId, CommitId};
+use crate::commit_graph::{
+    CommitGraphCommit, CommitGraphCommitRecord, CommitGraphContext, CommitGraphEdge, commit_edges,
+};
+use crate::entity_pk::{EntityPk, EntityPkComponent};
+use crate::live_state::{LiveStateRowFilter, LiveStateScanRequest, MaterializedLiveStateRow};
+use crate::storage_adapter::StorageAdapterRead;
+use crate::{GLOBAL_BRANCH_ID, LixError, NullableKeyFilter};
+
+const COMMIT_SCHEMA_KEY: &str = "lix_commit";
+const COMMIT_EDGE_SCHEMA_KEY: &str = "lix_commit_edge";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DerivedFileIdentity {
+    Null,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct DerivedProviderDescriptor {
+    schema_key: &'static str,
+    untracked: bool,
+    file_identity: DerivedFileIdentity,
+}
+
+const COMMIT_DESCRIPTOR: DerivedProviderDescriptor = DerivedProviderDescriptor {
+    schema_key: COMMIT_SCHEMA_KEY,
+    untracked: false,
+    file_identity: DerivedFileIdentity::Null,
+};
+const COMMIT_EDGE_DESCRIPTOR: DerivedProviderDescriptor = DerivedProviderDescriptor {
+    schema_key: COMMIT_EDGE_SCHEMA_KEY,
+    untracked: false,
+    file_identity: DerivedFileIdentity::Null,
+};
+const BRANCH_REF_DESCRIPTOR: DerivedProviderDescriptor = DerivedProviderDescriptor {
+    schema_key: BRANCH_REF_SCHEMA_KEY,
+    untracked: true,
+    file_identity: DerivedFileIdentity::Null,
+};
+#[derive(Debug, Clone, Copy)]
+enum RegisteredDerivedProvider {
+    Commit,
+    CommitEdge,
+    BranchRef,
+}
+
+impl RegisteredDerivedProvider {
+    const fn descriptor(self) -> DerivedProviderDescriptor {
+        match self {
+            Self::Commit => COMMIT_DESCRIPTOR,
+            Self::CommitEdge => COMMIT_EDGE_DESCRIPTOR,
+            Self::BranchRef => BRANCH_REF_DESCRIPTOR,
+        }
+    }
+}
+
+const DERIVED_PROVIDERS: &[RegisteredDerivedProvider] = &[
+    RegisteredDerivedProvider::Commit,
+    RegisteredDerivedProvider::CommitEdge,
+    RegisteredDerivedProvider::BranchRef,
+];
+
+struct DerivedReadContext<'a, S>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    store: &'a S,
+    commit_graph: &'a CommitGraphContext,
+    all_commits: Option<Vec<CommitGraphCommit>>,
+}
+
+impl<'a, S> DerivedReadContext<'a, S>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    fn new(store: &'a S, commit_graph: &'a CommitGraphContext) -> Self {
+        Self {
+            store,
+            commit_graph,
+            all_commits: None,
+        }
+    }
+
+    async fn all_commits(&mut self) -> Result<&[CommitGraphCommit], LixError> {
+        if self.all_commits.is_none() {
+            self.all_commits = Some(self.commit_graph.reader(self.store).all_commits().await?);
+        }
+        Ok(self
+            .all_commits
+            .as_deref()
+            .expect("derived commit scan cache was initialized"))
+    }
+}
+
+struct DerivedScanScope<'a> {
+    branch_ids: &'a [String],
+    storage_branch_ids: &'a [String],
+    retention: Option<bool>,
+}
+
+#[async_trait]
+trait DerivedLiveStateProvider<S>: Sync
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    fn descriptor(&self) -> DerivedProviderDescriptor;
+
+    async fn scan_all(
+        &self,
+        reads: &mut DerivedReadContext<'_, S>,
+        scope: &DerivedScanScope<'_>,
+    ) -> Result<Vec<MaterializedLiveStateRow>, LixError>;
+}
+
+#[async_trait]
+trait DerivedEntityPointProvider<S>: DerivedLiveStateProvider<S>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    async fn load_entity_points(
+        &self,
+        reads: &mut DerivedReadContext<'_, S>,
+        entity_pks: &[EntityPk],
+        scope: &DerivedScanScope<'_>,
+    ) -> Result<Vec<MaterializedLiveStateRow>, LixError>;
+}
+
+struct CommitProvider;
+
+#[async_trait]
+impl<S> DerivedLiveStateProvider<S> for CommitProvider
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    fn descriptor(&self) -> DerivedProviderDescriptor {
+        COMMIT_DESCRIPTOR
+    }
+
+    async fn scan_all(
+        &self,
+        reads: &mut DerivedReadContext<'_, S>,
+        scope: &DerivedScanScope<'_>,
+    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        let commits = reads.all_commits().await?;
+        let mut rows = Vec::with_capacity(commits.len() * scope.branch_ids.len());
+        for branch_id in scope.branch_ids {
+            for commit in commits {
+                rows.push(commit_row(
+                    commit.commit_id,
+                    commit.change.id,
+                    commit.change.created_at,
+                    branch_id,
+                )?);
+            }
+        }
+        Ok(rows)
+    }
+}
+
+#[async_trait]
+impl<S> DerivedEntityPointProvider<S> for CommitProvider
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    async fn load_entity_points(
+        &self,
+        reads: &mut DerivedReadContext<'_, S>,
+        entity_pks: &[EntityPk],
+        scope: &DerivedScanScope<'_>,
+    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        let commit_ids = entity_pks
+            .iter()
+            .filter_map(commit_id_from_entity_pk)
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        if commit_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let records = reads
+            .commit_graph
+            .reader(reads.store)
+            .load_commit_records(&commit_ids)
+            .await?;
+        let mut rows = Vec::with_capacity(records.len() * scope.branch_ids.len());
+        for branch_id in scope.branch_ids {
+            for (requested_commit_id, record) in commit_ids.iter().zip(&records) {
+                let Some(record) = record else {
+                    continue;
+                };
+                validate_commit_point_identity(*requested_commit_id, record)?;
+                rows.push(commit_row(
+                    record.commit_id,
+                    record.change_id,
+                    record.created_at,
+                    branch_id,
+                )?);
+            }
+        }
+        Ok(rows)
+    }
+}
+
+struct CommitEdgeProvider;
+
+#[async_trait]
+impl<S> DerivedLiveStateProvider<S> for CommitEdgeProvider
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    fn descriptor(&self) -> DerivedProviderDescriptor {
+        COMMIT_EDGE_DESCRIPTOR
+    }
+
+    async fn scan_all(
+        &self,
+        reads: &mut DerivedReadContext<'_, S>,
+        scope: &DerivedScanScope<'_>,
+    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        let commits = reads.all_commits().await?;
+        let edges = commit_edges(commits);
+        let mut rows = Vec::with_capacity(edges.len() * scope.branch_ids.len());
+        for branch_id in scope.branch_ids {
+            for edge in &edges {
+                rows.push(commit_edge_row(edge, branch_id)?);
+            }
+        }
+        Ok(rows)
+    }
+}
+
+struct BranchRefProvider;
+
+#[async_trait]
+impl<S> DerivedLiveStateProvider<S> for BranchRefProvider
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    fn descriptor(&self) -> DerivedProviderDescriptor {
+        BRANCH_REF_DESCRIPTOR
+    }
+
+    async fn scan_all(
+        &self,
+        reads: &mut DerivedReadContext<'_, S>,
+        scope: &DerivedScanScope<'_>,
+    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        if !scope
+            .storage_branch_ids
+            .iter()
+            .any(|branch_id| branch_id == GLOBAL_BRANCH_ID)
+        {
+            return Ok(Vec::new());
+        }
+        BranchHeadControlContext::new()
+            .reader(reads.store)
+            .scan()
+            .await?
+            .into_iter()
+            .map(|(branch_id, control)| branch_ref_row(&branch_id, control))
+            .collect()
+    }
+}
+
+#[async_trait]
+impl<S> DerivedEntityPointProvider<S> for BranchRefProvider
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    async fn load_entity_points(
+        &self,
+        reads: &mut DerivedReadContext<'_, S>,
+        entity_pks: &[EntityPk],
+        scope: &DerivedScanScope<'_>,
+    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        if !scope
+            .storage_branch_ids
+            .iter()
+            .any(|branch_id| branch_id == GLOBAL_BRANCH_ID)
+        {
+            return Ok(Vec::new());
+        }
+        let branch_ids = entity_pks
+            .iter()
+            .filter_map(uuid_string_from_entity_pk)
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        if branch_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let controls = BranchHeadControlContext::new()
+            .reader(reads.store)
+            .load_many(&branch_ids)
+            .await?;
+        branch_ids
+            .into_iter()
+            .zip(controls)
+            .filter_map(|(branch_id, control)| control.map(|control| (branch_id, control)))
+            .map(|(branch_id, control)| branch_ref_row(&branch_id, control))
+            .collect()
+    }
+}
+
+pub(super) async fn scan_derived_rows<S>(
+    store: &S,
+    commit_graph: &CommitGraphContext,
+    request: &LiveStateScanRequest,
+    projection_branch_ids: &[String],
+    storage_branch_ids: &[String],
+    retention: Option<bool>,
+) -> Result<Vec<MaterializedLiveStateRow>, LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    if matches!(request.filter.rows, LiveStateRowFilter::None) {
+        return Ok(Vec::new());
+    }
+    if !request.filter.branch_ids.is_empty() && projection_branch_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let branch_ids = if projection_branch_ids.is_empty() {
+        vec![GLOBAL_BRANCH_ID.to_string()]
+    } else {
+        projection_branch_ids.to_vec()
+    };
+    let scope = DerivedScanScope {
+        branch_ids: &branch_ids,
+        storage_branch_ids,
+        retention,
+    };
+    let mut reads = DerivedReadContext::new(store, commit_graph);
+    let mut rows = Vec::new();
+    for provider in DERIVED_PROVIDERS {
+        append_registered_provider_rows(*provider, &mut reads, request, &scope, &mut rows).await?;
+    }
+    Ok(rows)
+}
+
+async fn append_registered_provider_rows<S>(
+    provider: RegisteredDerivedProvider,
+    reads: &mut DerivedReadContext<'_, S>,
+    request: &LiveStateScanRequest,
+    scope: &DerivedScanScope<'_>,
+    rows: &mut Vec<MaterializedLiveStateRow>,
+) -> Result<(), LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    // Static dispatch keeps StorageAdapterRead's allocation-free `impl Future`
+    // contract. The helper's trait bound makes each registered capability
+    // require its implementation at compile time.
+    match provider {
+        RegisteredDerivedProvider::Commit => {
+            append_point_provider_rows(&CommitProvider, reads, request, scope, rows).await
+        }
+        RegisteredDerivedProvider::CommitEdge => {
+            append_full_scan_provider_rows(&CommitEdgeProvider, reads, request, scope, rows).await
+        }
+        RegisteredDerivedProvider::BranchRef => {
+            append_point_provider_rows(&BranchRefProvider, reads, request, scope, rows).await
+        }
+    }
+}
+
+async fn append_point_provider_rows<S, P>(
+    provider: &P,
+    reads: &mut DerivedReadContext<'_, S>,
+    request: &LiveStateScanRequest,
+    scope: &DerivedScanScope<'_>,
+    rows: &mut Vec<MaterializedLiveStateRow>,
+) -> Result<(), LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+    P: DerivedEntityPointProvider<S>,
+{
+    let descriptor = provider.descriptor();
+    if !provider_filter_allows(request, scope, descriptor) {
+        return Ok(());
+    }
+
+    let mut provider_rows = if request.filter.entity_pks.is_empty() {
+        provider
+            .scan_all(reads, scope)
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.derived.full_scan",
+                schema_key = descriptor.schema_key,
+            ))
+            .await?
+    } else {
+        provider
+            .load_entity_points(reads, &request.filter.entity_pks, scope)
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.derived.entity_points",
+                schema_key = descriptor.schema_key,
+            ))
+            .await?
+    };
+    if !request.filter.entity_pks.is_empty() {
+        provider_rows.retain(|row| request.filter.entity_pks.contains(&row.entity_pk));
+    }
+    rows.extend(provider_rows);
+    Ok(())
+}
+
+async fn append_full_scan_provider_rows<S, P>(
+    provider: &P,
+    reads: &mut DerivedReadContext<'_, S>,
+    request: &LiveStateScanRequest,
+    scope: &DerivedScanScope<'_>,
+    rows: &mut Vec<MaterializedLiveStateRow>,
+) -> Result<(), LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+    P: DerivedLiveStateProvider<S>,
+{
+    let descriptor = provider.descriptor();
+    if !provider_filter_allows(request, scope, descriptor) {
+        return Ok(());
+    }
+    let mut provider_rows = provider
+        .scan_all(reads, scope)
+        .instrument(tracing::debug_span!(
+            target: "lix_perf",
+            "lix.perf.derived.full_scan",
+            schema_key = descriptor.schema_key,
+        ))
+        .await?;
+    if !request.filter.entity_pks.is_empty() {
+        provider_rows.retain(|row| request.filter.entity_pks.contains(&row.entity_pk));
+    }
+    rows.extend(provider_rows);
+    Ok(())
+}
+
+fn provider_filter_allows(
+    request: &LiveStateScanRequest,
+    scope: &DerivedScanScope<'_>,
+    descriptor: DerivedProviderDescriptor,
+) -> bool {
+    schema_filter_allows(&request.filter.schema_keys, descriptor.schema_key)
+        && !scope
+            .retention
+            .is_some_and(|untracked| untracked != descriptor.untracked)
+        && file_filter_allows(&request.filter.file_ids, descriptor.file_identity)
+}
+
+pub(super) fn request_may_include_derived(request: &LiveStateScanRequest) -> bool {
+    request.filter.schema_keys.is_empty()
+        || request
+            .filter
+            .schema_keys
+            .iter()
+            .any(|schema_key| is_derived_schema(schema_key))
+}
+
+pub(super) fn is_derived_only_request(request: &LiveStateScanRequest) -> bool {
+    !request.filter.schema_keys.is_empty()
+        && request
+            .filter
+            .schema_keys
+            .iter()
+            .all(|schema_key| is_derived_schema(schema_key))
+}
+
+pub(super) fn is_derived_schema(schema_key: &str) -> bool {
+    DERIVED_PROVIDERS
+        .iter()
+        .any(|provider| provider.descriptor().schema_key == schema_key)
+}
+
+fn schema_filter_allows(schema_keys: &[String], schema_key: &str) -> bool {
+    schema_keys.is_empty() || schema_keys.iter().any(|candidate| candidate == schema_key)
+}
+
+fn file_filter_allows(
+    file_ids: &[NullableKeyFilter<String>],
+    identity: DerivedFileIdentity,
+) -> bool {
+    match identity {
+        DerivedFileIdentity::Null => {
+            file_ids.is_empty()
+                || file_ids.iter().any(|file_id| {
+                    matches!(file_id, NullableKeyFilter::Any | NullableKeyFilter::Null)
+                })
+        }
+    }
+}
+
+fn commit_id_from_entity_pk(entity_pk: &EntityPk) -> Option<CommitId> {
+    let [EntityPkComponent::Uuid(bytes)] = entity_pk.components.as_slice() else {
+        return None;
+    };
+    Some(CommitId::new(uuid::Uuid::from_bytes(*bytes)))
+}
+
+fn uuid_string_from_entity_pk(entity_pk: &EntityPk) -> Option<String> {
+    let [EntityPkComponent::Uuid(bytes)] = entity_pk.components.as_slice() else {
+        return None;
+    };
+    Some(uuid::Uuid::from_bytes(*bytes).as_hyphenated().to_string())
+}
+
+fn validate_commit_point_identity(
+    requested_commit_id: CommitId,
+    record: &CommitGraphCommitRecord,
+) -> Result<(), LixError> {
+    if record.commit_id == requested_commit_id {
+        return Ok(());
+    }
+    Err(LixError::new(
+        LixError::CODE_INTERNAL_ERROR,
+        format!(
+            "commit point lookup for {requested_commit_id} decoded record {}",
+            record.commit_id
+        ),
+    ))
+}
+
+fn commit_row(
+    commit_id: CommitId,
+    change_id: ChangeId,
+    created_at: crate::common::LixTimestamp,
+    branch_id: &str,
+) -> Result<MaterializedLiveStateRow, LixError> {
+    let snapshot_content =
+        serde_json::to_string(&serde_json::json!({ "id": commit_id })).map_err(|error| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("failed to encode derived lix_commit snapshot: {error}"),
+            )
+        })?;
+    Ok(MaterializedLiveStateRow {
+        entity_pk: EntityPk::uuid_from_bytes(*commit_id.as_uuid().as_bytes()),
+        schema_key: COMMIT_SCHEMA_KEY.to_string(),
+        file_id: None,
+        snapshot_content: Some(snapshot_content.into()),
+        metadata: None,
+        deleted: false,
+        created_at,
+        updated_at: created_at,
+        global: true,
+        change_id: Some(change_id),
+        commit_id: Some(commit_id),
+        untracked: false,
+        branch_id: branch_id.into(),
+    })
+}
+
+fn commit_edge_row(
+    edge: &CommitGraphEdge,
+    branch_id: &str,
+) -> Result<MaterializedLiveStateRow, LixError> {
+    let snapshot_content = serde_json::to_string(&serde_json::json!({
+        "parent_id": edge.parent_commit_id,
+        "child_id": edge.child_commit_id,
+        "parent_order": edge.parent_order,
+    }))
+    .map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("failed to encode derived lix_commit_edge snapshot: {error}"),
+        )
+    })?;
+    Ok(MaterializedLiveStateRow {
+        entity_pk: EntityPk::from_components(smallvec::smallvec![
+            EntityPkComponent::Uuid(*edge.child_commit_id.as_uuid().as_bytes()),
+            EntityPkComponent::Integer(i64::from(edge.parent_order)),
+        ])
+        .expect("commit edge primary key has two components"),
+        schema_key: COMMIT_EDGE_SCHEMA_KEY.to_string(),
+        file_id: None,
+        snapshot_content: Some(snapshot_content.into()),
+        metadata: None,
+        deleted: false,
+        created_at: crate::common::LixTimestamp::from_unix_millis_utc_lossy(0),
+        updated_at: crate::common::LixTimestamp::from_unix_millis_utc_lossy(0),
+        global: true,
+        change_id: None,
+        commit_id: Some(edge.child_commit_id),
+        untracked: false,
+        branch_id: branch_id.into(),
+    })
+}
+
+fn branch_ref_row(
+    branch_id: &str,
+    control: BranchHeadControl,
+) -> Result<MaterializedLiveStateRow, LixError> {
+    let snapshot_content = serde_json::to_string(&serde_json::json!({
+        "id": branch_id,
+        "commit_id": control.head_commit_id.to_string(),
+    }))
+    .map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("failed to encode direct branch-ref snapshot: {error}"),
+        )
+    })?;
+    Ok(MaterializedLiveStateRow {
+        entity_pk: EntityPk::uuid_from_canonical(branch_id).map_err(|error| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("direct branch-ref id is not a canonical UUID: {error}"),
+            )
+        })?,
+        schema_key: BRANCH_REF_SCHEMA_KEY.to_string(),
+        file_id: None,
+        snapshot_content: Some(snapshot_content.into()),
+        metadata: None,
+        deleted: false,
+        created_at: control.created_at,
+        updated_at: control.updated_at,
+        global: true,
+        change_id: Some(control.ref_change_id),
+        commit_id: None,
+        untracked: true,
+        branch_id: GLOBAL_BRANCH_ID.into(),
+    })
+}

--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -1,4 +1,5 @@
 mod context;
+mod derived;
 mod entity_field_index;
 mod reader;
 mod tracked_head;


### PR DESCRIPTION
## Summary

- introduce a typed serving contract for derived live-state providers
- centralize typed point versus full-scan selection without schema-specific planner branches
- migrate `lix_commit`, `lix_commit_edge`, and `lix_branch_ref` to the registry
- keep broad commit and edge scans on one cached commit materialization
- short-circuit proven-empty filters before any derived history access
- enforce point capability through a required trait implementation

This is a hard cut with no compatibility layer and no changenote.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p lix_engine --features all-simulations --all-targets -- -D warnings -A dead-code`
- `RUST_MIN_STACK=8388608 cargo test -p lix_engine --features all-simulations` (1741 unit + 802 integration + 3 doctests passed; 10 ignored)
- focused derived-provider regression tests, including proven-empty, typed identity, and mixed-provider selection

## Performance

Release RocksDB branch creation at 10k commits remains history-flat: 8.06 ms, 14.53 MB allocated, 0.89 MB incremental RSS. This is slightly better than the prior specialized path (8.20 ms, 14.59 MB, 0.97 MB).

All-plugin cold reopen also improved in the measured run: preview 8.09 ms and merge 13.48 ms versus 8.45 ms and 14.90 ms.

## Review

Two independent sub-agent reviews covered architecture/correctness and performance/regression risk. Both reported no blockers after fixes for proven-empty scans and compile-time capability enforcement.