### PR TITLE
perf(engine): let write-oriented schemas skip sidecars

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
@@ -1597,6 +1597,7 @@ where
     let schema = serde_json::json!({
         "x-lix-key": "tracked_crud_insert",
         "x-lix-primary-key": ["/path"],
+        "x-lix-columnar": false,
         "type": "object",
         "required": ["path", "value"],
         "properties": {

--- a/packages/engine/src/catalog/snapshot.rs
+++ b/packages/engine/src/catalog/snapshot.rs
@@ -3018,6 +3018,34 @@ mod tests {
     }
 
     #[test]
+    fn entity_columnar_sidecar_policy_defaults_on_and_accepts_explicit_opt_out() {
+        let mut schema = crate::schema::seed_schema_definition("lix_key_value")
+            .expect("key-value schema should exist")
+            .clone();
+        let compile = |schema: JsonValue| {
+            SchemaPlan::compile(
+                SchemaCatalogKey {
+                    schema_key: "lix_key_value".to_string(),
+                },
+                schema,
+                &BTreeMap::new(),
+                &BTreeMap::new(),
+            )
+            .expect("key-value schema should compile")
+        };
+
+        assert!(crate::schema::materializes_entity_columnar_sidecar(&schema));
+        let _ = compile(schema.clone());
+        schema["x-lix-columnar"] = json!(false);
+        crate::schema::validate_lix_schema_definition(&schema)
+            .expect("columnar storage policy should be a valid Lix schema extension");
+        assert!(!crate::schema::materializes_entity_columnar_sidecar(
+            &schema
+        ));
+        let _ = compile(schema);
+    }
+
+    #[test]
     fn fast_object_validation_accepts_key_value_rows_and_rejects_invalid_shapes() {
         let schema = crate::schema::seed_schema_definition("lix_key_value")
             .expect("key-value schema should exist");

--- a/packages/engine/src/schema/compatibility.rs
+++ b/packages/engine/src/schema/compatibility.rs
@@ -7,6 +7,7 @@ use crate::common::top_level_property_name;
 use crate::entity_pk::canonical_json_text;
 
 const DOC_ONLY_SCHEMA_FIELDS: &[&str] = &["$comment", "deprecated", "description", "title"];
+const STORAGE_POLICY_FIELDS: &[&str] = &["x-lix-columnar"];
 const CONSTRAINT_FIELDS: &[&str] = &[
     "x-lix-primary-key",
     "x-lix-unique",
@@ -246,7 +247,10 @@ fn top_level_semantic_fields(schema: &JsonValue) -> BTreeMap<String, JsonValue> 
     object
         .into_iter()
         .filter(|(key, _)| {
-            key != "properties" && key != "required" && !CONSTRAINT_FIELDS.contains(&key.as_str())
+            key != "properties"
+                && key != "required"
+                && !CONSTRAINT_FIELDS.contains(&key.as_str())
+                && !STORAGE_POLICY_FIELDS.contains(&key.as_str())
         })
         .collect()
 }
@@ -385,6 +389,22 @@ mod tests {
         next["properties"]["title"]["deprecated"] = json!(true);
 
         validate_schema_amendment(&previous, &next).expect("doc-only changes are compatible");
+    }
+
+    #[test]
+    fn allows_columnar_storage_policy_amendments() {
+        let previous = base_schema();
+        let mut opt_out = base_schema();
+        opt_out["x-lix-columnar"] = json!(false);
+        validate_schema_amendment(&previous, &opt_out)
+            .expect("an existing schema can opt out of derived columnar storage");
+
+        let mut explicit_default = base_schema();
+        explicit_default["x-lix-columnar"] = json!(true);
+        validate_schema_amendment(&previous, &explicit_default)
+            .expect("absent and explicit default columnar policies are compatible");
+        validate_schema_amendment(&opt_out, &explicit_default)
+            .expect("an existing schema can opt back into derived columnar storage");
     }
 
     #[test]

--- a/packages/engine/src/schema/definition.json
+++ b/packages/engine/src/schema/definition.json
@@ -65,6 +65,10 @@
             "description": "JSON Pointer (RFC 6901) to a property that participates in the primary key, e.g. `/id` or `/nested/field`."
           }
         },
+        "x-lix-columnar": {
+          "type": "boolean",
+          "description": "Whether commits synchronously materialize a typed analytical sidecar for this schema. Defaults to true; set false for write-oriented schemas that use the authoritative packed row layout."
+        },
         "x-lix-foreign-keys": {
           "type": "array",
           "items": {

--- a/packages/engine/src/schema/definition.rs
+++ b/packages/engine/src/schema/definition.rs
@@ -21,6 +21,13 @@ pub fn lix_schema_definition_json() -> &'static str {
     include_str!("definition.json")
 }
 
+pub(crate) fn materializes_entity_columnar_sidecar(schema: &JsonValue) -> bool {
+    schema
+        .get("x-lix-columnar")
+        .and_then(JsonValue::as_bool)
+        .unwrap_or(true)
+}
+
 pub fn validate_lix_schema_definition(schema: &JsonValue) -> Result<(), LixError> {
     if let Some(err) = detect_missing_pointer_slash(schema) {
         return Err(err);
@@ -488,6 +495,7 @@ fn assert_known_x_lix_top_level_fields(schema: &JsonValue) -> Result<(), LixErro
             key.as_str(),
             "x-lix-key"
                 | "x-lix-primary-key"
+                | "x-lix-columnar"
                 | "x-lix-unique"
                 | "x-lix-foreign-keys"
                 | "x-lix-state-foreign-keys"

--- a/packages/engine/src/schema/mod.rs
+++ b/packages/engine/src/schema/mod.rs
@@ -7,7 +7,9 @@ pub(crate) mod seed;
 mod tests;
 
 pub(crate) use compatibility::validate_schema_amendment;
-pub(crate) use definition::{compile_lix_schema, format_lix_schema_validation_errors};
+pub(crate) use definition::{
+    compile_lix_schema, format_lix_schema_validation_errors, materializes_entity_columnar_sidecar,
+};
 pub use definition::{
     lix_schema_definition, lix_schema_definition_json, validate_lix_schema,
     validate_lix_schema_definition,

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -4054,6 +4054,41 @@ mod tests {
         assert_eq!(manifest.row_count(), expected_rows);
     }
 
+    async fn assert_current_head_lacks_columnar_manifest(
+        session: &SessionContext<Memory>,
+        schema_key: &str,
+    ) {
+        let branch_id = session
+            .active_branch_id()
+            .await
+            .expect("active branch should resolve");
+        let head_read = session
+            .storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("branch-head read should open");
+        let head = session
+            .branch_ctx
+            .ref_reader(head_read)
+            .load_head(&branch_id)
+            .await
+            .expect("branch head should load")
+            .expect("active branch should have a head");
+        let sidecar_read = session
+            .storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("sidecar read should open");
+        let id = crate::live_state::entity_row_group_set_id(head.commit_id, schema_key);
+        assert!(
+            crate::columnar_row_group::load_row_group_manifest(&sidecar_read, id)
+                .await
+                .expect("sidecar manifest lookup should succeed")
+                .is_none(),
+            "write-oriented schema must not publish a columnar sidecar"
+        );
+    }
+
     async fn open_session_with_telemetry(
         spans: Arc<std::sync::Mutex<Vec<CompletedTelemetrySpan>>>,
     ) -> SessionContext<Memory> {
@@ -4860,6 +4895,125 @@ mod tests {
             .create_checkpoint()
             .await
             .expect("ordered packed current base should remain checkpointable");
+    }
+
+    #[tokio::test]
+    async fn columnar_opt_out_covers_certified_insert_and_complete_replacement() {
+        const ROW_COUNT: usize = 1_024;
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "x-lix-key": "columnar_opt_out_probe",
+            "x-lix-primary-key": ["/path"],
+            "x-lix-columnar": false,
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" },
+                "value": {
+                    "type": [
+                        "object", "array", "string", "number", "integer", "boolean", "null"
+                    ]
+                }
+            },
+            "required": ["path", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .expect("write-oriented schema should register");
+
+        let sql = "INSERT INTO columnar_opt_out_probe (path, value) VALUES ($1, lix_json($2))";
+        let inserts = (0..ROW_COUNT)
+            .map(|index| ExecuteBatchStatement {
+                sql: sql.to_owned(),
+                params: vec![
+                    Value::Text(format!("/{index:04}")),
+                    Value::Text(format!(r#"{{"before":{index}}}"#)),
+                ],
+            })
+            .collect::<Vec<_>>();
+        let inserted = session
+            .execute_batch(&inserts)
+            .await
+            .expect("certified parameter batch should insert")
+            .iter()
+            .map(ExecuteResult::rows_affected)
+            .sum::<u64>();
+        assert_eq!(inserted, ROW_COUNT as u64);
+        assert_current_head_lacks_columnar_manifest(&session, "columnar_opt_out_probe").await;
+
+        crate::transaction::take_complete_replacement_packed_current_base_publications();
+        let update_sql = "UPDATE columnar_opt_out_probe SET value = lix_json($1) WHERE path = $2";
+        let updates = (0..ROW_COUNT)
+            .map(|index| ExecuteBatchStatement {
+                sql: update_sql.to_owned(),
+                params: vec![
+                    Value::Text(format!(r#"{{"after":{index}}}"#)),
+                    Value::Text(format!("/{index:04}")),
+                ],
+            })
+            .collect::<Vec<_>>();
+        let updated = session
+            .execute_batch(&updates)
+            .await
+            .expect("complete replacement should update")
+            .iter()
+            .map(ExecuteResult::rows_affected)
+            .sum::<u64>();
+        assert_eq!(updated, ROW_COUNT as u64);
+        assert_eq!(
+            crate::transaction::take_complete_replacement_packed_current_base_publications(),
+            1,
+            "fixture must publish the certified complete replacement as a packed base"
+        );
+        assert_current_head_lacks_columnar_manifest(&session, "columnar_opt_out_probe").await;
+    }
+
+    #[tokio::test]
+    async fn columnar_opt_out_covers_generic_literal_batch_insert() {
+        const ROW_COUNT: usize = 1_024;
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "x-lix-key": "columnar_opt_out_literal_probe",
+            "x-lix-primary-key": ["/id"],
+            "x-lix-columnar": false,
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": { "type": "string" }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .expect("write-oriented literal schema should register");
+
+        let inserts = (0..ROW_COUNT)
+            .map(|index| ExecuteBatchStatement {
+                sql: format!(
+                    "INSERT INTO columnar_opt_out_literal_probe (id, value) VALUES ('{index:04}', 'literal-{index:04}')"
+                ),
+                params: Vec::new(),
+            })
+            .collect::<Vec<_>>();
+        let inserted = session
+            .execute_batch(&inserts)
+            .await
+            .expect("generic literal batch should insert")
+            .iter()
+            .map(ExecuteResult::rows_affected)
+            .sum::<u64>();
+        assert_eq!(inserted, ROW_COUNT as u64);
+        assert_current_head_lacks_columnar_manifest(&session, "columnar_opt_out_literal_probe")
+            .await;
     }
 
     #[tokio::test]

--- a/packages/engine/src/sql2/catalog/entity_surface.rs
+++ b/packages/engine/src/sql2/catalog/entity_surface.rs
@@ -239,6 +239,7 @@ fn certifies_path_value_replacement(schema: &JsonValue) -> bool {
         "additionalProperties",
         "x-lix-key",
         "x-lix-primary-key",
+        "x-lix-columnar",
     ];
     if object
         .keys()

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -3879,6 +3879,9 @@ fn prepare_entity_columnar_write_sets(
         else {
             return Ok(BTreeMap::new());
         };
+        if !crate::schema::materializes_entity_columnar_sidecar(schema) {
+            return Ok(BTreeMap::new());
+        }
         let Ok(spec) = crate::sql2::derive_entity_surface_spec_from_schema(schema) else {
             return Ok(BTreeMap::new());
         };
@@ -3920,6 +3923,9 @@ fn prepare_entity_columnar_write_sets(
         else {
             continue;
         };
+        if !crate::schema::materializes_entity_columnar_sidecar(schema) {
+            continue;
+        }
         let Ok(spec) = crate::sql2::derive_entity_surface_spec_from_schema(schema) else {
             continue;
         };


### PR DESCRIPTION
## Summary

- add an explicit `x-lix-columnar: false` schema policy for write-oriented entity schemas
- default the policy on so existing analytical/read behavior is unchanged
- enforce the policy centrally for certified, generic, and complete-replacement commit publication paths
- keep packed current state authoritative and fall back to packed scans when the derived sidecar is absent
- opt the tracked CRUD benchmark schema out of synchronous Arrow sidecar materialization

## Performance

Baseline is the immediately previous merged PR, #1127 (`dd03ad7ac`), using separately hashed optimized bench binaries.

| operation | adapter | #1127 | this PR | change |
|---|---:|---:|---:|---:|
| INSERT 10k (31-sample median) | RocksDB | 42.670 ms | 26.663 ms | **-37.5%** |
| INSERT 10k (31-sample median) | SlateDB | 41.906 ms | 23.163 ms | **-44.7%** |
| INSERT 1M (3-sample median) | RocksDB | 5.106 s | 2.351 s | **-53.9%** |
| INSERT 1M (3-sample median) | SlateDB | 4.494 s | 2.326 s | **-48.2%** |
| SELECT 10k (31-sample median) | RocksDB | 14.835 ms | 15.192 ms | +2.4% (noise) |
| SELECT 10k (31-sample median) | SlateDB | 15.640 ms | 15.467 ms | -1.1% |
| SELECT 1M hot (5 repeats) | RocksDB | 3.805 s/op | 3.511 s/op | -7.7% |
| SELECT 1M hot (5 repeats) | SlateDB | 4.004 s/op | 3.434 s/op | -14.2% |

Optimized binary hashes:
- #1127: `2faa348c22c13a2d1c90114f97ca3454203fae6716d34e4896995c8f19d19c08`
- this PR: `3dbce0dcd6d3d492a3d0e82c0e631497fe0c34cf3355dcfaf724c368d3676be7`

## Validation

- `cargo test -p lix_engine --lib`: 1783 passed, 8 ignored
- `cargo test -p lix_engine_benchmarks --test tracked_state_crud_public_result --features storage-benches,slatedb`: 8 passed
- `cargo clippy -p lix_engine --all-targets` (only unchanged `StorageWriteSet::apply` dead-code warning)
- `cargo fmt --all -- --check`
- independent extra-high review: no actionable findings

No changenote.