### PR TITLE
perf(sql): cache immutable analytical batches

### DIFF
--- a/packages/engine/src/live_state/entity_columnar_cache.rs
+++ b/packages/engine/src/live_state/entity_columnar_cache.rs
@@ -127,6 +127,23 @@ impl EntityColumnarShadowMaskCache {
         projection: Vec<usize>,
         batch: Arc<RecordBatch>,
     ) -> Arc<RecordBatch> {
+        self.insert_batch_with_limits(
+            key,
+            projection,
+            batch,
+            RECONCILED_BATCH_CACHE_ENTRIES,
+            RECONCILED_BATCH_CACHE_MAX_BYTES,
+        )
+    }
+
+    fn insert_batch_with_limits(
+        &mut self,
+        key: EntityColumnarShadowMaskKey,
+        projection: Vec<usize>,
+        batch: Arc<RecordBatch>,
+        max_entries: usize,
+        max_bytes: usize,
+    ) -> Arc<RecordBatch> {
         let key = EntityColumnarBatchKey {
             shadow: key,
             projection,
@@ -139,11 +156,11 @@ impl EntityColumnarShadowMaskCache {
             .iter()
             .map(|column| column.get_array_memory_size())
             .sum::<usize>();
-        if bytes > RECONCILED_BATCH_CACHE_MAX_BYTES {
+        if bytes > max_bytes {
             return batch;
         }
-        while self.batches.len() >= RECONCILED_BATCH_CACHE_ENTRIES
-            || self.batch_bytes.saturating_add(bytes) > RECONCILED_BATCH_CACHE_MAX_BYTES
+        while self.batches.len() >= max_entries
+            || self.batch_bytes.saturating_add(bytes) > max_bytes
         {
             let Some(evicted) = self.batch_insertion_order.pop_front() else {
                 break;
@@ -218,5 +235,92 @@ mod tests {
         assert!(cache.batch_bytes <= RECONCILED_BATCH_CACHE_MAX_BYTES);
         assert!(cache.batch(&shadow, &[0]).is_none());
         assert!(cache.batch(&shadow, &[2]).is_some());
+    }
+
+    #[test]
+    fn reconciled_batches_are_byte_bounded() {
+        let shadow = batch_cache_key();
+        let batch = test_batch(&[1, 2, 3, 4]);
+        let bytes = batch
+            .columns()
+            .iter()
+            .map(|column| column.get_array_memory_size())
+            .sum::<usize>();
+        let mut cache = EntityColumnarShadowMaskCache::default();
+
+        cache.insert_batch_with_limits(shadow.clone(), vec![0], Arc::clone(&batch), 8, bytes);
+        cache.insert_batch_with_limits(shadow.clone(), vec![1], Arc::clone(&batch), 8, bytes);
+
+        assert!(cache.batch(&shadow, &[0]).is_none());
+        assert!(cache.batch(&shadow, &[1]).is_some());
+        assert_eq!(cache.batch_bytes, bytes);
+
+        let oversized = test_batch(&[5, 6, 7, 8, 9]);
+        cache.insert_batch_with_limits(shadow.clone(), vec![2], oversized, 8, bytes);
+        assert!(cache.batch(&shadow, &[2]).is_none());
+        assert_eq!(cache.batch_bytes, bytes);
+    }
+
+    #[test]
+    fn batch_cache_key_covers_every_visibility_and_projection_dimension() {
+        let base = batch_cache_key();
+        let batch = test_batch(&[7]);
+        let mut cache = EntityColumnarShadowMaskCache::default();
+        let resident = cache.insert_batch(base.clone(), vec![1, 3], Arc::clone(&batch));
+        assert!(cache.batch(&base, &[1, 3]).is_some());
+        let duplicate = cache.insert_batch(base.clone(), vec![1, 3], test_batch(&[8]));
+        assert!(Arc::ptr_eq(&resident, &duplicate));
+        assert!(Arc::ptr_eq(&batch, &duplicate));
+
+        let variants = [
+            EntityColumnarShadowMaskKey {
+                row_groups: crate::columnar_row_group::RowGroupSetId::new([8; 16]),
+                ..base.clone()
+            },
+            EntityColumnarShadowMaskKey {
+                branch_id: Arc::from("other"),
+                ..base.clone()
+            },
+            EntityColumnarShadowMaskKey {
+                head_commit_id: crate::changelog::CommitId::for_test_label("other-head"),
+                ..base.clone()
+            },
+            EntityColumnarShadowMaskKey {
+                current_state_revision: 2,
+                ..base.clone()
+            },
+            EntityColumnarShadowMaskKey {
+                shadow_identity_digest: [9; 32],
+                ..base.clone()
+            },
+            EntityColumnarShadowMaskKey {
+                group_index: 1,
+                ..base.clone()
+            },
+        ];
+        for variant in variants {
+            assert!(cache.batch(&variant, &[1, 3]).is_none());
+        }
+        assert!(cache.batch(&base, &[3, 1]).is_none());
+        assert!(cache.batch(&base, &[1]).is_none());
+    }
+
+    fn batch_cache_key() -> EntityColumnarShadowMaskKey {
+        EntityColumnarShadowMaskKey {
+            row_groups: crate::columnar_row_group::RowGroupSetId::new([3; 16]),
+            branch_id: Arc::from("branch"),
+            head_commit_id: crate::changelog::CommitId::for_test_label("batch-cache-head"),
+            current_state_revision: 1,
+            shadow_identity_digest: [4; 32],
+            group_index: 0,
+        }
+    }
+
+    fn test_batch(values: &[i64]) -> Arc<RecordBatch> {
+        let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, false)]));
+        Arc::new(
+            RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(values.to_vec()))])
+                .expect("batch"),
+        )
     }
 }

--- a/packages/engine/src/sql2/entity_batch.rs
+++ b/packages/engine/src/sql2/entity_batch.rs
@@ -234,10 +234,7 @@ where
         &self,
         request: LiveStateScanRequest,
     ) -> Result<Option<Arc<EntityColumnarScanLayout>>, LixError> {
-        if !direct_entity_snapshot_request(&request)
-            || !request.filter.entity_pks.is_empty()
-            || request.limit.is_some()
-        {
+        if !direct_entity_columnar_request(&request) {
             return Ok(None);
         }
         Ok(self
@@ -292,14 +289,7 @@ where
         shadow_identities: Arc<HashSet<String, ahash::RandomState>>,
         shadow_identity_digest: [u8; 32],
     ) -> Result<Arc<BooleanArray>, LixError> {
-        let key = EntityColumnarShadowMaskKey {
-            row_groups: layout.id,
-            branch_id: Arc::clone(&layout.branch_id),
-            head_commit_id: layout.head_commit_id,
-            current_state_revision: layout.current_state_revision,
-            shadow_identity_digest,
-            group_index,
-        };
+        let key = entity_columnar_cache_key(&layout, group_index, shadow_identity_digest);
         if let Some(mask) = self
             .entity_columnar_shadow_masks
             .lock()
@@ -333,14 +323,7 @@ where
         shadow_identity_digest: [u8; 32],
         projection: &[usize],
     ) -> Result<Option<Statistics>, LixError> {
-        let key = EntityColumnarShadowMaskKey {
-            row_groups: layout.id,
-            branch_id: Arc::clone(&layout.branch_id),
-            head_commit_id: layout.head_commit_id,
-            current_state_revision: layout.current_state_revision,
-            shadow_identity_digest,
-            group_index,
-        };
+        let key = entity_columnar_cache_key(layout, group_index, shadow_identity_digest);
         Ok(self
             .entity_columnar_shadow_masks
             .lock()
@@ -356,14 +339,7 @@ where
         projection: Vec<usize>,
         statistics: Statistics,
     ) -> Result<(), LixError> {
-        let key = EntityColumnarShadowMaskKey {
-            row_groups: layout.id,
-            branch_id: Arc::clone(&layout.branch_id),
-            head_commit_id: layout.head_commit_id,
-            current_state_revision: layout.current_state_revision,
-            shadow_identity_digest,
-            group_index,
-        };
+        let key = entity_columnar_cache_key(layout, group_index, shadow_identity_digest);
         self.entity_columnar_shadow_masks
             .lock()
             .map_err(|_| entity_columnar_mask_error("entity columnar shadow-mask cache poisoned"))?
@@ -378,14 +354,7 @@ where
         shadow_identity_digest: [u8; 32],
         projection: &[usize],
     ) -> Result<Option<Arc<RecordBatch>>, LixError> {
-        let key = EntityColumnarShadowMaskKey {
-            row_groups: layout.id,
-            branch_id: Arc::clone(&layout.branch_id),
-            head_commit_id: layout.head_commit_id,
-            current_state_revision: layout.current_state_revision,
-            shadow_identity_digest,
-            group_index,
-        };
+        let key = entity_columnar_cache_key(layout, group_index, shadow_identity_digest);
         Ok(self
             .entity_columnar_shadow_masks
             .lock()
@@ -401,14 +370,7 @@ where
         projection: Vec<usize>,
         batch: Arc<RecordBatch>,
     ) -> Result<Arc<RecordBatch>, LixError> {
-        let key = EntityColumnarShadowMaskKey {
-            row_groups: layout.id,
-            branch_id: Arc::clone(&layout.branch_id),
-            head_commit_id: layout.head_commit_id,
-            current_state_revision: layout.current_state_revision,
-            shadow_identity_digest,
-            group_index,
-        };
+        let key = entity_columnar_cache_key(layout, group_index, shadow_identity_digest);
         Ok(self
             .entity_columnar_shadow_masks
             .lock()
@@ -429,6 +391,21 @@ where
             .reader(self.store.clone())
             .scan_direct_entity_snapshots_by_string_field(&request, column, values)
             .await
+    }
+}
+
+fn entity_columnar_cache_key(
+    layout: &EntityColumnarScanLayout,
+    group_index: usize,
+    shadow_identity_digest: [u8; 32],
+) -> EntityColumnarShadowMaskKey {
+    EntityColumnarShadowMaskKey {
+        row_groups: layout.id,
+        branch_id: Arc::clone(&layout.branch_id),
+        head_commit_id: layout.head_commit_id,
+        current_state_revision: layout.current_state_revision,
+        shadow_identity_digest,
+        group_index,
     }
 }
 
@@ -474,4 +451,61 @@ fn direct_entity_snapshot_request(request: &LiveStateScanRequest) -> bool {
         && request.filter.untracked.is_none()
         && request.filter.file_ids.is_empty()
         && request.filter.constraints.is_empty()
+}
+
+fn direct_entity_columnar_request(request: &LiveStateScanRequest) -> bool {
+    direct_entity_snapshot_request(request)
+        && request.filter.entity_pks.is_empty()
+        && request.limit.is_none()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cache_key_test_layout() -> EntityColumnarScanLayout {
+        EntityColumnarScanLayout {
+            id: crate::columnar_row_group::RowGroupSetId::new([41; 16]),
+            manifest: Arc::new(crate::columnar_row_group::RowGroupManifest {
+                namespace: "cache-key-test".to_owned(),
+                metadata: std::collections::HashMap::new(),
+                fields: Vec::new(),
+                groups: Vec::new(),
+            }),
+            overlay: Arc::new(Vec::new()),
+            branch_id: Arc::from("branch-a"),
+            head_commit_id: crate::changelog::CommitId::for_test_label("cache-key-head"),
+            current_state_revision: 17,
+            live_count: 0,
+        }
+    }
+
+    #[test]
+    fn columnar_cache_key_preserves_every_layout_dimension() {
+        let layout = cache_key_test_layout();
+        let key = entity_columnar_cache_key(&layout, 3, [43; 32]);
+
+        assert_eq!(key.row_groups, layout.id);
+        assert_eq!(key.branch_id, layout.branch_id);
+        assert_eq!(key.head_commit_id, layout.head_commit_id);
+        assert_eq!(key.current_state_revision, layout.current_state_revision);
+        assert_eq!(key.shadow_identity_digest, [43; 32]);
+        assert_eq!(key.group_index, 3);
+    }
+
+    #[test]
+    fn exact_primary_key_and_limit_bypass_columnar_scan() {
+        let mut request = LiveStateScanRequest::default();
+        assert!(direct_entity_columnar_request(&request));
+
+        request
+            .filter
+            .entity_pks
+            .push(EntityPk::single("point-read"));
+        assert!(!direct_entity_columnar_request(&request));
+
+        request.filter.entity_pks.clear();
+        request.limit = Some(1);
+        assert!(!direct_entity_columnar_request(&request));
+    }
 }

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::future::Future;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -991,65 +992,56 @@ async fn entity_columnar_scan_source(
                     .cloned();
                 let coordinates_prove_unshadowed =
                     coordinate_shadow_masks.is_some() && coordinate_keep.is_none();
-                let batch = if (shadow_identities.is_empty() && coordinate_shadow_masks.is_none())
-                    || coordinates_prove_unshadowed
-                {
-                    Arc::new(
-                        reader
-                            .load_entity_columnar_group(
-                                layout.clone(),
-                                group_index,
-                                public_projection,
+                let batch = cached_or_load_entity_columnar_batch(
+                    &reader,
+                    &layout,
+                    group_index,
+                    shadow_identity_digest,
+                    public_projection.clone(),
+                    async {
+                        let batch = if (shadow_identities.is_empty()
+                            && coordinate_shadow_masks.is_none())
+                            || coordinates_prove_unshadowed
+                        {
+                            Arc::new(
+                                reader
+                                    .load_entity_columnar_group(
+                                        layout.clone(),
+                                        group_index,
+                                        public_projection.clone(),
+                                    )
+                                    .await
+                                    .map_err(lix_error_to_datafusion_error)?,
                             )
-                            .await
-                            .map_err(lix_error_to_datafusion_error)?,
-                    )
-                } else if let Some(batch) = reader
-                    .cached_entity_columnar_batch(
-                        &layout,
-                        group_index,
-                        shadow_identity_digest,
-                        &public_projection,
-                    )
-                    .await
-                    .map_err(lix_error_to_datafusion_error)?
-                {
-                    batch
-                } else {
-                    let keep = if let Some(keep) = coordinate_keep {
-                        keep
-                    } else {
-                        reader
-                            .entity_columnar_shadow_mask(
-                                layout.clone(),
-                                group_index,
-                                identity_column,
-                                Arc::clone(&shadow_identities),
-                                shadow_identity_digest,
-                            )
-                            .await
-                            .map_err(lix_error_to_datafusion_error)?
-                    };
-                    let batch = reader
-                        .load_entity_columnar_group(
-                            layout.clone(),
-                            group_index,
-                            public_projection.clone(),
-                        )
-                        .await
-                        .map_err(lix_error_to_datafusion_error)?;
-                    let batch = Arc::new(filter_record_batch(&batch, keep.as_ref())?);
-                    reader
-                        .cache_entity_columnar_batch(
-                            &layout,
-                            group_index,
-                            shadow_identity_digest,
-                            public_projection,
-                            batch,
-                        )
-                        .await
-                        .map_err(lix_error_to_datafusion_error)?
-                };
+                        } else {
+                            let keep = if let Some(keep) = coordinate_keep {
+                                keep
+                            } else {
+                                reader
+                                    .entity_columnar_shadow_mask(
+                                        layout.clone(),
+                                        group_index,
+                                        identity_column,
+                                        Arc::clone(&shadow_identities),
+                                        shadow_identity_digest,
+                                    )
+                                    .await
+                                    .map_err(lix_error_to_datafusion_error)?
+                            };
+                            let batch = reader
+                                .load_entity_columnar_group(
+                                    layout.clone(),
+                                    group_index,
+                                    public_projection.clone(),
+                                )
+                                .await
+                                .map_err(lix_error_to_datafusion_error)?;
+                            Arc::new(filter_record_batch(&batch, keep.as_ref())?)
+                        };
+                        Ok(batch)
+                    },
+                )
+                .await?;
                 if !shadow_identities.is_empty() && !statistics_cached {
                     let statistics = entity_columnar_record_batch_statistics(batch.as_ref())?;
                     reader
@@ -1069,6 +1061,34 @@ async fn entity_columnar_scan_source(
             Ok(Box::pin(RecordBatchStreamAdapter::new(schema, batches)))
         },
     ))
+}
+
+async fn cached_or_load_entity_columnar_batch(
+    reader: &Arc<dyn EntitySnapshotReader>,
+    layout: &Arc<crate::sql2::entity_batch::EntityColumnarScanLayout>,
+    group_index: usize,
+    shadow_identity_digest: [u8; 32],
+    projection: Vec<usize>,
+    load: impl Future<Output = Result<Arc<RecordBatch>>>,
+) -> Result<Arc<RecordBatch>> {
+    if let Some(batch) = reader
+        .cached_entity_columnar_batch(layout, group_index, shadow_identity_digest, &projection)
+        .await
+        .map_err(lix_error_to_datafusion_error)?
+    {
+        return Ok(batch);
+    }
+    let batch = load.await?;
+    reader
+        .cache_entity_columnar_batch(
+            layout,
+            group_index,
+            shadow_identity_digest,
+            projection,
+            batch,
+        )
+        .await
+        .map_err(lix_error_to_datafusion_error)
 }
 
 fn entity_columnar_coordinate_shadow_masks(
@@ -2948,8 +2968,9 @@ fn json_to_string(value: &JsonValue) -> Result<String> {
 #[cfg(test)]
 #[expect(trivial_casts)]
 mod tests {
-    use std::collections::HashSet;
-    use std::sync::Arc;
+    use std::collections::{HashMap, HashSet};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
 
     use async_trait::async_trait;
     use bytes::Bytes;
@@ -2982,6 +3003,43 @@ mod tests {
 
     struct EmptyLiveStateReader;
     struct EmptyBranchRefReader;
+
+    #[derive(Default)]
+    struct TestCachingEntitySnapshotReader {
+        batch: Mutex<Option<Arc<RecordBatch>>>,
+    }
+
+    #[async_trait]
+    impl crate::sql2::EntitySnapshotReader for TestCachingEntitySnapshotReader {
+        async fn scan_entity_snapshots(
+            &self,
+            _request: LiveStateScanRequest,
+        ) -> Result<Option<Vec<Option<Bytes>>>, LixError> {
+            Ok(None)
+        }
+
+        async fn cached_entity_columnar_batch(
+            &self,
+            _layout: &crate::sql2::entity_batch::EntityColumnarScanLayout,
+            _group_index: usize,
+            _shadow_identity_digest: [u8; 32],
+            _projection: &[usize],
+        ) -> Result<Option<Arc<RecordBatch>>, LixError> {
+            Ok(self.batch.lock().expect("test batch cache lock").clone())
+        }
+
+        async fn cache_entity_columnar_batch(
+            &self,
+            _layout: &crate::sql2::entity_batch::EntityColumnarScanLayout,
+            _group_index: usize,
+            _shadow_identity_digest: [u8; 32],
+            _projection: Vec<usize>,
+            batch: Arc<RecordBatch>,
+        ) -> Result<Arc<RecordBatch>, LixError> {
+            let mut resident = self.batch.lock().expect("test batch cache lock");
+            Ok(Arc::clone(resident.get_or_insert(batch)))
+        }
+    }
 
     #[async_trait]
     impl LiveStateReader for EmptyLiveStateReader {
@@ -4744,5 +4802,108 @@ mod tests {
                 assert!(mask.is_none(), "unaffected group must avoid mask work");
             }
         }
+    }
+
+    fn cached_batch_test_layout(
+        branch_id: &'static str,
+        revision: u64,
+    ) -> Arc<crate::sql2::entity_batch::EntityColumnarScanLayout> {
+        Arc::new(crate::sql2::entity_batch::EntityColumnarScanLayout {
+            id: crate::columnar_row_group::RowGroupSetId::new([23; 16]),
+            manifest: Arc::new(crate::columnar_row_group::RowGroupManifest {
+                namespace: "cached_batch_test".to_owned(),
+                metadata: HashMap::new(),
+                fields: Vec::new(),
+                groups: Vec::new(),
+            }),
+            overlay: Arc::new(Vec::new()),
+            branch_id: Arc::from(branch_id),
+            head_commit_id: CommitId::for_test_label("cached-batch-test-head"),
+            current_state_revision: revision,
+            live_count: 2,
+        })
+    }
+
+    fn cached_batch_test_value(value: i64) -> Arc<RecordBatch> {
+        Arc::new(
+            RecordBatch::try_from_iter([(
+                "value",
+                Arc::new(Int64Array::from(vec![value, value])) as _,
+            )])
+            .expect("test batch"),
+        )
+    }
+
+    #[tokio::test]
+    async fn clean_columnar_batch_is_loaded_once() {
+        let concrete = Arc::new(TestCachingEntitySnapshotReader::default());
+        let reader: Arc<dyn crate::sql2::EntitySnapshotReader> = concrete;
+        let loads = Arc::new(AtomicUsize::new(0));
+        let digest = [31; 32];
+
+        let layout = cached_batch_test_layout("main", 7);
+        for _ in 0..2 {
+            let loads = Arc::clone(&loads);
+            let batch = cached_batch_test_value(7);
+            let result = super::cached_or_load_entity_columnar_batch(
+                &reader,
+                &layout,
+                0,
+                digest,
+                vec![2, 4],
+                async move {
+                    loads.fetch_add(1, Ordering::SeqCst);
+                    Ok(batch)
+                },
+            )
+            .await
+            .expect("clean batch should load");
+            assert_eq!(result.num_rows(), 2);
+        }
+
+        assert_eq!(loads.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn failed_clean_columnar_load_is_not_cached() {
+        let concrete = Arc::new(TestCachingEntitySnapshotReader::default());
+        let reader: Arc<dyn crate::sql2::EntitySnapshotReader> = concrete;
+        let layout = cached_batch_test_layout("main", 7);
+        let loads = Arc::new(AtomicUsize::new(0));
+        let first_loads = Arc::clone(&loads);
+        let error = super::cached_or_load_entity_columnar_batch(
+            &reader,
+            &layout,
+            0,
+            [37; 32],
+            vec![2],
+            async move {
+                first_loads.fetch_add(1, Ordering::SeqCst);
+                Err(datafusion::common::DataFusionError::Execution(
+                    "expected test failure".to_owned(),
+                ))
+            },
+        )
+        .await
+        .expect_err("failed load must surface");
+        assert!(error.to_string().contains("expected test failure"));
+
+        let retry_loads = Arc::clone(&loads);
+        let batch = cached_batch_test_value(9);
+        super::cached_or_load_entity_columnar_batch(
+            &reader,
+            &layout,
+            0,
+            [37; 32],
+            vec![2],
+            async move {
+                retry_loads.fetch_add(1, Ordering::SeqCst);
+                Ok(batch)
+            },
+        )
+        .await
+        .expect("retry should populate cache");
+
+        assert_eq!(loads.load(Ordering::SeqCst), 2);
     }
 }


### PR DESCRIPTION
## Summary
- reuse the existing repository-scoped bounded Arrow batch cache for pristine and proven-unshadowed immutable row groups
- centralize the complete visibility/cache key across row-group set, branch, head, revision, shadow digest, group, and ordered projection
- preserve exact-PK and LIMIT point paths outside the columnar cache
- add direct key isolation, canonical insertion, failure retry, byte/entry eviction, and eligibility tests

## Performance (warm analytical cache, SF0.2 / 1.2M lineitem rows)
Exact same-#1150 5-sample before/after:

| Query | Adapter | Before | After | Change |
|---|---:|---:|---:|---:|
| Q8 | RocksDB | 67.128 ms | 20.527 ms | -69.42% |
| Q8 | SlateDB | 67.960 ms | 20.427 ms | -69.94% |
| Q11 | RocksDB | 18.139 ms | 11.576 ms | -36.18% |
| Q11 | SlateDB | 17.955 ms | 11.342 ms | -36.83% |

Q8 scan poll time falls ~89.3%, with identical 1.572M rows, 67 batches, and 59.06 MB Arrow output. Sparse and moderate transactional overlays retain exact DuckDB parity on both adapters.

This is explicitly a warm-cache improvement. Cold Q8 remains 6.9–7.4x DuckDB and warm Q8 remains ~1.9x; neither yet meets the 1.5x project goal.

## OLTP guard
RocksDB 10k-fixture `read_one`, 1,000 hot repeats: 9.201 us/op, 999 point-cache hits / 1 miss. Exact primary-key and LIMIT requests are structurally excluded from the analytical columnar path.

## Validation
- 7 focused cache/key/eligibility tests
- sparse and moderate overlay result parity, RocksDB + SlateDB
- all-target/all-feature engine Clippy with warnings denied
- formatting and diff checks

## Improvement axis
Warm generalized analytical Q8 improves 69–70% and Q11 improves 36–37% on both supported KV adapters, exceeding the required 10% axis.

## Independent review
Approved with no blockers. Review verified key completeness, snapshot/transaction isolation, eviction accounting, canonical duplicate insertion, retry/cancellation behavior, overlay semantics, point-path exclusion, and the warm-only benchmark labeling.