### PR TITLE
Reuse certified entity columnar batches

### DIFF
--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -5710,7 +5710,8 @@ mod tests {
 
     #[tokio::test]
     async fn large_ordered_parameter_update_replaces_complete_packed_current_base() {
-        const ROW_COUNT: usize = 1_024;
+        const ROW_COUNT: usize = 2_048;
+        const PARTIAL_ROW_COUNT: usize = ROW_COUNT / 2;
         let session = open_session().await;
         let schema = serde_json::json!({
             "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -5750,6 +5751,7 @@ mod tests {
         session.execute_batch(&insert_statements).await.unwrap();
 
         crate::transaction::take_complete_replacement_packed_current_base_retirements();
+        crate::transaction::take_certified_entity_columnar_reuses();
         let update_sql =
             "UPDATE ordered_packed_update_probe SET value = lix_json($1) WHERE path = $2";
         for version in 1..=2 {
@@ -5771,6 +5773,11 @@ mod tests {
                 .sum::<u64>();
             assert_eq!(affected, ROW_COUNT as u64);
             assert_eq!(
+                crate::transaction::take_certified_entity_columnar_reuses(),
+                1,
+                "complete certified replacements should retain their executor-built columnar vectors"
+            );
+            assert_eq!(
                 crate::transaction::take_complete_replacement_packed_current_base_retirements(),
                 1,
                 "each complete certified replacement should swap one packed base reference"
@@ -5785,7 +5792,7 @@ mod tests {
 
         let rows = session
             .execute(
-                "SELECT path, value FROM ordered_packed_update_probe WHERE path IN ('0000', '1023') ORDER BY path",
+                "SELECT path, value FROM ordered_packed_update_probe WHERE path IN ('0000', '2047') ORDER BY path",
                 &[],
             )
             .await
@@ -5797,7 +5804,7 @@ mod tests {
         );
         assert_eq!(
             rows.rows()[1].get::<serde_json::Value>("value").unwrap(),
-            serde_json::json!("updated-2-1023")
+            serde_json::json!("updated-2-2047")
         );
         let working_diff = session
             .execute(
@@ -5812,13 +5819,29 @@ mod tests {
             "replacing a packed base must preserve its working-diff epoch"
         );
 
-        session
-            .execute(
-                "UPDATE ordered_packed_update_probe SET value = lix_json('\"partial\"') WHERE path = '0000'",
-                &[],
-            )
+        crate::transaction::take_certified_entity_columnar_reuses();
+        let partial_update_statements = (0..PARTIAL_ROW_COUNT)
+            .map(|row_index| ExecuteBatchStatement {
+                sql: update_sql.to_string(),
+                params: vec![
+                    Value::Text(format!("\"partial-{row_index:04}\"")),
+                    Value::Text(format!("{row_index:04}")),
+                ],
+            })
+            .collect::<Vec<_>>();
+        let partial_affected = session
+            .execute_batch(&partial_update_statements)
             .await
-            .unwrap();
+            .unwrap()
+            .iter()
+            .map(ExecuteResult::rows_affected)
+            .sum::<u64>();
+        assert_eq!(partial_affected, PARTIAL_ROW_COUNT as u64);
+        assert_eq!(
+            crate::transaction::take_certified_entity_columnar_reuses(),
+            0,
+            "a large partial replacement must not build an unpublished columnar base"
+        );
         assert_eq!(
             crate::transaction::take_complete_replacement_packed_current_base_retirements(),
             0,
@@ -5833,7 +5856,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             partial.rows()[0].get::<serde_json::Value>("value").unwrap(),
-            serde_json::json!("partial")
+            serde_json::json!("partial-0000")
         );
         session
             .create_checkpoint()

--- a/packages/engine/src/sql2/entity_columnar_layout.rs
+++ b/packages/engine/src/sql2/entity_columnar_layout.rs
@@ -82,6 +82,134 @@ where
     ))
 }
 
+/// Encodes the certified `{path, value}` replacement shape directly from its
+/// typed identity column and canonical JSON-value arena. This is physically
+/// equivalent to projecting the completed snapshot objects below, without a
+/// second JSON parse of every row at commit time.
+pub(crate) fn encode_certified_path_value_row_groups(
+    spec: &EntitySurfaceSpec,
+    entity_pks: &[EntityPk],
+    canonical_value_arena: &[u8],
+    value_offsets: &[(usize, usize)],
+) -> Result<Option<EncodedEntityRowGroups>, LixError> {
+    if entity_pks.is_empty() {
+        return Ok(None);
+    }
+    if !spec.certifies_path_value_replacement
+        || entity_pks.len() != value_offsets.len()
+        || spec.columns.len() != 2
+        || !spec.columns.iter().any(|column| column.name == "path")
+        || !spec.columns.iter().any(|column| column.name == "value")
+    {
+        return Err(entity_columnar_error(
+            "certified path/value projection does not match its entity schema",
+        ));
+    }
+
+    // Like the generic encoder, this is only a derived acceleration
+    // structure. Once the certified shape is established, projection and
+    // physical-limit failures must fall back to the authoritative JSON rows
+    // instead of rejecting the transaction.
+    Ok(optional_derived_row_group_set(
+        encode_certified_path_value_row_groups_impl(
+            spec,
+            entity_pks,
+            canonical_value_arena,
+            value_offsets,
+        ),
+    ))
+}
+
+fn encode_certified_path_value_row_groups_impl(
+    spec: &EntitySurfaceSpec,
+    entity_pks: &[EntityPk],
+    canonical_value_arena: &[u8],
+    value_offsets: &[(usize, usize)],
+) -> Result<EncodedEntityRowGroups, LixError> {
+    let mut fields = entity_visible_fields(spec);
+    fields.push(Field::new(
+        ENTITY_COLUMNAR_ENTITY_PK_FIELD,
+        DataType::Utf8,
+        false,
+    ));
+    let mut metadata = HashMap::new();
+    metadata.insert(
+        ENTITY_COLUMNAR_LAYOUT_FINGERPRINT_METADATA_KEY.to_string(),
+        spec.columnar_layout_fingerprint(),
+    );
+    metadata.insert(
+        ENTITY_COLUMNAR_BASE_COORDINATES_METADATA_KEY.to_string(),
+        "true".to_owned(),
+    );
+    let schema = Arc::new(Schema::new_with_metadata(fields, metadata));
+    let mut batches = Vec::with_capacity(entity_pks.len().div_ceil(ROW_GROUP_MAX_ROWS));
+    let mut input_locations = Vec::with_capacity(entity_pks.len());
+
+    for (group_index, start) in (0..entity_pks.len())
+        .step_by(ROW_GROUP_MAX_ROWS)
+        .enumerate()
+    {
+        let end = start
+            .saturating_add(ROW_GROUP_MAX_ROWS)
+            .min(entity_pks.len());
+        let paths = entity_pks[start..end]
+            .iter()
+            .map(EntityPk::as_single_string)
+            .collect::<Result<Vec<_>, _>>()?;
+        let values = value_offsets[start..end]
+            .iter()
+            .map(|&(value_start, value_end)| {
+                canonical_value_arena
+                    .get(value_start..value_end)
+                    .ok_or_else(|| entity_columnar_error("canonical value offset is out of bounds"))
+                    .and_then(|value| {
+                        std::str::from_utf8(value).map_err(|_| {
+                            entity_columnar_error("canonical value arena is not UTF-8")
+                        })
+                    })
+                    .map(|value| (value != "null").then_some(value))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let path_column: ArrayRef = Arc::new(StringArray::from(paths));
+        let value_column: ArrayRef = Arc::new(StringArray::from(values));
+        let mut columns = spec
+            .columns
+            .iter()
+            .map(|column| match column.name.as_str() {
+                "path" => Ok(Arc::clone(&path_column)),
+                "value" => Ok(Arc::clone(&value_column)),
+                _ => Err(entity_columnar_error(
+                    "certified path/value projection contains an unexpected column",
+                )),
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let entity_pk_json = entity_pks[start..end]
+            .iter()
+            .map(EntityPk::as_json_array_text)
+            .collect::<Result<Vec<_>, _>>()?;
+        columns.push(Arc::new(StringArray::from(entity_pk_json)));
+        batches.push(
+            RecordBatch::try_new(Arc::clone(&schema), columns)
+                .map_err(|error| entity_columnar_error(error.to_string()))?,
+        );
+        let group_index = u32::try_from(group_index)
+            .map_err(|_| entity_columnar_error("row-group index exceeds u32"))?;
+        for row_index in 0..end - start {
+            input_locations.push(RowGroupRowLocation {
+                group_index,
+                row_index: u32::try_from(row_index)
+                    .map_err(|_| entity_columnar_error("row index exceeds u32"))?,
+            });
+        }
+    }
+
+    let encoded = encode_row_group_set_preserving_batches(&spec.schema_key, schema, &batches)?;
+    Ok(EncodedEntityRowGroups {
+        encoded,
+        input_locations,
+    })
+}
+
 fn encode_registered_entity_row_groups_impl<'a, I>(
     spec: &EntitySurfaceSpec,
     rows: I,
@@ -335,6 +463,94 @@ mod tests {
         assert_eq!(
             identities,
             std::collections::BTreeSet::from([r#"["a",1]"#, r#"["b",2]"#])
+        );
+    }
+
+    #[test]
+    fn certified_path_value_projection_matches_generic_physical_layout() {
+        let spec = derive_entity_surface_spec_from_schema(&json!({
+            "x-lix-key": "json_pointer",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" },
+                "value": {
+                    "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+                }
+            },
+            "required": ["path", "value"],
+            "additionalProperties": false
+        }))
+        .expect("path/value spec");
+        let identities = [
+            EntityPk::single("/a"),
+            EntityPk::single("/b"),
+            EntityPk::single("/c"),
+        ];
+        let snapshots = [
+            json!({"path":"/a","value":{"x":1}}),
+            json!({"path":"/b","value":null}),
+            json!({"path":"/c","value":"hello"}),
+        ];
+        let canonical_snapshots = snapshots
+            .iter()
+            .map(JsonValue::to_string)
+            .collect::<Vec<_>>();
+        let generic = encode_registered_entity_row_groups(
+            &spec,
+            identities
+                .iter()
+                .zip(&snapshots)
+                .zip(&canonical_snapshots)
+                .map(|((entity_pk, snapshot), canonical)| EntityColumnarRowRef {
+                    entity_pk,
+                    snapshot_bytes: canonical.as_bytes(),
+                    snapshot_value: snapshot,
+                }),
+        )
+        .expect("generic encoding")
+        .expect("generic row groups");
+
+        let canonical_values = br#"{"x":1}null"hello""#;
+        let direct = encode_certified_path_value_row_groups(
+            &spec,
+            &identities,
+            canonical_values,
+            &[(0, 7), (7, 11), (11, 18)],
+        )
+        .expect("certified encoding")
+        .expect("certified row groups");
+
+        assert_eq!(direct.manifest, generic.manifest);
+        assert_eq!(direct.input_locations, generic.input_locations);
+    }
+
+    #[test]
+    fn certified_projection_failure_falls_back_to_authoritative_rows() {
+        let spec = derive_entity_surface_spec_from_schema(&json!({
+            "x-lix-key": "json_pointer",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" },
+                "value": {
+                    "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+                }
+            },
+            "required": ["path", "value"],
+            "additionalProperties": false
+        }))
+        .expect("path/value spec");
+
+        assert!(
+            encode_certified_path_value_row_groups(
+                &spec,
+                &[EntityPk::single("/a")],
+                b"null",
+                &[(0, 5)],
+            )
+            .expect("derived projection failure must not reject the authoritative update")
+            .is_none()
         );
     }
 

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -31,9 +31,9 @@ use crate::sql2::plan::predicate::{BoundPredicate, FilterSet};
 use crate::sql2::read_only::reject_read_only_entity_surface;
 use crate::sql2::value_contract::{json_bigint_value, json_double_value};
 use crate::transaction::types::{
-    CertifiedParameterInsertBatch, CertifiedParameterReplacementBatch,
-    CertifiedRawWriteBatchPreparation, PreparedRowFacts, RawWriteBatch, RawWriteRowRef,
-    TransactionJson, TransactionWrite, TransactionWriteMode,
+    CertifiedEntityColumnarBatch, CertifiedParameterInsertBatch,
+    CertifiedParameterReplacementBatch, CertifiedRawWriteBatchPreparation, PreparedRowFacts,
+    RawWriteBatch, RawWriteRowRef, TransactionJson, TransactionWrite, TransactionWriteMode,
 };
 use crate::wasm::WasmEntityKey;
 use crate::{LixError, NullableKeyFilter, Value, parse_row_metadata_value};
@@ -988,6 +988,7 @@ async fn try_execute_direct_path_value_replacement_batch(
         candidates.len()
     };
     let mut snapshot_offsets = Vec::with_capacity(replacement_capacity);
+    let mut value_offsets = Vec::with_capacity(replacement_capacity);
     let mut replacement_entity_pks = Vec::with_capacity(replacement_capacity);
     let mut affected_by_statement = vec![0_u64; row_count];
     let mut candidate_index = 0;
@@ -1029,6 +1030,7 @@ async fn try_execute_direct_path_value_replacement_batch(
         append_canonical_json_string(&mut normalized, entity_pk.as_single_string()?)
             .map_err(|error| with_parameter_batch_statement_index(error, statement_index))?;
         normalized.extend_from_slice(b",\"value\":");
+        let value_start = normalized.len();
         match parameter_batch.value(replacement.value_param_index, statement_index) {
             DirectParameterValue::Null => normalized.extend_from_slice(b"null"),
             DirectParameterValue::String(raw) => {
@@ -1040,6 +1042,7 @@ async fn try_execute_direct_path_value_replacement_batch(
                 unreachable!("the certified replacement value parameter is text")
             }
         }
+        value_offsets.push((value_start, normalized.len()));
         normalized.push(b'}');
         snapshot_offsets.push((start, normalized.len()));
         replacement_entity_pks.push(entity_pk.clone());
@@ -1055,9 +1058,34 @@ async fn try_execute_direct_path_value_replacement_batch(
         }
     }
     if !replacement_entity_pks.is_empty() {
+        const CERTIFIED_ENTITY_COLUMNAR_MIN_ROWS: usize = 1_024;
+        let entity_columnar = if complete_collection_replacement
+            && replacement_entity_pks.len() >= CERTIFIED_ENTITY_COLUMNAR_MIN_ROWS
+            && schema_catalog
+                .schema(&spec.schema_key)
+                .is_some_and(crate::schema::materializes_entity_columnar_sidecar)
+        {
+            crate::sql2::encode_certified_path_value_row_groups(
+                &spec,
+                &replacement_entity_pks,
+                &normalized,
+                &value_offsets,
+            )?
+            .map(|encoded| {
+                let (encoded, input_locations) = encoded.into_parts();
+                CertifiedEntityColumnarBatch::new(
+                    encoded,
+                    input_locations,
+                    replacement_entity_pks.len(),
+                )
+            })
+            .transpose()?
+        } else {
+            None
+        };
         let snapshots =
             TransactionJson::from_certified_row_content_arena(normalized, snapshot_offsets)?;
-        let rows = CertifiedParameterReplacementBatch::new(
+        let mut rows = CertifiedParameterReplacementBatch::new(
             replacement_entity_pks,
             snapshots,
             spec.schema_key.as_str().into(),
@@ -1072,6 +1100,9 @@ async fn try_execute_direct_path_value_replacement_batch(
                 complete_collection_replacement,
             },
         )?;
+        if let Some(entity_columnar) = entity_columnar {
+            rows = rows.with_entity_columnar(entity_columnar);
+        }
         ctx.stage_certified_parameter_batch_replace(rows)
             .instrument(tracing::debug_span!(
                 target: "lix_perf",

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -51,7 +51,7 @@ pub(crate) use entity_batch::{CurrentEntitySnapshotReader, EntitySnapshotReader}
 pub(crate) use entity_columnar_layout::{
     ENTITY_COLUMNAR_BASE_COORDINATES_METADATA_KEY, ENTITY_COLUMNAR_ENTITY_PK_FIELD,
     ENTITY_COLUMNAR_LAYOUT_FINGERPRINT_METADATA_KEY, EntityColumnarRowRef,
-    encode_registered_entity_row_groups,
+    encode_certified_path_value_row_groups, encode_registered_entity_row_groups,
 };
 pub(crate) use entity_projection::EntityProjectionDecoder;
 pub(crate) use exec::{SessionReadSqlResult, SqlWriteResult};

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -86,6 +86,8 @@ std::thread_local! {
         const { std::cell::Cell::new(0) };
     static COMPLETE_REPLACEMENT_PACKED_CURRENT_BASE_RETIREMENTS: std::cell::Cell<usize> =
         const { std::cell::Cell::new(0) };
+    static CERTIFIED_ENTITY_COLUMNAR_REUSES: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
 }
 
 #[cfg(test)]
@@ -102,6 +104,11 @@ pub(crate) fn take_complete_replacement_packed_current_base_publications() -> us
 #[cfg(test)]
 pub(crate) fn take_complete_replacement_packed_current_base_retirements() -> usize {
     COMPLETE_REPLACEMENT_PACKED_CURRENT_BASE_RETIREMENTS.with(|retirements| retirements.replace(0))
+}
+
+#[cfg(test)]
+pub(crate) fn take_certified_entity_columnar_reuses() -> usize {
+    CERTIFIED_ENTITY_COLUMNAR_REUSES.with(|reuses| reuses.replace(0))
 }
 
 /// Commits prepared transaction rows into tracked history and unified current
@@ -4076,6 +4083,31 @@ fn prepare_entity_columnar_write_sets(
         state_rows.certified_complete_collection_replacement() && insert_selection.is_empty();
     if !publishes_ordered_insert && !publishes_complete_replacement {
         return Ok(crate::live_state::EntityColumnarWriteSets::new());
+    }
+    if publishes_complete_replacement
+        && let Some((commit_id, schema_key, certified)) =
+            state_rows.dense_certified_entity_columnar()
+    {
+        if certified.input_locations().len() != state_rows.len() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "certified entity columnar coordinates lost row alignment before commit",
+            ));
+        }
+        let mut encoded =
+            crate::live_state::EntityColumnarWriteSets::with_state_row_count(state_rows.len());
+        for (state_row_index, &location) in certified.input_locations().iter().enumerate() {
+            encoded.set_state_row_location(state_row_index, location);
+        }
+        encoded.insert(
+            (commit_id, schema_key.to_string()),
+            certified.encoded().clone(),
+        );
+        #[cfg(test)]
+        CERTIFIED_ENTITY_COLUMNAR_REUSES.with(|reuses| {
+            reuses.set(reuses.get().saturating_add(1));
+        });
+        return Ok(encoded);
     }
     if (publishes_ordered_insert || publishes_complete_replacement)
         && let Some((commit_id, schema_key, snapshots)) = state_rows.dense_entity_columnar_input()

--- a/packages/engine/src/transaction/mod.rs
+++ b/packages/engine/src/transaction/mod.rs
@@ -17,6 +17,8 @@ pub mod bench {
 }
 
 #[cfg(test)]
+pub(crate) use commit::take_certified_entity_columnar_reuses;
+#[cfg(test)]
 pub(crate) use commit::take_complete_replacement_packed_current_base_publications;
 #[cfg(test)]
 pub(crate) use commit::take_complete_replacement_packed_current_base_retirements;

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -500,6 +500,44 @@ pub(crate) struct CertifiedParameterBatch {
     schema_key: SharedStr,
     branch_id: SharedStr,
     certificate: CertifiedRawWriteBatchPreparation,
+    entity_columnar: Option<CertifiedEntityColumnarBatch>,
+}
+
+/// Executor-produced analytical projection aligned with one certified dense
+/// entity replacement. JSON snapshots remain the durable history authority;
+/// this certificate only avoids decoding those same snapshots back into
+/// Arrow at the commit boundary.
+#[derive(Debug, Clone)]
+pub(crate) struct CertifiedEntityColumnarBatch {
+    encoded: crate::columnar_row_group::EncodedRowGroupSet,
+    input_locations: Vec<crate::columnar_row_group::RowGroupRowLocation>,
+}
+
+impl CertifiedEntityColumnarBatch {
+    pub(crate) fn new(
+        encoded: crate::columnar_row_group::EncodedRowGroupSet,
+        input_locations: Vec<crate::columnar_row_group::RowGroupRowLocation>,
+        row_count: usize,
+    ) -> Result<Self, LixError> {
+        if input_locations.len() != row_count {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "certified entity columnar coordinates are not row-aligned",
+            ));
+        }
+        Ok(Self {
+            encoded,
+            input_locations,
+        })
+    }
+
+    pub(crate) fn encoded(&self) -> &crate::columnar_row_group::EncodedRowGroupSet {
+        &self.encoded
+    }
+
+    pub(crate) fn input_locations(&self) -> &[crate::columnar_row_group::RowGroupRowLocation] {
+        &self.input_locations
+    }
 }
 
 impl CertifiedParameterBatch {
@@ -528,7 +566,16 @@ impl CertifiedParameterBatch {
             schema_key,
             branch_id,
             certificate,
+            entity_columnar: None,
         })
+    }
+
+    pub(crate) fn with_entity_columnar(
+        mut self,
+        entity_columnar: CertifiedEntityColumnarBatch,
+    ) -> Self {
+        self.entity_columnar = Some(entity_columnar);
+        self
     }
 
     pub(crate) fn len(&self) -> usize {
@@ -564,6 +611,7 @@ impl CertifiedParameterBatch {
             schema_key,
             branch_id,
             certificate,
+            entity_columnar,
         } = self;
         let row_count = entity_pks.len();
         let (mut strings, schema_key_ordinal, branch_id_ordinal) = if schema_key == branch_id {
@@ -612,6 +660,7 @@ impl CertifiedParameterBatch {
                 commit_id: None,
                 branch_id: branch_id_ordinal,
                 direct_change_ids: None,
+                entity_columnar,
             }),
             entity_pks,
             strings,
@@ -2527,6 +2576,10 @@ struct DenseCertifiedParameterSlots {
     /// Absent until commit-delta publication assigns direct addresses. The
     /// compact segment map derives every UUID without a million-row column.
     direct_change_ids: Option<OrderedAddressableCommitDeltaStage>,
+    /// Present only while row order and contents retain the executor's exact
+    /// complete-replacement certificate. Expanding the dense representation
+    /// drops this derived projection and restores the generic JSON path.
+    entity_columnar: Option<CertifiedEntityColumnarBatch>,
 }
 
 #[derive(Debug, Clone)]
@@ -2953,6 +3006,8 @@ impl PreparedStateBatch {
                     && left.commit_id == right.commit_id
                     && left.direct_change_ids.is_none()
                     && right.direct_change_ids.is_none()
+                    && left.entity_columnar.is_none()
+                    && right.entity_columnar.is_none()
                     && self.durable_predecessors.is_empty()
                     && other.durable_predecessors.is_empty()
                     && self.origins.is_empty()
@@ -3333,6 +3388,17 @@ impl PreparedStateBatch {
             commit_id,
             self.strings[dense.schema_key as usize].as_str(),
             &self.json[..dense.len],
+        ))
+    }
+
+    pub(crate) fn dense_certified_entity_columnar(
+        &self,
+    ) -> Option<(CommitId, &str, &CertifiedEntityColumnarBatch)> {
+        let dense = self.dense_certified_parameter.as_ref()?;
+        Some((
+            dense.commit_id?,
+            self.strings[dense.schema_key as usize].as_str(),
+            dense.entity_columnar.as_ref()?,
         ))
     }
 


### PR DESCRIPTION
## What changed

Carry the certified complete `{path, value}` replacement's typed identity/value projection from the SQL executor through transaction preparation and publish those already-encoded row groups at commit time.

This removes the redundant hot-path loop that serialized authoritative history JSON and then reparsed every row back into Arrow solely to build the current-generation analytical sidecar.

- retain canonical value offsets while the executor builds the authoritative snapshot arena
- encode the physically equivalent path/value/entity-PK row groups once
- preserve the derived carrier only while row order, schema, and complete-replacement proof remain exact
- fall back to authoritative generic semantics for partial batches, schema mutation/opt-out, and other certificate-invalidating shapes
- treat derived projection/physical-limit failures as sidecar fallback rather than rejecting valid SQL
- no changenote

JSON snapshots and commit deltas remain authoritative for history, diff, merge, and branch behavior. Durable row-group manifests, coordinates, and physical write counts are unchanged.

## Why

Profiling 1M public SQL UPDATE on #1136 showed two dominant Lix-only costs:

1. ~2.61s rebuilding Arrow from JSON at commit
2. ~2.28s in the tracked-root fence

This PR removes the first bottleneck. The root fence remains a separate stacked hard cut.

## Performance

Baseline is the immediately previous merged PR, #1136 (`0ce102abdda57f83c8ca48c3ac8682ca739ed814`). Same optimized benchmark fixture and public `executeBatch` bound UPDATE path.

| Rows | Adapter | #1136 | This PR | Change |
|---:|---|---:|---:|---:|
| 10K | RocksDB | 53.866 ms | 34.879 ms | **-35.2%** |
| 10K | SlateDB | 51.311 ms | 33.090 ms | **-35.5%** |
| 1M | RocksDB | 6.732 s | 4.147 s | **-38.4%** |
| 1M | SlateDB | 6.214 s | 3.547 s | **-42.9%** |

1M update-phase allocation accounting falls about 27.6% (RocksDB 5.424 GB → 3.925 GB; SlateDB 5.437 GB → 3.937 GB).

Physical accounting remains 31,216 puts, 2 deletes, and ~92.355 MB at 1M rows (298 puts, 2 deletes, ~1.750 MB at 10K).

Raw SQLite 1M UPDATE is 2.357s, so the remaining ratios are approximately 1.76× RocksDB and 1.51× SlateDB. This PR clears the stacked-PR threshold but does not claim the final 1.2× goal; the profiled tracked-root fence is next.

## Validation

- `cargo check -p lix_engine`
- `cargo clippy -p lix_engine --lib -- -D warnings`
- `RUST_MIN_STACK=16777216 cargo test -p lix_engine --lib`: 1,801 passed, 8 ignored
- public cross-adapter parity/OLAP suite: 8 passed
- exact direct-vs-generic row-group manifest/digest/coordinate equivalence, including JSON null
- complete 2,048-row replacement proves carrier reuse
- 1,024-of-2,048 partial replacement proves no unpublished sidecar is built
- derived projection failure proves authoritative UPDATE still commits via fallback
- staged schema amendment and columnar opt-out tests
- two independent adversarial reviews, including out-of-order/duplicate PK alignment and history/diff/merge/branch authority

Follow-up memory work is tracked in #1143 and #1144. The unrelated strict all-target lint issue on main is tracked in #1142.