### PR TITLE
test: update plugin WIT scorecard

### DIFF
--- a/packages/plugin-arena/tests/scorecard.rs
+++ b/packages/plugin-arena/tests/scorecard.rs
@@ -16,7 +16,13 @@ fn plugin_v1_wit_is_valid_and_has_no_guest_document_resource() {
     assert!(wit.contains("apply: func("));
     assert!(wit.contains("output: borrow<transition>"));
     assert!(wit.contains("resolve-conflicts: func("));
-    assert!(wit.contains("entities-changed: func("));
+    assert!(wit.contains("variant transition-request"));
+    assert!(wit.contains("open(open-request)"));
+    assert!(wit.contains("file-changed(file-changed-request)"));
+    assert!(wit.contains("entities-changed(entities-changed-request)"));
+    assert!(wit.contains("restore(restore-request)"));
+    assert!(wit.contains("cold-file-changed(cold-file-changed-request)"));
+    assert!(!wit.contains("path: option<string>"));
     assert!(!wit.contains("resource document"));
     assert!(!wit.contains("resource change-cursor"));
 }


### PR DESCRIPTION
## What changed

Update the plugin WIT scorecard to validate the universal `apply(transition-request, transition)` export and its five lifecycle variants instead of the removed standalone `entities-changed` export. The scorecard also asserts that plugin paths are no longer optional.

## Why

PR #1164 intentionally hard-cut the WIT lifecycle surface, but this workspace-level contract test still described the previous ABI.

## Validation

- `cargo test -p lix_plugin_arena --test scorecard plugin_v1_wit_is_valid_and_has_no_guest_document_resource`