### PR TITLE
fix(sql): keep aggregate statistics behind row-changing plans

### DIFF
--- a/packages/engine/src/sql2/aggregate_statistics.rs
+++ b/packages/engine/src/sql2/aggregate_statistics.rs
@@ -80,6 +80,11 @@ fn optimizable_partial_aggregate(plan: &dyn ExecutionPlan) -> Option<Arc<dyn Exe
             && partial.mode().input_mode() == AggregateInputMode::Raw
             && partial.group_expr().is_empty()
             && partial.filter_expr().iter().all(Option::is_none)
+            // An operator tree that changes rows can expose exact-looking
+            // column statistics that do not prove the aggregate over its
+            // output. Restrict this shortcut to a leaf source whose
+            // statistics apply directly to every consumed row.
+            && partial.input().children().is_empty()
         {
             return Some(child);
         }

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -3856,6 +3856,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn filtered_sum_does_not_use_unfiltered_exact_statistics() {
+        let storage = Memory::new();
+        let init_receipt = Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let engine = Engine::new(storage).await.expect("engine should open");
+        let session = engine
+            .open_session(init_receipt.main_branch_id)
+            .await
+            .expect("session should open");
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+                 VALUES (\
+                 lix_json('{\"x-lix-key\":\"aggregate_filter_test\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"value\":{\"type\":\"integer\"}},\"required\":[\"id\",\"value\"],\"additionalProperties\":false}'),\
+                 false, false)",
+                &[],
+            )
+            .await
+            .expect("test schema should register");
+        session
+            .execute(
+                "INSERT INTO aggregate_filter_test (id, value) VALUES ('a', 10), ('b', 20)",
+                &[],
+            )
+            .await
+            .expect("test rows should insert");
+
+        let result = session
+            .execute(
+                "SELECT SUM(value) AS total, AVG(value) AS average \
+                 FROM aggregate_filter_test WHERE value < 0",
+                &[],
+            )
+            .await
+            .expect("filtered aggregate should execute");
+
+        assert_eq!(result.rows()[0].values(), &[Value::Null, Value::Null]);
+    }
+
+    #[tokio::test]
     async fn execute_sql_rejects_extra_parameters() {
         let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
         let live_state = Arc::new(DummyLiveStateReader);


### PR DESCRIPTION
Closes #1135.

## What changed

- Restrict Lix's exact SUM/AVG statistics substitution to partial aggregates that consume a leaf source directly.
- Add a public SQL regression proving filtered `SUM` and `AVG` over an empty row set both return `NULL`.

## Root cause

`ExactAggregateStatistics` accepted exact-looking column sums from an operator tree whose filters/joins had changed the row set. TPC-H Q17 therefore substituted the full `lineitem.l_extendedprice` sum and reduced the query to a constant `ProjectionExec` over `PlaceholderRowExec`.

The leaf gate is intentionally conservative. It retains the fast path for direct `SUM/AVG(column) FROM table` scans and rejects derived/filter/join plans until exact-stat provenance can prove cardinality preservation.

## Impact

- Correctness axis: filtered SUM/AVG goes from silently wrong to SQL-correct (100% of the new regression).
- TPC-H Q17 blocker #1135 is fixed generically, without query recognition.
- Direct leaf aggregate-statistics optimization remains enabled.

## Validation

- `cargo test -p lix_engine sql2::aggregate_statistics --all-features` — 5 passed
- `cargo test -p lix_engine filtered_sum_does_not_use_unfiltered_exact_statistics --all-features` — passed
- `git diff --check` — passed
- Independent sub-agent root-cause and code review — no blocking findings