### PR TITLE
Publish immutable replacement parts

### DIFF
--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -4028,7 +4028,7 @@ mod tests {
         assert_eq!(overlay_rows, expected_overlay_rows);
     }
 
-    async fn assert_current_head_has_columnar_manifest(
+    async fn assert_current_head_uses_packed_delta_without_columnar_sidecar(
         session: &SessionContext<Memory>,
         schema_key: &str,
         expected_rows: u64,
@@ -4049,17 +4049,25 @@ mod tests {
             .await
             .expect("branch head should load")
             .expect("active branch should have a head");
-        let sidecar_read = session
+        let state_read = session
             .storage
             .begin_read(StorageReadOptions::default())
             .await
-            .expect("sidecar read should open");
+            .expect("replacement read should open");
+        let replay =
+            crate::tracked_state::load_commit_delta_replay_metadata(&state_read, head.commit_id)
+                .await
+                .expect("replacement metadata should load")
+                .expect("current head must publish replacement metadata");
+        assert_eq!(u64::from(replay.member_count), expected_rows);
         let id = crate::live_state::entity_row_group_set_id(head.commit_id, schema_key);
-        let manifest = crate::columnar_row_group::load_row_group_manifest(&sidecar_read, id)
+        let manifest = crate::columnar_row_group::load_row_group_manifest(&state_read, id)
             .await
-            .expect("sidecar manifest should load")
-            .expect("current packed base must publish its typed sidecar atomically");
-        assert_eq!(manifest.row_count(), expected_rows);
+            .expect("columnar manifest lookup should succeed");
+        assert!(
+            manifest.is_none(),
+            "UPDATE replacement parts supersede the synchronous typed sidecar"
+        );
     }
 
     async fn open_session_with_telemetry(
@@ -5671,7 +5679,7 @@ mod tests {
                 1,
                 "each complete certified replacement should swap one packed base reference"
             );
-            assert_current_head_has_columnar_manifest(
+            assert_current_head_uses_packed_delta_without_columnar_sidecar(
                 &session,
                 "ordered_packed_update_probe",
                 ROW_COUNT as u64,

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -6,6 +6,7 @@ mod context;
 mod diff;
 mod diff_id;
 mod merge;
+pub(crate) mod replacement_part;
 mod row_materialization;
 mod storage;
 mod tree;
@@ -45,6 +46,7 @@ pub(crate) use storage::{
     stage_addressable_commit_deltas_with_selected_source, stage_change_locators,
     stage_commit_deltas, stage_delete_change_locators, stage_delete_commit_delta_inventory_entry,
     stage_delete_commit_roots, stage_ordered_addressable_commit_deltas,
+    stage_ordered_addressable_replacement_parts,
 };
 #[cfg(feature = "storage-benches")]
 pub(crate) use storage::{

--- a/packages/engine/src/tracked_state/replacement_part.rs
+++ b/packages/engine/src/tracked_state/replacement_part.rs
@@ -1,0 +1,935 @@
+//! Point- and range-addressable immutable identity parts for complete replacements.
+//!
+//! A replacement part contains the ordered tracked key and canonical
+//! snapshot/metadata authority. Small JSON remains inline; large JSON keeps
+//! its content-addressed reference to avoid duplicate storage.
+//! Commit-wide timestamps, change identifiers, lifecycle metadata, and the
+//! row-group set identity belong to the publishing manifest.
+
+// Point/range/ordinal routing is the public handoff to the columnar scan layer;
+// UPDATE publication currently consumes only the writer and strict decoder.
+#![allow(dead_code)]
+
+use std::borrow::Cow;
+use std::ops::Range;
+
+use bytes::Bytes;
+
+use crate::LixError;
+
+pub(crate) const REPLACEMENT_PART_MAX_ROWS: usize = 512;
+pub(crate) const REPLACEMENT_PART_TARGET_BYTES: usize = 64 * 1024;
+pub(crate) const REPLACEMENT_PART_MAX_BYTES: usize = 4 * 1024 * 1024;
+
+const REPLACEMENT_PART_MAGIC: &[u8; 8] = b"LXRPI003";
+const REPLACEMENT_PART_COMPRESSED_MAGIC: &[u8; 8] = b"LXRPZ003";
+const REPLACEMENT_PART_MAX_DECODED_BYTES: usize = 16 * 1024 * 1024;
+const REPLACEMENT_DIRECTORY_MAGIC: &[u8; 8] = b"LXRPD001";
+const REPLACEMENT_PART_DIGEST_CONTEXT: &str = "lix tracked-state replacement identity part v1";
+const REPLACEMENT_DIRECTORY_DIGEST_CONTEXT: &str =
+    "lix tracked-state replacement part directory v1";
+const DIGEST_BYTES: usize = 32;
+const DIRECTORY_FIXED_ENTRY_BYTES: usize = DIGEST_BYTES + 4 + 2 + 4 + 4;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ReplacementPartRowRef<'a> {
+    /// Canonical bytes produced by the tracked-state key codec.
+    pub(crate) encoded_key: &'a [u8],
+    pub(crate) snapshot: crate::json_store::JsonSlotRef<'a>,
+    pub(crate) metadata: crate::json_store::JsonSlotRef<'a>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct EncodedReplacementPart {
+    digest: [u8; DIGEST_BYTES],
+    bytes: Bytes,
+    first_key: Bytes,
+    last_key: Bytes,
+    row_count: u16,
+}
+
+impl EncodedReplacementPart {
+    pub(crate) fn digest(&self) -> &[u8; DIGEST_BYTES] {
+        &self.digest
+    }
+
+    pub(crate) fn bytes(&self) -> &Bytes {
+        &self.bytes
+    }
+
+    pub(crate) fn first_key(&self) -> &[u8] {
+        &self.first_key
+    }
+
+    pub(crate) fn last_key(&self) -> &[u8] {
+        &self.last_key
+    }
+
+    pub(crate) fn row_count(&self) -> u16 {
+        self.row_count
+    }
+
+    pub(crate) fn directory_entry(&self, first_ordinal: u32) -> ReplacementPartDirectoryEntry {
+        ReplacementPartDirectoryEntry {
+            digest: self.digest,
+            first_key: self.first_key.clone(),
+            last_key: self.last_key.clone(),
+            first_ordinal,
+            row_count: self.row_count,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct DecodedReplacementPart {
+    key_arena: Bytes,
+    key_ranges: Vec<Range<usize>>,
+    snapshots: Vec<crate::json_store::JsonSlot>,
+    metadata: Vec<crate::json_store::JsonSlot>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ReplacementPartMatch {
+    pub(crate) ordinal: u16,
+}
+
+impl DecodedReplacementPart {
+    pub(crate) fn len(&self) -> usize {
+        self.key_ranges.len()
+    }
+
+    pub(crate) fn first_key(&self) -> Option<&[u8]> {
+        self.key_ranges
+            .first()
+            .map(|range| &self.key_arena[range.clone()])
+    }
+
+    pub(crate) fn last_key(&self) -> Option<&[u8]> {
+        self.key_ranges
+            .last()
+            .map(|range| &self.key_arena[range.clone()])
+    }
+
+    pub(crate) fn key(&self, ordinal: usize) -> Result<Option<&[u8]>, LixError> {
+        Ok(self
+            .key_ranges
+            .get(ordinal)
+            .map(|range| &self.key_arena[range.clone()]))
+    }
+
+    pub(crate) fn snapshot(
+        &self,
+        ordinal: usize,
+    ) -> Result<Option<crate::json_store::JsonSlotRef<'_>>, LixError> {
+        Ok(self.snapshots.get(ordinal).map(|slot| slot.as_ref_slot()))
+    }
+
+    pub(crate) fn metadata(
+        &self,
+        ordinal: usize,
+    ) -> Result<Option<crate::json_store::JsonSlotRef<'_>>, LixError> {
+        Ok(self.metadata.get(ordinal).map(|slot| slot.as_ref_slot()))
+    }
+
+    pub(crate) fn find(
+        &self,
+        encoded_key: &[u8],
+    ) -> Result<Option<ReplacementPartMatch>, LixError> {
+        let mut lower = 0usize;
+        let mut upper = self.key_ranges.len();
+        while lower < upper {
+            let middle = lower + (upper - lower) / 2;
+            let key = self.key(middle)?.ok_or_else(|| {
+                replacement_part_error("replacement part omitted a key during binary search")
+            })?;
+            if key < encoded_key {
+                lower = middle + 1;
+            } else {
+                upper = middle;
+            }
+        }
+        let Some(key) = self.key(lower)? else {
+            return Ok(None);
+        };
+        if key != encoded_key {
+            return Ok(None);
+        }
+        Ok(Some(ReplacementPartMatch {
+            ordinal: u16::try_from(lower)
+                .expect("replacement part row count is bounded below u16::MAX"),
+        }))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ReplacementPartDirectoryEntry {
+    digest: [u8; DIGEST_BYTES],
+    first_key: Bytes,
+    last_key: Bytes,
+    first_ordinal: u32,
+    row_count: u16,
+}
+
+impl ReplacementPartDirectoryEntry {
+    pub(crate) fn new(
+        digest: [u8; DIGEST_BYTES],
+        first_key: &[u8],
+        last_key: &[u8],
+        first_ordinal: u32,
+        row_count: u16,
+    ) -> Self {
+        Self {
+            digest,
+            first_key: Bytes::copy_from_slice(first_key),
+            last_key: Bytes::copy_from_slice(last_key),
+            first_ordinal,
+            row_count,
+        }
+    }
+
+    pub(crate) fn digest(&self) -> &[u8; DIGEST_BYTES] {
+        &self.digest
+    }
+
+    pub(crate) fn first_key(&self) -> &[u8] {
+        &self.first_key
+    }
+
+    pub(crate) fn last_key(&self) -> &[u8] {
+        &self.last_key
+    }
+
+    pub(crate) fn first_ordinal(&self) -> u32 {
+        self.first_ordinal
+    }
+
+    pub(crate) fn row_count(&self) -> u16 {
+        self.row_count
+    }
+
+    pub(crate) fn end_ordinal(&self) -> u32 {
+        self.first_ordinal + u32::from(self.row_count)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ReplacementPartDirectory {
+    entries: Vec<ReplacementPartDirectoryEntry>,
+    row_count: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ReplacementPartOrdinalRoute<'a> {
+    pub(crate) entry: &'a ReplacementPartDirectoryEntry,
+    pub(crate) local_ordinal: u16,
+}
+
+impl ReplacementPartDirectory {
+    pub(crate) fn try_new(
+        entries: Vec<ReplacementPartDirectoryEntry>,
+        row_count: u32,
+    ) -> Result<Self, LixError> {
+        let directory = Self { entries, row_count };
+        directory.validate()?;
+        Ok(directory)
+    }
+
+    pub(crate) fn entries(&self) -> &[ReplacementPartDirectoryEntry] {
+        &self.entries
+    }
+
+    pub(crate) fn row_count(&self) -> u32 {
+        self.row_count
+    }
+
+    pub(crate) fn encode(&self) -> Result<Bytes, LixError> {
+        self.validate()?;
+        let variable_bytes = self.entries.iter().try_fold(0usize, |total, entry| {
+            total
+                .checked_add(entry.first_key.len())
+                .and_then(|total| total.checked_add(entry.last_key.len()))
+                .ok_or_else(|| replacement_part_error("replacement directory size overflows"))
+        })?;
+        let capacity = REPLACEMENT_DIRECTORY_MAGIC
+            .len()
+            .checked_add(8)
+            .and_then(|size| {
+                size.checked_add(
+                    self.entries
+                        .len()
+                        .checked_mul(DIRECTORY_FIXED_ENTRY_BYTES)?,
+                )
+            })
+            .and_then(|size| size.checked_add(variable_bytes))
+            .ok_or_else(|| replacement_part_error("replacement directory size overflows"))?;
+        let mut encoded = Vec::with_capacity(capacity);
+        encoded.extend_from_slice(REPLACEMENT_DIRECTORY_MAGIC);
+        encoded.extend_from_slice(&self.row_count.to_be_bytes());
+        encoded.extend_from_slice(
+            &u32::try_from(self.entries.len())
+                .map_err(|_| replacement_part_error("replacement directory has too many parts"))?
+                .to_be_bytes(),
+        );
+        for entry in &self.entries {
+            encoded.extend_from_slice(&entry.digest);
+            encoded.extend_from_slice(&entry.first_ordinal.to_be_bytes());
+            encoded.extend_from_slice(&entry.row_count.to_be_bytes());
+            encode_sized_bytes(&mut encoded, &entry.first_key)?;
+            encode_sized_bytes(&mut encoded, &entry.last_key)?;
+        }
+        Ok(Bytes::from(encoded))
+    }
+
+    pub(crate) fn digest(&self) -> Result<[u8; DIGEST_BYTES], LixError> {
+        Ok(domain_digest(
+            REPLACEMENT_DIRECTORY_DIGEST_CONTEXT,
+            &self.encode()?,
+        ))
+    }
+
+    pub(crate) fn decode(encoded: &[u8]) -> Result<Self, LixError> {
+        let mut cursor = 0usize;
+        take_exact(encoded, &mut cursor, REPLACEMENT_DIRECTORY_MAGIC.len())?
+            .eq(REPLACEMENT_DIRECTORY_MAGIC)
+            .then_some(())
+            .ok_or_else(|| replacement_part_error("replacement directory has invalid magic"))?;
+        let row_count = decode_u32(encoded, &mut cursor)?;
+        let entry_count = usize::try_from(decode_u32(encoded, &mut cursor)?)
+            .expect("u32 directory count fits usize");
+        let minimum_remaining = entry_count
+            .checked_mul(DIRECTORY_FIXED_ENTRY_BYTES)
+            .ok_or_else(|| replacement_part_error("replacement directory count overflows"))?;
+        if encoded.len().saturating_sub(cursor) < minimum_remaining {
+            return Err(replacement_part_error("replacement directory is truncated"));
+        }
+        let mut entries = Vec::with_capacity(entry_count);
+        for _ in 0..entry_count {
+            let digest = take_exact(encoded, &mut cursor, DIGEST_BYTES)?
+                .try_into()
+                .expect("replacement digest length was checked");
+            let first_ordinal = decode_u32(encoded, &mut cursor)?;
+            let row_count = decode_u16(encoded, &mut cursor)?;
+            let first_key = Bytes::copy_from_slice(decode_sized_bytes(encoded, &mut cursor)?);
+            let last_key = Bytes::copy_from_slice(decode_sized_bytes(encoded, &mut cursor)?);
+            entries.push(ReplacementPartDirectoryEntry {
+                digest,
+                first_key,
+                last_key,
+                first_ordinal,
+                row_count,
+            });
+        }
+        if cursor != encoded.len() {
+            return Err(replacement_part_error(
+                "replacement directory has trailing bytes",
+            ));
+        }
+        Self::try_new(entries, row_count)
+    }
+
+    pub(crate) fn decode_content_addressed(
+        expected_digest: &[u8; DIGEST_BYTES],
+        encoded: &[u8],
+    ) -> Result<Self, LixError> {
+        if &domain_digest(REPLACEMENT_DIRECTORY_DIGEST_CONTEXT, encoded) != expected_digest {
+            return Err(replacement_part_error(
+                "replacement directory content digest mismatch",
+            ));
+        }
+        Self::decode(encoded)
+    }
+
+    pub(crate) fn route_key(&self, encoded_key: &[u8]) -> Option<&ReplacementPartDirectoryEntry> {
+        let mut lower = 0usize;
+        let mut upper = self.entries.len();
+        while lower < upper {
+            let middle = lower + (upper - lower) / 2;
+            if self.entries[middle].first_key.as_ref() <= encoded_key {
+                lower = middle + 1;
+            } else {
+                upper = middle;
+            }
+        }
+        let entry = self.entries.get(lower.checked_sub(1)?)?;
+        (encoded_key <= entry.last_key.as_ref()).then_some(entry)
+    }
+
+    pub(crate) fn route_ordinal(&self, ordinal: u32) -> Option<ReplacementPartOrdinalRoute<'_>> {
+        if ordinal >= self.row_count {
+            return None;
+        }
+        let mut lower = 0usize;
+        let mut upper = self.entries.len();
+        while lower < upper {
+            let middle = lower + (upper - lower) / 2;
+            if self.entries[middle].first_ordinal <= ordinal {
+                lower = middle + 1;
+            } else {
+                upper = middle;
+            }
+        }
+        let entry = self.entries.get(lower.checked_sub(1)?)?;
+        let local = ordinal.checked_sub(entry.first_ordinal)?;
+        (local < u32::from(entry.row_count)).then_some(ReplacementPartOrdinalRoute {
+            entry,
+            local_ordinal: u16::try_from(local).expect("local ordinal is bounded by u16 row count"),
+        })
+    }
+
+    /// Returns the contiguous directory slice whose key bounds may intersect
+    /// `[lower, upper)`. Gaps between parts remain gaps; callers still verify
+    /// exact membership inside each decoded part.
+    pub(crate) fn parts_overlapping(
+        &self,
+        lower: Option<&[u8]>,
+        upper: Option<&[u8]>,
+    ) -> Range<usize> {
+        if lower
+            .zip(upper)
+            .is_some_and(|(lower, upper)| lower >= upper)
+        {
+            return 0..0;
+        }
+        let start = lower.map_or(0, |lower| {
+            self.entries
+                .partition_point(|entry| entry.last_key.as_ref() < lower)
+        });
+        let end = upper.map_or(self.entries.len(), |upper| {
+            self.entries
+                .partition_point(|entry| entry.first_key.as_ref() < upper)
+        });
+        start.min(end)..end
+    }
+
+    fn validate(&self) -> Result<(), LixError> {
+        if self.row_count == 0 || self.entries.is_empty() {
+            return Err(replacement_part_error(
+                "replacement directory must contain at least one row",
+            ));
+        }
+        let mut expected_ordinal = 0u32;
+        let mut previous_last: Option<&[u8]> = None;
+        for entry in &self.entries {
+            if entry.row_count == 0
+                || usize::from(entry.row_count) > REPLACEMENT_PART_MAX_ROWS
+                || entry.first_key.is_empty()
+                || entry.last_key.is_empty()
+                || entry.first_key > entry.last_key
+                || previous_last.is_some_and(|previous| previous >= entry.first_key.as_ref())
+                || entry.first_ordinal != expected_ordinal
+            {
+                return Err(replacement_part_error(
+                    "replacement directory has invalid bounds or ordinals",
+                ));
+            }
+            expected_ordinal = expected_ordinal
+                .checked_add(u32::from(entry.row_count))
+                .ok_or_else(|| replacement_part_error("replacement row count overflows u32"))?;
+            previous_last = Some(&entry.last_key);
+        }
+        if expected_ordinal != self.row_count {
+            return Err(replacement_part_error(
+                "replacement directory row count does not match its parts",
+            ));
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn encode_replacement_part(
+    rows: &[ReplacementPartRowRef<'_>],
+) -> Result<EncodedReplacementPart, LixError> {
+    encode_replacement_part_with_compressor(rows, &mut None)
+}
+
+pub(crate) fn encode_replacement_part_with_compressor(
+    rows: &[ReplacementPartRowRef<'_>],
+    compressor: &mut Option<crate::compression::ZstdLevel1Compressor>,
+) -> Result<EncodedReplacementPart, LixError> {
+    if rows.is_empty() || rows.len() > REPLACEMENT_PART_MAX_ROWS {
+        return Err(replacement_part_error(format!(
+            "replacement part row count must be in 1..={REPLACEMENT_PART_MAX_ROWS}"
+        )));
+    }
+    if rows.iter().any(|row| {
+        row.encoded_key.is_empty() || row.encoded_key.len() > REPLACEMENT_PART_TARGET_BYTES
+    }) || rows
+        .windows(2)
+        .any(|pair| pair[0].encoded_key >= pair[1].encoded_key)
+    {
+        return Err(replacement_part_error(
+            "replacement part keys must be non-empty, bounded, and strictly ordered",
+        ));
+    }
+    let mut encoded =
+        Vec::with_capacity(REPLACEMENT_PART_MAGIC.len() + 2 + rows.len().saturating_mul(16));
+    encoded.extend_from_slice(REPLACEMENT_PART_MAGIC);
+    encoded.extend_from_slice(
+        &u16::try_from(rows.len())
+            .expect("replacement part row count fits u16")
+            .to_be_bytes(),
+    );
+    let mut previous_key = &[][..];
+    for row in rows {
+        let shared = previous_key
+            .iter()
+            .zip(row.encoded_key)
+            .take_while(|(left, right)| left == right)
+            .count();
+        let suffix = &row.encoded_key[shared..];
+        encoded.extend_from_slice(
+            &u16::try_from(shared)
+                .map_err(|_| replacement_part_error("replacement key prefix exceeds u16"))?
+                .to_be_bytes(),
+        );
+        encoded.extend_from_slice(
+            &u16::try_from(suffix.len())
+                .map_err(|_| replacement_part_error("replacement key suffix exceeds u16"))?
+                .to_be_bytes(),
+        );
+        encoded.extend_from_slice(suffix);
+        encode_json_slot(&mut encoded, row.snapshot, true)?;
+        encode_json_slot(&mut encoded, row.metadata, false)?;
+        previous_key = row.encoded_key;
+    }
+    if encoded.len() > REPLACEMENT_PART_MAX_DECODED_BYTES {
+        return Err(replacement_part_error(
+            "replacement part exceeds its decoded byte bound",
+        ));
+    }
+    if encoded.len() >= 1024 {
+        if compressor.is_none() {
+            *compressor = Some(crate::compression::ZstdLevel1Compressor::new().map_err(
+                |error| replacement_part_error(format!("replacement compressor failed: {error}")),
+            )?);
+        }
+        let compressed = compressor
+            .as_mut()
+            .expect("replacement compressor was initialized")
+            .compress(&encoded)
+            .map_err(|error| {
+                replacement_part_error(format!("replacement part compression failed: {error}"))
+            })?;
+        let mut physical = Vec::with_capacity(12 + compressed.len());
+        physical.extend_from_slice(REPLACEMENT_PART_COMPRESSED_MAGIC);
+        physical.extend_from_slice(
+            &u32::try_from(encoded.len())
+                .expect("decoded replacement part is bounded below u32")
+                .to_be_bytes(),
+        );
+        physical.extend_from_slice(&compressed);
+        if physical.len() < encoded.len() {
+            encoded = physical;
+        }
+    }
+    if encoded.len() > REPLACEMENT_PART_MAX_BYTES {
+        return Err(replacement_part_error(format!(
+            "replacement part exceeds {REPLACEMENT_PART_MAX_BYTES} physical bytes"
+        )));
+    }
+    let digest = domain_digest(REPLACEMENT_PART_DIGEST_CONTEXT, &encoded);
+    Ok(EncodedReplacementPart {
+        digest,
+        bytes: Bytes::from(encoded),
+        first_key: Bytes::copy_from_slice(
+            rows.first()
+                .expect("non-empty replacement rows have a first key")
+                .encoded_key,
+        ),
+        last_key: Bytes::copy_from_slice(
+            rows.last()
+                .expect("non-empty replacement rows have a last key")
+                .encoded_key,
+        ),
+        row_count: u16::try_from(rows.len()).expect("replacement part row count fits u16"),
+    })
+}
+
+pub(crate) fn decode_replacement_part(
+    expected_digest: &[u8; DIGEST_BYTES],
+    encoded: &[u8],
+) -> Result<DecodedReplacementPart, LixError> {
+    if encoded.len() > REPLACEMENT_PART_MAX_BYTES {
+        return Err(replacement_part_error(
+            "replacement part exceeds its physical byte bound",
+        ));
+    }
+    if &domain_digest(REPLACEMENT_PART_DIGEST_CONTEXT, encoded) != expected_digest {
+        return Err(replacement_part_error(
+            "replacement part content digest mismatch",
+        ));
+    }
+    let logical: Cow<'_, [u8]> = if let Some(compressed) =
+        encoded.strip_prefix(REPLACEMENT_PART_COMPRESSED_MAGIC)
+    {
+        let (uncompressed_len, compressed) = compressed
+            .split_at_checked(4)
+            .ok_or_else(|| replacement_part_error("compressed replacement part is truncated"))?;
+        let uncompressed_len = usize::try_from(u32::from_be_bytes(
+            uncompressed_len
+                .try_into()
+                .expect("four decoded-length bytes"),
+        ))
+        .expect("u32 fits usize");
+        if uncompressed_len > REPLACEMENT_PART_MAX_DECODED_BYTES {
+            return Err(replacement_part_error(
+                "compressed replacement part exceeds its decoded byte bound",
+            ));
+        }
+        let decoded =
+            crate::compression::decompress_zstd(compressed, uncompressed_len).map_err(|error| {
+                replacement_part_error(format!("replacement part decompression failed: {error}"))
+            })?;
+        Cow::Owned(decoded)
+    } else {
+        Cow::Borrowed(encoded)
+    };
+    let Some(body) = logical.strip_prefix(REPLACEMENT_PART_MAGIC) else {
+        return Err(replacement_part_error("replacement part has invalid magic"));
+    };
+    let mut cursor = 0usize;
+    let row_count = usize::from(decode_u16(body, &mut cursor)?);
+    if row_count == 0 || row_count > REPLACEMENT_PART_MAX_ROWS {
+        return Err(replacement_part_error(
+            "replacement part has an invalid row count",
+        ));
+    }
+    let mut key_arena = Vec::new();
+    let mut key_ranges = Vec::with_capacity(row_count);
+    let mut snapshots = Vec::with_capacity(row_count);
+    let mut metadata = Vec::with_capacity(row_count);
+    let mut previous_key = Vec::new();
+    for _ in 0..row_count {
+        let shared = usize::from(decode_u16(body, &mut cursor)?);
+        let suffix_len = usize::from(decode_u16(body, &mut cursor)?);
+        if shared > previous_key.len() {
+            return Err(replacement_part_error(
+                "replacement part key prefix exceeds the previous key",
+            ));
+        }
+        let suffix = take_exact(body, &mut cursor, suffix_len)?;
+        let mut key = Vec::with_capacity(shared + suffix_len);
+        key.extend_from_slice(&previous_key[..shared]);
+        key.extend_from_slice(suffix);
+        if key.is_empty() || (!previous_key.is_empty() && previous_key >= key) {
+            return Err(replacement_part_error(
+                "replacement part keys are not strictly ordered",
+            ));
+        }
+        let start = key_arena.len();
+        key_arena.extend_from_slice(&key);
+        key_ranges.push(start..key_arena.len());
+        snapshots.push(decode_json_slot(body, &mut cursor, true)?);
+        metadata.push(decode_json_slot(body, &mut cursor, false)?);
+        previous_key = key;
+    }
+    if cursor != body.len() {
+        return Err(replacement_part_error(
+            "replacement part has trailing bytes",
+        ));
+    }
+    Ok(DecodedReplacementPart {
+        key_arena: Bytes::from(key_arena),
+        key_ranges,
+        snapshots,
+        metadata,
+    })
+}
+
+pub(crate) fn decode_replacement_part_for_entry(
+    entry: &ReplacementPartDirectoryEntry,
+    encoded: &[u8],
+) -> Result<DecodedReplacementPart, LixError> {
+    let decoded = decode_replacement_part(entry.digest(), encoded)?;
+    if decoded.len() != usize::from(entry.row_count)
+        || decoded.first_key() != Some(entry.first_key())
+        || decoded.last_key() != Some(entry.last_key())
+    {
+        return Err(replacement_part_error(
+            "replacement part does not match its directory entry",
+        ));
+    }
+    Ok(decoded)
+}
+
+fn domain_digest(context: &str, encoded: &[u8]) -> [u8; DIGEST_BYTES] {
+    let mut hasher = blake3::Hasher::new_derive_key(context);
+    hasher.update(encoded);
+    *hasher.finalize().as_bytes()
+}
+
+fn encode_sized_bytes(out: &mut Vec<u8>, bytes: &[u8]) -> Result<(), LixError> {
+    let len = u32::try_from(bytes.len())
+        .map_err(|_| replacement_part_error("replacement directory key exceeds u32"))?;
+    out.extend_from_slice(&len.to_be_bytes());
+    out.extend_from_slice(bytes);
+    Ok(())
+}
+
+fn encode_u32_bytes(out: &mut Vec<u8>, bytes: &[u8]) -> Result<(), LixError> {
+    let len = u32::try_from(bytes.len())
+        .map_err(|_| replacement_part_error("replacement payload exceeds u32"))?;
+    out.extend_from_slice(&len.to_be_bytes());
+    out.extend_from_slice(bytes);
+    Ok(())
+}
+
+fn encode_json_slot(
+    out: &mut Vec<u8>,
+    slot: crate::json_store::JsonSlotRef<'_>,
+    required: bool,
+) -> Result<(), LixError> {
+    match slot {
+        crate::json_store::JsonSlotRef::None if required => Err(replacement_part_error(
+            "replacement snapshot payload is missing",
+        )),
+        crate::json_store::JsonSlotRef::None => {
+            out.push(0);
+            Ok(())
+        }
+        crate::json_store::JsonSlotRef::Ref(json_ref) => {
+            out.push(1);
+            out.extend_from_slice(json_ref.as_hash_bytes());
+            Ok(())
+        }
+        crate::json_store::JsonSlotRef::Inline(json) => {
+            out.push(2);
+            encode_u32_bytes(out, json.as_bytes())
+        }
+    }
+}
+
+fn decode_json_slot(
+    encoded: &[u8],
+    cursor: &mut usize,
+    required: bool,
+) -> Result<crate::json_store::JsonSlot, LixError> {
+    let tag = *take_exact(encoded, cursor, 1)?
+        .first()
+        .expect("one tag byte");
+    match tag {
+        0 if required => Err(replacement_part_error(
+            "replacement snapshot payload is missing",
+        )),
+        0 => Ok(crate::json_store::JsonSlot::None),
+        1 => Ok(crate::json_store::JsonSlot::Ref(
+            crate::json_store::JsonRef::from_hash_bytes(
+                take_exact(encoded, cursor, 32)?
+                    .try_into()
+                    .expect("JSON reference width checked"),
+            ),
+        )),
+        2 => {
+            let bytes = decode_u32_bytes(encoded, cursor)?;
+            let json = std::str::from_utf8(bytes)
+                .map_err(|_| replacement_part_error("replacement inline JSON is not UTF-8"))?;
+            Ok(crate::json_store::JsonSlot::Inline(json.to_owned().into()))
+        }
+        _ => Err(replacement_part_error(
+            "replacement JSON slot has an invalid tag",
+        )),
+    }
+}
+
+fn decode_u32_bytes<'a>(encoded: &'a [u8], cursor: &mut usize) -> Result<&'a [u8], LixError> {
+    let len = usize::try_from(decode_u32(encoded, cursor)?).expect("u32 length fits usize");
+    take_exact(encoded, cursor, len)
+}
+
+fn decode_sized_bytes<'a>(encoded: &'a [u8], cursor: &mut usize) -> Result<&'a [u8], LixError> {
+    let len = usize::try_from(decode_u32(encoded, cursor)?).expect("u32 key length fits usize");
+    if len == 0 || len > REPLACEMENT_PART_TARGET_BYTES {
+        return Err(replacement_part_error(
+            "replacement directory key has invalid length",
+        ));
+    }
+    take_exact(encoded, cursor, len)
+}
+
+fn decode_u16(encoded: &[u8], cursor: &mut usize) -> Result<u16, LixError> {
+    Ok(u16::from_be_bytes(
+        take_exact(encoded, cursor, 2)?
+            .try_into()
+            .expect("u16 width checked"),
+    ))
+}
+
+fn decode_u32(encoded: &[u8], cursor: &mut usize) -> Result<u32, LixError> {
+    Ok(u32::from_be_bytes(
+        take_exact(encoded, cursor, 4)?
+            .try_into()
+            .expect("u32 width checked"),
+    ))
+}
+
+fn take_exact<'a>(encoded: &'a [u8], cursor: &mut usize, len: usize) -> Result<&'a [u8], LixError> {
+    let end = cursor
+        .checked_add(len)
+        .ok_or_else(|| replacement_part_error("replacement codec offset overflows"))?;
+    let bytes = encoded
+        .get(*cursor..end)
+        .ok_or_else(|| replacement_part_error("replacement codec value is truncated"))?;
+    *cursor = end;
+    Ok(bytes)
+}
+
+fn replacement_part_error(message: impl Into<String>) -> LixError {
+    LixError::new(
+        LixError::CODE_INTERNAL_ERROR,
+        format!("tracked_state replacement part: {}", message.into()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ReplacementPartDirectory, ReplacementPartRowRef, decode_replacement_part,
+        decode_replacement_part_for_entry, encode_replacement_part,
+    };
+
+    fn rows<'a>(keys: &'a [&'a [u8]]) -> Vec<ReplacementPartRowRef<'a>> {
+        keys.iter()
+            .map(|key| ReplacementPartRowRef {
+                encoded_key: key,
+                snapshot: crate::json_store::JsonSlotRef::Inline("{}"),
+                metadata: crate::json_store::JsonSlotRef::None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn part_round_trips_exact_points_and_rejects_wrong_digest() {
+        let encoded = encode_replacement_part(&rows(&[b"alpha", b"beta", b"gamma"]))
+            .expect("encode replacement part");
+        let decoded = decode_replacement_part(encoded.digest(), encoded.bytes())
+            .expect("decode replacement part");
+        assert_eq!(decoded.len(), 3);
+        assert_eq!(decoded.first_key(), Some(b"alpha".as_slice()));
+        assert_eq!(decoded.last_key(), Some(b"gamma".as_slice()));
+        assert_eq!(
+            decoded.find(b"beta").expect("point lookup"),
+            Some(super::ReplacementPartMatch { ordinal: 1 })
+        );
+        assert_eq!(decoded.find(b"delta").expect("missing point"), None);
+
+        let mut wrong_digest = *encoded.digest();
+        wrong_digest[0] ^= 1;
+        assert!(decode_replacement_part(&wrong_digest, encoded.bytes()).is_err());
+    }
+
+    #[test]
+    fn part_rejects_unsorted_rows_and_physical_corruption() {
+        assert!(encode_replacement_part(&rows(&[b"beta", b"alpha"])).is_err());
+        let encoded =
+            encode_replacement_part(&rows(&[b"alpha", b"beta"])).expect("encode replacement part");
+        let mut corrupt = encoded.bytes().to_vec();
+        let last = corrupt.last_mut().expect("encoded part is non-empty");
+        *last ^= 1;
+        assert!(decode_replacement_part(encoded.digest(), &corrupt).is_err());
+    }
+
+    #[test]
+    fn part_preserves_content_references_without_inlining_payloads() {
+        let snapshot_ref = crate::json_store::JsonRef::for_content(&vec![b'x'; 8 * 1024 * 1024]);
+        let metadata_ref = crate::json_store::JsonRef::for_content(&vec![b'y'; 2 * 1024 * 1024]);
+        let rows = [ReplacementPartRowRef {
+            encoded_key: b"alpha",
+            snapshot: crate::json_store::JsonSlotRef::Ref(&snapshot_ref),
+            metadata: crate::json_store::JsonSlotRef::Ref(&metadata_ref),
+        }];
+        let encoded = encode_replacement_part(&rows).expect("encode referenced replacement part");
+        assert!(encoded.bytes().len() < 256);
+        let decoded = decode_replacement_part(encoded.digest(), encoded.bytes())
+            .expect("decode referenced replacement part");
+        assert_eq!(
+            decoded.snapshot(0).expect("snapshot slot"),
+            Some(crate::json_store::JsonSlotRef::Ref(&snapshot_ref))
+        );
+        assert_eq!(
+            decoded.metadata(0).expect("metadata slot"),
+            Some(crate::json_store::JsonSlotRef::Ref(&metadata_ref))
+        );
+    }
+
+    #[test]
+    fn directory_round_trips_and_routes_points_ordinals_and_ranges() {
+        let first =
+            encode_replacement_part(&rows(&[b"alpha", b"beta"])).expect("encode first part");
+        let second =
+            encode_replacement_part(&rows(&[b"delta", b"omega"])).expect("encode second part");
+        let directory = ReplacementPartDirectory::try_new(
+            vec![first.directory_entry(0), second.directory_entry(2)],
+            4,
+        )
+        .expect("build directory");
+        let encoded = directory.encode().expect("encode directory");
+        let decoded = ReplacementPartDirectory::decode(&encoded).expect("decode directory");
+        assert_eq!(decoded, directory);
+        assert_eq!(
+            decoded.digest().expect("directory digest"),
+            directory.digest().unwrap()
+        );
+        assert_eq!(
+            decoded.route_key(b"beta").expect("beta route").digest(),
+            first.digest()
+        );
+        assert!(decoded.route_key(b"charlie").is_none());
+        let ordinal = decoded.route_ordinal(3).expect("ordinal route");
+        assert_eq!(ordinal.entry.digest(), second.digest());
+        assert_eq!(ordinal.local_ordinal, 1);
+        assert!(decoded.route_ordinal(4).is_none());
+        assert_eq!(
+            decoded.parts_overlapping(Some(b"beta"), Some(b"omega")),
+            0..2
+        );
+        assert_eq!(
+            decoded.parts_overlapping(Some(b"charlie"), Some(b"delta")),
+            1..1
+        );
+        assert_eq!(decoded.parts_overlapping(Some(b"delta"), None), 1..2);
+    }
+
+    #[test]
+    fn directory_rejects_gaps_overlaps_and_tampering() {
+        let first =
+            encode_replacement_part(&rows(&[b"alpha", b"beta"])).expect("encode first part");
+        let overlapping =
+            encode_replacement_part(&rows(&[b"beta", b"delta"])).expect("encode overlapping part");
+        assert!(
+            ReplacementPartDirectory::try_new(
+                vec![first.directory_entry(0), overlapping.directory_entry(2)],
+                4,
+            )
+            .is_err()
+        );
+
+        let second =
+            encode_replacement_part(&rows(&[b"delta", b"omega"])).expect("encode second part");
+        assert!(
+            ReplacementPartDirectory::try_new(
+                vec![first.directory_entry(0), second.directory_entry(3)],
+                4,
+            )
+            .is_err()
+        );
+        let directory = ReplacementPartDirectory::try_new(
+            vec![first.directory_entry(0), second.directory_entry(2)],
+            4,
+        )
+        .expect("build directory");
+        let mut encoded = directory.encode().expect("encode directory").to_vec();
+        encoded.push(0);
+        assert!(ReplacementPartDirectory::decode(&encoded).is_err());
+
+        let encoded = directory.encode().expect("encode directory");
+        let mut wrong_digest = directory.digest().expect("directory digest");
+        wrong_digest[0] ^= 1;
+        assert!(
+            ReplacementPartDirectory::decode_content_addressed(&wrong_digest, &encoded).is_err()
+        );
+
+        let mut wrong_bounds = first.directory_entry(0);
+        wrong_bounds.last_key = b"charlie".as_slice().into();
+        assert!(decode_replacement_part_for_entry(&wrong_bounds, first.bytes()).is_err());
+    }
+}

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -38,9 +38,9 @@ use futures_util::{StreamExt, TryStreamExt, stream};
 pub(crate) const TRACKED_STATE_TREE_CHUNK_NAMESPACE: &str = "tracked_state.tree_chunk";
 pub(crate) const TRACKED_STATE_COMMIT_ROOT_NAMESPACE: &str = "tracked_state.commit_root";
 pub(crate) const TRACKED_STATE_COMMIT_DELTA_MANIFEST_NAMESPACE: &str =
-    "tracked_state.commit_delta_manifest.v5";
+    "tracked_state.commit_delta_manifest.v6";
 pub(crate) const TRACKED_STATE_COMMIT_DELTA_SEGMENT_NAMESPACE: &str =
-    "tracked_state.commit_delta_segment.v5";
+    "tracked_state.commit_delta_segment.v6";
 pub(crate) const TRACKED_STATE_CHANGE_LOCATOR_NAMESPACE: &str = "tracked_state.change_locator.v2";
 pub(crate) const TRACKED_STATE_TREE_CHUNK_SPACE: StorageSpace = StorageSpace::mutable(
     StorageSpaceId(0x0004_0001),
@@ -59,7 +59,7 @@ pub(crate) const TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE: StorageSpace = Stora
     StorageSpaceId(0x0004_0019),
     TRACKED_STATE_COMMIT_DELTA_MANIFEST_NAMESPACE,
 );
-pub(crate) const TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE: StorageSpace = StorageSpace::mutable(
+pub(crate) const TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE: StorageSpace = StorageSpace::immutable(
     StorageSpaceId(0x0004_001a),
     TRACKED_STATE_COMMIT_DELTA_SEGMENT_NAMESPACE,
 );
@@ -76,10 +76,10 @@ const COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 512;
 const GENERIC_COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 128;
 const GENERIC_COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 28 * 1024;
 const ORDERED_COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 64 * 1024;
-// Version 12 authenticates authoritative collection-replacement metadata and
-// binds it to its owning commit. Reject version 11 as a whole: accepting an
-// unauthenticated fallback could inherit unrelated state from another commit.
-const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD12";
+// Version 13 hard-cuts certified complete replacements to bounded identity
+// parts backed by one immutable columnar generation. Older manifests cannot
+// express that authority and are intentionally rejected.
+const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD13";
 const COMMIT_DELTA_PAYLOAD_OFFSET_BYTES: usize = size_of::<u32>();
 #[cfg(not(test))]
 const COMMIT_DELTA_MAX_SIDECAR_BYTES: usize = 64 * 1024 * 1024;
@@ -232,6 +232,13 @@ enum CommitDeltaPayloadLayout {
 
 type CommitDeltaPayloadIndexRef<'a> = CommitDeltaPayloadIndex<Cow<'a, [u8]>>;
 type OwnedCommitDeltaPayloadIndex = CommitDeltaPayloadIndex<Bytes>;
+
+fn replacement_payload_error(message: &str) -> LixError {
+    LixError::new(
+        LixError::CODE_INTERNAL_ERROR,
+        format!("tracked_state replacement {message}"),
+    )
+}
 
 impl<S> CommitDeltaPayloadIndex<S>
 where
@@ -527,6 +534,7 @@ impl CommitDeltaMember {
 pub(crate) struct CommitDeltaInventoryEntry {
     pub(crate) members: Vec<CommitDeltaMember>,
     pub(crate) segment_count: usize,
+    physical_segment_keys: Vec<Vec<u8>>,
     pub(crate) selected_source_commit_id: Option<CommitId>,
 }
 
@@ -538,6 +546,7 @@ pub(crate) struct CommitDeltaInventory {
 struct CommitDeltaPlane {
     manifests: BTreeMap<CommitId, CommitDeltaManifest>,
     segments: BTreeMap<CommitId, BTreeMap<usize, Bytes>>,
+    segment_keys: BTreeMap<CommitId, BTreeMap<usize, Bytes>>,
 }
 
 // Version the root metadata independently of storage backends. Version 3 is a
@@ -568,6 +577,8 @@ struct CommitDeltaManifest {
     lifecycle_summary: Option<CommitDeltaLifecycleSummary>,
     #[musli(with = storage_codec::option)]
     replacement_generation: Option<StoredCommitDeltaReplacementGeneration>,
+    #[musli(with = storage_codec::option)]
+    replacement_parts: Option<StoredReplacementPartsAuthority>,
     /// A complete leaf payload for a commit that fits in one segment. Keeping
     /// it in the directory preserves the one-record shape of tiny commits;
     /// larger commits use the indexed segment list below.
@@ -602,6 +613,13 @@ struct StoredCommitDeltaReplacementGeneration {
     integrity_digest: [u8; 32],
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+struct StoredReplacementPartsAuthority {
+    directory_digest: [u8; 32],
+    uniform_updated_at: crate::common::LixTimestamp,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CommitDeltaReplacementGeneration {
     pub(crate) scope: CommitDeltaReplacementScope,
@@ -632,6 +650,18 @@ struct CommitDeltaSegmentBounds {
     first_key: Vec<u8>,
     #[musli(bytes)]
     last_key: Vec<u8>,
+    #[musli(with = storage_codec::option)]
+    replacement_part: Option<StoredReplacementPart>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+struct StoredReplacementPart {
+    content_digest: [u8; 32],
+    owner_commit_id: [u8; 16],
+    first_address: u32,
+    uniform_created_at: crate::common::LixTimestamp,
+    uniform_updated_at: crate::common::LixTimestamp,
 }
 
 #[derive(Debug)]
@@ -1219,6 +1249,18 @@ fn commit_delta_segment_key(
     Ok(encoded)
 }
 
+fn commit_delta_segment_key_for_bounds(
+    commit_id: CommitId,
+    segment_index: usize,
+    bounds: &CommitDeltaSegmentBounds,
+) -> Result<Vec<u8>, LixError> {
+    let mut encoded = commit_delta_segment_key(commit_id, segment_index)?;
+    if let Some(part) = bounds.replacement_part.as_ref() {
+        encoded.extend_from_slice(&part.content_digest);
+    }
+    Ok(encoded)
+}
+
 pub(crate) async fn load_commit_root(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: &str,
@@ -1327,7 +1369,6 @@ pub(crate) fn stage_ordered_addressable_commit_deltas<'a, I>(
     deltas: I,
     order_certified: bool,
     publish_lifecycle_summary: bool,
-    replacement_generation: Option<&CommitDeltaReplacementGeneration>,
 ) -> Result<Option<OrderedAddressableCommitDeltaStage>, LixError>
 where
     I: ExactSizeIterator<Item = Result<TrackedStateCommitDeltaRef<'a>, LixError>> + Clone,
@@ -1368,9 +1409,7 @@ where
         }
     }
 
-    let lifecycle_summary = if let Some(generation) = replacement_generation {
-        Some(generation.lifecycle_summary.clone())
-    } else if publish_lifecycle_summary {
+    let lifecycle_summary = if publish_lifecycle_summary {
         lifecycle_summary_for_ordered_deltas(deltas.clone())?
     } else {
         None
@@ -1393,8 +1432,8 @@ where
         ),
         single_partition: None,
         lifecycle_summary,
-        replacement_generation: replacement_generation
-            .map(|generation| stored_replacement_generation(commit_id, generation)),
+        replacement_generation: None,
+        replacement_parts: None,
         inline_segment: Vec::new(),
         segments: Vec::with_capacity(row_count.div_ceil(COMMIT_DELTA_SEGMENT_MAX_ROWS)),
     };
@@ -1529,6 +1568,249 @@ where
     }))
 }
 
+/// Publishes a complete replacement as compact immutable identity parts.
+/// Parts own identity routing and JSON authority: small values are inline and
+/// large values remain content-addressed references into the JSON store.
+pub(crate) fn stage_ordered_addressable_replacement_parts<'a, I>(
+    writes: &mut StorageWriteSet,
+    deltas: I,
+    generation: &CommitDeltaReplacementGeneration,
+) -> Result<OrderedAddressableCommitDeltaStage, LixError>
+where
+    I: ExactSizeIterator<Item = Result<TrackedStateCommitDeltaRef<'a>, LixError>>,
+{
+    struct OwnedRow {
+        key: Vec<u8>,
+        snapshot: crate::json_store::JsonSlot,
+        metadata: crate::json_store::JsonSlot,
+    }
+
+    let row_count = deltas.len();
+    if row_count == 0 {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state replacement generation cannot be empty",
+        ));
+    }
+    let _span = tracing::debug_span!(
+        target: "lix_perf",
+        "lix.perf.materialization.commit_delta.replacement_parts",
+        row_count
+    )
+    .entered();
+    let mut commit_id = None;
+    let mut uniform_updated_at = None;
+    let mut previous_key = Vec::new();
+    let mut pending = Vec::with_capacity(COMMIT_DELTA_SEGMENT_MAX_ROWS);
+    let mut parts = Vec::with_capacity(row_count.div_ceil(COMMIT_DELTA_SEGMENT_MAX_ROWS));
+    let mut compressor = None;
+    for delta in deltas {
+        let delta = delta?;
+        if delta.delta.deleted
+            || !delta.authored
+            || delta.origin_key.is_some()
+            || delta.delta.created_at != generation.lifecycle_summary.uniform_created_at
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state replacement member violates immutable replacement invariants",
+            ));
+        }
+        let own_slot = |slot| match slot {
+            crate::json_store::JsonSlotRef::None => crate::json_store::JsonSlot::None,
+            crate::json_store::JsonSlotRef::Ref(json_ref) => {
+                crate::json_store::JsonSlot::Ref(*json_ref)
+            }
+            crate::json_store::JsonSlotRef::Inline(json) => {
+                crate::json_store::JsonSlot::Inline(json.into())
+            }
+        };
+        let snapshot = own_slot(delta.snapshot);
+        if snapshot.is_none() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state replacement member has no canonical snapshot",
+            ));
+        }
+        let metadata = own_slot(delta.metadata);
+        if commit_id
+            .replace(delta.delta.commit_id)
+            .is_some_and(|owner| owner != delta.delta.commit_id)
+            || uniform_updated_at
+                .replace(delta.delta.updated_at)
+                .is_some_and(|timestamp| timestamp != delta.delta.updated_at)
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state replacement members have nonuniform owner or timestamp",
+            ));
+        }
+        let key = encode_key_ref(TrackedStateKeyRef {
+            schema_key: delta.delta.schema_key,
+            file_id: delta.delta.file_id,
+            entity_pk: delta.delta.entity_pk,
+        });
+        if !previous_key.is_empty() && previous_key >= key {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state replacement members are not in canonical identity order",
+            ));
+        }
+        previous_key.clear();
+        previous_key.extend_from_slice(&key);
+        pending.push(OwnedRow {
+            key,
+            snapshot: snapshot.to_owned(),
+            metadata,
+        });
+        if pending.len() == COMMIT_DELTA_SEGMENT_MAX_ROWS {
+            encode_replacement_part_prefix(&mut pending, &mut parts, &mut compressor)?;
+        }
+    }
+    let commit_id = commit_id.expect("non-empty replacement has an owner");
+    addressable_change_id(commit_id, 0, 0)?;
+    let uniform_updated_at = uniform_updated_at.expect("non-empty replacement has a timestamp");
+
+    while !pending.is_empty() {
+        encode_replacement_part_prefix(&mut pending, &mut parts, &mut compressor)?;
+    }
+
+    fn encode_replacement_part_prefix(
+        pending: &mut Vec<OwnedRow>,
+        parts: &mut Vec<crate::tracked_state::replacement_part::EncodedReplacementPart>,
+        compressor: &mut Option<crate::compression::ZstdLevel1Compressor>,
+    ) -> Result<(), LixError> {
+        let mut candidate_len = pending.len().min(COMMIT_DELTA_SEGMENT_MAX_ROWS);
+        let encoded = loop {
+            let refs = pending[..candidate_len]
+                .iter()
+                .map(
+                    |row| crate::tracked_state::replacement_part::ReplacementPartRowRef {
+                        encoded_key: &row.key,
+                        snapshot: row.snapshot.as_ref_slot(),
+                        metadata: row.metadata.as_ref_slot(),
+                    },
+                )
+                .collect::<Vec<_>>();
+            match crate::tracked_state::replacement_part::encode_replacement_part_with_compressor(
+                &refs, compressor,
+            ) {
+                Ok(encoded)
+                    if encoded.bytes().len()
+                        <= crate::tracked_state::replacement_part::REPLACEMENT_PART_TARGET_BYTES
+                        || candidate_len == 1 =>
+                {
+                    break encoded;
+                }
+                Ok(_) => candidate_len = candidate_len.div_ceil(2),
+                Err(_) if candidate_len > 1 => candidate_len = candidate_len.div_ceil(2),
+                Err(error) => return Err(error),
+            }
+        };
+        parts.push(encoded);
+        pending.drain(..candidate_len);
+        Ok(())
+    }
+
+    let mut first_ordinal = 0u32;
+    let directory_entries = parts
+        .iter()
+        .map(|part| {
+            let entry = part.directory_entry(first_ordinal);
+            first_ordinal = first_ordinal
+                .checked_add(u32::from(part.row_count()))
+                .expect("replacement row count fits u32");
+            entry
+        })
+        .collect::<Vec<_>>();
+    let directory = crate::tracked_state::replacement_part::ReplacementPartDirectory::try_new(
+        directory_entries,
+        u32::try_from(row_count).map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state replacement row count exceeds u32",
+            )
+        })?,
+    )?;
+    let authority = StoredReplacementPartsAuthority {
+        directory_digest: directory.digest()?,
+        uniform_updated_at,
+    };
+    let mut manifest = CommitDeltaManifest {
+        selected_source_commit_id: None,
+        member_count: u32::try_from(row_count).expect("replacement row count was bounded"),
+        selection_fingerprint: [0; 32],
+        direct_segment_row_counts: Vec::with_capacity(parts.len()),
+        single_partition: Some(generation.scope.clone()),
+        lifecycle_summary: Some(generation.lifecycle_summary.clone()),
+        replacement_generation: Some(stored_replacement_generation(
+            commit_id, generation, &authority,
+        )),
+        replacement_parts: Some(authority),
+        inline_segment: Vec::new(),
+        segments: Vec::with_capacity(parts.len()),
+    };
+    writes.reserve_space(TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE, 1, 0);
+    writes.reserve_space(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, parts.len(), 0);
+    let mut first_address = 0u32;
+    for (segment_index, part) in parts.into_iter().enumerate() {
+        manifest.direct_segment_row_counts.push(part.row_count());
+        let bounds = CommitDeltaSegmentBounds {
+            first_key: part.first_key().to_vec(),
+            last_key: part.last_key().to_vec(),
+            replacement_part: Some(StoredReplacementPart {
+                content_digest: *part.digest(),
+                owner_commit_id: *commit_id.as_uuid().as_bytes(),
+                first_address,
+                uniform_created_at: generation.lifecycle_summary.uniform_created_at,
+                uniform_updated_at,
+            }),
+        };
+        let physical_key = commit_delta_segment_key_for_bounds(commit_id, segment_index, &bounds)?;
+        manifest.segments.push(bounds);
+        writes.put(
+            TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
+            key(physical_key),
+            value(part.bytes().to_vec()),
+        );
+        first_address = u32::try_from(segment_index + 1)
+            .expect("replacement segment count fits u32")
+            .checked_mul(u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS).expect("row limit fits u32"))
+            .expect("replacement direct address fits u32");
+    }
+    writes.put(
+        TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
+        key(commit_delta_manifest_key(commit_id)),
+        value(encode_commit_delta_manifest(&manifest)?),
+    );
+
+    let dense = manifest
+        .direct_segment_row_counts
+        .iter()
+        .take(manifest.direct_segment_row_counts.len().saturating_sub(1))
+        .all(|&count| usize::from(count) == COMMIT_DELTA_SEGMENT_MAX_ROWS);
+    let change_addresses = if dense {
+        OrderedChangeAddresses::Dense
+    } else {
+        let mut packed = Vec::with_capacity(row_count);
+        for (segment_index, &rows) in manifest.direct_segment_row_counts.iter().enumerate() {
+            let base = u32::try_from(segment_index)
+                .expect("replacement segment index fits u32")
+                .checked_mul(
+                    u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS).expect("row limit fits u32"),
+                )
+                .expect("replacement direct address fits u32");
+            packed.extend((0..rows).map(|ordinal| base + u32::from(ordinal) + 1));
+        }
+        OrderedChangeAddresses::Packed(packed)
+    };
+    Ok(OrderedAddressableCommitDeltaStage {
+        commit_id,
+        change_addresses,
+        row_count,
+    })
+}
+
 fn lifecycle_summary_for_ordered_deltas<'a, I>(
     deltas: I,
 ) -> Result<Option<CommitDeltaLifecycleSummary>, LixError>
@@ -1575,6 +1857,7 @@ where
 fn stored_replacement_generation(
     owner_commit_id: CommitId,
     generation: &CommitDeltaReplacementGeneration,
+    replacement_parts: &StoredReplacementPartsAuthority,
 ) -> StoredCommitDeltaReplacementGeneration {
     let mut stored = StoredCommitDeltaReplacementGeneration {
         owner_commit_id: *owner_commit_id.as_uuid().as_bytes(),
@@ -1584,14 +1867,18 @@ fn stored_replacement_generation(
             .map(|commit_id| *commit_id.as_uuid().as_bytes()),
         integrity_digest: [0; 32],
     };
-    stored.integrity_digest =
-        replacement_generation_integrity_digest(&stored, &generation.lifecycle_summary);
+    stored.integrity_digest = replacement_generation_integrity_digest(
+        &stored,
+        &generation.lifecycle_summary,
+        replacement_parts,
+    );
     stored
 }
 
 fn replacement_generation_integrity_digest(
     generation: &StoredCommitDeltaReplacementGeneration,
     lifecycle_summary: &CommitDeltaLifecycleSummary,
+    replacement_parts: &StoredReplacementPartsAuthority,
 ) -> [u8; 32] {
     let mut digest =
         blake3::Hasher::new_derive_key("lix tracked-state replacement generation certificate v1");
@@ -1619,6 +1906,8 @@ fn replacement_generation_integrity_digest(
     }
     digest.update(&lifecycle_summary.ordered_identity_digest);
     digest.update(&lifecycle_summary.uniform_created_at.packed().to_be_bytes());
+    digest.update(&replacement_parts.directory_digest);
+    digest.update(&replacement_parts.uniform_updated_at.packed().to_be_bytes());
     *digest.finalize().as_bytes()
 }
 
@@ -1705,6 +1994,7 @@ fn encode_ordered_addressable_commit_delta_segment<'a>(
                 .expect("ordered commit-delta segment is nonempty")
                 .key
                 .to_vec(),
+            replacement_part: None,
         };
         let encoded =
             try_encode_commit_delta_segment_with_payload_refs(entries, &payloads, compressor)?;
@@ -1891,6 +2181,7 @@ fn stage_commit_deltas_inner(
                 single_partition: single_partition_for_entries(&entries)?,
                 lifecycle_summary: None,
                 replacement_generation: None,
+                replacement_parts: None,
                 inline_segment,
                 segments: Vec::new(),
             })?),
@@ -1915,6 +2206,7 @@ fn stage_commit_deltas_inner(
         single_partition: single_partition_for_entries(&entries)?,
         lifecycle_summary: None,
         replacement_generation: None,
+        replacement_parts: None,
         inline_segment: Vec::new(),
         segments: Vec::with_capacity(segment_count),
     };
@@ -1935,6 +2227,7 @@ fn stage_commit_deltas_inner(
         manifest.segments.push(CommitDeltaSegmentBounds {
             first_key,
             last_key,
+            replacement_part: None,
         });
         writes.put(
             TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
@@ -2278,8 +2571,12 @@ async fn load_change_records_at_locators(
     let segment_keys = routes
         .iter()
         .map(|&(commit_id, segment_index)| {
-            commit_delta_segment_key(commit_id, segment_index)
-                .map(|key| StorageKey(Bytes::from(key)))
+            commit_delta_segment_key_for_bounds(
+                commit_id,
+                segment_index,
+                &manifests[&commit_id].segments[segment_index],
+            )
+            .map(|key| StorageKey(Bytes::from(key)))
         })
         .collect::<Result<Vec<_>, _>>()?;
     let segment_values =
@@ -2504,9 +2801,10 @@ async fn try_load_change_record_at_locator_in_manifest(
                 ),
             )
         })?;
-        let segment_key = StorageKey(Bytes::from(commit_delta_segment_key(
+        let segment_key = StorageKey(Bytes::from(commit_delta_segment_key_for_bounds(
             locator.commit_id,
             segment_index,
+            bounds,
         )?));
         let segment = PointReadPlan::new(
             TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
@@ -2775,8 +3073,12 @@ async fn load_local_commit_delta_values_encoded(
     let storage_keys = segment_ranges
         .iter()
         .map(|&(segment_index, _, _)| {
-            commit_delta_segment_key(commit_id, segment_index)
-                .map(|key| StorageKey(Bytes::from(key)))
+            commit_delta_segment_key_for_bounds(
+                commit_id,
+                segment_index,
+                &manifest.segments[segment_index],
+            )
+            .map(|key| StorageKey(Bytes::from(key)))
         })
         .collect::<Result<Vec<_>, _>>()?;
     let result = PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, &storage_keys)
@@ -2956,8 +3258,12 @@ async fn load_commit_delta_members_from_manifest(
         let segment_keys = segment_indices
             .iter()
             .map(|&segment_index| {
-                commit_delta_segment_key(commit_id, segment_index)
-                    .map(|key| StorageKey(Bytes::from(key)))
+                commit_delta_segment_key_for_bounds(
+                    commit_id,
+                    segment_index,
+                    &manifest.segments[segment_index],
+                )
+                .map(|key| StorageKey(Bytes::from(key)))
             })
             .collect::<Result<Vec<_>, _>>()?;
         let segments = PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, &segment_keys)
@@ -3375,8 +3681,12 @@ async fn load_local_owned_commit_delta_entries(
     let segment_keys = segment_routes
         .iter()
         .map(|&(commit_id, segment_index)| {
-            commit_delta_segment_key(commit_id, segment_index)
-                .map(|key| StorageKey(Bytes::from(key)))
+            commit_delta_segment_key_for_bounds(
+                commit_id,
+                segment_index,
+                &segmented_manifests[&commit_id].segments[segment_index],
+            )
+            .map(|key| StorageKey(Bytes::from(key)))
         })
         .collect::<Result<Vec<_>, _>>()?;
     let segment_values =
@@ -3583,10 +3893,9 @@ async fn load_local_owned_commit_delta_entries_one_ordered(
                 None => {
                     decoded_segments.push(None);
                     missing_indices.push(segment_index);
-                    missing_keys.push(StorageKey(Bytes::from(commit_delta_segment_key(
-                        commit_id,
-                        segment_index,
-                    )?)));
+                    missing_keys.push(StorageKey(Bytes::from(
+                        commit_delta_segment_key_for_bounds(commit_id, segment_index, bounds)?,
+                    )));
                 }
             }
         }
@@ -3666,8 +3975,12 @@ async fn load_local_owned_commit_delta_entries_one_ordered(
     let segment_keys = segment_indices
         .iter()
         .map(|&segment_index| {
-            commit_delta_segment_key(commit_id, segment_index)
-                .map(|key| StorageKey(Bytes::from(key)))
+            commit_delta_segment_key_for_bounds(
+                commit_id,
+                segment_index,
+                &manifest.segments[segment_index],
+            )
+            .map(|key| StorageKey(Bytes::from(key)))
         })
         .collect::<Result<Vec<_>, _>>()?;
     let segment_values =
@@ -3943,8 +4256,12 @@ async fn scan_local_commit_delta_values(
     let storage_keys = segment_indices
         .iter()
         .map(|&segment_index| {
-            commit_delta_segment_key(commit_id, segment_index)
-                .map(|key| StorageKey(Bytes::from(key)))
+            commit_delta_segment_key_for_bounds(
+                commit_id,
+                segment_index,
+                &manifest.segments[segment_index],
+            )
+            .map(|key| StorageKey(Bytes::from(key)))
         })
         .collect::<Result<Vec<_>, _>>()?;
     let segments = PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, &storage_keys)
@@ -4241,10 +4558,10 @@ async fn validate_no_orphan_commit_delta_segments(
         }
         let mut commit_ids = Vec::new();
         for entry in &page.value.entries {
-            if entry.key.0.len() != 20 {
+            if entry.key.0.len() != 20 && entry.key.0.len() != 52 {
                 return Err(LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
-                    "tracked_state commit_delta segment key is not commit-id plus u32 suffix",
+                    "tracked_state commit_delta segment key is not a physical segment address",
                 ));
             }
             let commit_id = commit_id_from_delta_key(&entry.key)?;
@@ -4295,6 +4612,19 @@ async fn validate_no_orphan_commit_delta_segments(
                     ),
                 ));
             }
+            if entry.key.0.as_ref()
+                != commit_delta_segment_key_for_bounds(
+                    commit_id,
+                    segment_index,
+                    &manifest.segments[segment_index],
+                )?
+                .as_slice()
+            {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state commit_delta physical segment key does not match its manifest",
+                ));
+            }
         }
         if !page.value.has_more {
             break;
@@ -4314,10 +4644,12 @@ pub(crate) async fn scan_commit_delta_inventory(
     let CommitDeltaPlane {
         manifests,
         mut segments,
+        mut segment_keys,
     } = scan_commit_delta_plane(store).await?;
     let mut inventory = CommitDeltaInventory::default();
     for (&commit_id, manifest) in &manifests {
         let physical_segments = segments.remove(&commit_id).unwrap_or_default();
+        let physical_segment_keys = segment_keys.remove(&commit_id).unwrap_or_default();
         let segment_count = manifest.segments.len();
         let mut members = Vec::new();
         if let Some(inline_segment) = manifest.inline_segment() {
@@ -4331,7 +4663,12 @@ pub(crate) async fn scan_commit_delta_inventory(
             }
             collect_strict_commit_delta_members(inline_segment, None, commit_id, 0, &mut members)?;
         } else {
-            validate_physical_commit_delta_segments(commit_id, &manifest, &physical_segments)?;
+            validate_physical_commit_delta_segments(
+                commit_id,
+                &manifest,
+                &physical_segments,
+                &physical_segment_keys,
+            )?;
             for (segment_index, bounds) in manifest.segments.iter().enumerate() {
                 collect_strict_commit_delta_members(
                     &physical_segments[&segment_index],
@@ -4349,6 +4686,14 @@ pub(crate) async fn scan_commit_delta_inventory(
             CommitDeltaInventoryEntry {
                 members,
                 segment_count,
+                physical_segment_keys: manifest
+                    .segments
+                    .iter()
+                    .enumerate()
+                    .map(|(segment_index, bounds)| {
+                        commit_delta_segment_key_for_bounds(commit_id, segment_index, bounds)
+                    })
+                    .collect::<Result<Vec<_>, _>>()?,
                 selected_source_commit_id: manifest.selected_source_commit_id(),
             },
         );
@@ -4421,6 +4766,7 @@ pub(crate) async fn scan_commit_delta_inventory(
         }
     }
     debug_assert!(segments.is_empty());
+    debug_assert!(segment_keys.is_empty());
     Ok(inventory)
 }
 
@@ -4451,11 +4797,12 @@ async fn scan_commit_delta_plane(
     }
 
     let mut segments = BTreeMap::<CommitId, BTreeMap<usize, Bytes>>::new();
+    let mut segment_keys = BTreeMap::<CommitId, BTreeMap<usize, Bytes>>::new();
     for (key, bytes) in segment_rows {
-        if key.0.len() != 20 {
+        if key.0.len() != 20 && key.0.len() != 52 {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
-                "tracked_state commit_delta segment key is not commit-id plus u32 suffix",
+                "tracked_state commit_delta segment key is not a physical segment address",
             ));
         }
         let commit_id = commit_id_from_delta_key(&key)?;
@@ -4465,6 +4812,10 @@ async fn scan_commit_delta_plane(
                 .expect("commit-delta segment suffix length checked"),
         ))
         .expect("u32 fits usize");
+        segment_keys
+            .entry(commit_id)
+            .or_default()
+            .insert(segment_index, key.0.clone());
         if segments
             .entry(commit_id)
             .or_default()
@@ -4495,6 +4846,7 @@ async fn scan_commit_delta_plane(
     Ok(CommitDeltaPlane {
         manifests,
         segments,
+        segment_keys,
     })
 }
 
@@ -4502,6 +4854,7 @@ fn validate_physical_commit_delta_segments(
     commit_id: CommitId,
     manifest: &CommitDeltaManifest,
     physical_segments: &BTreeMap<usize, Bytes>,
+    physical_segment_keys: &BTreeMap<usize, Bytes>,
 ) -> Result<(), LixError> {
     if physical_segments.len() != manifest.segments.len() {
         return Err(LixError::new(
@@ -4523,6 +4876,19 @@ fn validate_physical_commit_delta_segments(
             ),
         ));
     }
+    for (segment_index, bounds) in manifest.segments.iter().enumerate() {
+        if physical_segment_keys.get(&segment_index).is_none_or(|key| {
+            match commit_delta_segment_key_for_bounds(commit_id, segment_index, bounds) {
+                Ok(expected) => key.as_ref() != expected.as_slice(),
+                Err(_) => true,
+            }
+        }) {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state commit_delta physical segment key does not match its manifest",
+            ));
+        }
+    }
     Ok(())
 }
 
@@ -4535,10 +4901,10 @@ pub(crate) fn stage_delete_commit_delta_inventory_entry(
         TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
         key(commit_delta_manifest_key(commit_id)),
     );
-    for segment_index in 0..entry.segment_count {
+    for segment_key in &entry.physical_segment_keys {
         writes.delete(
             TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
-            key(commit_delta_segment_key(commit_id, segment_index)?),
+            key(segment_key.clone()),
         );
     }
     Ok(())
@@ -4944,15 +5310,87 @@ fn validate_commit_delta_manifest(manifest: &CommitDeltaManifest) -> Result<(), 
             || manifest.selected_source_commit_id.is_some()
             || manifest.direct_segment_row_counts.is_empty()
             || !manifest.inline_segment.is_empty()
+            || manifest.replacement_parts.is_none()
             || manifest.lifecycle_summary.as_ref().is_none_or(|summary| {
                 generation.integrity_digest
-                    != replacement_generation_integrity_digest(generation, summary)
+                    != replacement_generation_integrity_digest(
+                        generation,
+                        summary,
+                        manifest
+                            .replacement_parts
+                            .as_ref()
+                            .expect("replacement generation requires immutable parts"),
+                    )
             }))
     {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
             "tracked_state commit_delta manifest has an invalid replacement generation",
         ));
+    }
+    match manifest.replacement_parts.as_ref() {
+        Some(authority) => {
+            if manifest.replacement_generation.is_none()
+                || manifest.inline_segment().is_some()
+                || manifest.segments.is_empty()
+                || manifest
+                    .segments
+                    .iter()
+                    .any(|bounds| bounds.replacement_part.is_none())
+            {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state replacement-part authority has an invalid manifest shape",
+                ));
+            }
+            let directory = replacement_directory_from_manifest(manifest)?;
+            if directory.digest()? != authority.directory_digest {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state replacement-part directory digest mismatch",
+                ));
+            }
+            let generation = manifest
+                .replacement_generation
+                .as_ref()
+                .expect("replacement-part authority requires a generation");
+            if manifest.segments.iter().enumerate().any(|(index, bounds)| {
+                bounds.replacement_part.as_ref().is_none_or(|part| {
+                    part.owner_commit_id != generation.owner_commit_id
+                        || part.uniform_created_at
+                            != manifest
+                                .lifecycle_summary
+                                .as_ref()
+                                .expect("replacement generation has lifecycle summary")
+                                .uniform_created_at
+                        || part.first_address
+                            != u32::try_from(index)
+                                .expect("replacement part index fits u32")
+                                .saturating_mul(
+                                    u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS)
+                                        .expect("replacement row bound fits u32"),
+                                )
+                        || part.uniform_updated_at != authority.uniform_updated_at
+                })
+            }) {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state replacement-part authority does not match its owner generation",
+                ));
+            }
+        }
+        None => {
+            if manifest
+                .segments
+                .iter()
+                .any(|bounds| bounds.replacement_part.is_some())
+            {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state commit_delta has unauthorised replacement parts",
+                ));
+            }
+        }
     }
     if !manifest.direct_segment_row_counts.is_empty() {
         if manifest.selected_source_commit_id.is_some()
@@ -5052,6 +5490,45 @@ fn validate_commit_delta_manifest(manifest: &CommitDeltaManifest) -> Result<(), 
         ));
     }
     Ok(())
+}
+
+fn replacement_directory_from_manifest(
+    manifest: &CommitDeltaManifest,
+) -> Result<crate::tracked_state::replacement_part::ReplacementPartDirectory, LixError> {
+    let mut first_ordinal = 0u32;
+    let entries = manifest
+        .segments
+        .iter()
+        .zip(&manifest.direct_segment_row_counts)
+        .map(|(bounds, &row_count)| {
+            let replacement = bounds.replacement_part.as_ref().ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state replacement directory contains a generic segment",
+                )
+            })?;
+            let entry = crate::tracked_state::replacement_part::ReplacementPartDirectoryEntry::new(
+                replacement.content_digest,
+                &bounds.first_key,
+                &bounds.last_key,
+                first_ordinal,
+                row_count,
+            );
+            first_ordinal = first_ordinal
+                .checked_add(u32::from(row_count))
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "tracked_state replacement directory ordinal overflows",
+                    )
+                })?;
+            Ok(entry)
+        })
+        .collect::<Result<Vec<_>, LixError>>()?;
+    crate::tracked_state::replacement_part::ReplacementPartDirectory::try_new(
+        entries,
+        manifest.member_count,
+    )
 }
 
 impl CommitDeltaManifest {
@@ -5464,6 +5941,11 @@ fn decode_commit_delta_leaf(
     bytes: &[u8],
     expected_bounds: Option<&CommitDeltaSegmentBounds>,
 ) -> Result<DecodedLeafNodeRef, LixError> {
+    if let Some(bounds) = expected_bounds
+        && bounds.replacement_part.is_some()
+    {
+        return decode_replacement_part_as_commit_delta(bytes, bounds).map(|(leaf, _)| leaf);
+    }
     let (leaf_bytes, _) = split_commit_delta_segment(bytes)?;
     let leaf = match decode_node_ref(leaf_bytes)? {
         DecodedNodeRef::Leaf(leaf) => leaf,
@@ -5522,6 +6004,26 @@ fn decode_commit_delta_with_payloads<'a>(
     bytes: &'a [u8],
     expected_bounds: Option<&CommitDeltaSegmentBounds>,
 ) -> Result<(DecodedLeafNodeRef, CommitDeltaPayloadIndexRef<'a>), LixError> {
+    if let Some(bounds) = expected_bounds
+        && bounds.replacement_part.is_some()
+    {
+        let (leaf, payloads) = decode_replacement_part_as_commit_delta(bytes, bounds)?;
+        let entry_count = leaf.len();
+        let directory_len = entry_count
+            .checked_add(1)
+            .and_then(|count| count.checked_mul(4))
+            .expect("bounded replacement payload directory fits usize");
+        return Ok((
+            leaf,
+            CommitDeltaPayloadIndexRef {
+                sidecar: Cow::Owned(payloads),
+                offsets: 0..directory_len,
+                payload_start: directory_len,
+                entry_count,
+                layout: CommitDeltaPayloadLayout::Indexed,
+            },
+        ));
+    }
     let (_, encoded_sidecar) = split_commit_delta_segment(bytes)?;
     let leaf = decode_commit_delta_leaf(bytes, expected_bounds)?;
     let (&encoding, encoded_sidecar) = encoded_sidecar.split_first().ok_or_else(|| {
@@ -5681,6 +6183,101 @@ fn decode_commit_delta_with_payloads<'a>(
         ));
     }
     Ok((leaf, index))
+}
+
+fn decode_replacement_part_as_commit_delta(
+    bytes: &[u8],
+    bounds: &CommitDeltaSegmentBounds,
+) -> Result<(DecodedLeafNodeRef, Vec<u8>), LixError> {
+    let replacement = bounds.replacement_part.as_ref().ok_or_else(|| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state replacement segment is missing its physical metadata",
+        )
+    })?;
+    let decoded = crate::tracked_state::replacement_part::decode_replacement_part(
+        &replacement.content_digest,
+        bytes,
+    )?;
+    if decoded.first_key() != Some(bounds.first_key.as_slice())
+        || decoded.last_key() != Some(bounds.last_key.as_slice())
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state replacement part does not match its manifest bounds",
+        ));
+    }
+    let owner_commit_id = CommitId::new(uuid::Uuid::from_bytes(replacement.owner_commit_id));
+    let mut values = Vec::with_capacity(decoded.len());
+    let mut payload_offsets = Vec::with_capacity(decoded.len() + 1);
+    let mut payload_bytes = Vec::new();
+    for ordinal in 0..decoded.len() {
+        let packed = replacement
+            .first_address
+            .checked_add(u32::try_from(ordinal).expect("replacement part ordinal fits u32"))
+            .and_then(|address| address.checked_add(1))
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state replacement change address overflows",
+                )
+            })?;
+        values.push(encode_value_ref(TrackedStateIndexValueRef {
+            change_id: change_id_from_packed_address(owner_commit_id, packed),
+            commit_id: owner_commit_id,
+            deleted: false,
+            created_at: replacement.uniform_created_at,
+            updated_at: replacement.uniform_updated_at,
+        }));
+        payload_offsets.push(
+            u32::try_from(payload_bytes.len())
+                .map_err(|_| replacement_payload_error("payload directory exceeds u32"))?,
+        );
+        let snapshot = decoded
+            .snapshot(ordinal)?
+            .ok_or_else(|| replacement_payload_error("part omitted a snapshot"))?;
+        let metadata = decoded
+            .metadata(ordinal)?
+            .ok_or_else(|| replacement_payload_error("part omitted metadata authority"))?;
+        payload_bytes.push(COMMIT_DELTA_PAYLOAD_AUTHORED);
+        storage_codec::append(
+            "tracked_state replacement authored payload",
+            &mut payload_bytes,
+            &CommitDeltaAuthoredPayloadRef {
+                snapshot,
+                metadata,
+                origin_key: None,
+                base_coordinate: None,
+            },
+        )?;
+    }
+    let entries = (0..decoded.len())
+        .map(|ordinal| {
+            Ok(EncodedLeafEntryRef {
+                key: decoded.key(ordinal)?.ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "tracked_state replacement part omitted a key",
+                    )
+                })?,
+                value: &values[ordinal],
+            })
+        })
+        .collect::<Result<Vec<_>, LixError>>()?;
+    let encoded_leaf = encode_leaf_node_refs(&entries);
+    let DecodedNodeRef::Leaf(leaf) = decode_node_ref(&encoded_leaf)? else {
+        unreachable!("replacement leaf encoder returns a leaf")
+    };
+    payload_offsets.push(
+        u32::try_from(payload_bytes.len())
+            .map_err(|_| replacement_payload_error("payload directory exceeds u32"))?,
+    );
+    let mut sidecar = Vec::with_capacity(payload_offsets.len() * 4 + payload_bytes.len());
+    for offset in payload_offsets {
+        sidecar.extend_from_slice(&offset.to_be_bytes());
+    }
+    sidecar.extend_from_slice(&payload_bytes);
+    Ok((leaf, sidecar))
 }
 
 fn validate_decoded_commit_delta_bounds(
@@ -6548,7 +7145,6 @@ mod tests {
             deltas.iter().copied().map(Ok::<_, LixError>),
             false,
             false,
-            None,
         )
         .expect("ordered addressable deltas should stage")
         .expect("sorted deltas should use the streaming route");
@@ -6677,34 +7273,14 @@ mod tests {
             })
             .collect::<Vec<_>>();
         let mut writes = storage.new_write_set();
-        let replacement_generation = super::CommitDeltaReplacementGeneration {
-            scope: super::CommitDeltaReplacementScope {
-                schema_key: "irregular".to_string(),
-                file_id: None,
-            },
-            fallback_commit_id: Some(CommitId::for_test_label("irregular-fallback")),
-            lifecycle_summary: super::CommitDeltaLifecycleSummary {
-                scope: super::CommitDeltaReplacementScope {
-                    schema_key: "irregular".to_string(),
-                    file_id: None,
-                },
-                ordered_identity_digest:
-                    crate::collection_generation::ordered_single_string_identity_digest(
-                        fixtures.iter().map(|fixture| &fixture.entity_pk),
-                    )
-                    .expect("irregular identities are single strings"),
-                uniform_created_at: fixtures[0].created_at,
-            },
-        };
         let staged = super::stage_ordered_addressable_commit_deltas(
             &mut writes,
             deltas.iter().copied().map(Ok::<_, LixError>),
             true,
             false,
-            Some(&replacement_generation),
         )
         .expect("irregular ordered deltas should stage")
-        .expect("certified ordered deltas should use the streaming route");
+        .expect("ordered deltas should use the streaming route");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
@@ -6718,13 +7294,13 @@ mod tests {
             .await
             .expect("irregular selection certificate should load")
             .expect("irregular ordered commit should have a certificate");
-        assert_eq!(
+        assert!(
             super::load_commit_delta_replay_metadata(&read, commit_id)
                 .await
-                .expect("replacement replay metadata should load")
+                .expect("replay metadata should load")
                 .expect("ordered commit has replay metadata")
-                .replacement_generation,
-            Some(replacement_generation)
+                .replacement_generation
+                .is_none()
         );
         assert!(
             certificate
@@ -6760,95 +7336,90 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn replacement_generation_certificate_rejects_corruption_and_owner_substitution() {
-        let owner_commit_id = CommitId::for_test_label("replacement-certificate-owner");
-        let substituted_commit_id = CommitId::for_test_label("replacement-certificate-substitute");
-        let scope = super::CommitDeltaReplacementScope {
-            schema_key: "replacement_certificate".to_string(),
-            file_id: None,
-        };
-        let lifecycle_summary = super::CommitDeltaLifecycleSummary {
-            scope: scope.clone(),
-            ordered_identity_digest: [7; 32],
-            uniform_created_at: LixTimestamp::from_unix_millis_utc_lossy(42),
-        };
-        let generation = super::CommitDeltaReplacementGeneration {
-            scope: scope.clone(),
-            fallback_commit_id: Some(CommitId::for_test_label("replacement-certificate-fallback")),
-            lifecycle_summary: lifecycle_summary.clone(),
-        };
-        let encoded_key = encode_key_ref(TrackedStateKeyRef {
-            schema_key: &scope.schema_key,
-            file_id: None,
-            entity_pk: &EntityPk::single("member"),
-        });
-        let manifest = CommitDeltaManifest {
-            selected_source_commit_id: None,
-            member_count: 1,
-            selection_fingerprint: [0; 32],
-            direct_segment_row_counts: vec![1],
-            single_partition: Some(scope),
-            lifecycle_summary: Some(lifecycle_summary),
-            replacement_generation: Some(super::stored_replacement_generation(
-                owner_commit_id,
-                &generation,
-            )),
-            inline_segment: Vec::new(),
-            segments: vec![super::CommitDeltaSegmentBounds {
-                first_key: encoded_key.clone(),
-                last_key: encoded_key,
-            }],
-        };
-        let encoded = encode_commit_delta_manifest(&manifest)
-            .expect("valid replacement certificate should encode");
-        super::decode_commit_delta_manifest_for_commit(&encoded, owner_commit_id)
-            .expect("valid replacement certificate should decode for its owner");
-
-        let mut corrupted_fallback = manifest.clone();
-        corrupted_fallback
-            .replacement_generation
-            .as_mut()
-            .expect("fixture has a replacement generation")
-            .fallback_commit_id = Some(*substituted_commit_id.as_uuid().as_bytes());
-        let error = decode_commit_delta_manifest(
-            &encode_commit_delta_manifest(&corrupted_fallback)
-                .expect("structurally encodable fallback corruption"),
-        )
-        .expect_err("fallback corruption must fail its integrity certificate");
-        assert!(error.message.contains("invalid replacement generation"));
-
-        let mut corrupted_lifecycle = manifest.clone();
-        corrupted_lifecycle
-            .lifecycle_summary
-            .as_mut()
-            .expect("fixture has lifecycle metadata")
-            .uniform_created_at = LixTimestamp::from_unix_millis_utc_lossy(43);
-        let error = decode_commit_delta_manifest(
-            &encode_commit_delta_manifest(&corrupted_lifecycle)
-                .expect("structurally encodable lifecycle corruption"),
-        )
-        .expect_err("lifecycle corruption must fail its integrity certificate");
-        assert!(error.message.contains("invalid replacement generation"));
-
+    async fn complete_replacement_parts_are_bounded_content_addressed_and_replay_exactly() {
         let storage = StorageAdapter::new(Memory::new());
+        let commit_id = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x0199_0000_0000_7000_8000_0000_0000_0000,
+        ));
+        let created_at = LixTimestamp::from_unix_millis_utc_lossy(11);
+        let updated_at = LixTimestamp::from_unix_millis_utc_lossy(22);
+        let fixtures = (0..1_025)
+            .map(|index| CommitDeltaFixture {
+                schema_key: "alpha".to_string(),
+                file_id: None,
+                entity_pk: EntityPk::single(format!("entity-{index:05}")),
+                change_id: ChangeId::for_test_label(&format!("ignored-{index}")),
+                deleted: false,
+                created_at,
+                updated_at,
+            })
+            .collect::<Vec<_>>();
+        let mut deltas = commit_delta_refs(commit_id, &fixtures);
+        for (index, delta) in deltas.iter_mut().enumerate() {
+            delta.snapshot = crate::json_store::JsonSlotRef::Inline("{}");
+            delta.base_coordinate = Some(TrackedStateBaseCoordinate {
+                base_commit_id: commit_id,
+                group_index: u32::try_from(index / 257).expect("fixture group fits u32"),
+                row_index: u32::try_from(index % 257).expect("fixture row fits u32"),
+            });
+        }
+        let generation = super::CommitDeltaReplacementGeneration {
+            scope: super::CommitDeltaReplacementScope {
+                schema_key: "alpha".to_string(),
+                file_id: None,
+            },
+            fallback_commit_id: None,
+            lifecycle_summary: super::CommitDeltaLifecycleSummary {
+                scope: super::CommitDeltaReplacementScope {
+                    schema_key: "alpha".to_string(),
+                    file_id: None,
+                },
+                ordered_identity_digest: [3; 32],
+                uniform_created_at: created_at,
+            },
+        };
         let mut writes = storage.new_write_set();
-        writes.put(
-            TRACKED_STATE_COMMIT_DELTA_MANIFEST_SPACE,
-            key(commit_delta_manifest_key(substituted_commit_id)),
-            value(encoded),
-        );
+        let staged = super::stage_ordered_addressable_replacement_parts(
+            &mut writes,
+            deltas.iter().copied().map(Ok),
+            &generation,
+        )
+        .expect("replacement parts should stage");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
-            .expect("substituted manifest fixture should commit");
+            .expect("replacement parts should commit atomically");
+
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
-            .expect("substituted manifest read should open");
-        let error = super::load_commit_delta_replay_metadata(&read, substituted_commit_id)
+            .expect("read should open");
+        let physical = super::scan_full_space(&read, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE)
             .await
-            .expect_err("a valid certificate stored under another commit must fail closed");
-        assert!(error.message.contains("does not belong to commit"));
+            .expect("replacement parts should scan");
+        assert_eq!(physical.len(), 3);
+        assert!(physical.iter().all(|(key, bytes)| {
+            key.0.len() == 52
+                && (bytes.starts_with(b"LXRPI003") || bytes.starts_with(b"LXRPZ003"))
+                && bytes.len() <= 64 * 1024
+        }));
+
+        let keys = [
+            fixtures[0].key(),
+            fixtures[777].key(),
+            fixtures[1_024].key(),
+        ];
+        let values = load_commit_delta_values_for_test(&read, commit_id, &keys)
+            .await
+            .expect("replacement point replay should load");
+        assert!(values.iter().all(Option::is_some));
+        let change_id = staged
+            .change_id_at(777)
+            .expect("replacement row has a direct address");
+        let change_ids = load_commit_delta_change_ids(&read, commit_id)
+            .await
+            .expect("replacement addresses should scan without hydrating payloads");
+        assert_eq!(change_ids[777], change_id);
     }
 
     #[tokio::test]
@@ -7937,6 +8508,7 @@ mod tests {
                     }),
                     lifecycle_summary: None,
                     replacement_generation: None,
+                    replacement_parts: None,
                     inline_segment: segment,
                     segments: Vec::new(),
                 })
@@ -8270,7 +8842,9 @@ mod tests {
                 if coordinate == coordinates[1]
         ));
         assert!(matches!(
-            decoded.decode(2).expect("certified coordinate should decode"),
+            decoded
+                .decode(2)
+                .expect("replacement coordinate should decode"),
             super::CommitDeltaPayload::CertifiedRef {
                 origin_key: None,
                 base_coordinate: Some(coordinate),
@@ -8874,6 +9448,7 @@ mod tests {
                     single_partition: None,
                     lifecycle_summary: None,
                     replacement_generation: None,
+                    replacement_parts: None,
                     inline_segment: encode_commit_delta_segment(&entries),
                     segments: Vec::new(),
                 })

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -1805,6 +1805,13 @@ async fn stage_tracked_commit_delta_index(
             && state_row_indices
                 .iter()
                 .all(|&row_index| state_rows.row(row_index).addressable_change_id);
+        if replacement_generations.contains_key(&root.commit_id) && !can_stream_ordered_addressable
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "complete replacement generation cannot use generic commit-delta staging",
+            ));
+        }
         if can_stream_ordered_addressable {
             let replacement_generation = replacement_generations.get(&root.commit_id);
             let lifecycle_created_at = replacement_generation
@@ -1825,7 +1832,7 @@ async fn stage_tracked_commit_delta_index(
                 )
                 .entered();
                 let state_rows = &*state_rows;
-                let deltas = state_row_indices.iter().map(|&row_index| {
+                let make_delta = |row_index| {
                     let row = state_rows.row(row_index);
                     let mut delta = tracked_commit_delta_from_state_row(row)?;
                     if let Some(created_at) = lifecycle_created_at {
@@ -1840,28 +1847,53 @@ async fn stage_tracked_commit_delta_index(
                                 row_index: location.row_index,
                             },
                         );
-                    delta.certified = root.publish_head
-                        && host_certified_batch_owns_live_row(
-                            row,
-                            &root.branch_id,
-                            root.commit_id,
-                            host_certified_file_schemas,
-                        );
+                    if replacement_generation.is_none() {
+                        delta.certified = root.publish_head
+                            && host_certified_batch_owns_live_row(
+                                row,
+                                &root.branch_id,
+                                root.commit_id,
+                                host_certified_file_schemas,
+                            );
+                    }
                     Ok(delta)
-                });
+                };
                 let order_certified = state_rows.certified_tracked_keys_strictly_ordered()
                     && state_row_indices.len() == state_rows.len()
                     && state_row_indices
                         .iter()
                         .enumerate()
                         .all(|(index, &row_index)| index == row_index);
-                stage_ordered_addressable_commit_deltas(
-                    writes,
-                    deltas,
-                    order_certified,
-                    publish_lifecycle_summary,
-                    replacement_generation,
-                )?
+                let replacement_stage = if let Some(generation) = replacement_generation {
+                    if !order_certified {
+                        return Err(LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            "complete replacement generation is not in canonical identity order",
+                        ));
+                    }
+                    Some(
+                        crate::tracked_state::stage_ordered_addressable_replacement_parts(
+                            writes,
+                            state_row_indices
+                                .iter()
+                                .map(|&row_index| make_delta(row_index)),
+                            generation,
+                        )?,
+                    )
+                } else {
+                    None
+                };
+                match replacement_stage {
+                    Some(stage) => Some(stage),
+                    None => stage_ordered_addressable_commit_deltas(
+                        writes,
+                        state_row_indices
+                            .iter()
+                            .map(|&row_index| make_delta(row_index)),
+                        order_certified,
+                        publish_lifecycle_summary,
+                    )?,
+                }
             };
             if let Some(ordered_stage) = ordered_stage {
                 state_rows.set_ordered_addressable_change_ids(state_row_indices, ordered_stage)?;
@@ -4313,14 +4345,10 @@ fn prepare_entity_columnar_write_sets(
     }
     let publishes_ordered_insert =
         insert_selection.len() == state_rows.len() && insert_selection.covers_all(state_rows.len());
-    let publishes_complete_replacement =
-        state_rows.certified_complete_collection_replacement() && insert_selection.is_empty();
-    if !publishes_ordered_insert && !publishes_complete_replacement {
+    if !publishes_ordered_insert {
         return Ok(crate::live_state::EntityColumnarWriteSets::new());
     }
-    if (publishes_ordered_insert || publishes_complete_replacement)
-        && let Some((commit_id, schema_key, snapshots)) = state_rows.dense_entity_columnar_input()
-    {
+    if let Some((commit_id, schema_key, snapshots)) = state_rows.dense_entity_columnar_input() {
         let Some(schema) = entity_schema_catalog.and_then(|catalog| catalog.schema(schema_key))
         else {
             return Ok(crate::live_state::EntityColumnarWriteSets::new());
@@ -4348,7 +4376,7 @@ fn prepare_entity_columnar_write_sets(
     }
     let mut indices = BTreeMap::<(CommitId, String), Vec<usize>>::new();
     for (index, row) in state_rows.iter().enumerate() {
-        if !publishes_complete_replacement && !insert_selection.contains(index) {
+        if !insert_selection.contains(index) {
             return Ok(crate::live_state::EntityColumnarWriteSets::new());
         }
         let (Some(commit_id), Some(_snapshot)) = (row.commit_id, row.snapshot) else {


### PR DESCRIPTION
## What changed

- hard-cut tracked-state commit deltas to v6 / `LXCD13`;
- publish complete UPDATE replacements as bounded, independently compressed immutable parts;
- bind canonical key/ordinal ranges, part digests, row count, lifecycle timestamps, and directory digest into replacement-generation authority;
- preserve large snapshots/metadata as existing content-addressed `JsonRef`s while keeping the established <=1 KiB inline class;
- decode replacement rows through the standard authored-payload codec;
- remove the bespoke replacement payload decoder, forced-inline duplication, synchronous typed Arrow sidecar construction, and generic staging fallback for certified complete replacements;
- fail hard when a certified replacement cannot satisfy ordered/addressable invariants.

No backward compatibility and no changenote: older tracked-state layouts are intentionally rejected.

## Why

The previous UPDATE path rebuilt a full typed Arrow sidecar synchronously and duplicated large JSON into replacement history. At 1M rows this dominated commit latency, allocations, RSS, and physical writes. Complete replacements are already a full-set certificate, so they can publish one manifest-bound set of immutable patch/replacement parts instead of retaining the old per-row certified-reference encoding.

## Performance

Previous PR / latest-main artifact is the baseline.

### 1M rows

| Adapter / operation | Previous | This PR | Change |
|---|---:|---:|---:|
| RocksDB UPDATE (median, 3) | 2.494 s | 1.260 s | **-49.5%** |
| RocksDB INSERT | 3.056 s | 2.189 s | **-28.4%** |
| RocksDB SELECT | 521.8 ms | 406.4 ms | **-22.1%** |
| RocksDB DELETE | 1.676 ms | 1.311 ms | **-21.8%** |
| SlateDB INSERT | 3.054 s | 2.146 s | **-29.7%** |
| SlateDB SELECT | 531.1 ms | 430.2 ms | **-19.0%** |
| SlateDB DELETE | 1.537 ms | 1.129 ms | **-26.6%** |

SlateDB UPDATE is 1.211 s. Raw SQLite UPDATE is 1.001 s (1.21x). RocksDB UPDATE is 1.26x raw SQLite; the end goal is not claimed yet.

### Resource profile, 1M RocksDB UPDATE

- allocated bytes: 2.170 GB -> 1.255 GB (**-42.2%**)
- post-update RSS: 1.104 GB -> 862 MB (**-21.9%**)
- physical write bytes: 42.57 MB -> 3.24 MB (**-92.4%**)
- physical puts: 2052 -> 2003

### 10K rows

RocksDB: INSERT -11.8%, SELECT -20.7%, UPDATE -55.3%, DELETE -5.0%.

SlateDB: INSERT -13.9%, SELECT -11.3%, UPDATE -56.3%, DELETE statistically flat (+0.1%).

## Validation

- `cargo test -p lix_engine --features all-simulations` (1,828 unit + 806 integration/simulation tests; diff/merge/branch/checkpoint/rebuild paths included)
- `cargo test -p lix_rocksdb_storage` (15 tests)
- `cargo test -p lix_slatedb_storage` (65 tests)
- `cargo test -p lix_sqlite_storage` (2 tests)
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- focused replacement codec, point replay, overlay, history, diff, and merge tests

## Follow-up

The immutable parts and canonical directory are content-addressed. Rooting the generic commit-state manifest itself is deliberately separated for the converging OLAP/read-layout work: #1160.