### PR TITLE
Make Rust SDK execute and observe futures Send

### DIFF
--- a/packages/engine/src/catalog/revision.rs
+++ b/packages/engine/src/catalog/revision.rs
@@ -467,8 +467,8 @@ mod tests {
         let commit_id = CommitId::parse_lix(commit_id, "catalog revision test branch head")
             .expect("test commit id should parse");
         session
-            .with_write_transaction(move |transaction| {
-                Box::pin(async move { transaction.advance_branch_ref(&branch_id, commit_id).await })
+            .with_write_transaction_lending(async move |transaction| {
+                transaction.advance_branch_ref(&branch_id, commit_id).await
             })
             .await
             .expect("branch ref should move");

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -6664,29 +6664,31 @@ where
             certified_live_increments,
         )?;
 
-        let _stage_span = tracing::debug_span!(
+        async {
+            stage_hot_diff_batch(
+                self.writes,
+                diff_scope.as_deref().unwrap_or_default(),
+                diff_key_bytes,
+                diff_puts,
+            )?;
+            stage_hot_mutation_batch(self.writes, identities, next_value_bytes, next_value_ranges);
+            stage_incremental_file_delete_cascades(
+                self.store,
+                self.writes,
+                branch_id,
+                generation,
+                &sorted,
+                working_diff_capture_checkpoint_commit_id,
+                reset_working_diff_baselines,
+                &mut next_coverage,
+                &mut retired_untracked_json_refs,
+            )
+            .await
+        }
+        .instrument(tracing::debug_span!(
             target: "lix_perf",
             "lix.perf.materialization.hot.stage"
-        )
-        .entered();
-        stage_hot_diff_batch(
-            self.writes,
-            diff_scope.as_deref().unwrap_or_default(),
-            diff_key_bytes,
-            diff_puts,
-        )?;
-        stage_hot_mutation_batch(self.writes, identities, next_value_bytes, next_value_ranges);
-        stage_incremental_file_delete_cascades(
-            self.store,
-            self.writes,
-            branch_id,
-            generation,
-            &sorted,
-            working_diff_capture_checkpoint_commit_id,
-            reset_working_diff_baselines,
-            &mut next_coverage,
-            &mut retired_untracked_json_refs,
-        )
+        ))
         .await?;
         JsonStoreWriter::stage_untracked_reclaim_candidates(
             self.writes,

--- a/packages/engine/src/observe_invalidation.rs
+++ b/packages/engine/src/observe_invalidation.rs
@@ -111,6 +111,17 @@ impl ObserveInvalidation {
                 let Some(invalidation) = invalidation.upgrade() else {
                     break;
                 };
+                if invalidation.sender.receiver_count() == 0 {
+                    // Synchronize shutdown with startup. A new subscriber can race this
+                    // check; rechecking under the startup gate either keeps this watcher
+                    // alive or lets the contender start its replacement.
+                    let mut watcher_started = invalidation.external_watcher_started.lock().await;
+                    if invalidation.sender.receiver_count() == 0 {
+                        *watcher_started = false;
+                        break;
+                    }
+                    drop(watcher_started);
+                }
                 let current_revision = match storage.load_mutation_revision().await {
                     Ok(revision) => revision,
                     Err(error) => {
@@ -304,5 +315,35 @@ mod tests {
             *invalidation.external_watcher_started.lock().await,
             "contending retry should mark the watcher as started"
         );
+    }
+
+    #[tokio::test]
+    async fn external_watcher_stops_without_subscribers_and_restarts_on_demand() {
+        let invalidation = Arc::new(ObserveInvalidation::new());
+        let storage = StorageAdapter::new(Memory::new());
+        let observer = invalidation.subscribe();
+        invalidation
+            .ensure_external_watcher(storage.clone())
+            .await
+            .expect("watcher should start");
+        drop(observer);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if !*invalidation.external_watcher_started.lock().await {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("watcher should stop after its last subscriber is dropped");
+
+        let _replacement = invalidation.subscribe();
+        invalidation
+            .ensure_external_watcher(storage)
+            .await
+            .expect("watcher should restart");
+        assert!(*invalidation.external_watcher_started.lock().await);
     }
 }

--- a/packages/engine/src/session/checkpoint.rs
+++ b/packages/engine/src/session/checkpoint.rs
@@ -44,8 +44,7 @@ where
     /// the foreground checkpoint latency.
     pub async fn create_checkpoint(&self) -> Result<CreateCheckpointReceipt, LixError> {
         let outcome = self
-            .with_write_transaction(|transaction| {
-                Box::pin(async move {
+            .with_write_transaction_lending(async move |transaction| {
                     let branch_id = transaction.active_branch_id().to_string();
                     let (previous_recovery, mut gc_state) = transaction
                         .checkpoint_publication_state(&branch_id)
@@ -173,8 +172,7 @@ where
                         receipt: CreateCheckpointReceipt { commit_id },
                         gc_due,
                     })
-                })
-        })
+            })
             .await?;
         if outcome.gc_due {
             // GC debt is durable in the checkpoint transaction. The sweep is

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -1,7 +1,5 @@
 #![allow(clippy::match_wild_err_arm, clippy::option_if_let_else)]
 
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
@@ -493,23 +491,12 @@ where
         }
     }
 
-    pub(crate) async fn with_write_transaction<T, F>(&self, f: F) -> Result<T, LixError>
-    where
-        F: for<'tx> FnOnce(
-            &'tx mut Transaction<StorageImpl>,
-        ) -> Pin<Box<dyn Future<Output = Result<T, LixError>> + 'tx>>,
-    {
-        self.with_write_transaction_lending(async move |transaction| f(transaction).await)
-            .await
-    }
-
     /// Runs a transaction with a lending async closure.
     ///
-    /// Unlike the boxed compatibility entrypoint above, `AsyncFnOnce` ties
-    /// the returned future to both the transaction borrow and the closure's
-    /// captured borrows. Large callers can therefore borrow prepared input
-    /// for the duration of the transaction instead of deep-cloning it into a
-    /// `'static` closure environment.
+    /// `AsyncFnOnce` ties the returned future to both the transaction borrow
+    /// and the closure's captured borrows. Large callers can therefore borrow
+    /// prepared input for the duration of the transaction instead of
+    /// deep-cloning it into a `'static` closure environment.
     pub(crate) async fn with_write_transaction_lending<T, F>(&self, f: F) -> Result<T, LixError>
     where
         F: for<'tx> AsyncFnOnce(&'tx mut Transaction<StorageImpl>) -> Result<T, LixError>,
@@ -518,22 +505,6 @@ where
         let write_access = self.begin_session_write_access().await?;
         self.with_write_transaction_reserved_lending(write_access, f)
             .await
-    }
-
-    pub(super) async fn with_write_transaction_reserved<T, F>(
-        &self,
-        write_access: SessionWriteAccess,
-        f: F,
-    ) -> Result<T, LixError>
-    where
-        F: for<'tx> FnOnce(
-            &'tx mut Transaction<StorageImpl>,
-        ) -> Pin<Box<dyn Future<Output = Result<T, LixError>> + 'tx>>,
-    {
-        self.with_write_transaction_reserved_lending(write_access, async move |transaction| {
-            f(transaction).await
-        })
-        .await
     }
 
     pub(super) async fn with_write_transaction_reserved_lending<T, F>(

--- a/packages/engine/src/session/create_branch.rs
+++ b/packages/engine/src/session/create_branch.rs
@@ -42,58 +42,56 @@ where
         &self,
         options: CreateBranchOptions,
     ) -> Result<CreateBranchReceipt, LixError> {
-        self.with_write_transaction(|transaction| {
-            Box::pin(async move {
-                let branch_id = options
-                    .id
-                    .unwrap_or_else(|| transaction.functions().call_uuid_v7().to_string());
-                let source_head = if let Some(from_commit_id) = options.from_commit_id {
-                    let from_commit_id = BranchLifecycle::parse_commit_id(
-                        &from_commit_id,
+        self.with_write_transaction_lending(async move |transaction| {
+            let branch_id = options
+                .id
+                .unwrap_or_else(|| transaction.functions().call_uuid_v7().to_string());
+            let source_head = if let Some(from_commit_id) = options.from_commit_id {
+                let from_commit_id = BranchLifecycle::parse_commit_id(
+                    &from_commit_id,
+                    BranchOperation::CreateBranch,
+                    BranchReferenceRole::CommitSource,
+                )?;
+                let mut commit_graph = transaction.commit_graph_reader().await;
+                let commit = BranchLifecycle::require_existing_commit(
+                    &mut commit_graph,
+                    from_commit_id,
+                    BranchOperation::CreateBranch,
+                    BranchReferenceRole::CommitSource,
+                )
+                .await?;
+                commit.commit_id
+            } else {
+                let active_branch_id = transaction.active_branch_id().to_string();
+                let reader = transaction.branch_ref_reader().await;
+                BranchLifecycle::new(&reader)
+                    .require_existing_commit_id(
+                        &active_branch_id,
                         BranchOperation::CreateBranch,
-                        BranchReferenceRole::CommitSource,
-                    )?;
-                    let mut commit_graph = transaction.commit_graph_reader().await;
-                    let commit = BranchLifecycle::require_existing_commit(
-                        &mut commit_graph,
-                        from_commit_id,
-                        BranchOperation::CreateBranch,
-                        BranchReferenceRole::CommitSource,
+                        BranchReferenceRole::Source,
                     )
-                    .await?;
-                    commit.commit_id
-                } else {
-                    let active_branch_id = transaction.active_branch_id().to_string();
-                    let reader = transaction.branch_ref_reader().await;
-                    BranchLifecycle::new(&reader)
-                        .require_existing_commit_id(
-                            &active_branch_id,
-                            BranchOperation::CreateBranch,
-                            BranchReferenceRole::Source,
-                        )
-                        .await?
-                };
+                    .await?
+            };
 
-                let mut rows = RawWriteBatch::with_capacity(2);
-                rows.push(branch_descriptor_stage_row(
-                    &branch_id,
-                    &options.name,
-                    false,
-                ));
-                rows.push(branch_ref_stage_row(&branch_id, &source_head));
-                transaction
-                    .stage_write(TransactionWrite::Rows {
-                        mode: TransactionWriteMode::Insert,
-                        rows,
-                    })
-                    .await?;
-
-                Ok(CreateBranchReceipt {
-                    id: branch_id,
-                    name: options.name,
-                    hidden: false,
-                    commit_id: source_head.to_string(),
+            let mut rows = RawWriteBatch::with_capacity(2);
+            rows.push(branch_descriptor_stage_row(
+                &branch_id,
+                &options.name,
+                false,
+            ));
+            rows.push(branch_ref_stage_row(&branch_id, &source_head));
+            transaction
+                .stage_write(TransactionWrite::Rows {
+                    mode: TransactionWriteMode::Insert,
+                    rows,
                 })
+                .await?;
+
+            Ok(CreateBranchReceipt {
+                id: branch_id,
+                name: options.name,
+                hidden: false,
+                commit_id: source_head.to_string(),
             })
         })
         .await

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::future::Future;
 use std::ops::ControlFlow;
 use std::ops::Range;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -32,7 +31,7 @@ use serde_json::{Map as JsonMap, Value as JsonValue};
 use tracing::Instrument as _;
 
 use super::ExecuteIdempotency;
-use super::context::{SessionContext, SessionSqlExecutionContext, SessionWriteAccess};
+use super::context::{SessionContext, SessionSqlExecutionContext};
 use super::idempotency::{ExecuteIdempotencyReceipt, load_receipt};
 use super::transaction::SessionTransaction;
 
@@ -755,38 +754,36 @@ where
         crate::common::LixPath::try_from_file_path(&path)?;
         let write_access = self.begin_session_write_access().await?;
         let sql_planning_cache = Arc::clone(&self.sql_planning_cache);
-        self.with_write_transaction_reserved(write_access, |transaction| {
-            Box::pin(async move {
-                // `Blob` is reference-counted. Retaining a copy lets the rare
-                // general-write fallback reuse the same payload without a
-                // second allocation or a second transaction.
-                let fast_path = sql2::execute_fast_lix_file_path_writes(
-                    transaction,
-                    vec![(path.clone(), data.clone(), None, None)],
-                    sql2::FastLixFilePathWriteConflict::UpdateData,
-                    None,
-                )
-                .await?;
-                if let Some(count) = fast_path {
-                    return Ok(count);
-                }
+        self.with_write_transaction_reserved_lending(write_access, async move |transaction| {
+            // `Blob` is reference-counted. Retaining a copy lets the rare
+            // general-write fallback reuse the same payload without a
+            // second allocation or a second transaction.
+            let fast_path = sql2::execute_fast_lix_file_path_writes(
+                transaction,
+                vec![(path.clone(), data.clone(), None, None)],
+                sql2::FastLixFilePathWriteConflict::UpdateData,
+                None,
+            )
+            .await?;
+            if let Some(count) = fast_path {
+                return Ok(count);
+            }
 
-                // The fast helper declines pre-existing cross-scope path
-                // collisions before staging anything. The general provider
-                // handles those valid legacy layouts, so keep this request in
-                // the same transaction and use its public upsert semantics.
-                let statement = sql_planning_cache.parse_statement(NATIVE_FILE_UPSERT_SQL)?;
-                let plan = transaction
-                    .prepare_sql_write_logical_plan(NATIVE_FILE_UPSERT_SQL, &statement)?;
-                sql2::execute_write_logical_plan_result_with_metadata(
-                    transaction,
-                    plan,
-                    &[Value::Text(path), Value::Blob(data)],
-                    &ExecuteStatementMetadata::default(),
-                )
-                .await
-                .map(|result| result.rows_affected)
-            })
+            // The fast helper declines pre-existing cross-scope path
+            // collisions before staging anything. The general provider
+            // handles those valid legacy layouts, so keep this request in
+            // the same transaction and use its public upsert semantics.
+            let statement = sql_planning_cache.parse_statement(NATIVE_FILE_UPSERT_SQL)?;
+            let plan =
+                transaction.prepare_sql_write_logical_plan(NATIVE_FILE_UPSERT_SQL, &statement)?;
+            sql2::execute_write_logical_plan_result_with_metadata(
+                transaction,
+                plan,
+                &[Value::Text(path), Value::Blob(data)],
+                &ExecuteStatementMetadata::default(),
+            )
+            .await
+            .map(|result| result.rows_affected)
         })
         .await
     }
@@ -804,8 +801,7 @@ where
         self.ensure_open()?;
         validate_native_file_upsert_batch(&writes)?;
         let write_access = self.begin_session_write_access().await?;
-        self.with_write_transaction_reserved(write_access, |transaction| {
-            Box::pin(async move {
+        self.with_write_transaction_reserved_lending(write_access, async move |transaction| {
                 sql2::execute_fast_lix_file_path_writes(
                     transaction,
                     writes
@@ -826,7 +822,6 @@ where
                         "expected": "a filesystem layout that the direct path index can route unambiguously",
                     }))
                 })
-            })
         })
         .await
     }
@@ -854,9 +849,9 @@ where
             .storage
             .begin_read(StorageReadOptions::default())
             .await?;
-        let (data, file_view_mutations) = with_static_session_sql_read::<StorageImpl, _, _, _>(
+        let (data, file_view_mutations) = with_static_session_sql_read::<StorageImpl, _, _>(
             read_scope,
-            |read_store| async move {
+            |read_store: SharedStorageAdapterRead<StorageImpl::Read<'static>>| async move {
                 let active_branch_id = self.active_branch_id_from_reader(&read_store).await?;
                 let plugin_cache_snapshot = read_store.snapshot_cache_key();
                 let live_state: Arc<dyn crate::live_state::LiveStateReader> =
@@ -977,26 +972,23 @@ where
             let sql_for_planning = sql_for_error.clone();
             let params = params.to_vec();
             return self
-                .with_write_transaction_reserved(write_access, |transaction| {
-                    Box::pin(async move {
-                        let previous_origin_key =
-                            transaction.replace_origin_key(options.origin_key);
-                        let result = async {
-                            let tx_plan = transaction
-                                .prepare_sql_write_logical_plan(&sql_for_planning, &statement)?;
-                            let result = execute_prepared_transaction_write(
-                                transaction,
-                                tx_plan,
-                                &params,
-                                &metadata,
-                            )
-                            .await?;
-                            Ok(ExecuteResult::from_sql_write_result(result))
-                        }
-                        .await;
-                        transaction.replace_origin_key(previous_origin_key);
-                        result
-                    })
+                .with_write_transaction_reserved_lending(write_access, async move |transaction| {
+                    let previous_origin_key = transaction.replace_origin_key(options.origin_key);
+                    let result = async {
+                        let tx_plan = transaction
+                            .prepare_sql_write_logical_plan(&sql_for_planning, &statement)?;
+                        let result = execute_prepared_transaction_write(
+                            transaction,
+                            tx_plan,
+                            &params,
+                            &metadata,
+                        )
+                        .await?;
+                        Ok(ExecuteResult::from_sql_write_result(result))
+                    }
+                    .await;
+                    transaction.replace_origin_key(previous_origin_key);
+                    result
                 })
                 .await
                 .map_err(|error| normalize_sql_surface_error(error, &sql_for_error));
@@ -1038,9 +1030,9 @@ where
             .storage
             .begin_read(StorageReadOptions::default())
             .await?;
-        let read_result = with_static_session_sql_read::<StorageImpl, _, _, _>(
+        let read_result = with_static_session_sql_read::<StorageImpl, _, _>(
             read_scope,
-            |read_store| async move {
+            |read_store: SharedStorageAdapterRead<StorageImpl::Read<'static>>| async move {
                 self.execute_read_statement_with_store(
                     read_store,
                     sql,
@@ -1054,17 +1046,17 @@ where
                 .await
             },
         );
-        let (read_result, file_view_mutations) = match read_result.await {
+        let (mut read_result, file_view_mutations) = match read_result.await {
             Ok(result) => result,
             Err(error) => {
                 return Err(normalize_sql_surface_error(error, sql));
             }
         };
-        let runtime_storage_stats = match read_result.runtime_functions.as_ref() {
+        let runtime_storage_stats = match read_result.runtime_functions.take() {
             Some(runtime_functions) => {
                 self.persist_runtime_functions_if_needed(
                     runtime_functions,
-                    runtime_write_access.as_ref(),
+                    runtime_write_access.is_some(),
                 )
                 .await?
             }
@@ -1107,30 +1099,28 @@ where
         // this call's immediate stack frame while the write lease is held.
         let idempotency_for_commit = idempotency.clone();
         let result = self
-            .with_write_transaction_reserved(write_access, |transaction| {
-                Box::pin(async move {
-                    let previous_origin_key = transaction.replace_origin_key(options.origin_key);
-                    let result = async {
-                        let tx_plan = transaction
-                            .prepare_sql_write_logical_plan(&sql_for_planning, &statement)?;
-                        let result = execute_prepared_transaction_write(
-                            transaction,
-                            tx_plan,
-                            &params,
-                            &metadata,
-                        )
-                        .await?;
-                        let result = ExecuteResult::from_sql_write_result(result);
-                        let receipt =
-                            ExecuteIdempotencyReceipt::single(&idempotency_for_commit, &result)?;
-                        transaction
-                            .stage_execute_idempotency_receipt(&idempotency_for_commit, &receipt)?;
-                        Ok(result)
-                    }
-                    .await;
-                    transaction.replace_origin_key(previous_origin_key);
-                    result
-                })
+            .with_write_transaction_reserved_lending(write_access, async move |transaction| {
+                let previous_origin_key = transaction.replace_origin_key(options.origin_key);
+                let result = async {
+                    let tx_plan = transaction
+                        .prepare_sql_write_logical_plan(&sql_for_planning, &statement)?;
+                    let result = execute_prepared_transaction_write(
+                        transaction,
+                        tx_plan,
+                        &params,
+                        &metadata,
+                    )
+                    .await?;
+                    let result = ExecuteResult::from_sql_write_result(result);
+                    let receipt =
+                        ExecuteIdempotencyReceipt::single(&idempotency_for_commit, &result)?;
+                    transaction
+                        .stage_execute_idempotency_receipt(&idempotency_for_commit, &receipt)?;
+                    Ok(result)
+                }
+                .await;
+                transaction.replace_origin_key(previous_origin_key);
+                result
             })
             .await
             .map_err(|error| normalize_sql_surface_error(error, &sql_for_error));
@@ -1292,51 +1282,48 @@ where
 
         let sql_for_error = Arc::clone(&sql);
         let result = self
-            .with_write_transaction(move |transaction| {
-                Box::pin(async move {
-                    let plan = transaction.prepare_sql_write_logical_plan(&sql, &statement)?;
-                    let parameter_refs = parameter_rows
-                        .iter()
-                        .map(|parameters| parameters.as_ref())
-                        .collect::<Vec<_>>();
-                    let results = if let Some(results) =
-                        sql2::execute_write_logical_plan_value_batch(
-                            transaction,
-                            &plan,
-                            &parameter_refs,
-                        )
-                        .await?
-                    {
-                        Some(results)
-                    } else {
-                        let Some(parameter_batch) = sql2::parameter_record_batch(&parameter_refs)?
-                        else {
-                            return Err(LixError::new(
-                                LixError::CODE_INVALID_PARAM,
-                                "homogeneous write parameters cannot be lowered as one batch",
-                            ));
-                        };
-                        sql2::execute_write_logical_plan_parameter_batch(
-                            transaction,
-                            plan,
-                            &parameter_batch,
-                        )
-                        .await?
+            .with_write_transaction_lending(async move |transaction| {
+                let plan = transaction.prepare_sql_write_logical_plan(&sql, &statement)?;
+                let parameter_refs = parameter_rows
+                    .iter()
+                    .map(|parameters| parameters.as_ref())
+                    .collect::<Vec<_>>();
+                let results = if let Some(results) = sql2::execute_write_logical_plan_value_batch(
+                    transaction,
+                    &plan,
+                    &parameter_refs,
+                )
+                .await?
+                {
+                    Some(results)
+                } else {
+                    let Some(parameter_batch) = sql2::parameter_record_batch(&parameter_refs)?
+                    else {
+                        return Err(LixError::new(
+                            LixError::CODE_INVALID_PARAM,
+                            "homogeneous write parameters cannot be lowered as one batch",
+                        ));
                     };
-                    results
-                        .ok_or_else(|| {
-                            LixError::new(
-                                LixError::CODE_INVALID_PARAM,
-                                "write shape requires sequential execute_batch semantics",
-                            )
-                        })
-                        .map(|results| {
-                            results
-                                .into_iter()
-                                .map(ExecuteResult::from_sql_write_result)
-                                .collect()
-                        })
-                })
+                    sql2::execute_write_logical_plan_parameter_batch(
+                        transaction,
+                        plan,
+                        &parameter_batch,
+                    )
+                    .await?
+                };
+                results
+                    .ok_or_else(|| {
+                        LixError::new(
+                            LixError::CODE_INVALID_PARAM,
+                            "write shape requires sequential execute_batch semantics",
+                        )
+                    })
+                    .map(|results| {
+                        results
+                            .into_iter()
+                            .map(ExecuteResult::from_sql_write_result)
+                            .collect()
+                    })
             })
             .await;
         result.map_err(|error| normalize_sql_surface_error(error, &sql_for_error))
@@ -1591,31 +1578,28 @@ where
                                 "batch",
                                 Some(statement_index),
                             );
-                            let operation = async {
-                                // Keep the large statement executor behind a heap boundary. The
-                                // lending transaction closure already carries the whole parsed
-                                // batch; embedding this future in it makes debug poll stacks exceed
-                                // the standard 2 MiB worker stack for ordinary entity writes.
-                                Box::pin(execute_transaction_statement(
-                                    transaction,
-                                    &sql,
-                                    parsed.clone(),
-                                    &params,
-                                    options.clone(),
-                                    metadata,
-                                ))
-                                .await
-                                .map_err(|error| {
-                                    with_batch_statement_index(
-                                        normalize_sql_surface_error(error, &statement.sql),
-                                        statement_index,
-                                    )
-                                })
-                            };
+                            // Keep the large statement executor behind a heap boundary. The
+                            // lending transaction closure already carries the whole parsed batch;
+                            // embedding this future in it makes debug poll stacks exceed the
+                            // standard 2 MiB worker stack for ordinary entity writes.
+                            let operation = Box::pin(execute_transaction_statement(
+                                transaction,
+                                &sql,
+                                parsed.clone(),
+                                &params,
+                                options.clone(),
+                                metadata,
+                            ));
                             let result = match telemetry.as_ref() {
                                 Some(telemetry) => telemetry.instrument(operation).await,
                                 None => operation.await,
-                            };
+                            }
+                            .map_err(|error| {
+                                with_batch_statement_index(
+                                    normalize_sql_surface_error(error, &statement.sql),
+                                    statement_index,
+                                )
+                            });
                             if let Some(telemetry) = telemetry {
                                 telemetry.finish(&result);
                             }
@@ -1635,29 +1619,26 @@ where
                                 "batch",
                                 Some(statement_index),
                             );
-                            let operation = async {
-                                // See the auto-parameterized branch above. Both batch routes need
-                                // the same bounded poll-stack boundary.
-                                Box::pin(execute_transaction_statement(
-                                    transaction,
-                                    &statement.sql,
-                                    parsed,
-                                    &statement.params,
-                                    options.clone(),
-                                    metadata,
-                                ))
-                                .await
-                                .map_err(|error| {
-                                    with_batch_statement_index(
-                                        normalize_sql_surface_error(error, &statement.sql),
-                                        statement_index,
-                                    )
-                                })
-                            };
+                            // See the auto-parameterized branch above. Both batch routes need the
+                            // same bounded poll-stack boundary.
+                            let operation = Box::pin(execute_transaction_statement(
+                                transaction,
+                                &statement.sql,
+                                parsed,
+                                &statement.params,
+                                options.clone(),
+                                metadata,
+                            ));
                             let result = match telemetry.as_ref() {
                                 Some(telemetry) => telemetry.instrument(operation).await,
                                 None => operation.await,
-                            };
+                            }
+                            .map_err(|error| {
+                                with_batch_statement_index(
+                                    normalize_sql_surface_error(error, &statement.sql),
+                                    statement_index,
+                                )
+                            });
                             if let Some(telemetry) = telemetry {
                                 telemetry.finish(&result);
                             }
@@ -1695,9 +1676,9 @@ where
             .storage
             .begin_read(StorageReadOptions::default())
             .await?;
-        let (results, file_view_mutations) = with_static_session_sql_read::<StorageImpl, _, _, _>(
+        let (results, file_view_mutations) = with_static_session_sql_read::<StorageImpl, _, _>(
             read_scope,
-            |read_store| async move {
+            |read_store: SharedStorageAdapterRead<StorageImpl::Read<'static>>| async move {
                 let file_view_collector =
                     acknowledge_file_views.then(sql2::SessionFileViews::default);
                 let active_branch_id = self.active_branch_id_from_reader(&read_store).await?;
@@ -1817,9 +1798,9 @@ where
             .storage
             .begin_read(StorageReadOptions::default())
             .await?;
-        let (batch, file_view_mutations) = with_static_session_sql_read::<StorageImpl, _, _, _>(
+        let (batch, file_view_mutations) = with_static_session_sql_read::<StorageImpl, _, _>(
             read_scope,
-            |read_store| async move {
+            |read_store: SharedStorageAdapterRead<StorageImpl::Read<'static>>| async move {
                 let file_view_collector =
                     acknowledge_file_views.then(sql2::SessionFileViews::default);
                 let active_branch_id = self.active_branch_id_from_reader(&read_store).await?;
@@ -1931,19 +1912,17 @@ where
             let sql_for_planning = sql_for_error.clone();
             let params = params.to_vec();
             return self
-                .with_write_transaction_reserved(write_access, |transaction| {
-                    Box::pin(async move {
-                        let tx_plan = transaction
-                            .prepare_sql_write_logical_plan(&sql_for_planning, &statement)?;
-                        let result = sql2::execute_write_logical_plan_with_mode_result(
-                            transaction,
-                            tx_plan,
-                            &params,
-                            mode,
-                        )
-                        .await?;
-                        Ok(ExecuteResult::from_sql_write_result(result))
-                    })
+                .with_write_transaction_reserved_lending(write_access, async move |transaction| {
+                    let tx_plan = transaction
+                        .prepare_sql_write_logical_plan(&sql_for_planning, &statement)?;
+                    let result = sql2::execute_write_logical_plan_with_mode_result(
+                        transaction,
+                        tx_plan,
+                        &params,
+                        mode,
+                    )
+                    .await?;
+                    Ok(ExecuteResult::from_sql_write_result(result))
                 })
                 .await
                 .map_err(|error| normalize_sql_surface_error(error, &sql_for_error));
@@ -1959,8 +1938,8 @@ where
     /// sequence state.
     async fn persist_runtime_functions_if_needed(
         &self,
-        runtime_functions: &FunctionContext,
-        runtime_write_access: Option<&SessionWriteAccess>,
+        runtime_functions: FunctionContext,
+        has_runtime_write_access: bool,
     ) -> Result<Option<crate::storage_adapter::StorageWriteSetStats>, LixError> {
         let mut writes = StorageWriteSet::new();
         let read = SharedStorageAdapterRead::new(
@@ -1974,7 +1953,7 @@ where
         if writes.is_empty() {
             return Ok(None);
         }
-        if runtime_write_access.is_none() {
+        if !has_runtime_write_access {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 "runtime function state changed without reserved write access",
@@ -2470,14 +2449,13 @@ async fn hydrate_lix_file_data_result(
 /// storage implementations such as RocksDB naturally expose borrowed read snapshots. Keep
 /// the lifetime erasure private to session SQL execution so callers cannot
 /// receive the widened read as a general crate capability.
-async fn with_static_session_sql_read<StorageImpl, F, Fut, T>(
+async fn with_static_session_sql_read<StorageImpl, F, T>(
     read: StorageAdapterReadScope<StorageImpl::Read<'_>>,
     f: F,
 ) -> Result<T, LixError>
 where
     StorageImpl: Storage + 'static,
-    F: FnOnce(SharedStorageAdapterRead<StorageImpl::Read<'static>>) -> Fut,
-    Fut: Future<Output = Result<T, LixError>>,
+    F: AsyncFnOnce(SharedStorageAdapterRead<StorageImpl::Read<'static>>) -> Result<T, LixError>,
 {
     // SAFETY: the widened read is wrapped immediately in `SharedStorageAdapterRead`,
     // only passed into this private SQL execution closure, and explicitly

--- a/packages/engine/src/session/media_upload.rs
+++ b/packages/engine/src/session/media_upload.rs
@@ -278,18 +278,13 @@ where
         let path = state.path.clone();
         let write_access = self.begin_session_write_access().await?;
         let publish_result = self
-            .with_write_transaction_reserved(write_access, |transaction| {
-                Box::pin(async move {
-                    transaction.stage_atomic_cas_publication(
-                        finalization_writes,
-                        finalization_preconditions,
-                        publication_blob_id,
-                    )?;
-                    crate::sql2::execute_fast_lix_file_prepared_path_write(
-                        transaction,
-                        path,
-                        receipt,
-                    )
+            .with_write_transaction_reserved_lending(write_access, async move |transaction| {
+                transaction.stage_atomic_cas_publication(
+                    finalization_writes,
+                    finalization_preconditions,
+                    publication_blob_id,
+                )?;
+                crate::sql2::execute_fast_lix_file_prepared_path_write(transaction, path, receipt)
                     .await?
                     .ok_or_else(|| {
                         LixError::new(
@@ -297,7 +292,6 @@ where
                             "resumable file publication requires an unambiguous filesystem layout",
                         )
                     })
-                })
             })
             .await;
         if let Err(error) = publish_result {

--- a/packages/engine/src/session/merge/branch.rs
+++ b/packages/engine/src/session/merge/branch.rs
@@ -139,8 +139,7 @@ where
     ) -> Result<MergeBranchPreview, LixError> {
         let source_branch_id = options.source_branch_id;
 
-        self.with_write_transaction(|transaction| {
-            Box::pin(async move {
+        self.with_write_transaction_lending(async move |transaction| {
                 let active_branch_id = transaction.active_branch_id().to_string();
                 if source_branch_id == active_branch_id {
                     return Err(LixError::invalid_self_merge(active_branch_id));
@@ -238,7 +237,6 @@ where
                     &resolvable_plugin_conflicts,
                     &plugin_resolution_stats,
                 )
-            })
         })
         .instrument(tracing::debug_span!(target: "lix_perf", "lix.perf.merge_preview_total"))
         .await
@@ -256,250 +254,247 @@ where
     ) -> Result<MergeBranchReceipt, LixError> {
         let source_branch_id = options.source_branch_id;
 
-        self.with_write_transaction(|transaction| {
-            Box::pin(async move {
-                let active_branch_id = transaction.active_branch_id().to_string();
-                if source_branch_id == active_branch_id {
-                    return Err(LixError::invalid_self_merge(active_branch_id));
-                }
+        self.with_write_transaction_lending(async move |transaction| {
+            let active_branch_id = transaction.active_branch_id().to_string();
+            if source_branch_id == active_branch_id {
+                return Err(LixError::invalid_self_merge(active_branch_id));
+            }
 
-                let (target_head, source_head) = async {
-                    let reader = transaction.branch_ref_reader().await;
-                    let lifecycle = BranchLifecycle::new(&reader);
-                    let target_head = lifecycle
-                        .require_existing_commit_id(
-                            &active_branch_id,
-                            BranchOperation::MergeBranch,
-                            BranchReferenceRole::Target,
-                        )
-                        .await?;
-                    let source_head = lifecycle
-                        .require_existing_commit_id(
-                            &source_branch_id,
-                            BranchOperation::MergeBranch,
-                            BranchReferenceRole::Source,
-                        )
-                        .await?;
-                    Ok::<_, LixError>((target_head, source_head))
-                }
-                .instrument(tracing::debug_span!(
-                    target: "lix_perf",
-                    "lix.perf.merge_branch_refs"
-                ))
-                .await?;
-
-                let merge_base = async {
-                    let mut reader = transaction.commit_graph_reader().await;
-                    reader.merge_base(&target_head, &source_head).await
-                }
-                .instrument(tracing::debug_span!(
-                    target: "lix_perf",
-                    "lix.perf.merge_base"
-                ))
-                .await?;
-                let base_commit_id = merge_base;
-                let analysis = async {
-                    let mut reader = transaction.tracked_state_reader().await;
-                    analyze(
-                        &mut reader,
-                        MergeCommits {
-                            base_commit_id,
-                            target_commit_id: target_head,
-                            source_commit_id: source_head,
-                        },
+            let (target_head, source_head) = async {
+                let reader = transaction.branch_ref_reader().await;
+                let lifecycle = BranchLifecycle::new(&reader);
+                let target_head = lifecycle
+                    .require_existing_commit_id(
+                        &active_branch_id,
+                        BranchOperation::MergeBranch,
+                        BranchReferenceRole::Target,
                     )
-                    .await
-                }
-                .instrument(tracing::debug_span!(
-                    target: "lix_perf",
-                    "lix.perf.merge_analysis"
-                ))
-                .await?;
-                let derived_blob_files = async {
-                    let mut reader = transaction.tracked_state_reader().await;
-                    derived_plugin_blob_conflicts(&mut reader, &analysis).await
-                }
-                .instrument(tracing::debug_span!(
-                    target: "lix_perf",
-                    "lix.perf.merge_derived_blob_detection"
-                ))
-                .await?;
-
-                if analysis.outcome == MergeOutcome::AlreadyUpToDate {
-                    return Ok(MergeBranchReceipt {
-                        outcome: MergeBranchOutcome::AlreadyUpToDate,
-                        target_branch_id: active_branch_id,
-                        source_branch_id,
-                        base_commit_id: analysis.commits.base_commit_id.to_string(),
-                        target_head_after_commit_id: analysis.commits.target_commit_id.to_string(),
-                        target_head_before_commit_id: analysis.commits.target_commit_id.to_string(),
-                        source_head_before_commit_id: analysis.commits.source_commit_id.to_string(),
-                        created_merge_commit_id: None,
-                        change_stats: merge_change_stats_from_analysis(&analysis.stats),
-                    });
-                }
-
-                if analysis.outcome == MergeOutcome::FastForward {
-                    transaction
-                        .advance_branch_ref(&active_branch_id, analysis.commits.source_commit_id)
-                        .await?;
-
-                    return Ok(MergeBranchReceipt {
-                        outcome: MergeBranchOutcome::FastForward,
-                        target_branch_id: active_branch_id,
-                        source_branch_id,
-                        base_commit_id: analysis.commits.base_commit_id.to_string(),
-                        target_head_before_commit_id: analysis.commits.target_commit_id.to_string(),
-                        source_head_before_commit_id: analysis.commits.source_commit_id.to_string(),
-                        target_head_after_commit_id: analysis.commits.source_commit_id.to_string(),
-                        created_merge_commit_id: None,
-                        change_stats: merge_change_stats_from_analysis(&analysis.stats),
-                    });
-                }
-
-                let merge_plan = analysis
-                    .merge_plan()
-                    .expect("merge analysis should include a plan for mergeCommitted");
-
-                // Do the no-Wasm compatibility preflight and reject ordinary
-                // conflicts before constructing a Component Store. A merge
-                // with an unrelated unresolved row must not pay for (or be
-                // masked by) a plugin resolver invocation.
-                let resolvable_plugin_conflicts =
-                    resolvable_plugin_conflict_keys(&analysis, &derived_blob_files);
-                let effective_conflicts = if resolvable_plugin_conflicts
-                    .covers_all_with_derived_blobs(merge_plan.conflicts.len(), &derived_blob_files)
-                {
-                    Vec::new()
-                } else {
-                    analysis
-                        .conflict_batch()
-                        .expect("mergeCommitted analysis should include a conflict batch")
-                        .iter()
-                        .enumerate()
-                        .filter(|(index, conflict)| {
-                            !is_derived_blob_conflict(conflict.tracked(), &derived_blob_files)
-                                && !resolvable_plugin_conflicts.contains_index(*index)
-                        })
-                        .map(|(_, conflict)| conflict)
-                        .collect::<Vec<_>>()
-                };
-                if !effective_conflicts.is_empty() {
-                    return Err(merge_conflict_error(
-                        &effective_conflicts
-                            .into_iter()
-                            .map(merge_conflict_from_analysis)
-                            .collect::<Result<Vec<_>, _>>()?,
-                    )?);
-                }
-
-                let plugin_conflict_groups = async {
-                    let mut reader = transaction.tracked_state_reader().await;
-                    plugin_merge_conflict_groups(
-                        &mut reader,
-                        &analysis,
-                        &derived_blob_files,
-                        &resolvable_plugin_conflicts,
+                    .await?;
+                let source_head = lifecycle
+                    .require_existing_commit_id(
+                        &source_branch_id,
+                        BranchOperation::MergeBranch,
+                        BranchReferenceRole::Source,
                     )
-                    .await
-                }
-                .instrument(tracing::debug_span!(
-                    target: "lix_perf",
-                    "lix.perf.merge_plugin_conflict_inputs"
-                ))
-                .await?;
-                let semantic_branch_id = SharedStr::from(active_branch_id.as_str());
-                let resolved_plugin_rows = resolve_plugin_merge_conflict_groups(
-                    transaction,
-                    plugin_conflict_groups,
-                    &semantic_branch_id,
+                    .await?;
+                Ok::<_, LixError>((target_head, source_head))
+            }
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.merge_branch_refs"
+            ))
+            .await?;
+
+            let merge_base = async {
+                let mut reader = transaction.commit_graph_reader().await;
+                reader.merge_base(&target_head, &source_head).await
+            }
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.merge_base"
+            ))
+            .await?;
+            let base_commit_id = merge_base;
+            let analysis = async {
+                let mut reader = transaction.tracked_state_reader().await;
+                analyze(
+                    &mut reader,
+                    MergeCommits {
+                        base_commit_id,
+                        target_commit_id: target_head,
+                        source_commit_id: source_head,
+                    },
                 )
-                .instrument(tracing::debug_span!(
-                    target: "lix_perf",
-                    "lix.perf.merge_plugin_conflict_resolve"
-                ))
-                .await?;
+                .await
+            }
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.merge_analysis"
+            ))
+            .await?;
+            let derived_blob_files = async {
+                let mut reader = transaction.tracked_state_reader().await;
+                derived_plugin_blob_conflicts(&mut reader, &analysis).await
+            }
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.merge_derived_blob_detection"
+            ))
+            .await?;
 
-                let plugin_resolution_stats = async {
-                    let mut reader = transaction.tracked_state_reader().await;
-                    plugin_resolution_change_stats(&mut reader, &analysis, &resolved_plugin_rows)
-                        .await
-                }
-                .instrument(tracing::debug_span!(
-                    target: "lix_perf",
-                    "lix.perf.merge_plugin_resolution_stats"
-                ))
-                .await?;
-
-                let semantic_rows = async {
-                    let mut reader = transaction.tracked_state_reader().await;
-                    materialized_plugin_merge_rows(
-                        &mut reader,
-                        &analysis,
-                        &derived_blob_files,
-                        &semantic_branch_id,
-                        resolved_plugin_rows,
-                    )
-                    .await
-                }
-                .instrument(tracing::debug_span!(
-                    target: "lix_perf",
-                    "lix.perf.merge_materialized_rows"
-                ))
-                .await?;
-                if !semantic_rows.is_empty() {
-                    transaction
-                        .stage_write(TransactionWrite::Rows {
-                            mode: TransactionWriteMode::Replace,
-                            rows: semantic_rows,
-                        })
-                        .instrument(tracing::debug_span!(
-                            target: "lix_perf",
-                            "lix.perf.merge_stage_semantic_rows"
-                        ))
-                        .await?;
-                }
-                let created_merge_commit_id = tracing::debug_span!(
-                    target: "lix_perf",
-                    "lix.perf.merge_stage_commit"
-                )
-                .in_scope(|| {
-                    let mut selected_changes =
-                        StagedCommitChangeBatchBuilder::with_capacity(merge_plan.picks.len());
-                    for pick in merge_plan
-                        .picks
-                        .iter()
-                        .filter(|pick| !pick_is_derived_plugin_state(pick, &derived_blob_files))
-                    {
-                        selected_changes.push(
-                            pick.identity.clone(),
-                            pick.selected_row.commit_id,
-                            pick.change_id,
-                            pick.selected_row.deleted,
-                            pick.selected_row.created_at,
-                            pick.selected_row.updated_at,
-                        );
-                    }
-                    transaction.stage_merge_commit(
-                        active_branch_id.clone(),
-                        analysis.commits.source_commit_id,
-                        selected_changes.finish(),
-                    )
-                })?;
-                Ok(MergeBranchReceipt {
-                    outcome: MergeBranchOutcome::MergeCommitted,
+            if analysis.outcome == MergeOutcome::AlreadyUpToDate {
+                return Ok(MergeBranchReceipt {
+                    outcome: MergeBranchOutcome::AlreadyUpToDate,
                     target_branch_id: active_branch_id,
                     source_branch_id,
                     base_commit_id: analysis.commits.base_commit_id.to_string(),
-                    target_head_after_commit_id: created_merge_commit_id.clone(),
+                    target_head_after_commit_id: analysis.commits.target_commit_id.to_string(),
                     target_head_before_commit_id: analysis.commits.target_commit_id.to_string(),
                     source_head_before_commit_id: analysis.commits.source_commit_id.to_string(),
-                    created_merge_commit_id: Some(created_merge_commit_id),
-                    change_stats: merge_change_stats_with_plugin_resolutions(
-                        &analysis.stats,
-                        &plugin_resolution_stats,
-                    ),
-                })
+                    created_merge_commit_id: None,
+                    change_stats: merge_change_stats_from_analysis(&analysis.stats),
+                });
+            }
+
+            if analysis.outcome == MergeOutcome::FastForward {
+                transaction
+                    .advance_branch_ref(&active_branch_id, analysis.commits.source_commit_id)
+                    .await?;
+
+                return Ok(MergeBranchReceipt {
+                    outcome: MergeBranchOutcome::FastForward,
+                    target_branch_id: active_branch_id,
+                    source_branch_id,
+                    base_commit_id: analysis.commits.base_commit_id.to_string(),
+                    target_head_before_commit_id: analysis.commits.target_commit_id.to_string(),
+                    source_head_before_commit_id: analysis.commits.source_commit_id.to_string(),
+                    target_head_after_commit_id: analysis.commits.source_commit_id.to_string(),
+                    created_merge_commit_id: None,
+                    change_stats: merge_change_stats_from_analysis(&analysis.stats),
+                });
+            }
+
+            let merge_plan = analysis
+                .merge_plan()
+                .expect("merge analysis should include a plan for mergeCommitted");
+
+            // Do the no-Wasm compatibility preflight and reject ordinary
+            // conflicts before constructing a Component Store. A merge
+            // with an unrelated unresolved row must not pay for (or be
+            // masked by) a plugin resolver invocation.
+            let resolvable_plugin_conflicts =
+                resolvable_plugin_conflict_keys(&analysis, &derived_blob_files);
+            let effective_conflicts = if resolvable_plugin_conflicts
+                .covers_all_with_derived_blobs(merge_plan.conflicts.len(), &derived_blob_files)
+            {
+                Vec::new()
+            } else {
+                analysis
+                    .conflict_batch()
+                    .expect("mergeCommitted analysis should include a conflict batch")
+                    .iter()
+                    .enumerate()
+                    .filter(|(index, conflict)| {
+                        !is_derived_blob_conflict(conflict.tracked(), &derived_blob_files)
+                            && !resolvable_plugin_conflicts.contains_index(*index)
+                    })
+                    .map(|(_, conflict)| conflict)
+                    .collect::<Vec<_>>()
+            };
+            if !effective_conflicts.is_empty() {
+                return Err(merge_conflict_error(
+                    &effective_conflicts
+                        .into_iter()
+                        .map(merge_conflict_from_analysis)
+                        .collect::<Result<Vec<_>, _>>()?,
+                )?);
+            }
+
+            let plugin_conflict_groups = async {
+                let mut reader = transaction.tracked_state_reader().await;
+                plugin_merge_conflict_groups(
+                    &mut reader,
+                    &analysis,
+                    &derived_blob_files,
+                    &resolvable_plugin_conflicts,
+                )
+                .await
+            }
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.merge_plugin_conflict_inputs"
+            ))
+            .await?;
+            let semantic_branch_id = SharedStr::from(active_branch_id.as_str());
+            let resolved_plugin_rows = resolve_plugin_merge_conflict_groups(
+                transaction,
+                plugin_conflict_groups,
+                &semantic_branch_id,
+            )
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.merge_plugin_conflict_resolve"
+            ))
+            .await?;
+
+            let plugin_resolution_stats = async {
+                let mut reader = transaction.tracked_state_reader().await;
+                plugin_resolution_change_stats(&mut reader, &analysis, &resolved_plugin_rows).await
+            }
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.merge_plugin_resolution_stats"
+            ))
+            .await?;
+
+            let semantic_rows = async {
+                let mut reader = transaction.tracked_state_reader().await;
+                materialized_plugin_merge_rows(
+                    &mut reader,
+                    &analysis,
+                    &derived_blob_files,
+                    &semantic_branch_id,
+                    resolved_plugin_rows,
+                )
+                .await
+            }
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.merge_materialized_rows"
+            ))
+            .await?;
+            if !semantic_rows.is_empty() {
+                transaction
+                    .stage_write(TransactionWrite::Rows {
+                        mode: TransactionWriteMode::Replace,
+                        rows: semantic_rows,
+                    })
+                    .instrument(tracing::debug_span!(
+                        target: "lix_perf",
+                        "lix.perf.merge_stage_semantic_rows"
+                    ))
+                    .await?;
+            }
+            let created_merge_commit_id = tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.merge_stage_commit"
+            )
+            .in_scope(|| {
+                let mut selected_changes =
+                    StagedCommitChangeBatchBuilder::with_capacity(merge_plan.picks.len());
+                for pick in merge_plan
+                    .picks
+                    .iter()
+                    .filter(|pick| !pick_is_derived_plugin_state(pick, &derived_blob_files))
+                {
+                    selected_changes.push(
+                        pick.identity.clone(),
+                        pick.selected_row.commit_id,
+                        pick.change_id,
+                        pick.selected_row.deleted,
+                        pick.selected_row.created_at,
+                        pick.selected_row.updated_at,
+                    );
+                }
+                transaction.stage_merge_commit(
+                    active_branch_id.clone(),
+                    analysis.commits.source_commit_id,
+                    selected_changes.finish(),
+                )
+            })?;
+            Ok(MergeBranchReceipt {
+                outcome: MergeBranchOutcome::MergeCommitted,
+                target_branch_id: active_branch_id,
+                source_branch_id,
+                base_commit_id: analysis.commits.base_commit_id.to_string(),
+                target_head_after_commit_id: created_merge_commit_id.clone(),
+                target_head_before_commit_id: analysis.commits.target_commit_id.to_string(),
+                source_head_before_commit_id: analysis.commits.source_commit_id.to_string(),
+                created_merge_commit_id: Some(created_merge_commit_id),
+                change_stats: merge_change_stats_with_plugin_resolutions(
+                    &analysis.stats,
+                    &plugin_resolution_stats,
+                ),
             })
         })
         .instrument(tracing::debug_span!(

--- a/packages/engine/src/session/observe.rs
+++ b/packages/engine/src/session/observe.rs
@@ -48,7 +48,7 @@ where
 {
     session: SessionContext<StorageImpl>,
     query: ObserveQuery,
-    receiver: watch::Receiver<ObserveInvalidationEvent>,
+    receiver: Option<watch::Receiver<ObserveInvalidationEvent>>,
     sequence: u64,
     last_rows: Option<ExecuteResult>,
     last_shared_content: Option<ObserveSharedContent>,
@@ -61,7 +61,7 @@ where
 {
     pub async fn next(&mut self) -> Result<Option<ObserveEvent>, LixError> {
         if self.closed || self.session.is_closed() {
-            self.closed = true;
+            self.close();
             return Ok(None);
         }
         if self.last_rows.is_none() {
@@ -83,17 +83,17 @@ where
 
         loop {
             if self.closed || self.session.is_closed() {
-                self.closed = true;
+                self.close();
                 return Ok(None);
             }
 
             if !Box::pin(self.wait_for_invalidation()).await? {
-                self.closed = true;
+                self.close();
                 return Ok(None);
             }
 
             if self.session.is_closed() {
-                self.closed = true;
+                self.close();
                 return Ok(None);
             }
 
@@ -121,6 +121,7 @@ where
 
     pub fn close(&mut self) {
         self.closed = true;
+        self.receiver.take();
     }
 
     fn acknowledge_delivered_file_views(&self, rows: &ExecuteResult) {
@@ -130,14 +131,22 @@ where
     }
 
     async fn wait_for_invalidation(&mut self) -> Result<bool, LixError> {
-        if self.receiver.changed().await.is_err() {
+        let Some(receiver) = self.receiver.as_mut() else {
+            return Ok(false);
+        };
+        if receiver.changed().await.is_err() {
             return Ok(false);
         }
         self.invalidation_generation().map(|_| true)
     }
 
     fn invalidation_generation(&mut self) -> Result<u64, LixError> {
-        let event = self.receiver.borrow_and_update().clone();
+        let event = self
+            .receiver
+            .as_mut()
+            .expect("open observer retains its invalidation receiver")
+            .borrow_and_update()
+            .clone();
         match event {
             ObserveInvalidationEvent::Generation(generation) => Ok(generation),
             ObserveInvalidationEvent::TerminalStorageError(error) => Err(error),
@@ -157,10 +166,17 @@ where
             let before = self.invalidation_generation()?;
             let rows = Box::pin(self.execute_or_share(before)).await;
             drop(operation_guard);
+            // Closing transitions the shared session to `Closing` before it
+            // waits for active operations. Do not publish a snapshot that
+            // completed concurrently with that lifecycle boundary.
+            if self.session.is_closed() {
+                self.close();
+                return Ok(None);
+            }
             let rows = match rows {
                 Ok(rows) => rows,
                 Err(error) if error.code == LixError::CODE_CLOSED => {
-                    self.closed = true;
+                    self.close();
                     return Ok(None);
                 }
                 Err(error) => return Err(error),
@@ -240,7 +256,7 @@ where
         Ok(ObserveEvents {
             session: self.clone(),
             query: ObserveQuery::new(sql, params.to_vec(), shared_state),
-            receiver: self.observe_invalidation.subscribe(),
+            receiver: Some(self.observe_invalidation.subscribe()),
             sequence: 0,
             last_rows: None,
             last_shared_content: None,

--- a/packages/engine/src/session/switch_branch.rs
+++ b/packages/engine/src/session/switch_branch.rs
@@ -42,35 +42,33 @@ where
         let receipt_branch_id = branch_id.clone();
         let current_mode = self.mode.clone();
         let next_mode = self
-            .with_write_transaction(|transaction| {
-                Box::pin(async move {
-                    {
-                        let reader = transaction.branch_ref_reader().await;
-                        BranchLifecycle::new(&reader)
-                            .require_existing_commit_id(
-                                &branch_id,
-                                BranchOperation::SwitchBranch,
-                                BranchReferenceRole::Target,
-                            )
-                            .await?
-                    };
+            .with_write_transaction_lending(async move |transaction| {
+                {
+                    let reader = transaction.branch_ref_reader().await;
+                    BranchLifecycle::new(&reader)
+                        .require_existing_commit_id(
+                            &branch_id,
+                            BranchOperation::SwitchBranch,
+                            BranchReferenceRole::Target,
+                        )
+                        .await?
+                };
 
-                    match current_mode {
-                        SessionMode::Pinned { .. } => Ok(SessionMode::Pinned {
-                            branch_id: branch_id.clone(),
-                        }),
-                        SessionMode::Workspace {
+                match current_mode {
+                    SessionMode::Pinned { .. } => Ok(SessionMode::Pinned {
+                        branch_id: branch_id.clone(),
+                    }),
+                    SessionMode::Workspace {
+                        branch_id: selector,
+                    } => {
+                        let mut rows = RawWriteBatch::with_capacity(1);
+                        rows.push(workspace_branch_stage_row(&branch_id)?);
+                        transaction.stage_rows(rows).await?;
+                        Ok(SessionMode::Workspace {
                             branch_id: selector,
-                        } => {
-                            let mut rows = RawWriteBatch::with_capacity(1);
-                            rows.push(workspace_branch_stage_row(&branch_id)?);
-                            transaction.stage_rows(rows).await?;
-                            Ok(SessionMode::Workspace {
-                                branch_id: selector,
-                            })
-                        }
+                        })
                     }
-                })
+                }
             })
             .await?;
 

--- a/packages/engine/src/session/undo_redo.rs
+++ b/packages/engine/src/session/undo_redo.rs
@@ -43,16 +43,16 @@ where
 {
     /// Reverses the latest undoable tracked commit on the active branch.
     pub async fn undo(&self) -> Result<UndoReceipt, LixError> {
-        self.with_write_transaction(|transaction| {
-            Box::pin(async move { undo_in_transaction(transaction).await })
+        self.with_write_transaction_lending(async move |transaction| {
+            undo_in_transaction(transaction).await
         })
         .await
     }
 
     /// Replays the latest tracked commit abandoned by undo on the active branch.
     pub async fn redo(&self) -> Result<RedoReceipt, LixError> {
-        self.with_write_transaction(|transaction| {
-            Box::pin(async move { redo_in_transaction(transaction).await })
+        self.with_write_transaction_lending(async move |transaction| {
+            redo_in_transaction(transaction).await
         })
         .await
     }
@@ -665,25 +665,23 @@ mod tests {
             .expect("update commits");
 
         let duplicate = session
-            .with_write_transaction(|transaction| {
-                Box::pin(async move {
-                    let branch_id = transaction.active_branch_id().to_string();
-                    let head = transaction
-                        .load_branch_head(&branch_id)
-                        .await?
-                        .expect("branch has a head");
-                    let record = load_node(transaction, head).await?;
-                    let parent = only_parent(&record.parent_commit_ids, head, "test")?;
-                    let key = load_commit_delta(transaction, head)
-                        .await?
-                        .into_iter()
-                        .find(|(key, _)| key.schema_key == "lix_key_value")
-                        .expect("update delta contains the key-value row")
-                        .0;
-                    transaction
-                        .execute_tracked_state_transition(head, parent, vec![key.clone(), key])
-                        .await
-                })
+            .with_write_transaction_lending(async move |transaction| {
+                let branch_id = transaction.active_branch_id().to_string();
+                let head = transaction
+                    .load_branch_head(&branch_id)
+                    .await?
+                    .expect("branch has a head");
+                let record = load_node(transaction, head).await?;
+                let parent = only_parent(&record.parent_commit_ids, head, "test")?;
+                let key = load_commit_delta(transaction, head)
+                    .await?
+                    .into_iter()
+                    .find(|(key, _)| key.schema_key == "lix_key_value")
+                    .expect("update delta contains the key-value row")
+                    .0;
+                transaction
+                    .execute_tracked_state_transition(head, parent, vec![key.clone(), key])
+                    .await
             })
             .await
             .expect_err("duplicate transition identities are rejected");
@@ -691,25 +689,23 @@ mod tests {
         assert_eq!(value(&session, "typed").await.as_deref(), Some("after"));
 
         let stale = session
-            .with_write_transaction(|transaction| {
-                Box::pin(async move {
-                    let branch_id = transaction.active_branch_id().to_string();
-                    let head = transaction
-                        .load_branch_head(&branch_id)
-                        .await?
-                        .expect("branch has a head");
-                    let record = load_node(transaction, head).await?;
-                    let parent = only_parent(&record.parent_commit_ids, head, "test")?;
-                    let key = load_commit_delta(transaction, head)
-                        .await?
-                        .into_iter()
-                        .find(|(key, _)| key.schema_key == "lix_key_value")
-                        .expect("update delta contains the key-value row")
-                        .0;
-                    transaction
-                        .execute_tracked_state_transition(parent, head, vec![key])
-                        .await
-                })
+            .with_write_transaction_lending(async move |transaction| {
+                let branch_id = transaction.active_branch_id().to_string();
+                let head = transaction
+                    .load_branch_head(&branch_id)
+                    .await?
+                    .expect("branch has a head");
+                let record = load_node(transaction, head).await?;
+                let parent = only_parent(&record.parent_commit_ids, head, "test")?;
+                let key = load_commit_delta(transaction, head)
+                    .await?
+                    .into_iter()
+                    .find(|(key, _)| key.schema_key == "lix_key_value")
+                    .expect("update delta contains the key-value row")
+                    .0;
+                transaction
+                    .execute_tracked_state_transition(parent, head, vec![key])
+                    .await
             })
             .await
             .expect_err("non-head transition sources are rejected");

--- a/packages/engine/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/engine/src/tracked_state/commit_root_rebuild.rs
@@ -107,7 +107,7 @@ fn load_available_root<'a, S>(
     store: &'a S,
     commit_id: &'a str,
     seen: &'a mut HashSet<String>,
-) -> Pin<Box<dyn Future<Output = Result<Option<TrackedStateRootId>, LixError>> + 'a>>
+) -> Pin<Box<dyn Future<Output = Result<Option<TrackedStateRootId>, LixError>> + Send + 'a>>
 where
     S: StorageAdapterRead + ?Sized + 'a,
 {
@@ -315,12 +315,7 @@ where
                 deltas.len(),
                 &first_key,
                 &file_delete_cascades,
-                deltas.iter().copied().map(|delta| {
-                    Ok(TrackedStateRootMutationRef {
-                        delta,
-                        require_absence: false,
-                    })
-                }),
+                RebuildRootMutations::new(&deltas),
             )
             .await?
         {
@@ -331,6 +326,37 @@ where
         .stage_commit_root(&commit_id, parent_commit_id.as_deref(), deltas)
         .await
 }
+
+struct RebuildRootMutations<'iter, 'delta> {
+    inner: std::slice::Iter<'iter, TrackedStateDeltaRef<'delta>>,
+}
+
+impl<'iter, 'delta> RebuildRootMutations<'iter, 'delta> {
+    fn new(deltas: &'iter [TrackedStateDeltaRef<'delta>]) -> Self {
+        Self {
+            inner: deltas.iter(),
+        }
+    }
+}
+
+impl<'delta> Iterator for RebuildRootMutations<'_, 'delta> {
+    type Item = Result<TrackedStateRootMutationRef<'delta>, LixError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().copied().map(|delta| {
+            Ok(TrackedStateRootMutationRef {
+                delta,
+                require_absence: false,
+            })
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl ExactSizeIterator for RebuildRootMutations<'_, '_> {}
 
 fn first_parent_commit_id(commit: &CommitRecord) -> Option<CommitId> {
     commit.parent_commit_ids.first().copied()

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -6,7 +6,9 @@
 
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::future::Future;
 use std::ops::{Bound, Deref, Range};
+use std::pin::Pin;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::changelog::CommitId;
@@ -1966,7 +1968,7 @@ async fn load_change_records_by_ids(
     {
         return stream::iter(change_ids.iter().copied())
             .map(|change_id| async move {
-                load_change_record_by_id(store, change_id)
+                load_change_record_by_id_boxed(store, change_id)
                     .await?
                     .ok_or_else(|| {
                         LixError::new(
@@ -2005,6 +2007,18 @@ async fn load_change_records_by_ids(
         })
         .collect::<Result<Vec<_>, _>>()?;
     load_change_records_at_locators(store, &locators).await
+}
+
+fn load_change_record_by_id_boxed<'a, S>(
+    store: &'a S,
+    change_id: crate::changelog::ChangeId,
+) -> Pin<
+    Box<dyn Future<Output = Result<Option<crate::changelog::ChangeRecord>, LixError>> + Send + 'a>,
+>
+where
+    S: StorageAdapterRead + ?Sized + 'a,
+{
+    Box::pin(load_change_record_by_id(store, change_id))
 }
 
 async fn load_change_records_at_locators(

--- a/packages/engine/src/tracked_state/tree.rs
+++ b/packages/engine/src/tracked_state/tree.rs
@@ -2043,7 +2043,7 @@ impl TrackedStateTree {
         overlay: &'a storage::TrackedStateChunkOverlay,
         hash: [u8; TRACKED_STATE_HASH_BYTES],
         levels: &'a mut Vec<Vec<ChildSummary>>,
-    ) -> Pin<Box<dyn Future<Output = Result<(ChildSummary, usize), LixError>> + 'a>>
+    ) -> Pin<Box<dyn Future<Output = Result<(ChildSummary, usize), LixError>> + Send + 'a>>
     where
         S: StorageAdapterRead + ?Sized + 'a,
     {

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -4474,17 +4474,7 @@ async fn stage_tracked_roots(
                     state_row_indices.len(),
                     &first_mutation_key,
                     &file_delete_cascades,
-                    state_row_indices.iter().map(|&row_index| {
-                        let row = state_rows.row(row_index);
-                        Ok(TrackedStateRootMutationRef {
-                            delta: tracked_delta_from_state_row(row)?,
-                            require_absence: tracked_row_requires_absence(
-                                row_index,
-                                row,
-                                insert_selection,
-                            ),
-                        })
-                    }),
+                    OrderedStateRowMutations::new(state_row_indices, state_rows, insert_selection),
                 )
                 .await?
                 .is_some()
@@ -4575,6 +4565,51 @@ fn tracked_row_requires_absence(
     }
     row.snapshot.is_some() && !row.untracked && insert_selection.contains(row_index)
 }
+
+struct OrderedStateRowMutations<'a> {
+    row_indices: std::slice::Iter<'a, RowIndex>,
+    state_rows: &'a PreparedStateBatch,
+    insert_selection: &'a PreparedInsertSelection,
+}
+
+impl<'a> OrderedStateRowMutations<'a> {
+    fn new(
+        row_indices: &'a [RowIndex],
+        state_rows: &'a PreparedStateBatch,
+        insert_selection: &'a PreparedInsertSelection,
+    ) -> Self {
+        Self {
+            row_indices: row_indices.iter(),
+            state_rows,
+            insert_selection,
+        }
+    }
+}
+
+impl<'a> Iterator for OrderedStateRowMutations<'a> {
+    type Item = Result<TrackedStateRootMutationRef<'a>, LixError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let row_index = *self.row_indices.next()?;
+        let row = self.state_rows.row(row_index);
+        Some(
+            tracked_delta_from_state_row(row).map(|delta| TrackedStateRootMutationRef {
+                delta,
+                require_absence: tracked_row_requires_absence(
+                    row_index,
+                    row,
+                    self.insert_selection,
+                ),
+            }),
+        )
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.row_indices.size_hint()
+    }
+}
+
+impl ExactSizeIterator for OrderedStateRowMutations<'_> {}
 
 fn tracked_roots_parent_first(
     tracked_roots: &[PendingTrackedRoot],

--- a/packages/engine/tests/integration/observe.rs
+++ b/packages/engine/tests/integration/observe.rs
@@ -151,6 +151,59 @@ async fn observe_initial_next_waits_without_rejecting_same_session_write() {
 }
 
 #[tokio::test]
+async fn observe_close_during_initial_evaluation_does_not_publish_a_final_snapshot() {
+    let storage = BlockingBeginReadStorage::new();
+    let gate = storage.gate();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new(storage).await.expect("engine should open");
+    let session = Arc::new(
+        engine
+            .open_workspace_session()
+            .await
+            .expect("workspace session should open"),
+    );
+    let mut events = session
+        .observe("SELECT 1", &[])
+        .expect("observe should open");
+
+    gate.block_next_read();
+    let observer = thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("observer runtime should build");
+        runtime.block_on(async move { events.next().await })
+    });
+    gate.wait_until_blocked();
+
+    let closing_session = Arc::clone(&session);
+    let close = thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("close runtime should build");
+        runtime.block_on(async move { closing_session.close().await })
+    });
+    while !session.is_closed() {
+        thread::yield_now();
+    }
+    gate.release();
+
+    assert!(
+        observer
+            .join()
+            .expect("observer thread should join")
+            .expect("observe next should not fail")
+            .is_none(),
+        "closing a session must suppress an in-flight initial snapshot"
+    );
+    close
+        .join()
+        .expect("close thread should join")
+        .expect("session should close");
+}
+
+#[tokio::test]
 async fn observe_registration_allows_automatic_write_instead_of_rejecting() {
     let storage = BlockingBeginWriteStorage::new();
     let gate = storage.gate();
@@ -563,6 +616,42 @@ async fn observe_identical_queries_share_one_evaluation_per_generation() {
     );
 }
 
+#[tokio::test]
+async fn closing_retained_observer_releases_external_watcher_demand() {
+    let storage = CountingReadStorage::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("engine should open");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+    let mut events = session
+        .observe("SELECT 1", &[])
+        .expect("observe should open");
+    let _initial = next_event(&mut events, "initial snapshot").await;
+    events.close();
+    tokio::time::sleep(Duration::from_millis(600)).await;
+    let settled_revision_reads = storage.mutation_revision_read_count();
+    tokio::time::sleep(Duration::from_millis(600)).await;
+
+    assert_eq!(
+        storage.mutation_revision_read_count(),
+        settled_revision_reads,
+        "a closed observer must not retain external mutation polling demand"
+    );
+    assert!(
+        events
+            .next()
+            .await
+            .expect("closed next should succeed")
+            .is_none()
+    );
+}
+
 simulation_test!(
     observe_new_subscriber_receives_current_rows_after_unchanged_generation,
     |sim| async move {
@@ -768,6 +857,7 @@ simulation_test!(
 struct CountingReadStorage {
     inner: Memory,
     read_count: Arc<AtomicUsize>,
+    mutation_revision_read_count: Arc<AtomicUsize>,
 }
 
 #[derive(Clone)]
@@ -948,6 +1038,7 @@ struct BlockingReadState {
 struct CountingRead {
     inner: MemoryRead,
     read_count: Arc<AtomicUsize>,
+    mutation_revision_read_count: Arc<AtomicUsize>,
     counted: AtomicBool,
 }
 
@@ -956,6 +1047,7 @@ impl CountingReadStorage {
         Self {
             inner: Memory::new(),
             read_count: Arc::new(AtomicUsize::new(0)),
+            mutation_revision_read_count: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -965,6 +1057,10 @@ impl CountingReadStorage {
 
     fn read_count(&self) -> usize {
         self.read_count.load(Ordering::SeqCst)
+    }
+
+    fn mutation_revision_read_count(&self) -> usize {
+        self.mutation_revision_read_count.load(Ordering::SeqCst)
     }
 }
 
@@ -983,6 +1079,7 @@ impl Storage for CountingReadStorage {
         Ok(CountingRead {
             inner: self.inner.begin_read(opts).await?,
             read_count: Arc::clone(&self.read_count),
+            mutation_revision_read_count: Arc::clone(&self.mutation_revision_read_count),
             counted: AtomicBool::new(false),
         })
     }
@@ -1016,7 +1113,10 @@ impl StorageRead for CountingRead {
 
 impl CountingRead {
     fn count_user_read(&self, space: lix_engine::storage::StorageSpace) {
-        if space.id != SpaceId(0x0007_0001) && !self.counted.swap(true, Ordering::SeqCst) {
+        if space.id == SpaceId(0x0007_0001) {
+            self.mutation_revision_read_count
+                .fetch_add(1, Ordering::SeqCst);
+        } else if !self.counted.swap(true, Ordering::SeqCst) {
             self.read_count.fetch_add(1, Ordering::SeqCst);
         }
     }

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -45,7 +45,7 @@ tokio = { version = "1", features = ["rt", "sync"] }
 plugin_csv = { path = "../../plugins/csv", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
 criterion = { package = "codspeed-criterion-compat", version = "4" }
 tempfile = "3"
-tokio = { version = "1", features = ["rt", "macros"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 wasm-encoder = "0.248"
 zip = { version = "8", default-features = false }
 

--- a/packages/rs-sdk/src/lix.rs
+++ b/packages/rs-sdk/src/lix.rs
@@ -42,14 +42,20 @@ impl<StorageImpl> OpenLixOptions<StorageImpl> {
     }
 }
 
-/// Workspace-session handle for a Lix repository.
+/// Clonable workspace-session handle for a Lix repository.
+///
+/// Clones are concurrent handles to the same logical session: they share the
+/// active workspace branch, transaction exclusion, file-view state, and close
+/// lifecycle. Use [`Lix::open_session`] when an operation needs an independent
+/// pinned session and lifecycle.
+#[derive(Clone)]
 #[expect(missing_debug_implementations)]
 pub struct Lix<StorageImpl = Memory>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
-    engine: Engine<StorageImpl>,
-    session: SessionContext<StorageImpl>,
+    engine: Arc<Engine<StorageImpl>>,
+    session: Arc<SessionContext<StorageImpl>>,
 }
 
 /// Opens a Lix workspace session.
@@ -90,7 +96,10 @@ where
     let engine =
         open_or_initialize_engine(options.storage, options.wasm_runtime, telemetry, None).await?;
     let session = engine.open_workspace_session().await?;
-    Ok(Lix { engine, session })
+    Ok(Lix {
+        engine: Arc::new(engine),
+        session: Arc::new(session),
+    })
 }
 
 pub async fn open_lix_with_storage<StorageImpl>(
@@ -120,7 +129,10 @@ where
     )
     .await?;
     let session = engine.open_workspace_session().await?;
-    Ok(Lix { engine, session })
+    Ok(Lix {
+        engine: Arc::new(engine),
+        session: Arc::new(session),
+    })
 }
 
 impl<StorageImpl> Lix<StorageImpl>
@@ -153,7 +165,7 @@ where
         let session = self.engine.open_workspace_session().await?;
         Ok(Self {
             engine: self.engine.clone(),
-            session,
+            session: Arc::new(session),
         })
     }
 
@@ -190,7 +202,7 @@ where
         let session = self.engine.open_session(active_branch_id).await?;
         Ok(Self {
             engine: self.engine.clone(),
-            session,
+            session: Arc::new(session),
         })
     }
 
@@ -449,7 +461,7 @@ where
         Ok((
             Self {
                 engine: self.engine.clone(),
-                session,
+                session: Arc::new(session),
             },
             receipt,
         ))

--- a/packages/rs-sdk/tests/send_futures.rs
+++ b/packages/rs-sdk/tests/send_futures.rs
@@ -1,0 +1,101 @@
+use lix_sdk::{ExecuteBatchStatement, Lix, OpenLixOptions, open_lix};
+
+fn assert_send<T: Send>(_: T) {}
+fn assert_send_sync<T: Send + Sync>() {}
+
+#[tokio::test]
+async fn public_execution_and_observation_futures_are_send() {
+    let lix = open_lix(OpenLixOptions::default()).await.expect("open Lix");
+    assert_send_sync::<Lix>();
+
+    assert_send(lix.execute("SELECT 1", &[]));
+    assert_send(lix.execute_batch(&[ExecuteBatchStatement {
+        sql: "SELECT 1".to_owned(),
+        params: Vec::new(),
+    }]));
+    assert_send(lix.begin_transaction());
+
+    let mut events = lix.observe("SELECT 1", &[]).expect("observe query");
+    assert_send(events.next());
+
+    let mut transaction = lix.begin_transaction().await.expect("begin transaction");
+    assert_send(transaction.execute("SELECT 1", &[]));
+    assert_send(transaction.commit());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cloned_lix_queries_and_independent_observers_spawn_on_tokio() {
+    let lix = open_lix(OpenLixOptions::default()).await.expect("open Lix");
+    let query_lix = lix.clone();
+    let query = tokio::spawn(async move {
+        for _ in 0..32 {
+            query_lix.execute("SELECT 1", &[]).await?;
+        }
+        Ok::<_, lix_sdk::LixError>(())
+    });
+
+    let mut first = lix.observe("SELECT 1", &[]).expect("first observer");
+    let mut second = lix.observe("SELECT 2", &[]).expect("second observer");
+    let first = tokio::spawn(async move { first.next().await });
+    let second = tokio::spawn(async move { second.next().await });
+
+    query
+        .await
+        .expect("query task should join")
+        .expect("queries");
+    assert!(
+        first
+            .await
+            .expect("first observer task should join")
+            .expect("first observer next")
+            .is_some()
+    );
+    assert!(
+        second
+            .await
+            .expect("second observer task should join")
+            .expect("second observer next")
+            .is_some()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancelling_and_closing_spawned_observers_is_deterministic() {
+    let lix = open_lix(OpenLixOptions::default()).await.expect("open Lix");
+
+    let mut cancelled_events = lix.observe("SELECT 1", &[]).expect("cancel observer");
+    cancelled_events
+        .next()
+        .await
+        .expect("initial cancel observer next")
+        .expect("initial cancel observer event");
+    let cancelled = tokio::spawn(async move { cancelled_events.next().await });
+    tokio::task::yield_now().await;
+    cancelled.abort();
+    assert!(
+        cancelled
+            .await
+            .expect_err("cancelled observer task should not complete")
+            .is_cancelled()
+    );
+    lix.execute("SELECT 1", &[])
+        .await
+        .expect("session remains usable after observer cancellation");
+
+    let mut closing_events = lix.observe("SELECT 2", &[]).expect("closing observer");
+    closing_events
+        .next()
+        .await
+        .expect("initial closing observer next")
+        .expect("initial closing observer event");
+    let closing = tokio::spawn(async move { closing_events.next().await });
+    tokio::task::yield_now().await;
+    lix.close().await.expect("close Lix");
+    assert!(
+        closing
+            .await
+            .expect("closing observer task should join")
+            .expect("closing observer next")
+            .is_none()
+    );
+}

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -5007,7 +5007,7 @@ mod tests {
         let router = handler(server);
         let (session_id, _) = new_session(&router).await;
 
-        prime_external_observe_watcher(&router, &session_id).await;
+        let _priming_observer = prime_external_observe_watcher(&router, &session_id).await;
         let _paused_watcher = storage.pause_next_read();
         tokio::time::timeout(Duration::from_secs(1), storage.wait_for_paused_read())
             .await
@@ -5096,7 +5096,7 @@ mod tests {
         let router = handler(server);
         let (session_id, _) = new_session(&router).await;
 
-        prime_external_observe_watcher(&router, &session_id).await;
+        let _priming_observer = prime_external_observe_watcher(&router, &session_id).await;
         let _paused_watcher = storage.pause_next_read();
         tokio::time::timeout(Duration::from_secs(1), storage.wait_for_paused_read())
             .await
@@ -5141,7 +5141,7 @@ mod tests {
         );
     }
 
-    async fn prime_external_observe_watcher(router: &Router, session_id: &str) {
+    async fn prime_external_observe_watcher(router: &Router, session_id: &str) -> Body {
         let response = request(
             router,
             "POST",
@@ -5157,6 +5157,7 @@ mod tests {
             .expect("priming observe should produce an initial frame")
             .expect("priming observe stream should not end immediately")
             .expect("priming observe initial frame should be valid");
+        body
     }
 
     async fn app() -> TestApp {


### PR DESCRIPTION
Closes #1134.

## What changed

- make `Lix` cheaply clonable by sharing the engine and session context through `Arc`
- make public query, batch, transaction, commit, observer, and observer-next futures `Send`
- replace boxed write-transaction callback shims with lending async closures throughout the engine
- make observer cancellation and session close deterministic, including close during initial evaluation
- keep external revision detection shared per engine and active only while observers exist
- add compile-time and Tokio-spawn integration tests for the full Rust SDK contract

## Performance

- removes one allocation and dynamic dispatch from each implicit write transaction
- keeps cloning to two `Arc` increments rather than cloning storage state
- preserves the strategic transaction-open and commit boxes that bound async stack growth
- boxes only the rare recursive mixed/direct history fallback
- keeps observer wakeups event-driven; native external-change detection uses one shared 250 ms watcher per active engine and stops after the last subscription closes

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo +nightly test -Z bindeps -p lix_sdk --no-default-features --test send_futures` (3 passed)
- focused observer close/quiescence regressions (2 passed)
- `cargo +nightly test -Z bindeps -p lix_engine --features all-simulations` (1,830 unit passed, 8 ignored; 806 integration passed, 2 ignored; 3 doctests passed)

Reviewed independently for correctness/concurrency, performance, and API/test coverage by three sub-agents.
