### PR TITLE
refactor(engine): unify commit graph around topology-first nodes

### DIFF
--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -187,6 +187,12 @@ harness = false
 required-features = ["storage-benches", "slatedb"]
 
 [[bench]]
+name = "commit_graph_scale"
+path = "benches/commit_graph_scale.rs"
+harness = false
+required-features = ["storage-benches"]
+
+[[bench]]
 name = "repository_gc_scale"
 path = "benches/repository_gc_scale.rs"
 harness = false

--- a/packages/engine-benchmarks/benches/commit_graph_scale.rs
+++ b/packages/engine-benchmarks/benches/commit_graph_scale.rs
@@ -1,0 +1,91 @@
+use std::time::Instant;
+
+use lix_engine::changelog::bench::{append_ordered_linear_commits, stage_append_once};
+use lix_engine::storage_adapter::{Memory, StorageAdapter};
+use lix_engine::storage_bench::{
+    CommitGraphBenchMode, read_commit_graph_for_bench, seed_commit_graph_members_for_bench,
+};
+
+fn main() {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("create commit-graph benchmark runtime")
+        .block_on(run());
+}
+
+async fn run() {
+    let args = std::env::args().collect::<Vec<_>>();
+    let commits = parse_positive(args.get(1), "commits", 10_000);
+    let samples = parse_positive(args.get(2), "samples", 11);
+    let warmups = parse_nonnegative(args.get(3), "warmups", 3);
+    let mode_filter = args.get(4).map(String::as_str);
+    let append = append_ordered_linear_commits(commits).expect("build linear commit history");
+    let commit_ids = append.commit_ids();
+    let head_commit_id = commit_ids
+        .last()
+        .cloned()
+        .expect("linear history has a head");
+    let memory = Memory::new();
+    stage_append_once(memory.clone(), &append)
+        .await
+        .expect("seed linear commit history");
+    let storage = StorageAdapter::new(memory);
+    seed_commit_graph_members_for_bench(&storage, &commit_ids)
+        .await
+        .expect("seed representative member payloads");
+
+    for (name, mode) in [
+        ("all_nodes", CommitGraphBenchMode::AllNodes),
+        ("legacy_all_nodes", CommitGraphBenchMode::LegacyAllNodes),
+        ("reachable_nodes", CommitGraphBenchMode::ReachableNodes),
+        (
+            "legacy_reachable_nodes",
+            CommitGraphBenchMode::LegacyReachableNodes,
+        ),
+    ] {
+        if mode_filter.is_some_and(|filter| filter != name) {
+            continue;
+        }
+        for _ in 0..warmups {
+            std::hint::black_box(
+                read_commit_graph_for_bench(&storage, &head_commit_id, mode)
+                    .await
+                    .expect("warm commit graph read"),
+            );
+        }
+        let mut elapsed_us = Vec::with_capacity(samples);
+        let mut result = None;
+        for _ in 0..samples {
+            let started = Instant::now();
+            result = Some(
+                read_commit_graph_for_bench(&storage, &head_commit_id, mode)
+                    .await
+                    .expect("measured commit graph read"),
+            );
+            elapsed_us.push(started.elapsed().as_secs_f64() * 1_000_000.0);
+        }
+        elapsed_us.sort_by(f64::total_cmp);
+        let result = result.expect("positive sample count");
+        let median_us = elapsed_us[elapsed_us.len() / 2];
+        let p95_index = ((elapsed_us.len() - 1) * 95).div_ceil(100);
+        println!(
+            "commit_graph_scale,mode={name},commits={commits},samples={samples},median_us={median_us:.3},p95_us={:.3},nodes={},edges={},member_changes={}",
+            elapsed_us[p95_index], result.nodes, result.edges, result.member_changes,
+        );
+    }
+}
+
+fn parse_positive(value: Option<&String>, name: &str, default: usize) -> usize {
+    let parsed = parse_nonnegative(value, name, default);
+    assert!(parsed > 0, "{name} must be positive");
+    parsed
+}
+
+fn parse_nonnegative(value: Option<&String>, name: &str, default: usize) -> usize {
+    value.map_or(default, |value| {
+        value
+            .parse::<usize>()
+            .unwrap_or_else(|error| panic!("invalid {name} '{value}': {error}"))
+    })
+}

--- a/packages/engine/src/branch/lifecycle.rs
+++ b/packages/engine/src/branch/lifecycle.rs
@@ -1,6 +1,6 @@
 use crate::LixError;
 use crate::changelog::CommitId;
-use crate::commit_graph::{CommitGraphCommit, CommitGraphReader};
+use crate::commit_graph::{CommitGraphNode, CommitGraphReader};
 use crate::common::validate_non_empty_identity_value;
 
 use super::{BranchHead, BranchRefReader};
@@ -73,9 +73,9 @@ impl<'a> BranchLifecycle<'a> {
         commit_id: CommitId,
         operation: BranchOperation,
         role: BranchReferenceRole,
-    ) -> Result<CommitGraphCommit, LixError> {
+    ) -> Result<CommitGraphNode, LixError> {
         commit_graph
-            .load_commit(&commit_id)
+            .load_node(&commit_id)
             .await?
             .ok_or_else(|| LixError::commit_not_found(commit_id, operation.label(), role.label()))
     }

--- a/packages/engine/src/changelog/bench_support.rs
+++ b/packages/engine/src/changelog/bench_support.rs
@@ -245,6 +245,31 @@ pub fn append_ordered_commits(
     Ok(BenchAppend { append })
 }
 
+/// Builds one production-shaped first-parent chain for topology benchmarks.
+pub fn append_ordered_linear_commits(commit_count: usize) -> Result<BenchAppend, LixError> {
+    let mut append = ChangelogAppend::default();
+    append.commits.reserve(commit_count);
+    let mut parent_commit_id = None;
+    for commit_index in 0..commit_count {
+        let commit_id = CommitId::new(ordered_bench_uuid(commit_index, 0));
+        append.commits.push(CommitRecord {
+            format_version: 1,
+            commit_id,
+            generation: u64::try_from(commit_index).expect("benchmark commit index fits u64"),
+            parent_commit_ids: parent_commit_id.into_iter().collect(),
+            tracked_state_rootless: false,
+            change_id: ChangeId::new(ordered_bench_uuid(commit_index, 1)),
+            author_account_ids: Vec::new(),
+            created_at: crate::common::LixTimestamp::expect_parse(
+                "created_at",
+                "2026-05-20T00:00:00Z",
+            ),
+        });
+        parent_commit_id = Some(commit_id);
+    }
+    Ok(BenchAppend { append })
+}
+
 pub fn append_1c_with_commit_change_id(
     name: &str,
     commit_change_id: &str,

--- a/packages/engine/src/checkpoint.rs
+++ b/packages/engine/src/checkpoint.rs
@@ -6,9 +6,7 @@ use crate::LixError;
 use crate::changelog::{ChangeRecordProjection, CommitId};
 #[cfg(any(test, feature = "storage-benches"))]
 use crate::changelog::{ChangelogContext, ChangelogReader, CommitScanRequest};
-use crate::commit_graph::{
-    CommitGraphChangeHistoryRequest, CommitGraphCommitRecord, CommitGraphReader,
-};
+use crate::commit_graph::{CommitGraphChangeHistoryRequest, CommitGraphNode, CommitGraphReader};
 use crate::entity_pk::EntityPk;
 use crate::storage_adapter::StorageAdapterRead;
 use crate::tracked_state::{TrackedStateKey, TrackedStateStoreReader};
@@ -24,7 +22,7 @@ const CHECKPOINT_RECORD_SCAN_PAGE_SIZE: usize = 1_024;
 /// point reads turns a K-checkpoint history into K serial storage requests. A
 /// paged record scan trades that N+1 pattern for work linear in retained
 /// commits, which is substantially cheaper for remote LSM-backed storage.
-pub(crate) type CheckpointCommitRecords = HashMap<CommitId, CommitGraphCommitRecord>;
+pub(crate) type CheckpointCommitRecords = HashMap<CommitId, CommitGraphNode>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CheckpointHistoryEntry {
@@ -80,7 +78,7 @@ where
         for record in batch.entries {
             records.insert(
                 record.commit_id,
-                CommitGraphCommitRecord {
+                CommitGraphNode {
                     commit_id: record.commit_id,
                     change_id: record.change_id,
                     generation: record.generation,
@@ -250,7 +248,7 @@ async fn first_parent_distance(
                 "cycle encountered while finding the latest checkpoint",
             ));
         }
-        let Some(commit) = reader.load_commit_record(&current).await? else {
+        let Some(commit) = reader.load_node(&current).await? else {
             return Ok(None);
         };
         let Some(parent) = commit.parent_commit_ids.first().copied() else {
@@ -286,15 +284,12 @@ async fn checkpoint_history_from_checkpoint(
                 "cycle encountered while walking checkpoint history",
             ));
         }
-        let commit = reader
-            .load_commit_record(&commit_id)
-            .await?
-            .ok_or_else(|| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!("checkpoint history references missing commit '{commit_id}'"),
-                )
-            })?;
+        let commit = reader.load_node(&commit_id).await?.ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("checkpoint history references missing commit '{commit_id}'"),
+            )
+        })?;
         checkpoints.push(CheckpointHistoryEntry {
             commit_id,
             created_at: commit.created_at.to_string(),
@@ -372,6 +367,7 @@ pub(crate) async fn checkpoint_history_from_head(
             },
         )
         .await?
+        .entries
         .into_iter()
         .map(|entry| entry.observed_commit_id)
         .collect::<HashSet<_>>();
@@ -387,7 +383,7 @@ pub(crate) async fn checkpoint_history_from_head(
                 "cycle encountered while walking checkpoint first-parent history",
             ));
         }
-        let commit = reader.load_commit(&commit_id).await?.ok_or_else(|| {
+        let commit = reader.load_node(&commit_id).await?.ok_or_else(|| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 format!("checkpoint history references missing commit '{commit_id}'"),
@@ -397,7 +393,7 @@ pub(crate) async fn checkpoint_history_from_head(
         if is_root || marker_commits.contains(&commit_id) {
             checkpoints.push(CheckpointHistoryEntry {
                 commit_id,
-                created_at: commit.canonical_change.created_at.to_string(),
+                created_at: commit.created_at.to_string(),
                 depth,
             });
         }

--- a/packages/engine/src/commit_graph/context.rs
+++ b/packages/engine/src/commit_graph/context.rs
@@ -7,16 +7,17 @@
 )]
 
 use std::collections::{BTreeSet, HashMap};
+use std::sync::Arc;
 
 use crate::LixError;
 use crate::changelog::{
-    ChangeId, ChangeLoadRequest, ChangeRecord, ChangelogContext, ChangelogReader, CommitId,
-    CommitLoadRequest, CommitRecord, CommitScanRequest,
+    ChangeId, ChangeRecord, ChangelogContext, ChangelogReader, CommitId, CommitLoadRequest,
+    CommitRecord, CommitScanRequest,
 };
-use crate::commit_graph::walker::{best_common_ancestors, walk_reachable_commits};
+use crate::commit_graph::walker::{best_common_ancestors, walk_reachable_nodes};
 use crate::commit_graph::{
     CommitGraphChange, CommitGraphChangeHistoryEntry, CommitGraphChangeHistoryRequest,
-    CommitGraphCommit, CommitGraphCommitRecord, CommitGraphReader, ReachableCommitGraphCommit,
+    CommitGraphHistory, CommitGraphNode, CommitGraphReader, ReachableCommitGraphNode,
 };
 use crate::entity_pk::EntityPk;
 use crate::storage_adapter::StorageAdapterRead;
@@ -42,7 +43,9 @@ impl CommitGraphContext {
     {
         CommitGraphStoreReader {
             store,
-            canonical_change_cache: HashMap::new(),
+            node_cache: HashMap::new(),
+            reachable_nodes_cache: HashMap::new(),
+            member_changes_cache: HashMap::new(),
         }
     }
 }
@@ -53,44 +56,71 @@ where
     S: StorageAdapterRead,
 {
     store: S,
+    node_cache: HashMap<CommitId, Option<CommitGraphNode>>,
+    reachable_nodes_cache: HashMap<CommitId, Arc<[ReachableCommitGraphNode]>>,
     // A reader is bound to one pinned storage snapshot for the duration of a
     // SQL statement. File-history shaping asks the same reader for distinct
     // schema slices of that history, so retain immutable change records here.
-    canonical_change_cache: HashMap<ChangeId, Option<CommitGraphChange>>,
+    member_changes_cache: HashMap<Vec<String>, HashMap<CommitId, Vec<CommitGraphChange>>>,
 }
 
 impl<S> CommitGraphStoreReader<S>
 where
     S: StorageAdapterRead,
 {
-    /// Loads and parses a `lix_commit` canonical change by commit id.
-    pub(crate) async fn load_commit(
-        &mut self,
-        commit_id: &CommitId,
-    ) -> Result<Option<CommitGraphCommit>, LixError> {
-        self.load_changelog_commit(commit_id).await
+    #[cfg(feature = "storage-benches")]
+    pub(crate) fn store(&self) -> &S {
+        &self.store
     }
 
-    pub(crate) async fn load_commit_records(
+    /// Loads one topology node without reading its member delta or payloads.
+    pub(crate) async fn load_node(
+        &mut self,
+        commit_id: &CommitId,
+    ) -> Result<Option<CommitGraphNode>, LixError> {
+        Ok(self
+            .load_nodes(std::slice::from_ref(commit_id))
+            .await?
+            .into_iter()
+            .next()
+            .flatten())
+    }
+
+    pub(crate) async fn load_nodes(
         &mut self,
         commit_ids: &[CommitId],
-    ) -> Result<Vec<Option<CommitGraphCommitRecord>>, LixError> {
-        let mut reader = ChangelogContext::new().reader(&self.store);
-        let entries = reader
-            .load_commits(CommitLoadRequest { commit_ids })
-            .await?
-            .entries
+    ) -> Result<Vec<Option<CommitGraphNode>>, LixError> {
+        let uncached_ids = commit_ids
+            .iter()
+            .filter(|commit_id| !self.node_cache.contains_key(commit_id))
+            .copied()
+            .collect::<BTreeSet<_>>()
             .into_iter()
-            .map(|entry| entry.map(commit_graph_commit_record_from_commit_record))
-            .collect();
-        Ok(entries)
+            .collect::<Vec<_>>();
+        if !uncached_ids.is_empty() {
+            let mut reader = ChangelogContext::new().reader(&self.store);
+            let entries = reader
+                .load_commits(CommitLoadRequest {
+                    commit_ids: &uncached_ids,
+                })
+                .await?
+                .entries;
+            for (commit_id, entry) in uncached_ids.into_iter().zip(entries) {
+                self.node_cache
+                    .insert(commit_id, entry.map(commit_graph_node_from_commit_record));
+            }
+        }
+        Ok(commit_ids
+            .iter()
+            .map(|commit_id| self.node_cache.get(commit_id).cloned().unwrap_or(None))
+            .collect())
     }
 
     /// Loads every direct commit fact from the changelog.
     ///
     /// This is used by global commit surfaces where the caller wants the durable
     /// graph facts themselves, not reachability from a particular branch head.
-    pub(crate) async fn all_commits(&mut self) -> Result<Vec<CommitGraphCommit>, LixError> {
+    pub(crate) async fn all_nodes(&mut self) -> Result<Vec<CommitGraphNode>, LixError> {
         let mut commits = Vec::new();
         let mut start_after = None::<String>;
         loop {
@@ -102,7 +132,9 @@ where
                 })
                 .await?;
             for record in scan.entries {
-                commits.push(commit_graph_commit_from_commit_record(record, Vec::new()));
+                let node = commit_graph_node_from_commit_record(record);
+                self.node_cache.insert(node.commit_id, Some(node.clone()));
+                commits.push(node);
             }
             let Some(next) = scan.next_start_after else {
                 break;
@@ -114,11 +146,17 @@ where
     }
 
     /// Walks from `head_commit_id` through parent commits and records nearest depth.
-    pub(crate) async fn reachable_commits(
+    pub(crate) async fn reachable_nodes(
         &mut self,
         head_commit_id: &CommitId,
-    ) -> Result<Vec<ReachableCommitGraphCommit>, LixError> {
-        walk_reachable_commits(self, head_commit_id).await
+    ) -> Result<Arc<[ReachableCommitGraphNode]>, LixError> {
+        if let Some(nodes) = self.reachable_nodes_cache.get(head_commit_id) {
+            return Ok(Arc::clone(nodes));
+        }
+        let nodes = Arc::from(walk_reachable_nodes(self, head_commit_id).await?);
+        self.reachable_nodes_cache
+            .insert(*head_commit_id, Arc::clone(&nodes));
+        Ok(nodes)
     }
 
     /// Returns the best common ancestors shared by two commit heads.
@@ -130,7 +168,7 @@ where
         &mut self,
         left_commit_id: &CommitId,
         right_commit_id: &CommitId,
-    ) -> Result<Vec<CommitGraphCommit>, LixError> {
+    ) -> Result<Vec<CommitGraphNode>, LixError> {
         best_common_ancestors(self, left_commit_id, right_commit_id).await
     }
 
@@ -145,7 +183,7 @@ where
         right_commit_id: &CommitId,
     ) -> Result<CommitId, LixError> {
         let heads = self
-            .load_commit_records(&[*left_commit_id, *right_commit_id])
+            .load_nodes(&[*left_commit_id, *right_commit_id])
             .await?;
         let left = heads[0]
             .as_ref()
@@ -169,7 +207,7 @@ where
         ) && left_parent == right_parent
         {
             if self
-                .load_commit_records(&[*left_parent])
+                .load_nodes(&[*left_parent])
                 .await?
                 .into_iter()
                 .next()
@@ -213,63 +251,60 @@ where
         &mut self,
         start_commit_id: &CommitId,
         request: &CommitGraphChangeHistoryRequest,
-    ) -> Result<Vec<CommitGraphChangeHistoryEntry>, LixError> {
-        let commits = self.reachable_commits(start_commit_id).await?;
-        let mut member_change_ids = Vec::new();
-        let mut seen_change_ids = BTreeSet::new();
+    ) -> Result<CommitGraphHistory, LixError> {
+        let nodes = self.reachable_nodes(start_commit_id).await?;
+        let member_schema_keys = request
+            .schema_keys
+            .iter()
+            .filter(|schema_key| schema_key.as_str() != COMMIT_SCHEMA_KEY)
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut member_schema_keys = member_schema_keys;
+        member_schema_keys.sort();
+        member_schema_keys.dedup();
+        let may_include_members = request.schema_keys.is_empty() || !member_schema_keys.is_empty();
+        let may_include_commits = request.schema_keys.is_empty()
+            || request
+                .schema_keys
+                .iter()
+                .any(|schema_key| schema_key == COMMIT_SCHEMA_KEY);
+        let mut entries = Vec::new();
+        let mut seen_changes = BTreeSet::new();
 
-        for reachable in &commits {
+        for reachable in nodes.iter() {
             if !depth_matches(reachable.depth, request) {
                 continue;
             }
 
-            seen_change_ids.insert(reachable.commit.canonical_change.id);
-            for change_id in &reachable.commit.change_ids {
-                if seen_change_ids.insert(*change_id) {
-                    member_change_ids.push(*change_id);
+            let node = &reachable.commit;
+            if may_include_commits {
+                let canonical_change = canonical_commit_change(node);
+                if seen_changes.insert(history_change_identity(&canonical_change))
+                    && change_matches_history_request(&canonical_change, request)
+                {
+                    entries.push(CommitGraphChangeHistoryEntry {
+                        change: canonical_change,
+                        observed_commit_id: node.commit_id,
+                        start_commit_id: *start_commit_id,
+                        depth: reachable.depth,
+                    });
                 }
             }
-        }
 
-        let mut member_changes = self
-            .load_canonical_changes(&member_change_ids)
-            .await?
-            .into_iter();
-        let mut entries = Vec::new();
-        let mut seen_change_ids = BTreeSet::new();
-
-        for reachable in commits {
-            if !depth_matches(reachable.depth, request) {
+            if !may_include_members {
                 continue;
             }
-
-            let commit_id = reachable.commit.commit_id;
-            let canonical_change = reachable.commit.canonical_change;
-            if seen_change_ids.insert(canonical_change.id)
-                && change_matches_history_request(&canonical_change, request)
+            for change in self
+                .load_member_changes(node.commit_id, &member_schema_keys)
+                .await?
             {
-                entries.push(CommitGraphChangeHistoryEntry {
-                    change: canonical_change,
-                    observed_commit_id: commit_id,
-                    start_commit_id: *start_commit_id,
-                    depth: reachable.depth,
-                });
-            }
-
-            for change_id in reachable.commit.change_ids {
-                if !seen_change_ids.insert(change_id) {
+                if !seen_changes.insert(history_change_identity(&change)) {
                     continue;
                 }
-                let change = member_changes.next().flatten().ok_or_else(|| {
-                    LixError::new(
-                        "LIX_ERROR_UNKNOWN",
-                        format!("commit_graph references missing change '{change_id}'"),
-                    )
-                })?;
                 if change_matches_history_request(&change, request) {
                     entries.push(CommitGraphChangeHistoryEntry {
                         change,
-                        observed_commit_id: commit_id,
+                        observed_commit_id: node.commit_id,
                         start_commit_id: *start_commit_id,
                         depth: reachable.depth,
                     });
@@ -277,85 +312,42 @@ where
             }
         }
 
-        Ok(entries)
+        Ok(CommitGraphHistory {
+            entries,
+            reachable_nodes: nodes,
+        })
     }
 
-    async fn load_changelog_commit(
+    async fn load_member_changes(
         &mut self,
-        commit_id: &CommitId,
-    ) -> Result<Option<CommitGraphCommit>, LixError> {
-        let mut reader = ChangelogContext::new().reader(&self.store);
-        let batch = reader
-            .load_commits(CommitLoadRequest {
-                commit_ids: std::slice::from_ref(commit_id),
-            })
-            .await?;
-        let Some(entry) = batch.entries.into_iter().next().flatten() else {
-            return Ok(None);
-        };
-        let record = entry;
-        let members =
-            crate::tracked_state::load_commit_delta_members_with_payloads(&self.store, *commit_id)
-                .await?;
-        let mut change_ids = Vec::with_capacity(members.len());
-        for member in members {
-            let change_id = member.change.change_id;
-            change_ids.push(change_id);
-            self.canonical_change_cache.insert(
-                change_id,
-                Some(commit_graph_change_from_change_record(member.change)),
-            );
+        commit_id: CommitId,
+        schema_keys: &[String],
+    ) -> Result<Vec<CommitGraphChange>, LixError> {
+        if let Some(changes) = self
+            .member_changes_cache
+            .get(schema_keys)
+            .and_then(|by_commit| by_commit.get(&commit_id))
+        {
+            return Ok(changes.clone());
         }
-        change_ids.sort_unstable();
-        Ok(Some(commit_graph_commit_from_commit_record(
-            record, change_ids,
-        )))
-    }
-
-    async fn load_changelog_commit_record(
-        &mut self,
-        commit_id: &CommitId,
-    ) -> Result<Option<CommitGraphCommitRecord>, LixError> {
-        Ok(self
-            .load_commit_records(std::slice::from_ref(commit_id))
-            .await?
+        let members = crate::tracked_state::load_commit_delta_members_with_payloads_for_schemas(
+            &self.store,
+            commit_id,
+            schema_keys,
+            usize::MAX,
+        )
+        .await?
+        .expect("unbounded commit member load cannot exceed its segment limit");
+        let mut changes = members
             .into_iter()
-            .next()
-            .flatten())
-    }
-
-    async fn load_canonical_changes(
-        &mut self,
-        change_ids: &[ChangeId],
-    ) -> Result<Vec<Option<CommitGraphChange>>, LixError> {
-        let uncached_ids = change_ids
-            .iter()
-            .filter(|change_id| !self.canonical_change_cache.contains_key(change_id))
-            .copied()
-            .collect::<BTreeSet<_>>()
-            .into_iter()
+            .map(|member| commit_graph_change_from_change_record(member.change))
             .collect::<Vec<_>>();
-        if !uncached_ids.is_empty() {
-            let mut reader = ChangelogContext::new().reader(&self.store);
-            let batch = reader
-                .load_changes(ChangeLoadRequest {
-                    change_ids: &uncached_ids,
-                })
-                .await?;
-            for (change_id, entry) in uncached_ids.into_iter().zip(batch.entries) {
-                self.canonical_change_cache
-                    .insert(change_id, entry.map(commit_graph_change_from_change_record));
-            }
-        }
-        Ok(change_ids
-            .iter()
-            .map(|change_id| {
-                self.canonical_change_cache
-                    .get(change_id)
-                    .cloned()
-                    .unwrap_or(None)
-            })
-            .collect())
+        changes.sort_by_key(|change| change.id);
+        self.member_changes_cache
+            .entry(schema_keys.to_vec())
+            .or_default()
+            .insert(commit_id, changes.clone());
+        Ok(changes)
     }
 }
 
@@ -372,14 +364,8 @@ fn commit_graph_change_from_change_record(change: ChangeRecord) -> CommitGraphCh
     }
 }
 
-fn commit_graph_commit_record_from_commit_record(record: CommitRecord) -> CommitGraphCommitRecord {
-    CommitGraphCommitRecord {
-        commit_id: record.commit_id,
-        change_id: record.change_id,
-        generation: record.generation,
-        parent_commit_ids: record.parent_commit_ids,
-        created_at: record.created_at,
-    }
+fn commit_graph_node_from_commit_record(record: CommitRecord) -> CommitGraphNode {
+    record.into()
 }
 
 fn missing_commit_graph_error(commit_id: &CommitId) -> LixError {
@@ -394,32 +380,25 @@ impl<S> CommitGraphReader for CommitGraphStoreReader<S>
 where
     S: StorageAdapterRead,
 {
-    async fn load_commit(
+    async fn load_node(
         &mut self,
         commit_id: &CommitId,
-    ) -> Result<Option<CommitGraphCommit>, LixError> {
-        Self::load_commit(self, commit_id).await
+    ) -> Result<Option<CommitGraphNode>, LixError> {
+        Self::load_node(self, commit_id).await
     }
 
-    async fn load_commit_record(
-        &mut self,
-        commit_id: &CommitId,
-    ) -> Result<Option<CommitGraphCommitRecord>, LixError> {
-        self.load_changelog_commit_record(commit_id).await
-    }
-
-    async fn reachable_commits(
+    async fn reachable_nodes(
         &mut self,
         head_commit_id: &CommitId,
-    ) -> Result<Vec<ReachableCommitGraphCommit>, LixError> {
-        Self::reachable_commits(self, head_commit_id).await
+    ) -> Result<Arc<[ReachableCommitGraphNode]>, LixError> {
+        Self::reachable_nodes(self, head_commit_id).await
     }
 
     async fn change_history_from_commit(
         &mut self,
         start_commit_id: &CommitId,
         request: &CommitGraphChangeHistoryRequest,
-    ) -> Result<Vec<CommitGraphChangeHistoryEntry>, LixError> {
+    ) -> Result<CommitGraphHistory, LixError> {
         Self::change_history_from_commit(self, start_commit_id, request).await
     }
 }
@@ -443,35 +422,29 @@ fn change_matches_history_request(
                 .is_some_and(|file_id| request.file_ids.contains(file_id)))
 }
 
-fn commit_graph_commit_from_commit_record(
-    record: CommitRecord,
-    change_ids: Vec<ChangeId>,
-) -> CommitGraphCommit {
-    let change = commit_record_canonical_change(&record);
-    CommitGraphCommit {
-        canonical_change: change.clone(),
-        change,
-        commit_id: record.commit_id,
-        generation: record.generation,
-        change_ids,
-        author_account_ids: record.author_account_ids,
-        parent_commit_ids: record.parent_commit_ids,
-    }
+fn history_change_identity(
+    change: &CommitGraphChange,
+) -> (ChangeId, String, Option<String>, EntityPk) {
+    (
+        change.id,
+        change.schema_key.clone(),
+        change.file_id.clone(),
+        change.entity_pk.clone(),
+    )
 }
 
-fn commit_record_canonical_change(record: &CommitRecord) -> CommitGraphChange {
-    let snapshot_content =
-        crate::changelog::commit_row_snapshot_json(&record.commit_id.to_string())
-            .expect("lix_commit snapshot serialization should not fail");
+pub(crate) fn canonical_commit_change(node: &CommitGraphNode) -> CommitGraphChange {
+    let snapshot_content = crate::changelog::commit_row_snapshot_json(&node.commit_id.to_string())
+        .expect("lix_commit snapshot serialization should not fail");
     CommitGraphChange {
-        id: record.change_id,
-        entity_pk: EntityPk::uuid_from_canonical(&record.commit_id.to_string())
+        id: node.change_id,
+        entity_pk: EntityPk::uuid_from_canonical(&node.commit_id.to_string())
             .expect("commit IDs are canonical UUIDs"),
         schema_key: COMMIT_SCHEMA_KEY.to_string(),
         file_id: None,
         snapshot: crate::json_store::JsonSlot::from_json(&snapshot_content),
         metadata: crate::json_store::JsonSlot::None,
-        created_at: record.created_at,
+        created_at: node.created_at,
         origin_key: None,
     }
 }
@@ -504,6 +477,7 @@ mod tests {
     struct CountingMemoryRead {
         inner: MemoryRead,
         change_get_many_calls: Arc<AtomicUsize>,
+        delta_get_many_calls: Arc<AtomicUsize>,
     }
 
     impl StorageRead for CountingMemoryRead {
@@ -516,6 +490,15 @@ mod tests {
                 .any(|request| request.space == crate::changelog::CHANGE_SPACE)
             {
                 self.change_get_many_calls.fetch_add(1, Ordering::Relaxed);
+            }
+            if requests.iter().any(|request| {
+                matches!(
+                    request.space,
+                    crate::tracked_state::TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE
+                        | crate::tracked_state::TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE
+                )
+            }) {
+                self.delta_get_many_calls.fetch_add(1, Ordering::Relaxed);
             }
             self.inner.get_many(requests).await
         }
@@ -552,12 +535,8 @@ mod tests {
         ids
     }
 
-    fn change_ids<const N: usize>(labels: [&str; N]) -> Vec<ChangeId> {
-        labels.into_iter().map(change_id).collect()
-    }
-
     #[tokio::test]
-    async fn load_commit_parses_commit_snapshot() {
+    async fn load_node_returns_topology_without_member_payloads() {
         let storage = StorageAdapter::new(Memory::new());
         append_changes(
             &storage,
@@ -582,15 +561,14 @@ mod tests {
         let mut reader = graph.reader(read);
         let commit_1 = commit_id("commit-1");
         let commit = reader
-            .load_commit(&commit_1)
+            .load_node(&commit_1)
             .await
             .expect("commit load should succeed")
             .expect("commit should exist");
 
         assert_eq!(commit.commit_id, commit_id("commit-1"));
-        assert_eq!(commit.change_ids, change_ids(["change-1", "change-2"]));
         assert_eq!(commit.parent_commit_ids, commit_ids(["parent-1"]));
-        assert_eq!(commit.change.id, change_id("commit-1-change"));
+        assert_eq!(commit.change_id, change_id("commit-1-change"));
     }
 
     #[tokio::test]
@@ -605,7 +583,7 @@ mod tests {
         let missing = commit_id("missing");
 
         let commit = reader
-            .load_commit(&missing)
+            .load_node(&missing)
             .await
             .expect("commit load should succeed");
 
@@ -613,7 +591,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn all_commits_returns_parsed_commits_sorted_by_id() {
+    async fn all_nodes_returns_parsed_commits_sorted_by_id() {
         let storage = StorageAdapter::new(Memory::new());
         append_changes(
             &storage,
@@ -632,7 +610,7 @@ mod tests {
             .expect("read should open");
         let mut reader = graph.reader(read);
         let commits = reader
-            .all_commits()
+            .all_nodes()
             .await
             .expect("commit scan should succeed");
 
@@ -711,6 +689,7 @@ mod tests {
 
         assert_eq!(
             history
+                .entries
                 .iter()
                 .map(|entry| (
                     entry.change.id.clone(),
@@ -757,6 +736,7 @@ mod tests {
         .await;
 
         let change_get_many_calls = Arc::new(AtomicUsize::new(0));
+        let delta_get_many_calls = Arc::new(AtomicUsize::new(0));
         let read = memory
             .begin_read(StorageReadOptions::default())
             .await
@@ -765,6 +745,7 @@ mod tests {
         let mut reader = graph.reader(StorageAdapterReadScope::new(CountingMemoryRead {
             inner: read,
             change_get_many_calls: Arc::clone(&change_get_many_calls),
+            delta_get_many_calls,
         }));
         let request = CommitGraphChangeHistoryRequest {
             schema_keys: vec!["test_schema".to_string()],
@@ -788,10 +769,259 @@ mod tests {
             .await
             .expect("second history should resolve");
         assert_eq!(second, first);
+        assert!(Arc::ptr_eq(&first.reachable_nodes, &second.reachable_nodes));
         assert_eq!(
             change_get_many_calls.load(Ordering::Relaxed),
             calls_after_first,
             "a pinned reader should reuse previously loaded canonical changes",
+        );
+    }
+
+    #[tokio::test]
+    async fn schema_sliced_history_caches_full_selected_tombstone_identity() {
+        let storage = StorageAdapter::new(Memory::new());
+        let commit_id = commit_id("selected-tombstone-cache");
+        let shared_change_id = change_id("shared-selected-tombstone");
+        let alpha_pk = crate::entity_pk::EntityPk::single("alpha-entity");
+        let alpha_second_pk = crate::entity_pk::EntityPk::single("alpha-second-entity");
+        let beta_pk = crate::entity_pk::EntityPk::single("beta-entity");
+        let created_at = ts("2026-01-02T00:00:00Z");
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let mut writes = storage.new_write_set();
+        ChangelogContext::new()
+            .writer(&mut read, &mut writes)
+            .stage_append(ChangelogAppend {
+                changes: Vec::new(),
+                commits: vec![CommitRecord {
+                    format_version: 1,
+                    commit_id,
+                    generation: 0,
+                    parent_commit_ids: Vec::new(),
+                    tracked_state_rootless: false,
+                    change_id: change_id("selected-tombstone-commit-change"),
+                    author_account_ids: Vec::new(),
+                    created_at,
+                }],
+            })
+            .await
+            .expect("commit should stage");
+        let deltas = [
+            TrackedStateCommitDeltaRef {
+                delta: TrackedStateDeltaRef {
+                    schema_key: "alpha",
+                    file_id: None,
+                    entity_pk: &alpha_pk,
+                    change_id: shared_change_id,
+                    commit_id,
+                    deleted: true,
+                    created_at,
+                    updated_at: created_at,
+                },
+                snapshot: crate::json_store::JsonSlotRef::None,
+                metadata: crate::json_store::JsonSlotRef::None,
+                origin_key: None,
+                base_coordinate: None,
+                authored: false,
+                certified: false,
+            },
+            TrackedStateCommitDeltaRef {
+                delta: TrackedStateDeltaRef {
+                    schema_key: "beta",
+                    file_id: None,
+                    entity_pk: &beta_pk,
+                    change_id: shared_change_id,
+                    commit_id,
+                    deleted: true,
+                    created_at,
+                    updated_at: created_at,
+                },
+                snapshot: crate::json_store::JsonSlotRef::None,
+                metadata: crate::json_store::JsonSlotRef::None,
+                origin_key: None,
+                base_coordinate: None,
+                authored: false,
+                certified: false,
+            },
+            TrackedStateCommitDeltaRef {
+                delta: TrackedStateDeltaRef {
+                    schema_key: "alpha",
+                    file_id: None,
+                    entity_pk: &alpha_second_pk,
+                    change_id: shared_change_id,
+                    commit_id,
+                    deleted: true,
+                    created_at,
+                    updated_at: created_at,
+                },
+                snapshot: crate::json_store::JsonSlotRef::None,
+                metadata: crate::json_store::JsonSlotRef::None,
+                origin_key: None,
+                base_coordinate: None,
+                authored: false,
+                certified: false,
+            },
+        ];
+        stage_commit_deltas(&mut writes, &deltas).expect("selected tombstones should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("fixture should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("pinned read should open");
+        let mut reader = CommitGraphContext::new().reader(read);
+        let schema_history = |schema_key: &str| CommitGraphChangeHistoryRequest {
+            schema_keys: vec![schema_key.to_string()],
+            include_tombstones: true,
+            ..CommitGraphChangeHistoryRequest::default()
+        };
+        let alpha_first = reader
+            .change_history_from_commit(&commit_id, &schema_history("alpha"))
+            .await
+            .expect("alpha history should load");
+        let beta = reader
+            .change_history_from_commit(&commit_id, &schema_history("beta"))
+            .await
+            .expect("beta history should load");
+        let alpha_second = reader
+            .change_history_from_commit(&commit_id, &schema_history("alpha"))
+            .await
+            .expect("cached alpha history should load");
+
+        assert_eq!(alpha_first.entries.len(), 2);
+        assert!(
+            alpha_first
+                .entries
+                .iter()
+                .all(|entry| entry.change.schema_key == "alpha")
+        );
+        assert!(
+            alpha_first
+                .entries
+                .iter()
+                .any(|entry| entry.change.entity_pk == alpha_pk)
+        );
+        assert!(
+            alpha_first
+                .entries
+                .iter()
+                .any(|entry| entry.change.entity_pk == alpha_second_pk)
+        );
+        assert_eq!(beta.entries.len(), 1);
+        assert_eq!(beta.entries[0].change.schema_key, "beta");
+        assert_eq!(beta.entries[0].change.entity_pk, beta_pk);
+        assert_eq!(alpha_second.entries, alpha_first.entries);
+        assert!(Arc::ptr_eq(
+            &alpha_first.reachable_nodes,
+            &alpha_second.reachable_nodes
+        ));
+        let entity_history = reader
+            .change_history_from_commit(
+                &commit_id,
+                &CommitGraphChangeHistoryRequest {
+                    schema_keys: vec!["alpha".to_string()],
+                    entity_pks: vec![alpha_second_pk.clone()],
+                    include_tombstones: true,
+                    ..CommitGraphChangeHistoryRequest::default()
+                },
+            )
+            .await
+            .expect("identity-filtered selected tombstone should load");
+        assert_eq!(entity_history.entries.len(), 1);
+        assert_eq!(entity_history.entries[0].change.entity_pk, alpha_second_pk);
+    }
+
+    #[tokio::test]
+    async fn topology_reads_do_not_load_commit_member_payloads() {
+        let memory = Memory::new();
+        let storage = StorageAdapter::new(memory.clone());
+        append_changes(
+            &storage,
+            &[
+                entity_change("change-root", "entity-root", "test_schema", "{}"),
+                entity_change("change-head", "entity-head", "test_schema", "{}"),
+                commit_change("commit-root-change", "commit-root", &["change-root"], &[]),
+                commit_change(
+                    "commit-head-change",
+                    "commit-head",
+                    &["change-head"],
+                    &["commit-root"],
+                ),
+            ],
+        )
+        .await;
+
+        let delta_get_many_calls = Arc::new(AtomicUsize::new(0));
+        let read = memory
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let mut reader =
+            CommitGraphContext::new().reader(StorageAdapterReadScope::new(CountingMemoryRead {
+                inner: read,
+                change_get_many_calls: Arc::new(AtomicUsize::new(0)),
+                delta_get_many_calls: Arc::clone(&delta_get_many_calls),
+            }));
+        let head = commit_id("commit-head");
+        let root = commit_id("commit-root");
+
+        reader
+            .load_node(&head)
+            .await
+            .expect("node load should succeed");
+        reader
+            .reachable_nodes(&head)
+            .await
+            .expect("topology walk should succeed");
+        reader
+            .best_common_ancestors(&head, &root)
+            .await
+            .expect("ancestor walk should succeed");
+        reader.all_nodes().await.expect("node scan should succeed");
+        assert_eq!(
+            delta_get_many_calls.load(Ordering::Relaxed),
+            0,
+            "topology APIs must never touch commit member storage",
+        );
+
+        let commit_history = reader
+            .change_history_from_commit(
+                &head,
+                &CommitGraphChangeHistoryRequest {
+                    schema_keys: vec![super::COMMIT_SCHEMA_KEY.to_string()],
+                    include_tombstones: true,
+                    ..CommitGraphChangeHistoryRequest::default()
+                },
+            )
+            .await
+            .expect("commit-only history should derive node changes");
+        assert_eq!(commit_history.entries.len(), 2);
+        assert_eq!(
+            delta_get_many_calls.load(Ordering::Relaxed),
+            0,
+            "commit-only history must not hydrate unrelated member payloads",
+        );
+
+        let history = reader
+            .change_history_from_commit(
+                &head,
+                &CommitGraphChangeHistoryRequest {
+                    schema_keys: vec!["test_schema".to_string()],
+                    include_tombstones: true,
+                    ..CommitGraphChangeHistoryRequest::default()
+                },
+            )
+            .await
+            .expect("history should hydrate requested payloads");
+        assert_eq!(history.entries.len(), 2);
+        assert!(
+            delta_get_many_calls.load(Ordering::Relaxed) > 0,
+            "history payload hydration must remain explicit and observable",
         );
     }
 
@@ -857,12 +1087,12 @@ mod tests {
             .await
             .expect("history should resolve");
 
-        assert_eq!(history.len(), 1);
+        assert_eq!(history.entries.len(), 1);
         assert_eq!(
-            history[0].change.id,
+            history.entries[0].change.id,
             change_id("change-01920000-0000-7000-8000-0000000000a2")
         );
-        assert_eq!(history[0].depth, 1);
+        assert_eq!(history.entries[0].depth, 1);
     }
 
     #[tokio::test]
@@ -911,9 +1141,9 @@ mod tests {
             .await
             .expect("history should resolve");
 
-        assert!(hidden.is_empty());
-        assert_eq!(visible.len(), 1);
-        assert_eq!(visible[0].change.id, change_id("change-deleted"));
+        assert!(hidden.entries.is_empty());
+        assert_eq!(visible.entries.len(), 1);
+        assert_eq!(visible.entries[0].change.id, change_id("change-deleted"));
     }
 
     #[derive(Clone)]
@@ -921,7 +1151,6 @@ mod tests {
         change: CommitGraphChange,
         commit_change_ids: Vec<ChangeId>,
         parent_commit_ids: Vec<CommitId>,
-        author_account_ids: Vec<String>,
     }
 
     impl TestChange {
@@ -950,7 +1179,6 @@ mod tests {
                     .iter()
                     .map(|id| CommitId::for_test_label(id))
                     .collect(),
-                author_account_ids: Vec::new(),
             }
         }
 
@@ -978,7 +1206,6 @@ mod tests {
                 },
                 commit_change_ids: Vec::new(),
                 parent_commit_ids: Vec::new(),
-                author_account_ids: Vec::new(),
             }
         }
 
@@ -1028,15 +1255,7 @@ mod tests {
                 .as_single_string()
                 .expect("commit fixture should use single entity pk")
                 .to_string();
-            let commit = crate::commit_graph::CommitGraphCommit {
-                canonical_change: change.change.clone(),
-                change: change.change.clone(),
-                commit_id: CommitId::for_test_label(&commit_label),
-                generation: 0,
-                change_ids: change.commit_change_ids.clone(),
-                author_account_ids: change.author_account_ids.clone(),
-                parent_commit_ids: change.parent_commit_ids.clone(),
-            };
+            let commit_id = CommitId::for_test_label(&commit_label);
             for parent_commit_id in &change.parent_commit_ids {
                 if !provided_commit_ids.contains(parent_commit_id)
                     && staged_commit_ids.insert(*parent_commit_id)
@@ -1045,16 +1264,14 @@ mod tests {
                     generations.insert(*parent_commit_id, 0);
                 }
             }
-            let generation = commit
+            let generation = change
                 .parent_commit_ids
                 .iter()
                 .filter_map(|parent| generations.get(parent).copied())
                 .max()
                 .map_or(0, |parent_generation| parent_generation + 1);
-            let mut commit = commit;
-            commit.generation = generation;
             let mut members = Vec::new();
-            for change_id in &commit.change_ids {
+            for change_id in &change.commit_change_ids {
                 if let Some(change) = changes_by_id.get(change_id) {
                     members.push(change_record_from_test_change(change));
                 }
@@ -1062,17 +1279,17 @@ mod tests {
 
             append.commits.push(CommitRecord {
                 format_version: 1,
-                commit_id: commit.commit_id,
-                generation: commit.generation,
-                parent_commit_ids: commit.parent_commit_ids.clone(),
+                commit_id,
+                generation,
+                parent_commit_ids: change.parent_commit_ids.clone(),
                 tracked_state_rootless: false,
-                change_id: commit.canonical_change.id,
-                author_account_ids: commit.author_account_ids.clone(),
-                created_at: commit.canonical_change.created_at,
+                change_id: change.change.id,
+                author_account_ids: Vec::new(),
+                created_at: change.change.created_at,
             });
-            commit_members.push((commit.commit_id, members));
-            staged_commit_ids.insert(commit.commit_id);
-            generations.insert(commit.commit_id, generation);
+            commit_members.push((commit_id, members));
+            staged_commit_ids.insert(commit_id);
+            generations.insert(commit_id, generation);
         }
         writer
             .stage_append(append)
@@ -1148,32 +1365,19 @@ mod tests {
 
     fn parsed_commit(
         commit_label: &str,
-        change_ids: &[&str],
+        _change_ids: &[&str],
         parent_commit_ids: &[&str],
-    ) -> crate::commit_graph::CommitGraphCommit {
+    ) -> crate::commit_graph::CommitGraphNode {
         let commit_id = CommitId::for_test_label(commit_label);
-        let fixture = commit_change(
-            &format!("{commit_label}-change"),
-            commit_label,
-            change_ids,
-            parent_commit_ids,
-        );
-        let mut change = fixture.change;
-        change.entity_pk = crate::entity_pk::EntityPk::single(&commit_id);
-        crate::commit_graph::CommitGraphCommit {
-            canonical_change: change.clone(),
-            change,
+        crate::commit_graph::CommitGraphNode {
             commit_id,
+            change_id: ChangeId::for_test_label(&format!("{commit_label}-change")),
             generation: 0,
-            change_ids: change_ids
-                .iter()
-                .map(|change_id| ChangeId::for_test_label(change_id))
-                .collect(),
-            author_account_ids: Vec::new(),
             parent_commit_ids: parent_commit_ids
                 .iter()
                 .map(|parent_id| CommitId::for_test_label(parent_id))
                 .collect(),
+            created_at: ts("2026-01-01T00:00:00Z"),
         }
     }
 

--- a/packages/engine/src/commit_graph/mod.rs
+++ b/packages/engine/src/commit_graph/mod.rs
@@ -2,9 +2,9 @@ mod context;
 mod types;
 mod walker;
 
-pub(crate) use context::{CommitGraphContext, CommitGraphStoreReader};
+pub(crate) use context::{CommitGraphContext, CommitGraphStoreReader, canonical_commit_change};
 pub(crate) use types::{
     CommitGraphChange, CommitGraphChangeHistoryEntry, CommitGraphChangeHistoryRequest,
-    CommitGraphCommit, CommitGraphCommitRecord, CommitGraphEdge, CommitGraphReader,
-    ReachableCommitGraphCommit, commit_edges,
+    CommitGraphEdge, CommitGraphHistory, CommitGraphNode, CommitGraphReader,
+    ReachableCommitGraphNode, commit_edges,
 };

--- a/packages/engine/src/commit_graph/types.rs
+++ b/packages/engine/src/commit_graph/types.rs
@@ -1,5 +1,7 @@
+use std::sync::Arc;
+
 use crate::LixError;
-use crate::changelog::{ChangeId, CommitId};
+use crate::changelog::{ChangeId, CommitId, CommitRecord};
 use crate::common::LixTimestamp;
 use crate::entity_pk::EntityPk;
 
@@ -15,26 +17,13 @@ pub(crate) struct CommitGraphChange {
     pub(crate) origin_key: Option<String>,
 }
 
-/// Parsed `lix_commit` entity from the changelog.
+/// One topology-first commit fact.
 ///
-/// The graph reader projects direct changelog commit records into explicit
-/// parent ids plus the commit's referenced canonical changes. A merge commit
-/// points at selected existing change ids; it does not mint row/entity changes
-/// for the merge itself.
+/// Nodes contain exactly the changelog fields needed by graph algorithms and
+/// derived commit surfaces. Entity/change payloads are loaded separately only
+/// by history APIs that explicitly request them.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct CommitGraphCommit {
-    pub(crate) canonical_change: CommitGraphChange,
-    pub(crate) change: CommitGraphChange,
-    pub(crate) commit_id: CommitId,
-    pub(crate) generation: u64,
-    pub(crate) change_ids: Vec<ChangeId>,
-    pub(crate) author_account_ids: Vec<String>,
-    pub(crate) parent_commit_ids: Vec<CommitId>,
-}
-
-/// Lightweight commit metadata for graph walks that do not inspect members.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct CommitGraphCommitRecord {
+pub(crate) struct CommitGraphNode {
     pub(crate) commit_id: CommitId,
     pub(crate) change_id: ChangeId,
     pub(crate) generation: u64,
@@ -42,10 +31,22 @@ pub(crate) struct CommitGraphCommitRecord {
     pub(crate) created_at: LixTimestamp,
 }
 
+impl From<CommitRecord> for CommitGraphNode {
+    fn from(record: CommitRecord) -> Self {
+        Self {
+            commit_id: record.commit_id,
+            change_id: record.change_id,
+            generation: record.generation,
+            parent_commit_ids: record.parent_commit_ids,
+            created_at: record.created_at,
+        }
+    }
+}
+
 /// Commit reachable from a requested graph head.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ReachableCommitGraphCommit {
-    pub(crate) commit: CommitGraphCommit,
+pub(crate) struct ReachableCommitGraphNode {
+    pub(crate) commit: CommitGraphNode,
     pub(crate) depth: u32,
 }
 
@@ -57,7 +58,7 @@ pub(crate) struct CommitGraphEdge {
     pub(crate) parent_order: u32,
 }
 
-pub(crate) fn commit_edges(commits: &[CommitGraphCommit]) -> Vec<CommitGraphEdge> {
+pub(crate) fn commit_edges(commits: &[CommitGraphNode]) -> Vec<CommitGraphEdge> {
     commits
         .iter()
         .flat_map(|commit| {
@@ -97,41 +98,31 @@ pub(crate) struct CommitGraphChangeHistoryEntry {
     pub(crate) depth: u32,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CommitGraphHistory {
+    pub(crate) entries: Vec<CommitGraphChangeHistoryEntry>,
+    pub(crate) reachable_nodes: Arc<[ReachableCommitGraphNode]>,
+}
+
 /// Execution-scoped reader for commit graph facts.
 ///
 /// SQL surfaces consume this trait so they depend on graph semantics, not on
 /// changelog storage or traversal details.
 #[async_trait::async_trait]
 pub(crate) trait CommitGraphReader: Send + Sync {
-    async fn load_commit(
+    async fn load_node(
         &mut self,
         commit_id: &CommitId,
-    ) -> Result<Option<CommitGraphCommit>, LixError>;
+    ) -> Result<Option<CommitGraphNode>, LixError>;
 
-    async fn load_commit_record(
-        &mut self,
-        commit_id: &CommitId,
-    ) -> Result<Option<CommitGraphCommitRecord>, LixError> {
-        Ok(self
-            .load_commit(commit_id)
-            .await?
-            .map(|commit| CommitGraphCommitRecord {
-                commit_id: commit.commit_id,
-                change_id: commit.canonical_change.id,
-                generation: commit.generation,
-                parent_commit_ids: commit.parent_commit_ids,
-                created_at: commit.canonical_change.created_at,
-            }))
-    }
-
-    async fn reachable_commits(
+    async fn reachable_nodes(
         &mut self,
         head_commit_id: &CommitId,
-    ) -> Result<Vec<ReachableCommitGraphCommit>, LixError>;
+    ) -> Result<Arc<[ReachableCommitGraphNode]>, LixError>;
 
     async fn change_history_from_commit(
         &mut self,
         start_commit_id: &CommitId,
         request: &CommitGraphChangeHistoryRequest,
-    ) -> Result<Vec<CommitGraphChangeHistoryEntry>, LixError>;
+    ) -> Result<CommitGraphHistory, LixError>;
 }

--- a/packages/engine/src/commit_graph/walker.rs
+++ b/packages/engine/src/commit_graph/walker.rs
@@ -4,10 +4,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use crate::LixError;
 use crate::changelog::CommitId;
-use crate::commit_graph::{
-    CommitGraphCommit, CommitGraphCommitRecord, CommitGraphReader, CommitGraphStoreReader,
-    ReachableCommitGraphCommit,
-};
+use crate::commit_graph::{CommitGraphNode, CommitGraphStoreReader, ReachableCommitGraphNode};
 use crate::storage_adapter::StorageAdapterRead;
 
 /// Walks parent links from `head_commit_id` and returns reachable commits
@@ -16,14 +13,14 @@ use crate::storage_adapter::StorageAdapterRead;
 /// The walker is intentionally storage-free. It asks `CommitGraphReader` to
 /// load parsed commit facts and owns only traversal concerns: caching, cycle
 /// detection, and nearest-depth selection.
-pub(crate) async fn walk_reachable_commits<S>(
+pub(crate) async fn walk_reachable_nodes<S>(
     reader: &mut CommitGraphStoreReader<S>,
     head_commit_id: &CommitId,
-) -> Result<Vec<ReachableCommitGraphCommit>, LixError>
+) -> Result<Vec<ReachableCommitGraphNode>, LixError>
 where
     S: StorageAdapterRead,
 {
-    let mut loader = CommitTraversalLoader::new(reader);
+    let mut loader = NodeTraversalLoader::new(reader);
     loader.walk(head_commit_id).await
 }
 
@@ -50,45 +47,34 @@ pub(crate) async fn best_common_ancestors<S>(
     reader: &mut CommitGraphStoreReader<S>,
     left_commit_id: &CommitId,
     right_commit_id: &CommitId,
-) -> Result<Vec<CommitGraphCommit>, LixError>
+) -> Result<Vec<CommitGraphNode>, LixError>
 where
     S: StorageAdapterRead,
 {
-    let mut loader = CommitRecordTraversalLoader::new(reader);
+    let mut loader = NodeTraversalLoader::new(reader);
     let best = loader
         .best_common_ids(*left_commit_id, *right_commit_id)
         .await?;
-    drop(loader);
-    let mut hydrated = Vec::with_capacity(best.len());
+    let mut nodes = Vec::with_capacity(best.len());
     for commit_id in best {
-        let Some(commit) = reader.load_commit(&commit_id).await? else {
-            return Err(LixError::new(
-                "LIX_ERROR_UNKNOWN",
-                format!("commit_graph missing commit '{commit_id}'"),
-            ));
-        };
-        hydrated.push(commit);
+        nodes.push(loader.load_node(&commit_id).await?);
     }
-    Ok(hydrated)
+    Ok(nodes)
 }
 
-struct CommitRecordTraversalLoader<'a, S>
+struct NodeTraversalLoader<'a, S>
 where
     S: StorageAdapterRead,
 {
     reader: &'a mut CommitGraphStoreReader<S>,
-    loaded: BTreeMap<CommitId, CommitGraphCommitRecord>,
 }
 
-impl<'a, S> CommitRecordTraversalLoader<'a, S>
+impl<'a, S> NodeTraversalLoader<'a, S>
 where
     S: StorageAdapterRead,
 {
     fn new(reader: &'a mut CommitGraphStoreReader<S>) -> Self {
-        Self {
-            reader,
-            loaded: BTreeMap::new(),
-        }
+        Self { reader }
     }
 
     async fn best_common_ids(
@@ -101,8 +87,8 @@ where
         const BOTH: u8 = LEFT | RIGHT;
         const STALE: u8 = 4;
 
-        let left = self.load_commit_record(&left_commit_id).await?;
-        let right = self.load_commit_record(&right_commit_id).await?;
+        let left = self.load_node(&left_commit_id).await?;
+        let right = self.load_node(&right_commit_id).await?;
         let mut colors = BTreeMap::from([(left_commit_id, LEFT), (right_commit_id, RIGHT)]);
         if left_commit_id == right_commit_id {
             colors.insert(left_commit_id, BOTH);
@@ -120,7 +106,7 @@ where
             }
             let (generation, commit_id) = queue.pop_last().expect("queue is not empty");
             non_stale_queued.remove(&commit_id);
-            let commit = self.load_commit_record(&commit_id).await?;
+            let commit = self.load_node(&commit_id).await?;
             if commit.generation != generation {
                 return Err(LixError::unknown(format!(
                     "commit '{commit_id}' generation changed during graph walk"
@@ -133,7 +119,7 @@ where
                 colors.insert(commit_id, color);
             }
             for parent_commit_id in commit.parent_commit_ids {
-                let parent = self.load_commit_record(&parent_commit_id).await?;
+                let parent = self.load_node(&parent_commit_id).await?;
                 if parent.generation >= generation {
                     return Err(LixError::unknown(format!(
                         "commit '{commit_id}' parent '{parent_commit_id}' does not have a lower generation"
@@ -154,62 +140,21 @@ where
         Ok(best)
     }
 
-    async fn load_commit_record(
-        &mut self,
-        commit_id: &CommitId,
-    ) -> Result<CommitGraphCommitRecord, LixError> {
-        if let Some(commit) = self.loaded.get(commit_id) {
-            return Ok(commit.clone());
-        }
-        let Some(commit) = self.reader.load_commit_record(commit_id).await? else {
-            return Err(LixError::new(
-                "LIX_ERROR_UNKNOWN",
-                format!("commit_graph missing commit '{commit_id}'"),
-            ));
-        };
-        self.loaded.insert(*commit_id, commit.clone());
-        Ok(commit)
-    }
-}
-
-struct CommitTraversalLoader<'a, S>
-where
-    S: StorageAdapterRead,
-{
-    reader: &'a mut CommitGraphStoreReader<S>,
-    loaded: BTreeMap<CommitId, CommitGraphCommit>,
-}
-
-impl<'a, S> CommitTraversalLoader<'a, S>
-where
-    S: StorageAdapterRead,
-{
-    fn new(reader: &'a mut CommitGraphStoreReader<S>) -> Self {
-        Self {
-            reader,
-            loaded: BTreeMap::new(),
-        }
-    }
-
     async fn walk(
         &mut self,
         head_commit_id: &CommitId,
-    ) -> Result<Vec<ReachableCommitGraphCommit>, LixError> {
+    ) -> Result<Vec<ReachableCommitGraphNode>, LixError> {
         let mut visiting = BTreeSet::new();
         let mut nearest_depths = BTreeMap::new();
         self.walk_commit(head_commit_id, 0, &mut visiting, &mut nearest_depths)
             .await?;
-        let mut commits = nearest_depths
-            .into_iter()
-            .map(|(commit_id, depth)| {
-                let commit = self
-                    .loaded
-                    .get(&commit_id)
-                    .expect("visited commit should be cached")
-                    .clone();
-                ReachableCommitGraphCommit { commit, depth }
-            })
-            .collect::<Vec<_>>();
+        let mut commits = Vec::with_capacity(nearest_depths.len());
+        for (commit_id, depth) in nearest_depths {
+            commits.push(ReachableCommitGraphNode {
+                commit: self.load_node(&commit_id).await?,
+                depth,
+            });
+        }
         commits.sort_by(|left, right| {
             left.depth
                 .cmp(&right.depth)
@@ -253,7 +198,7 @@ where
                 }
             }
 
-            let commit = self.load_commit(&frame.commit_id).await?;
+            let commit = self.load_node(&frame.commit_id).await?;
             nearest_depths.insert(frame.commit_id, frame.depth);
 
             visiting.insert(frame.commit_id);
@@ -273,17 +218,13 @@ where
         Ok(())
     }
 
-    async fn load_commit(&mut self, commit_id: &CommitId) -> Result<CommitGraphCommit, LixError> {
-        if let Some(commit) = self.loaded.get(commit_id) {
-            return Ok(commit.clone());
-        }
-        let Some(commit) = self.reader.load_commit(commit_id).await? else {
+    async fn load_node(&mut self, commit_id: &CommitId) -> Result<CommitGraphNode, LixError> {
+        let Some(commit) = self.reader.load_node(commit_id).await? else {
             return Err(LixError::new(
                 "LIX_ERROR_UNKNOWN",
                 format!("commit_graph missing commit '{commit_id}'"),
             ));
         };
-        self.loaded.insert(*commit_id, commit.clone());
         Ok(commit)
     }
 }
@@ -337,7 +278,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reachable_commits_returns_commits_nearest_first() {
+    async fn reachable_nodes_returns_commits_nearest_first() {
         let storage = StorageAdapter::new(Memory::new());
         append_changes(
             &storage,
@@ -362,7 +303,7 @@ mod tests {
         let mut reader = graph.reader(read);
         let commit_head = commit_id("commit-head");
         let commits = reader
-            .reachable_commits(&commit_head)
+            .reachable_nodes(&commit_head)
             .await
             .expect("reachable commits should load");
 
@@ -380,7 +321,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reachable_commits_errors_on_missing_parent_commit() {
+    async fn reachable_nodes_errors_on_missing_parent_commit() {
         let storage = StorageAdapter::new(Memory::new());
         let error = append_changes_result(
             &storage,
@@ -402,7 +343,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reachable_commits_errors_on_cycle() {
+    async fn reachable_nodes_errors_on_cycle() {
         let storage = StorageAdapter::new(Memory::new());
         let mut writes = storage.new_write_set();
         for (label, parent) in [("commit-a", "commit-b"), ("commit-b", "commit-a")] {
@@ -436,7 +377,7 @@ mod tests {
         let mut reader = graph.reader(read);
         let commit_a = commit_id("commit-a");
         let error = reader
-            .reachable_commits(&commit_a)
+            .reachable_nodes(&commit_a)
             .await
             .expect_err("walker should reject parent cycles");
 
@@ -444,7 +385,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reachable_commits_dedupes_shared_ancestors_in_diamond() {
+    async fn reachable_nodes_dedupes_shared_ancestors_in_diamond() {
         let storage = StorageAdapter::new(Memory::new());
         append_changes(
             &storage,
@@ -470,7 +411,7 @@ mod tests {
         let mut reader = graph.reader(read);
         let commit_head = commit_id("commit-head");
         let commits = reader
-            .reachable_commits(&commit_head)
+            .reachable_nodes(&commit_head)
             .await
             .expect("reachable commits should load");
         let mut expected = vec![(commit_id("commit-head"), 0)];
@@ -490,7 +431,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reachable_commits_keeps_nearest_depth_for_multiple_paths() {
+    async fn reachable_nodes_keeps_nearest_depth_for_multiple_paths() {
         let storage = StorageAdapter::new(Memory::new());
         append_changes(
             &storage,
@@ -520,7 +461,7 @@ mod tests {
         let mut reader = graph.reader(read);
         let commit_head = commit_id("commit-head");
         let commits = reader
-            .reachable_commits(&commit_head)
+            .reachable_nodes(&commit_head)
             .await
             .expect("reachable commits should load");
 
@@ -538,7 +479,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reachable_commits_orders_same_depth_commits_by_id() {
+    async fn reachable_nodes_orders_same_depth_commits_by_id() {
         let storage = StorageAdapter::new(Memory::new());
         append_changes(
             &storage,
@@ -563,7 +504,7 @@ mod tests {
         let mut reader = graph.reader(read);
         let commit_head = commit_id("commit-head");
         let commits = reader
-            .reachable_commits(&commit_head)
+            .reachable_nodes(&commit_head)
             .await
             .expect("reachable commits should load");
         let mut expected = vec![(commit_id("commit-head"), 0)];
@@ -579,7 +520,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reachable_commits_errors_on_missing_head_commit() {
+    async fn reachable_nodes_errors_on_missing_head_commit() {
         let storage = StorageAdapter::new(Memory::new());
         let graph = CommitGraphContext::new();
         let read = storage
@@ -590,7 +531,7 @@ mod tests {
         let missing_head = commit_id("missing-head");
 
         let error = reader
-            .reachable_commits(&missing_head)
+            .reachable_nodes(&missing_head)
             .await
             .expect_err("missing head should fail");
 

--- a/packages/engine/src/live_state/derived.rs
+++ b/packages/engine/src/live_state/derived.rs
@@ -10,9 +10,7 @@ use tracing::Instrument;
 
 use crate::branch::{BRANCH_REF_SCHEMA_KEY, BranchHeadControl, BranchHeadControlContext};
 use crate::changelog::{ChangeId, CommitId};
-use crate::commit_graph::{
-    CommitGraphCommit, CommitGraphCommitRecord, CommitGraphContext, CommitGraphEdge, commit_edges,
-};
+use crate::commit_graph::{CommitGraphContext, CommitGraphEdge, CommitGraphNode, commit_edges};
 use crate::entity_pk::{EntityPk, EntityPkComponent};
 use crate::live_state::{LiveStateRowFilter, LiveStateScanRequest, MaterializedLiveStateRow};
 use crate::storage_adapter::StorageAdapterRead;
@@ -77,7 +75,7 @@ where
 {
     store: &'a S,
     commit_graph: &'a CommitGraphContext,
-    all_commits: Option<Vec<CommitGraphCommit>>,
+    all_nodes: Option<Vec<CommitGraphNode>>,
 }
 
 impl<'a, S> DerivedReadContext<'a, S>
@@ -88,16 +86,16 @@ where
         Self {
             store,
             commit_graph,
-            all_commits: None,
+            all_nodes: None,
         }
     }
 
-    async fn all_commits(&mut self) -> Result<&[CommitGraphCommit], LixError> {
-        if self.all_commits.is_none() {
-            self.all_commits = Some(self.commit_graph.reader(self.store).all_commits().await?);
+    async fn all_nodes(&mut self) -> Result<&[CommitGraphNode], LixError> {
+        if self.all_nodes.is_none() {
+            self.all_nodes = Some(self.commit_graph.reader(self.store).all_nodes().await?);
         }
         Ok(self
-            .all_commits
+            .all_nodes
             .as_deref()
             .expect("derived commit scan cache was initialized"))
     }
@@ -152,14 +150,14 @@ where
         reads: &mut DerivedReadContext<'_, S>,
         scope: &DerivedScanScope<'_>,
     ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-        let commits = reads.all_commits().await?;
+        let commits = reads.all_nodes().await?;
         let mut rows = Vec::with_capacity(commits.len() * scope.branch_ids.len());
         for branch_id in scope.branch_ids {
             for commit in commits {
                 rows.push(commit_row(
                     commit.commit_id,
-                    commit.change.id,
-                    commit.change.created_at,
+                    commit.change_id,
+                    commit.created_at,
                     branch_id,
                 )?);
             }
@@ -191,7 +189,7 @@ where
         let records = reads
             .commit_graph
             .reader(reads.store)
-            .load_commit_records(&commit_ids)
+            .load_nodes(&commit_ids)
             .await?;
         let mut rows = Vec::with_capacity(records.len() * scope.branch_ids.len());
         for branch_id in scope.branch_ids {
@@ -228,8 +226,65 @@ where
         reads: &mut DerivedReadContext<'_, S>,
         scope: &DerivedScanScope<'_>,
     ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-        let commits = reads.all_commits().await?;
+        let commits = reads.all_nodes().await?;
         let edges = commit_edges(commits);
+        let mut rows = Vec::with_capacity(edges.len() * scope.branch_ids.len());
+        for branch_id in scope.branch_ids {
+            for edge in &edges {
+                rows.push(commit_edge_row(edge, branch_id)?);
+            }
+        }
+        Ok(rows)
+    }
+}
+
+#[async_trait]
+impl<S> DerivedEntityPointProvider<S> for CommitEdgeProvider
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    async fn load_entity_points(
+        &self,
+        reads: &mut DerivedReadContext<'_, S>,
+        entity_pks: &[EntityPk],
+        scope: &DerivedScanScope<'_>,
+    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        let edge_ids = entity_pks
+            .iter()
+            .filter_map(commit_edge_id_from_entity_pk)
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let child_ids = edge_ids
+            .iter()
+            .map(|(child_commit_id, _)| *child_commit_id)
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let nodes = reads
+            .commit_graph
+            .reader(reads.store)
+            .load_nodes(&child_ids)
+            .await?;
+        let nodes_by_id = child_ids
+            .into_iter()
+            .zip(nodes)
+            .filter_map(|(commit_id, node)| node.map(|node| (commit_id, node)))
+            .collect::<std::collections::BTreeMap<_, _>>();
+        let mut edges = Vec::with_capacity(edge_ids.len());
+        for (child_commit_id, parent_order) in edge_ids {
+            let Some(node) = nodes_by_id.get(&child_commit_id) else {
+                continue;
+            };
+            let Some(parent_commit_id) = node.parent_commit_ids.get(parent_order as usize) else {
+                continue;
+            };
+            edges.push(CommitGraphEdge {
+                parent_commit_id: *parent_commit_id,
+                child_commit_id,
+                parent_order,
+            });
+        }
         let mut rows = Vec::with_capacity(edges.len() * scope.branch_ids.len());
         for branch_id in scope.branch_ids {
             for edge in &edges {
@@ -366,7 +421,7 @@ where
             append_point_provider_rows(&CommitProvider, reads, request, scope, rows).await
         }
         RegisteredDerivedProvider::CommitEdge => {
-            append_full_scan_provider_rows(&CommitEdgeProvider, reads, request, scope, rows).await
+            append_point_provider_rows(&CommitEdgeProvider, reads, request, scope, rows).await
         }
         RegisteredDerivedProvider::BranchRef => {
             append_point_provider_rows(&BranchRefProvider, reads, request, scope, rows).await
@@ -409,36 +464,6 @@ where
             ))
             .await?
     };
-    if !request.filter.entity_pks.is_empty() {
-        provider_rows.retain(|row| request.filter.entity_pks.contains(&row.entity_pk));
-    }
-    rows.extend(provider_rows);
-    Ok(())
-}
-
-async fn append_full_scan_provider_rows<S, P>(
-    provider: &P,
-    reads: &mut DerivedReadContext<'_, S>,
-    request: &LiveStateScanRequest,
-    scope: &DerivedScanScope<'_>,
-    rows: &mut Vec<MaterializedLiveStateRow>,
-) -> Result<(), LixError>
-where
-    S: StorageAdapterRead + ?Sized,
-    P: DerivedLiveStateProvider<S>,
-{
-    let descriptor = provider.descriptor();
-    if !provider_filter_allows(request, scope, descriptor) {
-        return Ok(());
-    }
-    let mut provider_rows = provider
-        .scan_all(reads, scope)
-        .instrument(tracing::debug_span!(
-            target: "lix_perf",
-            "lix.perf.derived.full_scan",
-            schema_key = descriptor.schema_key,
-        ))
-        .await?;
     if !request.filter.entity_pks.is_empty() {
         provider_rows.retain(|row| request.filter.entity_pks.contains(&row.entity_pk));
     }
@@ -507,6 +532,20 @@ fn commit_id_from_entity_pk(entity_pk: &EntityPk) -> Option<CommitId> {
     Some(CommitId::new(uuid::Uuid::from_bytes(*bytes)))
 }
 
+fn commit_edge_id_from_entity_pk(entity_pk: &EntityPk) -> Option<(CommitId, u32)> {
+    let [
+        EntityPkComponent::Uuid(bytes),
+        EntityPkComponent::Integer(parent_order),
+    ] = entity_pk.components.as_slice()
+    else {
+        return None;
+    };
+    Some((
+        CommitId::new(uuid::Uuid::from_bytes(*bytes)),
+        u32::try_from(*parent_order).ok()?,
+    ))
+}
+
 fn uuid_string_from_entity_pk(entity_pk: &EntityPk) -> Option<String> {
     let [EntityPkComponent::Uuid(bytes)] = entity_pk.components.as_slice() else {
         return None;
@@ -516,7 +555,7 @@ fn uuid_string_from_entity_pk(entity_pk: &EntityPk) -> Option<String> {
 
 fn validate_commit_point_identity(
     requested_commit_id: CommitId,
-    record: &CommitGraphCommitRecord,
+    record: &CommitGraphNode,
 ) -> Result<(), LixError> {
     if record.commit_id == requested_commit_id {
         return Ok(());

--- a/packages/engine/src/session/undo_redo.rs
+++ b/packages/engine/src/session/undo_redo.rs
@@ -1,7 +1,6 @@
 use crate::LixError;
 use crate::changelog::{ChangeRecordProjection, CommitId};
 use crate::checkpoint::CHECKPOINT_MARKER_SCHEMA_KEY;
-use crate::commit_graph::CommitGraphReader;
 use crate::entity_pk::EntityPk;
 use crate::sql2::SqlWriteExecutionContext;
 use crate::storage_adapter::Storage;
@@ -68,7 +67,7 @@ where
         .load_branch_head(&branch_id)
         .await?
         .ok_or_else(|| LixError::branch_not_found(&branch_id, "undo", "target"))?;
-    let head_record = load_commit_record(transaction, head).await?;
+    let head_record = load_node(transaction, head).await?;
     let (state, head_delta) =
         semantic_state_for_record(transaction, &branch_id, head, &head_record).await?;
     let target = state.undo_top.ok_or_else(|| {
@@ -80,7 +79,7 @@ where
     let target_record = if target == head {
         head_record
     } else {
-        load_commit_record(transaction, target).await?
+        load_node(transaction, target).await?
     };
     let parent = only_parent(&target_record.parent_commit_ids, target, "undo")?;
     let state_before_target = semantic_state_at(transaction, &branch_id, parent).await?;
@@ -126,7 +125,7 @@ where
         .load_branch_head(&branch_id)
         .await?
         .ok_or_else(|| LixError::branch_not_found(&branch_id, "redo", "target"))?;
-    let head_record = load_commit_record(transaction, head).await?;
+    let head_record = load_node(transaction, head).await?;
     let (state, _) = semantic_state_for_record(transaction, &branch_id, head, &head_record).await?;
     let redo_node = state.redo_top.ok_or_else(|| {
         LixError::new(
@@ -146,7 +145,7 @@ where
             .ok_or_else(|| missing_redo_node(redo_node))?;
         (node.target_commit_id, node.redo_next)
     };
-    let target_record = load_commit_record(transaction, target).await?;
+    let target_record = load_node(transaction, target).await?;
     only_parent(&target_record.parent_commit_ids, target, "redo")?;
 
     let target_delta = load_commit_delta(transaction, target).await?;
@@ -185,7 +184,7 @@ async fn semantic_state_at<S>(
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
-    let record = load_commit_record(transaction, commit_id).await?;
+    let record = load_node(transaction, commit_id).await?;
     if record.parent_commit_ids.len() != 1 {
         return Ok(SemanticState::default());
     }
@@ -256,7 +255,7 @@ async fn semantic_state_for_record<S>(
     transaction: &mut Transaction<S>,
     branch_id: &str,
     commit_id: CommitId,
-    record: &crate::commit_graph::CommitGraphCommitRecord,
+    record: &crate::commit_graph::CommitGraphNode,
 ) -> Result<
     (
         SemanticState,
@@ -418,17 +417,17 @@ where
     tracked.commit_delta_members(commit_id).await
 }
 
-async fn load_commit_record<S>(
+async fn load_node<S>(
     transaction: &mut Transaction<S>,
     commit_id: CommitId,
-) -> Result<crate::commit_graph::CommitGraphCommitRecord, LixError>
+) -> Result<crate::commit_graph::CommitGraphNode, LixError>
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
     transaction
         .commit_graph_reader()
         .await
-        .load_commit_record(&commit_id)
+        .load_node(&commit_id)
         .await?
         .ok_or_else(|| {
             LixError::new(
@@ -574,7 +573,7 @@ where
 mod tests {
     use serde_json::Value as JsonValue;
 
-    use super::{load_commit_delta, load_commit_record, only_parent};
+    use super::{load_commit_delta, load_node, only_parent};
     use crate::sql2::SqlWriteExecutionContext;
     use crate::storage::Memory;
     use crate::{
@@ -673,7 +672,7 @@ mod tests {
                         .load_branch_head(&branch_id)
                         .await?
                         .expect("branch has a head");
-                    let record = load_commit_record(transaction, head).await?;
+                    let record = load_node(transaction, head).await?;
                     let parent = only_parent(&record.parent_commit_ids, head, "test")?;
                     let key = load_commit_delta(transaction, head)
                         .await?
@@ -699,7 +698,7 @@ mod tests {
                         .load_branch_head(&branch_id)
                         .await?
                         .expect("branch has a head");
-                    let record = load_commit_record(transaction, head).await?;
+                    let record = load_node(transaction, head).await?;
                     let parent = only_parent(&record.parent_commit_ids, head, "test")?;
                     let key = load_commit_delta(transaction, head)
                         .await?

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -2429,8 +2429,8 @@ mod tests {
     use crate::branch::BranchRefReader;
     use crate::changelog::{ChangeId, CommitId};
     use crate::commit_graph::{
-        CommitGraphChangeHistoryEntry, CommitGraphChangeHistoryRequest, CommitGraphCommit,
-        CommitGraphReader, ReachableCommitGraphCommit,
+        CommitGraphChangeHistoryRequest, CommitGraphNode, CommitGraphReader,
+        ReachableCommitGraphNode,
     };
     use crate::common::LixTimestamp;
     use crate::functions::FunctionProviderHandle;
@@ -3063,17 +3063,17 @@ mod tests {
 
     #[async_trait]
     impl CommitGraphReader for DummyCommitGraphReader {
-        async fn load_commit(
+        async fn load_node(
             &mut self,
             _commit_id: &CommitId,
-        ) -> Result<Option<CommitGraphCommit>, LixError> {
+        ) -> Result<Option<CommitGraphNode>, LixError> {
             Ok(None)
         }
 
-        async fn reachable_commits(
+        async fn reachable_nodes(
             &mut self,
             _head_commit_id: &CommitId,
-        ) -> Result<Vec<ReachableCommitGraphCommit>, LixError> {
+        ) -> Result<Arc<[ReachableCommitGraphNode]>, LixError> {
             Ok(Vec::new().into())
         }
 
@@ -3081,8 +3081,11 @@ mod tests {
             &mut self,
             _start_commit_id: &CommitId,
             _request: &CommitGraphChangeHistoryRequest,
-        ) -> Result<Vec<CommitGraphChangeHistoryEntry>, LixError> {
-            Ok(Vec::new().into())
+        ) -> Result<crate::commit_graph::CommitGraphHistory, LixError> {
+            Ok(crate::commit_graph::CommitGraphHistory {
+                entries: Vec::new(),
+                reachable_nodes: Arc::from([]),
+            })
         }
     }
 

--- a/packages/engine/src/sql2/history_route.rs
+++ b/packages/engine/src/sql2/history_route.rs
@@ -372,29 +372,26 @@ where
     for as_of_commit_id in as_of_commit_ids {
         let as_of_commit_id =
             CommitId::parse_lix(as_of_commit_id, "history lixcol_as_of_commit_id")?;
-        let (entries, reachable_commits) = {
+        let (entries, reachable_nodes) = {
             let mut guard = commit_graph.lock().await;
-            let entries = guard
+            let history = guard
                 .change_history_from_commit(&as_of_commit_id, &request)
                 .await?;
-            let reachable_commits = if metadata_projection.commit_created_at
+            let reachable_nodes = if metadata_projection.commit_created_at
                 || query_source.certified_history_reader.is_some()
             {
-                guard.reachable_commits(&as_of_commit_id).await?
+                history.reachable_nodes
             } else {
-                Vec::new()
+                Arc::from([])
             };
-            (entries, reachable_commits)
+            (history.entries, reachable_nodes)
         };
-        let reachable_by_id = reachable_commits
+        let reachable_by_id = reachable_nodes
             .iter()
             .map(|reachable| {
                 (
                     reachable.commit.commit_id,
-                    (
-                        reachable.depth,
-                        reachable.commit.change.created_at.to_string(),
-                    ),
+                    (reachable.depth, reachable.commit.created_at.to_string()),
                 )
             })
             .collect::<BTreeMap<_, _>>();
@@ -837,7 +834,7 @@ mod tests {
     use crate::changelog::{ChangeId, CommitId};
     use crate::commit_graph::{
         CommitGraphChange, CommitGraphChangeHistoryEntry, CommitGraphChangeHistoryRequest,
-        CommitGraphCommit, CommitGraphReader, ReachableCommitGraphCommit,
+        CommitGraphNode, CommitGraphReader, ReachableCommitGraphNode,
     };
     use crate::entity_pk::EntityPk;
     use crate::json_store::{JsonSlot, JsonStoreContext};
@@ -965,7 +962,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn history_loader_preserves_projected_commit_timestamp() {
+    async fn history_loader_reuses_history_topology_for_projected_commit_timestamp() {
         let reachable_calls = Arc::new(AtomicUsize::new(0));
         let start_commit_id = CommitId::for_test_label("start");
         let metadata_schema = Arc::new(Schema::new(vec![Field::new(
@@ -990,7 +987,11 @@ mod tests {
         .await
         .expect("history load should enrich commit metadata");
 
-        assert_eq!(reachable_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            reachable_calls.load(Ordering::SeqCst),
+            0,
+            "commit metadata must not trigger a second topology walk",
+        );
         assert_eq!(rows.len(), 1);
         assert_eq!(
             rows[0].commit_created_at,
@@ -1041,47 +1042,59 @@ mod tests {
 
     #[async_trait::async_trait]
     impl CommitGraphReader for CountingCommitGraphReader {
-        async fn load_commit(
+        async fn load_node(
             &mut self,
             _commit_id: &CommitId,
-        ) -> Result<Option<CommitGraphCommit>, LixError> {
+        ) -> Result<Option<CommitGraphNode>, LixError> {
             Ok(None)
         }
 
-        async fn reachable_commits(
+        async fn reachable_nodes(
             &mut self,
             _head_commit_id: &CommitId,
-        ) -> Result<Vec<ReachableCommitGraphCommit>, LixError> {
+        ) -> Result<Arc<[ReachableCommitGraphNode]>, LixError> {
             self.reachable_calls.fetch_add(1, Ordering::SeqCst);
             if !self.include_reachable_commit {
-                return Ok(Vec::new());
+                return Ok(Arc::from([]));
             }
-            let change = test_change("commit-change", commit_timestamp());
-            Ok(vec![ReachableCommitGraphCommit {
-                commit: CommitGraphCommit {
-                    canonical_change: change.clone(),
-                    change,
+            Ok(Arc::from([ReachableCommitGraphNode {
+                commit: CommitGraphNode {
                     commit_id: self.start_commit_id,
+                    change_id: ChangeId::for_test_label("commit-change"),
                     generation: 0,
-                    change_ids: vec![ChangeId::for_test_label("entity-change")],
-                    author_account_ids: Vec::new(),
                     parent_commit_ids: Vec::new(),
+                    created_at: commit_timestamp(),
                 },
                 depth: 0,
-            }])
+            }]))
         }
 
         async fn change_history_from_commit(
             &mut self,
             _start_commit_id: &CommitId,
             _request: &CommitGraphChangeHistoryRequest,
-        ) -> Result<Vec<CommitGraphChangeHistoryEntry>, LixError> {
-            Ok(vec![CommitGraphChangeHistoryEntry {
-                change: test_change("entity-change", event_timestamp()),
-                observed_commit_id: self.start_commit_id,
-                start_commit_id: self.start_commit_id,
-                depth: 0,
-            }])
+        ) -> Result<crate::commit_graph::CommitGraphHistory, LixError> {
+            let reachable_nodes = self
+                .include_reachable_commit
+                .then(|| ReachableCommitGraphNode {
+                    commit: CommitGraphNode {
+                        commit_id: self.start_commit_id,
+                        change_id: ChangeId::for_test_label("commit-change"),
+                        generation: 0,
+                        parent_commit_ids: Vec::new(),
+                        created_at: commit_timestamp(),
+                    },
+                    depth: 0,
+                });
+            Ok(crate::commit_graph::CommitGraphHistory {
+                entries: vec![CommitGraphChangeHistoryEntry {
+                    change: test_change("entity-change", event_timestamp()),
+                    observed_commit_id: self.start_commit_id,
+                    start_commit_id: self.start_commit_id,
+                    depth: 0,
+                }],
+                reachable_nodes: reachable_nodes.into_iter().collect::<Vec<_>>().into(),
+            })
         }
     }
 

--- a/packages/engine/src/sql2/providers/change.rs
+++ b/packages/engine/src/sql2/providers/change.rs
@@ -195,9 +195,9 @@ where
             })
             .await?;
         for commit in scan.entries {
-            changes.push(LixChangeRow::DerivedCommit(commit_record_canonical_change(
-                &commit,
-            )));
+            changes.push(LixChangeRow::DerivedCommit(
+                crate::commit_graph::canonical_commit_change(&commit.into()),
+            ));
         }
         let Some(next) = scan.next_start_after else {
             break;
@@ -321,7 +321,7 @@ where
             )
         })?;
     Ok(Some(LixChangeRow::DerivedCommit(
-        commit_record_canonical_change(&commit),
+        crate::commit_graph::canonical_commit_change(&commit.into()),
     )))
 }
 
@@ -336,25 +336,6 @@ impl LixChangeRow {
             Self::Direct(change) => change.change_id,
             Self::DerivedCommit(change) => change.id,
         }
-    }
-}
-
-fn commit_record_canonical_change(
-    commit: &crate::changelog::CommitRecord,
-) -> crate::commit_graph::CommitGraphChange {
-    let snapshot_content =
-        crate::changelog::commit_row_snapshot_json(&commit.commit_id.to_string())
-            .expect("lix_commit snapshot serialization should not fail");
-    crate::commit_graph::CommitGraphChange {
-        id: commit.change_id,
-        entity_pk: crate::entity_pk::EntityPk::uuid_from_canonical(&commit.commit_id.to_string())
-            .expect("commit IDs are canonical UUIDs"),
-        schema_key: "lix_commit".to_string(),
-        file_id: None,
-        snapshot: crate::json_store::JsonSlot::from_json(&snapshot_content),
-        metadata: crate::json_store::JsonSlot::None,
-        created_at: commit.created_at,
-        origin_key: None,
     }
 }
 

--- a/packages/engine/src/sql2/providers/filesystem_history_path.rs
+++ b/packages/engine/src/sql2/providers/filesystem_history_path.rs
@@ -132,7 +132,7 @@ pub(super) async fn load_history_commit_parents(
     for as_of_commit_id in as_of_commit_ids {
         let as_of_commit_id =
             CommitId::parse_lix(as_of_commit_id, "history lixcol_as_of_commit_id")?;
-        for reachable in commit_graph.reachable_commits(&as_of_commit_id).await? {
+        for reachable in commit_graph.reachable_nodes(&as_of_commit_id).await?.iter() {
             parents_by_commit.insert(
                 reachable.commit.commit_id.to_string(),
                 reachable

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -797,8 +797,8 @@ mod tests {
     use crate::branch::{BranchHead, BranchRefReader};
     use crate::changelog::CommitId;
     use crate::commit_graph::{
-        CommitGraphChangeHistoryEntry, CommitGraphChangeHistoryRequest, CommitGraphCommit,
-        CommitGraphReader, ReachableCommitGraphCommit,
+        CommitGraphChangeHistoryRequest, CommitGraphNode, CommitGraphReader,
+        ReachableCommitGraphNode,
     };
     use crate::json_store::JsonStoreContext;
     use crate::live_state::{LiveStateReader, LiveStateScanRequest};
@@ -1305,17 +1305,17 @@ mod tests {
 
     #[async_trait]
     impl CommitGraphReader for EmptyCommitGraphReader {
-        async fn load_commit(
+        async fn load_node(
             &mut self,
             _commit_id: &CommitId,
-        ) -> Result<Option<CommitGraphCommit>, LixError> {
+        ) -> Result<Option<CommitGraphNode>, LixError> {
             Ok(None)
         }
 
-        async fn reachable_commits(
+        async fn reachable_nodes(
             &mut self,
             _head_commit_id: &CommitId,
-        ) -> Result<Vec<ReachableCommitGraphCommit>, LixError> {
+        ) -> Result<Arc<[ReachableCommitGraphNode]>, LixError> {
             Ok(Vec::new().into())
         }
 
@@ -1323,8 +1323,11 @@ mod tests {
             &mut self,
             _start_commit_id: &CommitId,
             _request: &CommitGraphChangeHistoryRequest,
-        ) -> Result<Vec<CommitGraphChangeHistoryEntry>, LixError> {
-            Ok(Vec::new().into())
+        ) -> Result<crate::commit_graph::CommitGraphHistory, LixError> {
+            Ok(crate::commit_graph::CommitGraphHistory {
+                entries: Vec::new(),
+                reachable_nodes: Arc::from([]),
+            })
         }
     }
 }

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -179,6 +179,153 @@ pub struct CheckpointCommitScanBenchResult {
     pub pages: usize,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CommitGraphBenchMode {
+    AllNodes,
+    LegacyAllNodes,
+    ReachableNodes,
+    LegacyReachableNodes,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct CommitGraphBenchResult {
+    pub nodes: usize,
+    pub edges: usize,
+    pub member_changes: usize,
+}
+
+/// Measures topology reads against the superseded eager commit shape.
+///
+/// Legacy modes deliberately reproduce the removed work: synthesized commit
+/// changes for broad scans, plus commit-member payload hydration for graph
+/// walks. The result counts keep that work observable to the optimizer.
+#[inline(never)]
+pub async fn read_commit_graph_for_bench<StorageImpl>(
+    storage: &StorageAdapter<StorageImpl>,
+    head_commit_id: &str,
+    mode: CommitGraphBenchMode,
+) -> Result<CommitGraphBenchResult, crate::LixError>
+where
+    StorageImpl: Storage,
+{
+    let read = storage.begin_read(ReadOptions::default()).await?;
+    let mut reader = crate::commit_graph::CommitGraphContext::new().reader(read);
+    let head_commit_id =
+        crate::changelog::CommitId::parse_lix(head_commit_id, "commit graph benchmark head")?;
+    let nodes = match mode {
+        CommitGraphBenchMode::AllNodes | CommitGraphBenchMode::LegacyAllNodes => {
+            reader.all_nodes().await?
+        }
+        CommitGraphBenchMode::ReachableNodes | CommitGraphBenchMode::LegacyReachableNodes => reader
+            .reachable_nodes(&head_commit_id)
+            .await?
+            .iter()
+            .map(|reachable| reachable.commit.clone())
+            .collect(),
+    };
+    let node_count = nodes.len();
+    let edges = crate::commit_graph::commit_edges(&nodes).len();
+    let mut member_changes = 0usize;
+    if matches!(
+        mode,
+        CommitGraphBenchMode::LegacyAllNodes | CommitGraphBenchMode::LegacyReachableNodes
+    ) {
+        let mut legacy_shape = Vec::with_capacity(nodes.len());
+        for node in nodes {
+            let canonical = crate::commit_graph::canonical_commit_change(&node);
+            let members = if mode == CommitGraphBenchMode::LegacyReachableNodes {
+                let members = crate::tracked_state::load_commit_delta_members_with_payloads(
+                    reader.store(),
+                    node.commit_id,
+                )
+                .await?;
+                member_changes = member_changes.saturating_add(members.len());
+                members
+            } else {
+                Vec::new()
+            };
+            let mut member_change_ids = Vec::with_capacity(members.len());
+            let member_payloads = members
+                .into_iter()
+                .map(|member| {
+                    member_change_ids.push(member.change.change_id);
+                    member.change
+                })
+                .collect::<Vec<_>>();
+            legacy_shape.push((
+                node,
+                canonical.clone(),
+                canonical,
+                member_change_ids,
+                member_payloads,
+            ));
+        }
+        std::hint::black_box(&legacy_shape);
+    }
+    Ok(CommitGraphBenchResult {
+        nodes: node_count,
+        edges,
+        member_changes,
+    })
+}
+
+/// Adds one representative tracked payload to every commit in a graph fixture.
+///
+/// The topology benchmark uses this to preserve the old reachable-commit
+/// model's payload-cache and retained-member costs instead of benchmarking an
+/// unrealistically commit-only history.
+pub async fn seed_commit_graph_members_for_bench<StorageImpl>(
+    storage: &StorageAdapter<StorageImpl>,
+    commit_ids: &[String],
+) -> Result<(), crate::LixError>
+where
+    StorageImpl: Storage,
+{
+    let mut writes = storage.new_write_set();
+    let created_at = crate::common::LixTimestamp::expect_parse(
+        "commit graph benchmark timestamp",
+        "2026-05-20T00:00:00Z",
+    );
+    for (index, commit_id) in commit_ids.iter().enumerate() {
+        let commit_id = crate::changelog::CommitId::parse_lix(
+            commit_id,
+            "commit graph benchmark member commit",
+        )?;
+        let entity_pk = crate::entity_pk::EntityPk::single(format!("bench-member-{index:08}"));
+        let snapshot = crate::json_store::JsonSlot::from_json(&format!(
+            "{{\"index\":{index},\"payload\":\"{}\"}}",
+            "x".repeat(192)
+        ));
+        crate::tracked_state::stage_commit_deltas(
+            &mut writes,
+            &[crate::tracked_state::TrackedStateCommitDeltaRef {
+                delta: crate::tracked_state::TrackedStateDeltaRef {
+                    schema_key: "commit_graph_bench_member",
+                    file_id: None,
+                    entity_pk: &entity_pk,
+                    change_id: crate::changelog::ChangeId::for_test_label(&format!(
+                        "commit-graph-bench-member-{index}"
+                    )),
+                    commit_id,
+                    deleted: false,
+                    created_at,
+                    updated_at: created_at,
+                },
+                snapshot: snapshot.as_ref_slot(),
+                metadata: crate::json_store::JsonSlotRef::None,
+                origin_key: None,
+                base_coordinate: None,
+                authored: true,
+                certified: false,
+            }],
+        )?;
+    }
+    storage
+        .commit_write_set(writes, StorageWriteOptions::default())
+        .await?;
+    Ok(())
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct RepositoryGcBenchResult {
     pub live_commits: usize,
@@ -1488,7 +1635,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn repository_gc_benchmark_plans_unreachable_commits_without_mutating() {
+    async fn repository_gc_benchmark_plans_unreachable_nodes_without_mutating() {
         let storage = Memory::new();
         Engine::initialize(storage.clone())
             .await

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -48,6 +48,10 @@ pub(crate) use storage::{
     TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, TRACKED_STATE_COMMIT_ROOT_SPACE,
     TRACKED_STATE_TREE_CHUNK_SPACE, decode_change_locator,
 };
+#[cfg(all(test, not(feature = "storage-benches")))]
+pub(crate) use storage::{
+    TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
+};
 #[cfg(test)]
 pub(crate) use storage::{load_commit_delta_change_ids, scan_commit_delta_members};
 pub(crate) use types::{


### PR DESCRIPTION
## Summary

- replace the parallel full/record commit graph models with one topology-first `CommitGraphNode`
- hydrate canonical member payloads only for history requests that need them, while sharing one statement-scoped reachable topology snapshot across SQL history slices
- centralize canonical `lix_commit` encoding and add exact typed point access for commit edges
- preserve full selected-tombstone identity in schema-sliced caches and history deduplication
- add a representative commit graph scale benchmark with an eager legacy oracle for latency, RSS, and hardware-counter profiling

## Why

Graph algorithms and derived commit surfaces only need identity, generation, parents, timestamp, and change ID. The previous full commit model eagerly loaded member payloads and duplicated canonical commit changes during traversal, increasing CPU, allocations, and retained memory while allowing graph callers to accidentally depend on payload materialization.

## Validation

- `RUST_MIN_STACK=8388608 cargo test -p lix_engine --features all-simulations` (1,786 unit, 802 integration, 3 doctests passed; 11 ignored)
- `cargo clippy -p lix_engine --features all-simulations --all-targets -- -D warnings -A dead-code`
- `cargo clippy -p lix_engine_benchmarks --features storage-benches --bench commit_graph_scale -- -D warnings`
- `cargo fmt --all -- --check`
- independent architecture and performance reviews: approved, no blockers

10k-commit release medians with one 192-byte tracked payload per commit:

- all nodes: 3.131 ms vs 6.316 ms eager legacy (50.4% faster)
- reachable nodes: 11.417 ms vs 47.348 ms eager legacy (75.9% faster)

50k-commit isolated-process peak RSS:

- all nodes: 87,628 KB vs 118,440 KB (26.0% lower)
- reachable nodes: 90,216 KB vs 213,988 KB (57.8% lower)

At 10k reachable commits, `perf stat` also fell from 462.2M to 326.2M cycles, 882.6M to 682.6M instructions, and 892k to 605k cache misses.
