### PR TITLE
build: use mold by default on Linux

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,12 +16,27 @@ lclippy = "b NPROC=$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null 
 # 	# https://blog.rust-lang.org/2023/11/09/parallel-rustc.html
 # 	"-Zthreads=8",
 # ]
+
+# Cross-target builds still compile executable build scripts and proc macros
+# for the Linux host. Cargo's host-config isolates those flags from the Wasm
+# target while keeping host linking on mold.
+[host.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+[host.aarch64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
 # keep host and generic-target rustflags in sync
 [target.'cfg(all())']
 # rustflags = [
 # 	# https://blog.rust-lang.org/2023/11/09/parallel-rustc.html
 # 	"-Zthreads=8",
 # ]
+
+# Use the parallel mold linker for native Linux binaries, build scripts, and
+# proc macros. WebAssembly targets remain linker-neutral.
+[target.'cfg(all(target_os = "linux", not(target_family = "wasm")))']
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 
 [target.wasm32-unknown-unknown]
 # rustflags = [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,10 @@ jobs:
           BINSTALL_NO_CONFIRM=true
           EOF
 
-      - name: Install LLVM build dependencies
+      - name: Install native build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y llvm-dev libclang-dev clang
+          sudo apt-get install -y llvm-dev libclang-dev clang mold
 
       - name: Restore compiler cache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -151,7 +151,13 @@ jobs:
         if: matrix.runtime == 'native'
         run: |
           sudo apt-get update
-          sudo apt-get install -y llvm-dev libclang-dev clang
+          sudo apt-get install -y llvm-dev libclang-dev clang mold
+
+      - name: Install mold for WebAssembly host tooling
+        if: matrix.runtime == 'browser'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mold
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -101,11 +101,11 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install LLVM build dependencies
+      - name: Install Linux native build dependencies
         if: startsWith(matrix.suffix, 'linux-')
         run: |
           sudo apt-get update
-          sudo apt-get install -y llvm-dev libclang-dev clang
+          sudo apt-get install -y llvm-dev libclang-dev clang mold
 
       - name: Install LLVM build dependencies (Windows)
         if: matrix.suffix == 'win32-x64'
@@ -161,10 +161,10 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install LLVM build dependencies
+      - name: Install native and WebAssembly host build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y llvm-dev libclang-dev clang
+          sudo apt-get install -y llvm-dev libclang-dev clang mold
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Outcome
Make mold the default linker for Linux target crates and Linux host build scripts/proc macros, including cross-Wasm builds. Darwin, Windows, and Wasm targets remain linker-neutral.

## Coverage
- x86_64-unknown-linux-gnu and aarch64-unknown-linux-gnu hosts
- native Cargo CI and JS SDK native CI
- browser/Wasm CI host tooling without leaking the flag to wasm32
- Linux x64/arm64 publish jobs and combined native+Wasm SDK publication

## Before / after
Representative warmed relink: cargo test -p lix_engine --test integration --profile test --no-run

- BFD: 9.77, 9.34, 9.37, 9.34, 9.39, 9.36, 9.37s; median 9.370s
- mold: 3.83, 3.90, 3.84, 3.82, 3.84, 3.86, 3.89s; median 3.840s
- improvement: 59.0% lower elapsed time, 2.44x faster

The target directories were independently primed and the seven samples were interleaved. ELF comments verify mold 2.30.0 for the candidate and no mold marker for BFD.

## Verification
- native rustc command and ELF marker prove mold selection
- cross-wasm32 build proves host build.rs uses mold while the Wasm target receives no mold flag
- Cargo configuration origins resolve for both host triples and Linux targets
- both changed workflow files parse as YAML
- independent sub-agent review: APPROVE