### PR TITLE
perf(sql): stream and hash analytical overlays

### DIFF
--- a/packages/engine/src/sql2/entity_batch.rs
+++ b/packages/engine/src/sql2/entity_batch.rs
@@ -6,6 +6,7 @@
 //! public-result reads consume those same bytes, keeping visibility proof in
 //! one place and leaving every unsupported shape on the established row path.
 
+use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
@@ -99,7 +100,7 @@ pub(crate) trait EntitySnapshotReader: Send + Sync {
         layout: Arc<EntityColumnarScanLayout>,
         group_index: usize,
         identity_column: usize,
-        shadow_identities: Arc<Vec<String>>,
+        shadow_identities: Arc<HashSet<String, ahash::RandomState>>,
         _shadow_identity_digest: [u8; 32],
     ) -> Result<Arc<BooleanArray>, LixError> {
         Ok(Arc::new(
@@ -288,7 +289,7 @@ where
         layout: Arc<EntityColumnarScanLayout>,
         group_index: usize,
         identity_column: usize,
-        shadow_identities: Arc<Vec<String>>,
+        shadow_identities: Arc<HashSet<String, ahash::RandomState>>,
         shadow_identity_digest: [u8; 32],
     ) -> Result<Arc<BooleanArray>, LixError> {
         let key = EntityColumnarShadowMaskKey {
@@ -436,7 +437,7 @@ async fn load_entity_columnar_shadow_mask<R: EntitySnapshotReader + ?Sized>(
     layout: Arc<EntityColumnarScanLayout>,
     group_index: usize,
     identity_column: usize,
-    shadow_identities: &[String],
+    shadow_identities: &HashSet<String, ahash::RandomState>,
 ) -> Result<BooleanArray, LixError> {
     let batch = reader
         .load_entity_columnar_group(layout, group_index, vec![identity_column])
@@ -453,11 +454,7 @@ async fn load_entity_columnar_shadow_mask<R: EntitySnapshotReader + ?Sized>(
     }
     Ok(BooleanArray::from(
         (0..identities.len())
-            .map(|index| {
-                shadow_identities
-                    .binary_search_by(|shadow| shadow.as_str().cmp(identities.value(index)))
-                    .is_err()
-            })
+            .map(|index| !shadow_identities.contains(identities.value(index)))
             .collect::<Vec<_>>(),
     ))
 }

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -1,13 +1,11 @@
-#[cfg(test)]
-use std::collections::HashSet;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::sync::Arc;
 
 use async_trait::async_trait;
 #[cfg(test)]
 use datafusion::arrow::array::Array;
 use datafusion::arrow::array::{ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray};
-use datafusion::arrow::compute::{concat_batches, filter_record_batch};
+use datafusion::arrow::compute::filter_record_batch;
 use datafusion::arrow::datatypes::{Schema, SchemaRef};
 use datafusion::arrow::record_batch::{RecordBatch, RecordBatchOptions};
 use datafusion::common::stats::{ColumnStatistics, Precision};
@@ -620,7 +618,11 @@ async fn entity_columnar_scan_source(
         }
         *hasher.finalize().as_bytes()
     };
-    let shadow_identities = Arc::new(shadow_identities);
+    let shadow_identities = Arc::new(
+        shadow_identities
+            .into_iter()
+            .collect::<HashSet<_, ahash::RandomState>>(),
+    );
     let mut overlay_cache_projection = projection.clone();
     overlay_cache_projection.push(usize::MAX);
     let filter_digest = blake3::hash(format!("{row_filters:?}").as_bytes());
@@ -665,69 +667,6 @@ async fn entity_columnar_scan_source(
         batches
     };
     let overlay_batches = Arc::new(overlay_batches);
-    if !layout.overlay.is_empty() {
-        let mut snapshot_cache_projection = overlay_cache_projection;
-        snapshot_cache_projection.push(usize::MAX - 1);
-        snapshot_cache_projection.extend(group_indices.iter().copied());
-        let snapshot = if let Some(batch) = reader
-            .cached_entity_columnar_batch(
-                &layout,
-                usize::MAX - 1,
-                shadow_identity_digest,
-                &snapshot_cache_projection,
-            )
-            .await
-            .map_err(lix_error_to_datafusion_error)?
-        {
-            batch
-        } else {
-            let mut batches = Vec::with_capacity(group_indices.len() + overlay_batches.len());
-            for &group_index in &group_indices {
-                let keep = reader
-                    .entity_columnar_shadow_mask(
-                        layout.clone(),
-                        group_index,
-                        identity_column,
-                        Arc::clone(&shadow_identities),
-                        shadow_identity_digest,
-                    )
-                    .await
-                    .map_err(lix_error_to_datafusion_error)?;
-                let batch = reader
-                    .load_entity_columnar_group(layout.clone(), group_index, projection.clone())
-                    .await
-                    .map_err(lix_error_to_datafusion_error)?;
-                batches.push(filter_record_batch(&batch, keep.as_ref())?);
-            }
-            batches.extend(overlay_batches.iter().cloned());
-            let batch = Arc::new(concat_batches(&schema, &batches)?);
-            reader
-                .cache_entity_columnar_batch(
-                    &layout,
-                    usize::MAX - 1,
-                    shadow_identity_digest,
-                    snapshot_cache_projection,
-                    batch,
-                )
-                .await
-                .map_err(lix_error_to_datafusion_error)?
-        };
-        let statistics = entity_columnar_record_batch_statistics(snapshot.as_ref())?;
-        let stream_schema = Arc::clone(&schema);
-        return Ok(batch_stream_source_with_statistics_and_source(
-            Arc::clone(&schema),
-            vec![statistics.clone()],
-            Some(statistics),
-            move |partition, _context| {
-                debug_assert_eq!(partition, 0);
-                let batches = stream::iter(vec![Ok(snapshot.as_ref().clone())]);
-                Ok(Box::pin(RecordBatchStreamAdapter::new(
-                    Arc::clone(&stream_schema),
-                    batches,
-                )))
-            },
-        ));
-    }
     let mut all_reconciled_statistics_cached = true;
     let mut base_statistics_cached = Vec::with_capacity(group_indices.len());
     let mut statistics = if layout.overlay.is_empty() {
@@ -798,7 +737,13 @@ async fn entity_columnar_scan_source(
             debug_assert!(partition < partition_count);
             if partition >= base_partition_count {
                 let schema = Arc::clone(&stream_schema);
-                let batches = stream::iter(overlay_batches.as_ref().clone().into_iter().map(Ok));
+                let batch = entity_columnar_overlay_partition(
+                    overlay_batches.as_ref(),
+                    base_partition_count,
+                    partition,
+                )
+                .expect("statistics expose exactly one entry per overlay partition");
+                let batches = stream::once(async move { Ok(batch) });
                 return Ok(Box::pin(RecordBatchStreamAdapter::new(schema, batches)));
             }
             let reader = Arc::clone(&reader);
@@ -883,6 +828,16 @@ async fn entity_columnar_scan_source(
             Ok(Box::pin(RecordBatchStreamAdapter::new(schema, batches)))
         },
     ))
+}
+
+fn entity_columnar_overlay_partition(
+    overlay_batches: &[RecordBatch],
+    base_partition_count: usize,
+    partition: usize,
+) -> Option<RecordBatch> {
+    overlay_batches
+        .get(partition.checked_sub(base_partition_count)?)
+        .cloned()
 }
 
 #[cfg(test)]
@@ -4161,5 +4116,45 @@ mod tests {
             "insert-c",
             "the updated row moved out of the predicate and its stale base was already shadowed"
         );
+    }
+
+    #[test]
+    fn each_overlay_batch_maps_to_exactly_one_stream_partition() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::Int64,
+            false,
+        )]));
+        let batch = |value| {
+            RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![Arc::new(Int64Array::from(vec![value]))],
+            )
+            .expect("batch")
+        };
+        let overlays = [batch(10), batch(20)];
+
+        assert!(super::entity_columnar_overlay_partition(&overlays, 3, 2).is_none());
+        assert_eq!(
+            super::entity_columnar_overlay_partition(&overlays, 3, 3)
+                .expect("first overlay")
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .value(0),
+            10
+        );
+        assert_eq!(
+            super::entity_columnar_overlay_partition(&overlays, 3, 4)
+                .expect("second overlay")
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .value(0),
+            20
+        );
+        assert!(super::entity_columnar_overlay_partition(&overlays, 3, 5).is_none());
     }
 }


### PR DESCRIPTION
## Summary

- replace per-base-row binary search over overlay identities with exact hashed membership
- stream immutable row groups and overlay Arrow batches as independent DataFusion partitions
- ensure every overlay batch is emitted by exactly one partition
- keep the optimization below SQL planning: there are no query-shape recognizers or special aggregate implementations

## 1M public-result performance

Sparse transactional state, five samples, same public-result boundary:

| Query | main RocksDB | PR RocksDB | Improvement | DuckDB | PR / DuckDB |
|---|---:|---:|---:|---:|---:|
| sort | 90.491 ms | 48.275 ms | 46.7% | 47.397 ms | 1.02x |
| group-by | 80.198 ms | 39.409 ms | 50.9% | 17.442 ms | 2.26x |
| aggregate | 64.922 ms | 26.071 ms | 59.8% | 4.222 ms | 6.18x |

SlateDB on this PR:
- sort: 50.869 ms (1.07x DuckDB)
- group-by: 41.543 ms
- aggregate: 29.134 ms

Sort now meets the broader 1.5x objective on both RocksDB and SlateDB. Group-by and aggregate remain follow-up work; this PR does not claim the full objective is complete.

The algorithm changes overlay shadow membership from O(base rows * log overlay rows) to expected O(base rows + overlay rows), and removes a full-snapshot Arrow concatenation/materialization barrier.

## Semantics and scope

- overlay identities are collected before predicate/tombstone filtering, so updates and deletes still shadow stale base rows
- hash collisions remain exact because membership compares canonical strings
- digesting remains deterministic because identities are sorted and deduplicated before hashing
- point-query CRUD paths do not enter this broad analytical scan source
- existing caches remain entry- and byte-bounded; the HashSet is shared per scan and not persistently cached

## Validation

- cargo test -p lix_engine --all-features --quiet: 804 integration tests plus doctests passed; unit suite passed
- analytical benchmark suite: 8/8 passed
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- git diff --check
- independent correctness review: GO
- independent performance review: GO
