### PR TITLE
refactor(engine): verify exact read identities

### DIFF
--- a/packages/engine-benchmarks/benches/changelog/scorecard.rs
+++ b/packages/engine-benchmarks/benches/changelog/scorecard.rs
@@ -87,7 +87,7 @@ fn cpu_scorecard() -> Result<Vec<(&'static str, Duration)>, LixError> {
 
 async fn storage_scorecard() -> Result<Vec<StorageScoreRow>, LixError> {
     let mut rows = Vec::new();
-    let samples = 1;
+    let samples = 5;
 
     rows.push(
         storage_row(
@@ -153,6 +153,45 @@ async fn storage_scorecard() -> Result<Vec<StorageScoreRow>, LixError> {
                     let append = changelog_bench::append_1c_100ch()?;
                     let store = changelog_bench::prepare_store(storage.create(), &append).await?;
                     let commit_ids = append.commit_ids();
+                    let start = Instant::now();
+                    black_box(changelog_bench::load_commits_direct(&store, &commit_ids).await?);
+                    Ok(start.elapsed())
+                })
+            },
+        )
+        .await?,
+    );
+
+    rows.push(
+        storage_row(
+            "load_commits_direct_batched / 1000c ordered",
+            samples,
+            |storage| {
+                Box::pin(async move {
+                    let append = changelog_bench::append_ordered_commits(0, 1000)?;
+                    let store = changelog_bench::prepare_store(storage.create(), &append).await?;
+                    let commit_ids = append.commit_ids();
+                    let start = Instant::now();
+                    black_box(changelog_bench::load_commits_direct(&store, &commit_ids).await?);
+                    Ok(start.elapsed())
+                })
+            },
+        )
+        .await?,
+    );
+
+    rows.push(
+        storage_row(
+            "load_commits_direct_batched / 1000c reversed_duplicate_missing",
+            samples,
+            |storage| {
+                Box::pin(async move {
+                    let append = changelog_bench::append_ordered_commits(0, 1000)?;
+                    let store = changelog_bench::prepare_store(storage.create(), &append).await?;
+                    let mut commit_ids = append.commit_ids();
+                    commit_ids.reverse();
+                    commit_ids.extend(commit_ids.iter().step_by(10).cloned().collect::<Vec<_>>());
+                    commit_ids.extend((0..100).map(|index| format!("missing-{index}")));
                     let start = Instant::now();
                     black_box(changelog_bench::load_commits_direct(&store, &commit_ids).await?);
                     Ok(start.elapsed())

--- a/packages/engine/src/changelog/bench_support.rs
+++ b/packages/engine/src/changelog/bench_support.rs
@@ -733,7 +733,10 @@ where
             commit_ids: &commit_ids,
         })
         .await?;
-    Ok(batch.entries.iter().filter(|entry| entry.is_some()).count())
+    Ok(batch
+        .into_iter()
+        .filter(|(_, entry)| entry.is_some())
+        .count())
 }
 
 async fn load_changes_with_lookup<StorageImpl, S: AsRef<str> + Sync>(
@@ -758,7 +761,10 @@ where
             change_ids: &change_ids,
         })
         .await?;
-    Ok(batch.entries.iter().filter(|entry| entry.is_some()).count())
+    Ok(batch
+        .into_iter()
+        .filter(|(_, entry)| entry.is_some())
+        .count())
 }
 
 #[expect(clippy::cast_possible_truncation)]

--- a/packages/engine/src/changelog/context.rs
+++ b/packages/engine/src/changelog/context.rs
@@ -40,7 +40,7 @@ use crate::storage_adapter::{
     BufferRange, EncodedMutationBatch, EncodedPut, PointReadPlan, ScanPlan, StorageAdapter,
     StorageAdapterRead, StorageCoreProjection, StorageGetManyRequest, StorageGetOptions,
     StorageKey, StoragePrefix, StorageProjectedValue, StorageReadOptions, StorageScanOptions,
-    StorageSpace, StorageWriteSet,
+    StorageSpace, StorageWriteSet, exact_get_many,
 };
 use crate::{LixError, storage_codec};
 
@@ -285,10 +285,10 @@ impl<S> ChangelogReader for ChangelogStoreReader<S>
 where
     S: ChangelogStorageRead + Send,
 {
-    async fn load_commits(
+    async fn load_commits<'a>(
         &mut self,
-        request: CommitLoadRequest<'_>,
-    ) -> Result<CommitLoadBatch, LixError> {
+        request: CommitLoadRequest<'a>,
+    ) -> Result<CommitLoadBatch<'a>, LixError> {
         load_commits_from_store(&mut self.store, request).await
     }
 
@@ -299,10 +299,10 @@ where
         scan_commits_from_store(&mut self.store, request).await
     }
 
-    async fn load_changes(
+    async fn load_changes<'a>(
         &mut self,
-        request: ChangeLoadRequest<'_>,
-    ) -> Result<ChangeLoadBatch, LixError> {
+        request: ChangeLoadRequest<'a>,
+    ) -> Result<ChangeLoadBatch<'a>, LixError> {
         load_changes_from_store(&mut self.store, request).await
     }
 
@@ -319,15 +319,13 @@ impl<S> ChangelogReader for ChangelogStoreWriter<'_, S>
 where
     S: ChangelogStorageRead + Send + ?Sized,
 {
-    async fn load_commits(
+    async fn load_commits<'a>(
         &mut self,
-        request: CommitLoadRequest<'_>,
-    ) -> Result<CommitLoadBatch, LixError> {
+        request: CommitLoadRequest<'a>,
+    ) -> Result<CommitLoadBatch<'a>, LixError> {
         let stored = load_commits_from_store(self.store, request).await?;
-        let entries = request
-            .commit_ids
-            .iter()
-            .zip(stored.entries)
+        let entries = stored
+            .into_iter()
             .map(|(commit_id, stored)| {
                 if let Some(record) = self.staged_commits.get(commit_id) {
                     return Some(record.clone());
@@ -335,7 +333,7 @@ where
                 stored
             })
             .collect();
-        Ok(CommitLoadBatch { entries })
+        CommitLoadBatch::try_new("changelog commit overlay", request.commit_ids, entries)
     }
 
     async fn scan_commits(
@@ -365,18 +363,16 @@ where
         Ok(batch)
     }
 
-    async fn load_changes(
+    async fn load_changes<'a>(
         &mut self,
-        request: ChangeLoadRequest<'_>,
-    ) -> Result<ChangeLoadBatch, LixError> {
+        request: ChangeLoadRequest<'a>,
+    ) -> Result<ChangeLoadBatch<'a>, LixError> {
         let stored = load_changes_from_store(self.store, request).await?;
-        let entries = request
-            .change_ids
-            .iter()
-            .zip(stored.entries)
+        let entries = stored
+            .into_iter()
             .map(|(change_id, stored)| self.staged_changes.get(change_id).cloned().or(stored))
             .collect();
-        Ok(ChangeLoadBatch { entries })
+        ChangeLoadBatch::try_new("changelog change overlay", request.change_ids, entries)
     }
 
     async fn scan_changes(
@@ -811,10 +807,10 @@ where
     }
 }
 
-async fn load_commits_from_store(
+async fn load_commits_from_store<'a>(
     store: &mut (impl ChangelogStorageRead + ?Sized),
-    request: CommitLoadRequest<'_>,
-) -> Result<CommitLoadBatch, LixError> {
+    request: CommitLoadRequest<'a>,
+) -> Result<CommitLoadBatch<'a>, LixError> {
     let keys = request
         .commit_ids
         .iter()
@@ -822,7 +818,7 @@ async fn load_commits_from_store(
         .collect::<Vec<_>>();
     let commit_values = get_many(store, COMMIT_SPACE, keys).await?;
     let mut entries = Vec::with_capacity(request.commit_ids.len());
-    for (_commit_id, value) in request.commit_ids.iter().zip(commit_values) {
+    for value in commit_values {
         let Some(value) = value else {
             entries.push(None);
             continue;
@@ -830,7 +826,7 @@ async fn load_commits_from_store(
         let record = storage_codec::decode("commit record", &value)?;
         entries.push(Some(record));
     }
-    Ok(CommitLoadBatch { entries })
+    CommitLoadBatch::try_new("changelog commit", request.commit_ids, entries)
 }
 
 async fn scan_commits_from_store(
@@ -883,10 +879,10 @@ async fn scan_commits_from_store(
     })
 }
 
-async fn load_changes_from_store(
+async fn load_changes_from_store<'a>(
     store: &mut (impl ChangelogStorageRead + ?Sized),
-    request: ChangeLoadRequest<'_>,
-) -> Result<ChangeLoadBatch, LixError> {
+    request: ChangeLoadRequest<'a>,
+) -> Result<ChangeLoadBatch<'a>, LixError> {
     let keys = request
         .change_ids
         .iter()
@@ -903,7 +899,7 @@ async fn load_changes_from_store(
                 .transpose()
         })
         .collect::<Result<Vec<_>, LixError>>()?;
-    Ok(ChangeLoadBatch { entries })
+    ChangeLoadBatch::try_new("changelog change", request.change_ids, entries)
 }
 
 async fn scan_changes_from_store(
@@ -1026,7 +1022,7 @@ where
             opts: StorageGetOptions::default(),
         })
         .collect::<Vec<_>>();
-    let mut values = read.get_many(&requests).await?.values.into_iter();
+    let mut values = exact_get_many(read, &requests).await?.values.into_iter();
     Ok(requests
         .iter()
         .map(|request| {

--- a/packages/engine/src/changelog/materialization.rs
+++ b/packages/engine/src/changelog/materialization.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use bytes::Bytes;
 
 use crate::LixError;
-use crate::common::SharedStr;
+use crate::common::{ExactBatch, SharedStr};
 use crate::json_store::{
     JsonLoadRequestRef, JsonReadScopeRef, JsonRef, JsonSlot, JsonStoreContext,
 };
@@ -86,9 +86,9 @@ where
     }
     let records = load_unique_change_records_in_order(store, &unique).await?;
     let mut by_id = HashMap::with_capacity(unique.len());
-    for (change_id, record) in unique.into_iter().zip(records) {
+    for (change_id, record) in records {
         if let Some(record) = record {
-            by_id.insert(change_id, record);
+            by_id.insert(*change_id, record);
         }
     }
     Ok(by_id)
@@ -102,15 +102,15 @@ where
 /// materialized value vector for the common identity mapping. Decoded records
 /// retain that same order so batch materialization does not need an
 /// intermediate `HashMap`.
-async fn load_unique_change_records_in_order<S>(
+async fn load_unique_change_records_in_order<'a, S>(
     store: &S,
-    unique: &[ChangeId],
-) -> Result<Vec<Option<ChangeRecord>>, LixError>
+    unique: &'a [ChangeId],
+) -> Result<ExactBatch<'a, ChangeId, ChangeRecord>, LixError>
 where
     S: StorageAdapterRead + ?Sized,
 {
     if unique.is_empty() {
-        return Ok(Vec::new());
+        return ExactBatch::try_new("change materialization", unique, Vec::new());
     }
     let keys = change_storage_keys(unique)?;
     let plan = PointReadPlan::from_unique_keys(CHANGE_SPACE, keys);
@@ -121,18 +121,8 @@ where
 fn decode_change_records_in_order(
     unique: &[ChangeId],
     values: Vec<Option<StorageProjectedValue>>,
-) -> Result<Vec<Option<ChangeRecord>>, LixError> {
-    if values.len() != unique.len() {
-        return Err(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!(
-                "change point read returned {} values for {} unique ids",
-                values.len(),
-                unique.len()
-            ),
-        ));
-    }
-    unique
+) -> Result<ExactBatch<'_, ChangeId, ChangeRecord>, LixError> {
+    let records = unique
         .iter()
         .copied()
         .zip(values)
@@ -148,7 +138,8 @@ fn decode_change_records_in_order(
                 ),
             )),
         })
-        .collect()
+        .collect::<Result<Vec<_>, _>>()?;
+    ExactBatch::try_new("change materialization", unique, records)
 }
 
 fn change_storage_keys(
@@ -415,6 +406,10 @@ mod tests {
             ],
         )
         .expect("ordered change records should decode");
+        let records = records
+            .into_iter()
+            .map(|(_, record)| record)
+            .collect::<Vec<_>>();
 
         assert_eq!(records.len(), change_ids.len());
         let first = records[0].as_ref().expect("first record");
@@ -438,7 +433,7 @@ mod tests {
         assert!(
             error
                 .to_string()
-                .contains("returned 1 values for 2 unique ids")
+                .contains("returned 1 values for 2 requested keys")
         );
     }
 

--- a/packages/engine/src/changelog/store.rs
+++ b/packages/engine/src/changelog/store.rs
@@ -79,20 +79,20 @@ fn uuid_from_key(key: &[u8], kind: &str) -> Result<uuid::Uuid, LixError> {
 
 #[async_trait]
 pub(crate) trait ChangelogReader {
-    async fn load_commits(
+    async fn load_commits<'a>(
         &mut self,
-        request: CommitLoadRequest<'_>,
-    ) -> Result<CommitLoadBatch, LixError>;
+        request: CommitLoadRequest<'a>,
+    ) -> Result<CommitLoadBatch<'a>, LixError>;
 
     async fn scan_commits(
         &mut self,
         request: CommitScanRequest<'_>,
     ) -> Result<CommitScanBatch, LixError>;
 
-    async fn load_changes(
+    async fn load_changes<'a>(
         &mut self,
-        request: ChangeLoadRequest<'_>,
-    ) -> Result<ChangeLoadBatch, LixError>;
+        request: ChangeLoadRequest<'a>,
+    ) -> Result<ChangeLoadBatch<'a>, LixError>;
 
     async fn scan_changes(
         &mut self,

--- a/packages/engine/src/changelog/types.rs
+++ b/packages/engine/src/changelog/types.rs
@@ -1,5 +1,6 @@
 use crate::LixError;
 use crate::common::LixTimestamp;
+use crate::common::{ExactBatch, ExactValue};
 use crate::entity_pk::EntityPk;
 use crate::json_store::{JsonRef, JsonSlot};
 use std::fmt;
@@ -333,9 +334,12 @@ pub(crate) struct CommitLoadRequest<'a> {
     pub(crate) commit_ids: &'a [CommitId],
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct CommitLoadBatch {
-    pub(crate) entries: Vec<Option<CommitRecord>>,
+pub(crate) type CommitLoadBatch<'a> = ExactBatch<'a, CommitId, CommitRecord>;
+
+impl ExactValue<CommitId> for CommitRecord {
+    fn matches_exact_key(&self, key: &CommitId) -> bool {
+        self.commit_id == *key
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -452,9 +456,12 @@ pub(crate) struct ChangeLoadRequest<'a> {
     pub(crate) change_ids: &'a [ChangeId],
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct ChangeLoadBatch {
-    pub(crate) entries: Vec<Option<ChangeRecord>>,
+pub(crate) type ChangeLoadBatch<'a> = ExactBatch<'a, ChangeId, ChangeRecord>;
+
+impl ExactValue<ChangeId> for ChangeRecord {
+    fn matches_exact_key(&self, key: &ChangeId) -> bool {
+        self.change_id == *key
+    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/packages/engine/src/commit_graph/context.rs
+++ b/packages/engine/src/commit_graph/context.rs
@@ -19,6 +19,7 @@ use crate::commit_graph::{
     CommitGraphChange, CommitGraphChangeHistoryEntry, CommitGraphChangeHistoryRequest,
     CommitGraphHistory, CommitGraphNode, CommitGraphReader, ReachableCommitGraphNode,
 };
+use crate::common::ExactBatch;
 use crate::entity_pk::EntityPk;
 use crate::storage_adapter::StorageAdapterRead;
 
@@ -83,13 +84,13 @@ where
             .await?
             .into_iter()
             .next()
-            .flatten())
+            .and_then(|(_, value)| value))
     }
 
-    pub(crate) async fn load_nodes(
+    pub(crate) async fn load_nodes<'a>(
         &mut self,
-        commit_ids: &[CommitId],
-    ) -> Result<Vec<Option<CommitGraphNode>>, LixError> {
+        commit_ids: &'a [CommitId],
+    ) -> Result<ExactBatch<'a, CommitId, CommitGraphNode>, LixError> {
         let uncached_ids = commit_ids
             .iter()
             .filter(|commit_id| !self.node_cache.contains_key(commit_id))
@@ -99,21 +100,21 @@ where
             .collect::<Vec<_>>();
         if !uncached_ids.is_empty() {
             let mut reader = ChangelogContext::new().reader(&self.store);
-            let entries = reader
+            let batch = reader
                 .load_commits(CommitLoadRequest {
                     commit_ids: &uncached_ids,
                 })
-                .await?
-                .entries;
-            for (commit_id, entry) in uncached_ids.into_iter().zip(entries) {
+                .await?;
+            for (commit_id, entry) in batch {
                 self.node_cache
-                    .insert(commit_id, entry.map(commit_graph_node_from_commit_record));
+                    .insert(*commit_id, entry.map(commit_graph_node_from_commit_record));
             }
         }
-        Ok(commit_ids
+        let nodes = commit_ids
             .iter()
             .map(|commit_id| self.node_cache.get(commit_id).cloned().unwrap_or(None))
-            .collect())
+            .collect();
+        ExactBatch::try_new("commit graph", commit_ids, nodes)
     }
 
     /// Loads every direct commit fact from the changelog.
@@ -182,14 +183,16 @@ where
         left_commit_id: &CommitId,
         right_commit_id: &CommitId,
     ) -> Result<CommitId, LixError> {
-        let heads = self
-            .load_nodes(&[*left_commit_id, *right_commit_id])
-            .await?;
-        let left = heads[0]
-            .as_ref()
+        let head_ids = [*left_commit_id, *right_commit_id];
+        let heads = self.load_nodes(&head_ids).await?;
+        let mut heads = heads.into_iter().map(|(_, node)| node);
+        let left = heads
+            .next()
+            .flatten()
             .ok_or_else(|| missing_commit_graph_error(left_commit_id))?;
-        let right = heads[1]
-            .as_ref()
+        let right = heads
+            .next()
+            .flatten()
             .ok_or_else(|| missing_commit_graph_error(right_commit_id))?;
 
         if left_commit_id == right_commit_id {
@@ -206,12 +209,13 @@ where
             right.parent_commit_ids.as_slice(),
         ) && left_parent == right_parent
         {
+            let parent_ids = [*left_parent];
             if self
-                .load_nodes(&[*left_parent])
+                .load_nodes(&parent_ids)
                 .await?
                 .into_iter()
                 .next()
-                .flatten()
+                .and_then(|(_, value)| value)
                 .is_none()
             {
                 return Err(missing_commit_graph_error(left_parent));

--- a/packages/engine/src/commit_graph/types.rs
+++ b/packages/engine/src/commit_graph/types.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::LixError;
 use crate::changelog::{ChangeId, CommitId, CommitRecord};
-use crate::common::LixTimestamp;
+use crate::common::{ExactValue, LixTimestamp};
 use crate::entity_pk::EntityPk;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -29,6 +29,12 @@ pub(crate) struct CommitGraphNode {
     pub(crate) generation: u64,
     pub(crate) parent_commit_ids: Vec<CommitId>,
     pub(crate) created_at: LixTimestamp,
+}
+
+impl ExactValue<CommitId> for CommitGraphNode {
+    fn matches_exact_key(&self, key: &CommitId) -> bool {
+        self.commit_id == *key
+    }
 }
 
 impl From<CommitRecord> for CommitGraphNode {

--- a/packages/engine/src/commit_graph/walker.rs
+++ b/packages/engine/src/commit_graph/walker.rs
@@ -343,6 +343,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn exact_graph_read_rejects_record_stored_under_another_commit_key() {
+        let storage = StorageAdapter::new(Memory::new());
+        let requested = commit_id("requested-commit");
+        let embedded = commit_id("embedded-commit");
+        let mut writes = storage.new_write_set();
+        writes.put(
+            crate::changelog::COMMIT_SPACE,
+            StorageKey(Bytes::copy_from_slice(requested.as_uuid().as_bytes())),
+            crate::changelog::encode_commit_record(&CommitRecord {
+                format_version: 1,
+                commit_id: embedded,
+                generation: 0,
+                parent_commit_ids: Vec::new(),
+                tracked_state_rootless: false,
+                change_id: ChangeId::for_test_label("mismatched-key-change"),
+                author_account_ids: Vec::new(),
+                created_at: ts("2026-01-01T00:00:00Z"),
+            })
+            .expect("mismatched commit should encode"),
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("mismatched commit should persist");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let mut reader = CommitGraphContext::new().reader(read);
+        let error = reader
+            .load_node(&requested)
+            .await
+            .expect_err("exact read must reject a mismatched embedded commit id");
+
+        assert!(
+            error
+                .message
+                .contains("identity does not match requested key")
+        );
+    }
+
+    #[tokio::test]
     async fn reachable_nodes_errors_on_cycle() {
         let storage = StorageAdapter::new(Memory::new());
         let mut writes = storage.new_write_set();

--- a/packages/engine/src/common/exact_batch.rs
+++ b/packages/engine/src/common/exact_batch.rs
@@ -1,0 +1,121 @@
+use crate::LixError;
+
+/// Canonical identity check for a value returned by an exact-key read.
+///
+/// Implementations compare borrowed identity components. Construction of an
+/// [`ExactBatch`] therefore adds no key clones, hashing, or index allocation.
+pub(crate) trait ExactValue<K> {
+    fn matches_exact_key(&self, key: &K) -> bool;
+}
+
+/// Opaque, identity-verified exact-read results in request order.
+///
+/// Missing values and duplicate requested keys remain distinct slots. The
+/// request slice is borrowed, so the batch retains no second key allocation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ExactBatch<'keys, K, V> {
+    requested: &'keys [K],
+    values: Vec<Option<V>>,
+}
+
+impl<'keys, K, V> ExactBatch<'keys, K, V>
+where
+    V: ExactValue<K>,
+{
+    pub(crate) fn try_new(
+        context: &str,
+        requested: &'keys [K],
+        values: Vec<Option<V>>,
+    ) -> Result<Self, LixError> {
+        if values.len() != requested.len() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "{context} exact read returned {} values for {} requested keys",
+                    values.len(),
+                    requested.len()
+                ),
+            ));
+        }
+        if let Some(index) = requested.iter().zip(&values).position(|(key, value)| {
+            value
+                .as_ref()
+                .is_some_and(|value| !value.matches_exact_key(key))
+        }) {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "{context} exact read returned a value whose identity does not match requested key at slot {index}"
+                ),
+            ));
+        }
+        Ok(Self { requested, values })
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.requested.len()
+    }
+
+    pub(crate) fn iter(&self) -> impl ExactSizeIterator<Item = (&K, Option<&V>)> {
+        self.requested
+            .iter()
+            .zip(&self.values)
+            .map(|(key, value)| (key, value.as_ref()))
+    }
+}
+
+impl<'keys, K, V> IntoIterator for ExactBatch<'keys, K, V> {
+    type Item = (&'keys K, Option<V>);
+    type IntoIter = std::iter::Zip<std::slice::Iter<'keys, K>, std::vec::IntoIter<Option<V>>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.requested.iter().zip(self.values)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    struct Value(u32);
+
+    impl ExactValue<u32> for Value {
+        fn matches_exact_key(&self, key: &u32) -> bool {
+            self.0 == *key
+        }
+    }
+
+    #[test]
+    fn rejects_short_long_and_mismatched_results() {
+        let keys = [1, 2];
+        for values in [vec![Some(Value(1))], vec![Some(Value(1)), None, None]] {
+            assert!(ExactBatch::try_new("test", &keys, values).is_err());
+        }
+        let error = ExactBatch::try_new("test", &keys, vec![Some(Value(2)), Some(Value(2))])
+            .expect_err("mismatched identity must fail");
+        assert!(
+            error
+                .to_string()
+                .contains("does not match requested key at slot 0")
+        );
+    }
+
+    #[test]
+    fn preserves_duplicate_missing_and_requested_order() {
+        let keys = [2, 1, 2, 3];
+        let batch = ExactBatch::try_new(
+            "test",
+            &keys,
+            vec![Some(Value(2)), Some(Value(1)), Some(Value(2)), None],
+        )
+        .expect("valid exact batch");
+        assert_eq!(
+            batch
+                .into_iter()
+                .map(|(key, value)| (*key, value.map(|value| value.0)))
+                .collect::<Vec<_>>(),
+            [(2, Some(2)), (1, Some(1)), (2, Some(2)), (3, None)]
+        );
+    }
+}

--- a/packages/engine/src/common/mod.rs
+++ b/packages/engine/src/common/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod error;
+pub(crate) mod exact_batch;
 mod execution_metadata;
 pub(crate) mod identity;
 pub(crate) mod json_pointer;
@@ -9,6 +10,7 @@ pub(crate) mod types;
 pub(crate) mod wire;
 
 pub use error::LixError;
+pub(crate) use exact_batch::{ExactBatch, ExactValue};
 pub use execution_metadata::{
     ExecuteStatementMetadata, MutationIdentity, RequestBlobSpliceProvenance, VerifiedRequestBlob,
 };

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -1675,23 +1675,34 @@ mod tests {
             .await
             .expect("verification read should open");
         let mut reader = ChangelogContext::new().reader(&read);
+        let commit_ids = [live_parent, live_head, dead_commit];
         let commits = reader
             .load_commits(CommitLoadRequest {
-                commit_ids: &[live_parent, live_head, dead_commit],
+                commit_ids: &commit_ids,
             })
             .await
             .expect("commit headers should load");
-        assert!(commits.entries[0].is_some());
-        assert!(commits.entries[1].is_some());
-        assert!(commits.entries[2].is_none());
+        assert_eq!(
+            commits
+                .iter()
+                .map(|(_, value)| value.is_some())
+                .collect::<Vec<_>>(),
+            [true, true, false]
+        );
+        let change_ids = [live_standalone.change_id, dead_standalone.change_id];
         let changes = reader
             .load_changes(ChangeLoadRequest {
-                change_ids: &[live_standalone.change_id, dead_standalone.change_id],
+                change_ids: &change_ids,
             })
             .await
             .expect("standalone facts should load");
-        assert!(changes.entries[0].is_some());
-        assert!(changes.entries[1].is_none());
+        assert_eq!(
+            changes
+                .iter()
+                .map(|(_, value)| value.is_some())
+                .collect::<Vec<_>>(),
+            [true, false]
+        );
         assert!(
             load_change_record_by_id(&read, live_member.change_id)
                 .await

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -820,13 +820,14 @@ mod tests {
                 .await
                 .expect("read should open"),
         );
+        let commit_ids = [CommitId::for_test_label(&receipt.initial_commit_id)];
         let commits = reader
             .load_commits(crate::changelog::CommitLoadRequest {
-                commit_ids: &[CommitId::for_test_label(&receipt.initial_commit_id)],
+                commit_ids: &commit_ids,
             })
             .await
             .expect("commit should load");
-        let Some(record) = commits.entries.into_iter().next().flatten() else {
+        let Some(record) = commits.into_iter().next().and_then(|(_, value)| value) else {
             panic!("initial commit should exist");
         };
 
@@ -862,23 +863,25 @@ mod tests {
                 .any(|member| member.change.change_id == sampled_change_id),
             "initial tracked changes are authoritative in the packed commit delta"
         );
+        let change_ids = [sampled_change_id];
         let changes = reader
             .load_changes(crate::changelog::ChangeLoadRequest {
-                change_ids: &[sampled_change_id],
+                change_ids: &change_ids,
             })
             .await
             .expect("standalone change index should load");
         assert!(
-            matches!(changes.entries.as_slice(), [None]),
+            changes.iter().all(|(_, value)| value.is_none()),
             "packed tracked changes must not be duplicated in the standalone change space"
         );
+        let derivable_change_ids = [commit_change_id];
         let missing_derivable = reader
             .load_changes(crate::changelog::ChangeLoadRequest {
-                change_ids: &[commit_change_id],
+                change_ids: &derivable_change_ids,
             })
             .await
             .expect("derivable change lookup should load");
-        assert!(matches!(missing_derivable.entries.as_slice(), [None]));
+        assert!(missing_derivable.iter().all(|(_, value)| value.is_none()));
         {
             let read = storage
                 .begin_read(crate::storage_adapter::StorageReadOptions::default())

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -3136,10 +3136,9 @@ mod tests {
                             commit_ids: &[typed_parent],
                         })
                         .await?
-                        .entries
                         .into_iter()
                         .next()
-                        .flatten()
+                        .and_then(|(_, value)| value)
                         .ok_or_else(|| {
                             LixError::unknown("test changelog parent commit is missing")
                         })?

--- a/packages/engine/src/live_state/derived.rs
+++ b/packages/engine/src/live_state/derived.rs
@@ -193,7 +193,7 @@ where
             .await?;
         let mut rows = Vec::with_capacity(records.len() * scope.branch_ids.len());
         for branch_id in scope.branch_ids {
-            for (requested_commit_id, record) in commit_ids.iter().zip(&records) {
+            for (requested_commit_id, record) in records.iter() {
                 let Some(record) = record else {
                     continue;
                 };
@@ -261,15 +261,11 @@ where
             .collect::<std::collections::BTreeSet<_>>()
             .into_iter()
             .collect::<Vec<_>>();
-        let nodes = reads
-            .commit_graph
-            .reader(reads.store)
-            .load_nodes(&child_ids)
-            .await?;
-        let nodes_by_id = child_ids
+        let mut graph_reader = reads.commit_graph.reader(reads.store);
+        let nodes = graph_reader.load_nodes(&child_ids).await?;
+        let nodes_by_id = nodes
             .into_iter()
-            .zip(nodes)
-            .filter_map(|(commit_id, node)| node.map(|node| (commit_id, node)))
+            .filter_map(|(commit_id, node)| node.map(|node| (*commit_id, node)))
             .collect::<std::collections::BTreeMap<_, _>>();
         let mut edges = Vec::with_capacity(edge_ids.len());
         for (child_commit_id, parent_order) in edge_ids {

--- a/packages/engine/src/session/idempotency.rs
+++ b/packages/engine/src/session/idempotency.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::storage_adapter::StorageSpaceId;
 use crate::storage_adapter::{
     StorageAdapterRead, StorageCoreProjection, StorageGetManyRequest, StorageGetOptions,
-    StorageKey, StorageProjectedValue, StorageSpace,
+    StorageKey, StorageProjectedValue, StorageSpace, exact_get_many,
 };
 use crate::{LixError, LixNotice, Value};
 
@@ -208,15 +208,17 @@ pub(crate) async fn load_receipt(
     idempotency: &ExecuteIdempotency,
 ) -> Result<Option<ExecuteIdempotencyReceipt>, LixError> {
     let key = receipt_key(idempotency)?;
-    let values = store
-        .get_many(&[StorageGetManyRequest {
+    let values = exact_get_many(
+        store,
+        &[StorageGetManyRequest {
             space: EXECUTE_IDEMPOTENCY_RECEIPT_SPACE,
             keys: &[key],
             opts: StorageGetOptions {
                 projection: StorageCoreProjection::FullValue,
             },
-        }])
-        .await?;
+        }],
+    )
+    .await?;
     let Some(value) = values.values.into_iter().next().flatten() else {
         return Ok(None);
     };

--- a/packages/engine/src/session/media_upload.rs
+++ b/packages/engine/src/session/media_upload.rs
@@ -7,6 +7,7 @@ use crate::storage_adapter::{
     MAX_SCAN_PAGE_ROWS, Storage, StorageCoreProjection, StorageGetManyRequest, StorageGetOptions,
     StorageKey, StorageKeyRange, StoragePrecondition, StorageProjectedValue, StorageReadOptions,
     StorageScanOptions, StorageSpace, StorageSpaceId, StorageValue, StorageWriteOptions,
+    exact_get_many,
 };
 use crate::transaction::{begin_commit_boundary, commit_at_boundary};
 use crate::{Blob, LixError};
@@ -369,15 +370,17 @@ async fn load_upload_state(
     store: &impl crate::storage_adapter::StorageAdapterRead,
     key: &StorageKey,
 ) -> Result<Option<UploadState>, LixError> {
-    let values = store
-        .get_many(&[StorageGetManyRequest {
+    let values = exact_get_many(
+        store,
+        &[StorageGetManyRequest {
             space: UPLOAD_STATE_SPACE,
             keys: std::slice::from_ref(key),
             opts: StorageGetOptions {
                 projection: StorageCoreProjection::FullValue,
             },
-        }])
-        .await?;
+        }],
+    )
+    .await?;
     let Some(value) = values.values.into_iter().next().flatten() else {
         return Ok(None);
     };
@@ -547,15 +550,17 @@ async fn load_upload_manifest_leaf(
     store: &impl crate::storage_adapter::StorageAdapterRead,
     key: &StorageKey,
 ) -> Result<Option<UploadManifestLeaf>, LixError> {
-    let values = store
-        .get_many(&[StorageGetManyRequest {
+    let values = exact_get_many(
+        store,
+        &[StorageGetManyRequest {
             space: UPLOAD_MANIFEST_LEAF_SPACE,
             keys: std::slice::from_ref(key),
             opts: StorageGetOptions {
                 projection: StorageCoreProjection::FullValue,
             },
-        }])
-        .await?;
+        }],
+    )
+    .await?;
     let Some(StorageProjectedValue::FullValue(value)) = values.values.into_iter().next().flatten()
     else {
         return Ok(None);

--- a/packages/engine/src/sql2/providers/change.rs
+++ b/packages/engine/src/sql2/providers/change.rs
@@ -279,10 +279,9 @@ where
             change_ids: std::slice::from_ref(&change_id),
         })
         .await?
-        .entries
         .into_iter()
         .next()
-        .flatten()
+        .and_then(|(_, value)| value)
     {
         return Ok(Some(LixChangeRow::Direct(change)));
     }
@@ -310,10 +309,9 @@ where
             commit_ids: std::slice::from_ref(&commit_id),
         })
         .await?
-        .entries
         .into_iter()
         .next()
-        .flatten()
+        .and_then(|(_, value)| value)
         .ok_or_else(|| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,

--- a/packages/engine/src/storage_adapter/context.rs
+++ b/packages/engine/src/storage_adapter/context.rs
@@ -13,6 +13,7 @@ use crate::storage_adapter::{
     StorageWriteSetError, StorageWriteSetStats,
 };
 
+use super::exact_get_many;
 use super::spaces::{MUTATION_REVISION_SPACE, TRACKED_MUTATION_REVISION_SPACE};
 
 const MUTATION_REVISION_KEY: &[u8] = b"global";
@@ -156,15 +157,17 @@ where
     where
         R: StorageAdapterRead + ?Sized,
     {
-        let values = read
-            .get_many(&[crate::storage::GetManyRequest {
+        let values = exact_get_many(
+            read,
+            &[crate::storage::GetManyRequest {
                 space: MUTATION_REVISION_SPACE,
                 keys: &[mutation_revision_key()],
                 opts: GetOptions {
                     projection: CoreProjection::FullValue,
                 },
-            }])
-            .await?;
+            }],
+        )
+        .await?;
         Ok(values
             .values
             .into_iter()
@@ -182,15 +185,17 @@ where
     where
         R: StorageAdapterRead + ?Sized,
     {
-        let values = read
-            .get_many(&[crate::storage::GetManyRequest {
+        let values = exact_get_many(
+            read,
+            &[crate::storage::GetManyRequest {
                 space: TRACKED_MUTATION_REVISION_SPACE,
                 keys: &[mutation_revision_key()],
                 opts: GetOptions {
                     projection: CoreProjection::FullValue,
                 },
-            }])
-            .await?;
+            }],
+        )
+        .await?;
         Ok(values
             .values
             .into_iter()

--- a/packages/engine/src/storage_adapter/mod.rs
+++ b/packages/engine/src/storage_adapter/mod.rs
@@ -36,6 +36,7 @@ pub use crate::storage::{
 pub(crate) use crate::storage::{PutBatch, PutEntry};
 
 pub use context::StorageAdapter;
+pub(crate) use point::exact_get_many;
 pub use point::{PointReadPlan, PointValues, RequestedToUnique, RequestedToUniqueRef};
 pub(crate) use read_scope::SharedStorageAdapterRead;
 pub use read_scope::{StorageAdapterRead, StorageAdapterReadScope};

--- a/packages/engine/src/storage_adapter/point.rs
+++ b/packages/engine/src/storage_adapter/point.rs
@@ -2,12 +2,45 @@ use std::collections::{HashMap, HashSet};
 
 use ahash::RandomState;
 
-use crate::storage::{GetOptions, Key, ProjectedValue, StorageError};
+use crate::storage::{
+    GetManyRequest, GetManyResult, GetOptions, Key, ProjectedValue, StorageError,
+};
 use crate::storage_adapter::{
     StorageAdapterRead, StorageReadResult, StorageReadStats, StorageSpace,
 };
 
 type FastHashBuilder = RandomState;
+
+/// Executes one flattened exact-read batch and enforces the storage contract.
+///
+/// Every consumer that interprets `get_many` slots must pass through this
+/// boundary so malformed backends cannot turn short reads into misses or
+/// shift extra values into a later logical request.
+pub(crate) async fn exact_get_many<R>(
+    read: &R,
+    requests: &[GetManyRequest<'_>],
+) -> Result<GetManyResult, StorageError>
+where
+    R: StorageAdapterRead + ?Sized,
+{
+    let expected = requests.iter().try_fold(0usize, |total, request| {
+        total.checked_add(request.keys.len())
+    });
+    let Some(expected) = expected else {
+        return Err(StorageError::Corruption(
+            "exact point-read request cardinality overflowed usize".to_string(),
+        ));
+    };
+    let result = read.get_many(requests).await?;
+    if result.values.len() != expected {
+        return Err(StorageError::Corruption(format!(
+            "exact point read returned {} values for {expected} requested keys in a {}-request batch",
+            result.values.len(),
+            requests.len()
+        )));
+    }
+    Ok(result)
+}
 
 #[derive(Clone, Debug)]
 pub struct PointReadPlan {
@@ -91,14 +124,16 @@ impl PointReadPlan {
     where
         R: StorageAdapterRead + ?Sized,
     {
-        let unique_values = read
-            .get_many(&[crate::storage::GetManyRequest {
+        let unique_values = exact_get_many(
+            read,
+            &[GetManyRequest {
                 space: self.space,
                 keys: &self.logical_unique_keys,
                 opts,
-            }])
-            .await?
-            .values;
+            }],
+        )
+        .await?
+        .values;
         Ok(StorageReadResult::new(
             PointValues {
                 unique_values,

--- a/packages/engine/src/storage_adapter/reader.rs
+++ b/packages/engine/src/storage_adapter/reader.rs
@@ -19,7 +19,7 @@ mod tests {
     };
     use crate::storage_adapter::{
         PointReadPlan, ScanPlan, SharedStorageAdapterRead, StorageAdapter, StorageAdapterRead,
-        StorageAdapterReadScope, StorageReadStats, StorageSpace,
+        StorageAdapterReadScope, StorageReadStats, StorageSpace, exact_get_many,
     };
 
     fn key(bytes: &'static str) -> Key {
@@ -87,6 +87,29 @@ mod tests {
     struct OverlapRead {
         entered: Arc<tokio::sync::Barrier>,
         release: Arc<tokio::sync::Semaphore>,
+    }
+
+    #[derive(Clone, Copy)]
+    struct WrongCardinalityRead {
+        returned: usize,
+    }
+
+    impl StorageRead for WrongCardinalityRead {
+        async fn get_many(
+            &self,
+            _requests: &[GetManyRequest<'_>],
+        ) -> Result<GetManyResult, StorageError> {
+            Ok(GetManyResult::new(vec![None; self.returned]))
+        }
+
+        async fn scan(
+            &self,
+            _space: StorageSpace,
+            _range: KeyRange,
+            _opts: ScanOptions,
+        ) -> Result<ScanChunk, StorageError> {
+            unreachable!("wrong-cardinality test does not scan")
+        }
     }
 
     impl StorageRead for OverlapRead {
@@ -199,6 +222,54 @@ mod tests {
             assert_eq!(result.stats.storage_calls, 1);
         }
         assert_eq!(*seen.lock().expect("spy lock"), [key("a"), key("b")]);
+    }
+
+    #[tokio::test]
+    async fn point_reads_reject_short_and_long_backend_results() {
+        let plan = PointReadPlan::from_unique_keys(space(), vec![key("a"), key("b")]);
+        for returned in [1, 3] {
+            let read = StorageAdapterReadScope::new(WrongCardinalityRead { returned });
+            let error = plan
+                .materialize(&read, GetOptions::default())
+                .await
+                .expect_err("malformed backend result must fail");
+            assert!(matches!(error, StorageError::Corruption(_)));
+            assert!(
+                error
+                    .to_string()
+                    .contains("2 requested keys in a 1-request batch")
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn exact_multi_request_reads_reject_short_and_long_backend_results() {
+        let left_keys = [key("a")];
+        let right_keys = [key("b"), key("c")];
+        let requests = [
+            GetManyRequest {
+                space: space(),
+                keys: &left_keys,
+                opts: GetOptions::default(),
+            },
+            GetManyRequest {
+                space: space(),
+                keys: &right_keys,
+                opts: GetOptions::default(),
+            },
+        ];
+        for returned in [2, 4] {
+            let read = StorageAdapterReadScope::new(WrongCardinalityRead { returned });
+            let error = exact_get_many(&read, &requests)
+                .await
+                .expect_err("malformed multi-request backend result must fail");
+            assert!(matches!(error, StorageError::Corruption(_)));
+            assert!(
+                error
+                    .to_string()
+                    .contains("3 requested keys in a 2-request batch")
+            );
+        }
     }
 
     #[tokio::test]

--- a/packages/engine/src/test_support.rs
+++ b/packages/engine/src/test_support.rs
@@ -556,9 +556,8 @@ async fn stage_test_changelog_commit(
         })
         .await?;
     let generation = parent_records
-        .entries
         .into_iter()
-        .map(|record| {
+        .map(|(_, record)| {
             record
                 .map(|record| record.generation)
                 .ok_or_else(|| crate::LixError::unknown("test changelog parent commit is missing"))

--- a/packages/engine/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/engine/src/tracked_state/commit_root_rebuild.rs
@@ -206,12 +206,18 @@ where
             commit_ids: &commit_ids,
         })
         .await?;
-    let entry = batch.entries.into_iter().next().flatten().ok_or_else(|| {
-        LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!("cannot rebuild tracked_state commit_root for unknown commit '{commit_id}'"),
-        )
-    })?;
+    let entry = batch
+        .into_iter()
+        .next()
+        .and_then(|(_, value)| value)
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "cannot rebuild tracked_state commit_root for unknown commit '{commit_id}'"
+                ),
+            )
+        })?;
     let commit = entry;
     // The packed delta is the sole membership and payload authority. Preserve
     // the identity value's original created_at independently from this

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -1703,13 +1703,14 @@ where
             return Ok(());
         }
         let commit_id_typed = CommitId::parse_lix(commit_id, "commit-delta winner commit_id")?;
+        let commit_ids = [commit_id_typed];
         let mut changelog_reader = ChangelogContext::new().reader(&mut self.store);
         let batch = changelog_reader
             .load_commits(CommitLoadRequest {
-                commit_ids: &[commit_id_typed],
+                commit_ids: &commit_ids,
             })
             .await?;
-        let Some(_) = batch.entries.into_iter().next().flatten() else {
+        let Some(_) = batch.into_iter().next().and_then(|(_, value)| value) else {
             return Err(LixError::unknown(format!(
                 "changelog commit '{commit_id}' is missing while validating tracked-state commit-root rows"
             )));
@@ -1813,7 +1814,7 @@ where
                 commit_ids: &commit_ids,
             })
             .await?;
-        let Some(entry) = batch.entries.into_iter().next().flatten() else {
+        let Some(entry) = batch.into_iter().next().and_then(|(_, value)| value) else {
             return Err(LixError::unknown(format!(
                 "changelog commit '{commit_id}' is missing while validating tracked-state commit-root metadata"
             )));
@@ -1886,7 +1887,7 @@ where
                 commit_ids: &commit_ids,
             })
             .await?;
-        let Some(commit) = batch.entries.into_iter().next().flatten() else {
+        let Some(commit) = batch.into_iter().next().and_then(|(_, value)| value) else {
             return Ok(None);
         };
         for parent_id in commit.parent_commit_ids.iter().skip(1) {
@@ -3141,13 +3142,14 @@ where
             return Ok(cached.clone());
         }
         let record = {
+            let commit_ids = [commit_id];
             let mut reader = ChangelogContext::new().reader(&self.store);
             let batch = reader
                 .load_commits(CommitLoadRequest {
-                    commit_ids: &[commit_id],
+                    commit_ids: &commit_ids,
                 })
                 .await?;
-            match batch.entries.into_iter().next().flatten() {
+            match batch.into_iter().next().and_then(|(_, value)| value) {
                 Some(record) => record,
                 None => {
                     return Err(LixError::new(

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -16,6 +16,7 @@ use crate::storage_adapter::{
     StorageCoreProjection, StorageError, StorageGetManyRequest, StorageGetManyResult,
     StorageGetOptions, StorageKey, StorageKeyRange, StorageProjectedValue, StorageScanChunk,
     StorageScanOptions, StorageSpace, StorageSpaceId, StorageValue, StorageWriteSet,
+    exact_get_many,
 };
 use crate::tracked_state::codec::{
     DecodedLeafNodeRef, DecodedNodeRef, EncodedLeafEntry, EncodedLeafEntryRef, PendingChunkBatch,
@@ -5671,18 +5672,7 @@ where
         &self,
         requests: &[StorageGetManyRequest<'_>],
     ) -> Result<StorageGetManyResult, StorageError> {
-        let mut result = self.store.get_many(requests).await?;
-        let requested = requests
-            .iter()
-            .map(|request| request.keys.len())
-            .sum::<usize>();
-        if result.values.len() != requested {
-            return Err(StorageError::Corruption(format!(
-                "tracked-state staged audit requested {} point reads but storage returned {} slots",
-                requested,
-                result.values.len()
-            )));
-        }
+        let mut result = exact_get_many(self.store, requests).await?;
         let mut slots = result.values.iter_mut();
         for request in requests {
             for (key, slot) in request.keys.iter().zip(slots.by_ref()) {

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -919,12 +919,11 @@ async fn stage_changelog_commits(
             commit_ids: &external_parent_ids,
         })
         .await?;
-    let mut generations = external_parent_ids
+    let mut generations = external_parent_records
         .into_iter()
-        .zip(external_parent_records.entries)
         .map(|(commit_id, record)| {
             record
-                .map(|record| (commit_id, record.generation))
+                .map(|record| (*commit_id, record.generation))
                 .ok_or_else(|| {
                     LixError::new(
                         LixError::CODE_INTERNAL_ERROR,
@@ -4141,7 +4140,7 @@ async fn ensure_explicit_branch_ref_targets_exist(
             commit_ids: &target_ids,
         })
         .await?;
-    for (commit_id, entry) in target_ids.into_iter().zip(commits.entries) {
+    for (commit_id, entry) in commits {
         if entry.is_none() {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
@@ -5345,13 +5344,14 @@ mod tests {
                 .await
                 .expect("read should open"),
         );
+        let commit_ids = [commit_id("test-uuid-1")];
         let commits = changelog_reader
             .load_commits(crate::changelog::CommitLoadRequest {
-                commit_ids: &[commit_id("test-uuid-1")],
+                commit_ids: &commit_ids,
             })
             .await
             .expect("changelog commit should load");
-        let Some(record) = commits.entries.into_iter().next().flatten() else {
+        let Some(record) = commits.into_iter().next().and_then(|(_, value)| value) else {
             panic!("changelog commit should exist");
         };
         assert_eq!(record.change_id, change_id("test-uuid-2"));
@@ -5380,14 +5380,15 @@ mod tests {
             .map(|member| &member.change)
             .expect("tracked change should have an authoritative packed payload");
         assert_eq!(change.schema_key, "test_schema");
+        let change_ids = [change_id("change-1"), record.change_id];
         let changes = changelog_reader
             .load_changes(crate::changelog::ChangeLoadRequest {
-                change_ids: &[change_id("change-1"), record.change_id],
+                change_ids: &change_ids,
             })
             .await
             .expect("changelog change should load");
         assert!(
-            changes.entries.iter().all(Option::is_none),
+            changes.iter().all(|(_, value)| value.is_none()),
             "tracked and derived commit changes must not be duplicated in changelog.change"
         );
 
@@ -7132,18 +7133,21 @@ mod tests {
                 .await
                 .expect("read should open"),
         );
+        let commit_ids = [
+            CommitId::for_test_label("parent-commit"),
+            CommitId::for_test_label("child-commit"),
+        ];
         let commits = changelog_reader
             .load_commits(crate::changelog::CommitLoadRequest {
-                commit_ids: &[
-                    CommitId::for_test_label("parent-commit"),
-                    CommitId::for_test_label("child-commit"),
-                ],
+                commit_ids: &commit_ids,
             })
             .await
             .expect("commits should load");
-        assert!(commits.entries.iter().all(Option::is_some));
-        assert_eq!(commits.entries[0].as_ref().unwrap().generation, 0);
-        assert_eq!(commits.entries[1].as_ref().unwrap().generation, 1);
+        let generations = commits
+            .into_iter()
+            .map(|(_, commit)| commit.expect("commit").generation)
+            .collect::<Vec<_>>();
+        assert_eq!(generations, [0, 1]);
     }
 
     #[tokio::test]
@@ -7205,15 +7209,16 @@ mod tests {
                 .await
                 .expect("read should open"),
         );
+        let change_ids = [change_id("change-untracked")];
         let changes = changelog_reader
             .load_changes(crate::changelog::ChangeLoadRequest {
-                change_ids: &[change_id("change-untracked")],
+                change_ids: &change_ids,
             })
             .await
             .expect("untracked changelog lookup should load");
         assert_eq!(
-            changes.entries,
-            vec![None],
+            changes.iter().all(|(_, value)| value.is_none()),
+            true,
             "untracked state is history-free and must not enter the changelog"
         );
     }
@@ -7422,13 +7427,14 @@ mod tests {
                 .await
                 .expect("read should open"),
         );
+        let commit_ids = [commit_id("test-uuid-1")];
         let commits = changelog_reader
             .load_commits(crate::changelog::CommitLoadRequest {
-                commit_ids: &[commit_id("test-uuid-1")],
+                commit_ids: &commit_ids,
             })
             .await
             .expect("changelog commit should load");
-        let Some(commit) = commits.entries.into_iter().next().flatten() else {
+        let Some(commit) = commits.into_iter().next().and_then(|(_, value)| value) else {
             panic!("changelog commit should exist");
         };
         assert_eq!(commit.change_id, change_id("test-uuid-2"));
@@ -7559,13 +7565,14 @@ mod tests {
                 .await
                 .expect("read should open"),
         );
+        let commit_ids = [commit_id("test-uuid-1")];
         let commits = changelog_reader
             .load_commits(crate::changelog::CommitLoadRequest {
-                commit_ids: &[commit_id("test-uuid-1")],
+                commit_ids: &commit_ids,
             })
             .await
             .expect("changelog commit should load");
-        let Some(commit) = commits.entries.into_iter().next().flatten() else {
+        let Some(commit) = commits.into_iter().next().and_then(|(_, value)| value) else {
             panic!("changelog commit should exist");
         };
         assert_eq!(commit.change_id, change_id("test-uuid-2"));


### PR DESCRIPTION
## Summary
- replace ordered raw `Vec<Option<Record>>` exact reads with a generic borrowed `ExactBatch<K, V>` that centrally verifies cardinality and decoded identity
- propagate keyed results through changelog, change materialization, commit graph, SQL, GC, initialization, tracked-state, and transaction consumers
- centralize flattened storage `get_many` cardinality validation for point plans, multi-space append collision checks, media uploads, idempotency, mutation revisions, and staged tracked-state reads
- expand the changelog scorecard with 1,000-key ordered and reversed/duplicate/missing workloads using five-sample medians

## Correctness
- rejects short and long single- and multi-request backend responses as storage corruption
- rejects a commit record stored under a different commit key before it can poison graph topology/cache state
- preserves duplicate requests, missing slots, and caller order without exposing unkeyed result vectors

## Performance
Five-process A/B medians versus `origin/main` stayed within noise (all latency deltas within ±5.5%). Median process RSS was 18.05 MB on main and 18.16 MB on this branch (+0.6%). The wrapper borrows request keys and adds no key clones, hash maps, or successful-path allocation.

## Validation
- `RUST_MIN_STACK=16777216 cargo test -p lix_engine --features all-simulations` (1,798 unit, 802 integration, doctests)
- `cargo clippy -p lix_engine --features all-simulations,storage-benches --all-targets -- -D warnings`
- two independent subagent reviews: correctness/architecture approved; performance/RSS approved

No changenote was added because this is an internal engine refactor with no public API or user-visible behavior change.