### PR TITLE
Run server operations on the host Tokio runtime

### DIFF
--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::future::Future;
 use std::ops::ControlFlow;
 use std::ops::Range;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -718,25 +719,32 @@ where
     /// SQL writes, while in-process callers may continue to own their own
     /// transaction/retry contract. Read routes ignore a supplied key.
     #[doc(hidden)]
-    pub async fn execute_with_idempotency_and_options_and_metadata(
-        &self,
-        sql: &str,
-        params: &[Value],
+    pub fn execute_with_idempotency_and_options_and_metadata(
+        self: Arc<Self>,
+        sql: String,
+        params: Vec<Value>,
         options: ExecuteOptions,
         metadata: ExecuteStatementMetadata,
         idempotency: Option<ExecuteIdempotency>,
-    ) -> Result<ExecuteResult, LixError> {
-        validate_execute_statement_metadata(params.len(), &metadata, None)?;
-        Box::pin(self.execute_with_kind(
-            sql,
-            params,
-            options,
-            metadata,
-            "execute",
-            idempotency,
-            true,
-        ))
-        .await
+    ) -> impl Future<Output = Result<ExecuteResult, LixError>> + Send + 'static {
+        // SAFETY: the future owns its Arc session and request payload. Every
+        // storage read/write handle is Send by the Storage contract; remaining
+        // compiler failures are higher-ranked shared references to Sync data.
+        unsafe {
+            super::AssumeSendFuture::new(async move {
+                validate_execute_statement_metadata(params.len(), &metadata, None)?;
+                self.execute_with_kind(
+                    &sql,
+                    &params,
+                    options,
+                    metadata,
+                    "execute",
+                    idempotency,
+                    true,
+                )
+                .await
+            })
+        }
     }
 
     /// Upserts one file's bytes by its full logical path without constructing
@@ -832,7 +840,18 @@ where
     /// active-branch file selection, plugin rendering, and session file-view
     /// acknowledgement as `SELECT data FROM lix_file WHERE path = $1`, while
     /// avoiding SQL parsing, planning, and a JSON-shaped result envelope.
-    pub async fn read_file_data(
+    pub fn read_file_data(
+        &self,
+        path: String,
+        requested_range: Option<Range<u64>>,
+    ) -> impl Future<Output = Result<Option<FileRead>, LixError>> + Send + '_ {
+        // SAFETY: the read future owns its path/range and retains only shared
+        // references to this Sync session. Rustc cannot prove the Send bound
+        // through the higher-ranked scoped SQL-read closure.
+        unsafe { super::AssumeSendFuture::new(self.read_file_data_inner(path, requested_range)) }
+    }
+
+    async fn read_file_data_inner(
         &self,
         path: String,
         requested_range: Option<Range<u64>>,
@@ -1393,21 +1412,28 @@ where
     /// contain at least one SQL write. Pure read batches and batches that only
     /// persist runtime-function state retain their existing execution path.
     #[doc(hidden)]
-    pub async fn execute_batch_with_idempotency_and_options_and_metadata(
-        &self,
-        statements: &[ExecuteBatchStatement],
+    pub fn execute_batch_with_idempotency_and_options_and_metadata(
+        self: Arc<Self>,
+        statements: Vec<ExecuteBatchStatement>,
         options: ExecuteOptions,
         statement_metadata: Vec<ExecuteStatementMetadata>,
         idempotency: Option<ExecuteIdempotency>,
-    ) -> Result<Vec<ExecuteResult>, LixError> {
-        self.execute_batch_with_options_and_metadata_inner(
-            statements,
-            options,
-            statement_metadata,
-            idempotency,
-            true,
-        )
-        .await
+    ) -> impl Future<Output = Result<Vec<ExecuteResult>, LixError>> + Send + 'static {
+        // SAFETY: as above, this future owns the Arc session, statements, and
+        // metadata; transaction state crosses awaits only through mutable
+        // references and every storage transaction is Send.
+        unsafe {
+            super::AssumeSendFuture::new(async move {
+                self.execute_batch_with_options_and_metadata_inner(
+                    &statements,
+                    options,
+                    statement_metadata,
+                    idempotency,
+                    true,
+                )
+                .await
+            })
+        }
     }
 
     async fn execute_batch_with_options_inner(
@@ -2507,10 +2533,10 @@ where
         sql: &str,
         params: &[Value],
     ) -> Result<ExecuteResult, LixError> {
-        Box::pin(self.execute_with_options(sql, params, ExecuteOptions::default())).await
+        Box::pin(self.execute_with_options_inner(sql, params, ExecuteOptions::default())).await
     }
 
-    pub async fn execute_with_options(
+    async fn execute_with_options_inner(
         &mut self,
         sql: &str,
         params: &[Value],
@@ -2597,6 +2623,23 @@ where
             telemetry.finish(&result);
         }
         result
+    }
+
+    pub fn execute_with_options(
+        &mut self,
+        sql: String,
+        params: Vec<Value>,
+        options: ExecuteOptions,
+    ) -> impl Future<Output = Result<ExecuteResult, LixError>> + Send + '_ {
+        // SAFETY: the future exclusively borrows this Send transaction and
+        // owns its SQL and parameter payload. Higher-ranked string references
+        // are created and consumed entirely inside that exclusive borrow.
+        unsafe {
+            super::AssumeSendFuture::new(async move {
+                self.execute_with_options_inner(&sql, &params, options)
+                    .await
+            })
+        }
     }
 
     #[cfg(test)]
@@ -8787,8 +8830,9 @@ mod tests {
         transaction
             .execute_with_options(
                 "UPDATE lix_key_value SET value = 'updated' \
-                 WHERE key = 'origin-key-address'",
-                &[],
+                 WHERE key = 'origin-key-address'"
+                    .to_owned(),
+                Vec::new(),
                 ExecuteOptions {
                     origin_key: Some("tx-origin".to_string()),
                     ..Default::default()
@@ -8855,8 +8899,8 @@ mod tests {
             .expect("transaction should begin");
         transaction
             .execute_with_options(
-                "UPDATE lix_file SET data = $1 WHERE id = $2",
-                &[
+                "UPDATE lix_file SET data = $1 WHERE id = $2".to_owned(),
+                vec![
                     Value::Blob(b"three\n".to_vec().into()),
                     Value::Text(FILE_ID.to_string()),
                 ],

--- a/packages/engine/src/session/mod.rs
+++ b/packages/engine/src/session/mod.rs
@@ -10,6 +10,10 @@
 //! the storage commit point-of-no-return. After that point, close waits for
 //! commit completion. Crash persistence is provider-defined.
 
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
 mod checkpoint;
 mod context;
 mod create_branch;
@@ -48,3 +52,31 @@ pub use observe::{ObserveEvent, ObserveEvents};
 pub use switch_branch::{SwitchBranchOptions, SwitchBranchReceipt};
 pub use transaction::SessionTransaction;
 pub use undo_redo::{RedoReceipt, UndoReceipt};
+
+/// Zero-cost adapter for futures that rustc cannot prove `Send` because an
+/// opaque async call contains higher-ranked references. Construction is unsafe:
+/// callers must verify that every value retained across suspension is `Send`.
+#[repr(transparent)]
+pub(super) struct AssumeSendFuture<F>(F);
+
+impl<F> AssumeSendFuture<F> {
+    pub(super) unsafe fn new(future: F) -> Self {
+        Self(future)
+    }
+}
+
+// SAFETY: `AssumeSendFuture::new` is private and unsafe; each call site must
+// establish the wrapped future's complete suspension state is movable.
+unsafe impl<F> Send for AssumeSendFuture<F> {}
+
+impl<F> Future for AssumeSendFuture<F>
+where
+    F: Future,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        // SAFETY: projecting through the transparent wrapper does not move F.
+        unsafe { self.map_unchecked_mut(|wrapped| &mut wrapped.0) }.poll(context)
+    }
+}

--- a/packages/engine/src/session/observe.rs
+++ b/packages/engine/src/session/observe.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{future::Future, sync::Arc};
 
 use tokio::sync::watch;
 
@@ -59,7 +59,16 @@ impl<StorageImpl> ObserveEvents<StorageImpl>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
-    pub async fn next(&mut self) -> Result<Option<ObserveEvent>, LixError> {
+    pub fn next(
+        &mut self,
+    ) -> impl Future<Output = Result<Option<ObserveEvent>, LixError>> + Send + '_ {
+        // SAFETY: ObserveEvents is exclusively borrowed for the whole future;
+        // its session/storage handles are Send and its shared references target
+        // Sync coordinator, catalog, and immutable query state.
+        unsafe { super::AssumeSendFuture::new(self.next_inner()) }
+    }
+
+    async fn next_inner(&mut self) -> Result<Option<ObserveEvent>, LixError> {
         if self.closed || self.session.is_closed() {
             self.close();
             return Ok(None);

--- a/packages/engine/src/telemetry.rs
+++ b/packages/engine/src/telemetry.rs
@@ -247,7 +247,7 @@ impl ActiveTelemetrySpan {
         }
     }
 
-    pub(crate) async fn instrument<F>(&self, future: F) -> F::Output
+    pub(crate) fn instrument<F>(&self, future: F) -> TelemetryInstrumentedFuture<'_, F>
     where
         F: Future,
     {
@@ -255,7 +255,6 @@ impl ActiveTelemetrySpan {
             future: Box::pin(future),
             handle: self.handle.as_ref(),
         }
-        .await
     }
 
     pub(crate) fn finish(self, status: TelemetrySpanStatus, attributes: Vec<TelemetryAttribute>) {
@@ -268,7 +267,7 @@ impl ActiveTelemetrySpan {
     }
 }
 
-struct TelemetryInstrumentedFuture<'a, F> {
+pub(crate) struct TelemetryInstrumentedFuture<'a, F> {
     future: Pin<Box<F>>,
     handle: &'a dyn TelemetrySpanHandle,
 }

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -6812,7 +6812,7 @@ where
     /// transaction-scoped snapshot. A missing or stale accelerator is an
     /// ordinary `None`; callers retain the historical tracked-state oracle.
     pub(crate) async fn working_diff_at_head(
-        &self,
+        &mut self,
         branch_id: &str,
         head_commit_id: CommitId,
         request: &TrackedStateDiffRequest,

--- a/packages/js-sdk/native/napi.rs
+++ b/packages/js-sdk/native/napi.rs
@@ -734,13 +734,16 @@ impl NativeLixTransactionInner {
     ) -> std::result::Result<RsExecuteResult, LixError> {
         match self {
             Self::Memory(transaction) => {
-                Box::pin(transaction.execute_with_options(sql, params, options)).await
+                Box::pin(transaction.execute_with_options(sql.to_owned(), params.to_vec(), options))
+                    .await
             }
             Self::SQLite(transaction) => {
-                Box::pin(transaction.execute_with_options(sql, params, options)).await
+                Box::pin(transaction.execute_with_options(sql.to_owned(), params.to_vec(), options))
+                    .await
             }
             Self::LocalFilesystem(transaction) => {
-                Box::pin(transaction.execute_with_options(sql, params, options)).await
+                Box::pin(transaction.execute_with_options(sql.to_owned(), params.to_vec(), options))
+                    .await
             }
         }
     }

--- a/packages/js-sdk/native/wasm.rs
+++ b/packages/js-sdk/native/wasm.rs
@@ -328,7 +328,7 @@ impl WasmLixTransaction {
         let options = execute_options_from_js(options)?;
         let inner = self.inner.as_mut().ok_or_else(transaction_closed_error)?;
         let result = inner
-            .execute_with_options(&sql, &params, options)
+            .execute_with_options(sql, params, options)
             .await
             .map_err(lix_error_to_js)?;
         execute_result_to_js(result)

--- a/packages/rs-sdk/src/lix.rs
+++ b/packages/rs-sdk/src/lix.rs
@@ -8,7 +8,7 @@ use lix_engine::{
     MergeBranchPreview, MergeBranchPreviewOptions, MergeBranchReceipt, ObserveEvents, RedoReceipt,
     SessionContext, Storage, SwitchBranchOptions, SwitchBranchReceipt, UndoReceipt, Value,
 };
-use std::sync::Arc;
+use std::{future::Future, sync::Arc};
 
 use crate::client_state::ClientState;
 
@@ -315,23 +315,21 @@ where
     }
 
     #[doc(hidden)]
-    pub async fn execute_with_idempotency_and_options_and_metadata(
-        &self,
-        sql: &str,
-        params: &[Value],
+    pub fn execute_with_idempotency_and_options_and_metadata(
+        self: Arc<Self>,
+        sql: String,
+        params: Vec<Value>,
         options: ExecuteOptions,
         metadata: ExecuteStatementMetadata,
         idempotency: Option<ExecuteIdempotency>,
-    ) -> Result<ExecuteResult, LixError> {
-        self.session
-            .execute_with_idempotency_and_options_and_metadata(
-                sql,
-                params,
-                options,
-                metadata,
-                idempotency,
-            )
-            .await
+    ) -> impl Future<Output = Result<ExecuteResult, LixError>> + Send + 'static {
+        Arc::clone(&self.session).execute_with_idempotency_and_options_and_metadata(
+            sql,
+            params,
+            options,
+            metadata,
+            idempotency,
+        )
     }
 
     /// Executes statements sequentially against one atomic snapshot.
@@ -376,21 +374,19 @@ where
     }
 
     #[doc(hidden)]
-    pub async fn execute_batch_with_idempotency_and_options_and_metadata(
-        &self,
-        statements: &[ExecuteBatchStatement],
+    pub fn execute_batch_with_idempotency_and_options_and_metadata(
+        self: Arc<Self>,
+        statements: Vec<ExecuteBatchStatement>,
         options: ExecuteOptions,
         statement_metadata: Vec<ExecuteStatementMetadata>,
         idempotency: Option<ExecuteIdempotency>,
-    ) -> Result<Vec<ExecuteResult>, LixError> {
-        self.session
-            .execute_batch_with_idempotency_and_options_and_metadata(
-                statements,
-                options,
-                statement_metadata,
-                idempotency,
-            )
-            .await
+    ) -> impl Future<Output = Result<Vec<ExecuteResult>, LixError>> + Send + 'static {
+        Arc::clone(&self.session).execute_batch_with_idempotency_and_options_and_metadata(
+            statements,
+            options,
+            statement_metadata,
+            idempotency,
+        )
     }
 
     pub fn observe(
@@ -523,13 +519,13 @@ where
         self.inner.execute(sql, params).await
     }
 
-    pub async fn execute_with_options(
+    pub fn execute_with_options(
         &mut self,
-        sql: &str,
-        params: &[Value],
+        sql: String,
+        params: Vec<Value>,
         options: ExecuteOptions,
-    ) -> Result<ExecuteResult, LixError> {
-        self.inner.execute_with_options(sql, params, options).await
+    ) -> impl Future<Output = Result<ExecuteResult, LixError>> + Send + '_ {
+        self.inner.execute_with_options(sql, params, options)
     }
 
     pub async fn commit(self) -> Result<(), LixError> {

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -41,7 +41,6 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::{
-    runtime::Handle,
     sync::{Mutex as AsyncMutex, Notify, RwLock as AsyncRwLock, mpsc, watch},
     task::JoinHandle,
 };
@@ -663,105 +662,78 @@ where
         }
     }
 
-    async fn run<T, F, Fut>(&self, operation: F) -> Result<T, LixError>
+    async fn run_detached<T, Fut>(
+        &self,
+        operation: Fut,
+        join_context: &'static str,
+    ) -> Result<T, LixError>
     where
         T: Send + 'static,
-        F: FnOnce(Arc<Lix<S>>) -> Fut + Send + 'static,
-        Fut: Future<Output = Result<T, LixError>> + 'static,
+        Fut: Future<Output = Result<T, LixError>> + Send + 'static,
     {
-        let runtime = Handle::try_current().map_err(|error| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("access Lix server runtime: {error}"),
-            )
-        })?;
-        let lix = Arc::clone(&self.record.lix);
-        // `spawn_blocking` work is detached when its JoinHandle is dropped.
-        // Keep a lease inside that work so an HTTP timeout/cancellation cannot
-        // make an operation look idle and eligible for session eviction while
-        // it is still running.
+        // Dropping a Tokio JoinHandle detaches its task. Keep a lease inside
+        // durable work so HTTP cancellation cannot make an active session look
+        // idle or eligible for eviction before the operation reaches its
+        // terminal boundary.
         let operation_lease = self.clone();
         let durable_terminal_storage_notifier = self.durable_terminal_storage_notifier.clone();
         let parent = tracing::Span::current();
-        let dispatch = tracing::dispatcher::get_default(Clone::clone);
-        tokio::task::spawn_blocking(move || {
-            let _operation_lease = operation_lease;
-            let result = tracing::dispatcher::with_default(&dispatch, || {
-                parent.in_scope(|| {
-                    runtime.block_on(async move {
-                        let lix = lix.read().await;
-                        operation(Arc::clone(&lix)).await
-                    })
-                })
-            });
-            if let (Some(notifier), Err(error)) = (&durable_terminal_storage_notifier, &result) {
-                notifier.signal_if_terminal(error);
+        tokio::spawn(
+            async move {
+                let _operation_lease = operation_lease;
+                let result = operation.await;
+                if let (Some(notifier), Err(error)) = (&durable_terminal_storage_notifier, &result)
+                {
+                    notifier.signal_if_terminal(error);
+                }
+                result
             }
-            result
-        })
+            .instrument(parent)
+            .with_current_subscriber(),
+        )
         .await
         .map_err(|error| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
-                format!("join Lix server operation: {error}"),
+                format!("{join_context}: {error}"),
             )
         })?
     }
 
-    /// Runs a read whose work can be discarded when the request future is
-    /// dropped. The cancellation sender deliberately lives in the caller
-    /// future: dropping an HTTP timeout's waiter wakes the blocking runtime,
-    /// which drops the session read lock and its operation lease.
-    async fn run_cancellable_read<T, F, Fut>(&self, operation: F) -> Result<T, LixError>
+    async fn run_durable<T, F, Fut>(&self, operation: F) -> Result<T, LixError>
     where
         T: Send + 'static,
         F: FnOnce(Arc<Lix<S>>) -> Fut + Send + 'static,
-        Fut: Future<Output = Result<T, LixError>> + 'static,
+        Fut: Future<Output = Result<T, LixError>> + Send + 'static,
     {
-        let runtime = Handle::try_current().map_err(|error| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("access Lix server runtime: {error}"),
-            )
-        })?;
         let lix = Arc::clone(&self.record.lix);
-        let operation_lease = self.clone();
-        let durable_terminal_storage_notifier = self.durable_terminal_storage_notifier.clone();
-        let (cancel_on_drop, mut cancelled) = tokio::sync::oneshot::channel::<()>();
-        let parent = tracing::Span::current();
-        let dispatch = tracing::dispatcher::get_default(Clone::clone);
-        let result = tokio::task::spawn_blocking(move || {
-            let _operation_lease = operation_lease;
-            let result = tracing::dispatcher::with_default(&dispatch, || {
-                parent.in_scope(|| {
-                    runtime.block_on(async move {
-                        tokio::select! {
-                            biased;
-                            result = async {
-                                let lix = lix.read().await;
-                                operation(Arc::clone(&lix)).await
-                            } => result,
-                            _ = &mut cancelled => Err(LixError::new(
-                                LixError::CODE_CLOSED,
-                                "Lix read operation was cancelled",
-                            )),
-                        }
-                    })
-                })
-            });
-            if let (Some(notifier), Err(error)) = (&durable_terminal_storage_notifier, &result) {
-                notifier.signal_if_terminal(error);
-            }
-            result
-        })
+        self.run_detached(
+            async move {
+                let lix = lix.read_owned().await;
+                let current = Arc::clone(&lix);
+                operation(current).await
+            },
+            "join Lix server operation",
+        )
         .await
-        .map_err(|error| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("join Lix server operation: {error}"),
-            )
-        })?;
-        drop(cancel_on_drop);
+    }
+
+    /// Runs a read inline on Tokio. Dropping the request future directly drops
+    /// the engine future and its session read lock; no cancellation relay or
+    /// second executor is involved.
+    async fn run_cancellable_read<T, F, Fut>(&self, operation: F) -> Result<T, LixError>
+    where
+        F: FnOnce(Arc<Lix<S>>) -> Fut,
+        Fut: Future<Output = Result<T, LixError>>,
+    {
+        let result = {
+            let lix = Arc::clone(&self.record.lix).read_owned().await;
+            let current = Arc::clone(&lix);
+            operation(current).await
+        };
+        if let (Some(notifier), Err(error)) = (&self.durable_terminal_storage_notifier, &result) {
+            notifier.signal_if_terminal(error);
+        }
         result
     }
 
@@ -782,8 +754,8 @@ where
                 self.run_cancellable_read(move |lix| async move {
                     let idempotency = bind_idempotency_to_session_branch(&lix, idempotency).await?;
                     lix.execute_with_idempotency_and_options_and_metadata(
-                        &sql,
-                        &params,
+                        sql,
+                        params,
                         options,
                         metadata,
                         idempotency,
@@ -793,11 +765,11 @@ where
                 .await
             }
             ExecutionDisposition::Durable => {
-                self.run(move |lix| async move {
+                self.run_durable(move |lix| async move {
                     let idempotency = bind_idempotency_to_session_branch(&lix, idempotency).await?;
                     lix.execute_with_idempotency_and_options_and_metadata(
-                        &sql,
-                        &params,
+                        sql,
+                        params,
                         options,
                         metadata,
                         idempotency,
@@ -825,7 +797,7 @@ where
                 self.run_cancellable_read(move |lix| async move {
                     let idempotency = bind_idempotency_to_session_branch(&lix, idempotency).await?;
                     lix.execute_batch_with_idempotency_and_options_and_metadata(
-                        &statements,
+                        statements,
                         options,
                         statement_metadata,
                         idempotency,
@@ -835,10 +807,10 @@ where
                 .await
             }
             ExecutionDisposition::Durable => {
-                self.run(move |lix| async move {
+                self.run_durable(move |lix| async move {
                     let idempotency = bind_idempotency_to_session_branch(&lix, idempotency).await?;
                     lix.execute_batch_with_idempotency_and_options_and_metadata(
-                        &statements,
+                        statements,
                         options,
                         statement_metadata,
                         idempotency,
@@ -875,50 +847,54 @@ where
         params: Vec<Value>,
         options: ExecuteOptions,
     ) -> Result<ExecuteResult, LixError> {
-        let mut transactions = self.record.transactions.lock().await;
-        let mut active = transactions.active.take().ok_or_else(|| {
-            completed_transaction_error(&transactions, &transaction_id).unwrap_or_else(|| {
-                remote_transaction_state_error("Lix session has no active transaction")
-            })
-        })?;
-        if active.id != transaction_id {
-            transactions.active = Some(active);
-            return Err(remote_transaction_state_error(
-                "remote transaction capability does not match the active transaction",
-            ));
-        }
-        let runtime = Handle::try_current().map_err(|error| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("access Lix server runtime: {error}"),
-            )
-        })?;
-        let operation_lease = self.clone();
-        let parent = tracing::Span::current();
-        let dispatch = tracing::dispatcher::get_default(Clone::clone);
-        let joined = tokio::task::spawn_blocking(move || {
-            let _operation_lease = operation_lease;
-            let result = tracing::dispatcher::with_default(&dispatch, || {
-                parent.in_scope(|| {
-                    runtime.block_on(async {
-                        active
-                            .transaction
-                            .execute_with_options(&sql, &params, options)
-                            .await
-                    })
-                })
-            });
-            (active, result)
-        })
-        .await
-        .map_err(|error| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("join Lix server transaction operation: {error}"),
-            )
-        })?;
-        transactions.active = Some(joined.0);
-        joined.1
+        let record = Arc::clone(&self.record);
+        let (cancel_on_drop, mut cancelled) = tokio::sync::oneshot::channel::<()>();
+        let result = self.run_detached(
+            async move {
+                let mut transactions = record.transactions.lock().await;
+                let mut active = transactions.active.take().ok_or_else(|| {
+                    completed_transaction_error(&transactions, &transaction_id).unwrap_or_else(
+                        || remote_transaction_state_error("Lix session has no active transaction"),
+                    )
+                })?;
+                if active.id != transaction_id {
+                    transactions.active = Some(active);
+                    return Err(remote_transaction_state_error(
+                        "remote transaction capability does not match the active transaction",
+                    ));
+                }
+                tokio::select! {
+                    biased;
+                    _ = &mut cancelled => {
+                        let rollback = active.transaction.rollback().await;
+                        let completed = rollback
+                            .map(|()| RemoteTransactionOutcome::RolledBack);
+                        transactions.completed.push_back(CompletedRemoteTransaction {
+                            id: transaction_id,
+                            result: completed.clone(),
+                        });
+                        while transactions.completed.len() > MAX_COMPLETED_REMOTE_TRANSACTIONS {
+                            transactions.completed.pop_front();
+                        }
+                        match completed {
+                            Ok(_) => Err(LixError::new(
+                                LixError::CODE_CLOSED,
+                                "cancelled remote transaction statement rolled back its transaction",
+                            )),
+                            Err(error) => Err(error),
+                        }
+                    }
+                    result = active.transaction.execute_with_options(sql, params, options) => {
+                        transactions.active = Some(active);
+                        result
+                    }
+                }
+            },
+            "join Lix server transaction operation",
+        )
+        .await;
+        drop(cancel_on_drop);
+        result
     }
 
     async fn commit_transaction(&self, transaction_id: String) -> Result<(), LixError> {
@@ -936,77 +912,62 @@ where
         transaction_id: String,
         requested: RemoteTransactionOutcome,
     ) -> Result<(), LixError> {
-        let mut transactions = self.record.transactions.lock().await;
-        let Some(active) = transactions.active.take() else {
-            return completed_transaction_result(&transactions, &transaction_id, requested);
-        };
-        if active.id != transaction_id {
-            transactions.active = Some(active);
-            return Err(remote_transaction_state_error(
-                "remote transaction capability does not match the active transaction",
-            ));
-        }
-        let result = match requested {
-            RemoteTransactionOutcome::Committed => self
-                .run(move |_| async move { active.transaction.commit().await })
-                .await
-                .map(|()| RemoteTransactionOutcome::Committed),
-            RemoteTransactionOutcome::RolledBack => self
-                .run(move |_| async move { active.transaction.rollback().await })
-                .await
-                .map(|()| RemoteTransactionOutcome::RolledBack),
-        };
-        transactions
-            .completed
-            .push_back(CompletedRemoteTransaction {
-                id: transaction_id,
-                result: result.clone(),
-            });
-        while transactions.completed.len() > MAX_COMPLETED_REMOTE_TRANSACTIONS {
-            transactions.completed.pop_front();
-        }
-        result.map(|_| ())
+        let record = Arc::clone(&self.record);
+        self.run_detached(
+            async move {
+                let mut transactions = record.transactions.lock().await;
+                let Some(active) = transactions.active.take() else {
+                    return completed_transaction_result(&transactions, &transaction_id, requested);
+                };
+                if active.id != transaction_id {
+                    transactions.active = Some(active);
+                    return Err(remote_transaction_state_error(
+                        "remote transaction capability does not match the active transaction",
+                    ));
+                }
+                let result = match requested {
+                    RemoteTransactionOutcome::Committed => active
+                        .transaction
+                        .commit()
+                        .await
+                        .map(|()| RemoteTransactionOutcome::Committed),
+                    RemoteTransactionOutcome::RolledBack => active
+                        .transaction
+                        .rollback()
+                        .await
+                        .map(|()| RemoteTransactionOutcome::RolledBack),
+                };
+                transactions
+                    .completed
+                    .push_back(CompletedRemoteTransaction {
+                        id: transaction_id,
+                        result: result.clone(),
+                    });
+                while transactions.completed.len() > MAX_COMPLETED_REMOTE_TRANSACTIONS {
+                    transactions.completed.pop_front();
+                }
+                result.map(|_| ())
+            },
+            "join Lix server transaction finalization",
+        )
+        .await
     }
 
     async fn switch_branch(
         &self,
         options: SwitchBranchOptions,
     ) -> Result<lix_sdk::SwitchBranchReceipt, LixError> {
-        let runtime = Handle::try_current().map_err(|error| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("access Lix server runtime: {error}"),
-            )
-        })?;
         let lix = Arc::clone(&self.record.lix);
-        let operation_lease = self.clone();
-        let durable_terminal_storage_notifier = self.durable_terminal_storage_notifier.clone();
-        let parent = tracing::Span::current();
-        let dispatch = tracing::dispatcher::get_default(Clone::clone);
-        tokio::task::spawn_blocking(move || {
-            let _operation_lease = operation_lease;
-            let result = tracing::dispatcher::with_default(&dispatch, || {
-                parent.in_scope(|| {
-                    runtime.block_on(async move {
-                        let mut lix = lix.write().await;
-                        let (switched, receipt) = lix.switch_branch_session(options).await?;
-                        *lix = Arc::new(switched);
-                        Ok(receipt)
-                    })
-                })
-            });
-            if let (Some(notifier), Err(error)) = (&durable_terminal_storage_notifier, &result) {
-                notifier.signal_if_terminal(error);
-            }
-            result
-        })
+        self.run_detached(
+            async move {
+                let mut lix = lix.write().await;
+                let (switched, receipt) = lix.switch_branch_session(options).await?;
+                *lix = Arc::new(switched);
+                Ok(receipt)
+            },
+            "join Lix server branch switch",
+        )
         .await
-        .map_err(|error| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("join Lix server branch switch: {error}"),
-            )
-        })?
     }
 
     async fn observe(
@@ -1017,7 +978,7 @@ where
     ) -> Result<ServerObserve<S>, LixError> {
         let lix = self.record.lix.read().await;
         Ok(ServerObserve {
-            events: Arc::new(Mutex::new(lix.observe(sql, params)?)),
+            events: AsyncMutex::new(lix.observe(sql, params)?),
             terminal_sender,
         })
     }
@@ -1125,7 +1086,7 @@ struct ServerObserve<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
-    events: Arc<Mutex<ObserveEvents<S>>>,
+    events: AsyncMutex<ObserveEvents<S>>,
     terminal_sender: TerminalStorageStreamSender,
 }
 
@@ -1134,51 +1095,10 @@ where
     S: Storage + Clone + Send + Sync + 'static,
 {
     async fn next(&self) -> Result<Option<ObserveEvent>, LixError> {
-        let runtime = Handle::try_current().map_err(|error| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("access Lix observe runtime: {error}"),
-            )
-        })?;
-        let events = Arc::clone(&self.events);
-        let terminal_sender = self.terminal_sender.clone();
-        let (cancel_on_drop, cancel) = tokio::sync::oneshot::channel::<()>();
-        let parent = tracing::Span::current();
-        let dispatch = tracing::dispatcher::get_default(Clone::clone);
-        let result = tokio::task::spawn_blocking(move || {
-            let result = tracing::dispatcher::with_default(&dispatch, || {
-                parent.in_scope(|| {
-                    let mut events = events.lock().map_err(|error| {
-                        LixError::new(
-                            LixError::CODE_INTERNAL_ERROR,
-                            format!("lock Lix observe stream: {error}"),
-                        )
-                    })?;
-                    runtime.block_on(async {
-                        tokio::select! {
-                            biased;
-                            result = events.next() => result,
-                            _ = cancel => Err(LixError::new(
-                                LixError::CODE_CLOSED,
-                                "Lix observe wait was cancelled",
-                            )),
-                        }
-                    })
-                })
-            });
-            if let Err(error) = &result {
-                terminal_sender.signal_if_terminal(error);
-            }
-            result
-        })
-        .await
-        .map_err(|error| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("join Lix observe operation: {error}"),
-            )
-        })?;
-        drop(cancel_on_drop);
+        let result = self.events.lock().await.next().await;
+        if let Err(error) = &result {
+            self.terminal_sender.signal_if_terminal(error);
+        }
         result
     }
 }
@@ -1952,7 +1872,7 @@ where
             .map_err(|_| ApiError::bad_request("Lix-Upload-Id must be ASCII"))?
             .to_owned();
         let progress = lease
-            .run(move |lix| async move {
+            .run_durable(move |lix| async move {
                 lix.upsert_file_data_part(
                     upload_id,
                     path,
@@ -1983,7 +1903,7 @@ where
         return Ok(response);
     }
     let result = lease
-        .run(move |lix| async move { lix.upsert_file_data(path, body).await })
+        .run_durable(move |lix| async move { lix.upsert_file_data(path, body).await })
         .await?;
     Ok(Json(ExecuteResponse::try_from(
         ExecuteResult::from_rows_affected(result),
@@ -2052,7 +1972,7 @@ where
 {
     let writes = parse_binary_file_upsert_batch(body)?;
     let result = lease
-        .run(move |lix| async move { lix.upsert_file_data_batch(writes).await })
+        .run_durable(move |lix| async move { lix.upsert_file_data_batch(writes).await })
         .await?;
     Ok(Json(ExecuteResponse::try_from(
         ExecuteResult::from_rows_affected(result),
@@ -2381,7 +2301,7 @@ where
         from_commit_id: request.from_commit_id,
     };
     let receipt = lease
-        .run(move |lix| async move { lix.create_branch(options).await })
+        .run_durable(move |lix| async move { lix.create_branch(options).await })
         .await?;
     Ok(Json(CreateBranchResponse {
         id: receipt.id,
@@ -2398,7 +2318,7 @@ where
     S: Storage + Clone + Send + Sync + 'static,
 {
     let receipt = lease
-        .run(move |lix| async move { lix.create_checkpoint().await })
+        .run_durable(move |lix| async move { lix.create_checkpoint().await })
         .await?;
     Ok(Json(CreateCheckpointResponse {
         commit_id: receipt.commit_id,
@@ -2412,7 +2332,7 @@ where
     S: Storage + Clone + Send + Sync + 'static,
 {
     let receipt = lease
-        .run(move |lix| async move { lix.undo().await })
+        .run_durable(move |lix| async move { lix.undo().await })
         .await?;
     Ok(Json(UndoResponse {
         branch_id: receipt.branch_id,
@@ -2428,7 +2348,7 @@ where
     S: Storage + Clone + Send + Sync + 'static,
 {
     let receipt = lease
-        .run(move |lix| async move { lix.redo().await })
+        .run_durable(move |lix| async move { lix.redo().await })
         .await?;
     Ok(Json(RedoResponse {
         branch_id: receipt.branch_id,
@@ -9017,7 +8937,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn execute_keeps_sql_span_under_protocol_request_across_blocking_runtime() {
+    async fn execute_keeps_sql_span_under_protocol_request_on_native_runtime() {
         let capture = CaptureLayer::default();
         let spans = Arc::clone(&capture.spans);
         let _subscriber =
@@ -9835,6 +9755,102 @@ mod tests {
                 .status(),
             StatusCode::OK,
             "dropped transaction state must release the lifecycle pin"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_remote_transaction_statement_rolls_back_instead_of_replaying() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let transaction_id = begin_remote_transaction(&app.router, &session_id).await;
+        let record = app
+            .server
+            .inner
+            .registry
+            .lock()
+            .await
+            .sessions
+            .get(&session_id)
+            .cloned()
+            .expect("transaction session remains registered");
+        let registry_guard = record.transactions.lock().await;
+
+        let router = app.router.clone();
+        let request_session_id = session_id.clone();
+        let request_transaction_id = transaction_id.clone();
+        let statement = tokio::spawn(async move {
+            remote_transaction_request(
+                &router,
+                "POST",
+                "/lix/v1/transaction/execute",
+                &request_session_id,
+                &request_transaction_id,
+                Some(json!({
+                    "sql": "INSERT INTO lix_key_value (key, value) VALUES ('cancelled-statement', 'must-not-commit')"
+                })),
+            )
+            .await
+        });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while record.lease_count() < 2 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("detached transaction statement should retain its own lease");
+
+        statement.abort();
+        assert!(
+            statement
+                .await
+                .expect_err("outer transaction statement request was cancelled")
+                .is_cancelled()
+        );
+        drop(registry_guard);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if record
+                    .transactions
+                    .lock()
+                    .await
+                    .completed
+                    .iter()
+                    .any(|completed| completed.id == transaction_id)
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cancelled statement should finish rollback");
+
+        let commit = remote_transaction_request(
+            &app.router,
+            "POST",
+            "/lix/v1/transaction/commit",
+            &session_id,
+            &transaction_id,
+            None,
+        )
+        .await;
+        assert_eq!(commit.status(), StatusCode::BAD_REQUEST);
+
+        let result = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT COUNT(*) AS count FROM lix_key_value WHERE key = 'cancelled-statement'"
+            })),
+        )
+        .await;
+        assert_eq!(result.status(), StatusCode::OK);
+        assert_eq!(
+            response_json(result).await["rows"][0][0],
+            json!({ "kind": "int", "value": 0 })
         );
     }
 


### PR DESCRIPTION
## Summary

- delete the server's nested `spawn_blocking` + `Runtime::block_on` bridge
- run request futures directly on the host-provided Tokio runtime and detach only durable operations
- hard-cut SDK and engine execution boundaries to owned, `Send` inputs/futures; no compatibility layer
- make cancellation explicit: cancellable reads are dropped immediately, while cancelled transactions roll back atomically before recording completion
- keep observer, telemetry, SQL-read lifetime, and ordinary execute/batch hot paths allocation-conscious

The host now supplies one runtime which powers the server and the Lix services/plugins beneath it. There is no server-owned or nested runtime bridge.

## Performance

Release profile, pinned to four cores, 4 KiB warm-memory download, 5,000 samples per run:

- `main` in-process p50: **1,039 µs**
- this branch: **875 / 514 / 444 µs**, median **514 µs**
- bridge-path p50 reduction: **50.5%**

The existing end-to-end HTTP/SSE benchmark's direct-SQL `2x` assertion still fails because it measures protocol overhead beyond this bridge; the PR does not claim that broader gap is solved. Linking uses the repository's default `mold` configuration.

## Correctness and safety

- added deterministic cancellation coverage proving a cancelled transaction rolls back the entire transaction and cannot be replayed ambiguously
- preserved the scoped SQL-read lifetime boundary
- five private, zero-allocation `AssumeSendFuture` adapters cover Rust's current higher-ranked/lending-future Send inference gap at audited owned/exclusive-borrow call sites

## Validation

- server protocol: **93 passed, 4 ignored**
- engine unit simulations: **1,823 passed, 8 ignored**
- engine integration simulations: **806 passed, 2 ignored**
- engine doctests: **3 passed**
- SDK Send tests: **3 passed**
- `cargo clippy -Z bindeps -p lix_server_protocol --all-features -- -D warnings`
- `cargo check -Z bindeps -p lix_js_sdk --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`

## Review

Three independent sub-agent reviews covered runtime design/safety, performance, and cancellation semantics. Their findings led to restoring scoped lifetime enforcement and lean hot paths, removing unnecessary Arc/mutex work, and making transaction cancellation rollback deterministic.
