### PR TITLE
Cut scalar UPDATE journal ingress overhead

### DIFF
--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -2,8 +2,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
 use std::ops::ControlFlow;
 use std::ops::Range;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, OnceLock};
 
 use crate::binary_cas::BlobId;
 use crate::branch::BranchRefReader;
@@ -78,7 +78,9 @@ impl LiteralParameterBuilder {
 /// so observation fanout does not copy large blob values per subscriber.
 #[derive(Debug, Clone)]
 pub struct ExecuteResult {
-    backing: Arc<ExecuteResultBacking>,
+    /// Mutation results without RETURNING carry no row backing. Keeping the
+    /// empty case inline avoids one Arc clone/drop pair for every scalar write.
+    backing: Option<Arc<ExecuteResultBacking>>,
     rows_affected: u64,
 }
 
@@ -96,10 +98,12 @@ struct ExecuteResultBacking {
 impl PartialEq for ExecuteResult {
     fn eq(&self, other: &Self) -> bool {
         self.rows_affected == other.rows_affected
-            && (Arc::ptr_eq(&self.backing, &other.backing)
-                || (self.backing.columns == other.backing.columns
-                    && self.backing.rows == other.backing.rows
-                    && self.backing.notices == other.backing.notices))
+            && (matches!(
+                (&self.backing, &other.backing),
+                (Some(left), Some(right)) if Arc::ptr_eq(left, right)
+            ) || (self.columns() == other.columns()
+                && self.rows() == other.rows()
+                && self.notices() == other.notices()))
     }
 }
 
@@ -177,7 +181,7 @@ impl ExecuteResult {
 
     pub fn from_rows_affected(rows_affected: u64) -> Self {
         Self {
-            backing: empty_execute_result_backing(),
+            backing: None,
             rows_affected,
         }
     }
@@ -210,53 +214,68 @@ impl ExecuteResult {
             })
             .collect();
         Self {
-            backing: Arc::new(ExecuteResultBacking {
+            backing: Some(Arc::new(ExecuteResultBacking {
                 columns,
                 rows,
                 notices,
                 file_view_mutations: Vec::new(),
-            }),
+            })),
             rows_affected,
         }
     }
 
     fn with_file_view_mutations(mut self, mutations: Vec<sql2::SessionFileViewMutation>) -> Self {
-        Arc::get_mut(&mut self.backing)
+        let backing = self.backing.get_or_insert_with(|| {
+            Arc::new(ExecuteResultBacking {
+                columns: Vec::new().into(),
+                rows: Vec::new(),
+                notices: Vec::new(),
+                file_view_mutations: Vec::new(),
+            })
+        });
+        Arc::get_mut(backing)
             .expect("fresh execute result backing must be uniquely owned")
             .file_view_mutations = mutations;
         self
     }
 
     pub(crate) fn file_view_mutations(&self) -> &[sql2::SessionFileViewMutation] {
-        &self.backing.file_view_mutations
+        self.backing
+            .as_deref()
+            .map_or(&[], |backing| backing.file_view_mutations.as_slice())
     }
 
     /// Returns the result-set column names in row value order.
     pub fn columns(&self) -> &[String] {
-        self.backing.columns.as_ref()
+        self.backing
+            .as_deref()
+            .map_or(&[], |backing| backing.columns.as_ref())
     }
 
     /// Returns the owned rows. Use `iter()` for name-based access.
     pub fn rows(&self) -> &[Row] {
-        &self.backing.rows
+        self.backing
+            .as_deref()
+            .map_or(&[], |backing| backing.rows.as_slice())
     }
 
     /// Iterates rows with borrowed access to the shared column metadata.
     pub fn iter(&self) -> impl Iterator<Item = RowRef<'_>> {
-        self.backing.rows.iter().map(|row| RowRef {
-            columns: self.backing.columns.as_ref(),
+        let columns = self.columns();
+        self.rows().iter().map(move |row| RowRef {
+            columns,
             values: row.values.as_slice(),
         })
     }
 
     /// Returns the number of rows in this result set.
     pub fn len(&self) -> usize {
-        self.backing.rows.len()
+        self.rows().len()
     }
 
     /// Returns true when this result set has no rows.
     pub fn is_empty(&self) -> bool {
-        self.backing.rows.is_empty()
+        self.rows().is_empty()
     }
 
     /// Returns the number of rows affected by a mutation statement.
@@ -266,7 +285,9 @@ impl ExecuteResult {
 
     /// Returns non-fatal diagnostics produced while executing the statement.
     pub fn notices(&self) -> &[LixNotice] {
-        &self.backing.notices
+        self.backing
+            .as_deref()
+            .map_or(&[], |backing| backing.notices.as_slice())
     }
 
     /// Looks up the value for `column_name` on an owned row from this set.
@@ -277,23 +298,10 @@ impl ExecuteResult {
 
     /// Returns the index for a column name.
     pub fn column_index(&self, column_name: &str) -> Option<usize> {
-        self.backing
-            .columns
+        self.columns()
             .iter()
             .position(|column| column == column_name)
     }
-}
-
-fn empty_execute_result_backing() -> Arc<ExecuteResultBacking> {
-    static EMPTY: OnceLock<Arc<ExecuteResultBacking>> = OnceLock::new();
-    Arc::clone(EMPTY.get_or_init(|| {
-        Arc::new(ExecuteResultBacking {
-            columns: Vec::new().into(),
-            rows: Vec::new(),
-            notices: Vec::new(),
-            file_view_mutations: Vec::new(),
-        })
-    }))
 }
 
 /// One owned row returned by a query.
@@ -2563,43 +2571,41 @@ where
             SqlStatementTelemetry::start(self.telemetry.as_ref(), sql, "transaction", None);
         let may_reuse_literal_shape = self.has_started_statement;
         self.has_started_statement = true;
+        // The explicit write lease already keeps one transaction operation
+        // active for this handle's lifetime, and `&mut self` excludes an
+        // overlapping execute or commit. A second manager guard per statement
+        // only repeated mutex/Notify traffic without adding a state boundary.
         let operation = async {
-            let _operation_guard = self.begin_session_operation()?;
             if may_reuse_literal_shape
                 && params.is_empty()
-                && let Some(parameter_count) = self.transaction.as_ref().and_then(|transaction| {
-                    transaction.prepared_literal_mutation_parameter_count(sql)
-                })
+                && let Some((normalized_shape, parameter_count)) = self
+                    .transaction
+                    .as_ref()
+                    .and_then(|transaction| transaction.prepared_literal_mutation_shape())
             {
-                if self.prepared_literal_params.len() != parameter_count {
-                    self.prepared_literal_params.clear();
-                    self.prepared_literal_params
-                        .resize_with(parameter_count, || Value::Text(String::new()));
-                }
-                if self
-                    .sql_planning_cache
-                    .decode_certified_update_literals_into_values(
+                if let Some(decoded_values) =
+                    self.sql_planning_cache.decode_update_literals_for_shape(
                         sql,
-                        &mut self.prepared_literal_params,
+                        normalized_shape,
+                        parameter_count,
+                        &mut self.prepared_literal_escape_scratch,
                     )
                 {
-                    let (transaction_slot, prepared_params) =
-                        (&mut self.transaction, &self.prepared_literal_params);
-                    let transaction = transaction_slot
+                    let transaction = self
+                        .transaction
                         .as_mut()
                         .ok_or_else(|| transaction_state_error("Lix transaction is closed"))?;
-                    transaction
-                        .flush_cached_prepared_mutation_barrier(
-                            options.origin_key.as_deref(),
-                            prepared_params,
-                        )
-                        .await?;
-                    let previous_origin_key =
-                        transaction.replace_origin_key(options.origin_key.clone());
                     let result = transaction
-                        .try_execute_cached_prepared_mutation(prepared_params)
+                        .try_execute_cached_literal_prepared_mutation(
+                            options.origin_key.as_deref(),
+                            &decoded_values,
+                        )
                         .await;
-                    transaction.replace_origin_key(previous_origin_key);
+                    for (index, value) in decoded_values.into_iter().enumerate() {
+                        if let std::borrow::Cow::Owned(value) = value {
+                            self.prepared_literal_escape_scratch[index] = value;
+                        }
+                    }
                     match result {
                         Ok(Some(result)) => {
                             return Ok(ExecuteResult::from_sql_write_result(result));
@@ -8349,8 +8355,19 @@ mod tests {
         );
         let cloned = result.clone();
 
-        assert!(Arc::ptr_eq(&result.backing, &cloned.backing));
+        assert!(Arc::ptr_eq(
+            result.backing.as_ref().unwrap(),
+            cloned.backing.as_ref().unwrap()
+        ));
         assert_eq!(result, cloned);
+    }
+
+    #[test]
+    fn mutation_result_equality_is_independent_of_empty_backing_representation() {
+        let inline = ExecuteResult::from_rows_affected(7);
+        let materialized = ExecuteResult::from_query_parts(Vec::new(), Vec::new(), 7, Vec::new());
+
+        assert_eq!(inline, materialized);
     }
 
     #[test]

--- a/packages/engine/src/session/transaction.rs
+++ b/packages/engine/src/session/transaction.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
-use crate::Value;
+use smallvec::SmallVec;
+
 use crate::catalog::CatalogFingerprint;
 use crate::functions::{DeterministicRuntimeGuard, FunctionContext};
 use crate::observe_invalidation::ObserveInvalidation;
@@ -33,7 +34,9 @@ pub struct SessionTransaction<StorageImpl: Storage + 'static = Memory> {
     commit_coordinator: Arc<CommitCoordinator<StorageImpl>>,
     pub(super) telemetry: Option<Arc<dyn TelemetrySink>>,
     pub(super) has_started_statement: bool,
-    pub(super) prepared_literal_params: Vec<Value>,
+    /// Reusable storage only for SQL literals containing doubled quote
+    /// escapes. Ordinary warm literals continue to borrow the SQL text.
+    pub(super) prepared_literal_escape_scratch: SmallVec<[String; 4]>,
 }
 
 impl<StorageImpl> SessionContext<StorageImpl>
@@ -92,7 +95,7 @@ where
             commit_coordinator: Arc::clone(&self.commit_coordinator),
             telemetry: self.telemetry.clone(),
             has_started_statement: false,
-            prepared_literal_params: Vec::new(),
+            prepared_literal_escape_scratch: SmallVec::new(),
         })
     }
 }
@@ -160,6 +163,7 @@ where
         self.transaction_manager.ensure_open()
     }
 
+    #[cfg(test)]
     pub(super) fn begin_session_operation(&self) -> Result<SessionOperationGuard, LixError> {
         self.transaction_manager.begin_transaction_operation()
     }
@@ -328,6 +332,7 @@ impl SessionTransactionManager {
         }
     }
 
+    #[cfg(test)]
     pub(super) fn begin_transaction_operation(&self) -> Result<SessionOperationGuard, LixError> {
         self.begin_operation(SessionOperationScope::Transaction)
     }
@@ -556,6 +561,7 @@ impl SessionTransactionState {
                 owner,
             } => match scope {
                 SessionOperationScope::Session => Err(active_transaction_error()),
+                #[cfg(test)]
                 SessionOperationScope::Transaction => {
                     *active_operations += 1;
                     Ok(())
@@ -655,6 +661,7 @@ impl SessionTransactionState {
 #[derive(Clone, Copy)]
 enum SessionOperationScope {
     Session,
+    #[cfg(test)]
     Transaction,
     TransactionCommit,
 }

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -4,7 +4,7 @@ use datafusion::arrow::array::{Array, BooleanArray, LargeStringArray, StringArra
 use datafusion::arrow::datatypes::DataType;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::ScalarValue;
-use serde_json::{Value as JsonValue, value::RawValue};
+use serde_json::Value as JsonValue;
 use tracing::Instrument;
 
 use crate::catalog::{SchemaPlanId, TypedJsonScalarRef};
@@ -1403,21 +1403,12 @@ fn append_direct_path_value_replacement_json_text(
 
 /// Appends a `lix_json` parameter in serde_json's stable compact form.
 ///
-/// Public parameters do not carry a canonical-JSON type certificate, but the
-/// common path is already produced by `JSON.stringify` or `serde_json`. A
-/// borrowed `RawValue` validates that input without building a DOM. The small
-/// lexical recognizer then proves that parsing into `Value` and serializing it
-/// would leave every byte unchanged: object keys are ordered, strings use the
-/// serializer's preferred escapes, and numbers are exact in-range integers.
-/// Inputs outside that deliberately narrow proof retain the canonical DOM
-/// fallback and therefore preserve existing SQL semantics.
+/// Public parameters do not carry a canonical-JSON type certificate. The
+/// streaming recognizer proves already-canonical input in one allocation-free
+/// scan. Noncanonical object order is reparsed into sorted compact bytes,
+/// without the former redundant serde validation scan. Inputs outside this
+/// deliberately narrow scalar grammar retain the canonical DOM fallback.
 fn append_canonical_json_parameter(normalized: &mut Vec<u8>, raw: &str) -> Result<(), LixError> {
-    serde_json::from_str::<&RawValue>(raw).map_err(|error| {
-        LixError::new(
-            LixError::CODE_TYPE_MISMATCH,
-            format!("lix_json argument is not valid JSON: {error}"),
-        )
-    })?;
     if CanonicalJsonText::recognizes(raw) {
         normalized.extend_from_slice(raw.as_bytes());
         return Ok(());
@@ -1444,13 +1435,18 @@ fn append_canonical_json_parameter(normalized: &mut Vec<u8>, raw: &str) -> Resul
 struct CanonicalJsonText<'a> {
     bytes: &'a [u8],
     position: usize,
+    remaining_depth: u8,
 }
 
 impl<'a> CanonicalJsonText<'a> {
+    // serde_json's default recursion limit rejects the 128th nested container.
+    const MAX_DEPTH: u8 = 127;
+
     fn recognizes(raw: &'a str) -> bool {
         let mut parser = Self {
             bytes: raw.as_bytes(),
             position: 0,
+            remaining_depth: Self::MAX_DEPTH,
         };
         parser.value() && parser.position == parser.bytes.len()
     }
@@ -1459,6 +1455,7 @@ impl<'a> CanonicalJsonText<'a> {
         let mut parser = Self {
             bytes: raw.as_bytes(),
             position: 0,
+            remaining_depth: Self::MAX_DEPTH,
         };
         parser.write_value(output) && parser.position == parser.bytes.len()
     }
@@ -1469,8 +1466,8 @@ impl<'a> CanonicalJsonText<'a> {
             Some(b't') => self.literal(b"true"),
             Some(b'f') => self.literal(b"false"),
             Some(b'"') => self.string(false).is_some(),
-            Some(b'[') => self.array(),
-            Some(b'{') => self.object(),
+            Some(b'[') => self.with_container_depth(Self::array),
+            Some(b'{') => self.with_container_depth(Self::object),
             Some(b'-' | b'0'..=b'9') => self.integer(),
             _ => false,
         }
@@ -1540,6 +1537,10 @@ impl<'a> CanonicalJsonText<'a> {
     }
 
     fn write_array(&mut self, output: &mut Vec<u8>) -> bool {
+        self.with_container_depth(|parser| parser.write_array_inner(output))
+    }
+
+    fn write_array_inner(&mut self, output: &mut Vec<u8>) -> bool {
         self.position += 1;
         output.push(b'[');
         if self.take(b']') {
@@ -1566,6 +1567,10 @@ impl<'a> CanonicalJsonText<'a> {
     }
 
     fn write_object(&mut self, output: &mut Vec<u8>) -> bool {
+        self.with_container_depth(|parser| parser.write_object_inner(output))
+    }
+
+    fn write_object_inner(&mut self, output: &mut Vec<u8>) -> bool {
         self.position += 1;
         if self.take(b'}') {
             output.extend_from_slice(b"{}");
@@ -1607,6 +1612,7 @@ impl<'a> CanonicalJsonText<'a> {
             let mut value_parser = Self {
                 bytes: value,
                 position: 0,
+                remaining_depth: self.remaining_depth,
             };
             if !value_parser.write_value(output) || value_parser.position != value.len() {
                 return false;
@@ -1630,6 +1636,10 @@ impl<'a> CanonicalJsonText<'a> {
     }
 
     fn skip_array(&mut self) -> bool {
+        self.with_container_depth(Self::skip_array_inner)
+    }
+
+    fn skip_array_inner(&mut self) -> bool {
         self.position += 1;
         if self.take(b']') {
             return true;
@@ -1648,6 +1658,10 @@ impl<'a> CanonicalJsonText<'a> {
     }
 
     fn skip_object(&mut self) -> bool {
+        self.with_container_depth(Self::skip_object_inner)
+    }
+
+    fn skip_object_inner(&mut self) -> bool {
         self.position += 1;
         if self.take(b'}') {
             return true;
@@ -1663,6 +1677,16 @@ impl<'a> CanonicalJsonText<'a> {
                 return false;
             }
         }
+    }
+
+    fn with_container_depth(&mut self, parse: impl FnOnce(&mut Self) -> bool) -> bool {
+        let Some(remaining_depth) = self.remaining_depth.checked_sub(1) else {
+            return false;
+        };
+        self.remaining_depth = remaining_depth;
+        let result = parse(self);
+        self.remaining_depth = self.remaining_depth.saturating_add(1);
+        result
     }
 
     fn string(&mut self, reject_escapes: bool) -> Option<&'a [u8]> {
@@ -1691,6 +1715,7 @@ impl<'a> CanonicalJsonText<'a> {
                         _ => return None,
                     }
                 }
+                0x00..=0x1f => return None,
                 _ => self.position += 1,
             }
         }
@@ -2800,6 +2825,36 @@ impl PreparedPathValueReplacementProgram {
         };
         Ok(primary_key)
     }
+
+    pub(crate) fn primary_key_text<'a>(
+        &self,
+        params: &'a [impl AsRef<str>],
+    ) -> Result<&'a str, LixError> {
+        params
+            .get(self.primary_key_param_index)
+            .map(AsRef::as_ref)
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INVALID_PARAM,
+                    "prepared path replacement primary key text is missing",
+                )
+            })
+    }
+
+    pub(crate) fn replacement_value_text<'a>(
+        &self,
+        params: &'a [impl AsRef<str>],
+    ) -> Result<&'a str, LixError> {
+        params
+            .get(self.value_param_index)
+            .map(AsRef::as_ref)
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INVALID_PARAM,
+                    "prepared path replacement value text is missing",
+                )
+            })
+    }
 }
 
 pub(crate) fn prepare_path_value_replacement_program_from_logical(
@@ -2973,6 +3028,14 @@ pub(crate) fn append_path_value_replacement_snapshot(
             ));
         }
     };
+    append_path_value_replacement_snapshot_text(primary_key, replacement_value, normalized)
+}
+
+pub(crate) fn append_path_value_replacement_snapshot_text(
+    primary_key: &str,
+    replacement_value: Option<&str>,
+    normalized: &mut Vec<u8>,
+) -> Result<(usize, usize), LixError> {
     let start = normalized.len();
     normalized.extend_from_slice(b"{\"path\":");
     if let Err(error) = append_canonical_json_string(normalized, primary_key) {
@@ -6882,7 +6945,7 @@ mod primary_key_route_tests {
     }
 
     #[test]
-    fn recognizes_only_json_text_unchanged_by_serde_value_roundtrip() {
+    fn streaming_json_canonicalizer_matches_serde_for_supported_text() {
         let canonical = [
             "null",
             "true",
@@ -6896,12 +6959,10 @@ mod primary_key_route_tests {
             r#"{"a":1,"b":{"c":"value"},"z":null}"#,
         ];
         for raw in canonical {
-            assert!(
-                CanonicalJsonText::recognizes(raw),
-                "expected {raw} to route"
-            );
+            let mut actual = Vec::new();
+            assert!(CanonicalJsonText::append_normalized(raw, &mut actual));
             let parsed: JsonValue = serde_json::from_str(raw).unwrap();
-            assert_eq!(serde_json::to_string(&parsed).unwrap(), raw);
+            assert_eq!(actual, serde_json::to_vec(&parsed).unwrap());
         }
 
         for raw in [
@@ -6911,21 +6972,54 @@ mod primary_key_route_tests {
             "1.0",
             "1e2",
             "18446744073709551616",
+            "\"literal\ncontrol\"",
             r#""unicode \u0061""#,
             r#""escaped\/slash""#,
-            r#"{"b":1,"a":2}"#,
             r#"{"a":1,"a":2}"#,
             r#"{"escaped\u0061":1}"#,
         ] {
-            assert!(
-                !CanonicalJsonText::recognizes(raw),
-                "expected {raw} to retain DOM canonicalization"
-            );
+            let mut actual = Vec::new();
+            assert!(!CanonicalJsonText::append_normalized(raw, &mut actual));
         }
     }
 
     #[test]
-    fn canonical_json_parameter_fallback_preserves_existing_normalization() {
+    fn streaming_json_recursion_limit_matches_serde_and_wide_canonical_objects_stay_direct() {
+        for depth in [127, 128, 129] {
+            let raw = format!("{}0{}", "[".repeat(depth), "]".repeat(depth));
+            assert_eq!(
+                CanonicalJsonText::recognizes(&raw),
+                serde_json::from_str::<JsonValue>(&raw).is_ok(),
+                "recognizer depth mismatch at {depth}"
+            );
+        }
+
+        let wide = format!(
+            "{{{}}}",
+            (0..16)
+                .map(|index| format!("\"k{index:02}\":{index}"))
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+        assert!(CanonicalJsonText::recognizes(&wide));
+        let mut actual = Vec::new();
+        append_canonical_json_parameter(&mut actual, &wide).unwrap();
+        assert_eq!(actual, wide.as_bytes());
+
+        let too_deep = format!(
+            "{}0{}",
+            "[".repeat(usize::from(CanonicalJsonText::MAX_DEPTH) + 1),
+            "]".repeat(usize::from(CanonicalJsonText::MAX_DEPTH) + 1)
+        );
+        assert!(!CanonicalJsonText::append_normalized(
+            &too_deep,
+            &mut Vec::new()
+        ));
+        assert!(append_canonical_json_parameter(&mut Vec::new(), &too_deep).is_err());
+    }
+
+    #[test]
+    fn canonical_json_parameter_preserves_existing_normalization() {
         for raw in [
             " { \"b\" : 1, \"a\" : 2 } ",
             r#"{"value":1.0,"escaped":"\u0061"}"#,

--- a/packages/engine/src/sql2/exec/mod.rs
+++ b/packages/engine/src/sql2/exec/mod.rs
@@ -127,6 +127,18 @@ pub(crate) fn append_path_value_replacement_snapshot(
     )
 }
 
+pub(crate) fn append_path_value_replacement_snapshot_text(
+    primary_key: &str,
+    replacement_value: Option<&str>,
+    normalized: &mut Vec<u8>,
+) -> Result<(usize, usize), crate::LixError> {
+    bound_public_write::append_path_value_replacement_snapshot_text(
+        primary_key,
+        replacement_value,
+        normalized,
+    )
+}
+
 #[cfg(test)]
 pub(crate) use bound_public_write::{
     take_certified_entity_insert_batch_executions,

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -59,8 +59,8 @@ pub(crate) use exec::{SessionReadSqlResult, SqlWriteResult};
 #[allow(unused_imports)]
 pub(crate) use exec::{
     SqlLogicalPlan, append_path_value_replacement_snapshot,
-    create_write_logical_plan_from_template, create_write_plan_template_from_parsed,
-    diff_command_query, execute_read_statement_from_parsed,
+    append_path_value_replacement_snapshot_text, create_write_logical_plan_from_template,
+    create_write_plan_template_from_parsed, diff_command_query, execute_read_statement_from_parsed,
     execute_read_statement_in_session_from_parsed, execute_transaction_read_statement_from_parsed,
     execute_write_logical_plan_parameter_batch, execute_write_logical_plan_result_with_metadata,
     execute_write_logical_plan_value_batch, parameter_record_batch, parameter_row,

--- a/packages/engine/src/sql2/planning_cache.rs
+++ b/packages/engine/src/sql2/planning_cache.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::hash::Hash;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex, MutexGuard};
@@ -7,6 +8,7 @@ use crate::sql2::plan::LogicalWritePlan;
 use crate::{LixError, Value};
 use datafusion::sql::parser::Statement as DataFusionStatement;
 use lru::LruCache;
+use smallvec::SmallVec;
 
 const PARSED_STATEMENT_CAPACITY: usize = 256;
 const PUBLIC_CATALOG_CAPACITY: usize = 16;
@@ -130,31 +132,25 @@ where
         decode_update_string_literals_into(sql, params)
     }
 
-    /// Decodes a shape-certified scalar UPDATE directly into reusable public
-    /// parameter slots. This is the scalar journal counterpart of the shared
-    /// batch decoder: no normalized SQL, AST clone, parameter vector, or
-    /// per-value string allocation is constructed for a warm statement.
-    pub(crate) fn decode_certified_update_literals_into_values(
+    /// Returns borrowed decoded string literals when a warm UPDATE still
+    /// matches its normalized shape. Ordinary literals borrow the caller's
+    /// SQL directly; SQL quote escapes allocate only the affected slot.
+    pub(crate) fn decode_update_literals_for_shape<'a>(
         &self,
-        sql: &str,
-        params: &mut [Value],
-    ) -> bool {
-        params.iter_mut().all(|param| match param {
-            Value::Text(value) => {
-                value.clear();
-                true
-            }
-            _ => false,
-        }) && decode_update_string_literals_with(sql, params.len(), |index, segment, escaped| {
-            let Some(Value::Text(value)) = params.get_mut(index) else {
-                return false;
-            };
-            value.push_str(segment);
-            if escaped {
-                value.push('\'');
-            }
-            true
-        })
+        sql: &'a str,
+        normalized_shape: &str,
+        parameter_count: usize,
+        escape_scratch: &mut SmallVec<[String; 4]>,
+    ) -> Option<SmallVec<[Cow<'a, str>; 4]>> {
+        if escape_scratch.len() < parameter_count {
+            escape_scratch.resize_with(parameter_count, String::new);
+        }
+        decode_update_string_literals_for_shape(
+            sql,
+            normalized_shape,
+            parameter_count,
+            escape_scratch,
+        )
     }
 
     /// Returns stable public-surface metadata for one catalog generation.
@@ -415,6 +411,142 @@ fn update_string_literals_match_shape(sql: &str, normalized_shape: &str) -> bool
     !quoted_identifier && param_count > 0 && shape.get(shape_cursor..) == Some(&bytes[copied..])
 }
 
+enum DecodedUpdateLiteral<'a> {
+    Borrowed(&'a str),
+    Escaped(usize),
+}
+
+fn decode_update_string_literals_for_shape<'a>(
+    sql: &'a str,
+    normalized_shape: &str,
+    parameter_count: usize,
+    escape_scratch: &mut [String],
+) -> Option<SmallVec<[Cow<'a, str>; 4]>> {
+    let trimmed = sql.trim_start();
+    let update = trimmed.get(.."UPDATE".len())?;
+    if !update.eq_ignore_ascii_case("UPDATE")
+        || !trimmed
+            .as_bytes()
+            .get("UPDATE".len())
+            .is_some_and(u8::is_ascii_whitespace)
+    {
+        return None;
+    }
+
+    let bytes = sql.as_bytes();
+    let shape = normalized_shape.as_bytes();
+    let mut cursor = 0;
+    let mut copied = 0;
+    let mut shape_cursor = 0;
+    let mut quoted_identifier = false;
+    let mut decoded = SmallVec::<[DecodedUpdateLiteral<'a>; 4]>::new();
+    while cursor < bytes.len() {
+        match bytes[cursor] {
+            b'"' => {
+                if quoted_identifier && bytes.get(cursor + 1) == Some(&b'"') {
+                    cursor += 2;
+                    continue;
+                }
+                quoted_identifier = !quoted_identifier;
+                cursor += 1;
+            }
+            b'-' if !quoted_identifier && bytes.get(cursor + 1) == Some(&b'-') => return None,
+            b'/' if !quoted_identifier && bytes.get(cursor + 1) == Some(&b'*') => return None,
+            b'?' | b'$' if !quoted_identifier => return None,
+            b'\'' if !quoted_identifier => {
+                if decoded.len() >= parameter_count
+                    || bytes[..cursor]
+                        .iter()
+                        .rposition(|byte| !byte.is_ascii_whitespace())
+                        .is_some_and(|index| {
+                            matches!(
+                                bytes[index],
+                                b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_'
+                            )
+                        })
+                {
+                    return None;
+                }
+                let outside = &bytes[copied..cursor];
+                if !shape
+                    .get(shape_cursor..)
+                    .is_some_and(|remaining| remaining.starts_with(outside))
+                {
+                    return None;
+                }
+                shape_cursor += outside.len();
+                if shape.get(shape_cursor) != Some(&b'$') {
+                    return None;
+                }
+                shape_cursor += 1;
+                let digit_start = shape_cursor;
+                let mut parameter_number = 0_usize;
+                while let Some(digit @ b'0'..=b'9') = shape.get(shape_cursor) {
+                    parameter_number = parameter_number
+                        .saturating_mul(10)
+                        .saturating_add(usize::from(*digit - b'0'));
+                    shape_cursor += 1;
+                }
+                if shape_cursor == digit_start || parameter_number != decoded.len() + 1 {
+                    return None;
+                }
+
+                cursor += 1;
+                let value_start = cursor;
+                let mut segment_start = cursor;
+                let mut escaped = false;
+                loop {
+                    let quote = bytes[cursor..]
+                        .iter()
+                        .position(|byte| *byte == b'\'')
+                        .map(|offset| cursor + offset)?;
+                    if bytes.get(quote + 1) == Some(&b'\'') {
+                        let value = &mut escape_scratch[decoded.len()];
+                        if !escaped {
+                            value.clear();
+                            value.reserve(quote.saturating_sub(value_start).saturating_add(1));
+                            escaped = true;
+                        }
+                        value.push_str(&sql[segment_start..quote]);
+                        value.push('\'');
+                        cursor = quote + 2;
+                        segment_start = cursor;
+                        continue;
+                    }
+                    let value = if escaped {
+                        escape_scratch[decoded.len()].push_str(&sql[segment_start..quote]);
+                        DecodedUpdateLiteral::Escaped(decoded.len())
+                    } else {
+                        DecodedUpdateLiteral::Borrowed(&sql[value_start..quote])
+                    };
+                    decoded.push(value);
+                    cursor = quote + 1;
+                    copied = cursor;
+                    break;
+                }
+            }
+            _ => cursor += 1,
+        }
+    }
+    if quoted_identifier
+        || decoded.len() != parameter_count
+        || shape.get(shape_cursor..) != Some(&bytes[copied..])
+    {
+        return None;
+    }
+    Some(
+        decoded
+            .into_iter()
+            .map(|value| match value {
+                DecodedUpdateLiteral::Borrowed(value) => Cow::Borrowed(value),
+                DecodedUpdateLiteral::Escaped(index) => {
+                    Cow::Owned(std::mem::take(&mut escape_scratch[index]))
+                }
+            })
+            .collect(),
+    )
+}
+
 fn decode_update_string_literals_into(sql: &str, params: &mut [String]) -> bool {
     params.iter_mut().for_each(String::clear);
     decode_update_string_literals_with(sql, params.len(), |index, segment, escaped| {
@@ -429,10 +561,10 @@ fn decode_update_string_literals_into(sql: &str, params: &mut [String]) -> bool 
     })
 }
 
-fn decode_update_string_literals_with(
-    sql: &str,
+fn decode_update_string_literals_with<'a>(
+    sql: &'a str,
     parameter_count: usize,
-    mut append: impl FnMut(usize, &str, bool) -> bool,
+    mut append: impl FnMut(usize, &'a str, bool) -> bool,
 ) -> bool {
     let bytes = sql.as_bytes();
     let mut cursor = 0_usize;
@@ -609,42 +741,57 @@ mod tests {
     }
 
     #[test]
-    fn certified_literal_value_decoder_reuses_text_storage() {
+    fn warm_literal_decoder_borrows_unescaped_slots_in_one_shape_pass() {
         let cache = test_cache(8);
-        let mut params = vec![
-            Value::Text(String::with_capacity(64)),
-            Value::Text(String::with_capacity(32)),
-        ];
-        let capacities = params
-            .iter()
-            .map(|value| match value {
-                Value::Text(value) => value.capacity(),
-                _ => unreachable!("test slots are text"),
-            })
-            .collect::<Vec<_>>();
+        let template = cache
+            .auto_parameterized_update(
+                "UPDATE notes SET value = lix_json('{\"text\":\"first\"}') WHERE id = 'a'",
+            )
+            .unwrap();
+        let mut escape_scratch = SmallVec::new();
+        let borrowed = cache
+            .decode_update_literals_for_shape(
+                "UPDATE notes SET value = lix_json('{\"text\":\"second\"}') WHERE id = 'b'",
+                &template.sql,
+                2,
+                &mut escape_scratch,
+            )
+            .unwrap();
+        assert!(matches!(borrowed[0], Cow::Borrowed(_)));
+        assert!(matches!(borrowed[1], Cow::Borrowed(_)));
+        assert_eq!(borrowed[0], "{\"text\":\"second\"}");
+        assert_eq!(borrowed[1], "b");
 
-        assert!(cache.decode_certified_update_literals_into_values(
-            "UPDATE notes SET value = lix_json('{\"text\":\"it''s warm\"}') WHERE id = 'row-1'",
-            &mut params,
-        ));
-        assert_eq!(
-            params,
-            [
-                Value::Text("{\"text\":\"it's warm\"}".to_string()),
-                Value::Text("row-1".to_string()),
-            ]
-        );
-        assert_eq!(
-            params
-                .iter()
-                .map(|value| match value {
-                    Value::Text(value) => value.capacity(),
-                    _ => unreachable!("test slots stay text"),
-                })
-                .collect::<Vec<_>>(),
-            capacities,
-            "warm decoding must retain the session-owned string buffers"
-        );
+        let escaped = cache
+            .decode_update_literals_for_shape(
+                "UPDATE notes SET value = lix_json('{\"text\":\"it''s fine\"}') WHERE id = 'c'",
+                &template.sql,
+                2,
+                &mut escape_scratch,
+            )
+            .unwrap();
+        assert!(matches!(escaped[0], Cow::Owned(_)));
+        assert!(matches!(escaped[1], Cow::Borrowed(_)));
+        assert_eq!(escaped[0], "{\"text\":\"it's fine\"}");
+
+        let recycled = match escaped.into_iter().next().unwrap() {
+            Cow::Owned(value) => value,
+            Cow::Borrowed(_) => panic!("escaped literal must own the scratch buffer"),
+        };
+        escape_scratch[0] = recycled;
+        let allocation = escape_scratch[0].as_ptr();
+        let escaped_again = cache
+            .decode_update_literals_for_shape(
+                "UPDATE notes SET value = lix_json('{\"text\":\"it''s fine\"}') WHERE id = 'd'",
+                &template.sql,
+                2,
+                &mut escape_scratch,
+            )
+            .unwrap();
+        let Cow::Owned(reused) = &escaped_again[0] else {
+            panic!("escaped literal must reuse owned scratch storage");
+        };
+        assert_eq!(reused.as_ptr(), allocation);
     }
 
     #[test]

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -6485,48 +6485,107 @@ where
             .is_some_and(|(cached_sql, _)| cached_sql.as_ref() == sql)
     }
 
-    pub(crate) fn prepared_literal_mutation_parameter_count(&self, sql: &str) -> Option<usize> {
+    pub(crate) fn prepared_literal_mutation_shape(&self) -> Option<(&str, usize)> {
         let (shape, program) = self.prepared_mutation_program.as_ref()?;
-        self.sql_planning_cache
-            .update_literal_shape_matches(sql, shape)
-            .then(|| program.parameter_count())
+        Some((shape, program.parameter_count()))
     }
 
-    pub(crate) async fn flush_cached_prepared_mutation_barrier(
+    /// Appends one shape-certified literal UPDATE without constructing public
+    /// `Value` DTOs. The explicit transaction has already admitted this plan;
+    /// borrowed literal slices flow directly into identity and snapshot
+    /// columns. Non-packed or dependent state returns to the generic path.
+    pub(crate) async fn try_execute_cached_literal_prepared_mutation(
         &mut self,
         next_origin_key: Option<&str>,
-        params: &[Value],
-    ) -> Result<(), LixError> {
-        let cached_sql = self
-            .prepared_mutation_program
-            .as_ref()
-            .map(|(sql, _)| Arc::clone(sql))
-            .ok_or_else(|| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "cached mutation barrier has no prepared mutation program",
-                )
-            })?;
-        self.flush_prepared_mutation_barrier(&cached_sql, next_origin_key, params)
-            .await
-    }
-
-    pub(crate) async fn try_execute_cached_prepared_mutation(
-        &mut self,
-        params: &[Value],
+        params: &[impl AsRef<str>],
     ) -> Result<Option<crate::sql2::SqlWriteResult>, LixError> {
-        let cached_sql = self
-            .prepared_mutation_program
+        if let Some(error) = &self.mutation_journal_terminal_error {
+            return Err(error.clone());
+        }
+        let Some((_, program)) = self.prepared_mutation_program.as_ref() else {
+            return Ok(None);
+        };
+        let program = Arc::clone(program);
+        let primary_key = program.primary_key_text(params)?;
+        let replacement_value = program.replacement_value_text(params)?;
+        let entity_pk = EntityPk::single(primary_key.to_owned());
+
+        let same_origin = self
+            .mutation_journal
             .as_ref()
-            .map(|(sql, _)| Arc::clone(sql))
-            .ok_or_else(|| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "cached mutation execution has no prepared mutation program",
-                )
-            })?;
-        self.try_execute_prepared_mutation(&cached_sql, params)
-            .await
+            .is_none_or(|journal| journal.origin_key.as_deref() == next_origin_key);
+        let ordered_append = same_origin
+            && self
+                .mutation_journal
+                .as_ref()
+                .and_then(TransactionMutationJournal::last_entity_pk)
+                .is_none_or(|last| last < &entity_pk);
+        let chunk_has_capacity = self
+            .mutation_journal
+            .as_ref()
+            .is_none_or(|journal| journal.entity_pks.len() < 4_096);
+        if !same_origin || !ordered_append || !chunk_has_capacity {
+            self.flush_mutation_journal().await?;
+        }
+        if !same_origin || !ordered_append {
+            self.lower_provisional_mutations_to_prepared().await?;
+            self.prepared_mutation_overlay_empty = false;
+        }
+
+        if !matches!(
+            self.prepared_mutation_membership,
+            PreparedMutationMembership::Packed(_)
+        ) {
+            return Ok(None);
+        }
+        if !self.prepared_mutation_overlay_empty {
+            if self.staged_writes.staged_identity_may_affect(
+                &self.active_branch_id,
+                &program.schema_key,
+                None,
+                &entity_pk,
+            )? {
+                return Ok(None);
+            }
+            self.prepared_mutation_overlay_empty = !self.staged_writes.has_staged_state_rows()?;
+        }
+        let PreparedMutationMembership::Packed(membership) = &mut self.prepared_mutation_membership
+        else {
+            unreachable!("packed literal mutation membership was checked above")
+        };
+        match membership.contains(&entity_pk)? {
+            Some(false) => return Ok(Some(crate::sql2::SqlWriteResult::affected(0))),
+            Some(true) => {}
+            None => return Ok(None),
+        }
+
+        let origin_key = next_origin_key.map(SharedStr::from);
+        let functions = self.functions.clone();
+        let (journal_slot, timestamp_slot) = (
+            &mut self.mutation_journal,
+            &mut self.prepared_mutation_timestamp,
+        );
+        let journal = journal_slot.get_or_insert_with(|| TransactionMutationJournal {
+            program: Arc::clone(&program),
+            origin_key: origin_key.clone(),
+            entity_pks: Vec::with_capacity(INITIAL_MUTATION_JOURNAL_ROWS),
+            snapshot_arena: Vec::with_capacity(INITIAL_MUTATION_JOURNAL_ARENA_BYTES),
+            snapshot_offsets: Vec::with_capacity(INITIAL_MUTATION_JOURNAL_ROWS),
+            timestamp: None,
+        });
+        debug_assert!(Arc::ptr_eq(&journal.program, &program));
+        debug_assert_eq!(journal.origin_key, origin_key);
+        let snapshot_offset = crate::sql2::append_path_value_replacement_snapshot_text(
+            primary_key,
+            Some(replacement_value),
+            &mut journal.snapshot_arena,
+        )?;
+        let timestamp = *timestamp_slot.get_or_insert_with(|| functions.call_timestamp());
+        journal.entity_pks.push(entity_pk);
+        journal.snapshot_offsets.push(snapshot_offset);
+        let journal_timestamp = journal.timestamp.get_or_insert(timestamp);
+        debug_assert_eq!(*journal_timestamp, timestamp);
+        Ok(Some(crate::sql2::SqlWriteResult::affected(1)))
     }
 
     pub(crate) fn remember_prepared_mutation(


### PR DESCRIPTION
## Summary

- fuse warm scalar `UPDATE` shape certification and SQL-literal decoding into one pass
- borrow ordinary literal text directly into the typed transaction mutation journal and reuse scratch storage only for doubled-quote escapes
- remove the redundant per-statement transaction-manager guard held beneath the explicit transaction write lease
- represent mutation-only `ExecuteResult` values without shared empty backing refcount traffic
- remove redundant JSON pre-validation while retaining an allocation-free canonical-object lane, serde-equivalent fallback semantics, and a serde-aligned recursion limit

This keeps #1158/#1169 durable mutation inventory, manifest authority, and current-state part descriptors unchanged. No changenote is included.

## Performance

Compared against the exact immediately previous merged tree, `a91a89ea4` (#1170), using separately built binaries alternated on the same host:

| Adapter / rows | Previous | This PR | Change |
| --- | ---: | ---: | ---: |
| RocksDB UPDATE / 10K | 42.70 ms | 39.00 ms | **-8.7%** |
| SlateDB UPDATE / 10K | 43.58 ms | 39.48 ms | **-9.4%** |
| RocksDB UPDATE / 1M | 1.767 s | 1.490 s | **-15.7%** |
| SlateDB UPDATE / 1M | 1.893 s | 1.583 s | **-16.4%** |

The 1M medians are the stacked-PR gate. The 10K figures are included without claiming a separate >10% signal.

Raw prepared SQLite remains 0.871 s at 1M, so UPDATE is now approximately 1.71× SQLite on RocksDB and 1.82× on SlateDB. The overall 1.2× goal is not yet complete.

## Validation

- `cargo test -p lix_engine`
  - library: 1,835 passed, 8 ignored
  - integration: 439 passed, 2 ignored
  - doctests: 3 passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- focused escaped-literal, read-your-writes, dependent-overlay, stale-reconciliation, origin, direct-sealing, JSON depth, wide-object, and result-equality tests
- two independent Luna extra-high reviews approved after resolving escaped-buffer reuse, decoder-failure recovery, JSON recursion-depth, and wide canonical-object allocation findings
