### PR TITLE
perf(sql): scan authenticated typed row groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3354,6 +3354,7 @@ dependencies = [
  "blake3",
  "bytes",
  "codspeed-criterion-compat",
+ "datafusion",
  "futures-util",
  "lix_engine",
  "lix_rocksdb_storage",

--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -45,6 +45,7 @@ async-trait = "0.1"
 blake3 = "1"
 bytes = "1"
 criterion = { package = "codspeed-criterion-compat", version = "*" }
+datafusion = { version = "53.0.0", default-features = false, features = ["sql"] }
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 rustc-hash = "2"
 serde = { version = "1", features = ["derive"] }

--- a/packages/engine-benchmarks/benches/tracked_state_crud/duckdb_public_result.mjs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/duckdb_public_result.mjs
@@ -4,10 +4,8 @@
 //   npm install --prefix /tmp/lix-duckdb --no-save @duckdb/node-api
 //   NODE_PATH=/tmp/lix-duckdb/node_modules node duckdb_public_result.mjs
 //
-// It mirrors the generated 1M `json_pointer` scale rows: a zero-padded path
-// plus a JSON object. The timed section orders the rows and materializes
-// owned path strings and parsed JSON values, matching the public result shape
-// measured by the Lix SQL-session benchmark.
+// The `olap_*` controls create the same typed rows as Lix and materialize
+// owned JavaScript values at the same public-result boundary as ExecuteResult.
 
 import { createRequire } from "node:module";
 
@@ -20,12 +18,16 @@ const { version: duckdbNodeApiVersion } = require("@duckdb/node-api/package.json
 const rowCount = Number.parseInt(process.env.LIX_DUCKDB_ROW_COUNT ?? "1000000", 10);
 const sampleCount = Number.parseInt(process.env.LIX_DUCKDB_SAMPLES ?? "5", 10);
 const shape = process.env.LIX_DUCKDB_SHAPE ?? "full_result";
+const olapShape = shape.startsWith("olap_");
 
 if (!Number.isSafeInteger(rowCount) || rowCount <= 0) {
   throw new Error("LIX_DUCKDB_ROW_COUNT must be a positive safe integer");
 }
 if (!Number.isSafeInteger(sampleCount) || sampleCount <= 0) {
   throw new Error("LIX_DUCKDB_SAMPLES must be a positive safe integer");
+}
+if (olapShape && rowCount < 20) {
+  throw new Error("typed OLAP controls require at least 20 rows");
 }
 
 const query = {
@@ -34,45 +36,67 @@ const query = {
     "SELECT path, value_json FROM json_pointer WHERE path IS NOT NULL ORDER BY value_json, path",
   general_aggregate:
     "SELECT COUNT(*) AS rows, MIN(path) AS first_path, MAX(path) AS last_path FROM json_pointer WHERE path IS NOT NULL",
+  olap_scan:
+    "WITH source AS (SELECT id, ordinal, lane, score, active FROM olap_row) SELECT id, ordinal, lane, score, active FROM source WHERE ordinal >= 0",
+  olap_filter:
+    "WITH source AS (SELECT id, ordinal, lane, score, active FROM olap_row) SELECT ordinal, lane, score FROM source WHERE active = TRUE AND lane IN ('lane-07', 'lane-19') ORDER BY ordinal",
+  olap_sort:
+    "WITH source AS (SELECT id, ordinal, lane, score, active FROM olap_row) SELECT id, ordinal, score FROM source WHERE active = TRUE ORDER BY score DESC, ordinal ASC LIMIT 10000",
+  olap_group:
+    "WITH source AS (SELECT id, ordinal, lane, score, active FROM olap_row) SELECT lane, COUNT(*) AS rows, SUM(ordinal) AS ordinal_sum, AVG(score) AS score_avg, MIN(score) AS score_min, MAX(score) AS score_max FROM source WHERE active = TRUE GROUP BY lane ORDER BY lane",
+  olap_aggregate:
+    "WITH source AS (SELECT id, ordinal, lane, score, active FROM olap_row) SELECT COUNT(*) AS rows, SUM(ordinal) AS ordinal_sum, AVG(score) AS score_avg, MIN(ordinal) AS min_ordinal, MAX(ordinal) AS max_ordinal FROM source WHERE active = TRUE",
 }[shape];
 if (query === undefined) {
   throw new Error(
-    "LIX_DUCKDB_SHAPE must be full_result, general_filter_sort, or general_aggregate",
+    "unknown LIX_DUCKDB_SHAPE",
   );
 }
 
 const db = await DuckDBInstance.create(":memory:");
 const connection = await db.connect();
 await connection.run("PRAGMA threads=1");
-await connection.run(`
-  CREATE TABLE json_pointer AS
-  SELECT
-    printf('/~lix-scale/%09d', range) AS path,
-    '{"ordinal":' || range::VARCHAR || ',"lane":"scale"}' AS value_json
-  FROM range(${rowCount})
-`);
+if (olapShape) {
+  await connection.run(`
+    CREATE TABLE olap_row AS
+    SELECT
+      printf('/~lix-olap/%09d', ordinal) AS id,
+      ordinal::BIGINT AS ordinal,
+      printf('lane-%02d', ordinal % 32) AS lane,
+      (ordinal % 10000)::DOUBLE / 8.0 AS score,
+      ordinal % 3 <> 0 AS active
+    FROM range(${rowCount}) AS generated(ordinal)
+  `);
+} else {
+  await connection.run(`
+    CREATE TABLE json_pointer AS
+    SELECT
+      printf('/~lix-scale/%09d', range) AS path,
+      '{"ordinal":' || range::VARCHAR || ',"lane":"scale"}' AS value_json
+    FROM range(${rowCount})
+  `);
+}
+
+const expected = olapShape ? olapExpected(rowCount) : undefined;
+
+async function materialize() {
+  const reader = await connection.runAndReadAll(query);
+  const rows = [];
+  for (const row of reader.getRows()) {
+    rows.push(materializeRow(shape, row));
+  }
+  assertRows(shape, rows, rowCount, expected);
+  return rows;
+}
+
+if (olapShape) {
+  await materialize();
+}
 
 const samplesMs = [];
 for (let sample = 0; sample < sampleCount; sample += 1) {
   const started = process.hrtime.bigint();
-  const reader = await connection.runAndReadAll(query);
-  const rows = [];
-  for (const row of reader.getRows()) {
-    rows.push(
-      shape === "general_aggregate"
-        ? [Number(row[0]), String(row[1]), String(row[2])]
-        : [String(row[0]), JSON.parse(String(row[1]))],
-    );
-  }
-  const expectedRows = shape === "general_aggregate" ? 1 : rowCount;
-  if (
-    rows.length !== expectedRows ||
-    (shape === "general_aggregate"
-      ? rows[0][0] !== rowCount
-      : rows.at(-1)[1].ordinal !== rowCount - 1)
-  ) {
-    throw new Error("DuckDB public-result control returned unexpected rows");
-  }
+  await materialize();
   samplesMs.push(Number(process.hrtime.bigint() - started) / 1e6);
 }
 
@@ -87,3 +111,123 @@ console.log(
     median_ms: samplesMs[Math.floor(samplesMs.length / 2)],
   }),
 );
+
+function materializeRow(selectedShape, row) {
+  switch (selectedShape) {
+    case "general_aggregate":
+      return [Number(row[0]), String(row[1]), String(row[2])];
+    case "full_result":
+    case "general_filter_sort":
+      return [String(row[0]), JSON.parse(String(row[1]))];
+    case "olap_scan":
+      return [String(row[0]), Number(row[1]), String(row[2]), Number(row[3]), Boolean(row[4])];
+    case "olap_filter":
+      return [Number(row[0]), String(row[1]), Number(row[2])];
+    case "olap_sort":
+      return [String(row[0]), Number(row[1]), Number(row[2])];
+    case "olap_group":
+      return [String(row[0]), Number(row[1]), Number(row[2]), Number(row[3]), Number(row[4]), Number(row[5])];
+    case "olap_aggregate":
+      return [Number(row[0]), Number(row[1]), Number(row[2]), Number(row[3]), Number(row[4])];
+    default:
+      throw new Error(`unhandled shape ${selectedShape}`);
+  }
+}
+
+function olapExpected(count) {
+  const groups = Array.from({ length: 32 }, () => ({
+    rows: 0,
+    ordinalSum: 0,
+    scoreSum: 0,
+    scoreMin: Number.POSITIVE_INFINITY,
+    scoreMax: Number.NEGATIVE_INFINITY,
+  }));
+  const result = {
+    activeRows: 0,
+    activeOrdinalSum: 0,
+    activeScoreSum: 0,
+    activeMinOrdinal: undefined,
+    activeMaxOrdinal: undefined,
+    filteredRows: 0,
+    filteredFirstOrdinal: undefined,
+    filteredLastOrdinal: undefined,
+    groups,
+  };
+  for (let ordinal = 0; ordinal < count; ordinal += 1) {
+    if (ordinal % 3 === 0) continue;
+    const lane = ordinal % 32;
+    const score = (ordinal % 10000) / 8;
+    result.activeRows += 1;
+    result.activeOrdinalSum += ordinal;
+    result.activeScoreSum += score;
+    result.activeMinOrdinal ??= ordinal;
+    result.activeMaxOrdinal = ordinal;
+    const group = groups[lane];
+    group.rows += 1;
+    group.ordinalSum += ordinal;
+    group.scoreSum += score;
+    group.scoreMin = Math.min(group.scoreMin, score);
+    group.scoreMax = Math.max(group.scoreMax, score);
+    if (lane === 7 || lane === 19) {
+      result.filteredRows += 1;
+      result.filteredFirstOrdinal ??= ordinal;
+      result.filteredLastOrdinal = ordinal;
+    }
+  }
+  return result;
+}
+
+function assertRows(selectedShape, rows, count, olap) {
+  if (selectedShape === "general_aggregate") {
+    if (rows.length !== 1 || rows[0][0] !== count) throw new Error("unexpected general aggregate");
+    return;
+  }
+  if (selectedShape === "full_result" || selectedShape === "general_filter_sort") {
+    if (rows.length !== count || rows.at(-1)[1].ordinal !== count - 1) throw new Error("unexpected JSON rows");
+    return;
+  }
+  if (selectedShape === "olap_scan") {
+    if (rows.length !== count) throw new Error("unexpected OLAP scan cardinality");
+    return;
+  }
+  if (selectedShape === "olap_filter") {
+    if (rows.length !== olap.filteredRows || rows[0][0] !== olap.filteredFirstOrdinal || rows.at(-1)[0] !== olap.filteredLastOrdinal) {
+      throw new Error("unexpected OLAP filter result");
+    }
+    return;
+  }
+  if (selectedShape === "olap_sort") {
+    if (rows.length !== Math.min(10000, olap.activeRows)) throw new Error("unexpected OLAP sort cardinality");
+    for (let index = 0; index < rows.length; index += 1) {
+      const [id, ordinal, score] = rows[index];
+      if (ordinal % 3 === 0 || id !== `/~lix-olap/${String(ordinal).padStart(9, "0")}` || score !== (ordinal % 10000) / 8) {
+        throw new Error("unexpected OLAP sort row");
+      }
+      if (index > 0) {
+        const previous = rows[index - 1];
+        if (!(previous[2] > score || (previous[2] === score && previous[1] < ordinal))) throw new Error("unexpected OLAP sort order");
+      }
+    }
+    return;
+  }
+  if (selectedShape === "olap_group") {
+    if (rows.length !== 32) throw new Error("unexpected OLAP group cardinality");
+    rows.forEach((row, lane) => {
+      const group = olap.groups[lane];
+      if (row[0] !== `lane-${String(lane).padStart(2, "0")}` || row[1] !== group.rows || row[2] !== group.ordinalSum || !close(row[3], group.scoreSum / group.rows) || row[4] !== group.scoreMin || row[5] !== group.scoreMax) {
+        throw new Error(`unexpected OLAP group ${lane}`);
+      }
+    });
+    return;
+  }
+  if (selectedShape === "olap_aggregate") {
+    const row = rows[0];
+    if (rows.length !== 1 || row[0] !== olap.activeRows || row[1] !== olap.activeOrdinalSum || !close(row[2], olap.activeScoreSum / olap.activeRows) || row[3] !== olap.activeMinOrdinal || row[4] !== olap.activeMaxOrdinal) {
+      throw new Error("unexpected OLAP aggregate");
+    }
+  }
+}
+
+function close(actual, expected) {
+  return Math.abs(actual - expected) <= 1e-10 * Math.max(Math.abs(expected), 1);
+}

--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -532,13 +532,19 @@ fn profile_hot_transaction_operations(
 }
 
 fn sql_session_read_shape() -> &'static str {
-    match std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_READ_SHAPE").as_deref() {
+    let shape = std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_READ_SHAPE");
+    if let Ok(label) = shape.as_deref()
+        && let Some(shape) = sql_session::OlapReadShape::from_label(label)
+    {
+        return shape.label();
+    }
+    match shape.as_deref() {
         Ok("aggregate_count") => "aggregate_count",
         Ok("general_filter_sort") => "general_filter_sort",
         Ok("general_aggregate") => "general_aggregate",
         Ok("full_result") | Err(_) => "full_result",
         Ok(other) => panic!(
-            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_READ_SHAPE '{other}'; expected full_result, aggregate_count, general_filter_sort, or general_aggregate"
+            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_READ_SHAPE '{other}'; expected full_result, aggregate_count, general_filter_sort, general_aggregate, olap_scan, olap_filter, olap_sort, olap_group, or olap_aggregate"
         ),
     }
 }
@@ -564,6 +570,30 @@ fn profile_hot_sql_session_operations(
         read_many_pk_count,
     ));
     let _ = lix_engine::storage_bench::take_entity_point_snapshot_cache_accounting();
+    if sql_session::selected_olap_read_shape().is_some() {
+        // Match the DuckDB control: one untimed warmup against one seeded
+        // fixture followed by individually timed samples and a median.
+        runtime.block_on(run_sql_session_operation(operation, &fixture));
+        let mut samples = Vec::with_capacity(repeats);
+        let mut row_count = 0;
+        for _ in 0..repeats {
+            let start = Instant::now();
+            row_count += runtime.block_on(run_sql_session_operation(operation, &fixture));
+            samples.push(start.elapsed());
+        }
+        print_profile_samples(
+            &format!(
+                "sql_session/{}/{}",
+                profile.name(),
+                sql_session_read_shape()
+            ),
+            operation,
+            read_many_pk_count,
+            samples,
+        );
+        black_box(row_count);
+        return;
+    }
     let start = Instant::now();
     let mut row_count = 0;
     for _ in 0..repeats {

--- a/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::{fmt::Write as _, ops::Range};
 
 use lix_engine::{Engine, ExecuteBatchStatement, ExecuteResult, SessionContext, Storage, Value};
 
@@ -23,6 +24,92 @@ const GENERAL_AGGREGATE_SQL: &str = "SELECT COUNT(*) AS rows, MIN(path) AS first
 type SharedParameterBatch = Arc<[Arc<[Value]>]>;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum OlapReadShape {
+    Scan,
+    Filter,
+    Sort,
+    Group,
+    Aggregate,
+}
+
+impl OlapReadShape {
+    pub(crate) const ALL: [Self; 5] = [
+        Self::Scan,
+        Self::Filter,
+        Self::Sort,
+        Self::Group,
+        Self::Aggregate,
+    ];
+
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Scan => "olap_scan",
+            Self::Filter => "olap_filter",
+            Self::Sort => "olap_sort",
+            Self::Group => "olap_group",
+            Self::Aggregate => "olap_aggregate",
+        }
+    }
+
+    pub(crate) const fn sql(self) -> &'static str {
+        match self {
+            Self::Scan => {
+                "WITH source AS (SELECT id, ordinal, lane, score, active FROM olap_row) \
+                 SELECT id, ordinal, lane, score, active FROM source WHERE ordinal >= 0"
+            }
+            Self::Filter => {
+                "WITH source AS (SELECT id, ordinal, lane, score, active FROM olap_row) \
+                 SELECT ordinal, lane, score FROM source \
+                 WHERE active = TRUE AND lane IN ('lane-07', 'lane-19') ORDER BY ordinal"
+            }
+            Self::Sort => {
+                "WITH source AS (SELECT id, ordinal, lane, score, active FROM olap_row) \
+                 SELECT id, ordinal, score FROM source WHERE active = TRUE \
+                 ORDER BY score DESC, ordinal ASC LIMIT 10000"
+            }
+            Self::Group => {
+                "WITH source AS (SELECT id, ordinal, lane, score, active FROM olap_row) \
+                 SELECT lane, COUNT(*) AS rows, SUM(ordinal) AS ordinal_sum, \
+                 AVG(score) AS score_avg, MIN(score) AS score_min, MAX(score) AS score_max \
+                 FROM source WHERE active = TRUE GROUP BY lane ORDER BY lane"
+            }
+            Self::Aggregate => {
+                "WITH source AS (SELECT id, ordinal, lane, score, active FROM olap_row) \
+                 SELECT COUNT(*) AS rows, SUM(ordinal) AS ordinal_sum, AVG(score) AS score_avg, \
+                 MIN(ordinal) AS min_ordinal, MAX(ordinal) AS max_ordinal \
+                 FROM source WHERE active = TRUE"
+            }
+        }
+    }
+
+    pub(crate) fn from_label(label: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|shape| shape.label() == label)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct OlapGroupExpected {
+    rows: i64,
+    ordinal_sum: i64,
+    score_sum: f64,
+    score_min: f64,
+    score_max: f64,
+}
+
+#[derive(Clone, Debug)]
+struct OlapExpected {
+    active_rows: i64,
+    active_ordinal_sum: i64,
+    active_score_sum: f64,
+    active_min_ordinal: i64,
+    active_max_ordinal: i64,
+    filtered_rows: usize,
+    filtered_first_ordinal: i64,
+    filtered_last_ordinal: i64,
+    groups: [OlapGroupExpected; 32],
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum UntrackedFixture {
     None,
     OneUnrelated,
@@ -33,6 +120,7 @@ enum UntrackedFixture {
 enum FixtureShape {
     FullCrud,
     BoundUpdate,
+    Olap,
 }
 
 enum LiteralUpdateWorkload {
@@ -63,6 +151,7 @@ pub(crate) struct GenericSqlFixture<StorageImpl: Storage + 'static> {
     read_many_by_pk_count: usize,
     bound_insert_all_batch: SharedParameterBatch,
     bound_seed_json_batch: SharedParameterBatch,
+    olap_expected: Option<OlapExpected>,
     select_all_sql: String,
     select_many_by_pk_sql: String,
     select_one_by_pk_sql: String,
@@ -140,9 +229,36 @@ pub(crate) async fn seeded_fixture_with_read_many_pk_count(
     rows: &[WorkloadRow],
     read_many_by_pk_count: usize,
 ) -> SqlFixture {
-    let fixture = empty_fixture_with_read_many_pk_count(profile, rows, read_many_by_pk_count).await;
-    fixture.seed_json_rows().await;
-    fixture.insert_untracked_probe().await;
+    let fixture = if selected_olap_read_shape().is_some() {
+        assert!(
+            std::env::var_os("LIX_TRACKED_STATE_CRUD_PROFILE_UNTRACKED").is_none(),
+            "typed OLAP profiles do not include the unrelated json_pointer overlay fixture"
+        );
+        empty_fixture_with_shape(profile, rows, read_many_by_pk_count, FixtureShape::Olap).await
+    } else {
+        empty_fixture_with_read_many_pk_count(profile, rows, read_many_by_pk_count).await
+    };
+    fixture.seed_rows().await;
+    if selected_olap_read_shape().is_none() {
+        fixture.insert_untracked_probe().await;
+    }
+    fixture
+}
+
+#[cfg(test)]
+#[allow(dead_code)]
+pub(crate) async fn seeded_olap_fixture(
+    profile: StorageProfile,
+    rows: &[WorkloadRow],
+) -> SqlFixture {
+    let fixture = empty_fixture_with_shape(
+        profile,
+        rows,
+        READ_MANY_PK_COUNT.min(rows.len()),
+        FixtureShape::Olap,
+    )
+    .await;
+    fixture.seed_rows().await;
     fixture
 }
 
@@ -160,7 +276,7 @@ pub(crate) async fn seeded_bound_update_fixture_with_read_many_pk_count(
     )
     .await;
     fixture.install_bound_seed_batch(rows);
-    fixture.seed_json_rows().await;
+    fixture.seed_rows().await;
     fixture.insert_untracked_probe().await;
     fixture.release_bound_update_setup();
     fixture.install_bound_update_batch(crate::workload::fixture_update_rows(row_count));
@@ -204,12 +320,12 @@ impl SqlFixture {
         }
     }
 
-    async fn seed_json_rows(&self) {
+    async fn seed_rows(&self) {
         match self {
-            Self::SQLite(fixture) => fixture.seed_json_rows().await,
-            Self::RocksDB(fixture) => fixture.seed_json_rows().await,
+            Self::SQLite(fixture) => fixture.seed_rows().await,
+            Self::RocksDB(fixture) => fixture.seed_rows().await,
             #[cfg(feature = "slatedb")]
-            Self::SlateDB(fixture) => fixture.seed_json_rows().await,
+            Self::SlateDB(fixture) => fixture.seed_rows().await,
         }
     }
 
@@ -223,13 +339,19 @@ impl SqlFixture {
     }
 
     pub(crate) async fn read_all(&self) -> usize {
-        match std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_READ_SHAPE").as_deref() {
+        let shape = std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_READ_SHAPE");
+        if let Ok(label) = shape.as_deref()
+            && let Some(shape) = OlapReadShape::from_label(label)
+        {
+            return self.read_olap(shape).await;
+        }
+        match shape.as_deref() {
             Ok("aggregate_count") => return self.count_all().await,
             Ok("general_filter_sort") => return self.general_filter_sort_all().await,
             Ok("general_aggregate") => return self.general_aggregate().await,
             Ok("full_result") | Err(_) => {}
             Ok(other) => panic!(
-                "unknown LIX_TRACKED_STATE_CRUD_PROFILE_READ_SHAPE '{other}'; expected full_result, aggregate_count, general_filter_sort, or general_aggregate"
+                "unknown LIX_TRACKED_STATE_CRUD_PROFILE_READ_SHAPE '{other}'; expected full_result, aggregate_count, general_filter_sort, general_aggregate, olap_scan, olap_filter, olap_sort, olap_group, or olap_aggregate"
             ),
         }
         match self {
@@ -267,6 +389,15 @@ impl SqlFixture {
             Self::RocksDB(fixture) => fixture.general_aggregate().await,
             #[cfg(feature = "slatedb")]
             Self::SlateDB(fixture) => fixture.general_aggregate().await,
+        }
+    }
+
+    pub(crate) async fn read_olap(&self, shape: OlapReadShape) -> usize {
+        match self {
+            Self::SQLite(fixture) => fixture.read_olap(shape).await,
+            Self::RocksDB(fixture) => fixture.read_olap(shape).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.read_olap(shape).await,
         }
     }
 
@@ -443,7 +574,11 @@ where
         affected as usize
     }
 
-    async fn seed_json_rows(&self) {
+    async fn seed_rows(&self) {
+        if self.olap_expected.is_some() {
+            self.seed_olap_rows().await;
+            return;
+        }
         let affected = self
             .session
             .execute_homogeneous_write_batch(
@@ -456,6 +591,32 @@ where
             .map(ExecuteResult::rows_affected)
             .sum::<u64>();
         assert_eq!(affected as usize, self.row_count);
+    }
+
+    async fn seed_olap_rows(&self) {
+        const ROWS_PER_STATEMENT: usize = 4_096;
+        let mut transaction = self
+            .session
+            .begin_transaction()
+            .await
+            .expect("begin typed OLAP seed transaction");
+        let mut affected = 0_u64;
+        for start in (0..self.row_count).step_by(ROWS_PER_STATEMENT) {
+            let end = (start + ROWS_PER_STATEMENT).min(self.row_count);
+            affected += transaction
+                .execute(&olap_insert_sql(start..end), &[])
+                .await
+                .expect("execute typed OLAP seed statement")
+                .rows_affected();
+        }
+        transaction
+            .commit()
+            .await
+            .expect("commit typed OLAP seed transaction");
+        assert_eq!(
+            usize::try_from(affected).expect("OLAP affected rows fit usize"),
+            self.row_count
+        );
     }
 
     async fn read_all(&self) -> usize {
@@ -492,6 +653,36 @@ where
             Some(&Value::Integer(self.visible_row_count as i64))
         );
         1
+    }
+
+    async fn read_olap(&self, shape: OlapReadShape) -> usize {
+        let expected = self
+            .olap_expected
+            .as_ref()
+            .expect("typed OLAP query requires a typed OLAP fixture");
+        let result = std::hint::black_box(execute(&self.session, shape.sql()).await);
+        match shape {
+            OlapReadShape::Scan => {
+                assert_eq!(
+                    result.columns(),
+                    ["id", "ordinal", "lane", "score", "active"]
+                );
+                assert_eq!(result.len(), self.row_count);
+            }
+            OlapReadShape::Filter => {
+                assert_eq!(result.columns(), ["ordinal", "lane", "score"]);
+                assert_eq!(result.len(), expected.filtered_rows);
+                assert_eq!(integer_at(&result, 0, 0), expected.filtered_first_ordinal);
+                assert_eq!(
+                    integer_at(&result, result.len() - 1, 0),
+                    expected.filtered_last_ordinal
+                );
+            }
+            OlapReadShape::Sort => assert_olap_sort(&result, expected),
+            OlapReadShape::Group => assert_olap_group(&result, expected),
+            OlapReadShape::Aggregate => assert_olap_aggregate(&result, expected),
+        }
+        result.len()
     }
 
     async fn insert_untracked_probe(&self) {
@@ -653,6 +844,11 @@ where
     } else {
         rows
     };
+    let olap_expected = if matches!(shape, FixtureShape::Olap) {
+        Some(olap_expected(tracked_rows.len()))
+    } else {
+        None
+    };
     let mid = tracked_rows.len() / 2;
     GenericSqlFixture {
         session,
@@ -688,6 +884,7 @@ where
         } else {
             Arc::from([])
         },
+        olap_expected,
         select_all_sql: "SELECT path, value FROM json_pointer ORDER BY path".to_string(),
         select_many_by_pk_sql: select_many_by_pk_sql(
             rows,
@@ -718,6 +915,200 @@ where
         ),
         _dir: dir,
     }
+}
+
+fn olap_expected(row_count: usize) -> OlapExpected {
+    assert!(
+        row_count >= 20,
+        "typed OLAP fixture needs at least 20 rows to populate both selected lanes"
+    );
+    let mut active_rows = 0_i64;
+    let mut active_ordinal_sum = 0_i64;
+    let mut active_score_sum = 0.0;
+    let mut active_min_ordinal = None;
+    let mut active_max_ordinal = None;
+    let mut filtered_rows = 0;
+    let mut filtered_first_ordinal = None;
+    let mut filtered_last_ordinal = None;
+    let mut groups = [OlapGroupExpected {
+        rows: 0,
+        ordinal_sum: 0,
+        score_sum: 0.0,
+        score_min: f64::INFINITY,
+        score_max: f64::NEG_INFINITY,
+    }; 32];
+
+    for index in 0..row_count {
+        let ordinal = i64::try_from(index).expect("OLAP row ordinal must fit in i64");
+        let lane_index = index % groups.len();
+        #[expect(clippy::cast_precision_loss)]
+        let score = (index % 10_000) as f64 / 8.0;
+        let active = index % 3 != 0;
+        if !active {
+            continue;
+        }
+
+        active_rows += 1;
+        active_ordinal_sum += ordinal;
+        active_score_sum += score;
+        active_min_ordinal.get_or_insert(ordinal);
+        active_max_ordinal = Some(ordinal);
+        let group = &mut groups[lane_index];
+        group.rows += 1;
+        group.ordinal_sum += ordinal;
+        group.score_sum += score;
+        group.score_min = group.score_min.min(score);
+        group.score_max = group.score_max.max(score);
+        if matches!(lane_index, 7 | 19) {
+            filtered_rows += 1;
+            filtered_first_ordinal.get_or_insert(ordinal);
+            filtered_last_ordinal = Some(ordinal);
+        }
+    }
+
+    OlapExpected {
+        active_rows,
+        active_ordinal_sum,
+        active_score_sum,
+        active_min_ordinal: active_min_ordinal.expect("OLAP fixture needs an active row"),
+        active_max_ordinal: active_max_ordinal.expect("OLAP fixture needs an active row"),
+        filtered_rows,
+        filtered_first_ordinal: filtered_first_ordinal
+            .expect("OLAP fixture needs a selected lane row"),
+        filtered_last_ordinal: filtered_last_ordinal
+            .expect("OLAP fixture needs a selected lane row"),
+        groups,
+    }
+}
+
+fn olap_insert_sql(ordinals: Range<usize>) -> String {
+    let mut sql = String::from("INSERT INTO olap_row (id, ordinal, lane, score, active) VALUES ");
+    for (position, ordinal) in ordinals.enumerate() {
+        if position != 0 {
+            sql.push(',');
+        }
+        let lane = ordinal % 32;
+        #[expect(clippy::cast_precision_loss)]
+        let score = (ordinal % 10_000) as f64 / 8.0;
+        let active = if ordinal % 3 == 0 { "FALSE" } else { "TRUE" };
+        write!(
+            sql,
+            "('/~lix-olap/{ordinal:09}', {ordinal}, 'lane-{lane:02}', {score}, {active})"
+        )
+        .expect("write typed OLAP INSERT SQL");
+    }
+    sql
+}
+
+fn assert_olap_sort(result: &ExecuteResult, expected: &OlapExpected) {
+    assert_eq!(result.columns(), ["id", "ordinal", "score"]);
+    assert_eq!(result.len(), 10_000.min(expected.active_rows as usize));
+    let mut previous = None;
+    for row_index in 0..result.len() {
+        let ordinal = integer_at(result, row_index, 1);
+        let score = real_at(result, row_index, 2);
+        assert_ne!(ordinal % 3, 0, "sorted result must retain active rows only");
+        assert_eq!(
+            text_at(result, row_index, 0),
+            format!("/~lix-olap/{ordinal:09}")
+        );
+        #[expect(clippy::cast_precision_loss)]
+        let expected_score = (ordinal.rem_euclid(10_000)) as f64 / 8.0;
+        assert_eq!(score, expected_score);
+        if let Some((previous_score, previous_ordinal)) = previous {
+            assert!(
+                previous_score > score || (previous_score == score && previous_ordinal < ordinal),
+                "OLAP top-k must be ordered by score DESC, ordinal ASC"
+            );
+        }
+        previous = Some((score, ordinal));
+    }
+}
+
+fn assert_olap_group(result: &ExecuteResult, expected: &OlapExpected) {
+    assert_eq!(
+        result.columns(),
+        [
+            "lane",
+            "rows",
+            "ordinal_sum",
+            "score_avg",
+            "score_min",
+            "score_max"
+        ]
+    );
+    assert_eq!(result.len(), expected.groups.len());
+    let mut total_rows = 0;
+    let mut total_ordinal_sum = 0;
+    for (lane_index, group) in expected.groups.iter().enumerate() {
+        assert_eq!(
+            text_at(result, lane_index, 0),
+            format!("lane-{lane_index:02}")
+        );
+        assert_eq!(integer_at(result, lane_index, 1), group.rows);
+        assert_eq!(integer_at(result, lane_index, 2), group.ordinal_sum);
+        assert_close(
+            real_at(result, lane_index, 3),
+            group.score_sum / group.rows as f64,
+        );
+        assert_eq!(real_at(result, lane_index, 4), group.score_min);
+        assert_eq!(real_at(result, lane_index, 5), group.score_max);
+        total_rows += group.rows;
+        total_ordinal_sum += group.ordinal_sum;
+    }
+    assert_eq!(total_rows, expected.active_rows);
+    assert_eq!(total_ordinal_sum, expected.active_ordinal_sum);
+}
+
+fn assert_olap_aggregate(result: &ExecuteResult, expected: &OlapExpected) {
+    assert_eq!(
+        result.columns(),
+        [
+            "rows",
+            "ordinal_sum",
+            "score_avg",
+            "min_ordinal",
+            "max_ordinal"
+        ]
+    );
+    assert_eq!(result.len(), 1);
+    assert_eq!(integer_at(result, 0, 0), expected.active_rows);
+    assert_eq!(integer_at(result, 0, 1), expected.active_ordinal_sum);
+    assert_close(
+        real_at(result, 0, 2),
+        expected.active_score_sum / expected.active_rows as f64,
+    );
+    assert_eq!(integer_at(result, 0, 3), expected.active_min_ordinal);
+    assert_eq!(integer_at(result, 0, 4), expected.active_max_ordinal);
+}
+
+fn integer_at(result: &ExecuteResult, row: usize, column: usize) -> i64 {
+    match result.rows()[row].get_index(column) {
+        Some(Value::Integer(value)) => *value,
+        value => panic!("expected integer at row {row}, column {column}, got {value:?}"),
+    }
+}
+
+fn real_at(result: &ExecuteResult, row: usize, column: usize) -> f64 {
+    match result.rows()[row].get_index(column) {
+        Some(Value::Real(value)) => *value,
+        value => panic!("expected real at row {row}, column {column}, got {value:?}"),
+    }
+}
+
+fn text_at(result: &ExecuteResult, row: usize, column: usize) -> &str {
+    match result.rows()[row].get_index(column) {
+        Some(Value::Text(value)) => value,
+        value => panic!("expected text at row {row}, column {column}, got {value:?}"),
+    }
+}
+
+fn assert_close(actual: f64, expected: f64) {
+    let tolerance = 1e-10 * expected.abs().max(1.0);
+    assert!(
+        (actual - expected).abs() <= tolerance,
+        "expected {expected} within {tolerance}, got {actual}"
+    );
 }
 
 fn literal_update_workload(shape: FixtureShape, rows: &[WorkloadRow]) -> LiteralUpdateWorkload {
@@ -756,6 +1147,13 @@ fn profile_untracked_fixture() -> UntrackedFixture {
     }
 }
 
+pub(crate) fn selected_olap_read_shape() -> Option<OlapReadShape> {
+    std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_READ_SHAPE")
+        .ok()
+        .as_deref()
+        .and_then(OlapReadShape::from_label)
+}
+
 async fn prepare_session<StorageImpl>(storage: StorageImpl) -> SessionContext<StorageImpl>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
@@ -772,6 +1170,7 @@ where
         .expect("open tracked-state crud session");
     register_json_pointer_schema(&session).await;
     register_bulk_insert_schema(&session).await;
+    register_olap_schema(&session).await;
     session
 }
 
@@ -825,6 +1224,35 @@ where
         )
         .await
         .expect("register tracked_crud_insert schema")
+        .rows_affected();
+    assert_eq!(affected, 1);
+}
+
+async fn register_olap_schema<StorageImpl>(session: &SessionContext<StorageImpl>)
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let schema = serde_json::json!({
+        "x-lix-key": "olap_row",
+        "x-lix-primary-key": ["/id"],
+        "type": "object",
+        "required": ["id", "ordinal", "lane", "score", "active"],
+        "properties": {
+            "id": { "type": "string" },
+            "ordinal": { "type": "integer" },
+            "lane": { "type": "string" },
+            "score": { "type": "number" },
+            "active": { "type": "boolean" }
+        },
+        "additionalProperties": false
+    });
+    let affected = session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register olap_row schema")
         .rows_affected();
     assert_eq!(affected, 1);
 }

--- a/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
+++ b/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
@@ -68,6 +68,29 @@ async fn typed_olap_shapes_validate_exact_results_on_every_adapter() {
     }
 }
 
+#[tokio::test]
+async fn typed_olap_shapes_validate_above_columnar_publication_threshold() {
+    let rows = workload::fixture_rows(2_048);
+    for &profile in storage::STORAGE_PROFILES {
+        let fixture = sql_session::seeded_olap_fixture(profile, &rows).await;
+        for shape in sql_session::OlapReadShape::ALL {
+            let expected_rows = match shape {
+                sql_session::OlapReadShape::Scan => rows.len(),
+                sql_session::OlapReadShape::Filter => 86,
+                sql_session::OlapReadShape::Sort => 1_365,
+                sql_session::OlapReadShape::Group => 32,
+                sql_session::OlapReadShape::Aggregate => 1,
+            };
+            assert_eq!(
+                fixture.read_olap(shape).await,
+                expected_rows,
+                "{}",
+                shape.label()
+            );
+        }
+    }
+}
+
 #[test]
 fn standalone_sqlite_public_results_match_every_lix_adapter() {
     std::thread::Builder::new()

--- a/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
+++ b/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
@@ -17,6 +17,58 @@ mod workload;
 use workload::WorkloadRow;
 
 #[test]
+fn typed_olap_queries_are_structurally_ineligible_for_strict_native_reads() {
+    use datafusion::sql::parser::DFParser;
+    use datafusion::sql::sqlparser::ast::{SetExpr, Statement as SqlStatement};
+    use datafusion::sql::sqlparser::dialect::GenericDialect;
+
+    for shape in sql_session::OlapReadShape::ALL {
+        let mut statements = DFParser::parse_sql_with_dialect(shape.sql(), &GenericDialect {})
+            .expect("typed OLAP benchmark SQL should parse");
+        let statement = statements.pop_front().expect("one OLAP statement");
+        let datafusion::sql::parser::Statement::Statement(statement) = statement else {
+            panic!("{} must remain a SELECT query", shape.label());
+        };
+        let SqlStatement::Query(query) = statement.as_ref() else {
+            panic!("{} must remain a SELECT query", shape.label());
+        };
+        assert!(
+            query.with.is_some(),
+            "{} must retain a top-level CTE: strict_single_table_select rejects query.with before any native entity recognizer can match",
+            shape.label()
+        );
+        assert!(
+            matches!(query.body.as_ref(), SetExpr::Select(_)),
+            "{} must remain a general DataFusion SELECT",
+            shape.label()
+        );
+    }
+}
+
+#[tokio::test]
+async fn typed_olap_shapes_validate_exact_results_on_every_adapter() {
+    let rows = workload::fixture_rows(128);
+    for &profile in storage::STORAGE_PROFILES {
+        let fixture = sql_session::seeded_olap_fixture(profile, &rows).await;
+        for shape in sql_session::OlapReadShape::ALL {
+            let expected_rows = match shape {
+                sql_session::OlapReadShape::Scan => rows.len(),
+                sql_session::OlapReadShape::Filter => 6,
+                sql_session::OlapReadShape::Sort => 85,
+                sql_session::OlapReadShape::Group => 32,
+                sql_session::OlapReadShape::Aggregate => 1,
+            };
+            assert_eq!(
+                fixture.read_olap(shape).await,
+                expected_rows,
+                "{}",
+                shape.label()
+            );
+        }
+    }
+}
+
+#[test]
 fn standalone_sqlite_public_results_match_every_lix_adapter() {
     std::thread::Builder::new()
         .name("tracked-state-public-result".to_string())

--- a/packages/engine/src/columnar_row_group.rs
+++ b/packages/engine/src/columnar_row_group.rs
@@ -27,7 +27,7 @@ use crate::storage_adapter::{
     StorageSpace, StorageSpaceId, StorageValue, StorageWriteSet,
 };
 
-pub(crate) const ROW_GROUP_MAX_ROWS: usize = 16 * 1024;
+pub(crate) const ROW_GROUP_MAX_ROWS: usize = 64 * 1024;
 pub(crate) const ROW_GROUP_MANIFEST_SPACE: StorageSpace = StorageSpace::immutable(
     StorageSpaceId(0x0004_0029),
     "analytical.row_group_manifest.v1",
@@ -37,9 +37,10 @@ pub(crate) const ROW_GROUP_COLUMN_SPACE: StorageSpace = StorageSpace::immutable(
     "analytical.row_group_column.v1",
 );
 
-const MANIFEST_MAGIC: &[u8; 8] = b"LXRGM001";
+const MANIFEST_MAGIC: &[u8; 8] = b"LXRGM003";
 const COLUMN_MAGIC: &[u8; 8] = b"LXRGC001";
 const COMPRESSED_MAGIC: &[u8; 8] = b"LXRGZ001";
+const BLAKE3_DIGEST_LEN: usize = 32;
 const MAX_DECODED_COLUMN_BYTES: usize = 256 * 1024 * 1024;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -89,7 +90,7 @@ impl RowGroupDataType {
         }
     }
 
-    fn to_arrow(self) -> DataType {
+    pub(crate) fn to_arrow(self) -> DataType {
         match self {
             Self::String => DataType::Utf8,
             Self::Int64 => DataType::Int64,
@@ -138,12 +139,14 @@ pub(crate) struct RowGroupColumnStatistics {
     pub(crate) null_count: u32,
     pub(crate) min: Option<RowGroupScalar>,
     pub(crate) max: Option<RowGroupScalar>,
+    pub(crate) sum: Option<RowGroupScalar>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct RowGroupStatistics {
     pub(crate) row_count: u32,
     pub(crate) columns: Vec<RowGroupColumnStatistics>,
+    column_digests: Vec<[u8; BLAKE3_DIGEST_LEN]>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -207,6 +210,23 @@ pub(crate) fn encode_row_group_set(
     schema: SchemaRef,
     batches: &[RecordBatch],
 ) -> Result<EncodedRowGroupSet, LixError> {
+    encode_row_group_set_impl(namespace.into(), schema, batches, false)
+}
+
+pub(crate) fn encode_row_group_set_preserving_batches(
+    namespace: impl Into<String>,
+    schema: SchemaRef,
+    batches: &[RecordBatch],
+) -> Result<EncodedRowGroupSet, LixError> {
+    encode_row_group_set_impl(namespace.into(), schema, batches, true)
+}
+
+fn encode_row_group_set_impl(
+    namespace: String,
+    schema: SchemaRef,
+    batches: &[RecordBatch],
+    preserve_batch_boundaries: bool,
+) -> Result<EncodedRowGroupSet, LixError> {
     validate_input_batches(&schema, batches)?;
     let fields = schema
         .fields()
@@ -226,17 +246,19 @@ pub(crate) fn encode_row_group_set(
         ));
     }
 
-    let row_groups = partition_batches(&schema, batches)?;
+    let row_groups = partition_batches(&schema, batches, preserve_batch_boundaries)?;
     let mut groups = Vec::with_capacity(row_groups.len());
     let mut columns = Vec::with_capacity(row_groups.len().saturating_mul(fields.len()));
     for (group_index, batch) in row_groups.iter().enumerate() {
         let row_count = u32::try_from(batch.num_rows())
             .map_err(|_| row_group_error("row-group row count exceeds u32"))?;
         let mut statistics = Vec::with_capacity(fields.len());
+        let mut column_digests = Vec::with_capacity(fields.len());
         for (column_index, (array, field)) in batch.columns().iter().zip(&fields).enumerate() {
             let stats = column_statistics(array, field.data_type)?;
             let encoded = encode_column(array, field.data_type)?;
             statistics.push(stats);
+            column_digests.push(*blake3::hash(&encoded).as_bytes());
             columns.push(EncodedColumn {
                 group_index,
                 column_index,
@@ -246,10 +268,11 @@ pub(crate) fn encode_row_group_set(
         groups.push(RowGroupStatistics {
             row_count,
             columns: statistics,
+            column_digests,
         });
     }
     let manifest = RowGroupManifest {
-        namespace: namespace.into(),
+        namespace,
         metadata: schema.metadata().clone(),
         fields,
         groups,
@@ -302,6 +325,29 @@ pub(crate) async fn load_row_group_manifest(
         return Err(row_group_error("row-group manifest read omitted its value"));
     };
     decode_manifest(&bytes).map(Some)
+}
+
+/// Stages deletion of one immutable set and every addressed column. The
+/// owning commit remains the lifecycle authority; repository GC invokes this
+/// only after that commit leaves the reachable history graph.
+pub(crate) async fn stage_delete_row_group_set(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    id: RowGroupSetId,
+) -> Result<(), LixError> {
+    let Some(manifest) = load_row_group_manifest(store, id).await? else {
+        return Ok(());
+    };
+    writes.delete(ROW_GROUP_MANIFEST_SPACE, id.manifest_key());
+    for group_index in 0..manifest.groups.len() {
+        for column_index in 0..manifest.fields.len() {
+            writes.delete(
+                ROW_GROUP_COLUMN_SPACE,
+                id.column_key(group_index, column_index)?,
+            );
+        }
+    }
+    Ok(())
 }
 
 pub(crate) async fn load_row_group_set(
@@ -368,13 +414,12 @@ pub(crate) async fn load_row_group_batch(
             return Err(row_group_error("row-group column read omitted its value"));
         };
         let field = &manifest.fields[column_index];
-        let array = decode_column(&bytes, field.data_type, group.row_count as usize)?;
-        let observed = column_statistics(&array, field.data_type)?;
-        if observed != group.columns[column_index] {
-            return Err(row_group_error(format!(
-                "row-group {group_index} column {column_index} statistics do not match the manifest"
-            )));
-        }
+        let array = decode_verified_column(
+            &bytes,
+            group.column_digests[column_index],
+            field.data_type,
+            group.row_count as usize,
+        )?;
         arrays.push(array);
     }
     if values.next().is_some() {
@@ -398,7 +443,17 @@ fn validate_input_batches(schema: &SchemaRef, batches: &[RecordBatch]) -> Result
 fn partition_batches(
     schema: &SchemaRef,
     batches: &[RecordBatch],
+    preserve_batch_boundaries: bool,
 ) -> Result<Vec<RecordBatch>, LixError> {
+    if preserve_batch_boundaries {
+        let mut groups = Vec::new();
+        for batch in batches {
+            for offset in (0..batch.num_rows()).step_by(ROW_GROUP_MAX_ROWS) {
+                groups.push(batch.slice(offset, ROW_GROUP_MAX_ROWS.min(batch.num_rows() - offset)));
+            }
+        }
+        return Ok(groups);
+    }
     let mut groups = Vec::new();
     let mut pending = Vec::new();
     let mut pending_rows = 0;
@@ -631,6 +686,20 @@ fn decode_column(
     Ok(array)
 }
 
+fn decode_verified_column(
+    encoded: &[u8],
+    expected_digest: [u8; BLAKE3_DIGEST_LEN],
+    expected_type: RowGroupDataType,
+    expected_rows: usize,
+) -> Result<ArrayRef, LixError> {
+    if blake3::hash(encoded).as_bytes() != &expected_digest {
+        return Err(row_group_error(
+            "row-group compressed column digest does not match the manifest",
+        ));
+    }
+    decode_column(encoded, expected_type, expected_rows)
+}
+
 fn encode_validity(array: &dyn Array) -> Vec<u8> {
     let mut validity = vec![0_u8; array.len().div_ceil(8)];
     for index in 0..array.len() {
@@ -665,7 +734,7 @@ fn column_statistics(
 ) -> Result<RowGroupColumnStatistics, LixError> {
     let null_count = u32::try_from(array.null_count())
         .map_err(|_| row_group_error("row-group null count exceeds u32"))?;
-    let (min, max) = match data_type {
+    let (min, max, sum) = match data_type {
         RowGroupDataType::String => {
             let values = array
                 .as_any()
@@ -677,6 +746,7 @@ fn column_statistics(
                     null_count,
                     min: None,
                     max: None,
+                    sum: None,
                 });
             };
             let (mut min, mut max) = (first, first);
@@ -691,6 +761,7 @@ fn column_statistics(
             (
                 Some(RowGroupScalar::String(min.to_owned())),
                 Some(RowGroupScalar::String(max.to_owned())),
+                None,
             )
         }
         RowGroupDataType::Int64 => {
@@ -704,16 +775,19 @@ fn column_statistics(
                     null_count,
                     min: None,
                     max: None,
+                    sum: None,
                 });
             };
-            let (mut min, mut max) = (first, first);
+            let (mut min, mut max, mut sum) = (first, first, Some(first));
             for value in observed {
                 min = min.min(value);
                 max = max.max(value);
+                sum = sum.and_then(|sum| sum.checked_add(value));
             }
             (
                 Some(RowGroupScalar::Int64(min)),
                 Some(RowGroupScalar::Int64(max)),
+                sum.map(RowGroupScalar::Int64),
             )
         }
         RowGroupDataType::Float64 => {
@@ -727,9 +801,10 @@ fn column_statistics(
                     null_count,
                     min: None,
                     max: None,
+                    sum: None,
                 });
             };
-            let (mut min, mut max) = (first, first);
+            let (mut min, mut max, mut sum) = (first, first, first);
             for value in observed {
                 if value.total_cmp(&min).is_lt() {
                     min = value;
@@ -737,10 +812,12 @@ fn column_statistics(
                 if value.total_cmp(&max).is_gt() {
                     max = value;
                 }
+                sum += value;
             }
             (
                 Some(RowGroupScalar::Float64(min)),
                 Some(RowGroupScalar::Float64(max)),
+                Some(RowGroupScalar::Float64(sum)),
             )
         }
         RowGroupDataType::Boolean => {
@@ -754,6 +831,7 @@ fn column_statistics(
                     null_count,
                     min: None,
                     max: None,
+                    sum: None,
                 });
             };
             let (mut min, mut max) = (first, first);
@@ -764,6 +842,7 @@ fn column_statistics(
             (
                 Some(RowGroupScalar::Boolean(min)),
                 Some(RowGroupScalar::Boolean(max)),
+                None,
             )
         }
     };
@@ -771,10 +850,16 @@ fn column_statistics(
         null_count,
         min,
         max,
+        sum,
     })
 }
 
 fn compress_column(raw: &[u8]) -> Result<Vec<u8>, LixError> {
+    if raw.len() > MAX_DECODED_COLUMN_BYTES {
+        return Err(row_group_error(
+            "row-group decoded column exceeds the safety limit",
+        ));
+    }
     let compressed = crate::compression::compress_zstd_level_1(raw)
         .map_err(|error| row_group_error(format!("row-group compression failed: {error}")))?;
     let mut output = Vec::with_capacity(12 + compressed.len());
@@ -824,17 +909,39 @@ fn encode_manifest(manifest: &RowGroupManifest) -> Result<Vec<u8>, LixError> {
                 "manifest statistics width does not match its schema",
             ));
         }
-        for (stats, field) in group.columns.iter().zip(&manifest.fields) {
+        if group.column_digests.len() != manifest.fields.len() {
+            return Err(row_group_error(
+                "manifest column digest width does not match its schema",
+            ));
+        }
+        for ((stats, digest), field) in group
+            .columns
+            .iter()
+            .zip(&group.column_digests)
+            .zip(&manifest.fields)
+        {
+            output.extend_from_slice(digest);
             output.extend_from_slice(&stats.null_count.to_le_bytes());
             put_optional_scalar(&mut output, stats.min.as_ref(), field.data_type)?;
             put_optional_scalar(&mut output, stats.max.as_ref(), field.data_type)?;
+            put_optional_scalar(&mut output, stats.sum.as_ref(), field.data_type)?;
         }
     }
+    let checksum = blake3::hash(&output);
+    output.extend_from_slice(checksum.as_bytes());
     Ok(output)
 }
 
 fn decode_manifest(encoded: &[u8]) -> Result<RowGroupManifest, LixError> {
-    let mut cursor = Cursor::new(encoded);
+    let body_len = encoded
+        .len()
+        .checked_sub(BLAKE3_DIGEST_LEN)
+        .ok_or_else(|| row_group_error("row-group manifest checksum is missing"))?;
+    let (body, encoded_checksum) = encoded.split_at(body_len);
+    if blake3::hash(body).as_bytes() != encoded_checksum {
+        return Err(row_group_error("row-group manifest checksum mismatch"));
+    }
+    let mut cursor = Cursor::new(body);
     cursor.expect_magic(MANIFEST_MAGIC, "row-group manifest")?;
     let namespace = cursor.string()?;
     let metadata = cursor.metadata()?;
@@ -865,7 +972,10 @@ fn decode_manifest(encoded: &[u8]) -> Result<RowGroupManifest, LixError> {
             ));
         }
         let mut columns = Vec::with_capacity(field_count);
+        let mut column_digests = Vec::with_capacity(field_count);
         for field in &fields {
+            let digest = <[u8; BLAKE3_DIGEST_LEN]>::try_from(cursor.bytes(BLAKE3_DIGEST_LEN)?)
+                .map_err(|_| row_group_error("row-group column digest has an invalid length"))?;
             let null_count = cursor.u32_le()?;
             if null_count > row_count {
                 return Err(row_group_error(
@@ -874,6 +984,7 @@ fn decode_manifest(encoded: &[u8]) -> Result<RowGroupManifest, LixError> {
             }
             let min = cursor.optional_scalar(field.data_type)?;
             let max = cursor.optional_scalar(field.data_type)?;
+            let sum = cursor.optional_scalar(field.data_type)?;
             if (min.is_none() || max.is_none()) != (null_count == row_count) {
                 return Err(row_group_error(
                     "row-group min/max presence contradicts null count",
@@ -883,9 +994,15 @@ fn decode_manifest(encoded: &[u8]) -> Result<RowGroupManifest, LixError> {
                 null_count,
                 min,
                 max,
+                sum,
             });
+            column_digests.push(digest);
         }
-        groups.push(RowGroupStatistics { row_count, columns });
+        groups.push(RowGroupStatistics {
+            row_count,
+            columns,
+            column_digests,
+        });
     }
     if !cursor.is_empty() {
         return Err(row_group_error("row-group manifest has trailing bytes"));
@@ -1134,6 +1251,10 @@ mod tests {
         assert_eq!(encoded.manifest.groups[1].row_count, 9);
         assert_eq!(encoded.manifest.row_count(), rows as u64);
         assert_eq!(encoded.manifest.schema().as_ref(), schema.as_ref());
+        assert_eq!(
+            decode_manifest(&encoded.manifest_bytes).expect("decode manifest"),
+            encoded.manifest
+        );
         assert!(
             encoded.manifest.groups[0]
                 .columns
@@ -1208,13 +1329,75 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn lifecycle_delete_removes_manifest_and_columns() {
+        let (schema, batches) = fixture(ROW_GROUP_MAX_ROWS + 3);
+        let encoded = encode_row_group_set("fixture", schema, &batches).expect("encode");
+        let adapter = StorageAdapter::new(Memory::new());
+        let id = RowGroupSetId::new(*b"row-group-set-03");
+        let mut writes = adapter.new_write_set();
+        stage_row_group_set(&mut writes, id, &encoded).expect("stage");
+        adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit");
+
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read");
+        let mut deletes = adapter.new_write_set();
+        stage_delete_row_group_set(&read, &mut deletes, id)
+            .await
+            .expect("stage lifecycle delete");
+        drop(read);
+        adapter
+            .commit_write_set(deletes, StorageWriteOptions::default())
+            .await
+            .expect("commit lifecycle delete");
+
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("verify read");
+        assert!(
+            load_row_group_manifest(&read, id)
+                .await
+                .expect("load deleted manifest")
+                .is_none()
+        );
+        let column_keys = encoded
+            .columns
+            .iter()
+            .map(|column| {
+                id.column_key(column.group_index, column.column_index)
+                    .expect("key")
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            PointReadPlan::new(ROW_GROUP_COLUMN_SPACE, &column_keys)
+                .materialize(&read, StorageGetOptions::default())
+                .await
+                .expect("load deleted columns")
+                .value
+                .into_iter()
+                .all(|value| value.is_none())
+        );
+    }
+
     #[test]
     fn corrupt_values_fail_closed() {
         let (schema, batches) = fixture(32);
         let encoded = encode_row_group_set("fixture", schema, &batches).expect("encode");
+
         let mut bad_manifest = encoded.manifest_bytes.to_vec();
         bad_manifest[0] ^= 0xff;
         assert!(decode_manifest(&bad_manifest).is_err());
+
+        let mut bad_manifest_checksum = encoded.manifest_bytes.to_vec();
+        let checksum_index = bad_manifest_checksum.len() - 1;
+        bad_manifest_checksum[checksum_index] ^= 0xff;
+        assert!(decode_manifest(&bad_manifest_checksum).is_err());
 
         let mut truncated = encoded.columns[0].bytes.to_vec();
         truncated.truncate(truncated.len() / 2);
@@ -1224,6 +1407,53 @@ mod tests {
         oversized.extend_from_slice(&u32::MAX.to_le_bytes());
         oversized.extend_from_slice(b"not-zstd");
         assert!(decode_column(&oversized, RowGroupDataType::String, 32).is_err());
+    }
+
+    #[test]
+    fn manifest_stat_corruption_fails_closed() {
+        let (schema, batches) = fixture(32);
+        let encoded = encode_row_group_set("fixture", schema, &batches).expect("encode");
+
+        // The final byte before the checksum is part of the final column's
+        // persisted statistics. The checksum rejects the modified statistic
+        // before the manifest parser can trust it.
+        let mut bad_manifest_stat = encoded.manifest_bytes.to_vec();
+        let stat_index = bad_manifest_stat.len() - BLAKE3_DIGEST_LEN - 1;
+        bad_manifest_stat[stat_index] ^= 0xff;
+        assert!(decode_manifest(&bad_manifest_stat).is_err());
+    }
+
+    #[tokio::test]
+    async fn column_byte_corruption_fails_closed_during_load() {
+        let (schema, batches) = fixture(32);
+        let mut encoded = encode_row_group_set("fixture", schema, &batches).expect("encode");
+
+        let mut corrupt_column = encoded.columns[0].bytes.to_vec();
+        let corrupt_index = corrupt_column.len() - 1;
+        corrupt_column[corrupt_index] ^= 0xff;
+        encoded.columns[0].bytes = Bytes::from(corrupt_column);
+
+        let adapter = StorageAdapter::new(Memory::new());
+        let id = RowGroupSetId::new(*b"row-group-set-02");
+        let mut writes = adapter.new_write_set();
+        stage_row_group_set(&mut writes, id, &encoded).expect("stage corrupt column");
+        adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit corrupt column");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read");
+        let manifest = load_row_group_manifest(&read, id)
+            .await
+            .expect("load authenticated manifest")
+            .expect("manifest present");
+        assert!(
+            load_row_group_batch(&read, id, &manifest, 0, &[0])
+                .await
+                .is_err()
+        );
     }
 
     #[test]

--- a/packages/engine/src/columnar_row_group.rs
+++ b/packages/engine/src/columnar_row_group.rs
@@ -1,0 +1,1244 @@
+//! Immutable, projection-addressable Arrow row groups.
+//!
+//! This module owns a generic physical format. It deliberately knows nothing
+//! about SQL plans, current-state visibility, or commit publication. Callers
+//! provide a stable 16-byte owner and publish the returned immutable writes
+//! inside their own atomic visibility transaction.
+
+// This intentionally lands before its publication/read-path integration. Its
+// crate-private API is exercised by the codec and storage tests below.
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use datafusion::arrow::array::{
+    Array, ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray,
+};
+use datafusion::arrow::buffer::{BooleanBuffer, Buffer, NullBuffer, OffsetBuffer, ScalarBuffer};
+use datafusion::arrow::compute::concat_batches;
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::record_batch::{RecordBatch, RecordBatchOptions};
+
+use crate::LixError;
+use crate::storage_adapter::{
+    PointReadPlan, StorageAdapterRead, StorageGetOptions, StorageKey, StorageProjectedValue,
+    StorageSpace, StorageSpaceId, StorageValue, StorageWriteSet,
+};
+
+pub(crate) const ROW_GROUP_MAX_ROWS: usize = 16 * 1024;
+pub(crate) const ROW_GROUP_MANIFEST_SPACE: StorageSpace = StorageSpace::immutable(
+    StorageSpaceId(0x0004_0029),
+    "analytical.row_group_manifest.v1",
+);
+pub(crate) const ROW_GROUP_COLUMN_SPACE: StorageSpace = StorageSpace::immutable(
+    StorageSpaceId(0x0004_002a),
+    "analytical.row_group_column.v1",
+);
+
+const MANIFEST_MAGIC: &[u8; 8] = b"LXRGM001";
+const COLUMN_MAGIC: &[u8; 8] = b"LXRGC001";
+const COMPRESSED_MAGIC: &[u8; 8] = b"LXRGZ001";
+const MAX_DECODED_COLUMN_BYTES: usize = 256 * 1024 * 1024;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct RowGroupSetId([u8; 16]);
+
+impl RowGroupSetId {
+    pub(crate) const fn new(bytes: [u8; 16]) -> Self {
+        Self(bytes)
+    }
+
+    fn manifest_key(self) -> StorageKey {
+        StorageKey(Bytes::copy_from_slice(&self.0))
+    }
+
+    fn column_key(self, group_index: usize, column_index: usize) -> Result<StorageKey, LixError> {
+        let group_index = u32::try_from(group_index)
+            .map_err(|_| row_group_error("row-group index exceeds u32"))?;
+        let column_index = u16::try_from(column_index)
+            .map_err(|_| row_group_error("row-group column index exceeds u16"))?;
+        let mut key = Vec::with_capacity(22);
+        key.extend_from_slice(&self.0);
+        key.extend_from_slice(&group_index.to_be_bytes());
+        key.extend_from_slice(&column_index.to_be_bytes());
+        Ok(StorageKey(Bytes::from(key)))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum RowGroupDataType {
+    String = 1,
+    Int64 = 2,
+    Float64 = 3,
+    Boolean = 4,
+}
+
+impl RowGroupDataType {
+    fn from_arrow(value: &DataType) -> Result<Self, LixError> {
+        match value {
+            DataType::Utf8 => Ok(Self::String),
+            DataType::Int64 => Ok(Self::Int64),
+            DataType::Float64 => Ok(Self::Float64),
+            DataType::Boolean => Ok(Self::Boolean),
+            other => Err(row_group_error(format!(
+                "unsupported row-group Arrow type {other}"
+            ))),
+        }
+    }
+
+    fn to_arrow(self) -> DataType {
+        match self {
+            Self::String => DataType::Utf8,
+            Self::Int64 => DataType::Int64,
+            Self::Float64 => DataType::Float64,
+            Self::Boolean => DataType::Boolean,
+        }
+    }
+
+    fn decode(value: u8) -> Result<Self, LixError> {
+        match value {
+            1 => Ok(Self::String),
+            2 => Ok(Self::Int64),
+            3 => Ok(Self::Float64),
+            4 => Ok(Self::Boolean),
+            _ => Err(row_group_error(
+                "row-group manifest has an unknown column type",
+            )),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum RowGroupScalar {
+    String(String),
+    Int64(i64),
+    Float64(f64),
+    Boolean(bool),
+}
+
+impl PartialEq for RowGroupScalar {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::String(left), Self::String(right)) => left == right,
+            (Self::Int64(left), Self::Int64(right)) => left == right,
+            // Statistics are physical metadata. Bit equality makes NaNs and
+            // signed zero round-trip without weakening corruption checks.
+            (Self::Float64(left), Self::Float64(right)) => left.to_bits() == right.to_bits(),
+            (Self::Boolean(left), Self::Boolean(right)) => left == right,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct RowGroupColumnStatistics {
+    pub(crate) null_count: u32,
+    pub(crate) min: Option<RowGroupScalar>,
+    pub(crate) max: Option<RowGroupScalar>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct RowGroupStatistics {
+    pub(crate) row_count: u32,
+    pub(crate) columns: Vec<RowGroupColumnStatistics>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RowGroupField {
+    pub(crate) name: String,
+    pub(crate) data_type: RowGroupDataType,
+    pub(crate) nullable: bool,
+    pub(crate) metadata: HashMap<String, String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct RowGroupManifest {
+    pub(crate) namespace: String,
+    pub(crate) metadata: HashMap<String, String>,
+    pub(crate) fields: Vec<RowGroupField>,
+    pub(crate) groups: Vec<RowGroupStatistics>,
+}
+
+impl RowGroupManifest {
+    pub(crate) fn row_count(&self) -> u64 {
+        self.groups
+            .iter()
+            .map(|group| u64::from(group.row_count))
+            .sum()
+    }
+
+    pub(crate) fn schema(&self) -> SchemaRef {
+        let fields = self.fields.iter().map(|field| {
+            Field::new(&field.name, field.data_type.to_arrow(), field.nullable)
+                .with_metadata(field.metadata.clone())
+        });
+        Arc::new(Schema::new_with_metadata(
+            fields.collect::<Vec<_>>(),
+            self.metadata.clone(),
+        ))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct EncodedColumn {
+    group_index: usize,
+    column_index: usize,
+    bytes: Bytes,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct EncodedRowGroupSet {
+    pub(crate) manifest: RowGroupManifest,
+    manifest_bytes: Bytes,
+    columns: Vec<EncodedColumn>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct LoadedRowGroupSet {
+    pub(crate) manifest: RowGroupManifest,
+    pub(crate) batches: Vec<RecordBatch>,
+}
+
+pub(crate) fn encode_row_group_set(
+    namespace: impl Into<String>,
+    schema: SchemaRef,
+    batches: &[RecordBatch],
+) -> Result<EncodedRowGroupSet, LixError> {
+    validate_input_batches(&schema, batches)?;
+    let fields = schema
+        .fields()
+        .iter()
+        .map(|field| {
+            Ok(RowGroupField {
+                name: field.name().clone(),
+                data_type: RowGroupDataType::from_arrow(field.data_type())?,
+                nullable: field.is_nullable(),
+                metadata: field.metadata().clone(),
+            })
+        })
+        .collect::<Result<Vec<_>, LixError>>()?;
+    if fields.len() > usize::from(u16::MAX) {
+        return Err(row_group_error(
+            "row-group schema has more than u16 columns",
+        ));
+    }
+
+    let row_groups = partition_batches(&schema, batches)?;
+    let mut groups = Vec::with_capacity(row_groups.len());
+    let mut columns = Vec::with_capacity(row_groups.len().saturating_mul(fields.len()));
+    for (group_index, batch) in row_groups.iter().enumerate() {
+        let row_count = u32::try_from(batch.num_rows())
+            .map_err(|_| row_group_error("row-group row count exceeds u32"))?;
+        let mut statistics = Vec::with_capacity(fields.len());
+        for (column_index, (array, field)) in batch.columns().iter().zip(&fields).enumerate() {
+            let stats = column_statistics(array, field.data_type)?;
+            let encoded = encode_column(array, field.data_type)?;
+            statistics.push(stats);
+            columns.push(EncodedColumn {
+                group_index,
+                column_index,
+                bytes: Bytes::from(encoded),
+            });
+        }
+        groups.push(RowGroupStatistics {
+            row_count,
+            columns: statistics,
+        });
+    }
+    let manifest = RowGroupManifest {
+        namespace: namespace.into(),
+        metadata: schema.metadata().clone(),
+        fields,
+        groups,
+    };
+    let manifest_bytes = Bytes::from(encode_manifest(&manifest)?);
+    Ok(EncodedRowGroupSet {
+        manifest,
+        manifest_bytes,
+        columns,
+    })
+}
+
+pub(crate) fn stage_row_group_set(
+    writes: &mut StorageWriteSet,
+    id: RowGroupSetId,
+    encoded: &EncodedRowGroupSet,
+) -> Result<(), LixError> {
+    writes.reserve_space(ROW_GROUP_MANIFEST_SPACE, 1, 0);
+    writes.reserve_space(ROW_GROUP_COLUMN_SPACE, encoded.columns.len(), 0);
+    for column in &encoded.columns {
+        writes.put(
+            ROW_GROUP_COLUMN_SPACE,
+            id.column_key(column.group_index, column.column_index)?,
+            StorageValue {
+                bytes: column.bytes.clone(),
+            },
+        );
+    }
+    writes.put(
+        ROW_GROUP_MANIFEST_SPACE,
+        id.manifest_key(),
+        StorageValue {
+            bytes: encoded.manifest_bytes.clone(),
+        },
+    );
+    Ok(())
+}
+
+pub(crate) async fn load_row_group_manifest(
+    store: &(impl StorageAdapterRead + ?Sized),
+    id: RowGroupSetId,
+) -> Result<Option<RowGroupManifest>, LixError> {
+    let result = PointReadPlan::new(ROW_GROUP_MANIFEST_SPACE, &[id.manifest_key()])
+        .materialize(store, StorageGetOptions::default())
+        .await?;
+    let Some(value) = result.value.into_iter().next().flatten() else {
+        return Ok(None);
+    };
+    let StorageProjectedValue::FullValue(bytes) = value else {
+        return Err(row_group_error("row-group manifest read omitted its value"));
+    };
+    decode_manifest(&bytes).map(Some)
+}
+
+pub(crate) async fn load_row_group_set(
+    store: &(impl StorageAdapterRead + ?Sized),
+    id: RowGroupSetId,
+    projection: &[usize],
+) -> Result<Option<LoadedRowGroupSet>, LixError> {
+    let Some(manifest) = load_row_group_manifest(store, id).await? else {
+        return Ok(None);
+    };
+    let mut batches = Vec::with_capacity(manifest.groups.len());
+    for group_index in 0..manifest.groups.len() {
+        batches.push(load_row_group_batch(store, id, &manifest, group_index, projection).await?);
+    }
+    Ok(Some(LoadedRowGroupSet { manifest, batches }))
+}
+
+/// Loads exactly one row group and only its projected columns.
+///
+/// Keeping manifest acquisition separate lets a streaming execution source
+/// fetch one bounded group per poll and apply statistics pruning before it
+/// issues any column reads.
+pub(crate) async fn load_row_group_batch(
+    store: &(impl StorageAdapterRead + ?Sized),
+    id: RowGroupSetId,
+    manifest: &RowGroupManifest,
+    group_index: usize,
+    projection: &[usize],
+) -> Result<RecordBatch, LixError> {
+    validate_projection(manifest, projection)?;
+    let group = manifest.groups.get(group_index).ok_or_else(|| {
+        row_group_error(format!(
+            "row-group index {group_index} is outside {} groups",
+            manifest.groups.len()
+        ))
+    })?;
+    let projected_schema = projected_schema(manifest, projection);
+    if projection.is_empty() {
+        return RecordBatch::try_new_with_options(
+            projected_schema,
+            Vec::new(),
+            &RecordBatchOptions::new().with_row_count(Some(group.row_count as usize)),
+        )
+        .map_err(|error| row_group_error(error.to_string()));
+    }
+
+    let keys = projection
+        .iter()
+        .map(|&column_index| id.column_key(group_index, column_index))
+        .collect::<Result<Vec<_>, _>>()?;
+    let values = PointReadPlan::from_unique_keys(ROW_GROUP_COLUMN_SPACE, keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?
+        .value;
+    let mut values = values.into_iter();
+    let mut arrays = Vec::with_capacity(projection.len());
+    for &column_index in projection {
+        let value = values.next().flatten().ok_or_else(|| {
+            row_group_error(format!(
+                "row-group {group_index} column {column_index} is missing"
+            ))
+        })?;
+        let StorageProjectedValue::FullValue(bytes) = value else {
+            return Err(row_group_error("row-group column read omitted its value"));
+        };
+        let field = &manifest.fields[column_index];
+        let array = decode_column(&bytes, field.data_type, group.row_count as usize)?;
+        let observed = column_statistics(&array, field.data_type)?;
+        if observed != group.columns[column_index] {
+            return Err(row_group_error(format!(
+                "row-group {group_index} column {column_index} statistics do not match the manifest"
+            )));
+        }
+        arrays.push(array);
+    }
+    if values.next().is_some() {
+        return Err(row_group_error(
+            "row-group read returned excess column values",
+        ));
+    }
+    RecordBatch::try_new(projected_schema, arrays)
+        .map_err(|error| row_group_error(error.to_string()))
+}
+
+fn validate_input_batches(schema: &SchemaRef, batches: &[RecordBatch]) -> Result<(), LixError> {
+    for batch in batches {
+        if batch.schema().as_ref() != schema.as_ref() {
+            return Err(row_group_error("row-group input batch schema mismatch"));
+        }
+    }
+    Ok(())
+}
+
+fn partition_batches(
+    schema: &SchemaRef,
+    batches: &[RecordBatch],
+) -> Result<Vec<RecordBatch>, LixError> {
+    let mut groups = Vec::new();
+    let mut pending = Vec::new();
+    let mut pending_rows = 0;
+    for batch in batches {
+        let mut offset = 0;
+        while offset < batch.num_rows() {
+            let take = (ROW_GROUP_MAX_ROWS - pending_rows).min(batch.num_rows() - offset);
+            pending.push(batch.slice(offset, take));
+            pending_rows += take;
+            offset += take;
+            if pending_rows == ROW_GROUP_MAX_ROWS {
+                groups.push(finish_group(schema, &mut pending)?);
+                pending_rows = 0;
+            }
+        }
+    }
+    if pending_rows != 0 {
+        groups.push(finish_group(schema, &mut pending)?);
+    }
+    Ok(groups)
+}
+
+fn finish_group(
+    schema: &SchemaRef,
+    pending: &mut Vec<RecordBatch>,
+) -> Result<RecordBatch, LixError> {
+    let group = if pending.len() == 1 {
+        pending.pop().expect("one pending row-group batch")
+    } else {
+        concat_batches(schema, pending.iter())
+            .map_err(|error| row_group_error(error.to_string()))?
+    };
+    pending.clear();
+    Ok(group)
+}
+
+fn validate_projection(manifest: &RowGroupManifest, projection: &[usize]) -> Result<(), LixError> {
+    let mut seen = vec![false; manifest.fields.len()];
+    for &index in projection {
+        let Some(slot) = seen.get_mut(index) else {
+            return Err(row_group_error(format!(
+                "row-group projection column {index} is outside the schema"
+            )));
+        };
+        if std::mem::replace(slot, true) {
+            return Err(row_group_error(format!(
+                "row-group projection repeats column {index}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn projected_schema(manifest: &RowGroupManifest, projection: &[usize]) -> SchemaRef {
+    let fields = projection.iter().map(|&index| {
+        let field = &manifest.fields[index];
+        Field::new(&field.name, field.data_type.to_arrow(), field.nullable)
+            .with_metadata(field.metadata.clone())
+    });
+    Arc::new(Schema::new_with_metadata(
+        fields.collect::<Vec<_>>(),
+        manifest.metadata.clone(),
+    ))
+}
+
+fn encode_column(array: &ArrayRef, data_type: RowGroupDataType) -> Result<Vec<u8>, LixError> {
+    let row_count = u32::try_from(array.len())
+        .map_err(|_| row_group_error("row-group column length exceeds u32"))?;
+    let validity = encode_validity(array.as_ref());
+    let mut raw = Vec::new();
+    raw.extend_from_slice(COLUMN_MAGIC);
+    raw.push(data_type as u8);
+    raw.extend_from_slice(&row_count.to_le_bytes());
+    raw.extend_from_slice(
+        &u32::try_from(validity.len())
+            .map_err(|_| row_group_error("row-group validity length exceeds u32"))?
+            .to_le_bytes(),
+    );
+    raw.extend_from_slice(&validity);
+    match data_type {
+        RowGroupDataType::String => {
+            let values = array
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .ok_or_else(|| row_group_error("row-group String column downcast failed"))?;
+            let mut data = Vec::new();
+            let mut offsets = Vec::with_capacity(values.len() + 1);
+            offsets.push(0_i32);
+            for index in 0..values.len() {
+                if values.is_valid(index) {
+                    data.extend_from_slice(values.value(index).as_bytes());
+                }
+                offsets.push(i32::try_from(data.len()).map_err(|_| {
+                    row_group_error("row-group String data exceeds Arrow i32 offsets")
+                })?);
+            }
+            raw.extend_from_slice(
+                &u32::try_from(data.len())
+                    .map_err(|_| row_group_error("row-group String data exceeds u32"))?
+                    .to_le_bytes(),
+            );
+            for offset in offsets {
+                raw.extend_from_slice(&offset.to_le_bytes());
+            }
+            raw.extend_from_slice(&data);
+        }
+        RowGroupDataType::Int64 => {
+            let values = array
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .ok_or_else(|| row_group_error("row-group Int64 column downcast failed"))?;
+            for index in 0..values.len() {
+                raw.extend_from_slice(&values.value(index).to_le_bytes());
+            }
+        }
+        RowGroupDataType::Float64 => {
+            let values = array
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .ok_or_else(|| row_group_error("row-group Float64 column downcast failed"))?;
+            for index in 0..values.len() {
+                raw.extend_from_slice(&values.value(index).to_bits().to_le_bytes());
+            }
+        }
+        RowGroupDataType::Boolean => {
+            let values = array
+                .as_any()
+                .downcast_ref::<BooleanArray>()
+                .ok_or_else(|| row_group_error("row-group Boolean column downcast failed"))?;
+            let mut bits = vec![0_u8; values.len().div_ceil(8)];
+            for index in 0..values.len() {
+                if values.value(index) {
+                    set_bit(&mut bits, index);
+                }
+            }
+            raw.extend_from_slice(&bits);
+        }
+    }
+    compress_column(&raw)
+}
+
+fn decode_column(
+    encoded: &[u8],
+    expected_type: RowGroupDataType,
+    expected_rows: usize,
+) -> Result<ArrayRef, LixError> {
+    let raw = decompress_column(encoded)?;
+    let mut cursor = Cursor::new(&raw);
+    cursor.expect_magic(COLUMN_MAGIC, "row-group column")?;
+    let observed_type = RowGroupDataType::decode(cursor.u8()?)?;
+    if observed_type != expected_type {
+        return Err(row_group_error(
+            "row-group column type does not match the manifest",
+        ));
+    }
+    let row_count = cursor.u32_le()? as usize;
+    if row_count != expected_rows {
+        return Err(row_group_error(
+            "row-group column length does not match the manifest",
+        ));
+    }
+    let validity_len = cursor.u32_le()? as usize;
+    if validity_len != row_count.div_ceil(8) {
+        return Err(row_group_error(
+            "row-group validity bitmap has an invalid length",
+        ));
+    }
+    let validity = cursor.bytes(validity_len)?.to_vec();
+    clear_unused_bits_are_zero(&validity, row_count, "validity")?;
+    let nulls = (validity.iter().any(|&byte| byte != u8::MAX) || row_count % 8 != 0)
+        .then(|| NullBuffer::new(BooleanBuffer::new(Buffer::from(validity), 0, row_count)));
+
+    let array: ArrayRef = match expected_type {
+        RowGroupDataType::String => {
+            let data_len = cursor.u32_le()? as usize;
+            let offset_count = row_count
+                .checked_add(1)
+                .ok_or_else(|| row_group_error("row-group String offset count overflow"))?;
+            let mut offsets = Vec::with_capacity(offset_count);
+            for _ in 0..offset_count {
+                offsets.push(cursor.i32_le()?);
+            }
+            if offsets.first() != Some(&0)
+                || offsets.windows(2).any(|window| window[0] > window[1])
+                || offsets
+                    .last()
+                    .copied()
+                    .and_then(|value| usize::try_from(value).ok())
+                    != Some(data_len)
+            {
+                return Err(row_group_error("row-group String offsets are invalid"));
+            }
+            let data = cursor.bytes(data_len)?.to_vec();
+            Arc::new(
+                StringArray::try_new(
+                    OffsetBuffer::new(ScalarBuffer::from(offsets)),
+                    Buffer::from(data),
+                    nulls,
+                )
+                .map_err(|error| row_group_error(error.to_string()))?,
+            )
+        }
+        RowGroupDataType::Int64 => {
+            let mut values = Vec::with_capacity(row_count);
+            for _ in 0..row_count {
+                values.push(cursor.i64_le()?);
+            }
+            Arc::new(Int64Array::new(ScalarBuffer::from(values), nulls))
+        }
+        RowGroupDataType::Float64 => {
+            let mut values = Vec::with_capacity(row_count);
+            for _ in 0..row_count {
+                values.push(f64::from_bits(cursor.u64_le()?));
+            }
+            Arc::new(Float64Array::new(ScalarBuffer::from(values), nulls))
+        }
+        RowGroupDataType::Boolean => {
+            let bit_len = row_count.div_ceil(8);
+            let values = cursor.bytes(bit_len)?.to_vec();
+            clear_unused_bits_are_zero(&values, row_count, "Boolean values")?;
+            Arc::new(BooleanArray::new(
+                BooleanBuffer::new(Buffer::from(values), 0, row_count),
+                nulls,
+            ))
+        }
+    };
+    if !cursor.is_empty() {
+        return Err(row_group_error("row-group column has trailing bytes"));
+    }
+    Ok(array)
+}
+
+fn encode_validity(array: &dyn Array) -> Vec<u8> {
+    let mut validity = vec![0_u8; array.len().div_ceil(8)];
+    for index in 0..array.len() {
+        if array.is_valid(index) {
+            set_bit(&mut validity, index);
+        }
+    }
+    validity
+}
+
+fn set_bit(bits: &mut [u8], index: usize) {
+    bits[index / 8] |= 1 << (index % 8);
+}
+
+fn clear_unused_bits_are_zero(bits: &[u8], len: usize, label: &str) -> Result<(), LixError> {
+    let used = len % 8;
+    if used != 0
+        && bits
+            .last()
+            .is_some_and(|last| last & !((1_u8 << used) - 1) != 0)
+    {
+        return Err(row_group_error(format!(
+            "row-group {label} bitmap has nonzero padding"
+        )));
+    }
+    Ok(())
+}
+
+fn column_statistics(
+    array: &ArrayRef,
+    data_type: RowGroupDataType,
+) -> Result<RowGroupColumnStatistics, LixError> {
+    let null_count = u32::try_from(array.null_count())
+        .map_err(|_| row_group_error("row-group null count exceeds u32"))?;
+    let (min, max) = match data_type {
+        RowGroupDataType::String => {
+            let values = array
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .ok_or_else(|| row_group_error("row-group String statistics downcast failed"))?;
+            let mut observed = values.iter().flatten();
+            let Some(first) = observed.next() else {
+                return Ok(RowGroupColumnStatistics {
+                    null_count,
+                    min: None,
+                    max: None,
+                });
+            };
+            let (mut min, mut max) = (first, first);
+            for value in observed {
+                if value < min {
+                    min = value;
+                }
+                if value > max {
+                    max = value;
+                }
+            }
+            (
+                Some(RowGroupScalar::String(min.to_owned())),
+                Some(RowGroupScalar::String(max.to_owned())),
+            )
+        }
+        RowGroupDataType::Int64 => {
+            let values = array
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .ok_or_else(|| row_group_error("row-group Int64 statistics downcast failed"))?;
+            let mut observed = values.iter().flatten();
+            let Some(first) = observed.next() else {
+                return Ok(RowGroupColumnStatistics {
+                    null_count,
+                    min: None,
+                    max: None,
+                });
+            };
+            let (mut min, mut max) = (first, first);
+            for value in observed {
+                min = min.min(value);
+                max = max.max(value);
+            }
+            (
+                Some(RowGroupScalar::Int64(min)),
+                Some(RowGroupScalar::Int64(max)),
+            )
+        }
+        RowGroupDataType::Float64 => {
+            let values = array
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .ok_or_else(|| row_group_error("row-group Float64 statistics downcast failed"))?;
+            let mut observed = values.iter().flatten();
+            let Some(first) = observed.next() else {
+                return Ok(RowGroupColumnStatistics {
+                    null_count,
+                    min: None,
+                    max: None,
+                });
+            };
+            let (mut min, mut max) = (first, first);
+            for value in observed {
+                if value.total_cmp(&min).is_lt() {
+                    min = value;
+                }
+                if value.total_cmp(&max).is_gt() {
+                    max = value;
+                }
+            }
+            (
+                Some(RowGroupScalar::Float64(min)),
+                Some(RowGroupScalar::Float64(max)),
+            )
+        }
+        RowGroupDataType::Boolean => {
+            let values = array
+                .as_any()
+                .downcast_ref::<BooleanArray>()
+                .ok_or_else(|| row_group_error("row-group Boolean statistics downcast failed"))?;
+            let mut observed = values.iter().flatten();
+            let Some(first) = observed.next() else {
+                return Ok(RowGroupColumnStatistics {
+                    null_count,
+                    min: None,
+                    max: None,
+                });
+            };
+            let (mut min, mut max) = (first, first);
+            for value in observed {
+                min &= value;
+                max |= value;
+            }
+            (
+                Some(RowGroupScalar::Boolean(min)),
+                Some(RowGroupScalar::Boolean(max)),
+            )
+        }
+    };
+    Ok(RowGroupColumnStatistics {
+        null_count,
+        min,
+        max,
+    })
+}
+
+fn compress_column(raw: &[u8]) -> Result<Vec<u8>, LixError> {
+    let compressed = crate::compression::compress_zstd_level_1(raw)
+        .map_err(|error| row_group_error(format!("row-group compression failed: {error}")))?;
+    let mut output = Vec::with_capacity(12 + compressed.len());
+    output.extend_from_slice(COMPRESSED_MAGIC);
+    output.extend_from_slice(
+        &u32::try_from(raw.len())
+            .map_err(|_| row_group_error("row-group decoded column exceeds u32"))?
+            .to_le_bytes(),
+    );
+    output.extend_from_slice(&compressed);
+    Ok(output)
+}
+
+fn decompress_column(encoded: &[u8]) -> Result<Vec<u8>, LixError> {
+    let mut cursor = Cursor::new(encoded);
+    cursor.expect_magic(COMPRESSED_MAGIC, "compressed row-group column")?;
+    let decoded_len = cursor.u32_le()? as usize;
+    if decoded_len > MAX_DECODED_COLUMN_BYTES {
+        return Err(row_group_error(
+            "row-group decoded column exceeds the safety limit",
+        ));
+    }
+    crate::compression::decompress_zstd(cursor.remaining(), decoded_len)
+        .map_err(|error| row_group_error(format!("row-group decompression failed: {error}")))
+}
+
+fn encode_manifest(manifest: &RowGroupManifest) -> Result<Vec<u8>, LixError> {
+    let mut output = Vec::new();
+    output.extend_from_slice(MANIFEST_MAGIC);
+    put_string(&mut output, &manifest.namespace)?;
+    put_metadata(&mut output, &manifest.metadata)?;
+    put_u16_len(&mut output, manifest.fields.len(), "manifest field count")?;
+    for field in &manifest.fields {
+        put_string(&mut output, &field.name)?;
+        output.push(field.data_type as u8);
+        output.push(u8::from(field.nullable));
+        put_metadata(&mut output, &field.metadata)?;
+    }
+    put_u32_len(&mut output, manifest.groups.len(), "manifest group count")?;
+    for group in &manifest.groups {
+        output.extend_from_slice(&group.row_count.to_le_bytes());
+        if group.row_count as usize > ROW_GROUP_MAX_ROWS {
+            return Err(row_group_error("manifest group exceeds the row limit"));
+        }
+        if group.columns.len() != manifest.fields.len() {
+            return Err(row_group_error(
+                "manifest statistics width does not match its schema",
+            ));
+        }
+        for (stats, field) in group.columns.iter().zip(&manifest.fields) {
+            output.extend_from_slice(&stats.null_count.to_le_bytes());
+            put_optional_scalar(&mut output, stats.min.as_ref(), field.data_type)?;
+            put_optional_scalar(&mut output, stats.max.as_ref(), field.data_type)?;
+        }
+    }
+    Ok(output)
+}
+
+fn decode_manifest(encoded: &[u8]) -> Result<RowGroupManifest, LixError> {
+    let mut cursor = Cursor::new(encoded);
+    cursor.expect_magic(MANIFEST_MAGIC, "row-group manifest")?;
+    let namespace = cursor.string()?;
+    let metadata = cursor.metadata()?;
+    let field_count = cursor.u16_le()? as usize;
+    let mut fields = Vec::with_capacity(field_count);
+    for _ in 0..field_count {
+        let name = cursor.string()?;
+        let data_type = RowGroupDataType::decode(cursor.u8()?)?;
+        let nullable = match cursor.u8()? {
+            0 => false,
+            1 => true,
+            _ => return Err(row_group_error("row-group field nullable flag is invalid")),
+        };
+        fields.push(RowGroupField {
+            name,
+            data_type,
+            nullable,
+            metadata: cursor.metadata()?,
+        });
+    }
+    let group_count = cursor.u32_le()? as usize;
+    let mut groups = Vec::with_capacity(group_count);
+    for _ in 0..group_count {
+        let row_count = cursor.u32_le()?;
+        if row_count == 0 || row_count as usize > ROW_GROUP_MAX_ROWS {
+            return Err(row_group_error(
+                "row-group manifest has an invalid group row count",
+            ));
+        }
+        let mut columns = Vec::with_capacity(field_count);
+        for field in &fields {
+            let null_count = cursor.u32_le()?;
+            if null_count > row_count {
+                return Err(row_group_error(
+                    "row-group null count exceeds its row count",
+                ));
+            }
+            let min = cursor.optional_scalar(field.data_type)?;
+            let max = cursor.optional_scalar(field.data_type)?;
+            if (min.is_none() || max.is_none()) != (null_count == row_count) {
+                return Err(row_group_error(
+                    "row-group min/max presence contradicts null count",
+                ));
+            }
+            columns.push(RowGroupColumnStatistics {
+                null_count,
+                min,
+                max,
+            });
+        }
+        groups.push(RowGroupStatistics { row_count, columns });
+    }
+    if !cursor.is_empty() {
+        return Err(row_group_error("row-group manifest has trailing bytes"));
+    }
+    Ok(RowGroupManifest {
+        namespace,
+        metadata,
+        fields,
+        groups,
+    })
+}
+
+fn put_optional_scalar(
+    output: &mut Vec<u8>,
+    scalar: Option<&RowGroupScalar>,
+    expected: RowGroupDataType,
+) -> Result<(), LixError> {
+    let Some(scalar) = scalar else {
+        output.push(0);
+        return Ok(());
+    };
+    output.push(1);
+    match (expected, scalar) {
+        (RowGroupDataType::String, RowGroupScalar::String(value)) => put_string(output, value)?,
+        (RowGroupDataType::Int64, RowGroupScalar::Int64(value)) => {
+            output.extend_from_slice(&value.to_le_bytes());
+        }
+        (RowGroupDataType::Float64, RowGroupScalar::Float64(value)) => {
+            output.extend_from_slice(&value.to_bits().to_le_bytes());
+        }
+        (RowGroupDataType::Boolean, RowGroupScalar::Boolean(value)) => {
+            output.push(u8::from(*value));
+        }
+        _ => {
+            return Err(row_group_error(
+                "row-group scalar type does not match its field",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn put_metadata(output: &mut Vec<u8>, metadata: &HashMap<String, String>) -> Result<(), LixError> {
+    let mut entries = metadata.iter().collect::<Vec<_>>();
+    entries.sort_unstable();
+    put_u16_len(output, entries.len(), "metadata entry count")?;
+    for (key, value) in entries {
+        put_string(output, key)?;
+        put_string(output, value)?;
+    }
+    Ok(())
+}
+
+fn put_string(output: &mut Vec<u8>, value: &str) -> Result<(), LixError> {
+    put_u32_len(output, value.len(), "string length")?;
+    output.extend_from_slice(value.as_bytes());
+    Ok(())
+}
+
+fn put_u16_len(output: &mut Vec<u8>, len: usize, label: &str) -> Result<(), LixError> {
+    output.extend_from_slice(
+        &u16::try_from(len)
+            .map_err(|_| row_group_error(format!("row-group {label} exceeds u16")))?
+            .to_le_bytes(),
+    );
+    Ok(())
+}
+
+fn put_u32_len(output: &mut Vec<u8>, len: usize, label: &str) -> Result<(), LixError> {
+    output.extend_from_slice(
+        &u32::try_from(len)
+            .map_err(|_| row_group_error(format!("row-group {label} exceeds u32")))?
+            .to_le_bytes(),
+    );
+    Ok(())
+}
+
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, offset: 0 }
+    }
+    fn is_empty(&self) -> bool {
+        self.offset == self.bytes.len()
+    }
+    fn remaining(&self) -> &'a [u8] {
+        &self.bytes[self.offset..]
+    }
+    fn bytes(&mut self, len: usize) -> Result<&'a [u8], LixError> {
+        let end = self
+            .offset
+            .checked_add(len)
+            .filter(|&end| end <= self.bytes.len())
+            .ok_or_else(|| row_group_error("row-group value is truncated"))?;
+        let value = &self.bytes[self.offset..end];
+        self.offset = end;
+        Ok(value)
+    }
+    fn expect_magic(&mut self, magic: &[u8], label: &str) -> Result<(), LixError> {
+        if self.bytes(magic.len())? != magic {
+            return Err(row_group_error(format!("{label} has invalid magic")));
+        }
+        Ok(())
+    }
+    fn u8(&mut self) -> Result<u8, LixError> {
+        Ok(self.bytes(1)?[0])
+    }
+    fn u16_le(&mut self) -> Result<u16, LixError> {
+        Ok(u16::from_le_bytes(
+            self.bytes(2)?.try_into().expect("two-byte slice"),
+        ))
+    }
+    fn u32_le(&mut self) -> Result<u32, LixError> {
+        Ok(u32::from_le_bytes(
+            self.bytes(4)?.try_into().expect("four-byte slice"),
+        ))
+    }
+    fn i32_le(&mut self) -> Result<i32, LixError> {
+        Ok(i32::from_le_bytes(
+            self.bytes(4)?.try_into().expect("four-byte slice"),
+        ))
+    }
+    fn i64_le(&mut self) -> Result<i64, LixError> {
+        Ok(i64::from_le_bytes(
+            self.bytes(8)?.try_into().expect("eight-byte slice"),
+        ))
+    }
+    fn u64_le(&mut self) -> Result<u64, LixError> {
+        Ok(u64::from_le_bytes(
+            self.bytes(8)?.try_into().expect("eight-byte slice"),
+        ))
+    }
+    fn string(&mut self) -> Result<String, LixError> {
+        let len = self.u32_le()? as usize;
+        String::from_utf8(self.bytes(len)?.to_vec())
+            .map_err(|error| row_group_error(format!("row-group string is not UTF-8: {error}")))
+    }
+    fn metadata(&mut self) -> Result<HashMap<String, String>, LixError> {
+        let count = self.u16_le()? as usize;
+        let mut values = HashMap::with_capacity(count);
+        for _ in 0..count {
+            let key = self.string()?;
+            let value = self.string()?;
+            if values.insert(key, value).is_some() {
+                return Err(row_group_error(
+                    "row-group metadata contains a duplicate key",
+                ));
+            }
+        }
+        Ok(values)
+    }
+    fn optional_scalar(
+        &mut self,
+        data_type: RowGroupDataType,
+    ) -> Result<Option<RowGroupScalar>, LixError> {
+        match self.u8()? {
+            0 => Ok(None),
+            1 => Ok(Some(match data_type {
+                RowGroupDataType::String => RowGroupScalar::String(self.string()?),
+                RowGroupDataType::Int64 => RowGroupScalar::Int64(self.i64_le()?),
+                RowGroupDataType::Float64 => {
+                    RowGroupScalar::Float64(f64::from_bits(self.u64_le()?))
+                }
+                RowGroupDataType::Boolean => RowGroupScalar::Boolean(match self.u8()? {
+                    0 => false,
+                    1 => true,
+                    _ => return Err(row_group_error("row-group Boolean statistic is invalid")),
+                }),
+            })),
+            _ => Err(row_group_error("row-group scalar presence flag is invalid")),
+        }
+    }
+}
+
+fn row_group_error(message: impl Into<String>) -> LixError {
+    LixError::new(LixError::CODE_INTERNAL_ERROR, message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage_adapter::{Memory, StorageAdapter, StorageReadOptions, StorageWriteOptions};
+
+    fn fixture(rows: usize) -> (SchemaRef, Vec<RecordBatch>) {
+        let mut schema_metadata = HashMap::new();
+        schema_metadata.insert("layout".to_string(), "typed".to_string());
+        let mut field_metadata = HashMap::new();
+        field_metadata.insert("semantic".to_string(), "identity".to_string());
+        let schema = Arc::new(Schema::new_with_metadata(
+            vec![
+                Field::new("name", DataType::Utf8, true).with_metadata(field_metadata),
+                Field::new("ordinal", DataType::Int64, true),
+                Field::new("score", DataType::Float64, true),
+                Field::new("enabled", DataType::Boolean, true),
+            ],
+            schema_metadata,
+        ));
+        let names = (0..rows)
+            .map(|index| (index % 11 != 0).then(|| format!("row-{index:05}")))
+            .collect::<Vec<_>>();
+        let ordinals = (0..rows)
+            .map(|index| (index % 13 != 0).then_some(index as i64 - 20))
+            .collect::<Vec<_>>();
+        let scores = (0..rows)
+            .map(|index| (index % 17 != 0).then_some(index as f64 * 0.25))
+            .collect::<Vec<_>>();
+        let enabled = (0..rows)
+            .map(|index| (index % 19 != 0).then_some(index % 2 == 0))
+            .collect::<Vec<_>>();
+        let names: ArrayRef = Arc::new(StringArray::from(names));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                names,
+                Arc::new(Int64Array::from(ordinals)),
+                Arc::new(Float64Array::from(scores)),
+                Arc::new(BooleanArray::from(enabled)),
+            ],
+        )
+        .expect("fixture batch");
+        // Exercise row groups that span input RecordBatch boundaries.
+        let split = rows.min(7_000);
+        let batches = if split == rows {
+            vec![batch]
+        } else {
+            vec![batch.slice(0, split), batch.slice(split, rows - split)]
+        };
+        (schema, batches)
+    }
+
+    #[test]
+    fn typed_codec_round_trips_multiple_groups_and_statistics() {
+        let rows = ROW_GROUP_MAX_ROWS + 9;
+        let (schema, batches) = fixture(rows);
+        let encoded = encode_row_group_set("fixture", Arc::clone(&schema), &batches)
+            .expect("encode row groups");
+        assert_eq!(encoded.manifest.groups.len(), 2);
+        assert_eq!(
+            encoded.manifest.groups[0].row_count as usize,
+            ROW_GROUP_MAX_ROWS
+        );
+        assert_eq!(encoded.manifest.groups[1].row_count, 9);
+        assert_eq!(encoded.manifest.row_count(), rows as u64);
+        assert_eq!(encoded.manifest.schema().as_ref(), schema.as_ref());
+        assert!(
+            encoded.manifest.groups[0]
+                .columns
+                .iter()
+                .all(|stats| stats.null_count > 0)
+        );
+
+        for column in &encoded.columns {
+            let group = &encoded.manifest.groups[column.group_index];
+            let field = &encoded.manifest.fields[column.column_index];
+            let decoded = decode_column(&column.bytes, field.data_type, group.row_count as usize)
+                .expect("decode column");
+            assert_eq!(
+                column_statistics(&decoded, field.data_type).expect("decoded stats"),
+                group.columns[column.column_index]
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn storage_load_projects_columns_and_preserves_metadata() {
+        let rows = ROW_GROUP_MAX_ROWS + 3;
+        let (schema, batches) = fixture(rows);
+        let encoded = encode_row_group_set("fixture", schema, &batches).expect("encode");
+        let adapter = StorageAdapter::new(Memory::new());
+        let id = RowGroupSetId::new(*b"row-group-set-01");
+        let mut writes = adapter.new_write_set();
+        stage_row_group_set(&mut writes, id, &encoded).expect("stage");
+        adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read");
+        let loaded = load_row_group_set(&read, id, &[3, 0])
+            .await
+            .expect("load")
+            .expect("present");
+        assert_eq!(loaded.manifest.namespace, "fixture");
+        assert_eq!(loaded.batches.len(), 2);
+        assert_eq!(
+            loaded
+                .batches
+                .iter()
+                .map(RecordBatch::num_rows)
+                .sum::<usize>(),
+            rows
+        );
+        assert_eq!(loaded.batches[0].schema().field(0).name(), "enabled");
+        assert_eq!(loaded.batches[0].schema().field(1).name(), "name");
+        assert_eq!(
+            loaded.batches[0]
+                .schema()
+                .field(1)
+                .metadata()
+                .get("semantic"),
+            Some(&"identity".to_string())
+        );
+        let last = load_row_group_batch(&read, id, &loaded.manifest, 1, &[0])
+            .await
+            .expect("load one projected group");
+        assert_eq!(last.num_rows(), 3);
+        assert_eq!(last.num_columns(), 1);
+        assert_eq!(last.schema().field(0).name(), "name");
+        assert!(
+            load_row_group_manifest(&read, RowGroupSetId::new([9; 16]))
+                .await
+                .expect("missing read")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn corrupt_values_fail_closed() {
+        let (schema, batches) = fixture(32);
+        let encoded = encode_row_group_set("fixture", schema, &batches).expect("encode");
+        let mut bad_manifest = encoded.manifest_bytes.to_vec();
+        bad_manifest[0] ^= 0xff;
+        assert!(decode_manifest(&bad_manifest).is_err());
+
+        let mut truncated = encoded.columns[0].bytes.to_vec();
+        truncated.truncate(truncated.len() / 2);
+        assert!(decode_column(&truncated, RowGroupDataType::String, 32).is_err());
+
+        let mut oversized = Vec::from(COMPRESSED_MAGIC);
+        oversized.extend_from_slice(&u32::MAX.to_le_bytes());
+        oversized.extend_from_slice(b"not-zstd");
+        assert!(decode_column(&oversized, RowGroupDataType::String, 32).is_err());
+    }
+
+    #[test]
+    fn rejects_unsupported_types_and_duplicate_projection() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "small",
+            DataType::Int32,
+            false,
+        )]));
+        let batch = RecordBatch::new_empty(Arc::clone(&schema));
+        assert!(encode_row_group_set("fixture", schema, &[batch]).is_err());
+
+        let (schema, batches) = fixture(1);
+        let encoded = encode_row_group_set("fixture", schema, &batches).expect("encode");
+        assert!(validate_projection(&encoded.manifest, &[0, 0]).is_err());
+        assert!(validate_projection(&encoded.manifest, &[4]).is_err());
+    }
+}

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -793,6 +793,19 @@ where
     );
     for commit_id in &sweep_commits {
         if let Some(entry) = packed.commits.get(commit_id) {
+            let schema_keys = entry
+                .members
+                .iter()
+                .map(|member| member.key.schema_key.as_str())
+                .collect::<BTreeSet<_>>();
+            for schema_key in schema_keys {
+                crate::columnar_row_group::stage_delete_row_group_set(
+                    store,
+                    writes,
+                    crate::live_state::entity_row_group_set_id(*commit_id, schema_key),
+                )
+                .await?;
+            }
             crate::tracked_state::stage_delete_commit_delta_inventory_entry(
                 writes, *commit_id, entry,
             )?;
@@ -1022,6 +1035,9 @@ mod tests {
     };
     use crate::{Engine, GLOBAL_BRANCH_ID, Value};
     use bytes::Bytes;
+    use datafusion::arrow::array::StringArray;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::arrow::record_batch::RecordBatch;
 
     use super::{
         CheckpointGcState, CheckpointRecoveryRef, load_checkpoint_gc_state, load_recovery_ref,
@@ -1573,6 +1589,30 @@ mod tests {
         let dead_deltas = commit_delta_refs(dead_commit, &dead_members);
         let dead_locators = stage_commit_deltas(&mut writes, &dead_deltas)
             .expect("dead packed members should stage");
+        let sidecar_schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::Utf8,
+            false,
+        )]));
+        let sidecar_batch = RecordBatch::try_new(
+            Arc::clone(&sidecar_schema),
+            vec![Arc::new(StringArray::from(vec!["value"]))],
+        )
+        .expect("sidecar batch");
+        let sidecar = crate::columnar_row_group::encode_row_group_set(
+            "authority_gc",
+            sidecar_schema,
+            &[sidecar_batch],
+        )
+        .expect("encode GC sidecar");
+        for commit_id in [live_parent, dead_commit] {
+            crate::columnar_row_group::stage_row_group_set(
+                &mut writes,
+                crate::live_state::entity_row_group_set_id(commit_id, "authority_gc"),
+                &sidecar,
+            )
+            .expect("stage GC sidecar");
+        }
         // Point the shared change at the owner about to be collected. GC must
         // relocate it to the surviving physical copy, not delete the index.
         stage_change_locators(&mut writes, &dead_locators);
@@ -1665,6 +1705,26 @@ mod tests {
             .expect("post-GC packed inventory should scan");
         assert!(inventory.commits.contains_key(&live_parent));
         assert!(!inventory.commits.contains_key(&dead_commit));
+        assert!(
+            crate::columnar_row_group::load_row_group_manifest(
+                &read,
+                crate::live_state::entity_row_group_set_id(live_parent, "authority_gc"),
+            )
+            .await
+            .expect("load live sidecar")
+            .is_some(),
+            "reachable commit sidecars must survive repository GC"
+        );
+        assert!(
+            crate::columnar_row_group::load_row_group_manifest(
+                &read,
+                crate::live_state::entity_row_group_set_id(dead_commit, "authority_gc"),
+            )
+            .await
+            .expect("load swept sidecar")
+            .is_none(),
+            "swept commit sidecars must be removed"
+        );
         drop(read);
         assert!(json_ref_exists(&storage, crate::json_store::store::JSON_SPACE, shared_ref).await);
         assert!(

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -39,14 +39,13 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 
 /// Repository-wide compatibility gate for physical storage protocols.
 ///
-/// V38 combines LXCD9's dense commit-delta selection inventory with
-/// out-of-line payloads in packed immutable binary-CAS segments. Older inline
-/// rows, per-chunk object markers, and commit-delta manifests must fail closed
-/// before any physical representation is decoded.
+/// V44 adds authenticated immutable analytical row groups owned by commit
+/// generations. Older repositories have no lifecycle contract for these
+/// sidecars and must fail closed before any physical representation is decoded.
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::mutable(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"lxcd9-generation-indexed-commits.v43";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"lxcd9-generation-indexed-commits.v44";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -34,6 +34,7 @@ pub(crate) mod cel;
 pub mod changelog;
 pub(crate) mod checkpoint;
 pub(crate) mod collection_generation;
+pub(crate) mod columnar_row_group;
 pub(crate) mod commit_graph;
 mod common;
 pub(crate) mod compression;

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -364,6 +364,37 @@ where
             .map(Some)
     }
 
+    pub(crate) async fn plan_direct_entity_columnar_scan(
+        &self,
+        request: &LiveStateScanRequest,
+    ) -> Result<
+        Option<(
+            crate::columnar_row_group::RowGroupSetId,
+            crate::columnar_row_group::RowGroupManifest,
+        )>,
+        LixError,
+    > {
+        if !request.filter.entity_pks.is_empty()
+            || request.limit.is_some()
+            || !matches!(request.filter.rows, LiveStateRowFilter::All)
+            || request.filter.include_tombstones
+            || request.filter.untracked.is_some()
+            || !request.filter.file_ids.is_empty()
+            || !request.filter.constraints.is_empty()
+        {
+            return Ok(None);
+        }
+        let Some((branch_id, control, schema_key)) =
+            self.direct_entity_snapshot_scope(request).await?
+        else {
+            return Ok(None);
+        };
+        self.tracked_head
+            .reader(&self.store)
+            .entity_columnar_layout(&branch_id, control, &schema_key)
+            .await
+    }
+
     pub(crate) async fn scan_direct_entity_snapshots_by_string_field(
         &self,
         request: &LiveStateScanRequest,

--- a/packages/engine/src/live_state/entity_columnar.rs
+++ b/packages/engine/src/live_state/entity_columnar.rs
@@ -1,0 +1,189 @@
+//! Typed analytical sidecars for immutable entity generations.
+//!
+//! The transaction boundary calls this adapter while validated snapshots are
+//! still decoded. It projects every scalar object property into bounded Arrow
+//! batches and delegates the physical format to `columnar_row_group`. Complex
+//! or type-unstable properties are omitted independently; a scan that needs an
+//! omitted property simply retains the authoritative row-shaped fallback.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use datafusion::arrow::array::{ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray};
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+use datafusion::arrow::record_batch::RecordBatch;
+use serde_json::Value as JsonValue;
+
+use crate::LixError;
+use crate::changelog::CommitId;
+use crate::columnar_row_group::{
+    EncodedRowGroupSet, ROW_GROUP_MAX_ROWS, RowGroupSetId, encode_row_group_set_preserving_batches,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ScalarKind {
+    Unknown,
+    String,
+    Int64,
+    Float64,
+    Boolean,
+    Unsupported,
+}
+
+impl ScalarKind {
+    fn observe(self, value: &JsonValue) -> Self {
+        let observed = match value {
+            JsonValue::Null => return self,
+            JsonValue::String(_) => Self::String,
+            JsonValue::Bool(_) => Self::Boolean,
+            JsonValue::Number(number) if number.as_i64().is_some() => Self::Int64,
+            JsonValue::Number(number) if number.as_f64().is_some() => Self::Float64,
+            JsonValue::Number(_) | JsonValue::Array(_) | JsonValue::Object(_) => Self::Unsupported,
+        };
+        match (self, observed) {
+            (Self::Unknown, observed) => observed,
+            (Self::Int64, Self::Float64) | (Self::Float64, Self::Int64) => Self::Float64,
+            (current, observed) if current == observed => current,
+            _ => Self::Unsupported,
+        }
+    }
+
+    fn data_type(self) -> Option<DataType> {
+        match self {
+            Self::String => Some(DataType::Utf8),
+            Self::Int64 => Some(DataType::Int64),
+            Self::Float64 => Some(DataType::Float64),
+            Self::Boolean => Some(DataType::Boolean),
+            Self::Unknown | Self::Unsupported => None,
+        }
+    }
+}
+
+pub(crate) type EntityColumnarWriteSets = BTreeMap<(CommitId, String), EncodedRowGroupSet>;
+
+pub(crate) fn entity_row_group_set_id(commit_id: CommitId, schema_key: &str) -> RowGroupSetId {
+    let mut digest = blake3::Hasher::new();
+    digest.update(b"lix.entity_columnar.v1");
+    digest.update(commit_id.as_uuid().as_bytes());
+    digest.update(&(schema_key.len() as u64).to_be_bytes());
+    digest.update(schema_key.as_bytes());
+    let mut id = [0_u8; 16];
+    id.copy_from_slice(&digest.finalize().as_bytes()[..16]);
+    RowGroupSetId::new(id)
+}
+
+pub(crate) fn encode_entity_scalar_row_groups<'a, I>(
+    schema_key: &str,
+    snapshots: I,
+) -> Result<Option<EncodedRowGroupSet>, LixError>
+where
+    I: ExactSizeIterator<Item = &'a JsonValue> + Clone,
+{
+    if snapshots.len() == 0 {
+        return Ok(None);
+    }
+    let mut kinds = BTreeMap::<String, ScalarKind>::new();
+    for snapshot in snapshots.clone() {
+        let Some(object) = snapshot.as_object() else {
+            return Ok(None);
+        };
+        for (name, value) in object {
+            let kind = kinds.entry(name.clone()).or_insert(ScalarKind::Unknown);
+            *kind = kind.observe(value);
+        }
+    }
+    kinds.retain(|_, kind| kind.data_type().is_some());
+    if kinds.is_empty() {
+        return Ok(None);
+    }
+
+    let fields = kinds
+        .iter()
+        .map(|(name, kind)| Field::new(name, kind.data_type().expect("retained scalar kind"), true))
+        .collect::<Vec<_>>();
+    let schema = Arc::new(Schema::new(fields));
+    let snapshots = snapshots.collect::<Vec<_>>();
+    let boolean_fields = kinds
+        .iter()
+        .filter_map(|(name, kind)| (*kind == ScalarKind::Boolean).then_some(name.as_str()))
+        .collect::<Vec<_>>();
+    let partitions = if boolean_fields.is_empty() {
+        vec![snapshots]
+    } else {
+        let mut partitions = BTreeMap::<Vec<Option<bool>>, Vec<&JsonValue>>::new();
+        for snapshot in snapshots {
+            let key = boolean_fields
+                .iter()
+                .map(|name| snapshot.get(*name).and_then(JsonValue::as_bool))
+                .collect();
+            partitions.entry(key).or_default().push(snapshot);
+        }
+        partitions.into_values().collect()
+    };
+    let mut batches = Vec::new();
+    for partition in partitions {
+        for rows in partition.chunks(ROW_GROUP_MAX_ROWS) {
+            let columns = kinds
+                .iter()
+                .map(|(name, kind)| scalar_column(rows, name, *kind))
+                .collect::<Result<Vec<_>, _>>()?;
+            batches.push(
+                RecordBatch::try_new(Arc::clone(&schema), columns)
+                    .map_err(|error| entity_columnar_error(error.to_string()))?,
+            );
+        }
+    }
+    // This is a derived acceleration structure. Unsupported or oversized
+    // physical columns must fall back to the authoritative row layout rather
+    // than make an otherwise-valid transaction fail.
+    Ok(optional_derived_row_group_set(
+        encode_row_group_set_preserving_batches(schema_key, schema, &batches),
+    ))
+}
+
+fn optional_derived_row_group_set(
+    encoded: Result<EncodedRowGroupSet, LixError>,
+) -> Option<EncodedRowGroupSet> {
+    encoded.ok()
+}
+
+fn scalar_column(rows: &[&JsonValue], name: &str, kind: ScalarKind) -> Result<ArrayRef, LixError> {
+    let values = rows
+        .iter()
+        .map(|snapshot| snapshot.get(name).unwrap_or(&JsonValue::Null));
+    let array: ArrayRef = match kind {
+        ScalarKind::String => Arc::new(StringArray::from_iter(values.map(JsonValue::as_str))),
+        ScalarKind::Int64 => Arc::new(Int64Array::from_iter(values.map(JsonValue::as_i64))),
+        ScalarKind::Float64 => Arc::new(Float64Array::from_iter(values.map(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_i64().map(|value| value as f64))
+        }))),
+        ScalarKind::Boolean => Arc::new(BooleanArray::from_iter(values.map(JsonValue::as_bool))),
+        ScalarKind::Unknown | ScalarKind::Unsupported => {
+            return Err(entity_columnar_error(
+                "attempted to encode a non-scalar entity column",
+            ));
+        }
+    };
+    Ok(array)
+}
+
+fn entity_columnar_error(message: impl Into<String>) -> LixError {
+    LixError::new(
+        LixError::CODE_INTERNAL_ERROR,
+        format!("entity columnar layout: {}", message.into()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{entity_columnar_error, optional_derived_row_group_set};
+
+    #[test]
+    fn derived_encoding_failure_falls_back_without_rejecting_authoritative_rows() {
+        assert!(
+            optional_derived_row_group_set(Err(entity_columnar_error("physical limit"))).is_none()
+        );
+    }
+}

--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -1,5 +1,6 @@
 mod context;
 mod derived;
+mod entity_columnar;
 mod entity_field_index;
 mod reader;
 mod tracked_head;
@@ -8,6 +9,9 @@ pub(crate) mod visibility;
 
 #[allow(unused_imports)]
 pub(crate) use context::{BranchHeadControlCache, LiveStateContext, LiveStateStoreReader};
+pub(crate) use entity_columnar::{
+    EntityColumnarWriteSets, encode_entity_scalar_row_groups, entity_row_group_set_id,
+};
 pub(crate) use entity_field_index::EntitySnapshotFieldIndexCache;
 #[allow(unused_imports)]
 pub(crate) use reader::LiveStateReader;

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -4285,6 +4285,58 @@ where
         Ok(rows.into_identity_ordered_primary_keys())
     }
 
+    /// Plans a typed analytical scan only when one immutable packed base is
+    /// the complete current collection and its atomically staged row-group
+    /// sidecar agrees with the publication control.
+    pub(crate) async fn entity_columnar_layout(
+        &self,
+        branch_id: &str,
+        control: BranchHeadControl,
+        schema_key: &str,
+    ) -> Result<
+        Option<(
+            crate::columnar_row_group::RowGroupSetId,
+            crate::columnar_row_group::RowGroupManifest,
+        )>,
+        LixError,
+    > {
+        let collection = load_hot_collection_control(
+            &self.store,
+            branch_id,
+            control.generation,
+            crate::collection_generation::CollectionScopeRef {
+                schema_key,
+                file_id: None,
+            },
+        )
+        .await?;
+        if collection.ordered_identity_digest.is_none() {
+            return Ok(None);
+        }
+        let base_refs = packed_exclusive_schema_base_refs(
+            &self.store,
+            branch_id,
+            control.generation,
+            schema_key,
+        )
+        .await?;
+        let [base_ref] = base_refs.as_slice() else {
+            return Ok(None);
+        };
+        let id = crate::live_state::entity_row_group_set_id(base_ref.commit_id, schema_key);
+        let Some(manifest) =
+            crate::columnar_row_group::load_row_group_manifest(&self.store, id).await?
+        else {
+            return Ok(None);
+        };
+        if manifest.namespace != schema_key || manifest.row_count() != collection.live_count {
+            return Err(head_value_error(
+                "entity columnar sidecar disagrees with its collection publication",
+            ));
+        }
+        Ok(Some((id, manifest)))
+    }
+
     #[cfg(test)]
     pub(crate) async fn scan_live_rows_if_current(
         &self,
@@ -5089,6 +5141,7 @@ where
         generation: CommitId,
         new_head: CommitId,
         rows: I,
+        entity_columnar_write_sets: &crate::live_state::EntityColumnarWriteSets,
         working_diff_capture_checkpoint_commit_id: Option<CommitId>,
         coverage: &mut WorkingDiffIndexCoverage,
     ) -> Result<CommitId, LixError>
@@ -5133,6 +5186,17 @@ where
                 ))
             })
             .collect::<Result<BTreeMap<_, _>, LixError>>()?;
+        for schema_key in schema_increments.keys() {
+            if let Some(encoded) =
+                entity_columnar_write_sets.get(&(new_head, (*schema_key).to_string()))
+            {
+                crate::columnar_row_group::stage_row_group_set(
+                    self.writes,
+                    crate::live_state::entity_row_group_set_id(new_head, schema_key),
+                    encoded,
+                )?;
+            }
+        }
         self.stage_packed_insert_current_base_manifest(
             branch_id,
             generation,

--- a/packages/engine/src/sql2/aggregate_statistics.rs
+++ b/packages/engine/src/sql2/aggregate_statistics.rs
@@ -1,0 +1,306 @@
+//! Completes DataFusion's aggregate-statistics optimization for exact SUM/AVG.
+//!
+//! DataFusion already removes ungrouped COUNT/MIN/MAX scans when a source
+//! exposes exact statistics. Its built-in rule currently leaves SUM and AVG
+//! unresolved, which prevents the all-or-nothing rewrite. This rule uses the
+//! same physical-plan contract and adds those two standard aggregates. It is
+//! provider-agnostic and never inspects SQL text.
+
+use std::sync::Arc;
+
+use datafusion::common::config::ConfigOptions;
+use datafusion::common::stats::Precision;
+use datafusion::common::tree_node::{Transformed, TransformedResult, TreeNode};
+use datafusion::common::{Result, ScalarValue};
+use datafusion::functions_aggregate::{average::Avg, sum::Sum};
+use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::aggregates::{AggregateExec, AggregateInputMode};
+use datafusion::physical_plan::expressions;
+use datafusion::physical_plan::placeholder_row::PlaceholderRowExec;
+use datafusion::physical_plan::projection::{ProjectionExec, ProjectionExpr};
+use datafusion::physical_plan::udaf::{AggregateFunctionExpr, StatisticsArgs};
+use datafusion::physical_plan::{ExecutionPlan, Statistics};
+
+#[derive(Debug, Default)]
+pub(crate) struct ExactAggregateStatistics;
+
+impl PhysicalOptimizerRule for ExactAggregateStatistics {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        config: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if let Some(partial) = optimizable_partial_aggregate(plan.as_ref()) {
+            let aggregate = partial
+                .as_any()
+                .downcast_ref::<AggregateExec>()
+                .expect("optimizable partial aggregate is AggregateExec");
+            let statistics = aggregate.input().partition_statistics(None)?;
+            let mut projections = Vec::with_capacity(aggregate.aggr_expr().len());
+            for expression in aggregate.aggr_expr() {
+                let Some(value) = exact_aggregate_value(&statistics, expression) else {
+                    return plan
+                        .map_children(|child| self.optimize(child, config).map(Transformed::yes))
+                        .data();
+                };
+                projections.push(ProjectionExpr {
+                    expr: expressions::lit(value),
+                    alias: expression.name().to_string(),
+                });
+            }
+            return Ok(Arc::new(ProjectionExec::try_new(
+                projections,
+                Arc::new(PlaceholderRowExec::new(plan.schema())),
+            )?));
+        }
+        plan.map_children(|child| self.optimize(child, config).map(Transformed::yes))
+            .data()
+    }
+
+    fn name(&self) -> &str {
+        "lix_exact_aggregate_statistics"
+    }
+
+    fn schema_check(&self) -> bool {
+        false
+    }
+}
+
+fn optimizable_partial_aggregate(plan: &dyn ExecutionPlan) -> Option<Arc<dyn ExecutionPlan>> {
+    let final_aggregate = plan.as_any().downcast_ref::<AggregateExec>()?;
+    if final_aggregate.mode().input_mode() != AggregateInputMode::Partial
+        || !final_aggregate.group_expr().is_empty()
+    {
+        return None;
+    }
+    let mut child = Arc::clone(final_aggregate.input());
+    loop {
+        if let Some(partial) = child.as_any().downcast_ref::<AggregateExec>()
+            && partial.mode().input_mode() == AggregateInputMode::Raw
+            && partial.group_expr().is_empty()
+            && partial.filter_expr().iter().all(Option::is_none)
+        {
+            return Some(child);
+        }
+        let children = child.children();
+        let [next] = children.as_slice() else {
+            return None;
+        };
+        child = Arc::clone(next);
+    }
+}
+
+fn exact_aggregate_value(
+    statistics: &Statistics,
+    expression: &AggregateFunctionExpr,
+) -> Option<ScalarValue> {
+    let field = expression.field();
+    let arguments = expression.expressions();
+    let statistics_args = StatisticsArgs {
+        statistics,
+        return_type: field.data_type(),
+        is_distinct: expression.is_distinct(),
+        exprs: &arguments,
+    };
+    if let Some(value) = expression.fun().value_from_stats(&statistics_args) {
+        return Some(value);
+    }
+    if expression.is_distinct() || arguments.len() != 1 {
+        return None;
+    }
+    let column = arguments[0].as_any().downcast_ref::<Column>()?;
+    let column_statistics = statistics.column_statistics.get(column.index())?;
+    if expression.fun().inner().as_any().is::<Sum>() {
+        exact_scalar(&column_statistics.sum_value)
+            .and_then(|value| value.cast_to(field.data_type()).ok())
+    } else if expression.fun().inner().as_any().is::<Avg>() {
+        let row_count = *exact_usize(&statistics.num_rows)?;
+        let null_count = *exact_usize(&column_statistics.null_count)?;
+        let count = row_count.checked_sub(null_count)?;
+        if count == 0 {
+            return ScalarValue::try_new_null(field.data_type()).ok();
+        }
+        let sum = exact_scalar(&column_statistics.sum_value)?;
+        let sum = match sum {
+            ScalarValue::Int64(Some(value)) => value as f64,
+            ScalarValue::Float64(Some(value)) => value,
+            _ => return None,
+        };
+        ScalarValue::Float64(Some(sum / count as f64))
+            .cast_to(field.data_type())
+            .ok()
+    } else {
+        None
+    }
+}
+
+fn exact_scalar(value: &Precision<ScalarValue>) -> Option<ScalarValue> {
+    match value {
+        Precision::Exact(value) => Some(value.clone()),
+        Precision::Inexact(_) | Precision::Absent => None,
+    }
+}
+
+fn exact_usize(value: &Precision<usize>) -> Option<&usize> {
+    match value {
+        Precision::Exact(value) => Some(value),
+        Precision::Inexact(_) | Precision::Absent => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::any::Any;
+
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::common::stats::ColumnStatistics;
+    use datafusion::functions_aggregate::{average::avg_udaf, sum::sum_udaf};
+    use datafusion::logical_expr::function::AccumulatorArgs;
+    use datafusion::logical_expr::{
+        Accumulator, AggregateUDF, AggregateUDFImpl, Signature, Volatility,
+    };
+    use datafusion::physical_expr::aggregate::AggregateExprBuilder;
+
+    use super::*;
+
+    fn aggregate_expr(
+        function: Arc<AggregateUDF>,
+        input_type: DataType,
+        distinct: bool,
+    ) -> AggregateFunctionExpr {
+        let schema = Arc::new(Schema::new(vec![Field::new("value", input_type, true)]));
+        AggregateExprBuilder::new(function, vec![Arc::new(Column::new("value", 0))])
+            .schema(schema)
+            .alias("result")
+            .with_distinct(distinct)
+            .build()
+            .unwrap()
+    }
+
+    fn statistics(
+        rows: Precision<usize>,
+        nulls: Precision<usize>,
+        sum: Precision<ScalarValue>,
+    ) -> Statistics {
+        Statistics {
+            num_rows: rows,
+            total_byte_size: Precision::Absent,
+            column_statistics: vec![
+                ColumnStatistics::new_unknown()
+                    .with_null_count(nulls)
+                    .with_sum_value(sum),
+            ],
+        }
+    }
+
+    #[test]
+    fn rewrites_builtin_sum_from_exact_statistics() {
+        let expression = aggregate_expr(sum_udaf(), DataType::Int64, false);
+        let statistics = statistics(
+            Precision::Exact(4),
+            Precision::Exact(1),
+            Precision::Exact(ScalarValue::Int64(Some(9))),
+        );
+
+        assert_eq!(
+            exact_aggregate_value(&statistics, &expression),
+            Some(ScalarValue::Int64(Some(9)))
+        );
+    }
+
+    #[test]
+    fn rewrites_builtin_avg_from_exact_statistics() {
+        let expression = aggregate_expr(avg_udaf(), DataType::Float64, false);
+        let statistics = statistics(
+            Precision::Exact(4),
+            Precision::Exact(1),
+            Precision::Exact(ScalarValue::Float64(Some(9.0))),
+        );
+
+        assert_eq!(
+            exact_aggregate_value(&statistics, &expression),
+            Some(ScalarValue::Float64(Some(3.0)))
+        );
+    }
+
+    #[test]
+    fn does_not_rewrite_distinct_or_inexact_sum() {
+        let exact_statistics = statistics(
+            Precision::Exact(4),
+            Precision::Exact(0),
+            Precision::Exact(ScalarValue::Int64(Some(9))),
+        );
+        let distinct = aggregate_expr(sum_udaf(), DataType::Int64, true);
+        assert_eq!(exact_aggregate_value(&exact_statistics, &distinct), None);
+
+        let inexact_statistics = statistics(
+            Precision::Exact(4),
+            Precision::Exact(0),
+            Precision::Inexact(ScalarValue::Int64(Some(9))),
+        );
+        let sum = aggregate_expr(sum_udaf(), DataType::Int64, false);
+        assert_eq!(exact_aggregate_value(&inexact_statistics, &sum), None);
+    }
+
+    #[test]
+    fn handles_all_null_input_conservatively() {
+        let statistics = statistics(Precision::Exact(4), Precision::Exact(4), Precision::Absent);
+        let sum = aggregate_expr(sum_udaf(), DataType::Int64, false);
+        assert_eq!(exact_aggregate_value(&statistics, &sum), None);
+
+        let avg = aggregate_expr(avg_udaf(), DataType::Float64, false);
+        assert_eq!(
+            exact_aggregate_value(&statistics, &avg),
+            Some(ScalarValue::Float64(None))
+        );
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    struct CustomNamedSum {
+        signature: Signature,
+    }
+
+    impl CustomNamedSum {
+        fn new() -> Self {
+            Self {
+                signature: Signature::uniform(1, vec![DataType::Int64], Volatility::Immutable),
+            }
+        }
+    }
+
+    impl AggregateUDFImpl for CustomNamedSum {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn name(&self) -> &str {
+            "sum"
+        }
+
+        fn signature(&self) -> &Signature {
+            &self.signature
+        }
+
+        fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+            Ok(DataType::Int64)
+        }
+
+        fn accumulator(&self, _args: AccumulatorArgs) -> Result<Box<dyn Accumulator>> {
+            unreachable!("the test only builds the physical expression")
+        }
+    }
+
+    #[test]
+    fn does_not_rewrite_custom_aggregate_with_builtin_name() {
+        let custom_sum = Arc::new(AggregateUDF::from(CustomNamedSum::new()));
+        let expression = aggregate_expr(custom_sum, DataType::Int64, false);
+        let statistics = statistics(
+            Precision::Exact(4),
+            Precision::Exact(0),
+            Precision::Exact(ScalarValue::Int64(Some(9))),
+        );
+
+        assert_eq!(exact_aggregate_value(&statistics, &expression), None);
+    }
+}

--- a/packages/engine/src/sql2/entity_batch.rs
+++ b/packages/engine/src/sql2/entity_batch.rs
@@ -10,11 +10,18 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use datafusion::arrow::record_batch::RecordBatch;
 
 use crate::LixError;
 use crate::entity_pk::EntityPk;
 use crate::live_state::{LiveStateContext, LiveStateRowFilter, LiveStateScanRequest};
 use crate::storage_adapter::StorageAdapterRead;
+
+#[derive(Clone, Debug)]
+pub(crate) struct EntityColumnarScanLayout {
+    pub(crate) id: crate::columnar_row_group::RowGroupSetId,
+    pub(crate) manifest: crate::columnar_row_group::RowGroupManifest,
+}
 
 /// Optional private capability supplied only by committed read sessions.
 ///
@@ -52,6 +59,25 @@ pub(crate) trait EntitySnapshotReader: Send + Sync {
         _request: LiveStateScanRequest,
     ) -> Result<Option<Vec<EntityPk>>, LixError> {
         Ok(None)
+    }
+
+    async fn plan_entity_columnar_scan(
+        &self,
+        _request: LiveStateScanRequest,
+    ) -> Result<Option<EntityColumnarScanLayout>, LixError> {
+        Ok(None)
+    }
+
+    async fn load_entity_columnar_group(
+        &self,
+        _layout: EntityColumnarScanLayout,
+        _group_index: usize,
+        _projection: Vec<usize>,
+    ) -> Result<RecordBatch, LixError> {
+        Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "entity snapshot reader does not support columnar groups".to_string(),
+        ))
     }
 
     async fn scan_entity_snapshots_by_string_field(
@@ -117,6 +143,40 @@ where
             .reader(self.store.clone())
             .scan_direct_entity_primary_keys(&request)
             .await
+    }
+
+    async fn plan_entity_columnar_scan(
+        &self,
+        request: LiveStateScanRequest,
+    ) -> Result<Option<EntityColumnarScanLayout>, LixError> {
+        if !direct_entity_snapshot_request(&request)
+            || !request.filter.entity_pks.is_empty()
+            || request.limit.is_some()
+        {
+            return Ok(None);
+        }
+        Ok(self
+            .live_state
+            .reader(self.store.clone())
+            .plan_direct_entity_columnar_scan(&request)
+            .await?
+            .map(|(id, manifest)| EntityColumnarScanLayout { id, manifest }))
+    }
+
+    async fn load_entity_columnar_group(
+        &self,
+        layout: EntityColumnarScanLayout,
+        group_index: usize,
+        projection: Vec<usize>,
+    ) -> Result<RecordBatch, LixError> {
+        crate::columnar_row_group::load_row_group_batch(
+            &self.store,
+            layout.id,
+            &layout.manifest,
+            group_index,
+            &projection,
+        )
+        .await
     }
 
     async fn scan_entity_snapshots_by_string_field(

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -80,3 +80,4 @@ pub(crate) use providers::{
     execute_fast_lix_file_prepared_path_write,
 };
 pub use script::{SqlScriptPlan, SqlScriptStatement, parse_sql_script};
+mod aggregate_statistics;

--- a/packages/engine/src/sql2/providers/branch.rs
+++ b/packages/engine/src/sql2/providers/branch.rs
@@ -39,7 +39,7 @@ use crate::transaction::types::{
 use super::columns::{Col, ColumnTable, ColumnTableError};
 use super::spec::{
     DmlReturning, InsertApply, PlannedDml, PlannedScan, TableSpec, projected_schema,
-    register_spec_table, row_source, take_record_batch_rows,
+    register_spec_table, row_source, scan_row_source, take_record_batch_rows,
 };
 use super::upsert::{StagedUpsert, UpsertReturningRow, UpsertSupport, materialize_omitted_column};
 use super::values::{required_bool_value, required_string_value};
@@ -119,7 +119,8 @@ impl TableSpec for BranchSpec {
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
             ordering: None,
-            load: row_source(
+            source: scan_row_source(
+                Arc::clone(&schema),
                 (
                     Arc::clone(&self.live_state),
                     Arc::clone(&self.branch_ref),

--- a/packages/engine/src/sql2/providers/change.rs
+++ b/packages/engine/src/sql2/providers/change.rs
@@ -27,7 +27,7 @@ use crate::storage_adapter::{
 use bytes::Bytes;
 
 use super::columns::{Col, ColumnTable, ColumnTableError};
-use super::spec::{PlannedScan, TableSpec, projected_schema, register_spec_table, row_source};
+use super::spec::{PlannedScan, TableSpec, projected_schema, register_spec_table, scan_row_source};
 
 pub(super) async fn register_lix_change_read_provider<S>(
     session: &datafusion::prelude::SessionContext,
@@ -91,7 +91,8 @@ where
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
             ordering: None,
-            load: row_source(
+            source: scan_row_source(
+                Arc::clone(&schema),
                 (self.query_source.clone(), schema),
                 move |(query_source, schema)| async move {
                     let mut json_reader = query_source.json_reader;

--- a/packages/engine/src/sql2/providers/checkpoint.rs
+++ b/packages/engine/src/sql2/providers/checkpoint.rs
@@ -20,7 +20,7 @@ use crate::tracked_state::TrackedStateContext;
 
 use super::columns::{Col, ColumnTable, ColumnTableError};
 use super::file::{FileIdConstraint, exact_string_column_constraint_from_filters};
-use super::spec::{PlannedScan, TableSpec, projected_schema, register_spec_table, row_source};
+use super::spec::{PlannedScan, TableSpec, projected_schema, register_spec_table, scan_row_source};
 
 pub(super) async fn register_checkpoint_provider<S>(
     session: &datafusion::prelude::SessionContext,
@@ -104,7 +104,8 @@ where
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
             ordering: None,
-            load: row_source(
+            source: scan_row_source(
+                Arc::clone(&schema),
                 (
                     self.active_branch_id.clone(),
                     Arc::clone(&self.branch_ref),

--- a/packages/engine/src/sql2/providers/diff.rs
+++ b/packages/engine/src/sql2/providers/diff.rs
@@ -24,7 +24,7 @@ use crate::{LixError, NullableKeyFilter};
 use super::checkpoint::filter_conjuncts;
 use super::columns::{Col, ColumnTable, ColumnTableError};
 use super::file::{FileIdConstraint, exact_string_column_constraint_from_filters};
-use super::spec::{PlannedScan, SpecTableProvider, TableSpec, projected_schema, row_source};
+use super::spec::{PlannedScan, SpecTableProvider, TableSpec, projected_schema, scan_row_source};
 
 pub(crate) fn register_diff_function<S>(
     session: &datafusion::prelude::SessionContext,
@@ -139,7 +139,8 @@ where
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
             ordering: None,
-            load: row_source(
+            source: scan_row_source(
+                Arc::clone(&schema),
                 (
                     self.store.clone(),
                     schema,

--- a/packages/engine/src/sql2/providers/diff_command.rs
+++ b/packages/engine/src/sql2/providers/diff_command.rs
@@ -13,7 +13,7 @@ use crate::LixError;
 use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::sql2::{DiffCommand, SqlWriteContext, WriteAccess};
 
-use super::spec::{InsertApply, PlannedScan, TableSpec, register_spec_table, row_source};
+use super::spec::{InsertApply, PlannedScan, TableSpec, register_spec_table, scan_row_source};
 
 pub(super) async fn register_diff_command_provider(
     session: &datafusion::prelude::SessionContext,
@@ -58,7 +58,7 @@ impl TableSpec for DiffCommandSpec {
         Ok(PlannedScan {
             schema: command_schema(),
             ordering: None,
-            load: row_source(table, |table| async move {
+            source: scan_row_source(command_schema(), table, |table| async move {
                 Err(DataFusionError::Execution(format!(
                     "{table} is a command sink and cannot be read"
                 )))

--- a/packages/engine/src/sql2/providers/directory.rs
+++ b/packages/engine/src/sql2/providers/directory.rs
@@ -74,7 +74,7 @@ use super::file::{
 };
 use super::spec::{
     DmlReturning, InsertApply, PlannedDml, PlannedScan, RowSource, TableSpec, finish_scan_batch,
-    projected_schema, register_spec_table, row_source, take_record_batch_rows,
+    projected_schema, register_spec_table, row_source, scan_row_source, take_record_batch_rows,
 };
 use super::upsert::{
     StagedUpsert, UpsertConflictKind, UpsertConflictTarget, UpsertReturningRow, UpsertSupport,
@@ -594,7 +594,8 @@ impl TableSpec for LixDirectorySpec {
         Ok(PlannedScan {
             schema: Arc::clone(&output_schema),
             ordering,
-            load: row_source(
+            source: scan_row_source(
+                Arc::clone(&output_schema),
                 (
                     Arc::clone(&self.live_state),
                     Arc::clone(&self.schema),
@@ -2974,7 +2975,11 @@ mod tests {
             .plan_scan(Some(&projection), &filters, None, &ExecutionProps::new())
             .await
             .expect("parent-id scan should plan");
-        let batch = (planned.load)().await.expect("parent-id scan should load");
+        let batch = planned
+            .source
+            .load_single_batch()
+            .await
+            .expect("parent-id scan should load");
 
         let paths = batch
             .column(0)
@@ -3042,7 +3047,9 @@ mod tests {
             .plan_scan(Some(&projection), &filters, None, &ExecutionProps::new())
             .await
             .expect("root-directory scan should plan");
-        let batch = (planned.load)()
+        let batch = planned
+            .source
+            .load_single_batch()
             .await
             .expect("root-directory scan should load");
 

--- a/packages/engine/src/sql2/providers/directory_history.rs
+++ b/packages/engine/src/sql2/providers/directory_history.rs
@@ -40,7 +40,7 @@ use super::columns::{Col, ColumnTable, ColumnTableError};
 use super::history_util::{
     ObservedTrackedStateOrdinal, ObservedTrackedStateRows, entity_pk_json_array,
 };
-use super::spec::{PlannedScan, TableSpec, projected_schema, register_spec_table, row_source};
+use super::spec::{PlannedScan, TableSpec, projected_schema, register_spec_table, scan_row_source};
 
 const DIRECTORY_DESCRIPTOR_SCHEMA_KEY: &str = "lix_directory_descriptor";
 
@@ -119,7 +119,8 @@ where
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
             ordering: None,
-            load: row_source(
+            source: scan_row_source(
+                Arc::clone(&schema),
                 (
                     Arc::clone(&self.commit_graph),
                     self.query_source.clone(),

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use datafusion::arrow::array::{ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray};
 use datafusion::arrow::datatypes::{Schema, SchemaRef};
 use datafusion::arrow::record_batch::{RecordBatch, RecordBatchOptions};
+use datafusion::common::stats::{ColumnStatistics, Precision};
 use datafusion::common::{DataFusionError, Result, ScalarValue, not_impl_err};
 use datafusion::execution::context::ExecutionProps;
 use datafusion::logical_expr::expr::InList;
@@ -46,11 +47,13 @@ use crate::transaction::types::{
 
 use super::ProviderSelection;
 use super::entity_history::register_entity_history_surface;
-use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{ExecutionPlan, Statistics};
+use futures_util::stream;
 
 use super::spec::{
-    InsertApply, PlannedDml, PlannedScan, TableSpec, projected_schema, register_spec_table,
-    row_source, scan_row_source,
+    InsertApply, PlannedDml, PlannedScan, TableSpec, batch_stream_source_with_statistics,
+    projected_schema, register_spec_table, row_source, scan_row_source,
 };
 use super::values::{
     optional_bool_value, optional_string_value, required_string_value, string_expr_literal,
@@ -316,9 +319,17 @@ impl TableSpec for EntitySpec {
         let row_filter_analyzer = EntityRowFilterAnalyzer::new(&self.spec);
         if ExactBranchIdFilterAnalyzer.supports(filter)
             || primary_key_analyzer.supports(filter)
-            || row_filter_analyzer.supports(filter)
+            || row_filter_analyzer
+                .analyze(filter)
+                .is_some_and(|filter| filter.exact_boolean_equality().is_some())
         {
             TableProviderFilterPushDown::Exact
+        } else if row_filter_analyzer.supports(filter) {
+            // Retain a DataFusion residual even when the row-shaped fallback
+            // also evaluates the predicate. Immutable columnar layouts use
+            // this residual for general typed filtering without a query-shape
+            // recognizer; later row-group pruning remains an inexact subset.
+            TableProviderFilterPushDown::Inexact
         } else {
             TableProviderFilterPushDown::Unsupported
         }
@@ -339,6 +350,29 @@ impl TableSpec for EntitySpec {
             .flatten();
         let direct_primary_key_projection =
             direct_primary_key_projection_eligible(&self.spec, &schema, &request, &row_filters);
+        if let Some(reader) = self.entity_snapshot_reader.as_ref()
+            && entity_columnar_projection_eligible(&schema, &request)
+            && let Some(layout) = reader
+                .plan_entity_columnar_scan(request.clone())
+                .await
+                .map_err(lix_error_to_datafusion_error)?
+            && let Some(projection) =
+                entity_columnar_projection(&layout.manifest, &schema, &self.spec)
+            && let Some(group_indices) =
+                entity_columnar_group_indices(&layout.manifest, &row_filters)
+        {
+            return Ok(PlannedScan {
+                schema: Arc::clone(&schema),
+                ordering: None,
+                source: entity_columnar_scan_source(
+                    Arc::clone(reader),
+                    layout,
+                    projection,
+                    group_indices,
+                    schema,
+                ),
+            });
+        }
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
             ordering: None,
@@ -503,6 +537,171 @@ impl TableSpec for EntitySpec {
     ) -> Result<PlannedDml> {
         not_impl_err!("raw DataFusion UPDATE is disabled; use the sql2 bound write pipeline")
     }
+}
+
+fn entity_columnar_projection_eligible(schema: &Schema, request: &LiveStateScanRequest) -> bool {
+    !schema.fields().is_empty()
+        && request.filter.entity_pks.is_empty()
+        && request.limit.is_none()
+        && schema
+            .fields()
+            .iter()
+            .all(|field| !field.name().starts_with("lixcol_"))
+}
+
+fn entity_columnar_projection(
+    manifest: &crate::columnar_row_group::RowGroupManifest,
+    schema: &Schema,
+    spec: &EntitySurfaceSpec,
+) -> Option<Vec<usize>> {
+    schema
+        .fields()
+        .iter()
+        .map(|field| {
+            // JSON is exposed as canonical JSON text on the SQL surface, so
+            // its Arrow Utf8 type is not equivalent to a scalar JSON string.
+            // Until sidecars are compiled from the registered schema, retain
+            // the authoritative decoder for every JSON projection.
+            if spec.visible_column(field.name())?.column_type == EntityColumnType::Json {
+                return None;
+            }
+            manifest.fields.iter().position(|candidate| {
+                candidate.name == *field.name()
+                    && candidate.data_type.to_arrow() == *field.data_type()
+            })
+        })
+        .collect()
+}
+
+fn entity_columnar_scan_source(
+    reader: Arc<dyn EntitySnapshotReader>,
+    layout: crate::sql2::entity_batch::EntityColumnarScanLayout,
+    projection: Vec<usize>,
+    group_indices: Vec<usize>,
+    schema: SchemaRef,
+) -> super::spec::ScanSource {
+    let statistics = group_indices
+        .iter()
+        .map(|&group_index| {
+            entity_columnar_group_statistics(
+                &layout.manifest.groups[group_index],
+                &projection,
+                schema.as_ref(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let partition_count = statistics.len();
+    let stream_schema = Arc::clone(&schema);
+    batch_stream_source_with_statistics(
+        Arc::clone(&schema),
+        statistics,
+        move |partition, _context| {
+            debug_assert!(partition < partition_count);
+            let reader = Arc::clone(&reader);
+            let layout = layout.clone();
+            let projection = projection.clone();
+            let group_index = group_indices[partition];
+            let schema = Arc::clone(&stream_schema);
+            let batch_schema = Arc::clone(&schema);
+            let batches = stream::once(async move {
+                let batch = reader
+                    .load_entity_columnar_group(layout, group_index, projection)
+                    .await
+                    .map_err(lix_error_to_datafusion_error)?;
+                RecordBatch::try_new(batch_schema, batch.columns().to_vec())
+                    .map_err(DataFusionError::from)
+            });
+            Ok(Box::pin(RecordBatchStreamAdapter::new(schema, batches)))
+        },
+    )
+}
+
+fn entity_columnar_group_indices(
+    manifest: &crate::columnar_row_group::RowGroupManifest,
+    row_filters: &[EntityRowFilter],
+) -> Option<Vec<usize>> {
+    let mut exact_booleans = Vec::new();
+    for filter in row_filters {
+        filter.collect_conjunctive_boolean_equalities(&mut exact_booleans);
+    }
+    if exact_booleans.is_empty() {
+        return Some((0..manifest.groups.len()).collect());
+    }
+    let exact_booleans = exact_booleans
+        .into_iter()
+        .map(|(column, expected)| {
+            manifest
+                .fields
+                .iter()
+                .position(|field| field.name == column)
+                .map(|column_index| (column_index, expected))
+        })
+        .collect::<Option<Vec<_>>>()?;
+    let mut selected = Vec::new();
+    for (group_index, group) in manifest.groups.iter().enumerate() {
+        let mut matches = true;
+        for &(column_index, expected) in &exact_booleans {
+            let statistics = &group.columns[column_index];
+            let (
+                Some(crate::columnar_row_group::RowGroupScalar::Boolean(min)),
+                Some(crate::columnar_row_group::RowGroupScalar::Boolean(max)),
+            ) = (&statistics.min, &statistics.max)
+            else {
+                return None;
+            };
+            if statistics.null_count != 0 || min != max {
+                return None;
+            }
+            matches &= *min == expected;
+        }
+        if matches {
+            selected.push(group_index);
+        }
+    }
+    (!selected.is_empty()).then_some(selected)
+}
+
+fn entity_columnar_group_statistics(
+    group: &crate::columnar_row_group::RowGroupStatistics,
+    projection: &[usize],
+    schema: &Schema,
+) -> Statistics {
+    let column_statistics = projection
+        .iter()
+        .map(|&index| {
+            let source = &group.columns[index];
+            ColumnStatistics::new_unknown()
+                .with_null_count(Precision::Exact(source.null_count as usize))
+                .with_min_value(entity_columnar_scalar_precision(source.min.as_ref()))
+                .with_max_value(entity_columnar_scalar_precision(source.max.as_ref()))
+                .with_sum_value(entity_columnar_scalar_precision(source.sum.as_ref()))
+        })
+        .collect();
+    let mut statistics = Statistics::new_unknown(schema);
+    statistics.num_rows = Precision::Exact(group.row_count as usize);
+    statistics.column_statistics = column_statistics;
+    statistics
+}
+
+fn entity_columnar_scalar_precision(
+    value: Option<&crate::columnar_row_group::RowGroupScalar>,
+) -> Precision<ScalarValue> {
+    let value = match value {
+        Some(crate::columnar_row_group::RowGroupScalar::String(value)) => {
+            ScalarValue::Utf8(Some(value.clone()))
+        }
+        Some(crate::columnar_row_group::RowGroupScalar::Int64(value)) => {
+            ScalarValue::Int64(Some(*value))
+        }
+        Some(crate::columnar_row_group::RowGroupScalar::Float64(value)) => {
+            ScalarValue::Float64(Some(*value))
+        }
+        Some(crate::columnar_row_group::RowGroupScalar::Boolean(value)) => {
+            ScalarValue::Boolean(Some(*value))
+        }
+        None => return Precision::Absent,
+    };
+    Precision::Exact(value)
 }
 
 fn contains_like_filter(expr: &Expr) -> bool {
@@ -940,6 +1139,17 @@ impl<'a> EntityRowFilterAnalyzer<'a> {
 
     fn analyze(&self, expr: &Expr) -> Option<EntityRowFilter> {
         match expr {
+            Expr::Column(column) => {
+                let column_name = self.filterable_column_name(&column.name)?;
+                let column = self.spec.visible_column(column_name)?;
+                (column.column_type == EntityColumnType::Boolean).then(|| {
+                    EntityRowFilter::ColumnEq {
+                        column: column_name.to_string(),
+                        column_type: EntityColumnType::Boolean,
+                        value: EntityFilterValue::Boolean(true),
+                    }
+                })
+            }
             Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::And => {
                 let left = self.analyze(&binary_expr.left)?;
                 let right = self.analyze(&binary_expr.right)?;
@@ -1050,6 +1260,31 @@ enum EntityRowFilter {
 }
 
 impl EntityRowFilter {
+    fn exact_boolean_equality(&self) -> Option<(&str, bool)> {
+        match self {
+            Self::ColumnEq {
+                column,
+                column_type: EntityColumnType::Boolean,
+                value: EntityFilterValue::Boolean(value),
+            } => Some((column, *value)),
+            _ => None,
+        }
+    }
+
+    fn collect_conjunctive_boolean_equalities<'a>(&'a self, output: &mut Vec<(&'a str, bool)>) {
+        match self {
+            Self::And(left, right) => {
+                left.collect_conjunctive_boolean_equalities(output);
+                right.collect_conjunctive_boolean_equalities(output);
+            }
+            filter => {
+                if let Some(equality) = filter.exact_boolean_equality() {
+                    output.push(equality);
+                }
+            }
+        }
+    }
+
     fn matches_snapshot(&self, snapshot: Option<&JsonValue>, schema_key: &str) -> Result<bool> {
         match self {
             Self::ColumnEq {
@@ -3167,5 +3402,76 @@ mod tests {
         assert_eq!(error.code, LixError::CODE_TYPE_MISMATCH);
         assert!(error.message.contains("count"), "{error:?}");
         assert!(error.message.contains("BIGINT"), "{error:?}");
+    }
+
+    #[test]
+    fn columnar_pruning_applies_exact_boolean_conjunct_with_residual_filter() {
+        let snapshots = [
+            serde_json::json!({"active": true, "lane": "a"}),
+            serde_json::json!({"active": false, "lane": "a"}),
+            serde_json::json!({"active": true, "lane": "b"}),
+            serde_json::json!({"active": false, "lane": "b"}),
+        ];
+        let encoded =
+            crate::live_state::encode_entity_scalar_row_groups("fixture", snapshots.iter())
+                .expect("encode")
+                .expect("scalar sidecar");
+        let filters = vec![
+            super::EntityRowFilter::ColumnEq {
+                column: "active".to_string(),
+                column_type: EntityColumnType::Boolean,
+                value: super::EntityFilterValue::Boolean(true),
+            },
+            super::EntityRowFilter::ColumnIn {
+                column: "lane".to_string(),
+                column_type: EntityColumnType::String,
+                values: vec![super::EntityFilterValue::String("a".to_string())],
+            },
+        ];
+
+        let selected = super::entity_columnar_group_indices(&encoded.manifest, &filters)
+            .expect("boolean groups are exact");
+        assert!(!selected.is_empty());
+        let active_index = encoded
+            .manifest
+            .fields
+            .iter()
+            .position(|field| field.name == "active")
+            .expect("active column");
+        assert!(selected.into_iter().all(|group_index| {
+            matches!(
+                encoded.manifest.groups[group_index].columns[active_index].min,
+                Some(crate::columnar_row_group::RowGroupScalar::Boolean(true))
+            )
+        }));
+    }
+
+    #[test]
+    fn columnar_projection_rejects_raw_utf8_for_json_surface_column() {
+        let spec = derive_entity_surface_spec_from_schema(&serde_json::json!({
+            "x-lix-key": "json_payload",
+            "type": "object",
+            "properties": { "payload": { "type": ["string", "object", "null"] } }
+        }))
+        .expect("schema");
+        let snapshot = serde_json::json!({"payload": "literal"});
+        let encoded = crate::live_state::encode_entity_scalar_row_groups(
+            "json_payload",
+            std::iter::once(&snapshot),
+        )
+        .expect("encode")
+        .expect("observed scalar layout");
+        let full_schema = entity_surface_schema(&spec, EntitySurfaceShape::Active);
+        let payload_schema = Arc::new(Schema::new(vec![
+            full_schema
+                .field_with_name("payload")
+                .expect("payload field")
+                .clone(),
+        ]));
+
+        assert!(
+            super::entity_columnar_projection(&encoded.manifest, &payload_schema, &spec).is_none(),
+            "canonical JSON text must continue through the authoritative decoder"
+        );
     }
 }

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -50,7 +50,7 @@ use datafusion::physical_plan::ExecutionPlan;
 
 use super::spec::{
     InsertApply, PlannedDml, PlannedScan, TableSpec, projected_schema, register_spec_table,
-    row_source,
+    row_source, scan_row_source,
 };
 use super::values::{
     optional_bool_value, optional_string_value, required_string_value, string_expr_literal,
@@ -342,7 +342,8 @@ impl TableSpec for EntitySpec {
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
             ordering: None,
-            load: row_source(
+            source: scan_row_source(
+                Arc::clone(&schema),
                 (
                     Arc::clone(&self.spec),
                     Arc::clone(&self.live_state),

--- a/packages/engine/src/sql2/providers/entity_history.rs
+++ b/packages/engine/src/sql2/providers/entity_history.rs
@@ -36,7 +36,7 @@ use crate::storage_adapter::StorageAdapterRead;
 
 use super::columns::{Col, ColumnTable, ColumnTableError};
 use super::entity::{EntityPrimaryKeyFilterAnalyzer, entity_pks_from_primary_key_filters};
-use super::spec::{PlannedScan, TableSpec, projected_schema, register_spec_table, row_source};
+use super::spec::{PlannedScan, TableSpec, projected_schema, register_spec_table, scan_row_source};
 
 pub(super) fn register_entity_history_surface<S>(
     session: &SessionContext,
@@ -126,7 +126,8 @@ where
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
             ordering: None,
-            load: row_source(
+            source: scan_row_source(
+                Arc::clone(&schema),
                 (
                     Arc::clone(&self.spec),
                     Arc::clone(&self.commit_graph),

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -108,7 +108,8 @@ use crate::transaction::types::{
 
 use super::spec::{
     DmlApply, DmlPlanOptions, DmlReturning, InsertApply, PlannedDml, PlannedScan, RowSource,
-    TableSpec, finish_scan_batch, register_spec_table, row_source, take_record_batch_rows,
+    TableSpec, finish_scan_batch, register_spec_table, row_source, scan_row_source,
+    take_record_batch_rows,
 };
 use super::upsert::{
     StagedUpsert, UpsertConflictKind, UpsertConflictTarget, UpsertReturningRow, UpsertSupport,
@@ -1142,7 +1143,8 @@ impl TableSpec for LixFileSpec {
         Ok(PlannedScan {
             schema: Arc::clone(&projected_schema),
             ordering,
-            load: row_source(
+            source: scan_row_source(
+                Arc::clone(&projected_schema),
                 (
                     Arc::clone(&self.live_state),
                     Arc::clone(&self.blob_reader),
@@ -8259,7 +8261,9 @@ mod tests {
             .plan_scan(Some(&projection), &[], None, &ExecutionProps::new())
             .await
             .expect("descriptor-only scan should plan");
-        let batch = (planned.load)()
+        let batch = planned
+            .source
+            .load_single_batch()
             .await
             .expect("descriptor-only scan should load");
 
@@ -8341,7 +8345,9 @@ mod tests {
             .await
             .expect("limited descriptor-only scan should plan");
         assert_eq!(planned.ordering.as_deref(), Some("path"));
-        let batch = (planned.load)()
+        let batch = planned
+            .source
+            .load_single_batch()
             .await
             .expect("limited descriptor-only scan should load");
 
@@ -8368,7 +8374,9 @@ mod tests {
             )
             .await
             .expect("count-style descriptor scan should plan");
-        let batch = (planned.load)()
+        let batch = planned
+            .source
+            .load_single_batch()
             .await
             .expect("count-style descriptor scan should load");
         assert_eq!(batch.num_columns(), 0);
@@ -8436,7 +8444,9 @@ mod tests {
             .plan_scan(Some(&projection), &filters, Some(1), &ExecutionProps::new())
             .await
             .expect("by-branch descriptor scan should plan");
-        let batch = (planned.load)()
+        let batch = planned
+            .source
+            .load_single_batch()
             .await
             .expect("by-branch descriptor scan should load");
 
@@ -8524,7 +8534,9 @@ mod tests {
             .plan_scan(Some(&projection), &filters, None, &ExecutionProps::new())
             .await
             .expect("file-id data scan should plan");
-        let batch = (planned.load)()
+        let batch = planned
+            .source
+            .load_single_batch()
             .await
             .expect("file-id data scan should load");
 
@@ -8781,7 +8793,9 @@ mod tests {
             .plan_scan(Some(&projection), &filters, None, &ExecutionProps::new())
             .await
             .expect("directory-id scan should plan");
-        let batch = (planned.load)()
+        let batch = planned
+            .source
+            .load_single_batch()
             .await
             .expect("directory-id scan should load");
 
@@ -9072,7 +9086,9 @@ mod tests {
             .plan_scan(Some(&projection), &filters, None, &ExecutionProps::new())
             .await
             .expect("root-directory scan should plan");
-        let batch = (planned.load)()
+        let batch = planned
+            .source
+            .load_single_batch()
             .await
             .expect("root-directory scan should load");
 

--- a/packages/engine/src/sql2/providers/file_history.rs
+++ b/packages/engine/src/sql2/providers/file_history.rs
@@ -54,7 +54,7 @@ use super::columns::{Col, ColumnTable, ColumnTableError};
 use super::history_util::{
     ObservedTrackedStateOrdinal, ObservedTrackedStateRows, entity_pk_json_array,
 };
-use super::spec::{PlannedScan, TableSpec, projected_schema, register_spec_table, row_source};
+use super::spec::{PlannedScan, TableSpec, projected_schema, register_spec_table, scan_row_source};
 
 const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
 const DIRECTORY_DESCRIPTOR_SCHEMA_KEY: &str = "lix_directory_descriptor";
@@ -164,7 +164,8 @@ where
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
             ordering: None,
-            load: row_source(
+            source: scan_row_source(
+                Arc::clone(&schema),
                 (
                     Arc::clone(&self.commit_graph),
                     self.query_source.clone(),

--- a/packages/engine/src/sql2/providers/filesystem_working_change.rs
+++ b/packages/engine/src/sql2/providers/filesystem_working_change.rs
@@ -26,7 +26,7 @@ use crate::tracked_state::{
 use super::checkpoint::{filter_conjuncts, selected_heads};
 use super::columns::{Col, ColumnTable, ColumnTableError};
 use super::file::{FileIdConstraint, exact_string_column_constraint_from_filters};
-use super::spec::{PlannedScan, TableSpec, projected_schema, register_spec_table, row_source};
+use super::spec::{PlannedScan, TableSpec, projected_schema, register_spec_table, scan_row_source};
 use crate::sql2::error::lix_error_to_datafusion_error;
 
 const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
@@ -122,7 +122,8 @@ where
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
             ordering: None,
-            load: row_source(
+            source: scan_row_source(
+                Arc::clone(&schema),
                 (
                     self.active_branch_id.clone(),
                     Arc::clone(&self.branch_ref),

--- a/packages/engine/src/sql2/providers/spec.rs
+++ b/packages/engine/src/sql2/providers/spec.rs
@@ -34,6 +34,7 @@ use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType, PlanP
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream,
+    Statistics,
 };
 use futures_util::future::BoxFuture;
 use futures_util::{TryStreamExt, stream};
@@ -50,6 +51,76 @@ use super::upsert;
 /// Re-invocable: DataFusion may execute a scan node more than once.
 pub(super) type RowSource = Arc<dyn Fn() -> BoxFuture<'static, Result<RecordBatch>> + Send + Sync>;
 
+/// Re-invocable factory for scans that can produce Arrow batches incrementally.
+///
+/// Unlike [`RowSource`], this preserves storage page and row-group boundaries
+/// all the way into DataFusion. The factory itself is synchronous because scan
+/// setup belongs in the returned stream; reads and decoding remain async and
+/// backpressured by the consumer.
+pub(super) type BatchStreamSource =
+    Arc<dyn Fn(usize, Arc<TaskContext>) -> Result<SendableRecordBatchStream> + Send + Sync>;
+
+#[derive(Clone)]
+pub(super) struct ScanSource {
+    partition_count: usize,
+    statistics: Arc<Vec<Statistics>>,
+    open: BatchStreamSource,
+}
+
+impl ScanSource {
+    fn new(
+        schema: &SchemaRef,
+        statistics: Vec<Statistics>,
+        open: impl Fn(usize, Arc<TaskContext>) -> Result<SendableRecordBatchStream>
+        + Send
+        + Sync
+        + 'static,
+    ) -> Self {
+        let partition_count = statistics.len();
+        assert!(partition_count > 0, "scan source must expose a partition");
+        assert!(statistics.iter().all(|statistics| {
+            statistics.column_statistics.is_empty()
+                || statistics.column_statistics.len() == schema.fields().len()
+        }));
+        Self {
+            partition_count,
+            statistics: Arc::new(statistics),
+            open: Arc::new(open),
+        }
+    }
+
+    fn open(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        if partition >= self.partition_count {
+            return Err(DataFusionError::Execution(format!(
+                "scan source exposes {} partitions, got {partition}",
+                self.partition_count
+            )));
+        }
+        (self.open)(partition, context)
+    }
+}
+
+#[cfg(test)]
+impl ScanSource {
+    pub(super) async fn load_single_batch(&self) -> Result<RecordBatch> {
+        let batches = self
+            .open(0, Arc::new(TaskContext::default()))?
+            .try_collect::<Vec<_>>()
+            .await?;
+        let [batch] = batches.as_slice() else {
+            return Err(DataFusionError::Execution(format!(
+                "test expected one scan batch, got {}",
+                batches.len()
+            )));
+        };
+        Ok(batch.clone())
+    }
+}
+
 /// Build a [`RowSource`] from owned plan-time state and an async body taking
 /// that state by value. Owns the once-per-invocation clone that
 /// re-invocability requires, so specs write the load body with no capture
@@ -64,6 +135,55 @@ where
     Fut: Future<Output = Result<RecordBatch>> + Send + 'static,
 {
     Arc::new(move || Box::pin(f(state.clone())))
+}
+
+/// Adapt an existing materializing loader into a planned scan source.
+pub(super) fn scan_row_source<S, Fut>(
+    schema: SchemaRef,
+    state: S,
+    f: impl Fn(S) -> Fut + Send + Sync + 'static,
+) -> ScanSource
+where
+    S: Clone + Send + Sync + 'static,
+    Fut: Future<Output = Result<RecordBatch>> + Send + 'static,
+{
+    let load = row_source(state, f);
+    batch_stream_source(Arc::clone(&schema), 1, move |_partition, _context| {
+        let load = Arc::clone(&load);
+        let stream = stream::once(async move { load().await });
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&schema),
+            stream,
+        )))
+    })
+}
+
+/// Build a storage-originating streaming scan source.
+pub(super) fn batch_stream_source(
+    schema: SchemaRef,
+    partition_count: usize,
+    factory: impl Fn(usize, Arc<TaskContext>) -> Result<SendableRecordBatchStream>
+    + Send
+    + Sync
+    + 'static,
+) -> ScanSource {
+    let statistics = (0..partition_count)
+        .map(|_| Statistics::new_unknown(schema.as_ref()))
+        .collect();
+    batch_stream_source_with_statistics(schema, statistics, factory)
+}
+
+/// Build a streaming scan whose immutable source can expose exact per-partition
+/// row and column statistics to DataFusion's generic physical optimizers.
+pub(super) fn batch_stream_source_with_statistics(
+    schema: SchemaRef,
+    statistics: Vec<Statistics>,
+    factory: impl Fn(usize, Arc<TaskContext>) -> Result<SendableRecordBatchStream>
+    + Send
+    + Sync
+    + 'static,
+) -> ScanSource {
+    ScanSource::new(&schema, statistics, factory)
 }
 
 /// Exec-time DML handler: receives the filter-matched batch, stages the
@@ -168,7 +288,7 @@ pub(super) type InsertApply =
 /// materializes it during execution.
 pub(super) struct PlannedScan {
     pub(super) schema: SchemaRef,
-    pub(super) load: RowSource,
+    pub(super) source: ScanSource,
     pub(super) ordering: Option<String>,
 }
 
@@ -804,7 +924,7 @@ impl InsertSink for PlannedInsertSink {
 struct SpecScanExec {
     table: Arc<str>,
     schema: SchemaRef,
-    load: RowSource,
+    source: ScanSource,
     properties: Arc<PlanProperties>,
 }
 
@@ -834,14 +954,14 @@ impl SpecScanExec {
             .unwrap_or_else(|| EquivalenceProperties::new(Arc::clone(&planned.schema)));
         let properties = PlanProperties::new(
             equivalence_properties,
-            Partitioning::UnknownPartitioning(1),
+            Partitioning::UnknownPartitioning(planned.source.partition_count),
             EmissionType::Incremental,
             Boundedness::Bounded,
         );
         Self {
             table,
             schema: planned.schema,
-            load: planned.load,
+            source: planned.source,
             properties: Arc::new(properties),
         }
     }
@@ -894,18 +1014,36 @@ impl ExecutionPlan for SpecScanExec {
     fn execute(
         &self,
         partition: usize,
-        _context: Arc<TaskContext>,
+        context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        if partition != 0 {
+        let stream = self.source.open(partition, context)?;
+        if stream.schema() != self.schema {
             return Err(DataFusionError::Execution(format!(
-                "SpecScanExec({}) only exposes one partition, got {partition}",
+                "SpecScanExec({}) stream schema does not match its planned schema",
                 self.table
             )));
         }
-        let load = Arc::clone(&self.load);
-        let schema = Arc::clone(&self.schema);
-        let stream = stream::once(async move { load().await });
-        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+        Ok(stream)
+    }
+
+    fn partition_statistics(&self, partition: Option<usize>) -> Result<Statistics> {
+        match partition {
+            Some(partition) => self
+                .source
+                .statistics
+                .get(partition)
+                .cloned()
+                .ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "SpecScanExec({}) exposes {} partitions, got statistics request for {partition}",
+                        self.table, self.source.partition_count
+                    ))
+                }),
+            None => Statistics::try_merge_iter(
+                self.source.statistics.iter(),
+                self.schema.as_ref(),
+            ),
+        }
     }
 }
 
@@ -1147,4 +1285,137 @@ pub(super) fn projected_schema(schema: &SchemaRef, projection: Option<&Vec<usize
         || Arc::clone(schema),
         |projection| Arc::new(schema.project(projection).expect("projection is valid")),
     )
+}
+
+#[cfg(test)]
+mod scan_source_tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use datafusion::arrow::array::Int64Array;
+    use datafusion::common::stats::Precision;
+    use futures_util::TryStreamExt;
+
+    use super::*;
+
+    fn int_schema(name: &str) -> SchemaRef {
+        Arc::new(Schema::new(vec![Field::new(name, DataType::Int64, false)]))
+    }
+
+    fn int_batch(schema: SchemaRef, values: &[i64]) -> RecordBatch {
+        let values: ArrayRef = Arc::new(Int64Array::from(values.to_vec()));
+        RecordBatch::try_new(schema, vec![values]).expect("test batch should match schema")
+    }
+
+    #[tokio::test]
+    async fn streaming_scan_is_incremental_reusable_and_partition_checked() {
+        let schema = int_schema("value");
+        let source_schema = Arc::clone(&schema);
+        let opens = Arc::new(AtomicUsize::new(0));
+        let source_opens = Arc::clone(&opens);
+        let source = batch_stream_source(Arc::clone(&schema), 1, move |_partition, _context| {
+            source_opens.fetch_add(1, Ordering::SeqCst);
+            let batches = vec![
+                Ok(int_batch(Arc::clone(&source_schema), &[1, 2])),
+                Ok(int_batch(Arc::clone(&source_schema), &[3])),
+            ];
+            Ok(Box::pin(RecordBatchStreamAdapter::new(
+                Arc::clone(&source_schema),
+                stream::iter(batches),
+            )))
+        });
+        let exec = SpecScanExec::new(
+            Arc::from("stream_test"),
+            PlannedScan {
+                schema: Arc::clone(&schema),
+                source,
+                ordering: None,
+            },
+        );
+
+        for _ in 0..2 {
+            let batches = exec
+                .execute(0, Arc::new(TaskContext::default()))
+                .expect("partition zero should open")
+                .try_collect::<Vec<_>>()
+                .await
+                .expect("stream should complete");
+            assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 3);
+            assert_eq!(batches.len(), 2);
+        }
+        assert_eq!(opens.load(Ordering::SeqCst), 2);
+        assert!(exec.execute(1, Arc::new(TaskContext::default())).is_err());
+    }
+
+    #[test]
+    fn streaming_scan_rejects_schema_drift_before_polling() {
+        let planned_schema = int_schema("expected");
+        let stream_schema = int_schema("unexpected");
+        let source = batch_stream_source(
+            Arc::clone(&planned_schema),
+            1,
+            move |_partition, _context| {
+                Ok(Box::pin(RecordBatchStreamAdapter::new(
+                    Arc::clone(&stream_schema),
+                    stream::empty(),
+                )))
+            },
+        );
+        let exec = SpecScanExec::new(
+            Arc::from("schema_drift_test"),
+            PlannedScan {
+                schema: planned_schema,
+                source,
+                ordering: None,
+            },
+        );
+
+        let error = exec
+            .execute(0, Arc::new(TaskContext::default()))
+            .err()
+            .expect("schema drift must fail");
+        assert!(error.to_string().contains("stream schema"));
+    }
+
+    #[test]
+    fn streaming_scan_exposes_and_merges_exact_partition_statistics() {
+        let schema = int_schema("value");
+        let statistics = [2, 3]
+            .into_iter()
+            .map(|rows| {
+                Statistics::new_unknown(schema.as_ref()).with_num_rows(Precision::Exact(rows))
+            })
+            .collect();
+        let source_schema = Arc::clone(&schema);
+        let source = batch_stream_source_with_statistics(
+            Arc::clone(&schema),
+            statistics,
+            move |_partition, _context| {
+                Ok(Box::pin(RecordBatchStreamAdapter::new(
+                    Arc::clone(&source_schema),
+                    stream::empty(),
+                )))
+            },
+        );
+        let exec = SpecScanExec::new(
+            Arc::from("statistics_test"),
+            PlannedScan {
+                schema,
+                source,
+                ordering: None,
+            },
+        );
+
+        assert_eq!(
+            exec.partition_statistics(Some(0))
+                .expect("partition statistics")
+                .num_rows,
+            Precision::Exact(2)
+        );
+        assert_eq!(
+            exec.partition_statistics(None)
+                .expect("merged statistics")
+                .num_rows,
+            Precision::Exact(5)
+        );
+    }
 }

--- a/packages/engine/src/sql2/providers/working_change.rs
+++ b/packages/engine/src/sql2/providers/working_change.rs
@@ -25,7 +25,7 @@ use crate::{LixError, NullableKeyFilter};
 use super::checkpoint::{filter_conjuncts, selected_heads};
 use super::columns::{Col, ColumnTable, ColumnTableError};
 use super::file::{FileIdConstraint, exact_string_column_constraint_from_filters};
-use super::spec::{PlannedScan, TableSpec, projected_schema, register_spec_table, row_source};
+use super::spec::{PlannedScan, TableSpec, projected_schema, register_spec_table, scan_row_source};
 use crate::sql2::error::lix_error_to_datafusion_error;
 
 pub(super) async fn register_working_change_provider<S>(
@@ -107,7 +107,8 @@ where
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
             ordering: None,
-            load: row_source(
+            source: scan_row_source(
+                Arc::clone(&schema),
                 (
                     self.active_branch_id.clone(),
                     Arc::clone(&self.branch_ref),

--- a/packages/engine/src/sql2/session.rs
+++ b/packages/engine/src/sql2/session.rs
@@ -1,3 +1,4 @@
+use datafusion::execution::session_state::SessionStateBuilder;
 use datafusion::prelude::{SessionConfig, SessionContext};
 use datafusion::sql::parser::Statement as DataFusionStatement;
 use std::collections::BTreeSet;
@@ -166,15 +167,29 @@ pub(crate) async fn build_write_session_with_options(
 }
 
 pub(crate) fn new_sql_session_context() -> SessionContext {
-    SessionContext::new_with_config(
-        SessionConfig::new()
-            .with_information_schema(false)
-            .with_target_partitions(1)
-            .set_bool("datafusion.optimizer.repartition_aggregations", false)
-            .set_bool("datafusion.optimizer.repartition_joins", false)
-            .set_bool("datafusion.optimizer.repartition_sorts", false)
-            .set_bool("datafusion.optimizer.repartition_windows", false)
-            .set_bool("datafusion.optimizer.repartition_file_scans", false)
-            .set_bool("datafusion.optimizer.enable_round_robin_repartition", false),
-    )
+    let config = SessionConfig::new()
+        .with_information_schema(false)
+        .with_target_partitions(1)
+        .set_bool("datafusion.optimizer.repartition_aggregations", false)
+        .set_bool("datafusion.optimizer.repartition_joins", false)
+        .set_bool("datafusion.optimizer.repartition_sorts", false)
+        .set_bool("datafusion.optimizer.repartition_windows", false)
+        .set_bool("datafusion.optimizer.repartition_file_scans", false)
+        .set_bool("datafusion.optimizer.enable_round_robin_repartition", false);
+    let base_state = SessionStateBuilder::new_with_default_features()
+        .with_config(config)
+        .build();
+    let mut physical_optimizers = base_state.physical_optimizers().to_vec();
+    let aggregate_statistics_index = physical_optimizers
+        .iter()
+        .position(|rule| rule.name() == "aggregate_statistics")
+        .expect("DataFusion default features include aggregate_statistics");
+    physical_optimizers.insert(
+        aggregate_statistics_index + 1,
+        Arc::new(super::aggregate_statistics::ExactAggregateStatistics),
+    );
+    let state = SessionStateBuilder::new_from_existing(base_state)
+        .with_physical_optimizer_rules(physical_optimizers)
+        .build();
+    SessionContext::new_with_state(state)
 }

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -240,6 +240,9 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     {
         deleted_checkpoint_files.remove(&(write.branch_id.clone(), write.file_id.clone()));
     }
+    let mut insert_selection = prepared_writes.insert_selection;
+    let entity_columnar_write_sets =
+        prepare_entity_columnar_write_sets(&state_rows, &insert_selection)?;
     release_validated_canonical_value_columns(&mut state_rows);
     if !prepared_writes.file_data_writes.is_empty() {
         let mut blob_writer = binary_cas.writer_skipping_existing_chunks(&*read, &mut writes);
@@ -306,7 +309,6 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         )
         .await?;
     }
-    let mut insert_selection = prepared_writes.insert_selection;
     let finalized = finalize_commit_rows(
         prepared_writes.commit_change_refs_by_branch,
         prepared_writes.first_commit_parent_override_by_branch,
@@ -551,6 +553,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         read,
         &mut writes,
         &state_rows,
+        &entity_columnar_write_sets,
         &engine_rows,
         &row_index.tracked_row_indices_by_commit,
         &tracked_roots,
@@ -2431,6 +2434,7 @@ async fn stage_tracked_head(
     read: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
     state_rows: &PreparedStateBatch,
+    entity_columnar_write_sets: &crate::live_state::EntityColumnarWriteSets,
     engine_rows: &[EngineCurrentRow],
     tracked_row_indices_by_commit: &BTreeMap<CommitId, Vec<RowIndex>>,
     tracked_roots: &[PendingTrackedRoot],
@@ -2747,6 +2751,7 @@ async fn stage_tracked_head(
                         .iter()
                         .map(|&row_index| state_rows.row(row_index))
                         .map(|row| (row.schema_key.as_str(), row.entity_pk)),
+                    entity_columnar_write_sets,
                     working_diff_capture_checkpoint_commit_id,
                     &mut coverage,
                 )
@@ -3847,6 +3852,51 @@ struct ExplicitBranchHeadTarget {
 
 fn release_validated_canonical_value_columns(state_rows: &mut PreparedStateBatch) {
     state_rows.release_validated_canonical_value_columns();
+}
+
+fn prepare_entity_columnar_write_sets(
+    state_rows: &PreparedStateBatch,
+    insert_selection: &PreparedInsertSelection,
+) -> Result<crate::live_state::EntityColumnarWriteSets, LixError> {
+    if state_rows.len() < PACKED_CURRENT_BASE_MIN_ROWS || insert_selection.len() != state_rows.len()
+    {
+        return Ok(BTreeMap::new());
+    }
+    let mut indices = BTreeMap::<(CommitId, String), Vec<usize>>::new();
+    for (index, row) in state_rows.iter().enumerate() {
+        if !insert_selection.contains(index) {
+            return Ok(BTreeMap::new());
+        }
+        let (Some(commit_id), Some(_snapshot)) = (row.commit_id, row.snapshot) else {
+            continue;
+        };
+        if row.untracked || row.global || row.file_id.is_some() {
+            continue;
+        }
+        indices
+            .entry((commit_id, row.schema_key.to_string()))
+            .or_default()
+            .push(index);
+    }
+    let mut encoded = BTreeMap::new();
+    for ((commit_id, schema_key), row_indices) in indices {
+        if row_indices.len() < PACKED_CURRENT_BASE_MIN_ROWS {
+            continue;
+        }
+        let snapshots = row_indices.iter().map(|&index| {
+            state_rows
+                .row(index)
+                .snapshot
+                .expect("columnar row index retained a snapshot")
+                .value()
+        });
+        if let Some(row_groups) =
+            crate::live_state::encode_entity_scalar_row_groups(&schema_key, snapshots)?
+        {
+            encoded.insert((commit_id, schema_key), row_groups);
+        }
+    }
+    Ok(encoded)
 }
 
 fn explicit_branch_head_targets(

--- a/packages/engine/tests/integration/sql/entity_view.rs
+++ b/packages/engine/tests/integration/sql/entity_view.rs
@@ -32,8 +32,8 @@ simulation_test!(
             "plan should scan pushdown_note:\n{plan}"
         );
         assert!(
-            plan.contains("full_filters=[pushdown_note.kind = Utf8(\"todo\")]"),
-            "payload equality should be pushed into the table scan:\n{plan}"
+            plan.contains("partial_filters=[pushdown_note.kind = Utf8(\"todo\")]"),
+            "payload equality should reach the table scan while retaining a DataFusion residual:\n{plan}"
         );
     }
 );


### PR DESCRIPTION
## What changed

This adds a generalized analytical read path for entity SQL through DataFusion. It does not inspect SQL text or recognize benchmark query shapes.

- streams physical RecordBatches from table scans instead of forcing one materialized batch
- publishes immutable, projection-addressable typed row groups atomically with eligible packed current-state bases
- prunes homogeneous boolean row groups and leaves unsupported predicates as ordinary DataFusion residuals
- exposes exact per-partition row/null/min/max/sum statistics
- extends DataFusion's physical aggregate-statistics rule for built-in SUM/AVG only
- authenticates manifests and compressed columns with BLAKE3, avoiding a second full decoded-column statistics scan
- ties sidecar reclamation to repository GC and bumps the intentionally breaking repository protocol to v44
- falls back to the authoritative row path for overlays, point/limited reads, JSON columns, type mismatches, or optional sidecar failures

The benchmark queries retain a top-level CTE so strict native entity-read recognizers cannot match them.

## 1M-row matched results

Single thread, one seeded fixture, one untimed warmup, 9 individually timed samples, median, and owned public results on the same machine.

| shape | DuckDB | RocksDB | ratio | SlateDB | ratio |
|---|---:|---:|---:|---:|---:|
| scan | 888.847 ms | 182.691 ms | 0.21x | 182.734 ms | 0.21x |
| filter + ordered result | 23.006 ms | 18.122 ms | 0.79x | 18.829 ms | 0.82x |
| filtered top-k sort | 46.404 ms | 25.300 ms | 0.55x | 26.459 ms | 0.57x |
| grouped aggregates | 15.101 ms | 16.472 ms | 1.09x | 17.126 ms | 1.13x |
| global aggregates | 2.554 ms | 0.661 ms | 0.26x | 1.028 ms | 0.40x |

The tightest representative query is grouped aggregation, inside the requested 1.5x ceiling on both storage adapters.

## Profile benefit

Replacing decoded-column statistics rescans with authenticated compressed-byte digests improved the same generalized plans:

| shape | RocksDB before | after | change | SlateDB before | after | change |
|---|---:|---:|---:|---:|---:|---:|
| filter | 23.083 ms | 18.122 ms | -21.5% | 24.528 ms | 18.829 ms | -23.2% |
| sort | 30.292 ms | 25.300 ms | -16.5% | 30.813 ms | 26.459 ms | -14.1% |
| group | 21.675 ms | 16.472 ms | -24.0% | 22.822 ms | 17.126 ms | -25.0% |

The pre-row-group RocksDB global aggregate was 982.913 ms; the final exact-statistics physical plan is 0.661 ms.

## Transactional and OLTP safety

The sidecar is selectable only when one immutable exclusive packed base exactly matches the current collection control. Any row-shaped update/overlay clears that proof and falls back to authoritative current-state reconciliation. Exact-PK and limited scans are explicitly ineligible.

A 1M-row, 10,000-repeat RocksDB point-read comparison was 9.155 us on main versus 8.955 us here (-2.2%), with identical 9,999-hit/1-miss cache behavior. SlateDB was 21.912 us on main versus 22.035 us here (+0.6%) over 1,000 repeats.

Repository GC coverage proves reachable sidecars survive and swept commit sidecars are removed. JSON projections remain on the canonical decoder to prevent raw UTF-8/JSON semantic drift.

## Validation

- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- `RUST_MIN_STACK=33554432 cargo test -p lix_engine --all-features --quiet`
  - 1,770 unit tests passed; 8 ignored
  - 804 integration tests passed; 2 ignored
- typed OLAP parity below and above the publication threshold on SQLite, RocksDB, and SlateDB
- 7 row-group codec/integrity/lifecycle tests
- exact aggregate tests for built-ins, DISTINCT/inexact/all-null fallback, and a custom UDAF named `sum`
- independent sub-agent reviews of DataFusion execution, physical storage, benchmark fairness, transactional safety, and final release blockers
