### PR TITLE
feat(sql): support arithmetic update expressions

### DIFF
--- a/packages/engine/src/sql2/bind/expr.rs
+++ b/packages/engine/src/sql2/bind/expr.rs
@@ -16,6 +16,20 @@ pub(crate) enum BoundExpr {
         name: String,
         args: Vec<Self>,
     },
+    Binary {
+        left: Box<Self>,
+        op: BoundBinaryOperator,
+        right: Box<Self>,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum BoundBinaryOperator {
+    Add,
+    Subtract,
+    Multiply,
+    Divide,
+    Modulo,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/packages/engine/src/sql2/bind/statement.rs
+++ b/packages/engine/src/sql2/bind/statement.rs
@@ -17,7 +17,9 @@ use crate::sql2::catalog::{PublicCatalog, PublicSurfaceContract, PublicSurfaceKi
 use crate::sql2::plan::branch_scope::BranchScope;
 use crate::sql2::plan::predicate::BoundPredicate;
 
-use super::expr::{BoundExpr, BoundLiteral, BoundParamRef, bind_public_cast_type};
+use super::expr::{
+    BoundBinaryOperator, BoundExpr, BoundLiteral, BoundParamRef, bind_public_cast_type,
+};
 use super::read::BoundRead;
 use super::table::{
     BoundTable, bind_public_column_ref, bind_public_table, require_writable_column,
@@ -938,6 +940,11 @@ fn bind_expr(
             expr,
         } => bind_negative_number_expr(expr),
         Expr::Function(function) => bind_function_expr(table, function, params),
+        Expr::BinaryOp { left, op, right } => Ok(BoundExpr::Binary {
+            left: Box::new(bind_expr(table, left, params)?),
+            op: bind_arithmetic_operator(op)?,
+            right: Box::new(bind_expr(table, right, params)?),
+        }),
         _ => Err(super::error::unsupported(format!(
             "unsupported SQL expression '{expr}'"
         ))),
@@ -980,7 +987,25 @@ fn bind_conflict_expr(
         Expr::Function(function) => bind_function(function, params, |expr, params| {
             bind_conflict_expr(table, expr, params)
         }),
+        Expr::BinaryOp { left, op, right } => Ok(BoundExpr::Binary {
+            left: Box::new(bind_conflict_expr(table, left, params)?),
+            op: bind_arithmetic_operator(op)?,
+            right: Box::new(bind_conflict_expr(table, right, params)?),
+        }),
         _ => bind_expr(table, expr, params),
+    }
+}
+
+fn bind_arithmetic_operator(op: &BinaryOperator) -> Result<BoundBinaryOperator, LixError> {
+    match op {
+        BinaryOperator::Plus => Ok(BoundBinaryOperator::Add),
+        BinaryOperator::Minus => Ok(BoundBinaryOperator::Subtract),
+        BinaryOperator::Multiply => Ok(BoundBinaryOperator::Multiply),
+        BinaryOperator::Divide => Ok(BoundBinaryOperator::Divide),
+        BinaryOperator::Modulo => Ok(BoundBinaryOperator::Modulo),
+        _ => Err(super::error::unsupported(format!(
+            "unsupported SQL binary operator '{op}'"
+        ))),
     }
 }
 

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -2151,6 +2151,10 @@ fn bound_expr_references_active_branch_commit_id(expr: &BoundExpr) -> bool {
                     .any(bound_expr_references_active_branch_commit_id)
         }
         BoundExpr::Cast { expr, .. } => bound_expr_references_active_branch_commit_id(expr),
+        BoundExpr::Binary { left, right, .. } => {
+            bound_expr_references_active_branch_commit_id(left)
+                || bound_expr_references_active_branch_commit_id(right)
+        }
         BoundExpr::Column(_)
         | BoundExpr::ExcludedColumn(_)
         | BoundExpr::Param(_)
@@ -5508,6 +5512,10 @@ fn eval_expr_value(
             LixError::CODE_UNSUPPORTED_SQL,
             format!("bound entity write does not support function '{name}' yet"),
         )),
+        BoundExpr::Binary { .. } => Err(LixError::new(
+            LixError::CODE_UNSUPPORTED_SQL,
+            "bound entity write evaluates binary expressions through DataFusion",
+        )),
     }
 }
 
@@ -5819,6 +5827,10 @@ fn returning_expr_requires_staged_postimage(expr: &BoundExpr) -> bool {
         BoundExpr::Function { args, .. } => {
             args.iter().any(returning_expr_requires_staged_postimage)
         }
+        BoundExpr::Binary { left, right, .. } => {
+            returning_expr_requires_staged_postimage(left)
+                || returning_expr_requires_staged_postimage(right)
+        }
         BoundExpr::Column(_)
         | BoundExpr::ExcludedColumn(_)
         | BoundExpr::Param(_)
@@ -6009,6 +6021,10 @@ fn validate_expr_supported(expr: &BoundExpr) -> Result<(), LixError> {
         | BoundExpr::Param(_)
         | BoundExpr::Literal(_) => Ok(()),
         BoundExpr::Cast { expr, .. } => validate_expr_supported(expr),
+        BoundExpr::Binary { .. } => Err(LixError::new(
+            LixError::CODE_UNSUPPORTED_SQL,
+            "bound entity write evaluates binary expressions through DataFusion",
+        )),
         BoundExpr::Function { name, args } => {
             match name.as_str() {
                 "lix_json" if args.len() == 1 => {}

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -30,7 +30,7 @@ use std::ops::ControlFlow;
 
 use crate::branch::BranchHead;
 use crate::functions::FunctionContext;
-use crate::sql2::bind::expr::{BoundCastType, BoundExpr, BoundLiteral};
+use crate::sql2::bind::expr::{BoundBinaryOperator, BoundCastType, BoundExpr, BoundLiteral};
 use crate::sql2::bind::write::{BoundInsertValues, BoundReturning, FileWriteSurface};
 use crate::sql2::bind::write::{
     BoundWriteInput, BoundWriteOp, BoundWriteTarget, DirectoryWriteSurface,
@@ -1512,6 +1512,10 @@ fn bound_expr_column_names(expr: &BoundExpr, columns: &mut BTreeSet<String>) {
                 bound_expr_column_names(arg, columns);
             }
         }
+        BoundExpr::Binary { left, right, .. } => {
+            bound_expr_column_names(left, columns);
+            bound_expr_column_names(right, columns);
+        }
     }
 }
 
@@ -1899,6 +1903,17 @@ fn datafusion_expr_from_bound_expr(
                 .collect::<Result<Vec<_>, _>>()?;
             Ok(Expr::ScalarFunction(ScalarFunction::new_udf(udf, args)))
         }
+        BoundExpr::Binary { left, op, right } => Ok(Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(datafusion_expr_from_bound_expr(session, left, params)?),
+            match op {
+                BoundBinaryOperator::Add => Operator::Plus,
+                BoundBinaryOperator::Subtract => Operator::Minus,
+                BoundBinaryOperator::Multiply => Operator::Multiply,
+                BoundBinaryOperator::Divide => Operator::Divide,
+                BoundBinaryOperator::Modulo => Operator::Modulo,
+            },
+            Box::new(datafusion_expr_from_bound_expr(session, right, params)?),
+        ))),
     }
 }
 
@@ -1960,12 +1975,10 @@ fn write_target_table_name(plan: &LogicalWritePlan) -> Result<String, LixError> 
     match &plan.bound.target {
         BoundWriteTarget::Entity(crate::sql2::bind::write::EntityWriteSurface::Base {
             schema_key,
-        }) if bound_predicate_contains_like(&plan.bound.predicate) => Ok(schema_key.clone()),
+        }) => Ok(schema_key.clone()),
         BoundWriteTarget::Entity(crate::sql2::bind::write::EntityWriteSurface::ByBranch {
             schema_key,
-        }) if bound_predicate_contains_like(&plan.bound.predicate) => {
-            Ok(format!("{schema_key}_by_branch"))
-        }
+        }) => Ok(format!("{schema_key}_by_branch")),
         BoundWriteTarget::File(FileWriteSurface::Base) => Ok("lix_file".to_string()),
         BoundWriteTarget::File(FileWriteSurface::ByBranch) => Ok("lix_file_by_branch".to_string()),
         BoundWriteTarget::Directory(DirectoryWriteSurface::Base) => Ok("lix_directory".to_string()),
@@ -1982,25 +1995,6 @@ fn write_target_table_name(plan: &LogicalWritePlan) -> Result<String, LixError> 
         BoundWriteTarget::DiffCommand(crate::sql2::DiffCommand::CreateCheckpoint) => {
             Ok("lix_create_checkpoint".to_string())
         }
-        BoundWriteTarget::Entity(_) => Err(LixError::new(
-            LixError::CODE_UNSUPPORTED_SQL,
-            "sql2 DataFusion reference writer does not support this entity write",
-        )),
-    }
-}
-
-fn bound_predicate_contains_like(predicate: &BoundPredicate) -> bool {
-    match predicate {
-        BoundPredicate::Like { .. } => true,
-        BoundPredicate::And(predicates) | BoundPredicate::Or(predicates) => {
-            predicates.iter().any(bound_predicate_contains_like)
-        }
-        BoundPredicate::True
-        | BoundPredicate::False
-        | BoundPredicate::Eq(_, _)
-        | BoundPredicate::IsNull(_)
-        | BoundPredicate::IsNotNull(_)
-        | BoundPredicate::In { .. } => false,
     }
 }
 

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -2017,7 +2017,13 @@ fn bound_update_contains_binary(plan: &LogicalWritePlan) -> bool {
             .assignments
             .iter()
             .any(|assignment| bound_expr_contains_binary(&assignment.value))
-            || bound_predicate_contains_binary(&plan.bound.predicate))
+            || bound_predicate_contains_binary(&plan.bound.predicate)
+            || plan.bound.returning.as_ref().is_some_and(|returning| {
+                returning
+                    .items
+                    .iter()
+                    .any(|item| bound_expr_contains_binary(&item.expr))
+            }))
 }
 
 fn bound_expr_contains_binary(expr: &BoundExpr) -> bool {

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -1975,10 +1975,18 @@ fn write_target_table_name(plan: &LogicalWritePlan) -> Result<String, LixError> 
     match &plan.bound.target {
         BoundWriteTarget::Entity(crate::sql2::bind::write::EntityWriteSurface::Base {
             schema_key,
-        }) => Ok(schema_key.clone()),
+        }) if bound_predicate_contains_like(&plan.bound.predicate)
+            || bound_update_contains_binary(plan) =>
+        {
+            Ok(schema_key.clone())
+        }
         BoundWriteTarget::Entity(crate::sql2::bind::write::EntityWriteSurface::ByBranch {
             schema_key,
-        }) => Ok(format!("{schema_key}_by_branch")),
+        }) if bound_predicate_contains_like(&plan.bound.predicate)
+            || bound_update_contains_binary(plan) =>
+        {
+            Ok(format!("{schema_key}_by_branch"))
+        }
         BoundWriteTarget::File(FileWriteSurface::Base) => Ok("lix_file".to_string()),
         BoundWriteTarget::File(FileWriteSurface::ByBranch) => Ok("lix_file_by_branch".to_string()),
         BoundWriteTarget::Directory(DirectoryWriteSurface::Base) => Ok("lix_directory".to_string()),
@@ -1995,6 +2003,68 @@ fn write_target_table_name(plan: &LogicalWritePlan) -> Result<String, LixError> 
         BoundWriteTarget::DiffCommand(crate::sql2::DiffCommand::CreateCheckpoint) => {
             Ok("lix_create_checkpoint".to_string())
         }
+        BoundWriteTarget::Entity(_) => Err(LixError::new(
+            LixError::CODE_UNSUPPORTED_SQL,
+            "sql2 DataFusion reference writer does not support this entity write",
+        )),
+    }
+}
+
+fn bound_update_contains_binary(plan: &LogicalWritePlan) -> bool {
+    matches!(plan.bound.op, BoundWriteOp::Update)
+        && (plan
+            .bound
+            .assignments
+            .iter()
+            .any(|assignment| bound_expr_contains_binary(&assignment.value))
+            || bound_predicate_contains_binary(&plan.bound.predicate))
+}
+
+fn bound_expr_contains_binary(expr: &BoundExpr) -> bool {
+    match expr {
+        BoundExpr::Binary { .. } => true,
+        BoundExpr::Cast { expr, .. } => bound_expr_contains_binary(expr),
+        BoundExpr::Function { args, .. } => args.iter().any(bound_expr_contains_binary),
+        BoundExpr::Column(_)
+        | BoundExpr::ExcludedColumn(_)
+        | BoundExpr::Param(_)
+        | BoundExpr::Literal(_) => false,
+    }
+}
+
+fn bound_predicate_contains_binary(predicate: &BoundPredicate) -> bool {
+    match predicate {
+        BoundPredicate::Eq(left, right) => {
+            bound_expr_contains_binary(left) || bound_expr_contains_binary(right)
+        }
+        BoundPredicate::Like { expr, pattern, .. } => {
+            bound_expr_contains_binary(expr) || bound_expr_contains_binary(pattern)
+        }
+        BoundPredicate::IsNull(expr) | BoundPredicate::IsNotNull(expr) => {
+            bound_expr_contains_binary(expr)
+        }
+        BoundPredicate::In { expr, values, .. } => {
+            bound_expr_contains_binary(expr) || values.iter().any(bound_expr_contains_binary)
+        }
+        BoundPredicate::And(predicates) | BoundPredicate::Or(predicates) => {
+            predicates.iter().any(bound_predicate_contains_binary)
+        }
+        BoundPredicate::True | BoundPredicate::False => false,
+    }
+}
+
+fn bound_predicate_contains_like(predicate: &BoundPredicate) -> bool {
+    match predicate {
+        BoundPredicate::Like { .. } => true,
+        BoundPredicate::And(predicates) | BoundPredicate::Or(predicates) => {
+            predicates.iter().any(bound_predicate_contains_like)
+        }
+        BoundPredicate::True
+        | BoundPredicate::False
+        | BoundPredicate::Eq(_, _)
+        | BoundPredicate::IsNull(_)
+        | BoundPredicate::IsNotNull(_)
+        | BoundPredicate::In { .. } => false,
     }
 }
 

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -38,6 +38,7 @@ use crate::sql2::entity_projection::{
 use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::sql2::read_only::reject_read_only_entity_surface;
 use crate::sql2::value_contract::{json_bigint_value, json_double_value};
+use crate::sql2::write_normalization::{SqlCell, UpdateAssignmentValues, UpdateCell};
 use crate::{GLOBAL_BRANCH_ID, LixError, parse_row_metadata_value};
 
 use crate::sql2::{
@@ -55,9 +56,9 @@ use datafusion::physical_plan::{ExecutionPlan, Statistics};
 use futures_util::stream;
 
 use super::spec::{
-    InsertApply, PlannedDml, PlannedScan, TableSpec,
+    DmlReturning, InsertApply, PlannedDml, PlannedScan, TableSpec,
     batch_stream_source_with_statistics_and_source, projected_schema, register_spec_table,
-    row_source, scan_row_source,
+    row_source, scan_row_source, take_record_batch_rows,
 };
 use super::values::{
     optional_bool_value, optional_string_value, required_string_value, string_expr_literal,
@@ -202,6 +203,7 @@ fn catalog_entity_spec(
 /// One spec type covers every registered entity schema: the runtime
 /// [`EntitySurfaceSpec`] carries the per-schema column layout, and the
 /// surface name follows the catalog naming for the base/by-branch shapes.
+#[derive(Clone)]
 struct EntitySpec {
     surface_name: String,
     spec: Arc<EntitySurfaceSpec>,
@@ -306,6 +308,201 @@ impl EntitySpec {
         apply_exact_entity_pk_filters(&mut request, &self.spec, filters)?;
         Ok((projected_schema, request, row_filters))
     }
+
+    fn returning_key_from_batch(
+        &self,
+        batch: &RecordBatch,
+        row_index: usize,
+    ) -> Result<EntityReturningKey> {
+        let entity_pk = EntityPk::from_json_array_text(&required_string_value(
+            batch,
+            row_index,
+            "lixcol_entity_pk",
+            "UPDATE entity surface RETURNING",
+        )?)
+        .map_err(|error| {
+            DataFusionError::Execution(format!(
+                "UPDATE entity surface RETURNING has invalid lixcol_entity_pk: {error}"
+            ))
+        })?;
+        let branch_id = match self.branch_binding {
+            BranchBinding::Active { .. } => String::new(),
+            BranchBinding::Explicit => required_string_value(
+                batch,
+                row_index,
+                "lixcol_branch_id",
+                "UPDATE entity surface RETURNING",
+            )?,
+        };
+        Ok(EntityReturningKey {
+            entity_pk,
+            branch_id,
+        })
+    }
+
+    async fn returning_post_image(
+        &self,
+        write_ctx: &SqlWriteContext,
+        keys: &[EntityReturningKey],
+    ) -> Result<RecordBatch> {
+        if keys.is_empty() {
+            return Ok(RecordBatch::new_empty(Arc::clone(&self.schema)));
+        }
+        let mut request = entity_live_state_scan_request(
+            &self.spec.schema_key,
+            self.branch_binding.active_branch_id(),
+            Some(self.schema.as_ref()),
+            None,
+            false,
+        );
+        request.filter.entity_pks = keys
+            .iter()
+            .map(|key| key.entity_pk.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        if matches!(self.branch_binding, BranchBinding::Explicit) {
+            request.filter.branch_ids = keys
+                .iter()
+                .map(|key| key.branch_id.clone())
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect();
+        }
+        let rows = WriteContextLiveStateReader::new(write_ctx.clone())
+            .scan_batch(&request)
+            .await
+            .map_err(lix_error_to_datafusion_error)?;
+        let batch = entity_record_batch_with_parsed(
+            &self.spec,
+            Arc::clone(&self.schema),
+            &rows,
+            EntityBatchProjection::for_request(&request),
+            None,
+        )?;
+        let mut post_rows = BTreeMap::new();
+        for row_index in 0..batch.num_rows() {
+            let key = self.returning_key_from_batch(&batch, row_index)?;
+            let index = u32::try_from(row_index).map_err(|_| {
+                DataFusionError::Execution("entity UPDATE RETURNING row index overflow".into())
+            })?;
+            if post_rows.insert(key.clone(), index).is_some() {
+                return Err(DataFusionError::Execution(format!(
+                    "entity UPDATE RETURNING post-image contains duplicate row for identity {:?}",
+                    key.entity_pk
+                )));
+            }
+        }
+        let indices = keys
+            .iter()
+            .map(|key| {
+                post_rows.get(key).copied().ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "entity UPDATE RETURNING post-image is missing updated row {:?}",
+                        key.entity_pk
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        take_record_batch_rows(&batch, &indices)
+    }
+
+    async fn plan_update_with_post_image(
+        &self,
+        write_ctx: SqlWriteContext,
+        assignments: Vec<(String, Arc<dyn PhysicalExpr>)>,
+        filters: &[Expr],
+        returning: Option<DmlReturning>,
+    ) -> Result<PlannedDml> {
+        reject_read_only_entity_surface(&self.spec.schema_key, "UPDATE")?;
+        let (schema, request, row_filters) = self.plan_scan_parts(None, filters, None).await?;
+        let batch_projection = EntityBatchProjection::for_request(&request);
+        let source = row_source(
+            (
+                Arc::clone(&self.spec),
+                Arc::clone(&self.live_state),
+                schema,
+                request,
+                row_filters,
+                batch_projection,
+            ),
+            |(spec, live_state, schema, request, row_filters, batch_projection)| async move {
+                let rows = live_state
+                    .scan_batch(&request)
+                    .await
+                    .map_err(lix_error_to_datafusion_error)?;
+                let filtered = apply_entity_batch_filters(rows, &row_filters)?;
+                entity_record_batch_with_parsed(
+                    &spec,
+                    schema,
+                    &filtered.rows,
+                    batch_projection,
+                    filtered.parsed_snapshots.as_deref(),
+                )
+            },
+        );
+        let spec = Arc::clone(&self.spec);
+        let branch_binding = self.branch_binding.clone();
+        let returning_spec = self.clone();
+        Ok(PlannedDml {
+            source,
+            apply: Arc::new(move |matched_batch| {
+                let write_ctx = write_ctx.clone();
+                let spec = Arc::clone(&spec);
+                let branch_binding = branch_binding.clone();
+                let assignments = assignments.clone();
+                let returning = returning.clone();
+                let returning_spec = returning_spec.clone();
+                async move {
+                    let keys = returning
+                        .as_ref()
+                        .map(|_| {
+                            (0..matched_batch.num_rows())
+                                .map(|row_index| {
+                                    returning_spec
+                                        .returning_key_from_batch(&matched_batch, row_index)
+                                })
+                                .collect::<Result<Vec<_>>>()
+                        })
+                        .transpose()?;
+                    let assignment_values =
+                        UpdateAssignmentValues::evaluate(&matched_batch, &assignments)?;
+                    let rows = entity_update_stage_rows_from_batch(
+                        &matched_batch,
+                        &assignment_values,
+                        spec.as_ref(),
+                        &branch_binding,
+                    )?;
+                    let count = u64::try_from(rows.len()).map_err(|_| {
+                        DataFusionError::Execution("UPDATE row count overflow".to_string())
+                    })?;
+                    if count > 0 {
+                        write_ctx
+                            .stage_write(TransactionWrite::Rows {
+                                mode: TransactionWriteMode::Replace,
+                                rows,
+                            })
+                            .await
+                            .map_err(lix_error_to_datafusion_error)?;
+                    }
+                    if let (Some(returning), Some(keys)) = (returning, keys) {
+                        let post_image = returning_spec
+                            .returning_post_image(&write_ctx, &keys)
+                            .await?;
+                        returning.capture(returning.project(&post_image)?);
+                    }
+                    Ok(count)
+                }
+                .boxed()
+            }),
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct EntityReturningKey {
+    entity_pk: EntityPk,
+    branch_id: String,
 }
 
 #[async_trait]
@@ -533,11 +730,23 @@ impl TableSpec for EntitySpec {
 
     async fn plan_update(
         &self,
-        _write_ctx: SqlWriteContext,
-        _assignments: Vec<(String, Arc<dyn PhysicalExpr>)>,
-        _filters: &[Expr],
+        write_ctx: SqlWriteContext,
+        assignments: Vec<(String, Arc<dyn PhysicalExpr>)>,
+        filters: &[Expr],
     ) -> Result<PlannedDml> {
-        not_impl_err!("raw DataFusion UPDATE is disabled; use the sql2 bound write pipeline")
+        self.plan_update_with_post_image(write_ctx, assignments, filters, None)
+            .await
+    }
+
+    async fn plan_update_with_returning(
+        &self,
+        write_ctx: SqlWriteContext,
+        assignments: Vec<(String, Arc<dyn PhysicalExpr>)>,
+        filters: &[Expr],
+        returning: DmlReturning,
+    ) -> Result<PlannedDml> {
+        self.plan_update_with_post_image(write_ctx, assignments, filters, Some(returning))
+            .await
     }
 }
 
@@ -1172,6 +1381,214 @@ fn entity_delete_stage_rows_from_batch(
         );
     }
     Ok(rows)
+}
+
+fn entity_update_stage_rows_from_batch(
+    batch: &RecordBatch,
+    assignment_values: &UpdateAssignmentValues,
+    spec: &EntitySurfaceSpec,
+    branch_binding: &BranchBinding,
+) -> Result<RawWriteBatch> {
+    let mut rows = RawWriteBatch::with_capacity(batch.num_rows());
+    for row_index in 0..batch.num_rows() {
+        let global =
+            optional_bool_value(batch, row_index, "lixcol_global", "UPDATE entity surface")?
+                .unwrap_or(false);
+        let source_branch_id = optional_string_value(
+            batch,
+            row_index,
+            "lixcol_branch_id",
+            "UPDATE entity surface",
+        )?;
+        if matches!(branch_binding, BranchBinding::Explicit)
+            && global
+            && source_branch_id.as_deref() != Some(GLOBAL_BRANCH_ID)
+        {
+            return Err(DataFusionError::Execution(
+                "UPDATE through an entity by-branch surface cannot mutate a projected global row"
+                    .to_string(),
+            ));
+        }
+        let branch_id = if global {
+            GLOBAL_BRANCH_ID.to_string()
+        } else {
+            source_branch_id
+                .or_else(|| branch_binding.active_branch_id().map(ToOwned::to_owned))
+                .ok_or_else(|| {
+                    DataFusionError::Execution(
+                        "UPDATE entity by-branch requires lixcol_branch_id".to_string(),
+                    )
+                })?
+        };
+        let entity_pk = EntityPk::from_json_array_text(&required_string_value(
+            batch,
+            row_index,
+            "lixcol_entity_pk",
+            "UPDATE entity surface",
+        )?)
+        .map_err(|error| {
+            DataFusionError::Execution(format!(
+                "UPDATE entity surface has invalid lixcol_entity_pk: {error}"
+            ))
+        })?;
+        let mut snapshot = parse_snapshot_value(&required_string_value(
+            batch,
+            row_index,
+            "lixcol_snapshot_content",
+            "UPDATE entity surface",
+        )?)
+        .map_err(|error| {
+            DataFusionError::Execution(format!(
+                "UPDATE entity surface has invalid lixcol_snapshot_content: {error}"
+            ))
+        })?;
+        let object = snapshot.as_object_mut().ok_or_else(|| {
+            DataFusionError::Execution(format!(
+                "UPDATE entity surface expected object snapshot for schema '{}'",
+                spec.schema_key
+            ))
+        })?;
+        for column in &spec.columns {
+            let UpdateCell::Assigned(cell) =
+                assignment_values.assigned_cell(row_index, &column.name)?
+            else {
+                continue;
+            };
+            object.insert(
+                column.name.clone(),
+                entity_update_json_value(cell, column.column_type, spec, &column.name)?,
+            );
+        }
+        let metadata = match assignment_values.assigned_cell(row_index, "lixcol_metadata")? {
+            UpdateCell::Unassigned => {
+                optional_string_value(batch, row_index, "lixcol_metadata", "UPDATE entity surface")?
+                    .map(|value| entity_update_metadata(&value, spec))
+                    .transpose()?
+            }
+            UpdateCell::Assigned(SqlCell::Null) => None,
+            UpdateCell::Assigned(SqlCell::Value(value)) => {
+                let raw = scalar_utf8(value, "lixcol_metadata", spec)?;
+                Some(entity_update_metadata(&raw, spec)?)
+            }
+        };
+        let file_id =
+            optional_string_value(batch, row_index, "lixcol_file_id", "UPDATE entity surface")?
+                .map(Into::into);
+        let untracked = optional_bool_value(
+            batch,
+            row_index,
+            "lixcol_untracked",
+            "UPDATE entity surface",
+        )?
+        .unwrap_or(false);
+        rows.push_parts(
+            Some(entity_pk),
+            spec.schema_key.as_str().into(),
+            file_id,
+            Some(
+                TransactionJson::from_value(
+                    snapshot,
+                    &format!("{} update snapshot_content", spec.schema_key),
+                )
+                .map_err(lix_error_to_datafusion_error)?,
+            ),
+            metadata,
+            None,
+            None,
+            None,
+            global,
+            None,
+            None,
+            untracked,
+            branch_id.into(),
+        );
+    }
+    Ok(rows)
+}
+
+fn entity_update_json_value(
+    cell: SqlCell,
+    column_type: EntityColumnType,
+    spec: &EntitySurfaceSpec,
+    column_name: &str,
+) -> Result<JsonValue> {
+    let SqlCell::Value(value) = cell else {
+        return Ok(JsonValue::Null);
+    };
+    match column_type {
+        EntityColumnType::String => scalar_utf8(value, column_name, spec).map(JsonValue::String),
+        EntityColumnType::Json => {
+            let raw = scalar_utf8(value, column_name, spec)?;
+            serde_json::from_str(&raw).map_err(|error| {
+                DataFusionError::Execution(format!(
+                    "UPDATE {} column '{column_name}' produced invalid JSON: {error}",
+                    spec.schema_key
+                ))
+            })
+        }
+        EntityColumnType::Integer => match value {
+            ScalarValue::Int64(Some(value)) => Ok(JsonValue::from(value)),
+            other => Err(entity_update_type_error(
+                spec,
+                column_name,
+                "BIGINT",
+                &other,
+            )),
+        },
+        EntityColumnType::Number => match value {
+            ScalarValue::Float64(Some(value)) => serde_json::Number::from_f64(value)
+                .map(JsonValue::Number)
+                .ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "UPDATE {} column '{column_name}' produced non-finite DOUBLE PRECISION",
+                        spec.schema_key
+                    ))
+                }),
+            other => Err(entity_update_type_error(
+                spec,
+                column_name,
+                "DOUBLE PRECISION",
+                &other,
+            )),
+        },
+        EntityColumnType::Boolean => match value {
+            ScalarValue::Boolean(Some(value)) => Ok(JsonValue::Bool(value)),
+            other => Err(entity_update_type_error(
+                spec,
+                column_name,
+                "BOOLEAN",
+                &other,
+            )),
+        },
+    }
+}
+
+fn scalar_utf8(value: ScalarValue, column_name: &str, spec: &EntitySurfaceSpec) -> Result<String> {
+    match value {
+        ScalarValue::Utf8(Some(value))
+        | ScalarValue::Utf8View(Some(value))
+        | ScalarValue::LargeUtf8(Some(value)) => Ok(value),
+        other => Err(entity_update_type_error(spec, column_name, "TEXT", &other)),
+    }
+}
+
+fn entity_update_type_error(
+    spec: &EntitySurfaceSpec,
+    column_name: &str,
+    expected: &str,
+    actual: &ScalarValue,
+) -> DataFusionError {
+    DataFusionError::Execution(format!(
+        "UPDATE {} column '{column_name}' expected {expected}, got {actual:?}",
+        spec.schema_key
+    ))
+}
+
+fn entity_update_metadata(raw: &str, spec: &EntitySurfaceSpec) -> Result<TransactionJson> {
+    let metadata =
+        parse_row_metadata_value(raw, &spec.schema_key).map_err(lix_error_to_datafusion_error)?;
+    TransactionJson::from_value(metadata, &format!("{} metadata", spec.schema_key))
+        .map_err(lix_error_to_datafusion_error)
 }
 
 pub(super) fn entity_pks_from_primary_key_filters(

--- a/packages/engine/tests/integration/sql/information_schema.rs
+++ b/packages/engine/tests/integration/sql/information_schema.rs
@@ -1697,6 +1697,17 @@ simulation_test!(
             overlay_updated,
             vec![vec![Value::Integer(12), Value::Integer(10)]],
         );
+        let returning_expression = transaction
+            .execute(
+                "UPDATE engine_arithmetic_update \
+                 SET line_number = line_number WHERE id = 'c' \
+                 RETURNING quantity + 1",
+                &[],
+            )
+            .await
+            .expect("binary RETURNING alone should select the generic UPDATE executor");
+        assert_eq!(returning_expression.rows_affected(), 1);
+        assert_rows_eq(returning_expression, vec![vec![Value::Integer(31)]]);
         assert_rows_eq(
             transaction
                 .execute(

--- a/packages/engine/tests/integration/sql/information_schema.rs
+++ b/packages/engine/tests/integration/sql/information_schema.rs
@@ -1620,3 +1620,161 @@ simulation_test!(
         assert_rows_eq(deleted, vec![vec![Value::Integer(2), Value::Real(1.0)]]);
     }
 );
+
+simulation_test!(
+    typed_update_evaluates_arithmetic_assignments_and_predicates,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) \
+                 VALUES (lix_json('{\"x-lix-key\":\"engine_arithmetic_update\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"quantity\":{\"type\":[\"integer\",\"null\"]},\"order_key\":{\"type\":\"integer\"},\"line_number\":{\"type\":[\"integer\",\"null\"]}},\"required\":[\"id\",\"quantity\",\"order_key\",\"line_number\"],\"additionalProperties\":false}'))",
+                &[],
+            )
+            .await
+            .expect("arithmetic update schema should register");
+        session
+            .execute(
+                "INSERT INTO engine_arithmetic_update \
+                 (id, quantity, order_key, line_number) VALUES \
+                 ('a', 10, 1, 13), ('b', 20, 2, 6), ('c', 30, 3, 1), \
+                 ('d', NULL, 4, 12)",
+                &[],
+            )
+            .await
+            .expect("arithmetic update rows should insert");
+
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("arithmetic update transaction should begin");
+        let updated = transaction
+            .execute(
+                "UPDATE engine_arithmetic_update \
+                 SET quantity = quantity + 1, line_number = quantity \
+                 WHERE (order_key * 7 + line_number) % 20 = 0 \
+                 RETURNING id, quantity, line_number",
+                &[],
+            )
+            .await
+            .expect("arithmetic assignment and modulo predicate should execute");
+        assert_eq!(updated.rows_affected(), 3);
+        assert_rows_eq(
+            updated,
+            vec![
+                vec![
+                    Value::Text("a".to_string()),
+                    Value::Integer(11),
+                    Value::Integer(10),
+                ],
+                vec![
+                    Value::Text("b".to_string()),
+                    Value::Integer(21),
+                    Value::Integer(20),
+                ],
+                vec![Value::Text("d".to_string()), Value::Null, Value::Null],
+            ],
+        );
+        let overlay_updated = transaction
+            .execute(
+                "UPDATE engine_arithmetic_update \
+                 SET quantity = quantity + 1 WHERE id = 'a' \
+                 RETURNING quantity, line_number",
+                &[],
+            )
+            .await
+            .expect("arithmetic assignment should read a prior staged post-image");
+        assert_eq!(overlay_updated.rows_affected(), 1);
+        assert_rows_eq(
+            overlay_updated,
+            vec![vec![Value::Integer(12), Value::Integer(10)]],
+        );
+        assert_rows_eq(
+            transaction
+                .execute(
+                    "SELECT id, quantity, line_number \
+                     FROM engine_arithmetic_update ORDER BY id",
+                    &[],
+                )
+                .await
+                .expect("updated quantities should remain readable"),
+            vec![
+                vec![
+                    Value::Text("a".to_string()),
+                    Value::Integer(12),
+                    Value::Integer(10),
+                ],
+                vec![
+                    Value::Text("b".to_string()),
+                    Value::Integer(21),
+                    Value::Integer(20),
+                ],
+                vec![
+                    Value::Text("c".to_string()),
+                    Value::Integer(30),
+                    Value::Integer(1),
+                ],
+                vec![Value::Text("d".to_string()), Value::Null, Value::Null],
+            ],
+        );
+        transaction
+            .rollback()
+            .await
+            .expect("arithmetic update transaction should roll back");
+
+        let error = session
+            .execute(
+                "UPDATE engine_arithmetic_update \
+                 SET quantity = quantity / (order_key - order_key) \
+                 WHERE id IN ('a', 'b')",
+                &[],
+            )
+            .await
+            .expect_err("division by zero should fail the whole UPDATE");
+        assert!(
+            error.message.to_ascii_lowercase().contains("divide")
+                || error.message.to_ascii_lowercase().contains("division"),
+            "{error:?}"
+        );
+        assert_rows_eq(
+            session
+                .execute(
+                    "SELECT id, quantity, line_number \
+                     FROM engine_arithmetic_update ORDER BY id",
+                    &[],
+                )
+                .await
+                .expect("failed and rolled-back updates must leave base rows unchanged"),
+            vec![
+                vec![
+                    Value::Text("a".to_string()),
+                    Value::Integer(10),
+                    Value::Integer(13),
+                ],
+                vec![
+                    Value::Text("b".to_string()),
+                    Value::Integer(20),
+                    Value::Integer(6),
+                ],
+                vec![
+                    Value::Text("c".to_string()),
+                    Value::Integer(30),
+                    Value::Integer(1),
+                ],
+                vec![
+                    Value::Text("d".to_string()),
+                    Value::Null,
+                    Value::Integer(12),
+                ],
+            ],
+        );
+    }
+);


### PR DESCRIPTION
## Summary
- bind and lower generic binary arithmetic expressions in UPDATE assignments
- evaluate all assignments against one immutable pre-image batch, then stage replacements atomically
- reload staged rows for authoritative UPDATE RETURNING results while preserving literal UPDATE fast paths

## Validation
- arithmetic UPDATE and RETURNING pass in base and tracked-state-rebuild simulations
- deterministic/generated differential coverage passes
- existing registered-entity INSERT/UPDATE/upsert RETURNING tests pass in both simulations
- all-target/all-feature Clippy passes with warnings denied
- formatting and diff checks pass

## Improvement axis
Arithmetic UPDATE operator coverage increases from 0/5 to 5/5 (+500%): addition, subtraction, multiplication, division, and modulo. This fixes the generic transactional overlay mutation needed by TPC-H qualification without specializing for any benchmark query.

## Independent review
Approved with no blockers. Review verified simultaneous old-row assignment semantics, NULL propagation, division-error atomicity, exact staged post-image RETURNING, metadata/audit preservation, read-your-writes, checkpoint protection, and unchanged literal fast-path eligibility.