### PR TITLE
Publish bounded current-state range directory

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -983,6 +983,9 @@ fn profile_sql_session_bound_updates(
         print_allocation_accounting("seed");
         reset_allocation_accounting();
         let _ = lix_engine::storage_bench::take_crud_physical_write_accounting();
+        let _ = lix_engine::storage_bench::take_crud_commit_state_manifest_bytes();
+        let _ = lix_engine::storage_bench::take_crud_current_state_directory_bytes();
+        let _ = lix_engine::storage_bench::take_crud_current_state_directory_recoveries();
         let _ = lix_engine::storage_bench::take_certified_entity_update_value_batch_accounting();
         let start = Instant::now();
         let result = if spread {
@@ -999,8 +1002,13 @@ fn profile_sql_session_bound_updates(
         let certificate =
             lix_engine::storage_bench::take_certified_entity_update_value_batch_accounting();
         let physical = lix_engine::storage_bench::take_crud_physical_write_accounting();
+        let manifest_bytes = lix_engine::storage_bench::take_crud_commit_state_manifest_bytes();
+        let directory_bytes = lix_engine::storage_bench::take_crud_current_state_directory_bytes();
+        let serving_metadata_bytes = manifest_bytes + directory_bytes;
+        let directory_recoveries =
+            lix_engine::storage_bench::take_crud_current_state_directory_recoveries();
         println!(
-            "tracked_state_crud generated update accounting: logical_rows={bound_update_row_count} certificate_attempts={} certificate_hits={} certificate_misses={} certified_rows={} physical_puts={} physical_deletes={} physical_written_bytes={}",
+            "tracked_state_crud generated update accounting: logical_rows={bound_update_row_count} certificate_attempts={} certificate_hits={} certificate_misses={} certified_rows={} staged_puts={} staged_deletes={} staged_value_bytes={} commit_state_manifest_value_bytes={manifest_bytes} current_state_directory_value_bytes={directory_bytes} encoded_serving_metadata_value_bytes={serving_metadata_bytes} current_state_directory_recoveries={directory_recoveries}",
             certificate.attempts,
             certificate.hits,
             certificate.misses,

--- a/packages/engine/src/commit_graph/context.rs
+++ b/packages/engine/src/commit_graph/context.rs
@@ -668,6 +668,7 @@ mod tests {
                     bytes: 0,
                 },
                 mutations: CommitStateMutationInventory::default(),
+                current_state_part_sets: Vec::new(),
                 snapshot_root: None,
             },
         )
@@ -1071,6 +1072,7 @@ mod tests {
                     bytes: 0,
                 },
                 mutations: staged.mutation_inventory().clone(),
+                current_state_part_sets: Vec::new(),
                 snapshot_root: None,
             },
         )
@@ -1572,6 +1574,7 @@ mod tests {
                     bytes: record.tracked_state_rootless_bytes,
                 },
                 mutations,
+                current_state_part_sets: Vec::new(),
                 snapshot_root: None,
             },
         )

--- a/packages/engine/src/commit_graph/walker.rs
+++ b/packages/engine/src/commit_graph/walker.rs
@@ -1071,6 +1071,7 @@ mod tests {
                     bytes: record.tracked_state_rootless_bytes,
                 },
                 mutations: CommitStateMutationInventory::default(),
+                current_state_part_sets: Vec::new(),
                 snapshot_root: None,
             },
         )

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -778,6 +778,20 @@ where
     );
     for commit_id in &sweep_authority_commits {
         if let Some(entry) = packed.commits.get(commit_id) {
+            if let Some(manifest) =
+                crate::tracked_state::load_commit_state_manifest(store, *commit_id).await?
+            {
+                for set in &manifest.current_state_part_sets {
+                    crate::tracked_state::stage_delete_current_state_part_directory(
+                        store,
+                        writes,
+                        &set.directory,
+                        set.owner_commit_id,
+                        set.mutation_directory_digest,
+                    )
+                    .await?;
+                }
+            }
             let schema_keys = entry
                 .members
                 .iter()
@@ -1391,6 +1405,7 @@ mod tests {
                 bytes: live.tracked_state_rootless_bytes,
             },
             mutations: CommitStateMutationInventory::default(),
+            current_state_part_sets: Vec::new(),
             snapshot_root: None,
         };
         drifted.generation += 1;
@@ -2143,6 +2158,7 @@ mod tests {
                     bytes: record.tracked_state_rootless_bytes,
                 },
                 mutations,
+                current_state_part_sets: Vec::new(),
                 snapshot_root: None,
             },
         )

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -51,7 +51,7 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::mutable(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"commit-state-manifest.v47";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"commit-state-manifest.v48";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately
@@ -395,6 +395,7 @@ where
                 created_at: plan.commit.created_at,
                 replay_debt: CommitStateReplayDebt::default(),
                 mutations: staged_delta.mutation_inventory().clone(),
+                current_state_part_sets: Vec::new(),
                 snapshot_root: Some(snapshot_root),
             },
         )?;

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -2857,6 +2857,7 @@ mod tests {
                     created_at: record.created_at,
                     replay_debt: CommitStateReplayDebt::default(),
                     mutations: Default::default(),
+                    current_state_part_sets: Vec::new(),
                     snapshot_root: Some(snapshot_root),
                 },
             )
@@ -3083,6 +3084,7 @@ mod tests {
                         bytes: record.tracked_state_rootless_bytes,
                     },
                     mutations: Default::default(),
+                    current_state_part_sets: Vec::new(),
                     snapshot_root: None,
                 },
             )
@@ -3299,6 +3301,7 @@ mod tests {
                     created_at: record.created_at,
                     replay_debt: CommitStateReplayDebt::default(),
                     mutations: mutation_inventory,
+                    current_state_part_sets: Vec::new(),
                     snapshot_root: Some(snapshot_root),
                 },
             )?;

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -37,6 +37,7 @@ fn stage_bench_commit_deltas(
                 bytes: u64::from(mutations.member_count),
             },
             mutations,
+            current_state_part_sets: Vec::new(),
             snapshot_root: None,
         },
     )?;
@@ -58,6 +59,9 @@ static ENTITY_POINT_SNAPSHOT_CACHE_MISSES: AtomicU64 = AtomicU64::new(0);
 static CRUD_PHYSICAL_PUTS: AtomicU64 = AtomicU64::new(0);
 static CRUD_PHYSICAL_DELETES: AtomicU64 = AtomicU64::new(0);
 static CRUD_PHYSICAL_WRITTEN_BYTES: AtomicU64 = AtomicU64::new(0);
+static CRUD_COMMIT_STATE_MANIFEST_BYTES: AtomicU64 = AtomicU64::new(0);
+static CRUD_CURRENT_STATE_DIRECTORY_BYTES: AtomicU64 = AtomicU64::new(0);
+static CRUD_CURRENT_STATE_DIRECTORY_RECOVERIES: AtomicU64 = AtomicU64::new(0);
 static MEDIA_UPLOAD_MANIFEST_LEAF_ROWS: AtomicU64 = AtomicU64::new(0);
 static MEDIA_UPLOAD_SUMMARIZED_CHUNK_ROWS: AtomicU64 = AtomicU64::new(0);
 static MEDIA_UPLOAD_CHUNK_PAYLOAD_HASH_BYTES: AtomicU64 = AtomicU64::new(0);
@@ -176,6 +180,30 @@ pub fn take_crud_physical_write_accounting() -> CrudPhysicalWriteAccounting {
         deletes: CRUD_PHYSICAL_DELETES.swap(0, Ordering::Relaxed),
         written_bytes: CRUD_PHYSICAL_WRITTEN_BYTES.swap(0, Ordering::Relaxed),
     }
+}
+
+pub(crate) fn record_crud_commit_state_manifest_bytes(bytes: usize) {
+    CRUD_COMMIT_STATE_MANIFEST_BYTES.fetch_add(bytes as u64, Ordering::Relaxed);
+}
+
+pub fn take_crud_commit_state_manifest_bytes() -> u64 {
+    CRUD_COMMIT_STATE_MANIFEST_BYTES.swap(0, Ordering::Relaxed)
+}
+
+pub(crate) fn record_crud_current_state_directory_bytes(bytes: usize) {
+    CRUD_CURRENT_STATE_DIRECTORY_BYTES.fetch_add(bytes as u64, Ordering::Relaxed);
+}
+
+pub fn take_crud_current_state_directory_bytes() -> u64 {
+    CRUD_CURRENT_STATE_DIRECTORY_BYTES.swap(0, Ordering::Relaxed)
+}
+
+pub(crate) fn record_crud_current_state_directory_recovery() {
+    CRUD_CURRENT_STATE_DIRECTORY_RECOVERIES.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn take_crud_current_state_directory_recoveries() -> u64 {
+    CRUD_CURRENT_STATE_DIRECTORY_RECOVERIES.swap(0, Ordering::Relaxed)
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/packages/engine/src/test_support.rs
+++ b/packages/engine/src/test_support.rs
@@ -557,6 +557,7 @@ fn stage_test_commit_state_manifest(
             created_at: record.created_at,
             replay_debt,
             mutations,
+            current_state_part_sets: Vec::new(),
             snapshot_root,
         },
     )

--- a/packages/engine/src/tracked_state/bench_support.rs
+++ b/packages/engine/src/tracked_state/bench_support.rs
@@ -39,6 +39,7 @@ fn stage_bench_commit_deltas(
                 bytes: u64::from(mutations.member_count),
             },
             mutations,
+            current_state_part_sets: Vec::new(),
             snapshot_root: None,
         },
     )?;

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -4739,6 +4739,7 @@ mod tests {
                 ),
                 replay_debt: Default::default(),
                 mutations: Default::default(),
+                current_state_part_sets: Vec::new(),
                 snapshot_root: Some(snapshot_root),
             },
         )

--- a/packages/engine/src/tracked_state/current_state_part.rs
+++ b/packages/engine/src/tracked_state/current_state_part.rs
@@ -1,0 +1,782 @@
+//! Persistent range directory for immutable committed current-state parts.
+//!
+//! Mutation inventory remains the historical authority. This directory is a
+//! content-addressed serving accelerator over a final, non-overlapping
+//! post-image part set and can therefore be rebuilt or discarded.
+
+#![allow(dead_code)]
+
+use std::mem::size_of;
+
+use bytes::Bytes;
+
+use crate::changelog::CommitId;
+use crate::storage_adapter::{
+    PointReadPlan, StorageAdapterRead, StorageGetOptions, StorageKey, StorageProjectedValue,
+    StorageSpace, StorageSpaceId, StorageValue, StorageWriteSet,
+};
+use crate::tracked_state::types::{CommitStateMutationInventory, CurrentStatePartSet};
+use crate::tracked_state::types::{CurrentStatePartDescriptor, CurrentStatePartDirectoryRoot};
+use crate::{LixError, storage_codec};
+
+pub(crate) const CURRENT_STATE_PART_DIRECTORY_SPACE: StorageSpace = StorageSpace::immutable(
+    StorageSpaceId(0x0004_002c),
+    "tracked_state.current_state_part_directory.v1",
+);
+
+const DIRECTORY_NODE_RAW_MAGIC: &[u8; 6] = b"LXCSDR";
+const DIRECTORY_NODE_ZSTD_MAGIC: &[u8; 6] = b"LXCSDZ";
+const DIRECTORY_NODE_MAX_DECODED_BYTES: usize = 16 * 1024 * 1024;
+const DIRECTORY_FANOUT: usize = 128;
+const DIRECTORY_HASH_CONTEXT: &str = "lix current-state part directory node v1";
+
+/// Publishes the serving directory for a certified complete replacement.
+/// Ordinary mutation inventories are not state partitions and return `None`.
+pub(crate) fn stage_complete_replacement_current_state_part_set(
+    writes: &mut StorageWriteSet,
+    commit_id: CommitId,
+    inventory: &CommitStateMutationInventory,
+) -> Result<Option<CurrentStatePartSet>, LixError> {
+    let Some(generation) = inventory.replacement_generation.as_ref() else {
+        return Ok(None);
+    };
+    let authority = inventory.replacement_parts.as_ref().ok_or_else(|| {
+        directory_error("replacement generation omitted its immutable part authority")
+    })?;
+    if inventory.parts.len() != inventory.direct_part_row_counts.len() || inventory.parts.is_empty()
+    {
+        return Err(directory_error(
+            "replacement generation has no complete directly-addressable part set",
+        ));
+    }
+    let mut first_ordinal = 0u32;
+    let descriptors = inventory
+        .parts
+        .iter()
+        .zip(&inventory.direct_part_row_counts)
+        .enumerate()
+        .map(|(part_index, (bounds, &row_count))| {
+            let part = bounds.replacement_part.as_ref().ok_or_else(|| {
+                directory_error("replacement state set contains a generic mutation part")
+            })?;
+            let descriptor = CurrentStatePartDescriptor {
+                first_key: bounds.first_key.clone(),
+                last_key: bounds.last_key.clone(),
+                content_digest: part.content_digest,
+                owner_commit_id: part.owner_commit_id,
+                part_index: u32::try_from(part_index)
+                    .map_err(|_| directory_error("part index overflows u32"))?,
+                first_ordinal,
+                row_count,
+                uniform_created_at: part.uniform_created_at,
+                uniform_updated_at: part.uniform_updated_at,
+            };
+            first_ordinal = first_ordinal
+                .checked_add(u32::from(row_count))
+                .ok_or_else(|| directory_error("row ordinal overflows u32"))?;
+            Ok(descriptor)
+        })
+        .collect::<Result<Vec<_>, LixError>>()?;
+    let directory = stage_current_state_part_directory(writes, &descriptors)?;
+    if directory.row_count != u64::from(inventory.member_count)
+        || directory.descriptor_digest != authority.directory_digest
+        || generation.owner_commit_id != *commit_id.as_uuid().as_bytes()
+    {
+        return Err(directory_error(
+            "replacement state set disagrees with its commit authority",
+        ));
+    }
+    Ok(Some(CurrentStatePartSet {
+        scope: generation.scope.clone(),
+        owner_commit_id: generation.owner_commit_id,
+        generation_integrity_digest: generation.integrity_digest,
+        mutation_directory_digest: authority.directory_digest,
+        directory,
+    }))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+struct DirectoryChild {
+    #[musli(bytes)]
+    first_key: Vec<u8>,
+    #[musli(bytes)]
+    last_key: Vec<u8>,
+    node_id: [u8; 32],
+    row_count: u64,
+    part_count: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+struct DirectoryNode {
+    kind: u8,
+    /// The semantic replacement-directory digest for the complete part set.
+    /// Every node carries it so a valid node from another tree cannot turn a
+    /// routing miss into an authoritative absence.
+    set_digest: [u8; 32],
+    parts: Vec<CurrentStatePartDescriptor>,
+    children: Vec<DirectoryChild>,
+}
+
+impl DirectoryNode {
+    fn leaf(set_digest: [u8; 32], parts: Vec<CurrentStatePartDescriptor>) -> Self {
+        Self {
+            kind: 0,
+            set_digest,
+            parts,
+            children: Vec::new(),
+        }
+    }
+
+    fn internal(set_digest: [u8; 32], children: Vec<DirectoryChild>) -> Self {
+        Self {
+            kind: 1,
+            set_digest,
+            parts: Vec::new(),
+            children,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct StagedNode {
+    child: DirectoryChild,
+}
+
+/// Stages one complete ordered post-image part set as a bounded persistent
+/// range directory. Equal nodes naturally share storage across generations.
+pub(crate) fn stage_current_state_part_directory(
+    writes: &mut StorageWriteSet,
+    descriptors: &[CurrentStatePartDescriptor],
+) -> Result<CurrentStatePartDirectoryRoot, LixError> {
+    validate_descriptors(descriptors)?;
+    // Reuse the historical replacement-directory certificate rather than
+    // inventing a second digest vocabulary for the same immutable part set.
+    let descriptor_digest = replacement_directory_digest(descriptors)?;
+    let mut level = descriptors
+        .chunks(DIRECTORY_FANOUT)
+        .map(|chunk| {
+            stage_node(
+                writes,
+                DirectoryNode::leaf(descriptor_digest, chunk.to_vec()),
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut tree_height = 1u16;
+    while level.len() > 1 {
+        level = level
+            .chunks(DIRECTORY_FANOUT)
+            .map(|chunk| {
+                stage_node(
+                    writes,
+                    DirectoryNode::internal(
+                        descriptor_digest,
+                        chunk.iter().map(|node| node.child.clone()).collect(),
+                    ),
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        tree_height = tree_height
+            .checked_add(1)
+            .ok_or_else(|| directory_error("tree height overflows"))?;
+    }
+    let root = level
+        .into_iter()
+        .next()
+        .ok_or_else(|| directory_error("cannot stage an empty part set"))?;
+    Ok(CurrentStatePartDirectoryRoot {
+        root_id: root.child.node_id,
+        descriptor_digest,
+        row_count: root.child.row_count,
+        part_count: root.child.part_count,
+        tree_height,
+    })
+}
+
+/// Routes one encoded identity to its bounded immutable state part.
+pub(crate) async fn route_current_state_part(
+    store: &(impl StorageAdapterRead + ?Sized),
+    root: &CurrentStatePartDirectoryRoot,
+    encoded_key: &[u8],
+) -> Result<Option<CurrentStatePartDescriptor>, LixError> {
+    let mut node_id = root.root_id;
+    loop {
+        let node = load_node(store, node_id, root.descriptor_digest).await?;
+        if node_id == root.root_id {
+            validate_root_summary(root, &node)?;
+        }
+        match node.kind {
+            0 => {
+                let parts = node.parts;
+                let index = parts.partition_point(|part| part.first_key.as_slice() <= encoded_key);
+                let Some(part) = index.checked_sub(1).and_then(|index| parts.get(index)) else {
+                    return Ok(None);
+                };
+                return Ok((encoded_key <= part.last_key.as_slice()).then(|| part.clone()));
+            }
+            1 => {
+                let children = node.children;
+                let upper =
+                    children.partition_point(|child| child.first_key.as_slice() <= encoded_key);
+                let Some(child) = upper.checked_sub(1).and_then(|index| children.get(index)) else {
+                    return Ok(None);
+                };
+                if encoded_key > child.last_key.as_slice() {
+                    return Ok(None);
+                }
+                node_id = child.node_id;
+            }
+            _ => unreachable!("validated directory node kind"),
+        }
+    }
+}
+
+/// Routes a caller-owned encoded-key batch while reading each shared
+/// directory node at most once for that batch.
+pub(crate) async fn route_current_state_parts(
+    store: &(impl StorageAdapterRead + ?Sized),
+    root: &CurrentStatePartDirectoryRoot,
+    encoded_keys: &[Bytes],
+) -> Result<Vec<Option<CurrentStatePartDescriptor>>, LixError> {
+    let mut routes = vec![None; encoded_keys.len()];
+    let mut pending = vec![(
+        root.root_id,
+        (0..encoded_keys.len()).collect::<Vec<usize>>(),
+    )];
+    while let Some((node_id, key_indices)) = pending.pop() {
+        let node = load_node(store, node_id, root.descriptor_digest).await?;
+        if node_id == root.root_id {
+            validate_root_summary(root, &node)?;
+        }
+        match node.kind {
+            0 => {
+                for key_index in key_indices {
+                    let key = &encoded_keys[key_index];
+                    let index = node
+                        .parts
+                        .partition_point(|part| part.first_key.as_slice() <= key.as_ref());
+                    let Some(part) = index.checked_sub(1).and_then(|index| node.parts.get(index))
+                    else {
+                        continue;
+                    };
+                    if key.as_ref() <= part.last_key.as_slice() {
+                        routes[key_index] = Some(part.clone());
+                    }
+                }
+            }
+            1 => {
+                let mut child_keys = std::collections::BTreeMap::<usize, Vec<usize>>::new();
+                for key_index in key_indices {
+                    let key = &encoded_keys[key_index];
+                    let upper = node
+                        .children
+                        .partition_point(|child| child.first_key.as_slice() <= key.as_ref());
+                    if let Some(child_index) = upper.checked_sub(1)
+                        && key.as_ref() <= node.children[child_index].last_key.as_slice()
+                    {
+                        child_keys.entry(child_index).or_default().push(key_index);
+                    }
+                }
+                pending.extend(
+                    child_keys
+                        .into_iter()
+                        .rev()
+                        .map(|(child_index, keys)| (node.children[child_index].node_id, keys)),
+                );
+            }
+            _ => unreachable!("validated directory node kind"),
+        }
+    }
+    Ok(routes)
+}
+
+/// Loads the complete ordered descriptor set for scans, rebuild, and audit.
+pub(crate) async fn load_current_state_part_descriptors(
+    store: &(impl StorageAdapterRead + ?Sized),
+    root: &CurrentStatePartDirectoryRoot,
+) -> Result<Vec<CurrentStatePartDescriptor>, LixError> {
+    let mut pending = vec![root.root_id];
+    let mut descriptors = Vec::with_capacity(root.part_count as usize);
+    while let Some(node_id) = pending.pop() {
+        let mut node = load_node(store, node_id, root.descriptor_digest).await?;
+        if node_id == root.root_id {
+            validate_root_summary(root, &node)?;
+        }
+        match node.kind {
+            0 => descriptors.append(&mut node.parts),
+            1 => {
+                pending.extend(node.children.into_iter().rev().map(|child| child.node_id));
+            }
+            _ => unreachable!("validated directory node kind"),
+        }
+    }
+    validate_descriptors(&descriptors)?;
+    if descriptors.len() != root.part_count as usize
+        || descriptors
+            .iter()
+            .map(|part| u64::from(part.row_count))
+            .sum::<u64>()
+            != root.row_count
+        || replacement_directory_digest(&descriptors)? != root.descriptor_digest
+    {
+        return Err(directory_error(
+            "root summary does not match its descriptor set",
+        ));
+    }
+    Ok(descriptors)
+}
+
+/// Deletes a complete replacement directory. First-slice leaf descriptors bind
+/// every node to one owner commit, so no node can be shared across owners yet.
+/// Sparse structural sharing will replace this with mark/sweep reachability.
+pub(crate) async fn stage_delete_current_state_part_directory(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    root: &CurrentStatePartDirectoryRoot,
+    expected_owner_commit_id: [u8; 16],
+    expected_mutation_directory_digest: [u8; 32],
+) -> Result<(), LixError> {
+    let descriptors = load_current_state_part_descriptors(store, root).await?;
+    if root.descriptor_digest != expected_mutation_directory_digest
+        || descriptors
+            .iter()
+            .any(|descriptor| descriptor.owner_commit_id != expected_owner_commit_id)
+    {
+        return Err(directory_error(
+            "refusing to delete a directory not owned by its dead authority",
+        ));
+    }
+    let mut pending = vec![root.root_id];
+    while let Some(node_id) = pending.pop() {
+        let node = load_node(store, node_id, root.descriptor_digest).await?;
+        if node.kind == 1 {
+            pending.extend(node.children.into_iter().map(|child| child.node_id));
+        }
+        writes.delete(
+            CURRENT_STATE_PART_DIRECTORY_SPACE,
+            StorageKey(Bytes::copy_from_slice(&node_id)),
+        );
+    }
+    Ok(())
+}
+
+fn stage_node(writes: &mut StorageWriteSet, node: DirectoryNode) -> Result<StagedNode, LixError> {
+    let (first_key, last_key, row_count, part_count) = node_summary(&node)?;
+    let bytes = encode_node(&node)?;
+    #[cfg(feature = "storage-benches")]
+    crate::storage_bench::record_crud_current_state_directory_bytes(bytes.len());
+    let node_id = node_digest(&bytes);
+    writes.put(
+        CURRENT_STATE_PART_DIRECTORY_SPACE,
+        StorageKey(Bytes::copy_from_slice(&node_id)),
+        StorageValue {
+            bytes: bytes.clone(),
+        },
+    );
+    Ok(StagedNode {
+        child: DirectoryChild {
+            first_key,
+            last_key,
+            node_id,
+            row_count,
+            part_count,
+        },
+    })
+}
+
+async fn load_node(
+    store: &(impl StorageAdapterRead + ?Sized),
+    node_id: [u8; 32],
+    expected_set_digest: [u8; 32],
+) -> Result<DirectoryNode, LixError> {
+    let key = StorageKey(Bytes::copy_from_slice(&node_id));
+    let result = PointReadPlan::new(CURRENT_STATE_PART_DIRECTORY_SPACE, &[key])
+        .materialize(store, StorageGetOptions::default())
+        .await?;
+    let value = result
+        .value
+        .into_iter()
+        .next()
+        .flatten()
+        .ok_or_else(|| directory_error("references a missing content-addressed node"))?;
+    let StorageProjectedValue::FullValue(bytes) = value else {
+        return Err(directory_error("node read omitted its value"));
+    };
+    if node_digest(&bytes) != node_id {
+        return Err(directory_error("node content digest mismatch"));
+    }
+    let node = decode_node(&bytes)?;
+    if node.set_digest != expected_set_digest {
+        return Err(directory_error("node belongs to a different part set"));
+    }
+    Ok(node)
+}
+
+fn encode_node(node: &DirectoryNode) -> Result<Bytes, LixError> {
+    let payload = storage_codec::encode("current-state part directory node", node)?;
+    if payload.len() > DIRECTORY_NODE_MAX_DECODED_BYTES {
+        return Err(directory_error("node exceeds its decoded size bound"));
+    }
+    let compressed = crate::compression::compress_zstd_level_1(&payload)
+        .map_err(|error| directory_error(format!("compression failed: {error}")))?;
+    let use_compressed = compressed.len().saturating_add(size_of::<u32>()) < payload.len();
+    let body = if use_compressed {
+        compressed.as_slice()
+    } else {
+        payload.as_slice()
+    };
+    let mut encoded = Vec::with_capacity(
+        DIRECTORY_NODE_RAW_MAGIC.len()
+            + if use_compressed { size_of::<u32>() } else { 0 }
+            + body.len(),
+    );
+    if use_compressed {
+        encoded.extend_from_slice(DIRECTORY_NODE_ZSTD_MAGIC);
+        encoded.extend_from_slice(
+            &u32::try_from(payload.len())
+                .map_err(|_| directory_error("node exceeds the decoded size bound"))?
+                .to_be_bytes(),
+        );
+    } else {
+        encoded.extend_from_slice(DIRECTORY_NODE_RAW_MAGIC);
+    }
+    encoded.extend_from_slice(body);
+    Ok(Bytes::from(encoded))
+}
+
+fn decode_node(bytes: &[u8]) -> Result<DirectoryNode, LixError> {
+    let payload = if let Some(payload) = bytes.strip_prefix(DIRECTORY_NODE_RAW_MAGIC) {
+        if payload.len() > DIRECTORY_NODE_MAX_DECODED_BYTES {
+            return Err(directory_error("raw node exceeds its decode bound"));
+        }
+        payload.to_vec()
+    } else if let Some(encoded) = bytes.strip_prefix(DIRECTORY_NODE_ZSTD_MAGIC) {
+        let (length, compressed) = encoded
+            .split_at_checked(size_of::<u32>())
+            .ok_or_else(|| directory_error("compressed node omitted its decoded length"))?;
+        let decoded_len = usize::try_from(u32::from_be_bytes(
+            length
+                .try_into()
+                .expect("checked node length is four bytes"),
+        ))
+        .expect("u32 fits usize");
+        if decoded_len > DIRECTORY_NODE_MAX_DECODED_BYTES {
+            return Err(directory_error("compressed node exceeds its decode bound"));
+        }
+        crate::compression::decompress_zstd(compressed, decoded_len)
+            .map_err(|error| directory_error(format!("decompression failed: {error}")))?
+    } else {
+        return Err(directory_error(
+            "node has an unsupported format; recreate the serving directory",
+        ));
+    };
+    let node = storage_codec::decode("current-state part directory node", &payload)?;
+    validate_node(&node)?;
+    Ok(node)
+}
+
+fn node_digest(bytes: &[u8]) -> [u8; 32] {
+    *blake3::Hasher::new_derive_key(DIRECTORY_HASH_CONTEXT)
+        .update(bytes)
+        .finalize()
+        .as_bytes()
+}
+
+fn replacement_directory_digest(
+    descriptors: &[CurrentStatePartDescriptor],
+) -> Result<[u8; 32], LixError> {
+    let entries = descriptors
+        .iter()
+        .map(|descriptor| {
+            crate::tracked_state::replacement_part::ReplacementPartDirectoryEntry::new(
+                descriptor.content_digest,
+                &descriptor.first_key,
+                &descriptor.last_key,
+                descriptor.first_ordinal,
+                descriptor.row_count,
+            )
+        })
+        .collect();
+    crate::tracked_state::replacement_part::ReplacementPartDirectory::try_new(
+        entries,
+        u32::try_from(
+            descriptors
+                .iter()
+                .map(|descriptor| u64::from(descriptor.row_count))
+                .sum::<u64>(),
+        )
+        .map_err(|_| directory_error("row count overflows u32"))?,
+    )?
+    .digest()
+}
+
+fn validate_root_summary(
+    root: &CurrentStatePartDirectoryRoot,
+    node: &DirectoryNode,
+) -> Result<(), LixError> {
+    let (_, _, row_count, part_count) = node_summary(node)?;
+    if row_count != root.row_count || part_count != root.part_count {
+        return Err(directory_error("root summary disagrees with its node"));
+    }
+    Ok(())
+}
+
+fn node_summary(node: &DirectoryNode) -> Result<(Vec<u8>, Vec<u8>, u64, u32), LixError> {
+    validate_node(node)?;
+    match node.kind {
+        0 => Ok((
+            node.parts[0].first_key.clone(),
+            node.parts
+                .last()
+                .expect("validated leaf is non-empty")
+                .last_key
+                .clone(),
+            node.parts
+                .iter()
+                .map(|part| u64::from(part.row_count))
+                .sum(),
+            u32::try_from(node.parts.len()).map_err(|_| directory_error("part count overflows"))?,
+        )),
+        1 => Ok((
+            node.children[0].first_key.clone(),
+            node.children
+                .last()
+                .expect("validated internal node is non-empty")
+                .last_key
+                .clone(),
+            node.children.iter().map(|child| child.row_count).sum(),
+            node.children.iter().map(|child| child.part_count).sum(),
+        )),
+        _ => unreachable!("validated directory node kind"),
+    }
+}
+
+fn validate_node(node: &DirectoryNode) -> Result<(), LixError> {
+    match node.kind {
+        0 => {
+            if !node.children.is_empty() || node.parts.len() > DIRECTORY_FANOUT {
+                return Err(directory_error("leaf exceeds bounded fanout"));
+            }
+            validate_descriptor_slice(&node.parts, false)
+        }
+        1 => {
+            if !node.parts.is_empty()
+                || node.children.is_empty()
+                || node.children.len() > DIRECTORY_FANOUT
+                || node.children.iter().any(|child| {
+                    child.first_key.is_empty()
+                        || child.last_key.is_empty()
+                        || child.first_key > child.last_key
+                        || child.row_count == 0
+                        || child.part_count == 0
+                })
+                || node
+                    .children
+                    .windows(2)
+                    .any(|pair| pair[0].last_key >= pair[1].first_key)
+            {
+                return Err(directory_error(
+                    "internal node has invalid or overlapping ranges",
+                ));
+            }
+            Ok(())
+        }
+        _ => Err(directory_error("node has an unknown kind")),
+    }
+}
+
+fn validate_descriptors(parts: &[CurrentStatePartDescriptor]) -> Result<(), LixError> {
+    validate_descriptor_slice(parts, true)
+}
+
+fn validate_descriptor_slice(
+    parts: &[CurrentStatePartDescriptor],
+    require_zero_origin: bool,
+) -> Result<(), LixError> {
+    let first = parts.first();
+    if first.is_none()
+        || (require_zero_origin
+            && first.is_some_and(|part| part.part_index != 0 || part.first_ordinal != 0))
+        || parts.iter().any(|part| {
+            part.first_key.is_empty()
+                || part.last_key.is_empty()
+                || part.first_key > part.last_key
+                || part.row_count == 0
+                || part.content_digest == [0; 32]
+        })
+        || parts
+            .windows(2)
+            .any(|pair| pair[0].last_key >= pair[1].first_key)
+        || parts.windows(2).any(|pair| {
+            pair[1].part_index != pair[0].part_index + 1
+                || pair[1].first_ordinal != pair[0].first_ordinal + u32::from(pair[0].row_count)
+                || pair[1].owner_commit_id != pair[0].owner_commit_id
+                || pair[1].uniform_created_at != pair[0].uniform_created_at
+                || pair[1].uniform_updated_at != pair[0].uniform_updated_at
+        })
+    {
+        return Err(directory_error(
+            "descriptor set is empty, unordered, or overlapping",
+        ));
+    }
+    Ok(())
+}
+
+fn directory_error(message: impl std::fmt::Display) -> LixError {
+    LixError::new(
+        LixError::CODE_INTERNAL_ERROR,
+        format!("tracked_state current-state part directory {message}"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::common::LixTimestamp;
+    use crate::storage_adapter::{Memory, StorageAdapter, StorageReadOptions, StorageWriteOptions};
+
+    use super::*;
+
+    fn descriptors(count: usize) -> Vec<CurrentStatePartDescriptor> {
+        let timestamp = LixTimestamp::from_unix_millis_utc_lossy(7);
+        (0..count)
+            .map(|index| CurrentStatePartDescriptor {
+                first_key: format!("key-{index:06}-a").into_bytes(),
+                last_key: format!("key-{index:06}-z").into_bytes(),
+                content_digest: *blake3::hash(&index.to_be_bytes()).as_bytes(),
+                owner_commit_id: [9; 16],
+                part_index: u32::try_from(index).expect("fixture index fits u32"),
+                first_ordinal: u32::try_from(index * 10).expect("fixture ordinal fits u32"),
+                row_count: 10,
+                uniform_created_at: timestamp,
+                uniform_updated_at: timestamp,
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn persistent_directory_routes_bounded_ranges_and_scans_in_order() {
+        let adapter = StorageAdapter::new(Memory::new());
+        let descriptors = descriptors(DIRECTORY_FANOUT * 2 + 7);
+        let mut writes = adapter.new_write_set();
+        let root = stage_current_state_part_directory(&mut writes, &descriptors)
+            .expect("directory should stage");
+        assert_eq!(root.tree_height, 2);
+        assert_eq!(root.part_count as usize, descriptors.len());
+        adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("directory should commit");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+
+        for index in [0, DIRECTORY_FANOUT, descriptors.len() - 1] {
+            let key = format!("key-{index:06}-m");
+            let routed = route_current_state_part(&read, &root, key.as_bytes())
+                .await
+                .expect("route should succeed")
+                .expect("key should be covered");
+            assert_eq!(routed, descriptors[index]);
+        }
+        assert!(
+            route_current_state_part(&read, &root, b"key-000001-zz")
+                .await
+                .expect("gap route should succeed")
+                .is_none()
+        );
+        assert_eq!(
+            load_current_state_part_descriptors(&read, &root)
+                .await
+                .expect("scan should succeed"),
+            descriptors
+        );
+
+        let mut foreign_descriptors = descriptors.clone();
+        foreign_descriptors[0].content_digest = [7; 32];
+        let mut foreign_writes = adapter.new_write_set();
+        let foreign_root =
+            stage_current_state_part_directory(&mut foreign_writes, &foreign_descriptors)
+                .expect("foreign directory should stage");
+        drop(read);
+        adapter
+            .commit_write_set(foreign_writes, StorageWriteOptions::default())
+            .await
+            .expect("foreign directory should commit");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("cross-wire read should open");
+        let forged_root = CurrentStatePartDirectoryRoot {
+            root_id: foreign_root.root_id,
+            ..root.clone()
+        };
+        assert!(
+            route_current_state_part(&read, &forged_root, b"key-000000-m")
+                .await
+                .is_err(),
+            "a valid root from another certified set must not authorize a miss"
+        );
+
+        let mut deletes = adapter.new_write_set();
+        assert!(
+            stage_delete_current_state_part_directory(
+                &read,
+                &mut deletes,
+                &root,
+                [8; 16],
+                root.descriptor_digest,
+            )
+            .await
+            .is_err(),
+            "GC must fail closed when a dead manifest is cross-wired"
+        );
+        stage_delete_current_state_part_directory(
+            &read,
+            &mut deletes,
+            &root,
+            [9; 16],
+            root.descriptor_digest,
+        )
+        .await
+        .expect("directory deletion should stage");
+        drop(read);
+        adapter
+            .commit_write_set(deletes, StorageWriteOptions::default())
+            .await
+            .expect("directory deletion should commit");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("post-delete read should open");
+        assert!(
+            route_current_state_part(&read, &root, b"key-000000-m")
+                .await
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn directory_rejects_overlap_and_owner_drift() {
+        let adapter = StorageAdapter::new(Memory::new());
+        let mut overlapping = descriptors(2);
+        overlapping[1].first_key = overlapping[0].last_key.clone();
+        assert!(
+            stage_current_state_part_directory(&mut adapter.new_write_set(), &overlapping).is_err()
+        );
+        let mut owner_drift = descriptors(2);
+        owner_drift[1].owner_commit_id = [8; 16];
+        assert!(
+            stage_current_state_part_directory(&mut adapter.new_write_set(), &owner_drift).is_err()
+        );
+
+        let mut oversized = descriptors(1);
+        oversized[0].first_key = vec![b'a'; DIRECTORY_NODE_MAX_DECODED_BYTES / 2 + 1];
+        oversized[0].last_key = vec![b'b'; DIRECTORY_NODE_MAX_DECODED_BYTES / 2 + 1];
+        assert!(
+            stage_current_state_part_directory(&mut adapter.new_write_set(), &oversized).is_err(),
+            "staging must not publish a node that its decoder rejects"
+        );
+    }
+}

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -3,6 +3,7 @@ mod bench_support;
 mod codec;
 mod commit_root_rebuild;
 mod context;
+mod current_state_part;
 mod diff;
 mod diff_id;
 mod merge;
@@ -18,6 +19,9 @@ pub(crate) use commit_root_rebuild::{
 };
 pub(crate) use context::{
     TrackedStateContext, TrackedStateStoreReader, descriptor_dependency_cascade_file_ids,
+};
+pub(crate) use current_state_part::{
+    stage_complete_replacement_current_state_part_set, stage_delete_current_state_part_directory,
 };
 pub(crate) use diff::{
     TrackedStateDiff, TrackedStateDiffEntry, TrackedStateDiffIdentity, TrackedStateDiffKind,

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -7061,10 +7061,7 @@ fn validate_commit_state_mutation_inventory(
         && (!inventory.parts.is_empty()
             || inventory.replacement_parts.is_none()
             || inventory.replacement_generation.is_none()
-            || inventory
-                .replacement_part_digests
-                .iter()
-                .any(|digest| *digest == [0; 32]))
+            || inventory.replacement_part_digests.contains(&[0; 32]))
     {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -31,10 +31,10 @@ pub(crate) use crate::tracked_state::types::{
 };
 use crate::tracked_state::types::{
     CommitStateManifest, CommitStateMutationInventory, CommitStateMutationPart,
-    StoredCommitDeltaReplacementGeneration, StoredReplacementPart, StoredReplacementPartsAuthority,
-    TRACKED_STATE_HASH_BYTES, TrackedStateBaseCoordinate, TrackedStateCommitDeltaRef,
-    TrackedStateCommitRoot, TrackedStateIndexValue, TrackedStateIndexValueRef, TrackedStateKey,
-    TrackedStateKeyRef, TrackedStateRootId,
+    CurrentStatePartDescriptor, StoredCommitDeltaReplacementGeneration, StoredReplacementPart,
+    StoredReplacementPartsAuthority, TRACKED_STATE_HASH_BYTES, TrackedStateBaseCoordinate,
+    TrackedStateCommitDeltaRef, TrackedStateCommitRoot, TrackedStateIndexValue,
+    TrackedStateIndexValueRef, TrackedStateKey, TrackedStateKeyRef, TrackedStateRootId,
 };
 use crate::{LixError, storage_codec};
 use bytes::Bytes;
@@ -80,7 +80,7 @@ const ORDERED_COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 64 * 1024;
 // replacements authoritative through their immutable part manifest. The
 // payload-less certified-reference encoding is intentionally rejected.
 const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD14";
-const COMMIT_STATE_MANIFEST_FORMAT_MAGIC: &[u8] = b"LXCS1";
+const COMMIT_STATE_MANIFEST_FORMAT_MAGIC: &[u8] = b"LXCS2";
 const COMMIT_DELTA_PAYLOAD_OFFSET_BYTES: usize = size_of::<u32>();
 #[cfg(not(test))]
 const COMMIT_DELTA_MAX_SIDECAR_BYTES: usize = 64 * 1024 * 1024;
@@ -584,6 +584,15 @@ fn commit_state_inventory_from_delta_manifest(
         member_count: manifest.member_count,
         selection_fingerprint: manifest.selection_fingerprint,
         direct_part_row_counts: manifest.direct_segment_row_counts.clone(),
+        replacement_part_digests: manifest
+            .segments
+            .iter()
+            .filter_map(|part| {
+                part.replacement_part
+                    .as_ref()
+                    .map(|part| part.content_digest)
+            })
+            .collect(),
         single_partition: manifest.single_partition.clone(),
         lifecycle_summary: manifest.lifecycle_summary.clone(),
         replacement_generation: manifest.replacement_generation.clone(),
@@ -605,9 +614,180 @@ fn commit_delta_manifest_from_commit_state(manifest: &CommitStateManifest) -> Co
     commit_delta_manifest_from_inventory(&manifest.mutations)
 }
 
+async fn expanded_commit_delta_manifest_from_commit_state(
+    store: &(impl StorageAdapterRead + ?Sized),
+    manifest: &CommitStateManifest,
+) -> Result<CommitDeltaManifest, LixError> {
+    let mut expanded = commit_delta_manifest_from_commit_state(manifest);
+    if manifest.mutations.replacement_part_digests.is_empty() {
+        return Ok(expanded);
+    }
+    let descriptors = match manifest.current_state_part_sets.first() {
+        Some(set) => match super::current_state_part::load_current_state_part_descriptors(
+            store,
+            &set.directory,
+        )
+        .await
+        {
+            Ok(descriptors)
+                if descriptors.len() == manifest.mutations.replacement_part_digests.len()
+                    && descriptors
+                        .iter()
+                        .zip(&manifest.mutations.replacement_part_digests)
+                        .all(|(descriptor, digest)| descriptor.content_digest == *digest) =>
+            {
+                Some(descriptors)
+            }
+            Ok(_) | Err(_) => {
+                #[cfg(feature = "storage-benches")]
+                crate::storage_bench::record_crud_current_state_directory_recovery();
+                None
+            }
+        },
+        None => None,
+    };
+    expanded.segments = match descriptors {
+        Some(descriptors) => descriptors
+            .into_iter()
+            .map(|descriptor| CommitDeltaSegmentBounds {
+                first_key: descriptor.first_key,
+                last_key: descriptor.last_key,
+                replacement_part: Some(StoredReplacementPart {
+                    content_digest: descriptor.content_digest,
+                    owner_commit_id: descriptor.owner_commit_id,
+                    first_address: descriptor.part_index.saturating_mul(
+                        u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS)
+                            .expect("replacement row bound fits u32"),
+                    ),
+                    uniform_created_at: descriptor.uniform_created_at,
+                    uniform_updated_at: descriptor.uniform_updated_at,
+                }),
+            })
+            .collect(),
+        None => recover_replacement_segment_bounds(store, manifest).await?,
+    };
+    Ok(expanded)
+}
+
+async fn recover_replacement_segment_bounds(
+    store: &(impl StorageAdapterRead + ?Sized),
+    manifest: &CommitStateManifest,
+) -> Result<Vec<CommitDeltaSegmentBounds>, LixError> {
+    let generation = manifest
+        .mutations
+        .replacement_generation
+        .as_ref()
+        .ok_or_else(|| {
+            replacement_payload_error("compact part inventory omitted its generation")
+        })?;
+    let lifecycle = manifest
+        .mutations
+        .lifecycle_summary
+        .as_ref()
+        .ok_or_else(|| {
+            replacement_payload_error("compact part inventory omitted lifecycle metadata")
+        })?;
+    let authority = manifest
+        .mutations
+        .replacement_parts
+        .as_ref()
+        .ok_or_else(|| {
+            replacement_payload_error("compact part inventory omitted part authority")
+        })?;
+    let keys = manifest
+        .mutations
+        .replacement_part_digests
+        .iter()
+        .enumerate()
+        .map(|(index, digest)| {
+            let mut key = commit_delta_segment_key(manifest.commit_id, index)?;
+            key.extend_from_slice(digest);
+            Ok(StorageKey(Bytes::from(key)))
+        })
+        .collect::<Result<Vec<_>, LixError>>()?;
+    let values = PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, &keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?;
+    manifest
+        .mutations
+        .replacement_part_digests
+        .iter()
+        .copied()
+        .zip(values.value)
+        .enumerate()
+        .map(|(index, (content_digest, value))| {
+            let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
+                replacement_payload_error("compact inventory references a missing part")
+            })?;
+            let decoded = crate::tracked_state::replacement_part::decode_replacement_part(
+                &content_digest,
+                &bytes,
+            )?;
+            let first_key = decoded
+                .first_key()
+                .ok_or_else(|| replacement_payload_error("replacement part is empty"))?
+                .to_vec();
+            let last_key = decoded
+                .last_key()
+                .ok_or_else(|| replacement_payload_error("replacement part is empty"))?
+                .to_vec();
+            Ok(CommitDeltaSegmentBounds {
+                first_key,
+                last_key,
+                replacement_part: Some(StoredReplacementPart {
+                    content_digest,
+                    owner_commit_id: generation.owner_commit_id,
+                    first_address: u32::try_from(index)
+                        .expect("replacement part index fits u32")
+                        .saturating_mul(
+                            u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS)
+                                .expect("replacement row bound fits u32"),
+                        ),
+                    uniform_created_at: lifecycle.uniform_created_at,
+                    uniform_updated_at: authority.uniform_updated_at,
+                }),
+            })
+        })
+        .collect()
+}
+
 fn commit_delta_manifest_from_inventory(
     inventory: &CommitStateMutationInventory,
 ) -> CommitDeltaManifest {
+    let replacement_parts = inventory
+        .parts
+        .is_empty()
+        .then_some(inventory.replacement_part_digests.as_slice())
+        .unwrap_or_default()
+        .iter()
+        .enumerate()
+        .map(|(index, &content_digest)| CommitDeltaSegmentBounds {
+            first_key: Vec::new(),
+            last_key: Vec::new(),
+            replacement_part: inventory
+                .replacement_generation
+                .as_ref()
+                .zip(
+                    inventory
+                        .lifecycle_summary
+                        .as_ref()
+                        .zip(inventory.replacement_parts.as_ref()),
+                )
+                .map(
+                    |(generation, (lifecycle, authority))| StoredReplacementPart {
+                        content_digest,
+                        owner_commit_id: generation.owner_commit_id,
+                        first_address: u32::try_from(index)
+                            .expect("replacement part index fits u32")
+                            .saturating_mul(
+                                u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS)
+                                    .expect("row limit fits u32"),
+                            ),
+                        uniform_created_at: lifecycle.uniform_created_at,
+                        uniform_updated_at: authority.uniform_updated_at,
+                    },
+                ),
+        });
     CommitDeltaManifest {
         selected_source_commit_id: inventory.selected_source_commit_id,
         member_count: inventory.member_count,
@@ -626,6 +806,7 @@ fn commit_delta_manifest_from_inventory(
                 last_key: part.last_key.clone(),
                 replacement_part: part.replacement_part.clone(),
             })
+            .chain(replacement_parts)
             .collect(),
     }
 }
@@ -1374,11 +1555,17 @@ async fn load_commit_delta_manifests(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_ids: &[CommitId],
 ) -> Result<Vec<Option<CommitDeltaManifest>>, LixError> {
-    Ok(load_commit_state_manifests(store, commit_ids)
-        .await?
-        .into_iter()
-        .map(|manifest| manifest.map(|manifest| commit_delta_manifest_from_commit_state(&manifest)))
-        .collect())
+    let states = load_commit_state_manifests(store, commit_ids).await?;
+    let mut manifests = Vec::with_capacity(states.len());
+    for state in states {
+        manifests.push(match state {
+            Some(state) => {
+                Some(expanded_commit_delta_manifest_from_commit_state(store, &state).await?)
+            }
+            None => None,
+        });
+    }
+    Ok(manifests)
 }
 
 /// Stages one complete commit authority record.
@@ -1391,10 +1578,13 @@ pub(crate) fn stage_commit_state_manifest(
     writes: &mut StorageWriteSet,
     manifest: &CommitStateManifest,
 ) -> Result<(), LixError> {
+    let encoded = encode_commit_state_manifest(manifest)?;
+    #[cfg(feature = "storage-benches")]
+    crate::storage_bench::record_crud_commit_state_manifest_bytes(encoded.len());
     writes.put(
         TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
         key(commit_state_manifest_key(manifest.commit_id)),
-        value(encode_commit_state_manifest(manifest)?),
+        value(encoded),
     );
     Ok(())
 }
@@ -2447,7 +2637,8 @@ pub(crate) async fn load_change_record_by_id(
         && let Some(commit_state) = load_commit_state_manifest(store, locator.commit_id).await?
         && direct_change_locator_in_commit_state(&commit_state, change_id) == Some(locator)
     {
-        let mutation_directory = commit_delta_manifest_from_commit_state(&commit_state);
+        let mutation_directory =
+            expanded_commit_delta_manifest_from_commit_state(store, &commit_state).await?;
         match try_load_change_record_at_locator_in_manifest(store, locator, &mutation_directory)
             .await
         {
@@ -2473,7 +2664,8 @@ async fn load_canonical_change_locator(
         && let Some(commit_state) = load_commit_state_manifest(store, locator.commit_id).await?
         && direct_change_locator_in_commit_state(&commit_state, change_id) == Some(locator)
     {
-        let mutation_directory = commit_delta_manifest_from_commit_state(&commit_state);
+        let mutation_directory =
+            expanded_commit_delta_manifest_from_commit_state(store, &commit_state).await?;
         match try_load_change_record_at_locator_in_manifest(store, locator, &mutation_directory)
             .await
         {
@@ -2680,10 +2872,18 @@ async fn load_change_records_at_locators(
     let segment_keys = routes
         .iter()
         .map(|&(commit_id, segment_index)| {
+            let bounds = manifests[&commit_id].segments.get(segment_index).ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "tracked_state selected change references out-of-range segment {segment_index} of commit '{commit_id}'"
+                    ),
+                )
+            })?;
             commit_delta_segment_key_for_bounds(
                 commit_id,
                 segment_index,
-                &manifests[&commit_id].segments[segment_index],
+                bounds,
             )
             .map(|key| StorageKey(Bytes::from(key)))
         })
@@ -3078,9 +3278,32 @@ pub(crate) async fn load_commit_delta_values_encoded_with_cache(
     encoded_keys: &[Bytes],
     point_cache: Option<&CommitDeltaPointReadCache>,
 ) -> Result<Vec<Option<TrackedStateIndexValue>>, LixError> {
-    let Some(manifest) = load_commit_delta_manifest_cached(store, commit_id, point_cache).await?
-    else {
-        return Ok(vec![None; encoded_keys.len()]);
+    let cached_manifest = point_cache
+        .map(|cache| cache.manifest(commit_id))
+        .transpose()?
+        .flatten();
+    let manifest = match cached_manifest {
+        Some(manifest) => manifest,
+        None => {
+            let Some(state) = load_commit_state_manifest(store, commit_id).await? else {
+                return Ok(vec![None; encoded_keys.len()]);
+            };
+            if !state.mutations.replacement_part_digests.is_empty() {
+                return load_compact_replacement_values_encoded(
+                    store,
+                    commit_id,
+                    encoded_keys,
+                    &state,
+                )
+                .await;
+            }
+            let manifest =
+                Arc::new(expanded_commit_delta_manifest_from_commit_state(store, &state).await?);
+            if let Some(point_cache) = point_cache {
+                point_cache.remember_manifest(commit_id, Arc::clone(&manifest))?;
+            }
+            manifest
+        }
     };
     let Some(source_commit_id) = manifest.selected_source_commit_id() else {
         return load_local_commit_delta_values_encoded(store, commit_id, encoded_keys, &manifest)
@@ -3118,6 +3341,124 @@ pub(crate) async fn load_commit_delta_values_encoded_with_cache(
     for (value, local) in values.iter_mut().zip(local) {
         if local.is_some() {
             *value = local;
+        }
+    }
+    Ok(values)
+}
+
+async fn load_compact_replacement_values_encoded(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+    encoded_keys: &[Bytes],
+    state: &CommitStateManifest,
+) -> Result<Vec<Option<TrackedStateIndexValue>>, LixError> {
+    if encoded_keys.is_empty() {
+        return Ok(Vec::new());
+    }
+    let Some(set) = state.current_state_part_sets.first() else {
+        let expanded = expanded_commit_delta_manifest_from_commit_state(store, state).await?;
+        return load_local_commit_delta_values_encoded(store, commit_id, encoded_keys, &expanded)
+            .await;
+    };
+    let generation = state
+        .mutations
+        .replacement_generation
+        .as_ref()
+        .ok_or_else(|| replacement_payload_error("compact state omitted its generation"))?;
+    let lifecycle =
+        state.mutations.lifecycle_summary.as_ref().ok_or_else(|| {
+            replacement_payload_error("compact state omitted lifecycle authority")
+        })?;
+    let authority = state
+        .mutations
+        .replacement_parts
+        .as_ref()
+        .ok_or_else(|| replacement_payload_error("compact state omitted part authority"))?;
+    let routes = match super::current_state_part::route_current_state_parts(
+        store,
+        &set.directory,
+        encoded_keys,
+    )
+    .await
+    {
+        Ok(routes) => routes,
+        Err(_) => {
+            #[cfg(feature = "storage-benches")]
+            crate::storage_bench::record_crud_current_state_directory_recovery();
+            let expanded = expanded_commit_delta_manifest_from_commit_state(store, state).await?;
+            return load_local_commit_delta_values_encoded(
+                store,
+                commit_id,
+                encoded_keys,
+                &expanded,
+            )
+            .await;
+        }
+    };
+    let mut grouped = BTreeMap::<u32, (CurrentStatePartDescriptor, Vec<usize>)>::new();
+    for (output_index, descriptor) in routes.into_iter().enumerate() {
+        let Some(descriptor) = descriptor else {
+            continue;
+        };
+        let expected_digest = state
+            .mutations
+            .replacement_part_digests
+            .get(descriptor.part_index as usize)
+            .ok_or_else(|| replacement_payload_error("directory part index is out of bounds"))?;
+        if descriptor.content_digest != *expected_digest
+            || state
+                .mutations
+                .direct_part_row_counts
+                .get(descriptor.part_index as usize)
+                != Some(&descriptor.row_count)
+            || descriptor.owner_commit_id != generation.owner_commit_id
+            || descriptor.uniform_created_at != lifecycle.uniform_created_at
+            || descriptor.uniform_updated_at != authority.uniform_updated_at
+        {
+            return Err(replacement_payload_error(
+                "directory descriptor disagrees with compact mutation authority",
+            ));
+        }
+        grouped
+            .entry(descriptor.part_index)
+            .or_insert_with(|| (descriptor, Vec::new()))
+            .1
+            .push(output_index);
+    }
+    let storage_keys = grouped
+        .values()
+        .map(|(descriptor, _)| {
+            let mut key = commit_delta_segment_key(commit_id, descriptor.part_index as usize)?;
+            key.extend_from_slice(&descriptor.content_digest);
+            Ok(StorageKey(Bytes::from(key)))
+        })
+        .collect::<Result<Vec<_>, LixError>>()?;
+    let loaded = PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, &storage_keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?;
+    let mut values = vec![None; encoded_keys.len()];
+    for ((_, (descriptor, output_indices)), value) in grouped.into_iter().zip(loaded.value) {
+        let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
+            replacement_payload_error("directory references a missing immutable state part")
+        })?;
+        let bounds = CommitDeltaSegmentBounds {
+            first_key: descriptor.first_key,
+            last_key: descriptor.last_key,
+            replacement_part: Some(StoredReplacementPart {
+                content_digest: descriptor.content_digest,
+                owner_commit_id: descriptor.owner_commit_id,
+                first_address: descriptor.part_index.saturating_mul(
+                    u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS)
+                        .expect("replacement row bound fits u32"),
+                ),
+                uniform_created_at: descriptor.uniform_created_at,
+                uniform_updated_at: descriptor.uniform_updated_at,
+            }),
+        };
+        let leaf = decode_commit_delta_segment(&bytes, Some(&bounds), commit_id)?;
+        for output_index in output_indices {
+            values[output_index] =
+                find_commit_delta_value(&leaf, &encoded_keys[output_index], commit_id)?;
         }
     }
     Ok(values)
@@ -4374,7 +4715,7 @@ pub(crate) async fn visit_change_records_from_commit_deltas(
                     "tracked_state commit-state scan key and manifest commit disagree",
                 ));
             }
-            let manifest = commit_delta_manifest_from_commit_state(&state);
+            let manifest = expanded_commit_delta_manifest_from_commit_state(store, &state).await?;
             let members =
                 load_commit_delta_members_from_manifest(store, commit_id, &manifest, &[]).await?;
             for member in members {
@@ -4692,7 +5033,7 @@ async fn scan_commit_delta_plane(
         );
         manifests.insert(
             commit_id,
-            commit_delta_manifest_from_commit_state(&manifest),
+            expanded_commit_delta_manifest_from_commit_state(store, &manifest).await?,
         );
     }
 
@@ -5028,13 +5369,13 @@ pub(crate) async fn load_commit_delta_selection_certificate(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
 ) -> Result<Option<CommitDeltaSelectionCertificate>, LixError> {
-    Ok(load_commit_delta_manifest(store, commit_id)
+    Ok(load_commit_state_manifest(store, commit_id)
         .await?
         .map(|manifest| CommitDeltaSelectionCertificate {
-            member_count: manifest.member_count,
-            selection_fingerprint: manifest.selection_fingerprint,
-            selected_source_commit_id: manifest.selected_source_commit_id(),
-            direct_segment_row_counts: manifest.direct_segment_row_counts,
+            member_count: manifest.mutations.member_count,
+            selection_fingerprint: manifest.mutations.selection_fingerprint,
+            selected_source_commit_id: manifest.mutations.selected_source_commit_id(),
+            direct_segment_row_counts: manifest.mutations.direct_part_row_counts,
         }))
 }
 
@@ -5050,11 +5391,16 @@ pub(crate) async fn load_commit_delta_replay_metadata_with_cache(
     commit_id: CommitId,
     point_cache: Option<&CommitDeltaPointReadCache>,
 ) -> Result<Option<CommitDeltaReplayMetadata>, LixError> {
-    Ok(
-        load_commit_delta_manifest_cached(store, commit_id, point_cache)
-            .await?
-            .map(|manifest| commit_delta_replay_metadata(&manifest)),
-    )
+    if let Some(manifest) = point_cache
+        .map(|cache| cache.manifest(commit_id))
+        .transpose()?
+        .flatten()
+    {
+        return Ok(Some(commit_delta_replay_metadata(&manifest)));
+    }
+    Ok(load_commit_state_manifest(store, commit_id)
+        .await?
+        .map(|manifest| commit_delta_replay_metadata_from_inventory(&manifest.mutations)))
 }
 
 fn commit_delta_replay_metadata(manifest: &CommitDeltaManifest) -> CommitDeltaReplayMetadata {
@@ -5075,6 +5421,30 @@ fn commit_delta_replay_metadata(manifest: &CommitDeltaManifest) -> CommitDeltaRe
         }),
     }
 }
+
+fn commit_delta_replay_metadata_from_inventory(
+    inventory: &CommitStateMutationInventory,
+) -> CommitDeltaReplayMetadata {
+    let lifecycle_summary = inventory.lifecycle_summary.clone();
+    CommitDeltaReplayMetadata {
+        member_count: inventory.member_count,
+        single_partition: inventory.single_partition.clone(),
+        lifecycle_summary: lifecycle_summary.clone(),
+        replacement_generation: inventory
+            .replacement_generation
+            .as_ref()
+            .zip(lifecycle_summary)
+            .map(
+                |(generation, lifecycle_summary)| CommitDeltaReplacementGeneration {
+                    scope: generation.scope.clone(),
+                    fallback_commit_id: generation
+                        .fallback_commit_id
+                        .map(|bytes| CommitId::new(uuid::Uuid::from_bytes(bytes))),
+                    lifecycle_summary,
+                },
+            ),
+    }
+}
 async fn load_commit_delta_manifest(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
@@ -5082,7 +5452,7 @@ async fn load_commit_delta_manifest(
     let Some(state) = load_commit_state_manifest(store, commit_id).await? else {
         return Ok(None);
     };
-    let manifest = commit_delta_manifest_from_commit_state(&state);
+    let manifest = expanded_commit_delta_manifest_from_commit_state(store, &state).await?;
     validate_commit_delta_manifest(&manifest)?;
     if manifest
         .replacement_generation
@@ -6598,7 +6968,63 @@ fn validate_commit_state_manifest(manifest: &CommitStateManifest) -> Result<(), 
         ));
     }
 
-    validate_commit_state_mutation_inventory(manifest.commit_id, &manifest.mutations)
+    validate_commit_state_mutation_inventory(manifest.commit_id, &manifest.mutations)?;
+    validate_current_state_part_sets(manifest)
+}
+
+fn validate_current_state_part_sets(manifest: &CommitStateManifest) -> Result<(), LixError> {
+    if manifest.current_state_part_sets.is_empty() {
+        return Ok(());
+    }
+    // The first publication slice covers the one certified replacement scope
+    // carried by the current mutation inventory. Sparse commits will publish
+    // multiple structurally shared scopes in the subsequent range-rewrite cut.
+    if manifest.current_state_part_sets.len() != 1 {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit_state_manifest has multiple current-state part sets before sparse range rewrite",
+        ));
+    }
+    let set = &manifest.current_state_part_sets[0];
+    let generation = manifest
+        .mutations
+        .replacement_generation
+        .as_ref()
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state current-state part set has no replacement-generation authority",
+            )
+        })?;
+    let authority = manifest
+        .mutations
+        .replacement_parts
+        .as_ref()
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state current-state part set has no immutable-part authority",
+            )
+        })?;
+    if set.scope != generation.scope
+        || set.owner_commit_id != *manifest.commit_id.as_uuid().as_bytes()
+        || set.owner_commit_id != generation.owner_commit_id
+        || set.generation_integrity_digest != generation.integrity_digest
+        || set.mutation_directory_digest != authority.directory_digest
+        || set.directory.descriptor_digest != authority.directory_digest
+        || set.directory.root_id == [0; 32]
+        || set.directory.descriptor_digest == [0; 32]
+        || set.directory.part_count == 0
+        || set.directory.row_count != u64::from(manifest.mutations.member_count)
+        || set.directory.part_count as usize != manifest.mutations.part_count()
+        || set.directory.tree_height == 0
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state current-state part set disagrees with its replacement authority",
+        ));
+    }
+    Ok(())
 }
 
 fn validate_commit_state_mutation_inventory(
@@ -6611,7 +7037,9 @@ fn validate_commit_state_mutation_inventory(
             "tracked_state commit_state_manifest selects itself as a mutation source",
         ));
     }
-    if !inventory.inline_part.is_empty() && !inventory.parts.is_empty() {
+    if !inventory.inline_part.is_empty()
+        && (!inventory.parts.is_empty() || !inventory.replacement_part_digests.is_empty())
+    {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
             "tracked_state commit_state_manifest mixes inline and external mutation parts",
@@ -6628,6 +7056,23 @@ fn validate_commit_state_mutation_inventory(
             LixError::CODE_INTERNAL_ERROR,
             "tracked_state commit_state_manifest has invalid or overlapping mutation-part bounds",
         ));
+    }
+    if !inventory.replacement_part_digests.is_empty()
+        && (!inventory.parts.is_empty()
+            || inventory.replacement_parts.is_none()
+            || inventory.replacement_generation.is_none()
+            || inventory
+                .replacement_part_digests
+                .iter()
+                .any(|digest| *digest == [0; 32]))
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit_state_manifest has an invalid compact replacement-part inventory",
+        ));
+    }
+    if !inventory.replacement_part_digests.is_empty() {
+        validate_compact_replacement_inventory(commit_id, inventory)?;
     }
     if inventory.member_count > 0
         && inventory.part_count() == 0
@@ -6660,12 +7105,14 @@ fn validate_commit_state_mutation_inventory(
         && inventory.lifecycle_summary.is_none()
         && inventory.replacement_generation.is_none()
         && inventory.replacement_parts.is_none()
+        && inventory.replacement_part_digests.is_empty()
         && inventory.inline_part.is_empty()
         && inventory.parts.is_empty();
     if !is_empty {
-        let mutation_directory = commit_delta_manifest_from_inventory(inventory);
-        validate_commit_delta_manifest(&mutation_directory)?;
-        if mutation_directory
+        if inventory.replacement_part_digests.is_empty() {
+            validate_commit_delta_manifest(&commit_delta_manifest_from_inventory(inventory))?;
+        }
+        if inventory
             .replacement_generation
             .as_ref()
             .is_some_and(|generation| generation.owner_commit_id != *commit_id.as_uuid().as_bytes())
@@ -6675,6 +7122,51 @@ fn validate_commit_state_mutation_inventory(
                 "tracked_state replacement generation does not belong to its commit-state authority",
             ));
         }
+    }
+    Ok(())
+}
+
+fn validate_compact_replacement_inventory(
+    commit_id: CommitId,
+    inventory: &CommitStateMutationInventory,
+) -> Result<(), LixError> {
+    let invalid = || {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit_state_manifest has an invalid compact replacement authority",
+        )
+    };
+    let generation = inventory
+        .replacement_generation
+        .as_ref()
+        .ok_or_else(invalid)?;
+    let lifecycle = inventory.lifecycle_summary.as_ref().ok_or_else(invalid)?;
+    let authority = inventory.replacement_parts.as_ref().ok_or_else(invalid)?;
+    let scope = inventory.single_partition.as_ref().ok_or_else(invalid)?;
+    if inventory.selected_source_commit_id.is_some()
+        || inventory.member_count == 0
+        || scope.schema_key.is_empty()
+        || generation.scope != *scope
+        || lifecycle.scope != *scope
+        || generation.owner_commit_id != *commit_id.as_uuid().as_bytes()
+        || generation.owner_commit_id == [0; 16]
+        || generation.integrity_digest
+            != replacement_generation_integrity_digest(generation, lifecycle, authority)
+        || !inventory.inline_part.is_empty()
+        || !inventory.parts.is_empty()
+        || inventory.replacement_part_digests.len() != inventory.direct_part_row_counts.len()
+        || inventory
+            .direct_part_row_counts
+            .iter()
+            .any(|&count| count == 0 || usize::from(count) > COMMIT_DELTA_SEGMENT_MAX_ROWS)
+        || inventory
+            .direct_part_row_counts
+            .iter()
+            .map(|&count| u64::from(count))
+            .sum::<u64>()
+            != u64::from(inventory.member_count)
+    {
+        return Err(invalid());
     }
     Ok(())
 }
@@ -6705,11 +7197,16 @@ mod tests {
         HOT_DIFF_SPACE, HOT_FILE_SPACE, HOT_ROW_SPACE, TRACKED_WORKING_DIFF_MARKER_SPACE,
     };
     use crate::storage_adapter::{
-        Memory, StorageAdapter, StorageReadOptions, StorageWriteOptions, StorageWriteSet,
+        Memory, StorageAdapter, StorageKey, StorageReadOptions, StorageWriteOptions,
+        StorageWriteSet,
     };
     use crate::tracked_state::codec::{
         EncodedLeafEntry, PendingChunk, PendingChunkBatch, TrackedStateKeyBatchBuilder,
         encode_key_ref, encode_value_ref, hash_bytes,
+    };
+    use crate::tracked_state::current_state_part::{
+        CURRENT_STATE_PART_DIRECTORY_SPACE, route_current_state_part,
+        stage_complete_replacement_current_state_part_set,
     };
     use crate::tracked_state::types::{
         CommitStateManifest, CommitStateMutationInventory, CommitStateReplayDebt,
@@ -6753,6 +7250,7 @@ mod tests {
                 bytes: u64::from(mutations.member_count),
             },
             mutations,
+            current_state_part_sets: Vec::new(),
             snapshot_root: None,
         }
     }
@@ -6762,7 +7260,16 @@ mod tests {
         commit_id: CommitId,
         mutations: &CommitStateMutationInventory,
     ) -> Result<(), LixError> {
-        let manifest = fixture_commit_state_manifest(commit_id, mutations.clone());
+        let mut compact_mutations = mutations.clone();
+        let mut manifest = fixture_commit_state_manifest(commit_id, compact_mutations.clone());
+        manifest.current_state_part_sets =
+            stage_complete_replacement_current_state_part_set(writes, commit_id, mutations)?
+                .into_iter()
+                .collect();
+        if !manifest.current_state_part_sets.is_empty() {
+            compact_mutations.parts.clear();
+            manifest.mutations = compact_mutations;
+        }
         stage_commit_state_manifest(writes, &manifest)
     }
 
@@ -7456,6 +7963,30 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
+        let authority = load_commit_state_manifest(&read, commit_id)
+            .await
+            .expect("replacement authority should load")
+            .expect("replacement authority should exist");
+        let state_set = authority
+            .current_state_part_sets
+            .first()
+            .expect("replacement should publish a current-state part set");
+        let directory_root = state_set.directory.clone();
+        assert_eq!(state_set.directory.part_count, 3);
+        let route_key = fixtures[777].key();
+        let routed = route_current_state_part(
+            &read,
+            &state_set.directory,
+            &encode_key_ref(TrackedStateKeyRef {
+                schema_key: &route_key.schema_key,
+                file_id: route_key.file_id.as_deref(),
+                entity_pk: &route_key.entity_pk,
+            }),
+        )
+        .await
+        .expect("current-state route should load")
+        .expect("replacement identity should be covered");
+        assert_eq!(routed.part_index, 1);
         let physical = super::scan_full_space(&read, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE)
             .await
             .expect("replacement parts should scan");
@@ -7482,6 +8013,39 @@ mod tests {
             .await
             .expect("replacement addresses should scan without hydrating payloads");
         assert_eq!(change_ids[777], change_id);
+        assert_eq!(
+            load_change_record_by_id(&read, change_id)
+                .await
+                .expect("direct replacement history should load")
+                .expect("direct replacement history should exist")
+                .entity_pk,
+            fixtures[777].entity_pk,
+        );
+
+        drop(read);
+        let mut deletes = storage.new_write_set();
+        deletes.delete(
+            CURRENT_STATE_PART_DIRECTORY_SPACE,
+            StorageKey(Bytes::copy_from_slice(&directory_root.root_id)),
+        );
+        storage
+            .commit_write_set(deletes, StorageWriteOptions::default())
+            .await
+            .expect("serving-directory corruption should stage");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("fallback read should open");
+        let values = load_commit_delta_values_for_test(&read, commit_id, &keys)
+            .await
+            .expect("missing serving directory should rebuild from history parts");
+        assert!(values.iter().all(Option::is_some));
+        assert!(
+            load_change_record_by_id(&read, change_id)
+                .await
+                .expect("historical authority should survive directory loss")
+                .is_some()
+        );
     }
 
     #[tokio::test]
@@ -7592,6 +8156,12 @@ mod tests {
         assert_eq!(loaded.change_id, explicit_change_id);
         assert_eq!(loaded.schema_key, explicit.schema_key);
         assert_eq!(loaded.entity_pk, explicit.entity_pk);
+        assert_eq!(
+            super::load_change_records_by_ids(&read, &[explicit_change_id])
+                .await
+                .expect("out-of-range batch should fall back to its locator"),
+            vec![loaded],
+        );
         let canonical = super::load_canonical_change_locator(&read, explicit_change_id)
             .await
             .expect("canonical locator read should succeed")
@@ -9670,6 +10240,7 @@ mod tests {
             TRACKED_STATE_TREE_CHUNK_SPACE,
             TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
             TRACKED_STATE_CHANGE_LOCATOR_SPACE,
+            CURRENT_STATE_PART_DIRECTORY_SPACE,
             BINARY_CAS_MANIFEST_SPACE,
             BINARY_CAS_MANIFEST_CHUNK_SPACE,
             BINARY_CAS_CHUNK_PRESENCE_SPACE,
@@ -9733,6 +10304,7 @@ mod tests {
                 member_count: 1,
                 selection_fingerprint: [3; 32],
                 direct_part_row_counts: vec![1],
+                replacement_part_digests: Vec::new(),
                 single_partition: Some(super::CommitDeltaReplacementScope {
                     schema_key: schema_key.to_owned(),
                     file_id: None,
@@ -9743,6 +10315,7 @@ mod tests {
                 inline_part: encode_commit_delta_segment(&[entry]),
                 parts: Vec::new(),
             },
+            current_state_part_sets: Vec::new(),
             snapshot_root: None,
         }
     }

--- a/packages/engine/src/tracked_state/types.rs
+++ b/packages/engine/src/tracked_state/types.rs
@@ -225,6 +225,53 @@ pub(crate) struct StoredReplacementPart {
     pub(crate) uniform_updated_at: LixTimestamp,
 }
 
+/// One immutable post-image range in a committed current-state partition.
+///
+/// This is deliberately distinct from [`CommitStateMutationPart`]. Mutation
+/// parts describe what a commit authored; current-state parts describe the
+/// strictly ordered, non-overlapping state that readers may serve directly.
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+pub(crate) struct CurrentStatePartDescriptor {
+    #[musli(bytes)]
+    pub(crate) first_key: Vec<u8>,
+    #[musli(bytes)]
+    pub(crate) last_key: Vec<u8>,
+    pub(crate) content_digest: [u8; 32],
+    pub(crate) owner_commit_id: [u8; 16],
+    pub(crate) part_index: u32,
+    pub(crate) first_ordinal: u32,
+    pub(crate) row_count: u16,
+    pub(crate) uniform_created_at: LixTimestamp,
+    pub(crate) uniform_updated_at: LixTimestamp,
+}
+
+/// Content-addressed root of a persistent current-state range directory.
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+pub(crate) struct CurrentStatePartDirectoryRoot {
+    pub(crate) root_id: [u8; 32],
+    pub(crate) descriptor_digest: [u8; 32],
+    pub(crate) row_count: u64,
+    pub(crate) part_count: u32,
+    pub(crate) tree_height: u16,
+}
+
+/// One authoritative current-state collection generation.
+///
+/// The mutation-directory digest binds this rebuildable serving projection to
+/// the commit's historical replacement certificate without making the serving
+/// directory part of commit semantics.
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+pub(crate) struct CurrentStatePartSet {
+    pub(crate) scope: CommitDeltaReplacementScope,
+    pub(crate) owner_commit_id: [u8; 16],
+    pub(crate) generation_integrity_digest: [u8; 32],
+    pub(crate) mutation_directory_digest: [u8; 32],
+    pub(crate) directory: CurrentStatePartDirectoryRoot,
+}
+
 /// Point-addressable immutable mutation inventory owned by one commit.
 ///
 /// The fields intentionally mirror the existing commit-delta directory. This
@@ -240,6 +287,10 @@ pub(crate) struct CommitStateMutationInventory {
     /// Exact row counts for every directly addressable part. Empty means the
     /// generic locator-indexed layout.
     pub(crate) direct_part_row_counts: Vec<u16>,
+    /// Compact physical identities for a complete replacement. Range bounds
+    /// live in the rebuildable current-state directory; history can always
+    /// recover them by decoding these immutable parts.
+    pub(crate) replacement_part_digests: Vec<[u8; 32]>,
     /// Authoritative collection-replacement scope. A miss within this scope
     /// cannot fall through to an older first-parent generation.
     #[musli(with = crate::storage_codec::option)]
@@ -264,7 +315,12 @@ impl CommitStateMutationInventory {
     }
 
     pub(crate) fn part_count(&self) -> usize {
-        usize::from(!self.inline_part.is_empty()) + self.parts.len()
+        usize::from(!self.inline_part.is_empty())
+            + if self.replacement_part_digests.is_empty() {
+                self.parts.len()
+            } else {
+                self.replacement_part_digests.len()
+            }
     }
 }
 
@@ -285,6 +341,7 @@ pub(crate) struct CommitStateManifest {
     pub(crate) created_at: LixTimestamp,
     pub(crate) replay_debt: CommitStateReplayDebt,
     pub(crate) mutations: CommitStateMutationInventory,
+    pub(crate) current_state_part_sets: Vec<CurrentStatePartSet>,
     #[musli(with = crate::storage_codec::option)]
     pub(crate) snapshot_root: Option<TrackedStateCommitRoot>,
 }

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -4771,6 +4771,21 @@ fn stage_commit_state_manifests(
                 ),
             ));
         }
+        let mut mutations = mutation_inventories
+            .get(&commit.commit_id)
+            .cloned()
+            .unwrap_or_default();
+        let current_state_part_sets: Vec<_> =
+            crate::tracked_state::stage_complete_replacement_current_state_part_set(
+                writes,
+                record.commit_id,
+                &mutations,
+            )?
+            .into_iter()
+            .collect();
+        if !current_state_part_sets.is_empty() {
+            mutations.parts.clear();
+        }
         stage_commit_state_manifest(
             writes,
             &CommitStateManifest {
@@ -4789,10 +4804,8 @@ fn stage_commit_state_manifests(
                 } else {
                     CommitStateReplayDebt::default()
                 },
-                mutations: mutation_inventories
-                    .get(&commit.commit_id)
-                    .cloned()
-                    .unwrap_or_default(),
+                mutations,
+                current_state_part_sets,
                 snapshot_root,
             },
         )?;
@@ -5806,6 +5819,7 @@ mod tests {
                     .get(&commit_id)
                     .cloned()
                     .expect("mixed certified inventory should stage"),
+                current_state_part_sets: Vec::new(),
                 snapshot_root: None,
             },
         )


### PR DESCRIPTION
## What changed

- add a distinct `CurrentStatePartDescriptor` / `CurrentStatePartSet` contract downstream of the sealed transaction mutation journal
- publish certified complete replacements through a fanout-128, content-addressed, zstd-compressed range directory
- compact replacement mutation inventory in the hot `CommitStateManifest` to digests and row counts while retaining immutable mutation parts as historical authority
- route healthy point reads through `O(log_128(parts))` directory descent and batch shared node reads; general scans expand the same ordered part set
- bind authoritative exact misses to the existing replacement-directory digest and validate owner, lifecycle, row count, content digest, and generation integrity
- retain an instrumented recovery path that reconstructs bounds from immutable history if the optional serving accelerator is absent or corrupt
- make GC validate the complete descriptor set and owner before deleting directory nodes
- hard-cut the repository protocol to `commit-state-manifest.v48` / `LXCS2`; backward compatibility is intentionally not provided

## Why

The old commit-state manifest repeated every immutable replacement part's key bounds in one growing hot record. At one million rows that record was 302,942 encoded value bytes. Point routing and scans both needed the same range information, but it was neither a bounded persistent index nor independently reclaimable.

This cut keeps `CommitStateMutationInventory` as semantic/history authority and makes the range directory an optional serving projection. It is the first slice of the post-image physical layout: complete replacements/checkpoints now have a strictly ordered, non-overlapping state-part set; sparse copy-on-write parent-range rewrite remains the next cut.

## Performance

Release builds, isolated target directories, current `main` at `558e683e8` (#1168), RocksDB unless noted. Byte counters measure staged encoded **value bytes**; they do not claim key, WAL, SST, object-store, or backend amplification.

| Workload | main | PR | delta |
|---|---:|---:|---:|
| 10K encoded manifest + directory value bytes | 4,371 B | 2,901 B | **-33.6%** |
| 10K total staged value bytes | 479,140 B | 477,670 B | -0.3% |
| 10K UPDATE median (5) | 11.216 ms | 11.056 ms | -1.4% |
| 1M encoded manifest + directory value bytes | 302,942 B | 162,408 B | **-46.4%** |
| 1M total staged value bytes | 3,239,419 B | 3,098,885 B | -4.3% |
| 1M UPDATE median (5) | 696.545 ms | 683.605 ms | -1.9% |
| 1M SlateDB UPDATE median (3) | 696.573 ms | 693.291 ms | -0.5% |
| 1M point read median (5) | 572.146 us | 565.945 us | -1.1% |
| 1M general SQL `read_all` median (3) | 274.676 ms | 284.441 ms | +3.6% |

The exact reduction in total staged value bytes equals the serving-metadata reduction in both sizes, validating the accounting boundary. Healthy benchmark runs reported zero directory recoveries. UPDATE and point reads are neutral/improved; the general DataFusion scan remains inside the 5% regression guard.

## Correctness and review

Two independent sub-agent reviews covered authority/fallback/GC correctness and physical-layout/benchmark validity. Their findings were fixed, including >128-part publication, direct and batched address-shaped history fallback, root cross-wire protection, compact authority validation, protocol fencing, bounded node decoding, GC ownership validation, and precise benchmark wording.

Validated after rebasing onto #1168:

- `cargo test -p lix_engine --features all-simulations` (1,826 unit + 808 integration; zero failures)
- `cargo test -p lix_rocksdb_storage`
- `cargo test -p lix_sqlite_storage`
- `cargo test -p lix_slatedb_storage`
- focused complete-replacement, missing-directory fallback, cross-wired-root, >128-part, oversized-node, direct ChangeId, and out-of-range batched ChangeId tests
- 10K/1M RocksDB UPDATE accounting, 1M SlateDB UPDATE, 1M point read, and 1M general SQL scan benchmarks
