### PR TITLE
Eliminate replacement-handle branch switching

### DIFF
--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -117,7 +117,7 @@ pub(crate) async fn load_workspace_branch_id_from_index(
 
 #[derive(Clone)]
 pub(crate) enum SessionMode {
-    Pinned { branch_id: String },
+    Pinned { branch_id: Arc<RwLock<String>> },
     Workspace { branch_id: Arc<RwLock<String>> },
 }
 
@@ -216,7 +216,7 @@ where
     ) -> Result<Self, LixError> {
         Ok(Self::new(
             SessionMode::Pinned {
-                branch_id: active_branch_id,
+                branch_id: Arc::new(RwLock::new(active_branch_id)),
             },
             storage,
             live_state,
@@ -478,14 +478,13 @@ where
     {
         self.ensure_open()?;
         match &self.mode {
-            SessionMode::Pinned { branch_id } => Ok(branch_id.clone()),
-            SessionMode::Workspace { branch_id } => branch_id
+            SessionMode::Pinned { branch_id } | SessionMode::Workspace { branch_id } => branch_id
                 .read()
                 .map(|branch_id| branch_id.clone())
                 .map_err(|_| {
                     LixError::new(
                         LixError::CODE_INTERNAL_ERROR,
-                        "workspace branch selector cache is poisoned",
+                        "session branch selector is poisoned",
                     )
                 }),
         }
@@ -503,17 +502,19 @@ where
     {
         self.ensure_open()?;
         let write_access = self.begin_session_write_access().await?;
-        self.with_write_transaction_reserved_lending(write_access, f)
+        self.with_write_transaction_reserved_lending(write_access, f, |_| Ok(()))
             .await
     }
 
-    pub(super) async fn with_write_transaction_reserved_lending<T, F>(
+    pub(super) async fn with_write_transaction_reserved_lending<T, F, A>(
         &self,
         write_access: SessionWriteAccess,
         f: F,
+        after_commit: A,
     ) -> Result<T, LixError>
     where
         F: for<'tx> AsyncFnOnce(&'tx mut Transaction<StorageImpl>) -> Result<T, LixError>,
+        A: FnOnce(&T) -> Result<(), LixError>,
     {
         let planner_validation_is_serialized = write_access.serializes_collaboration_writes();
         // Automatic writes already hold the collaboration gate, so taking the
@@ -560,9 +561,11 @@ where
                 let outcome = Box::pin(transaction.commit(&runtime_functions)).await?;
                 #[cfg(feature = "storage-benches")]
                 crate::storage_bench::record_crud_physical_writes(outcome.storage_stats);
+                let after_commit_result = after_commit(&value);
                 drop(write_access);
                 self.observe_invalidation
                     .bump_if_storage_changed(&outcome.storage_stats);
+                after_commit_result?;
                 Ok(value)
             }
             Err(error) => Err(error),

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -762,37 +762,41 @@ where
         crate::common::LixPath::try_from_file_path(&path)?;
         let write_access = self.begin_session_write_access().await?;
         let sql_planning_cache = Arc::clone(&self.sql_planning_cache);
-        self.with_write_transaction_reserved_lending(write_access, async move |transaction| {
-            // `Blob` is reference-counted. Retaining a copy lets the rare
-            // general-write fallback reuse the same payload without a
-            // second allocation or a second transaction.
-            let fast_path = sql2::execute_fast_lix_file_path_writes(
-                transaction,
-                vec![(path.clone(), data.clone(), None, None)],
-                sql2::FastLixFilePathWriteConflict::UpdateData,
-                None,
-            )
-            .await?;
-            if let Some(count) = fast_path {
-                return Ok(count);
-            }
+        self.with_write_transaction_reserved_lending(
+            write_access,
+            async move |transaction| {
+                // `Blob` is reference-counted. Retaining a copy lets the rare
+                // general-write fallback reuse the same payload without a
+                // second allocation or a second transaction.
+                let fast_path = sql2::execute_fast_lix_file_path_writes(
+                    transaction,
+                    vec![(path.clone(), data.clone(), None, None)],
+                    sql2::FastLixFilePathWriteConflict::UpdateData,
+                    None,
+                )
+                .await?;
+                if let Some(count) = fast_path {
+                    return Ok(count);
+                }
 
-            // The fast helper declines pre-existing cross-scope path
-            // collisions before staging anything. The general provider
-            // handles those valid legacy layouts, so keep this request in
-            // the same transaction and use its public upsert semantics.
-            let statement = sql_planning_cache.parse_statement(NATIVE_FILE_UPSERT_SQL)?;
-            let plan =
-                transaction.prepare_sql_write_logical_plan(NATIVE_FILE_UPSERT_SQL, &statement)?;
-            sql2::execute_write_logical_plan_result_with_metadata(
-                transaction,
-                plan,
-                &[Value::Text(path), Value::Blob(data)],
-                &ExecuteStatementMetadata::default(),
-            )
-            .await
-            .map(|result| result.rows_affected)
-        })
+                // The fast helper declines pre-existing cross-scope path
+                // collisions before staging anything. The general provider
+                // handles those valid legacy layouts, so keep this request in
+                // the same transaction and use its public upsert semantics.
+                let statement = sql_planning_cache.parse_statement(NATIVE_FILE_UPSERT_SQL)?;
+                let plan = transaction
+                    .prepare_sql_write_logical_plan(NATIVE_FILE_UPSERT_SQL, &statement)?;
+                sql2::execute_write_logical_plan_result_with_metadata(
+                    transaction,
+                    plan,
+                    &[Value::Text(path), Value::Blob(data)],
+                    &ExecuteStatementMetadata::default(),
+                )
+                .await
+                .map(|result| result.rows_affected)
+            },
+            |_| Ok(()),
+        )
         .await
     }
 
@@ -830,7 +834,7 @@ where
                         "expected": "a filesystem layout that the direct path index can route unambiguously",
                     }))
                 })
-        })
+        }, |_| Ok(()))
         .await
     }
 
@@ -991,24 +995,29 @@ where
             let sql_for_planning = sql_for_error.clone();
             let params = params.to_vec();
             return self
-                .with_write_transaction_reserved_lending(write_access, async move |transaction| {
-                    let previous_origin_key = transaction.replace_origin_key(options.origin_key);
-                    let result = async {
-                        let tx_plan = transaction
-                            .prepare_sql_write_logical_plan(&sql_for_planning, &statement)?;
-                        let result = execute_prepared_transaction_write(
-                            transaction,
-                            tx_plan,
-                            &params,
-                            &metadata,
-                        )
-                        .await?;
-                        Ok(ExecuteResult::from_sql_write_result(result))
-                    }
-                    .await;
-                    transaction.replace_origin_key(previous_origin_key);
-                    result
-                })
+                .with_write_transaction_reserved_lending(
+                    write_access,
+                    async move |transaction| {
+                        let previous_origin_key =
+                            transaction.replace_origin_key(options.origin_key);
+                        let result = async {
+                            let tx_plan = transaction
+                                .prepare_sql_write_logical_plan(&sql_for_planning, &statement)?;
+                            let result = execute_prepared_transaction_write(
+                                transaction,
+                                tx_plan,
+                                &params,
+                                &metadata,
+                            )
+                            .await?;
+                            Ok(ExecuteResult::from_sql_write_result(result))
+                        }
+                        .await;
+                        transaction.replace_origin_key(previous_origin_key);
+                        result
+                    },
+                    |_| Ok(()),
+                )
                 .await
                 .map_err(|error| normalize_sql_surface_error(error, &sql_for_error));
         }
@@ -1118,29 +1127,33 @@ where
         // this call's immediate stack frame while the write lease is held.
         let idempotency_for_commit = idempotency.clone();
         let result = self
-            .with_write_transaction_reserved_lending(write_access, async move |transaction| {
-                let previous_origin_key = transaction.replace_origin_key(options.origin_key);
-                let result = async {
-                    let tx_plan = transaction
-                        .prepare_sql_write_logical_plan(&sql_for_planning, &statement)?;
-                    let result = execute_prepared_transaction_write(
-                        transaction,
-                        tx_plan,
-                        &params,
-                        &metadata,
-                    )
-                    .await?;
-                    let result = ExecuteResult::from_sql_write_result(result);
-                    let receipt =
-                        ExecuteIdempotencyReceipt::single(&idempotency_for_commit, &result)?;
-                    transaction
-                        .stage_execute_idempotency_receipt(&idempotency_for_commit, &receipt)?;
-                    Ok(result)
-                }
-                .await;
-                transaction.replace_origin_key(previous_origin_key);
-                result
-            })
+            .with_write_transaction_reserved_lending(
+                write_access,
+                async move |transaction| {
+                    let previous_origin_key = transaction.replace_origin_key(options.origin_key);
+                    let result = async {
+                        let tx_plan = transaction
+                            .prepare_sql_write_logical_plan(&sql_for_planning, &statement)?;
+                        let result = execute_prepared_transaction_write(
+                            transaction,
+                            tx_plan,
+                            &params,
+                            &metadata,
+                        )
+                        .await?;
+                        let result = ExecuteResult::from_sql_write_result(result);
+                        let receipt =
+                            ExecuteIdempotencyReceipt::single(&idempotency_for_commit, &result)?;
+                        transaction
+                            .stage_execute_idempotency_receipt(&idempotency_for_commit, &receipt)?;
+                        Ok(result)
+                    }
+                    .await;
+                    transaction.replace_origin_key(previous_origin_key);
+                    result
+                },
+                |_| Ok(()),
+            )
             .await
             .map_err(|error| normalize_sql_surface_error(error, &sql_for_error));
 
@@ -1938,18 +1951,22 @@ where
             let sql_for_planning = sql_for_error.clone();
             let params = params.to_vec();
             return self
-                .with_write_transaction_reserved_lending(write_access, async move |transaction| {
-                    let tx_plan = transaction
-                        .prepare_sql_write_logical_plan(&sql_for_planning, &statement)?;
-                    let result = sql2::execute_write_logical_plan_with_mode_result(
-                        transaction,
-                        tx_plan,
-                        &params,
-                        mode,
-                    )
-                    .await?;
-                    Ok(ExecuteResult::from_sql_write_result(result))
-                })
+                .with_write_transaction_reserved_lending(
+                    write_access,
+                    async move |transaction| {
+                        let tx_plan = transaction
+                            .prepare_sql_write_logical_plan(&sql_for_planning, &statement)?;
+                        let result = sql2::execute_write_logical_plan_with_mode_result(
+                            transaction,
+                            tx_plan,
+                            &params,
+                            mode,
+                        )
+                        .await?;
+                        Ok(ExecuteResult::from_sql_write_result(result))
+                    },
+                    |_| Ok(()),
+                )
                 .await
                 .map_err(|error| normalize_sql_surface_error(error, &sql_for_error));
         }
@@ -5156,33 +5173,34 @@ mod tests {
             })
             .await
             .expect("a branch should start from a rootless history commit");
-        let (draft_session, _) = session
+        session
             .switch_branch(crate::SwitchBranchOptions {
                 branch_id: draft.id.clone(),
             })
             .await
             .expect("rootless draft should open");
-        draft_session
+        session
             .execute(
                 "UPDATE rootless_ordered_insert_probe SET value = 'draft' WHERE id = '00001'",
                 &[],
             )
             .await
             .expect("rootless draft should remain writable");
-        let (main_session, _) = draft_session
+        session
             .switch_branch(crate::SwitchBranchOptions {
                 branch_id: branch_id.clone(),
             })
             .await
             .expect("workspace should switch back to the rootless main branch");
-        main_session
+        let main_session = &session;
+        session
             .execute(
                 "UPDATE rootless_ordered_insert_probe SET value = 'main' WHERE id = '32767'",
                 &[],
             )
             .await
             .expect("rootless main branch should remain writable");
-        let merge = main_session
+        let merge = session
             .merge_branch(crate::MergeBranchOptions {
                 source_branch_id: draft.id,
             })
@@ -7248,13 +7266,13 @@ mod tests {
             })
             .await
             .unwrap();
-        let (historical_session, _) = session
+        session
             .switch_branch(crate::SwitchBranchOptions {
                 branch_id: historical_branch.id,
             })
             .await
             .unwrap();
-        let historical_points = historical_session
+        let historical_points = session
             .execute(
                 "SELECT path, value FROM packed_replacement_probe \
                  WHERE path IN ('/00000', '/32767') ORDER BY path",
@@ -7274,7 +7292,7 @@ mod tests {
                 .unwrap(),
             serde_json::json!({"updated": ROW_COUNT - 1})
         );
-        let (session, _) = historical_session
+        session
             .switch_branch(crate::SwitchBranchOptions {
                 branch_id: main_branch_id.clone(),
             })
@@ -7327,20 +7345,20 @@ mod tests {
             })
             .await
             .unwrap();
-        let (merge_source, _) = session
+        session
             .switch_branch(crate::SwitchBranchOptions {
                 branch_id: merge_base_branch.id.clone(),
             })
             .await
             .unwrap();
-        merge_source
+        session
             .execute(
                 "UPDATE packed_replacement_probe SET value = lix_json('{\"branch\":true}') WHERE path = '/00000'",
                 &[],
             )
             .await
             .unwrap();
-        let (session, _) = merge_source
+        session
             .switch_branch(crate::SwitchBranchOptions {
                 branch_id: main_branch_id.clone(),
             })

--- a/packages/engine/src/session/media_upload.rs
+++ b/packages/engine/src/session/media_upload.rs
@@ -278,13 +278,19 @@ where
         let path = state.path.clone();
         let write_access = self.begin_session_write_access().await?;
         let publish_result = self
-            .with_write_transaction_reserved_lending(write_access, async move |transaction| {
-                transaction.stage_atomic_cas_publication(
-                    finalization_writes,
-                    finalization_preconditions,
-                    publication_blob_id,
-                )?;
-                crate::sql2::execute_fast_lix_file_prepared_path_write(transaction, path, receipt)
+            .with_write_transaction_reserved_lending(
+                write_access,
+                async move |transaction| {
+                    transaction.stage_atomic_cas_publication(
+                        finalization_writes,
+                        finalization_preconditions,
+                        publication_blob_id,
+                    )?;
+                    crate::sql2::execute_fast_lix_file_prepared_path_write(
+                        transaction,
+                        path,
+                        receipt,
+                    )
                     .await?
                     .ok_or_else(|| {
                         LixError::new(
@@ -292,7 +298,9 @@ where
                             "resumable file publication requires an unambiguous filesystem layout",
                         )
                     })
-            })
+                },
+                |_| Ok(()),
+            )
             .await;
         if let Err(error) = publish_result {
             let read = self

--- a/packages/engine/src/session/observe.rs
+++ b/packages/engine/src/session/observe.rs
@@ -15,6 +15,7 @@ use super::{SessionContext, SessionMode};
 
 #[derive(Debug, Clone)]
 struct ObserveQuery {
+    scope: ObserveSessionScope,
     sql: String,
     params: Vec<Value>,
     shared_state: Option<Arc<ObserveQueryState>>,
@@ -22,11 +23,13 @@ struct ObserveQuery {
 
 impl ObserveQuery {
     fn new(
+        scope: ObserveSessionScope,
         sql: impl Into<String>,
         params: Vec<Value>,
         shared_state: Option<Arc<ObserveQueryState>>,
     ) -> Self {
         Self {
+            scope,
             sql: sql.into(),
             params,
             shared_state,
@@ -197,7 +200,17 @@ where
         }
     }
 
-    async fn execute_or_share(&self, generation: u64) -> Result<ObserveQueryEvaluation, LixError> {
+    async fn execute_or_share(
+        &mut self,
+        generation: u64,
+    ) -> Result<ObserveQueryEvaluation, LixError> {
+        let scope = self.session.observe_scope();
+        if self.query.scope != scope {
+            let key = ObserveQueryKey::new(scope.clone(), &self.query.sql, &self.query.params)?;
+            self.query.scope = scope;
+            self.query.shared_state = Some(self.session.observe_coordinator.state_for(&key));
+            self.last_shared_content = None;
+        }
         let Some(shared_state) = &self.query.shared_state else {
             return Box::pin(
                 self.session
@@ -259,12 +272,13 @@ where
                 "observe does not support durable runtime functions",
             ));
         }
-        let key = ObserveQueryKey::new(self.observe_scope(), sql, params)?;
+        let scope = self.observe_scope();
+        let key = ObserveQueryKey::new(scope.clone(), sql, params)?;
         let shared_state = Some(self.observe_coordinator.state_for(&key));
 
         Ok(ObserveEvents {
             session: self.clone(),
-            query: ObserveQuery::new(sql, params.to_vec(), shared_state),
+            query: ObserveQuery::new(scope, sql, params.to_vec(), shared_state),
             receiver: Some(self.observe_invalidation.subscribe()),
             sequence: 0,
             last_rows: None,
@@ -281,7 +295,12 @@ where
                     .unwrap_or_else(std::sync::PoisonError::into_inner)
                     .clone(),
             ),
-            SessionMode::Pinned { branch_id } => ObserveSessionScope::Branch(branch_id.clone()),
+            SessionMode::Pinned { branch_id } => ObserveSessionScope::Branch(
+                branch_id
+                    .read()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .clone(),
+            ),
         }
     }
 }

--- a/packages/engine/src/session/switch_branch.rs
+++ b/packages/engine/src/session/switch_branch.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use serde_json::json;
 
 use crate::GLOBAL_BRANCH_ID;
@@ -30,19 +28,27 @@ where
 {
     /// Switches the session's active branch selector.
     ///
-    /// Pinned sessions switch in memory and return a new pinned session.
-    /// Workspace sessions update the shared workspace selector and return a
-    /// new session pinned to that selection. Existing sessions retain the
-    /// branch snapshot they opened with, like ordinary database connections.
+    /// Pinned sessions update their in-memory selector. Workspace sessions
+    /// additionally persist the workspace selector. Clones of this session
+    /// observe the switch in place; independently opened sessions retain the
+    /// branch snapshot they opened with.
     pub async fn switch_branch(
         &self,
         options: SwitchBranchOptions,
-    ) -> Result<(Self, SwitchBranchReceipt), LixError> {
+    ) -> Result<SwitchBranchReceipt, LixError> {
         let branch_id = options.branch_id;
         let receipt_branch_id = branch_id.clone();
         let current_mode = self.mode.clone();
-        let next_mode = self
-            .with_write_transaction_lending(async move |transaction| {
+        let selector = match &self.mode {
+            SessionMode::Pinned { branch_id } | SessionMode::Workspace { branch_id } => {
+                branch_id.clone()
+            }
+        };
+        let observe_invalidation = self.observe_invalidation.clone();
+        let write_access = self.begin_session_write_access().await?;
+        self.with_write_transaction_reserved_lending(
+            write_access,
+            async move |transaction| {
                 {
                     let reader = transaction.branch_ref_reader().await;
                     BranchLifecycle::new(&reader)
@@ -54,58 +60,32 @@ where
                         .await?
                 };
 
-                match current_mode {
-                    SessionMode::Pinned { .. } => Ok(SessionMode::Pinned {
-                        branch_id: branch_id.clone(),
-                    }),
-                    SessionMode::Workspace {
-                        branch_id: selector,
-                    } => {
+                match &current_mode {
+                    SessionMode::Pinned { .. } => Ok(()),
+                    SessionMode::Workspace { .. } => {
                         let mut rows = RawWriteBatch::with_capacity(1);
                         rows.push(workspace_branch_stage_row(&branch_id)?);
                         transaction.stage_rows(rows).await?;
-                        Ok(SessionMode::Workspace {
-                            branch_id: selector,
-                        })
+                        Ok(())
                     }
                 }
-            })
-            .await?;
-
-        if let SessionMode::Workspace { branch_id } = &next_mode {
-            *branch_id.write().map_err(|_| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "workspace branch selector cache is poisoned",
-                )
-            })? = receipt_branch_id.clone();
-        }
-
-        let session = Self::new_with_transaction_manager(
-            next_mode,
-            self.storage.clone(),
-            Arc::clone(&self.live_state),
-            Arc::clone(&self.tracked_state),
-            Arc::clone(&self.binary_cas),
-            Arc::clone(&self.branch_ctx),
-            Arc::clone(&self.catalog_context),
-            Arc::clone(&self.sql_planning_cache),
-            Arc::clone(&self.deterministic_runtime_gate),
-            Arc::clone(&self.collaboration_write_gate),
-            Arc::clone(&self.commit_coordinator),
-            Arc::clone(&self.observe_coordinator),
-            Arc::clone(&self.observe_invalidation),
-            self.plugin_host.clone(),
-            self.telemetry.clone(),
-            self.transaction_manager(),
-            self.file_views.clone(),
-        );
-        Ok((
-            session,
-            SwitchBranchReceipt {
-                branch_id: receipt_branch_id,
             },
-        ))
+            |()| {
+                *selector.write().map_err(|_| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "session branch selector is poisoned",
+                    )
+                })? = receipt_branch_id.clone();
+                observe_invalidation.bump();
+                Ok(())
+            },
+        )
+        .await?;
+
+        Ok(SwitchBranchReceipt {
+            branch_id: receipt_branch_id,
+        })
     }
 }
 

--- a/packages/engine/src/transaction/bench_support.rs
+++ b/packages/engine/src/transaction/bench_support.rs
@@ -293,7 +293,7 @@ where
         let logical_rows = rows.len();
         let opened = super::open_transaction(
             &SessionMode::Pinned {
-                branch_id: BENCH_BRANCH_ID.to_string(),
+                branch_id: Arc::new(std::sync::RwLock::new(BENCH_BRANCH_ID.to_string())),
             },
             self.storage.clone(),
             Arc::clone(&self.live_state),

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -11294,7 +11294,15 @@ async fn resolve_active_branch_id(
     read: &(impl StorageAdapterRead + ?Sized),
 ) -> Result<String, LixError> {
     match mode {
-        SessionMode::Pinned { branch_id } => Ok(branch_id.clone()),
+        SessionMode::Pinned { branch_id } => branch_id
+            .read()
+            .map(|branch_id| branch_id.clone())
+            .map_err(|_| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "session branch selector is poisoned",
+                )
+            }),
         SessionMode::Workspace { branch_id } => {
             let branch_id = branch_id
                 .read()
@@ -12424,7 +12432,7 @@ mod tests {
         let catalog_context = Arc::new(CatalogContext::new());
         let opened = open_transaction(
             &SessionMode::Pinned {
-                branch_id: GLOBAL_BRANCH_ID.to_string(),
+                branch_id: Arc::new(std::sync::RwLock::new(GLOBAL_BRANCH_ID.to_string())),
             },
             storage.clone(),
             Arc::clone(&live_state),
@@ -12739,7 +12747,7 @@ mod tests {
         let catalog_context = Arc::new(CatalogContext::new());
         let opened = open_transaction(
             &SessionMode::Pinned {
-                branch_id: GLOBAL_BRANCH_ID.to_string(),
+                branch_id: Arc::new(std::sync::RwLock::new(GLOBAL_BRANCH_ID.to_string())),
             },
             storage.clone(),
             Arc::clone(&live_state),
@@ -13191,7 +13199,7 @@ mod tests {
         let catalog_context = Arc::new(CatalogContext::new());
         let opened = open_transaction(
             &SessionMode::Pinned {
-                branch_id: GLOBAL_BRANCH_ID.to_string(),
+                branch_id: Arc::new(std::sync::RwLock::new(GLOBAL_BRANCH_ID.to_string())),
             },
             storage,
             Arc::clone(&live_state),

--- a/packages/engine/tests/integration/branching.rs
+++ b/packages/engine/tests/integration/branching.rs
@@ -300,7 +300,6 @@ simulation_test!(
             )
             .await
             .expect("draft write should succeed");
-
         assert_key_value(
             &draft,
             "64726166-742d-8166-8465-722d62726100",
@@ -311,37 +310,42 @@ simulation_test!(
     }
 );
 
-simulation_test!(
-    switch_branch_returns_session_for_target_branch,
-    |sim| async move {
-        let (engine, main, draft) = create_draft_from_main(&sim).await;
-        draft
-            .execute(
-                "INSERT INTO lix_key_value (key, value) VALUES ('switch-draft-only', 'draft')",
-                &[],
-            )
-            .await
-            .expect("draft write should succeed");
+simulation_test!(switch_branch_updates_session_in_place, |sim| async move {
+    let (engine, main, draft) = create_draft_from_main(&sim).await;
+    draft
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('switch-draft-only', 'draft')",
+            &[],
+        )
+        .await
+        .expect("draft write should succeed");
+    let main_clone = main.clone();
 
-        let (switched, receipt) = main
-            .switch_branch(SwitchBranchOptions {
-                branch_id: "01930000-0000-7000-8000-000000000001".to_string(),
-            })
-            .await
-            .expect("switch should succeed");
+    let receipt = main
+        .switch_branch(SwitchBranchOptions {
+            branch_id: "01930000-0000-7000-8000-000000000001".to_string(),
+        })
+        .await
+        .expect("switch should succeed");
 
-        assert_eq!(receipt.branch_id, "01930000-0000-7000-8000-000000000001");
-        assert_key_value(&switched, "switch-draft-only", Some("\"draft\"")).await;
-        assert_key_value(&main, "switch-draft-only", None).await;
+    assert_eq!(receipt.branch_id, "01930000-0000-7000-8000-000000000001");
+    assert_key_value(&main, "switch-draft-only", Some("\"draft\"")).await;
+    assert_key_value(&main_clone, "switch-draft-only", Some("\"draft\"")).await;
 
-        drop(engine);
-    }
-);
+    drop(engine);
+});
 
 simulation_test!(
     cached_write_templates_are_isolated_across_branch_switches,
     |sim| async move {
         let (engine, main, _draft) = create_draft_from_main(&sim).await;
+        let main_snapshot = sim.wrap_session(
+            engine
+                .open_session(sim.main_branch_id().to_string())
+                .await
+                .expect("open independent main session"),
+            &engine,
+        );
         let insert_sql = "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)";
 
         main.execute(
@@ -354,27 +358,25 @@ simulation_test!(
         .await
         .expect("main write should warm the exact SQL template");
 
-        let (switched, _) = main
-            .switch_branch(SwitchBranchOptions {
-                branch_id: "01930000-0000-7000-8000-000000000001".to_string(),
-            })
-            .await
-            .expect("switch should succeed");
-        switched
-            .execute(
-                insert_sql,
-                &[
-                    Value::Text("template-draft-only".to_string()),
-                    Value::Text("draft".to_string()),
-                ],
-            )
-            .await
-            .expect("the same SQL should bind to the switched branch");
+        main.switch_branch(SwitchBranchOptions {
+            branch_id: "01930000-0000-7000-8000-000000000001".to_string(),
+        })
+        .await
+        .expect("switch should succeed");
+        main.execute(
+            insert_sql,
+            &[
+                Value::Text("template-draft-only".to_string()),
+                Value::Text("draft".to_string()),
+            ],
+        )
+        .await
+        .expect("the same SQL should bind to the switched branch");
 
-        assert_key_value(&switched, "template-draft-only", Some("\"draft\"")).await;
-        assert_key_value(&main, "template-draft-only", None).await;
-        assert_key_value(&main, "template-main-only", Some("\"main\"")).await;
-        assert_key_value(&switched, "template-main-only", None).await;
+        assert_key_value(&main, "template-draft-only", Some("\"draft\"")).await;
+        assert_key_value(&main_snapshot, "template-draft-only", None).await;
+        assert_key_value(&main_snapshot, "template-main-only", Some("\"main\"")).await;
+        assert_key_value(&main, "template-main-only", None).await;
 
         drop(engine);
     }
@@ -408,12 +410,11 @@ simulation_test!(
             "pinned session setup should not have moved the workspace selector"
         );
 
-        let (_switched, _receipt) = main
-            .switch_branch(SwitchBranchOptions {
-                branch_id: "01930000-0000-7000-8000-000000000001".to_string(),
-            })
-            .await
-            .expect("switch should succeed");
+        main.switch_branch(SwitchBranchOptions {
+            branch_id: "01930000-0000-7000-8000-000000000001".to_string(),
+        })
+        .await
+        .expect("switch should succeed");
 
         assert_eq!(
             engine
@@ -491,7 +492,7 @@ simulation_test!(
             sim.main_branch_id()
         );
 
-        let (workspace_switched, receipt) = workspace_a
+        let receipt = workspace_a
             .switch_branch(SwitchBranchOptions {
                 branch_id: "01930000-0000-7000-8000-000000000001".to_string(),
             })
@@ -500,7 +501,7 @@ simulation_test!(
 
         assert_eq!(receipt.branch_id, "01930000-0000-7000-8000-000000000001");
         assert_eq!(
-            workspace_switched
+            workspace_a
                 .active_branch_id()
                 .await
                 .expect("switched workspace selector should resolve"),

--- a/packages/engine/tests/integration/engine.rs
+++ b/packages/engine/tests/integration/engine.rs
@@ -272,27 +272,27 @@ async fn register_poison_task_schema(session: &lix_engine::SessionContext) {
 }
 
 simulation_test!(
-    session_close_state_is_shared_with_switched_session,
+    session_close_state_is_shared_with_cloned_session,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = engine
             .open_workspace_session()
             .await
             .expect("storage should open a session");
-        let (switched_session, _) = session
+        let cloned_session = session.clone();
+        session
             .switch_branch(SwitchBranchOptions {
                 branch_id: sim.main_branch_id().to_string(),
             })
             .await
             .expect("switch_branch should succeed before close");
-
         session.close().await.expect("close should succeed");
 
         assert_closed(
-            switched_session
+            cloned_session
                 .active_branch_id()
                 .await
-                .expect_err("derived session should observe closed state"),
+                .expect_err("cloned session should observe closed state"),
         );
     }
 );

--- a/packages/engine/tests/integration/observe.rs
+++ b/packages/engine/tests/integration/observe.rs
@@ -89,6 +89,62 @@ simulation_test!(observe_next_returns_initial_snapshot, |sim| async move {
     assert_key_value_row(&initial, "observe-initial", "v0");
 });
 
+simulation_test!(observe_follows_in_place_branch_switch, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let (raw_session, session) = open_workspace_session(&sim, &engine).await;
+    session
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('observe-switch', 'main')",
+            &[],
+        )
+        .await
+        .expect("seed main value");
+    let main_branch_id = session
+        .active_branch_id()
+        .await
+        .expect("active main branch");
+    let draft = session
+        .create_branch(lix_engine::CreateBranchOptions {
+            id: None,
+            name: "observe-switch-draft".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("create draft branch");
+    session
+        .switch_branch(lix_engine::SwitchBranchOptions {
+            branch_id: draft.id.clone(),
+        })
+        .await
+        .expect("switch to draft");
+    session
+        .execute(
+            "UPDATE lix_key_value SET value = 'draft' WHERE key = 'observe-switch'",
+            &[],
+        )
+        .await
+        .expect("update draft value");
+    session
+        .switch_branch(lix_engine::SwitchBranchOptions {
+            branch_id: main_branch_id,
+        })
+        .await
+        .expect("switch back to main");
+
+    let mut events = observe_key(&raw_session, "observe-switch");
+    let initial = next_event(&mut events, "main branch snapshot").await;
+    assert_key_value_row(&initial, "observe-switch", "main");
+
+    session
+        .switch_branch(lix_engine::SwitchBranchOptions {
+            branch_id: draft.id,
+        })
+        .await
+        .expect("switch observed session to draft");
+    let switched = next_event(&mut events, "draft branch snapshot").await;
+    assert_key_value_row(&switched, "observe-switch", "draft");
+});
+
 #[tokio::test]
 async fn observe_initial_next_waits_without_rejecting_same_session_write() {
     let storage = BlockingBeginReadStorage::new();

--- a/packages/engine/tests/integration/support/simulation_test/engine/simulation.rs
+++ b/packages/engine/tests/integration/support/simulation_test/engine/simulation.rs
@@ -104,6 +104,7 @@ impl Simulation {
 }
 
 /// Session wrapper that injects simulation behavior around normal execution.
+#[derive(Clone)]
 #[allow(
     dead_code,
     reason = "shared integration-test harness is compiled once per test target"
@@ -208,17 +209,8 @@ impl SimSession {
     pub async fn switch_branch(
         &self,
         options: SwitchBranchOptions,
-    ) -> Result<(Self, SwitchBranchReceipt), LixError> {
-        let (session, receipt) = self.session.switch_branch(options).await?;
-        Ok((
-            Self {
-                sim: self.sim.clone(),
-                engine: self.engine.clone(),
-                fs: SimFs::new(self.sim.clone(), self.engine.clone(), session.clone()),
-                session,
-            },
-            receipt,
-        ))
+    ) -> Result<SwitchBranchReceipt, LixError> {
+        self.session.switch_branch(options).await
     }
 }
 

--- a/packages/rs-sdk/src/lix.rs
+++ b/packages/rs-sdk/src/lix.rs
@@ -174,8 +174,8 @@ where
     ///
     /// Unlike a workspace session, a pinned session never reads or writes the
     /// shared workspace branch selector. The requested branch is validated
-    /// before the child handle is returned. To switch it, use
-    /// [`Self::switch_branch_session`] and retain the returned replacement.
+    /// before the child handle is returned. Branch switches update this
+    /// handle and its clones in place.
     pub async fn open_session(
         &self,
         active_branch_id: impl Into<String>,
@@ -432,35 +432,7 @@ where
         &self,
         options: SwitchBranchOptions,
     ) -> Result<SwitchBranchReceipt, LixError> {
-        if self.session.is_pinned() {
-            return Err(LixError::new(
-                LixError::CODE_INVALID_SESSION_STATE,
-                "switch_branch() cannot replace a borrowed pinned Lix handle",
-            )
-            .with_hint("use switch_branch_session() and retain the returned Lix handle"));
-        }
-        let (_lix, receipt) = self.switch_branch_session(options).await?;
-        Ok(receipt)
-    }
-
-    /// Switches branches and returns the replacement handle produced by the
-    /// engine session transition.
-    ///
-    /// Callers that own pinned sessions must retain the returned handle. The
-    /// compatibility [`Self::switch_branch`] method intentionally preserves
-    /// its existing receipt-only API for workspace sessions.
-    pub async fn switch_branch_session(
-        &self,
-        options: SwitchBranchOptions,
-    ) -> Result<(Self, SwitchBranchReceipt), LixError> {
-        let (session, receipt) = self.session.switch_branch(options).await?;
-        Ok((
-            Self {
-                engine: self.engine.clone(),
-                session: Arc::new(session),
-            },
-            receipt,
-        ))
+        self.session.switch_branch(options).await
     }
 
     pub async fn merge_branch(
@@ -643,24 +615,21 @@ mod tests {
             .open_session(main_branch_id.clone())
             .await
             .expect("open pinned main session");
-        let error = pinned
+        let pinned_clone = pinned.clone();
+        let receipt = pinned
             .switch_branch(SwitchBranchOptions {
-                branch_id: draft.id.clone(),
-            })
-            .await
-            .expect_err("receipt-only switching must reject pinned sessions");
-        assert_eq!(error.code, LixError::CODE_INVALID_SESSION_STATE);
-        let (switched, receipt) = pinned
-            .switch_branch_session(SwitchBranchOptions {
                 branch_id: draft.id.clone(),
             })
             .await
             .expect("switch pinned session");
 
         assert_eq!(receipt.branch_id, draft.id);
-        assert_eq!(pinned.active_branch_id().await.unwrap(), main_branch_id);
         assert_eq!(
-            switched.active_branch_id().await.unwrap(),
+            pinned.active_branch_id().await.unwrap(),
+            "01920000-0000-7000-8000-000000000501"
+        );
+        assert_eq!(
+            pinned_clone.active_branch_id().await.unwrap(),
             "01920000-0000-7000-8000-000000000501"
         );
         assert_eq!(root.active_branch_id().await.unwrap(), main_branch_id);

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -41,7 +41,7 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::{
-    sync::{Mutex as AsyncMutex, Notify, RwLock as AsyncRwLock, mpsc, watch},
+    sync::{Mutex as AsyncMutex, Notify, mpsc, watch},
     task::JoinHandle,
 };
 use tower_http::{
@@ -290,7 +290,7 @@ struct SessionRecord<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
-    lix: Arc<AsyncRwLock<Arc<Lix<S>>>>,
+    lix: Arc<Lix<S>>,
     transactions: AsyncMutex<RemoteTransactionRegistry<S>>,
     last_used: Mutex<Instant>,
     activity: Arc<SessionActivity>,
@@ -573,7 +573,7 @@ where
         request_blob_budget: Arc<RequestBlobCacheBudget>,
     ) -> Self {
         Self {
-            lix: Arc::new(AsyncRwLock::new(Arc::new(lix))),
+            lix: Arc::new(lix),
             transactions: AsyncMutex::new(RemoteTransactionRegistry::default()),
             last_used: Mutex::new(now),
             activity: Arc::new(SessionActivity::default()),
@@ -708,11 +708,7 @@ where
     {
         let lix = Arc::clone(&self.record.lix);
         self.run_detached(
-            async move {
-                let lix = lix.read_owned().await;
-                let current = Arc::clone(&lix);
-                operation(current).await
-            },
+            async move { operation(lix).await },
             "join Lix server operation",
         )
         .await
@@ -726,11 +722,7 @@ where
         F: FnOnce(Arc<Lix<S>>) -> Fut,
         Fut: Future<Output = Result<T, LixError>>,
     {
-        let result = {
-            let lix = Arc::clone(&self.record.lix).read_owned().await;
-            let current = Arc::clone(&lix);
-            operation(current).await
-        };
+        let result = operation(Arc::clone(&self.record.lix)).await;
         if let (Some(notifier), Err(error)) = (&self.durable_terminal_storage_notifier, &result) {
             notifier.signal_if_terminal(error);
         }
@@ -745,10 +737,7 @@ where
         metadata: ExecuteStatementMetadata,
         idempotency: Option<ExecuteIdempotency>,
     ) -> Result<ExecuteResult, LixError> {
-        let disposition = {
-            let lix = self.record.lix.read().await;
-            lix.execution_disposition(&sql)?
-        };
+        let disposition = self.record.lix.execution_disposition(&sql)?;
         match disposition {
             ExecutionDisposition::CancellableRead => {
                 self.run_cancellable_read(move |lix| async move {
@@ -788,10 +777,7 @@ where
         statement_metadata: Vec<ExecuteStatementMetadata>,
         idempotency: Option<ExecuteIdempotency>,
     ) -> Result<Vec<ExecuteResult>, LixError> {
-        let disposition = {
-            let lix = self.record.lix.read().await;
-            lix.execute_batch_disposition(&statements)?
-        };
+        let disposition = self.record.lix.execute_batch_disposition(&statements)?;
         match disposition {
             ExecutionDisposition::CancellableRead => {
                 self.run_cancellable_read(move |lix| async move {
@@ -829,7 +815,7 @@ where
                 "Lix session already has an active transaction",
             ));
         }
-        let lix = Arc::clone(&*self.record.lix.read().await);
+        let lix = Arc::clone(&self.record.lix);
         let id = generate_capability_id()?;
         let pin = RemoteTransactionPin::acquire(Arc::clone(&self.record.activity))?;
         transactions.active = Some(ActiveRemoteTransaction {
@@ -959,12 +945,7 @@ where
     ) -> Result<lix_sdk::SwitchBranchReceipt, LixError> {
         let lix = Arc::clone(&self.record.lix);
         self.run_detached(
-            async move {
-                let mut lix = lix.write().await;
-                let (switched, receipt) = lix.switch_branch_session(options).await?;
-                *lix = Arc::new(switched);
-                Ok(receipt)
-            },
+            async move { lix.switch_branch(options).await },
             "join Lix server branch switch",
         )
         .await
@@ -976,9 +957,8 @@ where
         params: &[Value],
         terminal_sender: TerminalStorageStreamSender,
     ) -> Result<ServerObserve<S>, LixError> {
-        let lix = self.record.lix.read().await;
         Ok(ServerObserve {
-            events: AsyncMutex::new(lix.observe(sql, params)?),
+            events: AsyncMutex::new(self.record.lix.observe(sql, params)?),
             terminal_sender,
         })
     }
@@ -1459,8 +1439,7 @@ where
         Some(active) => active.transaction.rollback().await,
         None => Ok(()),
     };
-    let lix = record.lix.write().await;
-    let close_result = lix.close().await;
+    let close_result = record.lix.close().await;
     rollback_result.and(close_result)
 }
 
@@ -9092,7 +9071,7 @@ mod tests {
         // Keep eviction cleanup blocked after the replacement is registered.
         // Shutdown must continue to track the whole create operation, not only
         // the child open and registry mutation.
-        let first_session_read = first_record.lix.read().await;
+        let first_transactions = first_record.transactions.lock().await;
         let branch_id = app
             .server
             .inner
@@ -9131,7 +9110,7 @@ mod tests {
             "close completed before pending eviction cleanup"
         );
 
-        drop(first_session_read);
+        drop(first_transactions);
         let replacement = replacement
             .await
             .expect("join replacement open")
@@ -9916,16 +9895,13 @@ mod tests {
         let (session_id, _) = new_session(&app.router).await;
         let child = {
             let registry = app.server.inner.registry.lock().await;
-            let current = Arc::clone(
+            Arc::clone(
                 &registry
                     .sessions
                     .get(&session_id)
                     .expect("registered child")
                     .lix,
-            );
-            drop(registry);
-            let current = current.read().await;
-            Arc::clone(&*current)
+            )
         };
         let root = Arc::clone(&app.server.inner.root);
 


### PR DESCRIPTION
## Summary

- hard-cut `SessionContext::switch_branch` to mutate the logical session in place and return only `SwitchBranchReceipt`
- remove the Rust SDK's replacement-returning `switch_branch_session` API and allow the existing receipt-only `switch_branch` API on pinned sessions
- replace the server's `RwLock<Arc<Lix>>` replacement slot with a plain `Arc<Lix>`
- make session clones share their in-memory branch selector while independently opened sessions remain isolated
- rebind live observations to the new branch's shared-query cache after a switch

## Why

Pinned branch state was immutable, so switching constructed a replacement `SessionContext`. Every owner then needed a second API or an outer mutable slot to retain that replacement. The server paid an async read-lock acquisition on every operation solely so branch switching could occasionally replace its `Lix` handle.

Branch identity is logical session state. This change stores the selector as shared session state and publishes its new value after the branch transaction commits but before the session write lease is released. Statements and competing switches therefore cannot observe a half-completed commit/selector transition.

## Breaking changes

- `SessionContext::switch_branch(...)` now returns `Result<SwitchBranchReceipt, LixError>` instead of `Result<(SessionContext, SwitchBranchReceipt), LixError>`.
- `Lix::switch_branch_session(...)` is removed.
- clones of one session now observe branch switches in place.

There is intentionally no compatibility adapter.

## Performance impact

- every server operation no longer awaits the replacement-slot `RwLock`
- branch switching no longer rebuilds `SessionContext`, `Lix`, and their Arc ownership graph
- ordinary engine branch reads use one short in-memory selector read; no storage read or async lock was added

## Validation

- `cargo test -Z bindeps -p lix_engine --features all-simulations`
  - unit: 1,823 passed, 8 ignored
  - integration: 808 passed, 2 ignored
  - doctests: 3 passed
- `cargo test -Z bindeps -p lix_server_protocol`
  - 92 passed, 4 ignored
- `cargo test -Z bindeps -p lix_sdk`
- `cargo check -Z bindeps --workspace --all-targets`
- `cargo clippy -Z bindeps -p lix_server_protocol --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Regression coverage proves session clones follow the in-place switch, independently opened sessions remain isolated, observations move to the new branch, and workspace branch selection remains durable across reopen.
