### PR TITLE
bench(engine): add neutral common-type TPC-H suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arrayref"
@@ -361,6 +364,7 @@ version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
 dependencies = [
+ "bitflags",
  "serde_core",
  "serde_json",
 ]
@@ -741,7 +745,7 @@ checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
 dependencies = [
  "cap-primitives",
  "cap-std",
- "rustix",
+ "rustix 1.1.4",
  "smallvec",
 ]
 
@@ -757,7 +761,7 @@ dependencies = [
  "io-lifetimes",
  "ipnet",
  "maybe-owned",
- "rustix",
+ "rustix 1.1.4",
  "rustix-linux-procfs",
  "windows-sys 0.59.0",
  "winx",
@@ -772,7 +776,7 @@ dependencies = [
  "cap-primitives",
  "io-extras",
  "io-lifetimes",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -785,7 +789,7 @@ dependencies = [
  "cap-primitives",
  "iana-time-zone",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "winx",
 ]
 
@@ -1055,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "7.2.2"
+version = "7.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
  "crossterm",
  "unicode-segmentation",
@@ -1377,15 +1381,14 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.29.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
- "document-features",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "winapi",
 ]
 
@@ -2076,6 +2079,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2118,19 +2132,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "document-features"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
-dependencies = [
- "litrs",
-]
-
-[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "duckdb"
+version = "1.10505.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "970e05eedd3f55c435194d9104f90a9b4a79a80d6e73251bc9ff43e178130c4e"
+dependencies = [
+ "arrow",
+ "cast",
+ "comfy-table",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink 0.10.0",
+ "libduckdb-sys",
+ "num-integer",
+ "strum",
+]
 
 [[package]]
 name = "duration-str"
@@ -2281,6 +2303,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2357,7 +2389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.59.0",
 ]
 
@@ -2629,6 +2661,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -3177,6 +3218,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libduckdb-sys"
+version = "1.10505.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb514dab5e271e849235c1cb98bd65a2ae107fbd619a6740219319c54a71d95"
+dependencies = [
+ "cc",
+ "flate2",
+ "pkg-config",
+ "serde",
+ "serde_json",
+ "tar",
+ "ureq",
+ "vcpkg",
+ "zip 6.0.0",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3258,6 +3316,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -3267,12 +3331,6 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
-
-[[package]]
-name = "litrs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lix_cli"
@@ -3295,7 +3353,7 @@ dependencies = [
  "sha2",
  "tokio",
  "uuid",
- "zip",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -3341,7 +3399,7 @@ dependencies = [
  "uuid",
  "web-time",
  "xxhash-rust",
- "zip",
+ "zip 8.6.0",
  "zstd",
 ]
 
@@ -3355,6 +3413,7 @@ dependencies = [
  "bytes",
  "codspeed-criterion-compat",
  "datafusion",
+ "duckdb",
  "futures-util",
  "lix_engine",
  "lix_rocksdb_storage",
@@ -3370,6 +3429,7 @@ dependencies = [
  "smallvec",
  "tempfile",
  "tokio",
+ "tpchgen",
  "tracing-subscriber",
  "ulid",
  "xxhash-rust",
@@ -3465,7 +3525,7 @@ dependencies = [
  "wasm-encoder 0.248.0",
  "wasmtime",
  "wasmtime-wasi",
- "zip",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -3497,7 +3557,7 @@ dependencies = [
  "uuid",
  "wasmtime",
  "wasmtime-wasi",
- "zip",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -3530,7 +3590,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
- "zip",
+ "zip 8.6.0",
  "zstd",
 ]
 
@@ -3666,7 +3726,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -4604,6 +4664,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rocksdb"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4622,7 +4696,7 @@ dependencies = [
  "bitflags",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.9.1",
  "libsqlite3-sys",
  "smallvec",
 ]
@@ -4660,6 +4734,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -4667,7 +4754,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -4678,7 +4765,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
 dependencies = [
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -5072,6 +5194,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5120,6 +5269,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5134,7 +5294,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -5438,6 +5598,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
+name = "tpchgen"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26c6d047694183517044ea72d2e0337b05b43d40809f0958f603a7e5a286855"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5580,6 +5746,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ab5172ab0c2b6d01a9bb4f9332f7c1211193ea002742188040d09ea4eafe867"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5590,6 +5790,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -5856,7 +6062,7 @@ dependencies = [
  "once_cell",
  "postcard",
  "pulley-interpreter",
- "rustix",
+ "rustix 1.1.4",
  "semver",
  "serde",
  "serde_derive",
@@ -5919,7 +6125,7 @@ dependencies = [
  "directories-next",
  "log",
  "postcard",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_derive",
  "sha2",
@@ -5997,7 +6203,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "rustix",
+ "rustix 1.1.4",
  "wasmtime-environ",
  "wasmtime-internal-versioned-export-macros",
  "windows-sys 0.61.2",
@@ -6098,7 +6304,7 @@ dependencies = [
  "io-extras",
  "io-lifetimes",
  "rand 0.10.1",
- "rustix",
+ "rustix 1.1.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6139,6 +6345,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -6328,6 +6543,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6734,6 +6958,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6810,6 +7044,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6844,6 +7084,20 @@ dependencies = [
 
 [[package]]
 name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zip"
 version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
@@ -6866,6 +7120,18 @@ name = "zmij"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -18,6 +18,7 @@ rocksdb = ["dep:lix_rocksdb_storage"]
 sqlite = ["dep:lix_sqlite_storage", "dep:rusqlite"]
 slatedb = ["dep:lix_slatedb_storage", "dep:object_store", "dep:slatedb", "dep:ulid"]
 storage-benches = ["lix_engine/storage-benches", "rocksdb", "sqlite"]
+tpch = ["dep:duckdb", "dep:tpchgen"]
 # Opt-in profiling build that routes Rust allocations through libc so tools
 # such as heaptrack can attribute transient allocation churn to call stacks.
 # Normal tracked-CRUD builds wrap mimalloc with byte accounting so latency
@@ -34,6 +35,8 @@ object_store = { version = "0.14", default-features = false, features = ["fs"], 
 slatedb = { version = "0.14.1", default-features = false, features = ["moka", "zstd"], optional = true }
 ulid = { version = "1.2.1", optional = true }
 rusqlite = { version = "0.32", features = ["bundled"], optional = true }
+duckdb = { version = "=1.10505.0", features = ["bundled"], optional = true }
+tpchgen = { version = "=3.0.0", optional = true }
 zstd = "0.13"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
@@ -116,6 +119,12 @@ name = "tracked_state_crud"
 path = "benches/tracked_state_crud/main.rs"
 harness = false
 required-features = ["storage-benches"]
+
+[[bench]]
+name = "tpch"
+path = "benches/tpch/main.rs"
+harness = false
+required-features = ["storage-benches", "tpch"]
 
 [[bench]]
 name = "tracked_working_diff"

--- a/packages/engine-benchmarks/benches/tpch/README.md
+++ b/packages/engine-benchmarks/benches/tpch/README.md
@@ -1,0 +1,31 @@
+# Neutral TPC-H benchmark
+
+This benchmark compares DuckDB and Lix through the same Rust process and the
+same owned-row result boundary. Both engines receive deterministic `tpchgen`
+data with common physical types: ISO dates are `VARCHAR`, monetary values are
+`DOUBLE`, and integral values are `BIGINT`. Consequently, these results must
+not be compared with published native-type TPC-H results.
+
+Run the full common-type suite with:
+
+```sh
+cargo bench -p lix_engine_benchmarks --bench tpch \
+  --features storage-benches,tpch
+```
+
+Set `LIX_TPCH_SCALE_FACTOR=0.2` for more than one million `lineitem` rows and
+`LIX_TPCH_SAMPLES=9` for qualification measurements. Set
+`LIX_TPCH_EXPLAIN=1` to emit the Lix physical profile. Set
+`LIX_TPCH_QUERY` to one integer from 1 through 22 to isolate a query. All eight
+tables and Q1-Q22 are live. Its JSON `suite` field deliberately says
+`tpch-derived-common-types` because the shared types differ from native TPC-H
+dates and decimals.
+
+Q17 is a regression guard for the correlated aggregate-statistics correctness
+defect fixed by <https://github.com/opral/lix/pull/1137>.
+
+The padded storage identity columns are present in both engines and absent
+from benchmark SQL. They make the initial load deterministically ordered and
+allow Lix to publish its normal packed analytical base. Results from this
+pristine state do not qualify transactional overlays; sparse and moderate
+overlay scenarios are separate required benchmark states.

--- a/packages/engine-benchmarks/benches/tpch/config.rs
+++ b/packages/engine-benchmarks/benches/tpch/config.rs
@@ -1,0 +1,59 @@
+use std::time::Duration;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Config {
+    pub(crate) scale_factor: f64,
+    pub(crate) samples: usize,
+}
+
+impl Config {
+    pub(crate) fn from_env() -> Self {
+        let scale_factor = env_parse("LIX_TPCH_SCALE_FACTOR", 0.01_f64);
+        let samples = env_parse("LIX_TPCH_SAMPLES", 5_usize);
+        assert!(
+            scale_factor.is_finite() && scale_factor >= 0.001,
+            "LIX_TPCH_SCALE_FACTOR must be finite and at least 0.001"
+        );
+        assert!(samples > 0, "LIX_TPCH_SAMPLES must be positive");
+        Self {
+            scale_factor,
+            samples,
+        }
+    }
+}
+
+fn env_parse<T>(name: &str, default: T) -> T
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    std::env::var(name).map_or(default, |value| {
+        value
+            .parse()
+            .unwrap_or_else(|error| panic!("invalid {name}={value:?}: {error}"))
+    })
+}
+
+pub(crate) fn median(samples: &[Duration]) -> Duration {
+    percentile(samples, 0.5)
+}
+
+pub(crate) fn p90(samples: &[Duration]) -> Duration {
+    percentile(samples, 0.9)
+}
+
+pub(crate) fn median_absolute_deviation(samples: &[Duration]) -> Duration {
+    let median = median(samples);
+    let deviations = samples
+        .iter()
+        .map(|sample| sample.abs_diff(median))
+        .collect::<Vec<_>>();
+    self::median(&deviations)
+}
+
+fn percentile(samples: &[Duration], percentile: f64) -> Duration {
+    let mut sorted = samples.to_vec();
+    sorted.sort_unstable();
+    let index = ((sorted.len() - 1) as f64 * percentile).ceil() as usize;
+    sorted[index]
+}

--- a/packages/engine-benchmarks/benches/tpch/data.rs
+++ b/packages/engine-benchmarks/benches/tpch/data.rs
@@ -1,0 +1,237 @@
+use tpchgen::generators::{
+    CustomerGenerator, LineItemGenerator, NationGenerator, OrderGenerator, PartGenerator,
+    PartSuppGenerator, RegionGenerator, SupplierGenerator,
+};
+
+#[derive(Debug)]
+pub(crate) struct Region {
+    pub(crate) rowkey: String,
+    pub(crate) regionkey: i64,
+    pub(crate) name: String,
+    pub(crate) comment: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct Nation {
+    pub(crate) rowkey: String,
+    pub(crate) nationkey: i64,
+    pub(crate) name: String,
+    pub(crate) regionkey: i64,
+    pub(crate) comment: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct Supplier {
+    pub(crate) rowkey: String,
+    pub(crate) suppkey: i64,
+    pub(crate) name: String,
+    pub(crate) address: String,
+    pub(crate) nationkey: i64,
+    pub(crate) phone: String,
+    pub(crate) acctbal: f64,
+    pub(crate) comment: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct Part {
+    pub(crate) rowkey: String,
+    pub(crate) partkey: i64,
+    pub(crate) name: String,
+    pub(crate) mfgr: String,
+    pub(crate) brand: String,
+    pub(crate) part_type: String,
+    pub(crate) size: i64,
+    pub(crate) container: String,
+    pub(crate) retailprice: f64,
+    pub(crate) comment: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct PartSupp {
+    pub(crate) rowkey: String,
+    pub(crate) partkey: i64,
+    pub(crate) suppkey: i64,
+    pub(crate) availqty: i64,
+    pub(crate) supplycost: f64,
+    pub(crate) comment: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct Customer {
+    pub(crate) rowkey: String,
+    pub(crate) custkey: i64,
+    pub(crate) name: String,
+    pub(crate) address: String,
+    pub(crate) nationkey: i64,
+    pub(crate) phone: String,
+    pub(crate) acctbal: f64,
+    pub(crate) mktsegment: String,
+    pub(crate) comment: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct Order {
+    pub(crate) rowkey: String,
+    pub(crate) orderkey: i64,
+    pub(crate) custkey: i64,
+    pub(crate) orderstatus: String,
+    pub(crate) totalprice: f64,
+    pub(crate) orderdate: String,
+    pub(crate) orderpriority: String,
+    pub(crate) clerk: String,
+    pub(crate) shippriority: i64,
+    pub(crate) comment: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct LineItem {
+    pub(crate) rowkey: String,
+    pub(crate) orderkey: i64,
+    pub(crate) partkey: i64,
+    pub(crate) suppkey: i64,
+    pub(crate) linenumber: i64,
+    pub(crate) quantity: i64,
+    pub(crate) extendedprice: f64,
+    pub(crate) discount: f64,
+    pub(crate) tax: f64,
+    pub(crate) returnflag: String,
+    pub(crate) linestatus: String,
+    pub(crate) shipdate: String,
+    pub(crate) commitdate: String,
+    pub(crate) receiptdate: String,
+    pub(crate) shipinstruct: String,
+    pub(crate) shipmode: String,
+    pub(crate) comment: String,
+}
+
+pub(crate) fn regions(scale_factor: f64) -> impl Iterator<Item = Region> {
+    RegionGenerator::new(scale_factor, 1, 1)
+        .iter()
+        .map(|row| Region {
+            rowkey: format!("{:012}", row.r_regionkey),
+            regionkey: row.r_regionkey,
+            name: row.r_name.to_string(),
+            comment: row.r_comment.to_string(),
+        })
+}
+
+pub(crate) fn nations(scale_factor: f64) -> impl Iterator<Item = Nation> {
+    NationGenerator::new(scale_factor, 1, 1)
+        .iter()
+        .map(|row| Nation {
+            rowkey: format!("{:012}", row.n_nationkey),
+            nationkey: row.n_nationkey,
+            name: row.n_name.to_string(),
+            regionkey: row.n_regionkey,
+            comment: row.n_comment.to_string(),
+        })
+}
+
+pub(crate) fn suppliers(scale_factor: f64) -> impl Iterator<Item = Supplier> {
+    SupplierGenerator::new(scale_factor, 1, 1)
+        .iter()
+        .map(|row| Supplier {
+            rowkey: format!("{:012}", row.s_suppkey),
+            suppkey: row.s_suppkey,
+            name: row.s_name.to_string(),
+            address: row.s_address.to_string(),
+            nationkey: row.s_nationkey,
+            phone: row.s_phone.to_string(),
+            acctbal: row.s_acctbal.as_f64(),
+            comment: row.s_comment,
+        })
+}
+
+pub(crate) fn customers(scale_factor: f64) -> impl Iterator<Item = Customer> {
+    CustomerGenerator::new(scale_factor, 1, 1)
+        .iter()
+        .map(|row| Customer {
+            rowkey: format!("{:012}", row.c_custkey),
+            custkey: row.c_custkey,
+            name: row.c_name.to_string(),
+            address: row.c_address.to_string(),
+            nationkey: row.c_nationkey,
+            phone: row.c_phone.to_string(),
+            acctbal: row.c_acctbal.as_f64(),
+            mktsegment: row.c_mktsegment.to_string(),
+            comment: row.c_comment.to_string(),
+        })
+}
+
+pub(crate) fn parts(scale_factor: f64) -> impl Iterator<Item = Part> {
+    PartGenerator::new(scale_factor, 1, 1)
+        .iter()
+        .map(|row| Part {
+            rowkey: format!("{:012}", row.p_partkey),
+            partkey: row.p_partkey,
+            name: row.p_name.to_string(),
+            mfgr: row.p_mfgr.to_string(),
+            brand: row.p_brand.to_string(),
+            part_type: row.p_type.to_string(),
+            size: i64::from(row.p_size),
+            container: row.p_container.to_string(),
+            retailprice: row.p_retailprice.as_f64(),
+            comment: row.p_comment.to_string(),
+        })
+}
+
+pub(crate) fn partsupps(scale_factor: f64) -> impl Iterator<Item = PartSupp> {
+    PartSuppGenerator::new(scale_factor, 1, 1)
+        .iter()
+        .enumerate()
+        .map(|(ordinal, row)| PartSupp {
+            // tpchgen emits each part's suppliers in generator order rather
+            // than numeric supplier-key order. The ordinal keeps the shared
+            // physical identity strictly increasing for both engines.
+            rowkey: format!("{ordinal:016}"),
+            partkey: row.ps_partkey,
+            suppkey: row.ps_suppkey,
+            availqty: i64::from(row.ps_availqty),
+            supplycost: row.ps_supplycost.as_f64(),
+            comment: row.ps_comment.to_string(),
+        })
+}
+
+pub(crate) fn orders(scale_factor: f64) -> impl Iterator<Item = Order> {
+    OrderGenerator::new(scale_factor, 1, 1)
+        .iter()
+        .map(|row| Order {
+            rowkey: format!("{:012}", row.o_orderkey),
+            orderkey: row.o_orderkey,
+            custkey: row.o_custkey,
+            orderstatus: row.o_orderstatus.to_string(),
+            totalprice: row.o_totalprice.as_f64(),
+            orderdate: row.o_orderdate.to_string(),
+            orderpriority: row.o_orderpriority.to_string(),
+            clerk: row.o_clerk.to_string(),
+            shippriority: i64::from(row.o_shippriority),
+            comment: row.o_comment.to_string(),
+        })
+}
+
+pub(crate) fn lineitems(scale_factor: f64) -> impl Iterator<Item = LineItem> {
+    LineItemGenerator::new(scale_factor, 1, 1)
+        .iter()
+        .map(|row| LineItem {
+            // Lix's initial analytical base is published only when fresh rows
+            // arrive in physical identity order. Fixed-width components make
+            // lexicographic identity order equal TPC-H order/line order.
+            rowkey: format!("{:012}:{:02}", row.l_orderkey, row.l_linenumber),
+            orderkey: row.l_orderkey,
+            partkey: row.l_partkey,
+            suppkey: row.l_suppkey,
+            linenumber: i64::from(row.l_linenumber),
+            quantity: row.l_quantity,
+            extendedprice: row.l_extendedprice.as_f64(),
+            discount: row.l_discount.as_f64(),
+            tax: row.l_tax.as_f64(),
+            returnflag: row.l_returnflag.to_string(),
+            linestatus: row.l_linestatus.to_string(),
+            shipdate: row.l_shipdate.to_string(),
+            commitdate: row.l_commitdate.to_string(),
+            receiptdate: row.l_receiptdate.to_string(),
+            shipinstruct: row.l_shipinstruct.to_string(),
+            shipmode: row.l_shipmode.to_string(),
+            comment: row.l_comment.to_string(),
+        })
+}

--- a/packages/engine-benchmarks/benches/tpch/duckdb.rs
+++ b/packages/engine-benchmarks/benches/tpch/duckdb.rs
@@ -1,0 +1,256 @@
+use datafusion::arrow::record_batch::RecordBatch;
+use duckdb::{Connection, params};
+
+use crate::data;
+
+pub(crate) fn seeded(scale_factor: f64) -> Connection {
+    let mut connection = Connection::open_in_memory().expect("open DuckDB TPC-H control");
+    connection
+        .execute_batch(
+            r#"
+            SET threads = 1;
+            CREATE TABLE region (
+                r_rowkey VARCHAR NOT NULL PRIMARY KEY,
+                r_regionkey BIGINT NOT NULL,
+                r_name VARCHAR NOT NULL,
+                r_comment VARCHAR NOT NULL
+            );
+            CREATE TABLE nation (
+                n_rowkey VARCHAR NOT NULL PRIMARY KEY,
+                n_nationkey BIGINT NOT NULL,
+                n_name VARCHAR NOT NULL,
+                n_regionkey BIGINT NOT NULL,
+                n_comment VARCHAR NOT NULL
+            );
+            CREATE TABLE supplier (
+                s_rowkey VARCHAR NOT NULL PRIMARY KEY,
+                s_suppkey BIGINT NOT NULL,
+                s_name VARCHAR NOT NULL,
+                s_address VARCHAR NOT NULL,
+                s_nationkey BIGINT NOT NULL,
+                s_phone VARCHAR NOT NULL,
+                s_acctbal DOUBLE NOT NULL,
+                s_comment VARCHAR NOT NULL
+            );
+            CREATE TABLE part (
+                p_rowkey VARCHAR NOT NULL PRIMARY KEY,
+                p_partkey BIGINT NOT NULL,
+                p_name VARCHAR NOT NULL,
+                p_mfgr VARCHAR NOT NULL,
+                p_brand VARCHAR NOT NULL,
+                p_type VARCHAR NOT NULL,
+                p_size BIGINT NOT NULL,
+                p_container VARCHAR NOT NULL,
+                p_retailprice DOUBLE NOT NULL,
+                p_comment VARCHAR NOT NULL
+            );
+            CREATE TABLE partsupp (
+                ps_rowkey VARCHAR NOT NULL PRIMARY KEY,
+                ps_partkey BIGINT NOT NULL,
+                ps_suppkey BIGINT NOT NULL,
+                ps_availqty BIGINT NOT NULL,
+                ps_supplycost DOUBLE NOT NULL,
+                ps_comment VARCHAR NOT NULL
+            );
+            CREATE TABLE customer (
+                c_rowkey VARCHAR NOT NULL PRIMARY KEY,
+                c_custkey BIGINT NOT NULL,
+                c_name VARCHAR NOT NULL,
+                c_address VARCHAR NOT NULL,
+                c_nationkey BIGINT NOT NULL,
+                c_phone VARCHAR NOT NULL,
+                c_acctbal DOUBLE NOT NULL,
+                c_mktsegment VARCHAR NOT NULL,
+                c_comment VARCHAR NOT NULL
+            );
+            CREATE TABLE orders (
+                o_rowkey VARCHAR NOT NULL PRIMARY KEY,
+                o_orderkey BIGINT NOT NULL,
+                o_custkey BIGINT NOT NULL,
+                o_orderstatus VARCHAR NOT NULL,
+                o_totalprice DOUBLE NOT NULL,
+                o_orderdate VARCHAR NOT NULL,
+                o_orderpriority VARCHAR NOT NULL,
+                o_clerk VARCHAR NOT NULL,
+                o_shippriority BIGINT NOT NULL,
+                o_comment VARCHAR NOT NULL
+            );
+            CREATE TABLE lineitem (
+                l_rowkey VARCHAR NOT NULL PRIMARY KEY,
+                l_orderkey BIGINT NOT NULL,
+                l_partkey BIGINT NOT NULL,
+                l_suppkey BIGINT NOT NULL,
+                l_linenumber BIGINT NOT NULL,
+                l_quantity BIGINT NOT NULL,
+                l_extendedprice DOUBLE NOT NULL,
+                l_discount DOUBLE NOT NULL,
+                l_tax DOUBLE NOT NULL,
+                l_returnflag VARCHAR NOT NULL,
+                l_linestatus VARCHAR NOT NULL,
+                l_shipdate VARCHAR NOT NULL,
+                l_commitdate VARCHAR NOT NULL,
+                l_receiptdate VARCHAR NOT NULL,
+                l_shipinstruct VARCHAR NOT NULL,
+                l_shipmode VARCHAR NOT NULL,
+                l_comment VARCHAR NOT NULL
+            );
+            "#,
+        )
+        .expect("create DuckDB TPC-H tables");
+
+    let transaction = connection.transaction().expect("begin DuckDB seed");
+    {
+        let mut appender = transaction.appender("region").expect("DuckDB appender");
+        for row in data::regions(scale_factor) {
+            appender
+                .append_row(params![row.rowkey, row.regionkey, row.name, row.comment,])
+                .expect("append DuckDB region");
+        }
+        appender.flush().expect("flush DuckDB region appender");
+    }
+    {
+        let mut appender = transaction.appender("nation").expect("DuckDB appender");
+        for row in data::nations(scale_factor) {
+            appender
+                .append_row(params![
+                    row.rowkey,
+                    row.nationkey,
+                    row.name,
+                    row.regionkey,
+                    row.comment,
+                ])
+                .expect("append DuckDB nation");
+        }
+        appender.flush().expect("flush DuckDB nation appender");
+    }
+    {
+        let mut appender = transaction.appender("supplier").expect("DuckDB appender");
+        for row in data::suppliers(scale_factor) {
+            appender
+                .append_row(params![
+                    row.rowkey,
+                    row.suppkey,
+                    row.name,
+                    row.address,
+                    row.nationkey,
+                    row.phone,
+                    row.acctbal,
+                    row.comment,
+                ])
+                .expect("append DuckDB supplier");
+        }
+        appender.flush().expect("flush DuckDB supplier appender");
+    }
+    {
+        let mut appender = transaction.appender("part").expect("DuckDB appender");
+        for row in data::parts(scale_factor) {
+            appender
+                .append_row(params![
+                    row.rowkey,
+                    row.partkey,
+                    row.name,
+                    row.mfgr,
+                    row.brand,
+                    row.part_type,
+                    row.size,
+                    row.container,
+                    row.retailprice,
+                    row.comment,
+                ])
+                .expect("append DuckDB part");
+        }
+        appender.flush().expect("flush DuckDB part appender");
+    }
+    {
+        let mut appender = transaction.appender("partsupp").expect("DuckDB appender");
+        for row in data::partsupps(scale_factor) {
+            appender
+                .append_row(params![
+                    row.rowkey,
+                    row.partkey,
+                    row.suppkey,
+                    row.availqty,
+                    row.supplycost,
+                    row.comment,
+                ])
+                .expect("append DuckDB partsupp");
+        }
+        appender.flush().expect("flush DuckDB partsupp appender");
+    }
+    {
+        let mut appender = transaction.appender("customer").expect("DuckDB appender");
+        for row in data::customers(scale_factor) {
+            appender
+                .append_row(params![
+                    row.rowkey,
+                    row.custkey,
+                    row.name,
+                    row.address,
+                    row.nationkey,
+                    row.phone,
+                    row.acctbal,
+                    row.mktsegment,
+                    row.comment,
+                ])
+                .expect("append DuckDB customer");
+        }
+        appender.flush().expect("flush DuckDB customer appender");
+    }
+    {
+        let mut appender = transaction.appender("orders").expect("DuckDB appender");
+        for row in data::orders(scale_factor) {
+            appender
+                .append_row(params![
+                    row.rowkey,
+                    row.orderkey,
+                    row.custkey,
+                    row.orderstatus,
+                    row.totalprice,
+                    row.orderdate,
+                    row.orderpriority,
+                    row.clerk,
+                    row.shippriority,
+                    row.comment,
+                ])
+                .expect("append DuckDB orders");
+        }
+        appender.flush().expect("flush DuckDB orders appender");
+    }
+    {
+        let mut appender = transaction.appender("lineitem").expect("DuckDB appender");
+        for row in data::lineitems(scale_factor) {
+            appender
+                .append_row(params![
+                    row.rowkey,
+                    row.orderkey,
+                    row.partkey,
+                    row.suppkey,
+                    row.linenumber,
+                    row.quantity,
+                    row.extendedprice,
+                    row.discount,
+                    row.tax,
+                    row.returnflag,
+                    row.linestatus,
+                    row.shipdate,
+                    row.commitdate,
+                    row.receiptdate,
+                    row.shipinstruct,
+                    row.shipmode,
+                    row.comment,
+                ])
+                .expect("append DuckDB lineitem");
+        }
+        appender.flush().expect("flush DuckDB lineitem appender");
+    }
+    transaction.commit().expect("commit DuckDB seed");
+    connection
+}
+
+pub(crate) fn query(connection: &Connection, sql: &str) -> Vec<RecordBatch> {
+    let mut statement = connection.prepare(sql).expect("prepare DuckDB TPC-H query");
+    statement
+        .query_arrow([])
+        .expect("execute DuckDB TPC-H query")
+        .collect()
+}

--- a/packages/engine-benchmarks/benches/tpch/lix.rs
+++ b/packages/engine-benchmarks/benches/tpch/lix.rs
@@ -1,0 +1,715 @@
+use std::fmt::Write as _;
+
+use lix_engine::{Engine, ExecuteResult, SessionContext, Storage, Value};
+use lix_rocksdb_storage::RocksDB;
+#[cfg(feature = "slatedb")]
+use lix_slatedb_storage::SlateDB;
+use tempfile::TempDir;
+
+use crate::data;
+
+const REGION_INSERT_COLUMNS: &str = r#"
+    INSERT INTO region (r_rowkey, r_regionkey, r_name, r_comment) VALUES
+"#;
+const NATION_INSERT_COLUMNS: &str = r#"
+    INSERT INTO nation (
+        n_rowkey, n_nationkey, n_name, n_regionkey, n_comment
+    ) VALUES
+"#;
+const SUPPLIER_INSERT_COLUMNS: &str = r#"
+    INSERT INTO supplier (
+        s_rowkey, s_suppkey, s_name, s_address, s_nationkey, s_phone,
+        s_acctbal, s_comment
+    ) VALUES
+"#;
+const PART_INSERT_COLUMNS: &str = r#"
+    INSERT INTO part (
+        p_rowkey, p_partkey, p_name, p_mfgr, p_brand, p_type, p_size,
+        p_container, p_retailprice, p_comment
+    ) VALUES
+"#;
+const PARTSUPP_INSERT_COLUMNS: &str = r#"
+    INSERT INTO partsupp (
+        ps_rowkey, ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment
+    ) VALUES
+"#;
+const CUSTOMER_INSERT_COLUMNS: &str = r#"
+    INSERT INTO customer (
+        c_rowkey, c_custkey, c_name, c_address, c_nationkey, c_phone,
+        c_acctbal, c_mktsegment, c_comment
+    ) VALUES
+"#;
+const ORDERS_INSERT_COLUMNS: &str = r#"
+    INSERT INTO orders (
+        o_rowkey, o_orderkey, o_custkey, o_orderstatus, o_totalprice,
+        o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment
+    ) VALUES
+"#;
+const LINEITEM_INSERT_COLUMNS: &str = r#"
+    INSERT INTO lineitem (
+        l_rowkey, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity,
+        l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus,
+        l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode,
+        l_comment
+    ) VALUES
+"#;
+const INSERT_ROWS_PER_STATEMENT: usize = 2_048;
+
+const REGION_SCHEMA: &str = r#"{
+    "x-lix-key":"region",
+    "x-lix-primary-key":["/r_rowkey"],
+    "type":"object",
+    "properties":{
+        "r_rowkey":{"type":"string"},
+        "r_regionkey":{"type":"integer"},
+        "r_name":{"type":"string"},
+        "r_comment":{"type":"string"}
+    },
+    "required":["r_rowkey","r_regionkey","r_name","r_comment"],
+    "additionalProperties":false
+}"#;
+
+const NATION_SCHEMA: &str = r#"{
+    "x-lix-key":"nation",
+    "x-lix-primary-key":["/n_rowkey"],
+    "type":"object",
+    "properties":{
+        "n_rowkey":{"type":"string"},
+        "n_nationkey":{"type":"integer"},
+        "n_name":{"type":"string"},
+        "n_regionkey":{"type":"integer"},
+        "n_comment":{"type":"string"}
+    },
+    "required":["n_rowkey","n_nationkey","n_name","n_regionkey","n_comment"],
+    "additionalProperties":false
+}"#;
+
+const SUPPLIER_SCHEMA: &str = r#"{
+    "x-lix-key":"supplier",
+    "x-lix-primary-key":["/s_rowkey"],
+    "type":"object",
+    "properties":{
+        "s_rowkey":{"type":"string"},
+        "s_suppkey":{"type":"integer"},
+        "s_name":{"type":"string"},
+        "s_address":{"type":"string"},
+        "s_nationkey":{"type":"integer"},
+        "s_phone":{"type":"string"},
+        "s_acctbal":{"type":"number"},
+        "s_comment":{"type":"string"}
+    },
+    "required":[
+        "s_rowkey","s_suppkey","s_name","s_address","s_nationkey",
+        "s_phone","s_acctbal","s_comment"
+    ],
+    "additionalProperties":false
+}"#;
+
+const PART_SCHEMA: &str = r#"{
+    "x-lix-key":"part",
+    "x-lix-primary-key":["/p_rowkey"],
+    "type":"object",
+    "properties":{
+        "p_rowkey":{"type":"string"},
+        "p_partkey":{"type":"integer"},
+        "p_name":{"type":"string"},
+        "p_mfgr":{"type":"string"},
+        "p_brand":{"type":"string"},
+        "p_type":{"type":"string"},
+        "p_size":{"type":"integer"},
+        "p_container":{"type":"string"},
+        "p_retailprice":{"type":"number"},
+        "p_comment":{"type":"string"}
+    },
+    "required":[
+        "p_rowkey","p_partkey","p_name","p_mfgr","p_brand","p_type",
+        "p_size","p_container","p_retailprice","p_comment"
+    ],
+    "additionalProperties":false
+}"#;
+
+const PARTSUPP_SCHEMA: &str = r#"{
+    "x-lix-key":"partsupp",
+    "x-lix-primary-key":["/ps_rowkey"],
+    "type":"object",
+    "properties":{
+        "ps_rowkey":{"type":"string"},
+        "ps_partkey":{"type":"integer"},
+        "ps_suppkey":{"type":"integer"},
+        "ps_availqty":{"type":"integer"},
+        "ps_supplycost":{"type":"number"},
+        "ps_comment":{"type":"string"}
+    },
+    "required":[
+        "ps_rowkey","ps_partkey","ps_suppkey","ps_availqty",
+        "ps_supplycost","ps_comment"
+    ],
+    "additionalProperties":false
+}"#;
+
+const CUSTOMER_SCHEMA: &str = r#"{
+    "x-lix-key":"customer",
+    "x-lix-primary-key":["/c_rowkey"],
+    "type":"object",
+    "properties":{
+        "c_rowkey":{"type":"string"},
+        "c_custkey":{"type":"integer"},
+        "c_name":{"type":"string"},
+        "c_address":{"type":"string"},
+        "c_nationkey":{"type":"integer"},
+        "c_phone":{"type":"string"},
+        "c_acctbal":{"type":"number"},
+        "c_mktsegment":{"type":"string"},
+        "c_comment":{"type":"string"}
+    },
+    "required":[
+        "c_rowkey","c_custkey","c_name","c_address","c_nationkey",
+        "c_phone","c_acctbal","c_mktsegment","c_comment"
+    ],
+    "additionalProperties":false
+}"#;
+
+const ORDERS_SCHEMA: &str = r#"{
+    "x-lix-key":"orders",
+    "x-lix-primary-key":["/o_rowkey"],
+    "type":"object",
+    "properties":{
+        "o_rowkey":{"type":"string"},
+        "o_orderkey":{"type":"integer"},
+        "o_custkey":{"type":"integer"},
+        "o_orderstatus":{"type":"string"},
+        "o_totalprice":{"type":"number"},
+        "o_orderdate":{"type":"string"},
+        "o_orderpriority":{"type":"string"},
+        "o_clerk":{"type":"string"},
+        "o_shippriority":{"type":"integer"},
+        "o_comment":{"type":"string"}
+    },
+    "required":[
+        "o_rowkey","o_orderkey","o_custkey","o_orderstatus","o_totalprice",
+        "o_orderdate","o_orderpriority","o_clerk","o_shippriority","o_comment"
+    ],
+    "additionalProperties":false
+}"#;
+
+const LINEITEM_SCHEMA: &str = r#"{
+    "x-lix-key":"lineitem",
+    "x-lix-primary-key":["/l_rowkey"],
+    "type":"object",
+    "properties":{
+        "l_rowkey":{"type":"string"},
+        "l_orderkey":{"type":"integer"},
+        "l_partkey":{"type":"integer"},
+        "l_suppkey":{"type":"integer"},
+        "l_linenumber":{"type":"integer"},
+        "l_quantity":{"type":"integer"},
+        "l_extendedprice":{"type":"number"},
+        "l_discount":{"type":"number"},
+        "l_tax":{"type":"number"},
+        "l_returnflag":{"type":"string"},
+        "l_linestatus":{"type":"string"},
+        "l_shipdate":{"type":"string"},
+        "l_commitdate":{"type":"string"},
+        "l_receiptdate":{"type":"string"},
+        "l_shipinstruct":{"type":"string"},
+        "l_shipmode":{"type":"string"},
+        "l_comment":{"type":"string"}
+    },
+    "required":[
+        "l_rowkey","l_orderkey","l_partkey","l_suppkey","l_linenumber","l_quantity",
+        "l_extendedprice","l_discount","l_tax","l_returnflag","l_linestatus",
+        "l_shipdate","l_commitdate","l_receiptdate","l_shipinstruct","l_shipmode",
+        "l_comment"
+    ],
+    "additionalProperties":false
+}"#;
+
+pub(crate) enum Fixture {
+    RocksDB {
+        session: SessionContext<RocksDB>,
+        _dir: TempDir,
+    },
+    #[cfg(feature = "slatedb")]
+    SlateDB {
+        session: SessionContext<SlateDB>,
+        _dir: TempDir,
+    },
+}
+
+impl Fixture {
+    pub(crate) async fn rocksdb(scale_factor: f64) -> Self {
+        let dir = TempDir::new().expect("create TPC-H RocksDB directory");
+        let storage = RocksDB::open(dir.path().join("tpch.rocksdb")).expect("open TPC-H RocksDB");
+        let session = prepare(storage, scale_factor).await;
+        Self::RocksDB { session, _dir: dir }
+    }
+
+    #[cfg(feature = "slatedb")]
+    pub(crate) async fn slatedb(scale_factor: f64) -> Self {
+        let dir = TempDir::new().expect("create TPC-H SlateDB directory");
+        let storage = SlateDB::open(dir.path().join("tpch.slatedb")).expect("open TPC-H SlateDB");
+        let session = prepare(storage, scale_factor).await;
+        Self::SlateDB { session, _dir: dir }
+    }
+
+    pub(crate) fn name(&self) -> &'static str {
+        match self {
+            Self::RocksDB { .. } => "rocksdb",
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB { .. } => "slatedb",
+        }
+    }
+
+    pub(crate) async fn query(&self, sql: &str) -> ExecuteResult {
+        match self {
+            Self::RocksDB { session, .. } => execute(session, sql).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB { session, .. } => execute(session, sql).await,
+        }
+    }
+
+    pub(crate) async fn explain_analyze(&self, sql: &str) -> String {
+        let result = self.query(&format!("EXPLAIN ANALYZE VERBOSE {sql}")).await;
+        result
+            .rows()
+            .iter()
+            .map(|row| {
+                row.values()
+                    .iter()
+                    .map(|value| match value {
+                        Value::Text(value) => value.clone(),
+                        value => format!("{value:?}"),
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\t")
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
+async fn prepare<S>(storage: S, scale_factor: f64) -> SessionContext<S>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize Lix TPC-H storage");
+    let engine = Engine::new(storage).await.expect("open Lix TPC-H engine");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("open Lix TPC-H session");
+    for schema in [
+        REGION_SCHEMA,
+        NATION_SCHEMA,
+        SUPPLIER_SCHEMA,
+        PART_SCHEMA,
+        PARTSUPP_SCHEMA,
+        CUSTOMER_SCHEMA,
+        ORDERS_SCHEMA,
+        LINEITEM_SCHEMA,
+    ] {
+        let registered = session
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .expect("register TPC-H schema")
+            .rows_affected();
+        assert_eq!(registered, 1);
+    }
+
+    let mut transaction = session
+        .begin_transaction()
+        .await
+        .expect("begin Lix region seed");
+    let rows = data::regions(scale_factor).collect::<Vec<_>>();
+    let affected = transaction
+        .execute(&region_insert_sql(&rows), &[])
+        .await
+        .expect("seed Lix region")
+        .rows_affected();
+    transaction.commit().await.expect("commit Lix region seed");
+    assert_eq!(affected, rows.len() as u64);
+
+    let mut transaction = session
+        .begin_transaction()
+        .await
+        .expect("begin Lix nation seed");
+    let rows = data::nations(scale_factor).collect::<Vec<_>>();
+    let affected = transaction
+        .execute(&nation_insert_sql(&rows), &[])
+        .await
+        .expect("seed Lix nation")
+        .rows_affected();
+    transaction.commit().await.expect("commit Lix nation seed");
+    assert_eq!(affected, rows.len() as u64);
+
+    let mut transaction = session
+        .begin_transaction()
+        .await
+        .expect("begin Lix supplier seed");
+    let mut rows = data::suppliers(scale_factor);
+    let mut affected = 0_u64;
+    let mut attempted = 0_u64;
+    loop {
+        let chunk = rows
+            .by_ref()
+            .take(INSERT_ROWS_PER_STATEMENT)
+            .collect::<Vec<_>>();
+        if chunk.is_empty() {
+            break;
+        }
+        attempted += chunk.len() as u64;
+        affected += transaction
+            .execute(&supplier_insert_sql(&chunk), &[])
+            .await
+            .expect("seed Lix supplier chunk")
+            .rows_affected();
+    }
+    transaction
+        .commit()
+        .await
+        .expect("commit Lix supplier seed");
+    assert_eq!(affected, attempted, "incomplete TPC-H supplier seed");
+
+    let mut transaction = session
+        .begin_transaction()
+        .await
+        .expect("begin Lix part seed");
+    let mut rows = data::parts(scale_factor);
+    let mut affected = 0_u64;
+    let mut attempted = 0_u64;
+    loop {
+        let chunk = rows
+            .by_ref()
+            .take(INSERT_ROWS_PER_STATEMENT)
+            .collect::<Vec<_>>();
+        if chunk.is_empty() {
+            break;
+        }
+        attempted += chunk.len() as u64;
+        affected += transaction
+            .execute(&part_insert_sql(&chunk), &[])
+            .await
+            .expect("seed Lix part chunk")
+            .rows_affected();
+    }
+    transaction.commit().await.expect("commit Lix part seed");
+    assert_eq!(affected, attempted, "incomplete TPC-H part seed");
+
+    let mut transaction = session
+        .begin_transaction()
+        .await
+        .expect("begin Lix partsupp seed");
+    let mut rows = data::partsupps(scale_factor);
+    let mut affected = 0_u64;
+    let mut attempted = 0_u64;
+    loop {
+        let chunk = rows
+            .by_ref()
+            .take(INSERT_ROWS_PER_STATEMENT)
+            .collect::<Vec<_>>();
+        if chunk.is_empty() {
+            break;
+        }
+        attempted += chunk.len() as u64;
+        affected += transaction
+            .execute(&partsupp_insert_sql(&chunk), &[])
+            .await
+            .expect("seed Lix partsupp chunk")
+            .rows_affected();
+    }
+    transaction
+        .commit()
+        .await
+        .expect("commit Lix partsupp seed");
+    assert_eq!(affected, attempted, "incomplete TPC-H partsupp seed");
+
+    let mut transaction = session
+        .begin_transaction()
+        .await
+        .expect("begin Lix customer seed");
+    let mut rows = data::customers(scale_factor);
+    let mut affected = 0_u64;
+    let mut attempted = 0_u64;
+    loop {
+        let chunk = rows
+            .by_ref()
+            .take(INSERT_ROWS_PER_STATEMENT)
+            .collect::<Vec<_>>();
+        if chunk.is_empty() {
+            break;
+        }
+        attempted += chunk.len() as u64;
+        affected += transaction
+            .execute(&customer_insert_sql(&chunk), &[])
+            .await
+            .expect("seed Lix customer chunk")
+            .rows_affected();
+    }
+    transaction
+        .commit()
+        .await
+        .expect("commit Lix customer seed");
+    assert_eq!(affected, attempted, "incomplete TPC-H customer seed");
+
+    let mut transaction = session
+        .begin_transaction()
+        .await
+        .expect("begin Lix orders seed");
+    let mut rows = data::orders(scale_factor);
+    let mut affected = 0_u64;
+    let mut attempted = 0_u64;
+    loop {
+        let chunk = rows
+            .by_ref()
+            .take(INSERT_ROWS_PER_STATEMENT)
+            .collect::<Vec<_>>();
+        if chunk.is_empty() {
+            break;
+        }
+        attempted += chunk.len() as u64;
+        affected += transaction
+            .execute(&orders_insert_sql(&chunk), &[])
+            .await
+            .expect("seed Lix orders chunk")
+            .rows_affected();
+    }
+    transaction.commit().await.expect("commit Lix orders seed");
+    assert_eq!(affected, attempted, "incomplete TPC-H orders seed");
+
+    let mut transaction = session
+        .begin_transaction()
+        .await
+        .expect("begin Lix lineitem seed");
+    let mut rows = data::lineitems(scale_factor);
+    let mut affected = 0_u64;
+    let mut attempted = 0_u64;
+    loop {
+        let chunk = rows
+            .by_ref()
+            .take(INSERT_ROWS_PER_STATEMENT)
+            .collect::<Vec<_>>();
+        if chunk.is_empty() {
+            break;
+        }
+        attempted += chunk.len() as u64;
+        affected += transaction
+            .execute(&lineitem_insert_sql(&chunk), &[])
+            .await
+            .expect("seed Lix lineitem chunk")
+            .rows_affected();
+    }
+    transaction
+        .commit()
+        .await
+        .expect("commit Lix lineitem seed");
+    assert_eq!(affected, attempted, "incomplete TPC-H lineitem seed");
+    session
+}
+
+fn region_insert_sql(rows: &[data::Region]) -> String {
+    let mut sql = REGION_INSERT_COLUMNS.to_string();
+    for (index, row) in rows.iter().enumerate() {
+        if index != 0 {
+            sql.push(',');
+        }
+        write!(
+            sql,
+            "('{}', {}, '{}', '{}')",
+            sql_string(&row.rowkey),
+            row.regionkey,
+            sql_string(&row.name),
+            sql_string(&row.comment),
+        )
+        .expect("write region SQL");
+    }
+    sql
+}
+
+fn nation_insert_sql(rows: &[data::Nation]) -> String {
+    let mut sql = NATION_INSERT_COLUMNS.to_string();
+    for (index, row) in rows.iter().enumerate() {
+        if index != 0 {
+            sql.push(',');
+        }
+        write!(
+            sql,
+            "('{}', {}, '{}', {}, '{}')",
+            sql_string(&row.rowkey),
+            row.nationkey,
+            sql_string(&row.name),
+            row.regionkey,
+            sql_string(&row.comment),
+        )
+        .expect("write nation SQL");
+    }
+    sql
+}
+
+fn supplier_insert_sql(rows: &[data::Supplier]) -> String {
+    let mut sql = SUPPLIER_INSERT_COLUMNS.to_string();
+    for (index, row) in rows.iter().enumerate() {
+        if index != 0 {
+            sql.push(',');
+        }
+        write!(
+            sql,
+            "('{}', {}, '{}', '{}', {}, '{}', {}, '{}')",
+            sql_string(&row.rowkey),
+            row.suppkey,
+            sql_string(&row.name),
+            sql_string(&row.address),
+            row.nationkey,
+            sql_string(&row.phone),
+            row.acctbal,
+            sql_string(&row.comment),
+        )
+        .expect("write supplier SQL");
+    }
+    sql
+}
+
+fn part_insert_sql(rows: &[data::Part]) -> String {
+    let mut sql = PART_INSERT_COLUMNS.to_string();
+    for (index, row) in rows.iter().enumerate() {
+        if index != 0 {
+            sql.push(',');
+        }
+        write!(
+            sql,
+            "('{}', {}, '{}', '{}', '{}', '{}', {}, '{}', {}, '{}')",
+            sql_string(&row.rowkey),
+            row.partkey,
+            sql_string(&row.name),
+            sql_string(&row.mfgr),
+            sql_string(&row.brand),
+            sql_string(&row.part_type),
+            row.size,
+            sql_string(&row.container),
+            row.retailprice,
+            sql_string(&row.comment),
+        )
+        .expect("write part SQL");
+    }
+    sql
+}
+
+fn partsupp_insert_sql(rows: &[data::PartSupp]) -> String {
+    let mut sql = PARTSUPP_INSERT_COLUMNS.to_string();
+    for (index, row) in rows.iter().enumerate() {
+        if index != 0 {
+            sql.push(',');
+        }
+        write!(
+            sql,
+            "('{}', {}, {}, {}, {}, '{}')",
+            sql_string(&row.rowkey),
+            row.partkey,
+            row.suppkey,
+            row.availqty,
+            row.supplycost,
+            sql_string(&row.comment),
+        )
+        .expect("write partsupp SQL");
+    }
+    sql
+}
+
+fn customer_insert_sql(rows: &[data::Customer]) -> String {
+    let mut sql = CUSTOMER_INSERT_COLUMNS.to_string();
+    for (index, row) in rows.iter().enumerate() {
+        if index != 0 {
+            sql.push(',');
+        }
+        write!(
+            sql,
+            "('{}', {}, '{}', '{}', {}, '{}', {}, '{}', '{}')",
+            sql_string(&row.rowkey),
+            row.custkey,
+            sql_string(&row.name),
+            sql_string(&row.address),
+            row.nationkey,
+            sql_string(&row.phone),
+            row.acctbal,
+            sql_string(&row.mktsegment),
+            sql_string(&row.comment),
+        )
+        .expect("write customer SQL");
+    }
+    sql
+}
+
+fn orders_insert_sql(rows: &[data::Order]) -> String {
+    let mut sql = ORDERS_INSERT_COLUMNS.to_string();
+    for (index, row) in rows.iter().enumerate() {
+        if index != 0 {
+            sql.push(',');
+        }
+        write!(
+            sql,
+            "('{}', {}, {}, '{}', {}, '{}', '{}', '{}', {}, '{}')",
+            sql_string(&row.rowkey),
+            row.orderkey,
+            row.custkey,
+            sql_string(&row.orderstatus),
+            row.totalprice,
+            sql_string(&row.orderdate),
+            sql_string(&row.orderpriority),
+            sql_string(&row.clerk),
+            row.shippriority,
+            sql_string(&row.comment),
+        )
+        .expect("write orders SQL");
+    }
+    sql
+}
+
+fn lineitem_insert_sql(rows: &[data::LineItem]) -> String {
+    let mut sql = LINEITEM_INSERT_COLUMNS.to_string();
+    for (index, row) in rows.iter().enumerate() {
+        if index != 0 {
+            sql.push(',');
+        }
+        write!(
+            sql,
+            "('{}', {}, {}, {}, {}, {}, {}, {}, {}, '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}')",
+            sql_string(&row.rowkey),
+            row.orderkey,
+            row.partkey,
+            row.suppkey,
+            row.linenumber,
+            row.quantity,
+            row.extendedprice,
+            row.discount,
+            row.tax,
+            sql_string(&row.returnflag),
+            sql_string(&row.linestatus),
+            sql_string(&row.shipdate),
+            sql_string(&row.commitdate),
+            sql_string(&row.receiptdate),
+            sql_string(&row.shipinstruct),
+            sql_string(&row.shipmode),
+            sql_string(&row.comment),
+        )
+        .expect("write lineitem SQL");
+    }
+    sql
+}
+
+fn sql_string(value: &str) -> String {
+    value.replace('\'', "''")
+}
+
+async fn execute<S>(session: &SessionContext<S>, sql: &str) -> ExecuteResult
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    session
+        .execute(sql, &[])
+        .await
+        .expect("execute Lix TPC-H query")
+}

--- a/packages/engine-benchmarks/benches/tpch/main.rs
+++ b/packages/engine-benchmarks/benches/tpch/main.rs
@@ -1,0 +1,142 @@
+mod config;
+mod data;
+mod duckdb;
+mod lix;
+mod queries;
+mod result;
+
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use config::Config;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let config = Config::from_env();
+    eprintln!(
+        "seeding deterministic TPC-H-derived data at scale factor {}",
+        config.scale_factor
+    );
+    let duckdb = duckdb::seeded(config.scale_factor);
+    #[allow(unused_mut)]
+    let mut lix_fixtures = vec![lix::Fixture::rocksdb(config.scale_factor).await];
+    #[cfg(feature = "slatedb")]
+    lix_fixtures.push(lix::Fixture::slatedb(config.scale_factor).await);
+
+    validate_loaded_keys(&duckdb, &lix_fixtures).await;
+
+    let selected_query = std::env::var("LIX_TPCH_QUERY")
+        .ok()
+        .map(|value| value.parse::<u8>().expect("LIX_TPCH_QUERY must be 1..=22"));
+    assert!(
+        selected_query.is_none_or(|number| (1..=22).contains(&number)),
+        "LIX_TPCH_QUERY must be 1..=22"
+    );
+    for query in queries::queries(config.scale_factor)
+        .into_iter()
+        .filter(|query| selected_query.is_none_or(|number| number == query.number))
+    {
+        let duckdb_rows = result::from_arrow(&duckdb::query(&duckdb, &query.sql));
+        for fixture in &lix_fixtures {
+            let lix_rows = result::from_lix(&fixture.query(&query.sql).await);
+            if std::env::var_os("LIX_TPCH_EXPLAIN").is_some() {
+                eprintln!(
+                    "Lix {} Q{} EXPLAIN ANALYZE:\n{}",
+                    fixture.name(),
+                    query.number,
+                    fixture.explain_analyze(&query.sql).await
+                );
+            }
+            result::assert_equivalent(&format!("TPC-H Q{}", query.number), &lix_rows, &duckdb_rows);
+        }
+
+        // Independent warmups keep the validation work out of timed samples.
+        black_box(result::from_arrow(&duckdb::query(&duckdb, &query.sql)));
+        for fixture in &lix_fixtures {
+            black_box(result::from_lix(&fixture.query(&query.sql).await));
+        }
+
+        let mut duckdb_samples = Vec::with_capacity(config.samples);
+        let mut lix_samples = (0..lix_fixtures.len())
+            .map(|_| Vec::with_capacity(config.samples))
+            .collect::<Vec<_>>();
+        for sample in 0..config.samples {
+            if sample % 2 == 0 {
+                let started = Instant::now();
+                black_box(result::from_arrow(&duckdb::query(&duckdb, &query.sql)));
+                duckdb_samples.push(started.elapsed());
+            }
+            for fixture_index in if sample % 2 == 0 {
+                (0..lix_fixtures.len()).collect::<Vec<_>>()
+            } else {
+                (0..lix_fixtures.len()).rev().collect::<Vec<_>>()
+            } {
+                let started = Instant::now();
+                black_box(result::from_lix(
+                    &lix_fixtures[fixture_index].query(&query.sql).await,
+                ));
+                lix_samples[fixture_index].push(started.elapsed());
+            }
+            if sample % 2 != 0 {
+                let started = Instant::now();
+                black_box(result::from_arrow(&duckdb::query(&duckdb, &query.sql)));
+                duckdb_samples.push(started.elapsed());
+            }
+        }
+        let duckdb_median = config::median(&duckdb_samples);
+
+        for (fixture, lix_samples) in lix_fixtures.iter().zip(lix_samples) {
+            let lix_median = config::median(&lix_samples);
+            println!(
+                "{}",
+                serde_json::json!({
+                    "suite": "tpch-derived-common-types",
+                    "scale_factor": config.scale_factor,
+                    "query": query.number,
+                    "backend": fixture.name(),
+                    "threads": 1,
+                    "boundary": "rust_owned_rows_end_to_end",
+                    "samples": config.samples,
+                    "duckdb_samples_ms": duckdb_samples.iter().copied().map(millis).collect::<Vec<_>>(),
+                    "lix_samples_ms": lix_samples.iter().copied().map(millis).collect::<Vec<_>>(),
+                    "duckdb_median_ms": millis(duckdb_median),
+                    "duckdb_p90_ms": millis(config::p90(&duckdb_samples)),
+                    "duckdb_mad_ms": millis(config::median_absolute_deviation(&duckdb_samples)),
+                    "lix_median_ms": millis(lix_median),
+                    "lix_p90_ms": millis(config::p90(&lix_samples)),
+                    "lix_mad_ms": millis(config::median_absolute_deviation(&lix_samples)),
+                    "lix_over_duckdb": lix_median.as_secs_f64() / duckdb_median.as_secs_f64(),
+                })
+            );
+        }
+    }
+}
+
+async fn validate_loaded_keys(duckdb: &::duckdb::Connection, fixtures: &[lix::Fixture]) {
+    const TABLE_KEYS: [(&str, &str); 8] = [
+        ("region", "SUM(r_regionkey)"),
+        ("nation", "SUM(n_nationkey), SUM(n_regionkey)"),
+        ("supplier", "SUM(s_suppkey), SUM(s_nationkey)"),
+        ("part", "SUM(p_partkey)"),
+        ("partsupp", "SUM(ps_partkey), SUM(ps_suppkey)"),
+        ("customer", "SUM(c_custkey), SUM(c_nationkey)"),
+        ("orders", "SUM(o_orderkey), SUM(o_custkey)"),
+        ("lineitem", "SUM(l_orderkey), SUM(l_linenumber)"),
+    ];
+    for (table, key_sums) in TABLE_KEYS {
+        let sql = format!("SELECT COUNT(*), {key_sums} FROM {table}");
+        let duckdb_rows = result::from_arrow(&duckdb::query(duckdb, &sql));
+        for fixture in fixtures {
+            let lix_rows = result::from_lix(&fixture.query(&sql).await);
+            result::assert_equivalent(
+                &format!("TPC-H {table} load checksum"),
+                &lix_rows,
+                &duckdb_rows,
+            );
+        }
+    }
+}
+
+fn millis(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}

--- a/packages/engine-benchmarks/benches/tpch/queries.rs
+++ b/packages/engine-benchmarks/benches/tpch/queries.rs
@@ -1,0 +1,289 @@
+//! Standard-substitution TPC-H queries adapted to Lix's current common types.
+//!
+//! Dates are ISO strings, so interval endpoints are precomputed and year
+//! extraction uses `substr`. Q15 uses a CTE rather than session-mutating views.
+
+#[derive(Clone, Debug)]
+pub(crate) struct Query {
+    pub(crate) number: u8,
+    pub(crate) sql: String,
+}
+
+const SQL: [&str; 22] = [
+    r#"SELECT l_returnflag, l_linestatus,
+              SUM(l_quantity) AS sum_qty,
+              SUM(l_extendedprice) AS sum_base_price,
+              SUM(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
+              SUM(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
+              AVG(l_quantity) AS avg_qty, AVG(l_extendedprice) AS avg_price,
+              AVG(l_discount) AS avg_disc, COUNT(*) AS count_order
+       FROM lineitem WHERE l_shipdate <= '1998-09-02'
+       GROUP BY l_returnflag, l_linestatus
+       ORDER BY l_returnflag, l_linestatus"#,
+    r#"SELECT s_acctbal, s_name, n_name, p_partkey, p_mfgr,
+              s_address, s_phone, s_comment
+       FROM part, supplier, partsupp, nation, region
+       WHERE p_partkey = ps_partkey AND s_suppkey = ps_suppkey
+         AND p_size = 15 AND p_type LIKE '%BRASS'
+         AND s_nationkey = n_nationkey AND n_regionkey = r_regionkey
+         AND r_name = 'EUROPE'
+         AND ps_supplycost = (
+             SELECT MIN(ps2.ps_supplycost)
+             FROM partsupp ps2, supplier s2, nation n2, region r2
+             WHERE p_partkey = ps2.ps_partkey
+               AND s2.s_suppkey = ps2.ps_suppkey
+               AND s2.s_nationkey = n2.n_nationkey
+               AND n2.n_regionkey = r2.r_regionkey AND r2.r_name = 'EUROPE')
+       ORDER BY s_acctbal DESC, n_name, s_name, p_partkey
+       LIMIT 100"#,
+    r#"SELECT l_orderkey,
+              SUM(l_extendedprice * (1 - l_discount)) AS revenue,
+              o_orderdate, o_shippriority
+       FROM customer, orders, lineitem
+       WHERE c_mktsegment = 'BUILDING' AND c_custkey = o_custkey
+         AND l_orderkey = o_orderkey AND o_orderdate < '1995-03-15'
+         AND l_shipdate > '1995-03-15'
+       GROUP BY l_orderkey, o_orderdate, o_shippriority
+       ORDER BY revenue DESC, o_orderdate, l_orderkey
+       LIMIT 10"#,
+    r#"SELECT o_orderpriority, COUNT(*) AS order_count
+       FROM orders
+       WHERE o_orderdate >= '1993-07-01' AND o_orderdate < '1993-10-01'
+         AND EXISTS (SELECT 1 FROM lineitem
+                     WHERE l_orderkey = o_orderkey
+                       AND l_commitdate < l_receiptdate)
+       GROUP BY o_orderpriority ORDER BY o_orderpriority"#,
+    r#"SELECT n_name, SUM(l_extendedprice * (1 - l_discount)) AS revenue
+       FROM customer, orders, lineitem, supplier, nation, region
+       WHERE c_custkey = o_custkey AND l_orderkey = o_orderkey
+         AND l_suppkey = s_suppkey AND c_nationkey = s_nationkey
+         AND s_nationkey = n_nationkey AND n_regionkey = r_regionkey
+         AND r_name = 'ASIA' AND o_orderdate >= '1994-01-01'
+         AND o_orderdate < '1995-01-01'
+       GROUP BY n_name ORDER BY revenue DESC"#,
+    r#"SELECT SUM(l_extendedprice * l_discount) AS revenue
+       FROM lineitem
+       WHERE l_shipdate >= '1994-01-01' AND l_shipdate < '1995-01-01'
+         AND l_discount BETWEEN 0.05 AND 0.07 AND l_quantity < 24"#,
+    r#"SELECT supp_nation, cust_nation, l_year, SUM(volume) AS revenue
+       FROM (SELECT n1.n_name AS supp_nation, n2.n_name AS cust_nation,
+                    substr(l_shipdate, 1, 4) AS l_year,
+                    l_extendedprice * (1 - l_discount) AS volume
+             FROM supplier, lineitem, orders, customer, nation n1, nation n2
+             WHERE s_suppkey = l_suppkey AND o_orderkey = l_orderkey
+               AND c_custkey = o_custkey AND s_nationkey = n1.n_nationkey
+               AND c_nationkey = n2.n_nationkey
+               AND ((n1.n_name = 'FRANCE' AND n2.n_name = 'GERMANY')
+                 OR (n1.n_name = 'GERMANY' AND n2.n_name = 'FRANCE'))
+               AND l_shipdate BETWEEN '1995-01-01' AND '1996-12-31') shipping
+       GROUP BY supp_nation, cust_nation, l_year
+       ORDER BY supp_nation, cust_nation, l_year"#,
+    r#"SELECT o_year,
+              SUM(CASE WHEN nation = 'BRAZIL' THEN volume ELSE 0 END)
+                / SUM(volume) AS mkt_share
+       FROM (SELECT substr(o_orderdate, 1, 4) AS o_year,
+                    l_extendedprice * (1 - l_discount) AS volume,
+                    n2.n_name AS nation
+             FROM part, supplier, lineitem, orders, customer,
+                  nation n1, nation n2, region
+             WHERE p_partkey = l_partkey AND s_suppkey = l_suppkey
+               AND l_orderkey = o_orderkey AND o_custkey = c_custkey
+               AND c_nationkey = n1.n_nationkey
+               AND n1.n_regionkey = r_regionkey AND r_name = 'AMERICA'
+               AND s_nationkey = n2.n_nationkey
+               AND o_orderdate BETWEEN '1995-01-01' AND '1996-12-31'
+               AND p_type = 'ECONOMY ANODIZED STEEL') all_nations
+       GROUP BY o_year ORDER BY o_year"#,
+    r#"SELECT nation, o_year, SUM(amount) AS sum_profit
+       FROM (SELECT n_name AS nation, substr(o_orderdate, 1, 4) AS o_year,
+                    l_extendedprice * (1 - l_discount)
+                      - ps_supplycost * l_quantity AS amount
+             FROM part, supplier, lineitem, partsupp, orders, nation
+             WHERE s_suppkey = l_suppkey AND ps_suppkey = l_suppkey
+               AND ps_partkey = l_partkey AND p_partkey = l_partkey
+               AND o_orderkey = l_orderkey AND s_nationkey = n_nationkey
+               AND p_name LIKE '%green%') profit
+       GROUP BY nation, o_year ORDER BY nation, o_year DESC"#,
+    r#"SELECT c_custkey, c_name,
+              SUM(l_extendedprice * (1 - l_discount)) AS revenue,
+              c_acctbal, n_name, c_address, c_phone, c_comment
+       FROM customer, orders, lineitem, nation
+       WHERE c_custkey = o_custkey AND l_orderkey = o_orderkey
+         AND o_orderdate >= '1993-10-01' AND o_orderdate < '1994-01-01'
+         AND l_returnflag = 'R' AND c_nationkey = n_nationkey
+       GROUP BY c_custkey, c_name, c_acctbal, c_phone, n_name,
+                c_address, c_comment
+       ORDER BY revenue DESC, c_custkey
+       LIMIT 20"#,
+    r#"SELECT ps_partkey, SUM(ps_supplycost * ps_availqty) AS value
+       FROM partsupp, supplier, nation
+       WHERE ps_suppkey = s_suppkey AND s_nationkey = n_nationkey
+         AND n_name = 'GERMANY'
+       GROUP BY ps_partkey
+       HAVING SUM(ps_supplycost * ps_availqty) >
+         (SELECT SUM(ps_supplycost * ps_availqty) * {Q11_FRACTION}
+          FROM partsupp, supplier, nation
+          WHERE ps_suppkey = s_suppkey AND s_nationkey = n_nationkey
+            AND n_name = 'GERMANY')
+       ORDER BY value DESC"#,
+    r#"SELECT l_shipmode,
+              SUM(CASE WHEN o_orderpriority = '1-URGENT'
+                         OR o_orderpriority = '2-HIGH' THEN 1 ELSE 0 END)
+                AS high_line_count,
+              SUM(CASE WHEN o_orderpriority <> '1-URGENT'
+                         AND o_orderpriority <> '2-HIGH' THEN 1 ELSE 0 END)
+                AS low_line_count
+       FROM orders, lineitem
+       WHERE o_orderkey = l_orderkey AND l_shipmode IN ('MAIL', 'SHIP')
+         AND l_commitdate < l_receiptdate AND l_shipdate < l_commitdate
+         AND l_receiptdate >= '1994-01-01' AND l_receiptdate < '1995-01-01'
+       GROUP BY l_shipmode ORDER BY l_shipmode"#,
+    r#"SELECT c_count, COUNT(*) AS custdist
+       FROM (SELECT c_custkey, COUNT(o_orderkey) AS c_count
+             FROM customer LEFT OUTER JOIN orders
+               ON c_custkey = o_custkey
+              AND o_comment NOT LIKE '%special%requests%'
+             GROUP BY c_custkey) c_orders
+       GROUP BY c_count ORDER BY custdist DESC, c_count DESC"#,
+    r#"SELECT 100.0 * SUM(CASE WHEN p_type LIKE 'PROMO%'
+                                THEN l_extendedprice * (1 - l_discount)
+                                ELSE 0 END)
+                       / SUM(l_extendedprice * (1 - l_discount)) AS promo_revenue
+       FROM lineitem, part
+       WHERE l_partkey = p_partkey AND l_shipdate >= '1995-09-01'
+         AND l_shipdate < '1995-10-01'"#,
+    r#"WITH revenue AS (
+         SELECT l_suppkey AS supplier_no,
+                SUM(l_extendedprice * (1 - l_discount)) AS total_revenue
+         FROM lineitem
+         WHERE l_shipdate >= '1996-01-01' AND l_shipdate < '1996-04-01'
+         GROUP BY l_suppkey)
+       SELECT s_suppkey, s_name, s_address, s_phone, total_revenue
+       FROM supplier, revenue
+       WHERE s_suppkey = supplier_no
+         AND total_revenue = (SELECT MAX(total_revenue) FROM revenue)
+       ORDER BY s_suppkey"#,
+    r#"SELECT p_brand, p_type, p_size,
+              COUNT(DISTINCT ps_suppkey) AS supplier_cnt
+       FROM partsupp, part
+       WHERE p_partkey = ps_partkey AND p_brand <> 'Brand#45'
+         AND p_type NOT LIKE 'MEDIUM POLISHED%'
+         AND p_size IN (49, 14, 23, 45, 19, 3, 36, 9)
+         AND ps_suppkey NOT IN
+           (SELECT s_suppkey FROM supplier
+            WHERE s_comment LIKE '%Customer%Complaints%')
+       GROUP BY p_brand, p_type, p_size
+       ORDER BY supplier_cnt DESC, p_brand, p_type, p_size"#,
+    r#"SELECT SUM(l_extendedprice) / 7.0 AS avg_yearly
+       FROM lineitem, part
+       WHERE p_partkey = l_partkey AND p_brand = 'Brand#23'
+         AND p_container = 'MED BOX'
+         AND l_quantity < (SELECT 0.2 * AVG(l2.l_quantity)
+                           FROM lineitem l2
+                           WHERE l2.l_partkey = p_partkey)"#,
+    r#"SELECT c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice,
+              SUM(l_quantity) AS sum_quantity
+       FROM customer, orders, lineitem
+       WHERE o_orderkey IN (SELECT l_orderkey FROM lineitem
+                            GROUP BY l_orderkey
+                            HAVING SUM(l_quantity) > 300)
+         AND c_custkey = o_custkey AND o_orderkey = l_orderkey
+       GROUP BY c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice
+       ORDER BY o_totalprice DESC, o_orderdate, o_orderkey
+       LIMIT 100"#,
+    r#"SELECT SUM(l_extendedprice * (1 - l_discount)) AS revenue
+       FROM lineitem, part
+       WHERE (p_partkey = l_partkey AND p_brand = 'Brand#12'
+              AND p_container IN ('SM CASE','SM BOX','SM PACK','SM PKG')
+              AND l_quantity BETWEEN 1 AND 11 AND p_size BETWEEN 1 AND 5
+              AND l_shipmode IN ('AIR','AIR REG')
+              AND l_shipinstruct = 'DELIVER IN PERSON')
+          OR (p_partkey = l_partkey AND p_brand = 'Brand#23'
+              AND p_container IN ('MED BAG','MED BOX','MED PKG','MED PACK')
+              AND l_quantity BETWEEN 10 AND 20 AND p_size BETWEEN 1 AND 10
+              AND l_shipmode IN ('AIR','AIR REG')
+              AND l_shipinstruct = 'DELIVER IN PERSON')
+          OR (p_partkey = l_partkey AND p_brand = 'Brand#34'
+              AND p_container IN ('LG CASE','LG BOX','LG PACK','LG PKG')
+              AND l_quantity BETWEEN 20 AND 30 AND p_size BETWEEN 1 AND 15
+              AND l_shipmode IN ('AIR','AIR REG')
+              AND l_shipinstruct = 'DELIVER IN PERSON')"#,
+    r#"SELECT s_name, s_address
+       FROM supplier, nation
+       WHERE s_suppkey IN (
+         SELECT ps_suppkey FROM partsupp
+         WHERE ps_partkey IN
+           (SELECT p_partkey FROM part WHERE p_name LIKE 'forest%')
+           AND ps_availqty >
+             (SELECT 0.5 * SUM(l_quantity) FROM lineitem
+              WHERE l_partkey = ps_partkey AND l_suppkey = ps_suppkey
+                AND l_shipdate >= '1994-01-01'
+                AND l_shipdate < '1995-01-01'))
+         AND s_nationkey = n_nationkey AND n_name = 'CANADA'
+       ORDER BY s_name"#,
+    r#"SELECT s_name, COUNT(*) AS numwait
+       FROM supplier, lineitem l1, orders, nation
+       WHERE s_suppkey = l1.l_suppkey AND o_orderkey = l1.l_orderkey
+         AND o_orderstatus = 'F' AND l1.l_receiptdate > l1.l_commitdate
+         AND EXISTS (SELECT 1 FROM lineitem l2
+                     WHERE l2.l_orderkey = l1.l_orderkey
+                       AND l2.l_suppkey <> l1.l_suppkey)
+         AND NOT EXISTS (SELECT 1 FROM lineitem l3
+                         WHERE l3.l_orderkey = l1.l_orderkey
+                           AND l3.l_suppkey <> l1.l_suppkey
+                           AND l3.l_receiptdate > l3.l_commitdate)
+         AND s_nationkey = n_nationkey AND n_name = 'SAUDI ARABIA'
+       GROUP BY s_name ORDER BY numwait DESC, s_name
+       LIMIT 100"#,
+    r#"SELECT cntrycode, COUNT(*) AS numcust, SUM(c_acctbal) AS totacctbal
+       FROM (SELECT substr(c_phone, 1, 2) AS cntrycode, c_acctbal
+             FROM customer
+             WHERE substr(c_phone, 1, 2) IN
+                   ('13','31','23','29','30','18','17')
+               AND c_acctbal >
+                 (SELECT AVG(c2.c_acctbal) FROM customer c2
+                  WHERE c2.c_acctbal > 0.0
+                    AND substr(c2.c_phone, 1, 2) IN
+                        ('13','31','23','29','30','18','17'))
+               AND NOT EXISTS (SELECT 1 FROM orders
+                               WHERE o_custkey = c_custkey)) custsale
+       GROUP BY cntrycode ORDER BY cntrycode"#,
+];
+
+pub(crate) fn queries(scale_factor: f64) -> Vec<Query> {
+    let q11_fraction = 0.0001 / scale_factor;
+    SQL.iter()
+        .enumerate()
+        .map(|(index, sql)| Query {
+            number: u8::try_from(index + 1).expect("TPC-H query number fits in u8"),
+            sql: sql.replace("{Q11_FRACTION}", &format!("{q11_fraction:.17}")),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn exposes_every_standard_query_in_order() {
+        let queries = super::queries(1.0);
+        assert_eq!(queries.len(), 22);
+        assert_eq!(
+            queries.iter().map(|query| query.number).collect::<Vec<_>>(),
+            (1..=22).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn q11_fraction_scales_with_the_dataset() {
+        assert!(
+            super::queries(0.01)[10]
+                .sql
+                .contains("* 0.01000000000000000")
+        );
+        assert!(
+            super::queries(1.0)[10]
+                .sql
+                .contains("* 0.00010000000000000")
+        );
+    }
+}

--- a/packages/engine-benchmarks/benches/tpch/result.rs
+++ b/packages/engine-benchmarks/benches/tpch/result.rs
@@ -1,0 +1,115 @@
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::ScalarValue;
+use lix_engine::{ExecuteResult, Value};
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum Cell {
+    Null,
+    Bool(bool),
+    Int(i128),
+    Float(f64),
+    Text(String),
+}
+
+pub(crate) type Rows = Vec<Vec<Cell>>;
+
+pub(crate) fn from_lix(result: &ExecuteResult) -> Rows {
+    result
+        .rows()
+        .iter()
+        .map(|row| row.values().iter().map(cell_from_lix).collect())
+        .collect()
+}
+
+pub(crate) fn from_arrow(batches: &[RecordBatch]) -> Rows {
+    let mut rows = Vec::new();
+    for batch in batches {
+        for row in 0..batch.num_rows() {
+            rows.push(
+                batch
+                    .columns()
+                    .iter()
+                    .map(|array| {
+                        let value = ScalarValue::try_from_array(array, row)
+                            .expect("DuckDB Arrow result scalar");
+                        cell_from_scalar(&value)
+                    })
+                    .collect(),
+            );
+        }
+    }
+    rows
+}
+
+pub(crate) fn assert_equivalent(label: &str, lix: &Rows, duckdb: &Rows) {
+    assert_eq!(lix.len(), duckdb.len(), "{label} row count");
+    for (row_index, (left, right)) in lix.iter().zip(duckdb).enumerate() {
+        assert_eq!(
+            left.len(),
+            right.len(),
+            "{label} column count at row {row_index}"
+        );
+        for (column_index, (left, right)) in left.iter().zip(right).enumerate() {
+            let equivalent = match (left, right) {
+                (Cell::Float(left), Cell::Float(right)) => {
+                    let tolerance = 1e-9 * left.abs().max(right.abs()).max(1.0);
+                    (left - right).abs() <= tolerance
+                }
+                (Cell::Int(left), Cell::Float(right)) | (Cell::Float(right), Cell::Int(left)) => {
+                    let left = *left as f64;
+                    let tolerance = 1e-9 * left.abs().max(right.abs()).max(1.0);
+                    (left - right).abs() <= tolerance
+                }
+                _ => left == right,
+            };
+            assert!(
+                equivalent,
+                "{label} mismatch at row {row_index}, column {column_index}: Lix={left:?}, DuckDB={right:?}"
+            );
+        }
+    }
+}
+
+fn cell_from_lix(value: &Value) -> Cell {
+    match value {
+        Value::Null => Cell::Null,
+        Value::Boolean(value) => Cell::Bool(*value),
+        Value::Integer(value) => Cell::Int(i128::from(*value)),
+        Value::Real(value) => Cell::Float(*value),
+        Value::Text(value) => Cell::Text(value.clone()),
+        Value::Json(value) => Cell::Text(value.to_string()),
+        Value::Blob(value) => Cell::Text(format!("{value:?}")),
+    }
+}
+
+fn cell_from_scalar(value: &ScalarValue) -> Cell {
+    match value {
+        ScalarValue::Null => Cell::Null,
+        ScalarValue::Boolean(value) => value.map_or(Cell::Null, Cell::Bool),
+        ScalarValue::Int8(value) => value.map_or(Cell::Null, |value| Cell::Int(i128::from(value))),
+        ScalarValue::Int16(value) => value.map_or(Cell::Null, |value| Cell::Int(i128::from(value))),
+        ScalarValue::Int32(value) => value.map_or(Cell::Null, |value| Cell::Int(i128::from(value))),
+        ScalarValue::Int64(value) => value.map_or(Cell::Null, |value| Cell::Int(i128::from(value))),
+        ScalarValue::UInt8(value) => value.map_or(Cell::Null, |value| Cell::Int(i128::from(value))),
+        ScalarValue::UInt16(value) => {
+            value.map_or(Cell::Null, |value| Cell::Int(i128::from(value)))
+        }
+        ScalarValue::UInt32(value) => {
+            value.map_or(Cell::Null, |value| Cell::Int(i128::from(value)))
+        }
+        ScalarValue::UInt64(value) => {
+            value.map_or(Cell::Null, |value| Cell::Int(i128::from(value)))
+        }
+        ScalarValue::Float32(value) => {
+            value.map_or(Cell::Null, |value| Cell::Float(f64::from(value)))
+        }
+        ScalarValue::Float64(value) => value.map_or(Cell::Null, Cell::Float),
+        ScalarValue::Utf8(value) | ScalarValue::Utf8View(value) | ScalarValue::LargeUtf8(value) => {
+            value.clone().map_or(Cell::Null, Cell::Text)
+        }
+        ScalarValue::Decimal128(value, _, scale) => value.map_or(Cell::Null, |value| {
+            Cell::Float(value as f64 / 10_f64.powi(i32::from(*scale)))
+        }),
+        other => Cell::Text(other.to_string()),
+    }
+}


### PR DESCRIPTION
## What changed

- Add deterministic `tpchgen` fixtures for all eight TPC-H tables.
- Load identical BIGINT/DOUBLE/VARCHAR schemas into DuckDB and Lix.
- Run adapted Q1-Q22 through the same Rust process and owned-row result boundary.
- Validate exact row counts and key checksums before timing.
- Differentially validate every result with numeric tolerance and deterministic tie-breaks.
- Alternate engine sample order and emit raw samples, p50, p90, and MAD.
- Add per-query isolation and Lix EXPLAIN ANALYZE capture.
- Gate bundled DuckDB and `tpchgen` behind the opt-in `tpch` feature.

## Why

The prior analytical comparison could favor a recognized identity scan and did not establish generalized SQL performance. This harness makes joins, aggregates, subqueries, EXISTS/NOT EXISTS, DISTINCT, CTEs, sorting, and limits part of the same neutral qualification path.

Coverage improves from two single-table queries over one table to Q1-Q22 over all eight tables (>10x query coverage and 8x table coverage).

## Fairness boundary

Both engines include SQL preparation/planning, execution, and conversion to the same owned Rust cells. Both currently use one thread. Dates are ISO strings and decimals are DOUBLE in both engines; the suite is therefore labeled `tpch-derived-common-types`, not native TPC-H.

## Validation

- `cargo check -p lix_engine_benchmarks --bench tpch --features storage-benches,tpch`
- `cargo check -p lix_engine_benchmarks --all-targets`
- Full SF0.01 Q1-Q22 RocksDB differential run: all queries equivalent to DuckDB.
- Q17 regression now passes after #1137.
- Independent fixture, fairness, query-semantics, and final harness reviews.

## Current baseline

At SF0.2 (~1.2M lineitem rows), before generalized optimizations:
- Q1: DuckDB 36.843 ms, Lix 87.735 ms, 2.381x
- Q6: DuckDB 10.229 ms, Lix 43.533 ms, 4.256x

These replace the earlier specialized-scan headline.

## Follow-ups required by the active OLAP goal

- SF0.2/SF1 qualification across Q1-Q22 with >=9 samples
- SlateDB and pristine/sparse/moderate overlay states
- separate planning, storage-to-Arrow, execution, and materialization phases
- generic pushdown/layout/vectorization PRs, each with >10% measured improvement

## Dependency note

The opt-in DuckDB dependency requires `comfy-table` 7.1.x, so the shared lockfile resolves `comfy-table`/crossterm to compatible versions even when the feature is disabled. Normal no-feature builds do not compile DuckDB or tpchgen.