### PR TITLE
fix(engine): bound automatic write future stack

### DIFF
--- a/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
+++ b/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
@@ -16,6 +16,9 @@ mod workload;
 
 use workload::WorkloadRow;
 
+static CERTIFIED_INSERT_COUNTER_TEST_LOCK: tokio::sync::Mutex<()> =
+    tokio::sync::Mutex::const_new(());
+
 #[test]
 fn typed_olap_queries_are_structurally_ineligible_for_strict_native_reads() {
     use datafusion::sql::parser::DFParser;
@@ -190,6 +193,7 @@ async fn standalone_sqlite_public_results_match_every_lix_adapter_async() {
 
 #[tokio::test]
 async fn insert_benchmark_hits_certified_parameter_batch_on_every_adapter() {
+    let _counter_guard = CERTIFIED_INSERT_COUNTER_TEST_LOCK.lock().await;
     let rows = [
         WorkloadRow {
             path: "/alpha".to_string(),
@@ -208,6 +212,26 @@ async fn insert_benchmark_hits_certified_parameter_batch_on_every_adapter() {
             sql_session::empty_fixture_with_read_many_pk_count(profile, &rows, rows.len()).await;
         assert_eq!(fixture.insert_all().await, rows.len());
     }
+}
+
+/// Regression for the automatic-write future retaining SlateDB's large
+/// adapter-specific open and commit futures on Tokio's default test stack.
+#[cfg(feature = "slatedb")]
+#[tokio::test]
+async fn slatedb_automatic_write_runs_on_default_stack() {
+    let _counter_guard = CERTIFIED_INSERT_COUNTER_TEST_LOCK.lock().await;
+    let rows = [WorkloadRow {
+        path: "/default-stack".to_string(),
+        value_json: r#"{"enabled":true}"#.to_string(),
+        updated_value_json: r#"{"enabled":false}"#.to_string(),
+    }];
+    let fixture = sql_session::empty_fixture_with_read_many_pk_count(
+        storage::StorageProfile::SlateDB,
+        &rows,
+        rows.len(),
+    )
+    .await;
+    assert_eq!(fixture.insert_all().await, rows.len());
 }
 
 #[test]

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -552,7 +552,7 @@ where
         // functions; that coherent opening snapshot remains the source of
         // truth for the mode.
         let _deterministic_runtime_guard = self.lock_deterministic_runtime().await;
-        let opened = open_transaction(
+        let opened = Box::pin(open_transaction(
             &self.mode,
             self.storage.clone(),
             Arc::clone(&self.live_state),
@@ -563,7 +563,7 @@ where
             Arc::clone(&self.catalog_context),
             Arc::clone(&self.sql_planning_cache),
             self.file_views.clone(),
-        )
+        ))
         .instrument(tracing::debug_span!(
             target: "lix_perf",
             "lix.perf.transaction_open"
@@ -586,7 +586,7 @@ where
         {
             Ok(value) => {
                 self.ensure_open()?;
-                let outcome = transaction.commit(&runtime_functions).await?;
+                let outcome = Box::pin(transaction.commit(&runtime_functions)).await?;
                 #[cfg(feature = "storage-benches")]
                 crate::storage_bench::record_crud_physical_writes(outcome.storage_stats);
                 drop(write_access);


### PR DESCRIPTION
## Summary
- heap-pin automatic transaction open and commit futures
- prevent SlateDB adapter futures from overflowing the default Tokio test stack
- add a focused cross-layer SlateDB regression without increasing stack size

## Evidence
- baseline exact insert benchmark test: SIGABRT from stack overflow
- fixed insert path across SQLite, RocksDB, and SlateDB: passed
- focused SlateDB default-stack regression: passed
- generic automatic-write runtime guard: passed
- independent sub-agent review: approved semantics, borrowing, cancellation, tracing, and commit ownership

This is isolated from the OLAP cleanup and changes no transaction semantics.