### PR TITLE
Remove legacy certified commit deltas and accelerate replacements

### DIFF
--- a/packages/engine-benchmarks/examples/storage_layout.rs
+++ b/packages/engine-benchmarks/examples/storage_layout.rs
@@ -266,7 +266,7 @@ async fn print_commit_delta_inventory(read: &impl lix_engine::storage_adapter::S
         .expect("decode commit-delta inventory")
     {
         println!(
-            "COMMIT_DELTA\tcommit={}\tphysical_key_bytes={}\tphysical_value_bytes={}\tsegments={}\tmembers={}\tauthored={}\tselected={}\tselected_tombstones={}\tcertified={}\tselected_certified={}\tselected_direct_addresses={}\tselected_source_commits={}\tdominant_selected_source_members={}",
+            "COMMIT_DELTA\tcommit={}\tphysical_key_bytes={}\tphysical_value_bytes={}\tsegments={}\tmembers={}\tauthored={}\tselected={}\tselected_tombstones={}\tselected_direct_addresses={}\tselected_source_commits={}\tdominant_selected_source_members={}",
             entry.commit_id,
             entry.physical_key_bytes,
             entry.physical_value_bytes,
@@ -275,8 +275,6 @@ async fn print_commit_delta_inventory(read: &impl lix_engine::storage_adapter::S
             entry.authored_members,
             entry.selected_members,
             entry.selected_tombstones,
-            entry.certified_members,
-            entry.selected_certified_members,
             entry.selected_direct_addresses,
             entry.selected_source_commits,
             entry.dominant_selected_source_members,

--- a/packages/engine/src/commit_graph/context.rs
+++ b/packages/engine/src/commit_graph/context.rs
@@ -832,7 +832,6 @@ mod tests {
                 origin_key: None,
                 base_coordinate: None,
                 authored: false,
-                certified: false,
             },
             TrackedStateCommitDeltaRef {
                 delta: TrackedStateDeltaRef {
@@ -850,7 +849,6 @@ mod tests {
                 origin_key: None,
                 base_coordinate: None,
                 authored: false,
-                certified: false,
             },
             TrackedStateCommitDeltaRef {
                 delta: TrackedStateDeltaRef {
@@ -868,7 +866,6 @@ mod tests {
                 origin_key: None,
                 base_coordinate: None,
                 authored: false,
-                certified: false,
             },
         ];
         stage_commit_deltas(&mut writes, &deltas).expect("selected tombstones should stage");
@@ -1325,7 +1322,6 @@ mod tests {
                     origin_key: change.origin_key.as_deref(),
                     base_coordinate: None,
                     authored: true,
-                    certified: false,
                 })
                 .collect::<Vec<_>>();
             stage_commit_deltas(&mut writes, &deltas).expect("packed commit members should stage");

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -739,7 +739,6 @@ where
                     || (borrowed_source_is_swept && !member.is_selected_tombstone())
                     || (dead_packed_change_ids.contains(&member.value.change_id)
                         && member.is_selected_payload_ref()),
-                certified: member.is_certified_payload_ref(),
             })
             .collect::<Vec<_>>();
         promoted_locators.extend(authoritative_promoted_locators(
@@ -2046,7 +2045,6 @@ mod tests {
                 origin_key: change.origin_key.as_deref(),
                 base_coordinate: None,
                 authored: true,
-                certified: false,
             })
             .collect()
     }

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -363,7 +363,6 @@ where
                 origin_key: change.origin_key.as_deref(),
                 base_coordinate: None,
                 authored: true,
-                certified: false,
             })
             .collect::<Vec<_>>();
         let locators = crate::tracked_state::stage_commit_deltas(&mut writes, &commit_deltas)?;

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -3198,7 +3198,6 @@ mod tests {
                     origin_key: change.origin_key.as_deref(),
                     base_coordinate: None,
                     authored: true,
-                    certified: false,
                 })
                 .collect::<Vec<_>>();
             stage_commit_deltas(writes, &commit_deltas)?;

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -1207,9 +1207,9 @@ pub(crate) async fn scan_certified_history_rows(
     Ok(builder.finish().into_rows())
 }
 
-/// Expands only the identity metadata needed to publish a certified packet in
-/// an immutable tracked-state root. Payload bytes remain owned by the packet
-/// and are not copied into ordinary change records.
+/// Expands the authoritative rows needed to publish a host-produced packet.
+/// Commit deltas are self-contained, so the packet is decoded once here and
+/// never becomes a second durable payload authority.
 pub(crate) fn materialize_certified_root_rows(
     branch_id: &str,
     file_id: &str,
@@ -1279,7 +1279,7 @@ pub(crate) fn materialize_certified_root_rows(
         branch_id,
         &request,
         &filter_index,
-        false,
+        true,
         None,
         &mut builder,
     )?;

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -884,14 +884,15 @@ async fn try_execute_direct_path_value_replacement_batch(
     let collection_generation = ctx
         .load_collection_generation(&active_branch_id, scope)
         .await?;
+    let ordered_identity_digest =
+        crate::collection_generation::ordered_single_string_identity_digest(
+            unique_entity_pks.iter(),
+        );
     let certified_generation_identity = !has_staged_collection_rows
         && collection_generation.is_some_and(|generation| {
             generation.live_count == unique_row_count as u64
                 && generation.ordered_identity_digest.is_some()
-                && generation.ordered_identity_digest
-                    == crate::collection_generation::ordered_single_string_identity_digest(
-                        unique_entity_pks.iter(),
-                    )
+                && generation.ordered_identity_digest == ordered_identity_digest
         });
     #[cfg(test)]
     if certified_generation_identity {
@@ -973,14 +974,24 @@ async fn try_execute_direct_path_value_replacement_batch(
             && collection_generation
                 .is_some_and(|generation| generation.live_count == unique_row_count as u64));
 
-    let estimated_row_bytes = unique_entity_pks
+    let (estimated_row_bytes, replacement_identity_replay_bytes) = unique_entity_pks
         .iter()
-        .map(|entity_pk| {
-            entity_pk
-                .as_single_string()
-                .map_or(32, |path| path.len().saturating_add(32))
+        .try_fold((0_usize, 0_usize), |(estimated, replay), entity_pk| {
+            Some((
+                estimated.checked_add(
+                    entity_pk
+                        .as_single_string()
+                        .map_or(32, |path| path.len().saturating_add(32)),
+                )?,
+                replay.checked_add(
+                    spec.schema_key
+                        .len()
+                        .checked_add(entity_pk.estimated_heap_bytes())?
+                        .checked_add(128)?,
+                )?,
+            ))
         })
-        .sum::<usize>();
+        .ok_or_else(|| LixError::unknown("certified replacement byte accounting overflowed"))?;
     let mut normalized = Vec::with_capacity(estimated_row_bytes);
     let replacement_capacity = if certified_generation_identity {
         unique_row_count
@@ -989,7 +1000,8 @@ async fn try_execute_direct_path_value_replacement_batch(
     };
     let mut snapshot_offsets = Vec::with_capacity(replacement_capacity);
     let mut replacement_entity_pks = Vec::with_capacity(replacement_capacity);
-    let mut affected_by_statement = vec![0_u64; row_count];
+    let mut affected_by_statement =
+        (!certified_generation_identity).then(|| vec![0_u64; row_count]);
     let mut candidate_index = 0;
     let mut ordinal_index = 0;
     for (identity_index, entity_pk) in unique_entity_pks.iter().enumerate() {
@@ -1045,9 +1057,11 @@ async fn try_execute_direct_path_value_replacement_batch(
         replacement_entity_pks.push(entity_pk.clone());
         if let Some(ordinals) = &sorted_statement_ordinals {
             for &affected_statement in &ordinals[first_statement_index..=last_statement_index] {
-                affected_by_statement[affected_statement] = 1;
+                if let Some(affected_by_statement) = &mut affected_by_statement {
+                    affected_by_statement[affected_statement] = 1;
+                }
             }
-        } else {
+        } else if let Some(affected_by_statement) = &mut affected_by_statement {
             affected_by_statement[statement_index] = 1;
         }
         if !certified_generation_identity {
@@ -1055,6 +1069,7 @@ async fn try_execute_direct_path_value_replacement_batch(
         }
     }
     if !replacement_entity_pks.is_empty() {
+        let normalized_len = normalized.len();
         let snapshots =
             TransactionJson::from_certified_row_content_arena(normalized, snapshot_offsets)?;
         let rows = CertifiedParameterReplacementBatch::new(
@@ -1070,6 +1085,16 @@ async fn try_execute_direct_path_value_replacement_batch(
                 },
                 tracked_keys_strictly_ordered: true,
                 complete_collection_replacement,
+                complete_collection_identity_digest: complete_collection_replacement
+                    .then_some(ordered_identity_digest)
+                    .flatten(),
+                complete_collection_replay_bytes: complete_collection_replacement
+                    .then(|| {
+                        replacement_identity_replay_bytes
+                            .checked_add(normalized_len)
+                            .and_then(|bytes| u64::try_from(bytes).ok())
+                    })
+                    .flatten(),
             },
         )?;
         ctx.stage_certified_parameter_batch_replace(rows)
@@ -1094,12 +1119,17 @@ async fn try_execute_direct_path_value_replacement_batch(
     if record_value_certificate {
         crate::storage_bench::record_certified_entity_update_value_batch_hit(row_count);
     }
-    Ok(Some(
+    Ok(Some(if certified_generation_identity {
+        (0..row_count)
+            .map(|_| SqlWriteResult::affected(1))
+            .collect()
+    } else {
         affected_by_statement
+            .expect("uncertified replacement tracks statement effects")
             .into_iter()
             .map(SqlWriteResult::affected)
-            .collect(),
-    ))
+            .collect()
+    }))
 }
 
 struct DirectPathValueReplacement {
@@ -2820,6 +2850,8 @@ async fn try_execute_direct_path_value_replacement(
             },
             tracked_keys_strictly_ordered: true,
             complete_collection_replacement: false,
+            complete_collection_identity_digest: None,
+            complete_collection_replay_bytes: None,
         },
     )?;
     ctx.stage_certified_parameter_batch_replace(rows).await?;
@@ -4388,6 +4420,8 @@ fn certified_direct_parameter_insert_batch(
         },
         tracked_keys_strictly_ordered,
         complete_collection_replacement: false,
+        complete_collection_identity_digest: None,
+        complete_collection_replay_bytes: None,
     };
     let rows = CertifiedParameterInsertBatch::new(
         entity_pks,
@@ -4533,6 +4567,8 @@ fn certified_direct_path_value_insert_batch(
             },
             tracked_keys_strictly_ordered: true,
             complete_collection_replacement: false,
+            complete_collection_identity_digest: None,
+            complete_collection_replay_bytes: None,
         },
     )?))
 }

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -316,7 +316,6 @@ where
                 origin_key: None,
                 base_coordinate: None,
                 authored: true,
-                certified: false,
             }],
         )?;
     }
@@ -628,8 +627,6 @@ pub struct CommitDeltaLayoutAccounting {
     pub authored_members: usize,
     pub selected_members: usize,
     pub selected_tombstones: usize,
-    pub certified_members: usize,
-    pub selected_certified_members: usize,
     pub selected_direct_addresses: usize,
     pub selected_source_commits: usize,
     pub dominant_selected_source_members: usize,
@@ -690,13 +687,6 @@ where
         let locator = crate::tracked_state::decode_change_locator(change_id, &value)?;
         locator_commit_by_change_id.insert(change_id, locator.commit_id);
     }
-    let certified_change_ids = inventory
-        .commits
-        .values()
-        .flat_map(|entry| &entry.members)
-        .filter(|member| member.is_certified_payload_ref())
-        .map(|member| member.value.change_id)
-        .collect::<std::collections::BTreeSet<_>>();
     let authored_commit_by_change_id = inventory
         .commits
         .iter()
@@ -727,19 +717,6 @@ where
                 .len()
                 .saturating_sub(authored_members)
                 .saturating_sub(selected_members);
-            let certified_members = entry
-                .members
-                .iter()
-                .filter(|member| member.is_certified_payload_ref())
-                .count();
-            let selected_certified_members = entry
-                .members
-                .iter()
-                .filter(|member| {
-                    member.is_selected_payload_ref()
-                        && certified_change_ids.contains(&member.value.change_id)
-                })
-                .count();
             let selected_direct_addresses = entry
                 .members
                 .iter()
@@ -786,8 +763,6 @@ where
                 authored_members,
                 selected_members,
                 selected_tombstones,
-                certified_members,
-                selected_certified_members,
                 selected_direct_addresses,
                 selected_source_commits: selected_members_by_source.len(),
                 dominant_selected_source_members: selected_members_by_source

--- a/packages/engine/src/test_support.rs
+++ b/packages/engine/src/test_support.rs
@@ -282,7 +282,6 @@ pub(crate) async fn stage_tracked_root_from_materialized_with_certified_replacem
                 origin_key: change.origin_key.as_deref(),
                 base_coordinate: None,
                 authored: true,
-                certified: false,
             }
         })
         .collect::<Vec<_>>();
@@ -364,7 +363,6 @@ pub(crate) async fn stage_rootless_tracked_commit_from_materialized(
                 origin_key: change.origin_key.as_deref(),
                 base_coordinate: None,
                 authored: true,
-                certified: false,
             }
         })
         .collect::<Vec<_>>();
@@ -440,7 +438,6 @@ pub(crate) async fn stage_tracked_root_from_materialized_with_parents(
                 origin_key: change.origin_key.as_deref(),
                 base_coordinate: None,
                 authored: true,
-                certified: false,
             }
         })
         .collect::<Vec<_>>();

--- a/packages/engine/src/tracked_state/bench_support.rs
+++ b/packages/engine/src/tracked_state/bench_support.rs
@@ -393,7 +393,6 @@ impl PackedHistoryDelta {
             origin_key: None,
             base_coordinate: None,
             authored: true,
-            certified: false,
         }
     }
 }

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -7969,7 +7969,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn historical_exact_read_requires_certified_rows_to_exist_in_root() {
+    async fn historical_exact_read_uses_self_contained_commit_payload() {
         const COMMIT_LABEL: &str = "certified-historical-exact";
         const BRANCH_ID: &str = "certified-branch";
         const FILE_ID: &str = "certified.csv";
@@ -8098,12 +8098,17 @@ mod tests {
                     created_at: control.created_at,
                     updated_at: control.created_at,
                 },
-                snapshot: crate::json_store::JsonSlotRef::None,
+                snapshot: crate::json_store::JsonSlotRef::Inline(
+                    certified[0]
+                        .snapshot_content
+                        .as_ref()
+                        .expect("certified fixture has a snapshot")
+                        .as_str(),
+                ),
                 metadata: crate::json_store::JsonSlotRef::None,
                 origin_key: Some("certified-origin"),
                 base_coordinate: None,
                 authored: true,
-                certified: true,
             }],
         )
         .expect("certified commit delta should stage");
@@ -8119,21 +8124,17 @@ mod tests {
             .expect("certified locator read should open");
         let inventory = crate::tracked_state::scan_commit_delta_inventory(&read)
             .await
-            .expect("certified inventory should hydrate");
+            .expect("authored inventory should load");
         let inventory_member = inventory
             .commits
             .get(&commit_id)
             .and_then(|entry| entry.members.first())
-            .expect("certified inventory member should exist");
+            .expect("authored inventory member should exist");
         assert!(inventory_member.change.snapshot.is_some());
-        assert!(
-            inventory_member.is_certified_payload_ref(),
-            "hydration must preserve certified wire provenance for GC re-encoding",
-        );
         let canonical = crate::tracked_state::load_change_record_by_id(&read, durable_change_id)
             .await
-            .expect("certified locator should hydrate")
-            .expect("certified locator should exist");
+            .expect("authored locator should load")
+            .expect("authored locator should exist");
         assert!(canonical.snapshot.is_some());
         assert_eq!(canonical.origin_key.as_deref(), Some("certified-origin"));
         drop(read);

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -87,9 +87,6 @@ const COMMIT_DELTA_MAX_SIDECAR_BYTES: usize = 64 * 1024 * 1024;
 const COMMIT_DELTA_MAX_SIDECAR_BYTES: usize = 1024 * 1024;
 const COMMIT_DELTA_SIDECAR_RAW: u8 = 0;
 const COMMIT_DELTA_SIDECAR_ZSTD: u8 = 1;
-/// Every entry is an authored, certified reference with one shared optional
-/// origin key. The leaf already carries the entry count, so only that shared
-/// origin needs a body.
 /// Every entry is an authored inline snapshot with empty metadata and origin
 /// columns. The indexed body stores raw JSON ranges without per-row Musli
 /// envelopes.
@@ -1516,10 +1513,10 @@ pub(crate) fn stage_ordered_addressable_replacement_parts<'a, I>(
 where
     I: ExactSizeIterator<Item = Result<TrackedStateCommitDeltaRef<'a>, LixError>>,
 {
-    struct OwnedRow {
+    struct BorrowedRow<'a> {
         key: Vec<u8>,
-        snapshot: crate::json_store::JsonSlot,
-        metadata: crate::json_store::JsonSlot,
+        snapshot: crate::json_store::JsonSlotRef<'a>,
+        metadata: crate::json_store::JsonSlotRef<'a>,
     }
 
     let row_count = deltas.len();
@@ -1553,23 +1550,12 @@ where
                 "tracked_state replacement member violates immutable replacement invariants",
             ));
         }
-        let own_slot = |slot| match slot {
-            crate::json_store::JsonSlotRef::None => crate::json_store::JsonSlot::None,
-            crate::json_store::JsonSlotRef::Ref(json_ref) => {
-                crate::json_store::JsonSlot::Ref(*json_ref)
-            }
-            crate::json_store::JsonSlotRef::Inline(json) => {
-                crate::json_store::JsonSlot::Inline(json.into())
-            }
-        };
-        let snapshot = own_slot(delta.snapshot);
-        if snapshot.is_none() {
+        if matches!(delta.snapshot, crate::json_store::JsonSlotRef::None) {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 "tracked_state replacement member has no canonical snapshot",
             ));
         }
-        let metadata = own_slot(delta.metadata);
         if commit_id
             .replace(delta.delta.commit_id)
             .is_some_and(|owner| owner != delta.delta.commit_id)
@@ -1595,10 +1581,10 @@ where
         }
         previous_key.clear();
         previous_key.extend_from_slice(&key);
-        pending.push(OwnedRow {
+        pending.push(BorrowedRow {
             key,
-            snapshot: snapshot.to_owned(),
-            metadata,
+            snapshot: delta.snapshot,
+            metadata: delta.metadata,
         });
         if pending.len() == COMMIT_DELTA_SEGMENT_MAX_ROWS {
             encode_replacement_part_prefix(&mut pending, &mut parts, &mut compressor)?;
@@ -1613,7 +1599,7 @@ where
     }
 
     fn encode_replacement_part_prefix(
-        pending: &mut Vec<OwnedRow>,
+        pending: &mut Vec<BorrowedRow<'_>>,
         parts: &mut Vec<crate::tracked_state::replacement_part::EncodedReplacementPart>,
         compressor: &mut Option<crate::compression::ZstdLevel1Compressor>,
     ) -> Result<(), LixError> {
@@ -1624,8 +1610,8 @@ where
                 .map(
                     |row| crate::tracked_state::replacement_part::ReplacementPartRowRef {
                         encoded_key: &row.key,
-                        snapshot: row.snapshot.as_ref_slot(),
-                        metadata: row.metadata.as_ref_slot(),
+                        snapshot: row.snapshot,
+                        metadata: row.metadata,
                     },
                 )
                 .collect::<Vec<_>>();

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -76,10 +76,10 @@ const COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 512;
 const GENERIC_COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 128;
 const GENERIC_COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 28 * 1024;
 const ORDERED_COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 64 * 1024;
-// Version 13 hard-cuts certified complete replacements to bounded identity
-// parts backed by one immutable columnar generation. Older manifests cannot
-// express that authority and are intentionally rejected.
-const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD13";
+// Version 14 makes every ordinary commit member self-contained and complete
+// replacements authoritative through their immutable part manifest. The
+// payload-less certified-reference encoding is intentionally rejected.
+const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD14";
 const COMMIT_DELTA_PAYLOAD_OFFSET_BYTES: usize = size_of::<u32>();
 #[cfg(not(test))]
 const COMMIT_DELTA_MAX_SIDECAR_BYTES: usize = 64 * 1024 * 1024;
@@ -90,7 +90,6 @@ const COMMIT_DELTA_SIDECAR_ZSTD: u8 = 1;
 /// Every entry is an authored, certified reference with one shared optional
 /// origin key. The leaf already carries the entry count, so only that shared
 /// origin needs a body.
-const COMMIT_DELTA_SIDECAR_UNIFORM_CERTIFIED_REF: u8 = 2;
 /// Every entry is an authored inline snapshot with empty metadata and origin
 /// columns. The indexed body stores raw JSON ranges without per-row Musli
 /// envelopes.
@@ -135,7 +134,6 @@ struct CommitDeltaPayloadRef<'a> {
     #[musli(with = storage_codec::option)]
     base_coordinate: Option<TrackedStateBaseCoordinate>,
     authored: bool,
-    certified: bool,
 }
 
 #[derive(Clone, Copy, musli::Encode)]
@@ -151,28 +149,9 @@ struct CommitDeltaAuthoredPayloadRef<'a> {
     base_coordinate: Option<TrackedStateBaseCoordinate>,
 }
 
-#[derive(Clone, Copy, musli::Encode)]
-#[musli(packed)]
-struct CommitDeltaCertifiedPayloadRef<'a> {
-    #[musli(with = storage_codec::option)]
-    origin_key: Option<&'a str>,
-    #[musli(with = storage_codec::option)]
-    base_coordinate: Option<TrackedStateBaseCoordinate>,
-}
-
-#[derive(Debug, musli::Decode)]
-#[musli(packed)]
-struct CommitDeltaCertifiedPayload {
-    #[musli(with = storage_codec::option)]
-    origin_key: Option<String>,
-    #[musli(with = storage_codec::option)]
-    base_coordinate: Option<TrackedStateBaseCoordinate>,
-}
-
 const COMMIT_DELTA_PAYLOAD_AUTHORED: u8 = 0;
 const COMMIT_DELTA_PAYLOAD_SELECTED_REF: u8 = 1;
 const COMMIT_DELTA_PAYLOAD_SELECTED_TOMBSTONE: u8 = 2;
-const COMMIT_DELTA_PAYLOAD_CERTIFIED_REF: u8 = 3;
 
 #[derive(Debug, musli::Decode)]
 #[musli(packed)]
@@ -192,10 +171,6 @@ enum CommitDeltaPayload {
     Authored(CommitDeltaAuthoredPayload),
     SelectedRef(Option<TrackedStateBaseCoordinate>),
     SelectedTombstone(Option<TrackedStateBaseCoordinate>),
-    CertifiedRef {
-        origin_key: Option<String>,
-        base_coordinate: Option<TrackedStateBaseCoordinate>,
-    },
 }
 
 #[cfg(test)]
@@ -226,7 +201,6 @@ struct CommitDeltaPayloadIndex<S> {
 #[derive(Debug, Clone, Copy)]
 enum CommitDeltaPayloadLayout {
     Indexed,
-    UniformCertifiedRef,
     AuthoredInline,
 }
 
@@ -257,21 +231,6 @@ where
             ));
         }
         match self.layout {
-            CommitDeltaPayloadLayout::UniformCertifiedRef => {
-                let (origin_key, base_coordinate) = if self.sidecar.as_ref().is_empty() {
-                    (None, None)
-                } else {
-                    let payload = storage_codec::decode::<CommitDeltaCertifiedPayload>(
-                        "tracked_state uniform certified commit_delta payload",
-                        self.sidecar.as_ref(),
-                    )?;
-                    (payload.origin_key, payload.base_coordinate)
-                };
-                return Ok(CommitDeltaPayload::CertifiedRef {
-                    origin_key,
-                    base_coordinate,
-                });
-            }
             CommitDeltaPayloadLayout::AuthoredInline => {
                 let payload = self.payload_range(entry_index)?;
                 if payload.is_empty() {
@@ -322,21 +281,6 @@ where
             COMMIT_DELTA_PAYLOAD_SELECTED_TOMBSTONE => Ok(CommitDeltaPayload::SelectedTombstone(
                 decode_optional_base_coordinate(payload)?,
             )),
-            COMMIT_DELTA_PAYLOAD_CERTIFIED_REF => {
-                let (origin_key, base_coordinate) = if payload.is_empty() {
-                    (None, None)
-                } else {
-                    let payload = storage_codec::decode::<CommitDeltaCertifiedPayload>(
-                        "tracked_state indexed certified commit_delta payload",
-                        payload,
-                    )?;
-                    (payload.origin_key, payload.base_coordinate)
-                };
-                Ok(CommitDeltaPayload::CertifiedRef {
-                    origin_key,
-                    base_coordinate,
-                })
-            }
             _ => Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 "tracked_state commit_delta member has an invalid payload tag",
@@ -427,8 +371,6 @@ pub(crate) struct LoadedCommitDeltaEntry {
     pub(crate) change_record: crate::changelog::ChangeRecord,
     pub(crate) base_coordinate: Option<TrackedStateBaseCoordinate>,
     selected_ref: bool,
-    certified_ref: bool,
-    owner_commit_id: CommitId,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -513,7 +455,6 @@ pub(crate) struct CommitDeltaMember {
     pub(crate) authored: bool,
     pub(crate) base_coordinate: Option<TrackedStateBaseCoordinate>,
     selected_tombstone: bool,
-    certified_ref: bool,
 }
 
 impl CommitDeltaMember {
@@ -523,10 +464,6 @@ impl CommitDeltaMember {
 
     pub(crate) fn is_selected_tombstone(&self) -> bool {
         self.selected_tombstone
-    }
-
-    pub(crate) fn is_certified_payload_ref(&self) -> bool {
-        self.certified_ref
     }
 }
 
@@ -1979,7 +1916,6 @@ fn encode_ordered_addressable_commit_delta_segment<'a>(
             origin_key: delta.origin_key,
             base_coordinate: delta.base_coordinate,
             authored: delta.authored,
-            certified: delta.certified,
         });
     }
     entries.with_entry_refs(|entries| {
@@ -2043,7 +1979,6 @@ fn stage_commit_deltas_inner(
             origin_key: delta.origin_key,
             base_coordinate: delta.base_coordinate,
             authored: delta.authored,
-            certified: delta.certified,
         });
     }
     let mutations = entries
@@ -2640,7 +2575,6 @@ async fn load_change_records_at_locators(
             )?);
         }
     }
-    hydrate_certified_loaded_entries(store, &mut loaded).await?;
     loaded
         .into_iter()
         .map(|entry| {
@@ -2690,25 +2624,12 @@ where
         ));
     }
     let key = decode_key(entry.key)?;
-    let (snapshot, metadata, origin_key, base_coordinate, certified_ref) = match payloads
-        .decode(ordinal)?
-    {
+    let (snapshot, metadata, origin_key, base_coordinate) = match payloads.decode(ordinal)? {
         CommitDeltaPayload::Authored(payload) => (
             payload.snapshot,
             payload.metadata,
             payload.origin_key,
             payload.base_coordinate,
-            false,
-        ),
-        CommitDeltaPayload::CertifiedRef {
-            origin_key,
-            base_coordinate,
-        } => (
-            crate::json_store::JsonSlot::None,
-            crate::json_store::JsonSlot::None,
-            origin_key,
-            base_coordinate,
-            true,
         ),
         CommitDeltaPayload::SelectedRef(_) | CommitDeltaPayload::SelectedTombstone(_) => {
             return Err(LixError::new(
@@ -2735,8 +2656,6 @@ where
         },
         base_coordinate,
         selected_ref: false,
-        certified_ref,
-        owner_commit_id: locator.commit_id,
     })
 }
 
@@ -2828,14 +2747,8 @@ async fn try_load_change_record_at_locator_in_manifest(
         })?;
         (segment, Some(bounds))
     };
-    let mut loaded = vec![Some(decode_change_at_locator(&segment, bounds, locator)?)];
-    hydrate_certified_loaded_entries(store, &mut loaded).await?;
     Ok(Some(
-        loaded
-            .pop()
-            .flatten()
-            .expect("one decoded change locator must remain")
-            .change_record,
+        decode_change_at_locator(&segment, bounds, locator)?.change_record,
     ))
 }
 
@@ -3226,7 +3139,6 @@ pub(crate) async fn load_commit_delta_members_with_payloads_for_schemas(
     for member in &mut members {
         member.value.commit_id = commit_id;
         member.authored = false;
-        member.certified_ref = false;
         member.selected_tombstone = member.value.deleted;
     }
     members.append(&mut local);
@@ -3327,110 +3239,6 @@ async fn hydrate_selected_members(
         member.change.snapshot = change_record.snapshot;
         member.change.metadata = change_record.metadata;
         member.change.origin_key = change_record.origin_key;
-    }
-    hydrate_certified_members(store, members).await?;
-    Ok(())
-}
-
-async fn hydrate_certified_members(
-    store: &(impl StorageAdapterRead + ?Sized),
-    members: &mut [CommitDeltaMember],
-) -> Result<(), LixError> {
-    let pending = members
-        .iter()
-        .enumerate()
-        .filter(|(_, member)| member.certified_ref)
-        .map(|(index, member)| {
-            (
-                index,
-                member.value.commit_id,
-                member.value.change_id,
-                member.key.clone(),
-            )
-        })
-        .collect::<Vec<_>>();
-    if pending.is_empty() {
-        return Ok(());
-    }
-    let commit_ids = pending
-        .iter()
-        .map(|(_, commit_id, _, _)| *commit_id)
-        .collect::<BTreeSet<_>>();
-    let request = crate::tracked_state::TrackedStateScanRequest {
-        filter: crate::tracked_state::TrackedStateFilter {
-            schema_keys: pending
-                .iter()
-                .map(|(_, _, _, key)| key.schema_key.clone())
-                .collect(),
-            entity_pks: pending
-                .iter()
-                .map(|(_, _, _, key)| key.entity_pk.clone())
-                .collect(),
-            file_ids: pending
-                .iter()
-                .map(|(_, _, _, key)| {
-                    key.file_id.clone().map_or(
-                        crate::NullableKeyFilter::Null,
-                        crate::NullableKeyFilter::Value,
-                    )
-                })
-                .collect(),
-            include_tombstones: true,
-        },
-        read_columns: crate::tracked_state::TrackedStateReadColumns {
-            columns: vec!["snapshot_content".to_owned(), "metadata".to_owned()],
-        },
-        limit: None,
-    };
-    let rows = crate::live_state::scan_certified_history_rows(store, &commit_ids, &request).await?;
-    let mut payloads = BTreeMap::new();
-    for row in rows {
-        let Some(commit_id) = row.commit_id else {
-            continue;
-        };
-        payloads.insert(
-            (commit_id, row.schema_key, row.file_id, row.entity_pk),
-            (
-                row.snapshot_content
-                    .map_or(crate::json_store::JsonSlot::None, |json| {
-                        crate::json_store::JsonSlot::Inline(json.as_str().into())
-                    }),
-                row.metadata
-                    .map_or(crate::json_store::JsonSlot::None, |json| {
-                        crate::json_store::JsonSlot::Inline(json.as_str().into())
-                    }),
-            ),
-        );
-    }
-    for (index, commit_id, change_id, key) in pending {
-        let lookup = (
-            commit_id,
-            key.schema_key.clone(),
-            key.file_id.clone(),
-            key.entity_pk.clone(),
-        );
-        let Some((snapshot, metadata)) = payloads.remove(&lookup) else {
-            let candidates = payloads
-                .keys()
-                .filter(|(candidate_commit, schema_key, file_id, _)| {
-                    *candidate_commit == commit_id
-                        && schema_key == &key.schema_key
-                        && file_id == &key.file_id
-                })
-                .take(5)
-                .map(|(_, _, _, entity_pk)| format!("{entity_pk:?}"))
-                .collect::<Vec<_>>()
-                .join(", ");
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "tracked_state certified change '{change_id}' has no certified payload at commit '{commit_id}' for schema '{}' file {:?} entity {:?}; candidates: {candidates}",
-                    key.schema_key, key.file_id, key.entity_pk
-                ),
-            ));
-        };
-        members[index].change.snapshot = snapshot;
-        members[index].change.metadata = metadata;
     }
     Ok(())
 }
@@ -3540,8 +3348,6 @@ pub(crate) async fn load_owned_commit_delta_entries(
         if let Some(mut entry) = entry {
             entry.value.commit_id = owner_commit_id;
             entry.selected_ref = true;
-            entry.certified_ref = false;
-            entry.owner_commit_id = owner_commit_id;
             output[request_index] = Some(entry);
         }
     }
@@ -4118,80 +3924,6 @@ async fn hydrate_selected_loaded_entries(
         entry.change_record.origin_key = change_record.origin_key;
         entry.selected_ref = false;
     }
-    hydrate_certified_loaded_entries(store, entries).await?;
-    Ok(())
-}
-
-async fn hydrate_certified_loaded_entries(
-    store: &(impl StorageAdapterRead + ?Sized),
-    entries: &mut [Option<LoadedCommitDeltaEntry>],
-) -> Result<(), LixError> {
-    let pending = entries
-        .iter()
-        .enumerate()
-        .filter_map(|(index, entry)| {
-            entry
-                .as_ref()
-                .filter(|entry| entry.certified_ref)
-                .map(|entry| {
-                    (
-                        index,
-                        entry.owner_commit_id,
-                        entry.change_record.change_id,
-                        entry.base_coordinate,
-                        TrackedStateKey {
-                            schema_key: entry.change_record.schema_key.clone(),
-                            file_id: entry.change_record.file_id.clone(),
-                            entity_pk: entry.change_record.entity_pk.clone(),
-                        },
-                    )
-                })
-        })
-        .collect::<Vec<_>>();
-    if pending.is_empty() {
-        return Ok(());
-    }
-    let mut members = pending
-        .iter()
-        .map(
-            |(_, commit_id, change_id, base_coordinate, key)| CommitDeltaMember {
-                key: key.clone(),
-                value: TrackedStateIndexValue {
-                    change_id: *change_id,
-                    commit_id: *commit_id,
-                    deleted: false,
-                    created_at: crate::common::LixTimestamp::from_unix_millis_utc_lossy(0),
-                    updated_at: crate::common::LixTimestamp::from_unix_millis_utc_lossy(0),
-                },
-                change: crate::changelog::ChangeRecord {
-                    format_version: 2,
-                    change_id: *change_id,
-                    schema_key: key.schema_key.clone(),
-                    entity_pk: key.entity_pk.clone(),
-                    file_id: key.file_id.clone(),
-                    snapshot: crate::json_store::JsonSlot::None,
-                    metadata: crate::json_store::JsonSlot::None,
-                    created_at: crate::common::LixTimestamp::from_unix_millis_utc_lossy(0),
-                    origin_key: None,
-                },
-                segment_index: 0,
-                ordinal: 0,
-                authored: true,
-                base_coordinate: *base_coordinate,
-                selected_tombstone: false,
-                certified_ref: true,
-            },
-        )
-        .collect::<Vec<_>>();
-    hydrate_certified_members(store, &mut members).await?;
-    for ((index, _, _, _, _), member) in pending.into_iter().zip(members) {
-        let entry = entries[index]
-            .as_mut()
-            .expect("certified entry came from the output batch");
-        entry.change_record.snapshot = member.change.snapshot;
-        entry.change_record.metadata = member.change.metadata;
-        entry.certified_ref = false;
-    }
     Ok(())
 }
 
@@ -4727,7 +4459,6 @@ pub(crate) async fn scan_commit_delta_inventory(
         for member in &mut selected {
             member.value.commit_id = commit_id;
             member.authored = false;
-            member.certified_ref = false;
             member.selected_tombstone = member.value.deleted;
         }
         let local = inventory
@@ -4994,55 +4725,33 @@ fn collect_strict_commit_delta_members(
         }
         let payload = payloads.decode(entry_index)?;
         let key = decode_key(entry.key)?;
-        let (
-            snapshot,
-            metadata,
-            origin_key,
-            base_coordinate,
-            authored,
-            selected_tombstone,
-            certified_ref,
-        ) = match payload {
-            CommitDeltaPayload::Authored(payload) => (
-                payload.snapshot,
-                payload.metadata,
-                payload.origin_key,
-                payload.base_coordinate,
-                true,
-                false,
-                false,
-            ),
-            CommitDeltaPayload::SelectedRef(base_coordinate) => (
-                crate::json_store::JsonSlot::None,
-                crate::json_store::JsonSlot::None,
-                None,
-                base_coordinate,
-                false,
-                false,
-                false,
-            ),
-            CommitDeltaPayload::SelectedTombstone(base_coordinate) => (
-                crate::json_store::JsonSlot::None,
-                crate::json_store::JsonSlot::None,
-                None,
-                base_coordinate,
-                false,
-                true,
-                false,
-            ),
-            CommitDeltaPayload::CertifiedRef {
-                origin_key,
-                base_coordinate,
-            } => (
-                crate::json_store::JsonSlot::None,
-                crate::json_store::JsonSlot::None,
-                origin_key,
-                base_coordinate,
-                true,
-                false,
-                true,
-            ),
-        };
+        let (snapshot, metadata, origin_key, base_coordinate, authored, selected_tombstone) =
+            match payload {
+                CommitDeltaPayload::Authored(payload) => (
+                    payload.snapshot,
+                    payload.metadata,
+                    payload.origin_key,
+                    payload.base_coordinate,
+                    true,
+                    false,
+                ),
+                CommitDeltaPayload::SelectedRef(base_coordinate) => (
+                    crate::json_store::JsonSlot::None,
+                    crate::json_store::JsonSlot::None,
+                    None,
+                    base_coordinate,
+                    false,
+                    false,
+                ),
+                CommitDeltaPayload::SelectedTombstone(base_coordinate) => (
+                    crate::json_store::JsonSlot::None,
+                    crate::json_store::JsonSlot::None,
+                    None,
+                    base_coordinate,
+                    false,
+                    true,
+                ),
+            };
         let change = crate::changelog::ChangeRecord {
             format_version: 2,
             change_id: value.change_id,
@@ -5063,7 +4772,6 @@ fn collect_strict_commit_delta_members(
             authored,
             base_coordinate,
             selected_tombstone,
-            certified_ref,
         });
     }
     Ok(())
@@ -5640,7 +5348,6 @@ fn encode_commit_delta_segment(entries: &[EncodedLeafEntry]) -> Vec<u8> {
             origin_key: None,
             base_coordinate: None,
             authored: true,
-            certified: false,
         };
         entries.len()
     ];
@@ -5674,42 +5381,8 @@ fn encode_commit_delta_segment_layout(
 ) -> Result<Vec<u8>, CommitDeltaSegmentEncodeError> {
     debug_assert_eq!(entries.len(), payloads.len());
     let leaf = encode_leaf_node_refs(entries);
-    let leaf_len = u32::try_from(leaf.len()).expect("commit-delta leaf fits u32");
-    let uniform_certified_origin = payloads.first().and_then(|first| {
-        payloads
-            .iter()
-            .all(|payload| {
-                payload.authored
-                    && payload.certified
-                    && payload.origin_key == first.origin_key
-                    && payload.base_coordinate.is_none()
-            })
-            .then_some(first.origin_key)
-    });
-    if let Some(origin_key) = uniform_certified_origin {
-        let mut encoded = Vec::with_capacity(
-            COMMIT_DELTA_FORMAT_MAGIC.len() + 4 + leaf.len() + 1 + origin_key.map_or(0, str::len),
-        );
-        encoded.extend_from_slice(COMMIT_DELTA_FORMAT_MAGIC);
-        encoded.extend_from_slice(&leaf_len.to_be_bytes());
-        encoded.extend_from_slice(&leaf);
-        encoded.push(COMMIT_DELTA_SIDECAR_UNIFORM_CERTIFIED_REF);
-        if origin_key.is_some() {
-            storage_codec::append(
-                "tracked_state uniform certified commit_delta payload",
-                &mut encoded,
-                &CommitDeltaCertifiedPayloadRef {
-                    origin_key,
-                    base_coordinate: None,
-                },
-            )
-            .map_err(CommitDeltaSegmentEncodeError::Codec)?;
-        }
-        return Ok(encoded);
-    }
     let authored_inline = payloads.iter().all(|payload| {
         payload.authored
-            && !payload.certified
             && matches!(payload.snapshot, crate::json_store::JsonSlotRef::Inline(_))
             && matches!(payload.metadata, crate::json_store::JsonSlotRef::None)
             && payload.origin_key.is_none()
@@ -5774,21 +5447,7 @@ fn encode_commit_delta_segment_layout(
         payload_offsets.push(
             u32::try_from(payload_bytes.len()).expect("commit-delta payload sidecar fits u32"),
         );
-        if payload.certified {
-            debug_assert!(payload.authored);
-            payload_bytes.push(COMMIT_DELTA_PAYLOAD_CERTIFIED_REF);
-            if payload.origin_key.is_some() || payload.base_coordinate.is_some() {
-                storage_codec::append(
-                    "tracked_state indexed certified commit_delta payload",
-                    &mut payload_bytes,
-                    &CommitDeltaCertifiedPayloadRef {
-                        origin_key: payload.origin_key,
-                        base_coordinate: payload.base_coordinate,
-                    },
-                )
-                .map_err(CommitDeltaSegmentEncodeError::Codec)?;
-            }
-        } else if payload.authored {
+        if payload.authored {
             payload_bytes.push(COMMIT_DELTA_PAYLOAD_AUTHORED);
             let authored = CommitDeltaAuthoredPayloadRef {
                 snapshot: payload.snapshot,
@@ -6032,19 +5691,6 @@ fn decode_commit_delta_with_payloads<'a>(
             "tracked_state commit_delta sidecar is missing its encoding",
         )
     })?;
-    if encoding == COMMIT_DELTA_SIDECAR_UNIFORM_CERTIFIED_REF {
-        let entry_count = leaf.len();
-        return Ok((
-            leaf,
-            CommitDeltaPayloadIndexRef {
-                sidecar: Cow::Borrowed(encoded_sidecar),
-                offsets: 0..0,
-                payload_start: 0,
-                entry_count,
-                layout: CommitDeltaPayloadLayout::UniformCertifiedRef,
-            },
-        ));
-    }
     let (uncompressed_len, encoded_sidecar) =
         encoded_sidecar.split_at_checked(4).ok_or_else(|| {
             LixError::new(
@@ -6457,44 +6103,29 @@ where
     }
     let payload = payloads.decode(index)?;
     let key = decode_key(entry.key)?;
-    let (snapshot, metadata, origin_key, base_coordinate, selected_ref, certified_ref) =
-        match payload {
-            CommitDeltaPayload::Authored(payload) => (
-                payload.snapshot,
-                payload.metadata,
-                payload.origin_key,
-                payload.base_coordinate,
-                false,
-                false,
-            ),
-            CommitDeltaPayload::SelectedRef(base_coordinate) => (
-                crate::json_store::JsonSlot::None,
-                crate::json_store::JsonSlot::None,
-                None,
-                base_coordinate,
-                true,
-                false,
-            ),
-            CommitDeltaPayload::SelectedTombstone(base_coordinate) => (
-                crate::json_store::JsonSlot::None,
-                crate::json_store::JsonSlot::None,
-                None,
-                base_coordinate,
-                false,
-                false,
-            ),
-            CommitDeltaPayload::CertifiedRef {
-                origin_key,
-                base_coordinate,
-            } => (
-                crate::json_store::JsonSlot::None,
-                crate::json_store::JsonSlot::None,
-                origin_key,
-                base_coordinate,
-                false,
-                true,
-            ),
-        };
+    let (snapshot, metadata, origin_key, base_coordinate, selected_ref) = match payload {
+        CommitDeltaPayload::Authored(payload) => (
+            payload.snapshot,
+            payload.metadata,
+            payload.origin_key,
+            payload.base_coordinate,
+            false,
+        ),
+        CommitDeltaPayload::SelectedRef(base_coordinate) => (
+            crate::json_store::JsonSlot::None,
+            crate::json_store::JsonSlot::None,
+            None,
+            base_coordinate,
+            true,
+        ),
+        CommitDeltaPayload::SelectedTombstone(base_coordinate) => (
+            crate::json_store::JsonSlot::None,
+            crate::json_store::JsonSlot::None,
+            None,
+            base_coordinate,
+            false,
+        ),
+    };
     let change_record = crate::changelog::ChangeRecord {
         format_version: 2,
         change_id: value.change_id,
@@ -6511,8 +6142,6 @@ where
         change_record,
         base_coordinate,
         selected_ref,
-        certified_ref,
-        owner_commit_id: expected_commit_id,
     })
 }
 
@@ -6996,7 +6625,6 @@ mod tests {
             origin_key,
             base_coordinate: None,
             authored: true,
-            certified: false,
         }
     }
 
@@ -7789,7 +7417,6 @@ mod tests {
                 origin_key: None,
                 base_coordinate: None,
                 authored: true,
-                certified: false,
             }],
         );
         let mut writes = orphan_storage.new_write_set();
@@ -8488,7 +8115,6 @@ mod tests {
                 origin_key: None,
                 base_coordinate: None,
                 authored: true,
-                certified: false,
             }],
         );
         segment.pop();
@@ -8590,7 +8216,6 @@ mod tests {
                 origin_key: Some("first"),
                 base_coordinate: None,
                 authored: true,
-                certified: false,
             },
             CommitDeltaPayloadRef {
                 snapshot: crate::json_store::JsonSlotRef::Inline(snapshots[1]),
@@ -8598,7 +8223,6 @@ mod tests {
                 origin_key: None,
                 base_coordinate: None,
                 authored: true,
-                certified: false,
             },
             CommitDeltaPayloadRef {
                 snapshot: crate::json_store::JsonSlotRef::Inline(snapshots[2]),
@@ -8606,7 +8230,6 @@ mod tests {
                 origin_key: Some("last"),
                 base_coordinate: None,
                 authored: true,
-                certified: false,
             },
         ];
         let mut encoded = encode_commit_delta_segment_with_raw_sidecar(&entries, &payloads);
@@ -8668,92 +8291,6 @@ mod tests {
     }
 
     #[test]
-    fn uniform_certified_payloads_store_shared_origin_once() {
-        let commit_id = CommitId::for_test_label("uniform-certified-sidecar");
-        let fixtures = packed_commit_delta_fixtures()
-            .into_iter()
-            .take(2)
-            .collect::<Vec<_>>();
-        let entries = fixtures
-            .iter()
-            .map(|fixture| EncodedLeafEntry {
-                key: encode_key_ref(TrackedStateKeyRef {
-                    schema_key: &fixture.schema_key,
-                    file_id: fixture.file_id.as_deref(),
-                    entity_pk: &fixture.entity_pk,
-                })
-                .into(),
-                value: encode_value_ref(TrackedStateIndexValueRef {
-                    change_id: fixture.change_id,
-                    commit_id,
-                    deleted: fixture.deleted,
-                    created_at: fixture.created_at,
-                    updated_at: fixture.updated_at,
-                })
-                .into(),
-            })
-            .collect::<Vec<_>>();
-        let mut payloads = vec![
-            CommitDeltaPayloadRef {
-                snapshot: crate::json_store::JsonSlotRef::None,
-                metadata: crate::json_store::JsonSlotRef::None,
-                origin_key: None,
-                base_coordinate: None,
-                authored: true,
-                certified: true,
-            };
-            entries.len()
-        ];
-
-        let encoded = encode_commit_delta_segment_with_payloads(&entries, &payloads);
-        let leaf_len = usize::try_from(u32::from_be_bytes(
-            encoded[COMMIT_DELTA_FORMAT_MAGIC.len()..COMMIT_DELTA_FORMAT_MAGIC.len() + 4]
-                .try_into()
-                .expect("fixed leaf length"),
-        ))
-        .expect("u32 fits usize");
-        let sidecar_header = COMMIT_DELTA_FORMAT_MAGIC.len() + 4 + leaf_len;
-        assert_eq!(
-            encoded[sidecar_header],
-            super::COMMIT_DELTA_SIDECAR_UNIFORM_CERTIFIED_REF
-        );
-        assert_eq!(encoded.len(), sidecar_header + 1);
-
-        let (_, decoded) =
-            decode_commit_delta_with_payloads(&encoded, None).expect("sidecar should decode");
-        for index in 0..entries.len() {
-            assert!(matches!(
-                decoded.decode(index).expect("payload should decode"),
-                super::CommitDeltaPayload::CertifiedRef {
-                    origin_key: None,
-                    base_coordinate: None
-                }
-            ));
-        }
-
-        for payload in &mut payloads {
-            payload.origin_key = Some("shared-origin");
-        }
-        let encoded = encode_commit_delta_segment_with_payloads(&entries, &payloads);
-        assert_eq!(
-            encoded[sidecar_header],
-            super::COMMIT_DELTA_SIDECAR_UNIFORM_CERTIFIED_REF
-        );
-        assert!(encoded.len() > sidecar_header + 1);
-        let (_, decoded) =
-            decode_commit_delta_with_payloads(&encoded, None).expect("sidecar should decode");
-        for index in 0..entries.len() {
-            assert!(matches!(
-                decoded.decode(index).expect("payload should decode"),
-                super::CommitDeltaPayload::CertifiedRef {
-                    origin_key: Some(origin),
-                    base_coordinate: None
-                } if origin == "shared-origin"
-            ));
-        }
-    }
-
-    #[test]
     fn indexed_payload_kinds_round_trip_columnar_base_coordinates() {
         let commit_id = CommitId::for_test_label("coordinate-codec-owner");
         let base_commit_id = CommitId::for_test_label("coordinate-codec-base");
@@ -8805,7 +8342,6 @@ mod tests {
                 origin_key: None,
                 base_coordinate: Some(coordinates[0]),
                 authored: true,
-                certified: false,
             },
             CommitDeltaPayloadRef {
                 snapshot: crate::json_store::JsonSlotRef::None,
@@ -8813,15 +8349,13 @@ mod tests {
                 origin_key: None,
                 base_coordinate: Some(coordinates[1]),
                 authored: false,
-                certified: false,
             },
             CommitDeltaPayloadRef {
-                snapshot: crate::json_store::JsonSlotRef::None,
+                snapshot: crate::json_store::JsonSlotRef::Inline(r#"{"authored":true}"#),
                 metadata: crate::json_store::JsonSlotRef::None,
                 origin_key: None,
                 base_coordinate: Some(coordinates[2]),
                 authored: true,
-                certified: true,
             },
         ];
         let encoded = encode_commit_delta_segment_with_raw_sidecar(&entries, &payloads);
@@ -8841,15 +8375,14 @@ mod tests {
             super::CommitDeltaPayload::SelectedRef(Some(coordinate))
                 if coordinate == coordinates[1]
         ));
-        assert!(matches!(
+        assert_eq!(
             decoded
                 .decode(2)
-                .expect("replacement coordinate should decode"),
-            super::CommitDeltaPayload::CertifiedRef {
-                origin_key: None,
-                base_coordinate: Some(coordinate),
-            } if coordinate == coordinates[2]
-        ));
+                .expect("authored coordinate should decode")
+                .authored_payload()
+                .base_coordinate,
+            Some(coordinates[2])
+        );
     }
 
     #[test]
@@ -8887,7 +8420,6 @@ mod tests {
                 origin_key: None,
                 base_coordinate: None,
                 authored: true,
-                certified: false,
             },
             CommitDeltaPayloadRef {
                 snapshot: crate::json_store::JsonSlotRef::Inline(&second_snapshot),
@@ -8895,7 +8427,6 @@ mod tests {
                 origin_key: None,
                 base_coordinate: None,
                 authored: true,
-                certified: false,
             },
         ];
         let encoded = encode_commit_delta_segment_with_payloads(&entries, &payloads);
@@ -8974,7 +8505,6 @@ mod tests {
                 origin_key: None,
                 base_coordinate: None,
                 authored: true,
-                certified: false,
             }],
         );
         let leaf_len = usize::try_from(u32::from_be_bytes(
@@ -9024,7 +8554,6 @@ mod tests {
                 origin_key: None,
                 base_coordinate: None,
                 authored: true,
-                certified: false,
             },
             CommitDeltaPayloadRef {
                 snapshot: crate::json_store::JsonSlotRef::Inline(r#"{"second":true}"#),
@@ -9032,7 +8561,6 @@ mod tests {
                 origin_key: None,
                 base_coordinate: None,
                 authored: true,
-                certified: false,
             },
         ];
         let mut encoded = encode_commit_delta_segment_with_raw_sidecar(&entries, &payloads);
@@ -9180,7 +8708,6 @@ mod tests {
                 origin_key: None,
                 base_coordinate: None,
                 authored: true,
-                certified: false,
             }],
         );
 

--- a/packages/engine/src/tracked_state/types.rs
+++ b/packages/engine/src/tracked_state/types.rs
@@ -77,9 +77,6 @@ pub(crate) struct TrackedStateCommitDeltaRef<'a> {
     pub(crate) origin_key: Option<&'a str>,
     pub(crate) base_coordinate: Option<TrackedStateBaseCoordinate>,
     pub(crate) authored: bool,
-    /// The durable payload is already present in a host-certified batch for
-    /// this commit and identity.
-    pub(crate) certified: bool,
 }
 
 /// One ordered tracked-root mutation with its insert-collision contract.

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -21,7 +21,9 @@ use crate::common::{LixTimestamp, compose_directory_path, compose_file_path};
 use crate::entity_pk::EntityPk;
 use crate::filesystem::stage_path_index_revision;
 use crate::functions::FunctionContext;
-use crate::json_store::{JsonStoreContext, JsonWritePlacementRef, NormalizedJsonRef};
+use crate::json_store::{
+    JSON_INLINE_MAX_BYTES, JsonRef, JsonStoreContext, JsonWritePlacementRef, NormalizedJsonRef,
+};
 use crate::live_state::{
     HotTrackedSnapshot, MaterializedLiveStateRow, TrackedHeadContext, TrackedWorkingDiffEpoch,
     WorkingDiffIndexCoverage, stage_delete_tracked_working_diff_epoch,
@@ -453,6 +455,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
             ));
         }
     }
+    let certified_packet_json_refs = certified_root_json_refs(&certified_packet_root_rows);
     let checkpoint_epochs = checkpoint_epoch_bindings(&prepared_writes.checkpoint_publications)?;
     // The current-state protocol removes the automatic mutable branch-ref
     // row for a normal branch-head advance, but `lix_change` remains an
@@ -517,6 +520,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &commit_rows,
         &selected_change_records,
         &certified_packet_root_rows,
+        &certified_packet_json_refs,
         &insert_selection,
         &replacement_generations,
     )
@@ -564,7 +568,13 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     let selected_change_payloads =
         materialize_selected_change_payloads(read, &selected_change_records).await?;
 
-    stage_state_json_payloads(&mut json_writer, &mut writes, &state_rows)?;
+    stage_state_json_payloads(
+        &mut json_writer,
+        &mut writes,
+        &state_rows,
+        &certified_packet_root_rows,
+        &certified_packet_json_refs,
+    )?;
 
     let branch_control_observations =
         observe_branch_head_controls(read, &tracked_roots, &state_rows, &engine_rows).await?;
@@ -800,13 +810,66 @@ fn stage_state_json_payloads(
     json_writer: &mut crate::json_store::JsonStoreWriter,
     writes: &mut StorageWriteSet,
     state_rows: &PreparedStateBatch,
+    certified_rows_by_commit: &BTreeMap<CommitId, Vec<MaterializedLiveStateRow>>,
+    certified_refs_by_commit: &BTreeMap<CommitId, Vec<CertifiedRootJsonRefs>>,
 ) -> Result<(), LixError> {
     json_writer.stage_batch(
         writes,
         JsonWritePlacementRef::OutOfBand,
-        state_rows.iter().flat_map(json_payloads_from_state_row),
+        state_rows
+            .iter()
+            .flat_map(json_payloads_from_state_row)
+            .chain(
+                certified_rows_by_commit
+                    .iter()
+                    .flat_map(|(commit_id, rows)| {
+                        let refs = &certified_refs_by_commit[commit_id];
+                        rows.iter().zip(refs).flat_map(|(row, refs)| {
+                            [
+                                row.snapshot_content.as_ref().zip(refs.snapshot.as_ref()),
+                                row.metadata.as_ref().zip(refs.metadata.as_ref()),
+                            ]
+                            .into_iter()
+                            .flatten()
+                            .map(|(json, json_ref)| {
+                                NormalizedJsonRef::trusted_prehashed(json.as_str(), *json_ref)
+                            })
+                        })
+                    }),
+            ),
     )?;
     Ok(())
+}
+
+#[derive(Clone, Copy, Default)]
+struct CertifiedRootJsonRefs {
+    snapshot: Option<JsonRef>,
+    metadata: Option<JsonRef>,
+}
+
+fn certified_root_json_refs(
+    rows_by_commit: &BTreeMap<CommitId, Vec<MaterializedLiveStateRow>>,
+) -> BTreeMap<CommitId, Vec<CertifiedRootJsonRefs>> {
+    let mut refs_by_commit = BTreeMap::new();
+    for (&commit_id, rows) in rows_by_commit {
+        let refs = rows
+            .iter()
+            .map(|row| CertifiedRootJsonRefs {
+                snapshot: row
+                    .snapshot_content
+                    .as_ref()
+                    .filter(|json| json.len() > JSON_INLINE_MAX_BYTES)
+                    .map(|json| JsonRef::for_content(json.as_bytes())),
+                metadata: row
+                    .metadata
+                    .as_ref()
+                    .filter(|json| json.len() > JSON_INLINE_MAX_BYTES)
+                    .map(|json| JsonRef::for_content(json.as_bytes())),
+            })
+            .collect::<Vec<_>>();
+        refs_by_commit.insert(commit_id, refs);
+    }
+    refs_by_commit
 }
 
 fn json_payloads_from_state_row(
@@ -1329,13 +1392,13 @@ fn branch_ref_change_record(root: &PendingTrackedRoot) -> Result<ChangeRecord, L
             format!("failed to serialize direct branch-ref change: {error}"),
         )
     })?;
-    if snapshot.len() > crate::json_store::JSON_INLINE_MAX_BYTES {
+    if snapshot.len() > JSON_INLINE_MAX_BYTES {
         return Err(LixError::new(
             LixError::CODE_INVALID_PARAM,
             format!(
                 "branch id is too long: its serialized branch ref is {} bytes, but the maximum is {} bytes",
                 snapshot.len(),
-                crate::json_store::JSON_INLINE_MAX_BYTES,
+                JSON_INLINE_MAX_BYTES,
             ),
         ));
     }
@@ -1467,22 +1530,29 @@ fn tracked_delta_from_certified_root_row(
     })
 }
 
-fn tracked_commit_delta_from_certified_root_row(
-    row: &MaterializedLiveStateRow,
-) -> Result<TrackedStateCommitDeltaRef<'_>, LixError> {
+fn tracked_commit_delta_from_certified_root_row<'a>(
+    row: &'a MaterializedLiveStateRow,
+    json_refs: &'a CertifiedRootJsonRefs,
+) -> Result<TrackedStateCommitDeltaRef<'a>, LixError> {
     Ok(TrackedStateCommitDeltaRef {
         delta: tracked_delta_from_certified_root_row(row)?,
-        snapshot: row
-            .snapshot_content
-            .as_ref()
-            .map_or(crate::json_store::JsonSlotRef::None, |snapshot| {
-                crate::json_store::JsonSlotRef::Inline(snapshot.as_str())
-            }),
+        snapshot: row.snapshot_content.as_ref().map_or(
+            crate::json_store::JsonSlotRef::None,
+            |snapshot| {
+                json_refs.snapshot.as_ref().map_or(
+                    crate::json_store::JsonSlotRef::Inline(snapshot.as_str()),
+                    crate::json_store::JsonSlotRef::Ref,
+                )
+            },
+        ),
         metadata: row
             .metadata
             .as_ref()
             .map_or(crate::json_store::JsonSlotRef::None, |metadata| {
-                crate::json_store::JsonSlotRef::Inline(metadata.as_str())
+                json_refs.metadata.as_ref().map_or(
+                    crate::json_store::JsonSlotRef::Inline(metadata.as_str()),
+                    crate::json_store::JsonSlotRef::Ref,
+                )
             }),
         origin_key: None,
         base_coordinate: None,
@@ -1776,6 +1846,7 @@ async fn stage_tracked_commit_delta_index(
     commit_rows: &[FinalizedCommitRow],
     selected_change_records: &HashMap<SelectedChangeKey, ChangeRecord>,
     certified_packet_root_rows: &BTreeMap<CommitId, Vec<MaterializedLiveStateRow>>,
+    certified_packet_json_refs: &BTreeMap<CommitId, Vec<CertifiedRootJsonRefs>>,
     insert_selection: &PreparedInsertSelection,
     replacement_generations: &BTreeMap<CommitId, CommitDeltaReplacementGeneration>,
 ) -> Result<BTreeSet<CommitId>, LixError> {
@@ -1793,6 +1864,16 @@ async fn stage_tracked_commit_delta_index(
             .get(&root.commit_id)
             .map(Vec::as_slice)
             .unwrap_or_default();
+        let certified_root_json_refs = certified_packet_json_refs
+            .get(&root.commit_id)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        if certified_root_rows.len() != certified_root_json_refs.len() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "certified root JSON placement does not match materialized rows",
+            ));
+        }
         let staged = commit_rows.get(&root.commit_id).ok_or_else(|| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
@@ -1917,8 +1998,10 @@ async fn stage_tracked_commit_delta_index(
                 );
             deltas.push(delta);
         }
-        for row in certified_root_rows {
-            deltas.push(tracked_commit_delta_from_certified_root_row(row)?);
+        for (row, json_refs) in certified_root_rows.iter().zip(certified_root_json_refs) {
+            deltas.push(tracked_commit_delta_from_certified_root_row(
+                row, json_refs,
+            )?);
             // Certified rows are addressed by commit plus identity. They do
             // not need standalone change locators in the public ledger.
             addressable.push(false);
@@ -5697,6 +5780,17 @@ mod tests {
             0x0192_0000_0000_7000_8000_4321_0000_0000,
         ));
         let timestamp = ts("2026-01-01T00:00:00Z");
+        let mut large_snapshot = String::with_capacity(4 * 1024 * 1024 + 2);
+        large_snapshot.push('"');
+        let mut random = 0x9e37_79b9_u32;
+        for _ in 0..(4 * 1024 * 1024) {
+            random ^= random << 13;
+            random ^= random >> 17;
+            random ^= random << 5;
+            large_snapshot.push(char::from(b'a' + (random % 26) as u8));
+        }
+        large_snapshot.push('"');
+        let large_snapshot = crate::common::SharedStr::from(large_snapshot);
         let mut state_rows = PreparedStateBatch::new();
         state_rows.push_parts_with_change_addressability(
             SchemaPlanId::for_test(0),
@@ -5707,7 +5801,8 @@ mod tests {
             Some(
                 crate::transaction::types::stage_json_from_value(
                     crate::transaction::types::TransactionJson::from_value_for_test(
-                        serde_json::json!({ "value": 1 }),
+                        serde_json::from_str(large_snapshot.as_str())
+                            .expect("large ordinary snapshot should parse"),
                     ),
                     "mixed certified ordinary snapshot",
                 )
@@ -5732,7 +5827,7 @@ mod tests {
                 entity_pk: EntityPk::single("certified"),
                 schema_key: "certified_schema".to_owned(),
                 file_id: Some("certified.csv".to_owned()),
-                snapshot_content: None,
+                snapshot_content: Some(large_snapshot.clone()),
                 metadata: None,
                 deleted: false,
                 created_at: timestamp,
@@ -5764,6 +5859,18 @@ mod tests {
             .await
             .expect("mixed certified read should open");
         let mut writes = StorageWriteSet::new();
+        let certified_json_refs = certified_root_json_refs(&certified_rows);
+        stage_state_json_payloads(
+            &mut JsonStoreContext::new().writer(),
+            &mut writes,
+            &state_rows,
+            &certified_rows,
+            &certified_json_refs,
+        )
+        .expect("duplicate large ordinary and certified payload should stage once");
+        let large_snapshot_ref = certified_json_refs[&commit_id][0]
+            .snapshot
+            .expect("large certified snapshot should use a JSON ref");
         stage_tracked_commit_delta_index(
             &read,
             &mut writes,
@@ -5774,6 +5881,7 @@ mod tests {
             &commits,
             &HashMap::new(),
             &certified_rows,
+            &certified_json_refs,
             &PreparedInsertSelection::new(),
             &BTreeMap::new(),
         )
@@ -5797,6 +5905,34 @@ mod tests {
             "certified packet identity must be present in the commit delta"
         );
         assert_eq!(records[1].0.schema_key, "ordinary_schema");
+        let packed_members =
+            crate::tracked_state::load_commit_delta_members_with_payloads(&read, commit_id)
+                .await
+                .expect("mixed certified payloads should load");
+        let certified = packed_members
+            .iter()
+            .find(|member| member.change.change_id == certified_change_id)
+            .expect("certified payload should be a commit member");
+        assert_eq!(
+            certified.change.snapshot,
+            crate::json_store::JsonSlot::Ref(large_snapshot_ref)
+        );
+        let loaded = JsonStoreContext::new()
+            .load_bytes_many(
+                &read,
+                crate::json_store::JsonLoadRequestRef {
+                    refs: &[large_snapshot_ref],
+                    scope: crate::json_store::JsonReadScopeRef::OutOfBand,
+                },
+            )
+            .await
+            .expect("large certified JSON ref should resolve")
+            .into_values();
+        assert_eq!(
+            loaded[0].as_deref(),
+            Some(large_snapshot.as_bytes()),
+            "large certified history payload must round-trip exactly"
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -1035,17 +1035,25 @@ async fn stage_changelog_commits(
             })
             .and_then(|rows| u64::try_from(rows).ok())
             .ok_or_else(|| LixError::unknown("tracked-state rootless row count exceeds u64"))?;
-        let commit_delta_bytes = tracked_row_indices_by_commit
+        let commit_row_indices = tracked_row_indices_by_commit
             .get(&commit_id)
-            .into_iter()
-            .flatten()
-            .try_fold(0_u64, |bytes, &row_index| {
-                bytes
-                    .checked_add(prepared_state_row_replay_bytes(state_rows.row(row_index))?)
-                    .ok_or_else(|| {
-                        LixError::unknown("tracked-state rootless byte count exceeds u64")
-                    })
-            })?;
+            .map(Vec::as_slice);
+        let commit_delta_bytes = if state_rows.certified_complete_collection_replacement()
+            && commit_row_indices.is_some_and(|indices| indices.len() == state_rows.len())
+        {
+            if let Some(certified_bytes) = state_rows.certified_complete_collection_replay_bytes() {
+                #[cfg(debug_assertions)]
+                debug_assert_eq!(
+                    certified_bytes,
+                    replay_bytes_for_rows(state_rows, commit_row_indices)?
+                );
+                certified_bytes
+            } else {
+                replay_bytes_for_rows(state_rows, commit_row_indices)?
+            }
+        } else {
+            replay_bytes_for_rows(state_rows, commit_row_indices)?
+        };
         let has_unbounded_payload_sources = certified_packet_root_rows
             .get(&commit_id)
             .is_some_and(|rows| !rows.is_empty())
@@ -2076,13 +2084,25 @@ async fn certify_complete_replacement_generations(
         else {
             continue;
         };
-        let Some(ordered_identity_digest) =
+        let certified_identity_digest = state_rows.certified_complete_collection_identity_digest();
+        #[cfg(debug_assertions)]
+        if let Some(certified_identity_digest) = certified_identity_digest {
+            debug_assert_eq!(
+                Some(certified_identity_digest),
+                crate::collection_generation::ordered_single_string_identity_digest(
+                    row_indices
+                        .iter()
+                        .map(|&row_index| state_rows.row(row_index).entity_pk),
+                )
+            );
+        }
+        let Some(ordered_identity_digest) = certified_identity_digest.or_else(|| {
             crate::collection_generation::ordered_single_string_identity_digest(
                 row_indices
                     .iter()
                     .map(|&row_index| state_rows.row(row_index).entity_pk),
             )
-        else {
+        }) else {
             continue;
         };
         let mut current = root.parent_commit_id;
@@ -2253,6 +2273,20 @@ fn prepared_state_row_replay_bytes(row: PreparedStateRowRef<'_>) -> Result<u64, 
         .and_then(|bytes| bytes.checked_add(metadata_bytes))
         .and_then(|bytes| u64::try_from(bytes).ok())
         .ok_or_else(|| LixError::unknown("tracked-state replay row bytes exceed u64"))
+}
+
+fn replay_bytes_for_rows(
+    state_rows: &PreparedStateBatch,
+    row_indices: Option<&[RowIndex]>,
+) -> Result<u64, LixError> {
+    row_indices
+        .into_iter()
+        .flatten()
+        .try_fold(0_u64, |bytes, &row_index| {
+            bytes
+                .checked_add(prepared_state_row_replay_bytes(state_rows.row(row_index))?)
+                .ok_or_else(|| LixError::unknown("tracked-state rootless byte count exceeds u64"))
+        })
 }
 
 fn select_new_rootless_ordered_commits(

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -516,7 +516,6 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &tracked_roots,
         &commit_rows,
         &selected_change_records,
-        &host_certified_file_schemas,
         &certified_packet_root_rows,
         &insert_selection,
         &replacement_generations,
@@ -1432,7 +1431,6 @@ fn tracked_commit_delta_from_state_row(
         origin_key: row.origin_key.map(crate::common::SharedStr::as_str),
         base_coordinate: None,
         authored: true,
-        certified: false,
     })
 }
 
@@ -1481,7 +1479,6 @@ fn tracked_commit_delta_from_certified_root_row(
         origin_key: None,
         base_coordinate: None,
         authored: true,
-        certified: row.snapshot_content.is_none() && row.metadata.is_none(),
     })
 }
 
@@ -1538,7 +1535,6 @@ fn tracked_commit_delta_from_selected_change_ref<'a>(
         origin_key: record.and_then(|record| record.origin_key.as_deref()),
         base_coordinate: None,
         authored: false,
-        certified: false,
     })
 }
 
@@ -1771,7 +1767,6 @@ async fn stage_tracked_commit_delta_index(
     tracked_roots: &[PendingTrackedRoot],
     commit_rows: &[FinalizedCommitRow],
     selected_change_records: &HashMap<SelectedChangeKey, ChangeRecord>,
-    host_certified_file_schemas: &BTreeMap<String, BTreeMap<String, BTreeSet<String>>>,
     certified_packet_root_rows: &BTreeMap<CommitId, Vec<MaterializedLiveStateRow>>,
     insert_selection: &PreparedInsertSelection,
     replacement_generations: &BTreeMap<CommitId, CommitDeltaReplacementGeneration>,
@@ -1847,15 +1842,6 @@ async fn stage_tracked_commit_delta_index(
                                 row_index: location.row_index,
                             },
                         );
-                    if replacement_generation.is_none() {
-                        delta.certified = root.publish_head
-                            && host_certified_batch_owns_live_row(
-                                row,
-                                &root.branch_id,
-                                root.commit_id,
-                                host_certified_file_schemas,
-                            );
-                    }
                     Ok(delta)
                 };
                 let order_certified = state_rows.certified_tracked_keys_strictly_ordered()
@@ -1920,13 +1906,6 @@ async fn stage_tracked_commit_delta_index(
                         group_index: location.group_index,
                         row_index: location.row_index,
                     },
-                );
-            delta.certified = root.publish_head
-                && host_certified_batch_owns_live_row(
-                    row,
-                    &root.branch_id,
-                    root.commit_id,
-                    host_certified_file_schemas,
                 );
             deltas.push(delta);
         }
@@ -5760,7 +5739,6 @@ mod tests {
             &roots,
             &commits,
             &HashMap::new(),
-            &BTreeMap::new(),
             &certified_rows,
             &PreparedInsertSelection::new(),
             &BTreeMap::new(),

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -485,6 +485,8 @@ pub(crate) struct CertifiedRawWriteBatchPreparation {
     pub(crate) facts: PreparedRowFacts,
     pub(crate) tracked_keys_strictly_ordered: bool,
     pub(crate) complete_collection_replacement: bool,
+    pub(crate) complete_collection_identity_digest: Option<[u8; 32]>,
+    pub(crate) complete_collection_replay_bytes: Option<u64>,
 }
 
 /// Dense, typed columns produced by certified SQL parameter-batch paths.
@@ -624,6 +626,10 @@ impl CertifiedParameterBatch {
             origin_column_index: HashMap::new(),
             certified_tracked_keys_strictly_ordered: certificate.tracked_keys_strictly_ordered,
             certified_complete_collection_replacement: certificate.complete_collection_replacement,
+            certified_complete_collection_identity_digest: certificate
+                .complete_collection_identity_digest,
+            certified_complete_collection_replay_bytes: certificate
+                .complete_collection_replay_bytes,
         })
     }
 }
@@ -1057,6 +1063,10 @@ impl RawWriteBatch {
             origin_column_index: HashMap::new(),
             certified_tracked_keys_strictly_ordered: certificate.tracked_keys_strictly_ordered,
             certified_complete_collection_replacement: certificate.complete_collection_replacement,
+            certified_complete_collection_identity_digest: certificate
+                .complete_collection_identity_digest,
+            certified_complete_collection_replay_bytes: certificate
+                .complete_collection_replay_bytes,
         })
     }
 
@@ -2488,6 +2498,8 @@ pub(crate) struct PreparedStateBatch {
     /// A typed producer proved this batch replaces every live row in one
     /// tracked, unfiled collection under the transaction's branch snapshot.
     certified_complete_collection_replacement: bool,
+    certified_complete_collection_identity_digest: Option<[u8; 32]>,
+    certified_complete_collection_replay_bytes: Option<u64>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2646,6 +2658,8 @@ impl PreparedStateBatch {
             origin_column_index: HashMap::new(),
             certified_tracked_keys_strictly_ordered: false,
             certified_complete_collection_replacement: false,
+            certified_complete_collection_identity_digest: None,
+            certified_complete_collection_replay_bytes: None,
         }
     }
 
@@ -2665,6 +2679,14 @@ impl PreparedStateBatch {
 
     pub(crate) fn certified_complete_collection_replacement(&self) -> bool {
         self.certified_complete_collection_replacement
+    }
+
+    pub(crate) fn certified_complete_collection_identity_digest(&self) -> Option<[u8; 32]> {
+        self.certified_complete_collection_identity_digest
+    }
+
+    pub(crate) fn certified_complete_collection_replay_bytes(&self) -> Option<u64> {
+        self.certified_complete_collection_replay_bytes
     }
 
     pub(crate) fn iter(&self) -> PreparedStateRows<'_> {
@@ -2990,6 +3012,8 @@ impl PreparedStateBatch {
         self.entity_pks.append(&mut other.entity_pks);
         self.json.append(&mut other.json);
         self.certified_complete_collection_replacement = false;
+        self.certified_complete_collection_identity_digest = None;
+        self.certified_complete_collection_replay_bytes = None;
         true
     }
 
@@ -3009,6 +3033,8 @@ impl PreparedStateBatch {
         other.expand_dense_certified_parameter();
         self.certified_tracked_keys_strictly_ordered = false;
         self.certified_complete_collection_replacement = false;
+        self.certified_complete_collection_identity_digest = None;
+        self.certified_complete_collection_replay_bytes = None;
         let entity_base =
             u32::try_from(self.entity_pks.len()).expect("prepared entity column must fit u32");
         let json_base = u32::try_from(self.json.len()).expect("prepared JSON column must fit u32");
@@ -3077,6 +3103,8 @@ impl PreparedStateBatch {
         self.expand_dense_certified_parameter();
         self.certified_tracked_keys_strictly_ordered = false;
         self.certified_complete_collection_replacement = false;
+        self.certified_complete_collection_identity_digest = None;
+        self.certified_complete_collection_replay_bytes = None;
         self.slots.swap(left, right);
     }
 
@@ -3097,6 +3125,8 @@ impl PreparedStateBatch {
         self.expand_dense_certified_parameter();
         self.certified_tracked_keys_strictly_ordered = false;
         self.certified_complete_collection_replacement = false;
+        self.certified_complete_collection_identity_digest = None;
+        self.certified_complete_collection_replay_bytes = None;
         debug_assert!(
             source_by_destination
                 .iter()
@@ -3145,6 +3175,8 @@ impl PreparedStateBatch {
         if retained_len != self.slots.len() {
             self.certified_tracked_keys_strictly_ordered = false;
             self.certified_complete_collection_replacement = false;
+            self.certified_complete_collection_identity_digest = None;
+            self.certified_complete_collection_replay_bytes = None;
         }
         self.slots.truncate(retained_len);
         if !self.should_compact_owner_columns(retained_len) {
@@ -3981,6 +4013,8 @@ mod tests {
             },
             tracked_keys_strictly_ordered: true,
             complete_collection_replacement: false,
+            complete_collection_identity_digest: None,
+            complete_collection_replay_bytes: None,
         };
         let timestamp = LixTimestamp::expect_parse("timestamp", "2026-08-02T00:00:00.000Z");
         let mut prepared = CertifiedParameterInsertBatch::new(
@@ -4060,6 +4094,8 @@ mod tests {
                 },
                 tracked_keys_strictly_ordered: true,
                 complete_collection_replacement: true,
+                complete_collection_identity_digest: Some([7; 32]),
+                complete_collection_replay_bytes: Some(321),
             },
         )
         .expect("certified replacement should construct")
@@ -4071,14 +4107,31 @@ mod tests {
 
         assert!(prepared.is_dense_certified_parameter());
         assert!(prepared.certified_complete_collection_replacement());
+        assert_eq!(
+            prepared.certified_complete_collection_identity_digest(),
+            Some([7; 32])
+        );
+        assert_eq!(
+            prepared.certified_complete_collection_replay_bytes(),
+            Some(321)
+        );
         assert!(prepared.certified_tracked_keys_strictly_ordered());
         prepared.truncate_rows(2);
         assert!(prepared.is_dense_certified_parameter());
         assert!(prepared.certified_complete_collection_replacement());
+        assert_eq!(
+            prepared.certified_complete_collection_identity_digest(),
+            Some([7; 32])
+        );
 
         prepared.truncate_rows(1);
         assert!(!prepared.is_dense_certified_parameter());
         assert!(!prepared.certified_complete_collection_replacement());
+        assert_eq!(
+            prepared.certified_complete_collection_identity_digest(),
+            None
+        );
+        assert_eq!(prepared.certified_complete_collection_replay_bytes(), None);
         assert!(!prepared.certified_tracked_keys_strictly_ordered());
         assert_eq!(prepared.row(0).entity_pk, &EntityPk::single("a"));
     }
@@ -4093,6 +4146,8 @@ mod tests {
             },
             tracked_keys_strictly_ordered: true,
             complete_collection_replacement: false,
+            complete_collection_identity_digest: None,
+            complete_collection_replay_bytes: None,
         };
         let prepare = |key: &str, timestamp| {
             CertifiedParameterReplacementBatch::new(


### PR DESCRIPTION
## Summary

- hard-cut the commit-delta format to LXCD14 and remove the payload-less certified-ref encoding, provenance fields, hydration rescans, and legacy GC/benchmark branches
- make immutable replacement parts/manifests the complete-set authority while ordinary commit members carry self-contained authored payloads
- carry the certified replacement identity digest and replay-byte total through commit, avoiding two additional million-row traversals
- remove the million-entry affected-statement allocation and keep replacement-part payload staging borrowed
- route expanded certified snapshot/metadata through the normal inline-or-content-addressed JSON contract, globally deduplicated with ordinary transaction JSON

No backward compatibility and no changenote.

## Performance

1M UPDATE, previous PR #1161 as baseline:

| Adapter | #1161 | This PR | Improvement | vs paired raw SQLite (876.45 ms) |
| --- | ---: | ---: | ---: | ---: |
| RocksDB | 1.194827 s | 1.050299 s | 12.1% | 1.198x |
| SlateDB | ~1.211 s | 1.039337 s | 14.2% | 1.186x |

RocksDB UPDATE allocations fall from 1.255 GB to 1.139 GB (~9.25%). Physical accounting is unchanged at 3,239,352 bytes, 2,003 puts, and 2 deletes for 1M rows.

## Validation

- `cargo test -p lix_engine --lib`: 1,827 passed, 0 failed, 8 ignored
- `cargo clippy -p lix_engine --all-targets`: clean except the pre-existing unused `StorageWriteSet::apply` warning
- `cargo fmt --all -- --check`
- `git diff --check`
- extra-high independent review: no blockers
- regression coverage includes identical incompressible >4 MiB JSON shared by ordinary and certified lanes, stored once by content ref and round-tripped exactly
