### PR TITLE
ci: remove deleted git text plugin build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,6 @@ jobs:
         run: |
           rustup target add wasm32-wasip2
           cargo build --release -p plugin_csv --target wasm32-wasip2
-          cargo build --release -p plugin_git_text --target wasm32-wasip2
 
   js-sdk-test:
     name: JS SDK ${{ matrix.name }} Test


### PR DESCRIPTION
Removes the stale downstream build for the deleted `plugin_git_text` package. The existing CSV component build continues to verify that a plugin can compile through the packaged public API.

This fixes the only failing step in the post-merge Cargo Test job for #1166.