### PR TITLE
perf(engine): coalesce certified point replacements

### DIFF
--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -1976,8 +1976,14 @@ async fn execute_entity_write(
         ));
     }
 
-    let spec = entity_spec(ctx, schema_key)?;
-    validate_bound_write_supported(plan, &spec)?;
+    let catalog = ctx.public_catalog()?;
+    let spec = catalog.entity_spec(schema_key).ok_or_else(|| {
+        LixError::new(
+            LixError::CODE_SCHEMA_DEFINITION,
+            format!("entity surface '{schema_key}' is not visible"),
+        )
+    })?;
+    validate_bound_write_supported(plan, spec)?;
     // Only `lix_active_branch_commit_id()` needs the current branch head.
     // Normal entity mutations already stage against the transaction's active
     // branch, so eagerly opening another read here makes the common write
@@ -1992,20 +1998,20 @@ async fn execute_entity_write(
     match plan.bound.op {
         BoundWriteOp::Insert => {
             if no_op {
-                entity_insert_batch(ctx, plan, &spec, params, active_branch_commit_id.as_ref())?;
+                entity_insert_batch(ctx, plan, spec, params, active_branch_commit_id.as_ref())?;
                 return Ok(empty_entity_returning_result(plan));
             }
             if plan.bound.conflict.is_some() {
-                entity_upsert(ctx, plan, &spec, params, active_branch_commit_id.as_ref()).await
+                entity_upsert(ctx, plan, spec, params, active_branch_commit_id.as_ref()).await
             } else {
-                entity_insert(ctx, plan, &spec, params, active_branch_commit_id.as_ref()).await
+                entity_insert(ctx, plan, spec, params, active_branch_commit_id.as_ref()).await
             }
         }
         BoundWriteOp::Update => {
             if no_op {
                 return Ok(empty_entity_returning_result(plan));
             }
-            entity_update(ctx, plan, &spec, params, active_branch_commit_id.as_ref()).await
+            entity_update(ctx, plan, spec, params, active_branch_commit_id.as_ref()).await
         }
         BoundWriteOp::Delete => {
             if no_op {
@@ -2018,7 +2024,7 @@ async fn execute_entity_write(
             {
                 return Ok(result);
             }
-            entity_delete(ctx, plan, &spec, params, active_branch_commit_id.as_ref()).await
+            entity_delete(ctx, plan, spec, params, active_branch_commit_id.as_ref()).await
         }
     }
 }
@@ -2762,7 +2768,9 @@ async fn try_execute_direct_path_value_replacement(
         return Ok(None);
     }
 
-    let candidates = scan_entity_candidates(ctx, plan, spec, params).await?;
+    let entity_pk = EntityPk::single(primary_key.clone());
+    let candidates =
+        scan_entity_candidates_for_pks(ctx, plan, spec, vec![entity_pk.clone()], false).await?;
     if candidates.is_empty() {
         return Ok(Some(SqlWriteResult::affected(0)));
     }
@@ -2795,8 +2803,8 @@ async fn try_execute_direct_path_value_replacement(
         TransactionJson::from_certified_row_content_arena(normalized, vec![(0, normalized_len)])?
             .pop()
             .expect("one certified replacement snapshot");
-    let rows = RawWriteBatch::from_certified_parameter_replacement(
-        vec![EntityPk::single(primary_key.clone())],
+    let rows = CertifiedParameterReplacementBatch::new(
+        vec![entity_pk],
         vec![snapshot],
         spec.schema_key.as_str().into(),
         ctx.active_branch_id().into(),
@@ -2810,7 +2818,7 @@ async fn try_execute_direct_path_value_replacement(
             complete_collection_replacement: false,
         },
     )?;
-    ctx.stage_parameter_batch_replace(rows).await?;
+    ctx.stage_certified_parameter_batch_replace(rows).await?;
     #[cfg(test)]
     CERTIFIED_SINGLE_PATH_VALUE_REPLACEMENTS.with(|executions| {
         executions.set(executions.get().saturating_add(1));

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -3862,6 +3862,18 @@ fn prepare_entity_columnar_write_sets(
     {
         return Ok(BTreeMap::new());
     }
+    if insert_selection.covers_all(state_rows.len())
+        && let Some((commit_id, schema_key, snapshots)) = state_rows.dense_entity_columnar_input()
+    {
+        let snapshots = snapshots.iter().map(|snapshot| snapshot.value());
+        let mut encoded = BTreeMap::new();
+        if let Some(row_groups) =
+            crate::live_state::encode_entity_scalar_row_groups(schema_key, snapshots)?
+        {
+            encoded.insert((commit_id, schema_key.to_string()), row_groups);
+        }
+        return Ok(encoded);
+    }
     let mut indices = BTreeMap::<(CommitId, String), Vec<usize>>::new();
     for (index, row) in state_rows.iter().enumerate() {
         if !insert_selection.contains(index) {

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -379,6 +379,10 @@ impl PreparedInsertSelection {
         self.count == 0
     }
 
+    pub(crate) fn covers_all(&self, row_count: usize) -> bool {
+        self.row_count == row_count && self.count == row_count
+    }
+
     pub(crate) fn contains(&self, row_index: usize) -> bool {
         if row_index >= self.row_count {
             return false;

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -608,7 +608,7 @@ impl CertifiedParameterBatch {
                 facts: certificate.facts,
                 schema_key: schema_key_ordinal,
                 origin_key,
-                timestamp,
+                timestamps: DenseParameterTimestamps::Scalar(timestamp),
                 commit_id: None,
                 branch_id: branch_id_ordinal,
                 direct_change_ids: None,
@@ -691,28 +691,6 @@ impl RawWriteBatch {
             #[cfg(test)]
             origin_promotions: 0,
         }
-    }
-
-    /// Constructs a fixed-shape, complete tracked replacement batch.
-    ///
-    /// The SQL certificate has already proven that every row is an ordinary
-    /// unfiled, branch-local replacement with canonical row content. Keeping
-    /// this separate from mutable `push_parts` ingress preserves one shared
-    /// snapshot arena and one schema/branch dictionary for the whole batch.
-    pub(crate) fn from_certified_parameter_replacement(
-        entity_pks: Vec<EntityPk>,
-        snapshots: Vec<TransactionJson>,
-        schema_key: SharedStr,
-        branch_id: SharedStr,
-        certificate: CertifiedRawWriteBatchPreparation,
-    ) -> Result<Self, LixError> {
-        Self::from_certified_parameter_rows(
-            entity_pks,
-            snapshots,
-            schema_key,
-            branch_id,
-            certificate,
-        )
     }
 
     fn from_certified_parameter_rows(
@@ -2543,12 +2521,50 @@ struct DenseCertifiedParameterSlots {
     facts: PreparedRowFacts,
     schema_key: u32,
     origin_key: Option<u32>,
-    timestamp: LixTimestamp,
+    timestamps: DenseParameterTimestamps,
     commit_id: Option<CommitId>,
     branch_id: u32,
     /// Absent until commit-delta publication assigns direct addresses. The
     /// compact segment map derives every UUID without a million-row column.
     direct_change_ids: Option<OrderedAddressableCommitDeltaStage>,
+}
+
+#[derive(Debug, Clone)]
+enum DenseParameterTimestamps {
+    Scalar(LixTimestamp),
+    PerRow(Vec<LixTimestamp>),
+}
+
+impl DenseParameterTimestamps {
+    fn get(&self, row_index: usize) -> LixTimestamp {
+        match self {
+            Self::Scalar(timestamp) => *timestamp,
+            Self::PerRow(timestamps) => timestamps[row_index],
+        }
+    }
+
+    fn append(&mut self, left_len: usize, right_len: usize, right: Self) {
+        if let (Self::Scalar(left), Self::Scalar(right)) = (&*self, &right)
+            && left == right
+        {
+            return;
+        }
+        let mut timestamps = match self {
+            Self::Scalar(timestamp) => {
+                let mut timestamps = Vec::with_capacity(left_len.saturating_add(right_len));
+                timestamps.resize(left_len, *timestamp);
+                timestamps
+            }
+            Self::PerRow(timestamps) => std::mem::take(timestamps),
+        };
+        match right {
+            Self::Scalar(timestamp) => {
+                timestamps.resize(timestamps.len().saturating_add(right_len), timestamp);
+            }
+            Self::PerRow(mut right) => timestamps.append(&mut right),
+        }
+        *self = Self::PerRow(timestamps);
+    }
 }
 
 /// Borrowed row projection over a [`PreparedStateBatch`].
@@ -2678,8 +2694,8 @@ impl PreparedStateBatch {
                 metadata: None,
                 origin: None,
                 origin_key: dense.origin_key.map(|index| &self.strings[index as usize]),
-                created_at: dense.timestamp,
-                updated_at: dense.timestamp,
+                created_at: dense.timestamps.get(index),
+                updated_at: dense.timestamps.get(index),
                 global: false,
                 change_id: Some(dense.direct_change_ids.as_ref().map_or_else(
                     ChangeId::default,
@@ -2875,8 +2891,8 @@ impl PreparedStateBatch {
                 metadata: None,
                 origin: None,
                 origin_key: dense.origin_key,
-                created_at: dense.timestamp,
-                updated_at: dense.timestamp,
+                created_at: dense.timestamps.get(row_index),
+                updated_at: dense.timestamps.get(row_index),
                 global: false,
                 change_id: Some(dense.direct_change_ids.as_ref().map_or_else(
                     ChangeId::default,
@@ -2909,6 +2925,74 @@ impl PreparedStateBatch {
         });
     }
 
+    /// Extends one fixed-shape certified parameter journal without expanding
+    /// either side into row slots. Repeated `Transaction::execute` calls
+    /// arrive as singleton batches; compatible ordered writes are one logical
+    /// columnar morsel and only need row-cardinal identity, JSON, and timestamp
+    /// columns.
+    fn try_append_dense_certified_parameter(&mut self, other: &mut Self) -> bool {
+        let compatible = match (
+            self.dense_certified_parameter.as_ref(),
+            other.dense_certified_parameter.as_ref(),
+        ) {
+            (Some(left), Some(right)) => {
+                let same_origin_key = match (left.origin_key, right.origin_key) {
+                    (None, None) => true,
+                    (Some(left), Some(right)) => {
+                        self.strings[left as usize] == other.strings[right as usize]
+                    }
+                    (None, Some(_)) | (Some(_), None) => false,
+                };
+                left.schema_plan_id == right.schema_plan_id
+                    && left.facts == right.facts
+                    && self.strings[left.schema_key as usize]
+                        == other.strings[right.schema_key as usize]
+                    && self.strings[left.branch_id as usize]
+                        == other.strings[right.branch_id as usize]
+                    && same_origin_key
+                    && left.commit_id == right.commit_id
+                    && left.direct_change_ids.is_none()
+                    && right.direct_change_ids.is_none()
+                    && self.durable_predecessors.is_empty()
+                    && other.durable_predecessors.is_empty()
+                    && self.origins.is_empty()
+                    && other.origins.is_empty()
+                    && self.origin_column_sets.is_empty()
+                    && other.origin_column_sets.is_empty()
+                    && self.certified_tracked_keys_strictly_ordered
+                    && other.certified_tracked_keys_strictly_ordered
+                    && self
+                        .entity_pks
+                        .last()
+                        .zip(other.entity_pks.first())
+                        .is_some_and(|(left, right)| left < right)
+            }
+            (None, _) | (_, None) => false,
+        };
+        if !compatible {
+            return false;
+        }
+
+        let right = other
+            .dense_certified_parameter
+            .take()
+            .expect("compatible dense parameter batch");
+        let left = self
+            .dense_certified_parameter
+            .as_mut()
+            .expect("compatible dense parameter batch");
+        left.timestamps
+            .append(left.len, right.len, right.timestamps);
+        left.len = left
+            .len
+            .checked_add(right.len)
+            .expect("prepared dense parameter row count overflowed");
+        self.entity_pks.append(&mut other.entity_pks);
+        self.json.append(&mut other.json);
+        self.certified_complete_collection_replacement = false;
+        true
+    }
+
     /// Appends another batch without materializing row-owned intermediates.
     pub(crate) fn append(&mut self, mut other: Self) {
         if other.is_empty() {
@@ -2916,6 +3000,9 @@ impl PreparedStateBatch {
         }
         if self.is_empty() {
             *self = other;
+            return;
+        }
+        if self.try_append_dense_certified_parameter(&mut other) {
             return;
         }
         self.expand_dense_certified_parameter();
@@ -3232,6 +3319,20 @@ impl PreparedStateBatch {
             dense.facts,
             self.strings[dense.schema_key as usize].as_str(),
             self.strings[dense.branch_id as usize].as_str(),
+        ))
+    }
+
+    /// Returns the contiguous snapshot column for a single certified entity
+    /// generation. Commit-time derived indexes can consume this column
+    /// directly instead of first allocating row ordinals and projecting the
+    /// same fixed metadata through `PreparedStateRowRef` for every row.
+    pub(crate) fn dense_entity_columnar_input(&self) -> Option<(CommitId, &str, &[StageJson])> {
+        let dense = self.dense_certified_parameter.as_ref()?;
+        let commit_id = dense.commit_id?;
+        Some((
+            commit_id,
+            self.strings[dense.schema_key as usize].as_str(),
+            &self.json[..dense.len],
         ))
     }
 
@@ -3980,6 +4081,63 @@ mod tests {
         assert!(!prepared.certified_complete_collection_replacement());
         assert!(!prepared.certified_tracked_keys_strictly_ordered());
         assert_eq!(prepared.row(0).entity_pk, &EntityPk::single("a"));
+    }
+
+    #[test]
+    fn compatible_dense_replacements_coalesce_with_per_row_timestamps() {
+        let certificate = CertifiedRawWriteBatchPreparation {
+            schema_plan_id: SchemaPlanId::for_test(9),
+            facts: PreparedRowFacts {
+                row_content_validated: true,
+                requires_transaction_validation: false,
+            },
+            tracked_keys_strictly_ordered: true,
+            complete_collection_replacement: false,
+        };
+        let prepare = |key: &str, timestamp| {
+            CertifiedParameterReplacementBatch::new(
+                vec![EntityPk::single(key)],
+                vec![
+                    TransactionJson::from_certified_shared_normalized_row_content(
+                        format!(r#"{{"id":"{key}"}}"#).into(),
+                    ),
+                ],
+                "dense_replacement".into(),
+                "main".into(),
+                certificate,
+            )
+            .expect("certified replacement should construct")
+            .into_dense_prepared(None, timestamp)
+            .expect("certified replacement should prepare")
+        };
+        let first_timestamp = LixTimestamp::expect_parse("timestamp", "2026-08-02T00:00:00.000Z");
+        let second_timestamp = LixTimestamp::expect_parse("timestamp", "2026-08-02T00:00:01.000Z");
+        let commit_id = CommitId::for_test_label("dense-coalesced-replacements");
+        let mut prepared = prepare("a", first_timestamp);
+        prepared.set_commit_id_all(commit_id);
+        let mut second = prepare("b", second_timestamp);
+        second.set_commit_id_all(commit_id);
+
+        prepared.append(second);
+
+        assert!(prepared.is_dense_certified_parameter());
+        assert_eq!(prepared.len(), 2);
+        assert_eq!(prepared.row(0).created_at, first_timestamp);
+        assert_eq!(prepared.row(1).created_at, second_timestamp);
+        assert_eq!(prepared.row(0).commit_id, Some(commit_id));
+        assert_eq!(prepared.row(1).commit_id, Some(commit_id));
+        assert!(prepared.certified_tracked_keys_strictly_ordered());
+        let (columnar_commit_id, schema_key, snapshots) = prepared
+            .dense_entity_columnar_input()
+            .expect("coalesced replacement retains contiguous columnar input");
+        assert_eq!(columnar_commit_id, commit_id);
+        assert_eq!(schema_key, "dense_replacement");
+        assert_eq!(snapshots.len(), 2);
+
+        prepared.append(prepare("a", second_timestamp));
+        assert!(!prepared.is_dense_certified_parameter());
+        assert!(!prepared.certified_tracked_keys_strictly_ordered());
+        assert_eq!(prepared.len(), 3);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- route certified point replacements through typed transaction ingress instead of expanding singleton `RawWriteBatch` slots
- coalesce compatible ordered replacements into one dense columnar morsel while preserving per-statement timestamps
- feed dense snapshot columns directly into the authenticated row-group encoder without allocating one ordinal per row
- retain sequential/indexed fallback semantics for repeated, out-of-order, dependent, or unsupported writes

## Performance

Required baseline is the immediately previous CRUD PR #1122 (`2b8f24be5`), measured with the exact saved benchmark executable.

- 1M RocksDB transaction UPDATE alternating pairs: +13.3%, -3.5%, +10.9%; median paired improvement **+10.9%**
- 10k RocksDB: 82.11 ms -> 79.50 ms (**+3.2%**)
- 10k SlateDB: 77.43 ms -> 75.32 ms (**+2.7%**)
- RSS remained effectively flat

Because OLAP PR #1123 landed between stacked CRUD cuts, I also isolated current main. Exact #1123 vs this head is neutral at 1M (RocksDB 12.645 s -> 12.664 s; SlateDB 14.562 s -> 14.459 s) while removing the slot and row-ordinal allocations.

## Correctness

- full `lix_engine` unit, integration, branch/merge/diff, and doctest suite passes
- `cargo clippy -p lix_engine --all-targets` passes
- independent review found no ordering, timestamp, dictionary, staged-schema, or read-your-writes regressions
- no changenote