### PR TITLE
Hard-cut tracked commit state into one manifest

### DIFF
--- a/packages/engine/src/columnar_row_group.rs
+++ b/packages/engine/src/columnar_row_group.rs
@@ -58,6 +58,10 @@ impl RowGroupSetId {
         Self(bytes)
     }
 
+    pub(crate) const fn as_bytes(self) -> [u8; 16] {
+        self.0
+    }
+
     fn manifest_key(self) -> StorageKey {
         StorageKey(Bytes::copy_from_slice(&self.0))
     }

--- a/packages/engine/src/commit_graph/context.rs
+++ b/packages/engine/src/commit_graph/context.rs
@@ -24,11 +24,12 @@ use crate::entity_pk::EntityPk;
 use crate::storage_adapter::StorageAdapterRead;
 
 const COMMIT_SCHEMA_KEY: &str = "lix_commit";
-/// Read model for resolving changelog commits into entity state at a head.
+/// Read model for resolving authoritative commit manifests into entity state
+/// at a head.
 ///
-/// This module does not own durable storage. It reads immutable changelog
-/// facts through a caller-provided KV store and applies commit graph rules on
-/// top.
+/// The changelog commit plane is a compact serving projection. Every graph
+/// read validates it against the commit-state manifest before exposing
+/// topology.
 #[derive(Clone)]
 pub(crate) struct CommitGraphContext;
 
@@ -105,9 +106,12 @@ where
                     commit_ids: &uncached_ids,
                 })
                 .await?;
-            for (commit_id, entry) in batch {
-                self.node_cache
-                    .insert(*commit_id, entry.map(commit_graph_node_from_commit_record));
+            let manifests =
+                crate::tracked_state::load_commit_state_manifests(&self.store, &uncached_ids)
+                    .await?;
+            for ((commit_id, record), manifest) in batch.into_iter().zip(manifests) {
+                let node = commit_graph_node_from_authority(*commit_id, record, manifest)?;
+                self.node_cache.insert(*commit_id, node);
             }
         }
         let nodes = commit_ids
@@ -117,7 +121,7 @@ where
         ExactBatch::try_new("commit graph", commit_ids, nodes)
     }
 
-    /// Loads every direct commit fact from the changelog.
+    /// Loads every direct commit fact from the commit-state authority.
     ///
     /// This is used by global commit surfaces where the caller wants the durable
     /// graph facts themselves, not reachability from a particular branch head.
@@ -132,8 +136,17 @@ where
                     limit: Some(1024),
                 })
                 .await?;
-            for record in scan.entries {
-                let node = commit_graph_node_from_commit_record(record);
+            let commit_ids = scan
+                .entries
+                .iter()
+                .map(|record| record.commit_id)
+                .collect::<Vec<_>>();
+            let manifests =
+                crate::tracked_state::load_commit_state_manifests(&self.store, &commit_ids).await?;
+            for (record, manifest) in scan.entries.into_iter().zip(manifests) {
+                let commit_id = record.commit_id;
+                let node = commit_graph_node_from_authority(commit_id, Some(record), manifest)?
+                    .expect("scanned commit projection produces a graph node");
                 self.node_cache.insert(node.commit_id, Some(node.clone()));
                 commits.push(node);
             }
@@ -142,7 +155,6 @@ where
             };
             start_after = Some(next.to_string());
         }
-        commits.sort_by_key(|left| left.commit_id);
         Ok(commits)
     }
 
@@ -368,8 +380,51 @@ fn commit_graph_change_from_change_record(change: ChangeRecord) -> CommitGraphCh
     }
 }
 
-fn commit_graph_node_from_commit_record(record: CommitRecord) -> CommitGraphNode {
-    record.into()
+fn commit_graph_node_from_authority(
+    commit_id: CommitId,
+    record: Option<CommitRecord>,
+    manifest: Option<crate::tracked_state::CommitStateManifest>,
+) -> Result<Option<CommitGraphNode>, LixError> {
+    // Public graph membership belongs to the compact changelog projection.
+    // GC may retain an immutable manifest after removing that projection so
+    // selected payloads remain addressable for recovery.
+    let Some(record) = record else {
+        return Ok(None);
+    };
+    let Some(manifest) = manifest else {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "commit_graph projection for commit '{commit_id}' has no commit-state authority"
+            ),
+        ));
+    };
+    let manifest_rootless = manifest.replay_debt.depth > 0;
+    if record.commit_id != manifest.commit_id
+        || record.generation != manifest.generation
+        || record.parent_commit_ids != manifest.parent_commit_ids
+        || record.change_id != manifest.commit_change_id
+        || record.author_account_ids != manifest.author_account_ids
+        || record.created_at != manifest.created_at
+        || record.tracked_state_rootless != manifest_rootless
+        || record.tracked_state_rootless_depth != manifest.replay_debt.depth
+        || record.tracked_state_rootless_rows != manifest.replay_debt.rows
+        || record.tracked_state_rootless_bytes != manifest.replay_debt.bytes
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "commit_graph projection disagrees with commit-state authority for commit '{commit_id}'"
+            ),
+        ));
+    }
+    Ok(Some(CommitGraphNode {
+        commit_id: manifest.commit_id,
+        change_id: manifest.commit_change_id,
+        generation: manifest.generation,
+        parent_commit_ids: manifest.parent_commit_ids,
+        created_at: manifest.created_at,
+    }))
 }
 
 fn missing_commit_graph_error(commit_id: &CommitId) -> LixError {
@@ -470,18 +525,20 @@ mod tests {
         GetManyResult, KeyRange, ScanChunk, ScanOptions, StorageError, StorageRead,
     };
     use crate::storage_adapter::{
-        Memory, MemoryRead, Storage, StorageAdapter, StorageAdapterReadScope, StorageReadOptions,
-        StorageWriteOptions,
+        Memory, MemoryRead, Storage, StorageAdapter, StorageAdapterReadScope, StorageKey,
+        StorageReadOptions, StorageWriteOptions,
     };
     use crate::tracked_state::{
-        TrackedStateCommitDeltaRef, TrackedStateDeltaRef, stage_commit_deltas,
+        CommitStateManifest, CommitStateMutationInventory, CommitStateReplayDebt,
+        TrackedStateCommitDeltaRef, TrackedStateDeltaRef, stage_commit_deltas_for_commit_state,
+        stage_commit_state_manifest,
     };
 
     #[derive(Clone)]
     struct CountingMemoryRead {
         inner: MemoryRead,
         change_get_many_calls: Arc<AtomicUsize>,
-        delta_get_many_calls: Arc<AtomicUsize>,
+        member_segment_get_many_calls: Arc<AtomicUsize>,
     }
 
     impl StorageRead for CountingMemoryRead {
@@ -496,13 +553,10 @@ mod tests {
                 self.change_get_many_calls.fetch_add(1, Ordering::Relaxed);
             }
             if requests.iter().any(|request| {
-                matches!(
-                    request.space,
-                    crate::tracked_state::TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE
-                        | crate::tracked_state::TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE
-                )
+                request.space == crate::tracked_state::TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE
             }) {
-                self.delta_get_many_calls.fetch_add(1, Ordering::Relaxed);
+                self.member_segment_get_many_calls
+                    .fetch_add(1, Ordering::Relaxed);
             }
             self.inner.get_many(requests).await
         }
@@ -592,6 +646,138 @@ mod tests {
             .expect("commit load should succeed");
 
         assert_eq!(commit, None);
+    }
+
+    #[tokio::test]
+    async fn retained_manifest_without_projection_is_not_a_public_graph_node() {
+        let storage = StorageAdapter::new(Memory::new());
+        let commit_id = commit_id("retained-payload-authority");
+        let mut writes = storage.new_write_set();
+        stage_commit_state_manifest(
+            &mut writes,
+            &CommitStateManifest {
+                commit_id,
+                generation: 0,
+                parent_commit_ids: Vec::new(),
+                commit_change_id: change_id("retained-payload-authority-change"),
+                author_account_ids: Vec::new(),
+                created_at: ts("2026-01-01T00:00:00Z"),
+                replay_debt: CommitStateReplayDebt {
+                    depth: 1,
+                    rows: 0,
+                    bytes: 0,
+                },
+                mutations: CommitStateMutationInventory::default(),
+                snapshot_root: None,
+            },
+        )
+        .expect("retained payload authority should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("retained payload authority should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let mut reader = CommitGraphContext::new().reader(read);
+        assert!(
+            reader
+                .load_node(&commit_id)
+                .await
+                .expect("retained authority lookup should succeed")
+                .is_none()
+        );
+        assert!(
+            reader
+                .all_nodes()
+                .await
+                .expect("retained authority scan should succeed")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn load_node_rejects_projection_without_commit_state_authority() {
+        let storage = StorageAdapter::new(Memory::new());
+        append_changes(
+            &storage,
+            &[commit_change(
+                "missing-authority-change",
+                "missing-authority",
+                &[],
+                &[],
+            )],
+        )
+        .await;
+        let commit_id = commit_id("missing-authority");
+        let mut writes = storage.new_write_set();
+        writes.delete(
+            crate::tracked_state::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+            StorageKey(bytes::Bytes::copy_from_slice(
+                commit_id.as_uuid().as_bytes(),
+            )),
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("manifest deletion should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let error = CommitGraphContext::new()
+            .reader(read)
+            .load_node(&commit_id)
+            .await
+            .expect_err("a changelog projection cannot replace missing authority");
+        assert!(error.message.contains("has no commit-state authority"));
+    }
+
+    #[tokio::test]
+    async fn load_node_rejects_changelog_projection_drift() {
+        let storage = StorageAdapter::new(Memory::new());
+        append_changes(
+            &storage,
+            &[commit_change(
+                "drift-authority-change",
+                "drift-authority",
+                &[],
+                &[],
+            )],
+        )
+        .await;
+        let commit_id = commit_id("drift-authority");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("authority read should open");
+        let mut manifest = crate::tracked_state::load_commit_state_manifest(&read, commit_id)
+            .await
+            .expect("authority should load")
+            .expect("authority should exist");
+        drop(read);
+        manifest.commit_change_id = change_id("different-authority-change");
+        let mut writes = storage.new_write_set();
+        stage_commit_state_manifest(&mut writes, &manifest)
+            .expect("drifted but structurally valid authority should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("drifted authority should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let error = CommitGraphContext::new()
+            .reader(read)
+            .load_node(&commit_id)
+            .await
+            .expect_err("projection drift must fail closed");
+        assert!(error.message.contains("projection disagrees"));
     }
 
     #[tokio::test]
@@ -740,7 +926,7 @@ mod tests {
         .await;
 
         let change_get_many_calls = Arc::new(AtomicUsize::new(0));
-        let delta_get_many_calls = Arc::new(AtomicUsize::new(0));
+        let member_segment_get_many_calls = Arc::new(AtomicUsize::new(0));
         let read = memory
             .begin_read(StorageReadOptions::default())
             .await
@@ -749,7 +935,7 @@ mod tests {
         let mut reader = graph.reader(StorageAdapterReadScope::new(CountingMemoryRead {
             inner: read,
             change_get_many_calls: Arc::clone(&change_get_many_calls),
-            delta_get_many_calls,
+            member_segment_get_many_calls,
         }));
         let request = CommitGraphChangeHistoryRequest {
             schema_keys: vec!["test_schema".to_string()],
@@ -804,9 +990,9 @@ mod tests {
                     commit_id,
                     generation: 0,
                     parent_commit_ids: Vec::new(),
-                    tracked_state_rootless: false,
-                    tracked_state_rootless_depth: 0,
-                    tracked_state_rootless_rows: 0,
+                    tracked_state_rootless: true,
+                    tracked_state_rootless_depth: 1,
+                    tracked_state_rootless_rows: 3,
                     tracked_state_rootless_bytes: 0,
                     change_id: change_id("selected-tombstone-commit-change"),
                     author_account_ids: Vec::new(),
@@ -868,7 +1054,27 @@ mod tests {
                 authored: false,
             },
         ];
-        stage_commit_deltas(&mut writes, &deltas).expect("selected tombstones should stage");
+        let staged = stage_commit_deltas_for_commit_state(&mut writes, &deltas)
+            .expect("selected tombstones should stage");
+        stage_commit_state_manifest(
+            &mut writes,
+            &CommitStateManifest {
+                commit_id,
+                generation: 0,
+                parent_commit_ids: Vec::new(),
+                commit_change_id: change_id("selected-tombstone-commit-change"),
+                author_account_ids: Vec::new(),
+                created_at,
+                replay_debt: CommitStateReplayDebt {
+                    depth: 1,
+                    rows: 3,
+                    bytes: 0,
+                },
+                mutations: staged.mutation_inventory().clone(),
+                snapshot_root: None,
+            },
+        )
+        .expect("selected tombstone commit-state manifest should stage");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
@@ -960,7 +1166,7 @@ mod tests {
         )
         .await;
 
-        let delta_get_many_calls = Arc::new(AtomicUsize::new(0));
+        let member_segment_get_many_calls = Arc::new(AtomicUsize::new(0));
         let read = memory
             .begin_read(StorageReadOptions::default())
             .await
@@ -969,7 +1175,7 @@ mod tests {
             CommitGraphContext::new().reader(StorageAdapterReadScope::new(CountingMemoryRead {
                 inner: read,
                 change_get_many_calls: Arc::new(AtomicUsize::new(0)),
-                delta_get_many_calls: Arc::clone(&delta_get_many_calls),
+                member_segment_get_many_calls: Arc::clone(&member_segment_get_many_calls),
             }));
         let head = commit_id("commit-head");
         let root = commit_id("commit-root");
@@ -988,7 +1194,7 @@ mod tests {
             .expect("ancestor walk should succeed");
         reader.all_nodes().await.expect("node scan should succeed");
         assert_eq!(
-            delta_get_many_calls.load(Ordering::Relaxed),
+            member_segment_get_many_calls.load(Ordering::Relaxed),
             0,
             "topology APIs must never touch commit member storage",
         );
@@ -1006,7 +1212,7 @@ mod tests {
             .expect("commit-only history should derive node changes");
         assert_eq!(commit_history.entries.len(), 2);
         assert_eq!(
-            delta_get_many_calls.load(Ordering::Relaxed),
+            member_segment_get_many_calls.load(Ordering::Relaxed),
             0,
             "commit-only history must not hydrate unrelated member payloads",
         );
@@ -1023,9 +1229,10 @@ mod tests {
             .await
             .expect("history should hydrate requested payloads");
         assert_eq!(history.entries.len(), 2);
-        assert!(
-            delta_get_many_calls.load(Ordering::Relaxed) > 0,
-            "history payload hydration must remain explicit and observable",
+        assert_eq!(
+            member_segment_get_many_calls.load(Ordering::Relaxed),
+            0,
+            "these tiny commit inventories are inline in their authority manifests",
         );
     }
 
@@ -1286,9 +1493,11 @@ mod tests {
                 commit_id,
                 generation,
                 parent_commit_ids: change.parent_commit_ids.clone(),
-                tracked_state_rootless: false,
-                tracked_state_rootless_depth: 0,
-                tracked_state_rootless_rows: 0,
+                tracked_state_rootless: true,
+                tracked_state_rootless_depth: u16::try_from(generation + 1)
+                    .expect("test commit generation should fit replay depth"),
+                tracked_state_rootless_rows: u64::try_from(members.len())
+                    .expect("test member count should fit u64"),
                 tracked_state_rootless_bytes: 0,
                 change_id: change.change.id,
                 author_account_ids: Vec::new(),
@@ -1298,11 +1507,13 @@ mod tests {
             staged_commit_ids.insert(commit_id);
             generations.insert(commit_id, generation);
         }
+        let commit_records = append.commits.clone();
         writer
             .stage_append(append)
             .await
             .expect("changelog append should stage");
         drop(writer);
+        let mut inventories = BTreeMap::new();
         for (commit_id, members) in &commit_members {
             let deltas = members
                 .iter()
@@ -1324,12 +1535,47 @@ mod tests {
                     authored: true,
                 })
                 .collect::<Vec<_>>();
-            stage_commit_deltas(&mut writes, &deltas).expect("packed commit members should stage");
+            let staged = stage_commit_deltas_for_commit_state(&mut writes, &deltas)
+                .expect("packed commit members should stage");
+            inventories.insert(*commit_id, staged.mutation_inventory().clone());
+        }
+        for record in &commit_records {
+            stage_test_commit_manifest(
+                &mut writes,
+                record,
+                inventories.remove(&record.commit_id).unwrap_or_default(),
+            );
         }
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
             .expect("commit should succeed");
+    }
+
+    fn stage_test_commit_manifest(
+        writes: &mut crate::storage_adapter::StorageWriteSet,
+        record: &CommitRecord,
+        mutations: CommitStateMutationInventory,
+    ) {
+        stage_commit_state_manifest(
+            writes,
+            &CommitStateManifest {
+                commit_id: record.commit_id,
+                generation: record.generation,
+                parent_commit_ids: record.parent_commit_ids.clone(),
+                commit_change_id: record.change_id,
+                author_account_ids: record.author_account_ids.clone(),
+                created_at: record.created_at,
+                replay_debt: CommitStateReplayDebt {
+                    depth: record.tracked_state_rootless_depth,
+                    rows: record.tracked_state_rootless_rows,
+                    bytes: record.tracked_state_rootless_bytes,
+                },
+                mutations,
+                snapshot_root: None,
+            },
+        )
+        .expect("test commit-state manifest should stage");
     }
 
     fn append_empty_commit(append: &mut ChangelogAppend, commit_id: CommitId) {
@@ -1339,8 +1585,8 @@ mod tests {
             commit_id,
             generation: 0,
             parent_commit_ids: Vec::new(),
-            tracked_state_rootless: false,
-            tracked_state_rootless_depth: 0,
+            tracked_state_rootless: true,
+            tracked_state_rootless_depth: 1,
             tracked_state_rootless_rows: 0,
             tracked_state_rootless_bytes: 0,
             change_id: ChangeId::for_test_label(&change_id),

--- a/packages/engine/src/commit_graph/types.rs
+++ b/packages/engine/src/commit_graph/types.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::LixError;
-use crate::changelog::{ChangeId, CommitId, CommitRecord};
+use crate::changelog::{ChangeId, CommitId};
 use crate::common::{ExactValue, LixTimestamp};
 use crate::entity_pk::EntityPk;
 
@@ -19,7 +19,7 @@ pub(crate) struct CommitGraphChange {
 
 /// One topology-first commit fact.
 ///
-/// Nodes contain exactly the changelog fields needed by graph algorithms and
+/// Nodes contain exactly the manifest fields needed by graph algorithms and
 /// derived commit surfaces. Entity/change payloads are loaded separately only
 /// by history APIs that explicitly request them.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -34,18 +34,6 @@ pub(crate) struct CommitGraphNode {
 impl ExactValue<CommitId> for CommitGraphNode {
     fn matches_exact_key(&self, key: &CommitId) -> bool {
         self.commit_id == *key
-    }
-}
-
-impl From<CommitRecord> for CommitGraphNode {
-    fn from(record: CommitRecord) -> Self {
-        Self {
-            commit_id: record.commit_id,
-            change_id: record.change_id,
-            generation: record.generation,
-            parent_commit_ids: record.parent_commit_ids,
-            created_at: record.created_at,
-        }
     }
 }
 

--- a/packages/engine/src/commit_graph/walker.rs
+++ b/packages/engine/src/commit_graph/walker.rs
@@ -248,6 +248,10 @@ mod tests {
     use crate::commit_graph::CommitGraphContext;
     use crate::storage_adapter::StorageAdapter;
     use crate::storage_adapter::{Memory, StorageKey, StorageReadOptions, StorageWriteOptions};
+    use crate::tracked_state::{
+        CommitStateManifest, CommitStateMutationInventory, CommitStateReplayDebt,
+        stage_commit_state_manifest,
+    };
 
     fn ts(value: &str) -> crate::common::LixTimestamp {
         crate::common::LixTimestamp::expect_parse("timestamp", value)
@@ -394,24 +398,27 @@ mod tests {
         let mut writes = storage.new_write_set();
         for (label, parent) in [("commit-a", "commit-b"), ("commit-b", "commit-a")] {
             let commit_id = commit_id(label);
+            let record = CommitRecord {
+                format_version: 1,
+                commit_id,
+                generation: 1,
+                parent_commit_ids: commit_ids([parent]),
+                tracked_state_rootless: true,
+                tracked_state_rootless_depth: 1,
+                tracked_state_rootless_rows: 0,
+                tracked_state_rootless_bytes: 0,
+                change_id: ChangeId::for_test_label(&format!("{label}-change")),
+                author_account_ids: Vec::new(),
+                created_at: ts("2026-01-01T00:00:00Z"),
+            };
             writes.put(
                 crate::changelog::COMMIT_SPACE,
                 StorageKey(Bytes::copy_from_slice(commit_id.as_uuid().as_bytes())),
-                crate::changelog::encode_commit_record(&CommitRecord {
-                    format_version: 1,
-                    commit_id,
-                    generation: 1,
-                    parent_commit_ids: commit_ids([parent]),
-                    tracked_state_rootless: false,
-                    tracked_state_rootless_depth: 0,
-                    tracked_state_rootless_rows: 0,
-                    tracked_state_rootless_bytes: 0,
-                    change_id: ChangeId::for_test_label(&format!("{label}-change")),
-                    author_account_ids: Vec::new(),
-                    created_at: ts("2026-01-01T00:00:00Z"),
-                })
-                .expect("cycle commit should encode"),
+                crate::changelog::encode_commit_record(&record)
+                    .expect("cycle commit should encode"),
             );
+            stage_test_commit_manifest(&mut writes, &record)
+                .expect("cycle commit authority should stage");
         }
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -685,24 +692,26 @@ mod tests {
         .await;
         let child = commit_id("commit-child");
         let mut writes = storage.new_write_set();
+        let record = CommitRecord {
+            format_version: 1,
+            commit_id: child,
+            generation: 0,
+            parent_commit_ids: commit_ids(["commit-root"]),
+            tracked_state_rootless: true,
+            tracked_state_rootless_depth: 2,
+            tracked_state_rootless_rows: 0,
+            tracked_state_rootless_bytes: 0,
+            change_id: ChangeId::for_test_label("commit-child-change"),
+            author_account_ids: Vec::new(),
+            created_at: ts("2026-01-01T00:00:00Z"),
+        };
         writes.put(
             crate::changelog::COMMIT_SPACE,
             StorageKey(Bytes::copy_from_slice(child.as_uuid().as_bytes())),
-            crate::changelog::encode_commit_record(&CommitRecord {
-                format_version: 1,
-                commit_id: child,
-                generation: 0,
-                parent_commit_ids: commit_ids(["commit-root"]),
-                tracked_state_rootless: false,
-                tracked_state_rootless_depth: 0,
-                tracked_state_rootless_rows: 0,
-                tracked_state_rootless_bytes: 0,
-                change_id: ChangeId::for_test_label("commit-child-change"),
-                author_account_ids: Vec::new(),
-                created_at: ts("2026-01-01T00:00:00Z"),
-            })
-            .expect("corrupt commit should encode"),
+            crate::changelog::encode_commit_record(&record).expect("corrupt commit should encode"),
         );
+        stage_test_commit_manifest(&mut writes, &record)
+            .expect("matching corrupt authority should stage");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
@@ -1017,8 +1026,9 @@ mod tests {
                 commit_id: typed_commit_id,
                 generation,
                 parent_commit_ids,
-                tracked_state_rootless: false,
-                tracked_state_rootless_depth: 0,
+                tracked_state_rootless: true,
+                tracked_state_rootless_depth: u16::try_from(generation + 1)
+                    .expect("test generation should fit replay depth"),
                 tracked_state_rootless_rows: 0,
                 tracked_state_rootless_bytes: 0,
                 change_id: change.change.id,
@@ -1027,15 +1037,43 @@ mod tests {
             });
             generations.insert(typed_commit_id, generation);
         }
+        let commit_records = append.commits.clone();
         ChangelogContext::new()
             .writer(&mut read, &mut writes)
             .stage_append(append)
             .await?;
+        for record in &commit_records {
+            stage_test_commit_manifest(&mut writes, record)?;
+        }
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
             .expect("commit should succeed");
         Ok(())
+    }
+
+    fn stage_test_commit_manifest(
+        writes: &mut crate::storage_adapter::StorageWriteSet,
+        record: &CommitRecord,
+    ) -> Result<(), LixError> {
+        stage_commit_state_manifest(
+            writes,
+            &CommitStateManifest {
+                commit_id: record.commit_id,
+                generation: record.generation,
+                parent_commit_ids: record.parent_commit_ids.clone(),
+                commit_change_id: record.change_id,
+                author_account_ids: record.author_account_ids.clone(),
+                created_at: record.created_at,
+                replay_debt: CommitStateReplayDebt {
+                    depth: record.tracked_state_rootless_depth,
+                    rows: record.tracked_state_rootless_rows,
+                    bytes: record.tracked_state_rootless_bytes,
+                },
+                mutations: CommitStateMutationInventory::default(),
+                snapshot_root: None,
+            },
+        )
     }
 
     fn commit_change(

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -303,6 +303,23 @@ where
         let storage = self.storage();
         let read =
             SharedStorageAdapterRead::new(storage.begin_read(StorageReadOptions::default()).await?);
+        let typed_head_commit_id = crate::changelog::CommitId::parse_lix(
+            &head_commit_id,
+            "tracked-state branch rebuild authority",
+        )?;
+        crate::tracked_state::load_commit_state_manifest(
+            &read,
+            typed_head_commit_id,
+        )
+        .await?
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "cannot rebuild tracked_state root for commit '{head_commit_id}' without its commit-state manifest"
+                ),
+            )
+        })?;
         let mut writes = StorageWriteSet::new();
         let rebuild_result = self
             .tracked_state

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -412,20 +412,12 @@ where
     let phase_started = Instant::now();
     let changelog_plan = plan_and_stage_authority_gc(&store, writes, &roots).await?;
     let changelog_us = elapsed_micros(phase_started);
-    // Changelog reachability is the logical correctness boundary. A
-    // tracked root has the same commit id, so dead root metadata can be
-    // deleted directly without inventorying every retained root.
-    let sweep_tracked_commit_roots = changelog_plan.sweep.commits.clone();
-
-    // Removing a dead changelog commit invalidates its derived root metadata
-    // and its commit-addressed delta index. Immutable tree/CAS payloads remain
-    // content-addressed maintenance work, but delta rows have no shared
-    // ownership and must be reclaimed in the same logical GC pass.
+    let swept_snapshot_authorities = changelog_plan.sweep.commits.clone();
+    // Removing a dead changelog commit invalidates its commit-addressed delta
+    // inventory. Immutable tree/CAS payloads remain content-addressed
+    // maintenance work, but delta rows have no shared ownership and must be
+    // reclaimed in the same logical GC pass.
     let phase_started = Instant::now();
-    crate::tracked_state::stage_delete_commit_roots(
-        writes,
-        sweep_tracked_commit_roots.iter().copied(),
-    );
     // Old serving generations are derived data. Removing them in the same
     // atomic sweep as their untracked payload-root withdrawal prevents stale
     // branch generations from accumulating indefinitely.
@@ -495,7 +487,7 @@ where
     Ok(RepositoryGcPlan {
         changelog: changelog_plan,
         sweep: RepositoryGcSweep {
-            tracked_commit_roots: sweep_tracked_commit_roots,
+            tracked_commit_roots: swept_snapshot_authorities,
         },
         profile: RepositoryGcProfile {
             root_discovery_us,
@@ -518,18 +510,6 @@ where
     let standalone_changes = scan_all_gc_standalone_changes(store.clone()).await?;
     let packed = crate::tracked_state::scan_commit_delta_inventory(store).await?;
 
-    if let Some(commit_id) = packed
-        .commits
-        .keys()
-        .find(|commit_id| !commits.contains(commit_id))
-    {
-        return Err(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!(
-                "garbage collection found packed commit-delta authority for missing commit '{commit_id}'"
-            ),
-        ));
-    }
     if let Some(change_id) = standalone_changes.keys().find(|change_id| {
         packed.commits.values().any(|entry| {
             entry
@@ -567,51 +547,112 @@ where
         pending.extend(commits.parent_commit_ids(commit).iter().copied());
     }
 
-    // A selected cascade tombstone intentionally carries no payload and
-    // cannot be promoted into canonical change authority. If it is the only
-    // surviving reference to a change, retain the authored owner's commit
-    // ancestry as an authority root. Ordinary selected rows carry matching
-    // identity and are promoted below, so they do not retain dead history.
-    let referenced_change_ids = live_commits
-        .iter()
-        .filter_map(|commit_id| packed.commits.get(commit_id))
-        .flat_map(|entry| entry.members.iter().map(|member| member.value.change_id))
-        .collect::<BTreeSet<_>>();
-    let promotable_change_ids = live_commits
-        .iter()
-        .filter_map(|commit_id| packed.commits.get(commit_id))
-        .flat_map(|entry| entry.members.iter())
-        .filter(|member| member.authored || member.is_selected_payload_ref())
-        .map(|member| member.value.change_id)
-        .collect::<BTreeSet<_>>();
-    let mut authority_roots = packed
-        .commits
-        .iter()
-        .filter(|(commit_id, _)| !live_commits.contains(commit_id))
-        .filter_map(|(commit_id, entry)| {
-            entry
-                .members
-                .iter()
-                .any(|member| {
-                    member.authored
-                        && referenced_change_ids.contains(&member.value.change_id)
-                        && !promotable_change_ids.contains(&member.value.change_id)
-                })
-                .then_some(*commit_id)
-        })
-        .collect::<Vec<_>>();
-    while let Some(commit_id) = authority_roots.pop() {
-        if !live_commits.insert(commit_id) {
-            continue;
-        }
-        let commit = commits.get(commit_id).ok_or_else(|| {
+    // GC is destructive, so the hard-cut commit-state manifest must be
+    // present and agree with every live changelog topology projection before
+    // payload reachability or sweep mutations are derived. Missing authority
+    // must not silently turn a live commit into an empty mutation owner.
+    for commit_id in &live_commits {
+        let commit = commits
+            .get(*commit_id)
+            .expect("live commit existence was checked during graph walk");
+        let authority = packed.commits.get(commit_id).ok_or_else(|| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
-                format!("canonical authority references missing commit '{commit_id}'"),
+                format!("live commit '{commit_id}' has no commit-state authority"),
             )
         })?;
-        authority_roots.extend(commits.parent_commit_ids(commit).iter().copied());
+        let topology = &authority.authority;
+        let manifest_rootless = topology.replay_debt.depth > 0;
+        if topology.generation != commit.generation
+            || topology.parent_commit_ids != commits.parent_commit_ids(commit)
+            || topology.commit_change_id != commit.change_id
+            || topology.author_account_ids != commit.author_account_ids
+            || topology.created_at != commit.created_at
+            || manifest_rootless != commit.tracked_state_rootless
+            || topology.replay_debt.depth != commit.tracked_state_rootless_depth
+            || topology.replay_debt.rows != commit.tracked_state_rootless_rows
+            || topology.replay_debt.bytes != commit.tracked_state_rootless_bytes
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("live commit '{commit_id}' disagrees with its commit-state authority"),
+            ));
+        }
     }
+
+    // Mutation parts are immutable: direct ChangeIds encode their physical
+    // part slot and ordinal. Retain selected-source and authored-owner parts
+    // instead of rewriting them into a surviving commit. Logical commit
+    // reachability remains independent, so an authority owner may disappear
+    // from `lix_commit` while its immutable mutation part remains addressable.
+    let referenced_change_ids = live_commits
+        .iter()
+        .map(|commit_id| {
+            packed
+                .commits
+                .get(commit_id)
+                .expect("live commit-state authorities were validated")
+        })
+        .flat_map(|entry| entry.members.iter().map(|member| member.value.change_id))
+        .collect::<BTreeSet<_>>();
+    let mut retained_authority_commits = live_commits.clone();
+    let mut authority_roots = live_commits
+        .iter()
+        .map(|commit_id| {
+            packed
+                .commits
+                .get(commit_id)
+                .expect("live commit-state authorities were validated")
+        })
+        .filter_map(|entry| entry.selected_source_commit_id)
+        .collect::<Vec<_>>();
+    authority_roots.extend(
+        packed
+            .commits
+            .iter()
+            .filter(|(commit_id, _)| !live_commits.contains(commit_id))
+            .filter_map(|(commit_id, entry)| {
+                entry
+                    .members
+                    .iter()
+                    .any(|member| {
+                        member.authored && referenced_change_ids.contains(&member.value.change_id)
+                    })
+                    .then_some(*commit_id)
+            }),
+    );
+    while let Some(commit_id) = authority_roots.pop() {
+        if !retained_authority_commits.insert(commit_id) {
+            continue;
+        }
+        if !packed.commits.contains_key(&commit_id) {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("canonical mutation authority '{commit_id}' is missing"),
+            ));
+        }
+    }
+    if let Some((commit_id, source_commit_id)) = live_commits.iter().find_map(|commit_id| {
+        packed
+            .commits
+            .get(commit_id)
+            .and_then(|entry| entry.selected_source_commit_id)
+            .filter(|source_commit_id| !packed.commits.contains_key(source_commit_id))
+            .map(|source_commit_id| (*commit_id, source_commit_id))
+    }) {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "live commit '{commit_id}' references missing mutation authority '{source_commit_id}'"
+            ),
+        ));
+    }
+    let sweep_authority_commits = packed
+        .commits
+        .keys()
+        .filter(|commit_id| !retained_authority_commits.contains(commit_id))
+        .copied()
+        .collect::<Vec<_>>();
 
     let standalone_root_ids = roots
         .iter()
@@ -646,12 +687,14 @@ where
             &mut live_payload_hashes,
         );
     }
-    for commit_id in &live_commits {
-        if let Some(entry) = packed.commits.get(commit_id) {
-            for member in &entry.members {
-                live_change_ids.insert(member.value.change_id);
-                collect_change_payload_hashes(&member.change, &mut live_payload_hashes);
-            }
+    for commit_id in &retained_authority_commits {
+        let entry = packed
+            .commits
+            .get(commit_id)
+            .expect("retained mutation authorities were validated");
+        for member in &entry.members {
+            live_change_ids.insert(member.value.change_id);
+            collect_change_payload_hashes(&member.change, &mut live_payload_hashes);
         }
     }
 
@@ -667,7 +710,7 @@ where
         .collect::<Vec<_>>();
 
     let mut dead_payload_hashes = BTreeSet::new();
-    for commit_id in &sweep_commits {
+    for commit_id in &sweep_authority_commits {
         if let Some(entry) = packed.commits.get(commit_id) {
             for member in &entry.members {
                 collect_change_payload_hashes(&member.change, &mut dead_payload_hashes);
@@ -688,7 +731,7 @@ where
         .map(JsonRef::from_hash_bytes)
         .collect::<Vec<_>>();
 
-    let dead_packed_change_ids = sweep_commits
+    let dead_packed_change_ids = sweep_authority_commits
         .iter()
         .filter_map(|commit_id| packed.commits.get(commit_id))
         .flat_map(|entry| entry.members.iter().map(|member| member.value.change_id))
@@ -697,56 +740,7 @@ where
         writes,
         dead_packed_change_ids.difference(&live_change_ids).copied(),
     );
-    // Selected commit rows persist only a canonical-reference tag. When GC
-    // removes the original authored owner, promote a surviving full selected
-    // row in-place before relocating the locator. This keeps immutable
-    // history self-contained without retaining an otherwise dead commit.
-    let mut promoted_locators = Vec::new();
-    for commit_id in &live_commits {
-        let Some(entry) = packed.commits.get(commit_id) else {
-            continue;
-        };
-        let borrowed_source_is_swept = entry
-            .selected_source_commit_id
-            .is_some_and(|source_commit_id| sweep_commits.contains(&source_commit_id));
-        if !borrowed_source_is_swept
-            && !entry.members.iter().any(|member| {
-                dead_packed_change_ids.contains(&member.value.change_id)
-                    && member.is_selected_payload_ref()
-            })
-        {
-            continue;
-        }
-        let deltas = entry
-            .members
-            .iter()
-            .map(|member| crate::tracked_state::TrackedStateCommitDeltaRef {
-                delta: crate::tracked_state::TrackedStateDeltaRef {
-                    schema_key: &member.key.schema_key,
-                    file_id: member.key.file_id.as_deref(),
-                    entity_pk: &member.key.entity_pk,
-                    change_id: member.value.change_id,
-                    commit_id: *commit_id,
-                    deleted: member.value.deleted,
-                    created_at: member.value.created_at,
-                    updated_at: member.value.updated_at,
-                },
-                snapshot: member.change.snapshot.as_ref_slot(),
-                metadata: member.change.metadata.as_ref_slot(),
-                origin_key: member.change.origin_key.as_deref(),
-                base_coordinate: member.base_coordinate,
-                authored: member.authored
-                    || (borrowed_source_is_swept && !member.is_selected_tombstone())
-                    || (dead_packed_change_ids.contains(&member.value.change_id)
-                        && member.is_selected_payload_ref()),
-            })
-            .collect::<Vec<_>>();
-        promoted_locators.extend(authoritative_promoted_locators(
-            &deltas,
-            crate::tracked_state::stage_commit_deltas(writes, &deltas)?,
-        )?);
-    }
-    let relocated_locators = live_commits
+    let relocated_locators = retained_authority_commits
         .iter()
         .filter_map(|commit_id| {
             packed
@@ -776,22 +770,13 @@ where
         })
         .into_values()
         .collect::<Vec<_>>();
-    let relocated_locators = promoted_locators
-        .into_iter()
-        .chain(relocated_locators)
-        .fold(BTreeMap::new(), |mut locators, locator| {
-            locators.entry(locator.change_id).or_insert(locator);
-            locators
-        })
-        .into_values()
-        .collect::<Vec<_>>();
     crate::tracked_state::stage_change_locators(writes, &relocated_locators);
 
     writes.delete_batch(
         COMMIT_SPACE,
         sweep_commits.iter().map(|commit_id| commit_key(*commit_id)),
     );
-    for commit_id in &sweep_commits {
+    for commit_id in &sweep_authority_commits {
         if let Some(entry) = packed.commits.get(commit_id) {
             let schema_keys = entry
                 .members
@@ -846,40 +831,17 @@ where
     })
 }
 
-fn authoritative_promoted_locators(
-    deltas: &[crate::tracked_state::TrackedStateCommitDeltaRef<'_>],
-    staged_locators: Vec<crate::tracked_state::CommitDeltaChangeLocator>,
-) -> Result<Vec<crate::tracked_state::CommitDeltaChangeLocator>, LixError> {
-    if staged_locators.len() != deltas.len() {
-        return Err(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            "promoted commit-delta locator count does not match its members",
-        ));
-    }
-    // The caller supplies decoded members and staged locators in the same
-    // physical-key order. Only rows that are authoritative after promotion
-    // may become canonical locator targets; selected cascade tombstones
-    // intentionally remain payload-free even when another row causes this
-    // commit to be packed again.
-    let mut promoted = Vec::new();
-    for (delta, locator) in deltas.iter().zip(staged_locators) {
-        if delta.delta.change_id != locator.change_id {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                "promoted commit-delta locator order does not match its members",
-            ));
-        }
-        if delta.authored {
-            promoted.push(locator);
-        }
-    }
-    Ok(promoted)
-}
-
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 struct GcCommitInventoryEntry {
     commit_id: CommitId,
+    generation: u64,
+    tracked_state_rootless: bool,
+    tracked_state_rootless_depth: u16,
+    tracked_state_rootless_rows: u64,
+    tracked_state_rootless_bytes: u64,
     change_id: ChangeId,
+    author_account_ids: Vec<String>,
+    created_at: crate::common::LixTimestamp,
     parent_start: usize,
     parent_len: usize,
 }
@@ -891,10 +853,6 @@ struct GcCommitInventory {
 }
 
 impl GcCommitInventory {
-    fn contains(&self, commit_id: &CommitId) -> bool {
-        self.get(*commit_id).is_some()
-    }
-
     fn get(&self, commit_id: CommitId) -> Option<&GcCommitInventoryEntry> {
         self.entries
             .binary_search_by_key(&commit_id, |entry| entry.commit_id)
@@ -946,7 +904,14 @@ where
                 .extend(commit.parent_commit_ids.into_iter());
             commits.entries.push(GcCommitInventoryEntry {
                 commit_id: commit.commit_id,
+                generation: commit.generation,
+                tracked_state_rootless: commit.tracked_state_rootless,
+                tracked_state_rootless_depth: commit.tracked_state_rootless_depth,
+                tracked_state_rootless_rows: commit.tracked_state_rootless_rows,
+                tracked_state_rootless_bytes: commit.tracked_state_rootless_bytes,
                 change_id: commit.change_id,
+                author_account_ids: commit.author_account_ids,
+                created_at: commit.created_at,
                 parent_start,
                 parent_len,
             });
@@ -1008,7 +973,7 @@ fn elapsed_micros(started: Instant) -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
+    use std::collections::{BTreeMap, BTreeSet};
     use std::sync::Arc;
 
     use crate::branch::{BranchHeadControlContext, stage_branch_head_control};
@@ -1028,10 +993,11 @@ mod tests {
         StorageKey, StorageReadOptions, StorageSpace, StorageWriteOptions,
     };
     use crate::tracked_state::{
+        CommitStateManifest, CommitStateMutationInventory, CommitStateReplayDebt,
         TrackedStateCommitDeltaRef, TrackedStateContext, TrackedStateDeltaRef,
         load_change_record_by_id, scan_change_records_from_commit_deltas,
         scan_commit_delta_inventory, stage_addressable_commit_deltas_with_selected_source,
-        stage_change_locators, stage_commit_deltas,
+        stage_change_locators, stage_commit_deltas_for_commit_state, stage_commit_state_manifest,
     };
     use crate::{Engine, GLOBAL_BRANCH_ID, Value};
     use bytes::Bytes;
@@ -1353,7 +1319,115 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn authority_gc_materializes_tombstone_only_checkpoint_alias_before_source_sweep() {
+    async fn authority_gc_rejects_missing_live_commit_state_before_staging_deletes() {
+        let storage = StorageAdapter::new(Memory::new());
+        let live = gc_authority_record("gc-missing-live-authority");
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("missing-authority fixture read should open");
+        let mut writes = storage.new_write_set();
+        ChangelogContext::new()
+            .writer(&mut read, &mut writes)
+            .stage_append(ChangelogAppend {
+                commits: vec![live.clone()],
+                changes: Vec::new(),
+            })
+            .await
+            .expect("missing-authority commit should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("missing-authority fixture should commit");
+
+        let read = SharedStorageAdapterRead::new(
+            storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("missing-authority GC read should open"),
+        );
+        let mut gc_writes = storage.new_write_set();
+        let error = super::plan_and_stage_authority_gc(
+            &read,
+            &mut gc_writes,
+            &[GcRoot::BranchHead(live.commit_id)],
+        )
+        .await
+        .expect_err("GC must reject a live commit without hard-cut authority");
+        assert!(error.message.contains("has no commit-state authority"));
+        assert!(
+            gc_writes.is_empty(),
+            "authority validation must precede every destructive GC mutation"
+        );
+    }
+
+    #[tokio::test]
+    async fn authority_gc_rejects_live_topology_drift_before_staging_deletes() {
+        let storage = StorageAdapter::new(Memory::new());
+        let live = gc_authority_record("gc-live-authority-drift");
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("authority-drift fixture read should open");
+        let mut writes = storage.new_write_set();
+        ChangelogContext::new()
+            .writer(&mut read, &mut writes)
+            .stage_append(ChangelogAppend {
+                commits: vec![live.clone()],
+                changes: Vec::new(),
+            })
+            .await
+            .expect("authority-drift commit should stage");
+        let mut drifted = CommitStateManifest {
+            commit_id: live.commit_id,
+            generation: live.generation,
+            parent_commit_ids: live.parent_commit_ids.clone(),
+            commit_change_id: live.change_id,
+            author_account_ids: live.author_account_ids.clone(),
+            created_at: live.created_at,
+            replay_debt: CommitStateReplayDebt {
+                depth: live.tracked_state_rootless_depth,
+                rows: live.tracked_state_rootless_rows,
+                bytes: live.tracked_state_rootless_bytes,
+            },
+            mutations: CommitStateMutationInventory::default(),
+            snapshot_root: None,
+        };
+        drifted.generation += 1;
+        stage_commit_state_manifest(&mut writes, &drifted)
+            .expect("internally valid but projection-drifted authority should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("authority-drift fixture should commit");
+
+        let read = SharedStorageAdapterRead::new(
+            storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("authority-drift GC read should open"),
+        );
+        let mut gc_writes = storage.new_write_set();
+        let error = super::plan_and_stage_authority_gc(
+            &read,
+            &mut gc_writes,
+            &[GcRoot::BranchHead(live.commit_id)],
+        )
+        .await
+        .expect_err("GC must reject topology projection drift");
+        assert!(
+            error
+                .message
+                .contains("disagrees with its commit-state authority")
+        );
+        assert!(
+            gc_writes.is_empty(),
+            "authority validation must precede every destructive GC mutation"
+        );
+    }
+
+    #[tokio::test]
+    async fn authority_gc_retains_tombstone_only_checkpoint_alias_source() {
         let storage = Memory::new();
         let storage_adapter = StorageAdapter::new(storage);
         let source_commit = CommitId::for_test_label("gc-tombstone-alias-source");
@@ -1448,21 +1522,39 @@ mod tests {
         let mut source_deltas =
             commit_delta_refs(source_commit, std::slice::from_ref(&source_change));
         source_deltas[0].base_coordinate = Some(base_coordinate);
-        let source_locators = stage_commit_deltas(&mut writes, &source_deltas)
+        let source_stage = stage_commit_deltas_for_commit_state(&mut writes, &source_deltas)
             .expect("source tombstone should stage");
-        stage_change_locators(&mut writes, &source_locators);
+        stage_change_locators(&mut writes, &source_stage.locators);
         let authority_deltas =
             commit_delta_refs(authority_commit, std::slice::from_ref(&source_change));
-        stage_commit_deltas(&mut writes, &authority_deltas)
+        let authority_stage = stage_commit_deltas_for_commit_state(&mut writes, &authority_deltas)
             .expect("surviving tombstone authority should stage");
         let alias_local = commit_delta_refs(alias_commit, std::slice::from_ref(&marker_change));
-        stage_addressable_commit_deltas_with_selected_source(
+        let alias_stage = stage_addressable_commit_deltas_with_selected_source(
             &mut writes,
             &alias_local,
             &[false],
             source_commit,
         )
         .expect("tombstone-only alias should stage");
+        let inventories = BTreeMap::from([
+            (source_commit, source_stage.mutation_inventory().clone()),
+            (
+                authority_commit,
+                authority_stage.mutation_inventory().clone(),
+            ),
+            (alias_commit, alias_stage.mutation_inventory().clone()),
+        ]);
+        for record in &commits {
+            stage_test_commit_state_manifest(
+                &mut writes,
+                record,
+                inventories
+                    .get(&record.commit_id)
+                    .cloned()
+                    .unwrap_or_default(),
+            );
+        }
         storage_adapter
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
@@ -1495,12 +1587,12 @@ mod tests {
         let inventory = scan_commit_delta_inventory(&read)
             .await
             .expect("materialized tombstone alias inventory should load");
-        assert!(!inventory.commits.contains_key(&source_commit));
+        assert!(inventory.commits.contains_key(&source_commit));
         let alias = inventory
             .commits
             .get(&alias_commit)
-            .expect("live alias should remain materialized");
-        assert_eq!(alias.selected_source_commit_id, None);
+            .expect("live alias should remain readable");
+        assert_eq!(alias.selected_source_commit_id, Some(source_commit));
         assert_eq!(alias.members.len(), 2);
         assert!(alias.members.iter().all(|member| member.value.deleted));
         assert_eq!(
@@ -1510,7 +1602,7 @@ mod tests {
                 .find(|member| member.value.change_id == source_change.change_id)
                 .and_then(|member| member.base_coordinate),
             Some(base_coordinate),
-            "GC promotion must preserve the immutable columnar-base address"
+            "retained immutable authority must preserve the columnar-base address"
         );
         assert_eq!(
             alias
@@ -1523,11 +1615,11 @@ mod tests {
         );
         scan_change_records_from_commit_deltas(&read)
             .await
-            .expect("materialized cascade tombstone must preserve canonical history");
+            .expect("retained cascade tombstone authority must preserve canonical history");
     }
 
     #[tokio::test]
-    async fn authority_gc_sweeps_dead_packed_and_standalone_facts_but_keeps_shared_payloads() {
+    async fn authority_gc_retains_immutable_packed_owner_and_sweeps_dead_standalone_fact() {
         let storage = Memory::new();
         let storage_adapter = StorageAdapter::new(storage.clone());
         let shared_ref = stage_bare_json(&storage, r#"{"payload":"shared"}"#).await;
@@ -1611,7 +1703,7 @@ mod tests {
         let mut writer = ChangelogContext::new().writer(&mut read, &mut writes);
         writer
             .stage_append(ChangelogAppend {
-                commits,
+                commits: commits.clone(),
                 changes: vec![live_standalone.clone(), dead_standalone.clone()],
             })
             .await
@@ -1621,11 +1713,27 @@ mod tests {
         // The surviving copy is a merge/checkpoint selection. Once the
         // original owner dies, GC promotes it through locator relocation.
         live_deltas[0].authored = false;
-        stage_commit_deltas(&mut writes, &live_deltas).expect("live packed member should stage");
+        let live_stage = stage_commit_deltas_for_commit_state(&mut writes, &live_deltas)
+            .expect("live packed member should stage");
         let dead_members = vec![dead_shared_member.clone(), dead_only_member.clone()];
         let dead_deltas = commit_delta_refs(dead_commit, &dead_members);
-        let dead_locators = stage_commit_deltas(&mut writes, &dead_deltas)
+        let dead_stage = stage_commit_deltas_for_commit_state(&mut writes, &dead_deltas)
             .expect("dead packed members should stage");
+        let dead_locators = dead_stage.locators.clone();
+        let inventories = BTreeMap::from([
+            (live_parent, live_stage.mutation_inventory().clone()),
+            (dead_commit, dead_stage.mutation_inventory().clone()),
+        ]);
+        for record in &commits {
+            stage_test_commit_state_manifest(
+                &mut writes,
+                record,
+                inventories
+                    .get(&record.commit_id)
+                    .cloned()
+                    .unwrap_or_default(),
+            );
+        }
         let sidecar_schema = Arc::new(Schema::new(vec![Field::new(
             "value",
             DataType::Utf8,
@@ -1682,8 +1790,8 @@ mod tests {
             "a payload shared with live packed history must stay live"
         );
         assert!(
-            plan.sweep.json_payloads.contains(&dead_only_ref),
-            "a payload referenced only by dead packed and standalone facts must sweep"
+            !plan.sweep.json_payloads.contains(&dead_only_ref),
+            "co-resident immutable part members and their payloads remain reachable"
         );
         storage_adapter
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -1726,14 +1834,14 @@ mod tests {
         assert!(
             load_change_record_by_id(&read, live_member.change_id)
                 .await
-                .expect("relocated live locator should load")
+                .expect("retained live authority should load")
                 .is_some()
         );
         assert!(
             load_change_record_by_id(&read, dead_only_member.change_id)
                 .await
-                .expect("dead locator lookup should succeed")
-                .is_none()
+                .expect("co-resident authority lookup should succeed")
+                .is_some()
         );
         let canonical_changes = scan_change_records_from_commit_deltas(&read)
             .await
@@ -1746,13 +1854,13 @@ mod tests {
         assert!(
             canonical_changes
                 .iter()
-                .all(|change| change.change_id != dead_only_member.change_id)
+                .any(|change| change.change_id == dead_only_member.change_id)
         );
         let inventory = scan_commit_delta_inventory(&read)
             .await
             .expect("post-GC packed inventory should scan");
         assert!(inventory.commits.contains_key(&live_parent));
-        assert!(!inventory.commits.contains_key(&dead_commit));
+        assert!(inventory.commits.contains_key(&dead_commit));
         assert!(
             crate::columnar_row_group::load_row_group_manifest(
                 &read,
@@ -1769,14 +1877,14 @@ mod tests {
                 crate::live_state::entity_row_group_set_id(dead_commit, "authority_gc"),
             )
             .await
-            .expect("load swept sidecar")
-            .is_none(),
-            "swept commit sidecars must be removed"
+            .expect("load retained authority sidecar")
+            .is_some(),
+            "sidecars co-owned by retained immutable authority must survive"
         );
         drop(read);
         assert!(json_ref_exists(&storage, crate::json_store::store::JSON_SPACE, shared_ref).await);
         assert!(
-            !json_ref_exists(
+            json_ref_exists(
                 &storage,
                 crate::json_store::store::JSON_SPACE,
                 dead_only_ref,
@@ -1790,59 +1898,6 @@ mod tests {
                 live_standalone_ref,
             )
             .await
-        );
-    }
-
-    #[test]
-    fn promoted_locator_filter_excludes_selected_tombstones() {
-        let commit_id = CommitId::for_test_label("mixed-promotion-commit");
-        let change_id = ChangeId::for_test_label("shared-promotion-change");
-        let mut tombstone =
-            packed_change("selected-tombstone", "a-selected-tombstone", JsonSlot::None);
-        tombstone.change_id = change_id;
-        let mut promoted = packed_change("promoted-owner", "z-promoted-owner", JsonSlot::None);
-        promoted.change_id = change_id;
-        let unrelated_change_id = ChangeId::for_test_label("unrelated-authored-change");
-        let mut unrelated = packed_change(
-            "unrelated-authority",
-            "zz-unrelated-authority",
-            JsonSlot::None,
-        );
-        unrelated.change_id = unrelated_change_id;
-        let changes = [tombstone, promoted, unrelated];
-        let mut deltas = commit_delta_refs(commit_id, &changes);
-        deltas[0].authored = false;
-        let locators = vec![
-            crate::tracked_state::CommitDeltaChangeLocator {
-                change_id,
-                commit_id,
-                segment_index: 0,
-                ordinal: 0,
-            },
-            crate::tracked_state::CommitDeltaChangeLocator {
-                change_id,
-                commit_id,
-                segment_index: 0,
-                ordinal: 1,
-            },
-            crate::tracked_state::CommitDeltaChangeLocator {
-                change_id: unrelated_change_id,
-                commit_id,
-                segment_index: 1,
-                ordinal: 0,
-            },
-        ];
-
-        let filtered = super::authoritative_promoted_locators(&deltas, locators)
-            .expect("mixed promotion locators should filter");
-
-        assert_eq!(filtered.len(), 2);
-        assert_eq!(
-            filtered
-                .iter()
-                .map(|locator| locator.change_id)
-                .collect::<BTreeSet<_>>(),
-            BTreeSet::from([change_id, unrelated_change_id]),
         );
     }
 
@@ -2023,6 +2078,25 @@ mod tests {
         }
     }
 
+    fn gc_authority_record(label: &str) -> CommitRecord {
+        CommitRecord {
+            format_version: 1,
+            commit_id: CommitId::for_test_label(label),
+            generation: 0,
+            parent_commit_ids: Vec::new(),
+            tracked_state_rootless: true,
+            tracked_state_rootless_depth: 1,
+            tracked_state_rootless_rows: 0,
+            tracked_state_rootless_bytes: 0,
+            change_id: ChangeId::for_test_label(&format!("{label}-header")),
+            author_account_ids: Vec::new(),
+            created_at: LixTimestamp::expect_parse(
+                "authority GC record timestamp",
+                "2026-01-01T00:00:00.000Z",
+            ),
+        }
+    }
+
     fn commit_delta_refs<'a>(
         commit_id: CommitId,
         changes: &'a [ChangeRecord],
@@ -2047,6 +2121,32 @@ mod tests {
                 authored: true,
             })
             .collect()
+    }
+
+    fn stage_test_commit_state_manifest(
+        writes: &mut crate::storage_adapter::StorageWriteSet,
+        record: &CommitRecord,
+        mutations: CommitStateMutationInventory,
+    ) {
+        stage_commit_state_manifest(
+            writes,
+            &CommitStateManifest {
+                commit_id: record.commit_id,
+                generation: record.generation,
+                parent_commit_ids: record.parent_commit_ids.clone(),
+                commit_change_id: record.change_id,
+                author_account_ids: record.author_account_ids.clone(),
+                created_at: record.created_at,
+                replay_debt: CommitStateReplayDebt {
+                    depth: record.tracked_state_rootless_depth,
+                    rows: record.tracked_state_rootless_rows,
+                    bytes: record.tracked_state_rootless_bytes,
+                },
+                mutations,
+                snapshot_root: None,
+            },
+        )
+        .expect("GC fixture commit-state manifest should stage");
     }
 
     async fn json_ref_exists(storage: &Memory, space: StorageSpace, json_ref: JsonRef) -> bool {

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -28,7 +28,10 @@ use crate::storage_adapter::{
     StorageAdapter, StorageGetOptions, StorageKey, StorageProjectedValue, StorageSpace,
     StorageSpaceId, StorageWriteSet,
 };
-use crate::tracked_state::{TrackedStateCommitDeltaRef, TrackedStateContext, TrackedStateDeltaRef};
+use crate::tracked_state::{
+    CommitStateManifest, CommitStateReplayDebt, TrackedStateCommitDeltaRef, TrackedStateContext,
+    TrackedStateDeltaRef, stage_commit_deltas_for_commit_state, stage_commit_state_manifest,
+};
 use bytes::Bytes;
 use serde_json::json;
 
@@ -48,7 +51,7 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::mutable(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"lxcd9-generation-indexed-commits.v46";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"commit-state-manifest.v47";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately
@@ -365,12 +368,36 @@ where
                 authored: true,
             })
             .collect::<Vec<_>>();
-        let locators = crate::tracked_state::stage_commit_deltas(&mut writes, &commit_deltas)?;
-        crate::tracked_state::stage_change_locators(&mut writes, &locators);
-        tracked_state
-            .writer(&read, &mut writes)
+        let staged_delta = stage_commit_deltas_for_commit_state(&mut writes, &commit_deltas)?;
+        crate::tracked_state::stage_change_locators(&mut writes, &staged_delta.locators);
+        let mut tracked_writer = tracked_state.writer(&read, &mut writes);
+        tracked_writer
             .stage_commit_root(&receipt.initial_commit_id, None, root_deltas)
             .await?;
+        let snapshot_root = tracked_writer
+            .staged_commit_roots()
+            .find(|root| root.commit_id == plan.commit.id)
+            .cloned()
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "repository initialization did not stage its snapshot root",
+                )
+            })?;
+        stage_commit_state_manifest(
+            &mut writes,
+            &CommitStateManifest {
+                commit_id: plan.commit.id,
+                generation: 0,
+                parent_commit_ids: plan.commit.parent_ids.clone(),
+                commit_change_id: plan.commit.change_id,
+                author_account_ids: plan.commit.author_account_ids.clone(),
+                created_at: plan.commit.created_at,
+                replay_debt: CommitStateReplayDebt::default(),
+                mutations: staged_delta.mutation_inventory().clone(),
+                snapshot_root: Some(snapshot_root),
+            },
+        )?;
 
         // Seed both visible branches with a complete hot current-state generation.
         // The initial commit is shared, but the branch-scoped marker and

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -1634,8 +1634,9 @@ mod tests {
     use crate::storage_adapter::{Memory, StorageReadOptions, StorageWriteOptions};
     use crate::storage_adapter::{StorageAdapter, StorageWriteSet};
     use crate::tracked_state::{
-        MaterializedTrackedStateRow, TrackedStateCommitDeltaRef, TrackedStateDeltaRef,
-        TrackedStateScanRequest, stage_commit_deltas,
+        CommitStateManifest, CommitStateReplayDebt, MaterializedTrackedStateRow,
+        TrackedStateCommitDeltaRef, TrackedStateDeltaRef, TrackedStateScanRequest,
+        stage_commit_deltas_for_commit_state, stage_commit_state_manifest,
     };
     use serde_json::json;
 
@@ -2781,10 +2782,11 @@ mod tests {
     ) {
         let mut writes = storage.new_write_set();
         let mut append = ChangelogAppend::default();
+        let mut records = std::collections::BTreeMap::new();
         for commit_id in commit_ids {
             let commit_id_text = CommitId::for_test_label(commit_id).to_string();
             let commit_change_id = format!("{commit_id_text}:commit");
-            append.commits.push(crate::changelog::CommitRecord {
+            let record = crate::changelog::CommitRecord {
                 format_version: 1,
                 commit_id: CommitId::for_test_label(&commit_id_text),
                 generation: 0,
@@ -2796,7 +2798,9 @@ mod tests {
                 change_id: ChangeId::for_test_label(&commit_change_id),
                 author_account_ids: Vec::new(),
                 created_at: ts("1970-01-01T00:00:00.000Z"),
-            });
+            };
+            records.insert(record.commit_id, record.clone());
+            append.commits.push(record);
         }
         let mut changelog_read = read;
         let mut writer = ChangelogContext::new().writer(&mut changelog_read, &mut writes);
@@ -2806,11 +2810,37 @@ mod tests {
         drop(writer);
         for commit_id in commit_ids {
             let commit_id_text = CommitId::for_test_label(commit_id).to_string();
-            TrackedStateContext::new()
-                .writer(read, &mut writes)
+            let typed_commit_id = CommitId::for_test_label(commit_id);
+            let tracked_state = TrackedStateContext::new();
+            let mut root_writer = tracked_state.writer(read, &mut writes);
+            root_writer
                 .stage_commit_root(&commit_id_text, None, [])
                 .await
                 .expect("empty tracked roots should stage");
+            let snapshot_root = root_writer
+                .staged_commit_roots()
+                .find(|root| root.commit_id == typed_commit_id)
+                .cloned()
+                .expect("empty tracked snapshot should stage");
+            drop(root_writer);
+            let record = records
+                .get(&typed_commit_id)
+                .expect("empty commit record should exist");
+            stage_commit_state_manifest(
+                &mut writes,
+                &CommitStateManifest {
+                    commit_id: record.commit_id,
+                    generation: record.generation,
+                    parent_commit_ids: record.parent_commit_ids.clone(),
+                    commit_change_id: record.change_id,
+                    author_account_ids: record.author_account_ids.clone(),
+                    created_at: record.created_at,
+                    replay_debt: CommitStateReplayDebt::default(),
+                    mutations: Default::default(),
+                    snapshot_root: Some(snapshot_root),
+                },
+            )
+            .expect("empty commit-state authority should stage");
         }
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -3000,8 +3030,9 @@ mod tests {
                 commit_id,
                 generation,
                 parent_commit_ids: parents,
-                tracked_state_rootless: false,
-                tracked_state_rootless_depth: 0,
+                tracked_state_rootless: true,
+                tracked_state_rootless_depth: u16::try_from(generation + 1)
+                    .expect("fixture generation should fit replay depth"),
                 tracked_state_rootless_rows: 0,
                 tracked_state_rootless_bytes: 0,
                 change_id: ChangeId::for_test_label(&format!("{commit_id}:change")),
@@ -3009,12 +3040,34 @@ mod tests {
                 created_at: ts("1970-01-01T00:00:00.000Z"),
             });
         }
+        let commit_records = append.commits.clone();
         let mut changelog_read = &read;
         let mut writer = ChangelogContext::new().writer(&mut changelog_read, &mut writes);
         crate::changelog::ChangelogWriter::stage_append(&mut writer, append)
             .await
             .expect("mixed derived commits should stage");
         drop(writer);
+        for record in commit_records {
+            stage_commit_state_manifest(
+                &mut writes,
+                &CommitStateManifest {
+                    commit_id: record.commit_id,
+                    generation: record.generation,
+                    parent_commit_ids: record.parent_commit_ids,
+                    commit_change_id: record.change_id,
+                    author_account_ids: record.author_account_ids,
+                    created_at: record.created_at,
+                    replay_debt: CommitStateReplayDebt {
+                        depth: record.tracked_state_rootless_depth,
+                        rows: record.tracked_state_rootless_rows,
+                        bytes: record.tracked_state_rootless_bytes,
+                    },
+                    mutations: Default::default(),
+                    snapshot_root: None,
+                },
+            )
+            .expect("mixed derived commit authority should stage");
+        }
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
@@ -3152,15 +3205,15 @@ mod tests {
             } else {
                 0
             };
-            let mut append = ChangelogAppend::default();
-            append.commits.push(crate::changelog::CommitRecord {
+            let typed_parent_ids = parent_ids
+                .iter()
+                .map(|id| CommitId::for_test_label(id))
+                .collect::<Vec<_>>();
+            let record = crate::changelog::CommitRecord {
                 format_version: 1,
                 commit_id: CommitId::for_test_label(&commit_id),
                 generation,
-                parent_commit_ids: parent_ids
-                    .iter()
-                    .map(|id| CommitId::for_test_label(id))
-                    .collect(),
+                parent_commit_ids: typed_parent_ids,
                 tracked_state_rootless: false,
                 tracked_state_rootless_depth: 0,
                 tracked_state_rootless_rows: 0,
@@ -3168,7 +3221,9 @@ mod tests {
                 change_id: ChangeId::for_test_label(&commit_change_id),
                 author_account_ids: Vec::new(),
                 created_at: commit_created_at,
-            });
+            };
+            let mut append = ChangelogAppend::default();
+            append.commits.push(record.clone());
             let mut changelog_read = store;
             let mut writer = ChangelogContext::new().writer(&mut changelog_read, writes);
             crate::changelog::ChangelogWriter::stage_append(&mut writer, append).await?;
@@ -3200,11 +3255,33 @@ mod tests {
                     authored: true,
                 })
                 .collect::<Vec<_>>();
-            stage_commit_deltas(writes, &commit_deltas)?;
-            TrackedStateContext::new()
-                .writer(&*store, writes)
+            let staged_delta = stage_commit_deltas_for_commit_state(writes, &commit_deltas)?;
+            let mutation_inventory = staged_delta.mutation_inventory().clone();
+            let tracked_state = TrackedStateContext::new();
+            let mut root_writer = tracked_state.writer(&*store, writes);
+            root_writer
                 .stage_commit_root(&commit_id, parent_commit_id.as_deref(), root_deltas)
                 .await?;
+            let snapshot_root = root_writer
+                .staged_commit_roots()
+                .find(|root| root.commit_id == typed_commit_id)
+                .cloned()
+                .ok_or_else(|| LixError::unknown("test materialization did not stage a root"))?;
+            drop(root_writer);
+            stage_commit_state_manifest(
+                writes,
+                &CommitStateManifest {
+                    commit_id: record.commit_id,
+                    generation: record.generation,
+                    parent_commit_ids: record.parent_commit_ids,
+                    commit_change_id: record.change_id,
+                    author_account_ids: record.author_account_ids,
+                    created_at: record.created_at,
+                    replay_debt: CommitStateReplayDebt::default(),
+                    mutations: mutation_inventory,
+                    snapshot_root: Some(snapshot_root),
+                },
+            )?;
         }
 
         Ok(())

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -5043,14 +5043,17 @@ mod tests {
             .and_then(|(_, record)| record)
             .expect("head commit should exist");
         assert!(record.tracked_state_rootless);
-        assert_eq!(record.tracked_state_rootless_depth, 1);
-        assert_eq!(record.tracked_state_rootless_rows, ROW_COUNT as u64);
+        assert!(record.tracked_state_rootless_depth >= 1);
+        assert!(record.tracked_state_rootless_rows >= ROW_COUNT as u64);
         assert!(record.tracked_state_rootless_bytes > record.tracked_state_rootless_rows);
         assert!(
-            crate::tracked_state::load_commit_root(&history_read, &head.commit_id.to_string(),)
-                .await
-                .expect("root lookup should succeed")
-                .is_none(),
+            crate::tracked_state::load_authoritative_commit_root(
+                &history_read,
+                &head.commit_id.to_string(),
+            )
+            .await
+            .expect("root lookup should succeed")
+            .is_none(),
             "rootless production commit must skip the duplicate immutable tree"
         );
 
@@ -5127,16 +5130,19 @@ mod tests {
             descendant_record.tracked_state_rootless,
             "a sparse descendant must extend the rootless first-parent interval"
         );
-        assert_eq!(descendant_record.tracked_state_rootless_depth, 2);
+        assert_eq!(
+            descendant_record.tracked_state_rootless_depth,
+            record.tracked_state_rootless_depth + 1
+        );
         assert_eq!(
             descendant_record.tracked_state_rootless_rows,
-            ROW_COUNT as u64 + 1
+            record.tracked_state_rootless_rows + 1
         );
         assert!(
             descendant_record.tracked_state_rootless_bytes > record.tracked_state_rootless_bytes
         );
         assert!(
-            crate::tracked_state::load_commit_root(
+            crate::tracked_state::load_authoritative_commit_root(
                 &descendant_history_read,
                 &descendant.commit_id.to_string(),
             )
@@ -5266,7 +5272,7 @@ mod tests {
             .and_then(|(_, record)| record)
             .expect("reseed commit should exist");
         assert!(reseed_record.tracked_state_rootless);
-        assert_eq!(reseed_record.tracked_state_rootless_depth, 1);
+        assert!(reseed_record.tracked_state_rootless_depth >= 1);
 
         let mut rooted_fence = None;
         for generation_offset in 1..=32 {
@@ -5307,10 +5313,13 @@ mod tests {
                 assert_eq!(record.tracked_state_rootless_rows, 0);
                 assert_eq!(record.tracked_state_rootless_bytes, 0);
                 assert!(
-                    crate::tracked_state::load_commit_root(&read, &head.commit_id.to_string())
-                        .await
-                        .expect("root-fence lookup should succeed")
-                        .is_some(),
+                    crate::tracked_state::load_authoritative_commit_root(
+                        &read,
+                        &head.commit_id.to_string(),
+                    )
+                    .await
+                    .expect("root-fence lookup should succeed")
+                    .is_some(),
                     "a rooted fence must publish its immutable accelerator"
                 );
                 rooted_fence = Some(head.commit_id);

--- a/packages/engine/src/sql2/providers/change.rs
+++ b/packages/engine/src/sql2/providers/change.rs
@@ -9,7 +9,7 @@ use datafusion::logical_expr::{Expr, Operator, TableProviderFilterPushDown};
 use crate::LixError;
 use crate::changelog::{
     COMMIT_CHANGE_ID_SPACE, ChangeId, ChangeLoadRequest, ChangeRecord, ChangeScanRequest,
-    ChangelogContext, ChangelogReader, CommitId, CommitLoadRequest, CommitScanRequest,
+    ChangelogContext, ChangelogReader, CommitId,
 };
 use crate::serialize_row_metadata;
 
@@ -167,7 +167,7 @@ where
     }
     let packed_changes =
         crate::tracked_state::scan_change_records_from_commit_deltas(&store).await?;
-    let mut reader = ChangelogContext::new().reader(store);
+    let mut reader = ChangelogContext::new().reader(store.clone());
     let mut changes = packed_changes
         .into_iter()
         .map(LixChangeRow::Direct)
@@ -186,23 +186,11 @@ where
         };
         start_after = Some(next.to_string());
     }
-    let mut start_after = None::<String>;
-    loop {
-        let scan = reader
-            .scan_commits(CommitScanRequest {
-                start_after: start_after.as_deref(),
-                limit: Some(1024),
-            })
-            .await?;
-        for commit in scan.entries {
-            changes.push(LixChangeRow::DerivedCommit(
-                crate::commit_graph::canonical_commit_change(&commit.into()),
-            ));
-        }
-        let Some(next) = scan.next_start_after else {
-            break;
-        };
-        start_after = Some(next.to_string());
+    let mut graph_reader = crate::commit_graph::CommitGraphContext::new().reader(store);
+    for commit in graph_reader.all_nodes().await? {
+        changes.push(LixChangeRow::DerivedCommit(
+            crate::commit_graph::canonical_commit_change(&commit),
+        ));
     }
     changes.sort_by_key(LixChangeRow::change_id);
     if let Some(limit) = limit {
@@ -304,14 +292,10 @@ where
             format!("changelog commit change-id index has invalid commit id: {error}"),
         )
     })?);
-    let commit = reader
-        .load_commits(CommitLoadRequest {
-            commit_ids: std::slice::from_ref(&commit_id),
-        })
+    let commit = crate::commit_graph::CommitGraphContext::new()
+        .reader(store)
+        .load_node(&commit_id)
         .await?
-        .into_iter()
-        .next()
-        .and_then(|(_, value)| value)
         .ok_or_else(|| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
@@ -319,7 +303,7 @@ where
             )
         })?;
     Ok(Some(LixChangeRow::DerivedCommit(
-        crate::commit_graph::canonical_commit_change(&commit.into()),
+        crate::commit_graph::canonical_commit_change(&commit),
     )))
 }
 

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -10,6 +10,39 @@ use crate::storage_adapter::{
 };
 use crate::{ReadOptions, WriteOptions};
 
+fn stage_bench_commit_deltas(
+    writes: &mut StorageWriteSet,
+    deltas: &[crate::tracked_state::TrackedStateCommitDeltaRef<'_>],
+) -> Result<Vec<crate::tracked_state::CommitDeltaChangeLocator>, crate::LixError> {
+    let staged = crate::tracked_state::stage_commit_deltas_for_commit_state(writes, deltas)?;
+    let commit_id = deltas
+        .first()
+        .map(|delta| delta.delta.commit_id)
+        .unwrap_or_default();
+    let mutations = staged.mutation_inventory().clone();
+    crate::tracked_state::stage_commit_state_manifest(
+        writes,
+        &crate::tracked_state::CommitStateManifest {
+            commit_id,
+            generation: 0,
+            parent_commit_ids: Vec::new(),
+            commit_change_id: crate::changelog::ChangeId::for_test_label(&format!(
+                "{commit_id}:bench-commit"
+            )),
+            author_account_ids: Vec::new(),
+            created_at: crate::common::LixTimestamp::from_unix_millis_utc_lossy(0),
+            replay_debt: crate::tracked_state::CommitStateReplayDebt {
+                depth: 1,
+                rows: u64::from(mutations.member_count),
+                bytes: u64::from(mutations.member_count),
+            },
+            mutations,
+            snapshot_root: None,
+        },
+    )?;
+    Ok(staged.locators)
+}
+
 static TRANSACTION_ROWS_STAGED: AtomicU64 = AtomicU64::new(0);
 static TRANSACTION_UNTRACKED_ROWS: AtomicU64 = AtomicU64::new(0);
 static TRANSACTION_VALIDATION_BRANCHS: AtomicU64 = AtomicU64::new(0);
@@ -296,7 +329,7 @@ where
             "{{\"index\":{index},\"payload\":\"{}\"}}",
             "x".repeat(192)
         ));
-        crate::tracked_state::stage_commit_deltas(
+        stage_bench_commit_deltas(
             &mut writes,
             &[crate::tracked_state::TrackedStateCommitDeltaRef {
                 delta: crate::tracked_state::TrackedStateDeltaRef {
@@ -642,7 +675,7 @@ where
     let mut physical_bytes_by_commit =
         std::collections::BTreeMap::<crate::changelog::CommitId, (u64, u64)>::new();
     for space in [
-        crate::tracked_state::TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
+        crate::tracked_state::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
         crate::tracked_state::TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
     ] {
         for entry in scan_layout_entries(read, space).await {
@@ -1372,8 +1405,7 @@ fn native_storage_spaces() -> &'static [crate::storage_adapter::StorageSpace] {
         crate::json_store::store::JSON_SPACE,
         crate::json_store::UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE,
         crate::tracked_state::TRACKED_STATE_TREE_CHUNK_SPACE,
-        crate::tracked_state::TRACKED_STATE_COMMIT_ROOT_SPACE,
-        crate::tracked_state::TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
+        crate::tracked_state::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
         crate::tracked_state::TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
         crate::tracked_state::TRACKED_STATE_CHANGE_LOCATOR_SPACE,
         crate::binary_cas::kv::BINARY_CAS_MANIFEST_SPACE,
@@ -1629,11 +1661,12 @@ mod tests {
             .expect("repeat repository gc plan");
 
         assert_eq!(first.swept_commits, 10);
-        // Each unreachable commit removes its changelog record, exact-ID
-        // locator, and derived tracked-root record.
-        assert_eq!(first.staged_deletes, 30);
-        assert_eq!(first.key_shared_buffers, 3);
-        assert_eq!(first.key_shared_bytes, 30 * 16);
+        // Each unreachable commit removes its changelog projection and the
+        // unified commit-state authority. The hard cut retired the separate
+        // tracked-root record.
+        assert_eq!(first.staged_deletes, 20);
+        assert_eq!(first.key_shared_buffers, 2);
+        assert_eq!(first.key_shared_bytes, 20 * 16);
         assert_eq!(second.swept_commits, first.swept_commits);
         assert_eq!(second.staged_deletes, first.staged_deletes);
     }

--- a/packages/engine/src/test_support.rs
+++ b/packages/engine/src/test_support.rs
@@ -9,8 +9,9 @@ use crate::storage_adapter::StorageAdapter;
 use crate::storage_adapter::StorageAdapterRead;
 use crate::storage_adapter::StorageWriteSet;
 use crate::tracked_state::{
-    MaterializedTrackedStateRow, TrackedStateCommitDeltaRef, TrackedStateContext,
-    TrackedStateDeltaRef, TrackedStateKey,
+    CommitStateManifest, CommitStateMutationInventory, CommitStateReplayDebt,
+    MaterializedTrackedStateRow, TrackedStateCommitDeltaRef, TrackedStateCommitRoot,
+    TrackedStateContext, TrackedStateDeltaRef, TrackedStateKey,
 };
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -285,9 +286,9 @@ pub(crate) async fn stage_tracked_root_from_materialized_with_certified_replacem
             }
         })
         .collect::<Vec<_>>();
-    stage_test_commit_deltas_by_owner(writes, &commit_deltas)?;
-    tracked_state
-        .writer(read, writes)
+    let mut inventories = stage_test_commit_deltas_by_owner(writes, &commit_deltas)?;
+    let mut root_writer = tracked_state.writer(read, writes);
+    root_writer
         .stage_commit_root_with_absence_guards(
             &commit_id_text,
             parent_commit_id_text.as_deref(),
@@ -296,6 +297,15 @@ pub(crate) async fn stage_tracked_root_from_materialized_with_certified_replacem
             certified_replacement_markers,
         )
         .await?;
+    let snapshot_root = root_writer
+        .staged_commit_roots()
+        .find(|root| root.commit_id == commit_id)
+        .cloned()
+        .ok_or_else(|| crate::LixError::unknown("test rooted commit did not stage a root"))?;
+    drop(root_writer);
+    let mutations = inventories.remove(&commit_id).unwrap_or_default();
+    reject_unconsumed_test_inventories(&inventories, commit_id)?;
+    stage_test_commit_state_manifest(writes, &staged, mutations, Some(snapshot_root))?;
     Ok(())
 }
 
@@ -366,7 +376,10 @@ pub(crate) async fn stage_rootless_tracked_commit_from_materialized(
             }
         })
         .collect::<Vec<_>>();
-    stage_test_commit_deltas_by_owner(writes, &commit_deltas)
+    let mut inventories = stage_test_commit_deltas_by_owner(writes, &commit_deltas)?;
+    let mutations = inventories.remove(&commit_id).unwrap_or_default();
+    reject_unconsumed_test_inventories(&inventories, commit_id)?;
+    stage_test_commit_state_manifest(writes, &staged, mutations, None)
 }
 
 #[cfg(test)]
@@ -441,31 +454,57 @@ pub(crate) async fn stage_tracked_root_from_materialized_with_parents(
             }
         })
         .collect::<Vec<_>>();
-    stage_test_commit_deltas_by_owner(writes, &commit_deltas)?;
-    tracked_state
-        .writer(read, writes)
+    let typed_commit_id = test_commit_id(&commit_id_text);
+    let mut inventories = stage_test_commit_deltas_by_owner(writes, &commit_deltas)?;
+    let mutations = inventories.remove(&typed_commit_id).unwrap_or_default();
+    for (owner_commit_id, owner_mutations) in inventories {
+        let mut owner_manifest = crate::tracked_state::load_commit_state_manifest(
+            &*read,
+            owner_commit_id,
+        )
+        .await?
+        .ok_or_else(|| {
+            crate::LixError::unknown(format!(
+                "test fixture staged mutations for owner commit '{owner_commit_id}' without an existing commit-state authority"
+            ))
+        })?;
+        owner_manifest.mutations = owner_mutations;
+        crate::tracked_state::stage_commit_state_manifest(writes, &owner_manifest)?;
+    }
+    let mut root_writer = tracked_state.writer(read, writes);
+    root_writer
         .stage_commit_root(
             &commit_id_text,
             commit_root_parent_commit_id_text.as_deref(),
             root_deltas,
         )
         .await?;
+    let snapshot_root = root_writer
+        .staged_commit_roots()
+        .find(|root| root.commit_id == typed_commit_id)
+        .cloned()
+        .ok_or_else(|| crate::LixError::unknown("test rooted commit did not stage a root"))?;
+    drop(root_writer);
+    stage_test_commit_state_manifest(writes, &staged, mutations, Some(snapshot_root))?;
     Ok(())
 }
 
 fn stage_test_commit_deltas_by_owner(
     writes: &mut StorageWriteSet,
     deltas: &[TrackedStateCommitDeltaRef<'_>],
-) -> Result<(), crate::LixError> {
+) -> Result<BTreeMap<CommitId, CommitStateMutationInventory>, crate::LixError> {
     let mut by_owner = BTreeMap::<CommitId, Vec<TrackedStateCommitDeltaRef<'_>>>::new();
     for delta in deltas {
         let owner = delta.delta.commit_id;
         by_owner.entry(owner).or_default().push(*delta);
     }
     let mut canonical_locators = BTreeMap::new();
-    for owner_deltas in by_owner.values() {
-        let locators = crate::tracked_state::stage_commit_deltas(writes, owner_deltas)?;
-        for locator in locators {
+    let mut inventories = BTreeMap::new();
+    for (owner, owner_deltas) in &by_owner {
+        let staged =
+            crate::tracked_state::stage_commit_deltas_for_commit_state(writes, owner_deltas)?;
+        inventories.insert(*owner, staged.mutation_inventory().clone());
+        for locator in staged.locators {
             canonical_locators
                 .entry(locator.change_id)
                 .or_insert(locator);
@@ -475,7 +514,52 @@ fn stage_test_commit_deltas_by_owner(
         writes,
         &canonical_locators.into_values().collect::<Vec<_>>(),
     );
-    Ok(())
+    Ok(inventories)
+}
+
+fn reject_unconsumed_test_inventories(
+    inventories: &BTreeMap<CommitId, CommitStateMutationInventory>,
+    expected_owner: CommitId,
+) -> Result<(), crate::LixError> {
+    if inventories.is_empty() {
+        return Ok(());
+    }
+    Err(crate::LixError::unknown(format!(
+        "test fixture for commit '{expected_owner}' staged mutation inventories for unexpected owners: {:?}",
+        inventories.keys().collect::<Vec<_>>()
+    )))
+}
+
+fn stage_test_commit_state_manifest(
+    writes: &mut StorageWriteSet,
+    staged: &TestStagedChangelogCommit,
+    mutations: CommitStateMutationInventory,
+    snapshot_root: Option<TrackedStateCommitRoot>,
+) -> Result<(), crate::LixError> {
+    let record = &staged.record;
+    let replay_debt = if snapshot_root.is_some() {
+        CommitStateReplayDebt::default()
+    } else {
+        CommitStateReplayDebt {
+            depth: record.tracked_state_rootless_depth,
+            rows: record.tracked_state_rootless_rows,
+            bytes: record.tracked_state_rootless_bytes,
+        }
+    };
+    crate::tracked_state::stage_commit_state_manifest(
+        writes,
+        &CommitStateManifest {
+            commit_id: record.commit_id,
+            generation: record.generation,
+            parent_commit_ids: record.parent_commit_ids.clone(),
+            commit_change_id: record.change_id,
+            author_account_ids: record.author_account_ids.clone(),
+            created_at: record.created_at,
+            replay_debt,
+            mutations,
+            snapshot_root,
+        },
+    )
 }
 
 #[cfg(test)]
@@ -492,7 +576,7 @@ pub(crate) async fn stage_empty_changelog_commit(
         .map(|parent| vec![parent.clone()])
         .unwrap_or_default();
     let commit_change_id = format!("{commit_id_text}:commit");
-    stage_test_changelog_commit(
+    let staged = stage_test_changelog_commit(
         read,
         writes,
         &commit_id_text,
@@ -502,7 +586,23 @@ pub(crate) async fn stage_empty_changelog_commit(
         false,
     )
     .await?;
-    Ok(())
+    let tracked_state = TrackedStateContext::new();
+    let mut root_writer = tracked_state.writer(&*read, writes);
+    root_writer
+        .stage_commit_root(&commit_id_text, parent_commit_id_text.as_deref(), [])
+        .await?;
+    let snapshot_root = root_writer
+        .staged_commit_roots()
+        .find(|root| root.commit_id == staged.record.commit_id)
+        .cloned()
+        .ok_or_else(|| crate::LixError::unknown("empty test commit did not stage a root"))?;
+    drop(root_writer);
+    stage_test_commit_state_manifest(
+        writes,
+        &staged,
+        CommitStateMutationInventory::default(),
+        Some(snapshot_root),
+    )
 }
 
 #[cfg(test)]
@@ -518,7 +618,7 @@ pub(crate) async fn stage_empty_changelog_commit_with_parents(
         .map(|parent| test_commit_id(parent).to_string())
         .collect::<Vec<_>>();
     let commit_change_id = format!("{commit_id_text}:commit");
-    stage_test_changelog_commit(
+    let staged = stage_test_changelog_commit(
         read,
         writes,
         &commit_id_text,
@@ -528,7 +628,24 @@ pub(crate) async fn stage_empty_changelog_commit_with_parents(
         false,
     )
     .await?;
-    Ok(())
+    let first_parent = parent_id_texts.first().map(String::as_str);
+    let tracked_state = TrackedStateContext::new();
+    let mut root_writer = tracked_state.writer(&*read, writes);
+    root_writer
+        .stage_commit_root(&commit_id_text, first_parent, [])
+        .await?;
+    let snapshot_root = root_writer
+        .staged_commit_roots()
+        .find(|root| root.commit_id == staged.record.commit_id)
+        .cloned()
+        .ok_or_else(|| crate::LixError::unknown("empty test commit did not stage a root"))?;
+    drop(root_writer);
+    stage_test_commit_state_manifest(
+        writes,
+        &staged,
+        CommitStateMutationInventory::default(),
+        Some(snapshot_root),
+    )
 }
 
 async fn stage_test_changelog_commit(
@@ -608,7 +725,7 @@ async fn stage_test_changelog_commit(
         .first()
         .map(|row| crate::common::LixTimestamp::expect_parse("created_at", &row.created_at))
         .unwrap_or_else(test_timestamp);
-    append.commits.push(CommitRecord {
+    let record = CommitRecord {
         format_version: 1,
         commit_id: typed_commit_id,
         generation,
@@ -620,14 +737,19 @@ async fn stage_test_changelog_commit(
         change_id: typed_commit_change_id,
         author_account_ids: Vec::new(),
         created_at,
-    });
+    };
+    append.commits.push(record.clone());
     let mut writer = ChangelogContext::new().writer(&mut read, writes);
     writer.stage_append(append).await?;
     change_commit_ids.sort_by_key(|(row_index, _)| *row_index);
-    Ok(TestStagedChangelogCommit { change_commit_ids })
+    Ok(TestStagedChangelogCommit {
+        record,
+        change_commit_ids,
+    })
 }
 
 struct TestStagedChangelogCommit {
+    record: CommitRecord,
     change_commit_ids: Vec<(usize, CommitId)>,
 }
 

--- a/packages/engine/src/tracked_state/bench_support.rs
+++ b/packages/engine/src/tracked_state/bench_support.rs
@@ -6,12 +6,44 @@ use crate::json_store::{
 use crate::storage_adapter::Storage;
 use crate::storage_adapter::{
     SharedStorageAdapterRead, StorageAdapter, StorageReadOptions, StorageWriteOptions,
-    StorageWriteSetStats,
+    StorageWriteSet, StorageWriteSetStats,
 };
 use crate::tracked_state::{
-    TrackedStateCommitDeltaRef, TrackedStateContext, TrackedStateDeltaRef, TrackedStateFilter,
-    TrackedStateKey, TrackedStateReadColumns, TrackedStateScanRequest,
+    CommitStateManifest, CommitStateReplayDebt, TrackedStateCommitDeltaRef, TrackedStateContext,
+    TrackedStateDeltaRef, TrackedStateFilter, TrackedStateKey, TrackedStateReadColumns,
+    TrackedStateScanRequest,
 };
+
+fn stage_bench_commit_deltas(
+    writes: &mut StorageWriteSet,
+    deltas: &[TrackedStateCommitDeltaRef<'_>],
+) -> Result<Vec<super::storage::CommitDeltaChangeLocator>, crate::LixError> {
+    let staged = super::storage::stage_commit_deltas_for_commit_state(writes, deltas)?;
+    let commit_id = deltas
+        .first()
+        .map(|delta| delta.delta.commit_id)
+        .unwrap_or_default();
+    let mutations = staged.mutation_inventory().clone();
+    super::storage::stage_commit_state_manifest(
+        writes,
+        &CommitStateManifest {
+            commit_id,
+            generation: 0,
+            parent_commit_ids: Vec::new(),
+            commit_change_id: ChangeId::for_test_label(&format!("{commit_id}:bench-commit")),
+            author_account_ids: Vec::new(),
+            created_at: crate::common::LixTimestamp::from_unix_millis_utc_lossy(0),
+            replay_debt: CommitStateReplayDebt {
+                depth: 1,
+                rows: u64::from(mutations.member_count),
+                bytes: u64::from(mutations.member_count),
+            },
+            mutations,
+            snapshot_root: None,
+        },
+    )?;
+    Ok(staged.locators)
+}
 
 #[derive(Clone, Debug)]
 pub struct BenchTrackedRow {
@@ -194,7 +226,7 @@ where
                 .iter()
                 .map(PackedHistoryDelta::as_commit_ref)
                 .collect::<Vec<_>>();
-            let locators = super::storage::stage_commit_deltas(&mut writes, &deltas)
+            let locators = stage_bench_commit_deltas(&mut writes, &deltas)
                 .expect("stage packed-history commit delta");
             super::storage::stage_change_locators(&mut writes, &locators);
         }
@@ -805,7 +837,7 @@ impl OwnedDelta {
         commit_id: &str,
         index: usize,
         deleted: bool,
-        _writes: &mut crate::storage_adapter::StorageWriteSet,
+        _writes: &mut StorageWriteSet,
     ) -> Self {
         let change_id = format!("tracked-crud-change-{commit_id}-{index}");
         Self {

--- a/packages/engine/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/engine/src/tracked_state/commit_root_rebuild.rs
@@ -41,6 +41,17 @@ pub(crate) async fn rebuild_commit_root_at<S>(
 where
     S: StorageAdapterRead + ?Sized,
 {
+    let typed_commit_id = CommitId::parse_lix(commit_id, "commit-root rebuild authority")?;
+    storage::load_commit_state_manifest(rebuilder.store, typed_commit_id)
+        .await?
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "cannot rebuild tracked_state root for commit '{commit_id}' without its commit-state manifest"
+                ),
+            )
+        })?;
     let plans =
         load_rebuild_plans_to_nearest_available_root(rebuilder.store, commit_id, true).await?;
     let mut report = None;
@@ -60,6 +71,26 @@ where
     writer
         .validate_staged_commit_root_against_changelog(commit_id)
         .await?;
+    let staged_roots = writer.staged_commit_roots().cloned().collect::<Vec<_>>();
+    drop(writer);
+    for snapshot_root in staged_roots {
+        let mut manifest = storage::load_commit_state_manifest(rebuilder.store, snapshot_root.commit_id)
+            .await?
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "cannot publish rebuilt tracked_state root for commit '{}' without its commit-state manifest",
+                        snapshot_root.commit_id
+                    ),
+                )
+            })?;
+        // The rebuilt tree is an optional immutable accelerator. Preserve
+        // replay debt: it remains the physical-policy authority projected by
+        // the changelog, while readers may serve through this equivalent root.
+        manifest.snapshot_root = Some(snapshot_root);
+        storage::stage_commit_state_manifest(rebuilder.writes, &manifest)?;
+    }
     Ok(report)
 }
 
@@ -115,7 +146,8 @@ where
         if !seen.insert(commit_id.to_string()) {
             return Ok(None);
         }
-        let Some(metadata) = storage::load_commit_root(store, commit_id).await? else {
+        let Some(metadata) = storage::load_authoritative_commit_root(store, commit_id).await?
+        else {
             seen.remove(commit_id);
             return Ok(None);
         };

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -977,7 +977,7 @@ pub(crate) struct TrackedStateStoreReader<S> {
 struct DiffCommitRootValidationCache {
     commit_delta_winners: HashMap<String, HashMap<TrackedStateIdentity, ChangeId>>,
     commit_root_metadata: HashMap<String, TrackedStateCommitRoot>,
-    commit_roots: HashMap<String, TrackedStateRootId>,
+    commit_roots: HashMap<String, Option<TrackedStateRootId>>,
     tree_values: HashMap<(TrackedStateRootId, TrackedStateKey), Option<TrackedStateIndexValue>>,
     changelog_first_parents: HashMap<String, Option<CommitId>>,
 }
@@ -1634,33 +1634,82 @@ where
                 }
             }
 
-            let metadata = self
-                .load_cached_commit_root_metadata(&current_commit_id, cache)
+            let current_metadata =
+                storage::load_authoritative_commit_root(&self.store, &current_commit_id).await?;
+            let (parent_commit_id, parent_value, current_is_rootless) = if let Some(metadata) =
+                current_metadata
+            {
+                self.validate_commit_root_parent_matches_changelog(
+                    &current_commit_id,
+                    &metadata,
+                    cache,
+                )
                 .await?;
-            self.validate_commit_root_parent_matches_changelog(
-                &current_commit_id,
-                &metadata,
-                cache,
-            )
-            .await?;
-            let Some(parent) = metadata.parent_roots.first() else {
-                return Err(LixError::unknown(format!(
-                    "tracked-state diff row references changelog change '{}' that is not the first-parent winner for commit '{}' and identity {:?}",
-                    row.change_id, root_commit_id, winner_identity
-                )));
+                let Some(parent) = metadata.parent_roots.first() else {
+                    return Err(LixError::unknown(format!(
+                        "tracked-state diff row references changelog change '{}' that is not the first-parent winner for commit '{}' and identity {:?}",
+                        row.change_id, root_commit_id, winner_identity
+                    )));
+                };
+                let parent_value = self
+                    .load_cached_tree_value(&parent.root_id, &key, cache)
+                    .await?;
+                (parent.commit_id, parent_value, false)
+            } else {
+                // Rootless commits have no per-commit snapshot ancestry. The
+                // bounded point replay is their complete state proof,
+                // including selected-source and engine-owned mutations that
+                // are not direct commit-delta winners.
+                let root_id = self
+                    .load_cached_commit_root_optional(&current_commit_id, cache)
+                    .await?;
+                debug_assert!(root_id.is_none());
+                let current_value = self
+                    .replay_index_values_for_keys_at_commit(
+                        &current_commit_id,
+                        std::slice::from_ref(&key),
+                    )
+                    .await?
+                    .into_iter()
+                    .next()
+                    .flatten();
+                (
+                    CommitId::parse_lix(&current_commit_id, "rootless diff row proof commit_id")?,
+                    current_value,
+                    true,
+                )
             };
-            let parent_value = self
-                .load_cached_tree_value(&parent.root_id, &key, cache)
-                .await?;
+            if current_is_rootless {
+                let structurally_equal = parent_value.as_ref().is_some_and(|proof| {
+                    proof.change_id == row_value.change_id
+                        && proof.commit_id == row_value.commit_id
+                        && proof.deleted == row_value.deleted
+                        && proof.updated_at == row_value.updated_at
+                });
+                if !structurally_equal {
+                    return Err(LixError::unknown(format!(
+                        "tracked-state commit-root row for commit '{}' does not match rootless replay at '{}' for inherited identity {:?}",
+                        root_commit_id,
+                        parent_commit_id,
+                        tracked_state_identity_from_key(&key)
+                    )));
+                }
+                self.validate_diff_row_created_at(row, &key, &current_commit_id, change_created_at)
+                    .await?;
+                // Point replay already proved the row against the complete
+                // bounded interval. A rootless manifest deliberately has no
+                // per-commit snapshot ancestry to walk beyond that proof.
+                return Ok(());
+            }
             if parent_value.as_ref() != Some(&row_value) {
                 return Err(LixError::unknown(format!(
                     "tracked-state commit-root row for commit '{}' does not match parent root '{}' for inherited identity {:?}",
                     root_commit_id,
-                    parent.commit_id,
+                    parent_commit_id,
                     tracked_state_identity_from_key(&key)
                 )));
             }
-            current_commit_id = parent.commit_id.to_string();
+            current_commit_id = parent_commit_id.to_string();
         }
     }
 
@@ -1679,29 +1728,32 @@ where
             .load_cached_changelog_first_parent(commit_id, cache)
             .await?;
         let expected_parent = match changelog_first_parent {
-            Some(first_parent_id) => {
-                self.nearest_available_commit_root_parent(&first_parent_id.to_string(), cache)
-                    .await?
-            }
+            Some(first_parent_id) => Some((
+                first_parent_id,
+                self.load_cached_commit_root_optional(&first_parent_id.to_string(), cache)
+                    .await?,
+            )),
             None => None,
         };
         match (expected_parent, metadata.parent_roots.first()) {
             (None, None) => Ok(()),
             (Some((expected_parent_id, expected_root)), Some(parent))
-                if parent.commit_id == expected_parent_id && parent.root_id == expected_root =>
+                if parent.commit_id == expected_parent_id
+                    && expected_root
+                        .as_ref()
+                        .is_none_or(|expected_root| parent.root_id == *expected_root) =>
             {
                 Ok(())
             }
-            (Some((expected_parent_id, expected_root)), Some(parent))
+            (Some((expected_parent_id, Some(_))), Some(parent))
                 if parent.commit_id == expected_parent_id =>
             {
-                let _ = expected_root;
                 Err(LixError::unknown(format!(
                     "tracked-state commit-root metadata for commit '{commit_id}' references stale root for commit-root parent '{expected_parent_id}'"
                 )))
             }
             (Some((expected_parent_id, _)), Some(parent)) => Err(LixError::unknown(format!(
-                "tracked-state commit-root metadata for commit '{}' references parent '{}' but nearest available first-parent root is '{}'",
+                "tracked-state commit-root metadata for commit '{}' references parent '{}' but its first parent is '{}'",
                 commit_id, parent.commit_id, expected_parent_id
             ))),
             (Some((expected_parent_id, _)), None) => Err(LixError::unknown(format!(
@@ -1712,33 +1764,6 @@ where
                 commit_id, parent.commit_id
             ))),
         }
-    }
-
-    async fn nearest_available_commit_root_parent(
-        &mut self,
-        start_commit_id: &str,
-        cache: &mut DiffCommitRootValidationCache,
-    ) -> Result<Option<(String, TrackedStateRootId)>, LixError> {
-        let mut current = Some(start_commit_id.to_string());
-        let mut seen = HashSet::new();
-        while let Some(commit_id) = current {
-            if !seen.insert(commit_id.clone()) {
-                return Err(LixError::unknown(format!(
-                    "tracked-state commit-root parent chain contains cycle at commit '{commit_id}'"
-                )));
-            }
-            if let Some(root_id) = self
-                .load_cached_commit_root_optional(&commit_id, cache)
-                .await?
-            {
-                return Ok(Some((commit_id, root_id)));
-            }
-            current = self
-                .load_cached_changelog_first_parent(&commit_id, cache)
-                .await?
-                .map(|id| id.to_string());
-        }
-        Ok(None)
     }
 
     async fn load_cached_commit_delta_winners(
@@ -1791,6 +1816,22 @@ where
                 "changelog commit '{commit_id}' is missing while validating tracked-state commit-root rows"
             )));
         };
+        let manifest = storage::load_commit_state_manifest(&self.store, commit_id_typed)
+            .await?
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "tracked_state commit_state_manifest is missing for commit '{commit_id}'"
+                    ),
+                )
+            })?;
+        if manifest.mutations.member_count == 0 {
+            cache
+                .commit_delta_winners
+                .insert(commit_id.to_string(), HashMap::new());
+            return Ok(());
+        }
         let mut winners = HashMap::new();
         for (key, value) in storage::scan_commit_delta_members(&self.store, commit_id_typed).await?
         {
@@ -1825,7 +1866,7 @@ where
         if let Some(metadata) = cache.commit_root_metadata.get(commit_id) {
             return Ok(metadata.clone());
         }
-        let metadata = storage::load_commit_root(&self.store, commit_id)
+        let metadata = storage::load_authoritative_commit_root(&self.store, commit_id)
             .await?
             .ok_or_else(|| missing_commit_root_error(commit_id))?;
         cache
@@ -1840,14 +1881,26 @@ where
         cache: &mut DiffCommitRootValidationCache,
     ) -> Result<Option<TrackedStateRootId>, LixError> {
         if let Some(root_id) = cache.commit_roots.get(commit_id) {
-            return Ok(Some(root_id.clone()));
+            return Ok(root_id.clone());
         }
-        let root_id = storage::load_root(&self.store, commit_id).await?;
-        if let Some(root_id) = &root_id {
-            cache
-                .commit_roots
-                .insert(commit_id.to_string(), root_id.clone());
-        }
+        let typed_commit_id = CommitId::parse_lix(
+            commit_id,
+            "tracked-state optional authoritative root lookup",
+        )?;
+        let manifest = storage::load_commit_state_manifest(&self.store, typed_commit_id)
+            .await?
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "tracked_state commit_state_manifest is missing for commit '{commit_id}'"
+                    ),
+                )
+            })?;
+        let root_id = manifest.snapshot_root.map(|root| root.root_id);
+        cache
+            .commit_roots
+            .insert(commit_id.to_string(), root_id.clone());
         Ok(root_id)
     }
 
@@ -1911,19 +1964,45 @@ where
         change_created_at: crate::common::LixTimestamp,
     ) -> Result<(), LixError> {
         let mut expected_created_at = change_created_at;
-        let Some(metadata) = storage::load_commit_root(&self.store, commit_id).await? else {
-            return Err(missing_commit_root_error(commit_id));
-        };
-        if let Some(parent) = metadata.parent_roots.first() {
-            let parent_value = self
-                .tree
-                .get_many(&self.store, &parent.root_id, std::slice::from_ref(key))
+        if let Some(metadata) =
+            storage::load_authoritative_commit_root(&self.store, commit_id).await?
+        {
+            if let Some(parent) = metadata.parent_roots.first() {
+                let parent_value = self
+                    .tree
+                    .get_many(&self.store, &parent.root_id, std::slice::from_ref(key))
+                    .await?
+                    .into_iter()
+                    .next()
+                    .flatten();
+                if let Some(parent_value) = parent_value {
+                    expected_created_at = parent_value.created_at();
+                }
+            }
+        } else {
+            let typed_commit_id = CommitId::parse_lix(commit_id, "diff row owner commit_id")?;
+            storage::load_commit_state_manifest(&self.store, typed_commit_id)
                 .await?
-                .into_iter()
-                .next()
-                .flatten();
-            if let Some(parent_value) = parent_value {
-                expected_created_at = parent_value.created_at();
+                .ok_or_else(|| missing_commit_root_error(commit_id))?;
+            if let Some(parent_commit_id) = self
+                .load_cached_changelog_first_parent(
+                    commit_id,
+                    &mut DiffCommitRootValidationCache::new(),
+                )
+                .await?
+            {
+                if let Some(parent_value) = self
+                    .replay_index_values_for_keys_at_commit(
+                        &parent_commit_id.to_string(),
+                        std::slice::from_ref(key),
+                    )
+                    .await?
+                    .into_iter()
+                    .next()
+                    .flatten()
+                {
+                    expected_created_at = parent_value.created_at();
+                }
             }
         }
         if expected_created_at == change_created_at {
@@ -1945,8 +2024,8 @@ where
             return Ok(());
         }
         Err(LixError::unknown(format!(
-            "tracked-state diff row for change '{}' created_at '{}' does not match first ancestry timestamp '{}'",
-            row.change_id, row.created_at, expected_created_at
+            "tracked-state diff row for change '{}' at commit '{}' created_at '{}' does not match first ancestry timestamp '{}'",
+            row.change_id, commit_id, row.created_at, expected_created_at
         )))
     }
 
@@ -1993,7 +2072,9 @@ where
         key: &TrackedStateKey,
     ) -> Result<Option<crate::common::LixTimestamp>, LixError> {
         let row_commit_id = row.commit_id.to_string();
-        let Some(metadata) = storage::load_commit_root(&self.store, &row_commit_id).await? else {
+        let Some(metadata) =
+            storage::load_authoritative_commit_root(&self.store, &row_commit_id).await?
+        else {
             return Ok(None);
         };
         let Some(parent) = metadata.parent_roots.first() else {
@@ -2014,6 +2095,7 @@ where
     /// Normal diff validates root metadata and changed rows only. Maintenance
     /// and repair tooling can call this when it deliberately needs fsck-level
     /// assurance for every unchanged row too.
+    #[cfg(test)]
     pub(crate) async fn validate_commit_root_against_changelog(
         &mut self,
         commit_id: &str,
@@ -2025,24 +2107,53 @@ where
         .await
     }
 
+    #[cfg(test)]
     async fn validate_tree_rows_at_commit_against_changelog(
         &mut self,
         commit_id: &str,
         request: &TrackedStateTreeScanRequest,
     ) -> Result<(), LixError> {
-        let mut validation_cache = DiffCommitRootValidationCache::new();
         let metadata = self
-            .load_cached_commit_root_metadata(commit_id, &mut validation_cache)
+            .load_cached_commit_root_metadata(commit_id, &mut DiffCommitRootValidationCache::new())
             .await?;
+        self.validate_commit_root_metadata_against_changelog_with_request(
+            commit_id, metadata, request,
+        )
+        .await
+    }
+
+    async fn validate_commit_root_metadata_against_changelog(
+        &mut self,
+        commit_id: &str,
+        metadata: TrackedStateCommitRoot,
+    ) -> Result<(), LixError> {
+        self.validate_commit_root_metadata_against_changelog_with_request(
+            commit_id,
+            metadata,
+            &TrackedStateTreeScanRequest::default(),
+        )
+        .await
+    }
+
+    async fn validate_commit_root_metadata_against_changelog_with_request(
+        &mut self,
+        commit_id: &str,
+        metadata: TrackedStateCommitRoot,
+        request: &TrackedStateTreeScanRequest,
+    ) -> Result<(), LixError> {
+        let mut validation_cache = DiffCommitRootValidationCache::new();
+        validation_cache
+            .commit_root_metadata
+            .insert(commit_id.to_string(), metadata.clone());
         self.validate_commit_root_parent_matches_changelog(
             commit_id,
             &metadata,
             &mut validation_cache,
         )
         .await?;
-        let root = metadata.root_id;
+        let root = metadata.root_id.clone();
         let rows = self.tree.scan(&self.store, &root, request).await?;
-        self.validate_commit_root_coverage(commit_id, request, &rows)
+        self.validate_commit_root_coverage(commit_id, request, &rows, &metadata)
             .await?;
         let rows = rows
             .into_iter()
@@ -2058,6 +2169,7 @@ where
         commit_id: &str,
         request: &TrackedStateTreeScanRequest,
         rows: &[(TrackedStateKey, TrackedStateIndexValue)],
+        metadata: &TrackedStateCommitRoot,
     ) -> Result<(), LixError> {
         let row_map = rows
             .iter()
@@ -2087,9 +2199,6 @@ where
             }
         }
 
-        let metadata = self
-            .load_cached_commit_root_metadata(commit_id, &mut cache)
-            .await?;
         let Some(parent) = metadata.parent_roots.first() else {
             return Ok(());
         };
@@ -3003,121 +3112,66 @@ where
         }
         let descriptor_keys = descriptor_key_builder.finish();
 
-        let mut values = vec![None; keys.len()];
-        let mut pending_cascades = vec![None; keys.len()];
-        let mut unresolved = (0..keys.len()).collect::<Vec<_>>();
-        let mut next_unresolved = Vec::with_capacity(keys.len());
-        let mut unresolved_keys = Vec::with_capacity(keys.len());
-        let mut descriptor_ordinals = Vec::with_capacity(file_ids.len());
-        let mut descriptor_query = Vec::with_capacity(file_ids.len());
-        let mut descriptor_selected = vec![false; file_ids.len()];
+        let interval = self.point_replay_interval(commit_id).await?;
+        let mut values = if let Some(root_id) = interval.baseline_root.as_ref() {
+            self.tree
+                .get_many_encoded(&self.store, root_id, keys)
+                .await?
+        } else {
+            vec![None; keys.len()]
+        };
         let mut cascades = vec![None; file_ids.len()];
-        let mut current_commit_id =
-            CommitId::parse_lix(commit_id, "tracked-state batch replay commit_id")?;
-        let mut seen_commit_ids = HashSet::new();
-
-        loop {
-            if !seen_commit_ids.insert(current_commit_id) {
-                return Err(LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!(
-                        "cannot batch-replay tracked_state commit '{commit_id}': first-parent cycle includes commit '{current_commit_id}'"
-                    ),
-                ));
-            }
+        for &current_commit_id in interval.commits().iter().rev() {
             let replay_commit = self.load_point_replay_commit(current_commit_id).await?;
-            unresolved_keys.clear();
-            unresolved_keys.extend(unresolved.iter().map(|&index| keys[index].clone()));
-            if let Some(root_id) = replay_commit.root_id {
-                let baseline = self
-                    .tree
-                    .get_many_encoded(&self.store, &root_id, &unresolved_keys)
-                    .await?;
-                for (&index, value) in unresolved.iter().zip(baseline) {
-                    values[index] = match (&pending_cascades[index], value) {
-                        (Some(cascade), Some(value)) if !value.deleted => {
-                            Some(cascade_tombstone(cascade, &value))
-                        }
-                        (_, value) => value,
-                    };
-                }
-                break;
-            }
-
             let deltas = storage::load_commit_delta_values_encoded_with_cache(
                 &self.store,
                 current_commit_id,
-                &unresolved_keys,
+                keys,
                 Some(&self.commit_delta_point_cache),
             )
             .await?;
-
-            // A cascade descriptor is shared by every row in its file. Build
-            // and read one descriptor key per distinct file, not per row.
-            descriptor_ordinals.clear();
-            descriptor_query.clear();
-            for &index in &unresolved {
-                let ordinal = key_file_id_ordinals[index];
-                if ordinal == u32::MAX || descriptor_selected[ordinal as usize] {
-                    continue;
-                }
-                descriptor_selected[ordinal as usize] = true;
-                descriptor_ordinals.push(ordinal);
-                descriptor_query.push(descriptor_keys[ordinal as usize].clone());
-            }
             let descriptor_deltas = storage::load_commit_delta_values_encoded_with_cache(
                 &self.store,
                 current_commit_id,
-                &descriptor_query,
+                &descriptor_keys,
                 Some(&self.commit_delta_point_cache),
             )
             .await?;
-            for (&file_id_ordinal, value) in descriptor_ordinals.iter().zip(descriptor_deltas) {
+            for (file_id_ordinal, value) in descriptor_deltas.into_iter().enumerate() {
                 if let Some(value) = value.filter(|value| value.deleted) {
-                    cascades[file_id_ordinal as usize] = Some(value);
+                    cascades[file_id_ordinal] = Some(value);
                 }
             }
-
-            next_unresolved.clear();
-            for (&index, delta) in unresolved.iter().zip(deltas) {
-                if let Some(delta) = delta {
-                    values[index] = match &pending_cascades[index] {
-                        Some(cascade) if !delta.deleted => Some(cascade_tombstone(cascade, &delta)),
-                        _ => Some(delta),
-                    };
-                } else {
-                    if let Some(generation) = replay_commit.replacement_generation.as_ref() {
-                        let decoded_key = decode_key_shared(keys[index].clone())?;
-                        if replacement_scope_covers_key(&generation.scope, decoded_key.as_ref()) {
-                            values[index] = None;
-                            continue;
-                        }
+            for (index, delta) in deltas.into_iter().enumerate() {
+                let file_id_ordinal = key_file_id_ordinals[index];
+                if file_id_ordinal != u32::MAX
+                    && let Some(cascade) = cascades[file_id_ordinal as usize].as_ref()
+                    && let Some(value) = values[index].as_ref().filter(|value| !value.deleted)
+                {
+                    values[index] = Some(cascade_tombstone(cascade, value));
+                }
+                let replacement_generation = match replay_commit.replacement_generation.as_ref() {
+                    Some(generation) => {
+                        let key = decode_key_shared(keys[index].clone())?;
+                        replacement_scope_covers_key(&generation.scope, key.as_ref())
+                            .then_some(generation)
                     }
-                    if pending_cascades[index].is_none()
-                        && key_file_id_ordinals[index] != u32::MAX
-                        && let Some(cascade) = &cascades[key_file_id_ordinals[index] as usize]
-                    {
-                        pending_cascades[index] = Some(cascade.clone());
+                    None => None,
+                };
+                if let Some(mut delta) = delta {
+                    if let Some(generation) = replacement_generation {
+                        delta.created_at = generation.lifecycle_summary.uniform_created_at;
+                    } else if let Some(previous) = values[index].as_ref() {
+                        delta.created_at = previous.created_at;
                     }
-                    next_unresolved.push(index);
+                    values[index] = Some(delta);
+                } else if replacement_generation.is_some() {
+                    values[index] = None;
                 }
             }
-            for &ordinal in &descriptor_ordinals {
-                descriptor_selected[ordinal as usize] = false;
-                cascades[ordinal as usize] = None;
+            for cascade in &mut cascades {
+                *cascade = None;
             }
-            if next_unresolved.is_empty() {
-                break;
-            }
-            std::mem::swap(&mut unresolved, &mut next_unresolved);
-            let replay_parent_commit_id = match replay_commit.replacement_generation.as_ref() {
-                Some(generation) => generation.fallback_commit_id,
-                None => replay_commit.parent_commit_id,
-            };
-            let Some(parent_commit_id) = replay_parent_commit_id else {
-                break;
-            };
-            current_commit_id = parent_commit_id;
         }
         Ok(values)
     }
@@ -3127,117 +3181,75 @@ where
         commit_id: &str,
         keys: &[TrackedStateKey],
     ) -> Result<Vec<Option<TrackedStateIndexValue>>, LixError> {
-        let mut values = vec![None; keys.len()];
-        let mut pending_cascades = vec![None; keys.len()];
-        let mut unresolved = (0..keys.len()).collect::<Vec<_>>();
-        let mut current_commit_id =
-            CommitId::parse_lix(commit_id, "tracked-state point replay commit_id")?;
-        let mut seen_commit_ids = HashSet::new();
-
-        loop {
-            if !seen_commit_ids.insert(current_commit_id) {
-                return Err(LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!(
-                        "cannot point-replay tracked_state commit '{commit_id}': first-parent cycle includes commit '{current_commit_id}'"
-                    ),
-                ));
-            }
+        let interval = self.point_replay_interval(commit_id).await?;
+        let mut values = if let Some(root_id) = interval.baseline_root.as_ref() {
+            self.tree.get_many(&self.store, root_id, keys).await?
+        } else {
+            vec![None; keys.len()]
+        };
+        let descriptor_keys = keys
+            .iter()
+            .map(file_descriptor_key_for_file_scoped_key)
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .flatten()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        // Root construction applies oldest mutations first and preserves the
+        // first visible `created_at` on ordinary upserts. Certified replacement
+        // generations instead carry their lifecycle timestamp explicitly.
+        for &current_commit_id in interval.commits().iter().rev() {
             let replay_commit = self.load_point_replay_commit(current_commit_id).await?;
-            if let Some(root_id) = replay_commit.root_id {
-                let unresolved_keys = unresolved
-                    .iter()
-                    .map(|&index| keys[index].clone())
-                    .collect::<Vec<_>>();
-                let baseline = self
-                    .tree
-                    .get_many(&self.store, &root_id, &unresolved_keys)
-                    .await?;
-                for (index, value) in unresolved.into_iter().zip(baseline) {
-                    values[index] = match (&pending_cascades[index], value) {
-                        (Some(cascade), Some(value)) if !value.deleted => {
-                            Some(cascade_tombstone(cascade, &value))
-                        }
-                        (_, value) => value,
-                    };
-                }
-                break;
-            }
-
-            let unresolved_keys = unresolved
-                .iter()
-                .map(|&index| keys[index].clone())
-                .collect::<Vec<_>>();
             let deltas = self
-                .load_replayed_commit_delta_values(current_commit_id, &unresolved_keys)
+                .load_replayed_commit_delta_values(current_commit_id, keys)
                 .await?;
-            let descriptor_keys = unresolved_keys
-                .iter()
-                .map(file_descriptor_key_for_file_scoped_key)
-                .collect::<Result<Vec<_>, _>>()?
-                .into_iter()
-                .flatten()
-                .collect::<BTreeSet<_>>()
-                .into_iter()
-                .collect::<Vec<_>>();
             let descriptor_deltas = self
                 .load_replayed_commit_delta_values(current_commit_id, &descriptor_keys)
                 .await?;
             let mut cascades = BTreeMap::new();
-            for (key, value) in descriptor_keys.into_iter().zip(descriptor_deltas) {
+            for (key, value) in descriptor_keys.iter().zip(descriptor_deltas) {
                 let Some(value) = value else {
                     continue;
                 };
-                if let Some(file_id) = file_delete_cascade(&key, &value)? {
+                if let Some(file_id) = file_delete_cascade(key, &value)? {
                     cascades.insert(file_id, value);
                 }
             }
-            let mut next_unresolved = Vec::new();
-            for (index, delta) in unresolved.into_iter().zip(deltas) {
-                if let Some(delta) = delta {
-                    values[index] = match &pending_cascades[index] {
-                        Some(cascade) if !delta.deleted => Some(cascade_tombstone(cascade, &delta)),
-                        _ => Some(delta),
-                    };
-                } else if replay_commit
-                    .replacement_generation
+            for (index, key) in keys.iter().enumerate() {
+                if let Some(cascade) = key
+                    .file_id
                     .as_ref()
-                    .is_some_and(|generation| {
-                        replacement_scope_covers_key(
-                            &generation.scope,
-                            TrackedStateKeyRef {
-                                schema_key: &keys[index].schema_key,
-                                file_id: keys[index].file_id.as_deref(),
-                                entity_pk: &keys[index].entity_pk,
-                            },
-                        )
-                    })
+                    .and_then(|file_id| cascades.get(file_id))
+                    && let Some(value) = values[index].as_ref().filter(|value| !value.deleted)
                 {
-                    values[index] = None;
-                } else {
-                    if pending_cascades[index].is_none()
-                        && let Some(cascade) = keys[index]
-                            .file_id
-                            .as_ref()
-                            .and_then(|file_id| cascades.get(file_id))
-                    {
-                        pending_cascades[index] = Some(cascade.clone());
+                    values[index] = Some(cascade_tombstone(cascade, value));
+                }
+                let replacement_generation =
+                    replay_commit
+                        .replacement_generation
+                        .as_ref()
+                        .filter(|generation| {
+                            replacement_scope_covers_key(
+                                &generation.scope,
+                                TrackedStateKeyRef {
+                                    schema_key: &key.schema_key,
+                                    file_id: key.file_id.as_deref(),
+                                    entity_pk: &key.entity_pk,
+                                },
+                            )
+                        });
+                if let Some(mut delta) = deltas[index].clone() {
+                    if let Some(generation) = replacement_generation {
+                        delta.created_at = generation.lifecycle_summary.uniform_created_at;
+                    } else if let Some(previous) = values[index].as_ref() {
+                        delta.created_at = previous.created_at;
                     }
-                    next_unresolved.push(index);
+                    values[index] = Some(delta);
+                } else if replacement_generation.is_some() {
+                    values[index] = None;
                 }
             }
-            if next_unresolved.is_empty() {
-                break;
-            }
-            unresolved = next_unresolved;
-            let replay_parent_commit_id = match replay_commit.replacement_generation.as_ref() {
-                Some(generation) => generation.fallback_commit_id,
-                None => replay_commit.parent_commit_id,
-            };
-            let Some(parent_commit_id) = replay_parent_commit_id else {
-                break;
-            };
-            current_commit_id = parent_commit_id;
         }
         Ok(values)
     }
@@ -3269,17 +3281,47 @@ where
                 }
             }
         };
-        let root_id = if record.tracked_state_rootless {
-            None
-        } else {
-            Some(
-                self.tree
-                    .load_root(&self.store, &commit_id.to_string())
-                    .await?
-                    .ok_or_else(|| missing_commit_root_error(&commit_id.to_string()))?,
-            )
-        };
-        let replacement_generation = if record.tracked_state_rootless {
+        let manifest = storage::load_commit_state_manifest(&self.store, commit_id)
+            .await?
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "tracked_state commit_state_manifest is missing for commit '{commit_id}'"
+                    ),
+                )
+            })?;
+        if manifest.generation != record.generation
+            || manifest.parent_commit_ids != record.parent_commit_ids
+            || manifest.commit_change_id != record.change_id
+            || manifest.author_account_ids != record.author_account_ids
+            || manifest.created_at != record.created_at
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "tracked_state commit_state_manifest disagrees with the topology projection for commit '{commit_id}'"
+                ),
+            ));
+        }
+        let root_id = manifest
+            .snapshot_root
+            .as_ref()
+            .map(|root| root.root_id.clone());
+        let rootless = manifest.replay_debt.depth > 0;
+        if rootless != record.tracked_state_rootless
+            || manifest.replay_debt.depth != record.tracked_state_rootless_depth
+            || manifest.replay_debt.rows != record.tracked_state_rootless_rows
+            || manifest.replay_debt.bytes != record.tracked_state_rootless_bytes
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "tracked_state commit_state_manifest disagrees with the replay projection for commit '{commit_id}'"
+                ),
+            ));
+        }
+        let replacement_generation = if rootless && manifest.mutations.member_count != 0 {
             storage::load_commit_delta_replay_metadata_with_cache(
                 &self.store,
                 commit_id,
@@ -3291,9 +3333,9 @@ where
             None
         };
         let replay_commit = PointReplayCommit {
-            parent_commit_id: record.parent_commit_ids.first().copied(),
+            parent_commit_id: manifest.parent_commit_ids.first().copied(),
             root_id,
-            rootless: record.tracked_state_rootless,
+            rootless,
             replacement_generation,
         };
         self.point_replay_commits
@@ -3507,18 +3549,51 @@ impl<S> TrackedStateWriter<'_, S>
 where
     S: StorageAdapterRead + ?Sized,
 {
+    pub(crate) fn staged_commit_roots(&self) -> impl Iterator<Item = &TrackedStateCommitRoot> {
+        self.staged_roots.values()
+    }
+
     pub(crate) async fn validate_staged_commit_root_against_changelog(
         &self,
         commit_id: &str,
     ) -> Result<(), LixError> {
-        let read = storage::TrackedStateStagedRead::new(
+        let typed_commit_id =
+            CommitId::parse_lix(commit_id, "staged commit-root validation commit_id")?;
+        let metadata = self
+            .staged_roots
+            .values()
+            .find(|metadata| metadata.commit_id == typed_commit_id)
+            .cloned()
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("tracked-state staged root for commit '{commit_id}' is missing"),
+                )
+            })?;
+        let mut staged_manifests = Vec::with_capacity(self.staged_roots.len());
+        for metadata in self.staged_roots.values() {
+            let mut manifest = storage::load_commit_state_manifest(self.store, metadata.commit_id)
+                .await?
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!(
+                            "cannot audit rebuilt tracked_state root for commit '{}' without its commit-state manifest",
+                            metadata.commit_id
+                        ),
+                    )
+                })?;
+            manifest.snapshot_root = Some(metadata.clone());
+            staged_manifests.push(manifest);
+        }
+        let read = storage::TrackedStateStagedRead::with_commit_state_manifests(
             self.store,
-            self.staged_roots.values(),
             &self.chunk_overlay,
+            staged_manifests,
         )?;
         TrackedStateContext::new()
             .reader(read)
-            .validate_commit_root_against_changelog(commit_id)
+            .validate_commit_root_metadata_against_changelog(commit_id, metadata)
             .await
     }
 
@@ -3562,7 +3637,10 @@ where
             Some(parent_commit_id) => {
                 let metadata = match self.staged_roots.get(parent_commit_id) {
                     Some(metadata) => Some(metadata.clone()),
-                    None => storage::load_commit_root(self.store, parent_commit_id).await?,
+                    None => {
+                        storage::load_authoritative_commit_root(self.store, parent_commit_id)
+                            .await?
+                    }
                 };
                 let Some(metadata) = metadata else {
                     return Err(LixError::new(
@@ -3596,7 +3674,6 @@ where
                 primary_chunk_count: 0,
                 primary_chunk_bytes: 0,
             };
-            storage::stage_commit_root(self.writes, &metadata)?;
             self.staged_roots.insert(commit_id.to_string(), metadata);
             return Ok(TrackedStateWriteReport {
                 commit_id: typed_commit_id,
@@ -3615,11 +3692,7 @@ where
             .collect::<BTreeSet<_>>();
         let mut cascade_mutations = BTreeMap::<Vec<u8>, Vec<u8>>::new();
         if let Some(base_root) = base_root.as_ref() {
-            let staged_read = storage::TrackedStateStagedRead::new(
-                self.store,
-                self.staged_roots.values(),
-                &self.chunk_overlay,
-            )?;
+            let staged_read = storage::TrackedStateStagedRead::new(self.store, &self.chunk_overlay);
             let mut cascades = BTreeMap::<String, &TrackedStateDeltaRef<'_>>::new();
             for delta in &deltas {
                 if delta.schema_key != FILE_DESCRIPTOR_SCHEMA_KEY || !delta.deleted {
@@ -3730,11 +3803,7 @@ where
             // into this same write set. Read through both staged root metadata
             // and the chunk overlay so a child can preserve `created_at` from
             // an ancestor whose chunks have not reached storage yet.
-            let staged_read = storage::TrackedStateStagedRead::new(
-                self.store,
-                self.staged_roots.values(),
-                &self.chunk_overlay,
-            )?;
+            let staged_read = storage::TrackedStateStagedRead::new(self.store, &self.chunk_overlay);
             self.tree.get_many(&staged_read, base_root, &keys).await?
         } else {
             vec![None; deltas.len()]
@@ -3775,11 +3844,8 @@ where
                 }
             }
             if !marker_keys.is_empty() {
-                let staged_read = storage::TrackedStateStagedRead::new(
-                    self.store,
-                    self.staged_roots.values(),
-                    &self.chunk_overlay,
-                )?;
+                let staged_read =
+                    storage::TrackedStateStagedRead::new(self.store, &self.chunk_overlay);
                 let marker_values = self
                     .tree
                     .get_many(&staged_read, base_root, &marker_keys)
@@ -3927,7 +3993,6 @@ where
                 )
             })?,
         };
-        storage::stage_commit_root(self.writes, &metadata)?;
         self.staged_roots.insert(commit_id.to_string(), metadata);
 
         Ok(TrackedStateWriteReport {
@@ -3970,7 +4035,7 @@ where
         let parent_metadata = match parent_commit_id {
             Some(parent_commit_id) => Some(match self.staged_roots.get(parent_commit_id) {
                 Some(metadata) => metadata.clone(),
-                None => storage::load_commit_root(self.store, parent_commit_id)
+                None => storage::load_authoritative_commit_root(self.store, parent_commit_id)
                     .await?
                     .ok_or_else(|| {
                         LixError::new(
@@ -4130,7 +4195,6 @@ where
                 )
             })?,
         };
-        storage::stage_commit_root(self.writes, &metadata)?;
         self.staged_roots.insert(commit_id.to_string(), metadata);
 
         Ok(Some(TrackedStateWriteReport {
@@ -4649,6 +4713,37 @@ mod tests {
         ))
     }
 
+    fn stage_snapshot_authority_for_test(
+        writes: &mut StorageWriteSet,
+        snapshot_root: TrackedStateCommitRoot,
+    ) -> Result<(), LixError> {
+        let parent_commit_ids = snapshot_root
+            .parent_roots
+            .iter()
+            .map(|parent| parent.commit_id)
+            .collect::<Vec<_>>();
+        storage::stage_commit_state_manifest(
+            writes,
+            &crate::tracked_state::CommitStateManifest {
+                commit_id: snapshot_root.commit_id,
+                generation: u64::from(!parent_commit_ids.is_empty()),
+                parent_commit_ids,
+                commit_change_id: ChangeId::for_test_label(&format!(
+                    "{}:snapshot-authority",
+                    snapshot_root.commit_id
+                )),
+                author_account_ids: Vec::new(),
+                created_at: crate::common::LixTimestamp::expect_parse(
+                    "snapshot authority created_at",
+                    "1970-01-01T00:00:00.000Z",
+                ),
+                replay_debt: Default::default(),
+                mutations: Default::default(),
+                snapshot_root: Some(snapshot_root),
+            },
+        )
+    }
+
     fn change_id(label: &str) -> String {
         ChangeId::for_test_label(label).to_string()
     }
@@ -4675,6 +4770,17 @@ mod tests {
                 .commit_write_set(writes, StorageWriteOptions::default())
                 .await
                 .expect("parent changelog commit should commit");
+        }
+        {
+            let mut writes = storage.new_write_set();
+            writes.delete(
+                storage::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+                commit_root_key("missing-parent"),
+            );
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .expect("missing parent authority should commit");
         }
 
         write_root_for_test(
@@ -4726,7 +4832,7 @@ mod tests {
             .await
             .expect("child root should load")
             .expect("child root should exist");
-        let metadata = storage::load_commit_root(&read, "child")
+        let metadata = storage::load_authoritative_commit_root(&read, "child")
             .await
             .expect("metadata should load")
             .expect("metadata should exist");
@@ -5312,9 +5418,9 @@ mod tests {
         drop(writer);
 
         let arenas = writes.arena_stats();
-        assert_eq!(arenas.put_descriptors, report.primary_chunk_puts + 1);
-        assert_eq!(arenas.key_shared_buffers, 2);
-        assert_eq!(arenas.value_shared_buffers, 2);
+        assert_eq!(arenas.put_descriptors, report.primary_chunk_puts);
+        assert_eq!(arenas.key_shared_buffers, 1);
+        assert_eq!(arenas.value_shared_buffers, 1);
         assert_eq!(arenas.key_inline_allocations, 0);
         assert_eq!(arenas.value_inline_allocations, 0);
         assert!(
@@ -5398,7 +5504,12 @@ mod tests {
                 .await
                 .expect("bulk child root should stage")
                 .expect("dense changed rows should take the dense merge");
+            let staged_roots = writer.staged_commit_roots().cloned().collect::<Vec<_>>();
             drop(writer);
+            for root in staged_roots {
+                stage_snapshot_authority_for_test(&mut writes, root)
+                    .expect("bulk snapshot authority should stage");
+            }
             bulk_storage
                 .commit_write_set(writes, StorageWriteOptions::default())
                 .await
@@ -5413,8 +5524,8 @@ mod tests {
                 .await
                 .expect("generic parent read should open");
             let mut writes = generic_storage.new_write_set();
-            tracked_state
-                .writer(&read, &mut writes)
+            let mut writer = tracked_state.writer(&read, &mut writes);
+            writer
                 .stage_commit_root(
                     &parent_commit_id,
                     None,
@@ -5422,6 +5533,14 @@ mod tests {
                 )
                 .await
                 .expect("generic parent root should stage");
+            let parent_root = writer
+                .staged_commit_roots()
+                .find(|root| root.commit_id == parent_commit_id)
+                .cloned()
+                .expect("generic parent metadata should stage");
+            drop(writer);
+            stage_snapshot_authority_for_test(&mut writes, parent_root)
+                .expect("generic parent authority should stage");
             generic_storage
                 .commit_write_set(writes, StorageWriteOptions::default())
                 .await
@@ -5433,8 +5552,8 @@ mod tests {
                 .await
                 .expect("generic child read should open");
             let mut writes = generic_storage.new_write_set();
-            tracked_state
-                .writer(&read, &mut writes)
+            let mut writer = tracked_state.writer(&read, &mut writes);
+            writer
                 .stage_commit_root(
                     &child_commit_id,
                     Some(&parent_commit_id),
@@ -5442,6 +5561,14 @@ mod tests {
                 )
                 .await
                 .expect("generic child root should stage");
+            let child_root = writer
+                .staged_commit_roots()
+                .find(|root| root.commit_id == child_commit_id)
+                .cloned()
+                .expect("generic child metadata should stage");
+            drop(writer);
+            stage_snapshot_authority_for_test(&mut writes, child_root)
+                .expect("generic child authority should stage");
             generic_storage
                 .commit_write_set(writes, StorageWriteOptions::default())
                 .await
@@ -5657,8 +5784,8 @@ mod tests {
         drop(writer);
 
         let arenas = writes.arena_stats();
-        assert_eq!(arenas.key_shared_buffers, 4);
-        assert_eq!(arenas.value_shared_buffers, 4);
+        assert_eq!(arenas.key_shared_buffers, 2);
+        assert_eq!(arenas.value_shared_buffers, 2);
         assert_eq!(arenas.key_inline_allocations, 0);
         assert_eq!(arenas.value_inline_allocations, 0);
 
@@ -6081,16 +6208,24 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
-        let parent_metadata = storage::load_commit_root(&read, "parent")
+        let parent_metadata = storage::load_authoritative_commit_root(&read, "parent")
             .await
             .expect("parent metadata should load")
             .expect("parent metadata should exist");
         let mut writes = storage.new_write_set();
-        let report = tracked_state
-            .writer(&mut read, &mut writes)
+        let mut writer = tracked_state.writer(&mut read, &mut writes);
+        let report = writer
             .stage_commit_root("empty-child", Some("parent"), [])
             .await
             .expect("empty child root should stage");
+        let child_root = writer
+            .staged_commit_roots()
+            .find(|root| root.commit_id == CommitId::for_test_label("empty-child"))
+            .cloned()
+            .expect("empty child metadata should stage");
+        drop(writer);
+        stage_snapshot_authority_for_test(&mut writes, child_root)
+            .expect("empty child authority should stage");
 
         assert_eq!(report.changed_rows, 0);
         assert_eq!(report.primary_chunk_puts, 0);
@@ -6104,7 +6239,7 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should reopen");
-        let child_metadata = storage::load_commit_root(&read, "empty-child")
+        let child_metadata = storage::load_authoritative_commit_root(&read, "empty-child")
             .await
             .expect("child metadata should load")
             .expect("child metadata should exist");
@@ -6262,7 +6397,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn explicit_rebuild_repairs_missing_child_root_from_nearest_parent() {
+    async fn retired_root_projection_is_not_authoritative() {
         let storage = StorageAdapter::new(Memory::new());
         let tracked_state = TrackedStateContext::new();
         write_root_for_test(
@@ -6283,89 +6418,6 @@ mod tests {
         )
         .await
         .expect("child root should write");
-        {
-            let mut writes = storage.new_write_set();
-            writes.delete(
-                storage::TRACKED_STATE_COMMIT_ROOT_SPACE,
-                commit_root_key("child"),
-            );
-            storage
-                .commit_write_set(writes, StorageWriteOptions::default())
-                .await
-                .expect("child commit_root delete should commit");
-        }
-
-        let error = tracked_state
-            .reader(
-                storage
-                    .begin_read(StorageReadOptions::default())
-                    .await
-                    .expect("self-diff read should open"),
-            )
-            .diff_commits("child", "child", &test_schema_diff_request())
-            .await
-            .expect_err("current-protocol self-diff must validate its root");
-        assert!(error.message.contains("commit_root is missing"));
-        let error = tracked_state
-            .reader(
-                storage
-                    .begin_read(StorageReadOptions::default())
-                    .await
-                    .expect("read should open"),
-            )
-            .diff_commits("base", "child", &test_schema_diff_request())
-            .await
-            .expect_err("current-protocol history must fail closed before repair");
-        assert!(
-            error.message.contains("commit_root is missing"),
-            "unexpected error: {}",
-            error.message
-        );
-        let error = tracked_state
-            .reader(
-                storage
-                    .begin_read(StorageReadOptions::default())
-                    .await
-                    .expect("scan read should open"),
-            )
-            .scan_batch_at_commit("child", &TrackedStateScanRequest::default())
-            .await
-            .expect_err("current-protocol scan must fail closed before repair");
-        assert!(error.message.contains("commit_root is missing"));
-        let error = tracked_state
-            .reader(
-                storage
-                    .begin_read(StorageReadOptions::default())
-                    .await
-                    .expect("exact read should open"),
-            )
-            .load_batch_at_commit(
-                "child",
-                &[TrackedStateKey {
-                    schema_key: "test_schema".to_owned(),
-                    file_id: None,
-                    entity_pk: EntityPk::single("entity-a"),
-                }],
-            )
-            .await
-            .expect_err("current-protocol exact read must fail closed before repair");
-        assert!(error.message.contains("commit_root is missing"));
-
-        let mut read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("read should open");
-        let mut writes = storage.new_write_set();
-        tracked_state
-            .root_rebuilder(&mut read, &mut writes)
-            .rebuild_commit_root_at("child")
-            .await
-            .expect("child root should repair");
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("repaired root should commit");
-
         let diff = tracked_state
             .reader(
                 storage
@@ -6375,7 +6427,7 @@ mod tests {
             )
             .diff_commits("base", "child", &test_schema_diff_request())
             .await
-            .expect("diff should use repaired root");
+            .expect("commit-state authority should expose the snapshot root");
 
         assert_eq!(diff.entries.len(), 1);
         assert_eq!(
@@ -6427,19 +6479,8 @@ mod tests {
         )
         .await
         .expect("child root should write");
-        {
-            let mut writes = storage.new_write_set();
-            for commit_id in ["middle", "child"] {
-                writes.delete(
-                    storage::TRACKED_STATE_COMMIT_ROOT_SPACE,
-                    commit_root_key(commit_id),
-                );
-            }
-            storage
-                .commit_write_set(writes, StorageWriteOptions::default())
-                .await
-                .expect("commit_root deletes should commit");
-        }
+        delete_root_chunk_for_test(&storage, "middle").await;
+        delete_root_chunk_for_test(&storage, "child").await;
 
         let mut read = storage
             .begin_read(StorageReadOptions::default())
@@ -6478,7 +6519,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn explicit_rebuild_repairs_missing_ancestor_chain() {
+    async fn explicit_rebuild_rejects_missing_commit_state_authority() {
         let storage = StorageAdapter::new(Memory::new());
         let tracked_state = TrackedStateContext::new();
         write_root_for_test(
@@ -6517,7 +6558,7 @@ mod tests {
             let mut writes = storage.new_write_set();
             for commit_id in ["middle", "child"] {
                 writes.delete(
-                    storage::TRACKED_STATE_COMMIT_ROOT_SPACE,
+                    storage::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
                     commit_root_key(commit_id),
                 );
             }
@@ -6532,83 +6573,73 @@ mod tests {
             .await
             .expect("read should open");
         let mut writes = storage.new_write_set();
-        tracked_state
+        let error = tracked_state
             .root_rebuilder(&read, &mut writes)
             .rebuild_commit_root_at("child")
             .await
-            .expect("explicit rebuild should repair missing ancestor chain");
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("repaired roots should commit");
-
-        let diff = tracked_state
-            .reader(
-                storage
-                    .begin_read(StorageReadOptions::default())
-                    .await
-                    .expect("read should open"),
-            )
-            .diff_commits("base", "child", &test_schema_diff_request())
-            .await
-            .expect("diff should accept explicitly rebuilt chain");
-
-        assert_eq!(diff.entries.len(), 1);
-        assert_eq!(
-            diff.entries[0]
-                .after
-                .as_ref()
-                .map(|row| row.change_id.to_string()),
-            Some(change_id("change-child"))
-        );
+            .expect_err("semantic authority cannot be reconstructed from a serving index");
+        assert!(error.message.contains("without its commit-state manifest"));
     }
 
     #[tokio::test]
     async fn explicit_rebuild_errors_on_first_parent_cycle() {
         let storage = StorageAdapter::new(Memory::new());
         let tracked_state = TrackedStateContext::new();
-        {
-            let mut read = storage
-                .begin_read(StorageReadOptions::default())
-                .await
-                .expect("read should open");
-            let mut writes = storage.new_write_set();
-            crate::test_support::stage_empty_changelog_commit(
-                &mut read,
-                &mut writes,
+        write_root_for_test(
+            &storage,
+            &tracked_state,
+            "commit-a",
+            None,
+            &[row_with_value(
+                "entity-a",
+                "commit-a:change",
                 "commit-a",
-                None,
-            )
-            .await
-            .expect("commit-a should stage");
-            storage
-                .commit_write_set(writes, StorageWriteOptions::default())
-                .await
-                .expect("commit-a should commit");
-        }
+                "a",
+            )],
+        )
+        .await
+        .expect("commit-a should commit");
+        write_root_for_test(
+            &storage,
+            &tracked_state,
+            "commit-b",
+            Some("commit-a"),
+            &[row_with_value(
+                "entity-b",
+                "commit-b:change",
+                "commit-b",
+                "b",
+            )],
+        )
+        .await
+        .expect("commit-b should commit");
         {
-            let mut read = storage
+            let read = storage
                 .begin_read(StorageReadOptions::default())
                 .await
-                .expect("read should open");
-            let mut writes = storage.new_write_set();
-            crate::test_support::stage_empty_changelog_commit_with_parents(
-                &mut read,
-                &mut writes,
-                "commit-b",
-                &["commit-a".to_string()],
-            )
-            .await
-            .expect("commit-b should stage");
-            storage
-                .commit_write_set(writes, StorageWriteOptions::default())
-                .await
-                .expect("commit-b should commit");
-        }
-        {
+                .expect("cycle authority read should open");
             let mut writes = storage.new_write_set();
             let commit_a = CommitId::for_test_label("commit-a");
             let commit_b = CommitId::for_test_label("commit-b");
+            let mut manifest = storage::load_commit_state_manifest(&read, commit_a)
+                .await
+                .expect("commit-a authority should load")
+                .expect("commit-a authority should exist");
+            manifest.generation = 2;
+            manifest.parent_commit_ids = vec![commit_b];
+            manifest
+                .snapshot_root
+                .as_mut()
+                .expect("commit-a should have a snapshot root")
+                .parent_roots = vec![TrackedStateCommitRootParent {
+                commit_id: commit_b,
+                root_id: storage::load_root(&read, "commit-b")
+                    .await
+                    .expect("commit-b root should load")
+                    .expect("commit-b root should exist"),
+            }];
+            storage::stage_commit_state_manifest(&mut writes, &manifest)
+                .expect("corrupt cycle authority should stage");
             writes.put(
                 crate::changelog::COMMIT_SPACE,
                 crate::storage_adapter::StorageKey(Bytes::copy_from_slice(
@@ -6617,7 +6648,7 @@ mod tests {
                 crate::changelog::encode_commit_record(&CommitRecord {
                     format_version: 1,
                     commit_id: commit_a,
-                    generation: 1,
+                    generation: manifest.generation,
                     parent_commit_ids: vec![commit_b],
                     tracked_state_rootless: false,
                     tracked_state_rootless_depth: 0,
@@ -6828,6 +6859,23 @@ mod tests {
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
             .expect("repaired root should commit");
+
+        let authority_read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("authority read should open");
+        let repaired_authority =
+            storage::load_commit_state_manifest(&authority_read, CommitId::for_test_label("child"))
+                .await
+                .expect("repaired authority should load")
+                .expect("child authority should exist");
+        let repaired_root = storage::load_authoritative_commit_root(&authority_read, "child")
+            .await
+            .expect("repaired root should load")
+            .expect("repaired root should exist");
+        assert_eq!(repaired_authority.snapshot_root, Some(repaired_root));
+        assert_eq!(repaired_authority.replay_debt, Default::default());
+        drop(authority_read);
 
         let rows = tracked_state
             .reader(
@@ -7423,7 +7471,7 @@ mod tests {
             .await
             .expect_err("materialization must reject missing packed authority");
         assert!(
-            error.message.contains("missing from owning commit"),
+            error.message.contains("commit_state_manifest is missing"),
             "unexpected error: {error}"
         );
     }
@@ -7603,17 +7651,7 @@ mod tests {
         assert_eq!(loaded.created_at, "2026-01-01T00:00:00.000Z");
         assert_eq!(loaded.updated_at, "2026-01-03T00:00:00.000Z");
 
-        {
-            let mut writes = storage.new_write_set();
-            writes.delete(
-                storage::TRACKED_STATE_COMMIT_ROOT_SPACE,
-                commit_root_key("child"),
-            );
-            storage
-                .commit_write_set(writes, StorageWriteOptions::default())
-                .await
-                .expect("child root delete should commit");
-        }
+        delete_root_chunk_for_test(&storage, "child").await;
         {
             let read = storage
                 .begin_read(StorageReadOptions::default())
@@ -8162,8 +8200,12 @@ mod tests {
             .expect("certified row should carry a change id");
         let durable_change_id = ChangeId::for_test_label("certified-reference-durable-change-id");
         assert_ne!(durable_change_id, certified_change_id);
+        let mut authority = crate::tracked_state::load_commit_state_manifest(&read, commit_id)
+            .await
+            .expect("commit-state authority should load")
+            .expect("root fixture should publish commit-state authority");
         let mut writes = storage.new_write_set();
-        let locators = crate::tracked_state::stage_commit_deltas(
+        let staged = crate::tracked_state::stage_commit_deltas_for_commit_state(
             &mut writes,
             &[crate::tracked_state::TrackedStateCommitDeltaRef {
                 delta: TrackedStateDeltaRef {
@@ -8190,7 +8232,10 @@ mod tests {
             }],
         )
         .expect("certified commit delta should stage");
-        crate::tracked_state::stage_change_locators(&mut writes, &locators);
+        crate::tracked_state::stage_change_locators(&mut writes, &staged.locators);
+        authority.mutations = staged.mutation_inventory().clone();
+        crate::tracked_state::stage_commit_state_manifest(&mut writes, &authority)
+            .expect("certified commit-state authority should update atomically");
         drop(read);
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -8755,20 +8800,30 @@ mod tests {
             )
             .await
             .expect("stale root should write");
-        storage::stage_commit_root(
-            &mut writes,
-            &TrackedStateCommitRoot {
-                commit_id: CommitId::for_test_label(commit_id),
-                root_id: result.root_id,
-                parent_roots: Vec::new(),
-                changed_key_count: rows.len() as u64,
-                row_count_estimate: result.row_count as u64,
-                tree_height: result.tree_height as u32,
-                primary_chunk_count: result.chunk_count as u64,
-                primary_chunk_bytes: result.chunk_bytes as u64,
-            },
-        )
-        .expect("stale metadata should encode");
+        let typed_commit_id = CommitId::for_test_label(commit_id);
+        let mut stale_root = TrackedStateCommitRoot {
+            commit_id: typed_commit_id,
+            root_id: result.root_id,
+            parent_roots: Vec::new(),
+            changed_key_count: rows.len() as u64,
+            row_count_estimate: result.row_count as u64,
+            tree_height: result.tree_height as u32,
+            primary_chunk_count: result.chunk_count as u64,
+            primary_chunk_bytes: result.chunk_bytes as u64,
+        };
+        let mut manifest = storage::load_commit_state_manifest(&read, typed_commit_id)
+            .await
+            .expect("commit-state authority should load")
+            .expect("root fixture should publish commit-state authority");
+        stale_root.parent_roots = manifest
+            .snapshot_root
+            .as_ref()
+            .map(|root| root.parent_roots.clone())
+            .unwrap_or_default();
+        manifest.snapshot_root = Some(stale_root);
+        manifest.replay_debt = Default::default();
+        storage::stage_commit_state_manifest(&mut writes, &manifest)
+            .expect("stale authority should encode");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await

--- a/packages/engine/src/tracked_state/diff.rs
+++ b/packages/engine/src/tracked_state/diff.rs
@@ -1218,8 +1218,8 @@ mod tests {
     use super::*;
     use crate::NullableKeyFilter;
     use crate::entity_pk::EntityPk;
-    use crate::storage_adapter::StorageAdapter;
     use crate::storage_adapter::{Memory, StorageReadOptions, StorageWriteOptions};
+    use crate::storage_adapter::{StorageAdapter, StorageAdapterRead, StorageWriteSet};
     use crate::tracked_state::types::{
         TrackedStateCommitRoot, TrackedStateCommitRootParent, TrackedStateMutation,
         TrackedStateRootId,
@@ -1232,6 +1232,30 @@ mod tests {
 
     fn change_id(label: &str) -> String {
         ChangeId::for_test_label(label).to_string()
+    }
+
+    async fn stage_snapshot_authority_for_test(
+        read: &(impl StorageAdapterRead + ?Sized),
+        writes: &mut StorageWriteSet,
+        snapshot_root: &TrackedStateCommitRoot,
+    ) -> Result<(), LixError> {
+        let mut manifest =
+            crate::tracked_state::storage::load_unchecked_commit_state_manifest_for_test(
+                read,
+                snapshot_root.commit_id,
+            )
+            .await?
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "corrupt-root fixture has no commit-state manifest",
+                )
+            })?;
+        manifest.snapshot_root = Some(snapshot_root.clone());
+        manifest.replay_debt = Default::default();
+        crate::tracked_state::storage::stage_unchecked_commit_state_manifest_for_test(
+            writes, &manifest,
+        )
     }
 
     #[test]
@@ -1942,6 +1966,25 @@ mod tests {
             file_id: None,
             entity_pk: EntityPk::single("entity-a"),
         };
+        {
+            let mut read = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("corrupt commit read should open");
+            let mut writes = storage.new_write_set();
+            crate::test_support::stage_empty_changelog_commit(
+                &mut read,
+                &mut writes,
+                "right-corrupt",
+                None,
+            )
+            .await
+            .expect("corrupt commit authority should stage");
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .expect("corrupt commit authority should commit");
+        }
         let result = {
             let mut read = storage
                 .begin_read(StorageReadOptions::default())
@@ -1963,7 +2006,8 @@ mod tests {
                 )
                 .await
                 .expect("corrupt root should write");
-            crate::tracked_state::storage::stage_commit_root(
+            stage_snapshot_authority_for_test(
+                &read,
                 &mut writes,
                 &TrackedStateCommitRoot {
                     commit_id: CommitId::for_test_label("right-corrupt"),
@@ -1976,6 +2020,7 @@ mod tests {
                     primary_chunk_bytes: result.chunk_bytes as u64,
                 },
             )
+            .await
             .expect("metadata should encode");
             storage
                 .commit_write_set(writes, StorageWriteOptions::default())
@@ -1999,7 +2044,8 @@ mod tests {
             error
                 .message
                 .contains("does not match changelog change identity")
-                || error.message.contains("changelog commit"),
+                || error.message.contains("changelog commit")
+                || error.message.contains("has no authoritative payload"),
             "unexpected error: {error}"
         );
 
@@ -2125,7 +2171,7 @@ mod tests {
             .expect("unrelated row should appear in valid diff");
         let (source_key, source_value) = source_row.into_index_entry();
 
-        let result = {
+        {
             let mut read = storage
                 .begin_read(StorageReadOptions::default())
                 .await
@@ -2139,6 +2185,17 @@ mod tests {
             )
             .await
             .expect("empty right changelog should write");
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .expect("empty right changelog should commit");
+        };
+        let result = {
+            let mut read = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("read should open");
+            let mut writes = storage.new_write_set();
             let result = crate::tracked_state::tree::TrackedStateTree::new()
                 .apply_mutations(
                     &mut read,
@@ -2154,7 +2211,8 @@ mod tests {
                 )
                 .await
                 .expect("corrupt root should write");
-            crate::tracked_state::storage::stage_commit_root(
+            stage_snapshot_authority_for_test(
+                &read,
                 &mut writes,
                 &TrackedStateCommitRoot {
                     commit_id: CommitId::for_test_label("right-corrupt"),
@@ -2167,6 +2225,7 @@ mod tests {
                     primary_chunk_bytes: result.chunk_bytes as u64,
                 },
             )
+            .await
             .expect("metadata should encode");
             storage
                 .commit_write_set(writes, StorageWriteOptions::default())
@@ -2626,7 +2685,7 @@ mod tests {
         )
         .await
         .expect("source add root should write");
-        let source_update = row_with_times(
+        let mut source_update = row_with_times(
             "entity-a",
             None,
             "source-update-a",
@@ -2634,6 +2693,7 @@ mod tests {
             "2026-01-01T00:00:00Z",
             "2026-01-02T00:00:00Z",
         );
+        source_update.commit_id = CommitId::for_test_label("source-update");
         write_root_committed_for_test(
             &storage,
             &tracked_state,
@@ -3043,7 +3103,7 @@ mod tests {
             .await
             .expect_err("extra commit-root parents must be rejected");
         assert!(
-            error.message.contains("more than one first-parent root"),
+            is_commit_root_validation_error(&error),
             "unexpected error: {error}"
         );
     }
@@ -3275,8 +3335,8 @@ mod tests {
     }
 
     async fn write_root_for_test(
-        read: &mut (impl crate::storage_adapter::StorageAdapterRead + ?Sized),
-        writes: &mut crate::storage_adapter::StorageWriteSet,
+        read: &mut (impl StorageAdapterRead + ?Sized),
+        writes: &mut StorageWriteSet,
         tracked_state: &TrackedStateContext,
         commit_id: &str,
         parent_commit_id: Option<&str>,
@@ -3338,7 +3398,8 @@ mod tests {
             )
             .await
             .expect("corrupt root should write");
-        crate::tracked_state::storage::stage_commit_root(
+        stage_snapshot_authority_for_test(
+            &read,
             &mut writes,
             &TrackedStateCommitRoot {
                 commit_id: CommitId::for_test_label(commit_id),
@@ -3351,6 +3412,7 @@ mod tests {
                 primary_chunk_bytes: result.chunk_bytes as u64,
             },
         )
+        .await
         .expect("metadata should encode");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -3377,6 +3439,7 @@ mod tests {
     fn is_commit_root_validation_error(error: &LixError) -> bool {
         error.message.contains("not the first-parent winner")
             || error.message.contains("does not match parent root")
+            || error.message.contains("snapshot ancestry disagrees")
             || error
                 .message
                 .contains("does not match changelog first-parent winners")

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -40,32 +40,34 @@ pub(crate) use storage::{
     load_change_record_by_id, load_commit_delta_change_records,
     load_commit_delta_members_with_payloads, load_commit_delta_members_with_payloads_for_schemas,
     load_commit_delta_replay_metadata, load_commit_delta_selection_certificate,
-    load_owned_commit_delta_entries, load_owned_commit_delta_entries_one_ordered_ref,
-    scan_change_records_from_commit_deltas, scan_commit_delta_inventory, scan_commit_delta_values,
-    selected_change_selection_fingerprint, stage_addressable_commit_deltas,
-    stage_addressable_commit_deltas_with_selected_source, stage_change_locators,
-    stage_commit_deltas, stage_delete_change_locators, stage_delete_commit_delta_inventory_entry,
-    stage_delete_commit_roots, stage_ordered_addressable_commit_deltas,
-    stage_ordered_addressable_replacement_parts,
+    load_commit_state_manifest, load_commit_state_manifests, load_owned_commit_delta_entries,
+    load_owned_commit_delta_entries_one_ordered_ref, scan_change_records_from_commit_deltas,
+    scan_commit_delta_inventory, scan_commit_delta_values, selected_change_selection_fingerprint,
+    stage_addressable_commit_deltas, stage_addressable_commit_deltas_with_selected_source,
+    stage_change_locators, stage_commit_deltas_for_commit_state, stage_commit_state_manifest,
+    stage_delete_change_locators, stage_delete_commit_delta_inventory_entry,
+    stage_ordered_addressable_commit_deltas, stage_ordered_addressable_replacement_parts,
 };
 #[cfg(feature = "storage-benches")]
 pub(crate) use storage::{
-    TRACKED_STATE_CHANGE_LOCATOR_SPACE, TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
-    TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, TRACKED_STATE_COMMIT_ROOT_SPACE,
-    TRACKED_STATE_TREE_CHUNK_SPACE, decode_change_locator,
+    TRACKED_STATE_CHANGE_LOCATOR_SPACE, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
+    TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE, TRACKED_STATE_TREE_CHUNK_SPACE,
+    decode_change_locator,
 };
 #[cfg(all(test, not(feature = "storage-benches")))]
 pub(crate) use storage::{
-    TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
+    TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
 };
 #[cfg(test)]
 pub(crate) use storage::{
-    load_commit_delta_change_ids, load_commit_root, scan_commit_delta_members,
+    load_authoritative_commit_root, load_commit_delta_change_ids, scan_commit_delta_members,
 };
+pub(crate) use types::{COMMIT_STATE_MAX_REPLAY_BYTES, COMMIT_STATE_MAX_REPLAY_DEPTH};
 pub(crate) use types::{
+    CommitStateManifest, CommitStateMutationInventory, CommitStateReplayDebt,
     MaterializedTrackedStateRow, TrackedStateBaseCoordinate, TrackedStateCommitDeltaRef,
-    TrackedStateDeltaRef, TrackedStateFilter, TrackedStateIndexValue, TrackedStateReadColumns,
-    TrackedStateRootMutationRef, TrackedStateScanRequest,
+    TrackedStateCommitRoot, TrackedStateDeltaRef, TrackedStateFilter, TrackedStateIndexValue,
+    TrackedStateReadColumns, TrackedStateRootMutationRef, TrackedStateScanRequest,
 };
 pub(crate) use types::{TrackedStateKey, TrackedStateKeyRef};
 #[cfg(feature = "storage-benches")]

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -26,7 +26,12 @@ use crate::tracked_state::codec::{
     encode_key_ref, encode_key_ref_into, encode_leaf_node_refs, encode_schema_key_prefix,
     encode_value_ref,
 };
+pub(crate) use crate::tracked_state::types::{
+    CommitDeltaLifecycleSummary, CommitDeltaReplacementScope,
+};
 use crate::tracked_state::types::{
+    CommitStateManifest, CommitStateMutationInventory, CommitStateMutationPart,
+    StoredCommitDeltaReplacementGeneration, StoredReplacementPart, StoredReplacementPartsAuthority,
     TRACKED_STATE_HASH_BYTES, TrackedStateBaseCoordinate, TrackedStateCommitDeltaRef,
     TrackedStateCommitRoot, TrackedStateIndexValue, TrackedStateIndexValueRef, TrackedStateKey,
     TrackedStateKeyRef, TrackedStateRootId,
@@ -36,28 +41,14 @@ use bytes::Bytes;
 use futures_util::{StreamExt, TryStreamExt, stream};
 
 pub(crate) const TRACKED_STATE_TREE_CHUNK_NAMESPACE: &str = "tracked_state.tree_chunk";
-pub(crate) const TRACKED_STATE_COMMIT_ROOT_NAMESPACE: &str = "tracked_state.commit_root";
-pub(crate) const TRACKED_STATE_COMMIT_DELTA_MANIFEST_NAMESPACE: &str =
-    "tracked_state.commit_delta_manifest.v6";
 pub(crate) const TRACKED_STATE_COMMIT_DELTA_SEGMENT_NAMESPACE: &str =
     "tracked_state.commit_delta_segment.v6";
 pub(crate) const TRACKED_STATE_CHANGE_LOCATOR_NAMESPACE: &str = "tracked_state.change_locator.v2";
+pub(crate) const TRACKED_STATE_COMMIT_STATE_MANIFEST_NAMESPACE: &str =
+    "tracked_state.commit_state_manifest.v1";
 pub(crate) const TRACKED_STATE_TREE_CHUNK_SPACE: StorageSpace = StorageSpace::mutable(
     StorageSpaceId(0x0004_0001),
     TRACKED_STATE_TREE_CHUNK_NAMESPACE,
-);
-pub(crate) const TRACKED_STATE_COMMIT_ROOT_SPACE: StorageSpace = StorageSpace::mutable(
-    StorageSpaceId(0x0004_0004),
-    TRACKED_STATE_COMMIT_ROOT_NAMESPACE,
-);
-/// One commit-addressed directory for bounded packed tracked deltas.
-///
-/// Immutable roots are sparse checkpoints. The manifest maps an identity to
-/// one small front-coded segment, avoiding both one RocksDB key per mutation
-/// on writes and full-commit hydration for historical point replay.
-pub(crate) const TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE: StorageSpace = StorageSpace::mutable(
-    StorageSpaceId(0x0004_0019),
-    TRACKED_STATE_COMMIT_DELTA_MANIFEST_NAMESPACE,
 );
 pub(crate) const TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE: StorageSpace = StorageSpace::immutable(
     StorageSpaceId(0x0004_001a),
@@ -71,6 +62,15 @@ pub(crate) const TRACKED_STATE_CHANGE_LOCATOR_SPACE: StorageSpace = StorageSpace
     StorageSpaceId(0x0004_0018),
     TRACKED_STATE_CHANGE_LOCATOR_NAMESPACE,
 );
+/// Hard-cut tracked commit authority.
+///
+/// Current repositories publish this one manifest per commit, including
+/// commits with no tracked mutations. The former topology, delta-directory,
+/// and root authority spaces are not part of the current protocol.
+pub(crate) const TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE: StorageSpace = StorageSpace::mutable(
+    StorageSpaceId(0x0004_002b),
+    TRACKED_STATE_COMMIT_STATE_MANIFEST_NAMESPACE,
+);
 
 const COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 512;
 const GENERIC_COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 128;
@@ -80,6 +80,7 @@ const ORDERED_COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 64 * 1024;
 // replacements authoritative through their immutable part manifest. The
 // payload-less certified-reference encoding is intentionally rejected.
 const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD14";
+const COMMIT_STATE_MANIFEST_FORMAT_MAGIC: &[u8] = b"LXCS1";
 const COMMIT_DELTA_PAYLOAD_OFFSET_BYTES: usize = size_of::<u32>();
 #[cfg(not(test))]
 const COMMIT_DELTA_MAX_SIDECAR_BYTES: usize = 64 * 1024 * 1024;
@@ -383,6 +384,13 @@ pub(crate) struct AddressableCommitDeltaStage {
     /// Final ids by input delta ordinal. Non-addressable entries retain the
     /// nil sentinel and never require a second per-row index.
     pub(crate) assigned_change_ids: Vec<crate::changelog::ChangeId>,
+    mutation_inventory: CommitStateMutationInventory,
+}
+
+impl AddressableCommitDeltaStage {
+    pub(crate) fn mutation_inventory(&self) -> &CommitStateMutationInventory {
+        &self.mutation_inventory
+    }
 }
 
 /// Compact assignment map for an already ordered, fully addressable commit.
@@ -396,6 +404,7 @@ pub(crate) struct OrderedAddressableCommitDeltaStage {
     commit_id: CommitId,
     change_addresses: OrderedChangeAddresses,
     row_count: usize,
+    mutation_inventory: CommitStateMutationInventory,
 }
 
 #[derive(Debug, Clone)]
@@ -405,6 +414,9 @@ enum OrderedChangeAddresses {
 }
 
 impl OrderedAddressableCommitDeltaStage {
+    pub(crate) fn mutation_inventory(&self) -> &CommitStateMutationInventory {
+        &self.mutation_inventory
+    }
     pub(crate) fn assigned_change_ids(
         &self,
     ) -> impl Iterator<Item = crate::changelog::ChangeId> + '_ {
@@ -438,6 +450,7 @@ impl OrderedAddressableCommitDeltaStage {
             commit_id,
             change_addresses: OrderedChangeAddresses::Dense,
             row_count,
+            mutation_inventory: CommitStateMutationInventory::default(),
         }
     }
 }
@@ -455,12 +468,9 @@ pub(crate) struct CommitDeltaMember {
 }
 
 impl CommitDeltaMember {
+    #[cfg(feature = "storage-benches")]
     pub(crate) fn is_selected_payload_ref(&self) -> bool {
         !self.authored && !self.selected_tombstone
-    }
-
-    pub(crate) fn is_selected_tombstone(&self) -> bool {
-        self.selected_tombstone
     }
 }
 
@@ -470,6 +480,17 @@ pub(crate) struct CommitDeltaInventoryEntry {
     pub(crate) segment_count: usize,
     physical_segment_keys: Vec<Vec<u8>>,
     pub(crate) selected_source_commit_id: Option<CommitId>,
+    pub(crate) authority: CommitStateTopologyProjection,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CommitStateTopologyProjection {
+    pub(crate) generation: u64,
+    pub(crate) parent_commit_ids: Vec<CommitId>,
+    pub(crate) commit_change_id: crate::changelog::ChangeId,
+    pub(crate) author_account_ids: Vec<String>,
+    pub(crate) created_at: crate::common::LixTimestamp,
+    pub(crate) replay_debt: crate::tracked_state::types::CommitStateReplayDebt,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -479,6 +500,7 @@ pub(crate) struct CommitDeltaInventory {
 
 struct CommitDeltaPlane {
     manifests: BTreeMap<CommitId, CommitDeltaManifest>,
+    authorities: BTreeMap<CommitId, CommitStateTopologyProjection>,
     segments: BTreeMap<CommitId, BTreeMap<usize, Bytes>>,
     segment_keys: BTreeMap<CommitId, BTreeMap<usize, Bytes>>,
 }
@@ -487,7 +509,6 @@ struct CommitDeltaPlane {
 // hard cut for derived commit rows, prefix-friendly keys, and compact tree
 // nodes. Reject older roots before their differently ordered state can be
 // inherited or traversed.
-const TRACKED_STATE_COMMIT_ROOT_MAGIC: &[u8] = b"LXTR3";
 
 #[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
 #[musli(packed)]
@@ -519,39 +540,6 @@ struct CommitDeltaManifest {
     #[musli(bytes)]
     inline_segment: Vec<u8>,
     segments: Vec<CommitDeltaSegmentBounds>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, musli::Encode, musli::Decode)]
-#[musli(packed)]
-pub(crate) struct CommitDeltaReplacementScope {
-    pub(crate) schema_key: String,
-    #[musli(with = storage_codec::option)]
-    pub(crate) file_id: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
-#[musli(packed)]
-pub(crate) struct CommitDeltaLifecycleSummary {
-    pub(crate) scope: CommitDeltaReplacementScope,
-    pub(crate) ordered_identity_digest: [u8; 32],
-    pub(crate) uniform_created_at: crate::common::LixTimestamp,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
-#[musli(packed)]
-struct StoredCommitDeltaReplacementGeneration {
-    owner_commit_id: [u8; 16],
-    scope: CommitDeltaReplacementScope,
-    #[musli(with = storage_codec::option)]
-    fallback_commit_id: Option<[u8; 16]>,
-    integrity_digest: [u8; 32],
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
-#[musli(packed)]
-struct StoredReplacementPartsAuthority {
-    directory_digest: [u8; 32],
-    uniform_updated_at: crate::common::LixTimestamp,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -588,14 +576,58 @@ struct CommitDeltaSegmentBounds {
     replacement_part: Option<StoredReplacementPart>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
-#[musli(packed)]
-struct StoredReplacementPart {
-    content_digest: [u8; 32],
-    owner_commit_id: [u8; 16],
-    first_address: u32,
-    uniform_created_at: crate::common::LixTimestamp,
-    uniform_updated_at: crate::common::LixTimestamp,
+fn commit_state_inventory_from_delta_manifest(
+    manifest: &CommitDeltaManifest,
+) -> CommitStateMutationInventory {
+    CommitStateMutationInventory {
+        selected_source_commit_id: manifest.selected_source_commit_id,
+        member_count: manifest.member_count,
+        selection_fingerprint: manifest.selection_fingerprint,
+        direct_part_row_counts: manifest.direct_segment_row_counts.clone(),
+        single_partition: manifest.single_partition.clone(),
+        lifecycle_summary: manifest.lifecycle_summary.clone(),
+        replacement_generation: manifest.replacement_generation.clone(),
+        replacement_parts: manifest.replacement_parts.clone(),
+        inline_part: manifest.inline_segment.clone(),
+        parts: manifest
+            .segments
+            .iter()
+            .map(|part| CommitStateMutationPart {
+                first_key: part.first_key.clone(),
+                last_key: part.last_key.clone(),
+                replacement_part: part.replacement_part.clone(),
+            })
+            .collect(),
+    }
+}
+
+fn commit_delta_manifest_from_commit_state(manifest: &CommitStateManifest) -> CommitDeltaManifest {
+    commit_delta_manifest_from_inventory(&manifest.mutations)
+}
+
+fn commit_delta_manifest_from_inventory(
+    inventory: &CommitStateMutationInventory,
+) -> CommitDeltaManifest {
+    CommitDeltaManifest {
+        selected_source_commit_id: inventory.selected_source_commit_id,
+        member_count: inventory.member_count,
+        selection_fingerprint: inventory.selection_fingerprint,
+        direct_segment_row_counts: inventory.direct_part_row_counts.clone(),
+        single_partition: inventory.single_partition.clone(),
+        lifecycle_summary: inventory.lifecycle_summary.clone(),
+        replacement_generation: inventory.replacement_generation.clone(),
+        replacement_parts: inventory.replacement_parts.clone(),
+        inline_segment: inventory.inline_part.clone(),
+        segments: inventory
+            .parts
+            .iter()
+            .map(|part| CommitDeltaSegmentBounds {
+                first_key: part.first_key.clone(),
+                last_key: part.last_key.clone(),
+                replacement_part: part.replacement_part.clone(),
+            })
+            .collect(),
+    }
 }
 
 #[derive(Debug)]
@@ -1153,18 +1185,30 @@ pub(crate) async fn load_root(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: &str,
 ) -> Result<Option<TrackedStateRootId>, LixError> {
-    Ok(load_commit_root(store, commit_id)
+    Ok(load_authoritative_commit_root(store, commit_id)
         .await?
         .map(|metadata| metadata.root_id))
 }
 
-/// Commit-root keys are the raw 16 UUID bytes of the commit id; binary
-/// UUIDv7 order matches the former hyphenated-text key order.
-fn commit_root_key(commit_id: CommitId) -> Vec<u8> {
-    commit_id.as_uuid().as_bytes().to_vec()
+/// Resolves snapshot metadata only through the hard-cut commit authority.
+///
+/// Tree chunks are content addressed; the commit-state manifest is the only
+/// durable mapping from a commit to a snapshot root.
+pub(crate) async fn load_authoritative_commit_root(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: &str,
+) -> Result<Option<TrackedStateCommitRoot>, LixError> {
+    let commit_id = CommitId::parse_lix(commit_id, "tracked-state authoritative root lookup")?;
+    Ok(load_commit_state_manifest(store, commit_id)
+        .await?
+        .and_then(|manifest| manifest.snapshot_root))
 }
 
 fn commit_delta_manifest_key(commit_id: CommitId) -> Vec<u8> {
+    commit_id.as_uuid().as_bytes().to_vec()
+}
+
+fn commit_state_manifest_key(commit_id: CommitId) -> Vec<u8> {
     commit_id.as_uuid().as_bytes().to_vec()
 }
 
@@ -1195,65 +1239,154 @@ fn commit_delta_segment_key_for_bounds(
     Ok(encoded)
 }
 
-pub(crate) async fn load_commit_root(
+/// Loads the hard-cut semantic authority for one tracked commit.
+pub(crate) async fn load_commit_state_manifest(
     store: &(impl StorageAdapterRead + ?Sized),
-    commit_id: &str,
-) -> Result<Option<TrackedStateCommitRoot>, LixError> {
-    // parse_lix canonicalizes test labels to the same synthetic UUID the
-    // staging path produces, so label-keyed test fixtures keep matching.
-    let typed_commit_id = CommitId::parse_lix(commit_id, "tracked-state commit root lookup")?;
+    commit_id: CommitId,
+) -> Result<Option<CommitStateManifest>, LixError> {
     let Some(bytes) = get_one(
         store,
-        TRACKED_STATE_COMMIT_ROOT_SPACE,
-        commit_root_key(typed_commit_id),
+        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+        commit_state_manifest_key(commit_id),
     )
     .await?
     else {
         return Ok(None);
     };
-    let metadata = decode_commit_root(&bytes)?;
-    if metadata.commit_id != typed_commit_id {
+    let manifest = decode_commit_state_manifest(&bytes)?;
+    if manifest.commit_id != commit_id {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
             format!(
-                "tracked_state commit_root key for commit '{commit_id}' contains root metadata for commit '{}'",
-                metadata.commit_id
+                "tracked_state commit_state_manifest key for commit '{commit_id}' contains manifest for commit '{}'",
+                manifest.commit_id
             ),
         ));
     }
-    Ok(Some(metadata))
+    Ok(Some(manifest))
 }
 
-pub(crate) fn stage_commit_root(
+/// Bulk-loads commit authorities in request order.
+pub(crate) async fn load_commit_state_manifests(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_ids: &[CommitId],
+) -> Result<Vec<Option<CommitStateManifest>>, LixError> {
+    let keys = commit_ids
+        .iter()
+        .map(|commit_id| StorageKey(Bytes::from(commit_state_manifest_key(*commit_id))))
+        .collect::<Vec<_>>();
+    let values = PointReadPlan::new(TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE, &keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?;
+    commit_ids
+        .iter()
+        .copied()
+        .zip(values.value)
+        .map(|(commit_id, value)| {
+            let Some(bytes) = value.and_then(full_value_bytes) else {
+                return Ok(None);
+            };
+            let manifest = decode_commit_state_manifest(&bytes)?;
+            if manifest.commit_id != commit_id {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "tracked_state commit-state batch key for commit '{commit_id}' contains manifest for commit '{}'",
+                        manifest.commit_id
+                    ),
+                ));
+            }
+            Ok(Some(manifest))
+        })
+        .collect()
+}
+
+/// Loads deliberately malformed authority without semantic validation so a
+/// corruption test can replace one forged record with another.
+#[cfg(test)]
+pub(crate) async fn load_unchecked_commit_state_manifest_for_test(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+) -> Result<Option<CommitStateManifest>, LixError> {
+    let Some(bytes) = get_one(
+        store,
+        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+        commit_state_manifest_key(commit_id),
+    )
+    .await?
+    else {
+        return Ok(None);
+    };
+    let payload = bytes
+        .strip_prefix(COMMIT_STATE_MANIFEST_FORMAT_MAGIC)
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state corrupt-test commit_state_manifest has an unsupported format",
+            )
+        })?;
+    let manifest = storage_codec::decode("tracked_state commit_state_manifest", payload)?;
+    Ok(Some(manifest))
+}
+
+async fn load_commit_delta_manifests(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_ids: &[CommitId],
+) -> Result<Vec<Option<CommitDeltaManifest>>, LixError> {
+    Ok(load_commit_state_manifests(store, commit_ids)
+        .await?
+        .into_iter()
+        .map(|manifest| manifest.map(|manifest| commit_delta_manifest_from_commit_state(&manifest)))
+        .collect())
+}
+
+/// Stages one complete commit authority record.
+///
+/// Callers must invoke this only after the immutable mutation inventory and
+/// optional snapshot metadata are final. Publishing a partially populated
+/// manifest and patching it later would make an intermediate representation
+/// authoritative to read-your-writes consumers.
+pub(crate) fn stage_commit_state_manifest(
     writes: &mut StorageWriteSet,
-    metadata: &TrackedStateCommitRoot,
+    manifest: &CommitStateManifest,
 ) -> Result<(), LixError> {
     writes.put(
-        TRACKED_STATE_COMMIT_ROOT_SPACE,
-        key(commit_root_key(metadata.commit_id)),
-        value(encode_commit_root(metadata)?),
+        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+        key(commit_state_manifest_key(manifest.commit_id)),
+        value(encode_commit_state_manifest(manifest)?),
     );
     Ok(())
 }
 
-pub(crate) fn stage_delete_commit_roots(
+/// Stages deliberately malformed authority for corruption tests. Production
+/// publication must always use [`stage_commit_state_manifest`].
+#[cfg(test)]
+pub(crate) fn stage_unchecked_commit_state_manifest_for_test(
     writes: &mut StorageWriteSet,
-    commit_ids: impl IntoIterator<Item = CommitId>,
-) {
-    writes.delete_batch(
-        TRACKED_STATE_COMMIT_ROOT_SPACE,
-        commit_ids.into_iter().map(commit_root_key),
+    manifest: &CommitStateManifest,
+) -> Result<(), LixError> {
+    let payload = storage_codec::encode("tracked_state commit_state_manifest", manifest)?;
+    let mut encoded = Vec::with_capacity(COMMIT_STATE_MANIFEST_FORMAT_MAGIC.len() + payload.len());
+    encoded.extend_from_slice(COMMIT_STATE_MANIFEST_FORMAT_MAGIC);
+    encoded.extend_from_slice(&payload);
+    writes.put(
+        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+        key(commit_state_manifest_key(manifest.commit_id)),
+        value(encoded),
     );
+    Ok(())
 }
 
 /// Stages all tracked mutations for one immutable commit as bounded, sorted
 /// front-coded segments plus one tiny directory. A full commit no longer
 /// writes one backend key for every affected identity.
-pub(crate) fn stage_commit_deltas(
+/// Stages bounded immutable mutation parts and returns the exact inventory
+/// that the caller must publish in the commit-state authority.
+pub(crate) fn stage_commit_deltas_for_commit_state(
     writes: &mut StorageWriteSet,
     deltas: &[TrackedStateCommitDeltaRef<'_>],
-) -> Result<Vec<CommitDeltaChangeLocator>, LixError> {
-    Ok(stage_commit_deltas_inner(writes, deltas, None, None)?.locators)
+) -> Result<AddressableCommitDeltaStage, LixError> {
+    stage_commit_deltas_inner(writes, deltas, None, None)
 }
 
 pub(crate) fn stage_addressable_commit_deltas(
@@ -1314,6 +1447,7 @@ where
             commit_id: CommitId::default(),
             change_addresses: OrderedChangeAddresses::Dense,
             row_count: 0,
+            mutation_inventory: CommitStateMutationInventory::default(),
         }));
     };
     let commit_id = first.delta.commit_id;
@@ -1372,8 +1506,6 @@ where
         segments: Vec::with_capacity(row_count.div_ceil(COMMIT_DELTA_SEGMENT_MAX_ROWS)),
     };
     let mut segment_row_counts = Vec::with_capacity(manifest.segments.capacity());
-    writes.reserve_space(TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE, 1, 0);
-
     while !pending.is_empty() || source.len() > 0 {
         while pending.len() < COMMIT_DELTA_SEGMENT_MAX_ROWS {
             let Some(delta) = source.next() else {
@@ -1464,11 +1596,6 @@ where
             .expect("one ordered segment remains inline in its manifest");
         manifest.inline_segment = inline_segment;
     }
-    writes.put(
-        TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
-        key(commit_delta_manifest_key(commit_id)),
-        value(encode_commit_delta_manifest(&manifest)?),
-    );
     let dense_addresses = segment_row_counts
         .iter()
         .take(segment_row_counts.len().saturating_sub(1))
@@ -1499,6 +1626,7 @@ where
         commit_id,
         change_addresses,
         row_count,
+        mutation_inventory: commit_state_inventory_from_delta_manifest(&manifest),
     }))
 }
 
@@ -1673,7 +1801,6 @@ where
         inline_segment: Vec::new(),
         segments: Vec::with_capacity(parts.len()),
     };
-    writes.reserve_space(TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE, 1, 0);
     writes.reserve_space(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, parts.len(), 0);
     let mut first_address = 0u32;
     for (segment_index, part) in parts.into_iter().enumerate() {
@@ -1701,12 +1828,6 @@ where
             .checked_mul(u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS).expect("row limit fits u32"))
             .expect("replacement direct address fits u32");
     }
-    writes.put(
-        TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
-        key(commit_delta_manifest_key(commit_id)),
-        value(encode_commit_delta_manifest(&manifest)?),
-    );
-
     let dense = manifest
         .direct_segment_row_counts
         .iter()
@@ -1731,6 +1852,7 @@ where
         commit_id,
         change_addresses,
         row_count,
+        mutation_inventory: commit_state_inventory_from_delta_manifest(&manifest),
     })
 }
 
@@ -1934,6 +2056,7 @@ fn stage_commit_deltas_inner(
         return Ok(AddressableCommitDeltaStage {
             locators: Vec::new(),
             assigned_change_ids: Vec::new(),
+            mutation_inventory: CommitStateMutationInventory::default(),
         });
     };
     let mut entries = TrackedStateMutationBatchBuilder::with_row_capacity(deltas.len());
@@ -2084,29 +2207,40 @@ fn stage_commit_deltas_inner(
             value.updated_at,
         )
     }));
+    // A direct-address inventory is valid only when every row owns the slot
+    // encoded into its assigned ChangeId. Mixed batches need locator fallback
+    // for all rows because the inventory cannot describe per-row ownership;
+    // selected-source aliases likewise cannot certify only their local part.
+    let direct_segment_row_counts =
+        if selected_source_commit_id.is_none() && addressable.iter().all(|&direct| direct) {
+            encoded_segments
+                .iter()
+                .map(|(range, _)| {
+                    u16::try_from(range.len()).expect("commit-delta segment row count fits u16")
+                })
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+    let has_dense_address_inventory = !direct_segment_row_counts.is_empty();
     let segment_count = encoded_segments.len();
-    writes.reserve_space(TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE, 1, 0);
     if segment_count == 1 {
         let (_, inline_segment) = encoded_segments
             .pop()
             .expect("non-empty commit delta has one encoded segment");
-        writes.put(
-            TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
-            key(commit_delta_manifest_key(commit_id)),
-            value(encode_commit_delta_manifest(&CommitDeltaManifest {
-                selected_source_commit_id: selected_source_commit_id
-                    .map(|commit_id| *commit_id.as_uuid().as_bytes()),
-                member_count,
-                selection_fingerprint,
-                direct_segment_row_counts: Vec::new(),
-                single_partition: single_partition_for_entries(&entries)?,
-                lifecycle_summary: None,
-                replacement_generation: None,
-                replacement_parts: None,
-                inline_segment,
-                segments: Vec::new(),
-            })?),
-        );
+        let manifest = CommitDeltaManifest {
+            selected_source_commit_id: selected_source_commit_id
+                .map(|commit_id| *commit_id.as_uuid().as_bytes()),
+            member_count,
+            selection_fingerprint,
+            direct_segment_row_counts,
+            single_partition: single_partition_for_entries(&entries)?,
+            lifecycle_summary: None,
+            replacement_generation: None,
+            replacement_parts: None,
+            inline_segment,
+            segments: Vec::new(),
+        };
         let locators = commit_delta_change_locators(commit_id, 0, &entries)?
             .into_iter()
             .enumerate()
@@ -2115,6 +2249,7 @@ fn stage_commit_deltas_inner(
         return Ok(AddressableCommitDeltaStage {
             locators,
             assigned_change_ids,
+            mutation_inventory: commit_state_inventory_from_delta_manifest(&manifest),
         });
     }
     writes.reserve_space(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, segment_count, 0);
@@ -2123,7 +2258,7 @@ fn stage_commit_deltas_inner(
             .map(|commit_id| *commit_id.as_uuid().as_bytes()),
         member_count,
         selection_fingerprint,
-        direct_segment_row_counts: Vec::new(),
+        direct_segment_row_counts,
         single_partition: single_partition_for_entries(&entries)?,
         lifecycle_summary: None,
         replacement_generation: None,
@@ -2133,7 +2268,6 @@ fn stage_commit_deltas_inner(
     };
     let mut locators = Vec::with_capacity(entries.len());
     for (segment_index, (range, encoded)) in encoded_segments.into_iter().enumerate() {
-        let segment_start = range.start;
         let segment_entries = &entries[range];
         let first_key = segment_entries
             .first()
@@ -2155,23 +2289,18 @@ fn stage_commit_deltas_inner(
             key(commit_delta_segment_key(commit_id, segment_index)?),
             value(encoded),
         );
-        locators.extend(
-            commit_delta_change_locators(commit_id, segment_index, segment_entries)?
-                .into_iter()
-                .enumerate()
-                .filter_map(|(ordinal, locator)| {
-                    (!addressable[segment_start + ordinal]).then_some(locator)
-                }),
-        );
+        if !has_dense_address_inventory {
+            locators.extend(commit_delta_change_locators(
+                commit_id,
+                segment_index,
+                segment_entries,
+            )?);
+        }
     }
-    writes.put(
-        TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
-        key(commit_delta_manifest_key(commit_id)),
-        value(encode_commit_delta_manifest(&manifest)?),
-    );
     Ok(AddressableCommitDeltaStage {
         locators,
         assigned_change_ids,
+        mutation_inventory: commit_state_inventory_from_delta_manifest(&manifest),
     })
 }
 
@@ -2274,9 +2403,13 @@ pub(crate) async fn load_change_record_by_id(
 ) -> Result<Option<crate::changelog::ChangeRecord>, LixError> {
     let mut direct_error = None;
     if let Some(locator) = direct_change_locator(change_id)
-        && let Some(manifest) = load_commit_delta_manifest(store, locator.commit_id).await?
+        && let Some(commit_state) = load_commit_state_manifest(store, locator.commit_id).await?
+        && direct_change_locator_in_commit_state(&commit_state, change_id) == Some(locator)
     {
-        match try_load_change_record_at_locator_in_manifest(store, locator, &manifest).await {
+        let mutation_directory = commit_delta_manifest_from_commit_state(&commit_state);
+        match try_load_change_record_at_locator_in_manifest(store, locator, &mutation_directory)
+            .await
+        {
             Ok(Some(record)) => return Ok(Some(record)),
             Ok(None) => {}
             Err(error) => direct_error = Some(error),
@@ -2296,9 +2429,13 @@ async fn load_canonical_change_locator(
 ) -> Result<Option<CommitDeltaChangeLocator>, LixError> {
     let mut direct_error = None;
     if let Some(locator) = direct_change_locator(change_id)
-        && let Some(manifest) = load_commit_delta_manifest(store, locator.commit_id).await?
+        && let Some(commit_state) = load_commit_state_manifest(store, locator.commit_id).await?
+        && direct_change_locator_in_commit_state(&commit_state, change_id) == Some(locator)
     {
-        match try_load_change_record_at_locator_in_manifest(store, locator, &manifest).await {
+        let mutation_directory = commit_delta_manifest_from_commit_state(&commit_state);
+        match try_load_change_record_at_locator_in_manifest(store, locator, &mutation_directory)
+            .await
+        {
             Ok(Some(_)) => return Ok(Some(locator)),
             Ok(None) => {}
             Err(error) => direct_error = Some(error),
@@ -2329,6 +2466,26 @@ pub(crate) fn direct_change_locator(
         segment_index: packed / segment_row_limit,
         ordinal,
     })
+}
+
+/// Resolves a direct `ChangeId` only when its encoded slot is present in the
+/// authoritative commit-state inventory.
+///
+/// This is the hard-cut point route: physical part slots remain stable even
+/// when the optional snapshot root is rebuilt or compacted.
+pub(crate) fn direct_change_locator_in_commit_state(
+    manifest: &CommitStateManifest,
+    change_id: crate::changelog::ChangeId,
+) -> Option<CommitDeltaChangeLocator> {
+    let locator = direct_change_locator(change_id)?;
+    if locator.commit_id != manifest.commit_id {
+        return None;
+    }
+    let rows = manifest
+        .mutations
+        .direct_part_row_counts
+        .get(usize::try_from(locator.segment_index).ok()?)?;
+    (locator.ordinal < *rows).then_some(locator)
 }
 
 async fn load_change_locator_by_id(
@@ -2450,19 +2607,12 @@ async fn load_change_records_at_locators(
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect::<Vec<_>>();
-    let manifest_keys = commit_ids
-        .iter()
-        .map(|commit_id| StorageKey(Bytes::from(commit_delta_manifest_key(*commit_id))))
-        .collect::<Vec<_>>();
-    let manifest_values =
-        PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE, &manifest_keys)
-            .materialize(store, StorageGetOptions::default())
-            .await?;
+    let manifest_values = load_commit_delta_manifests(store, &commit_ids).await?;
     let manifests = commit_ids
         .into_iter()
-        .zip(manifest_values.value)
+        .zip(manifest_values)
         .map(|(commit_id, value)| {
-            let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
+            let manifest = value.ok_or_else(|| {
                 LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
                     format!(
@@ -2470,10 +2620,7 @@ async fn load_change_records_at_locators(
                     ),
                 )
             })?;
-            Ok((
-                commit_id,
-                decode_commit_delta_manifest_for_commit(&bytes, commit_id)?,
-            ))
+            Ok((commit_id, manifest))
         })
         .collect::<Result<BTreeMap<_, _>, LixError>>()?;
 
@@ -2898,6 +3045,17 @@ pub(crate) async fn load_commit_delta_values_encoded_with_cache(
         return load_local_commit_delta_values_encoded(store, commit_id, encoded_keys, &manifest)
             .await;
     };
+    if load_commit_state_manifest(store, source_commit_id)
+        .await?
+        .is_none()
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "tracked_state selected-source commit '{commit_id}' references missing authority '{source_commit_id}'"
+            ),
+        ));
+    }
     let mut values =
         match load_commit_delta_manifest_cached(store, source_commit_id, point_cache).await? {
             Some(source_manifest) => {
@@ -3290,23 +3448,14 @@ pub(crate) async fn load_owned_commit_delta_entries(
             output[request_index].is_none().then_some(*commit_id)
         })
         .collect::<BTreeSet<_>>();
-    let manifest_keys = owner_commit_ids
-        .iter()
-        .map(|commit_id| StorageKey(Bytes::from(commit_delta_manifest_key(*commit_id))))
-        .collect::<Vec<_>>();
-    let manifest_values =
-        PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE, &manifest_keys)
-            .materialize(store, StorageGetOptions::default())
-            .await?;
+    let owner_commit_ids = owner_commit_ids.into_iter().collect::<Vec<_>>();
+    let manifest_values = load_commit_delta_manifests(store, &owner_commit_ids).await?;
     let mut owner_manifests = BTreeMap::new();
-    for (commit_id, value) in owner_commit_ids.into_iter().zip(manifest_values.value) {
-        let Some(bytes) = value.and_then(full_value_bytes) else {
+    for (commit_id, manifest) in owner_commit_ids.into_iter().zip(manifest_values) {
+        let Some(manifest) = manifest else {
             continue;
         };
-        owner_manifests.insert(
-            commit_id,
-            decode_commit_delta_manifest_for_commit(&bytes, commit_id)?,
-        );
+        owner_manifests.insert(commit_id, manifest);
     }
     let mut source_requests = Vec::new();
     let mut source_outputs = Vec::new();
@@ -3421,24 +3570,16 @@ async fn load_local_owned_commit_delta_entries(
         .keys()
         .copied()
         .collect::<Vec<_>>();
-    let manifest_keys = commit_ids
-        .iter()
-        .map(|commit_id| StorageKey(Bytes::from(commit_delta_manifest_key(*commit_id))))
-        .collect::<Vec<_>>();
-    let manifest_values =
-        PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE, &manifest_keys)
-            .materialize(store, StorageGetOptions::default())
-            .await?;
+    let manifest_values = load_commit_delta_manifests(store, &commit_ids).await?;
 
     let mut output = (0..requests.len()).map(|_| None).collect::<Vec<_>>();
     let mut segmented_manifests = BTreeMap::<CommitId, CommitDeltaManifest>::new();
     let mut lookups_by_segment = BTreeMap::<(CommitId, usize), Vec<(usize, Vec<u8>)>>::new();
 
-    for (commit_id, manifest_value) in commit_ids.into_iter().zip(manifest_values.value) {
-        let Some(bytes) = manifest_value.and_then(full_value_bytes) else {
+    for (commit_id, manifest) in commit_ids.into_iter().zip(manifest_values) {
+        let Some(manifest) = manifest else {
             continue;
         };
-        let manifest = decode_commit_delta_manifest_for_commit(&bytes, commit_id)?;
         let request_indices = request_indices_by_commit
             .get(&commit_id)
             .expect("manifest commit came from the requested commit set");
@@ -3544,23 +3685,9 @@ async fn load_local_owned_commit_delta_entries_one_ordered(
     {
         Some(manifest) => PointReadCommitDeltaManifest::Cached(manifest),
         None => {
-            let manifest_key = StorageKey(Bytes::from(commit_delta_manifest_key(commit_id)));
-            let manifest_values = PointReadPlan::new(
-                TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
-                std::slice::from_ref(&manifest_key),
-            )
-            .materialize(store, StorageGetOptions::default())
-            .await?;
-            let Some(bytes) = manifest_values
-                .value
-                .into_iter()
-                .next()
-                .flatten()
-                .and_then(full_value_bytes)
-            else {
+            let Some(manifest) = load_commit_delta_manifest(store, commit_id).await? else {
                 return Ok((0..keys.len()).map(|_| None).collect());
             };
-            let manifest = decode_commit_delta_manifest_for_commit(&bytes, commit_id)?;
             match point_cache {
                 Some(cache) => {
                     let manifest = Arc::new(manifest);
@@ -4169,7 +4296,7 @@ pub(crate) async fn visit_change_records_from_commit_deltas(
     mut visit: impl FnMut(crate::changelog::ChangeRecord) -> Result<(), LixError>,
 ) -> Result<usize, LixError> {
     let plan = ScanPlan::range(
-        TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
+        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
         StorageKeyRange {
             lower: Bound::Unbounded,
             upper: Bound::Unbounded,
@@ -4199,7 +4326,14 @@ pub(crate) async fn visit_change_records_from_commit_deltas(
                 unreachable!("full commit-delta scan returned a key-only row");
             };
             let commit_id = commit_id_from_delta_key(&entry.key)?;
-            let manifest = decode_commit_delta_manifest_for_commit(bytes, commit_id)?;
+            let state = decode_commit_state_manifest(bytes)?;
+            if state.commit_id != commit_id {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state commit-state scan key and manifest commit disagree",
+                ));
+            }
+            let manifest = commit_delta_manifest_from_commit_state(&state);
             let members =
                 load_commit_delta_members_from_manifest(store, commit_id, &manifest, &[]).await?;
             for member in members {
@@ -4287,25 +4421,11 @@ async fn validate_no_orphan_commit_delta_segments(
                 commit_ids.push(commit_id);
             }
         }
-        let manifest_keys = commit_ids
-            .iter()
-            .map(|commit_id| StorageKey(Bytes::from(commit_delta_manifest_key(*commit_id))))
-            .collect::<Vec<_>>();
-        let manifests =
-            PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE, &manifest_keys)
-                .materialize(store, StorageGetOptions::default())
-                .await?;
+        let manifests = load_commit_delta_manifests(store, &commit_ids).await?;
         let manifests = commit_ids
             .into_iter()
-            .zip(manifests.value)
-            .map(|(commit_id, value)| {
-                value
-                    .and_then(full_value_bytes)
-                    .map(|bytes| decode_commit_delta_manifest_for_commit(&bytes, commit_id))
-                    .transpose()
-                    .map(|manifest| (commit_id, manifest))
-            })
-            .collect::<Result<BTreeMap<_, _>, LixError>>()?;
+            .zip(manifests)
+            .collect::<BTreeMap<_, _>>();
         for entry in &page.value.entries {
             let commit_id = commit_id_from_delta_key(&entry.key)?;
             let segment_index = usize::try_from(u32::from_be_bytes(
@@ -4361,6 +4481,7 @@ pub(crate) async fn scan_commit_delta_inventory(
 ) -> Result<CommitDeltaInventory, LixError> {
     let CommitDeltaPlane {
         manifests,
+        mut authorities,
         mut segments,
         mut segment_keys,
     } = scan_commit_delta_plane(store).await?;
@@ -4413,6 +4534,9 @@ pub(crate) async fn scan_commit_delta_inventory(
                     })
                     .collect::<Result<Vec<_>, _>>()?,
                 selected_source_commit_id: manifest.selected_source_commit_id(),
+                authority: authorities
+                    .remove(&commit_id)
+                    .expect("every decoded mutation manifest has topology authority"),
             },
         );
     }
@@ -4484,33 +4608,51 @@ pub(crate) async fn scan_commit_delta_inventory(
     }
     debug_assert!(segments.is_empty());
     debug_assert!(segment_keys.is_empty());
+    debug_assert!(authorities.is_empty());
     Ok(inventory)
 }
 
 async fn scan_commit_delta_plane(
     store: &(impl StorageAdapterRead + ?Sized),
 ) -> Result<CommitDeltaPlane, LixError> {
-    let manifest_rows = scan_full_space(store, TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE).await?;
+    let commit_state_rows =
+        scan_full_space(store, TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE).await?;
     let segment_rows = scan_full_space(store, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE).await?;
 
     let mut manifests = BTreeMap::<CommitId, CommitDeltaManifest>::new();
-    for (key, bytes) in manifest_rows {
+    let mut authorities = BTreeMap::<CommitId, CommitStateTopologyProjection>::new();
+    for (key, bytes) in commit_state_rows {
         if key.0.len() != 16 {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
-                "tracked_state commit_delta manifest key is not a 16-byte commit id",
+                "tracked_state commit_state_manifest key is not a 16-byte commit id",
             ));
         }
         let commit_id = commit_id_from_delta_key(&key)?;
-        let manifest = decode_commit_delta_manifest_for_commit(&bytes, commit_id)?;
-        if manifests.insert(commit_id, manifest).is_some() {
+        let manifest = decode_commit_state_manifest(&bytes)?;
+        if manifest.commit_id != commit_id || manifests.contains_key(&commit_id) {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 format!(
-                    "tracked_state commit_delta inventory found duplicate manifest for commit '{commit_id}'"
+                    "tracked_state commit-state inventory found duplicate or mismatched manifest for commit '{commit_id}'"
                 ),
             ));
         }
+        authorities.insert(
+            commit_id,
+            CommitStateTopologyProjection {
+                generation: manifest.generation,
+                parent_commit_ids: manifest.parent_commit_ids.clone(),
+                commit_change_id: manifest.commit_change_id,
+                author_account_ids: manifest.author_account_ids.clone(),
+                created_at: manifest.created_at,
+                replay_debt: manifest.replay_debt,
+            },
+        );
+        manifests.insert(
+            commit_id,
+            commit_delta_manifest_from_commit_state(&manifest),
+        );
     }
 
     let mut segments = BTreeMap::<CommitId, BTreeMap<usize, Bytes>>::new();
@@ -4562,6 +4704,7 @@ async fn scan_commit_delta_plane(
 
     Ok(CommitDeltaPlane {
         manifests,
+        authorities,
         segments,
         segment_keys,
     })
@@ -4615,8 +4758,8 @@ pub(crate) fn stage_delete_commit_delta_inventory_entry(
     entry: &CommitDeltaInventoryEntry,
 ) -> Result<(), LixError> {
     writes.delete(
-        TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
-        key(commit_delta_manifest_key(commit_id)),
+        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+        key(commit_state_manifest_key(commit_id)),
     );
     for segment_key in &entry.physical_segment_keys {
         writes.delete(
@@ -4798,14 +4941,6 @@ fn is_payload_free_selected_tombstone(member: &CommitDeltaMember) -> bool {
     member.selected_tombstone
 }
 
-fn encode_commit_delta_manifest(manifest: &CommitDeltaManifest) -> Result<Vec<u8>, LixError> {
-    let payload = storage_codec::encode("tracked_state packed commit_delta manifest", manifest)?;
-    let mut encoded = Vec::with_capacity(COMMIT_DELTA_FORMAT_MAGIC.len() + payload.len());
-    encoded.extend_from_slice(COMMIT_DELTA_FORMAT_MAGIC);
-    encoded.extend_from_slice(&payload);
-    Ok(encoded)
-}
-
 fn selection_fingerprint<'a>(
     members: impl IntoIterator<
         Item = (
@@ -4899,24 +5034,15 @@ fn commit_delta_replay_metadata(manifest: &CommitDeltaManifest) -> CommitDeltaRe
         }),
     }
 }
-
-fn decode_commit_delta_manifest(bytes: &[u8]) -> Result<CommitDeltaManifest, LixError> {
-    let Some(payload) = bytes.strip_prefix(COMMIT_DELTA_FORMAT_MAGIC) else {
-        return Err(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            "tracked_state commit_delta manifest has an unsupported format; recreate the repository",
-        ));
-    };
-    let manifest = storage_codec::decode("tracked_state packed commit_delta manifest", payload)?;
-    validate_commit_delta_manifest(&manifest)?;
-    Ok(manifest)
-}
-
-fn decode_commit_delta_manifest_for_commit(
-    bytes: &[u8],
+async fn load_commit_delta_manifest(
+    store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
-) -> Result<CommitDeltaManifest, LixError> {
-    let manifest = decode_commit_delta_manifest(bytes)?;
+) -> Result<Option<CommitDeltaManifest>, LixError> {
+    let Some(state) = load_commit_state_manifest(store, commit_id).await? else {
+        return Ok(None);
+    };
+    let manifest = commit_delta_manifest_from_commit_state(&state);
+    validate_commit_delta_manifest(&manifest)?;
     if manifest
         .replacement_generation
         .as_ref()
@@ -4927,23 +5053,7 @@ fn decode_commit_delta_manifest_for_commit(
             format!("tracked_state replacement generation does not belong to commit '{commit_id}'"),
         ));
     }
-    Ok(manifest)
-}
-
-async fn load_commit_delta_manifest(
-    store: &(impl StorageAdapterRead + ?Sized),
-    commit_id: CommitId,
-) -> Result<Option<CommitDeltaManifest>, LixError> {
-    let Some(bytes) = get_one(
-        store,
-        TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
-        commit_delta_manifest_key(commit_id),
-    )
-    .await?
-    else {
-        return Ok(None);
-    };
-    decode_commit_delta_manifest_for_commit(&bytes, commit_id).map(Some)
+    Ok(Some(manifest))
 }
 
 async fn load_commit_delta_manifest_cached(
@@ -4969,6 +5079,21 @@ async fn load_commit_delta_manifest_cached(
 }
 
 fn validate_commit_delta_manifest(manifest: &CommitDeltaManifest) -> Result<(), LixError> {
+    // Every protocol commit has a commit-state manifest, including commits
+    // whose only contribution is topology. Its canonical empty mutation
+    // inventory is a valid delta with no physical segment to read.
+    if manifest.member_count == 0
+        && manifest.selected_source_commit_id.is_none()
+        && manifest.direct_segment_row_counts.is_empty()
+        && manifest.single_partition.is_none()
+        && manifest.lifecycle_summary.is_none()
+        && manifest.replacement_generation.is_none()
+        && manifest.replacement_parts.is_none()
+        && manifest.inline_segment.is_empty()
+        && manifest.segments.is_empty()
+    {
+        return Ok(());
+    }
     if manifest
         .single_partition
         .as_ref()
@@ -4992,6 +5117,8 @@ fn validate_commit_delta_manifest(manifest: &CommitDeltaManifest) -> Result<(), 
         ));
     }
     if let Some(generation) = manifest.replacement_generation.as_ref()
+        // Replacement authority is independent of whether its sole compact
+        // mutation part is inline or addressed through the external directory.
         && (generation.scope.schema_key.is_empty()
             || generation.owner_commit_id == [0; 16]
             || manifest.single_partition.as_ref() != Some(&generation.scope)
@@ -6242,51 +6369,54 @@ impl TrackedStateChunkOverlay {
 
 /// Point-read overlay used to audit rebuilt roots before their write set is
 /// published. Changelog reads fall through to the coherent base snapshot;
-/// commit-root and tree-chunk reads see bytes staged by the root writer first.
+/// content-addressed tree chunks staged by the root writer are visible here.
 #[derive(Debug)]
 pub(crate) struct TrackedStateStagedRead<'a, S: ?Sized> {
     store: &'a S,
-    commit_roots: HashMap<[u8; 16], Bytes>,
     chunks: &'a TrackedStateChunkOverlay,
+    commit_states: HashMap<Vec<u8>, Bytes>,
 }
 
 impl<'a, S> TrackedStateStagedRead<'a, S>
 where
     S: StorageAdapterRead + ?Sized,
 {
-    pub(crate) fn new<'root>(
-        store: &'a S,
-        commit_roots: impl IntoIterator<Item = &'root TrackedStateCommitRoot>,
-        chunks: &'a TrackedStateChunkOverlay,
-    ) -> Result<Self, LixError> {
-        let mut encoded_roots = HashMap::new();
-        for metadata in commit_roots {
-            let key = *metadata.commit_id.as_uuid().as_bytes();
-            let value = Bytes::from(encode_commit_root(metadata)?);
-            if let Some(existing) = encoded_roots.insert(key, value.clone())
-                && existing != value
-            {
-                return Err(LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "tracked-state staged audit contains conflicting commit roots",
-                ));
-            }
+    pub(crate) fn new(store: &'a S, chunks: &'a TrackedStateChunkOverlay) -> Self {
+        Self {
+            store,
+            chunks,
+            commit_states: HashMap::new(),
         }
+    }
+
+    pub(crate) fn with_commit_state_manifests(
+        store: &'a S,
+        chunks: &'a TrackedStateChunkOverlay,
+        manifests: impl IntoIterator<Item = CommitStateManifest>,
+    ) -> Result<Self, LixError> {
+        let commit_states = manifests
+            .into_iter()
+            .map(|manifest| {
+                Ok((
+                    commit_state_manifest_key(manifest.commit_id),
+                    Bytes::from(encode_commit_state_manifest(&manifest)?),
+                ))
+            })
+            .collect::<Result<HashMap<_, _>, LixError>>()?;
         Ok(Self {
             store,
-            commit_roots: encoded_roots,
             chunks,
+            commit_states,
         })
     }
 
     fn staged_bytes(&self, space: StorageSpaceId, key: &StorageKey) -> Option<Bytes> {
-        if space == TRACKED_STATE_COMMIT_ROOT_SPACE.id {
-            let key = <&[u8; 16]>::try_from(key.0.as_ref()).ok()?;
-            return self.commit_roots.get(key).cloned();
-        }
         if space == TRACKED_STATE_TREE_CHUNK_SPACE.id {
             let key = <&[u8; TRACKED_STATE_HASH_BYTES]>::try_from(key.0.as_ref()).ok()?;
             return self.chunks.staged_chunk_bytes(key);
+        }
+        if space == TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE.id {
+            return self.commit_states.get(key.0.as_ref()).cloned();
         }
         None
     }
@@ -6322,7 +6452,7 @@ where
         range: StorageKeyRange,
         opts: StorageScanOptions,
     ) -> Result<StorageScanChunk, StorageError> {
-        if space == TRACKED_STATE_COMMIT_ROOT_SPACE || space == TRACKED_STATE_TREE_CHUNK_SPACE {
+        if space == TRACKED_STATE_TREE_CHUNK_SPACE {
             return Err(StorageError::Io(
                 "tracked-state staged audit supports point reads only for overlay spaces"
                     .to_string(),
@@ -6349,22 +6479,163 @@ fn full_value_bytes(value: StorageProjectedValue) -> Option<Bytes> {
     }
 }
 
-fn encode_commit_root(metadata: &TrackedStateCommitRoot) -> Result<Vec<u8>, LixError> {
-    let payload = storage_codec::encode("tracked_state commit_root", metadata)?;
-    let mut encoded = Vec::with_capacity(TRACKED_STATE_COMMIT_ROOT_MAGIC.len() + payload.len());
-    encoded.extend_from_slice(TRACKED_STATE_COMMIT_ROOT_MAGIC);
+fn encode_commit_state_manifest(manifest: &CommitStateManifest) -> Result<Vec<u8>, LixError> {
+    validate_commit_state_manifest(manifest)?;
+    let payload = storage_codec::encode("tracked_state commit_state_manifest", manifest)?;
+    let mut encoded = Vec::with_capacity(COMMIT_STATE_MANIFEST_FORMAT_MAGIC.len() + payload.len());
+    encoded.extend_from_slice(COMMIT_STATE_MANIFEST_FORMAT_MAGIC);
     encoded.extend_from_slice(&payload);
     Ok(encoded)
 }
 
-fn decode_commit_root(bytes: &[u8]) -> Result<TrackedStateCommitRoot, LixError> {
-    let Some(payload) = bytes.strip_prefix(TRACKED_STATE_COMMIT_ROOT_MAGIC) else {
+fn decode_commit_state_manifest(bytes: &[u8]) -> Result<CommitStateManifest, LixError> {
+    let Some(payload) = bytes.strip_prefix(COMMIT_STATE_MANIFEST_FORMAT_MAGIC) else {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
-            "tracked_state commit_root has an unsupported format; recreate the repository",
+            "tracked_state commit_state_manifest has an unsupported format; recreate the repository",
         ));
     };
-    storage_codec::decode("tracked_state commit_root", payload)
+    let manifest = storage_codec::decode("tracked_state commit_state_manifest", payload)?;
+    validate_commit_state_manifest(&manifest)?;
+    Ok(manifest)
+}
+
+fn validate_commit_state_manifest(manifest: &CommitStateManifest) -> Result<(), LixError> {
+    let mut parents = BTreeSet::new();
+    for parent in &manifest.parent_commit_ids {
+        if *parent == manifest.commit_id || !parents.insert(*parent) {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state commit_state_manifest has a self or duplicate parent",
+            ));
+        }
+    }
+
+    match &manifest.snapshot_root {
+        Some(root) => {
+            if root.commit_id != manifest.commit_id {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state commit_state_manifest snapshot belongs to another commit",
+                ));
+            }
+            if root.parent_roots.first().map(|parent| parent.commit_id)
+                != manifest.parent_commit_ids.first().copied()
+                || root
+                    .parent_roots
+                    .iter()
+                    .any(|parent| !parents.contains(&parent.commit_id))
+            {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state commit_state_manifest snapshot ancestry disagrees with commit topology",
+                ));
+            }
+        }
+        None if manifest.replay_debt.depth == 0 => {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state rootless commit_state_manifest has zero replay depth",
+            ));
+        }
+        None => {}
+    }
+    if manifest.replay_debt.depth == 0
+        && (manifest.replay_debt.rows != 0 || manifest.replay_debt.bytes != 0)
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit_state_manifest has replay work at zero depth",
+        ));
+    }
+    if manifest.replay_debt.depth > crate::tracked_state::COMMIT_STATE_MAX_REPLAY_DEPTH
+        || manifest.replay_debt.bytes > crate::tracked_state::COMMIT_STATE_MAX_REPLAY_BYTES
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit_state_manifest replay debt exceeds the protocol bound",
+        ));
+    }
+
+    validate_commit_state_mutation_inventory(manifest.commit_id, &manifest.mutations)
+}
+
+fn validate_commit_state_mutation_inventory(
+    commit_id: CommitId,
+    inventory: &CommitStateMutationInventory,
+) -> Result<(), LixError> {
+    if inventory.selected_source_commit_id() == Some(commit_id) {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit_state_manifest selects itself as a mutation source",
+        ));
+    }
+    if !inventory.inline_part.is_empty() && !inventory.parts.is_empty() {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit_state_manifest mixes inline and external mutation parts",
+        ));
+    }
+    if inventory.parts.iter().any(|part| {
+        part.first_key.is_empty() || part.last_key.is_empty() || part.first_key > part.last_key
+    }) || inventory
+        .parts
+        .windows(2)
+        .any(|pair| pair[0].last_key >= pair[1].first_key)
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit_state_manifest has invalid or overlapping mutation-part bounds",
+        ));
+    }
+    if inventory.member_count > 0
+        && inventory.part_count() == 0
+        && inventory.selected_source_commit_id.is_none()
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit_state_manifest has members without mutation parts",
+        ));
+    }
+    if !inventory.direct_part_row_counts.is_empty() {
+        let direct_rows = &inventory.direct_part_row_counts;
+        if direct_rows.len() != inventory.part_count()
+            || direct_rows
+                .iter()
+                .any(|&rows| rows == 0 || usize::from(rows) > COMMIT_DELTA_SEGMENT_MAX_ROWS)
+            || direct_rows.iter().map(|&rows| u64::from(rows)).sum::<u64>()
+                != u64::from(inventory.member_count)
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state commit_state_manifest has an invalid direct mutation address inventory",
+            ));
+        }
+    }
+    let is_empty = inventory.member_count == 0
+        && inventory.selected_source_commit_id.is_none()
+        && inventory.direct_part_row_counts.is_empty()
+        && inventory.single_partition.is_none()
+        && inventory.lifecycle_summary.is_none()
+        && inventory.replacement_generation.is_none()
+        && inventory.replacement_parts.is_none()
+        && inventory.inline_part.is_empty()
+        && inventory.parts.is_empty();
+    if !is_empty {
+        let mutation_directory = commit_delta_manifest_from_inventory(inventory);
+        validate_commit_delta_manifest(&mutation_directory)?;
+        if mutation_directory
+            .replacement_generation
+            .as_ref()
+            .is_some_and(|generation| generation.owner_commit_id != *commit_id.as_uuid().as_bytes())
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state replacement generation does not belong to its commit-state authority",
+            ));
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -6392,35 +6663,159 @@ mod tests {
     use crate::live_state::{
         HOT_DIFF_SPACE, HOT_FILE_SPACE, HOT_ROW_SPACE, TRACKED_WORKING_DIFF_MARKER_SPACE,
     };
-    use crate::storage_adapter::{Memory, StorageAdapter, StorageReadOptions, StorageWriteOptions};
+    use crate::storage_adapter::{
+        Memory, StorageAdapter, StorageReadOptions, StorageWriteOptions, StorageWriteSet,
+    };
     use crate::tracked_state::codec::{
         EncodedLeafEntry, PendingChunk, PendingChunkBatch, TrackedStateKeyBatchBuilder,
         encode_key_ref, encode_value_ref, hash_bytes,
     };
     use crate::tracked_state::types::{
+        CommitStateManifest, CommitStateMutationInventory, CommitStateReplayDebt,
         TrackedStateBaseCoordinate, TrackedStateCommitDeltaRef, TrackedStateCommitRoot,
-        TrackedStateCommitRootParent, TrackedStateDeltaRef, TrackedStateIndexValue,
-        TrackedStateIndexValueRef, TrackedStateKey, TrackedStateKeyRef, TrackedStateRootId,
+        TrackedStateDeltaRef, TrackedStateIndexValue, TrackedStateIndexValueRef, TrackedStateKey,
+        TrackedStateKeyRef, TrackedStateRootId,
     };
 
     use super::{
-        COMMIT_DELTA_FORMAT_MAGIC, CommitDeltaChangeLocator, CommitDeltaManifest,
-        CommitDeltaPayloadRef, DecodedCommitDeltaBatch, DecodedCommitDeltaCache,
-        DecodedCommitDeltaSegment, GENERIC_COMMIT_DELTA_SEGMENT_MAX_ROWS,
-        TRACKED_STATE_CHANGE_LOCATOR_SPACE, TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
-        TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, TRACKED_STATE_COMMIT_ROOT_MAGIC,
-        TRACKED_STATE_COMMIT_ROOT_SPACE, TRACKED_STATE_TREE_CHUNK_SPACE, TrackedStateChunkOverlay,
-        commit_delta_manifest_key, decode_commit_delta_manifest, decode_commit_delta_with_payloads,
-        decode_commit_root, encode_commit_delta_manifest, encode_commit_delta_segment,
+        COMMIT_DELTA_FORMAT_MAGIC, COMMIT_STATE_MANIFEST_FORMAT_MAGIC, CommitDeltaChangeLocator,
+        CommitDeltaManifest, CommitDeltaPayloadRef, DecodedCommitDeltaBatch,
+        DecodedCommitDeltaCache, DecodedCommitDeltaSegment, GENERIC_COMMIT_DELTA_SEGMENT_MAX_ROWS,
+        TRACKED_STATE_CHANGE_LOCATOR_SPACE, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
+        TRACKED_STATE_TREE_CHUNK_SPACE, TrackedStateChunkOverlay,
+        decode_commit_delta_with_payloads, decode_commit_state_manifest,
+        direct_change_locator_in_commit_state, encode_commit_delta_segment,
         encode_commit_delta_segment_with_payloads, encode_commit_delta_segment_with_raw_sidecar,
-        encode_commit_root, key, load_change_record_by_id, load_commit_delta_change_ids,
+        encode_commit_state_manifest, key, load_change_record_by_id, load_commit_delta_change_ids,
         load_commit_delta_change_records, load_commit_delta_members_with_payloads,
-        load_commit_delta_values_encoded, load_owned_commit_delta_entries,
-        scan_change_records_from_commit_deltas, scan_commit_delta_inventory,
-        scan_commit_delta_members, scan_commit_delta_values,
-        stage_addressable_commit_deltas_with_selected_source, stage_change_locators,
-        stage_commit_deltas, stage_delete_commit_delta_inventory_entry, value,
+        load_commit_delta_values_encoded, load_commit_state_manifest,
+        load_owned_commit_delta_entries, scan_change_records_from_commit_deltas,
+        scan_commit_delta_inventory, scan_commit_delta_members, scan_commit_delta_values,
+        stage_change_locators, stage_commit_state_manifest,
+        stage_delete_commit_delta_inventory_entry, value,
     };
+
+    fn fixture_commit_state_manifest(
+        commit_id: CommitId,
+        mutations: CommitStateMutationInventory,
+    ) -> CommitStateManifest {
+        CommitStateManifest {
+            commit_id,
+            generation: 0,
+            parent_commit_ids: Vec::new(),
+            commit_change_id: ChangeId::for_test_label(&format!("{commit_id}:commit")),
+            author_account_ids: Vec::new(),
+            created_at: LixTimestamp::from_unix_millis_utc_lossy(0),
+            replay_debt: CommitStateReplayDebt {
+                depth: 1,
+                rows: u64::from(mutations.member_count),
+                bytes: u64::from(mutations.member_count),
+            },
+            mutations,
+            snapshot_root: None,
+        }
+    }
+
+    fn stage_fixture_manifest(
+        writes: &mut StorageWriteSet,
+        commit_id: CommitId,
+        mutations: &CommitStateMutationInventory,
+    ) -> Result<(), LixError> {
+        let manifest = fixture_commit_state_manifest(commit_id, mutations.clone());
+        stage_commit_state_manifest(writes, &manifest)
+    }
+
+    fn stage_commit_deltas(
+        writes: &mut StorageWriteSet,
+        deltas: &[TrackedStateCommitDeltaRef<'_>],
+    ) -> Result<Vec<CommitDeltaChangeLocator>, LixError> {
+        let staged = super::stage_commit_deltas_for_commit_state(writes, deltas)?;
+        let commit_id = deltas
+            .first()
+            .map(|delta| delta.delta.commit_id)
+            .unwrap_or_default();
+        stage_fixture_manifest(writes, commit_id, staged.mutation_inventory())?;
+        Ok(staged.locators)
+    }
+
+    fn stage_addressable_commit_deltas(
+        writes: &mut StorageWriteSet,
+        deltas: &[TrackedStateCommitDeltaRef<'_>],
+        addressable: &[bool],
+    ) -> Result<super::AddressableCommitDeltaStage, LixError> {
+        let staged = super::stage_addressable_commit_deltas(writes, deltas, addressable)?;
+        let commit_id = deltas
+            .first()
+            .map(|delta| delta.delta.commit_id)
+            .unwrap_or_default();
+        let mutations = fixture_addressable_inventory(&staged);
+        stage_fixture_manifest(writes, commit_id, &mutations)?;
+        Ok(staged)
+    }
+
+    fn stage_addressable_commit_deltas_with_selected_source(
+        writes: &mut StorageWriteSet,
+        deltas: &[TrackedStateCommitDeltaRef<'_>],
+        addressable: &[bool],
+        selected_source_commit_id: CommitId,
+    ) -> Result<super::AddressableCommitDeltaStage, LixError> {
+        let staged = super::stage_addressable_commit_deltas_with_selected_source(
+            writes,
+            deltas,
+            addressable,
+            selected_source_commit_id,
+        )?;
+        let commit_id = deltas
+            .first()
+            .map(|delta| delta.delta.commit_id)
+            .unwrap_or_default();
+        let mutations = fixture_addressable_inventory(&staged);
+        stage_fixture_manifest(writes, commit_id, &mutations)?;
+        Ok(staged)
+    }
+
+    fn fixture_addressable_inventory(
+        staged: &super::AddressableCommitDeltaStage,
+    ) -> CommitStateMutationInventory {
+        let mut mutations = staged.mutation_inventory().clone();
+        if mutations.direct_part_row_counts.is_empty()
+            && staged
+                .assigned_change_ids
+                .iter()
+                .any(|change_id| *change_id != ChangeId::default())
+        {
+            let mut row_counts = vec![0_u16; mutations.part_count()];
+            for locator in staged.locators.iter().copied().chain(
+                staged
+                    .assigned_change_ids
+                    .iter()
+                    .copied()
+                    .filter(|change_id| *change_id != ChangeId::default())
+                    .filter_map(super::direct_change_locator),
+            ) {
+                let rows = &mut row_counts[locator.segment_index as usize];
+                *rows = (*rows).max(locator.ordinal + 1);
+            }
+            mutations.direct_part_row_counts = row_counts;
+        }
+        mutations
+    }
+
+    fn stage_ordered_addressable_commit_deltas<'a, I>(
+        writes: &mut StorageWriteSet,
+        deltas: I,
+        order_certified: bool,
+    ) -> Result<Option<super::OrderedAddressableCommitDeltaStage>, LixError>
+    where
+        I: ExactSizeIterator<Item = Result<TrackedStateCommitDeltaRef<'a>, LixError>> + Clone,
+    {
+        let staged =
+            super::stage_ordered_addressable_commit_deltas(writes, deltas, order_certified, false)?;
+        if let Some(staged) = &staged {
+            stage_fixture_manifest(writes, staged.commit_id, staged.mutation_inventory())?;
+        }
+        Ok(staged)
+    }
 
     #[test]
     fn decoded_commit_delta_point_cache_reuses_an_immutable_segment() {
@@ -6619,7 +7014,6 @@ mod tests {
         const FIRST_LIVE_STATE_SPACE: [u8; 4] = 0x0004_001b_u32.to_be_bytes();
         for space in [
             TRACKED_STATE_CHANGE_LOCATOR_SPACE,
-            TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
             TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
         ] {
             assert!(
@@ -6688,7 +7082,7 @@ mod tests {
         let deltas = commit_delta_refs(commit_id, &fixtures);
         let mut writes = storage.new_write_set();
         let staged =
-            super::stage_addressable_commit_deltas(&mut writes, &deltas, &vec![true; deltas.len()])
+            stage_addressable_commit_deltas(&mut writes, &deltas, &vec![true; deltas.len()])
                 .expect("addressable deltas should stage");
         assert!(staged.locators.is_empty());
         assert!(
@@ -6708,6 +7102,16 @@ mod tests {
             .expect("addressable read should open");
         let source_index = fixtures.len() / 2;
         let change_id = staged.assigned_change_ids[source_index];
+        let authority = load_commit_state_manifest(&read, commit_id)
+            .await
+            .expect("commit-state authority should load")
+            .expect("commit-state authority should exist");
+        assert_eq!(authority.mutations, fixture_addressable_inventory(&staged));
+        assert_eq!(
+            direct_change_locator_in_commit_state(&authority, change_id),
+            super::direct_change_locator(change_id),
+            "the authoritative inventory must retain the assigned direct slot"
+        );
         assert!(
             super::load_change_locator_by_id(&read, change_id)
                 .await
@@ -6754,10 +7158,9 @@ mod tests {
             })
             .collect::<Vec<_>>();
         let mut writes = storage.new_write_set();
-        let staged = super::stage_ordered_addressable_commit_deltas(
+        let staged = stage_ordered_addressable_commit_deltas(
             &mut writes,
             deltas.iter().copied().map(Ok::<_, LixError>),
-            false,
             false,
         )
         .expect("ordered addressable deltas should stage")
@@ -6771,7 +7174,7 @@ mod tests {
                 .all(|change_id| *change_id != ChangeId::default())
         );
         let mut generic_writes = generic_storage.new_write_set();
-        let generic = super::stage_addressable_commit_deltas(
+        let generic = stage_addressable_commit_deltas(
             &mut generic_writes,
             &deltas,
             &vec![true; deltas.len()],
@@ -6894,7 +7297,9 @@ mod tests {
             false,
         )
         .expect("irregular ordered deltas should stage")
-        .expect("ordered deltas should use the streaming route");
+        .expect("certified ordered deltas should use the streaming route");
+        stage_fixture_manifest(&mut writes, staged.commit_id, staged.mutation_inventory())
+            .expect("commit-state authority should stage");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
@@ -6999,6 +7404,8 @@ mod tests {
             &generation,
         )
         .expect("replacement parts should stage");
+        stage_fixture_manifest(&mut writes, staged.commit_id, staged.mutation_inventory())
+            .expect("replacement commit-state authority should stage");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
@@ -7049,9 +7456,8 @@ mod tests {
         let mut writes = storage.new_write_set();
         let target_deltas =
             commit_delta_refs(addressable_commit_id, std::slice::from_ref(&address_target));
-        let target_staged =
-            super::stage_addressable_commit_deltas(&mut writes, &target_deltas, &[false])
-                .expect("non-addressable target should stage");
+        let target_staged = stage_addressable_commit_deltas(&mut writes, &target_deltas, &[false])
+            .expect("non-addressable target should stage");
         stage_change_locators(&mut writes, &target_staged.locators);
 
         let explicit_change_id =
@@ -7065,7 +7471,7 @@ mod tests {
         let explicit_deltas =
             commit_delta_refs(explicit_commit_id, std::slice::from_ref(&explicit));
         let explicit_staged =
-            super::stage_addressable_commit_deltas(&mut writes, &explicit_deltas, &[false])
+            stage_addressable_commit_deltas(&mut writes, &explicit_deltas, &[false])
                 .expect("explicit change should stage with a locator");
         assert_eq!(explicit_staged.locators.len(), 1);
         stage_change_locators(&mut writes, &explicit_staged.locators);
@@ -7110,9 +7516,8 @@ mod tests {
         let mut writes = storage.new_write_set();
         let target_deltas =
             commit_delta_refs(addressable_commit_id, std::slice::from_ref(&address_target));
-        let target_staged =
-            super::stage_addressable_commit_deltas(&mut writes, &target_deltas, &[false])
-                .expect("inline target should stage");
+        let target_staged = stage_addressable_commit_deltas(&mut writes, &target_deltas, &[false])
+            .expect("inline target should stage");
         stage_change_locators(&mut writes, &target_staged.locators);
 
         let explicit_change_id = super::addressable_change_id(addressable_commit_id, 1, 0)
@@ -7126,7 +7531,7 @@ mod tests {
         let explicit_deltas =
             commit_delta_refs(explicit_commit_id, std::slice::from_ref(&explicit));
         let explicit_staged =
-            super::stage_addressable_commit_deltas(&mut writes, &explicit_deltas, &[false])
+            stage_addressable_commit_deltas(&mut writes, &explicit_deltas, &[false])
                 .expect("out-of-range explicit change should stage");
         assert_eq!(explicit_staged.locators.len(), 1);
         stage_change_locators(&mut writes, &explicit_staged.locators);
@@ -7235,6 +7640,29 @@ mod tests {
             .await
             .expect("a known empty commit has no manifest")
             .is_empty()
+        );
+
+        let topology_only_commit_id = CommitId::for_test_label("topology-only-authority");
+        let mut writes = storage.new_write_set();
+        stage_fixture_manifest(
+            &mut writes,
+            topology_only_commit_id,
+            &CommitStateMutationInventory::default(),
+        )
+        .expect("topology-only commit-state authority should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("topology-only commit-state authority should commit");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        assert!(
+            load_commit_delta_change_ids(&read, topology_only_commit_id)
+                .await
+                .expect("topology-only authority has an empty mutation inventory")
+                .is_empty()
         );
     }
 
@@ -7604,7 +8032,7 @@ mod tests {
             None,
         );
         let mut writes = storage.new_write_set();
-        let staged = super::stage_addressable_commit_deltas(&mut writes, &[owner], &[true])
+        let staged = stage_addressable_commit_deltas(&mut writes, &[owner], &[true])
             .expect("direct owner should stage");
         assert!(staged.locators.is_empty());
         fixture.change_id = staged.assigned_change_ids[0];
@@ -7683,7 +8111,7 @@ mod tests {
 
         let mut writes = storage.new_write_set();
         let source_deltas = commit_delta_refs(source_commit, &fixtures[..2]);
-        let source_stage = super::stage_addressable_commit_deltas(
+        let source_stage = stage_addressable_commit_deltas(
             &mut writes,
             &source_deltas,
             &vec![true; source_deltas.len()],
@@ -7798,7 +8226,7 @@ mod tests {
             });
         }
         let chunks = PendingChunkBatch::from_parts(Bytes::from(data_arena), descriptors);
-        let mut writes = crate::storage_adapter::StorageWriteSet::new();
+        let mut writes = StorageWriteSet::new();
         let mut overlay = TrackedStateChunkOverlay::new();
         overlay.stage_chunks(&mut writes, &chunks);
 
@@ -7849,7 +8277,7 @@ mod tests {
         assert_eq!(
             writes.stats().staged_puts,
             4,
-            "generic history keeps 300 compact rows in three read-friendly segments plus its manifest"
+            "generic history keeps 300 compact rows in three read-friendly segments plus its commit-state authority"
         );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -8045,7 +8473,7 @@ mod tests {
         assert_eq!(
             writes.stats().staged_puts,
             3,
-            "the oversized four-row candidate should become two segments plus one manifest"
+            "the oversized four-row candidate should become two segments plus its commit-state authority"
         );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -8105,28 +8533,27 @@ mod tests {
         );
         segment.pop();
         let mut writes = storage.new_write_set();
-        writes.put(
-            TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
-            key(commit_delta_manifest_key(commit_id)),
-            value(
-                encode_commit_delta_manifest(&CommitDeltaManifest {
-                    selected_source_commit_id: None,
-                    member_count: 0,
-                    selection_fingerprint: [0; 32],
-                    direct_segment_row_counts: Vec::new(),
-                    single_partition: Some(super::CommitDeltaReplacementScope {
-                        schema_key: fixture.schema_key.clone(),
-                        file_id: fixture.file_id.clone(),
-                    }),
-                    lifecycle_summary: None,
-                    replacement_generation: None,
-                    replacement_parts: None,
-                    inline_segment: segment,
-                    segments: Vec::new(),
-                })
-                .expect("manifest should encode"),
-            ),
-        );
+        let delta_manifest = CommitDeltaManifest {
+            selected_source_commit_id: None,
+            member_count: 1,
+            selection_fingerprint: [0; 32],
+            direct_segment_row_counts: Vec::new(),
+            single_partition: Some(super::CommitDeltaReplacementScope {
+                schema_key: fixture.schema_key.clone(),
+                file_id: fixture.file_id.clone(),
+            }),
+            lifecycle_summary: None,
+            replacement_generation: None,
+            replacement_parts: None,
+            inline_segment: segment,
+            segments: Vec::new(),
+        };
+        stage_fixture_manifest(
+            &mut writes,
+            commit_id,
+            &super::commit_state_inventory_from_delta_manifest(&delta_manifest),
+        )
+        .expect("commit-state authority should stage");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
@@ -8858,7 +9285,7 @@ mod tests {
         assert_eq!(
             writes.stats().staged_puts,
             1,
-            "a one-segment commit should remain one physical record"
+            "a one-segment commit should remain inline in its commit-state authority"
         );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -8900,7 +9327,7 @@ mod tests {
         assert_eq!(
             deletes.stats().staged_deletes,
             1,
-            "GC should delete the inline manifest only"
+            "GC should delete the inline commit-state authority"
         );
     }
 
@@ -8949,25 +9376,24 @@ mod tests {
         entries.sort_unstable_by(|left, right| left.key.cmp(&right.key));
 
         let mut writes = storage.new_write_set();
-        writes.put(
-            TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
-            key(commit_delta_manifest_key(commit_id)),
-            value(
-                encode_commit_delta_manifest(&CommitDeltaManifest {
-                    selected_source_commit_id: None,
-                    member_count: 0,
-                    selection_fingerprint: [0; 32],
-                    direct_segment_row_counts: Vec::new(),
-                    single_partition: None,
-                    lifecycle_summary: None,
-                    replacement_generation: None,
-                    replacement_parts: None,
-                    inline_segment: encode_commit_delta_segment(&entries),
-                    segments: Vec::new(),
-                })
-                .expect("inline manifest should encode"),
-            ),
-        );
+        let delta_manifest = CommitDeltaManifest {
+            selected_source_commit_id: None,
+            member_count: 2,
+            selection_fingerprint: [0; 32],
+            direct_segment_row_counts: Vec::new(),
+            single_partition: None,
+            lifecycle_summary: None,
+            replacement_generation: None,
+            replacement_parts: None,
+            inline_segment: encode_commit_delta_segment(&entries),
+            segments: Vec::new(),
+        };
+        stage_fixture_manifest(
+            &mut writes,
+            commit_id,
+            &super::commit_state_inventory_from_delta_manifest(&delta_manifest),
+        )
+        .expect("commit-state authority should stage");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
@@ -9190,17 +9616,6 @@ mod tests {
     }
 
     #[test]
-    fn packed_commit_delta_manifest_rejects_unknown_format() {
-        let error = decode_commit_delta_manifest(b"LXCD11old-manifest")
-            .expect_err("old packed manifests must fail loudly");
-        assert!(
-            error
-                .to_string()
-                .contains("unsupported format; recreate the repository")
-        );
-    }
-
-    #[test]
     fn native_storage_space_ids_are_unique_across_owner_layouts() {
         let spaces = [
             REPOSITORY_PROTOCOL_SPACE,
@@ -9212,8 +9627,6 @@ mod tests {
             JSON_SPACE,
             UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE,
             TRACKED_STATE_TREE_CHUNK_SPACE,
-            TRACKED_STATE_COMMIT_ROOT_SPACE,
-            TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
             TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
             TRACKED_STATE_CHANGE_LOCATOR_SPACE,
             BINARY_CAS_MANIFEST_SPACE,
@@ -9239,94 +9652,242 @@ mod tests {
         }
     }
 
-    #[test]
-    fn commit_root_codec_roundtrips_with_parent_metadata() {
-        let metadata = TrackedStateCommitRoot {
-            commit_id: CommitId::for_test_label("child"),
-            root_id: TrackedStateRootId::new([2; 32]),
-            parent_roots: vec![TrackedStateCommitRootParent {
-                commit_id: CommitId::for_test_label("parent"),
-                root_id: TrackedStateRootId::new([1; 32]),
-            }],
-            changed_key_count: 7,
-            row_count_estimate: 42,
-            tree_height: 3,
-            primary_chunk_count: 5,
-            primary_chunk_bytes: 4096,
+    fn commit_state_manifest_fixture() -> CommitStateManifest {
+        let commit_id = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x018f_ffff_1234_7000_8000_0000_ffff_ffff,
+        ));
+        let schema_key = "manifest-schema";
+        let entity_pk = EntityPk::single("manifest-entity");
+        let timestamp = LixTimestamp::from_unix_millis_utc_lossy(1234);
+        let entry = EncodedLeafEntry {
+            key: encode_key_ref(TrackedStateKeyRef {
+                schema_key,
+                file_id: None,
+                entity_pk: &entity_pk,
+            })
+            .into(),
+            value: encode_value_ref(TrackedStateIndexValueRef {
+                change_id: super::change_id_from_packed_address(commit_id, 1),
+                commit_id,
+                deleted: false,
+                created_at: timestamp,
+                updated_at: timestamp,
+            })
+            .into(),
         };
-
-        let encoded = encode_commit_root(&metadata).expect("commit root should encode");
-        assert!(encoded.starts_with(TRACKED_STATE_COMMIT_ROOT_MAGIC));
-        let decoded = decode_commit_root(&encoded).expect("commit root should decode");
-
-        assert_eq!(decoded, metadata);
-    }
-
-    #[test]
-    fn commit_root_codec_rejects_malformed_storage_bytes() {
-        let error = decode_commit_root(b"LXTR1not-musli")
-            .expect_err("old commit-root versions must fail loudly");
-
-        assert!(
-            error
-                .to_string()
-                .contains("unsupported format; recreate the repository")
-        );
-    }
-
-    #[test]
-    fn commit_root_codec_rejects_pre_v3_roots() {
-        let metadata = TrackedStateCommitRoot {
-            commit_id: CommitId::for_test_label("legacy"),
-            root_id: TrackedStateRootId::new([7; 32]),
-            parent_roots: Vec::new(),
-            changed_key_count: 1,
-            row_count_estimate: 1,
-            tree_height: 1,
-            primary_chunk_count: 1,
-            primary_chunk_bytes: 128,
-        };
-        let unversioned = crate::storage_codec::encode("tracked_state commit_root", &metadata)
-            .expect("pre-v3 commit root should encode");
-        let mut v2 = b"LXTR2".to_vec();
-        v2.extend_from_slice(&unversioned);
-
-        for old_bytes in [&unversioned, &v2] {
-            let error = decode_commit_root(old_bytes)
-                .expect_err("pre-v3 roots must not enter the v3 tree layout");
-
-            assert_eq!(error.code, LixError::CODE_INTERNAL_ERROR);
-            assert!(
-                error
-                    .message
-                    .contains("unsupported format; recreate the repository")
-            );
+        CommitStateManifest {
+            commit_id,
+            generation: 7,
+            parent_commit_ids: vec![CommitId::for_test_label("manifest-parent")],
+            commit_change_id: ChangeId::for_test_label("manifest-commit-change"),
+            author_account_ids: vec!["account-a".to_string()],
+            created_at: timestamp,
+            replay_debt: CommitStateReplayDebt {
+                depth: 2,
+                rows: 1,
+                bytes: 64,
+            },
+            mutations: CommitStateMutationInventory {
+                selected_source_commit_id: None,
+                member_count: 1,
+                selection_fingerprint: [3; 32],
+                direct_part_row_counts: vec![1],
+                single_partition: Some(super::CommitDeltaReplacementScope {
+                    schema_key: schema_key.to_owned(),
+                    file_id: None,
+                }),
+                lifecycle_summary: None,
+                replacement_generation: None,
+                replacement_parts: None,
+                inline_part: encode_commit_delta_segment(&[entry]),
+                parts: Vec::new(),
+            },
+            snapshot_root: None,
         }
     }
 
     #[test]
-    fn commit_root_codec_rejects_trailing_bytes() {
-        let metadata = TrackedStateCommitRoot {
-            commit_id: CommitId::for_test_label("commit"),
-            root_id: TrackedStateRootId::new([9; 32]),
-            parent_roots: Vec::new(),
+    fn commit_state_manifest_codec_roundtrips_all_authority_planes() {
+        let expected = commit_state_manifest_fixture();
+        let encoded = encode_commit_state_manifest(&expected).expect("manifest should encode");
+        assert!(encoded.starts_with(COMMIT_STATE_MANIFEST_FORMAT_MAGIC));
+
+        let decoded = decode_commit_state_manifest(&encoded).expect("manifest should round trip");
+        assert_eq!(decoded, expected);
+    }
+
+    #[tokio::test]
+    async fn commit_state_manifest_space_roundtrips_by_exact_commit_id() {
+        let storage = StorageAdapter::new(Memory::new());
+        let expected = commit_state_manifest_fixture();
+        let mut writes = storage.new_write_set();
+        stage_commit_state_manifest(&mut writes, &expected).expect("manifest should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("manifest should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        assert_eq!(
+            load_commit_state_manifest(&read, expected.commit_id)
+                .await
+                .expect("manifest should load"),
+            Some(expected)
+        );
+    }
+
+    #[tokio::test]
+    async fn authoritative_root_is_visible_only_through_commit_state() {
+        let storage = StorageAdapter::new(Memory::new());
+        let mut manifest = commit_state_manifest_fixture();
+        manifest.replay_debt = CommitStateReplayDebt::default();
+        let authoritative = TrackedStateCommitRoot {
+            commit_id: manifest.commit_id,
+            root_id: TrackedStateRootId::new([1; 32]),
+            parent_roots: vec![crate::tracked_state::types::TrackedStateCommitRootParent {
+                commit_id: manifest.parent_commit_ids[0],
+                root_id: TrackedStateRootId::new([3; 32]),
+            }],
             changed_key_count: 1,
-            row_count_estimate: 2,
+            row_count_estimate: 1,
             tree_height: 1,
             primary_chunk_count: 1,
-            primary_chunk_bytes: 128,
+            primary_chunk_bytes: 64,
         };
-        let mut encoded = encode_commit_root(&metadata).expect("commit root should encode");
-        encoded.push(0);
+        manifest.snapshot_root = Some(authoritative.clone());
+        let mut writes = storage.new_write_set();
+        stage_commit_state_manifest(&mut writes, &manifest).expect("authority should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("root fixtures should commit");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
 
-        let error = decode_commit_root(&encoded)
-            .expect_err("trailing bytes should fail commit root decode");
-
-        assert!(
-            error
-                .to_string()
-                .contains("failed to decode tracked_state commit_root")
+        assert_eq!(
+            super::load_authoritative_commit_root(&read, &manifest.commit_id.to_string())
+                .await
+                .expect("authority should load"),
+            Some(authoritative)
         );
+        drop(read);
+
+        manifest.snapshot_root = None;
+        manifest.replay_debt = CommitStateReplayDebt {
+            depth: 1,
+            rows: 1,
+            bytes: 64,
+        };
+        let mut writes = storage.new_write_set();
+        stage_commit_state_manifest(&mut writes, &manifest)
+            .expect("rootless authority should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("rootless authority should commit");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("rootless read should open");
+        assert!(
+            super::load_authoritative_commit_root(&read, &manifest.commit_id.to_string())
+                .await
+                .expect("rootless authority should load")
+                .is_none(),
+            "a stale derived root must not override rootless authority"
+        );
+    }
+
+    #[test]
+    fn commit_state_direct_change_route_rejects_holes_and_other_commits() {
+        let manifest = commit_state_manifest_fixture();
+        let first = super::change_id_from_packed_address(manifest.commit_id, 1);
+        let hole = super::change_id_from_packed_address(manifest.commit_id, 2);
+        let other = super::change_id_from_packed_address(
+            CommitId::with_change_address_space(uuid::Uuid::from_u128(
+                0x018f_ffff_1234_7000_8000_0001_ffff_ffff,
+            )),
+            1,
+        );
+
+        let locator = direct_change_locator_in_commit_state(&manifest, first)
+            .expect("first direct address should route");
+        assert_eq!(locator.segment_index, 0);
+        assert_eq!(locator.ordinal, 0);
+        assert!(direct_change_locator_in_commit_state(&manifest, hole).is_none());
+        assert!(direct_change_locator_in_commit_state(&manifest, other).is_none());
+    }
+
+    #[test]
+    fn commit_state_manifest_allows_accelerators_and_rejects_replay_drift() {
+        let mut mixed = commit_state_manifest_fixture();
+        mixed.mutations.parts.push(super::CommitStateMutationPart {
+            first_key: vec![1],
+            last_key: vec![2],
+            replacement_part: None,
+        });
+        assert!(
+            encode_commit_state_manifest(&mixed)
+                .expect_err("inline and external parts must be exclusive")
+                .message
+                .contains("mixes inline and external")
+        );
+
+        let mut rooted_with_debt = commit_state_manifest_fixture();
+        rooted_with_debt.snapshot_root = Some(TrackedStateCommitRoot {
+            commit_id: rooted_with_debt.commit_id,
+            root_id: TrackedStateRootId::new([4; 32]),
+            parent_roots: vec![crate::tracked_state::types::TrackedStateCommitRootParent {
+                commit_id: rooted_with_debt.parent_commit_ids[0],
+                root_id: TrackedStateRootId::new([5; 32]),
+            }],
+            changed_key_count: 1,
+            row_count_estimate: 1,
+            tree_height: 1,
+            primary_chunk_count: 1,
+            primary_chunk_bytes: 64,
+        });
+        let encoded = encode_commit_state_manifest(&rooted_with_debt)
+            .expect("an immutable snapshot accelerator may coexist with replay debt");
+        assert_eq!(
+            decode_commit_state_manifest(&encoded).expect("accelerated manifest should decode"),
+            rooted_with_debt
+        );
+
+        let mut invalid_debt = rooted_with_debt.clone();
+        invalid_debt.replay_debt.depth = 0;
+        assert!(
+            encode_commit_state_manifest(&invalid_debt)
+                .expect_err("replay rows at zero depth must be rejected")
+                .message
+                .contains("replay work at zero depth")
+        );
+
+        let mut forged_empty_authority = commit_state_manifest_fixture();
+        forged_empty_authority.mutations = CommitStateMutationInventory::default();
+        forged_empty_authority.mutations.replacement_parts =
+            Some(super::StoredReplacementPartsAuthority {
+                directory_digest: [7; 32],
+                uniform_updated_at: forged_empty_authority.created_at,
+            });
+        assert!(
+            encode_commit_state_manifest(&forged_empty_authority)
+                .expect_err("replacement-part authority without a generation must be rejected")
+                .message
+                .contains("replacement-part authority has an invalid manifest shape")
+        );
+    }
+
+    #[test]
+    fn commit_state_manifest_rejects_old_formats() {
+        let error = decode_commit_state_manifest(b"LXCS0old")
+            .expect_err("old commit-state formats must fail closed");
+        assert!(error.message.contains("recreate the repository"));
     }
 
     #[test]

--- a/packages/engine/src/tracked_state/types.rs
+++ b/packages/engine/src/tracked_state/types.rs
@@ -5,6 +5,8 @@ use crate::entity_pk::EntityPk;
 use bytes::Bytes;
 
 pub(crate) const TRACKED_STATE_HASH_BYTES: usize = 32;
+pub(crate) const COMMIT_STATE_MAX_REPLAY_DEPTH: u16 = 32;
+pub(crate) const COMMIT_STATE_MAX_REPLAY_BYTES: u64 = 256 * 1024 * 1024;
 
 /// Content-addressed root id for one tracked-state commit-root tree.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, musli::Encode, musli::Decode)]
@@ -144,6 +146,147 @@ pub(crate) struct TrackedStateCommitRoot {
 pub(crate) struct TrackedStateCommitRootParent {
     pub(crate) commit_id: CommitId,
     pub(crate) root_id: TrackedStateRootId,
+}
+
+/// Bounded first-parent replay work carried by a commit's canonical mutation
+/// interval.
+///
+/// Zero debt means the snapshot root is the canonical serving layout. Nonzero
+/// debt means readers can reconstruct the state from the bounded interval;
+/// [`CommitStateManifest::snapshot_root`] may still contain an equivalent,
+/// rebuildable snapshot accelerator without changing that policy.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+pub(crate) struct CommitStateReplayDebt {
+    pub(crate) depth: u16,
+    pub(crate) rows: u64,
+    pub(crate) bytes: u64,
+}
+
+/// Key bounds for one existing commit-addressed mutation segment.
+///
+/// Segment slot order is durable because directly addressable `ChangeId`s
+/// encode that slot and the row ordinal. Snapshot compaction may replace the
+/// optional root, but must never reorder these entries.
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+pub(crate) struct CommitStateMutationPart {
+    #[musli(bytes)]
+    pub(crate) first_key: Vec<u8>,
+    #[musli(bytes)]
+    pub(crate) last_key: Vec<u8>,
+    #[musli(with = crate::storage_codec::option)]
+    pub(crate) replacement_part: Option<StoredReplacementPart>,
+}
+
+/// One collection partition replaced by a certified immutable generation.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, musli::Encode, musli::Decode)]
+#[musli(packed)]
+pub(crate) struct CommitDeltaReplacementScope {
+    pub(crate) schema_key: String,
+    #[musli(with = crate::storage_codec::option)]
+    pub(crate) file_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+pub(crate) struct CommitDeltaLifecycleSummary {
+    pub(crate) scope: CommitDeltaReplacementScope,
+    pub(crate) ordered_identity_digest: [u8; 32],
+    pub(crate) uniform_created_at: LixTimestamp,
+}
+
+/// Durable certificate binding a replacement generation to its owner and
+/// immutable replacement-part directory.
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+pub(crate) struct StoredCommitDeltaReplacementGeneration {
+    pub(crate) owner_commit_id: [u8; 16],
+    pub(crate) scope: CommitDeltaReplacementScope,
+    #[musli(with = crate::storage_codec::option)]
+    pub(crate) fallback_commit_id: Option<[u8; 16]>,
+    pub(crate) integrity_digest: [u8; 32],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+pub(crate) struct StoredReplacementPartsAuthority {
+    pub(crate) directory_digest: [u8; 32],
+    pub(crate) uniform_updated_at: LixTimestamp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+pub(crate) struct StoredReplacementPart {
+    pub(crate) content_digest: [u8; 32],
+    pub(crate) owner_commit_id: [u8; 16],
+    pub(crate) first_address: u32,
+    pub(crate) uniform_created_at: LixTimestamp,
+    pub(crate) uniform_updated_at: LixTimestamp,
+}
+
+/// Point-addressable immutable mutation inventory owned by one commit.
+///
+/// The fields intentionally mirror the existing commit-delta directory. This
+/// lets the hard-cut manifest become authoritative without changing the
+/// bounded LXCD14 segment and payload-sidecar codec in the same step.
+#[derive(Debug, Clone, Default, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+pub(crate) struct CommitStateMutationInventory {
+    #[musli(with = crate::storage_codec::option)]
+    pub(crate) selected_source_commit_id: Option<[u8; 16]>,
+    pub(crate) member_count: u32,
+    pub(crate) selection_fingerprint: [u8; 32],
+    /// Exact row counts for every directly addressable part. Empty means the
+    /// generic locator-indexed layout.
+    pub(crate) direct_part_row_counts: Vec<u16>,
+    /// Authoritative collection-replacement scope. A miss within this scope
+    /// cannot fall through to an older first-parent generation.
+    #[musli(with = crate::storage_codec::option)]
+    pub(crate) single_partition: Option<CommitDeltaReplacementScope>,
+    #[musli(with = crate::storage_codec::option)]
+    pub(crate) lifecycle_summary: Option<CommitDeltaLifecycleSummary>,
+    #[musli(with = crate::storage_codec::option)]
+    pub(crate) replacement_generation: Option<StoredCommitDeltaReplacementGeneration>,
+    #[musli(with = crate::storage_codec::option)]
+    pub(crate) replacement_parts: Option<StoredReplacementPartsAuthority>,
+    /// Tiny commits retain their only part inline so an exact history lookup
+    /// remains one backend point read.
+    #[musli(bytes)]
+    pub(crate) inline_part: Vec<u8>,
+    pub(crate) parts: Vec<CommitStateMutationPart>,
+}
+
+impl CommitStateMutationInventory {
+    pub(crate) fn selected_source_commit_id(&self) -> Option<CommitId> {
+        self.selected_source_commit_id
+            .map(|bytes| CommitId::new(uuid::Uuid::from_bytes(bytes)))
+    }
+
+    pub(crate) fn part_count(&self) -> usize {
+        usize::from(!self.inline_part.is_empty()) + self.parts.len()
+    }
+}
+
+/// Single semantic authority for one tracked commit.
+///
+/// Compact topology projections, point locators, current-state HOT rows, and
+/// snapshot tree chunks remain rebuildable serving indexes. None may carry
+/// commit semantics absent from this manifest.
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+pub(crate) struct CommitStateManifest {
+    pub(crate) commit_id: CommitId,
+    pub(crate) generation: u64,
+    pub(crate) parent_commit_ids: Vec<CommitId>,
+    pub(crate) commit_change_id: ChangeId,
+    #[musli(with = crate::storage_codec::id_string_seq)]
+    pub(crate) author_account_ids: Vec<String>,
+    pub(crate) created_at: LixTimestamp,
+    pub(crate) replay_debt: CommitStateReplayDebt,
+    pub(crate) mutations: CommitStateMutationInventory,
+    #[musli(with = crate::storage_codec::option)]
+    pub(crate) snapshot_root: Option<TrackedStateCommitRoot>,
 }
 
 /// Materialized tracked-state commit-root row.

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -31,11 +31,13 @@ use crate::live_state::{
 };
 use crate::storage_adapter::{StorageAdapterRead, StoragePrecondition, StorageWriteSet};
 use crate::tracked_state::{
-    CommitDeltaReplacementGeneration, CommitDeltaReplacementScope, MaterializedTrackedStateRow,
-    TrackedStateCommitDeltaRef, TrackedStateContext, TrackedStateDeltaRef, TrackedStateFilter,
-    TrackedStateKey, TrackedStateKeyRef, TrackedStateReadColumns, TrackedStateRootMutationRef,
-    TrackedStateScanRequest, encode_key_ref, load_commit_delta_change_records,
-    load_commit_delta_replay_metadata, stage_addressable_commit_deltas, stage_change_locators,
+    CommitDeltaReplacementGeneration, CommitDeltaReplacementScope, CommitStateManifest,
+    CommitStateMutationInventory, CommitStateReplayDebt, MaterializedTrackedStateRow,
+    TrackedStateCommitDeltaRef, TrackedStateCommitRoot, TrackedStateContext, TrackedStateDeltaRef,
+    TrackedStateFilter, TrackedStateKey, TrackedStateKeyRef, TrackedStateReadColumns,
+    TrackedStateRootMutationRef, TrackedStateScanRequest, encode_key_ref,
+    load_commit_delta_change_records, load_commit_delta_replay_metadata,
+    stage_addressable_commit_deltas, stage_change_locators, stage_commit_state_manifest,
     stage_ordered_addressable_commit_deltas,
 };
 use crate::transaction::staging::{PreparedInsertSelection, PreparedWriteSet};
@@ -57,17 +59,11 @@ type RowIndex = usize;
 // amplification dominates the cost of retaining one immutable manifest.
 const PACKED_CURRENT_BASE_MIN_ROWS: usize = 1_024;
 
-// Large certified commits already retain one ordered, payload-bearing delta
-// run and publish a packed current head. Rebuilding the same identities into
-// an immutable tree in the synchronous commit window duplicates the dominant
-// write work. Complete replacements persist an authoritative partition scope;
-// that scope begins a new base generation and therefore resets its replay
-// accounting without a foreground tree fence. Sparse intervals remain bounded
-// until the remaining tracked-state shapes move to partition manifests too.
-const ROOTLESS_ORDERED_COMMIT_MIN_ROWS: usize = 32 * 1_024;
-const ROOTLESS_MAX_FIRST_PARENT_DEPTH: u16 = 32;
-const ROOTLESS_MAX_REPLAY_ROWS: u64 = 1_048_576;
-const ROOTLESS_MAX_REPLAY_BYTES: u64 = 256 * 1024 * 1024;
+// Complete replacements retain an authoritative partition generation.
+// Ordinary non-empty ordered commits start bounded rootless intervals
+// regardless of workload size; replacement generations reset replay
+// accounting because exact misses in their scope are authoritative.
+const ROOTLESS_MAX_REPLAY_BYTES: u64 = crate::tracked_state::COMMIT_STATE_MAX_REPLAY_BYTES;
 
 fn compare_certified_predecessors(
     left: &crate::live_state::CertifiedCurrentStatePredecessorRef<'_>,
@@ -509,7 +505,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     )
     .await?;
 
-    let ordered_addressable_commits = stage_tracked_commit_delta_index(
+    let staged_delta_index = stage_tracked_commit_delta_index(
         read,
         &mut writes,
         &mut state_rows,
@@ -529,7 +525,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &state_rows,
         &row_index.tracked_row_indices_by_commit,
         &tracked_roots,
-        &ordered_addressable_commits,
+        &staged_delta_index.ordered_addressable_commits,
         &certified_packet_root_rows,
     );
     let replacement_generation_commits = replacement_generations
@@ -554,6 +550,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &row_index.tracked_row_indices_by_commit,
         &commit_rows,
         &certified_packet_root_rows,
+        &staged_delta_index.inventories,
     )
     .instrument(tracing::debug_span!(
         target: "lix_perf",
@@ -587,7 +584,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     )
     .await?;
 
-    stage_tracked_roots(
+    let staged_snapshot_roots = stage_tracked_roots(
         tracked_state,
         read,
         &mut writes,
@@ -607,6 +604,14 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         "lix.perf.materialization.tracked_roots"
     ))
     .await?;
+    stage_commit_state_manifests(
+        &mut writes,
+        &commit_rows,
+        &staged_delta_index.inventories,
+        &rootless_ordered_commits,
+        &staged_commits,
+        &staged_snapshot_roots,
+    )?;
     // HOT publication has adapter-specific checkpoint, packed-base, and
     // point-row futures. Keep their combined async state out of the parent
     // commit future so an inactive bulk branch cannot inflate every ordinary
@@ -628,7 +633,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &explicit_branch_targets,
         &branch_control_observations,
         &checkpoint_epochs,
-        &ordered_addressable_commits,
+        &staged_delta_index.ordered_addressable_commits,
     ))
     .instrument(tracing::debug_span!(
         target: "lix_perf",
@@ -911,8 +916,14 @@ fn index_prepared_rows(rows: &PreparedStateBatch) -> Result<PreparedRowIndex, Li
 
 #[derive(Clone, Debug)]
 struct StagedChangelogCommit {
+    record: CommitRecord,
     change_count: usize,
     selected_change_batches: Vec<StagedCommitChangeBatch>,
+}
+
+struct StagedCommitDeltaIndex {
+    ordered_addressable_commits: BTreeSet<CommitId>,
+    inventories: BTreeMap<CommitId, CommitStateMutationInventory>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1010,6 +1021,7 @@ async fn stage_changelog_commits(
     tracked_row_indices_by_commit: &BTreeMap<CommitId, Vec<RowIndex>>,
     commit_rows: &[FinalizedCommitRow],
     certified_packet_root_rows: &BTreeMap<CommitId, Vec<MaterializedLiveStateRow>>,
+    mutation_inventories: &BTreeMap<CommitId, CommitStateMutationInventory>,
 ) -> Result<BTreeMap<CommitId, StagedChangelogCommit>, LixError> {
     let mut commits = Vec::with_capacity(commit_rows.len());
     let staged_commit_ids = commit_rows
@@ -1046,10 +1058,39 @@ async fn stage_changelog_commits(
                 format!("commit '{commit_id}' has a missing parent"),
             )
         })?;
-        generations.insert(*commit_id, record.generation);
-        rootless_depths.insert(*commit_id, record.tracked_state_rootless_depth);
-        rootless_rows.insert(*commit_id, record.tracked_state_rootless_rows);
-        rootless_bytes.insert(*commit_id, record.tracked_state_rootless_bytes);
+        let manifest = crate::tracked_state::load_commit_state_manifest(read, *commit_id)
+            .await?
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("commit '{commit_id}' has no commit-state authority"),
+                )
+            })?;
+        // Replay debt is the durable layout authority. A rootless commit may
+        // later gain an immutable snapshot accelerator without changing its
+        // changelog topology projection.
+        let manifest_rootless = manifest.replay_debt.depth > 0;
+        if manifest.generation != record.generation
+            || manifest.parent_commit_ids != record.parent_commit_ids
+            || manifest.commit_change_id != record.change_id
+            || manifest.author_account_ids != record.author_account_ids
+            || manifest.created_at != record.created_at
+            || manifest_rootless != record.tracked_state_rootless
+            || manifest.replay_debt.depth != record.tracked_state_rootless_depth
+            || manifest.replay_debt.rows != record.tracked_state_rootless_rows
+            || manifest.replay_debt.bytes != record.tracked_state_rootless_bytes
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "commit '{commit_id}' topology projection disagrees with commit-state authority"
+                ),
+            ));
+        }
+        generations.insert(*commit_id, manifest.generation);
+        rootless_depths.insert(*commit_id, manifest.replay_debt.depth);
+        rootless_rows.insert(*commit_id, manifest.replay_debt.rows);
+        rootless_bytes.insert(*commit_id, manifest.replay_debt.bytes);
     }
     let mut staged_parent_count = BTreeMap::<CommitId, usize>::new();
     let mut children = BTreeMap::<CommitId, Vec<CommitId>>::new();
@@ -1119,7 +1160,11 @@ async fn stage_changelog_commits(
         let has_unbounded_payload_sources = certified_packet_root_rows
             .get(&commit_id)
             .is_some_and(|rows| !rows.is_empty())
-            || selected_change_count(&commit.selected_change_batches) > 0;
+            || selected_change_count(&commit.selected_change_batches) > 0
+            || mutation_inventories
+                .get(&commit_id)
+                .and_then(CommitStateMutationInventory::selected_source_commit_id)
+                .is_some();
         let first_parent = commit.parent_commit_ids.first().copied();
         let parent_rootless_depth = first_parent
             .and_then(|parent| rootless_depths.get(&parent).copied())
@@ -1139,7 +1184,6 @@ async fn stage_changelog_commits(
         let (rootless_depth, cumulative_rootless_rows, cumulative_rootless_bytes) =
             if selected_as_new_rootless
                 && replacement_generation_commit_ids.contains(&commit_id)
-                && commit_delta_rows <= ROOTLESS_MAX_REPLAY_ROWS
                 && commit_delta_bytes <= ROOTLESS_MAX_REPLAY_BYTES
                 && !has_unbounded_payload_sources
             {
@@ -1155,9 +1199,8 @@ async fn stage_changelog_commits(
                 let next_depth = parent_rootless_depth
                     .checked_add(1)
                     .ok_or_else(|| LixError::unknown("tracked-state rootless depth exceeds u16"))?;
-                if next_depth <= ROOTLESS_MAX_FIRST_PARENT_DEPTH
-                    && next_rootless_rows <= ROOTLESS_MAX_REPLAY_ROWS
-                    && next_rootless_bytes <= ROOTLESS_MAX_REPLAY_BYTES
+                if next_depth <= crate::tracked_state::COMMIT_STATE_MAX_REPLAY_DEPTH
+                    && next_rootless_bytes <= crate::tracked_state::COMMIT_STATE_MAX_REPLAY_BYTES
                     && !has_unbounded_payload_sources
                 {
                     rootless_commit_ids.insert(commit_id);
@@ -1171,6 +1214,10 @@ async fn stage_changelog_commits(
                     loop {
                         if let Some(staged_parent) = commit_rows_by_id.get(&cursor) {
                             staged_root_rebuild_commits.insert(cursor);
+                            rootless_commit_ids.remove(&cursor);
+                            rootless_depths.insert(cursor, 0);
+                            rootless_rows.insert(cursor, 0);
+                            rootless_bytes.insert(cursor, 0);
                             let Some(parent) = staged_parent.parent_commit_ids.first().copied()
                             else {
                                 break;
@@ -1186,8 +1233,7 @@ async fn stage_changelog_commits(
                     (0, 0, 0)
                 }
             } else if selected_as_new_rootless
-                && commit_delta_rows <= ROOTLESS_MAX_REPLAY_ROWS
-                && commit_delta_bytes <= ROOTLESS_MAX_REPLAY_BYTES
+                && commit_delta_bytes <= crate::tracked_state::COMMIT_STATE_MAX_REPLAY_BYTES
                 && !has_unbounded_payload_sources
             {
                 (1, commit_delta_rows, commit_delta_bytes)
@@ -1256,7 +1302,7 @@ async fn stage_changelog_commits(
                 )
             })?;
         }
-        commits.push(CommitRecord {
+        let record = CommitRecord {
             format_version: 1,
             commit_id: commit_row.commit_id,
             generation,
@@ -1268,7 +1314,8 @@ async fn stage_changelog_commits(
             change_id: commit_row.change_id,
             author_account_ids: Vec::new(),
             created_at: commit_row.created_at,
-        });
+        };
+        commits.push(record.clone());
         let change_count = state_row_indices.len()
             + certified_packet_root_rows
                 .get(&commit_row.commit_id)
@@ -1277,6 +1324,7 @@ async fn stage_changelog_commits(
         staged.insert(
             commit_row.commit_id,
             StagedChangelogCommit {
+                record,
                 change_count,
                 selected_change_batches: commit_row.selected_change_batches.clone(),
             },
@@ -1848,8 +1896,9 @@ async fn stage_tracked_commit_delta_index(
     certified_packet_json_refs: &BTreeMap<CommitId, Vec<CertifiedRootJsonRefs>>,
     insert_selection: &PreparedInsertSelection,
     replacement_generations: &BTreeMap<CommitId, CommitDeltaReplacementGeneration>,
-) -> Result<BTreeSet<CommitId>, LixError> {
+) -> Result<StagedCommitDeltaIndex, LixError> {
     let mut ordered_addressable_commits = BTreeSet::new();
+    let mut inventories = BTreeMap::new();
     let commit_rows = commit_rows
         .iter()
         .map(|commit| (commit.commit_id, commit))
@@ -1970,6 +2019,7 @@ async fn stage_tracked_commit_delta_index(
                 }
             };
             if let Some(ordered_stage) = ordered_stage {
+                inventories.insert(root.commit_id, ordered_stage.mutation_inventory().clone());
                 state_rows.set_ordered_addressable_change_ids(state_row_indices, ordered_stage)?;
                 ordered_addressable_commits.insert(root.commit_id);
                 continue;
@@ -2125,7 +2175,14 @@ async fn stage_tracked_commit_delta_index(
         } else {
             stage_addressable_commit_deltas(writes, &deltas, &addressable)?
         };
+        inventories.insert(root.commit_id, staged.mutation_inventory().clone());
         drop(deltas);
+        let assigned_change_ids = staged
+            .assigned_change_ids
+            .iter()
+            .copied()
+            .filter(|change_id| *change_id != ChangeId::default())
+            .collect::<std::collections::HashSet<_>>();
         for (source_index, &row_index) in state_row_indices.iter().enumerate() {
             if !state_rows.row(row_index).addressable_change_id {
                 continue;
@@ -2142,11 +2199,17 @@ async fn stage_tracked_commit_delta_index(
         let authored_locators = staged
             .locators
             .into_iter()
-            .filter(|locator| authored_change_ids.contains(&locator.change_id))
+            .filter(|locator| {
+                authored_change_ids.contains(&locator.change_id)
+                    || assigned_change_ids.contains(&locator.change_id)
+            })
             .collect::<Vec<_>>();
         stage_change_locators(writes, &authored_locators);
     }
-    Ok(ordered_addressable_commits)
+    Ok(StagedCommitDeltaIndex {
+        ordered_addressable_commits,
+        inventories,
+    })
 }
 
 async fn certify_complete_replacement_generations(
@@ -2264,30 +2327,6 @@ async fn certify_complete_replacement_generations(
             lifecycle_summary = Some(summary.clone());
             current = record.parent_commit_ids.first().copied();
         };
-        // A fallback that is itself rootless means the interval contained an
-        // uncertified partition shape. Decline the hard cut and let the normal
-        // root fence preserve bounded replay.
-        if let Some(fallback_commit_id) = fallback_commit_id {
-            let commit_ids = [fallback_commit_id];
-            let fallback = ChangelogContext::new()
-                .reader(read)
-                .load_commits(ChangelogCommitLoadRequest {
-                    commit_ids: &commit_ids,
-                })
-                .await?
-                .into_iter()
-                .next()
-                .and_then(|(_, record)| record)
-                .ok_or_else(|| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        format!("replacement fallback '{fallback_commit_id}' is missing"),
-                    )
-                })?;
-            if fallback.tracked_state_rootless {
-                continue;
-            }
-        }
         let Some(lifecycle_summary) = lifecycle_summary else {
             continue;
         };
@@ -2310,7 +2349,6 @@ fn certified_complete_replacement_scope(
 ) -> Option<CommitDeltaReplacementScope> {
     if !state_rows.certified_complete_collection_replacement()
         || row_indices.is_empty()
-        || row_indices.len() < ROOTLESS_ORDERED_COMMIT_MIN_ROWS
         || row_indices.len() != state_rows.len()
     {
         return None;
@@ -2385,15 +2423,15 @@ fn select_new_rootless_ordered_commits(
             .get(&root.commit_id)
             .map(Vec::as_slice)
             .unwrap_or_default();
-        let starts_large_ordered_interval = can_start_rootless_interval
+        let starts_ordered_interval = can_start_rootless_interval
             && root.publish_head
-            && row_indices.len() >= ROOTLESS_ORDERED_COMMIT_MIN_ROWS
+            && !row_indices.is_empty()
             && ordered_addressable_commits.contains(&root.commit_id)
             && certified_packet_root_rows
                 .get(&root.commit_id)
                 .is_none_or(Vec::is_empty)
             && row_indices.len() == state_rows.len();
-        if starts_large_ordered_interval {
+        if starts_ordered_interval {
             rootless.insert(root.commit_id);
         }
     }
@@ -4544,10 +4582,10 @@ async fn stage_tracked_roots(
     insert_selection: &PreparedInsertSelection,
     certified_packet_root_rows: &BTreeMap<CommitId, Vec<MaterializedLiveStateRow>>,
     certified_replacement_markers_by_commit: &BTreeMap<CommitId, BTreeSet<TrackedStateKey>>,
-) -> Result<(), LixError> {
+) -> Result<BTreeMap<CommitId, TrackedStateCommitRoot>, LixError> {
     let root_fence_ids = tracked_root_fence_ids(tracked_roots);
     if root_fence_ids.is_empty() {
-        return Ok(());
+        return Ok(BTreeMap::new());
     }
     let mut tracked_writer = tracked_state.writer(read, writes);
     let mut staged_rebuild_plan_ids = BTreeSet::new();
@@ -4706,6 +4744,68 @@ async fn stage_tracked_roots(
                 certified_replacement_markers,
             )
             .await?;
+    }
+    Ok(tracked_writer
+        .staged_commit_roots()
+        .map(|root| (root.commit_id, root.clone()))
+        .collect())
+}
+
+fn stage_commit_state_manifests(
+    writes: &mut StorageWriteSet,
+    commit_rows: &[FinalizedCommitRow],
+    mutation_inventories: &BTreeMap<CommitId, CommitStateMutationInventory>,
+    rootless_commit_ids: &BTreeSet<CommitId>,
+    staged_commits: &BTreeMap<CommitId, StagedChangelogCommit>,
+    snapshot_roots: &BTreeMap<CommitId, TrackedStateCommitRoot>,
+) -> Result<(), LixError> {
+    for commit in commit_rows {
+        let staged = staged_commits.get(&commit.commit_id).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "commit '{}' has no staged topology projection for commit-state publication",
+                    commit.commit_id
+                ),
+            )
+        })?;
+        let record = &staged.record;
+        let rootless = rootless_commit_ids.contains(&commit.commit_id);
+        let snapshot_root = snapshot_roots.get(&commit.commit_id).cloned();
+        if rootless == snapshot_root.is_some() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "commit '{}' has inconsistent mutation-journal and snapshot-root publication",
+                    commit.commit_id
+                ),
+            ));
+        }
+        stage_commit_state_manifest(
+            writes,
+            &CommitStateManifest {
+                commit_id: record.commit_id,
+                generation: record.generation,
+                parent_commit_ids: record.parent_commit_ids.clone(),
+                commit_change_id: record.change_id,
+                author_account_ids: record.author_account_ids.clone(),
+                created_at: record.created_at,
+                replay_debt: if rootless {
+                    CommitStateReplayDebt {
+                        depth: record.tracked_state_rootless_depth,
+                        rows: record.tracked_state_rootless_rows,
+                        bytes: record.tracked_state_rootless_bytes,
+                    }
+                } else {
+                    CommitStateReplayDebt::default()
+                },
+                mutations: mutation_inventories
+                    .get(&commit.commit_id)
+                    .cloned()
+                    .unwrap_or_default(),
+                snapshot_root,
+            },
+        )?;
     }
     Ok(())
 }
@@ -5341,14 +5441,14 @@ mod tests {
     // `tracked_state::storage` intentionally keeps this internal; this test
     // observes the durable space rather than reaching through that module.
     const TRACKED_STATE_TREE_CHUNK_SPACE_ID: SpaceId = SpaceId(0x0004_0001);
-    const TRACKED_STATE_COMMIT_ROOT_SPACE_ID: SpaceId = SpaceId(0x0004_0004);
+    const TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE_ID: SpaceId = SpaceId(0x0004_002b);
     const TRACKED_STATE_TREE_CHUNK_SPACE: StorageSpace = StorageSpace::mutable(
         TRACKED_STATE_TREE_CHUNK_SPACE_ID,
         "tracked_state.tree_chunk",
     );
-    const TRACKED_STATE_COMMIT_ROOT_SPACE: StorageSpace = StorageSpace::mutable(
-        TRACKED_STATE_COMMIT_ROOT_SPACE_ID,
-        "tracked_state.commit_root",
+    const TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE: StorageSpace = StorageSpace::mutable(
+        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE_ID,
+        "tracked_state.commit_state_manifest.v1",
     );
     // V11 has no tracked-head marker space. Keep the retired v10 ID here only
     // as a negative test sentinel: normal serving and staging must never read
@@ -5529,7 +5629,7 @@ mod tests {
                         .tree_chunk_get_many_calls
                         .fetch_add(1, Ordering::Relaxed);
                 }
-                if space.id == TRACKED_STATE_COMMIT_ROOT_SPACE_ID {
+                if space.id == TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE_ID {
                     self.counts
                         .commit_root_get_many_calls
                         .fetch_add(1, Ordering::Relaxed);
@@ -5552,7 +5652,7 @@ mod tests {
                     .tree_chunk_scan_calls
                     .fetch_add(1, Ordering::Relaxed);
             }
-            if space.id == TRACKED_STATE_COMMIT_ROOT_SPACE_ID {
+            if space.id == TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE_ID {
                 self.counts
                     .commit_root_scan_calls
                     .fetch_add(1, Ordering::Relaxed);
@@ -5681,7 +5781,7 @@ mod tests {
         let large_snapshot_ref = certified_json_refs[&commit_id][0]
             .snapshot
             .expect("large certified snapshot should use a JSON ref");
-        stage_tracked_commit_delta_index(
+        let staged_index = stage_tracked_commit_delta_index(
             &read,
             &mut writes,
             &mut state_rows,
@@ -5697,6 +5797,29 @@ mod tests {
         )
         .await
         .expect("mixed certified delta should stage");
+        stage_commit_state_manifest(
+            &mut writes,
+            &CommitStateManifest {
+                commit_id,
+                generation: 0,
+                parent_commit_ids: Vec::new(),
+                commit_change_id: change_id("mixed-certified-commit"),
+                author_account_ids: Vec::new(),
+                created_at: timestamp,
+                replay_debt: CommitStateReplayDebt {
+                    depth: 1,
+                    rows: 2,
+                    bytes: 2,
+                },
+                mutations: staged_index
+                    .inventories
+                    .get(&commit_id)
+                    .cloned()
+                    .expect("mixed certified inventory should stage"),
+                snapshot_root: None,
+            },
+        )
+        .expect("mixed certified authority should stage");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
@@ -5746,7 +5869,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ordinary_tracked_commit_appends_changelog_and_root() {
+    async fn ordinary_unaddressed_tracked_commit_appends_changelog_and_root() {
         let storage = StorageAdapter::new(Memory::new());
         let binary_cas = BinaryCasContext::new();
         let branch_ctx = BranchContext::new();
@@ -5779,11 +5902,11 @@ mod tests {
         .expect("commit should flush staged rows");
         assert!(
             writes.has_mutations_in_space(TRACKED_STATE_TREE_CHUNK_SPACE),
-            "an ordinary tracked commit must write immutable tree chunks"
+            "an unaddressed tracked commit still requires immutable tree chunks"
         );
         assert!(
-            writes.has_mutations_in_space(TRACKED_STATE_COMMIT_ROOT_SPACE),
-            "an ordinary tracked commit must write commit-root metadata"
+            writes.has_mutations_in_space(TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE),
+            "an unaddressed tracked commit still requires commit-state authority"
         );
         assert!(
             writes.has_mutations_in_space(HOT_ROW_SPACE),
@@ -6490,7 +6613,7 @@ mod tests {
         .expect("first rooted commit should stage");
         assert!(
             writes.has_mutations_in_space(TRACKED_STATE_TREE_CHUNK_SPACE)
-                && writes.has_mutations_in_space(TRACKED_STATE_COMMIT_ROOT_SPACE),
+                && writes.has_mutations_in_space(TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE),
             "first ordinary commit must publish its immutable root"
         );
         storage
@@ -6543,7 +6666,7 @@ mod tests {
         .expect("second rooted commit should stage");
         assert!(
             writes.has_mutations_in_space(TRACKED_STATE_TREE_CHUNK_SPACE)
-                && writes.has_mutations_in_space(TRACKED_STATE_COMMIT_ROOT_SPACE),
+                && writes.has_mutations_in_space(TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE),
             "serial ordinary commit must publish its immutable root"
         );
         storage
@@ -6596,7 +6719,7 @@ mod tests {
         .expect("third rooted commit should stage");
         assert!(
             writes.has_mutations_in_space(TRACKED_STATE_TREE_CHUNK_SPACE)
-                && writes.has_mutations_in_space(TRACKED_STATE_COMMIT_ROOT_SPACE),
+                && writes.has_mutations_in_space(TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE),
             "serial ordinary commit must publish its immutable root"
         );
         storage
@@ -6641,7 +6764,7 @@ mod tests {
         .expect("rooted delete commit should stage");
         assert!(
             writes.has_mutations_in_space(TRACKED_STATE_TREE_CHUNK_SPACE)
-                && writes.has_mutations_in_space(TRACKED_STATE_COMMIT_ROOT_SPACE),
+                && writes.has_mutations_in_space(TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE),
             "serial delete commit must publish its immutable root"
         );
         storage
@@ -6802,7 +6925,7 @@ mod tests {
         .await
         .expect("normal rooted commit should stage");
         assert!(
-            writes.has_mutations_in_space(TRACKED_STATE_COMMIT_ROOT_SPACE),
+            writes.has_mutations_in_space(TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE),
             "ordinary parent must publish a root"
         );
         storage
@@ -6847,8 +6970,8 @@ mod tests {
         .await
         .expect("selected-reference commit should stage");
         assert!(
-            writes.has_mutations_in_space(TRACKED_STATE_COMMIT_ROOT_SPACE),
-            "selected-reference commits must publish root metadata"
+            writes.has_mutations_in_space(TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE),
+            "selected-reference commits must publish commit-state authority"
         );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -6911,8 +7034,8 @@ mod tests {
             "an ordinary tracked commit must write immutable tree chunks"
         );
         assert!(
-            writes.has_mutations_in_space(TRACKED_STATE_COMMIT_ROOT_SPACE),
-            "an ordinary tracked commit must write commit-root metadata"
+            writes.has_mutations_in_space(TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE),
+            "an ordinary tracked commit must write commit-state authority"
         );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -6968,12 +7091,12 @@ mod tests {
         assert_eq!(
             counts.commit_root_get_many_calls.load(Ordering::Relaxed),
             0,
-            "a current head projection must not first look up root metadata"
+            "a current head projection must not first look up commit-state authority"
         );
         assert_eq!(
             counts.commit_root_scan_calls.load(Ordering::Relaxed),
             0,
-            "a current head projection must not scan root metadata"
+            "a current head projection must not scan commit-state authority"
         );
 
         let loaded = live_state_context()
@@ -7033,12 +7156,12 @@ mod tests {
         assert_eq!(
             counts.commit_root_get_many_calls.load(Ordering::Relaxed),
             0,
-            "neither serving read may look up root metadata"
+            "neither serving read may look up commit-state authority"
         );
         assert_eq!(
             counts.commit_root_scan_calls.load(Ordering::Relaxed),
             0,
-            "neither serving read may scan root metadata"
+            "neither serving read may scan commit-state authority"
         );
     }
 
@@ -7528,12 +7651,12 @@ mod tests {
         assert_eq!(
             counts.commit_root_get_many_calls.load(Ordering::Relaxed),
             0,
-            "current global and branch projections must not look up root metadata"
+            "current global and branch projections must not look up commit-state authority"
         );
         assert_eq!(
             counts.commit_root_scan_calls.load(Ordering::Relaxed),
             0,
-            "current global and branch projections must not scan root metadata"
+            "current global and branch projections must not scan commit-state authority"
         );
     }
 
@@ -7586,6 +7709,7 @@ mod tests {
             ]),
             &commits,
             &BTreeMap::new(),
+            &BTreeMap::new(),
         )
         .await
         .expect("child-before-parent input should still stage parent first");
@@ -7636,6 +7760,82 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![1, 2]
         );
+    }
+
+    #[tokio::test]
+    async fn staged_chain_closes_the_complete_rootless_interval_at_the_depth_fence() {
+        let storage = StorageAdapter::new(Memory::new());
+        let mut writes = StorageWriteSet::new();
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let commit_count = usize::from(crate::tracked_state::COMMIT_STATE_MAX_REPLAY_DEPTH) + 1;
+        let commit_ids = (0..commit_count)
+            .map(|index| CommitId::for_test_label(&format!("staged-fence-commit-{index}")))
+            .collect::<Vec<_>>();
+        let state_rows = PreparedStateBatch::from_test_rows(
+            commit_ids
+                .iter()
+                .enumerate()
+                .map(|(index, commit_id)| {
+                    let mut row = tracked_global_row(&format!("staged-fence-change-{index}"));
+                    row.commit_id = Some(*commit_id);
+                    row
+                })
+                .collect(),
+        );
+        let commit_rows = commit_ids
+            .iter()
+            .enumerate()
+            .map(|(index, commit_id)| FinalizedCommitRow {
+                commit_id: *commit_id,
+                parent_commit_ids: index
+                    .checked_sub(1)
+                    .map(|parent| vec![commit_ids[parent]])
+                    .unwrap_or_default(),
+                created_at: ts("2026-01-01T00:00:00Z"),
+                change_id: ChangeId::for_test_label(&format!("staged-fence-record-{index}")),
+                selected_change_batches: Vec::new(),
+            })
+            .collect::<Vec<_>>();
+        let row_indices = commit_ids
+            .iter()
+            .enumerate()
+            .map(|(index, commit_id)| (*commit_id, vec![index]))
+            .collect::<BTreeMap<_, _>>();
+        let mut rootless_commit_ids = BTreeSet::from([commit_ids[0]]);
+        let mut durable_root_rebuild_parents = BTreeSet::new();
+        let mut staged_root_rebuild_commits = BTreeSet::new();
+
+        let staged = stage_changelog_commits(
+            &mut read,
+            &mut writes,
+            &state_rows,
+            &[],
+            &[],
+            &[],
+            &mut rootless_commit_ids,
+            &BTreeSet::new(),
+            &mut durable_root_rebuild_parents,
+            &mut staged_root_rebuild_commits,
+            &row_indices,
+            &commit_rows,
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+        )
+        .await
+        .expect("depth fence should close a fully staged interval");
+
+        assert!(rootless_commit_ids.is_empty());
+        assert!(durable_root_rebuild_parents.is_empty());
+        assert_eq!(staged_root_rebuild_commits.len(), commit_count - 1);
+        assert!(staged.values().all(|commit| {
+            !commit.record.tracked_state_rootless
+                && commit.record.tracked_state_rootless_depth == 0
+                && commit.record.tracked_state_rootless_rows == 0
+                && commit.record.tracked_state_rootless_bytes == 0
+        }));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

This is a no-backward-compatibility physical-layout hard cut.

- Replaces the separate durable commit-root and commit-delta-manifest authority planes with one `CommitStateManifest` per public commit.
- Keeps immutable mutation parts and content-addressed snapshot chunks external, while the manifest binds topology, replay debt, mutation routing, optional snapshot acceleration, and certified replacement generations.
- Makes replay debt the logical layout authority. Explicit rebuild may attach an equivalent immutable snapshot accelerator without rewriting graph semantics.
- Uses compact key/ordinal routing for fully addressable batches; mixed authored/selected batches retain exact fallback locators.
- Binds certified replacement generations to owner commit, schema scope, immutable replacement-part directory, lifecycle, fallback, and identity digest. Exact misses inside replacement scope are authoritative.
- Keeps real graph parents separate from replacement fallback traversal.
- Makes commit graph and destructive GC fail closed when a visible `CommitRecord` is missing or drifts from its manifest.
- Separates public graph reachability from retained immutable payload authority, so GC may remove a public projection while preserving manifest/parts needed by live recovery references.
- Removes the old durable namespaces and advances the repository protocol to v47. Existing repositories must be recreated.

This does not add schema knobs, SQL recognizers, OLAP query bypasses, or benchmark-sized row caps. SQL semantics remain outside this physical storage contract.

## Why

The old layout synchronously rebuilt an immutable root while also retaining a packed mutation journal. That duplicated authority and write work, created drift-prone readers, and made small complete replacements pay a root fence that large certified replacements already avoided.

The hard cut makes the journal plus one commit-state manifest authoritative, with snapshot roots treated as optional accelerators. This preserves point routing and bounded replay while allowing foreground writes to skip redundant root construction.

## Current-main before / after

Release profile, isolated builds, setup excluded, RocksDB, 10K certified bound UPDATE, median 3. Baseline is current `main` `0f784b730` after #1161/#1163; branch is `a7dbe1018`.

| Axis | main | branch | change |
|---|---:|---:|---:|
| latency | 15.139 ms | 11.333 ms | -25.1% |
| physical puts | 294 | 55 | -81.3% |
| physical written bytes | 1,165,875 | 479,140 | -58.9% |

The broader public SQL UPDATE path is neutral after the #1163 rebase: 10K RocksDB median 7 was 136.138 ms on main and 135.875 ms on this branch. The benefit is isolated to commit materialization/storage; SQL planning and result work are unchanged.

Prior hot-point measurement was neutral (8.885 us/op → 8.888 us/op). At the maximum bounded journal interval, 10K base rows plus 32 commits x 100 repeated updates, setup writes improved 101.1 ms → 19.9 ms (-80.3%); cold historical diff remained bounded at 1.629 ms versus 0.242 ms with a synchronous root. An explicit rebuild can attach a snapshot accelerator without changing authority.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUST_MIN_STACK=8388608 cargo test -p lix_engine --features all-simulations`
  - 1,833 unit tests passed, 8 ignored
  - 806 integration tests passed, 2 ignored
  - 3 doctests passed
- Focused immutable replacement-part, forged-authority rejection, point/replay, graph corruption, authority GC, branch, diff, merge, checkpoint, and history tests.

Two final sub-agent reviews approved the rebased authority/GC contract and performance/maintenance shape. One review found a fail-closed empty-inventory omission for forged replacement authority; it is fixed and covered by a codec regression test.
