### PR TITLE
perf(session): bound transaction batch poll stacks

### DIFF
--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -1568,14 +1568,18 @@ where
                                 Some(statement_index),
                             );
                             let operation = async {
-                                execute_transaction_statement(
+                                // Keep the large statement executor behind a heap boundary. The
+                                // lending transaction closure already carries the whole parsed
+                                // batch; embedding this future in it makes debug poll stacks exceed
+                                // the standard 2 MiB worker stack for ordinary entity writes.
+                                Box::pin(execute_transaction_statement(
                                     transaction,
                                     &sql,
                                     parsed.clone(),
                                     &params,
                                     options.clone(),
                                     metadata,
-                                )
+                                ))
                                 .await
                                 .map_err(|error| {
                                     with_batch_statement_index(
@@ -1608,14 +1612,16 @@ where
                                 Some(statement_index),
                             );
                             let operation = async {
-                                execute_transaction_statement(
+                                // See the auto-parameterized branch above. Both batch routes need
+                                // the same bounded poll-stack boundary.
+                                Box::pin(execute_transaction_statement(
                                     transaction,
                                     &statement.sql,
                                     parsed,
                                     &statement.params,
                                     options.clone(),
                                     metadata,
-                                )
+                                ))
                                 .await
                                 .map_err(|error| {
                                     with_batch_statement_index(


### PR DESCRIPTION
## Summary
- add heap-backed poll boundaries to both sequential transaction-batch fallback routes
- keep borrowed batch inputs and all transaction semantics unchanged
- prevent valid undo/redo dependency-closure transactions from overflowing Tokio standard worker stacks

## Validation
- exact default-stack regression passes 100/100
- 58/58 execute tests pass
- 14/14 undo/redo tests pass
- exact regression passes with `all-simulations`
- all-target/all-feature engine Clippy passes with warnings denied

## Improvement axis
The independently measured minimum passing worker stack drops from 2,288 KiB to 1,936 KiB: 352 KiB, or 15.38%. The patched path passes on the standard 2 MiB worker stack; the untouched baseline overflows below 2,288 KiB.

## Independent review
Approved with no blockers. Review verified that boxing changes future storage only: lifetimes, cancellation, statement ordering, atomic commit, read-your-writes, error indexing, telemetry, idempotency staging, and plugin lease behavior remain unchanged. Fast parameter-batch and read-only routes remain allocation-free.