### PR TITLE
Route sequential updates through the mutation journal

### DIFF
--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -433,6 +433,26 @@ impl<S> LiveStateStoreReader<S>
 where
     S: StorageAdapterRead,
 {
+    pub(crate) async fn prepare_packed_identity_membership(
+        &self,
+        branch_id: &str,
+        schema_key: &str,
+    ) -> Result<Option<crate::live_state::PackedIdentityMembership>, LixError> {
+        let Some(cache) = self.branch_head_control_cache.as_ref() else {
+            return Ok(None);
+        };
+        let controls =
+            load_branch_head_controls(&self.store, &[branch_id.to_owned()], Some(cache.as_ref()))
+                .await?;
+        let Some(control) = controls.get(branch_id).copied() else {
+            return Ok(None);
+        };
+        self.tracked_head
+            .transaction_reader(&self.store, std::sync::Arc::clone(&cache.hot_state))
+            .prepare_packed_identity_membership(branch_id, control.generation, schema_key)
+            .await
+    }
+
     /// Returns raw current-state snapshot bytes for one current SQL entity scan.
     ///
     /// `None` means the normal materialized visibility path remains

--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -31,7 +31,7 @@ pub(crate) use tracked_head::{
     CurrentStateDeltaRef, DeferredFreshHotPlan, DeferredFreshHotRowRef, DeferredFreshHotRows,
     EntityColumnarOverlayRow, HOT_DIFF_SPACE, HOT_FILE_SPACE, HOT_ROW_SPACE, HotTrackedSnapshot,
     PACKED_CURRENT_BASE_CONTROL_SPACE, PACKED_CURRENT_BASE_SPACE,
-    PACKED_CURRENT_EXCLUSIVE_SCHEMA_BASE_SPACE, ROOT_CURRENT_BASE_SPACE,
+    PACKED_CURRENT_EXCLUSIVE_SCHEMA_BASE_SPACE, PackedIdentityMembership, ROOT_CURRENT_BASE_SPACE,
     TRACKED_WORKING_DIFF_MARKER_SPACE, TrackedHeadContext, TrackedWorkingDiff,
     TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage, materialize_certified_root_rows,
     scan_certified_history_rows, stage_certified_entity_batches,

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -15,7 +15,7 @@ pub(crate) use hot::{
     DeferredFreshHotRowRef, DeferredFreshHotRows, EntityColumnarOverlayRow, HOT_DIFF_SPACE,
     HOT_FILE_SPACE, HOT_ROW_SPACE, HotStateTransactionCache, HotTrackedSnapshot,
     PACKED_CURRENT_BASE_CONTROL_SPACE, PACKED_CURRENT_BASE_SPACE,
-    PACKED_CURRENT_EXCLUSIVE_SCHEMA_BASE_SPACE, ROOT_CURRENT_BASE_SPACE,
+    PACKED_CURRENT_EXCLUSIVE_SCHEMA_BASE_SPACE, PackedIdentityMembership, ROOT_CURRENT_BASE_SPACE,
     materialize_certified_root_rows, scan_certified_history_rows, stage_certified_entity_batches,
 };
 

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -1984,6 +1984,36 @@ impl HotStateTransactionCache {
     }
 }
 
+pub(crate) struct PackedIdentityMembership {
+    cache: Arc<HotStateTransactionCache>,
+    commit_id: CommitId,
+    schema_key: String,
+    live_count: u64,
+    ordered_identity_digest: [u8; 32],
+    encoded_key: Vec<u8>,
+}
+
+impl PackedIdentityMembership {
+    pub(crate) fn contains(&mut self, entity_pk: &EntityPk) -> Result<Option<bool>, LixError> {
+        self.encoded_key.clear();
+        let encoded = crate::tracked_state::encode_key_ref_into(
+            &mut self.encoded_key,
+            TrackedStateKeyRef {
+                schema_key: &self.schema_key,
+                file_id: None,
+                entity_pk,
+            },
+        );
+        self.cache
+            .commit_delta_points
+            .cached_live_member(self.commit_id, &self.encoded_key[encoded])
+    }
+
+    pub(crate) fn complete_generation(&self) -> (u64, [u8; 32]) {
+        (self.live_count, self.ordered_identity_digest)
+    }
+}
+
 fn hot_state_cache_lock_error() -> LixError {
     LixError::new(
         LixError::CODE_INTERNAL_ERROR,
@@ -3925,6 +3955,85 @@ impl<S> HotStateStoreReader<S>
 where
     S: StorageAdapterRead,
 {
+    pub(crate) async fn prepare_packed_identity_membership(
+        &self,
+        branch_id: &str,
+        generation: CommitId,
+        schema_key: &str,
+    ) -> Result<Option<PackedIdentityMembership>, LixError> {
+        let Some(cache) = self.transaction_cache.as_ref() else {
+            return Ok(None);
+        };
+        let base_refs =
+            packed_exclusive_schema_base_refs(&self.store, branch_id, generation, schema_key)
+                .await?;
+        let [base_ref] = base_refs.as_slice() else {
+            return Ok(None);
+        };
+        let collection = self
+            .collection_control(
+                branch_id,
+                generation,
+                crate::collection_generation::CollectionScopeRef {
+                    schema_key,
+                    file_id: None,
+                },
+            )
+            .await?;
+        let Some(ordered_identity_digest) = collection.ordered_identity_digest else {
+            return Ok(None);
+        };
+        if collection.active_generation != generation
+            || collection.live_count == DEFERRED_ROOT_LIVE_COUNT
+        {
+            return Ok(None);
+        }
+        let filter = TrackedStateFilter {
+            schema_keys: vec![schema_key.to_owned()],
+            file_ids: vec![NullableKeyFilter::Null],
+            ..TrackedStateFilter::default()
+        };
+        let Some(hot) =
+            hot_scan_entries(&self.store, branch_id, generation, &filter, Some(1), None).await?
+        else {
+            return Ok(None);
+        };
+        let has_hot_rows = match hot {
+            HotScanEntries::Decoded(rows) => !rows.is_empty(),
+            HotScanEntries::Finite(batches) => batches
+                .iter()
+                .flat_map(|batch| batch.values.iter())
+                .any(Option::is_some),
+        };
+        if has_hot_rows {
+            return Ok(None);
+        }
+        let certified = scan_certified_entity_batch_rows(
+            &self.store,
+            branch_id,
+            generation,
+            &TrackedStateScanRequest {
+                filter,
+                read_columns: Default::default(),
+                limit: Some(1),
+            },
+            Some(1),
+            Some(cache),
+        )
+        .await?;
+        if !certified.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(PackedIdentityMembership {
+            cache: Arc::clone(cache),
+            commit_id: base_ref.commit_id,
+            schema_key: schema_key.to_owned(),
+            live_count: collection.live_count,
+            ordered_identity_digest,
+            encoded_key: Vec::new(),
+        }))
+    }
+
     async fn collection_control(
         &self,
         branch_id: &str,

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -2588,6 +2588,17 @@ where
                 sql2::bind_statement_route(&statement)?,
                 sql2::BoundStatementRoute::Read
             );
+            if is_read {
+                transaction.flush_prepared_mutations().await?;
+            } else {
+                transaction
+                    .flush_prepared_mutation_barrier(
+                        &planning_sql,
+                        options.origin_key.as_deref(),
+                        params,
+                    )
+                    .await?;
+            }
             // A successful explicit transaction retains its function provider
             // until commit. Rewind deterministic runtime state whenever this
             // statement fails, including errors before a direct RETURNING
@@ -2669,6 +2680,7 @@ where
         let _operation_guard = self.begin_session_operation()?;
         let statement = self.sql_planning_cache.parse_statement(sql)?;
         let transaction = self.transaction_mut()?;
+        transaction.flush_prepared_mutations().await?;
         match sql2::bind_statement_route(&statement)? {
             sql2::BoundStatementRoute::Write => {
                 execute_transaction_write_with_mode(transaction, sql, statement, params, mode)
@@ -2689,6 +2701,7 @@ where
         let _operation_guard = self.begin_session_operation()?;
         let statement = self.sql_planning_cache.parse_statement(sql)?;
         let transaction = self.transaction_mut()?;
+        transaction.flush_prepared_mutations().await?;
         match sql2::bind_statement_route(&statement)? {
             sql2::BoundStatementRoute::Write => execute_transaction_write_with_mode_and_trace(
                 transaction,
@@ -2712,6 +2725,7 @@ where
     ) -> Result<crate::live_state::MaterializedLiveStateBatch, LixError> {
         let _operation_guard = self.begin_session_operation()?;
         let transaction = self.transaction_mut()?;
+        transaction.flush_prepared_mutations().await?;
         <crate::transaction::Transaction<StorageImpl> as sql2::SqlWriteExecutionContext>::scan_live_state_batch(
             transaction,
             request,
@@ -2887,7 +2901,13 @@ where
 {
     let previous_origin_key = transaction.replace_origin_key(options.origin_key);
     let result = async {
+        match transaction.try_execute_prepared_mutation(sql, params).await {
+            Ok(Some(result)) => return Ok(ExecuteResult::from_sql_write_result(result)),
+            Ok(None) => {}
+            Err(error) => return Err(error),
+        }
         let tx_plan = transaction.prepare_sql_write_logical_plan(sql, &statement)?;
+        transaction.remember_prepared_mutation(sql, &tx_plan)?;
         let checkpoint = (checkpoint_post_stage_returning
             && sql2::write_plan_requires_post_stage_returning_checkpoint(&tx_plan))
         .then(|| transaction.begin_sql_statement_checkpoint())

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -2584,6 +2584,29 @@ where
                 };
             let params = auto_params.as_deref().unwrap_or(params);
             let transaction = self.transaction_mut()?;
+            if transaction.prepared_mutation_matches(&planning_sql) {
+                transaction
+                    .flush_prepared_mutation_barrier(
+                        &planning_sql,
+                        options.origin_key.as_deref(),
+                        params,
+                    )
+                    .await?;
+                let previous_origin_key =
+                    transaction.replace_origin_key(options.origin_key.clone());
+                let result = transaction
+                    .try_execute_prepared_mutation(&planning_sql, params)
+                    .await;
+                transaction.replace_origin_key(previous_origin_key);
+                return match result {
+                    Ok(Some(result)) => Ok(ExecuteResult::from_sql_write_result(result)),
+                    Ok(None) => Err(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "prepared transaction mutation disappeared during warm execution",
+                    )),
+                    Err(error) => Err(normalize_sql_surface_error(error, sql)),
+                };
+            }
             let is_read = matches!(
                 sql2::bind_statement_route(&statement)?,
                 sql2::BoundStatementRoute::Read
@@ -2908,6 +2931,14 @@ where
         }
         let tx_plan = transaction.prepare_sql_write_logical_plan(sql, &statement)?;
         transaction.remember_prepared_mutation(sql, &tx_plan)?;
+        // The first statement is the producer of the typed program. Feed it
+        // through that program immediately so a homogeneous transaction never
+        // creates one legacy prepared row before entering the journal.
+        match transaction.try_execute_prepared_mutation(sql, params).await {
+            Ok(Some(result)) => return Ok(ExecuteResult::from_sql_write_result(result)),
+            Ok(None) => {}
+            Err(error) => return Err(error),
+        }
         let checkpoint = (checkpoint_post_stage_returning
             && sql2::write_plan_requires_post_stage_returning_checkpoint(&tx_plan))
         .then(|| transaction.begin_sql_statement_checkpoint())

--- a/packages/engine/src/session/transaction.rs
+++ b/packages/engine/src/session/transaction.rs
@@ -124,6 +124,7 @@ where
             .as_ref()
             .is_some_and(SessionWriteAccess::serializes_collaboration_writes);
         let operation_guard = self.begin_session_commit_operation()?;
+        self.transaction_mut()?.flush_prepared_mutations().await?;
         let transaction = self
             .transaction
             .take()

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -2937,6 +2937,26 @@ pub(crate) fn prepare_path_value_replacement_row_known_live(
     params: &[Value],
 ) -> Result<PreparedPathValueReplacementRow, LixError> {
     let primary_key = program.primary_key(params)?;
+    let entity_pk = EntityPk::single(primary_key.to_owned());
+    let mut normalized = Vec::with_capacity(primary_key.len().saturating_add(32));
+    let (start, end) =
+        append_path_value_replacement_snapshot(program, primary_key, params, &mut normalized)?;
+    let snapshot =
+        TransactionJson::from_certified_row_content_arena(normalized, vec![(start, end)])?
+            .pop()
+            .expect("one certified replacement snapshot");
+    Ok(PreparedPathValueReplacementRow {
+        entity_pk,
+        snapshot,
+    })
+}
+
+pub(crate) fn append_path_value_replacement_snapshot(
+    program: &PreparedPathValueReplacementProgram,
+    primary_key: &str,
+    params: &[Value],
+    normalized: &mut Vec<u8>,
+) -> Result<(usize, usize), LixError> {
     let replacement_value = match params.get(program.value_param_index) {
         Some(Value::Text(value)) => Some(value.as_str()),
         Some(Value::Null) => None,
@@ -2947,32 +2967,29 @@ pub(crate) fn prepare_path_value_replacement_row_known_live(
             ));
         }
     };
-    let entity_pk = EntityPk::single(primary_key.to_owned());
-
-    let mut normalized = Vec::with_capacity(primary_key.len().saturating_add(32));
+    let start = normalized.len();
     normalized.extend_from_slice(b"{\"path\":");
-    append_canonical_json_string(&mut normalized, primary_key)?;
+    if let Err(error) = append_canonical_json_string(normalized, primary_key) {
+        normalized.truncate(start);
+        return Err(error);
+    }
     normalized.extend_from_slice(b",\"value\":");
-    match replacement_value {
+    let result = match replacement_value {
         None => normalized.extend_from_slice(b"null"),
         Some(raw) => {
-            append_canonical_json_parameter(&mut normalized, raw)?;
+            if let Err(error) = append_canonical_json_parameter(normalized, raw) {
+                normalized.truncate(start);
+                return Err(error);
+            }
         }
-    }
+    };
+    let () = result;
     normalized.push(b'}');
-    let normalized_len = normalized.len();
-    let snapshot =
-        TransactionJson::from_certified_row_content_arena(normalized, vec![(0, normalized_len)])?
-            .pop()
-            .expect("one certified replacement snapshot");
     #[cfg(test)]
     CERTIFIED_SINGLE_PATH_VALUE_REPLACEMENTS.with(|executions| {
         executions.set(executions.get().saturating_add(1));
     });
-    Ok(PreparedPathValueReplacementRow {
-        entity_pk,
-        snapshot,
-    })
+    Ok((start, normalized.len()))
 }
 
 /// Stage entity INSERT/UPDATE rows and, when requested, retain their final

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -2759,6 +2759,65 @@ async fn try_execute_direct_path_value_replacement(
     spec: &EntitySurfaceSpec,
     params: &[Value],
 ) -> Result<Option<SqlWriteResult>, LixError> {
+    let Some(program) = prepare_path_value_replacement_program(ctx, plan, spec) else {
+        return Ok(None);
+    };
+    execute_prepared_path_value_replacement(ctx, &program, params)
+        .await
+        .map(Some)
+}
+
+/// Immutable admission program for the ordinary tracked `path/value` point
+/// replacement. The generic logical plan proves this shape once; explicit
+/// transactions can then reuse these bound slots without reparsing, cloning,
+/// resolving, and descending through the write executor for every row.
+#[derive(Debug)]
+pub(crate) struct PreparedPathValueReplacementProgram {
+    pub(crate) schema_key: String,
+    pub(crate) schema_plan_id: SchemaPlanId,
+    primary_key_param_index: usize,
+    value_param_index: usize,
+}
+
+pub(crate) struct PreparedPathValueReplacementRow {
+    pub(crate) entity_pk: EntityPk,
+    pub(crate) snapshot: TransactionJson,
+}
+
+impl PreparedPathValueReplacementProgram {
+    pub(crate) fn primary_key<'a>(&self, params: &'a [Value]) -> Result<&'a str, LixError> {
+        let Some(Value::Text(primary_key)) = params.get(self.primary_key_param_index) else {
+            return Err(LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                "prepared path replacement primary key must be text",
+            ));
+        };
+        Ok(primary_key)
+    }
+}
+
+pub(crate) fn prepare_path_value_replacement_program_from_logical(
+    ctx: &dyn SqlWriteExecutionContext,
+    plan: &LogicalWritePlan,
+) -> Option<PreparedPathValueReplacementProgram> {
+    let BoundWriteTarget::Entity(surface) = &plan.bound.target else {
+        return None;
+    };
+    let schema_key = match surface {
+        EntityWriteSurface::Base { schema_key } | EntityWriteSurface::ByBranch { schema_key } => {
+            schema_key
+        }
+    };
+    let catalog = ctx.public_catalog().ok()?;
+    let spec = catalog.entity_spec(schema_key)?;
+    prepare_path_value_replacement_program(ctx, plan, spec)
+}
+
+pub(crate) fn prepare_path_value_replacement_program(
+    ctx: &dyn SqlWriteExecutionContext,
+    plan: &LogicalWritePlan,
+    spec: &EntitySurfaceSpec,
+) -> Option<PreparedPathValueReplacementProgram> {
     if spec.has_inter_row_constraints
         || !matches!(plan.bound.input, BoundWriteInput::None)
         || plan.bound.conflict.is_some()
@@ -2772,44 +2831,90 @@ async fn try_execute_direct_path_value_replacement(
                 .any(|path| path.as_slice() == [assignment.column.name.as_str()])
         })
     {
-        return Ok(None);
+        return None;
     }
     let Some(primary_key_param_index) =
         bound_single_text_primary_key_param(spec, &plan.bound.predicate)
     else {
-        return Ok(None);
+        return None;
     };
     let Some(replacement) =
         direct_path_value_replacement(spec, plan, Some(primary_key_param_index))
     else {
-        return Ok(None);
-    };
-    let Some(Value::Text(primary_key)) = params.get(primary_key_param_index) else {
-        return Ok(None);
-    };
-    let replacement_value = match params.get(replacement.value_param_index) {
-        Some(Value::Text(value)) => Some(value.as_str()),
-        Some(Value::Null) => None,
-        _ => return Ok(None),
+        return None;
     };
     let Some(schema_catalog) = ctx.schema_catalog_snapshot() else {
-        return Ok(None);
+        return None;
     };
     let Some((schema_plan_id, schema_plan)) = schema_catalog.plan_for_key(&spec.schema_key) else {
-        return Ok(None);
+        return None;
     };
     if !schema_plan.accepts_canonical_certificate() {
-        return Ok(None);
+        return None;
     }
 
-    let entity_pk = EntityPk::single(primary_key.clone());
-    let candidates =
-        scan_entity_candidates_for_pks(ctx, plan, spec, vec![entity_pk.clone()], false).await?;
+    Some(PreparedPathValueReplacementProgram {
+        schema_key: spec.schema_key.clone(),
+        schema_plan_id,
+        primary_key_param_index,
+        value_param_index: replacement.value_param_index,
+    })
+}
+
+pub(crate) async fn execute_prepared_path_value_replacement(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    program: &PreparedPathValueReplacementProgram,
+    params: &[Value],
+) -> Result<SqlWriteResult, LixError> {
+    let Some(row) = prepare_path_value_replacement_row(ctx, program, params).await? else {
+        return Ok(SqlWriteResult::affected(0));
+    };
+    let rows = CertifiedParameterReplacementBatch::new(
+        vec![row.entity_pk],
+        vec![row.snapshot],
+        program.schema_key.as_str().into(),
+        ctx.active_branch_id().into(),
+        CertifiedRawWriteBatchPreparation {
+            schema_plan_id: program.schema_plan_id,
+            facts: PreparedRowFacts {
+                row_content_validated: true,
+                requires_transaction_validation: false,
+            },
+            tracked_keys_strictly_ordered: true,
+            complete_collection_replacement: None,
+        },
+    )?;
+    ctx.stage_certified_parameter_batch_replace(rows).await?;
+    Ok(SqlWriteResult::affected(1))
+}
+
+pub(crate) async fn prepare_path_value_replacement_row(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    program: &PreparedPathValueReplacementProgram,
+    params: &[Value],
+) -> Result<Option<PreparedPathValueReplacementRow>, LixError> {
+    let primary_key = program.primary_key(params)?;
+    let entity_pk = EntityPk::single(primary_key.to_owned());
+    let candidates = ctx
+        .scan_live_state_batch(&LiveStateScanRequest {
+            filter: LiveStateFilter {
+                schema_keys: vec![program.schema_key.clone()],
+                entity_pks: vec![entity_pk.clone()],
+                branch_ids: vec![ctx.active_branch_id().to_owned()],
+                include_tombstones: false,
+                ..LiveStateFilter::default()
+            },
+            ..LiveStateScanRequest::default()
+        })
+        .await?;
     if candidates.is_empty() {
-        return Ok(Some(SqlWriteResult::affected(0)));
+        return Ok(None);
     }
     if candidates.len() != 1 {
-        return Ok(None);
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "prepared path replacement resolved multiple visible rows",
+        ));
     }
     let candidate = candidates.row(0);
     if candidate.untracked()
@@ -2818,8 +2923,31 @@ async fn try_execute_direct_path_value_replacement(
         || candidate.metadata().is_some()
         || candidate.branch_id() != ctx.active_branch_id()
     {
-        return Ok(None);
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "prepared path replacement escaped its certified storage scope",
+        ));
     }
+
+    prepare_path_value_replacement_row_known_live(program, params).map(Some)
+}
+
+pub(crate) fn prepare_path_value_replacement_row_known_live(
+    program: &PreparedPathValueReplacementProgram,
+    params: &[Value],
+) -> Result<PreparedPathValueReplacementRow, LixError> {
+    let primary_key = program.primary_key(params)?;
+    let replacement_value = match params.get(program.value_param_index) {
+        Some(Value::Text(value)) => Some(value.as_str()),
+        Some(Value::Null) => None,
+        _ => {
+            return Err(LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                "prepared path replacement value must be text or null",
+            ));
+        }
+    };
+    let entity_pk = EntityPk::single(primary_key.to_owned());
 
     let mut normalized = Vec::with_capacity(primary_key.len().saturating_add(32));
     normalized.extend_from_slice(b"{\"path\":");
@@ -2837,27 +2965,14 @@ async fn try_execute_direct_path_value_replacement(
         TransactionJson::from_certified_row_content_arena(normalized, vec![(0, normalized_len)])?
             .pop()
             .expect("one certified replacement snapshot");
-    let rows = CertifiedParameterReplacementBatch::new(
-        vec![entity_pk],
-        vec![snapshot],
-        spec.schema_key.as_str().into(),
-        ctx.active_branch_id().into(),
-        CertifiedRawWriteBatchPreparation {
-            schema_plan_id,
-            facts: PreparedRowFacts {
-                row_content_validated: true,
-                requires_transaction_validation: false,
-            },
-            tracked_keys_strictly_ordered: true,
-            complete_collection_replacement: None,
-        },
-    )?;
-    ctx.stage_certified_parameter_batch_replace(rows).await?;
     #[cfg(test)]
     CERTIFIED_SINGLE_PATH_VALUE_REPLACEMENTS.with(|executions| {
         executions.set(executions.get().saturating_add(1));
     });
-    Ok(Some(SqlWriteResult::affected(1)))
+    Ok(PreparedPathValueReplacementRow {
+        entity_pk,
+        snapshot,
+    })
 }
 
 /// Stage entity INSERT/UPDATE rows and, when requested, retain their final

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -32,8 +32,8 @@ use crate::sql2::read_only::reject_read_only_entity_surface;
 use crate::sql2::value_contract::{json_bigint_value, json_double_value};
 use crate::transaction::types::{
     CertifiedParameterInsertBatch, CertifiedParameterReplacementBatch,
-    CertifiedRawWriteBatchPreparation, PreparedRowFacts, RawWriteBatch, RawWriteRowRef,
-    TransactionJson, TransactionWrite, TransactionWriteMode,
+    CertifiedRawWriteBatchPreparation, CompleteCollectionReplacementProof, PreparedRowFacts,
+    RawWriteBatch, RawWriteRowRef, TransactionJson, TransactionWrite, TransactionWriteMode,
 };
 use crate::wasm::WasmEntityKey;
 use crate::{LixError, NullableKeyFilter, Value, parse_row_metadata_value};
@@ -969,7 +969,7 @@ async fn try_execute_direct_path_value_replacement_batch(
             }
         }
     }
-    let complete_collection_replacement = certified_generation_identity
+    let replaces_complete_collection = certified_generation_identity
         || (candidates.len() == unique_row_count
             && collection_generation
                 .is_some_and(|generation| generation.live_count == unique_row_count as u64));
@@ -1084,15 +1084,15 @@ async fn try_execute_direct_path_value_replacement_batch(
                     requires_transaction_validation: false,
                 },
                 tracked_keys_strictly_ordered: true,
-                complete_collection_replacement,
-                complete_collection_identity_digest: complete_collection_replacement
-                    .then_some(ordered_identity_digest)
-                    .flatten(),
-                complete_collection_replay_bytes: complete_collection_replacement
+                complete_collection_replacement: replaces_complete_collection
                     .then(|| {
-                        replacement_identity_replay_bytes
-                            .checked_add(normalized_len)
-                            .and_then(|bytes| u64::try_from(bytes).ok())
+                        Some(CompleteCollectionReplacementProof {
+                            ordered_identity_digest: ordered_identity_digest?,
+                            replay_bytes: u64::try_from(
+                                replacement_identity_replay_bytes.checked_add(normalized_len)?,
+                            )
+                            .ok()?,
+                        })
                     })
                     .flatten(),
             },
@@ -2849,9 +2849,7 @@ async fn try_execute_direct_path_value_replacement(
                 requires_transaction_validation: false,
             },
             tracked_keys_strictly_ordered: true,
-            complete_collection_replacement: false,
-            complete_collection_identity_digest: None,
-            complete_collection_replay_bytes: None,
+            complete_collection_replacement: None,
         },
     )?;
     ctx.stage_certified_parameter_batch_replace(rows).await?;
@@ -4419,9 +4417,7 @@ fn certified_direct_parameter_insert_batch(
             requires_transaction_validation: false,
         },
         tracked_keys_strictly_ordered,
-        complete_collection_replacement: false,
-        complete_collection_identity_digest: None,
-        complete_collection_replay_bytes: None,
+        complete_collection_replacement: None,
     };
     let rows = CertifiedParameterInsertBatch::new(
         entity_pks,
@@ -4566,9 +4562,7 @@ fn certified_direct_path_value_insert_batch(
                 requires_transaction_validation: false,
             },
             tracked_keys_strictly_ordered: true,
-            complete_collection_replacement: false,
-            complete_collection_identity_digest: None,
-            complete_collection_replay_bytes: None,
+            complete_collection_replacement: None,
         },
     )?))
 }

--- a/packages/engine/src/sql2/exec/mod.rs
+++ b/packages/engine/src/sql2/exec/mod.rs
@@ -95,6 +95,31 @@ pub(crate) enum SqlLogicalPlan {
     Write(SqlWriteLogicalPlan),
 }
 
+pub(crate) fn prepare_path_value_replacement_program(
+    ctx: &dyn crate::sql2::SqlWriteExecutionContext,
+    plan: &SqlLogicalPlan,
+) -> Option<bound_public_write::PreparedPathValueReplacementProgram> {
+    let SqlLogicalPlan::Write(write) = plan else {
+        return None;
+    };
+    bound_public_write::prepare_path_value_replacement_program_from_logical(ctx, &write.plan)
+}
+
+pub(crate) async fn prepare_path_value_replacement_row(
+    ctx: &mut dyn crate::sql2::SqlWriteExecutionContext,
+    program: &bound_public_write::PreparedPathValueReplacementProgram,
+    params: &[crate::Value],
+) -> Result<Option<bound_public_write::PreparedPathValueReplacementRow>, crate::LixError> {
+    bound_public_write::prepare_path_value_replacement_row(ctx, program, params).await
+}
+
+pub(crate) fn prepare_path_value_replacement_row_known_live(
+    program: &bound_public_write::PreparedPathValueReplacementProgram,
+    params: &[crate::Value],
+) -> Result<bound_public_write::PreparedPathValueReplacementRow, crate::LixError> {
+    bound_public_write::prepare_path_value_replacement_row_known_live(program, params)
+}
+
 #[cfg(test)]
 pub(crate) use bound_public_write::{
     take_certified_entity_insert_batch_executions,

--- a/packages/engine/src/sql2/exec/mod.rs
+++ b/packages/engine/src/sql2/exec/mod.rs
@@ -113,11 +113,18 @@ pub(crate) async fn prepare_path_value_replacement_row(
     bound_public_write::prepare_path_value_replacement_row(ctx, program, params).await
 }
 
-pub(crate) fn prepare_path_value_replacement_row_known_live(
+pub(crate) fn append_path_value_replacement_snapshot(
     program: &bound_public_write::PreparedPathValueReplacementProgram,
+    primary_key: &str,
     params: &[crate::Value],
-) -> Result<bound_public_write::PreparedPathValueReplacementRow, crate::LixError> {
-    bound_public_write::prepare_path_value_replacement_row_known_live(program, params)
+    normalized: &mut Vec<u8>,
+) -> Result<(usize, usize), crate::LixError> {
+    bound_public_write::append_path_value_replacement_snapshot(
+        program,
+        primary_key,
+        params,
+        normalized,
+    )
 }
 
 #[cfg(test)]

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -54,6 +54,7 @@ pub(crate) use entity_columnar_layout::{
     encode_registered_entity_row_groups,
 };
 pub(crate) use entity_projection::EntityProjectionDecoder;
+pub(crate) use exec::bound_public_write::PreparedPathValueReplacementProgram;
 pub(crate) use exec::{SessionReadSqlResult, SqlWriteResult};
 #[allow(unused_imports)]
 pub(crate) use exec::{
@@ -62,8 +63,9 @@ pub(crate) use exec::{
     execute_read_statement_in_session_from_parsed, execute_transaction_read_statement_from_parsed,
     execute_write_logical_plan_parameter_batch, execute_write_logical_plan_result_with_metadata,
     execute_write_logical_plan_value_batch, parameter_record_batch, parameter_row,
-    prepare_read_session, prepare_read_session_at_head,
-    write_plan_requires_post_stage_returning_checkpoint,
+    prepare_path_value_replacement_program, prepare_path_value_replacement_row,
+    prepare_path_value_replacement_row_known_live, prepare_read_session,
+    prepare_read_session_at_head, write_plan_requires_post_stage_returning_checkpoint,
 };
 #[cfg(test)]
 pub(crate) use exec::{

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -58,14 +58,15 @@ pub(crate) use exec::bound_public_write::PreparedPathValueReplacementProgram;
 pub(crate) use exec::{SessionReadSqlResult, SqlWriteResult};
 #[allow(unused_imports)]
 pub(crate) use exec::{
-    SqlLogicalPlan, create_write_logical_plan_from_template,
-    create_write_plan_template_from_parsed, diff_command_query, execute_read_statement_from_parsed,
+    SqlLogicalPlan, append_path_value_replacement_snapshot,
+    create_write_logical_plan_from_template, create_write_plan_template_from_parsed,
+    diff_command_query, execute_read_statement_from_parsed,
     execute_read_statement_in_session_from_parsed, execute_transaction_read_statement_from_parsed,
     execute_write_logical_plan_parameter_batch, execute_write_logical_plan_result_with_metadata,
     execute_write_logical_plan_value_batch, parameter_record_batch, parameter_row,
     prepare_path_value_replacement_program, prepare_path_value_replacement_row,
-    prepare_path_value_replacement_row_known_live, prepare_read_session,
-    prepare_read_session_at_head, write_plan_requires_post_stage_returning_checkpoint,
+    prepare_read_session, prepare_read_session_at_head,
+    write_plan_requires_post_stage_returning_checkpoint,
 };
 #[cfg(test)]
 pub(crate) use exec::{

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -12,7 +12,7 @@ mod storage;
 mod tree;
 mod types;
 
-pub(crate) use codec::encode_key_ref;
+pub(crate) use codec::{encode_key_ref, encode_key_ref_into};
 pub(crate) use commit_root_rebuild::{
     load_rebuild_plans_to_nearest_available_root, stage_rebuild_plan_with_writer,
 };

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -766,6 +766,47 @@ struct CommitDeltaPointReadCacheInner {
 }
 
 impl CommitDeltaPointReadCache {
+    pub(crate) fn cached_live_member(
+        &self,
+        commit_id: CommitId,
+        encoded_key: &[u8],
+    ) -> Result<Option<bool>, LixError> {
+        let manifest = {
+            let cache = self.inner.lock().map_err(|_| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "transaction commit-delta point cache lock is poisoned",
+                )
+            })?;
+            let Some((_, manifest)) = cache
+                .manifests
+                .iter()
+                .find(|(cached_commit_id, _)| *cached_commit_id == commit_id)
+            else {
+                return Ok(None);
+            };
+            Arc::clone(manifest)
+        };
+        if manifest.selected_source_commit_id.is_some() || manifest.inline_segment().is_some() {
+            return Ok(None);
+        }
+        let Some(segment_index) = commit_delta_segment_for_key(&manifest, encoded_key) else {
+            return Ok(Some(false));
+        };
+        let Some(segment) = self.segment(
+            commit_id,
+            segment_index,
+            manifest.segments.get(segment_index),
+        )?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(
+            find_commit_delta_value(&segment.leaf, encoded_key, commit_id)?
+                .is_some_and(|value| !value.deleted),
+        ))
+    }
+
     fn should_admit_segment(
         &self,
         commit_id: CommitId,

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -1141,19 +1141,16 @@ async fn stage_changelog_commits(
         let commit_row_indices = tracked_row_indices_by_commit
             .get(&commit_id)
             .map(Vec::as_slice);
-        let commit_delta_bytes = if state_rows.certified_complete_collection_replacement()
-            && commit_row_indices.is_some_and(|indices| indices.len() == state_rows.len())
+        let commit_delta_bytes = if let Some(proof) = state_rows
+            .complete_collection_replacement_proof()
+            .filter(|_| commit_row_indices.is_some_and(|indices| indices.len() == state_rows.len()))
         {
-            if let Some(certified_bytes) = state_rows.certified_complete_collection_replay_bytes() {
-                #[cfg(debug_assertions)]
-                debug_assert_eq!(
-                    certified_bytes,
-                    replay_bytes_for_rows(state_rows, commit_row_indices)?
-                );
-                certified_bytes
-            } else {
+            #[cfg(debug_assertions)]
+            debug_assert_eq!(
+                proof.replay_bytes,
                 replay_bytes_for_rows(state_rows, commit_row_indices)?
-            }
+            );
+            proof.replay_bytes
         } else {
             replay_bytes_for_rows(state_rows, commit_row_indices)?
         };
@@ -2229,27 +2226,19 @@ async fn certify_complete_replacement_generations(
         else {
             continue;
         };
-        let certified_identity_digest = state_rows.certified_complete_collection_identity_digest();
+        let Some(replacement_proof) = state_rows.complete_collection_replacement_proof() else {
+            continue;
+        };
         #[cfg(debug_assertions)]
-        if let Some(certified_identity_digest) = certified_identity_digest {
-            debug_assert_eq!(
-                Some(certified_identity_digest),
-                crate::collection_generation::ordered_single_string_identity_digest(
-                    row_indices
-                        .iter()
-                        .map(|&row_index| state_rows.row(row_index).entity_pk),
-                )
-            );
-        }
-        let Some(ordered_identity_digest) = certified_identity_digest.or_else(|| {
+        debug_assert_eq!(
+            Some(replacement_proof.ordered_identity_digest),
             crate::collection_generation::ordered_single_string_identity_digest(
                 row_indices
                     .iter()
-                    .map(|&row_index| state_rows.row(row_index).entity_pk),
+                    .map(|&row_index| state_rows.row(row_index).entity_pk)
             )
-        }) else {
-            continue;
-        };
+        );
+        let ordered_identity_digest = replacement_proof.ordered_identity_digest;
         let mut current = root.parent_commit_id;
         let mut seen = BTreeSet::new();
         let mut lifecycle_summary = None;
@@ -2347,7 +2336,7 @@ fn certified_complete_replacement_scope(
     row_indices: &[RowIndex],
     commit_id: CommitId,
 ) -> Option<CommitDeltaReplacementScope> {
-    if !state_rows.certified_complete_collection_replacement()
+    if state_rows.complete_collection_replacement_proof().is_none()
         || row_indices.is_empty()
         || row_indices.len() != state_rows.len()
     {
@@ -3015,41 +3004,42 @@ async fn stage_tracked_head(
                         .change_id
                         .is_some_and(|change_id| change_id != ChangeId::default())
             });
-        let complete_replacement_schema = (state_rows.certified_complete_collection_replacement()
-            && ordered_addressable_commits.contains(&root.commit_id)
-            && !is_checkpoint_publication
-            && state_row_indices.len() >= PACKED_CURRENT_BASE_MIN_ROWS
-            && certified_fresh_plugin_file_id.is_none()
-            && !host_certified_live_increments.contains_key(&root.branch_id)
-            && staged.selected_change_batches.is_empty()
-            && selected_materialization.is_none()
-            && untracked_deltas.is_empty()
-            && engine_rows.is_empty()
-            && explicit_branch_targets.is_empty()
-            && state_row_indices.len() == state_rows.len()
-            && insert_selection.is_empty())
-        .then(|| state_rows.first())
-        .flatten()
-        .filter(|first| {
-            state_row_indices.iter().all(|&row_index| {
-                let row = state_rows.row(row_index);
-                row.schema_key == first.schema_key
-                    && row.branch_id.as_str() == root.branch_id
-                    && !row.global
-                    && !row.untracked
-                    && row.snapshot.is_some()
-                    && row.metadata.is_none()
-                    && row.file_id.is_none()
-                    && row.schema_key != BRANCH_REF_SCHEMA_KEY
-                    && row.schema_key
-                        != crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY
-                    && row.commit_id == Some(root.commit_id)
-                    && row
-                        .change_id
-                        .is_some_and(|change_id| change_id != ChangeId::default())
+        let complete_replacement_schema =
+            (state_rows.complete_collection_replacement_proof().is_some()
+                && ordered_addressable_commits.contains(&root.commit_id)
+                && !is_checkpoint_publication
+                && state_row_indices.len() >= PACKED_CURRENT_BASE_MIN_ROWS
+                && certified_fresh_plugin_file_id.is_none()
+                && !host_certified_live_increments.contains_key(&root.branch_id)
+                && staged.selected_change_batches.is_empty()
+                && selected_materialization.is_none()
+                && untracked_deltas.is_empty()
+                && engine_rows.is_empty()
+                && explicit_branch_targets.is_empty()
+                && state_row_indices.len() == state_rows.len()
+                && insert_selection.is_empty())
+            .then(|| state_rows.first())
+            .flatten()
+            .filter(|first| {
+                state_row_indices.iter().all(|&row_index| {
+                    let row = state_rows.row(row_index);
+                    row.schema_key == first.schema_key
+                        && row.branch_id.as_str() == root.branch_id
+                        && !row.global
+                        && !row.untracked
+                        && row.snapshot.is_some()
+                        && row.metadata.is_none()
+                        && row.file_id.is_none()
+                        && row.schema_key != BRANCH_REF_SCHEMA_KEY
+                        && row.schema_key
+                            != crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY
+                        && row.commit_id == Some(root.commit_id)
+                        && row
+                            .change_id
+                            .is_some_and(|change_id| change_id != ChangeId::default())
+                })
             })
-        })
-        .map(|row| row.schema_key.as_str());
+            .map(|row| row.schema_key.as_str());
         let absence_guards =
             if can_publish_ordered_packed_current_base || complete_replacement_schema.is_some() {
                 Vec::new()

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -489,6 +489,10 @@ pub(crate) struct Transaction<StorageImpl: Storage + 'static = Memory> {
         Arc<crate::sql2::PreparedPathValueReplacementProgram>,
     )>,
     prepared_mutation_membership: PreparedMutationMembership,
+    /// One logical timestamp for a homogeneous columnar mutation generation.
+    /// Immutable replacement parts require their post-image rows to share the
+    /// same lifecycle boundary, so sealing must not preserve per-call clocks.
+    prepared_mutation_timestamp: Option<LixTimestamp>,
     mutation_journal: Option<TransactionMutationJournal>,
     staged_writes: Arc<TransactionWriteBuffer>,
     filesystem_path_index_cache: Arc<FilesystemPathIndexCache>,
@@ -529,8 +533,9 @@ struct TransactionMutationJournal {
     program: Arc<crate::sql2::PreparedPathValueReplacementProgram>,
     origin_key: Option<SharedStr>,
     entity_pks: Vec<EntityPk>,
-    snapshots: Vec<TransactionJson>,
-    timestamps: Vec<LixTimestamp>,
+    snapshot_arena: Vec<u8>,
+    snapshot_offsets: Vec<(usize, usize)>,
+    timestamp: Option<LixTimestamp>,
 }
 
 enum PreparedMutationMembership {
@@ -1355,6 +1360,7 @@ where
                 sql_planning_cache,
                 prepared_mutation_program: None,
                 prepared_mutation_membership: PreparedMutationMembership::Unprepared,
+                prepared_mutation_timestamp: None,
                 mutation_journal: None,
                 staged_writes,
                 filesystem_path_index_cache: Arc::new(FilesystemPathIndexCache::default()),
@@ -6362,38 +6368,66 @@ where
                 None
             }
         };
-        let row = match cached_membership {
+        let fallback_row = match cached_membership {
             Some(false) => return Ok(Some(crate::sql2::SqlWriteResult::affected(0))),
-            Some(true) => {
-                crate::sql2::prepare_path_value_replacement_row_known_live(&program, params)?
-            }
+            Some(true) => None,
             None => {
                 let Some(row) =
                     crate::sql2::prepare_path_value_replacement_row(self, &program, params).await?
                 else {
                     return Ok(Some(crate::sql2::SqlWriteResult::affected(0)));
                 };
-                row
+                Some(row)
             }
         };
-        debug_assert_eq!(row.entity_pk, entity_pk);
-        let timestamp = self.functions.call_timestamp();
+        debug_assert!(
+            fallback_row
+                .as_ref()
+                .is_none_or(|row| row.entity_pk == entity_pk)
+        );
         let origin_key = self.origin_key.clone();
-        let journal = self
-            .mutation_journal
-            .get_or_insert_with(|| TransactionMutationJournal {
-                program: Arc::clone(&program),
-                origin_key: origin_key.clone(),
-                entity_pks: Vec::with_capacity(4_096),
-                snapshots: Vec::with_capacity(4_096),
-                timestamps: Vec::with_capacity(4_096),
-            });
+        let functions = self.functions.clone();
+        let (journal_slot, timestamp_slot) = (
+            &mut self.mutation_journal,
+            &mut self.prepared_mutation_timestamp,
+        );
+        let journal = journal_slot.get_or_insert_with(|| TransactionMutationJournal {
+            program: Arc::clone(&program),
+            origin_key: origin_key.clone(),
+            entity_pks: Vec::with_capacity(4_096),
+            snapshot_arena: Vec::with_capacity(4_096 * 64),
+            snapshot_offsets: Vec::with_capacity(4_096),
+            timestamp: None,
+        });
         debug_assert!(Arc::ptr_eq(&journal.program, &program));
         debug_assert_eq!(journal.origin_key, origin_key);
-        journal.entity_pks.push(row.entity_pk);
-        journal.snapshots.push(row.snapshot);
-        journal.timestamps.push(timestamp);
+        let snapshot_offset = match fallback_row {
+            Some(row) => {
+                let start = journal.snapshot_arena.len();
+                journal
+                    .snapshot_arena
+                    .extend_from_slice(row.snapshot.normalized().as_bytes());
+                (start, journal.snapshot_arena.len())
+            }
+            None => crate::sql2::append_path_value_replacement_snapshot(
+                &program,
+                program.primary_key(params)?,
+                params,
+                &mut journal.snapshot_arena,
+            )?,
+        };
+        let timestamp = *timestamp_slot.get_or_insert_with(|| functions.call_timestamp());
+        journal.entity_pks.push(entity_pk);
+        journal.snapshot_offsets.push(snapshot_offset);
+        let journal_timestamp = journal.timestamp.get_or_insert(timestamp);
+        debug_assert_eq!(*journal_timestamp, timestamp);
         Ok(Some(crate::sql2::SqlWriteResult::affected(1)))
+    }
+
+    pub(crate) fn prepared_mutation_matches(&self, sql: &str) -> bool {
+        self.prepared_mutation_program
+            .as_ref()
+            .is_some_and(|(cached_sql, _)| cached_sql.as_ref() == sql)
     }
 
     pub(crate) fn remember_prepared_mutation(
@@ -6408,31 +6442,47 @@ where
         {
             self.prepared_mutation_program = None;
             self.prepared_mutation_membership = PreparedMutationMembership::Unprepared;
+            self.prepared_mutation_timestamp = None;
             return Ok(());
         }
         self.prepared_mutation_program =
             crate::sql2::prepare_path_value_replacement_program(self, plan)
                 .map(|program| (Arc::<str>::from(sql), Arc::new(program)));
         self.prepared_mutation_membership = PreparedMutationMembership::Unprepared;
+        self.prepared_mutation_timestamp = None;
         Ok(())
     }
 
     pub(crate) async fn flush_prepared_mutations(&mut self) -> Result<(), LixError> {
-        let complete_generation = match &self.prepared_mutation_membership {
-            PreparedMutationMembership::Packed(membership) => {
-                Some(membership.complete_generation())
-            }
-            PreparedMutationMembership::Unprepared | PreparedMutationMembership::Unavailable => {
-                None
-            }
+        let complete_generation = match (
+            &self.prepared_mutation_program,
+            &self.prepared_mutation_membership,
+        ) {
+            (Some((_, program)), PreparedMutationMembership::Packed(membership)) => Some((
+                program.schema_key.clone(),
+                self.active_branch_id.clone(),
+                membership.complete_generation(),
+            )),
+            (
+                _,
+                PreparedMutationMembership::Unprepared | PreparedMutationMembership::Unavailable,
+            )
+            | (None, PreparedMutationMembership::Packed(_)) => None,
         };
         self.flush_mutation_journal().await?;
-        if let Some((live_count, ordered_identity_digest)) = complete_generation {
-            self.staged_writes
-                .certify_complete_collection_replacement(live_count, ordered_identity_digest)?;
+        if let Some((schema_key, branch_id, (live_count, ordered_identity_digest))) =
+            complete_generation
+        {
+            self.staged_writes.certify_complete_collection_replacement(
+                schema_key.as_str(),
+                &branch_id,
+                live_count,
+                ordered_identity_digest,
+            )?;
         }
         self.prepared_mutation_program = None;
         self.prepared_mutation_membership = PreparedMutationMembership::Unprepared;
+        self.prepared_mutation_timestamp = None;
         Ok(())
     }
 
@@ -6476,6 +6526,7 @@ where
         if !same_program {
             self.prepared_mutation_program = None;
             self.prepared_mutation_membership = PreparedMutationMembership::Unprepared;
+            self.prepared_mutation_timestamp = None;
         }
         Ok(())
     }
@@ -6496,7 +6547,10 @@ where
         }
         let rows = CertifiedParameterReplacementBatch::new(
             journal.entity_pks,
-            journal.snapshots,
+            TransactionJson::from_certified_row_content_arena(
+                journal.snapshot_arena,
+                journal.snapshot_offsets,
+            )?,
             journal.program.schema_key.as_str().into(),
             self.active_branch_id.clone().into(),
             CertifiedRawWriteBatchPreparation {
@@ -6509,7 +6563,15 @@ where
                 complete_collection_replacement: None,
             },
         )?
-        .into_dense_prepared_with_timestamps(journal.origin_key.as_ref(), journal.timestamps)?;
+        .into_dense_prepared(
+            journal.origin_key.as_ref(),
+            journal.timestamp.ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "non-empty transaction mutation journal has no lifecycle timestamp",
+                )
+            })?,
+        )?;
         self.staged_writes
             .stage_write(PreparedTransactionWrite::Rows {
                 mode: TransactionWriteMode::Replace,

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -114,10 +114,11 @@ use crate::transaction::stale_commit::{
     StaleCommitPlan, StalePluginReconciliationPlan, classify_stale_commit,
 };
 use crate::transaction::types::{
-    CertifiedParameterInsertBatch, CertifiedParameterReplacementBatch, PreparedRowFacts,
-    PreparedStateBatch, PreparedTransactionWrite, RawWriteBatch, RawWriteRowRef,
-    StagedCommitChangeBatch, StagedCommitChangeBatchBuilder, TransactionFileData, TransactionJson,
-    TransactionWrite, TransactionWriteMode, TransactionWriteOperation, TransactionWriteOrigin,
+    CertifiedParameterInsertBatch, CertifiedParameterReplacementBatch,
+    CertifiedRawWriteBatchPreparation, PreparedRowFacts, PreparedStateBatch,
+    PreparedTransactionWrite, RawWriteBatch, RawWriteRowRef, StagedCommitChangeBatch,
+    StagedCommitChangeBatchBuilder, TransactionFileData, TransactionJson, TransactionWrite,
+    TransactionWriteMode, TransactionWriteOperation, TransactionWriteOrigin,
     TransactionWriteOutcome, TransactionWriteRow, canonicalize_transaction_json_batch,
     stage_json_from_value,
 };
@@ -483,6 +484,12 @@ pub(crate) struct Transaction<StorageImpl: Storage + 'static = Memory> {
     /// to SQL planning only after commit opens a new transaction snapshot.
     sql_schema_snapshot: Arc<CatalogSnapshot>,
     sql_planning_cache: Arc<SqlPlanningCache<CatalogFingerprint>>,
+    prepared_mutation_program: Option<(
+        Arc<str>,
+        Arc<crate::sql2::PreparedPathValueReplacementProgram>,
+    )>,
+    prepared_mutation_membership: PreparedMutationMembership,
+    mutation_journal: Option<TransactionMutationJournal>,
     staged_writes: Arc<TransactionWriteBuffer>,
     filesystem_path_index_cache: Arc<FilesystemPathIndexCache>,
     filesystem_path_index_epoch: Arc<AtomicUsize>,
@@ -516,6 +523,26 @@ pub(crate) struct Transaction<StorageImpl: Storage + 'static = Memory> {
     pending_plugin_actor_publications: Vec<PendingPluginActorPublication>,
     plugin_generation_read_guard: Option<tokio::sync::OwnedRwLockReadGuard<()>>,
     plugin_generation_upgrade_guard: Option<tokio::sync::OwnedRwLockWriteGuard<()>>,
+}
+
+struct TransactionMutationJournal {
+    program: Arc<crate::sql2::PreparedPathValueReplacementProgram>,
+    origin_key: Option<SharedStr>,
+    entity_pks: Vec<EntityPk>,
+    snapshots: Vec<TransactionJson>,
+    timestamps: Vec<LixTimestamp>,
+}
+
+enum PreparedMutationMembership {
+    Unprepared,
+    Unavailable,
+    Packed(crate::live_state::PackedIdentityMembership),
+}
+
+impl TransactionMutationJournal {
+    fn last_entity_pk(&self) -> Option<&EntityPk> {
+        self.entity_pks.last()
+    }
 }
 
 /// One already-resolved tracked-state transition. The expected side is
@@ -1326,6 +1353,9 @@ where
                 schema_resolver,
                 sql_schema_snapshot: sql_schema_catalog,
                 sql_planning_cache,
+                prepared_mutation_program: None,
+                prepared_mutation_membership: PreparedMutationMembership::Unprepared,
+                mutation_journal: None,
                 staged_writes,
                 filesystem_path_index_cache: Arc::new(FilesystemPathIndexCache::default()),
                 filesystem_path_index_epoch: Arc::new(AtomicUsize::new(0)),
@@ -6284,6 +6314,208 @@ where
             &plan,
         );
         Ok(crate::sql2::create_write_logical_plan_from_template(plan))
+    }
+
+    pub(crate) async fn try_execute_prepared_mutation(
+        &mut self,
+        sql: &str,
+        params: &[Value],
+    ) -> Result<Option<crate::sql2::SqlWriteResult>, LixError> {
+        let Some((cached_sql, program)) = self.prepared_mutation_program.as_ref() else {
+            return Ok(None);
+        };
+        if cached_sql.as_ref() != sql {
+            return Ok(None);
+        }
+        let program = Arc::clone(program);
+        let entity_pk = EntityPk::single(program.primary_key(params)?.to_owned());
+        if self
+            .mutation_journal
+            .as_ref()
+            .and_then(TransactionMutationJournal::last_entity_pk)
+            .is_some_and(|last| last >= &entity_pk)
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "prepared mutation order barrier was not flushed before statement checkpoint",
+            ));
+        }
+        if matches!(
+            self.prepared_mutation_membership,
+            PreparedMutationMembership::Unprepared
+        ) {
+            let read = self.opening_read();
+            let base = self
+                .live_state
+                .transaction_reader(read, Arc::clone(&self.branch_head_control_cache));
+            self.prepared_mutation_membership = match base
+                .prepare_packed_identity_membership(&self.active_branch_id, &program.schema_key)
+                .await?
+            {
+                Some(membership) => PreparedMutationMembership::Packed(membership),
+                None => PreparedMutationMembership::Unavailable,
+            };
+        }
+        let cached_membership = match &mut self.prepared_mutation_membership {
+            PreparedMutationMembership::Packed(membership) => membership.contains(&entity_pk)?,
+            PreparedMutationMembership::Unprepared | PreparedMutationMembership::Unavailable => {
+                None
+            }
+        };
+        let row = match cached_membership {
+            Some(false) => return Ok(Some(crate::sql2::SqlWriteResult::affected(0))),
+            Some(true) => {
+                crate::sql2::prepare_path_value_replacement_row_known_live(&program, params)?
+            }
+            None => {
+                let Some(row) =
+                    crate::sql2::prepare_path_value_replacement_row(self, &program, params).await?
+                else {
+                    return Ok(Some(crate::sql2::SqlWriteResult::affected(0)));
+                };
+                row
+            }
+        };
+        debug_assert_eq!(row.entity_pk, entity_pk);
+        let timestamp = self.functions.call_timestamp();
+        let origin_key = self.origin_key.clone();
+        let journal = self
+            .mutation_journal
+            .get_or_insert_with(|| TransactionMutationJournal {
+                program: Arc::clone(&program),
+                origin_key: origin_key.clone(),
+                entity_pks: Vec::with_capacity(4_096),
+                snapshots: Vec::with_capacity(4_096),
+                timestamps: Vec::with_capacity(4_096),
+            });
+        debug_assert!(Arc::ptr_eq(&journal.program, &program));
+        debug_assert_eq!(journal.origin_key, origin_key);
+        journal.entity_pks.push(row.entity_pk);
+        journal.snapshots.push(row.snapshot);
+        journal.timestamps.push(timestamp);
+        Ok(Some(crate::sql2::SqlWriteResult::affected(1)))
+    }
+
+    pub(crate) fn remember_prepared_mutation(
+        &mut self,
+        sql: &str,
+        plan: &crate::sql2::SqlLogicalPlan,
+    ) -> Result<(), LixError> {
+        let domain = Domain::schema_catalog(self.active_branch_id.clone(), false);
+        if self
+            .staged_writes
+            .has_staged_schema_catalog_change(&domain)?
+        {
+            self.prepared_mutation_program = None;
+            self.prepared_mutation_membership = PreparedMutationMembership::Unprepared;
+            return Ok(());
+        }
+        self.prepared_mutation_program =
+            crate::sql2::prepare_path_value_replacement_program(self, plan)
+                .map(|program| (Arc::<str>::from(sql), Arc::new(program)));
+        self.prepared_mutation_membership = PreparedMutationMembership::Unprepared;
+        Ok(())
+    }
+
+    pub(crate) async fn flush_prepared_mutations(&mut self) -> Result<(), LixError> {
+        let complete_generation = match &self.prepared_mutation_membership {
+            PreparedMutationMembership::Packed(membership) => {
+                Some(membership.complete_generation())
+            }
+            PreparedMutationMembership::Unprepared | PreparedMutationMembership::Unavailable => {
+                None
+            }
+        };
+        self.flush_mutation_journal().await?;
+        if let Some((live_count, ordered_identity_digest)) = complete_generation {
+            self.staged_writes
+                .certify_complete_collection_replacement(live_count, ordered_identity_digest)?;
+        }
+        self.prepared_mutation_program = None;
+        self.prepared_mutation_membership = PreparedMutationMembership::Unprepared;
+        Ok(())
+    }
+
+    pub(crate) async fn flush_prepared_mutation_barrier(
+        &mut self,
+        next_sql: &str,
+        next_origin_key: Option<&str>,
+        params: &[Value],
+    ) -> Result<(), LixError> {
+        let same_program = self
+            .prepared_mutation_program
+            .as_ref()
+            .is_some_and(|(sql, _)| sql.as_ref() == next_sql);
+        let same_origin = self
+            .mutation_journal
+            .as_ref()
+            .is_none_or(|journal| journal.origin_key.as_deref() == next_origin_key);
+        let ordered_append = if same_program
+            && same_origin
+            && self
+                .mutation_journal
+                .as_ref()
+                .is_none_or(|journal| journal.entity_pks.len() < 4_096)
+        {
+            self.prepared_mutation_program
+                .as_ref()
+                .and_then(|(_, program)| program.primary_key(params).ok())
+                .map(EntityPk::single)
+                .is_none_or(|entity_pk| {
+                    self.mutation_journal
+                        .as_ref()
+                        .and_then(TransactionMutationJournal::last_entity_pk)
+                        .is_none_or(|last| last < &entity_pk)
+                })
+        } else {
+            false
+        };
+        if !same_program || !same_origin || !ordered_append {
+            self.flush_mutation_journal().await?;
+        }
+        if !same_program {
+            self.prepared_mutation_program = None;
+            self.prepared_mutation_membership = PreparedMutationMembership::Unprepared;
+        }
+        Ok(())
+    }
+
+    async fn flush_mutation_journal(&mut self) -> Result<(), LixError> {
+        let Some(journal) = self.mutation_journal.take() else {
+            return Ok(());
+        };
+        if journal.entity_pks.is_empty() {
+            return Ok(());
+        }
+        self.ensure_plugin_generation_read_guard().await;
+        #[cfg(feature = "storage-benches")]
+        {
+            let row_count = journal.entity_pks.len();
+            crate::storage_bench::record_transaction_rows_staged(row_count);
+            crate::storage_bench::record_transaction_untracked_rows(0);
+        }
+        let rows = CertifiedParameterReplacementBatch::new(
+            journal.entity_pks,
+            journal.snapshots,
+            journal.program.schema_key.as_str().into(),
+            self.active_branch_id.clone().into(),
+            CertifiedRawWriteBatchPreparation {
+                schema_plan_id: journal.program.schema_plan_id,
+                facts: PreparedRowFacts {
+                    row_content_validated: true,
+                    requires_transaction_validation: false,
+                },
+                tracked_keys_strictly_ordered: true,
+                complete_collection_replacement: None,
+            },
+        )?
+        .into_dense_prepared_with_timestamps(journal.origin_key.as_ref(), journal.timestamps)?;
+        self.staged_writes
+            .stage_write(PreparedTransactionWrite::Rows {
+                mode: TransactionWriteMode::Replace,
+                rows,
+            })?;
+        Ok(())
     }
 
     /// Returns this transaction's prepared runtime functions.

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -930,6 +930,27 @@ impl TransactionWriteBuffer {
         }
     }
 
+    pub(crate) fn certify_complete_collection_replacement(
+        &self,
+        expected_live_count: u64,
+        expected_ordered_identity_digest: [u8; 32],
+    ) -> Result<bool, LixError> {
+        let mut rows = self.rows.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "failed to acquire transaction journal rows for replacement certification",
+            )
+        })?;
+        let batch = match &mut *rows {
+            StagedPreparedRows::AppendOnly { rows, .. }
+            | StagedPreparedRows::Indexed { rows, .. } => rows,
+        };
+        Ok(batch.certify_complete_collection_replacement(
+            expected_live_count,
+            expected_ordered_identity_digest,
+        ))
+    }
+
     pub(crate) fn is_file_cohort_eligible(&self, branch_id: &str) -> bool {
         let rows = self.rows.lock().unwrap_or_else(|error| error.into_inner());
         let rows = match &*rows {

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -932,6 +932,8 @@ impl TransactionWriteBuffer {
 
     pub(crate) fn certify_complete_collection_replacement(
         &self,
+        expected_schema_key: &str,
+        expected_branch_id: &str,
         expected_live_count: u64,
         expected_ordered_identity_digest: [u8; 32],
     ) -> Result<bool, LixError> {
@@ -946,6 +948,8 @@ impl TransactionWriteBuffer {
             | StagedPreparedRows::Indexed { rows, .. } => rows,
         };
         Ok(batch.certify_complete_collection_replacement(
+            expected_schema_key,
+            expected_branch_id,
             expected_live_count,
             expected_ordered_identity_digest,
         ))

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -484,9 +484,16 @@ pub(crate) struct CertifiedRawWriteBatchPreparation {
     pub(crate) schema_plan_id: SchemaPlanId,
     pub(crate) facts: PreparedRowFacts,
     pub(crate) tracked_keys_strictly_ordered: bool,
-    pub(crate) complete_collection_replacement: bool,
-    pub(crate) complete_collection_identity_digest: Option<[u8; 32]>,
-    pub(crate) complete_collection_replay_bytes: Option<u64>,
+    pub(crate) complete_collection_replacement: Option<CompleteCollectionReplacementProof>,
+}
+
+/// Ephemeral proof used to construct an authoritative immutable replacement
+/// manifest. Absence means an ordinary mutation batch; there is no separate
+/// legacy certification bit or partially-populated proof state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CompleteCollectionReplacementProof {
+    pub(crate) ordered_identity_digest: [u8; 32],
+    pub(crate) replay_bytes: u64,
 }
 
 /// Dense, typed columns produced by certified SQL parameter-batch paths.
@@ -625,11 +632,7 @@ impl CertifiedParameterBatch {
             origin_column_sets: Vec::new(),
             origin_column_index: HashMap::new(),
             certified_tracked_keys_strictly_ordered: certificate.tracked_keys_strictly_ordered,
-            certified_complete_collection_replacement: certificate.complete_collection_replacement,
-            certified_complete_collection_identity_digest: certificate
-                .complete_collection_identity_digest,
-            certified_complete_collection_replay_bytes: certificate
-                .complete_collection_replay_bytes,
+            complete_collection_replacement: certificate.complete_collection_replacement,
         })
     }
 }
@@ -1062,11 +1065,7 @@ impl RawWriteBatch {
             origin_column_sets: Vec::new(),
             origin_column_index: HashMap::new(),
             certified_tracked_keys_strictly_ordered: certificate.tracked_keys_strictly_ordered,
-            certified_complete_collection_replacement: certificate.complete_collection_replacement,
-            certified_complete_collection_identity_digest: certificate
-                .complete_collection_identity_digest,
-            certified_complete_collection_replay_bytes: certificate
-                .complete_collection_replay_bytes,
+            complete_collection_replacement: certificate.complete_collection_replacement,
         })
     }
 
@@ -2495,11 +2494,9 @@ pub(crate) struct PreparedStateBatch {
     /// The typed producer proved strictly ordered, unique tracked keys. Any
     /// row topology change clears this proof.
     certified_tracked_keys_strictly_ordered: bool,
-    /// A typed producer proved this batch replaces every live row in one
-    /// tracked, unfiled collection under the transaction's branch snapshot.
-    certified_complete_collection_replacement: bool,
-    certified_complete_collection_identity_digest: Option<[u8; 32]>,
-    certified_complete_collection_replay_bytes: Option<u64>,
+    /// Proof material consumed when publishing the immutable replacement
+    /// manifest. Row-topology changes clear the proof as one atomic value.
+    complete_collection_replacement: Option<CompleteCollectionReplacementProof>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2657,9 +2654,7 @@ impl PreparedStateBatch {
             origin_column_sets: Vec::new(),
             origin_column_index: HashMap::new(),
             certified_tracked_keys_strictly_ordered: false,
-            certified_complete_collection_replacement: false,
-            certified_complete_collection_identity_digest: None,
-            certified_complete_collection_replay_bytes: None,
+            complete_collection_replacement: None,
         }
     }
 
@@ -2677,16 +2672,10 @@ impl PreparedStateBatch {
         self.certified_tracked_keys_strictly_ordered
     }
 
-    pub(crate) fn certified_complete_collection_replacement(&self) -> bool {
-        self.certified_complete_collection_replacement
-    }
-
-    pub(crate) fn certified_complete_collection_identity_digest(&self) -> Option<[u8; 32]> {
-        self.certified_complete_collection_identity_digest
-    }
-
-    pub(crate) fn certified_complete_collection_replay_bytes(&self) -> Option<u64> {
-        self.certified_complete_collection_replay_bytes
+    pub(crate) fn complete_collection_replacement_proof(
+        &self,
+    ) -> Option<CompleteCollectionReplacementProof> {
+        self.complete_collection_replacement
     }
 
     pub(crate) fn iter(&self) -> PreparedStateRows<'_> {
@@ -3011,9 +3000,7 @@ impl PreparedStateBatch {
             .expect("prepared dense parameter row count overflowed");
         self.entity_pks.append(&mut other.entity_pks);
         self.json.append(&mut other.json);
-        self.certified_complete_collection_replacement = false;
-        self.certified_complete_collection_identity_digest = None;
-        self.certified_complete_collection_replay_bytes = None;
+        self.complete_collection_replacement = None;
         true
     }
 
@@ -3032,9 +3019,7 @@ impl PreparedStateBatch {
         self.expand_dense_certified_parameter();
         other.expand_dense_certified_parameter();
         self.certified_tracked_keys_strictly_ordered = false;
-        self.certified_complete_collection_replacement = false;
-        self.certified_complete_collection_identity_digest = None;
-        self.certified_complete_collection_replay_bytes = None;
+        self.complete_collection_replacement = None;
         let entity_base =
             u32::try_from(self.entity_pks.len()).expect("prepared entity column must fit u32");
         let json_base = u32::try_from(self.json.len()).expect("prepared JSON column must fit u32");
@@ -3102,9 +3087,7 @@ impl PreparedStateBatch {
     pub(crate) fn swap_rows(&mut self, left: usize, right: usize) {
         self.expand_dense_certified_parameter();
         self.certified_tracked_keys_strictly_ordered = false;
-        self.certified_complete_collection_replacement = false;
-        self.certified_complete_collection_identity_digest = None;
-        self.certified_complete_collection_replay_bytes = None;
+        self.complete_collection_replacement = None;
         self.slots.swap(left, right);
     }
 
@@ -3124,9 +3107,7 @@ impl PreparedStateBatch {
         }
         self.expand_dense_certified_parameter();
         self.certified_tracked_keys_strictly_ordered = false;
-        self.certified_complete_collection_replacement = false;
-        self.certified_complete_collection_identity_digest = None;
-        self.certified_complete_collection_replay_bytes = None;
+        self.complete_collection_replacement = None;
         debug_assert!(
             source_by_destination
                 .iter()
@@ -3174,9 +3155,7 @@ impl PreparedStateBatch {
         self.expand_dense_certified_parameter();
         if retained_len != self.slots.len() {
             self.certified_tracked_keys_strictly_ordered = false;
-            self.certified_complete_collection_replacement = false;
-            self.certified_complete_collection_identity_digest = None;
-            self.certified_complete_collection_replay_bytes = None;
+            self.complete_collection_replacement = None;
         }
         self.slots.truncate(retained_len);
         if !self.should_compact_owner_columns(retained_len) {
@@ -4012,9 +3991,7 @@ mod tests {
                 requires_transaction_validation: false,
             },
             tracked_keys_strictly_ordered: true,
-            complete_collection_replacement: false,
-            complete_collection_identity_digest: None,
-            complete_collection_replay_bytes: None,
+            complete_collection_replacement: None,
         };
         let timestamp = LixTimestamp::expect_parse("timestamp", "2026-08-02T00:00:00.000Z");
         let mut prepared = CertifiedParameterInsertBatch::new(
@@ -4093,9 +4070,10 @@ mod tests {
                     requires_transaction_validation: false,
                 },
                 tracked_keys_strictly_ordered: true,
-                complete_collection_replacement: true,
-                complete_collection_identity_digest: Some([7; 32]),
-                complete_collection_replay_bytes: Some(321),
+                complete_collection_replacement: Some(CompleteCollectionReplacementProof {
+                    ordered_identity_digest: [7; 32],
+                    replay_bytes: 321,
+                }),
             },
         )
         .expect("certified replacement should construct")
@@ -4106,32 +4084,21 @@ mod tests {
         .expect("certified replacement should prepare");
 
         assert!(prepared.is_dense_certified_parameter());
-        assert!(prepared.certified_complete_collection_replacement());
         assert_eq!(
-            prepared.certified_complete_collection_identity_digest(),
-            Some([7; 32])
-        );
-        assert_eq!(
-            prepared.certified_complete_collection_replay_bytes(),
-            Some(321)
+            prepared.complete_collection_replacement_proof(),
+            Some(CompleteCollectionReplacementProof {
+                ordered_identity_digest: [7; 32],
+                replay_bytes: 321,
+            })
         );
         assert!(prepared.certified_tracked_keys_strictly_ordered());
         prepared.truncate_rows(2);
         assert!(prepared.is_dense_certified_parameter());
-        assert!(prepared.certified_complete_collection_replacement());
-        assert_eq!(
-            prepared.certified_complete_collection_identity_digest(),
-            Some([7; 32])
-        );
+        assert!(prepared.complete_collection_replacement_proof().is_some());
 
         prepared.truncate_rows(1);
         assert!(!prepared.is_dense_certified_parameter());
-        assert!(!prepared.certified_complete_collection_replacement());
-        assert_eq!(
-            prepared.certified_complete_collection_identity_digest(),
-            None
-        );
-        assert_eq!(prepared.certified_complete_collection_replay_bytes(), None);
+        assert_eq!(prepared.complete_collection_replacement_proof(), None);
         assert!(!prepared.certified_tracked_keys_strictly_ordered());
         assert_eq!(prepared.row(0).entity_pk, &EntityPk::single("a"));
     }
@@ -4145,9 +4112,7 @@ mod tests {
                 requires_transaction_validation: false,
             },
             tracked_keys_strictly_ordered: true,
-            complete_collection_replacement: false,
-            complete_collection_identity_digest: None,
-            complete_collection_replay_bytes: None,
+            complete_collection_replacement: None,
         };
         let prepare = |key: &str, timestamp| {
             CertifiedParameterReplacementBatch::new(

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -570,23 +570,6 @@ impl CertifiedParameterBatch {
         self.into_dense_prepared_timestamps(origin_key, DenseParameterTimestamps::Scalar(timestamp))
     }
 
-    pub(crate) fn into_dense_prepared_with_timestamps(
-        self,
-        origin_key: Option<&SharedStr>,
-        timestamps: Vec<LixTimestamp>,
-    ) -> Result<PreparedStateBatch, LixError> {
-        if timestamps.len() != self.len() {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                "certified replacement timestamp column is not aligned",
-            ));
-        }
-        self.into_dense_prepared_timestamps(
-            origin_key,
-            DenseParameterTimestamps::PerRow(timestamps),
-        )
-    }
-
     fn into_dense_prepared_timestamps(
         self,
         origin_key: Option<&SharedStr>,
@@ -2705,13 +2688,12 @@ impl PreparedStateBatch {
 
     pub(crate) fn certify_complete_collection_replacement(
         &mut self,
+        expected_schema_key: &str,
+        expected_branch_id: &str,
         expected_live_count: u64,
         expected_ordered_identity_digest: [u8; 32],
     ) -> bool {
-        if self.len() as u64 != expected_live_count
-            || self.is_empty()
-            || !self.certified_tracked_keys_strictly_ordered
-        {
+        if u64::try_from(self.len()).ok() != Some(expected_live_count) || self.is_empty() {
             return false;
         }
         let Some(actual_digest) =
@@ -2725,7 +2707,15 @@ impl PreparedStateBatch {
             return false;
         }
         let Some(replay_bytes) = self.iter().try_fold(0_u64, |bytes, row| {
-            if row.snapshot.is_none() || row.file_id.is_some() || row.untracked || row.global {
+            if row.schema_key.as_str() != expected_schema_key
+                || row.branch_id.as_str() != expected_branch_id
+                || row.snapshot.is_none()
+                || row.file_id.is_some()
+                || row.origin.is_some()
+                || row.origin_key.is_some()
+                || row.untracked
+                || row.global
+            {
                 return None;
             }
             let row_bytes = row
@@ -2738,10 +2728,23 @@ impl PreparedStateBatch {
         }) else {
             return false;
         };
+        // A complete replacement is one immutable post-image generation, not
+        // a sequence of row statements. Canonicalize its lifecycle boundary
+        // exactly where the complete-set proof becomes authoritative so the
+        // durable part encoder never inherits legacy per-call timestamps.
+        let replacement_timestamp = self.row(0).updated_at;
+        if let Some(dense) = &mut self.dense_certified_parameter {
+            dense.timestamps = DenseParameterTimestamps::Scalar(replacement_timestamp);
+        } else {
+            for slot in &mut self.slots {
+                slot.updated_at = replacement_timestamp;
+            }
+        }
         self.complete_collection_replacement = Some(CompleteCollectionReplacementProof {
             ordered_identity_digest: expected_ordered_identity_digest,
             replay_bytes,
         });
+        self.certified_tracked_keys_strictly_ordered = true;
         true
     }
 
@@ -4214,6 +4217,19 @@ mod tests {
         assert_eq!(prepared.row(0).commit_id, Some(commit_id));
         assert_eq!(prepared.row(1).commit_id, Some(commit_id));
         assert!(prepared.certified_tracked_keys_strictly_ordered());
+        let ordered_identity_digest =
+            crate::collection_generation::ordered_single_string_identity_digest(
+                prepared.iter().map(|row| row.entity_pk),
+            )
+            .expect("single-string identities should hash");
+        assert!(prepared.certify_complete_collection_replacement(
+            "dense_replacement",
+            "main",
+            2,
+            ordered_identity_digest,
+        ));
+        assert_eq!(prepared.row(0).updated_at, first_timestamp);
+        assert_eq!(prepared.row(1).updated_at, first_timestamp);
         let (columnar_commit_id, schema_key, snapshots) = prepared
             .dense_entity_columnar_input()
             .expect("coalesced replacement retains contiguous columnar input");
@@ -4225,6 +4241,54 @@ mod tests {
         assert!(!prepared.is_dense_certified_parameter());
         assert!(!prepared.certified_tracked_keys_strictly_ordered());
         assert_eq!(prepared.len(), 3);
+    }
+
+    #[test]
+    fn complete_replacement_certificate_rejects_rows_outside_collection_scope() {
+        let certificate = CertifiedRawWriteBatchPreparation {
+            schema_plan_id: SchemaPlanId::for_test(10),
+            facts: PreparedRowFacts {
+                row_content_validated: true,
+                requires_transaction_validation: false,
+            },
+            tracked_keys_strictly_ordered: true,
+            complete_collection_replacement: None,
+        };
+        let prepare = |schema_key: &str, key: &str, timestamp| {
+            CertifiedParameterReplacementBatch::new(
+                vec![EntityPk::single(key)],
+                vec![
+                    TransactionJson::from_certified_shared_normalized_row_content(
+                        format!(r#"{{"id":"{key}"}}"#).into(),
+                    ),
+                ],
+                schema_key.into(),
+                "main".into(),
+                certificate,
+            )
+            .expect("certified replacement should construct")
+            .into_dense_prepared(None, timestamp)
+            .expect("certified replacement should prepare")
+        };
+        let first_timestamp = LixTimestamp::expect_parse("timestamp", "2026-08-02T00:00:00.000Z");
+        let second_timestamp = LixTimestamp::expect_parse("timestamp", "2026-08-02T00:00:01.000Z");
+        let mut prepared = prepare("other_schema", "a", first_timestamp);
+        prepared.append(prepare("target_schema", "b", second_timestamp));
+        let ordered_identity_digest =
+            crate::collection_generation::ordered_single_string_identity_digest(
+                prepared.iter().map(|row| row.entity_pk),
+            )
+            .expect("single-string identities should hash");
+
+        assert!(!prepared.certify_complete_collection_replacement(
+            "target_schema",
+            "main",
+            2,
+            ordered_identity_digest,
+        ));
+        assert_eq!(prepared.row(0).updated_at, first_timestamp);
+        assert_eq!(prepared.row(1).updated_at, second_timestamp);
+        assert!(prepared.complete_collection_replacement_proof().is_none());
     }
 
     #[test]

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -567,6 +567,31 @@ impl CertifiedParameterBatch {
         origin_key: Option<&SharedStr>,
         timestamp: LixTimestamp,
     ) -> Result<PreparedStateBatch, LixError> {
+        self.into_dense_prepared_timestamps(origin_key, DenseParameterTimestamps::Scalar(timestamp))
+    }
+
+    pub(crate) fn into_dense_prepared_with_timestamps(
+        self,
+        origin_key: Option<&SharedStr>,
+        timestamps: Vec<LixTimestamp>,
+    ) -> Result<PreparedStateBatch, LixError> {
+        if timestamps.len() != self.len() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "certified replacement timestamp column is not aligned",
+            ));
+        }
+        self.into_dense_prepared_timestamps(
+            origin_key,
+            DenseParameterTimestamps::PerRow(timestamps),
+        )
+    }
+
+    fn into_dense_prepared_timestamps(
+        self,
+        origin_key: Option<&SharedStr>,
+        timestamps: DenseParameterTimestamps,
+    ) -> Result<PreparedStateBatch, LixError> {
         let Self {
             entity_pks,
             snapshots,
@@ -617,7 +642,7 @@ impl CertifiedParameterBatch {
                 facts: certificate.facts,
                 schema_key: schema_key_ordinal,
                 origin_key,
-                timestamps: DenseParameterTimestamps::Scalar(timestamp),
+                timestamps,
                 commit_id: None,
                 branch_id: branch_id_ordinal,
                 direct_change_ids: None,
@@ -2676,6 +2701,48 @@ impl PreparedStateBatch {
         &self,
     ) -> Option<CompleteCollectionReplacementProof> {
         self.complete_collection_replacement
+    }
+
+    pub(crate) fn certify_complete_collection_replacement(
+        &mut self,
+        expected_live_count: u64,
+        expected_ordered_identity_digest: [u8; 32],
+    ) -> bool {
+        if self.len() as u64 != expected_live_count
+            || self.is_empty()
+            || !self.certified_tracked_keys_strictly_ordered
+        {
+            return false;
+        }
+        let Some(actual_digest) =
+            crate::collection_generation::ordered_single_string_identity_digest(
+                self.iter().map(|row| row.entity_pk),
+            )
+        else {
+            return false;
+        };
+        if actual_digest != expected_ordered_identity_digest {
+            return false;
+        }
+        let Some(replay_bytes) = self.iter().try_fold(0_u64, |bytes, row| {
+            if row.snapshot.is_none() || row.file_id.is_some() || row.untracked || row.global {
+                return None;
+            }
+            let row_bytes = row
+                .schema_key
+                .len()
+                .checked_add(row.entity_pk.estimated_heap_bytes())?
+                .checked_add(128)?
+                .checked_add(row.snapshot?.normalized().len())?;
+            bytes.checked_add(u64::try_from(row_bytes).ok()?)
+        }) else {
+            return false;
+        };
+        self.complete_collection_replacement = Some(CompleteCollectionReplacementProof {
+            ordered_identity_digest: expected_ordered_identity_digest,
+            replay_bytes,
+        });
+        true
     }
 
     pub(crate) fn iter(&self) -> PreparedStateRows<'_> {


### PR DESCRIPTION
## What changed

- add a transaction-owned, chunked mutation journal for repeated typed path/value replacements;
- route the first and subsequent explicit SQL transaction updates through one prepared mutation program instead of leaving one legacy prepared row before the journal;
- use a packed current-generation identity cursor to answer membership without one live-state point read per statement;
- build canonical JSON snapshots into one shared byte arena and flush dense columnar chunks;
- seal homogeneous complete replacements with one lifecycle timestamp and a scope-bound complete-set certificate;
- remove the legacy replacement-certification state and unused per-row timestamp constructor;
- preserve semantic barriers for reads, dependent/out-of-order writes, origins, schema changes, and unsupported statements.

No backward compatibility and no changenote.

## Why

The bound parameter-batch path optimized by #1161 was already close to SQLite, but one million awaited `transaction.execute(...)` calls still repeated SQL/session ingress, point membership reads, owned JSON allocation, and generic staging. This cut makes those sequential calls feed a shared typed journal and reuse the complete-replacement publication path from #1158.

## Performance

Baseline is exact `origin/main` at `4b3dc4f12` (#1158). Measurements use the same release benchmark binary configuration and fixture on RocksDB and SlateDB.

### Sequential explicit transaction UPDATE (`sql_session`)

| Rows / adapter | Current main | This PR | Change |
|---|---:|---:|---:|
| 10K RocksDB (median, 7) | 227.065 ms | 60.918 ms | **-73.2%** |
| 10K SlateDB (median, 7) | 230.340 ms | 60.276 ms | **-73.8%** |
| 1M RocksDB (median, 3) | 22.787 s | 3.043 s | **-86.6%** |
| 1M SlateDB (median, 3) | 22.963 s | 3.118 s | **-86.4%** |

This workload opens one explicit transaction and issues one awaited SQL `execute()` per row. It is intentionally distinct from #1161's already-columnar `sql_session_bound` batch.

### Existing bound batch lane (`sql_session_bound`, 1M, median 3)

- RocksDB: 1.092 s
- SlateDB: 1.057 s
- certificate attempts/hits: 1 / 1
- physical writes: 2,003 puts, 2 deletes, 3.24 MB

The bound lane does not regress. The remaining sequential gap is the transaction-wide `PreparedStateBatch` reconstruction; the next cut is to seal borrowed journal columns directly through #1158's ordered mutation-part stage.

## Validation

- `cargo test -p lix_engine`: 1,823 unit tests, 439 integration tests, and 3 doc tests passed; 10 manual/release probes ignored
- `cargo clippy -p lix_engine --all-targets --all-features -- -D warnings`
- focused explicit transaction read-your-writes, escaped JSON, out-of-order replacement, and mixed-schema certificate tests
- extra-high read-only review; its scope-binding P1 was fixed and re-review approved
