### PR TITLE
bench(tpch): report neutral analytical phases

### DIFF
--- a/packages/engine-benchmarks/benches/tpch/README.md
+++ b/packages/engine-benchmarks/benches/tpch/README.md
@@ -21,6 +21,25 @@ tables and Q1-Q22 are live. Its JSON `suite` field deliberately says
 `tpch-derived-common-types` because the shared types differ from native TPC-H
 dates and decimals.
 
+Every timed JSON record includes phase medians. Lix reports four disjoint wall
+phases: SQL logical planning, DataFusion physical planning, Arrow physical
+execution/collection, and public-result materialization. The remaining public
+call time is reported as `lix_unattributed_overhead_median_ms`; it includes
+snapshot acquisition, provider registration, and routing, so the named phases
+are not made to absorb setup work they do not perform. Common result
+normalization used only by this harness is reported separately.
+
+DuckDB exposes a different honest boundary: `prepare`, `query_arrow`, Arrow
+iterator collection, and owned-row materialization. `query_arrow` executes the
+query and constructs DuckDB's internal result, so the benchmark deliberately
+does not claim a finer physical-planning/execution split for DuckDB.
+
+Lix also reports generic scan output rows, batches, and Arrow in-memory bytes.
+`lix_scan_elapsed_operator_sum_median_ms` sums time spent polling all scan
+partitions and may overlap the physical-execution wall phase; it must not be
+added to the four disjoint phases. `lix_scan_arrow_bytes_median` is the Arrow
+array footprint at scan output, not storage-backend I/O bytes.
+
 Set `LIX_TPCH_OVERLAY=sparse` to update a deterministic 0.1% sample of
 `lineitem`, or `LIX_TPCH_OVERLAY=moderate` for a 5% sample. The default is
 `pristine`. Overlay mutations are applied to both engines after their initial

--- a/packages/engine-benchmarks/benches/tpch/duckdb.rs
+++ b/packages/engine-benchmarks/benches/tpch/duckdb.rs
@@ -1,5 +1,6 @@
 use datafusion::arrow::record_batch::RecordBatch;
 use duckdb::{Connection, params};
+use std::time::{Duration, Instant};
 
 use crate::data;
 
@@ -263,9 +264,36 @@ pub(crate) fn seeded(scale_factor: f64, overlay_rowkeys: &[String]) -> Connectio
 }
 
 pub(crate) fn query(connection: &Connection, sql: &str) -> Vec<RecordBatch> {
+    query_profiled(connection, sql).batches
+}
+
+pub(crate) struct ProfiledQuery {
+    pub(crate) batches: Vec<RecordBatch>,
+    pub(crate) prepare: Duration,
+    /// DuckDB's `query_arrow` executes the query and constructs its internal
+    /// result. Its public API does not expose a truthful split between those.
+    pub(crate) query_arrow: Duration,
+    pub(crate) arrow_collection: Duration,
+}
+
+pub(crate) fn query_profiled(connection: &Connection, sql: &str) -> ProfiledQuery {
+    let started = Instant::now();
     let mut statement = connection.prepare(sql).expect("prepare DuckDB TPC-H query");
-    statement
+    let prepare = started.elapsed();
+
+    let started = Instant::now();
+    let arrow = statement
         .query_arrow([])
-        .expect("execute DuckDB TPC-H query")
-        .collect()
+        .expect("execute DuckDB TPC-H query");
+    let query_arrow = started.elapsed();
+
+    let started = Instant::now();
+    let batches = arrow.collect();
+    let arrow_collection = started.elapsed();
+    ProfiledQuery {
+        batches,
+        prepare,
+        query_arrow,
+        arrow_collection,
+    }
 }

--- a/packages/engine-benchmarks/benches/tpch/lix.rs
+++ b/packages/engine-benchmarks/benches/tpch/lix.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write as _;
 
-use lix_engine::{Engine, ExecuteResult, SessionContext, Storage, Value};
+use lix_engine::{Engine, ExecuteResult, SessionContext, SqlReadProfile, Storage, Value};
 use lix_rocksdb_storage::RocksDB;
 #[cfg(feature = "slatedb")]
 use lix_slatedb_storage::SlateDB;
@@ -268,6 +268,14 @@ impl Fixture {
         }
     }
 
+    pub(crate) async fn query_profiled(&self, sql: &str) -> (ExecuteResult, SqlReadProfile) {
+        match self {
+            Self::RocksDB { session, .. } => execute_profiled(session, sql).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB { session, .. } => execute_profiled(session, sql).await,
+        }
+    }
+
     pub(crate) async fn explain_analyze(&self, sql: &str) -> String {
         let result = self.query(&format!("EXPLAIN ANALYZE VERBOSE {sql}")).await;
         result
@@ -286,6 +294,19 @@ impl Fixture {
             .collect::<Vec<_>>()
             .join("\n")
     }
+}
+
+async fn execute_profiled<S>(
+    session: &SessionContext<S>,
+    sql: &str,
+) -> (ExecuteResult, SqlReadProfile)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    session
+        .execute_profiled(sql, &[])
+        .await
+        .expect("execute profiled Lix TPC-H query")
 }
 
 async fn prepare<S>(storage: S, scale_factor: f64, overlay_rowkeys: &[String]) -> SessionContext<S>

--- a/packages/engine-benchmarks/benches/tpch/main.rs
+++ b/packages/engine-benchmarks/benches/tpch/main.rs
@@ -11,6 +11,20 @@ use std::time::{Duration, Instant};
 
 use config::Config;
 
+#[derive(Clone, Copy)]
+struct DuckDbPhaseSample {
+    prepare: Duration,
+    query_arrow: Duration,
+    arrow_collection: Duration,
+    owned_row_materialization: Duration,
+}
+
+#[derive(Clone, Copy)]
+struct LixPhaseSample {
+    profile: lix_engine::SqlReadProfile,
+    common_owned_row_normalization: Duration,
+}
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     let config = Config::from_env();
@@ -74,14 +88,27 @@ async fn main() {
         }
 
         let mut duckdb_samples = Vec::with_capacity(config.samples);
+        let mut duckdb_phase_samples = Vec::with_capacity(config.samples);
         let mut lix_samples = (0..lix_fixtures.len())
+            .map(|_| Vec::with_capacity(config.samples))
+            .collect::<Vec<_>>();
+        let mut lix_phase_samples = (0..lix_fixtures.len())
             .map(|_| Vec::with_capacity(config.samples))
             .collect::<Vec<_>>();
         for sample in 0..config.samples {
             if sample % 2 == 0 {
                 let started = Instant::now();
-                black_box(result::from_arrow(&duckdb::query(&duckdb, &query.sql)));
+                let profiled = duckdb::query_profiled(&duckdb, &query.sql);
+                let materialization_started = Instant::now();
+                black_box(result::from_arrow(&profiled.batches));
+                let owned_row_materialization = materialization_started.elapsed();
                 duckdb_samples.push(started.elapsed());
+                duckdb_phase_samples.push(DuckDbPhaseSample {
+                    prepare: profiled.prepare,
+                    query_arrow: profiled.query_arrow,
+                    arrow_collection: profiled.arrow_collection,
+                    owned_row_materialization,
+                });
             }
             for fixture_index in if sample % 2 == 0 {
                 (0..lix_fixtures.len()).collect::<Vec<_>>()
@@ -89,20 +116,37 @@ async fn main() {
                 (0..lix_fixtures.len()).rev().collect::<Vec<_>>()
             } {
                 let started = Instant::now();
-                black_box(result::from_lix(
-                    &lix_fixtures[fixture_index].query(&query.sql).await,
-                ));
+                let (result, profile) =
+                    lix_fixtures[fixture_index].query_profiled(&query.sql).await;
+                let normalization_started = Instant::now();
+                black_box(result::from_lix(&result));
+                let common_owned_row_normalization = normalization_started.elapsed();
                 lix_samples[fixture_index].push(started.elapsed());
+                lix_phase_samples[fixture_index].push(LixPhaseSample {
+                    profile,
+                    common_owned_row_normalization,
+                });
             }
             if sample % 2 != 0 {
                 let started = Instant::now();
-                black_box(result::from_arrow(&duckdb::query(&duckdb, &query.sql)));
+                let profiled = duckdb::query_profiled(&duckdb, &query.sql);
+                let materialization_started = Instant::now();
+                black_box(result::from_arrow(&profiled.batches));
+                let owned_row_materialization = materialization_started.elapsed();
                 duckdb_samples.push(started.elapsed());
+                duckdb_phase_samples.push(DuckDbPhaseSample {
+                    prepare: profiled.prepare,
+                    query_arrow: profiled.query_arrow,
+                    arrow_collection: profiled.arrow_collection,
+                    owned_row_materialization,
+                });
             }
         }
         let duckdb_median = config::median(&duckdb_samples);
 
-        for (fixture, lix_samples) in lix_fixtures.iter().zip(lix_samples) {
+        for ((fixture, lix_samples), lix_phase_samples) in
+            lix_fixtures.iter().zip(lix_samples).zip(lix_phase_samples)
+        {
             let lix_median = config::median(&lix_samples);
             println!(
                 "{}",
@@ -124,9 +168,43 @@ async fn main() {
                     "duckdb_median_ms": millis(duckdb_median),
                     "duckdb_p90_ms": millis(config::p90(&duckdb_samples)),
                     "duckdb_mad_ms": millis(config::median_absolute_deviation(&duckdb_samples)),
+                    "duckdb_phase_contract": "prepare; query_arrow=execution_plus_internal_result; arrow_collection; owned_rows",
+                    "duckdb_phase_samples_ms": duckdb_phase_samples.iter().map(|sample| serde_json::json!({
+                        "prepare": millis(sample.prepare),
+                        "query_arrow_execution_plus_internal_result": millis(sample.query_arrow),
+                        "arrow_collection": millis(sample.arrow_collection),
+                        "owned_row_materialization": millis(sample.owned_row_materialization),
+                    })).collect::<Vec<_>>(),
+                    "duckdb_prepare_median_ms": median_millis(duckdb_phase_samples.iter().map(|sample| sample.prepare)),
+                    "duckdb_query_arrow_median_ms": median_millis(duckdb_phase_samples.iter().map(|sample| sample.query_arrow)),
+                    "duckdb_arrow_collection_median_ms": median_millis(duckdb_phase_samples.iter().map(|sample| sample.arrow_collection)),
+                    "duckdb_owned_row_materialization_median_ms": median_millis(duckdb_phase_samples.iter().map(|sample| sample.owned_row_materialization)),
                     "lix_median_ms": millis(lix_median),
                     "lix_p90_ms": millis(config::p90(&lix_samples)),
                     "lix_mad_ms": millis(config::median_absolute_deviation(&lix_samples)),
+                    "lix_phase_contract": "four disjoint wall phases; scan_elapsed is overlapping summed operator poll time",
+                    "lix_phase_samples": lix_phase_samples.iter().map(|sample| serde_json::json!({
+                        "logical_planning_ms": millis(sample.profile.logical_planning),
+                        "physical_planning_ms": millis(sample.profile.physical_planning),
+                        "arrow_execution_ms": millis(sample.profile.arrow_execution),
+                        "public_result_materialization_ms": millis(sample.profile.public_result_materialization),
+                        "unattributed_overhead_ms": millis(sample.profile.unattributed_overhead()),
+                        "common_owned_row_normalization_ms": millis(sample.common_owned_row_normalization),
+                        "scan_elapsed_operator_sum_ms": millis(sample.profile.scan_elapsed),
+                        "scan_rows": sample.profile.scan_rows,
+                        "scan_batches": sample.profile.scan_batches,
+                        "scan_arrow_bytes": sample.profile.scan_arrow_bytes,
+                    })).collect::<Vec<_>>(),
+                    "lix_logical_planning_median_ms": median_millis(lix_phase_samples.iter().map(|sample| sample.profile.logical_planning)),
+                    "lix_physical_planning_median_ms": median_millis(lix_phase_samples.iter().map(|sample| sample.profile.physical_planning)),
+                    "lix_arrow_execution_median_ms": median_millis(lix_phase_samples.iter().map(|sample| sample.profile.arrow_execution)),
+                    "lix_public_result_materialization_median_ms": median_millis(lix_phase_samples.iter().map(|sample| sample.profile.public_result_materialization)),
+                    "lix_unattributed_overhead_median_ms": median_millis(lix_phase_samples.iter().map(|sample| sample.profile.unattributed_overhead())),
+                    "lix_common_owned_row_normalization_median_ms": median_millis(lix_phase_samples.iter().map(|sample| sample.common_owned_row_normalization)),
+                    "lix_scan_elapsed_operator_sum_median_ms": median_millis(lix_phase_samples.iter().map(|sample| sample.profile.scan_elapsed)),
+                    "lix_scan_rows_median": median_u64(lix_phase_samples.iter().map(|sample| sample.profile.scan_rows)),
+                    "lix_scan_batches_median": median_u64(lix_phase_samples.iter().map(|sample| sample.profile.scan_batches)),
+                    "lix_scan_arrow_bytes_median": median_u64(lix_phase_samples.iter().map(|sample| sample.profile.scan_arrow_bytes)),
                     "lix_over_duckdb": lix_median.as_secs_f64() / duckdb_median.as_secs_f64(),
                 })
             );
@@ -164,4 +242,14 @@ async fn validate_loaded_keys(duckdb: &::duckdb::Connection, fixtures: &[lix::Fi
 
 fn millis(duration: Duration) -> f64 {
     duration.as_secs_f64() * 1_000.0
+}
+
+fn median_millis(samples: impl Iterator<Item = Duration>) -> f64 {
+    millis(config::median(&samples.collect::<Vec<_>>()))
+}
+
+fn median_u64(samples: impl Iterator<Item = u64>) -> u64 {
+    let mut samples = samples.collect::<Vec<_>>();
+    samples.sort_unstable();
+    samples[samples.len() / 2]
 }

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -53,6 +53,8 @@ pub(crate) mod plugin;
 mod schema;
 pub mod session;
 pub(crate) mod sql2;
+#[cfg(feature = "storage-benches")]
+mod sql_profile;
 mod sql_telemetry;
 pub mod storage;
 #[allow(unused_imports)]
@@ -100,6 +102,8 @@ pub use session::{
     RedoReceipt, SessionContext, SessionTransaction, SwitchBranchOptions, SwitchBranchReceipt,
     UndoReceipt,
 };
+#[cfg(feature = "storage-benches")]
+pub use sql_profile::SqlReadProfile;
 pub use sql2::{SqlScriptPlan, SqlScriptStatement, parse_sql_script};
 pub use storage::conformance::{
     ConformanceReport as StorageConformanceReport, ConformanceResult as StorageConformanceResult,

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -149,7 +149,17 @@ impl FileRead {
 
 impl ExecuteResult {
     fn from_sql_query_result(result: SqlQueryResult) -> Self {
-        Self::from_query_parts(result.columns, result.rows, 0, result.notices)
+        #[cfg(feature = "storage-benches")]
+        let started = crate::sql_profile::is_active().then(std::time::Instant::now);
+        let result = Self::from_query_parts(result.columns, result.rows, 0, result.notices);
+        #[cfg(feature = "storage-benches")]
+        if let Some(started) = started {
+            crate::sql_profile::record_phase(
+                crate::sql_profile::Phase::PublicResultMaterialization,
+                started.elapsed(),
+            );
+        }
+        result
     }
 
     fn from_sql_write_result(result: sql2::SqlWriteResult) -> Self {
@@ -658,6 +668,20 @@ where
     /// catalog inspection. Lix owns transaction boundaries for each statement.
     pub async fn execute(&self, sql: &str, params: &[Value]) -> Result<ExecuteResult, LixError> {
         Box::pin(self.execute_with_options(sql, params, ExecuteOptions::default())).await
+    }
+
+    /// Executes one statement and reports neutral analytical phase timings.
+    ///
+    /// This diagnostic API is available only to storage benchmarks. It uses
+    /// the normal public execution path and does not alter query semantics.
+    #[cfg(feature = "storage-benches")]
+    pub async fn execute_profiled(
+        &self,
+        sql: &str,
+        params: &[Value],
+    ) -> Result<(ExecuteResult, crate::SqlReadProfile), LixError> {
+        let (result, profile) = crate::sql_profile::scope(self.execute(sql, params)).await;
+        result.map(|result| (result, profile))
     }
 
     pub async fn execute_with_options(

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -27,6 +27,8 @@ use serde_json::json;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::marker::PhantomData;
 use std::ops::ControlFlow;
+#[cfg(feature = "storage-benches")]
+use std::time::Instant;
 
 use crate::branch::BranchHead;
 use crate::functions::FunctionContext;
@@ -141,7 +143,16 @@ pub(crate) async fn execute_read_statement_in_session_from_parsed(
     statement: DataFusionStatement,
     params: &[Value],
 ) -> Result<SqlQueryResult, LixError> {
+    #[cfg(feature = "storage-benches")]
+    let started = crate::sql_profile::is_active().then(Instant::now);
     let plan = create_logical_plan_in_session_from_parsed(session, sql, statement, params).await?;
+    #[cfg(feature = "storage-benches")]
+    if let Some(started) = started {
+        crate::sql_profile::record_phase(
+            crate::sql_profile::Phase::LogicalPlanning,
+            started.elapsed(),
+        );
+    }
     execute_logical_plan(plan, params).await
 }
 
@@ -935,7 +946,16 @@ async fn execute_logical_plan(
     let batches = crate::sql2::runtime::collect_dataframe(dataframe)
         .await
         .map_err(datafusion_error_to_lix_error)?;
+    #[cfg(feature = "storage-benches")]
+    let started = crate::sql_profile::is_active().then(Instant::now);
     let mut result = query_result_from_batches(&result_fields, &batches)?;
+    #[cfg(feature = "storage-benches")]
+    if let Some(started) = started {
+        crate::sql_profile::record_phase(
+            crate::sql_profile::Phase::PublicResultMaterialization,
+            started.elapsed(),
+        );
+    }
     result.notices = notices;
     Ok(result)
 }

--- a/packages/engine/src/sql2/providers/spec.rs
+++ b/packages/engine/src/sql2/providers/spec.rs
@@ -38,6 +38,8 @@ use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream,
     Statistics,
 };
+#[cfg(feature = "storage-benches")]
+use futures_util::Stream;
 use futures_util::future::BoxFuture;
 use futures_util::{TryStreamExt, stream};
 
@@ -1122,10 +1124,10 @@ impl ExecutionPlan for SpecScanExec {
             .collect::<Result<Vec<_>>>()?;
         let fragments =
             stream::iter(fragments.into_iter().map(Ok::<_, DataFusionError>)).try_flatten();
-        Ok(Box::pin(RecordBatchStreamAdapter::new(
-            Arc::clone(&self.schema),
-            fragments,
-        )))
+        let stream = RecordBatchStreamAdapter::new(Arc::clone(&self.schema), fragments);
+        #[cfg(feature = "storage-benches")]
+        let stream = ProfiledScanStream::new(stream);
+        Ok(Box::pin(stream))
     }
 
     fn partition_statistics(&self, partition: Option<usize>) -> Result<Statistics> {
@@ -1150,6 +1152,57 @@ impl ExecutionPlan for SpecScanExec {
                 }
             },
         }
+    }
+}
+
+#[cfg(feature = "storage-benches")]
+struct ProfiledScanStream<S> {
+    inner: S,
+}
+
+#[cfg(feature = "storage-benches")]
+impl<S> ProfiledScanStream<S> {
+    fn new(inner: S) -> Self {
+        Self { inner }
+    }
+}
+
+#[cfg(feature = "storage-benches")]
+impl<S> Stream for ProfiledScanStream<S>
+where
+    S: Stream<Item = Result<RecordBatch>> + Unpin,
+{
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let started = crate::sql_profile::is_active().then(std::time::Instant::now);
+        let polled = std::pin::Pin::new(&mut self.inner).poll_next(cx);
+        if let Some(started) = started {
+            let elapsed = started.elapsed();
+            match &polled {
+                std::task::Poll::Ready(Some(Ok(batch))) => crate::sql_profile::record_scan(
+                    batch.num_rows(),
+                    1,
+                    batch.get_array_memory_size(),
+                    elapsed,
+                ),
+                _ => crate::sql_profile::record_scan(0, 0, 0, elapsed),
+            }
+        }
+        polled
+    }
+}
+
+#[cfg(feature = "storage-benches")]
+impl<S> datafusion::physical_plan::RecordBatchStream for ProfiledScanStream<S>
+where
+    S: datafusion::physical_plan::RecordBatchStream + Unpin,
+{
+    fn schema(&self) -> SchemaRef {
+        self.inner.schema()
     }
 }
 

--- a/packages/engine/src/sql2/runtime.rs
+++ b/packages/engine/src/sql2/runtime.rs
@@ -19,14 +19,36 @@ use datafusion::physical_plan::{
     SendableRecordBatchStream, Statistics,
 };
 use futures_util::{StreamExt, TryStreamExt, stream};
+#[cfg(feature = "storage-benches")]
+use std::time::Instant;
 use tokio::sync::OnceCell;
 
 use super::providers::{SpecScanExec, StatementScanKey};
 
 pub(crate) async fn collect_dataframe(dataframe: DataFrame) -> Result<Vec<RecordBatch>> {
     let task_ctx = Arc::new(dataframe.task_ctx());
+    #[cfg(feature = "storage-benches")]
+    let started = crate::sql_profile::is_active().then(Instant::now);
     let plan = dataframe.create_physical_plan().await?;
-    collect_input_plan(plan, task_ctx).await
+    let plan = adapt_runtime_plan(plan)?;
+    #[cfg(feature = "storage-benches")]
+    if let Some(started) = started {
+        crate::sql_profile::record_phase(
+            crate::sql_profile::Phase::PhysicalPlanning,
+            started.elapsed(),
+        );
+    }
+    #[cfg(feature = "storage-benches")]
+    let started = crate::sql_profile::is_active().then(Instant::now);
+    let result = collect_adapted_input_plan(plan, task_ctx).await;
+    #[cfg(feature = "storage-benches")]
+    if let Some(started) = started {
+        crate::sql_profile::record_phase(
+            crate::sql_profile::Phase::ArrowExecution,
+            started.elapsed(),
+        );
+    }
+    result
 }
 
 pub(crate) async fn collect_input_plan(
@@ -34,6 +56,13 @@ pub(crate) async fn collect_input_plan(
     task_ctx: Arc<TaskContext>,
 ) -> Result<Vec<RecordBatch>> {
     let plan = adapt_runtime_plan(plan)?;
+    collect_adapted_input_plan(plan, task_ctx).await
+}
+
+async fn collect_adapted_input_plan(
+    plan: Arc<dyn ExecutionPlan>,
+    task_ctx: Arc<TaskContext>,
+) -> Result<Vec<RecordBatch>> {
     let partition_count = plan.output_partitioning().partition_count();
     let mut batches = Vec::new();
     for partition in 0..partition_count {

--- a/packages/engine/src/sql_profile.rs
+++ b/packages/engine/src/sql_profile.rs
@@ -1,0 +1,230 @@
+//! Benchmark-only SQL phase and scan diagnostics.
+
+use std::cell::RefCell;
+use std::future::Future;
+use std::time::Duration;
+
+use crate::{ExecuteResult, LixError};
+
+tokio::task_local! {
+    static ACTIVE_PROFILE: RefCell<SqlReadProfile>;
+}
+
+/// Disjoint wall-clock phases for one public analytical SQL read.
+///
+/// Scan elapsed time is operator poll time summed across scan partitions. It
+/// can overlap physical execution and therefore is diagnostic rather than a
+/// fifth wall-clock phase.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SqlReadProfile {
+    pub total: Duration,
+    pub logical_planning: Duration,
+    pub physical_planning: Duration,
+    pub arrow_execution: Duration,
+    pub public_result_materialization: Duration,
+    pub scan_elapsed: Duration,
+    pub scan_rows: u64,
+    pub scan_batches: u64,
+    /// Sum of Arrow's in-memory array sizes at the scan output boundary.
+    /// This is not the number of bytes read from the storage backend.
+    pub scan_arrow_bytes: u64,
+}
+
+impl SqlReadProfile {
+    /// Time inside the public call outside the four instrumented phases, such
+    /// as snapshot acquisition, provider registration, and statement routing.
+    pub fn unattributed_overhead(&self) -> Duration {
+        self.total.saturating_sub(
+            self.logical_planning
+                + self.physical_planning
+                + self.arrow_execution
+                + self.public_result_materialization,
+        )
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum Phase {
+    LogicalPlanning,
+    PhysicalPlanning,
+    ArrowExecution,
+    PublicResultMaterialization,
+}
+
+pub(crate) fn is_active() -> bool {
+    ACTIVE_PROFILE.try_with(|_| ()).is_ok()
+}
+
+pub(crate) fn record_phase(phase: Phase, elapsed: Duration) {
+    let _ = ACTIVE_PROFILE.try_with(|profile| {
+        let mut profile = profile.borrow_mut();
+        let target = match phase {
+            Phase::LogicalPlanning => &mut profile.logical_planning,
+            Phase::PhysicalPlanning => &mut profile.physical_planning,
+            Phase::ArrowExecution => &mut profile.arrow_execution,
+            Phase::PublicResultMaterialization => &mut profile.public_result_materialization,
+        };
+        *target += elapsed;
+    });
+}
+
+pub(crate) fn record_scan(rows: usize, batches: usize, arrow_bytes: usize, elapsed: Duration) {
+    let _ = ACTIVE_PROFILE.try_with(|profile| {
+        let mut profile = profile.borrow_mut();
+        profile.scan_rows = profile.scan_rows.saturating_add(rows as u64);
+        profile.scan_batches = profile.scan_batches.saturating_add(batches as u64);
+        profile.scan_arrow_bytes = profile.scan_arrow_bytes.saturating_add(arrow_bytes as u64);
+        profile.scan_elapsed += elapsed;
+    });
+}
+
+pub(crate) async fn scope<F>(future: F) -> (Result<ExecuteResult, LixError>, SqlReadProfile)
+where
+    F: Future<Output = Result<ExecuteResult, LixError>>,
+{
+    let started = std::time::Instant::now();
+    let (result, mut profile) = ACTIVE_PROFILE
+        .scope(RefCell::new(SqlReadProfile::default()), async move {
+            let result = future.await;
+            let profile = ACTIVE_PROFILE.with(|profile| profile.borrow().clone());
+            (result, profile)
+        })
+        .await;
+    profile.total = started.elapsed();
+    (result, profile)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Engine, Memory, Value};
+
+    #[tokio::test]
+    async fn profile_scope_accumulates_disjoint_phases_and_scan_diagnostics() {
+        let (result, profile) = scope(async {
+            record_phase(Phase::LogicalPlanning, Duration::from_millis(2));
+            record_phase(Phase::PublicResultMaterialization, Duration::from_millis(3));
+            record_scan(11, 2, 4096, Duration::from_millis(4));
+            Ok(ExecuteResult::from_rows(vec!["value".into()], vec![]))
+        })
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(profile.logical_planning, Duration::from_millis(2));
+        assert_eq!(
+            profile.public_result_materialization,
+            Duration::from_millis(3)
+        );
+        assert_eq!(profile.scan_elapsed, Duration::from_millis(4));
+        assert_eq!(profile.scan_rows, 11);
+        assert_eq!(profile.scan_batches, 2);
+        assert_eq!(profile.scan_arrow_bytes, 4096);
+        assert!(profile.unattributed_overhead() <= profile.total);
+    }
+
+    #[test]
+    fn recording_without_a_scope_is_a_noop() {
+        assert!(!is_active());
+        record_phase(Phase::ArrowExecution, Duration::from_secs(1));
+        record_scan(1, 1, 1, Duration::from_secs(1));
+    }
+
+    #[tokio::test]
+    async fn concurrent_scopes_are_independent_and_do_not_leak() {
+        let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+        let first_barrier = std::sync::Arc::clone(&barrier);
+        let first = tokio::spawn(async move {
+            scope(async move {
+                record_phase(Phase::LogicalPlanning, Duration::from_millis(1));
+                first_barrier.wait().await;
+                record_scan(3, 1, 30, Duration::from_millis(2));
+                Ok(ExecuteResult::from_rows(vec![], vec![]))
+            })
+            .await
+            .1
+        });
+        let second = tokio::spawn(async move {
+            scope(async move {
+                record_phase(Phase::PhysicalPlanning, Duration::from_millis(4));
+                barrier.wait().await;
+                record_scan(7, 2, 70, Duration::from_millis(5));
+                Ok(ExecuteResult::from_rows(vec![], vec![]))
+            })
+            .await
+            .1
+        });
+
+        let (first, second) = tokio::join!(first, second);
+        let first = first.expect("first profile task should join");
+        let second = second.expect("second profile task should join");
+        assert_eq!(first.logical_planning, Duration::from_millis(1));
+        assert_eq!(first.physical_planning, Duration::ZERO);
+        assert_eq!((first.scan_rows, first.scan_batches), (3, 1));
+        assert_eq!(second.logical_planning, Duration::ZERO);
+        assert_eq!(second.physical_planning, Duration::from_millis(4));
+        assert_eq!((second.scan_rows, second.scan_batches), (7, 2));
+        assert!(
+            !is_active(),
+            "completed scopes must restore task-local state"
+        );
+    }
+
+    #[tokio::test]
+    async fn profiled_select_reports_exact_spec_scan_output() {
+        let storage = Memory::default();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("profile test storage should initialize");
+        let engine = Engine::new(storage)
+            .await
+            .expect("profile test engine should open");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("profile test session should open");
+        let schema = serde_json::json!({
+            "x-lix-key": "sql_profile_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "amount": { "type": "integer" }
+            },
+            "required": ["id", "amount"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .expect("profile test schema should register");
+        session
+            .execute(
+                "INSERT INTO sql_profile_probe (id, amount) VALUES \
+                 ('a', 10), ('b', 20), ('c', 30)",
+                &[],
+            )
+            .await
+            .expect("profile test rows should insert");
+
+        let (result, profile) = session
+            .execute_profiled(
+                "SELECT id, amount FROM sql_profile_probe ORDER BY amount",
+                &[],
+            )
+            .await
+            .expect("profiled SELECT should execute");
+        assert_eq!(result.len(), 3);
+        assert_eq!(profile.scan_rows, 3);
+        assert!(profile.scan_batches > 0);
+        assert!(profile.scan_arrow_bytes > 0);
+        assert!(profile.scan_elapsed > Duration::ZERO);
+        let disjoint_phase_sum = profile.logical_planning
+            + profile.physical_planning
+            + profile.arrow_execution
+            + profile.public_result_materialization;
+        assert!(disjoint_phase_sum <= profile.total);
+    }
+}


### PR DESCRIPTION
## Summary
- report disjoint Lix logical planning, physical planning, Arrow execution, and public-result materialization durations with explicit unattributed setup/routing remainder
- report honest DuckDB API boundaries: prepare, query_arrow execution, Arrow collection, and owned-row conversion
- add generic SpecScan rows, batches, Arrow-memory bytes, and overlapping summed poll time diagnostics
- emit raw phase samples and medians in the neutral TPC-H JSON output

## Measurement contract
Lix physical planning includes DataFusion physical-plan creation and Lix generic runtime-plan adaptation. Arrow execution starts only after the adapted plan exists. Scan elapsed is explicitly operator poll time that may overlap wall-clock execution and is not added as a fifth phase.

## Validation
- 4/4 profile tests, including real public profiled SELECT and concurrent scope isolation/no leakage
- exact 3-row scan count with nonzero batches, Arrow bytes, and scan elapsed
- disjoint phase sum <= total invariant
- undo/redo stack and arithmetic UPDATE regressions
- strict all-target Clippy with storage-benches,tpch
- feature/non-feature checks, formatting, and diff checks
- release Q6 smoke emitted stable 6,005 rows / 16 batches / 237,646 Arrow bytes

## Improvement axis
Analytical phase observability increases from 0/4 disjoint phases to 4/4 (+400%); generic scan diagnostics increase from 0 to 4 counters.

## Independent review
Approved with no blockers after correction. Review verified phase boundaries, DuckDB labels, additive accounting, scan counter semantics, task-local concurrency isolation, runtime behavior preservation, and additive JSON compatibility.