### PR TITLE
Publish certified replacement generations for dense updates

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
@@ -159,7 +159,7 @@ enum FixtureShape {
     Olap,
 }
 
-enum LiteralUpdateWorkload {
+enum UpdateWorkload {
     Transaction(Vec<String>),
     ExecuteBatch(Vec<ExecuteBatchStatement>),
 }
@@ -192,7 +192,7 @@ pub(crate) struct GenericSqlFixture<StorageImpl: Storage + 'static> {
     select_many_by_pk_sql: String,
     select_one_by_pk_sql: String,
     update_one_by_pk_sql: String,
-    update_all_workload: LiteralUpdateWorkload,
+    update_all_workload: UpdateWorkload,
     bound_update_all_batch: SharedParameterBatch,
     delete_all_sql: String,
     delete_one_by_pk_sql: String,
@@ -938,10 +938,10 @@ where
     #[expect(clippy::cast_possible_truncation)]
     async fn update_all(&self) -> usize {
         let affected = match &self.update_all_workload {
-            LiteralUpdateWorkload::Transaction(statements) => {
+            UpdateWorkload::Transaction(statements) => {
                 Box::pin(execute_many_in_transaction(&self.session, statements)).await
             }
-            LiteralUpdateWorkload::ExecuteBatch(statements) => self
+            UpdateWorkload::ExecuteBatch(statements) => self
                 .session
                 .execute_batch(statements)
                 .await
@@ -1111,7 +1111,7 @@ where
         ),
         select_one_by_pk_sql: select_by_pk_sql(&tracked_rows[mid..][..1]),
         update_one_by_pk_sql: update_row_sql(&tracked_rows[mid]),
-        update_all_workload: literal_update_workload(shape, tracked_rows),
+        update_all_workload: update_workload(shape, tracked_rows),
         bound_update_all_batch: if matches!(shape, FixtureShape::FullCrud) {
             tracked_rows
                 .iter()
@@ -1483,24 +1483,41 @@ fn assert_close(actual: f64, expected: f64) {
     );
 }
 
-fn literal_update_workload(shape: FixtureShape, rows: &[WorkloadRow]) -> LiteralUpdateWorkload {
+fn update_workload(shape: FixtureShape, rows: &[WorkloadRow]) -> UpdateWorkload {
     if !matches!(shape, FixtureShape::FullCrud) {
-        return LiteralUpdateWorkload::Transaction(Vec::new());
+        return UpdateWorkload::Transaction(Vec::new());
     }
     match std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_UPDATE_API").as_deref() {
-        Ok("execute_batch") => LiteralUpdateWorkload::ExecuteBatch(
-            rows.iter()
-                .map(|row| ExecuteBatchStatement {
-                    sql: update_row_sql(row),
-                    params: Vec::new(),
-                })
-                .collect(),
-        ),
+        Ok("execute_batch") => UpdateWorkload::ExecuteBatch(literal_update_batch(rows)),
+        Ok("execute_batch_parameterized") => {
+            UpdateWorkload::ExecuteBatch(parameterized_update_batch(rows))
+        }
         Ok(other) => panic!(
-            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_UPDATE_API '{other}'; expected execute_batch"
+            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_UPDATE_API '{other}'; expected execute_batch or execute_batch_parameterized"
         ),
-        Err(_) => LiteralUpdateWorkload::Transaction(rows.iter().map(update_row_sql).collect()),
+        Err(_) => UpdateWorkload::Transaction(rows.iter().map(update_row_sql).collect()),
     }
+}
+
+fn parameterized_update_batch(rows: &[WorkloadRow]) -> Vec<ExecuteBatchStatement> {
+    rows.iter()
+        .map(|row| ExecuteBatchStatement {
+            sql: BOUND_UPDATE_ALL_SQL.to_string(),
+            params: vec![
+                Value::Text(row.updated_value_json.clone()),
+                Value::Text(row.path.clone()),
+            ],
+        })
+        .collect()
+}
+
+fn literal_update_batch(rows: &[WorkloadRow]) -> Vec<ExecuteBatchStatement> {
+    rows.iter()
+        .map(|row| ExecuteBatchStatement {
+            sql: update_row_sql(row),
+            params: Vec::new(),
+        })
+        .collect()
 }
 
 /// Profile-only unified-current-state fixture switch. `one_unrelated` keeps

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -1378,6 +1378,10 @@ struct HeadValueView<'a> {
 }
 
 impl CertifiedCurrentStatePredecessor {
+    pub(crate) fn created_at(&self) -> Result<LixTimestamp, LixError> {
+        Ok(self.view()?.created_at)
+    }
+
     fn view(&self) -> Result<HeadValueView<'_>, LixError> {
         match self {
             Self::Encoded(bytes) => decode_head_value(bytes),

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -6956,7 +6956,7 @@ mod tests {
 
     #[tokio::test]
     async fn complete_replacement_publishes_packed_current_base_and_accepts_later_overlays() {
-        const ROW_COUNT: usize = 1_024;
+        const ROW_COUNT: usize = 32 * 1_024;
         let session = open_session().await;
         let schema = serde_json::json!({
             "x-lix-key": "packed_replacement_probe",
@@ -6987,7 +6987,7 @@ mod tests {
             .map(|row_index| ExecuteBatchStatement {
                 sql: insert_sql.to_string(),
                 params: vec![
-                    Value::Text(format!("/{row_index:04}")),
+                    Value::Text(format!("/{row_index:05}")),
                     Value::Text(format!(r#"{{"old":{row_index}}}"#)),
                 ],
             })
@@ -6995,6 +6995,7 @@ mod tests {
         session.execute_batch(&inserts).await.unwrap();
 
         crate::transaction::take_complete_replacement_packed_current_base_publications();
+        crate::transaction::take_rootless_replacement_generation_publications();
         sql2::take_certified_generation_identity_replacements();
         let update_sql = "UPDATE packed_replacement_probe SET value = lix_json($1) WHERE path = $2";
         let updates = (0..ROW_COUNT)
@@ -7002,7 +7003,7 @@ mod tests {
                 sql: update_sql.to_string(),
                 params: vec![
                     Value::Text(format!(r#"{{"updated":{row_index}}}"#)),
-                    Value::Text(format!("/{row_index:04}")),
+                    Value::Text(format!("/{row_index:05}")),
                 ],
             })
             .collect::<Vec<_>>();
@@ -7024,6 +7025,210 @@ mod tests {
             1,
             "the certified full replacement must publish one packed current base"
         );
+        assert_eq!(
+            crate::transaction::take_rootless_replacement_generation_publications(),
+            1,
+            "the certified replacement must publish a rootless partition generation"
+        );
+
+        let update_commit_id = session
+            .execute("SELECT commit_id FROM lix_branch WHERE name = 'main'", &[])
+            .await
+            .unwrap()
+            .rows()[0]
+            .get::<String>("commit_id")
+            .unwrap();
+        let read = session
+            .storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .unwrap();
+        let historical = session
+            .tracked_state
+            .reader(read)
+            .scan_batch_at_commit(
+                &update_commit_id,
+                &crate::tracked_state::TrackedStateScanRequest {
+                    filter: crate::tracked_state::TrackedStateFilter {
+                        schema_keys: vec!["packed_replacement_probe".to_string()],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(historical.len(), ROW_COUNT);
+        assert!(
+            historical
+                .iter()
+                .all(|row| row.snapshot_content().is_some_and(|snapshot| {
+                    snapshot.contains("updated") && !snapshot.contains("old")
+                })),
+            "historical replay must stop at the replacement generation"
+        );
+        let read = session
+            .storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .unwrap();
+        let historical_all = session
+            .tracked_state
+            .reader(read)
+            .scan_batch_at_commit(
+                &update_commit_id,
+                &crate::tracked_state::TrackedStateScanRequest::default(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            historical_all
+                .iter()
+                .filter(|row| row.schema_key() == "packed_replacement_probe")
+                .count(),
+            ROW_COUNT,
+            "an unfiltered replay must compose the replacement with inherited partitions"
+        );
+        assert!(
+            historical_all
+                .iter()
+                .any(|row| row.schema_key() == "lix_registered_schema"),
+            "the replacement generation must retain unrelated durable partitions"
+        );
+
+        let mut rebuild_writes = session.storage.new_write_set();
+        {
+            let read = session
+                .storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .unwrap();
+            session
+                .tracked_state
+                .root_rebuilder(&read, &mut rebuild_writes)
+                .rebuild_commit_root_at(&update_commit_id)
+                .await
+                .unwrap();
+        }
+        session
+            .storage
+            .commit_write_set(rebuild_writes, StorageWriteOptions::default())
+            .await
+            .unwrap();
+        let read = session
+            .storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .unwrap();
+        let rebuilt = session
+            .tracked_state
+            .reader(read)
+            .scan_batch_at_commit(
+                &update_commit_id,
+                &crate::tracked_state::TrackedStateScanRequest {
+                    filter: crate::tracked_state::TrackedStateFilter {
+                        schema_keys: vec!["packed_replacement_probe".to_string()],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let rebuilt_rows = rebuilt.into_rows();
+        let historical_rows = historical.into_rows();
+        assert_eq!(rebuilt_rows.len(), historical_rows.len());
+        for (row_index, (rebuilt_row, historical_row)) in
+            rebuilt_rows.iter().zip(&historical_rows).enumerate()
+        {
+            assert_eq!(
+                rebuilt_row, historical_row,
+                "rebuilt replacement row {row_index} must equal replayed state"
+            );
+        }
+
+        crate::transaction::take_rootless_replacement_generation_publications();
+        let second_updates = (0..ROW_COUNT)
+            .map(|row_index| ExecuteBatchStatement {
+                sql: update_sql.to_string(),
+                params: vec![
+                    Value::Text(format!(r#"{{"second":{row_index}}}"#)),
+                    Value::Text(format!("/{row_index:05}")),
+                ],
+            })
+            .collect::<Vec<_>>();
+        session.execute_batch(&second_updates).await.unwrap();
+        assert_eq!(
+            crate::transaction::take_rootless_replacement_generation_publications(),
+            1,
+            "a repeated replacement must collapse to one generation over the same durable fallback"
+        );
+        let second_commit_id = session
+            .execute("SELECT commit_id FROM lix_branch WHERE name = 'main'", &[])
+            .await
+            .unwrap()
+            .rows()[0]
+            .get::<String>("commit_id")
+            .unwrap();
+        for (before, after) in [
+            (&update_commit_id, &second_commit_id),
+            (&second_commit_id, &update_commit_id),
+        ] {
+            let diff = session
+                .execute(
+                    "SELECT COUNT(*) AS entries FROM lix_diff($1, $2) \
+                     WHERE schema_key = 'packed_replacement_probe' AND diff_type = 'modified'",
+                    &[Value::Text(before.clone()), Value::Text(after.clone())],
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                diff.rows()[0].get::<i64>("entries").unwrap(),
+                ROW_COUNT as i64,
+                "replacement generations must retain the real commit graph in both diff directions"
+            );
+        }
+        let main_branch_id = session.active_branch_id().await.unwrap();
+        let historical_branch = session
+            .create_branch(crate::CreateBranchOptions {
+                id: Some("01930000-0000-7000-8000-00000000b002".to_string()),
+                name: "replacement-generation-history".to_string(),
+                from_commit_id: Some(update_commit_id.clone()),
+            })
+            .await
+            .unwrap();
+        let (historical_session, _) = session
+            .switch_branch(crate::SwitchBranchOptions {
+                branch_id: historical_branch.id,
+            })
+            .await
+            .unwrap();
+        let historical_points = historical_session
+            .execute(
+                "SELECT path, value FROM packed_replacement_probe \
+                 WHERE path IN ('/00000', '/32767') ORDER BY path",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            historical_points.rows()[0]
+                .get::<serde_json::Value>("value")
+                .unwrap(),
+            serde_json::json!({"updated": 0})
+        );
+        assert_eq!(
+            historical_points.rows()[1]
+                .get::<serde_json::Value>("value")
+                .unwrap(),
+            serde_json::json!({"updated": ROW_COUNT - 1})
+        );
+        let (session, _) = historical_session
+            .switch_branch(crate::SwitchBranchOptions {
+                branch_id: main_branch_id.clone(),
+            })
+            .await
+            .unwrap();
 
         let broad_rows = session
             .execute(
@@ -7037,18 +7242,18 @@ mod tests {
             broad_rows.rows()[0]
                 .get::<serde_json::Value>("value")
                 .unwrap(),
-            serde_json::json!({"updated": 0})
+            serde_json::json!({"second": 0})
         );
         assert_eq!(
             broad_rows.rows()[ROW_COUNT - 1]
                 .get::<serde_json::Value>("value")
                 .unwrap(),
-            serde_json::json!({"updated": ROW_COUNT - 1})
+            serde_json::json!({"second": ROW_COUNT - 1})
         );
 
         let rows = session
             .execute(
-                "SELECT path, value FROM packed_replacement_probe WHERE path IN ('/0000', '/1023') ORDER BY path",
+                "SELECT path, value FROM packed_replacement_probe WHERE path IN ('/00000', '/32767') ORDER BY path",
                 &[],
             )
             .await
@@ -7056,23 +7261,128 @@ mod tests {
         assert_eq!(rows.len(), 2);
         assert_eq!(
             rows.rows()[0].get::<serde_json::Value>("value").unwrap(),
-            serde_json::json!({"updated": 0})
+            serde_json::json!({"second": 0})
         );
         assert_eq!(
             rows.rows()[1].get::<serde_json::Value>("value").unwrap(),
-            serde_json::json!({"updated": 1023})
+            serde_json::json!({"second": ROW_COUNT - 1})
         );
+
+        let merge_base_branch = session
+            .create_branch(crate::CreateBranchOptions {
+                id: Some("01930000-0000-7000-8000-00000000b003".to_string()),
+                name: "replacement-generation-merge".to_string(),
+                from_commit_id: Some(second_commit_id.clone()),
+            })
+            .await
+            .unwrap();
+        let (merge_source, _) = session
+            .switch_branch(crate::SwitchBranchOptions {
+                branch_id: merge_base_branch.id.clone(),
+            })
+            .await
+            .unwrap();
+        merge_source
+            .execute(
+                "UPDATE packed_replacement_probe SET value = lix_json('{\"branch\":true}') WHERE path = '/00000'",
+                &[],
+            )
+            .await
+            .unwrap();
+        let (session, _) = merge_source
+            .switch_branch(crate::SwitchBranchOptions {
+                branch_id: main_branch_id.clone(),
+            })
+            .await
+            .unwrap();
+        session
+            .execute(
+                "UPDATE packed_replacement_probe SET value = lix_json('{\"main\":true}') WHERE path = '/32767'",
+                &[],
+            )
+            .await
+            .unwrap();
+        let merge = session
+            .merge_branch(crate::MergeBranchOptions {
+                source_branch_id: merge_base_branch.id,
+            })
+            .await
+            .unwrap();
+        assert_eq!(merge.outcome, crate::MergeBranchOutcome::MergeCommitted);
+
+        let merged_commit_id = session
+            .execute("SELECT commit_id FROM lix_branch WHERE name = 'main'", &[])
+            .await
+            .unwrap()
+            .rows()[0]
+            .get::<String>("commit_id")
+            .unwrap();
+        let merged_rows = session
+            .execute(
+                "SELECT path, value FROM packed_replacement_probe ORDER BY path",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            merged_rows.len(),
+            ROW_COUNT,
+            "merging sparse descendants of a replacement generation must not lose rows"
+        );
+        assert_eq!(
+            merged_rows.rows()[0]
+                .get::<serde_json::Value>("value")
+                .unwrap(),
+            serde_json::json!({"branch": true})
+        );
+        assert_eq!(
+            merged_rows.rows()[ROW_COUNT - 1]
+                .get::<serde_json::Value>("value")
+                .unwrap(),
+            serde_json::json!({"main": true})
+        );
+        let merged_diff = session
+            .execute(
+                "SELECT COUNT(*) AS entries FROM lix_diff($1, $2) \
+                 WHERE schema_key = 'packed_replacement_probe' AND diff_type = 'modified'",
+                &[
+                    Value::Text(second_commit_id.clone()),
+                    Value::Text(merged_commit_id.clone()),
+                ],
+            )
+            .await
+            .unwrap();
+        assert_eq!(merged_diff.rows()[0].get::<i64>("entries").unwrap(), 2);
+        let merged_history = session
+            .execute(
+                &format!(
+                    "SELECT value FROM packed_replacement_probe_history('{merged_commit_id}') \
+                     WHERE path = '/00000' ORDER BY lixcol_depth"
+                ),
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            merged_history.rows()[0]
+                .get::<serde_json::Value>("value")
+                .unwrap(),
+            serde_json::json!({"branch": true})
+        );
+        assert!(merged_history.rows().iter().any(|row| {
+            row.get::<serde_json::Value>("value").ok() == Some(serde_json::json!({"second": 0}))
+        }));
 
         session
             .execute(
-                "UPDATE packed_replacement_probe SET value = lix_json('{\"overlay\":true}') WHERE path = '/0000'",
+                "UPDATE packed_replacement_probe SET value = lix_json('{\"overlay\":true}') WHERE path = '/00000'",
                 &[],
             )
             .await
             .unwrap();
         session
             .execute(
-                "DELETE FROM packed_replacement_probe WHERE path = '/1023'",
+                "DELETE FROM packed_replacement_probe WHERE path = '/32767'",
                 &[],
             )
             .await
@@ -7085,10 +7395,103 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(rows.len(), ROW_COUNT - 1);
-        assert_eq!(rows.rows()[0].get::<String>("path").unwrap(), "/0000");
+        assert_eq!(rows.rows()[0].get::<String>("path").unwrap(), "/00000");
         assert_eq!(
             rows.rows()[0].get::<serde_json::Value>("value").unwrap(),
             serde_json::json!({"overlay": true})
+        );
+
+        session
+            .execute(
+                "INSERT INTO packed_replacement_probe (path, value) VALUES ('/32767', lix_json('{\"reinserted\":true}'))",
+                &[],
+            )
+            .await
+            .unwrap();
+        let reinsert_commit_id = session
+            .execute("SELECT commit_id FROM lix_branch WHERE name = 'main'", &[])
+            .await
+            .unwrap()
+            .rows()[0]
+            .get::<String>("commit_id")
+            .unwrap();
+        let read = session
+            .storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .unwrap();
+        let reinserted = session
+            .tracked_state
+            .reader(read)
+            .scan_batch_at_commit(
+                &reinsert_commit_id,
+                &crate::tracked_state::TrackedStateScanRequest {
+                    filter: crate::tracked_state::TrackedStateFilter {
+                        schema_keys: vec!["packed_replacement_probe".to_string()],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let reinserted_created_at = reinserted
+            .iter()
+            .find(|row| row.entity_pk().as_single_string().ok() == Some("/32767"))
+            .expect("reinserted row must be visible")
+            .created_at();
+
+        crate::transaction::take_rootless_replacement_generation_publications();
+        let post_reinsert_updates = (0..ROW_COUNT)
+            .map(|row_index| ExecuteBatchStatement {
+                sql: update_sql.to_string(),
+                params: vec![
+                    Value::Text(format!(r#"{{"post_reinsert":{row_index}}}"#)),
+                    Value::Text(format!("/{row_index:05}")),
+                ],
+            })
+            .collect::<Vec<_>>();
+        session.execute_batch(&post_reinsert_updates).await.unwrap();
+        assert_eq!(
+            crate::transaction::take_rootless_replacement_generation_publications(),
+            0,
+            "a delete/reinsert interval must decline replacement certification without complete lifecycle evidence"
+        );
+        let post_reinsert_commit_id = session
+            .execute("SELECT commit_id FROM lix_branch WHERE name = 'main'", &[])
+            .await
+            .unwrap()
+            .rows()[0]
+            .get::<String>("commit_id")
+            .unwrap();
+        let read = session
+            .storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .unwrap();
+        let post_reinsert = session
+            .tracked_state
+            .reader(read)
+            .scan_batch_at_commit(
+                &post_reinsert_commit_id,
+                &crate::tracked_state::TrackedStateScanRequest {
+                    filter: crate::tracked_state::TrackedStateFilter {
+                        schema_keys: vec!["packed_replacement_probe".to_string()],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            post_reinsert
+                .iter()
+                .find(|row| row.entity_pk().as_single_string().ok() == Some("/32767"))
+                .expect("updated reinserted row must be visible")
+                .created_at(),
+            reinserted_created_at,
+            "full updates must preserve the newer lifecycle of a reinserted identity"
         );
     }
 

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -913,6 +913,7 @@ impl TrackedStateContext {
             point_value_cache: HashMap::new(),
             commit_delta_value_cache: HashMap::new(),
             point_replay_commits: HashMap::new(),
+            commit_delta_point_cache: storage::CommitDeltaPointReadCache::default(),
         }
     }
 
@@ -968,6 +969,9 @@ pub(crate) struct TrackedStateStoreReader<S> {
     /// in one snapshot, so resolving neighbouring observed revisions never
     /// reloads the same changelog records.
     point_replay_commits: HashMap<CommitId, PointReplayCommit>,
+    /// Shares decoded immutable manifests between rootless topology discovery
+    /// and the later delta scan in this storage snapshot.
+    commit_delta_point_cache: storage::CommitDeltaPointReadCache,
 }
 
 struct DiffCommitRootValidationCache {
@@ -983,6 +987,7 @@ struct PointReplayCommit {
     parent_commit_id: Option<CommitId>,
     root_id: Option<TrackedStateRootId>,
     rootless: bool,
+    replacement_generation: Option<storage::CommitDeltaReplacementGeneration>,
 }
 
 /// One immutable first-parent interval shared by every cached suffix view.
@@ -1437,10 +1442,11 @@ where
                     entity_pk: row.entity_pk(),
                 });
             }
-            let loaded = storage::load_commit_delta_values_encoded(
+            let loaded = storage::load_commit_delta_values_encoded_with_cache(
                 &self.store,
                 commit_id,
                 &encoded_keys.finish(),
+                Some(&self.commit_delta_point_cache),
             )
             .await?;
             let mut fallback_rows = Vec::new();
@@ -1460,10 +1466,11 @@ where
                     fallback_rows.push(index);
                 }
             }
-            let fallback_values = storage::load_commit_delta_values_encoded(
+            let fallback_values = storage::load_commit_delta_values_encoded_with_cache(
                 &self.store,
                 commit_id,
                 &fallback_keys.finish(),
+                Some(&self.commit_delta_point_cache),
             )
             .await?;
             let mut fallbacks = vec![None; commit_rows.len()];
@@ -2968,10 +2975,11 @@ where
                 break;
             }
 
-            let deltas = storage::load_commit_delta_values_encoded(
+            let deltas = storage::load_commit_delta_values_encoded_with_cache(
                 &self.store,
                 current_commit_id,
                 &unresolved_keys,
+                Some(&self.commit_delta_point_cache),
             )
             .await?;
 
@@ -2988,10 +2996,11 @@ where
                 descriptor_ordinals.push(ordinal);
                 descriptor_query.push(descriptor_keys[ordinal as usize].clone());
             }
-            let descriptor_deltas = storage::load_commit_delta_values_encoded(
+            let descriptor_deltas = storage::load_commit_delta_values_encoded_with_cache(
                 &self.store,
                 current_commit_id,
                 &descriptor_query,
+                Some(&self.commit_delta_point_cache),
             )
             .await?;
             for (&file_id_ordinal, value) in descriptor_ordinals.iter().zip(descriptor_deltas) {
@@ -3008,6 +3017,13 @@ where
                         _ => Some(delta),
                     };
                 } else {
+                    if let Some(generation) = replay_commit.replacement_generation.as_ref() {
+                        let decoded_key = decode_key_shared(keys[index].clone())?;
+                        if replacement_scope_covers_key(&generation.scope, decoded_key.as_ref()) {
+                            values[index] = None;
+                            continue;
+                        }
+                    }
                     if pending_cascades[index].is_none()
                         && key_file_id_ordinals[index] != u32::MAX
                         && let Some(cascade) = &cascades[key_file_id_ordinals[index] as usize]
@@ -3025,7 +3041,11 @@ where
                 break;
             }
             std::mem::swap(&mut unresolved, &mut next_unresolved);
-            let Some(parent_commit_id) = replay_commit.parent_commit_id else {
+            let replay_parent_commit_id = match replay_commit.replacement_generation.as_ref() {
+                Some(generation) => generation.fallback_commit_id,
+                None => replay_commit.parent_commit_id,
+            };
+            let Some(parent_commit_id) = replay_parent_commit_id else {
                 break;
             };
             current_commit_id = parent_commit_id;
@@ -3110,6 +3130,21 @@ where
                         Some(cascade) if !delta.deleted => Some(cascade_tombstone(cascade, &delta)),
                         _ => Some(delta),
                     };
+                } else if replay_commit
+                    .replacement_generation
+                    .as_ref()
+                    .is_some_and(|generation| {
+                        replacement_scope_covers_key(
+                            &generation.scope,
+                            TrackedStateKeyRef {
+                                schema_key: &keys[index].schema_key,
+                                file_id: keys[index].file_id.as_deref(),
+                                entity_pk: &keys[index].entity_pk,
+                            },
+                        )
+                    })
+                {
+                    values[index] = None;
                 } else {
                     if pending_cascades[index].is_none()
                         && let Some(cascade) = keys[index]
@@ -3126,7 +3161,11 @@ where
                 break;
             }
             unresolved = next_unresolved;
-            let Some(parent_commit_id) = replay_commit.parent_commit_id else {
+            let replay_parent_commit_id = match replay_commit.replacement_generation.as_ref() {
+                Some(generation) => generation.fallback_commit_id,
+                None => replay_commit.parent_commit_id,
+            };
+            let Some(parent_commit_id) = replay_parent_commit_id else {
                 break;
             };
             current_commit_id = parent_commit_id;
@@ -3171,10 +3210,22 @@ where
                     .ok_or_else(|| missing_commit_root_error(&commit_id.to_string()))?,
             )
         };
+        let replacement_generation = if record.tracked_state_rootless {
+            storage::load_commit_delta_replay_metadata_with_cache(
+                &self.store,
+                commit_id,
+                Some(&self.commit_delta_point_cache),
+            )
+            .await?
+            .and_then(|metadata| metadata.replacement_generation)
+        } else {
+            None
+        };
         let replay_commit = PointReplayCommit {
             parent_commit_id: record.parent_commit_ids.first().copied(),
             root_id,
             rootless: record.tracked_state_rootless,
+            replacement_generation,
         };
         self.point_replay_commits
             .insert(commit_id, replay_commit.clone());
@@ -3213,10 +3264,11 @@ where
                 entity_pk: &key.entity_pk,
             });
         }
-        let values = storage::load_commit_delta_values_encoded(
+        let values = storage::load_commit_delta_values_encoded_with_cache(
             &self.store,
             commit_id,
             &encoded_keys.finish(),
+            Some(&self.commit_delta_point_cache),
         )
         .await?;
         for ((index, key), value) in missing.into_iter().zip(values) {
@@ -3237,7 +3289,13 @@ where
         commit_id: CommitId,
         schema_keys: &[String],
     ) -> Result<storage::DecodedCommitDeltaBatch, LixError> {
-        storage::scan_commit_delta_values(&self.store, commit_id, schema_keys).await
+        storage::scan_commit_delta_values_with_cache(
+            &self.store,
+            commit_id,
+            schema_keys,
+            Some(&self.commit_delta_point_cache),
+        )
+        .await
     }
 
     async fn point_replay_interval(
@@ -3269,7 +3327,11 @@ where
                 break Some(root_id);
             }
             commits.push(current_commit_id);
-            let Some(parent_commit_id) = replay_commit.parent_commit_id else {
+            let replay_parent_commit_id = match replay_commit.replacement_generation.as_ref() {
+                Some(generation) => generation.fallback_commit_id,
+                None => replay_commit.parent_commit_id,
+            };
+            let Some(parent_commit_id) = replay_parent_commit_id else {
                 break None;
             };
             if let Some(tail) = self.point_replay_intervals.get(&parent_commit_id) {
@@ -4108,6 +4170,13 @@ fn compare_tracked_state_key_refs(
         .cmp(right.schema_key)
         .then_with(|| left.file_id.cmp(&right.file_id))
         .then_with(|| left.entity_pk.cmp(right.entity_pk))
+}
+
+fn replacement_scope_covers_key(
+    scope: &storage::CommitDeltaReplacementScope,
+    key: TrackedStateKeyRef<'_>,
+) -> bool {
+    scope.schema_key == key.schema_key && scope.file_id.as_deref() == key.file_id
 }
 
 fn schema_keys_with_file_descriptors(schema_keys: &[String]) -> Vec<String> {

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -34,16 +34,17 @@ pub(crate) use row_materialization::{
 };
 pub(crate) use storage::{
     CommitDeltaChangeLocator, CommitDeltaMember, CommitDeltaPointReadCache,
+    CommitDeltaReplacementGeneration, CommitDeltaReplacementScope,
     OrderedAddressableCommitDeltaStage, commit_delta_contains_schema, direct_change_locator,
     load_change_record_by_id, load_commit_delta_change_records,
     load_commit_delta_members_with_payloads, load_commit_delta_members_with_payloads_for_schemas,
-    load_commit_delta_selection_certificate, load_owned_commit_delta_entries,
-    load_owned_commit_delta_entries_one_ordered_ref, scan_change_records_from_commit_deltas,
-    scan_commit_delta_inventory, scan_commit_delta_values, selected_change_selection_fingerprint,
-    stage_addressable_commit_deltas, stage_addressable_commit_deltas_with_selected_source,
-    stage_change_locators, stage_commit_deltas, stage_delete_change_locators,
-    stage_delete_commit_delta_inventory_entry, stage_delete_commit_roots,
-    stage_ordered_addressable_commit_deltas,
+    load_commit_delta_replay_metadata, load_commit_delta_selection_certificate,
+    load_owned_commit_delta_entries, load_owned_commit_delta_entries_one_ordered_ref,
+    scan_change_records_from_commit_deltas, scan_commit_delta_inventory, scan_commit_delta_values,
+    selected_change_selection_fingerprint, stage_addressable_commit_deltas,
+    stage_addressable_commit_deltas_with_selected_source, stage_change_locators,
+    stage_commit_deltas, stage_delete_change_locators, stage_delete_commit_delta_inventory_entry,
+    stage_delete_commit_roots, stage_ordered_addressable_commit_deltas,
 };
 #[cfg(feature = "storage-benches")]
 pub(crate) use storage::{

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -38,9 +38,9 @@ use futures_util::{StreamExt, TryStreamExt, stream};
 pub(crate) const TRACKED_STATE_TREE_CHUNK_NAMESPACE: &str = "tracked_state.tree_chunk";
 pub(crate) const TRACKED_STATE_COMMIT_ROOT_NAMESPACE: &str = "tracked_state.commit_root";
 pub(crate) const TRACKED_STATE_COMMIT_DELTA_MANIFEST_NAMESPACE: &str =
-    "tracked_state.commit_delta_manifest.v3";
+    "tracked_state.commit_delta_manifest.v5";
 pub(crate) const TRACKED_STATE_COMMIT_DELTA_SEGMENT_NAMESPACE: &str =
-    "tracked_state.commit_delta_segment.v3";
+    "tracked_state.commit_delta_segment.v5";
 pub(crate) const TRACKED_STATE_CHANGE_LOCATOR_NAMESPACE: &str = "tracked_state.change_locator.v2";
 pub(crate) const TRACKED_STATE_TREE_CHUNK_SPACE: StorageSpace = StorageSpace::mutable(
     StorageSpaceId(0x0004_0001),
@@ -76,10 +76,10 @@ const COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 512;
 const GENERIC_COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 128;
 const GENERIC_COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 28 * 1024;
 const ORDERED_COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 64 * 1024;
-// Version 10 adds optional columnar-base coordinates to indexed payload
-// records. Reject version 9 as a whole instead of letting coordinate-aware
-// decoders ambiguously interpret its shorter authored/certified records.
-const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD10";
+// Version 12 authenticates authoritative collection-replacement metadata and
+// binds it to its owning commit. Reject version 11 as a whole: accepting an
+// unauthenticated fallback could inherit unrelated state from another commit.
+const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD12";
 const COMMIT_DELTA_PAYLOAD_OFFSET_BYTES: usize = size_of::<u32>();
 #[cfg(not(test))]
 const COMMIT_DELTA_MAX_SIDECAR_BYTES: usize = 64 * 1024 * 1024;
@@ -558,12 +558,63 @@ struct CommitDeltaManifest {
     /// Exact dense address inventory for ordered, fully addressable commits.
     /// An empty column denotes the generic unordered/mixed-address layout.
     direct_segment_row_counts: Vec<u16>,
+    /// Collection partitions for which this commit is an authoritative base
+    /// generation. A miss in one of these scopes must not fall through to a
+    /// first-parent run. This persists the SQL executor's complete-replacement
+    /// certificate without synthesizing one tombstone per predecessor row.
+    #[musli(with = storage_codec::option)]
+    single_partition: Option<CommitDeltaReplacementScope>,
+    #[musli(with = storage_codec::option)]
+    lifecycle_summary: Option<CommitDeltaLifecycleSummary>,
+    #[musli(with = storage_codec::option)]
+    replacement_generation: Option<StoredCommitDeltaReplacementGeneration>,
     /// A complete leaf payload for a commit that fits in one segment. Keeping
     /// it in the directory preserves the one-record shape of tiny commits;
     /// larger commits use the indexed segment list below.
     #[musli(bytes)]
     inline_segment: Vec<u8>,
     segments: Vec<CommitDeltaSegmentBounds>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, musli::Encode, musli::Decode)]
+#[musli(packed)]
+pub(crate) struct CommitDeltaReplacementScope {
+    pub(crate) schema_key: String,
+    #[musli(with = storage_codec::option)]
+    pub(crate) file_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+pub(crate) struct CommitDeltaLifecycleSummary {
+    pub(crate) scope: CommitDeltaReplacementScope,
+    pub(crate) ordered_identity_digest: [u8; 32],
+    pub(crate) uniform_created_at: crate::common::LixTimestamp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+struct StoredCommitDeltaReplacementGeneration {
+    owner_commit_id: [u8; 16],
+    scope: CommitDeltaReplacementScope,
+    #[musli(with = storage_codec::option)]
+    fallback_commit_id: Option<[u8; 16]>,
+    integrity_digest: [u8; 32],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CommitDeltaReplacementGeneration {
+    pub(crate) scope: CommitDeltaReplacementScope,
+    pub(crate) fallback_commit_id: Option<CommitId>,
+    pub(crate) lifecycle_summary: CommitDeltaLifecycleSummary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CommitDeltaReplayMetadata {
+    pub(crate) member_count: u32,
+    pub(crate) single_partition: Option<CommitDeltaReplacementScope>,
+    pub(crate) lifecycle_summary: Option<CommitDeltaLifecycleSummary>,
+    pub(crate) replacement_generation: Option<CommitDeltaReplacementGeneration>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1275,6 +1326,8 @@ pub(crate) fn stage_ordered_addressable_commit_deltas<'a, I>(
     writes: &mut StorageWriteSet,
     deltas: I,
     order_certified: bool,
+    publish_lifecycle_summary: bool,
+    replacement_generation: Option<&CommitDeltaReplacementGeneration>,
 ) -> Result<Option<OrderedAddressableCommitDeltaStage>, LixError>
 where
     I: ExactSizeIterator<Item = Result<TrackedStateCommitDeltaRef<'a>, LixError>> + Clone,
@@ -1315,6 +1368,13 @@ where
         }
     }
 
+    let lifecycle_summary = if let Some(generation) = replacement_generation {
+        Some(generation.lifecycle_summary.clone())
+    } else if publish_lifecycle_summary {
+        lifecycle_summary_for_ordered_deltas(deltas.clone())?
+    } else {
+        None
+    };
     let mut compressor = None;
     let mut source = deltas;
     let mut pending = VecDeque::with_capacity(COMMIT_DELTA_SEGMENT_MAX_ROWS);
@@ -1331,6 +1391,10 @@ where
         direct_segment_row_counts: Vec::with_capacity(
             row_count.div_ceil(COMMIT_DELTA_SEGMENT_MAX_ROWS),
         ),
+        single_partition: None,
+        lifecycle_summary,
+        replacement_generation: replacement_generation
+            .map(|generation| stored_replacement_generation(commit_id, generation)),
         inline_segment: Vec::new(),
         segments: Vec::with_capacity(row_count.div_ceil(COMMIT_DELTA_SEGMENT_MAX_ROWS)),
     };
@@ -1405,6 +1469,22 @@ where
         );
     }
 
+    manifest.single_partition = if segment_row_counts.len() == 1 {
+        let (bounds, _) = first_segment
+            .as_ref()
+            .expect("one ordered segment remains available for partition certification");
+        single_partition_from_bounds(&bounds.first_key, &bounds.last_key)?
+    } else {
+        let first = manifest
+            .segments
+            .first()
+            .expect("multi-segment ordered commit has first bounds");
+        let last = manifest
+            .segments
+            .last()
+            .expect("multi-segment ordered commit has last bounds");
+        single_partition_from_bounds(&first.first_key, &last.last_key)?
+    };
     if segment_row_counts.len() == 1 {
         let (_, inline_segment) = first_segment
             .take()
@@ -1449,6 +1529,99 @@ where
     }))
 }
 
+fn lifecycle_summary_for_ordered_deltas<'a, I>(
+    deltas: I,
+) -> Result<Option<CommitDeltaLifecycleSummary>, LixError>
+where
+    I: Iterator<Item = Result<TrackedStateCommitDeltaRef<'a>, LixError>>,
+{
+    let mut hasher = blake3::Hasher::new();
+    let mut scope = None::<(&'a str, Option<&'a str>)>;
+    let mut uniform_created_at = None;
+    for delta in deltas {
+        let delta = delta?;
+        if delta.delta.deleted {
+            return Ok(None);
+        }
+        let candidate_scope = (delta.delta.schema_key, delta.delta.file_id);
+        if scope.is_some_and(|scope| scope != candidate_scope) {
+            return Ok(None);
+        }
+        scope.get_or_insert(candidate_scope);
+        if uniform_created_at.is_some_and(|created_at| created_at != delta.delta.created_at) {
+            return Ok(None);
+        }
+        uniform_created_at.get_or_insert(delta.delta.created_at);
+        let Ok(identity) = delta.delta.entity_pk.as_single_string() else {
+            return Ok(None);
+        };
+        hasher.update(&(identity.len() as u64).to_le_bytes());
+        hasher.update(identity.as_bytes());
+    }
+    Ok(scope
+        .zip(uniform_created_at)
+        .map(
+            |((schema_key, file_id), uniform_created_at)| CommitDeltaLifecycleSummary {
+                scope: CommitDeltaReplacementScope {
+                    schema_key: schema_key.to_string(),
+                    file_id: file_id.map(str::to_string),
+                },
+                ordered_identity_digest: *hasher.finalize().as_bytes(),
+                uniform_created_at,
+            },
+        ))
+}
+
+fn stored_replacement_generation(
+    owner_commit_id: CommitId,
+    generation: &CommitDeltaReplacementGeneration,
+) -> StoredCommitDeltaReplacementGeneration {
+    let mut stored = StoredCommitDeltaReplacementGeneration {
+        owner_commit_id: *owner_commit_id.as_uuid().as_bytes(),
+        scope: generation.scope.clone(),
+        fallback_commit_id: generation
+            .fallback_commit_id
+            .map(|commit_id| *commit_id.as_uuid().as_bytes()),
+        integrity_digest: [0; 32],
+    };
+    stored.integrity_digest =
+        replacement_generation_integrity_digest(&stored, &generation.lifecycle_summary);
+    stored
+}
+
+fn replacement_generation_integrity_digest(
+    generation: &StoredCommitDeltaReplacementGeneration,
+    lifecycle_summary: &CommitDeltaLifecycleSummary,
+) -> [u8; 32] {
+    let mut digest =
+        blake3::Hasher::new_derive_key("lix tracked-state replacement generation certificate v1");
+    digest.update(&generation.owner_commit_id);
+    digest.update(&(generation.scope.schema_key.len() as u64).to_be_bytes());
+    digest.update(generation.scope.schema_key.as_bytes());
+    match generation.scope.file_id.as_deref() {
+        Some(file_id) => {
+            digest.update(&[1]);
+            digest.update(&(file_id.len() as u64).to_be_bytes());
+            digest.update(file_id.as_bytes());
+        }
+        None => {
+            digest.update(&[0]);
+        }
+    }
+    match generation.fallback_commit_id {
+        Some(fallback_commit_id) => {
+            digest.update(&[1]);
+            digest.update(&fallback_commit_id);
+        }
+        None => {
+            digest.update(&[0]);
+        }
+    }
+    digest.update(&lifecycle_summary.ordered_identity_digest);
+    digest.update(&lifecycle_summary.uniform_created_at.packed().to_be_bytes());
+    *digest.finalize().as_bytes()
+}
+
 fn compare_tracked_state_key_refs(
     left: TrackedStateKeyRef<'_>,
     right: TrackedStateKeyRef<'_>,
@@ -1457,6 +1630,32 @@ fn compare_tracked_state_key_refs(
         .cmp(right.schema_key)
         .then_with(|| left.file_id.cmp(&right.file_id))
         .then_with(|| left.entity_pk.cmp(right.entity_pk))
+}
+
+fn single_partition_for_entries(
+    entries: &[EncodedLeafEntry],
+) -> Result<Option<CommitDeltaReplacementScope>, LixError> {
+    let Some(first) = entries.first() else {
+        return Ok(None);
+    };
+    let last = entries.last().expect("non-empty entries have a last key");
+    single_partition_from_bounds(&first.key, &last.key)
+}
+
+fn single_partition_from_bounds(
+    first_key: &[u8],
+    last_key: &[u8],
+) -> Result<Option<CommitDeltaReplacementScope>, LixError> {
+    let first = decode_key(first_key)?;
+    let last = decode_key(last_key)?;
+    Ok(
+        (first.schema_key == last.schema_key && first.file_id == last.file_id).then_some(
+            CommitDeltaReplacementScope {
+                schema_key: first.schema_key,
+                file_id: first.file_id,
+            },
+        ),
+    )
 }
 
 fn encode_ordered_addressable_commit_delta_segment<'a>(
@@ -1689,6 +1888,9 @@ fn stage_commit_deltas_inner(
                 member_count,
                 selection_fingerprint,
                 direct_segment_row_counts: Vec::new(),
+                single_partition: single_partition_for_entries(&entries)?,
+                lifecycle_summary: None,
+                replacement_generation: None,
                 inline_segment,
                 segments: Vec::new(),
             })?),
@@ -1710,6 +1912,9 @@ fn stage_commit_deltas_inner(
         member_count,
         selection_fingerprint,
         direct_segment_row_counts: Vec::new(),
+        single_partition: single_partition_for_entries(&entries)?,
+        lifecycle_summary: None,
+        replacement_generation: None,
         inline_segment: Vec::new(),
         segments: Vec::with_capacity(segment_count),
     };
@@ -2051,7 +2256,10 @@ async fn load_change_records_at_locators(
                     ),
                 )
             })?;
-            Ok((commit_id, decode_commit_delta_manifest(&bytes)?))
+            Ok((
+                commit_id,
+                decode_commit_delta_manifest_for_commit(&bytes, commit_id)?,
+            ))
         })
         .collect::<Result<BTreeMap<_, _>, LixError>>()?;
 
@@ -2470,23 +2678,47 @@ fn decode_locator_varint(bytes: &[u8], cursor: &mut usize) -> Option<u64> {
 /// Callers may pass `Bytes` slices that retain decoded commit-delta arenas, so
 /// replay does not need to allocate schema/file strings merely to perform a
 /// point lookup.
+#[cfg(test)]
 pub(crate) async fn load_commit_delta_values_encoded(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
     encoded_keys: &[Bytes],
 ) -> Result<Vec<Option<TrackedStateIndexValue>>, LixError> {
-    let Some(manifest) = load_commit_delta_manifest(store, commit_id).await? else {
+    load_commit_delta_values_encoded_with_cache(store, commit_id, encoded_keys, None).await
+}
+
+pub(crate) async fn load_commit_delta_values_encoded_with_cache(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+    encoded_keys: &[Bytes],
+    point_cache: Option<&CommitDeltaPointReadCache>,
+) -> Result<Vec<Option<TrackedStateIndexValue>>, LixError> {
+    let Some(manifest) = load_commit_delta_manifest_cached(store, commit_id, point_cache).await?
+    else {
         return Ok(vec![None; encoded_keys.len()]);
     };
     let Some(source_commit_id) = manifest.selected_source_commit_id() else {
-        return load_local_commit_delta_values_encoded(store, commit_id, encoded_keys).await;
+        return load_local_commit_delta_values_encoded(store, commit_id, encoded_keys, &manifest)
+            .await;
     };
     let mut values =
-        load_local_commit_delta_values_encoded(store, source_commit_id, encoded_keys).await?;
+        match load_commit_delta_manifest_cached(store, source_commit_id, point_cache).await? {
+            Some(source_manifest) => {
+                load_local_commit_delta_values_encoded(
+                    store,
+                    source_commit_id,
+                    encoded_keys,
+                    &source_manifest,
+                )
+                .await?
+            }
+            None => vec![None; encoded_keys.len()],
+        };
     for value in values.iter_mut().flatten() {
         value.commit_id = commit_id;
     }
-    let local = load_local_commit_delta_values_encoded(store, commit_id, encoded_keys).await?;
+    let local =
+        load_local_commit_delta_values_encoded(store, commit_id, encoded_keys, &manifest).await?;
     for (value, local) in values.iter_mut().zip(local) {
         if local.is_some() {
             *value = local;
@@ -2499,14 +2731,12 @@ async fn load_local_commit_delta_values_encoded(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
     encoded_keys: &[Bytes],
+    manifest: &CommitDeltaManifest,
 ) -> Result<Vec<Option<TrackedStateIndexValue>>, LixError> {
     if encoded_keys.is_empty() {
         return Ok(Vec::new());
     }
     let mut values = vec![None; encoded_keys.len()];
-    let Some(manifest) = load_commit_delta_manifest(store, commit_id).await? else {
-        return Ok(values);
-    };
     if let Some(inline_segment) = manifest.inline_segment() {
         let leaf = decode_commit_delta_segment(inline_segment, None, commit_id)?;
         for (output_index, encoded_key) in encoded_keys.iter().enumerate() {
@@ -2519,7 +2749,7 @@ async fn load_local_commit_delta_values_encoded(
     // arena; rows retain only their output ordinal.
     let mut lookups = Vec::<(usize, usize)>::with_capacity(encoded_keys.len());
     for (output_index, encoded_key) in encoded_keys.iter().enumerate() {
-        if let Some(segment_index) = commit_delta_segment_for_key(&manifest, encoded_key) {
+        if let Some(segment_index) = commit_delta_segment_for_key(manifest, encoded_key) {
             lookups.push((segment_index, output_index));
         }
     }
@@ -2973,7 +3203,10 @@ pub(crate) async fn load_owned_commit_delta_entries(
         let Some(bytes) = value.and_then(full_value_bytes) else {
             continue;
         };
-        owner_manifests.insert(commit_id, decode_commit_delta_manifest(&bytes)?);
+        owner_manifests.insert(
+            commit_id,
+            decode_commit_delta_manifest_for_commit(&bytes, commit_id)?,
+        );
     }
     let mut source_requests = Vec::new();
     let mut source_outputs = Vec::new();
@@ -3107,7 +3340,7 @@ async fn load_local_owned_commit_delta_entries(
         let Some(bytes) = manifest_value.and_then(full_value_bytes) else {
             continue;
         };
-        let manifest = decode_commit_delta_manifest(&bytes)?;
+        let manifest = decode_commit_delta_manifest_for_commit(&bytes, commit_id)?;
         let request_indices = request_indices_by_commit
             .get(&commit_id)
             .expect("manifest commit came from the requested commit set");
@@ -3225,7 +3458,7 @@ async fn load_local_owned_commit_delta_entries_one_ordered(
             else {
                 return Ok((0..keys.len()).map(|_| None).collect());
             };
-            let manifest = decode_commit_delta_manifest(&bytes)?;
+            let manifest = decode_commit_delta_manifest_for_commit(&bytes, commit_id)?;
             match point_cache {
                 Some(cache) => {
                     let manifest = Arc::new(manifest);
@@ -3658,14 +3891,32 @@ pub(crate) async fn scan_commit_delta_values(
     commit_id: CommitId,
     schema_keys: &[String],
 ) -> Result<DecodedCommitDeltaBatch, LixError> {
-    let Some(manifest) = load_commit_delta_manifest(store, commit_id).await? else {
+    scan_commit_delta_values_with_cache(store, commit_id, schema_keys, None).await
+}
+
+pub(crate) async fn scan_commit_delta_values_with_cache(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+    schema_keys: &[String],
+    point_cache: Option<&CommitDeltaPointReadCache>,
+) -> Result<DecodedCommitDeltaBatch, LixError> {
+    let Some(manifest) = load_commit_delta_manifest_cached(store, commit_id, point_cache).await?
+    else {
         return Ok(DecodedCommitDeltaBatch::default());
     };
     let Some(source_commit_id) = manifest.selected_source_commit_id() else {
-        return scan_local_commit_delta_values(store, commit_id, schema_keys).await;
+        return scan_local_commit_delta_values(store, commit_id, schema_keys, &manifest).await;
     };
-    let source = scan_local_commit_delta_values(store, source_commit_id, schema_keys).await?;
-    let local = scan_local_commit_delta_values(store, commit_id, schema_keys).await?;
+    let source = match load_commit_delta_manifest_cached(store, source_commit_id, point_cache)
+        .await?
+    {
+        Some(source_manifest) => {
+            scan_local_commit_delta_values(store, source_commit_id, schema_keys, &source_manifest)
+                .await?
+        }
+        None => DecodedCommitDeltaBatch::default(),
+    };
+    let local = scan_local_commit_delta_values(store, commit_id, schema_keys, &manifest).await?;
     merge_selected_source_batches(source, local, commit_id)
 }
 
@@ -3673,10 +3924,8 @@ async fn scan_local_commit_delta_values(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
     schema_keys: &[String],
+    manifest: &CommitDeltaManifest,
 ) -> Result<DecodedCommitDeltaBatch, LixError> {
-    let Some(manifest) = load_commit_delta_manifest(store, commit_id).await? else {
-        return Ok(DecodedCommitDeltaBatch::default());
-    };
     let requested_schemas = schema_keys
         .iter()
         .map(String::as_str)
@@ -3687,7 +3936,7 @@ async fn scan_local_commit_delta_values(
         batch.push_leaf(leaf, commit_id, &requested_schemas)?;
         return Ok(batch.finish());
     }
-    let segment_indices = commit_delta_segments_for_schemas(&manifest, &requested_schemas);
+    let segment_indices = commit_delta_segments_for_schemas(manifest, &requested_schemas);
     if segment_indices.is_empty() {
         return Ok(DecodedCommitDeltaBatch::default());
     }
@@ -3915,7 +4164,7 @@ pub(crate) async fn visit_change_records_from_commit_deltas(
                 unreachable!("full commit-delta scan returned a key-only row");
             };
             let commit_id = commit_id_from_delta_key(&entry.key)?;
-            let manifest = decode_commit_delta_manifest(bytes)?;
+            let manifest = decode_commit_delta_manifest_for_commit(bytes, commit_id)?;
             let members =
                 load_commit_delta_members_from_manifest(store, commit_id, &manifest, &[]).await?;
             for member in members {
@@ -4017,7 +4266,7 @@ async fn validate_no_orphan_commit_delta_segments(
             .map(|(commit_id, value)| {
                 value
                     .and_then(full_value_bytes)
-                    .map(|bytes| decode_commit_delta_manifest(&bytes))
+                    .map(|bytes| decode_commit_delta_manifest_for_commit(&bytes, commit_id))
                     .transpose()
                     .map(|manifest| (commit_id, manifest))
             })
@@ -4190,7 +4439,7 @@ async fn scan_commit_delta_plane(
             ));
         }
         let commit_id = commit_id_from_delta_key(&key)?;
-        let manifest = decode_commit_delta_manifest(&bytes)?;
+        let manifest = decode_commit_delta_manifest_for_commit(&bytes, commit_id)?;
         if manifests.insert(commit_id, manifest).is_some() {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
@@ -4553,6 +4802,44 @@ pub(crate) async fn load_commit_delta_selection_certificate(
         }))
 }
 
+pub(crate) async fn load_commit_delta_replay_metadata(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+) -> Result<Option<CommitDeltaReplayMetadata>, LixError> {
+    load_commit_delta_replay_metadata_with_cache(store, commit_id, None).await
+}
+
+pub(crate) async fn load_commit_delta_replay_metadata_with_cache(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+    point_cache: Option<&CommitDeltaPointReadCache>,
+) -> Result<Option<CommitDeltaReplayMetadata>, LixError> {
+    Ok(
+        load_commit_delta_manifest_cached(store, commit_id, point_cache)
+            .await?
+            .map(|manifest| commit_delta_replay_metadata(&manifest)),
+    )
+}
+
+fn commit_delta_replay_metadata(manifest: &CommitDeltaManifest) -> CommitDeltaReplayMetadata {
+    let lifecycle_summary = manifest.lifecycle_summary.clone();
+    CommitDeltaReplayMetadata {
+        member_count: manifest.member_count,
+        single_partition: manifest.single_partition.clone(),
+        lifecycle_summary: lifecycle_summary.clone(),
+        replacement_generation: manifest.replacement_generation.as_ref().map(|generation| {
+            CommitDeltaReplacementGeneration {
+                scope: generation.scope.clone(),
+                fallback_commit_id: generation
+                    .fallback_commit_id
+                    .map(|bytes| CommitId::new(uuid::Uuid::from_bytes(bytes))),
+                lifecycle_summary: lifecycle_summary
+                    .expect("validated replacement generation has lifecycle metadata"),
+            }
+        }),
+    }
+}
+
 fn decode_commit_delta_manifest(bytes: &[u8]) -> Result<CommitDeltaManifest, LixError> {
     let Some(payload) = bytes.strip_prefix(COMMIT_DELTA_FORMAT_MAGIC) else {
         return Err(LixError::new(
@@ -4562,6 +4849,24 @@ fn decode_commit_delta_manifest(bytes: &[u8]) -> Result<CommitDeltaManifest, Lix
     };
     let manifest = storage_codec::decode("tracked_state packed commit_delta manifest", payload)?;
     validate_commit_delta_manifest(&manifest)?;
+    Ok(manifest)
+}
+
+fn decode_commit_delta_manifest_for_commit(
+    bytes: &[u8],
+    commit_id: CommitId,
+) -> Result<CommitDeltaManifest, LixError> {
+    let manifest = decode_commit_delta_manifest(bytes)?;
+    if manifest
+        .replacement_generation
+        .as_ref()
+        .is_some_and(|generation| generation.owner_commit_id != *commit_id.as_uuid().as_bytes())
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("tracked_state replacement generation does not belong to commit '{commit_id}'"),
+        ));
+    }
     Ok(manifest)
 }
 
@@ -4578,10 +4883,77 @@ async fn load_commit_delta_manifest(
     else {
         return Ok(None);
     };
-    decode_commit_delta_manifest(&bytes).map(Some)
+    decode_commit_delta_manifest_for_commit(&bytes, commit_id).map(Some)
+}
+
+async fn load_commit_delta_manifest_cached(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+    point_cache: Option<&CommitDeltaPointReadCache>,
+) -> Result<Option<Arc<CommitDeltaManifest>>, LixError> {
+    if let Some(manifest) = point_cache
+        .map(|cache| cache.manifest(commit_id))
+        .transpose()?
+        .flatten()
+    {
+        return Ok(Some(manifest));
+    }
+    let Some(manifest) = load_commit_delta_manifest(store, commit_id).await? else {
+        return Ok(None);
+    };
+    let manifest = Arc::new(manifest);
+    if let Some(point_cache) = point_cache {
+        point_cache.remember_manifest(commit_id, Arc::clone(&manifest))?;
+    }
+    Ok(Some(manifest))
 }
 
 fn validate_commit_delta_manifest(manifest: &CommitDeltaManifest) -> Result<(), LixError> {
+    if manifest
+        .single_partition
+        .as_ref()
+        .is_some_and(|scope| scope.schema_key.is_empty())
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit_delta manifest has an invalid single-partition certificate",
+        ));
+    }
+    if let Some(summary) = manifest.lifecycle_summary.as_ref()
+        && (summary.scope.schema_key.is_empty()
+            || manifest.single_partition.as_ref() != Some(&summary.scope)
+            || manifest.member_count == 0
+            || manifest.selected_source_commit_id.is_some()
+            || manifest.direct_segment_row_counts.is_empty())
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit_delta manifest has invalid lifecycle metadata",
+        ));
+    }
+    if let Some(generation) = manifest.replacement_generation.as_ref()
+        && (generation.scope.schema_key.is_empty()
+            || generation.owner_commit_id == [0; 16]
+            || manifest.single_partition.as_ref() != Some(&generation.scope)
+            || manifest
+                .lifecycle_summary
+                .as_ref()
+                .map(|summary| &summary.scope)
+                != Some(&generation.scope)
+            || manifest.member_count == 0
+            || manifest.selected_source_commit_id.is_some()
+            || manifest.direct_segment_row_counts.is_empty()
+            || !manifest.inline_segment.is_empty()
+            || manifest.lifecycle_summary.as_ref().is_none_or(|summary| {
+                generation.integrity_digest
+                    != replacement_generation_integrity_digest(generation, summary)
+            }))
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit_delta manifest has an invalid replacement generation",
+        ));
+    }
     if !manifest.direct_segment_row_counts.is_empty() {
         if manifest.selected_source_commit_id.is_some()
             || manifest
@@ -4619,6 +4991,18 @@ fn validate_commit_delta_manifest(manifest: &CommitDeltaManifest) -> Result<(), 
                 "tracked_state commit_delta manifest mixes inline and indexed segments",
             ));
         }
+        let leaf = decode_commit_delta_leaf(&manifest.inline_segment, None)?;
+        let actual_single_partition = match (leaf.first_key(), leaf.last_key()) {
+            (Some(first), Some(last)) => single_partition_from_bounds(first, last)?,
+            (None, None) => None,
+            _ => unreachable!("a decoded leaf has both first and last keys or neither"),
+        };
+        if manifest.single_partition != actual_single_partition {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state inline commit_delta partition certificate does not match its rows",
+            ));
+        }
         return Ok(());
     }
     if manifest.segments.is_empty() {
@@ -4648,6 +5032,24 @@ fn validate_commit_delta_manifest(manifest: &CommitDeltaManifest) -> Result<(), 
             ));
         }
         previous_last = Some(&bounds.last_key);
+    }
+    let actual_single_partition = single_partition_from_bounds(
+        &manifest
+            .segments
+            .first()
+            .expect("non-empty manifest segments have first bounds")
+            .first_key,
+        &manifest
+            .segments
+            .last()
+            .expect("non-empty manifest segments have last bounds")
+            .last_key,
+    )?;
+    if manifest.single_partition != actual_single_partition {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit_delta single-partition certificate does not match segment bounds",
+        ));
     }
     Ok(())
 }
@@ -6145,6 +6547,8 @@ mod tests {
             &mut writes,
             deltas.iter().copied().map(Ok::<_, LixError>),
             false,
+            false,
+            None,
         )
         .expect("ordered addressable deltas should stage")
         .expect("sorted deltas should use the streaming route");
@@ -6190,6 +6594,14 @@ mod tests {
             fixtures.len()
         );
         assert_eq!(certificate.selection_fingerprint, [0; 32]);
+        assert!(
+            super::load_commit_delta_replay_metadata(&read, commit_id)
+                .await
+                .expect("replay metadata should load")
+                .expect("ordered commit has replay metadata")
+                .replacement_generation
+                .is_none()
+        );
         let generic_read = generic_storage
             .begin_read(StorageReadOptions::default())
             .await
@@ -6265,10 +6677,31 @@ mod tests {
             })
             .collect::<Vec<_>>();
         let mut writes = storage.new_write_set();
+        let replacement_generation = super::CommitDeltaReplacementGeneration {
+            scope: super::CommitDeltaReplacementScope {
+                schema_key: "irregular".to_string(),
+                file_id: None,
+            },
+            fallback_commit_id: Some(CommitId::for_test_label("irregular-fallback")),
+            lifecycle_summary: super::CommitDeltaLifecycleSummary {
+                scope: super::CommitDeltaReplacementScope {
+                    schema_key: "irregular".to_string(),
+                    file_id: None,
+                },
+                ordered_identity_digest:
+                    crate::collection_generation::ordered_single_string_identity_digest(
+                        fixtures.iter().map(|fixture| &fixture.entity_pk),
+                    )
+                    .expect("irregular identities are single strings"),
+                uniform_created_at: fixtures[0].created_at,
+            },
+        };
         let staged = super::stage_ordered_addressable_commit_deltas(
             &mut writes,
             deltas.iter().copied().map(Ok::<_, LixError>),
             true,
+            false,
+            Some(&replacement_generation),
         )
         .expect("irregular ordered deltas should stage")
         .expect("certified ordered deltas should use the streaming route");
@@ -6285,6 +6718,14 @@ mod tests {
             .await
             .expect("irregular selection certificate should load")
             .expect("irregular ordered commit should have a certificate");
+        assert_eq!(
+            super::load_commit_delta_replay_metadata(&read, commit_id)
+                .await
+                .expect("replacement replay metadata should load")
+                .expect("ordered commit has replay metadata")
+                .replacement_generation,
+            Some(replacement_generation)
+        );
         assert!(
             certificate
                 .direct_segment_row_counts
@@ -6316,6 +6757,98 @@ mod tests {
             row_start += usize::from(segment_rows);
         }
         assert_eq!(row_start, ROW_COUNT);
+    }
+
+    #[tokio::test]
+    async fn replacement_generation_certificate_rejects_corruption_and_owner_substitution() {
+        let owner_commit_id = CommitId::for_test_label("replacement-certificate-owner");
+        let substituted_commit_id = CommitId::for_test_label("replacement-certificate-substitute");
+        let scope = super::CommitDeltaReplacementScope {
+            schema_key: "replacement_certificate".to_string(),
+            file_id: None,
+        };
+        let lifecycle_summary = super::CommitDeltaLifecycleSummary {
+            scope: scope.clone(),
+            ordered_identity_digest: [7; 32],
+            uniform_created_at: LixTimestamp::from_unix_millis_utc_lossy(42),
+        };
+        let generation = super::CommitDeltaReplacementGeneration {
+            scope: scope.clone(),
+            fallback_commit_id: Some(CommitId::for_test_label("replacement-certificate-fallback")),
+            lifecycle_summary: lifecycle_summary.clone(),
+        };
+        let encoded_key = encode_key_ref(TrackedStateKeyRef {
+            schema_key: &scope.schema_key,
+            file_id: None,
+            entity_pk: &EntityPk::single("member"),
+        });
+        let manifest = CommitDeltaManifest {
+            selected_source_commit_id: None,
+            member_count: 1,
+            selection_fingerprint: [0; 32],
+            direct_segment_row_counts: vec![1],
+            single_partition: Some(scope),
+            lifecycle_summary: Some(lifecycle_summary),
+            replacement_generation: Some(super::stored_replacement_generation(
+                owner_commit_id,
+                &generation,
+            )),
+            inline_segment: Vec::new(),
+            segments: vec![super::CommitDeltaSegmentBounds {
+                first_key: encoded_key.clone(),
+                last_key: encoded_key,
+            }],
+        };
+        let encoded = encode_commit_delta_manifest(&manifest)
+            .expect("valid replacement certificate should encode");
+        super::decode_commit_delta_manifest_for_commit(&encoded, owner_commit_id)
+            .expect("valid replacement certificate should decode for its owner");
+
+        let mut corrupted_fallback = manifest.clone();
+        corrupted_fallback
+            .replacement_generation
+            .as_mut()
+            .expect("fixture has a replacement generation")
+            .fallback_commit_id = Some(*substituted_commit_id.as_uuid().as_bytes());
+        let error = decode_commit_delta_manifest(
+            &encode_commit_delta_manifest(&corrupted_fallback)
+                .expect("structurally encodable fallback corruption"),
+        )
+        .expect_err("fallback corruption must fail its integrity certificate");
+        assert!(error.message.contains("invalid replacement generation"));
+
+        let mut corrupted_lifecycle = manifest.clone();
+        corrupted_lifecycle
+            .lifecycle_summary
+            .as_mut()
+            .expect("fixture has lifecycle metadata")
+            .uniform_created_at = LixTimestamp::from_unix_millis_utc_lossy(43);
+        let error = decode_commit_delta_manifest(
+            &encode_commit_delta_manifest(&corrupted_lifecycle)
+                .expect("structurally encodable lifecycle corruption"),
+        )
+        .expect_err("lifecycle corruption must fail its integrity certificate");
+        assert!(error.message.contains("invalid replacement generation"));
+
+        let storage = StorageAdapter::new(Memory::new());
+        let mut writes = storage.new_write_set();
+        writes.put(
+            TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
+            key(commit_delta_manifest_key(substituted_commit_id)),
+            value(encoded),
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("substituted manifest fixture should commit");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("substituted manifest read should open");
+        let error = super::load_commit_delta_replay_metadata(&read, substituted_commit_id)
+            .await
+            .expect_err("a valid certificate stored under another commit must fail closed");
+        assert!(error.message.contains("does not belong to commit"));
     }
 
     #[tokio::test]
@@ -7398,6 +7931,12 @@ mod tests {
                     member_count: 0,
                     selection_fingerprint: [0; 32],
                     direct_segment_row_counts: Vec::new(),
+                    single_partition: Some(super::CommitDeltaReplacementScope {
+                        schema_key: fixture.schema_key.clone(),
+                        file_id: fixture.file_id.clone(),
+                    }),
+                    lifecycle_summary: None,
+                    replacement_generation: None,
                     inline_segment: segment,
                     segments: Vec::new(),
                 })
@@ -8332,6 +8871,9 @@ mod tests {
                     member_count: 0,
                     selection_fingerprint: [0; 32],
                     direct_segment_row_counts: Vec::new(),
+                    single_partition: None,
+                    lifecycle_summary: None,
+                    replacement_generation: None,
                     inline_segment: encode_commit_delta_segment(&entries),
                     segments: Vec::new(),
                 })
@@ -8561,7 +9103,7 @@ mod tests {
 
     #[test]
     fn packed_commit_delta_manifest_rejects_unknown_format() {
-        let error = decode_commit_delta_manifest(b"LXCD8not-an-lxcd9-manifest")
+        let error = decode_commit_delta_manifest(b"LXCD11old-manifest")
             .expect_err("old packed manifests must fail loudly");
         assert!(
             error

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -29,10 +29,11 @@ use crate::live_state::{
 };
 use crate::storage_adapter::{StorageAdapterRead, StoragePrecondition, StorageWriteSet};
 use crate::tracked_state::{
-    MaterializedTrackedStateRow, TrackedStateCommitDeltaRef, TrackedStateContext,
-    TrackedStateDeltaRef, TrackedStateFilter, TrackedStateKey, TrackedStateKeyRef,
-    TrackedStateReadColumns, TrackedStateRootMutationRef, TrackedStateScanRequest, encode_key_ref,
-    load_commit_delta_change_records, stage_addressable_commit_deltas, stage_change_locators,
+    CommitDeltaReplacementGeneration, CommitDeltaReplacementScope, MaterializedTrackedStateRow,
+    TrackedStateCommitDeltaRef, TrackedStateContext, TrackedStateDeltaRef, TrackedStateFilter,
+    TrackedStateKey, TrackedStateKeyRef, TrackedStateReadColumns, TrackedStateRootMutationRef,
+    TrackedStateScanRequest, encode_key_ref, load_commit_delta_change_records,
+    load_commit_delta_replay_metadata, stage_addressable_commit_deltas, stage_change_locators,
     stage_ordered_addressable_commit_deltas,
 };
 use crate::transaction::staging::{PreparedInsertSelection, PreparedWriteSet};
@@ -56,13 +57,12 @@ type RowIndex = usize;
 const PACKED_CURRENT_BASE_MIN_ROWS: usize = 1_024;
 
 // Large certified commits already retain one ordered, payload-bearing delta
-// journal and publish a packed current head. Rebuilding the same identities
-// into an immutable tree in the synchronous commit window duplicates the
-// dominant write work. Keep small commits rooted for cheap cold point reads;
-// large ordered commits and a bounded run of first-parent descendants use the
-// existing rootless replay protocol. Periodic root fences rebuild that short
-// interval, keeping cold point/history/merge work bounded without putting the
-// duplicate tree build back in every bulk commit window.
+// run and publish a packed current head. Rebuilding the same identities into
+// an immutable tree in the synchronous commit window duplicates the dominant
+// write work. Complete replacements persist an authoritative partition scope;
+// that scope begins a new base generation and therefore resets its replay
+// accounting without a foreground tree fence. Sparse intervals remain bounded
+// until the remaining tracked-state shapes move to partition manifests too.
 const ROOTLESS_ORDERED_COMMIT_MIN_ROWS: usize = 32 * 1_024;
 const ROOTLESS_MAX_FIRST_PARENT_DEPTH: u16 = 32;
 const ROOTLESS_MAX_REPLAY_ROWS: u64 = 1_048_576;
@@ -86,6 +86,8 @@ std::thread_local! {
         const { std::cell::Cell::new(0) };
     static COMPLETE_REPLACEMENT_PACKED_CURRENT_BASE_RETIREMENTS: std::cell::Cell<usize> =
         const { std::cell::Cell::new(0) };
+    static ROOTLESS_REPLACEMENT_GENERATION_PUBLICATIONS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
 }
 
 #[cfg(test)]
@@ -102,6 +104,11 @@ pub(crate) fn take_complete_replacement_packed_current_base_publications() -> us
 #[cfg(test)]
 pub(crate) fn take_complete_replacement_packed_current_base_retirements() -> usize {
     COMPLETE_REPLACEMENT_PACKED_CURRENT_BASE_RETIREMENTS.with(|retirements| retirements.replace(0))
+}
+
+#[cfg(test)]
+pub(crate) fn take_rootless_replacement_generation_publications() -> usize {
+    ROOTLESS_REPLACEMENT_GENERATION_PUBLICATIONS.with(|count| count.replace(0))
 }
 
 /// Commits prepared transaction rows into tracked history and unified current
@@ -492,6 +499,13 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     }
 
     let selected_change_records = load_selected_change_records(read, &commit_rows).await?;
+    let replacement_generations = certify_complete_replacement_generations(
+        read,
+        &state_rows,
+        &row_index.tracked_row_indices_by_commit,
+        &tracked_roots,
+    )
+    .await?;
 
     let ordered_addressable_commits = stage_tracked_commit_delta_index(
         read,
@@ -504,6 +518,8 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &selected_change_records,
         &host_certified_file_schemas,
         &certified_packet_root_rows,
+        &insert_selection,
+        &replacement_generations,
     )
     .await?;
 
@@ -514,6 +530,11 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &ordered_addressable_commits,
         &certified_packet_root_rows,
     );
+    let replacement_generation_commits = replacement_generations
+        .keys()
+        .filter(|commit_id| rootless_ordered_commits.contains(commit_id))
+        .copied()
+        .collect::<BTreeSet<_>>();
     let mut durable_root_rebuild_parents = BTreeSet::new();
     let mut staged_root_rebuild_commits = BTreeSet::new();
 
@@ -525,6 +546,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &engine_rows,
         &[],
         &mut rootless_ordered_commits,
+        &replacement_generation_commits,
         &mut durable_root_rebuild_parents,
         &mut staged_root_rebuild_commits,
         &row_index.tracked_row_indices_by_commit,
@@ -921,6 +943,7 @@ async fn stage_changelog_commits(
     _branch_ref_rows: &[EngineCurrentRow],
     compact_change_ids: &[ChangeId],
     rootless_commit_ids: &mut BTreeSet<CommitId>,
+    replacement_generation_commit_ids: &BTreeSet<CommitId>,
     durable_root_rebuild_parents: &mut BTreeSet<CommitId>,
     staged_root_rebuild_commits: &mut BTreeSet<CommitId>,
     tracked_row_indices_by_commit: &BTreeMap<CommitId, Vec<RowIndex>>,
@@ -1045,7 +1068,21 @@ async fn stage_changelog_commits(
             .checked_add(commit_delta_bytes)
             .ok_or_else(|| LixError::unknown("tracked-state rootless byte count exceeds u64"))?;
         let (rootless_depth, cumulative_rootless_rows, cumulative_rootless_bytes) =
-            if parent_rootless_depth > 0 {
+            if selected_as_new_rootless
+                && replacement_generation_commit_ids.contains(&commit_id)
+                && commit_delta_rows <= ROOTLESS_MAX_REPLAY_ROWS
+                && commit_delta_bytes <= ROOTLESS_MAX_REPLAY_BYTES
+                && !has_unbounded_payload_sources
+            {
+                // A persisted partition replacement is a new immutable base
+                // generation. Reads stop at its scope descriptor, so prior
+                // rows in that partition do not contribute to replay cost.
+                #[cfg(test)]
+                ROOTLESS_REPLACEMENT_GENERATION_PUBLICATIONS.with(|count| {
+                    count.set(count.get().saturating_add(1));
+                });
+                (1, commit_delta_rows, commit_delta_bytes)
+            } else if parent_rootless_depth > 0 {
                 let next_depth = parent_rootless_depth
                     .checked_add(1)
                     .ok_or_else(|| LixError::unknown("tracked-state rootless depth exceeds u16"))?;
@@ -1362,6 +1399,11 @@ fn tracked_delta_from_state_row(
             "tracked staged row is missing commit_id before tracked root staging",
         ));
     };
+    let created_at = row
+        .durable_predecessor
+        .map(crate::live_state::CertifiedCurrentStatePredecessor::created_at)
+        .transpose()?
+        .unwrap_or(row.created_at);
     Ok(TrackedStateDeltaRef {
         schema_key: row.schema_key,
         file_id: row.file_id.map(crate::common::SharedStr::as_str),
@@ -1369,7 +1411,7 @@ fn tracked_delta_from_state_row(
         change_id,
         commit_id,
         deleted: row.snapshot.is_none(),
-        created_at: row.created_at,
+        created_at,
         updated_at: row.updated_at,
     })
 }
@@ -1731,6 +1773,8 @@ async fn stage_tracked_commit_delta_index(
     selected_change_records: &HashMap<SelectedChangeKey, ChangeRecord>,
     host_certified_file_schemas: &BTreeMap<String, BTreeMap<String, BTreeSet<String>>>,
     certified_packet_root_rows: &BTreeMap<CommitId, Vec<MaterializedLiveStateRow>>,
+    insert_selection: &PreparedInsertSelection,
+    replacement_generations: &BTreeMap<CommitId, CommitDeltaReplacementGeneration>,
 ) -> Result<BTreeSet<CommitId>, LixError> {
     let mut ordered_addressable_commits = BTreeSet::new();
     let commit_rows = commit_rows
@@ -1762,6 +1806,17 @@ async fn stage_tracked_commit_delta_index(
                 .iter()
                 .all(|&row_index| state_rows.row(row_index).addressable_change_id);
         if can_stream_ordered_addressable {
+            let replacement_generation = replacement_generations.get(&root.commit_id);
+            let lifecycle_created_at = replacement_generation
+                .map(|generation| generation.lifecycle_summary.uniform_created_at);
+            let publish_lifecycle_summary = replacement_generation.is_some()
+                || state_row_indices.iter().all(|&row_index| {
+                    tracked_row_requires_absence(
+                        row_index,
+                        state_rows.row(row_index),
+                        insert_selection,
+                    )
+                });
             let ordered_stage = {
                 let _span = tracing::debug_span!(
                     target: "lix_perf",
@@ -1773,6 +1828,9 @@ async fn stage_tracked_commit_delta_index(
                 let deltas = state_row_indices.iter().map(|&row_index| {
                     let row = state_rows.row(row_index);
                     let mut delta = tracked_commit_delta_from_state_row(row)?;
+                    if let Some(created_at) = lifecycle_created_at {
+                        delta.delta.created_at = created_at;
+                    }
                     delta.base_coordinate = entity_columnar_write_sets
                         .state_row_location(row_index)
                         .map(
@@ -1797,7 +1855,13 @@ async fn stage_tracked_commit_delta_index(
                         .iter()
                         .enumerate()
                         .all(|(index, &row_index)| index == row_index);
-                stage_ordered_addressable_commit_deltas(writes, deltas, order_certified)?
+                stage_ordered_addressable_commit_deltas(
+                    writes,
+                    deltas,
+                    order_certified,
+                    publish_lifecycle_summary,
+                    replacement_generation,
+                )?
             };
             if let Some(ordered_stage) = ordered_stage {
                 state_rows.set_ordered_addressable_change_ids(state_row_indices, ordered_stage)?;
@@ -1982,6 +2046,183 @@ async fn stage_tracked_commit_delta_index(
         stage_change_locators(writes, &authored_locators);
     }
     Ok(ordered_addressable_commits)
+}
+
+async fn certify_complete_replacement_generations(
+    read: &(impl StorageAdapterRead + ?Sized),
+    state_rows: &PreparedStateBatch,
+    tracked_row_indices_by_commit: &BTreeMap<CommitId, Vec<RowIndex>>,
+    tracked_roots: &[PendingTrackedRoot],
+) -> Result<BTreeMap<CommitId, CommitDeltaReplacementGeneration>, LixError> {
+    let mut generations = BTreeMap::new();
+    for root in tracked_roots {
+        let row_indices = tracked_row_indices_by_commit
+            .get(&root.commit_id)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        let Some(scope) =
+            certified_complete_replacement_scope(state_rows, row_indices, root.commit_id)
+        else {
+            continue;
+        };
+        let Some(ordered_identity_digest) =
+            crate::collection_generation::ordered_single_string_identity_digest(
+                row_indices
+                    .iter()
+                    .map(|&row_index| state_rows.row(row_index).entity_pk),
+            )
+        else {
+            continue;
+        };
+        let mut current = root.parent_commit_id;
+        let mut seen = BTreeSet::new();
+        let mut lifecycle_summary = None;
+        let fallback_commit_id = loop {
+            let Some(commit_id) = current else {
+                break None;
+            };
+            if !seen.insert(commit_id) {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "cannot certify replacement generation '{}': first-parent cycle includes '{commit_id}'",
+                        root.commit_id
+                    ),
+                ));
+            }
+            let commit_ids = [commit_id];
+            let record = ChangelogContext::new()
+                .reader(read)
+                .load_commits(ChangelogCommitLoadRequest {
+                    commit_ids: &commit_ids,
+                })
+                .await?
+                .into_iter()
+                .next()
+                .and_then(|(_, record)| record)
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!(
+                            "replacement generation '{}' has missing parent '{commit_id}'",
+                            root.commit_id
+                        ),
+                    )
+                })?;
+            if !record.tracked_state_rootless {
+                break Some(commit_id);
+            }
+            let Some(metadata) = load_commit_delta_replay_metadata(read, commit_id).await? else {
+                // Missing replay evidence cannot certify that this interval
+                // belongs exclusively to the replaced partition.
+                break Some(commit_id);
+            };
+            if metadata.single_partition.as_ref() != Some(&scope) {
+                // Resetting global replay accounting is safe only when the
+                // entire skipped interval belongs to the replaced partition.
+                break Some(commit_id);
+            }
+            if let Some(parent_generation) = metadata.replacement_generation {
+                if parent_generation.scope != scope {
+                    break Some(commit_id);
+                }
+                if usize::try_from(metadata.member_count).ok() != Some(row_indices.len())
+                    || parent_generation.lifecycle_summary.ordered_identity_digest
+                        != ordered_identity_digest
+                {
+                    break Some(commit_id);
+                }
+                lifecycle_summary = Some(parent_generation.lifecycle_summary);
+                break parent_generation.fallback_commit_id;
+            }
+            let Some(summary) = metadata.lifecycle_summary.as_ref() else {
+                // A same-partition sparse commit may have deleted and later
+                // reinserted one identity with a new lifecycle. Do not carry
+                // an older full-set summary across any commit that does not
+                // itself prove the complete ordered identity set.
+                break Some(commit_id);
+            };
+            if usize::try_from(metadata.member_count).ok() != Some(row_indices.len())
+                || summary.scope != scope
+                || summary.ordered_identity_digest != ordered_identity_digest
+            {
+                break Some(commit_id);
+            }
+            lifecycle_summary = Some(summary.clone());
+            current = record.parent_commit_ids.first().copied();
+        };
+        // A fallback that is itself rootless means the interval contained an
+        // uncertified partition shape. Decline the hard cut and let the normal
+        // root fence preserve bounded replay.
+        if let Some(fallback_commit_id) = fallback_commit_id {
+            let commit_ids = [fallback_commit_id];
+            let fallback = ChangelogContext::new()
+                .reader(read)
+                .load_commits(ChangelogCommitLoadRequest {
+                    commit_ids: &commit_ids,
+                })
+                .await?
+                .into_iter()
+                .next()
+                .and_then(|(_, record)| record)
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!("replacement fallback '{fallback_commit_id}' is missing"),
+                    )
+                })?;
+            if fallback.tracked_state_rootless {
+                continue;
+            }
+        }
+        let Some(lifecycle_summary) = lifecycle_summary else {
+            continue;
+        };
+        generations.insert(
+            root.commit_id,
+            CommitDeltaReplacementGeneration {
+                scope,
+                fallback_commit_id,
+                lifecycle_summary,
+            },
+        );
+    }
+    Ok(generations)
+}
+
+fn certified_complete_replacement_scope(
+    state_rows: &PreparedStateBatch,
+    row_indices: &[RowIndex],
+    commit_id: CommitId,
+) -> Option<CommitDeltaReplacementScope> {
+    if !state_rows.certified_complete_collection_replacement()
+        || row_indices.is_empty()
+        || row_indices.len() < ROOTLESS_ORDERED_COMMIT_MIN_ROWS
+        || row_indices.len() != state_rows.len()
+    {
+        return None;
+    }
+    let first = state_rows.row(row_indices[0]);
+    if first.commit_id != Some(commit_id)
+        || first.snapshot.is_none()
+        || first.untracked
+        || first.global
+        || row_indices.iter().any(|&row_index| {
+            let row = state_rows.row(row_index);
+            row.commit_id != Some(commit_id)
+                || row.schema_key != first.schema_key
+                || row.file_id != first.file_id
+                || row.snapshot.is_none()
+                || row.untracked
+                || row.global
+        })
+    {
+        return None;
+    }
+    Some(CommitDeltaReplacementScope {
+        schema_key: first.schema_key.to_string(),
+        file_id: first.file_id.map(ToString::to_string),
+    })
 }
 
 fn prepared_state_row_replay_bytes(row: PreparedStateRowRef<'_>) -> Result<u64, LixError> {
@@ -5493,6 +5734,8 @@ mod tests {
             &HashMap::new(),
             &BTreeMap::new(),
             &certified_rows,
+            &PreparedInsertSelection::new(),
+            &BTreeMap::new(),
         )
         .await
         .expect("mixed certified delta should stage");
@@ -7348,6 +7591,7 @@ mod tests {
             &[],
             &[],
             &mut rootless_commit_ids,
+            &BTreeSet::new(),
             &mut durable_root_rebuild_parents,
             &mut staged_root_rebuild_commits,
             &BTreeMap::from([

--- a/packages/engine/src/transaction/mod.rs
+++ b/packages/engine/src/transaction/mod.rs
@@ -22,6 +22,8 @@ pub(crate) use commit::take_complete_replacement_packed_current_base_publication
 pub(crate) use commit::take_complete_replacement_packed_current_base_retirements;
 #[cfg(test)]
 pub(crate) use commit::take_ordered_packed_current_base_publications;
+#[cfg(test)]
+pub(crate) use commit::take_rootless_replacement_generation_publications;
 pub(crate) use commit_coordinator::CommitCoordinator;
 pub(crate) use context::CertifiedHistoryStoreReader;
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- certify complete dense entity replacements as first-class replacement generations
- publish the already encoded columnar row groups as the packed current base and retire superseded exclusive bases
- stop first-parent replay at the authoritative replacement scope while retaining a durable fallback for unrelated partitions
- hard-cut commit-delta storage to LXCD12/v5 and bind owner commit, scope, fallback, identity digest, and lifecycle timestamp with a BLAKE3 certificate
- share decoded commit-delta manifests across snapshot-scoped topology, scan, and exact-key replay
- keep the literal `execute_batch` benchmark stable and add an explicit parameterized public API workload

This intentionally has no storage-format backward compatibility and no changenote.

## Why

Profiling the 1M UPDATE path showed duplicate replay/root construction and per-row generation work dominating storage-adapter commit time. A certified complete replacement is already an immutable new collection generation; replaying predecessors and rebuilding the same packed head is unnecessary.

This PR is the replacement-generation/current-state publication cut. It does **not** claim the generic chunked immutable patch/replacement-part manifest: a direct row-group-part prototype was removed because point history would decode the entire 1M-row part without range-addressable segments. Point-addressable immutable mutation parts are the next physical-layout cut.

## Performance

Same host, release build, public SQL `SessionContext::execute_batch`, identical literal workload on this branch and the immediately previous PR #1149 artifact:

| 1M UPDATE | #1149 | This PR | Change |
| --- | ---: | ---: | ---: |
| RocksDB | 2.885 s | 1.779 s | -38.3% |
| SlateDB | 2.777 s | 1.602 s | -42.3% |

At 10K, where the >=32K replacement-generation cut is intentionally inactive, 15-sample medians remained effectively flat: RocksDB 37.49 -> 36.73 ms; SlateDB 35.07 -> 36.02 ms (overlapping sample ranges).

The fair parameterized public-API comparison against raw prepared SQLite shows the remaining gap:

| UPDATE | Raw SQLite | RocksDB | SlateDB |
| --- | ---: | ---: | ---: |
| 10K | 14.74 ms | 34.05 ms (2.31x) | 31.14 ms (2.11x) |
| 1M | 1.038 s | 1.616 s (1.56x) | 1.550 s (1.49x) |

So this is a >10% stacked optimization, but not yet the 1.2x endpoint. The remaining 1M gap is the duplicate per-row commit-delta representation; eliminating it safely depends on bounded key/range routing into immutable parts.

## Validation

- `cargo test --manifest-path packages/engine/Cargo.toml --lib`: 1,823 passed, 8 ignored on rebased main
- `cargo test --manifest-path packages/engine/Cargo.toml --tests`: 438 integration tests passed, 2 ignored on rebased main
- focused 32K replacement/overlay/branch/merge/diff/history regression
- focused manifest corruption and cross-commit substitution regression
- `cargo clippy --manifest-path packages/engine/Cargo.toml --lib -- -D warnings`
- `cargo fmt --all`
- `git diff --check`
