### PR TITLE
Seal scalar updates from immutable mutation journal

### DIFF
--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -34,7 +34,7 @@ use tracing::Instrument as _;
 use super::ExecuteIdempotency;
 use super::context::{SessionContext, SessionSqlExecutionContext};
 use super::idempotency::{ExecuteIdempotencyReceipt, load_receipt};
-use super::transaction::SessionTransaction;
+use super::transaction::{SessionTransaction, transaction_state_error};
 
 const MAX_INITIAL_LITERAL_COLUMN_BYTES: usize = 64 * 1024 * 1024;
 
@@ -2565,7 +2565,52 @@ where
         self.has_started_statement = true;
         let operation = async {
             let _operation_guard = self.begin_session_operation()?;
-            let auto_parameterized = (may_reuse_literal_shape && params.is_empty())
+            if may_reuse_literal_shape
+                && params.is_empty()
+                && let Some(parameter_count) = self.transaction.as_ref().and_then(|transaction| {
+                    transaction.prepared_literal_mutation_parameter_count(sql)
+                })
+            {
+                if self.prepared_literal_params.len() != parameter_count {
+                    self.prepared_literal_params.clear();
+                    self.prepared_literal_params
+                        .resize_with(parameter_count, || Value::Text(String::new()));
+                }
+                if self
+                    .sql_planning_cache
+                    .decode_certified_update_literals_into_values(
+                        sql,
+                        &mut self.prepared_literal_params,
+                    )
+                {
+                    let (transaction_slot, prepared_params) =
+                        (&mut self.transaction, &self.prepared_literal_params);
+                    let transaction = transaction_slot
+                        .as_mut()
+                        .ok_or_else(|| transaction_state_error("Lix transaction is closed"))?;
+                    transaction
+                        .flush_cached_prepared_mutation_barrier(
+                            options.origin_key.as_deref(),
+                            prepared_params,
+                        )
+                        .await?;
+                    let previous_origin_key =
+                        transaction.replace_origin_key(options.origin_key.clone());
+                    let result = transaction
+                        .try_execute_cached_prepared_mutation(prepared_params)
+                        .await;
+                    transaction.replace_origin_key(previous_origin_key);
+                    match result {
+                        Ok(Some(result)) => {
+                            return Ok(ExecuteResult::from_sql_write_result(result));
+                        }
+                        Ok(None) => {}
+                        Err(error) => return Err(normalize_sql_surface_error(error, sql)),
+                    }
+                }
+            }
+            let auto_parameterized = params
+                .is_empty()
                 .then(|| self.sql_planning_cache.auto_parameterized_update(sql))
                 .flatten();
             let (planning_sql, statement, auto_params) =
@@ -2598,21 +2643,20 @@ where
                     .try_execute_prepared_mutation(&planning_sql, params)
                     .await;
                 transaction.replace_origin_key(previous_origin_key);
-                return match result {
-                    Ok(Some(result)) => Ok(ExecuteResult::from_sql_write_result(result)),
-                    Ok(None) => Err(LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        "prepared transaction mutation disappeared during warm execution",
-                    )),
-                    Err(error) => Err(normalize_sql_surface_error(error, sql)),
-                };
+                match result {
+                    Ok(Some(result)) => {
+                        return Ok(ExecuteResult::from_sql_write_result(result));
+                    }
+                    Ok(None) => {}
+                    Err(error) => return Err(normalize_sql_surface_error(error, sql)),
+                }
             }
             let is_read = matches!(
                 sql2::bind_statement_route(&statement)?,
                 sql2::BoundStatementRoute::Read
             );
             if is_read {
-                transaction.flush_prepared_mutations().await?;
+                transaction.flush_prepared_mutations_for_read().await?;
             } else {
                 transaction
                     .flush_prepared_mutation_barrier(
@@ -2748,7 +2792,7 @@ where
     ) -> Result<crate::live_state::MaterializedLiveStateBatch, LixError> {
         let _operation_guard = self.begin_session_operation()?;
         let transaction = self.transaction_mut()?;
-        transaction.flush_prepared_mutations().await?;
+        transaction.flush_prepared_mutations_for_read().await?;
         <crate::transaction::Transaction<StorageImpl> as sql2::SqlWriteExecutionContext>::scan_live_state_batch(
             transaction,
             request,
@@ -5924,6 +5968,7 @@ mod tests {
             "required": ["id", "value"],
             "additionalProperties": false
         });
+        crate::transaction::take_direct_journal_replacement_publications();
         let mut transaction = session.begin_transaction().await.unwrap();
         transaction
             .execute(
@@ -8896,6 +8941,648 @@ mod tests {
                 .expect("JSON value should decode"),
             serde_json::json!({"step": 2})
         );
+    }
+
+    #[tokio::test]
+    async fn packed_mutation_membership_defers_to_transaction_overlay() {
+        const ROW_COUNT: usize = 1_024;
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "x-lix-key": "packed_journal_overlay_probe",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "required": ["path", "value"],
+            "properties": {
+                "path": { "type": "string" },
+                "value": {
+                    "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+                }
+            },
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .expect("overlay probe schema should register");
+        let inserts = (0..ROW_COUNT)
+            .map(|row_index| ExecuteBatchStatement {
+                sql: "INSERT INTO packed_journal_overlay_probe (path, value) VALUES ($1, lix_json($2))"
+                    .to_string(),
+                params: vec![
+                    Value::Text(format!("{row_index:04}")),
+                    Value::Text("{\"state\":\"base\"}".to_string()),
+                ],
+            })
+            .collect::<Vec<_>>();
+        session
+            .execute_batch(&inserts)
+            .await
+            .expect("packed base should seed");
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("transaction should begin");
+        let update_sql =
+            "UPDATE packed_journal_overlay_probe SET value = lix_json($1) WHERE path = $2";
+        transaction
+            .execute(
+                update_sql,
+                &[
+                    Value::Text("{\"state\":\"updated-base\"}".to_string()),
+                    Value::Text("0000".to_string()),
+                ],
+            )
+            .await
+            .expect("base update should prepare packed membership");
+        transaction
+            .execute(
+                "INSERT INTO packed_journal_overlay_probe (path, value) VALUES ('2000', lix_json('{\"state\":\"inserted\"}'))",
+                &[],
+            )
+            .await
+            .expect("transaction-local insert should stage");
+        let inserted_update = transaction
+            .execute(
+                update_sql,
+                &[
+                    Value::Text("{\"state\":\"updated-insert\"}".to_string()),
+                    Value::Text("2000".to_string()),
+                ],
+            )
+            .await
+            .expect("update must observe the transaction-local insert");
+        assert_eq!(inserted_update.rows_affected(), 1);
+
+        transaction
+            .execute(
+                "DELETE FROM packed_journal_overlay_probe WHERE path = '0001'",
+                &[],
+            )
+            .await
+            .expect("transaction-local delete should stage");
+        let deleted_update = transaction
+            .execute(
+                update_sql,
+                &[
+                    Value::Text("{\"state\":\"must-not-resurrect\"}".to_string()),
+                    Value::Text("0001".to_string()),
+                ],
+            )
+            .await
+            .expect("update after a staged delete should remain a no-op");
+        assert_eq!(deleted_update.rows_affected(), 0);
+        transaction
+            .commit()
+            .await
+            .expect("transaction should commit");
+
+        let rows = session
+            .execute(
+                "SELECT path, value FROM packed_journal_overlay_probe \
+                 WHERE path IN ('0000', '0001', '2000') ORDER BY path",
+                &[],
+            )
+            .await
+            .expect("committed overlay result should be readable");
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows.rows()[0].get::<String>("path").unwrap(), "0000");
+        assert_eq!(
+            rows.rows()[0].get::<serde_json::Value>("value").unwrap(),
+            serde_json::json!({"state": "updated-base"})
+        );
+        assert_eq!(rows.rows()[1].get::<String>("path").unwrap(), "2000");
+        assert_eq!(
+            rows.rows()[1].get::<serde_json::Value>("value").unwrap(),
+            serde_json::json!({"state": "updated-insert"})
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_complete_journal_replacement_preserves_disjoint_insert() {
+        const ROW_COUNT: usize = 1_024;
+        let storage = Memory::default();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("storage should initialize");
+        let engine = Engine::new(storage)
+            .await
+            .expect("initialized storage should create engine");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("replacement session should open");
+        let concurrent_session = engine
+            .open_workspace_session()
+            .await
+            .expect("concurrent session should open");
+        let schema = serde_json::json!({
+            "x-lix-key": "stale_journal_replacement_probe",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "required": ["path", "value"],
+            "properties": {
+                "path": { "type": "string" },
+                "value": {
+                    "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+                }
+            },
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .expect("stale replacement schema should register");
+        let inserts = (0..ROW_COUNT)
+            .map(|row_index| ExecuteBatchStatement {
+                sql: "INSERT INTO stale_journal_replacement_probe (path, value) VALUES ($1, lix_json($2))"
+                    .to_string(),
+                params: vec![
+                    Value::Text(format!("{row_index:04}")),
+                    Value::Text("{\"state\":\"base\"}".to_string()),
+                ],
+            })
+            .collect::<Vec<_>>();
+        session
+            .execute_batch(&inserts)
+            .await
+            .expect("packed base should seed");
+        let original_created_at = session
+            .execute(
+                "SELECT lixcol_created_at FROM stale_journal_replacement_probe WHERE path = '0000'",
+                &[],
+            )
+            .await
+            .expect("seed lifecycle should be readable")
+            .rows()[0]
+            .get::<String>("lixcol_created_at")
+            .unwrap()
+            .clone();
+        let mut replacement = session
+            .begin_transaction()
+            .await
+            .expect("replacement transaction should begin");
+        let update_sql =
+            "UPDATE stale_journal_replacement_probe SET value = lix_json($1) WHERE path = $2";
+        for row_index in 0..ROW_COUNT {
+            let result = replacement
+                .execute(
+                    update_sql,
+                    &[
+                        Value::Text("{\"state\":\"replacement\"}".to_string()),
+                        Value::Text(format!("{row_index:04}")),
+                    ],
+                )
+                .await
+                .expect("replacement row should stage");
+            assert_eq!(result.rows_affected(), 1);
+        }
+
+        concurrent_session
+            .execute(
+                "INSERT INTO stale_journal_replacement_probe (path, value) \
+                 VALUES ('2000', lix_json('{\"state\":\"concurrent\"}'))",
+                &[],
+            )
+            .await
+            .expect("disjoint insert should commit first");
+        replacement
+            .commit()
+            .await
+            .expect("stale disjoint replacement should reconcile");
+
+        let rows = concurrent_session
+            .execute(
+                "SELECT COUNT(*) AS count FROM stale_journal_replacement_probe",
+                &[],
+            )
+            .await
+            .expect("final generation should be readable");
+        assert_eq!(
+            rows.rows()[0].get::<i64>("count").unwrap(),
+            (ROW_COUNT + 1) as i64,
+            "the stale complete-set proof must not erase the disjoint insert"
+        );
+        let concurrent = concurrent_session
+            .execute(
+                "SELECT value FROM stale_journal_replacement_probe WHERE path = '2000'",
+                &[],
+            )
+            .await
+            .expect("concurrent row should remain point-readable");
+        assert_eq!(
+            concurrent.rows()[0]
+                .get::<serde_json::Value>("value")
+                .unwrap(),
+            serde_json::json!({"state": "concurrent"})
+        );
+        let reconciled_created_at = session
+            .execute(
+                "SELECT lixcol_created_at FROM stale_journal_replacement_probe WHERE path = '0000'",
+                &[],
+            )
+            .await
+            .expect("reconciled lifecycle should be readable")
+            .rows()[0]
+            .get::<String>("lixcol_created_at")
+            .unwrap()
+            .clone();
+        assert_eq!(reconciled_created_at, original_created_at);
+    }
+
+    #[tokio::test]
+    async fn sequential_complete_update_seals_direct_journal() {
+        const ROW_COUNT: usize = 8_193;
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "x-lix-key": "direct_journal_seal_probe",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "required": ["path", "value"],
+            "properties": {
+                "path": { "type": "string" },
+                "value": {
+                    "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+                }
+            },
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .expect("direct journal schema should register");
+        let inserts = (0..ROW_COUNT)
+            .map(|row_index| ExecuteBatchStatement {
+                sql:
+                    "INSERT INTO direct_journal_seal_probe (path, value) VALUES ($1, lix_json($2))"
+                        .to_string(),
+                params: vec![
+                    Value::Text(format!("{row_index:04}")),
+                    Value::Text("{\"state\":\"base\"}".to_string()),
+                ],
+            })
+            .collect::<Vec<_>>();
+        session
+            .execute_batch(&inserts)
+            .await
+            .expect("packed base should seed");
+
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("direct journal transaction should begin");
+        let update_sql =
+            "UPDATE direct_journal_seal_probe SET value = lix_json($1) WHERE path = $2";
+        for row_index in 0..ROW_COUNT {
+            let result = transaction
+                .execute(
+                    update_sql,
+                    &[
+                        Value::Text("{\"state\":\"replacement\"}".to_string()),
+                        Value::Text(format!("{row_index:04}")),
+                    ],
+                )
+                .await
+                .expect("direct journal row should stage");
+            assert_eq!(result.rows_affected(), 1);
+        }
+        assert_eq!(
+            crate::transaction::take_direct_journal_replacement_publications(),
+            0
+        );
+        let visible = transaction
+            .execute(
+                "SELECT path, value FROM direct_journal_seal_probe \
+                 WHERE path IN ('0000', '4096', '8192') ORDER BY path",
+                &[],
+            )
+            .await
+            .expect("point reads must route across immutable journal chunks");
+        assert_eq!(visible.len(), 3);
+        for (row, expected_path) in visible.rows().iter().zip(["0000", "4096", "8192"]) {
+            assert_eq!(row.get::<String>("path").unwrap(), expected_path);
+            assert_eq!(
+                row.get::<serde_json::Value>("value").unwrap(),
+                serde_json::json!({"state": "replacement"})
+            );
+        }
+        transaction
+            .commit()
+            .await
+            .expect("direct journal should commit");
+        assert_eq!(
+            crate::transaction::take_direct_journal_replacement_publications(),
+            1,
+            "the complete scalar generation must seal without PreparedStateBatch"
+        );
+
+        // Replacement-part bytes are content-addressed without their commit
+        // owner. Publishing the same post-image again must bind a fresh
+        // physical commit instead of reusing the decoded leaf from above.
+        let mut repeated = session
+            .begin_transaction()
+            .await
+            .expect("repeated direct journal transaction should begin");
+        for row_index in 0..ROW_COUNT {
+            repeated
+                .execute(
+                    update_sql,
+                    &[
+                        Value::Text("{\"state\":\"replacement\"}".to_string()),
+                        Value::Text(format!("{row_index:04}")),
+                    ],
+                )
+                .await
+                .expect("identical repeated journal row should stage");
+        }
+        repeated
+            .commit()
+            .await
+            .expect("identical replacement generation should commit");
+        assert_eq!(
+            crate::transaction::take_direct_journal_replacement_publications(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_mutation_journal_is_visible_before_commit() {
+        const ROW_COUNT: usize = 1_024;
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "x-lix-key": "journal_read_your_writes_probe",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "required": ["path", "value"],
+            "properties": {
+                "path": { "type": "string" },
+                "value": {
+                    "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+                }
+            },
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+        session
+            .execute_batch(
+                &(0..ROW_COUNT)
+                    .map(|row_index| ExecuteBatchStatement {
+                        sql: "INSERT INTO journal_read_your_writes_probe (path, value) VALUES ($1, lix_json($2))".to_string(),
+                        params: vec![
+                            Value::Text(format!("{row_index:04}")),
+                            Value::Text("{\"state\":\"base\"}".to_string()),
+                        ],
+                    })
+                    .collect::<Vec<_>>(),
+            )
+            .await
+            .unwrap();
+
+        let original_created_at = session
+            .execute(
+                "SELECT lixcol_created_at FROM journal_read_your_writes_probe WHERE path = '0000'",
+                &[],
+            )
+            .await
+            .unwrap()
+            .rows()[0]
+            .get::<String>("lixcol_created_at")
+            .unwrap()
+            .clone();
+
+        let mut transaction = session.begin_transaction().await.unwrap();
+        let update_sql =
+            "UPDATE journal_read_your_writes_probe SET value = lix_json($1) WHERE path = $2";
+        for row_index in 0..ROW_COUNT {
+            transaction
+                .execute(
+                    update_sql,
+                    &[
+                        Value::Text("{\"state\":\"replacement\"}".to_string()),
+                        Value::Text(format!("{row_index:04}")),
+                    ],
+                )
+                .await
+                .unwrap();
+        }
+        let visible = transaction
+            .execute(
+                "SELECT path, value, lixcol_created_at FROM journal_read_your_writes_probe \
+                 WHERE path IN ('0000', '1023') ORDER BY path",
+                &[],
+            )
+            .await
+            .expect("a read barrier must expose the immutable mutation journal");
+        assert_eq!(visible.len(), 2);
+        for row in visible.rows() {
+            assert_eq!(
+                row.get::<serde_json::Value>("value").unwrap(),
+                serde_json::json!({"state": "replacement"})
+            );
+            assert_eq!(
+                row.get::<String>("lixcol_created_at").unwrap().as_str(),
+                original_created_at.as_str()
+            );
+        }
+        transaction.commit().await.unwrap();
+        assert_eq!(
+            crate::transaction::take_direct_journal_replacement_publications(),
+            1,
+            "an intervening read must not reconstruct the immutable journal"
+        );
+    }
+
+    #[tokio::test]
+    async fn mixed_journal_fallback_preserves_created_at() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "x-lix-key": "mixed_journal_lifecycle_probe",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "required": ["path", "value"],
+            "properties": {
+                "path": { "type": "string" },
+                "value": {
+                    "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+                }
+            },
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+        session
+            .execute(
+                "INSERT INTO mixed_journal_lifecycle_probe (path, value) \
+                 VALUES ('existing', lix_json('{\"state\":\"base\"}'))",
+                &[],
+            )
+            .await
+            .unwrap();
+        let original_created_at = session
+            .execute(
+                "SELECT lixcol_created_at FROM mixed_journal_lifecycle_probe WHERE path = 'existing'",
+                &[],
+            )
+            .await
+            .unwrap()
+            .rows()[0]
+            .get::<String>("lixcol_created_at")
+            .unwrap()
+            .clone();
+
+        let mut transaction = session.begin_transaction().await.unwrap();
+        transaction
+            .execute(
+                "INSERT INTO mixed_journal_lifecycle_probe (path, value) \
+                 VALUES ('inserted', lix_json('{\"state\":\"inserted\"}'))",
+                &[],
+            )
+            .await
+            .unwrap();
+        transaction
+            .execute(
+                "UPDATE mixed_journal_lifecycle_probe SET value = lix_json($1) WHERE path = $2",
+                &[
+                    Value::Text("{\"state\":\"updated\"}".to_string()),
+                    Value::Text("existing".to_string()),
+                ],
+            )
+            .await
+            .unwrap();
+        transaction.commit().await.unwrap();
+
+        let created_at = session
+            .execute(
+                "SELECT lixcol_created_at FROM mixed_journal_lifecycle_probe WHERE path = 'existing'",
+                &[],
+            )
+            .await
+            .unwrap()
+            .rows()[0]
+            .get::<String>("lixcol_created_at")
+            .unwrap()
+            .clone();
+        assert_eq!(created_at, original_created_at);
+    }
+
+    #[tokio::test]
+    async fn checkpoint_parent_without_collection_lifecycle_uses_safe_lane() {
+        const ROW_COUNT: usize = 1_024;
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "x-lix-key": "rooted_journal_parent_probe",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "required": ["path", "value"],
+            "properties": {
+                "path": { "type": "string" },
+                "value": {
+                    "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+                }
+            },
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+        session
+            .execute_batch(
+                &(0..ROW_COUNT)
+                    .map(|row_index| ExecuteBatchStatement {
+                        sql: "INSERT INTO rooted_journal_parent_probe (path, value) VALUES ($1, lix_json($2))".to_string(),
+                        params: vec![
+                            Value::Text(format!("{row_index:04}")),
+                            Value::Text("{\"state\":\"base\"}".to_string()),
+                        ],
+                    })
+                    .collect::<Vec<_>>(),
+            )
+            .await
+            .unwrap();
+        let original_created_at = session
+            .execute(
+                "SELECT lixcol_created_at FROM rooted_journal_parent_probe WHERE path = '0000'",
+                &[],
+            )
+            .await
+            .unwrap()
+            .rows()[0]
+            .get::<String>("lixcol_created_at")
+            .unwrap()
+            .clone();
+        session.create_checkpoint().await.unwrap();
+
+        crate::transaction::take_direct_journal_replacement_publications();
+        let mut transaction = session.begin_transaction().await.unwrap();
+        let update_sql =
+            "UPDATE rooted_journal_parent_probe SET value = lix_json($1) WHERE path = $2";
+        for row_index in 0..ROW_COUNT {
+            transaction
+                .execute(
+                    update_sql,
+                    &[
+                        Value::Text("{\"state\":\"replacement\"}".to_string()),
+                        Value::Text(format!("{row_index:04}")),
+                    ],
+                )
+                .await
+                .unwrap();
+        }
+        let visible_created_at = transaction
+            .execute(
+                "SELECT lixcol_created_at FROM rooted_journal_parent_probe WHERE path = '0000'",
+                &[],
+            )
+            .await
+            .expect("fallback read must hydrate lifecycle without lowering the journal")
+            .rows()[0]
+            .get::<String>("lixcol_created_at")
+            .unwrap()
+            .clone();
+        assert_eq!(visible_created_at, original_created_at);
+        transaction
+            .commit()
+            .await
+            .expect("a parent without collection lifecycle authority must use the safe lane");
+        assert_eq!(
+            crate::transaction::take_direct_journal_replacement_publications(),
+            0
+        );
+        let committed_created_at = session
+            .execute(
+                "SELECT lixcol_created_at FROM rooted_journal_parent_probe WHERE path = '0000'",
+                &[],
+            )
+            .await
+            .unwrap()
+            .rows()[0]
+            .get::<String>("lixcol_created_at")
+            .unwrap()
+            .clone();
+        assert_eq!(committed_created_at, original_created_at);
     }
 
     #[tokio::test]

--- a/packages/engine/src/session/transaction.rs
+++ b/packages/engine/src/session/transaction.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::Value;
 use crate::catalog::CatalogFingerprint;
 use crate::functions::{DeterministicRuntimeGuard, FunctionContext};
 use crate::observe_invalidation::ObserveInvalidation;
@@ -32,6 +33,7 @@ pub struct SessionTransaction<StorageImpl: Storage + 'static = Memory> {
     commit_coordinator: Arc<CommitCoordinator<StorageImpl>>,
     pub(super) telemetry: Option<Arc<dyn TelemetrySink>>,
     pub(super) has_started_statement: bool,
+    pub(super) prepared_literal_params: Vec<Value>,
 }
 
 impl<StorageImpl> SessionContext<StorageImpl>
@@ -90,6 +92,7 @@ where
             commit_coordinator: Arc::clone(&self.commit_coordinator),
             telemetry: self.telemetry.clone(),
             has_started_statement: false,
+            prepared_literal_params: Vec::new(),
         })
     }
 }

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -2785,6 +2785,12 @@ pub(crate) struct PreparedPathValueReplacementRow {
 }
 
 impl PreparedPathValueReplacementProgram {
+    pub(crate) fn parameter_count(&self) -> usize {
+        self.primary_key_param_index
+            .max(self.value_param_index)
+            .saturating_add(1)
+    }
+
     pub(crate) fn primary_key<'a>(&self, params: &'a [Value]) -> Result<&'a str, LixError> {
         let Some(Value::Text(primary_key)) = params.get(self.primary_key_param_index) else {
             return Err(LixError::new(

--- a/packages/engine/src/sql2/planning_cache.rs
+++ b/packages/engine/src/sql2/planning_cache.rs
@@ -130,6 +130,33 @@ where
         decode_update_string_literals_into(sql, params)
     }
 
+    /// Decodes a shape-certified scalar UPDATE directly into reusable public
+    /// parameter slots. This is the scalar journal counterpart of the shared
+    /// batch decoder: no normalized SQL, AST clone, parameter vector, or
+    /// per-value string allocation is constructed for a warm statement.
+    pub(crate) fn decode_certified_update_literals_into_values(
+        &self,
+        sql: &str,
+        params: &mut [Value],
+    ) -> bool {
+        params.iter_mut().all(|param| match param {
+            Value::Text(value) => {
+                value.clear();
+                true
+            }
+            _ => false,
+        }) && decode_update_string_literals_with(sql, params.len(), |index, segment, escaped| {
+            let Some(Value::Text(value)) = params.get_mut(index) else {
+                return false;
+            };
+            value.push_str(segment);
+            if escaped {
+                value.push('\'');
+            }
+            true
+        })
+    }
+
     /// Returns stable public-surface metadata for one catalog generation.
     ///
     /// Callers are responsible for using a key that changes whenever any
@@ -390,6 +417,23 @@ fn update_string_literals_match_shape(sql: &str, normalized_shape: &str) -> bool
 
 fn decode_update_string_literals_into(sql: &str, params: &mut [String]) -> bool {
     params.iter_mut().for_each(String::clear);
+    decode_update_string_literals_with(sql, params.len(), |index, segment, escaped| {
+        let Some(value) = params.get_mut(index) else {
+            return false;
+        };
+        value.push_str(segment);
+        if escaped {
+            value.push('\'');
+        }
+        true
+    })
+}
+
+fn decode_update_string_literals_with(
+    sql: &str,
+    parameter_count: usize,
+    mut append: impl FnMut(usize, &str, bool) -> bool,
+) -> bool {
     let bytes = sql.as_bytes();
     let mut cursor = 0_usize;
     let mut param_index = 0_usize;
@@ -405,9 +449,10 @@ fn decode_update_string_literals_into(sql: &str, params: &mut [String]) -> bool 
                 cursor += 1;
             }
             b'\'' if !quoted_identifier => {
-                let Some(value) = params.get_mut(param_index) else {
+                if param_index >= parameter_count {
                     return false;
-                };
+                }
+                let current_param = param_index;
                 param_index += 1;
                 cursor += 1;
                 let mut segment_start = cursor;
@@ -419,9 +464,11 @@ fn decode_update_string_literals_into(sql: &str, params: &mut [String]) -> bool 
                     else {
                         return false;
                     };
-                    value.push_str(&sql[segment_start..quote]);
-                    if bytes.get(quote + 1) == Some(&b'\'') {
-                        value.push('\'');
+                    let escaped = bytes.get(quote + 1) == Some(&b'\'');
+                    if !append(current_param, &sql[segment_start..quote], escaped) {
+                        return false;
+                    }
+                    if escaped {
                         cursor = quote + 2;
                         segment_start = cursor;
                         continue;
@@ -433,7 +480,7 @@ fn decode_update_string_literals_into(sql: &str, params: &mut [String]) -> bool 
             _ => cursor += 1,
         }
     }
-    !quoted_identifier && param_index == params.len()
+    !quoted_identifier && param_index == parameter_count
 }
 
 #[cfg(test)]
@@ -559,6 +606,45 @@ mod tests {
             "UPDATE notes SET value = 'only-one'",
             &mut params,
         ));
+    }
+
+    #[test]
+    fn certified_literal_value_decoder_reuses_text_storage() {
+        let cache = test_cache(8);
+        let mut params = vec![
+            Value::Text(String::with_capacity(64)),
+            Value::Text(String::with_capacity(32)),
+        ];
+        let capacities = params
+            .iter()
+            .map(|value| match value {
+                Value::Text(value) => value.capacity(),
+                _ => unreachable!("test slots are text"),
+            })
+            .collect::<Vec<_>>();
+
+        assert!(cache.decode_certified_update_literals_into_values(
+            "UPDATE notes SET value = lix_json('{\"text\":\"it''s warm\"}') WHERE id = 'row-1'",
+            &mut params,
+        ));
+        assert_eq!(
+            params,
+            [
+                Value::Text("{\"text\":\"it's warm\"}".to_string()),
+                Value::Text("row-1".to_string()),
+            ]
+        );
+        assert_eq!(
+            params
+                .iter()
+                .map(|value| match value {
+                    Value::Text(value) => value.capacity(),
+                    _ => unreachable!("test slots stay text"),
+                })
+                .collect::<Vec<_>>(),
+            capacities,
+            "warm decoding must retain the session-owned string buffers"
+        );
     }
 
     #[test]

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -641,12 +641,24 @@ struct DecodedCommitDeltaSegment {
 struct DecodedCommitDeltaCacheEntry {
     digest: [u8; 32],
     encoded: Bytes,
+    /// Replacement-part bytes are content-addressed independently of their
+    /// publishing commit, while decoding synthesizes commit ids and lifecycle
+    /// timestamps from these bounds. Cache that semantic binding with the
+    /// bytes so identical post-images in consecutive commits cannot reuse a
+    /// leaf decoded for the previous owner.
+    expected_bounds: Option<CommitDeltaSegmentBounds>,
     decoded: Arc<DecodedCommitDeltaSegment>,
 }
 
 impl DecodedCommitDeltaCacheEntry {
     fn resident_bytes(&self) -> usize {
-        size_of::<Self>() + self.encoded.len() + self.decoded.resident_bytes
+        size_of::<Self>()
+            + self.encoded.len()
+            + self
+                .expected_bounds
+                .as_ref()
+                .map_or(0, |bounds| bounds.first_key.len() + bounds.last_key.len())
+            + self.decoded.resident_bytes
     }
 }
 
@@ -664,11 +676,11 @@ impl DecodedCommitDeltaCache {
         bytes: &[u8],
         expected_bounds: Option<&CommitDeltaSegmentBounds>,
     ) -> Result<Option<Arc<DecodedCommitDeltaSegment>>, LixError> {
-        let Some(position) = self
-            .entries
-            .iter()
-            .position(|entry| entry.digest == digest && entry.encoded.as_ref() == bytes)
-        else {
+        let Some(position) = self.entries.iter().position(|entry| {
+            entry.digest == digest
+                && entry.encoded.as_ref() == bytes
+                && entry.expected_bounds.as_ref() == expected_bounds
+        }) else {
             return Ok(None);
         };
         validate_decoded_commit_delta_bounds(
@@ -688,11 +700,13 @@ impl DecodedCommitDeltaCache {
         &mut self,
         digest: [u8; 32],
         encoded: Bytes,
+        expected_bounds: Option<CommitDeltaSegmentBounds>,
         decoded: Arc<DecodedCommitDeltaSegment>,
     ) {
         let entry = DecodedCommitDeltaCacheEntry {
             digest,
             encoded,
+            expected_bounds,
             decoded,
         };
         let entry_bytes = entry.resident_bytes();
@@ -700,7 +714,9 @@ impl DecodedCommitDeltaCache {
             return;
         }
         if let Some(position) = self.entries.iter().position(|existing| {
-            existing.digest == entry.digest && existing.encoded == entry.encoded
+            existing.digest == entry.digest
+                && existing.encoded == entry.encoded
+                && existing.expected_bounds == entry.expected_bounds
         }) {
             let previous = self
                 .entries
@@ -6118,7 +6134,12 @@ fn decode_commit_delta_with_payloads_cached(
     decoded_commit_delta_cache()
         .lock()
         .expect("decoded commit-delta cache lock poisoned")
-        .insert(digest, Bytes::copy_from_slice(bytes), Arc::clone(&decoded));
+        .insert(
+            digest,
+            Bytes::copy_from_slice(bytes),
+            expected_bounds.cloned(),
+            Arc::clone(&decoded),
+        );
     Ok(Some(decoded))
 }
 
@@ -6906,6 +6927,7 @@ mod tests {
         cache.insert(
             digest,
             encoded.clone().into(),
+            None,
             std::sync::Arc::clone(&decoded),
         );
         let reused = cache

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -40,7 +40,9 @@ use crate::tracked_state::{
     stage_addressable_commit_deltas, stage_change_locators, stage_commit_state_manifest,
     stage_ordered_addressable_commit_deltas,
 };
-use crate::transaction::staging::{PreparedInsertSelection, PreparedWriteSet};
+use crate::transaction::staging::{
+    OrderedMutationJournal, PreparedInsertSelection, PreparedWriteSet,
+};
 #[cfg(test)]
 use crate::transaction::types::StagedCommitChangeBatchBuilder;
 use crate::transaction::types::{
@@ -88,6 +90,10 @@ std::thread_local! {
 }
 
 #[cfg(test)]
+static DIRECT_JOURNAL_REPLACEMENT_PUBLICATIONS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+#[cfg(test)]
 pub(crate) fn take_ordered_packed_current_base_publications() -> usize {
     ORDERED_PACKED_CURRENT_BASE_PUBLICATIONS.with(|publications| publications.replace(0))
 }
@@ -106,6 +112,11 @@ pub(crate) fn take_complete_replacement_packed_current_base_retirements() -> usi
 #[cfg(test)]
 pub(crate) fn take_rootless_replacement_generation_publications() -> usize {
     ROOTLESS_REPLACEMENT_GENERATION_PUBLICATIONS.with(|count| count.replace(0))
+}
+
+#[cfg(test)]
+pub(crate) fn take_direct_journal_replacement_publications() -> usize {
+    DIRECT_JOURNAL_REPLACEMENT_PUBLICATIONS.swap(0, std::sync::atomic::Ordering::Relaxed)
 }
 
 /// Commits prepared transaction rows into tracked history and unified current
@@ -207,6 +218,14 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         crate::gc::stage_checkpoint_gc_state(&mut writes, &publication.gc_state)?;
     }
     let mut json_writer = JsonStoreContext::new().writer();
+    let ordered_replacements = prepared_writes
+        .commit_change_refs_by_branch
+        .values()
+        .filter_map(|refs| {
+            refs.ordered_mutation_journal()
+                .map(|journal| (refs.commit_id, Arc::clone(journal)))
+        })
+        .collect::<BTreeMap<_, _>>();
 
     let filesystem_view_changed = prepared_writes.state_rows.iter().any(|row| {
         matches!(
@@ -497,13 +516,27 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     }
 
     let selected_change_records = load_selected_change_records(read, &commit_rows).await?;
-    let replacement_generations = certify_complete_replacement_generations(
+    let mut replacement_generations = certify_complete_replacement_generations(
         read,
         &state_rows,
         &row_index.tracked_row_indices_by_commit,
         &tracked_roots,
     )
     .await?;
+    for (commit_id, generation) in
+        certify_ordered_journal_replacement_generations(read, &ordered_replacements, &tracked_roots)
+            .await?
+    {
+        if replacement_generations
+            .insert(commit_id, generation)
+            .is_some()
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "commit has both prepared and immutable replacement authorities",
+            ));
+        }
+    }
 
     let staged_delta_index = stage_tracked_commit_delta_index(
         read,
@@ -518,6 +551,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &certified_packet_json_refs,
         &insert_selection,
         &replacement_generations,
+        &ordered_replacements,
     )
     .await?;
 
@@ -527,6 +561,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &tracked_roots,
         &staged_delta_index.ordered_addressable_commits,
         &certified_packet_root_rows,
+        &ordered_replacements,
     );
     let replacement_generation_commits = replacement_generations
         .keys()
@@ -551,6 +586,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &commit_rows,
         &certified_packet_root_rows,
         &staged_delta_index.inventories,
+        &ordered_replacements,
     )
     .instrument(tracing::debug_span!(
         target: "lix_perf",
@@ -571,6 +607,19 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &certified_packet_root_rows,
         &certified_packet_json_refs,
     )?;
+    for journal in ordered_replacements.values() {
+        json_writer.stage_batch(
+            &mut writes,
+            JsonWritePlacementRef::OutOfBand,
+            journal.iter().filter_map(|row| match row.snapshot_slot() {
+                crate::json_store::JsonSlotRef::Ref(json_ref) => Some(
+                    NormalizedJsonRef::trusted_prehashed(row.snapshot(), *json_ref),
+                ),
+                crate::json_store::JsonSlotRef::Inline(_)
+                | crate::json_store::JsonSlotRef::None => None,
+            }),
+        )?;
+    }
 
     let branch_control_observations =
         observe_branch_head_controls(read, &tracked_roots, &state_rows, &engine_rows).await?;
@@ -634,6 +683,8 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &branch_control_observations,
         &checkpoint_epochs,
         &staged_delta_index.ordered_addressable_commits,
+        &replacement_generation_commits,
+        &ordered_replacements,
     ))
     .instrument(tracing::debug_span!(
         target: "lix_perf",
@@ -1022,6 +1073,7 @@ async fn stage_changelog_commits(
     commit_rows: &[FinalizedCommitRow],
     certified_packet_root_rows: &BTreeMap<CommitId, Vec<MaterializedLiveStateRow>>,
     mutation_inventories: &BTreeMap<CommitId, CommitStateMutationInventory>,
+    ordered_replacements: &BTreeMap<CommitId, Arc<OrderedMutationJournal>>,
 ) -> Result<BTreeMap<CommitId, StagedChangelogCommit>, LixError> {
     let mut commits = Vec::with_capacity(commit_rows.len());
     let staged_commit_ids = commit_rows
@@ -1129,10 +1181,17 @@ async fn stage_changelog_commits(
             .get(&commit_id)
             .map_or(0, Vec::len)
             .checked_add(
-                certified_packet_root_rows
+                ordered_replacements
                     .get(&commit_id)
-                    .map_or(0, Vec::len),
+                    .map_or(0, |journal| journal.row_count()),
             )
+            .and_then(|rows| {
+                rows.checked_add(
+                    certified_packet_root_rows
+                        .get(&commit_id)
+                        .map_or(0, Vec::len),
+                )
+            })
             .and_then(|rows| {
                 rows.checked_add(selected_change_count(&commit.selected_change_batches))
             })
@@ -1141,7 +1200,9 @@ async fn stage_changelog_commits(
         let commit_row_indices = tracked_row_indices_by_commit
             .get(&commit_id)
             .map(Vec::as_slice);
-        let commit_delta_bytes = if let Some(proof) = state_rows
+        let commit_delta_bytes = if let Some(journal) = ordered_replacements.get(&commit_id) {
+            journal.replacement_proof().replay_bytes
+        } else if let Some(proof) = state_rows
             .complete_collection_replacement_proof()
             .filter(|_| commit_row_indices.is_some_and(|indices| indices.len() == state_rows.len()))
         {
@@ -1314,6 +1375,9 @@ async fn stage_changelog_commits(
         };
         commits.push(record.clone());
         let change_count = state_row_indices.len()
+            + ordered_replacements
+                .get(&commit_row.commit_id)
+                .map_or(0, |journal| journal.row_count())
             + certified_packet_root_rows
                 .get(&commit_row.commit_id)
                 .map_or(0, Vec::len)
@@ -1893,6 +1957,7 @@ async fn stage_tracked_commit_delta_index(
     certified_packet_json_refs: &BTreeMap<CommitId, Vec<CertifiedRootJsonRefs>>,
     insert_selection: &PreparedInsertSelection,
     replacement_generations: &BTreeMap<CommitId, CommitDeltaReplacementGeneration>,
+    ordered_replacements: &BTreeMap<CommitId, Arc<OrderedMutationJournal>>,
 ) -> Result<StagedCommitDeltaIndex, LixError> {
     let mut ordered_addressable_commits = BTreeSet::new();
     let mut inventories = BTreeMap::new();
@@ -1901,6 +1966,61 @@ async fn stage_tracked_commit_delta_index(
         .map(|commit| (commit.commit_id, commit))
         .collect::<BTreeMap<_, _>>();
     for root in tracked_roots {
+        if let Some(journal) = ordered_replacements.get(&root.commit_id) {
+            #[cfg(test)]
+            DIRECT_JOURNAL_REPLACEMENT_PUBLICATIONS
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            if !state_rows.is_empty()
+                || certified_packet_root_rows
+                    .get(&root.commit_id)
+                    .is_some_and(|rows| !rows.is_empty())
+                || commit_rows
+                    .get(&root.commit_id)
+                    .is_some_and(|commit| !commit.selected_change_batches.is_empty())
+            {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "immutable replacement journal overlaps another commit payload lane",
+                ));
+            }
+            let generation = replacement_generations
+                .get(&root.commit_id)
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "immutable replacement journal has no lifecycle generation",
+                    )
+                })?;
+            let created_at = generation.lifecycle_summary.uniform_created_at;
+            let stage = crate::tracked_state::stage_ordered_addressable_replacement_parts(
+                writes,
+                journal.iter().map(|row| {
+                    Ok(TrackedStateCommitDeltaRef {
+                        delta: TrackedStateDeltaRef {
+                            schema_key: journal.schema_key(),
+                            file_id: None,
+                            entity_pk: row.entity_pk(),
+                            // Direct-address encoders derive the final id from
+                            // part/row coordinates and ignore this sentinel.
+                            change_id: ChangeId::default(),
+                            commit_id: root.commit_id,
+                            deleted: false,
+                            created_at,
+                            updated_at: journal.timestamp(),
+                        },
+                        snapshot: row.snapshot_slot(),
+                        metadata: crate::json_store::JsonSlotRef::None,
+                        origin_key: None,
+                        base_coordinate: None,
+                        authored: true,
+                    })
+                }),
+                generation,
+            )?;
+            inventories.insert(root.commit_id, stage.mutation_inventory().clone());
+            ordered_addressable_commits.insert(root.commit_id);
+            continue;
+        }
         let state_row_indices = tracked_row_indices_by_commit
             .get(&root.commit_id)
             .map(Vec::as_slice)
@@ -2331,6 +2451,113 @@ async fn certify_complete_replacement_generations(
     Ok(generations)
 }
 
+async fn certify_ordered_journal_replacement_generations(
+    read: &(impl StorageAdapterRead + ?Sized),
+    journals: &BTreeMap<CommitId, Arc<OrderedMutationJournal>>,
+    tracked_roots: &[PendingTrackedRoot],
+) -> Result<BTreeMap<CommitId, CommitDeltaReplacementGeneration>, LixError> {
+    let mut generations = BTreeMap::new();
+    for root in tracked_roots {
+        let Some(journal) = journals.get(&root.commit_id) else {
+            continue;
+        };
+        if journal.commit_id() != root.commit_id || journal.row_count() == 0 {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "immutable replacement journal owner or cardinality changed",
+            ));
+        }
+        let scope = CommitDeltaReplacementScope {
+            schema_key: journal.schema_key().to_owned(),
+            file_id: None,
+        };
+        let proof = journal.replacement_proof();
+        let mut current = root.parent_commit_id;
+        let mut seen = BTreeSet::new();
+        let mut lifecycle_summary = None;
+        let fallback_commit_id = loop {
+            let Some(commit_id) = current else {
+                break None;
+            };
+            if !seen.insert(commit_id) {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "cannot certify immutable replacement '{}': first-parent cycle includes '{commit_id}'",
+                        root.commit_id
+                    ),
+                ));
+            }
+            let record = ChangelogContext::new()
+                .reader(read)
+                .load_commits(ChangelogCommitLoadRequest {
+                    commit_ids: &[commit_id],
+                })
+                .await?
+                .into_iter()
+                .next()
+                .and_then(|(_, record)| record)
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!(
+                            "immutable replacement '{}' has missing parent '{commit_id}'",
+                            root.commit_id
+                        ),
+                    )
+                })?;
+            if !record.tracked_state_rootless {
+                break Some(commit_id);
+            }
+            let Some(metadata) = load_commit_delta_replay_metadata(read, commit_id).await? else {
+                break Some(commit_id);
+            };
+            if metadata.single_partition.as_ref() != Some(&scope) {
+                break Some(commit_id);
+            }
+            if let Some(parent_generation) = metadata.replacement_generation {
+                if parent_generation.scope != scope {
+                    break Some(commit_id);
+                }
+                if usize::try_from(metadata.member_count).ok() != Some(journal.row_count())
+                    || parent_generation.lifecycle_summary.ordered_identity_digest
+                        != proof.ordered_identity_digest
+                {
+                    break Some(commit_id);
+                }
+                lifecycle_summary = Some(parent_generation.lifecycle_summary);
+                break parent_generation.fallback_commit_id;
+            }
+            let Some(summary) = metadata.lifecycle_summary.as_ref() else {
+                break Some(commit_id);
+            };
+            if usize::try_from(metadata.member_count).ok() != Some(journal.row_count())
+                || summary.scope != scope
+                || summary.ordered_identity_digest != proof.ordered_identity_digest
+            {
+                break Some(commit_id);
+            }
+            lifecycle_summary = Some(summary.clone());
+            current = record.parent_commit_ids.first().copied();
+        };
+        let Some(lifecycle_summary) = lifecycle_summary else {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "immutable replacement journal lacks parent lifecycle authority; hydrate predecessors and lower it before commit",
+            ));
+        };
+        generations.insert(
+            root.commit_id,
+            CommitDeltaReplacementGeneration {
+                scope,
+                fallback_commit_id,
+                lifecycle_summary,
+            },
+        );
+    }
+    Ok(generations)
+}
+
 fn certified_complete_replacement_scope(
     state_rows: &PreparedStateBatch,
     row_indices: &[RowIndex],
@@ -2404,10 +2631,15 @@ fn select_new_rootless_ordered_commits(
     tracked_roots: &[PendingTrackedRoot],
     ordered_addressable_commits: &BTreeSet<CommitId>,
     certified_packet_root_rows: &BTreeMap<CommitId, Vec<MaterializedLiveStateRow>>,
+    ordered_replacements: &BTreeMap<CommitId, Arc<OrderedMutationJournal>>,
 ) -> BTreeSet<CommitId> {
     let can_start_rootless_interval = tracked_roots.len() == 1;
     let mut rootless = BTreeSet::new();
     for root in tracked_roots {
+        if ordered_replacements.contains_key(&root.commit_id) {
+            rootless.insert(root.commit_id);
+            continue;
+        }
         let row_indices = tracked_row_indices_by_commit
             .get(&root.commit_id)
             .map(Vec::as_slice)
@@ -2863,6 +3095,8 @@ async fn stage_tracked_head(
     observations: &BTreeMap<String, BranchHeadControlObservation>,
     checkpoint_epochs: &BTreeMap<String, CommitId>,
     ordered_addressable_commits: &BTreeSet<CommitId>,
+    replacement_generation_commits: &BTreeSet<CommitId>,
+    ordered_replacements: &BTreeMap<CommitId, Arc<OrderedMutationJournal>>,
 ) -> Result<StagedHotHeads, LixError> {
     let lifecycle_ids = lifecycle_snapshot_commit_ids(
         tracked_roots,
@@ -3006,6 +3240,7 @@ async fn stage_tracked_head(
             });
         let complete_replacement_schema =
             (state_rows.complete_collection_replacement_proof().is_some()
+                && replacement_generation_commits.contains(&root.commit_id)
                 && ordered_addressable_commits.contains(&root.commit_id)
                 && !is_checkpoint_publication
                 && state_row_indices.len() >= PACKED_CURRENT_BASE_MIN_ROWS
@@ -3149,6 +3384,55 @@ async fn stage_tracked_head(
             .as_ref()
             .map(|epoch| epoch.coverage)
             .unwrap_or_default();
+        if let Some(journal) = ordered_replacements.get(&root.commit_id) {
+            if is_checkpoint_publication
+                || !staged.selected_change_batches.is_empty()
+                || !untracked_deltas.is_empty()
+                || !engine_rows.is_empty()
+                || !explicit_branch_targets.is_empty()
+            {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "immutable replacement journal entered an incompatible HOT publication lane",
+                ));
+            }
+            let (generation, _retired_predecessor_bases) = tracked_head
+                .writer(read, writes)
+                .stage_complete_collection_replacement_current_base(
+                    &root.branch_id,
+                    parent_generation,
+                    root.commit_id,
+                    journal.schema_key(),
+                    journal.row_count(),
+                    entity_columnar_write_sets,
+                    working_diff_capture_checkpoint_commit_id,
+                    &mut coverage,
+                )
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.materialization.tracked_head.stage_direct_replacement_parts"
+                ))
+                .await?;
+            if let Some(epoch) = working_diff_epoch {
+                let next_epoch = TrackedWorkingDiffEpoch {
+                    checkpoint_commit_id: epoch.checkpoint_commit_id,
+                    generation,
+                    coverage,
+                };
+                if next_epoch != epoch {
+                    stage_tracked_working_diff_epoch(writes, &root.branch_id, next_epoch)?;
+                }
+            }
+            let mut control = normal_branch_head_control(
+                root,
+                parent_control,
+                generation,
+                working_diff_checkpoint_commit_id,
+            )?;
+            control.note_schemas(std::iter::once(journal.schema_key()));
+            insert_direct_branch_control(&mut controls, &root.branch_id, control)?;
+            continue;
+        }
         if can_publish_ordered_packed_current_base {
             #[cfg(test)]
             ORDERED_PACKED_CURRENT_BASE_PUBLICATIONS.with(|publications| {
@@ -5784,6 +6068,7 @@ mod tests {
             &certified_json_refs,
             &PreparedInsertSelection::new(),
             &BTreeMap::new(),
+            &BTreeMap::new(),
         )
         .await
         .expect("mixed certified delta should stage");
@@ -7700,6 +7985,7 @@ mod tests {
             &commits,
             &BTreeMap::new(),
             &BTreeMap::new(),
+            &BTreeMap::new(),
         )
         .await
         .expect("child-before-parent input should still stage parent first");
@@ -7811,6 +8097,7 @@ mod tests {
             &mut staged_root_rebuild_commits,
             &row_indices,
             &commit_rows,
+            &BTreeMap::new(),
             &BTreeMap::new(),
             &BTreeMap::new(),
         )

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -52,8 +52,9 @@ use crate::gc::{
 #[cfg(test)]
 use crate::live_state::LiveStateRowRequest;
 use crate::live_state::{
-    BranchHeadControlCache, LiveStateContext, LiveStateExactBatchRequest, LiveStateExactRowRequest,
-    LiveStateFilter, LiveStateProjection, LiveStateScanRequest, MaterializedLiveStateBatch,
+    BranchHeadControlCache, CertifiedCurrentStatePredecessor, LiveStateContext,
+    LiveStateExactBatchRequest, LiveStateExactRowRequest, LiveStateFilter, LiveStateProjection,
+    LiveStateReader, LiveStateScanRequest, MaterializedLiveStateBatch,
     MaterializedLiveStateExactBatch, MaterializedLiveStateRow, MaterializedLiveStateRowRef,
     StagedLiveStateRows, TrackedHeadContext, TrackedWorkingDiff, overlay_load_exact_batch,
     overlay_scan_batch,
@@ -107,18 +108,17 @@ use crate::transaction::normalization::{
 };
 use crate::transaction::schema_resolver::TransactionSchemaResolver;
 use crate::transaction::staging::{
-    PreparedStateRowOverlay, PreparedWriteSet, TransactionWriteBuffer,
-    TransactionWriteBufferCheckpoint,
+    ImmutableMutationChunkStage, ImmutableMutationJournalChunk, PreparedStateRowOverlay,
+    PreparedWriteSet, TransactionWriteBuffer, TransactionWriteBufferCheckpoint,
 };
 use crate::transaction::stale_commit::{
     StaleCommitPlan, StalePluginReconciliationPlan, classify_stale_commit,
 };
 use crate::transaction::types::{
-    CertifiedParameterInsertBatch, CertifiedParameterReplacementBatch,
-    CertifiedRawWriteBatchPreparation, PreparedRowFacts, PreparedStateBatch,
-    PreparedTransactionWrite, RawWriteBatch, RawWriteRowRef, StagedCommitChangeBatch,
-    StagedCommitChangeBatchBuilder, TransactionFileData, TransactionJson, TransactionWrite,
-    TransactionWriteMode, TransactionWriteOperation, TransactionWriteOrigin,
+    CertifiedParameterInsertBatch, CertifiedParameterReplacementBatch, PreparedRowFacts,
+    PreparedStateBatch, PreparedTransactionWrite, RawWriteBatch, RawWriteRowRef,
+    StagedCommitChangeBatch, StagedCommitChangeBatchBuilder, TransactionFileData, TransactionJson,
+    TransactionWrite, TransactionWriteMode, TransactionWriteOperation, TransactionWriteOrigin,
     TransactionWriteOutcome, TransactionWriteRow, canonicalize_transaction_json_batch,
     stage_json_from_value,
 };
@@ -489,11 +489,19 @@ pub(crate) struct Transaction<StorageImpl: Storage + 'static = Memory> {
         Arc<crate::sql2::PreparedPathValueReplacementProgram>,
     )>,
     prepared_mutation_membership: PreparedMutationMembership,
+    /// Once proven, a homogeneous prepared generation can avoid locking the
+    /// generic row overlay for every independent scalar mutation. Changing
+    /// the prepared program invalidates this transaction-local proof.
+    prepared_mutation_overlay_empty: bool,
     /// One logical timestamp for a homogeneous columnar mutation generation.
     /// Immutable replacement parts require their post-image rows to share the
     /// same lifecycle boundary, so sealing must not preserve per-call clocks.
     prepared_mutation_timestamp: Option<LixTimestamp>,
     mutation_journal: Option<TransactionMutationJournal>,
+    /// Sealing consumes the journal's owned column buffers. If any fallible
+    /// validation or staging step rejects those buffers, this transaction can
+    /// no longer provide statement atomicity and must remain rollback-only.
+    mutation_journal_terminal_error: Option<LixError>,
     staged_writes: Arc<TransactionWriteBuffer>,
     filesystem_path_index_cache: Arc<FilesystemPathIndexCache>,
     filesystem_path_index_epoch: Arc<AtomicUsize>,
@@ -537,6 +545,9 @@ struct TransactionMutationJournal {
     snapshot_offsets: Vec<(usize, usize)>,
     timestamp: Option<LixTimestamp>,
 }
+
+const INITIAL_MUTATION_JOURNAL_ROWS: usize = 16;
+const INITIAL_MUTATION_JOURNAL_ARENA_BYTES: usize = 1_024;
 
 enum PreparedMutationMembership {
     Unprepared,
@@ -795,6 +806,30 @@ where
                 format!("branch '{}' does not exist", self.active_branch_id),
             ));
         };
+
+        // A complete-set journal is certified against the coherent opening
+        // snapshot. If this branch advanced, expose its identities—with exact
+        // current predecessor lifecycle—to the established stale-write
+        // classifier and generic reconciliation lane. Unchanged-head commits
+        // retain the zero-reconstruction direct path.
+        let journal_descriptors = prepared_writes.ordered_mutation_journal_descriptors();
+        if !journal_descriptors.is_empty() {
+            let base = self
+                .live_state
+                .transaction_reader(read, Arc::clone(&self.branch_head_control_cache));
+            let mut predecessors_by_commit = BTreeMap::new();
+            for descriptor in journal_descriptors {
+                let predecessors = load_immutable_mutation_predecessors(
+                    &base,
+                    &descriptor.schema_key,
+                    &descriptor.branch_id,
+                    &descriptor.entity_pk_chunks,
+                )
+                .await?;
+                predecessors_by_commit.insert(descriptor.commit_id, predecessors);
+            }
+            prepared_writes.hydrate_and_lower_ordered_mutation_journals(predecessors_by_commit)?;
+        }
 
         let mut tracked = self.tracked_state.reader(read);
         let opening_head_text = opening_head.to_string();
@@ -1360,8 +1395,10 @@ where
                 sql_planning_cache,
                 prepared_mutation_program: None,
                 prepared_mutation_membership: PreparedMutationMembership::Unprepared,
+                prepared_mutation_overlay_empty: false,
                 prepared_mutation_timestamp: None,
                 mutation_journal: None,
+                mutation_journal_terminal_error: None,
                 staged_writes,
                 filesystem_path_index_cache: Arc::new(FilesystemPathIndexCache::default()),
                 filesystem_path_index_epoch: Arc::new(AtomicUsize::new(0)),
@@ -6327,6 +6364,9 @@ where
         sql: &str,
         params: &[Value],
     ) -> Result<Option<crate::sql2::SqlWriteResult>, LixError> {
+        if let Some(error) = &self.mutation_journal_terminal_error {
+            return Err(error.clone());
+        }
         let Some((cached_sql, program)) = self.prepared_mutation_program.as_ref() else {
             return Ok(None);
         };
@@ -6362,6 +6402,21 @@ where
                 None => PreparedMutationMembership::Unavailable,
             };
         }
+        if !self.prepared_mutation_overlay_empty {
+            if self.staged_writes.staged_identity_may_affect(
+                &self.active_branch_id,
+                &program.schema_key,
+                None,
+                &entity_pk,
+            )? {
+                // A transaction-local predecessor is part of the mutable
+                // overlay, not durable history. Keep dependent statements on
+                // the generic executor so INSERT/UPDATE/DELETE coalescing
+                // retains lifecycle and constraint semantics.
+                return Ok(None);
+            }
+            self.prepared_mutation_overlay_empty = !self.staged_writes.has_staged_state_rows()?;
+        }
         let cached_membership = match &mut self.prepared_mutation_membership {
             PreparedMutationMembership::Packed(membership) => membership.contains(&entity_pk)?,
             PreparedMutationMembership::Unprepared | PreparedMutationMembership::Unavailable => {
@@ -6394,9 +6449,9 @@ where
         let journal = journal_slot.get_or_insert_with(|| TransactionMutationJournal {
             program: Arc::clone(&program),
             origin_key: origin_key.clone(),
-            entity_pks: Vec::with_capacity(4_096),
-            snapshot_arena: Vec::with_capacity(4_096 * 64),
-            snapshot_offsets: Vec::with_capacity(4_096),
+            entity_pks: Vec::with_capacity(INITIAL_MUTATION_JOURNAL_ROWS),
+            snapshot_arena: Vec::with_capacity(INITIAL_MUTATION_JOURNAL_ARENA_BYTES),
+            snapshot_offsets: Vec::with_capacity(INITIAL_MUTATION_JOURNAL_ROWS),
             timestamp: None,
         });
         debug_assert!(Arc::ptr_eq(&journal.program, &program));
@@ -6430,6 +6485,50 @@ where
             .is_some_and(|(cached_sql, _)| cached_sql.as_ref() == sql)
     }
 
+    pub(crate) fn prepared_literal_mutation_parameter_count(&self, sql: &str) -> Option<usize> {
+        let (shape, program) = self.prepared_mutation_program.as_ref()?;
+        self.sql_planning_cache
+            .update_literal_shape_matches(sql, shape)
+            .then(|| program.parameter_count())
+    }
+
+    pub(crate) async fn flush_cached_prepared_mutation_barrier(
+        &mut self,
+        next_origin_key: Option<&str>,
+        params: &[Value],
+    ) -> Result<(), LixError> {
+        let cached_sql = self
+            .prepared_mutation_program
+            .as_ref()
+            .map(|(sql, _)| Arc::clone(sql))
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "cached mutation barrier has no prepared mutation program",
+                )
+            })?;
+        self.flush_prepared_mutation_barrier(&cached_sql, next_origin_key, params)
+            .await
+    }
+
+    pub(crate) async fn try_execute_cached_prepared_mutation(
+        &mut self,
+        params: &[Value],
+    ) -> Result<Option<crate::sql2::SqlWriteResult>, LixError> {
+        let cached_sql = self
+            .prepared_mutation_program
+            .as_ref()
+            .map(|(sql, _)| Arc::clone(sql))
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "cached mutation execution has no prepared mutation program",
+                )
+            })?;
+        self.try_execute_prepared_mutation(&cached_sql, params)
+            .await
+    }
+
     pub(crate) fn remember_prepared_mutation(
         &mut self,
         sql: &str,
@@ -6442,6 +6541,7 @@ where
         {
             self.prepared_mutation_program = None;
             self.prepared_mutation_membership = PreparedMutationMembership::Unprepared;
+            self.prepared_mutation_overlay_empty = false;
             self.prepared_mutation_timestamp = None;
             return Ok(());
         }
@@ -6449,41 +6549,119 @@ where
             crate::sql2::prepare_path_value_replacement_program(self, plan)
                 .map(|program| (Arc::<str>::from(sql), Arc::new(program)));
         self.prepared_mutation_membership = PreparedMutationMembership::Unprepared;
+        self.prepared_mutation_overlay_empty = false;
         self.prepared_mutation_timestamp = None;
         Ok(())
     }
 
     pub(crate) async fn flush_prepared_mutations(&mut self) -> Result<(), LixError> {
-        let complete_generation = match (
-            &self.prepared_mutation_program,
-            &self.prepared_mutation_membership,
-        ) {
-            (Some((_, program)), PreparedMutationMembership::Packed(membership)) => Some((
-                program.schema_key.clone(),
-                self.active_branch_id.clone(),
-                membership.complete_generation(),
-            )),
-            (
-                _,
-                PreparedMutationMembership::Unprepared | PreparedMutationMembership::Unavailable,
-            )
-            | (None, PreparedMutationMembership::Packed(_)) => None,
-        };
-        self.flush_mutation_journal().await?;
-        if let Some((schema_key, branch_id, (live_count, ordered_identity_digest))) =
-            complete_generation
+        if let Some(error) = &self.mutation_journal_terminal_error {
+            return Err(error.clone());
+        }
+        let generation_seed = self.prepared_mutation_collection_generation_seed();
+        let mut complete_generation = resolve_prepared_mutation_collection_generation(
+            generation_seed,
+            self.opening_read(),
+            Arc::clone(&self.live_state),
+            Arc::clone(&self.branch_head_control_cache),
+            self.active_branch_id.clone(),
+        )
+        .await?
+        .map(|(schema_key, generation)| (schema_key, self.active_branch_id.clone(), generation));
+        if let Some((schema_key, _, (live_count, ordered_identity_digest))) =
+            complete_generation.as_ref()
         {
-            self.staged_writes.certify_complete_collection_replacement(
-                schema_key.as_str(),
-                &branch_id,
-                live_count,
-                ordered_identity_digest,
-            )?;
+            let opening_read = self.opening_read();
+            if opening_parent_complete_lifecycle_created_at(
+                &opening_read,
+                self.opening_active_branch_head,
+                schema_key,
+                *live_count,
+                *ordered_identity_digest,
+            )
+            .await?
+            .is_none()
+            {
+                complete_generation = None;
+            }
+        }
+        self.flush_mutation_journal().await?;
+        let replacement_certified =
+            if let Some((schema_key, branch_id, (live_count, ordered_identity_digest))) =
+                complete_generation
+            {
+                self.staged_writes.certify_complete_collection_replacement(
+                    schema_key.as_str(),
+                    &branch_id,
+                    live_count,
+                    ordered_identity_digest,
+                )?
+            } else {
+                false
+            };
+        if !replacement_certified {
+            self.lower_provisional_mutations_to_prepared().await?;
         }
         self.prepared_mutation_program = None;
         self.prepared_mutation_membership = PreparedMutationMembership::Unprepared;
+        self.prepared_mutation_overlay_empty = false;
         self.prepared_mutation_timestamp = None;
         Ok(())
+    }
+
+    /// Flushes pending mutations into the transaction-visible row overlay.
+    /// The immutable journal itself is a staged read source, so an intervening
+    /// read seals only the current mutable chunk and does not reconstruct a
+    /// `PreparedStateBatch`.
+    pub(crate) async fn flush_prepared_mutations_for_read(&mut self) -> Result<(), LixError> {
+        self.flush_mutation_journal().await?;
+        let generation_seed = self.prepared_mutation_collection_generation_seed();
+        let Some((schema_key, (live_count, ordered_identity_digest))) =
+            resolve_prepared_mutation_collection_generation(
+                generation_seed,
+                self.opening_read(),
+                Arc::clone(&self.live_state),
+                Arc::clone(&self.branch_head_control_cache),
+                self.active_branch_id.clone(),
+            )
+            .await?
+        else {
+            self.hydrate_provisional_mutation_predecessors().await?;
+            return Ok(());
+        };
+        let opening_read = self.opening_read();
+        if let Some(created_at) = opening_parent_complete_lifecycle_created_at(
+            &opening_read,
+            self.opening_active_branch_head,
+            &schema_key,
+            live_count,
+            ordered_identity_digest,
+        )
+        .await?
+        {
+            self.staged_writes
+                .set_ordered_mutation_overlay_created_at(created_at)?;
+        } else {
+            self.hydrate_provisional_mutation_predecessors().await?;
+        }
+        Ok(())
+    }
+
+    fn prepared_mutation_collection_generation_seed(
+        &self,
+    ) -> Option<(String, Option<(u64, [u8; 32])>)> {
+        let Some((_, program)) = &self.prepared_mutation_program else {
+            return None;
+        };
+        let generation = match &self.prepared_mutation_membership {
+            PreparedMutationMembership::Packed(membership) => {
+                Some(membership.complete_generation())
+            }
+            PreparedMutationMembership::Unprepared | PreparedMutationMembership::Unavailable => {
+                None
+            }
+        };
+        Some((program.schema_key.clone(), generation))
     }
 
     pub(crate) async fn flush_prepared_mutation_barrier(
@@ -6500,13 +6678,7 @@ where
             .mutation_journal
             .as_ref()
             .is_none_or(|journal| journal.origin_key.as_deref() == next_origin_key);
-        let ordered_append = if same_program
-            && same_origin
-            && self
-                .mutation_journal
-                .as_ref()
-                .is_none_or(|journal| journal.entity_pks.len() < 4_096)
-        {
+        let ordered_append = if same_program && same_origin {
             self.prepared_mutation_program
                 .as_ref()
                 .and_then(|(_, program)| program.primary_key(params).ok())
@@ -6520,18 +6692,38 @@ where
         } else {
             false
         };
-        if !same_program || !same_origin || !ordered_append {
+        let chunk_has_capacity = self
+            .mutation_journal
+            .as_ref()
+            .is_none_or(|journal| journal.entity_pks.len() < 4_096);
+        if !same_program || !same_origin || !ordered_append || !chunk_has_capacity {
             self.flush_mutation_journal().await?;
+        }
+        if !same_program || !same_origin || !ordered_append {
+            self.lower_provisional_mutations_to_prepared().await?;
+            self.prepared_mutation_overlay_empty = false;
         }
         if !same_program {
             self.prepared_mutation_program = None;
             self.prepared_mutation_membership = PreparedMutationMembership::Unprepared;
+            self.prepared_mutation_overlay_empty = false;
             self.prepared_mutation_timestamp = None;
         }
         Ok(())
     }
 
     async fn flush_mutation_journal(&mut self) -> Result<(), LixError> {
+        if let Some(error) = &self.mutation_journal_terminal_error {
+            return Err(error.clone());
+        }
+        let result = self.flush_mutation_journal_inner().await;
+        if let Err(error) = &result {
+            self.mutation_journal_terminal_error = Some(error.clone());
+        }
+        result
+    }
+
+    async fn flush_mutation_journal_inner(&mut self) -> Result<(), LixError> {
         let Some(journal) = self.mutation_journal.take() else {
             return Ok(());
         };
@@ -6545,39 +6737,166 @@ where
             crate::storage_bench::record_transaction_rows_staged(row_count);
             crate::storage_bench::record_transaction_untracked_rows(0);
         }
-        let rows = CertifiedParameterReplacementBatch::new(
-            journal.entity_pks,
-            TransactionJson::from_certified_row_content_arena(
-                journal.snapshot_arena,
-                journal.snapshot_offsets,
-            )?,
+        let timestamp = journal.timestamp.ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "non-empty transaction mutation journal has no lifecycle timestamp",
+            )
+        })?;
+        let chunk = ImmutableMutationJournalChunk::try_new(
+            journal.program.schema_plan_id,
             journal.program.schema_key.as_str().into(),
             self.active_branch_id.clone().into(),
-            CertifiedRawWriteBatchPreparation {
-                schema_plan_id: journal.program.schema_plan_id,
-                facts: PreparedRowFacts {
-                    row_content_validated: true,
-                    requires_transaction_validation: false,
-                },
-                tracked_keys_strictly_ordered: true,
-                complete_collection_replacement: None,
-            },
-        )?
-        .into_dense_prepared(
-            journal.origin_key.as_ref(),
-            journal.timestamp.ok_or_else(|| {
+            journal.origin_key,
+            journal.entity_pks,
+            journal.snapshot_arena,
+            journal.snapshot_offsets,
+            None,
+            timestamp,
+        )?;
+        match self.staged_writes.stage_immutable_mutation_chunk(chunk)? {
+            ImmutableMutationChunkStage::Staged => {}
+            ImmutableMutationChunkStage::RequiresGeneric(chunk) => {
+                self.lower_provisional_mutations_to_prepared().await?;
+                let chunk = self.hydrate_immutable_mutation_chunk(chunk).await?;
+                self.staged_writes
+                    .stage_write(PreparedTransactionWrite::Rows {
+                        mode: TransactionWriteMode::Replace,
+                        rows: chunk.into_prepared(false)?,
+                    })?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn lower_provisional_mutations_to_prepared(&mut self) -> Result<(), LixError> {
+        self.hydrate_provisional_mutation_predecessors().await?;
+        self.staged_writes.lower_immutable_mutations_to_prepared()
+    }
+
+    async fn hydrate_provisional_mutation_predecessors(&mut self) -> Result<(), LixError> {
+        let Some(descriptor) = self
+            .staged_writes
+            .provisional_mutation_journal_descriptor()?
+        else {
+            return Ok(());
+        };
+        if descriptor.predecessors_complete() {
+            return Ok(());
+        }
+        let schema_key = descriptor.schema_key().to_owned();
+        let branch_id = descriptor.branch_id().to_owned();
+        let row_count = descriptor
+            .entity_pk_chunks()
+            .iter()
+            .map(|chunk| chunk.len())
+            .sum();
+        let mut predecessors = Vec::with_capacity(row_count);
+        for entity_pks in descriptor.entity_pk_chunks() {
+            let request = LiveStateExactBatchRequest {
+                rows: entity_pks
+                    .iter()
+                    .cloned()
+                    .map(|entity_pk| LiveStateExactRowRequest {
+                        schema_key: schema_key.clone(),
+                        branch_id: branch_id.clone(),
+                        entity_pk,
+                        file_id: None,
+                    })
+                    .collect(),
+                projection: LiveStateProjection::default(),
+                untracked: Some(false),
+                include_tombstones: false,
+            };
+            let current = load_opening_exact_live_state_batch(
+                self.opening_read(),
+                Arc::clone(&self.live_state),
+                Arc::clone(&self.branch_head_control_cache),
+                &request,
+            )
+            .await?;
+            for (slot, expected_entity_pk) in entity_pks.iter().enumerate() {
+                let row = current.row(slot).ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "partial immutable mutation lost its current-state predecessor",
+                    )
+                })?;
+                if row.schema_key() != schema_key
+                    || row.branch_id() != branch_id
+                    || row.entity_pk() != expected_entity_pk
+                {
+                    return Err(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "partial immutable mutation predecessor order changed",
+                    ));
+                }
+                predecessors.push(row.durable_predecessor().cloned().ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "partial immutable mutation predecessor lacks durable evidence",
+                    )
+                })?);
+            }
+        }
+        self.staged_writes
+            .hydrate_immutable_mutation_predecessors(predecessors)?;
+        Ok(())
+    }
+
+    async fn hydrate_immutable_mutation_chunk(
+        &mut self,
+        mut chunk: ImmutableMutationJournalChunk,
+    ) -> Result<ImmutableMutationJournalChunk, LixError> {
+        let entity_pks = Arc::clone(chunk.entity_pks());
+        let request = LiveStateExactBatchRequest {
+            rows: entity_pks
+                .iter()
+                .cloned()
+                .map(|entity_pk| LiveStateExactRowRequest {
+                    schema_key: chunk.schema_key().to_owned(),
+                    branch_id: chunk.branch_id().to_owned(),
+                    entity_pk,
+                    file_id: None,
+                })
+                .collect(),
+            projection: LiveStateProjection::default(),
+            untracked: Some(false),
+            include_tombstones: false,
+        };
+        let current = load_opening_exact_live_state_batch(
+            self.opening_read(),
+            Arc::clone(&self.live_state),
+            Arc::clone(&self.branch_head_control_cache),
+            &request,
+        )
+        .await?;
+        let mut predecessors = Vec::with_capacity(entity_pks.len());
+        for (slot, expected_entity_pk) in entity_pks.iter().enumerate() {
+            let row = current.row(slot).ok_or_else(|| {
                 LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
-                    "non-empty transaction mutation journal has no lifecycle timestamp",
+                    "mixed immutable mutation lost its current-state predecessor",
                 )
-            })?,
-        )?;
-        self.staged_writes
-            .stage_write(PreparedTransactionWrite::Rows {
-                mode: TransactionWriteMode::Replace,
-                rows,
             })?;
-        Ok(())
+            if row.schema_key() != chunk.schema_key()
+                || row.branch_id() != chunk.branch_id()
+                || row.entity_pk() != expected_entity_pk
+            {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "mixed immutable mutation predecessor order changed",
+                ));
+            }
+            predecessors.push(row.durable_predecessor().cloned().ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "mixed immutable mutation predecessor lacks durable evidence",
+                )
+            })?);
+        }
+        chunk.attach_durable_predecessors(predecessors)?;
+        Ok(chunk)
     }
 
     /// Returns this transaction's prepared runtime functions.
@@ -7323,6 +7642,61 @@ where
     }
 }
 
+async fn load_immutable_mutation_predecessors<R>(
+    reader: &R,
+    schema_key: &str,
+    branch_id: &str,
+    entity_pk_chunks: &[Arc<[EntityPk]>],
+) -> Result<Vec<CertifiedCurrentStatePredecessor>, LixError>
+where
+    R: LiveStateReader + ?Sized,
+{
+    let row_count = entity_pk_chunks.iter().map(|chunk| chunk.len()).sum();
+    let mut predecessors = Vec::with_capacity(row_count);
+    for entity_pks in entity_pk_chunks {
+        let request = LiveStateExactBatchRequest {
+            rows: entity_pks
+                .iter()
+                .cloned()
+                .map(|entity_pk| LiveStateExactRowRequest {
+                    schema_key: schema_key.to_owned(),
+                    branch_id: branch_id.to_owned(),
+                    entity_pk,
+                    file_id: None,
+                })
+                .collect(),
+            projection: LiveStateProjection::default(),
+            untracked: Some(false),
+            include_tombstones: false,
+        };
+        let current = reader.load_exact_batch(&request).await?;
+        for (slot, expected_entity_pk) in entity_pks.iter().enumerate() {
+            let row = current.row(slot).ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "immutable mutation lost its current-state predecessor",
+                )
+            })?;
+            if row.schema_key() != schema_key
+                || row.branch_id() != branch_id
+                || row.entity_pk() != expected_entity_pk
+            {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "immutable mutation predecessor order changed",
+                ));
+            }
+            predecessors.push(row.durable_predecessor().cloned().ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "immutable mutation predecessor lacks durable evidence",
+                )
+            })?);
+        }
+    }
+    Ok(predecessors)
+}
+
 fn conflict_resolution_limits(conflict_count: usize) -> Result<WasmTransitionLimits, LixError> {
     let conflict_count = u32::try_from(conflict_count).map_err(|_| {
         LixError::new(
@@ -7364,6 +7738,82 @@ fn empty_state_transition(current: CommitId, desired: CommitId) -> LixError {
         LixError::CODE_INTERNAL_ERROR,
         format!("tracked-state transition from '{current}' to '{desired}' is empty"),
     )
+}
+
+async fn opening_parent_complete_lifecycle_created_at(
+    read: &(impl StorageAdapterRead + ?Sized),
+    parent_commit_id: Option<CommitId>,
+    schema_key: &str,
+    live_count: u64,
+    ordered_identity_digest: [u8; 32],
+) -> Result<Option<LixTimestamp>, LixError> {
+    let Some(parent_commit_id) = parent_commit_id else {
+        return Ok(None);
+    };
+    let Some(manifest) =
+        crate::tracked_state::load_commit_state_manifest(read, parent_commit_id).await?
+    else {
+        return Ok(None);
+    };
+    let expected_scope = crate::tracked_state::CommitDeltaReplacementScope {
+        schema_key: schema_key.to_owned(),
+        file_id: None,
+    };
+    if manifest.mutations.member_count != u32::try_from(live_count).unwrap_or(u32::MAX)
+        || manifest.mutations.single_partition.as_ref() != Some(&expected_scope)
+    {
+        return Ok(None);
+    }
+    Ok(manifest
+        .mutations
+        .lifecycle_summary
+        .as_ref()
+        .filter(|summary| {
+            summary.scope == expected_scope
+                && summary.ordered_identity_digest == ordered_identity_digest
+        })
+        .map(|summary| summary.uniform_created_at))
+}
+
+async fn resolve_prepared_mutation_collection_generation(
+    seed: Option<(String, Option<(u64, [u8; 32])>)>,
+    read: impl StorageAdapterRead + Send,
+    live_state: Arc<LiveStateContext>,
+    branch_head_control_cache: Arc<BranchHeadControlCache>,
+    branch_id: String,
+) -> Result<Option<(String, (u64, [u8; 32]))>, LixError> {
+    let Some((schema_key, generation)) = seed else {
+        return Ok(None);
+    };
+    if let Some(generation) = generation {
+        return Ok(Some((schema_key, generation)));
+    }
+    let base = live_state.transaction_reader(read, branch_head_control_cache);
+    let generation = base
+        .collection_generation(
+            &branch_id,
+            crate::collection_generation::CollectionScopeRef {
+                schema_key: &schema_key,
+                file_id: None,
+            },
+        )
+        .await?
+        .and_then(|generation| {
+            generation
+                .ordered_identity_digest
+                .map(|digest| (generation.live_count, digest))
+        });
+    Ok(generation.map(|generation| (schema_key, generation)))
+}
+
+async fn load_opening_exact_live_state_batch(
+    read: impl StorageAdapterRead + Send,
+    live_state: Arc<LiveStateContext>,
+    branch_head_control_cache: Arc<BranchHeadControlCache>,
+    request: &LiveStateExactBatchRequest,
+) -> Result<MaterializedLiveStateExactBatch, LixError> {
+    let base = live_state.transaction_reader(read, branch_head_control_cache);
+    base.load_exact_batch(request).await
 }
 
 fn diff_record_identity(record: &ChangeRecord) -> (String, EntityPk, Option<String>) {
@@ -7446,7 +7896,7 @@ where
         &self.active_branch_id
     }
 
-    fn live_state(&self) -> Arc<dyn crate::live_state::LiveStateReader> {
+    fn live_state(&self) -> Arc<dyn LiveStateReader> {
         Arc::new(TransactionReadLiveStateReader {
             base: self.live_state.transaction_reader(
                 self.read_store.clone(),
@@ -7579,7 +8029,7 @@ struct TransactionReadLiveStateReader<R: crate::storage_adapter::StorageRead> {
 }
 
 #[async_trait]
-impl<R> crate::live_state::LiveStateReader for TransactionReadLiveStateReader<R>
+impl<R> LiveStateReader for TransactionReadLiveStateReader<R>
 where
     R: crate::storage_adapter::StorageRead + 'static,
 {
@@ -9757,7 +10207,7 @@ struct PluginUpgradeBlobRefSnapshot {
 
 async fn preflight_owned_generation_upgrades(
     host: &PluginRuntimeHost,
-    base: &dyn crate::live_state::LiveStateReader,
+    base: &dyn LiveStateReader,
     staged: &impl StagedLiveStateRows,
     base_blob_reader: &dyn BlobDataReader,
     staged_writes: &TransactionWriteBuffer,

--- a/packages/engine/src/transaction/mod.rs
+++ b/packages/engine/src/transaction/mod.rs
@@ -21,6 +21,8 @@ pub(crate) use commit::take_complete_replacement_packed_current_base_publication
 #[cfg(test)]
 pub(crate) use commit::take_complete_replacement_packed_current_base_retirements;
 #[cfg(test)]
+pub(crate) use commit::take_direct_journal_replacement_publications;
+#[cfg(test)]
 pub(crate) use commit::take_ordered_packed_current_base_publications;
 #[cfg(test)]
 pub(crate) use commit::take_rootless_replacement_generation_publications;

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -12,13 +12,14 @@ use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::{Arc, Mutex};
 
+use bytes::Bytes;
 use smallvec::SmallVec;
 
 use crate::GLOBAL_BRANCH_ID;
 use crate::binary_cas::{BlobBytesBatch, BlobId};
 use crate::catalog::SchemaPlanId;
 use crate::changelog::{ChangeId, CommitId};
-use crate::common::SharedStr;
+use crate::common::{LixTimestamp, SharedStr};
 use crate::domain::{Domain, DomainRowIdentity};
 use crate::entity_pk::EntityPk;
 #[cfg(test)]
@@ -30,17 +31,20 @@ use crate::live_state::LiveStateRowRequest;
 #[cfg(test)]
 use crate::live_state::MaterializedLiveStateRow;
 use crate::live_state::{
-    LiveStateExactBatchRequest, LiveStateExactRowRequest, LiveStateScanRequest,
-    MaterializedLiveStateBatch, MaterializedLiveStateBatchBuilder, MaterializedLiveStateExactBatch,
+    CertifiedCurrentStatePredecessor, LiveStateExactBatchRequest, LiveStateExactRowRequest,
+    LiveStateScanRequest, MaterializedLiveStateBatch, MaterializedLiveStateBatchBuilder,
+    MaterializedLiveStateExactBatch,
 };
 use crate::transaction::types::StagedCommitChangeRefs;
 use crate::transaction::types::{
-    LogicalPrimaryKey, PreparedStateBatch, PreparedStateRowRef, PreparedTransactionWrite,
-    StageJson, StagedCommitChangeBatch, TransactionFileData, TransactionWriteMode,
-    TransactionWriteOperation, TransactionWriteOrigin, TransactionWriteOutcome,
+    CertifiedParameterReplacementBatch, CertifiedRawWriteBatchPreparation,
+    CompleteCollectionReplacementProof, LogicalPrimaryKey, PreparedRowFacts, PreparedStateBatch,
+    PreparedStateRowRef, PreparedTransactionWrite, StageJson, StagedCommitChangeBatch,
+    TransactionFileData, TransactionJson, TransactionWriteMode, TransactionWriteOperation,
+    TransactionWriteOrigin, TransactionWriteOutcome,
 };
 #[cfg(test)]
-use crate::transaction::types::{TestPreparedStateRow, TransactionJson, stage_json_from_value};
+use crate::transaction::types::{TestPreparedStateRow, stage_json_from_value};
 use crate::{LixError, NullableKeyFilter};
 
 /// Transaction-local write buffer after transaction-boundary preparation.
@@ -52,6 +56,7 @@ use crate::{LixError, NullableKeyFilter};
 pub(crate) struct TransactionWriteBuffer {
     functions: FunctionProviderHandle,
     rows: Mutex<StagedPreparedRows>,
+    ordered_mutations: Mutex<Option<OrderedMutationJournal>>,
     commit_change_refs_by_branch: Mutex<BTreeMap<String, StagedCommitChangeRefs>>,
     first_commit_parent_override_by_branch: Mutex<BTreeMap<String, CommitId>>,
     checkpoint_publications: Mutex<Vec<CheckpointPublication>>,
@@ -68,12 +73,439 @@ pub(crate) struct TransactionWriteBuffer {
 /// to restore an explicit transaction after a post-stage SQL error.
 pub(crate) struct TransactionWriteBufferCheckpoint {
     rows: StagedPreparedRows,
+    ordered_mutations: Option<OrderedMutationJournal>,
     commit_change_refs_by_branch: BTreeMap<String, StagedCommitChangeRefs>,
     first_commit_parent_override_by_branch: BTreeMap<String, CommitId>,
     checkpoint_publications: Vec<CheckpointPublication>,
     extra_commit_parents_by_branch: BTreeMap<String, Vec<CommitId>>,
     intermediate_commits: Vec<StagedIntermediateCommit>,
     file_data_writes: Vec<TransactionFileData>,
+}
+
+/// One immutable, fixed-shape journal chunk produced by typed SQL mutation
+/// ingress. Identity and canonical JSON remain columnar owners; commit can
+/// borrow them directly while encoding immutable mutation parts.
+#[derive(Clone, Debug)]
+pub(crate) struct ImmutableMutationJournalChunk {
+    schema_plan_id: SchemaPlanId,
+    schema_key: SharedStr,
+    branch_id: SharedStr,
+    origin_key: Option<SharedStr>,
+    entity_pks: Arc<[EntityPk]>,
+    snapshot_arena: Bytes,
+    snapshot_offsets: Arc<[(u32, u32)]>,
+    large_snapshot_refs: Arc<[(u16, crate::json_store::JsonRef)]>,
+    durable_predecessors: Option<Arc<[CertifiedCurrentStatePredecessor]>>,
+    timestamp: LixTimestamp,
+}
+
+impl PartialEq for ImmutableMutationJournalChunk {
+    fn eq(&self, other: &Self) -> bool {
+        self.schema_plan_id == other.schema_plan_id
+            && self.schema_key == other.schema_key
+            && self.branch_id == other.branch_id
+            && self.origin_key == other.origin_key
+            && self.entity_pks == other.entity_pks
+            && self.snapshot_arena == other.snapshot_arena
+            && self.snapshot_offsets == other.snapshot_offsets
+            && self.large_snapshot_refs == other.large_snapshot_refs
+            && self.timestamp == other.timestamp
+            && self.durable_predecessors.as_ref().map(|values| {
+                values
+                    .iter()
+                    .map(CertifiedCurrentStatePredecessor::created_at)
+                    .collect::<Result<Vec<_>, _>>()
+                    .ok()
+            }) == other.durable_predecessors.as_ref().map(|values| {
+                values
+                    .iter()
+                    .map(CertifiedCurrentStatePredecessor::created_at)
+                    .collect::<Result<Vec<_>, _>>()
+                    .ok()
+            })
+    }
+}
+
+impl Eq for ImmutableMutationJournalChunk {}
+
+impl ImmutableMutationJournalChunk {
+    #[expect(clippy::too_many_arguments)]
+    pub(crate) fn try_new(
+        schema_plan_id: SchemaPlanId,
+        schema_key: SharedStr,
+        branch_id: SharedStr,
+        origin_key: Option<SharedStr>,
+        entity_pks: Vec<EntityPk>,
+        snapshot_arena: Vec<u8>,
+        snapshot_offsets: Vec<(usize, usize)>,
+        durable_predecessors: Option<Vec<CertifiedCurrentStatePredecessor>>,
+        timestamp: LixTimestamp,
+    ) -> Result<Self, LixError> {
+        if entity_pks.is_empty() || entity_pks.len() != snapshot_offsets.len() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "immutable mutation journal columns are empty or misaligned",
+            ));
+        }
+        if durable_predecessors
+            .as_ref()
+            .is_some_and(|predecessors| predecessors.len() != entity_pks.len())
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "immutable mutation predecessor column is misaligned",
+            ));
+        }
+        if !entity_pks.windows(2).all(|pair| pair[0] < pair[1]) {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "immutable mutation journal identities are not strictly ordered",
+            ));
+        }
+        let arena_len = snapshot_arena.len();
+        std::str::from_utf8(&snapshot_arena).map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "immutable mutation journal arena is not UTF-8",
+            )
+        })?;
+        let mut previous_end = 0usize;
+        let mut offsets = Vec::with_capacity(snapshot_offsets.len());
+        for (start, end) in snapshot_offsets {
+            if start != previous_end || end <= start || end > arena_len {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "immutable mutation journal offsets are invalid",
+                ));
+            }
+            std::str::from_utf8(&snapshot_arena[start..end]).map_err(|_| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "immutable mutation journal offset splits UTF-8",
+                )
+            })?;
+            offsets.push((
+                u32::try_from(start).map_err(|_| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "immutable mutation journal arena exceeds u32",
+                    )
+                })?,
+                u32::try_from(end).map_err(|_| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "immutable mutation journal arena exceeds u32",
+                    )
+                })?,
+            ));
+            previous_end = end;
+        }
+        if previous_end != arena_len {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "immutable mutation journal offsets do not cover the arena",
+            ));
+        }
+        let large_snapshot_refs = offsets
+            .iter()
+            .enumerate()
+            .filter_map(|(index, &(start, end))| {
+                let bytes = &snapshot_arena[start as usize..end as usize];
+                (bytes.len() > crate::json_store::JSON_INLINE_MAX_BYTES).then(|| {
+                    (
+                        u16::try_from(index)
+                            .expect("immutable mutation chunk row ordinal fits u16"),
+                        crate::json_store::JsonRef::for_content(bytes),
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+        Ok(Self {
+            schema_plan_id,
+            schema_key,
+            branch_id,
+            origin_key,
+            entity_pks: entity_pks.into(),
+            snapshot_arena: Bytes::from(snapshot_arena),
+            snapshot_offsets: offsets.into(),
+            large_snapshot_refs: large_snapshot_refs.into(),
+            durable_predecessors: durable_predecessors.map(Into::into),
+            timestamp,
+        })
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.entity_pks.len()
+    }
+
+    pub(crate) fn entity_pks(&self) -> &Arc<[EntityPk]> {
+        &self.entity_pks
+    }
+
+    pub(crate) fn attach_durable_predecessors(
+        &mut self,
+        predecessors: Vec<CertifiedCurrentStatePredecessor>,
+    ) -> Result<(), LixError> {
+        if predecessors.len() != self.len() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "immutable mutation predecessor column does not match its rows",
+            ));
+        }
+        self.durable_predecessors = Some(predecessors.into());
+        Ok(())
+    }
+
+    pub(crate) fn entity_pk(&self, index: usize) -> &EntityPk {
+        &self.entity_pks[index]
+    }
+
+    pub(crate) fn snapshot(&self, index: usize) -> &str {
+        let (start, end) = self.snapshot_offsets[index];
+        std::str::from_utf8(&self.snapshot_arena[start as usize..end as usize])
+            .expect("validated immutable mutation journal UTF-8")
+    }
+
+    pub(crate) fn snapshot_slot(&self, index: usize) -> crate::json_store::JsonSlotRef<'_> {
+        let snapshot = self.snapshot(index);
+        if snapshot.len() <= crate::json_store::JSON_INLINE_MAX_BYTES {
+            return crate::json_store::JsonSlotRef::Inline(snapshot);
+        }
+        let index = u16::try_from(index).expect("immutable mutation chunk row ordinal fits u16");
+        let position = self
+            .large_snapshot_refs
+            .binary_search_by_key(&index, |(ordinal, _)| *ordinal)
+            .expect("large immutable mutation snapshot has a content ref");
+        crate::json_store::JsonSlotRef::Ref(&self.large_snapshot_refs[position].1)
+    }
+
+    pub(crate) fn schema_key(&self) -> &str {
+        self.schema_key.as_str()
+    }
+
+    pub(crate) fn branch_id(&self) -> &str {
+        self.branch_id.as_str()
+    }
+
+    pub(crate) fn origin_key(&self) -> Option<&str> {
+        self.origin_key.as_deref()
+    }
+
+    pub(crate) fn timestamp(&self) -> LixTimestamp {
+        self.timestamp
+    }
+
+    pub(crate) fn into_prepared(
+        self,
+        allow_missing_predecessors: bool,
+    ) -> Result<PreparedStateBatch, LixError> {
+        let offsets = self
+            .snapshot_offsets
+            .iter()
+            .map(|&(start, end)| (start as usize, end as usize))
+            .collect();
+        let mut rows = CertifiedParameterReplacementBatch::new(
+            self.entity_pks.iter().cloned().collect(),
+            TransactionJson::from_certified_row_content_arena(
+                self.snapshot_arena.to_vec(),
+                offsets,
+            )?,
+            self.schema_key,
+            self.branch_id,
+            CertifiedRawWriteBatchPreparation {
+                schema_plan_id: self.schema_plan_id,
+                facts: PreparedRowFacts {
+                    row_content_validated: true,
+                    requires_transaction_validation: false,
+                },
+                tracked_keys_strictly_ordered: true,
+                complete_collection_replacement: None,
+            },
+        )?
+        .into_dense_prepared(self.origin_key.as_ref(), self.timestamp)?;
+        let Some(predecessors) = self.durable_predecessors else {
+            if allow_missing_predecessors {
+                return Ok(rows);
+            }
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "partial immutable mutation journal lacks durable predecessor evidence",
+            ));
+        };
+        for (index, predecessor) in predecessors.iter().cloned().enumerate() {
+            rows.set_durable_predecessor(index, Some(predecessor));
+        }
+        Ok(rows)
+    }
+}
+
+/// Certified transaction-wide sequence of immutable journal chunks.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct OrderedMutationJournal {
+    /// Persistent chunk directory. Statement checkpoints clone this owner on
+    /// every scalar execute, so the directory itself must remain O(1) to
+    /// checkpoint; only the once-per-4K append performs copy-on-write.
+    chunks: Arc<Vec<ImmutableMutationJournalChunk>>,
+    row_count: usize,
+    commit_id: CommitId,
+    replacement_proof: Option<CompleteCollectionReplacementProof>,
+    overlay_uniform_created_at: Option<LixTimestamp>,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct OrderedMutationJournalRowRef<'a> {
+    chunk: &'a ImmutableMutationJournalChunk,
+    row_index: usize,
+}
+
+impl<'a> OrderedMutationJournalRowRef<'a> {
+    pub(crate) fn entity_pk(&self) -> &'a EntityPk {
+        self.chunk.entity_pk(self.row_index)
+    }
+
+    pub(crate) fn snapshot(&self) -> &'a str {
+        self.chunk.snapshot(self.row_index)
+    }
+
+    pub(crate) fn snapshot_slot(&self) -> crate::json_store::JsonSlotRef<'a> {
+        self.chunk.snapshot_slot(self.row_index)
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct OrderedMutationJournalRows<'a> {
+    journal: &'a OrderedMutationJournal,
+    chunk_index: usize,
+    row_index: usize,
+    remaining: usize,
+}
+
+/// Cheap read-only identity projection used to bulk-hydrate provisional
+/// predecessor evidence before generic lowering.
+#[derive(Clone)]
+pub(crate) struct ProvisionalMutationJournalDescriptor {
+    schema_key: SharedStr,
+    branch_id: SharedStr,
+    entity_pk_chunks: Vec<Arc<[EntityPk]>>,
+    predecessors_complete: bool,
+}
+
+pub(crate) enum ImmutableMutationChunkStage {
+    Staged,
+    RequiresGeneric(ImmutableMutationJournalChunk),
+}
+
+impl ProvisionalMutationJournalDescriptor {
+    pub(crate) fn schema_key(&self) -> &str {
+        self.schema_key.as_str()
+    }
+
+    pub(crate) fn branch_id(&self) -> &str {
+        self.branch_id.as_str()
+    }
+
+    pub(crate) fn entity_pk_chunks(&self) -> &[Arc<[EntityPk]>] {
+        &self.entity_pk_chunks
+    }
+
+    pub(crate) fn predecessors_complete(&self) -> bool {
+        self.predecessors_complete
+    }
+}
+
+impl<'a> Iterator for OrderedMutationJournalRows<'a> {
+    type Item = OrderedMutationJournalRowRef<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.chunk_index < self.journal.chunks.len() {
+            let chunk = &self.journal.chunks[self.chunk_index];
+            if self.row_index < chunk.len() {
+                let row = OrderedMutationJournalRowRef {
+                    chunk,
+                    row_index: self.row_index,
+                };
+                self.row_index += 1;
+                self.remaining -= 1;
+                return Some(row);
+            }
+            self.chunk_index += 1;
+            self.row_index = 0;
+        }
+        None
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+impl ExactSizeIterator for OrderedMutationJournalRows<'_> {}
+
+impl OrderedMutationJournal {
+    pub(crate) fn iter(&self) -> OrderedMutationJournalRows<'_> {
+        OrderedMutationJournalRows {
+            journal: self,
+            chunk_index: 0,
+            row_index: 0,
+            remaining: self.row_count,
+        }
+    }
+
+    pub(crate) fn row_count(&self) -> usize {
+        self.row_count
+    }
+
+    pub(crate) fn commit_id(&self) -> CommitId {
+        self.commit_id
+    }
+
+    pub(crate) fn schema_key(&self) -> &str {
+        self.chunks[0].schema_key()
+    }
+
+    pub(crate) fn branch_id(&self) -> &str {
+        self.chunks[0].branch_id()
+    }
+
+    pub(crate) fn timestamp(&self) -> LixTimestamp {
+        self.chunks[0].timestamp()
+    }
+
+    pub(crate) fn replacement_proof(&self) -> CompleteCollectionReplacementProof {
+        self.replacement_proof
+            .expect("drained ordered mutation journal is replacement-certified")
+    }
+
+    fn into_prepared(self) -> Result<PreparedStateBatch, LixError> {
+        let proof = self.replacement_proof;
+        let schema_key = self.schema_key().to_owned();
+        let branch_id = self.branch_id().to_owned();
+        let mut chunks = Arc::try_unwrap(self.chunks)
+            .unwrap_or_else(|chunks| (*chunks).clone())
+            .into_iter();
+        let Some(first) = chunks.next() else {
+            return Ok(PreparedStateBatch::new());
+        };
+        let mut rows = first.into_prepared(proof.is_some())?;
+        for chunk in chunks {
+            rows.append(chunk.into_prepared(proof.is_some())?);
+        }
+        rows.set_commit_id_all(self.commit_id);
+        if let Some(proof) = proof {
+            if !rows.certify_complete_collection_replacement(
+                &schema_key,
+                &branch_id,
+                u64::try_from(rows.len()).expect("prepared replacement row count fits u64"),
+                proof.ordered_identity_digest,
+            ) {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "immutable replacement proof changed during generic lowering",
+                ));
+            }
+        }
+        Ok(rows)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -310,6 +742,14 @@ pub(crate) struct PreparedWriteSet {
     pub(crate) extra_commit_parents_by_branch: BTreeMap<String, Vec<CommitId>>,
     pub(crate) intermediate_commits: Vec<StagedIntermediateCommit>,
     pub(crate) file_data_writes: Vec<TransactionFileData>,
+}
+
+#[derive(Clone)]
+pub(crate) struct DrainedMutationJournalDescriptor {
+    pub(crate) commit_id: CommitId,
+    pub(crate) schema_key: String,
+    pub(crate) branch_id: String,
+    pub(crate) entity_pk_chunks: Vec<Arc<[EntityPk]>>,
 }
 
 pub(crate) struct PreparedWriteValidationSet<'a> {
@@ -747,6 +1187,78 @@ impl<'a> PreparedWriteValidationSet<'a> {
 }
 
 impl PreparedWriteSet {
+    pub(crate) fn ordered_mutation_journal_descriptors(
+        &self,
+    ) -> Vec<DrainedMutationJournalDescriptor> {
+        self.commit_change_refs_by_branch
+            .values()
+            .filter_map(|refs| {
+                refs.ordered_mutation_journal()
+                    .map(|journal| DrainedMutationJournalDescriptor {
+                        commit_id: refs.commit_id,
+                        schema_key: journal.schema_key().to_owned(),
+                        branch_id: journal.branch_id().to_owned(),
+                        entity_pk_chunks: journal
+                            .chunks
+                            .iter()
+                            .map(|chunk| Arc::clone(chunk.entity_pks()))
+                            .collect(),
+                    })
+            })
+            .collect()
+    }
+
+    pub(crate) fn hydrate_and_lower_ordered_mutation_journals(
+        &mut self,
+        mut predecessors_by_commit: BTreeMap<CommitId, Vec<CertifiedCurrentStatePredecessor>>,
+    ) -> Result<(), LixError> {
+        let journals = self
+            .commit_change_refs_by_branch
+            .values_mut()
+            .filter_map(|refs| {
+                refs.take_ordered_mutation_journal()
+                    .map(|journal| (refs.commit_id, journal))
+            })
+            .collect::<Vec<_>>();
+        for (commit_id, journal) in journals {
+            let mut journal = Arc::try_unwrap(journal).unwrap_or_else(|journal| (*journal).clone());
+            let mut predecessors = predecessors_by_commit
+                .remove(&commit_id)
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "stale immutable journal lacks hydrated predecessor evidence",
+                    )
+                })?
+                .into_iter();
+            for chunk in Arc::make_mut(&mut journal.chunks) {
+                let values = predecessors.by_ref().take(chunk.len()).collect::<Vec<_>>();
+                chunk.attach_durable_predecessors(values)?;
+            }
+            if predecessors.next().is_some() {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "stale immutable journal has excess predecessor evidence",
+                ));
+            }
+            let rows = journal.into_prepared()?;
+            let previous_len = self.state_rows.len();
+            let row_count = rows.len();
+            self.state_rows.append(rows);
+            self.insert_selection.resize_rows(previous_len);
+            for _ in 0..row_count {
+                self.insert_selection.push_not_insert();
+            }
+        }
+        if !predecessors_by_commit.is_empty() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "predecessor evidence does not belong to an immutable journal",
+            ));
+        }
+        Ok(())
+    }
+
     pub(crate) fn append_cohort_member(
         &mut self,
         mut other: Self,
@@ -921,6 +1433,7 @@ impl TransactionWriteBuffer {
         Self {
             functions,
             rows: Mutex::new(StagedPreparedRows::default()),
+            ordered_mutations: Mutex::new(None),
             commit_change_refs_by_branch: Mutex::new(BTreeMap::new()),
             first_commit_parent_override_by_branch: Mutex::new(BTreeMap::new()),
             checkpoint_publications: Mutex::new(Vec::new()),
@@ -937,6 +1450,62 @@ impl TransactionWriteBuffer {
         expected_live_count: u64,
         expected_ordered_identity_digest: [u8; 32],
     ) -> Result<bool, LixError> {
+        let mut ordered = self.ordered_mutations.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "failed to acquire immutable transaction mutation journal",
+            )
+        })?;
+        if let Some(journal) = ordered.as_mut() {
+            if journal.row_count != usize::try_from(expected_live_count).unwrap_or(usize::MAX)
+                || journal.schema_key() != expected_schema_key
+                || journal.branch_id() != expected_branch_id
+                || journal
+                    .chunks
+                    .iter()
+                    .any(|chunk| chunk.origin_key().is_some())
+            {
+                return Ok(false);
+            }
+            let actual_digest = crate::collection_generation::ordered_single_string_identity_digest(
+                journal
+                    .chunks
+                    .iter()
+                    .flat_map(|chunk| chunk.entity_pks.iter()),
+            );
+            if actual_digest != Some(expected_ordered_identity_digest) {
+                return Ok(false);
+            }
+            let replay_bytes = journal.chunks.iter().try_fold(0_u64, |bytes, chunk| {
+                (0..chunk.len()).try_fold(bytes, |bytes, index| {
+                    let row_bytes = chunk
+                        .schema_key()
+                        .len()
+                        .checked_add(chunk.entity_pk(index).estimated_heap_bytes())
+                        .and_then(|value| value.checked_add(128))
+                        .and_then(|value| value.checked_add(chunk.snapshot(index).len()))
+                        .and_then(|value| u64::try_from(value).ok())
+                        .ok_or_else(|| {
+                            LixError::new(
+                                LixError::CODE_INTERNAL_ERROR,
+                                "immutable mutation replay bytes exceed u64",
+                            )
+                        })?;
+                    bytes.checked_add(row_bytes).ok_or_else(|| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            "immutable mutation replay bytes exceed u64",
+                        )
+                    })
+                })
+            })?;
+            journal.replacement_proof = Some(CompleteCollectionReplacementProof {
+                ordered_identity_digest: expected_ordered_identity_digest,
+                replay_bytes,
+            });
+            return Ok(true);
+        }
+        drop(ordered);
         let mut rows = self.rows.lock().map_err(|_| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
@@ -953,6 +1522,231 @@ impl TransactionWriteBuffer {
             expected_live_count,
             expected_ordered_identity_digest,
         ))
+    }
+
+    /// Appends one immutable, strictly ordered typed mutation chunk without
+    /// reconstructing generic prepared rows. The transaction must later
+    /// certify the accumulated journal as a complete replacement; otherwise
+    /// durable predecessor evidence is required for generic lowering.
+    pub(crate) fn stage_immutable_mutation_chunk(
+        &self,
+        chunk: ImmutableMutationJournalChunk,
+    ) -> Result<ImmutableMutationChunkStage, LixError> {
+        let count = chunk.len();
+        let rows = self.rows.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "failed to acquire transaction prepared rows",
+            )
+        })?;
+        let rows_are_empty = match &*rows {
+            StagedPreparedRows::AppendOnly { rows, .. }
+            | StagedPreparedRows::Indexed { rows, .. } => rows.is_empty(),
+        };
+        drop(rows);
+        if !rows_are_empty {
+            return Ok(ImmutableMutationChunkStage::RequiresGeneric(chunk));
+        }
+
+        let mut ordered = self.ordered_mutations.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "failed to acquire immutable transaction mutation journal",
+            )
+        })?;
+        if let Some(existing) = ordered.as_ref() {
+            let compatible = existing.schema_key() == chunk.schema_key()
+                && existing.branch_id() == chunk.branch_id()
+                && existing.timestamp() == chunk.timestamp()
+                && existing.chunks[0].origin_key() == chunk.origin_key()
+                && existing
+                    .chunks
+                    .last()
+                    .and_then(|previous| previous.entity_pks.last())
+                    .zip(chunk.entity_pks.first())
+                    .is_some_and(|(previous, next)| previous < next);
+            if !compatible {
+                return Ok(ImmutableMutationChunkStage::RequiresGeneric(chunk));
+            }
+        }
+
+        let mut commit_change_refs = self.commit_change_refs_by_branch.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "failed to acquire transaction staged commit change refs",
+            )
+        })?;
+        let branch_id = chunk.branch_id().to_owned();
+        let refs = commit_change_refs.entry(branch_id).or_insert_with(|| {
+            let timestamp = self.functions.call_timestamp();
+            StagedCommitChangeRefs::new(
+                CommitId::with_change_address_space(self.functions.call_uuid_v7()),
+                ChangeId::from(self.functions.call_uuid_v7()),
+                ChangeId::from(self.functions.call_uuid_v7()),
+                timestamp,
+            )
+        });
+        refs.add_change_count(count);
+        match ordered.as_mut() {
+            Some(existing) => {
+                existing.row_count = existing.row_count.checked_add(count).ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "immutable mutation journal row count overflowed",
+                    )
+                })?;
+                Arc::make_mut(&mut existing.chunks).push(chunk);
+                existing.replacement_proof = None;
+            }
+            None => {
+                *ordered = Some(OrderedMutationJournal {
+                    chunks: Arc::new(vec![chunk]),
+                    row_count: count,
+                    commit_id: refs.commit_id,
+                    replacement_proof: None,
+                    overlay_uniform_created_at: None,
+                });
+            }
+        }
+        Ok(ImmutableMutationChunkStage::Staged)
+    }
+
+    /// Attaches exact current-state predecessor evidence to provisional
+    /// immutable chunks before a partial/mixed journal is lowered. Callers
+    /// obtain this column with one bulk exact read; boolean membership alone
+    /// is deliberately insufficient because it does not preserve created_at.
+    pub(crate) fn hydrate_immutable_mutation_predecessors(
+        &self,
+        predecessors: Vec<CertifiedCurrentStatePredecessor>,
+    ) -> Result<(), LixError> {
+        let mut ordered = self.ordered_mutations.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "failed to acquire immutable transaction mutation journal",
+            )
+        })?;
+        let journal = ordered.as_mut().ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "transaction has no provisional immutable mutation journal",
+            )
+        })?;
+        if predecessors.len() != journal.row_count {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "bulk predecessor evidence does not align with immutable mutation rows",
+            ));
+        }
+        let mut predecessors = predecessors.into_iter();
+        for chunk in Arc::make_mut(&mut journal.chunks) {
+            let values = predecessors.by_ref().take(chunk.len()).collect::<Vec<_>>();
+            debug_assert_eq!(values.len(), chunk.len());
+            chunk.durable_predecessors = Some(values.into());
+        }
+        debug_assert!(predecessors.next().is_none());
+        Ok(())
+    }
+
+    pub(crate) fn set_ordered_mutation_overlay_created_at(
+        &self,
+        created_at: LixTimestamp,
+    ) -> Result<(), LixError> {
+        let mut ordered = self.ordered_mutations.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "failed to acquire immutable transaction mutation journal",
+            )
+        })?;
+        let journal = ordered.as_mut().ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "transaction has no provisional immutable mutation journal",
+            )
+        })?;
+        journal.overlay_uniform_created_at = Some(created_at);
+        Ok(())
+    }
+
+    pub(crate) fn provisional_mutation_journal_descriptor(
+        &self,
+    ) -> Result<Option<ProvisionalMutationJournalDescriptor>, LixError> {
+        let ordered = self.ordered_mutations.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "failed to acquire immutable transaction mutation journal",
+            )
+        })?;
+        Ok(ordered
+            .as_ref()
+            .map(|journal| ProvisionalMutationJournalDescriptor {
+                schema_key: journal.chunks[0].schema_key.clone(),
+                branch_id: journal.chunks[0].branch_id.clone(),
+                entity_pk_chunks: journal
+                    .chunks
+                    .iter()
+                    .map(|chunk| Arc::clone(&chunk.entity_pks))
+                    .collect(),
+                predecessors_complete: journal
+                    .chunks
+                    .iter()
+                    .all(|chunk| chunk.durable_predecessors.is_some()),
+            }))
+    }
+
+    /// Materializes a provisional journal only for semantics that require the
+    /// generic transaction overlay. Partial journals must first attach durable
+    /// predecessor evidence; certified complete replacements may lower
+    /// without it because their lifecycle is recovered from manifest history.
+    pub(crate) fn lower_immutable_mutations_to_prepared(&self) -> Result<(), LixError> {
+        let mut ordered = self.ordered_mutations.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "failed to acquire immutable transaction mutation journal",
+            )
+        })?;
+        if ordered.as_ref().is_some_and(|journal| {
+            journal.replacement_proof.is_none()
+                && journal
+                    .chunks
+                    .iter()
+                    .any(|chunk| chunk.durable_predecessors.is_none())
+        }) {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "partial immutable mutation journal must bulk-hydrate durable predecessors before lowering",
+            ));
+        }
+        let journal = ordered.take();
+        drop(ordered);
+        let Some(journal) = journal else {
+            return Ok(());
+        };
+        let rows = journal.into_prepared()?;
+        let last_key = rows.last().map(TrackedStateKey::from_row);
+        let mut insert_selection = PreparedInsertSelection::new();
+        insert_selection.resize_rows(rows.len());
+        let mut staged = self.rows.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "failed to acquire transaction prepared rows",
+            )
+        })?;
+        let existing_is_empty = match &*staged {
+            StagedPreparedRows::AppendOnly { rows, .. }
+            | StagedPreparedRows::Indexed { rows, .. } => rows.is_empty(),
+        };
+        if !existing_is_empty {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "cannot lower immutable mutations over existing prepared rows",
+            ));
+        }
+        *staged = StagedPreparedRows::AppendOnly {
+            rows,
+            insert_selection,
+            last_key,
+        };
+        Ok(())
     }
 
     pub(crate) fn is_file_cohort_eligible(&self, branch_id: &str) -> bool {
@@ -1002,6 +1796,12 @@ impl TransactionWriteBuffer {
                 "failed to acquire transaction staged writes lock",
             )
         })?;
+        let ordered_mutations = self.ordered_mutations.lock().map_err(|_| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "failed to acquire immutable transaction mutation journal",
+            )
+        })?;
         let file_data_writes = self.file_data_writes.lock().map_err(|_| {
             LixError::new(
                 "LIX_ERROR_UNKNOWN",
@@ -1046,6 +1846,7 @@ impl TransactionWriteBuffer {
 
         Ok(TransactionWriteBufferCheckpoint {
             rows: rows.clone(),
+            ordered_mutations: ordered_mutations.clone(),
             commit_change_refs_by_branch: commit_change_refs_by_branch.clone(),
             first_commit_parent_override_by_branch: first_commit_parent_override_by_branch.clone(),
             checkpoint_publications: checkpoint_publications.clone(),
@@ -1064,6 +1865,7 @@ impl TransactionWriteBuffer {
     ) -> Result<(), LixError> {
         let TransactionWriteBufferCheckpoint {
             rows,
+            ordered_mutations,
             commit_change_refs_by_branch,
             first_commit_parent_override_by_branch,
             checkpoint_publications,
@@ -1075,6 +1877,12 @@ impl TransactionWriteBuffer {
             LixError::new(
                 "LIX_ERROR_UNKNOWN",
                 "failed to acquire transaction staged writes lock",
+            )
+        })?;
+        let mut ordered_mutations_guard = self.ordered_mutations.lock().map_err(|_| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "failed to acquire immutable transaction mutation journal",
             )
         })?;
         let mut file_data_guard = self.file_data_writes.lock().map_err(|_| {
@@ -1120,6 +1928,7 @@ impl TransactionWriteBuffer {
             })?;
 
         *rows_guard = rows;
+        *ordered_mutations_guard = ordered_mutations;
         *file_data_guard = file_data_writes;
         *commit_change_refs_guard = commit_change_refs_by_branch;
         *extra_parents_guard = extra_commit_parents_by_branch;
@@ -1535,6 +2344,12 @@ impl TransactionWriteBuffer {
                 "failed to acquire transaction staged writes lock",
             )
         })?;
+        let mut ordered_mutations_guard = self.ordered_mutations.lock().map_err(|_| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "failed to acquire immutable transaction mutation journal",
+            )
+        })?;
         let mut file_data_guard = self.file_data_writes.lock().map_err(|_| {
             LixError::new(
                 "LIX_ERROR_UNKNOWN",
@@ -1588,6 +2403,39 @@ impl TransactionWriteBuffer {
                 ..
             } => (rows, insert_selection),
         };
+        let ordered_replacement = std::mem::take(&mut *ordered_mutations_guard);
+        if ordered_replacement
+            .as_ref()
+            .is_some_and(|journal| journal.replacement_proof.is_none())
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "immutable mutation journal reached commit without complete-replacement certification",
+            ));
+        }
+        if ordered_replacement.is_some() && !state_rows.is_empty() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "immutable replacement journal overlaps generic prepared rows",
+            ));
+        }
+        if let Some(journal) = ordered_replacement {
+            let refs = commit_change_refs_guard
+                .get_mut(journal.branch_id())
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "immutable mutation journal has no commit membership",
+                    )
+                })?;
+            if refs.commit_id != journal.commit_id() {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "immutable mutation journal commit owner changed",
+                ));
+            }
+            refs.attach_ordered_mutation_journal(Arc::new(journal))?;
+        }
         Ok(PreparedWriteSet {
             state_rows,
             insert_selection,
@@ -1822,6 +2670,67 @@ impl TransactionWriteBuffer {
     pub(crate) fn staging_overlay(self: &Arc<Self>) -> Result<PreparedStateRowOverlay, LixError> {
         Ok(PreparedStateRowOverlay {
             staged_writes: Arc::clone(self),
+        })
+    }
+
+    /// Returns whether a staged row can override this exact tracked identity.
+    /// The normal monotonically ordered journal answers future identities from
+    /// its tail without building an index; irregular/overlapping transactions
+    /// already have the exact identity map.
+    pub(crate) fn staged_identity_may_affect(
+        &self,
+        branch_id: &str,
+        schema_key: &str,
+        file_id: Option<&str>,
+        entity_pk: &EntityPk,
+    ) -> Result<bool, LixError> {
+        let ordered = self.ordered_mutations.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "failed to acquire immutable transaction mutation journal",
+            )
+        })?;
+        if ordered.as_ref().is_some_and(|journal| {
+            ordered_mutation_journal_row(journal, branch_id, schema_key, file_id, entity_pk)
+                .is_some()
+        }) {
+            return Ok(true);
+        }
+        drop(ordered);
+        let rows = self.rows.lock().map_err(|_| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "failed to acquire transaction staged writes lock",
+            )
+        })?;
+        Ok(match &*rows {
+            StagedPreparedRows::AppendOnly { last_key, .. } => {
+                last_key.as_ref().is_some_and(|last_key| {
+                    compare_tracked_key_to_parts(last_key, schema_key, file_id, entity_pk)
+                        != std::cmp::Ordering::Less
+                })
+            }
+            StagedPreparedRows::Indexed { by_identity, .. } => {
+                by_identity.contains_key(&PreparedStateRowIdentity {
+                    schema_key: schema_key.into(),
+                    entity_pk: entity_pk.clone(),
+                    file_id: file_id.map(Into::into),
+                    branch_id: branch_id.into(),
+                })
+            }
+        })
+    }
+
+    pub(crate) fn has_staged_state_rows(&self) -> Result<bool, LixError> {
+        let rows = self.rows.lock().map_err(|_| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "failed to acquire transaction staged writes lock",
+            )
+        })?;
+        Ok(match &*rows {
+            StagedPreparedRows::AppendOnly { rows, .. }
+            | StagedPreparedRows::Indexed { rows, .. } => !rows.is_empty(),
         })
     }
 
@@ -2422,11 +3331,14 @@ impl PreparedStateRowOverlay {
             return Ok(MaterializedLiveStateBatch::default());
         }
 
+        let mut rows = MaterializedLiveStateBatchBuilder::with_capacity(0);
+        append_matching_ordered_mutations(&mut rows, &self.staged_writes, request)?;
+
         if self
             .staged_writes
             .append_only_scan_is_definitely_absent(request)?
         {
-            return Ok(MaterializedLiveStateBatch::default());
+            return Ok(rows.finish());
         }
 
         self.staged_writes.ensure_identity_index(false)?;
@@ -2443,13 +3355,17 @@ impl PreparedStateRowOverlay {
                 by_candidate,
                 ..
             } => (rows, by_identity, by_candidate),
-            StagedPreparedRows::AppendOnly { rows, .. } => {
-                debug_assert!(rows.is_empty(), "nonempty reads must promote the journal");
-                return Ok(MaterializedLiveStateBatch::default());
+            StagedPreparedRows::AppendOnly {
+                rows: staged_rows, ..
+            } => {
+                debug_assert!(
+                    staged_rows.is_empty(),
+                    "nonempty reads must promote the journal"
+                );
+                return Ok(rows.finish());
             }
         };
 
-        let mut rows = MaterializedLiveStateBatchBuilder::with_capacity(staged_rows.len());
         if let Some(slots) = by_candidate.slots_for_filter(&request.filter) {
             // `slots_for_filter` already selected these rows by schema and,
             // when present, entity primary key. Rechecking a large entity-PK
@@ -2526,14 +3442,14 @@ impl crate::live_state::StagedLiveStateRows for PreparedStateRowOverlay {
         if request.rows.is_empty() {
             return Ok(MaterializedLiveStateExactBatch::default());
         }
+        let mut builder = MaterializedLiveStateBatchBuilder::with_capacity(request.rows.len());
+        let mut slots =
+            load_ordered_mutation_exact_batch(&mut builder, &self.staged_writes, request)?;
         if self
             .staged_writes
             .append_only_exact_batch_is_definitely_absent(request)?
         {
-            return MaterializedLiveStateExactBatch::new(
-                MaterializedLiveStateBatch::default(),
-                vec![None; request.rows.len()],
-            );
+            return MaterializedLiveStateExactBatch::new(builder.finish(), slots);
         }
         self.staged_writes.ensure_identity_index(false)?;
         let rows_guard = self.staged_writes.rows.lock().map_err(|_| {
@@ -2548,38 +3464,35 @@ impl crate::live_state::StagedLiveStateRows for PreparedStateRowOverlay {
             } => (rows, by_identity),
             StagedPreparedRows::AppendOnly { rows, .. } => {
                 debug_assert!(rows.is_empty(), "nonempty reads must promote the journal");
-                return MaterializedLiveStateExactBatch::new(
-                    MaterializedLiveStateBatch::default(),
-                    vec![None; request.rows.len()],
-                );
+                return MaterializedLiveStateExactBatch::new(builder.finish(), slots);
             }
         };
-        let mut builder = MaterializedLiveStateBatchBuilder::with_capacity(request.rows.len());
-        let slots = request
-            .rows
-            .iter()
-            .map(|request_row| {
-                let identity = PreparedStateRowIdentity::from_exact_request(request_row);
-                let Some(RowSlot::State(index)) = by_identity.get(&identity).copied() else {
-                    return None;
-                };
-                let row = staged_rows.get(index)?;
-                if request
-                    .untracked
-                    .is_some_and(|untracked| row.untracked != untracked)
-                {
-                    return None;
-                }
-                if row.snapshot.is_none() && !request.include_tombstones {
-                    None
-                } else {
-                    Some(
-                        u32::try_from(push_prepared_materialized(&mut builder, row))
-                            .expect("staged exact batch ordinal must fit u32"),
-                    )
-                }
-            })
-            .collect();
+        for (request_index, request_row) in request.rows.iter().enumerate() {
+            if slots[request_index].is_some() {
+                continue;
+            }
+            let identity = PreparedStateRowIdentity::from_exact_request(request_row);
+            let Some(RowSlot::State(index)) = by_identity.get(&identity).copied() else {
+                continue;
+            };
+            let Some(row) = staged_rows.get(index) else {
+                continue;
+            };
+            if request
+                .untracked
+                .is_some_and(|untracked| row.untracked != untracked)
+            {
+                continue;
+            }
+            if row.snapshot.is_none() && !request.include_tombstones {
+                continue;
+            } else {
+                slots[request_index] = Some(
+                    u32::try_from(push_prepared_materialized(&mut builder, row))
+                        .expect("staged exact batch ordinal must fit u32"),
+                );
+            }
+        }
         MaterializedLiveStateExactBatch::new(builder.finish(), slots)
     }
 
@@ -2629,6 +3542,181 @@ impl crate::live_state::StagedLiveStateRows for PreparedStateRowOverlay {
         }
         Ok(false)
     }
+}
+
+fn ordered_mutation_journal_row<'a>(
+    journal: &'a OrderedMutationJournal,
+    branch_id: &str,
+    schema_key: &str,
+    file_id: Option<&str>,
+    entity_pk: &EntityPk,
+) -> Option<(&'a ImmutableMutationJournalChunk, usize)> {
+    if file_id.is_some() || journal.branch_id() != branch_id || journal.schema_key() != schema_key {
+        return None;
+    }
+    let chunk_index = journal.chunks.partition_point(|chunk| {
+        chunk
+            .entity_pks
+            .last()
+            .is_some_and(|last_entity_pk| last_entity_pk < entity_pk)
+    });
+    let chunk = journal.chunks.get(chunk_index)?;
+    chunk
+        .entity_pks
+        .binary_search(entity_pk)
+        .ok()
+        .map(|index| (chunk, index))
+}
+
+fn push_ordered_mutation_materialized(
+    output: &mut MaterializedLiveStateBatchBuilder,
+    journal: &OrderedMutationJournal,
+    chunk: &ImmutableMutationJournalChunk,
+    row_index: usize,
+) -> Result<usize, LixError> {
+    let snapshot = chunk.snapshot(row_index);
+    let snapshot =
+        SharedStr::from_utf8_slice(chunk.snapshot_arena.clone(), snapshot).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "immutable mutation snapshot escaped its shared arena",
+            )
+        })?;
+    let created_at = if let Some(created_at) = journal.overlay_uniform_created_at {
+        created_at
+    } else {
+        chunk
+            .durable_predecessors
+            .as_ref()
+            .and_then(|predecessors| predecessors.get(row_index))
+            .map(CertifiedCurrentStatePredecessor::created_at)
+            .transpose()?
+            .unwrap_or_else(|| chunk.timestamp())
+    };
+    let ordinal = output.push_materialized_ref(
+        chunk.entity_pk(row_index),
+        chunk.schema_key(),
+        None,
+        Some(snapshot),
+        None,
+        false,
+        created_at,
+        chunk.timestamp(),
+        false,
+        None,
+        Some(journal.commit_id()),
+        false,
+        chunk.branch_id(),
+    );
+    if let Some(predecessor) = chunk
+        .durable_predecessors
+        .as_ref()
+        .and_then(|predecessors| predecessors.get(row_index))
+    {
+        output.set_durable_predecessor(ordinal, predecessor.clone());
+    }
+    Ok(ordinal)
+}
+
+fn append_matching_ordered_mutations(
+    output: &mut MaterializedLiveStateBatchBuilder,
+    staged_writes: &TransactionWriteBuffer,
+    request: &LiveStateScanRequest,
+) -> Result<(), LixError> {
+    let ordered = staged_writes.ordered_mutations.lock().map_err(|_| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "failed to acquire immutable transaction mutation journal",
+        )
+    })?;
+    let Some(journal) = ordered.as_ref() else {
+        return Ok(());
+    };
+    if request.filter.untracked == Some(true)
+        || (!request.filter.schema_keys.is_empty()
+            && !request
+                .filter
+                .schema_keys
+                .iter()
+                .any(|schema_key| schema_key == journal.schema_key()))
+        || (!request.filter.branch_ids.is_empty()
+            && !request
+                .filter
+                .branch_ids
+                .iter()
+                .any(|branch_id| branch_id == journal.branch_id()))
+        || !nullable_key_matches_filters(None, &request.filter.file_ids)
+    {
+        return Ok(());
+    }
+    if request.filter.entity_pks.is_empty() {
+        for chunk in journal.chunks.iter() {
+            for row_index in 0..chunk.len() {
+                push_ordered_mutation_materialized(output, journal, chunk, row_index)?;
+            }
+        }
+        return Ok(());
+    }
+
+    // Preserve the journal's identity order while routing each requested key
+    // through the chunk directory. This avoids the previous O(journal rows ×
+    // requested keys) membership loop for large IN predicates.
+    let mut requested = request.filter.entity_pks.iter().collect::<Vec<_>>();
+    requested.sort_unstable();
+    requested.dedup();
+    for entity_pk in requested {
+        let Some((chunk, row_index)) = ordered_mutation_journal_row(
+            journal,
+            journal.branch_id(),
+            journal.schema_key(),
+            None,
+            entity_pk,
+        ) else {
+            continue;
+        };
+        push_ordered_mutation_materialized(output, journal, chunk, row_index)?;
+    }
+    Ok(())
+}
+
+fn load_ordered_mutation_exact_batch(
+    output: &mut MaterializedLiveStateBatchBuilder,
+    staged_writes: &TransactionWriteBuffer,
+    request: &LiveStateExactBatchRequest,
+) -> Result<Vec<Option<u32>>, LixError> {
+    let ordered = staged_writes.ordered_mutations.lock().map_err(|_| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "failed to acquire immutable transaction mutation journal",
+        )
+    })?;
+    let Some(journal) = ordered.as_ref() else {
+        return Ok(vec![None; request.rows.len()]);
+    };
+    request
+        .rows
+        .iter()
+        .map(|request_row| {
+            if request.untracked == Some(true) {
+                return Ok(None);
+            }
+            let Some((chunk, row_index)) = ordered_mutation_journal_row(
+                journal,
+                &request_row.branch_id,
+                &request_row.schema_key,
+                request_row.file_id.as_deref(),
+                &request_row.entity_pk,
+            ) else {
+                return Ok(None);
+            };
+            Ok(Some(
+                u32::try_from(push_ordered_mutation_materialized(
+                    output, journal, chunk, row_index,
+                )?)
+                .expect("staged exact batch ordinal must fit u32"),
+            ))
+        })
+        .collect()
 }
 
 /// Answers the uncommon collection-generation probe directly from the sorted
@@ -4962,9 +6050,9 @@ mod tests {
             test_uuid_value(self.uuid_count)
         }
 
-        fn timestamp(&mut self) -> crate::common::LixTimestamp {
+        fn timestamp(&mut self) -> LixTimestamp {
             self.timestamp_count += 1;
-            crate::common::LixTimestamp::expect_parse(
+            LixTimestamp::expect_parse(
                 "timestamp",
                 &format!("2026-01-01T00:00:00.{:03}Z", self.timestamp_count),
             )
@@ -4995,7 +6083,7 @@ mod tests {
         .expect("test snapshot should prepare");
         TestPreparedStateRow {
             schema_plan_id: SchemaPlanId::for_test(0),
-            facts: crate::transaction::types::PreparedRowFacts::default(),
+            facts: PreparedRowFacts::default(),
             entity_pk: EntityPk::single(key),
             schema_key: "lix_key_value".into(),
             file_id: None,
@@ -5003,14 +6091,8 @@ mod tests {
             metadata: None,
             origin: None,
             origin_key: None,
-            created_at: crate::common::LixTimestamp::expect_parse(
-                "created_at",
-                "2026-01-01T00:00:00.000Z",
-            ),
-            updated_at: crate::common::LixTimestamp::expect_parse(
-                "updated_at",
-                "2026-01-01T00:00:00.000Z",
-            ),
+            created_at: LixTimestamp::expect_parse("created_at", "2026-01-01T00:00:00.000Z"),
+            updated_at: LixTimestamp::expect_parse("updated_at", "2026-01-01T00:00:00.000Z"),
             global: true,
             change_id: None,
             commit_id: None,

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -3703,6 +3703,10 @@ pub(crate) struct StagedCommitChangeRefs {
     /// separate so staging/finalization clones only `Arc` owners rather than
     /// copying schema/file/entity or metadata columns.
     selected_change_batches: Vec<StagedCommitChangeBatch>,
+    /// Certified immutable mutation columns for this commit. This owner is
+    /// attached only at drain, after complete-replacement certification, and
+    /// is cloned through commit finalization in O(1).
+    ordered_mutation_journal: Option<Arc<crate::transaction::staging::OrderedMutationJournal>>,
     pub(crate) allow_empty: bool,
 }
 
@@ -3715,6 +3719,7 @@ impl Default for StagedCommitChangeRefs {
             created_at: LixTimestamp::expect_parse("created_at", "1970-01-01T00:00:00.000Z"),
             tracked_change_count: 0,
             selected_change_batches: Vec::new(),
+            ordered_mutation_journal: None,
             allow_empty: false,
         }
     }
@@ -3722,6 +3727,10 @@ impl Default for StagedCommitChangeRefs {
 
 impl StagedCommitChangeRefs {
     pub(crate) fn absorb_cohort_membership(&mut self, mut other: Self) {
+        debug_assert!(
+            self.ordered_mutation_journal.is_none() && other.ordered_mutation_journal.is_none(),
+            "immutable replacement journals cannot join commit cohorts"
+        );
         self.tracked_change_count = self
             .tracked_change_count
             .saturating_add(other.tracked_change_count);
@@ -3925,6 +3934,31 @@ impl<'a> StagedCommitChangeRef<'a> {
 }
 
 impl StagedCommitChangeRefs {
+    pub(crate) fn attach_ordered_mutation_journal(
+        &mut self,
+        journal: Arc<crate::transaction::staging::OrderedMutationJournal>,
+    ) -> Result<(), LixError> {
+        if self.ordered_mutation_journal.replace(journal).is_some() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "commit received more than one immutable mutation journal",
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn ordered_mutation_journal(
+        &self,
+    ) -> Option<&Arc<crate::transaction::staging::OrderedMutationJournal>> {
+        self.ordered_mutation_journal.as_ref()
+    }
+
+    pub(crate) fn take_ordered_mutation_journal(
+        &mut self,
+    ) -> Option<Arc<crate::transaction::staging::OrderedMutationJournal>> {
+        self.ordered_mutation_journal.take()
+    }
+
     pub(crate) fn new(
         commit_id: CommitId,
         commit_change_id: ChangeId,
@@ -3938,6 +3972,7 @@ impl StagedCommitChangeRefs {
             created_at,
             tracked_change_count: 0,
             selected_change_batches: Vec::new(),
+            ordered_mutation_journal: None,
             allow_empty: false,
         }
     }


### PR DESCRIPTION
## What changed

- make typed immutable journal chunks the transaction authority for eligible ordered scalar JSON-pointer updates
- reuse the prepared literal shape from the first statement and append scalar calls into shared column buffers
- serve read-your-writes directly from the journal, with logarithmic chunk routing for point and multi-key reads
- preserve lifecycle metadata from certified manifest summaries or bulk-hydrated opening predecessors
- encode #1158 replacement parts directly from borrowed journal columns without reconstructing `PreparedStateBatch`
- keep dependent, partial, stale-head, and unsupported writes on the lifecycle-safe generic lane

## Why

The previous path converted scalar SQL parameters into row-owned writes, reconstructed prepared state, and then encoded immutable replacement parts at commit. At 1M rows those ownership conversions and generic staging costs dominated UPDATE latency.

This cut makes the in-flight columnar journal the direct precursor to the immutable mutation inventory and atomic `CommitStateManifest` publication.

## Performance

Sequential literal UPDATEs in one explicit transaction, compared with merged #1168 using the same fixture and benchmark boundary:

| Backend / rows | #1168 | This PR | Change |
| --- | ---: | ---: | ---: |
| RocksDB / 10K | 60.92 ms | 42.26 ms | **-30.6%** |
| SlateDB / 10K | 60.28 ms | 42.98 ms | **-28.7%** |
| RocksDB / 1M | 3.043 s | 1.749 s | **-42.5%** |
| SlateDB / 1M | 3.118 s | 1.814 s | **-41.8%** |

The stricter prepared raw-SQLite 1M baseline is 871 ms, so UPDATE remains about 2.0-2.1x slower and needs another cut to reach the 1.2x goal.

## Validation

- `cargo test -p lix_engine --lib --quiet` — 1,831 passed, 8 ignored
- `cargo check -p lix_sdk --test send_futures --quiet`
- `cargo clippy --workspace --all-targets`
- focused lifecycle, stale-head, dependent-write, read-your-writes, and three-chunk routing tests
- two independent extra-high review passes, both approved with no blockers

No changenote: this is an internal engine/storage-layout optimization with no compatibility contract.
