### PR TITLE
perf(sql): reuse decoded row-group columns

### DIFF
--- a/packages/engine/src/columnar_row_group.rs
+++ b/packages/engine/src/columnar_row_group.rs
@@ -173,6 +173,13 @@ pub(crate) struct RowGroupManifest {
 }
 
 impl RowGroupManifest {
+    /// Content identity of the complete persisted manifest, including every
+    /// column digest. Decoded-column caches use this in addition to the set
+    /// identifier so corrupted or replaced manifests can never alias.
+    pub(crate) fn content_digest(&self) -> Result<[u8; BLAKE3_DIGEST_LEN], LixError> {
+        Ok(*blake3::hash(&encode_manifest(self)?).as_bytes())
+    }
+
     pub(crate) fn row_count(&self) -> u64 {
         self.groups
             .iter()
@@ -480,6 +487,30 @@ pub(crate) async fn load_row_group_batch(
         .map_err(|error| row_group_error(error.to_string()));
     }
 
+    let arrays = load_row_group_columns(store, id, manifest, group_index, projection).await?;
+    RecordBatch::try_new(projected_schema, arrays)
+        .map_err(|error| row_group_error(error.to_string()))
+}
+
+/// Loads, verifies, decompresses, and decodes exactly the requested columns.
+/// The returned arrays follow `projection` order and retain no storage bytes.
+pub(crate) async fn load_row_group_columns(
+    store: &(impl StorageAdapterRead + ?Sized),
+    id: RowGroupSetId,
+    manifest: &RowGroupManifest,
+    group_index: usize,
+    projection: &[usize],
+) -> Result<Vec<ArrayRef>, LixError> {
+    validate_projection(manifest, projection)?;
+    let group = manifest.groups.get(group_index).ok_or_else(|| {
+        row_group_error(format!(
+            "row-group index {group_index} is outside {} groups",
+            manifest.groups.len()
+        ))
+    })?;
+    if projection.is_empty() {
+        return Ok(Vec::new());
+    }
     let keys = projection
         .iter()
         .map(|&column_index| id.column_key(group_index, column_index))
@@ -513,8 +544,15 @@ pub(crate) async fn load_row_group_batch(
             "row-group read returned excess column values",
         ));
     }
-    RecordBatch::try_new(projected_schema, arrays)
-        .map_err(|error| row_group_error(error.to_string()))
+    Ok(arrays)
+}
+
+pub(crate) fn row_group_projected_schema(
+    manifest: &RowGroupManifest,
+    projection: &[usize],
+) -> Result<SchemaRef, LixError> {
+    validate_projection(manifest, projection)?;
+    Ok(projected_schema(manifest, projection))
 }
 
 fn validate_input_batches(schema: &SchemaRef, batches: &[RecordBatch]) -> Result<(), LixError> {

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -89,6 +89,7 @@ struct CachedEntityColumnarLayout {
     key: EntityColumnarLayoutCacheKey,
     id: crate::columnar_row_group::RowGroupSetId,
     manifest: std::sync::Arc<crate::columnar_row_group::RowGroupManifest>,
+    manifest_digest: [u8; 32],
     overlay: std::sync::Arc<Vec<crate::live_state::EntityColumnarOverlayRow>>,
     head_commit_id: CommitId,
     live_count: u64,
@@ -123,6 +124,7 @@ impl EntityColumnarLayoutCache {
         key: EntityColumnarLayoutCacheKey,
         id: crate::columnar_row_group::RowGroupSetId,
         manifest: crate::columnar_row_group::RowGroupManifest,
+        manifest_digest: [u8; 32],
         overlay: Vec<crate::live_state::EntityColumnarOverlayRow>,
         head_commit_id: CommitId,
         live_count: u64,
@@ -131,6 +133,7 @@ impl EntityColumnarLayoutCache {
             key,
             id,
             manifest,
+            manifest_digest,
             overlay,
             head_commit_id,
             live_count,
@@ -144,6 +147,7 @@ impl EntityColumnarLayoutCache {
         key: EntityColumnarLayoutCacheKey,
         id: crate::columnar_row_group::RowGroupSetId,
         manifest: crate::columnar_row_group::RowGroupManifest,
+        manifest_digest: [u8; 32],
         overlay: Vec<crate::live_state::EntityColumnarOverlayRow>,
         head_commit_id: CommitId,
         live_count: u64,
@@ -161,6 +165,7 @@ impl EntityColumnarLayoutCache {
             key,
             id,
             manifest,
+            manifest_digest,
             overlay,
             head_commit_id,
             live_count,
@@ -302,6 +307,7 @@ pub(crate) struct LiveStateContext {
     entity_columnar_layout_cache: std::sync::Arc<EntityColumnarLayoutCache>,
     entity_columnar_scan_cache:
         std::sync::Arc<std::sync::Mutex<crate::live_state::EntityColumnarShadowMaskCache>>,
+    entity_decoded_column_cache: crate::live_state::EntityDecodedColumnCache,
 }
 
 impl LiveStateContext {
@@ -309,6 +315,8 @@ impl LiveStateContext {
         _tracked_state: TrackedStateContext,
         commit_graph: CommitGraphContext,
     ) -> Self {
+        let entity_columnar_array_budget =
+            std::sync::Arc::new(crate::live_state::EntityColumnarArrayBudget::default());
         Self {
             tracked_head: TrackedHeadContext::new(),
             commit_graph,
@@ -317,8 +325,14 @@ impl LiveStateContext {
             entity_point_snapshot_cache: std::sync::Arc::new(EntityPointSnapshotCache::default()),
             entity_columnar_layout_cache: std::sync::Arc::new(EntityColumnarLayoutCache::default()),
             entity_columnar_scan_cache: std::sync::Arc::new(std::sync::Mutex::new(
-                crate::live_state::EntityColumnarShadowMaskCache::default(),
+                crate::live_state::EntityColumnarShadowMaskCache::with_array_budget(
+                    std::sync::Arc::clone(&entity_columnar_array_budget),
+                ),
             )),
+            entity_decoded_column_cache:
+                crate::live_state::EntityDecodedColumnCache::with_array_budget(
+                    entity_columnar_array_budget,
+                ),
         }
     }
 
@@ -326,6 +340,12 @@ impl LiveStateContext {
         &self,
     ) -> std::sync::Arc<std::sync::Mutex<crate::live_state::EntityColumnarShadowMaskCache>> {
         std::sync::Arc::clone(&self.entity_columnar_scan_cache)
+    }
+
+    pub(crate) fn entity_decoded_column_cache(
+        &self,
+    ) -> crate::live_state::EntityDecodedColumnCache {
+        self.entity_decoded_column_cache.clone()
     }
 
     /// Creates a visible live-state reader over a caller-provided KV store.
@@ -533,6 +553,7 @@ where
         Option<(
             crate::columnar_row_group::RowGroupSetId,
             std::sync::Arc<crate::columnar_row_group::RowGroupManifest>,
+            [u8; 32],
             std::sync::Arc<Vec<crate::live_state::EntityColumnarOverlayRow>>,
             String,
             CommitId,
@@ -566,6 +587,7 @@ where
             return Ok(Some((
                 layout.id,
                 std::sync::Arc::clone(&layout.manifest),
+                layout.manifest_digest,
                 std::sync::Arc::clone(&layout.overlay),
                 branch_id,
                 layout.head_commit_id,
@@ -578,25 +600,29 @@ where
             .reader(&self.store)
             .entity_columnar_layout(&branch_id, control, &schema_key)
             .await?;
-        Ok(layout.map(|(id, manifest, overlay, live_count)| {
-            let layout = self.entity_columnar_layout_cache.insert(
-                key,
-                id,
-                manifest,
-                overlay,
-                control.head_commit_id,
-                live_count,
-            );
-            (
-                layout.id,
-                std::sync::Arc::clone(&layout.manifest),
-                std::sync::Arc::clone(&layout.overlay),
-                branch_id,
-                layout.head_commit_id,
-                control.current_state_revision,
-                layout.live_count,
-            )
-        }))
+        let Some((id, manifest, overlay, live_count)) = layout else {
+            return Ok(None);
+        };
+        let manifest_digest = manifest.content_digest()?;
+        let layout = self.entity_columnar_layout_cache.insert(
+            key,
+            id,
+            manifest,
+            manifest_digest,
+            overlay,
+            control.head_commit_id,
+            live_count,
+        );
+        Ok(Some((
+            layout.id,
+            std::sync::Arc::clone(&layout.manifest),
+            layout.manifest_digest,
+            std::sync::Arc::clone(&layout.overlay),
+            branch_id,
+            layout.head_commit_id,
+            control.current_state_revision,
+            layout.live_count,
+        )))
     }
 
     #[cfg(test)]
@@ -1673,6 +1699,7 @@ mod tests {
             key,
             crate::columnar_row_group::RowGroupSetId::new([1; 16]),
             empty_columnar_manifest(),
+            [2; 32],
             Vec::new(),
             CommitId::for_test_label("columnar-cache-head"),
             1_000_000,
@@ -1692,6 +1719,7 @@ mod tests {
             first,
             crate::columnar_row_group::RowGroupSetId::new([1; 16]),
             empty_columnar_manifest(),
+            [2; 32],
             Vec::new(),
             CommitId::for_test_label("columnar-cache-head-7"),
             1_000_000,
@@ -1701,6 +1729,7 @@ mod tests {
             columnar_cache_key(8),
             crate::columnar_row_group::RowGroupSetId::new([2; 16]),
             empty_columnar_manifest(),
+            [3; 32],
             Vec::new(),
             CommitId::for_test_label("columnar-cache-head-8"),
             999_999,
@@ -1717,6 +1746,7 @@ mod tests {
             key,
             crate::columnar_row_group::RowGroupSetId::new([1; 16]),
             empty_columnar_manifest(),
+            [2; 32],
             Vec::new(),
             CommitId::for_test_label("columnar-cache-head"),
             1_000_000,

--- a/packages/engine/src/live_state/entity_columnar_cache.rs
+++ b/packages/engine/src/live_state/entity_columnar_cache.rs
@@ -1,7 +1,7 @@
 //! Repository-scoped reconciliation artifacts for analytical entity scans.
 
 use std::collections::{HashMap, VecDeque};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use datafusion::arrow::array::{Array, BooleanArray};
 use datafusion::arrow::record_batch::RecordBatch;
@@ -11,6 +11,113 @@ const SHADOW_MASK_CACHE_ENTRIES: usize = 256;
 const STATISTICS_PROJECTIONS_PER_MASK: usize = 8;
 const RECONCILED_BATCH_CACHE_ENTRIES: usize = 256;
 const RECONCILED_BATCH_CACHE_MAX_BYTES: usize = 256 * 1024 * 1024;
+
+/// One repository-wide budget for immutable and reconciled Arrow arrays.
+/// Exact-batch and decoded-column entries often clone the same immutable
+/// `ArrayRef`. Pointer identity plus reference counts charges that allocation
+/// once; independently constructed (including sliced or filtered) arrays are
+/// conservatively separate allocations.
+pub(crate) struct EntityColumnarArrayBudget {
+    state: Mutex<EntityColumnarArrayBudgetState>,
+    max: usize,
+}
+
+#[derive(Default)]
+struct EntityColumnarArrayBudgetState {
+    used: usize,
+    arrays: HashMap<usize, (usize, usize)>,
+}
+
+impl Default for EntityColumnarArrayBudget {
+    fn default() -> Self {
+        Self::new(RECONCILED_BATCH_CACHE_MAX_BYTES)
+    }
+}
+
+impl EntityColumnarArrayBudget {
+    pub(crate) fn new(max: usize) -> Self {
+        Self {
+            state: Mutex::new(EntityColumnarArrayBudgetState::default()),
+            max,
+        }
+    }
+
+    pub(crate) fn try_reserve(&self, arrays: &[datafusion::arrow::array::ArrayRef]) -> bool {
+        let mut requested = HashMap::<usize, (usize, usize)>::new();
+        for array in arrays {
+            let identity = Arc::as_ptr(array) as *const () as usize;
+            let entry = requested
+                .entry(identity)
+                .or_insert((array.get_array_memory_size(), 0));
+            let Some(references) = entry.1.checked_add(1) else {
+                return false;
+            };
+            entry.1 = references;
+        }
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let Some(additional) = requested
+            .iter()
+            .filter(|(identity, _)| !state.arrays.contains_key(identity))
+            .map(|(_, (bytes, _))| *bytes)
+            .try_fold(0_usize, usize::checked_add)
+        else {
+            return false;
+        };
+        let Some(next_used) = state.used.checked_add(additional) else {
+            return false;
+        };
+        if next_used > self.max
+            || requested.iter().any(|(identity, (bytes, references))| {
+                state.arrays.get(identity).is_some_and(|resident| {
+                    resident.0 != *bytes || resident.1.checked_add(*references).is_none()
+                })
+            })
+        {
+            return false;
+        }
+        state.used = next_used;
+        for (identity, (bytes, references)) in requested {
+            let resident = state.arrays.entry(identity).or_insert((bytes, 0));
+            resident.1 = resident
+                .1
+                .checked_add(references)
+                .expect("reference-count overflow was preflighted");
+        }
+        true
+    }
+
+    pub(crate) fn release(&self, arrays: &[datafusion::arrow::array::ArrayRef]) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for array in arrays {
+            let identity = Arc::as_ptr(array) as *const () as usize;
+            let Some((bytes, references)) = state.arrays.get_mut(&identity) else {
+                debug_assert!(false, "released an unreserved columnar array");
+                continue;
+            };
+            debug_assert!(*references > 0, "columnar array reference underflow");
+            *references = references.saturating_sub(1);
+            if *references == 0 {
+                let bytes = *bytes;
+                state.arrays.remove(&identity);
+                state.used = state.used.saturating_sub(bytes);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn used(&self) -> usize {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .used
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct EntityColumnarBatchKey {
@@ -28,13 +135,28 @@ pub(crate) struct EntityColumnarShadowMaskKey {
     pub(crate) group_index: usize,
 }
 
-#[derive(Default)]
 pub(crate) struct EntityColumnarShadowMaskCache {
     entries: HashMap<EntityColumnarShadowMaskKey, EntityColumnarShadowCacheEntry>,
     insertion_order: VecDeque<EntityColumnarShadowMaskKey>,
     batches: HashMap<EntityColumnarBatchKey, (Arc<RecordBatch>, usize)>,
     batch_insertion_order: VecDeque<EntityColumnarBatchKey>,
     batch_bytes: usize,
+    array_budget: Arc<EntityColumnarArrayBudget>,
+}
+
+impl Default for EntityColumnarShadowMaskCache {
+    fn default() -> Self {
+        Self::with_array_budget(Arc::new(EntityColumnarArrayBudget::default()))
+    }
+}
+
+impl Drop for EntityColumnarShadowMaskCache {
+    fn drop(&mut self) {
+        for (batch, _) in self.batches.values() {
+            self.array_budget.release(batch.columns());
+        }
+        self.batch_bytes = 0;
+    }
 }
 
 struct EntityColumnarShadowCacheEntry {
@@ -44,6 +166,17 @@ struct EntityColumnarShadowCacheEntry {
 }
 
 impl EntityColumnarShadowMaskCache {
+    pub(crate) fn with_array_budget(array_budget: Arc<EntityColumnarArrayBudget>) -> Self {
+        Self {
+            entries: HashMap::new(),
+            insertion_order: VecDeque::new(),
+            batches: HashMap::new(),
+            batch_insertion_order: VecDeque::new(),
+            batch_bytes: 0,
+            array_budget,
+        }
+    }
+
     pub(crate) fn get(&self, key: &EntityColumnarShadowMaskKey) -> Option<Arc<BooleanArray>> {
         self.entries.get(key).map(|entry| Arc::clone(&entry.mask))
     }
@@ -163,10 +296,20 @@ impl EntityColumnarShadowMaskCache {
             || self.batch_bytes.saturating_add(bytes) > max_bytes
         {
             let Some(evicted) = self.batch_insertion_order.pop_front() else {
-                break;
+                return batch;
             };
-            if let Some((_, evicted_bytes)) = self.batches.remove(&evicted) {
+            if let Some((evicted_batch, evicted_bytes)) = self.batches.remove(&evicted) {
                 self.batch_bytes = self.batch_bytes.saturating_sub(evicted_bytes);
+                self.array_budget.release(evicted_batch.columns());
+            }
+        }
+        while !self.array_budget.try_reserve(batch.columns()) {
+            let Some(evicted) = self.batch_insertion_order.pop_front() else {
+                return batch;
+            };
+            if let Some((evicted_batch, evicted_bytes)) = self.batches.remove(&evicted) {
+                self.batch_bytes = self.batch_bytes.saturating_sub(evicted_bytes);
+                self.array_budget.release(evicted_batch.columns());
             }
         }
         self.batch_bytes = self.batch_bytes.saturating_add(bytes);
@@ -181,6 +324,103 @@ mod tests {
     use super::*;
     use datafusion::arrow::array::Int64Array;
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
+
+    fn budget_array(values: usize) -> datafusion::arrow::array::ArrayRef {
+        Arc::new(Int64Array::from(vec![1; values]))
+    }
+
+    #[test]
+    fn shared_budget_charges_identical_arc_once_until_last_release() {
+        let array = budget_array(8);
+        let bytes = array.get_array_memory_size();
+        let budget = EntityColumnarArrayBudget::new(bytes);
+        assert!(budget.try_reserve(&[Arc::clone(&array), Arc::clone(&array)]));
+        assert_eq!(budget.used(), bytes);
+        budget.release(std::slice::from_ref(&array));
+        assert_eq!(budget.used(), bytes);
+        budget.release(std::slice::from_ref(&array));
+        assert_eq!(budget.used(), 0);
+    }
+
+    #[test]
+    fn shared_budget_treats_distinct_and_sliced_array_objects_separately() {
+        let base = budget_array(8);
+        let slice = base.slice(0, 4);
+        let distinct = budget_array(8);
+        let expected = base
+            .get_array_memory_size()
+            .saturating_add(slice.get_array_memory_size())
+            .saturating_add(distinct.get_array_memory_size());
+        let budget = EntityColumnarArrayBudget::new(expected);
+        assert!(budget.try_reserve(&[
+            Arc::clone(&base),
+            Arc::clone(&slice),
+            Arc::clone(&distinct),
+        ]));
+        assert_eq!(budget.used(), expected);
+        budget.release(&[base, slice, distinct]);
+        assert_eq!(budget.used(), 0);
+    }
+
+    #[test]
+    fn failed_aggregate_reservation_is_atomic_and_concurrent_shares_dedupe() {
+        let first = budget_array(8);
+        let second = budget_array(8);
+        let bytes = first.get_array_memory_size();
+        let budget = Arc::new(EntityColumnarArrayBudget::new(bytes));
+        assert!(!budget.try_reserve(&[Arc::clone(&first), second]));
+        assert_eq!(budget.used(), 0);
+
+        let barrier = Arc::new(std::sync::Barrier::new(3));
+        let handles = (0..2)
+            .map(|_| {
+                let budget = Arc::clone(&budget);
+                let array = Arc::clone(&first);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    assert!(budget.try_reserve(std::slice::from_ref(&array)));
+                    array
+                })
+            })
+            .collect::<Vec<_>>();
+        barrier.wait();
+        let arrays = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("budget thread"))
+            .collect::<Vec<_>>();
+        assert_eq!(budget.used(), bytes);
+        for array in arrays {
+            budget.release(std::slice::from_ref(&array));
+        }
+        assert_eq!(budget.used(), 0);
+    }
+
+    #[test]
+    fn abstract_budget_and_reference_overflow_fail_without_mutation() {
+        let array = budget_array(8);
+        let bytes = array.get_array_memory_size();
+        let identity = Arc::as_ptr(&array) as *const () as usize;
+        let budget = EntityColumnarArrayBudget::new(usize::MAX);
+        assert!(budget.try_reserve(std::slice::from_ref(&array)));
+        {
+            let mut state = budget.state.lock().expect("budget lock");
+            state.arrays.get_mut(&identity).expect("resident array").1 = usize::MAX;
+        }
+        assert!(!budget.try_reserve(std::slice::from_ref(&array)));
+        {
+            let mut state = budget.state.lock().expect("budget lock");
+            assert_eq!(state.used, bytes);
+            assert_eq!(state.arrays[&identity].1, usize::MAX);
+            state.arrays.get_mut(&identity).expect("resident array").1 = 1;
+        }
+        budget.release(std::slice::from_ref(&array));
+
+        let overflow = EntityColumnarArrayBudget::new(usize::MAX);
+        overflow.state.lock().expect("budget lock").used = usize::MAX;
+        assert!(!overflow.try_reserve(std::slice::from_ref(&array)));
+        assert_eq!(overflow.used(), usize::MAX);
+    }
 
     #[test]
     fn statistics_projections_are_bounded_per_mask() {

--- a/packages/engine/src/live_state/entity_decoded_column_cache.rs
+++ b/packages/engine/src/live_state/entity_decoded_column_cache.rs
@@ -1,0 +1,885 @@
+//! Repository-owned decoded columns for immutable analytical row groups.
+//!
+//! Entries are addressed only by persisted content. Visibility artifacts
+//! (providers, overlays, coordinate masks, and transaction state) deliberately
+//! live above this cache and are never retained here.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+
+use datafusion::arrow::array::{Array, ArrayRef};
+use tokio::sync::watch;
+
+use crate::LixError;
+use crate::columnar_row_group::{RowGroupManifest, RowGroupSetId};
+
+const DECODED_COLUMN_CACHE_MAX_BYTES: usize = 256 * 1024 * 1024;
+const DECODED_COLUMN_CACHE_MAX_ENTRIES: usize = 4_096;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct DecodedColumnKey {
+    row_groups: RowGroupSetId,
+    manifest_digest: [u8; 32],
+    group_index: usize,
+    column_index: usize,
+}
+
+struct CacheState {
+    entries: HashMap<DecodedColumnKey, (ArrayRef, usize)>,
+    insertion_order: VecDeque<DecodedColumnKey>,
+    bytes: usize,
+    in_flight: HashSet<DecodedColumnKey>,
+    generation: u64,
+}
+
+struct CacheInner {
+    state: Mutex<CacheState>,
+    changes: watch::Sender<u64>,
+    max_bytes: usize,
+    max_entries: usize,
+    array_budget: Arc<crate::live_state::EntityColumnarArrayBudget>,
+    #[cfg(test)]
+    waiter_observed: tokio::sync::Notify,
+}
+
+impl Drop for CacheInner {
+    fn drop(&mut self) {
+        let state = self
+            .state
+            .get_mut()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for (array, _) in state.entries.values() {
+            self.array_budget.release(std::slice::from_ref(array));
+        }
+        state.bytes = 0;
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct EntityDecodedColumnCache {
+    inner: Arc<CacheInner>,
+}
+
+impl Default for EntityDecodedColumnCache {
+    fn default() -> Self {
+        Self::with_limits(
+            DECODED_COLUMN_CACHE_MAX_BYTES,
+            DECODED_COLUMN_CACHE_MAX_ENTRIES,
+        )
+    }
+}
+
+impl EntityDecodedColumnCache {
+    fn with_limits(max_bytes: usize, max_entries: usize) -> Self {
+        Self::with_limits_and_budget(
+            max_bytes,
+            max_entries,
+            Arc::new(crate::live_state::EntityColumnarArrayBudget::new(max_bytes)),
+        )
+    }
+
+    pub(crate) fn with_array_budget(
+        array_budget: Arc<crate::live_state::EntityColumnarArrayBudget>,
+    ) -> Self {
+        Self::with_limits_and_budget(
+            DECODED_COLUMN_CACHE_MAX_BYTES,
+            DECODED_COLUMN_CACHE_MAX_ENTRIES,
+            array_budget,
+        )
+    }
+
+    fn with_limits_and_budget(
+        max_bytes: usize,
+        max_entries: usize,
+        array_budget: Arc<crate::live_state::EntityColumnarArrayBudget>,
+    ) -> Self {
+        let (changes, _) = watch::channel(0);
+        Self {
+            inner: Arc::new(CacheInner {
+                state: Mutex::new(CacheState {
+                    entries: HashMap::new(),
+                    insertion_order: VecDeque::new(),
+                    bytes: 0,
+                    in_flight: HashSet::new(),
+                    generation: 0,
+                }),
+                changes,
+                max_bytes,
+                max_entries,
+                array_budget,
+                #[cfg(test)]
+                waiter_observed: tokio::sync::Notify::new(),
+            }),
+        }
+    }
+
+    pub(crate) async fn load_projection<S>(
+        &self,
+        store: &S,
+        id: RowGroupSetId,
+        manifest_digest: [u8; 32],
+        manifest: &RowGroupManifest,
+        group_index: usize,
+        projection: &[usize],
+    ) -> Result<Vec<ArrayRef>, LixError>
+    where
+        S: crate::storage_adapter::StorageAdapterRead + ?Sized,
+    {
+        self.load_projection_with(
+            id,
+            manifest_digest,
+            group_index,
+            projection,
+            |claimed| async move {
+                let arrays = crate::columnar_row_group::load_row_group_columns(
+                    store,
+                    id,
+                    manifest,
+                    group_index,
+                    &claimed,
+                )
+                .await?;
+                Ok(claimed.into_iter().zip(arrays).collect())
+            },
+        )
+        .await
+    }
+
+    async fn load_projection_with<F, Fut>(
+        &self,
+        id: RowGroupSetId,
+        manifest_digest: [u8; 32],
+        group_index: usize,
+        projection: &[usize],
+        mut load: F,
+    ) -> Result<Vec<ArrayRef>, LixError>
+    where
+        F: FnMut(Vec<usize>) -> Fut,
+        Fut: Future<Output = Result<Vec<(usize, ArrayRef)>, LixError>>,
+    {
+        let mut resolved = HashMap::<usize, ArrayRef>::new();
+        loop {
+            let (claimed, mut changed) = {
+                let mut state = self.lock()?;
+                let mut missing = Vec::new();
+                for &column_index in projection {
+                    if resolved.contains_key(&column_index) {
+                        continue;
+                    }
+                    let key = DecodedColumnKey {
+                        row_groups: id,
+                        manifest_digest,
+                        group_index,
+                        column_index,
+                    };
+                    if let Some((array, _)) = state.entries.get(&key) {
+                        resolved.insert(column_index, Arc::clone(array));
+                    } else {
+                        missing.push(key);
+                    }
+                }
+                if missing.is_empty() {
+                    return projection
+                        .iter()
+                        .map(|index| {
+                            resolved.get(index).cloned().ok_or_else(|| {
+                                cache_error("decoded-column projection assembly lost a column")
+                            })
+                        })
+                        .collect();
+                }
+                let claimed = missing
+                    .into_iter()
+                    .filter(|key| state.in_flight.insert(*key))
+                    .collect::<Vec<_>>();
+                (claimed, self.inner.changes.subscribe())
+            };
+
+            if claimed.is_empty() {
+                #[cfg(test)]
+                self.inner.waiter_observed.notify_waiters();
+                changed
+                    .changed()
+                    .await
+                    .map_err(|_| cache_error("decoded-column cache coordination channel closed"))?;
+                continue;
+            }
+
+            let mut claim = ColumnLoadClaim::new(Arc::clone(&self.inner), claimed);
+            let claimed_indices = claim
+                .keys
+                .iter()
+                .map(|key| key.column_index)
+                .collect::<Vec<_>>();
+            let loaded = load(claimed_indices).await?;
+            let expected = claim
+                .keys
+                .iter()
+                .map(|key| key.column_index)
+                .collect::<HashSet<_>>();
+            if loaded.len() != expected.len()
+                || loaded.iter().any(|(index, _)| !expected.contains(index))
+                || loaded
+                    .iter()
+                    .map(|(index, _)| *index)
+                    .collect::<HashSet<_>>()
+                    .len()
+                    != loaded.len()
+            {
+                return Err(cache_error(
+                    "decoded-column loader returned a mismatched projection",
+                ));
+            }
+            for (index, array) in &loaded {
+                resolved.insert(*index, Arc::clone(array));
+            }
+            claim.publish(loaded)?;
+        }
+    }
+
+    fn lock(&self) -> Result<std::sync::MutexGuard<'_, CacheState>, LixError> {
+        self.inner
+            .state
+            .lock()
+            .map_err(|_| cache_error("decoded-column cache lock poisoned"))
+    }
+}
+
+struct ColumnLoadClaim {
+    inner: Arc<CacheInner>,
+    keys: Vec<DecodedColumnKey>,
+    finished: bool,
+}
+
+impl ColumnLoadClaim {
+    fn new(inner: Arc<CacheInner>, keys: Vec<DecodedColumnKey>) -> Self {
+        Self {
+            inner,
+            keys,
+            finished: false,
+        }
+    }
+
+    fn publish(&mut self, loaded: Vec<(usize, ArrayRef)>) -> Result<(), LixError> {
+        let arrays = loaded.into_iter().collect::<HashMap<_, _>>();
+        let mut state = self
+            .inner
+            .state
+            .lock()
+            .map_err(|_| cache_error("decoded-column cache lock poisoned"))?;
+        for key in &self.keys {
+            let array = arrays
+                .get(&key.column_index)
+                .expect("loader projection was validated");
+            let bytes = array.get_array_memory_size();
+            if bytes <= self.inner.max_bytes && self.inner.max_entries != 0 {
+                while state.entries.len() >= self.inner.max_entries
+                    || state.bytes.saturating_add(bytes) > self.inner.max_bytes
+                {
+                    let Some(evicted) = state.insertion_order.pop_front() else {
+                        break;
+                    };
+                    if let Some((evicted_array, evicted_bytes)) = state.entries.remove(&evicted) {
+                        state.bytes = state.bytes.saturating_sub(evicted_bytes);
+                        self.inner
+                            .array_budget
+                            .release(std::slice::from_ref(&evicted_array));
+                    }
+                }
+                let mut reserved = self
+                    .inner
+                    .array_budget
+                    .try_reserve(std::slice::from_ref(array));
+                while !reserved {
+                    let Some(evicted) = state.insertion_order.pop_front() else {
+                        break;
+                    };
+                    if let Some((evicted_array, evicted_bytes)) = state.entries.remove(&evicted) {
+                        state.bytes = state.bytes.saturating_sub(evicted_bytes);
+                        self.inner
+                            .array_budget
+                            .release(std::slice::from_ref(&evicted_array));
+                    }
+                    reserved = self
+                        .inner
+                        .array_budget
+                        .try_reserve(std::slice::from_ref(array));
+                }
+                if reserved {
+                    state.bytes = state.bytes.saturating_add(bytes);
+                    state.insertion_order.push_back(*key);
+                    state.entries.insert(*key, (Arc::clone(array), bytes));
+                }
+            }
+            state.in_flight.remove(key);
+        }
+        state.generation = state.generation.wrapping_add(1);
+        self.inner.changes.send_replace(state.generation);
+        self.finished = true;
+        Ok(())
+    }
+}
+
+impl Drop for ColumnLoadClaim {
+    fn drop(&mut self) {
+        if self.finished {
+            return;
+        }
+        let mut state = self
+            .inner
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for key in &self.keys {
+            state.in_flight.remove(key);
+        }
+        state.generation = state.generation.wrapping_add(1);
+        self.inner.changes.send_replace(state.generation);
+    }
+}
+
+fn cache_error(message: impl Into<String>) -> LixError {
+    LixError::new(LixError::CODE_INTERNAL_ERROR, message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use datafusion::arrow::array::Int64Array;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use tokio::sync::Notify;
+
+    use super::*;
+
+    struct CountingRead<R> {
+        inner: R,
+        column_reads: Arc<Mutex<Vec<usize>>>,
+    }
+
+    impl<R> crate::storage_adapter::StorageAdapterRead for CountingRead<R>
+    where
+        R: crate::storage_adapter::StorageAdapterRead,
+    {
+        fn snapshot_cache_key(&self) -> Option<u128> {
+            self.inner.snapshot_cache_key()
+        }
+
+        fn get_many(
+            &self,
+            requests: &[crate::storage::GetManyRequest<'_>],
+        ) -> impl Future<
+            Output = Result<crate::storage::GetManyResult, crate::storage::StorageError>,
+        > + Send {
+            for request in requests {
+                if request.space == crate::columnar_row_group::ROW_GROUP_COLUMN_SPACE {
+                    self.column_reads
+                        .lock()
+                        .expect("column reads lock")
+                        .push(request.keys.len());
+                }
+            }
+            self.inner.get_many(requests)
+        }
+
+        fn scan(
+            &self,
+            space: crate::storage::StorageSpace,
+            range: crate::storage::KeyRange,
+            opts: crate::storage::ScanOptions,
+        ) -> impl Future<Output = Result<crate::storage::ScanChunk, crate::storage::StorageError>> + Send
+        {
+            self.inner.scan(space, range, opts)
+        }
+    }
+
+    fn array(column: usize) -> ArrayRef {
+        Arc::new(Int64Array::from(vec![column as i64; 8]))
+    }
+
+    fn loaded(columns: Vec<usize>) -> Vec<(usize, ArrayRef)> {
+        columns
+            .into_iter()
+            .map(|column| (column, array(column)))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn storage_reads_only_new_columns_and_reuses_decoded_arcs() {
+        use crate::storage_adapter::{
+            Memory, StorageAdapter, StorageReadOptions, StorageWriteOptions,
+        };
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64, false),
+            Field::new("b", DataType::Int64, false),
+            Field::new("c", DataType::Int64, false),
+        ]));
+        let batch = datafusion::arrow::record_batch::RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![array(10), array(20), array(30)],
+        )
+        .expect("row-group batch");
+        let encoded = crate::columnar_row_group::encode_row_group_set(
+            "decoded-cache-storage-test",
+            schema,
+            &[batch],
+        )
+        .expect("encode row group");
+        let id = RowGroupSetId::new(*b"decoded-cache-01");
+        let adapter = StorageAdapter::new(Memory::new());
+        let mut writes = adapter.new_write_set();
+        crate::columnar_row_group::stage_row_group_set(&mut writes, id, &encoded)
+            .expect("stage row group");
+        adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit row group");
+        let column_reads = Arc::new(Mutex::new(Vec::new()));
+        let read = CountingRead {
+            inner: adapter
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("begin read"),
+            column_reads: Arc::clone(&column_reads),
+        };
+        let cache = EntityDecodedColumnCache::default();
+        let digest = encoded.manifest.content_digest().expect("manifest digest");
+
+        let first = cache
+            .load_projection(&read, id, digest, &encoded.manifest, 0, &[1, 0])
+            .await
+            .expect("first projection");
+        let second = cache
+            .load_projection(&read, id, digest, &encoded.manifest, 0, &[0, 2, 1])
+            .await
+            .expect("overlapping projection");
+
+        assert_eq!(*column_reads.lock().expect("column reads lock"), vec![2, 1]);
+        assert!(Arc::ptr_eq(&first[1], &second[0]));
+        assert!(Arc::ptr_eq(&first[0], &second[2]));
+        assert_eq!(
+            second
+                .iter()
+                .map(|value| {
+                    value
+                        .as_any()
+                        .downcast_ref::<Int64Array>()
+                        .expect("int array")
+                        .value(0)
+                })
+                .collect::<Vec<_>>(),
+            vec![10, 30, 20]
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_projection_never_invokes_loader() {
+        let cache = EntityDecodedColumnCache::default();
+        let loads = AtomicUsize::new(0);
+        let arrays = cache
+            .load_projection_with(RowGroupSetId::new([16; 16]), [17; 32], 0, &[], |_columns| {
+                loads.fetch_add(1, Ordering::SeqCst);
+                std::future::ready(Ok(Vec::new()))
+            })
+            .await
+            .expect("empty projection");
+        assert!(arrays.is_empty());
+        assert_eq!(loads.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn overlapping_ordered_projections_reuse_array_identity() {
+        let cache = EntityDecodedColumnCache::default();
+        let loads = Arc::new(Mutex::new(Vec::<Vec<usize>>::new()));
+        let first = cache
+            .load_projection_with(RowGroupSetId::new([1; 16]), [2; 32], 3, &[2, 0], {
+                let loads = Arc::clone(&loads);
+                move |columns| {
+                    loads.lock().expect("loads lock").push(columns.clone());
+                    std::future::ready(Ok(loaded(columns)))
+                }
+            })
+            .await
+            .expect("first projection");
+        let second = cache
+            .load_projection_with(RowGroupSetId::new([1; 16]), [2; 32], 3, &[0, 1, 2], {
+                let loads = Arc::clone(&loads);
+                move |columns| {
+                    loads.lock().expect("loads lock").push(columns.clone());
+                    std::future::ready(Ok(loaded(columns)))
+                }
+            })
+            .await
+            .expect("overlapping projection");
+
+        assert_eq!(
+            *loads.lock().expect("loads lock"),
+            vec![vec![2, 0], vec![1]]
+        );
+        assert!(Arc::ptr_eq(&first[1], &second[0]));
+        assert!(Arc::ptr_eq(&first[0], &second[2]));
+        assert_eq!(
+            second
+                .iter()
+                .map(|value| {
+                    value
+                        .as_any()
+                        .downcast_ref::<Int64Array>()
+                        .expect("int array")
+                        .value(0)
+                })
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_overlaps_claim_each_missing_column_once() {
+        let cache = EntityDecodedColumnCache::default();
+        let first_started = Arc::new(tokio::sync::Barrier::new(2));
+        let release_first = Arc::new(Notify::new());
+        let first_loads = Arc::new(Mutex::new(Vec::new()));
+        let second_loads = Arc::new(Mutex::new(Vec::new()));
+
+        let first_task = tokio::spawn({
+            let cache = cache.clone();
+            let started = Arc::clone(&first_started);
+            let release = Arc::clone(&release_first);
+            let loads = Arc::clone(&first_loads);
+            async move {
+                cache
+                    .load_projection_with(
+                        RowGroupSetId::new([3; 16]),
+                        [4; 32],
+                        0,
+                        &[0, 1],
+                        move |columns| {
+                            let started = Arc::clone(&started);
+                            let release = Arc::clone(&release);
+                            let loads = Arc::clone(&loads);
+                            async move {
+                                loads.lock().expect("loads lock").push(columns.clone());
+                                started.wait().await;
+                                release.notified().await;
+                                Ok(loaded(columns))
+                            }
+                        },
+                    )
+                    .await
+            }
+        });
+        first_started.wait().await;
+        let waiter_observed = cache.inner.waiter_observed.notified();
+        let second_task = tokio::spawn({
+            let cache = cache.clone();
+            let loads = Arc::clone(&second_loads);
+            async move {
+                cache
+                    .load_projection_with(
+                        RowGroupSetId::new([3; 16]),
+                        [4; 32],
+                        0,
+                        &[1, 2],
+                        move |columns| {
+                            loads.lock().expect("loads lock").push(columns.clone());
+                            std::future::ready(Ok(loaded(columns)))
+                        },
+                    )
+                    .await
+            }
+        });
+        waiter_observed.await;
+        release_first.notify_one();
+        first_task.await.expect("first join").expect("first load");
+        second_task
+            .await
+            .expect("second join")
+            .expect("second load");
+
+        assert_eq!(*first_loads.lock().expect("loads lock"), vec![vec![0, 1]]);
+        assert_eq!(*second_loads.lock().expect("loads lock"), vec![vec![2]]);
+    }
+
+    #[tokio::test]
+    async fn waiters_retry_after_owner_error_and_cancellation() {
+        let cache = EntityDecodedColumnCache::default();
+        let started = Arc::new(tokio::sync::Barrier::new(2));
+        let release = Arc::new(Notify::new());
+        let owner = tokio::spawn({
+            let cache = cache.clone();
+            let started = Arc::clone(&started);
+            let release = Arc::clone(&release);
+            async move {
+                cache
+                    .load_projection_with(
+                        RowGroupSetId::new([5; 16]),
+                        [6; 32],
+                        0,
+                        &[0],
+                        move |_columns| {
+                            let started = Arc::clone(&started);
+                            let release = Arc::clone(&release);
+                            async move {
+                                started.wait().await;
+                                release.notified().await;
+                                Err(cache_error("corrupt or missing test column"))
+                            }
+                        },
+                    )
+                    .await
+            }
+        });
+        started.wait().await;
+        let waiter_observed = cache.inner.waiter_observed.notified();
+        let error_waiter = tokio::spawn({
+            let cache = cache.clone();
+            async move {
+                cache
+                    .load_projection_with(
+                        RowGroupSetId::new([5; 16]),
+                        [6; 32],
+                        0,
+                        &[0],
+                        |columns| std::future::ready(Ok(loaded(columns))),
+                    )
+                    .await
+            }
+        });
+        waiter_observed.await;
+        release.notify_one();
+        let error = owner
+            .await
+            .expect("owner join")
+            .expect_err("failure must surface");
+        assert!(error.to_string().contains("corrupt or missing"));
+        tokio::time::timeout(std::time::Duration::from_secs(1), error_waiter)
+            .await
+            .expect("error waiter must wake")
+            .expect("error waiter join")
+            .expect("error waiter retry");
+
+        let cancel_started = Arc::new(tokio::sync::Barrier::new(2));
+        let never = Arc::new(Notify::new());
+        let cancelled_owner = tokio::spawn({
+            let cache = cache.clone();
+            let started = Arc::clone(&cancel_started);
+            let never = Arc::clone(&never);
+            async move {
+                cache
+                    .load_projection_with(
+                        RowGroupSetId::new([7; 16]),
+                        [8; 32],
+                        0,
+                        &[0],
+                        move |_columns| {
+                            let started = Arc::clone(&started);
+                            let never = Arc::clone(&never);
+                            async move {
+                                started.wait().await;
+                                never.notified().await;
+                                Ok(Vec::new())
+                            }
+                        },
+                    )
+                    .await
+            }
+        });
+        cancel_started.wait().await;
+        let waiter_observed = cache.inner.waiter_observed.notified();
+        let cancel_waiter = tokio::spawn({
+            let cache = cache.clone();
+            async move {
+                cache
+                    .load_projection_with(
+                        RowGroupSetId::new([7; 16]),
+                        [8; 32],
+                        0,
+                        &[0],
+                        |columns| std::future::ready(Ok(loaded(columns))),
+                    )
+                    .await
+            }
+        });
+        waiter_observed.await;
+        cancelled_owner.abort();
+        let _ = cancelled_owner.await;
+        tokio::time::timeout(std::time::Duration::from_secs(1), cancel_waiter)
+            .await
+            .expect("cancellation waiter must wake")
+            .expect("cancellation waiter join")
+            .expect("cancellation waiter retry");
+    }
+
+    #[tokio::test]
+    async fn digest_entry_byte_and_oversize_limits_are_enforced() {
+        let bytes = array(0).get_array_memory_size();
+        let entry_cache = EntityDecodedColumnCache::with_limits(usize::MAX, 2);
+        let entry_loads = Arc::new(AtomicUsize::new(0));
+        for projection in [&[0, 1][..], &[2][..], &[0][..]] {
+            entry_cache
+                .load_projection_with(RowGroupSetId::new([7; 16]), [8; 32], 0, projection, {
+                    let loads = Arc::clone(&entry_loads);
+                    move |columns| {
+                        loads.fetch_add(columns.len(), Ordering::SeqCst);
+                        std::future::ready(Ok(loaded(columns)))
+                    }
+                })
+                .await
+                .expect("entry-bounded load");
+        }
+        assert_eq!(entry_loads.load(Ordering::SeqCst), 4);
+
+        let byte_cache = EntityDecodedColumnCache::with_limits(bytes, 8);
+        byte_cache
+            .load_projection_with(
+                RowGroupSetId::new([9; 16]),
+                [10; 32],
+                0,
+                &[0, 1],
+                |columns| std::future::ready(Ok(loaded(columns))),
+            )
+            .await
+            .expect("byte-bounded load");
+        assert_eq!(byte_cache.lock().expect("cache lock").entries.len(), 1);
+
+        let oversize = EntityDecodedColumnCache::with_limits(bytes - 1, 8);
+        let oversize_loads = Arc::new(AtomicUsize::new(0));
+        for _ in 0..2 {
+            oversize
+                .load_projection_with(RowGroupSetId::new([11; 16]), [12; 32], 0, &[0], {
+                    let loads = Arc::clone(&oversize_loads);
+                    move |columns| {
+                        loads.fetch_add(1, Ordering::SeqCst);
+                        std::future::ready(Ok(loaded(columns)))
+                    }
+                })
+                .await
+                .expect("oversize result remains usable");
+        }
+        assert_eq!(oversize_loads.load(Ordering::SeqCst), 2);
+        assert!(oversize.lock().expect("cache lock").entries.is_empty());
+
+        let digest_cache = EntityDecodedColumnCache::default();
+        let digest_loads = Arc::new(AtomicUsize::new(0));
+        for digest in [[13; 32], [14; 32]] {
+            digest_cache
+                .load_projection_with(RowGroupSetId::new([15; 16]), digest, 0, &[0], {
+                    let loads = Arc::clone(&digest_loads);
+                    move |columns| {
+                        loads.fetch_add(1, Ordering::SeqCst);
+                        std::future::ready(Ok(loaded(columns)))
+                    }
+                })
+                .await
+                .expect("digest-specific load");
+        }
+        assert_eq!(digest_loads.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn shared_budget_bounds_exact_batch_and_decoded_layers() {
+        let resident_array = array(0);
+        let bytes = resident_array.get_array_memory_size();
+        let budget = Arc::new(crate::live_state::EntityColumnarArrayBudget::new(bytes));
+        let mut exact = crate::live_state::EntityColumnarShadowMaskCache::with_array_budget(
+            Arc::clone(&budget),
+        );
+        let shadow = crate::live_state::EntityColumnarShadowMaskKey {
+            row_groups: RowGroupSetId::new([18; 16]),
+            branch_id: Arc::from("main"),
+            head_commit_id: crate::changelog::CommitId::for_test_label(
+                "shared-columnar-budget-head",
+            ),
+            current_state_revision: 1,
+            shadow_identity_digest: [19; 32],
+            group_index: 0,
+        };
+        let exact_batch = Arc::new(
+            datafusion::arrow::record_batch::RecordBatch::try_from_iter([(
+                "v",
+                Arc::clone(&resident_array),
+            )])
+            .expect("exact batch"),
+        );
+        exact.insert_batch(shadow.clone(), vec![0], exact_batch);
+
+        let decoded =
+            EntityDecodedColumnCache::with_limits_and_budget(usize::MAX, 8, Arc::clone(&budget));
+        let decoded_loads = Arc::new(AtomicUsize::new(0));
+        for _ in 0..2 {
+            decoded
+                .load_projection_with(RowGroupSetId::new([18; 16]), [20; 32], 0, &[1], {
+                    let loads = Arc::clone(&decoded_loads);
+                    let resident_array = Arc::clone(&resident_array);
+                    move |columns| {
+                        loads.fetch_add(1, Ordering::SeqCst);
+                        assert_eq!(columns, vec![1]);
+                        std::future::ready(Ok(vec![(1, Arc::clone(&resident_array))]))
+                    }
+                })
+                .await
+                .expect("shared immutable array remains reusable");
+        }
+
+        assert_eq!(budget.used(), bytes);
+        assert_eq!(decoded_loads.load(Ordering::SeqCst), 1);
+        assert_eq!(decoded.lock().expect("decoded cache lock").entries.len(), 1);
+        assert!(exact.batch(&shadow, &[0]).is_some());
+        drop(exact);
+        assert_eq!(budget.used(), bytes);
+        drop(decoded);
+        assert_eq!(budget.used(), 0);
+    }
+
+    #[tokio::test]
+    async fn dropping_one_cache_releases_capacity_to_its_sibling() {
+        let bytes = array(0).get_array_memory_size();
+        let budget = Arc::new(crate::live_state::EntityColumnarArrayBudget::new(bytes));
+        {
+            let mut exact = crate::live_state::EntityColumnarShadowMaskCache::with_array_budget(
+                Arc::clone(&budget),
+            );
+            exact.insert_batch(
+                crate::live_state::EntityColumnarShadowMaskKey {
+                    row_groups: RowGroupSetId::new([21; 16]),
+                    branch_id: Arc::from("main"),
+                    head_commit_id: crate::changelog::CommitId::for_test_label(
+                        "released-columnar-budget-head",
+                    ),
+                    current_state_revision: 1,
+                    shadow_identity_digest: [22; 32],
+                    group_index: 0,
+                },
+                vec![0],
+                Arc::new(
+                    datafusion::arrow::record_batch::RecordBatch::try_from_iter([("v", array(0))])
+                        .expect("exact batch"),
+                ),
+            );
+            assert_eq!(budget.used(), bytes);
+        }
+        assert_eq!(budget.used(), 0);
+
+        let decoded =
+            EntityDecodedColumnCache::with_limits_and_budget(usize::MAX, 8, Arc::clone(&budget));
+        let loads = Arc::new(AtomicUsize::new(0));
+        for _ in 0..2 {
+            decoded
+                .load_projection_with(RowGroupSetId::new([21; 16]), [23; 32], 0, &[0], {
+                    let loads = Arc::clone(&loads);
+                    move |columns| {
+                        loads.fetch_add(1, Ordering::SeqCst);
+                        std::future::ready(Ok(loaded(columns)))
+                    }
+                })
+                .await
+                .expect("released capacity admits sibling entry");
+        }
+        assert_eq!(loads.load(Ordering::SeqCst), 1);
+        assert_eq!(budget.used(), bytes);
+        drop(decoded);
+        assert_eq!(budget.used(), 0);
+    }
+}

--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -2,6 +2,7 @@ mod context;
 mod derived;
 mod entity_columnar;
 mod entity_columnar_cache;
+mod entity_decoded_column_cache;
 mod entity_field_index;
 mod reader;
 mod tracked_head;
@@ -12,8 +13,9 @@ pub(crate) mod visibility;
 pub(crate) use context::{BranchHeadControlCache, LiveStateContext, LiveStateStoreReader};
 pub(crate) use entity_columnar::{EntityColumnarWriteSets, entity_row_group_set_id};
 pub(crate) use entity_columnar_cache::{
-    EntityColumnarShadowMaskCache, EntityColumnarShadowMaskKey,
+    EntityColumnarArrayBudget, EntityColumnarShadowMaskCache, EntityColumnarShadowMaskKey,
 };
+pub(crate) use entity_decoded_column_cache::EntityDecodedColumnCache;
 pub(crate) use entity_field_index::EntitySnapshotFieldIndexCache;
 #[allow(unused_imports)]
 pub(crate) use reader::LiveStateReader;

--- a/packages/engine/src/sql2/entity_batch.rs
+++ b/packages/engine/src/sql2/entity_batch.rs
@@ -28,6 +28,7 @@ use crate::storage_adapter::StorageAdapterRead;
 pub(crate) struct EntityColumnarScanLayout {
     pub(crate) id: crate::columnar_row_group::RowGroupSetId,
     pub(crate) manifest: Arc<crate::columnar_row_group::RowGroupManifest>,
+    pub(crate) manifest_digest: [u8; 32],
     pub(crate) overlay: Arc<Vec<crate::live_state::EntityColumnarOverlayRow>>,
     pub(crate) branch_id: Arc<str>,
     pub(crate) head_commit_id: crate::changelog::CommitId,
@@ -173,15 +174,18 @@ pub(crate) struct CurrentEntitySnapshotReader<S> {
     live_state: Arc<LiveStateContext>,
     store: S,
     entity_columnar_shadow_masks: Arc<Mutex<EntityColumnarShadowMaskCache>>,
+    entity_decoded_columns: crate::live_state::EntityDecodedColumnCache,
 }
 
 impl<S> CurrentEntitySnapshotReader<S> {
     pub(crate) fn new(live_state: Arc<LiveStateContext>, store: S) -> Self {
         let entity_columnar_shadow_masks = live_state.entity_columnar_scan_cache();
+        let entity_decoded_columns = live_state.entity_decoded_column_cache();
         Self {
             live_state,
             store,
             entity_columnar_shadow_masks,
+            entity_decoded_columns,
         }
     }
 }
@@ -246,6 +250,7 @@ where
                 |(
                     id,
                     manifest,
+                    manifest_digest,
                     overlay,
                     branch_id,
                     head_commit_id,
@@ -255,6 +260,7 @@ where
                     Arc::new(EntityColumnarScanLayout {
                         id,
                         manifest,
+                        manifest_digest,
                         overlay,
                         branch_id: Arc::from(branch_id),
                         head_commit_id,
@@ -271,14 +277,41 @@ where
         group_index: usize,
         projection: Vec<usize>,
     ) -> Result<RecordBatch, LixError> {
-        crate::columnar_row_group::load_row_group_batch(
-            &self.store,
-            layout.id,
-            &layout.manifest,
-            group_index,
-            &projection,
-        )
-        .await
+        let schema =
+            crate::columnar_row_group::row_group_projected_schema(&layout.manifest, &projection)?;
+        let row_count = layout
+            .manifest
+            .groups
+            .get(group_index)
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("row-group index {group_index} is outside the manifest"),
+                )
+            })?
+            .row_count as usize;
+        let arrays = self
+            .entity_decoded_columns
+            .load_projection(
+                &self.store,
+                layout.id,
+                layout.manifest_digest,
+                &layout.manifest,
+                group_index,
+                &projection,
+            )
+            .await?;
+        if projection.is_empty() {
+            return RecordBatch::try_new_with_options(
+                schema,
+                arrays,
+                &datafusion::arrow::record_batch::RecordBatchOptions::new()
+                    .with_row_count(Some(row_count)),
+            )
+            .map_err(|error| LixError::new(LixError::CODE_INTERNAL_ERROR, error.to_string()));
+        }
+        RecordBatch::try_new(schema, arrays)
+            .map_err(|error| LixError::new(LixError::CODE_INTERNAL_ERROR, error.to_string()))
     }
 
     async fn entity_columnar_shadow_mask(
@@ -472,6 +505,7 @@ mod tests {
                 fields: Vec::new(),
                 groups: Vec::new(),
             }),
+            manifest_digest: [42; 32],
             overlay: Arc::new(Vec::new()),
             branch_id: Arc::from("branch-a"),
             head_commit_id: crate::changelog::CommitId::for_test_label("cache-key-head"),

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -4762,6 +4762,7 @@ mod tests {
         let layout = crate::sql2::entity_batch::EntityColumnarScanLayout {
             id: crate::live_state::entity_row_group_set_id(base_commit_id, &spec.schema_key),
             manifest: Arc::new(encoded.manifest.clone()),
+            manifest_digest: encoded.manifest.content_digest().expect("manifest digest"),
             overlay: Arc::new(vec![
                 crate::live_state::EntityColumnarOverlayRow {
                     entity_pk: identities[0].clone(),
@@ -4816,6 +4817,7 @@ mod tests {
                 fields: Vec::new(),
                 groups: Vec::new(),
             }),
+            manifest_digest: [24; 32],
             overlay: Arc::new(Vec::new()),
             branch_id: Arc::from(branch_id),
             head_commit_id: CommitId::for_test_label("cached-batch-test-head"),


### PR DESCRIPTION
## Summary
- cache immutable decoded Arrow columns by row-group content, manifest digest, group, and column
- coalesce concurrent overlapping projection misses and multi-get only newly claimed columns
- assemble arbitrary ordered projections by Arc reuse, then apply current shadow masks/overlays above the immutable layer
- share one 256 MiB allocation-identity/refcount budget with the exact-batch cache so identical arrays are charged once
- keep transactions, exact primary-key reads, and LIMIT paths outside this analytical cache

## Performance
Neutral SF0.2 Q11, 9 samples, pristine, exact parent/candidate binaries. The host shifted between runs, so normalized Lix/DuckDB ratios are the authoritative >10% axis:

| Adapter | Parent ratio | Candidate ratio | Change | Per-index paired change |
|---|---:|---:|---:|---:|
| RocksDB | 4.390x | 3.825x | -12.88% | -13.39% |
| SlateDB | 4.503x | 3.759x | -16.53% | -18.18% |

Raw Lix medians fell 17.539→11.963 ms (-31.79%) RocksDB and 17.991→11.757 ms (-34.65%) SlateDB, but those raw percentages include the host-wide speed shift. Arrow execution and scan polling decline with identical 322,002 rows, 9 batches, and 8,996,720 Arrow bytes.

## Regression guards
- uncontended Q1-Q22: exact correctness and identical scan counters for all 44 backend/query records; normalized deltas range -8.33% to +3.39%
- sparse Q11: +0.17% RocksDB / +1.06% SlateDB
- moderate Q11: -1.28% / -1.07%
- transaction read-your-writes, exact PK/LIMIT bypass, overlay ordering, codec/storage, and #1151 exact-cache interaction pass

## Correctness and resource bounds
- deterministic loader/waiter error and cancellation wakeups; failures remain retryable
- real cross-projection storage test reads two columns then only the one new column and reuses identical ArrayRefs
- one shared 256 MiB unique-allocation budget; duplicate Arcs refcounted, atomic non-admission on cap/overflow, eviction/drop release proven across both caches
- 8/8 budget and 8/8 decoded-cache tests; strict all-target/all-feature Clippy, formatting, and diff checks pass

## Improvement axis
Pristine generalized Q11 improves the normalized Lix/DuckDB ratio by 12.88% on RocksDB and 16.53% on SlateDB, exceeding the required 10% axis.

## Independent review
Approved with no blockers after three corrections: deterministic concurrency/interaction gates, shared-budget drop accounting, and allocation-identity accounting. Review independently audited code, tests, raw methodology, full-suite guards, and overlay guards.