### PR TITLE
perf(engine): scan exclusive packed snapshots directly

### DIFF
--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -4237,6 +4237,14 @@ where
         entity_pks: &[EntityPk],
         limit: Option<usize>,
     ) -> Result<Vec<Option<Bytes>>, LixError> {
+        if entity_pks.is_empty()
+            && limit.is_none()
+            && let Some(snapshots) = self
+                .scan_exclusive_entity_snapshots(branch_id, control, schema_key)
+                .await?
+        {
+            return Ok(snapshots);
+        }
         self.scan_entity_snapshots_for_generation(
             branch_id,
             control.generation,
@@ -4246,6 +4254,86 @@ where
             limit,
         )
         .await
+    }
+
+    /// Reads one atomically published exclusive collection straight from its
+    /// packed commit payload column. The publication proof excludes HOT,
+    /// root, certified, and multi-base winners, so manufacturing a generic
+    /// live-state batch only to discard every column except the snapshot is
+    /// unnecessary read and allocation amplification.
+    async fn scan_exclusive_entity_snapshots(
+        &self,
+        branch_id: &str,
+        control: BranchHeadControl,
+        schema_key: &str,
+    ) -> Result<Option<Vec<Option<Bytes>>>, LixError> {
+        let Some((commit_id, live_count)) = self
+            .exclusive_entity_base(branch_id, control, schema_key)
+            .await?
+        else {
+            return Ok(None);
+        };
+        let Some(members) =
+            crate::tracked_state::load_commit_delta_members_with_payloads_for_schemas(
+                &self.store,
+                commit_id,
+                &[schema_key.to_owned()],
+                PACKED_BROAD_SNAPSHOT_MAX_SEGMENTS,
+            )
+            .await?
+        else {
+            return Ok(None);
+        };
+        let capacity = usize::try_from(live_count)
+            .map_err(|_| head_value_error("exclusive entity live count exceeds usize"))?;
+        let mut snapshots = Vec::with_capacity(capacity);
+        let mut deferred_refs = Vec::new();
+        let mut deferred_rows = Vec::new();
+        for member in members {
+            if member.value.deleted
+                || member.key.schema_key != schema_key
+                || member.key.file_id.is_some()
+            {
+                return Err(head_value_error(
+                    "exclusive entity base contains a non-live or file-scoped member",
+                ));
+            }
+            match member.change.snapshot {
+                JsonSlot::None => snapshots.push(None),
+                JsonSlot::Inline(json) => {
+                    snapshots.push(Some(Bytes::from(json.into_string())));
+                }
+                JsonSlot::Ref(json_ref) => {
+                    deferred_rows.push(snapshots.len());
+                    deferred_refs.push(json_ref);
+                    snapshots.push(None);
+                }
+            }
+        }
+        if snapshots.len() != capacity {
+            return Err(head_value_error(format!(
+                "exclusive entity base expected {live_count} live rows, decoded {}",
+                snapshots.len()
+            )));
+        }
+        if !deferred_refs.is_empty() {
+            let loaded = JsonStoreContext::new()
+                .load_bytes_many(
+                    &self.store,
+                    JsonLoadRequestRef {
+                        refs: &deferred_refs,
+                        scope: JsonReadScopeRef::OutOfBand,
+                    },
+                )
+                .await?
+                .into_values();
+            for (row_index, value) in deferred_rows.into_iter().zip(loaded) {
+                snapshots[row_index] = Some(value.ok_or_else(|| {
+                    head_value_error("exclusive entity snapshot payload is missing")
+                })?);
+            }
+        }
+        Ok(Some(snapshots))
     }
 
     pub(crate) async fn scan_entity_primary_keys(
@@ -4300,6 +4388,32 @@ where
         )>,
         LixError,
     > {
+        let Some((commit_id, live_count)) = self
+            .exclusive_entity_base(branch_id, control, schema_key)
+            .await?
+        else {
+            return Ok(None);
+        };
+        let id = crate::live_state::entity_row_group_set_id(commit_id, schema_key);
+        let Some(manifest) =
+            crate::columnar_row_group::load_row_group_manifest(&self.store, id).await?
+        else {
+            return Ok(None);
+        };
+        if manifest.namespace != schema_key || manifest.row_count() != live_count {
+            return Err(head_value_error(
+                "entity columnar sidecar disagrees with its collection publication",
+            ));
+        }
+        Ok(Some((id, manifest)))
+    }
+
+    async fn exclusive_entity_base(
+        &self,
+        branch_id: &str,
+        control: BranchHeadControl,
+        schema_key: &str,
+    ) -> Result<Option<(CommitId, u64)>, LixError> {
         let collection = load_hot_collection_control(
             &self.store,
             branch_id,
@@ -4323,18 +4437,17 @@ where
         let [base_ref] = base_refs.as_slice() else {
             return Ok(None);
         };
-        let id = crate::live_state::entity_row_group_set_id(base_ref.commit_id, schema_key);
-        let Some(manifest) =
-            crate::columnar_row_group::load_row_group_manifest(&self.store, id).await?
-        else {
-            return Ok(None);
-        };
-        if manifest.namespace != schema_key || manifest.row_count() != collection.live_count {
+        let active_base_refs =
+            packed_current_base_refs(&self.store, branch_id, control.generation).await?;
+        if !active_base_refs
+            .iter()
+            .any(|active| active.commit_id == base_ref.commit_id)
+        {
             return Err(head_value_error(
-                "entity columnar sidecar disagrees with its collection publication",
+                "exclusive schema index references an inactive packed current base",
             ));
         }
-        Ok(Some((id, manifest)))
+        Ok(Some((base_ref.commit_id, collection.live_count)))
     }
 
     #[cfg(test)]

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -6183,6 +6183,27 @@ mod tests {
             "the certified full replacement must publish one packed current base"
         );
 
+        let broad_rows = session
+            .execute(
+                "SELECT path, value FROM packed_replacement_probe ORDER BY path",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(broad_rows.len(), ROW_COUNT);
+        assert_eq!(
+            broad_rows.rows()[0]
+                .get::<serde_json::Value>("value")
+                .unwrap(),
+            serde_json::json!({"updated": 0})
+        );
+        assert_eq!(
+            broad_rows.rows()[ROW_COUNT - 1]
+                .get::<serde_json::Value>("value")
+                .unwrap(),
+            serde_json::json!({"updated": ROW_COUNT - 1})
+        );
+
         let rows = session
             .execute(
                 "SELECT path, value FROM packed_replacement_probe WHERE path IN ('/0000', '/1023') ORDER BY path",
@@ -6216,12 +6237,12 @@ mod tests {
             .unwrap();
         let rows = session
             .execute(
-                "SELECT path, value FROM packed_replacement_probe WHERE path IN ('/0000', '/1023') ORDER BY path",
+                "SELECT path, value FROM packed_replacement_probe ORDER BY path",
                 &[],
             )
             .await
             .unwrap();
-        assert_eq!(rows.len(), 1);
+        assert_eq!(rows.len(), ROW_COUNT - 1);
         assert_eq!(rows.rows()[0].get::<String>("path").unwrap(), "/0000");
         assert_eq!(
             rows.rows()[0].get::<serde_json::Value>("value").unwrap(),


### PR DESCRIPTION
## Summary

- read immutable, identity-certified exclusive entity bases straight from packed commit payloads
- bypass generic live-state batch materialization when publication metadata proves there can be no hot, root, certified, or multi-base winner
- retain the established scan path for overlays, point reads, limits, unsupported layouts, and every non-exclusive state
- validate the exclusive index against active packed bases and fail closed on corrupt publication metadata

## Performance

Compared with the immediately previous CRUD PR (#1124):

| public SQL SELECT | #1124 | this PR | improvement |
| --- | ---: | ---: | ---: |
| RocksDB, 10k rows (31-sample median) | 16.90 ms | 15.18 ms | 10.2% |
| SlateDB, 10k rows (31-sample median) | 17.50 ms | 15.64 ms | 10.6% |
| RocksDB, 1M rows (3-sample median) | 5.47 s | 4.06 s | 25.7% |
| SlateDB, 1M rows (3-sample median) | 6.08 s | 2.03 s | 66.7% |

The 1M process peak RSS remains effectively flat because fixture construction determines the high-water mark.

## Validation

- `cargo check -p lix_engine`
- `cargo test -p lix_engine` with `RUST_MIN_STACK=16777216`: 1,773 unit tests, 435 integration tests (2 ignored), and 3 doctests passed
- `cargo clippy -p lix_engine --all-targets` passes with the existing dead-code warning for `StorageWriteSet::apply`
- expanded complete-replacement coverage verifies direct broad reads before overlays and generic fallback after sparse update/delete
- independent source review found no remaining issues after validating exclusive-index membership against active packed bases

No changenote.