### PR TITLE
Seal UPDATE journals directly into mutation parts

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -928,6 +928,7 @@ fn profile_sql_session_operation(
 ) {
     let mut samples = Vec::with_capacity(sample_count);
     for _ in 0..sample_count {
+        maybe_print_profile_rss_phase("before_seed");
         let fixture = if operation.needs_seed() {
             runtime.block_on(sql_session::seeded_fixture_with_read_many_pk_count(
                 profile,
@@ -941,10 +942,14 @@ fn profile_sql_session_operation(
                 read_many_pk_count,
             ))
         };
+        maybe_print_profile_rss_phase("after_seed");
+        reset_allocation_accounting();
         let start = Instant::now();
         let result = runtime.block_on(run_sql_session_operation(operation, &fixture));
         samples.push(start.elapsed());
         black_box(result);
+        maybe_print_profile_rss_phase("after_operation");
+        print_allocation_accounting("operation");
     }
     let profile_layer = if matches!(operation, TransactionBenchOp::ReadAll) {
         format!(

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -1986,7 +1986,7 @@ impl HotStateTransactionCache {
 
 pub(crate) struct PackedIdentityMembership {
     cache: Arc<HotStateTransactionCache>,
-    commit_id: CommitId,
+    cursor: crate::tracked_state::CommitDeltaLiveMembershipCursor,
     schema_key: String,
     live_count: u64,
     ordered_identity_digest: [u8; 32],
@@ -1994,19 +1994,19 @@ pub(crate) struct PackedIdentityMembership {
 }
 
 impl PackedIdentityMembership {
-    pub(crate) fn contains(&mut self, entity_pk: &EntityPk) -> Result<Option<bool>, LixError> {
+    pub(crate) fn contains_single_string(
+        &mut self,
+        entity_pk: &str,
+    ) -> Result<Option<bool>, LixError> {
         self.encoded_key.clear();
-        let encoded = crate::tracked_state::encode_key_ref_into(
+        let encoded = crate::tracked_state::encode_single_string_key_ref_into(
             &mut self.encoded_key,
-            TrackedStateKeyRef {
-                schema_key: &self.schema_key,
-                file_id: None,
-                entity_pk,
-            },
+            &self.schema_key,
+            None,
+            entity_pk,
         );
-        self.cache
-            .commit_delta_points
-            .cached_live_member(self.commit_id, &self.encoded_key[encoded])
+        self.cursor
+            .cached_live_member(&self.cache.commit_delta_points, &self.encoded_key[encoded])
     }
 
     pub(crate) fn complete_generation(&self) -> (u64, [u8; 32]) {
@@ -4024,9 +4024,12 @@ where
         if !certified.is_empty() {
             return Ok(None);
         }
+        let cursor = cache
+            .commit_delta_points
+            .live_membership_cursor(base_ref.commit_id);
         Ok(Some(PackedIdentityMembership {
             cache: Arc::clone(cache),
-            commit_id: base_ref.commit_id,
+            cursor,
             schema_key: schema_key.to_owned(),
             live_count: collection.live_count,
             ordered_identity_digest,

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -2558,7 +2558,8 @@ where
         sql: &str,
         params: &[Value],
     ) -> Result<ExecuteResult, LixError> {
-        Box::pin(self.execute_with_options_inner(sql, params, ExecuteOptions::default())).await
+        self.execute_with_options_inner(sql, params, ExecuteOptions::default())
+            .await
     }
 
     async fn execute_with_options_inner(

--- a/packages/engine/src/sql2/planning_cache.rs
+++ b/packages/engine/src/sql2/planning_cache.rs
@@ -433,6 +433,21 @@ fn decode_update_string_literals_for_shape<'a>(
         return None;
     }
 
+    // The entity UPDATE lane has exactly two string parameters. Once its
+    // normalized shape is certified, compare the three static SQL spans and
+    // scan only the two quoted values. The generic state machine below is
+    // retained for wider mutation programs, but rerunning it over every byte
+    // of one million homogeneous statements is unnecessary.
+    if parameter_count == 2
+        && let Some((prefix, remainder)) = normalized_shape.split_once("$1")
+        && let Some((middle, suffix)) = remainder.split_once("$2")
+        && !prefix.contains('$')
+        && !middle.contains('$')
+        && !suffix.contains('$')
+    {
+        return decode_two_update_string_literals(sql, prefix, middle, suffix, escape_scratch);
+    }
+
     let bytes = sql.as_bytes();
     let shape = normalized_shape.as_bytes();
     let mut cursor = 0;
@@ -536,6 +551,81 @@ fn decode_update_string_literals_for_shape<'a>(
     }
     Some(
         decoded
+            .into_iter()
+            .map(|value| match value {
+                DecodedUpdateLiteral::Borrowed(value) => Cow::Borrowed(value),
+                DecodedUpdateLiteral::Escaped(index) => {
+                    Cow::Owned(std::mem::take(&mut escape_scratch[index]))
+                }
+            })
+            .collect(),
+    )
+}
+
+fn decode_two_update_string_literals<'a>(
+    sql: &'a str,
+    prefix: &str,
+    middle: &str,
+    suffix: &str,
+    escape_scratch: &mut [String],
+) -> Option<SmallVec<[Cow<'a, str>; 4]>> {
+    fn decode_one<'a>(
+        sql: &'a str,
+        cursor: &mut usize,
+        scratch: &mut String,
+        scratch_index: usize,
+    ) -> Option<DecodedUpdateLiteral<'a>> {
+        let bytes = sql.as_bytes();
+        if bytes.get(*cursor) != Some(&b'\'') {
+            return None;
+        }
+        *cursor += 1;
+        let value_start = *cursor;
+        let mut segment_start = *cursor;
+        let mut escaped = false;
+        loop {
+            let quote = bytes[*cursor..]
+                .iter()
+                .position(|byte| *byte == b'\'')
+                .map(|offset| *cursor + offset)?;
+            if bytes.get(quote + 1) == Some(&b'\'') {
+                if !escaped {
+                    scratch.clear();
+                    scratch.reserve(quote.saturating_sub(value_start).saturating_add(1));
+                    escaped = true;
+                }
+                scratch.push_str(&sql[segment_start..quote]);
+                scratch.push('\'');
+                *cursor = quote + 2;
+                segment_start = *cursor;
+                continue;
+            }
+            *cursor = quote + 1;
+            return if escaped {
+                scratch.push_str(&sql[segment_start..quote]);
+                Some(DecodedUpdateLiteral::Escaped(scratch_index))
+            } else {
+                Some(DecodedUpdateLiteral::Borrowed(&sql[value_start..quote]))
+            };
+        }
+    }
+
+    let bytes = sql.as_bytes();
+    if !bytes.starts_with(prefix.as_bytes()) {
+        return None;
+    }
+    let mut cursor = prefix.len();
+    let first = decode_one(sql, &mut cursor, &mut escape_scratch[0], 0)?;
+    if !bytes[cursor..].starts_with(middle.as_bytes()) {
+        return None;
+    }
+    cursor += middle.len();
+    let second = decode_one(sql, &mut cursor, &mut escape_scratch[1], 1)?;
+    if bytes.get(cursor..) != Some(suffix.as_bytes()) {
+        return None;
+    }
+    Some(
+        [first, second]
             .into_iter()
             .map(|value| match value {
                 DecodedUpdateLiteral::Borrowed(value) => Cow::Borrowed(value),

--- a/packages/engine/src/tracked_state/codec.rs
+++ b/packages/engine/src/tracked_state/codec.rs
@@ -490,6 +490,24 @@ pub(crate) fn encode_key_ref_into(out: &mut Vec<u8>, key: TrackedStateKeyRef<'_>
     start..out.len()
 }
 
+/// Encodes the dominant one-component string identity without constructing
+/// an owned `EntityPk`. Typed SQL ingress has already certified this physical
+/// identity shape, so membership probes can stay borrowed until journal seal.
+pub(crate) fn encode_single_string_key_ref_into(
+    out: &mut Vec<u8>,
+    schema_key: &str,
+    file_id: Option<&str>,
+    entity_pk: &str,
+) -> Range<usize> {
+    let start = out.len();
+    write_key_string(out, schema_key, KEY_PART_FINAL);
+    write_file_id(out, file_id);
+    out.push(ENTITY_PK_CODEC_V1);
+    out.push(ENTITY_PK_STRING);
+    write_key_bytes(out, entity_pk.as_bytes(), KEY_PART_FINAL);
+    start..out.len()
+}
+
 pub(crate) fn encode_schema_key_prefix(schema_key: &str) -> Vec<u8> {
     let mut out = Vec::with_capacity(schema_key.len() + 2);
     write_key_string(&mut out, schema_key, KEY_PART_FINAL);
@@ -2339,6 +2357,20 @@ mod tests {
                 entity_pk: EntityPk::single("entity"),
             }
         );
+    }
+
+    #[test]
+    fn borrowed_single_string_key_encoding_matches_owned_entity_pk() {
+        for value in ["entity", "nul\0escaped", "café"] {
+            let expected = encode_key(&TrackedStateKey {
+                schema_key: "schema".to_string(),
+                file_id: None,
+                entity_pk: EntityPk::single(value),
+            });
+            let mut actual = Vec::new();
+            let encoded = encode_single_string_key_ref_into(&mut actual, "schema", None, value);
+            assert_eq!(&actual[encoded], expected.as_slice());
+        }
     }
 
     #[test]

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -13,7 +13,7 @@ mod storage;
 mod tree;
 mod types;
 
-pub(crate) use codec::{encode_key_ref, encode_key_ref_into};
+pub(crate) use codec::{encode_key_ref, encode_single_string_key_ref_into};
 pub(crate) use commit_root_rebuild::{
     load_rebuild_plans_to_nearest_available_root, stage_rebuild_plan_with_writer,
 };
@@ -38,8 +38,8 @@ pub(crate) use row_materialization::{
     materialize_batch_from_index_entry_refs,
 };
 pub(crate) use storage::{
-    CommitDeltaChangeLocator, CommitDeltaMember, CommitDeltaPointReadCache,
-    CommitDeltaReplacementGeneration, CommitDeltaReplacementScope,
+    CommitDeltaChangeLocator, CommitDeltaLiveMembershipCursor, CommitDeltaMember,
+    CommitDeltaPointReadCache, CommitDeltaReplacementGeneration, CommitDeltaReplacementScope,
     OrderedAddressableCommitDeltaStage, commit_delta_contains_schema, direct_change_locator,
     load_change_record_by_id, load_commit_delta_change_records,
     load_commit_delta_members_with_payloads, load_commit_delta_members_with_payloads_for_schemas,
@@ -72,6 +72,7 @@ pub(crate) use types::{
     MaterializedTrackedStateRow, TrackedStateBaseCoordinate, TrackedStateCommitDeltaRef,
     TrackedStateCommitRoot, TrackedStateDeltaRef, TrackedStateFilter, TrackedStateIndexValue,
     TrackedStateReadColumns, TrackedStateRootMutationRef, TrackedStateScanRequest,
+    TrackedStateSingleStringReplacementRef,
 };
 pub(crate) use types::{TrackedStateKey, TrackedStateKeyRef};
 #[cfg(feature = "storage-benches")]

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -24,7 +24,7 @@ use crate::tracked_state::codec::{
     DecodedLeafNodeRef, DecodedNodeRef, EncodedLeafEntry, EncodedLeafEntryRef, PendingChunkBatch,
     TrackedStateMutationBatchBuilder, decode_key, decode_key_shared, decode_node_ref, decode_value,
     encode_key_ref, encode_key_ref_into, encode_leaf_node_refs, encode_schema_key_prefix,
-    encode_value_ref,
+    encode_single_string_key_ref_into, encode_value_ref,
 };
 pub(crate) use crate::tracked_state::types::{
     CommitDeltaLifecycleSummary, CommitDeltaReplacementScope,
@@ -35,6 +35,7 @@ use crate::tracked_state::types::{
     StoredReplacementPartsAuthority, TRACKED_STATE_HASH_BYTES, TrackedStateBaseCoordinate,
     TrackedStateCommitDeltaRef, TrackedStateCommitRoot, TrackedStateIndexValue,
     TrackedStateIndexValueRef, TrackedStateKey, TrackedStateKeyRef, TrackedStateRootId,
+    TrackedStateSingleStringReplacementRef,
 };
 use crate::{LixError, storage_codec};
 use bytes::Bytes;
@@ -954,6 +955,17 @@ pub(crate) struct CommitDeltaPointReadCache {
     inner: Mutex<CommitDeltaPointReadCacheInner>,
 }
 
+/// Transaction-owned cursor for a monotonically scanned immutable generation.
+/// The manifest and current decoded segment stay outside the shared cache
+/// mutex; an ordered UPDATE therefore touches the LRU only when it crosses a
+/// physical part boundary instead of twice for every row.
+pub(crate) struct CommitDeltaLiveMembershipCursor {
+    commit_id: CommitId,
+    manifest: Option<Arc<CommitDeltaManifest>>,
+    segment_index: Option<usize>,
+    segment: Option<Arc<DecodedCommitDeltaSegment>>,
+}
+
 #[derive(Default)]
 struct CommitDeltaPointReadCacheInner {
     manifests: VecDeque<(CommitId, Arc<CommitDeltaManifest>)>,
@@ -963,26 +975,30 @@ struct CommitDeltaPointReadCacheInner {
 }
 
 impl CommitDeltaPointReadCache {
-    pub(crate) fn cached_live_member(
+    pub(crate) fn live_membership_cursor(
         &self,
         commit_id: CommitId,
+    ) -> CommitDeltaLiveMembershipCursor {
+        CommitDeltaLiveMembershipCursor {
+            commit_id,
+            manifest: None,
+            segment_index: None,
+            segment: None,
+        }
+    }
+}
+
+impl CommitDeltaLiveMembershipCursor {
+    pub(crate) fn cached_live_member(
+        &mut self,
+        cache: &CommitDeltaPointReadCache,
         encoded_key: &[u8],
     ) -> Result<Option<bool>, LixError> {
-        let manifest = {
-            let cache = self.inner.lock().map_err(|_| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "transaction commit-delta point cache lock is poisoned",
-                )
-            })?;
-            let Some((_, manifest)) = cache
-                .manifests
-                .iter()
-                .find(|(cached_commit_id, _)| *cached_commit_id == commit_id)
-            else {
-                return Ok(None);
-            };
-            Arc::clone(manifest)
+        if self.manifest.is_none() {
+            self.manifest = cache.manifest(self.commit_id)?;
+        }
+        let Some(manifest) = self.manifest.as_ref() else {
+            return Ok(None);
         };
         if manifest.selected_source_commit_id.is_some() || manifest.inline_segment().is_some() {
             return Ok(None);
@@ -990,20 +1006,25 @@ impl CommitDeltaPointReadCache {
         let Some(segment_index) = commit_delta_segment_for_key(&manifest, encoded_key) else {
             return Ok(Some(false));
         };
-        let Some(segment) = self.segment(
-            commit_id,
-            segment_index,
-            manifest.segments.get(segment_index),
-        )?
-        else {
+        if self.segment_index != Some(segment_index) || self.segment.is_none() {
+            self.segment = cache.segment(
+                self.commit_id,
+                segment_index,
+                manifest.segments.get(segment_index),
+            )?;
+            self.segment_index = Some(segment_index);
+        }
+        let Some(segment) = self.segment.as_ref() else {
             return Ok(None);
         };
         Ok(Some(
-            find_commit_delta_value(&segment.leaf, encoded_key, commit_id)?
+            find_commit_delta_value(&segment.leaf, encoded_key, self.commit_id)?
                 .is_some_and(|value| !value.deleted),
         ))
     }
+}
 
+impl CommitDeltaPointReadCache {
     fn should_admit_segment(
         &self,
         commit_id: CommitId,
@@ -1880,13 +1901,67 @@ where
 /// Publishes a complete replacement as compact immutable identity parts.
 /// Parts own identity routing and JSON authority: small values are inline and
 /// large values remain content-addressed references into the JSON store.
-pub(crate) fn stage_ordered_addressable_replacement_parts<'a, I>(
+pub(crate) struct ReplacementPartInput<'a> {
+    key: Vec<u8>,
+    commit_id: CommitId,
+    created_at: crate::common::LixTimestamp,
+    updated_at: crate::common::LixTimestamp,
+    snapshot: crate::json_store::JsonSlotRef<'a>,
+    metadata: crate::json_store::JsonSlotRef<'a>,
+}
+
+pub(crate) trait ReplacementPartInputRef<'a>: Copy {
+    fn into_replacement_part_input(self) -> Result<ReplacementPartInput<'a>, LixError>;
+}
+
+impl<'a> ReplacementPartInputRef<'a> for TrackedStateCommitDeltaRef<'a> {
+    fn into_replacement_part_input(self) -> Result<ReplacementPartInput<'a>, LixError> {
+        if self.delta.deleted || !self.authored || self.origin_key.is_some() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state replacement member violates immutable replacement invariants",
+            ));
+        }
+        Ok(ReplacementPartInput {
+            key: encode_key_ref(TrackedStateKeyRef {
+                schema_key: self.delta.schema_key,
+                file_id: self.delta.file_id,
+                entity_pk: self.delta.entity_pk,
+            }),
+            commit_id: self.delta.commit_id,
+            created_at: self.delta.created_at,
+            updated_at: self.delta.updated_at,
+            snapshot: self.snapshot,
+            metadata: self.metadata,
+        })
+    }
+}
+
+impl<'a> ReplacementPartInputRef<'a> for TrackedStateSingleStringReplacementRef<'a> {
+    fn into_replacement_part_input(self) -> Result<ReplacementPartInput<'a>, LixError> {
+        let mut key = Vec::with_capacity(
+            self.schema_key.len() + self.file_id.map_or(0, str::len) + self.entity_pk.len() + 8,
+        );
+        encode_single_string_key_ref_into(&mut key, self.schema_key, self.file_id, self.entity_pk);
+        Ok(ReplacementPartInput {
+            key,
+            commit_id: self.commit_id,
+            created_at: self.created_at,
+            updated_at: self.updated_at,
+            snapshot: self.snapshot,
+            metadata: self.metadata,
+        })
+    }
+}
+
+pub(crate) fn stage_ordered_addressable_replacement_parts<'a, I, R>(
     writes: &mut StorageWriteSet,
     deltas: I,
     generation: &CommitDeltaReplacementGeneration,
 ) -> Result<OrderedAddressableCommitDeltaStage, LixError>
 where
-    I: ExactSizeIterator<Item = Result<TrackedStateCommitDeltaRef<'a>, LixError>>,
+    I: ExactSizeIterator<Item = Result<R, LixError>>,
+    R: ReplacementPartInputRef<'a>,
 {
     struct BorrowedRow<'a> {
         key: Vec<u8>,
@@ -1914,12 +1989,8 @@ where
     let mut parts = Vec::with_capacity(row_count.div_ceil(COMMIT_DELTA_SEGMENT_MAX_ROWS));
     let mut compressor = None;
     for delta in deltas {
-        let delta = delta?;
-        if delta.delta.deleted
-            || !delta.authored
-            || delta.origin_key.is_some()
-            || delta.delta.created_at != generation.lifecycle_summary.uniform_created_at
-        {
+        let delta = delta?.into_replacement_part_input()?;
+        if delta.created_at != generation.lifecycle_summary.uniform_created_at {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 "tracked_state replacement member violates immutable replacement invariants",
@@ -1932,22 +2003,18 @@ where
             ));
         }
         if commit_id
-            .replace(delta.delta.commit_id)
-            .is_some_and(|owner| owner != delta.delta.commit_id)
+            .replace(delta.commit_id)
+            .is_some_and(|owner| owner != delta.commit_id)
             || uniform_updated_at
-                .replace(delta.delta.updated_at)
-                .is_some_and(|timestamp| timestamp != delta.delta.updated_at)
+                .replace(delta.updated_at)
+                .is_some_and(|timestamp| timestamp != delta.updated_at)
         {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 "tracked_state replacement members have nonuniform owner or timestamp",
             ));
         }
-        let key = encode_key_ref(TrackedStateKeyRef {
-            schema_key: delta.delta.schema_key,
-            file_id: delta.delta.file_id,
-            entity_pk: delta.delta.entity_pk,
-        });
+        let key = delta.key;
         if !previous_key.is_empty() && previous_key >= key {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
@@ -7971,6 +8038,44 @@ mod tests {
             &generation,
         )
         .expect("replacement parts should stage");
+        let mut borrowed_writes = storage.new_write_set();
+        let borrowed_staged = super::stage_ordered_addressable_replacement_parts(
+            &mut borrowed_writes,
+            fixtures.iter().map(|fixture| {
+                Ok(
+                    crate::tracked_state::TrackedStateSingleStringReplacementRef {
+                        schema_key: &fixture.schema_key,
+                        file_id: fixture.file_id.as_deref(),
+                        entity_pk: fixture
+                            .entity_pk
+                            .as_single_string()
+                            .expect("fixture identity is one string"),
+                        commit_id,
+                        created_at: fixture.created_at,
+                        updated_at: fixture.updated_at,
+                        snapshot: crate::json_store::JsonSlotRef::Inline("{}"),
+                        metadata: crate::json_store::JsonSlotRef::None,
+                    },
+                )
+            }),
+            &generation,
+        )
+        .expect("borrowed replacement parts should stage");
+        assert_eq!(borrowed_staged.commit_id, staged.commit_id);
+        assert_eq!(borrowed_staged.row_count(), staged.row_count());
+        assert_eq!(
+            borrowed_staged.mutation_inventory(),
+            staged.mutation_inventory()
+        );
+        assert_eq!(
+            borrowed_staged.assigned_change_ids().collect::<Vec<_>>(),
+            staged.assigned_change_ids().collect::<Vec<_>>()
+        );
+        assert_eq!(
+            format!("{borrowed_writes:?}"),
+            format!("{writes:?}"),
+            "borrowed and generic replacement staging must be byte-identical"
+        );
         stage_fixture_manifest(&mut writes, staged.commit_id, staged.mutation_inventory())
             .expect("replacement commit-state authority should stage");
         storage

--- a/packages/engine/src/tracked_state/types.rs
+++ b/packages/engine/src/tracked_state/types.rs
@@ -81,6 +81,23 @@ pub(crate) struct TrackedStateCommitDeltaRef<'a> {
     pub(crate) authored: bool,
 }
 
+/// Typed complete-replacement member produced directly by the transaction
+/// journal's dominant one-column string identity lane. Invalid mutation
+/// states (delete, selected-source payload, origin override) are deliberately
+/// unrepresentable, so immutable replacement parts can be sealed without
+/// constructing an `EntityPk` per row.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct TrackedStateSingleStringReplacementRef<'a> {
+    pub(crate) schema_key: &'a str,
+    pub(crate) file_id: Option<&'a str>,
+    pub(crate) entity_pk: &'a str,
+    pub(crate) commit_id: CommitId,
+    pub(crate) created_at: LixTimestamp,
+    pub(crate) updated_at: LixTimestamp,
+    pub(crate) snapshot: crate::json_store::JsonSlotRef<'a>,
+    pub(crate) metadata: crate::json_store::JsonSlotRef<'a>,
+}
+
 /// One ordered tracked-root mutation with its insert-collision contract.
 ///
 /// Bulk commit assembly keeps this zero-copy form until it has compared the

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -35,8 +35,8 @@ use crate::tracked_state::{
     CommitStateMutationInventory, CommitStateReplayDebt, MaterializedTrackedStateRow,
     TrackedStateCommitDeltaRef, TrackedStateCommitRoot, TrackedStateContext, TrackedStateDeltaRef,
     TrackedStateFilter, TrackedStateKey, TrackedStateKeyRef, TrackedStateReadColumns,
-    TrackedStateRootMutationRef, TrackedStateScanRequest, encode_key_ref,
-    load_commit_delta_change_records, load_commit_delta_replay_metadata,
+    TrackedStateRootMutationRef, TrackedStateScanRequest, TrackedStateSingleStringReplacementRef,
+    encode_key_ref, load_commit_delta_change_records, load_commit_delta_replay_metadata,
     stage_addressable_commit_deltas, stage_change_locators, stage_commit_state_manifest,
     stage_ordered_addressable_commit_deltas,
 };
@@ -1995,24 +1995,15 @@ async fn stage_tracked_commit_delta_index(
             let stage = crate::tracked_state::stage_ordered_addressable_replacement_parts(
                 writes,
                 journal.iter().map(|row| {
-                    Ok(TrackedStateCommitDeltaRef {
-                        delta: TrackedStateDeltaRef {
-                            schema_key: journal.schema_key(),
-                            file_id: None,
-                            entity_pk: row.entity_pk(),
-                            // Direct-address encoders derive the final id from
-                            // part/row coordinates and ignore this sentinel.
-                            change_id: ChangeId::default(),
-                            commit_id: root.commit_id,
-                            deleted: false,
-                            created_at,
-                            updated_at: journal.timestamp(),
-                        },
+                    Ok(TrackedStateSingleStringReplacementRef {
+                        schema_key: journal.schema_key(),
+                        file_id: None,
+                        entity_pk: row.identity(),
+                        commit_id: root.commit_id,
+                        created_at,
+                        updated_at: journal.timestamp(),
                         snapshot: row.snapshot_slot(),
                         metadata: crate::json_store::JsonSlotRef::None,
-                        origin_key: None,
-                        base_coordinate: None,
-                        authored: true,
                     })
                 }),
                 generation,

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -540,7 +540,8 @@ pub(crate) struct Transaction<StorageImpl: Storage + 'static = Memory> {
 struct TransactionMutationJournal {
     program: Arc<crate::sql2::PreparedPathValueReplacementProgram>,
     origin_key: Option<SharedStr>,
-    entity_pks: Vec<EntityPk>,
+    identity_arena: Vec<u8>,
+    identity_offsets: Vec<(usize, usize)>,
     snapshot_arena: Vec<u8>,
     snapshot_offsets: Vec<(usize, usize)>,
     timestamp: Option<LixTimestamp>,
@@ -556,8 +557,23 @@ enum PreparedMutationMembership {
 }
 
 impl TransactionMutationJournal {
-    fn last_entity_pk(&self) -> Option<&EntityPk> {
-        self.entity_pks.last()
+    fn len(&self) -> usize {
+        self.identity_offsets.len()
+    }
+
+    fn last_identity(&self) -> Option<&str> {
+        let &(start, end) = self.identity_offsets.last()?;
+        Some(
+            std::str::from_utf8(&self.identity_arena[start..end])
+                .expect("transaction journal identities are appended from str"),
+        )
+    }
+
+    fn append_identity(&mut self, identity: &str) {
+        let start = self.identity_arena.len();
+        self.identity_arena.extend_from_slice(identity.as_bytes());
+        self.identity_offsets
+            .push((start, self.identity_arena.len()));
     }
 }
 
@@ -6374,12 +6390,12 @@ where
             return Ok(None);
         }
         let program = Arc::clone(program);
-        let entity_pk = EntityPk::single(program.primary_key(params)?.to_owned());
+        let primary_key = program.primary_key(params)?;
         if self
             .mutation_journal
             .as_ref()
-            .and_then(TransactionMutationJournal::last_entity_pk)
-            .is_some_and(|last| last >= &entity_pk)
+            .and_then(TransactionMutationJournal::last_identity)
+            .is_some_and(|last| last >= primary_key)
         {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
@@ -6403,6 +6419,7 @@ where
             };
         }
         if !self.prepared_mutation_overlay_empty {
+            let entity_pk = EntityPk::single(primary_key.to_owned());
             if self.staged_writes.staged_identity_may_affect(
                 &self.active_branch_id,
                 &program.schema_key,
@@ -6418,7 +6435,9 @@ where
             self.prepared_mutation_overlay_empty = !self.staged_writes.has_staged_state_rows()?;
         }
         let cached_membership = match &mut self.prepared_mutation_membership {
-            PreparedMutationMembership::Packed(membership) => membership.contains(&entity_pk)?,
+            PreparedMutationMembership::Packed(membership) => {
+                membership.contains_single_string(primary_key)?
+            }
             PreparedMutationMembership::Unprepared | PreparedMutationMembership::Unavailable => {
                 None
             }
@@ -6438,7 +6457,7 @@ where
         debug_assert!(
             fallback_row
                 .as_ref()
-                .is_none_or(|row| row.entity_pk == entity_pk)
+                .is_none_or(|row| row.entity_pk.as_single_string().ok() == Some(primary_key))
         );
         let origin_key = self.origin_key.clone();
         let functions = self.functions.clone();
@@ -6449,7 +6468,8 @@ where
         let journal = journal_slot.get_or_insert_with(|| TransactionMutationJournal {
             program: Arc::clone(&program),
             origin_key: origin_key.clone(),
-            entity_pks: Vec::with_capacity(INITIAL_MUTATION_JOURNAL_ROWS),
+            identity_arena: Vec::with_capacity(INITIAL_MUTATION_JOURNAL_ARENA_BYTES),
+            identity_offsets: Vec::with_capacity(INITIAL_MUTATION_JOURNAL_ROWS),
             snapshot_arena: Vec::with_capacity(INITIAL_MUTATION_JOURNAL_ARENA_BYTES),
             snapshot_offsets: Vec::with_capacity(INITIAL_MUTATION_JOURNAL_ROWS),
             timestamp: None,
@@ -6466,13 +6486,13 @@ where
             }
             None => crate::sql2::append_path_value_replacement_snapshot(
                 &program,
-                program.primary_key(params)?,
+                primary_key,
                 params,
                 &mut journal.snapshot_arena,
             )?,
         };
         let timestamp = *timestamp_slot.get_or_insert_with(|| functions.call_timestamp());
-        journal.entity_pks.push(entity_pk);
+        journal.append_identity(primary_key);
         journal.snapshot_offsets.push(snapshot_offset);
         let journal_timestamp = journal.timestamp.get_or_insert(timestamp);
         debug_assert_eq!(*journal_timestamp, timestamp);
@@ -6508,7 +6528,6 @@ where
         let program = Arc::clone(program);
         let primary_key = program.primary_key_text(params)?;
         let replacement_value = program.replacement_value_text(params)?;
-        let entity_pk = EntityPk::single(primary_key.to_owned());
 
         let same_origin = self
             .mutation_journal
@@ -6518,12 +6537,12 @@ where
             && self
                 .mutation_journal
                 .as_ref()
-                .and_then(TransactionMutationJournal::last_entity_pk)
-                .is_none_or(|last| last < &entity_pk);
+                .and_then(TransactionMutationJournal::last_identity)
+                .is_none_or(|last| last < primary_key);
         let chunk_has_capacity = self
             .mutation_journal
             .as_ref()
-            .is_none_or(|journal| journal.entity_pks.len() < 4_096);
+            .is_none_or(|journal| journal.len() < 4_096);
         if !same_origin || !ordered_append || !chunk_has_capacity {
             self.flush_mutation_journal().await?;
         }
@@ -6539,6 +6558,7 @@ where
             return Ok(None);
         }
         if !self.prepared_mutation_overlay_empty {
+            let entity_pk = EntityPk::single(primary_key.to_owned());
             if self.staged_writes.staged_identity_may_affect(
                 &self.active_branch_id,
                 &program.schema_key,
@@ -6553,7 +6573,7 @@ where
         else {
             unreachable!("packed literal mutation membership was checked above")
         };
-        match membership.contains(&entity_pk)? {
+        match membership.contains_single_string(primary_key)? {
             Some(false) => return Ok(Some(crate::sql2::SqlWriteResult::affected(0))),
             Some(true) => {}
             None => return Ok(None),
@@ -6568,7 +6588,8 @@ where
         let journal = journal_slot.get_or_insert_with(|| TransactionMutationJournal {
             program: Arc::clone(&program),
             origin_key: origin_key.clone(),
-            entity_pks: Vec::with_capacity(INITIAL_MUTATION_JOURNAL_ROWS),
+            identity_arena: Vec::with_capacity(INITIAL_MUTATION_JOURNAL_ARENA_BYTES),
+            identity_offsets: Vec::with_capacity(INITIAL_MUTATION_JOURNAL_ROWS),
             snapshot_arena: Vec::with_capacity(INITIAL_MUTATION_JOURNAL_ARENA_BYTES),
             snapshot_offsets: Vec::with_capacity(INITIAL_MUTATION_JOURNAL_ROWS),
             timestamp: None,
@@ -6581,7 +6602,7 @@ where
             &mut journal.snapshot_arena,
         )?;
         let timestamp = *timestamp_slot.get_or_insert_with(|| functions.call_timestamp());
-        journal.entity_pks.push(entity_pk);
+        journal.append_identity(primary_key);
         journal.snapshot_offsets.push(snapshot_offset);
         let journal_timestamp = journal.timestamp.get_or_insert(timestamp);
         debug_assert_eq!(*journal_timestamp, timestamp);
@@ -6741,12 +6762,11 @@ where
             self.prepared_mutation_program
                 .as_ref()
                 .and_then(|(_, program)| program.primary_key(params).ok())
-                .map(EntityPk::single)
                 .is_none_or(|entity_pk| {
                     self.mutation_journal
                         .as_ref()
-                        .and_then(TransactionMutationJournal::last_entity_pk)
-                        .is_none_or(|last| last < &entity_pk)
+                        .and_then(TransactionMutationJournal::last_identity)
+                        .is_none_or(|last| last < entity_pk)
                 })
         } else {
             false
@@ -6754,7 +6774,7 @@ where
         let chunk_has_capacity = self
             .mutation_journal
             .as_ref()
-            .is_none_or(|journal| journal.entity_pks.len() < 4_096);
+            .is_none_or(|journal| journal.len() < 4_096);
         if !same_program || !same_origin || !ordered_append || !chunk_has_capacity {
             self.flush_mutation_journal().await?;
         }
@@ -6786,13 +6806,13 @@ where
         let Some(journal) = self.mutation_journal.take() else {
             return Ok(());
         };
-        if journal.entity_pks.is_empty() {
+        if journal.identity_offsets.is_empty() {
             return Ok(());
         }
         self.ensure_plugin_generation_read_guard().await;
         #[cfg(feature = "storage-benches")]
         {
-            let row_count = journal.entity_pks.len();
+            let row_count = journal.len();
             crate::storage_bench::record_transaction_rows_staged(row_count);
             crate::storage_bench::record_transaction_untracked_rows(0);
         }
@@ -6802,12 +6822,13 @@ where
                 "non-empty transaction mutation journal has no lifecycle timestamp",
             )
         })?;
-        let chunk = ImmutableMutationJournalChunk::try_new(
+        let chunk = ImmutableMutationJournalChunk::try_new_single_string_identities(
             journal.program.schema_plan_id,
             journal.program.schema_key.as_str().into(),
             self.active_branch_id.clone().into(),
             journal.origin_key,
-            journal.entity_pks,
+            journal.identity_arena,
+            journal.identity_offsets,
             journal.snapshot_arena,
             journal.snapshot_offsets,
             None,
@@ -6907,7 +6928,7 @@ where
         &mut self,
         mut chunk: ImmutableMutationJournalChunk,
     ) -> Result<ImmutableMutationJournalChunk, LixError> {
-        let entity_pks = Arc::clone(chunk.entity_pks());
+        let entity_pks = chunk.materialized_entity_pks();
         let request = LiveStateExactBatchRequest {
             rows: entity_pks
                 .iter()

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -91,7 +91,8 @@ pub(crate) struct ImmutableMutationJournalChunk {
     schema_key: SharedStr,
     branch_id: SharedStr,
     origin_key: Option<SharedStr>,
-    entity_pks: Arc<[EntityPk]>,
+    identity_arena: Bytes,
+    identity_offsets: Arc<[(u32, u32)]>,
     snapshot_arena: Bytes,
     snapshot_offsets: Arc<[(u32, u32)]>,
     large_snapshot_refs: Arc<[(u16, crate::json_store::JsonRef)]>,
@@ -105,7 +106,8 @@ impl PartialEq for ImmutableMutationJournalChunk {
             && self.schema_key == other.schema_key
             && self.branch_id == other.branch_id
             && self.origin_key == other.origin_key
-            && self.entity_pks == other.entity_pks
+            && self.identity_arena == other.identity_arena
+            && self.identity_offsets == other.identity_offsets
             && self.snapshot_arena == other.snapshot_arena
             && self.snapshot_offsets == other.snapshot_offsets
             && self.large_snapshot_refs == other.large_snapshot_refs
@@ -130,18 +132,99 @@ impl Eq for ImmutableMutationJournalChunk {}
 
 impl ImmutableMutationJournalChunk {
     #[expect(clippy::too_many_arguments)]
-    pub(crate) fn try_new(
+    pub(crate) fn try_new_single_string_identities(
         schema_plan_id: SchemaPlanId,
         schema_key: SharedStr,
         branch_id: SharedStr,
         origin_key: Option<SharedStr>,
-        entity_pks: Vec<EntityPk>,
+        identity_arena: Vec<u8>,
+        identity_offsets: Vec<(usize, usize)>,
         snapshot_arena: Vec<u8>,
         snapshot_offsets: Vec<(usize, usize)>,
         durable_predecessors: Option<Vec<CertifiedCurrentStatePredecessor>>,
         timestamp: LixTimestamp,
     ) -> Result<Self, LixError> {
-        if entity_pks.is_empty() || entity_pks.len() != snapshot_offsets.len() {
+        if identity_offsets.len() != snapshot_offsets.len() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "immutable mutation identity arena is misaligned",
+            ));
+        }
+        let identity_bytes = Bytes::from(identity_arena);
+        let mut previous_end = 0usize;
+        let mut offsets = Vec::with_capacity(identity_offsets.len());
+        let mut previous_identity = None;
+        for (start, end) in identity_offsets {
+            if start != previous_end || end < start || end > identity_bytes.len() {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "immutable mutation identity offsets are invalid",
+                ));
+            }
+            let value = std::str::from_utf8(&identity_bytes[start..end]).map_err(|_| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "immutable mutation identity offset splits UTF-8",
+                )
+            })?;
+            if previous_identity.is_some_and(|previous| previous >= value) {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "immutable mutation journal identities are not strictly ordered",
+                ));
+            }
+            offsets.push((
+                u32::try_from(start).map_err(|_| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "immutable mutation identity arena exceeds u32",
+                    )
+                })?,
+                u32::try_from(end).map_err(|_| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "immutable mutation identity arena exceeds u32",
+                    )
+                })?,
+            ));
+            previous_identity = Some(value);
+            previous_end = end;
+        }
+        if previous_end != identity_bytes.len() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "immutable mutation identity offsets do not cover the arena",
+            ));
+        }
+        Self::try_new_validated_single_string_identities(
+            schema_plan_id,
+            schema_key,
+            branch_id,
+            origin_key,
+            identity_bytes,
+            offsets.into(),
+            snapshot_arena,
+            snapshot_offsets,
+            durable_predecessors,
+            timestamp,
+        )
+    }
+
+    #[expect(clippy::too_many_arguments)]
+    fn try_new_validated_single_string_identities(
+        schema_plan_id: SchemaPlanId,
+        schema_key: SharedStr,
+        branch_id: SharedStr,
+        origin_key: Option<SharedStr>,
+        identity_arena: Bytes,
+        identity_offsets: Arc<[(u32, u32)]>,
+        snapshot_arena: Vec<u8>,
+        snapshot_offsets: Vec<(usize, usize)>,
+        durable_predecessors: Option<Vec<CertifiedCurrentStatePredecessor>>,
+        timestamp: LixTimestamp,
+    ) -> Result<Self, LixError> {
+        let row_count = identity_offsets.len();
+        if row_count == 0 || row_count != snapshot_offsets.len() {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 "immutable mutation journal columns are empty or misaligned",
@@ -149,17 +232,11 @@ impl ImmutableMutationJournalChunk {
         }
         if durable_predecessors
             .as_ref()
-            .is_some_and(|predecessors| predecessors.len() != entity_pks.len())
+            .is_some_and(|predecessors| predecessors.len() != row_count)
         {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 "immutable mutation predecessor column is misaligned",
-            ));
-        }
-        if !entity_pks.windows(2).all(|pair| pair[0] < pair[1]) {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                "immutable mutation journal identities are not strictly ordered",
             ));
         }
         let arena_len = snapshot_arena.len();
@@ -225,7 +302,8 @@ impl ImmutableMutationJournalChunk {
             schema_key,
             branch_id,
             origin_key,
-            entity_pks: entity_pks.into(),
+            identity_arena,
+            identity_offsets,
             snapshot_arena: Bytes::from(snapshot_arena),
             snapshot_offsets: offsets.into(),
             large_snapshot_refs: large_snapshot_refs.into(),
@@ -235,11 +313,21 @@ impl ImmutableMutationJournalChunk {
     }
 
     pub(crate) fn len(&self) -> usize {
-        self.entity_pks.len()
+        self.identity_offsets.len()
     }
 
-    pub(crate) fn entity_pks(&self) -> &Arc<[EntityPk]> {
-        &self.entity_pks
+    pub(crate) fn materialized_entity_pks(&self) -> Arc<[EntityPk]> {
+        self.identity_offsets
+            .iter()
+            .map(|&(start, end)| {
+                let value = std::str::from_utf8(&self.identity_arena[start as usize..end as usize])
+                    .expect("validated immutable mutation identity UTF-8");
+                let value = SharedStr::from_utf8_slice(self.identity_arena.clone(), value)
+                    .expect("validated immutable mutation identity remains in its arena");
+                EntityPk::from_validated_shared_string(value)
+            })
+            .collect::<Vec<_>>()
+            .into()
     }
 
     pub(crate) fn attach_durable_predecessors(
@@ -256,8 +344,10 @@ impl ImmutableMutationJournalChunk {
         Ok(())
     }
 
-    pub(crate) fn entity_pk(&self, index: usize) -> &EntityPk {
-        &self.entity_pks[index]
+    fn identity(&self, index: usize) -> &str {
+        let (start, end) = self.identity_offsets[index];
+        std::str::from_utf8(&self.identity_arena[start as usize..end as usize])
+            .expect("validated immutable mutation identity UTF-8")
     }
 
     pub(crate) fn snapshot(&self, index: usize) -> &str {
@@ -299,13 +389,14 @@ impl ImmutableMutationJournalChunk {
         self,
         allow_missing_predecessors: bool,
     ) -> Result<PreparedStateBatch, LixError> {
+        let entity_pks = self.materialized_entity_pks();
         let offsets = self
             .snapshot_offsets
             .iter()
             .map(|&(start, end)| (start as usize, end as usize))
             .collect();
         let mut rows = CertifiedParameterReplacementBatch::new(
-            self.entity_pks.iter().cloned().collect(),
+            entity_pks.iter().cloned().collect(),
             TransactionJson::from_certified_row_content_arena(
                 self.snapshot_arena.to_vec(),
                 offsets,
@@ -359,8 +450,8 @@ pub(crate) struct OrderedMutationJournalRowRef<'a> {
 }
 
 impl<'a> OrderedMutationJournalRowRef<'a> {
-    pub(crate) fn entity_pk(&self) -> &'a EntityPk {
-        self.chunk.entity_pk(self.row_index)
+    pub(crate) fn identity(&self) -> &'a str {
+        self.chunk.identity(self.row_index)
     }
 
     pub(crate) fn snapshot(&self) -> &'a str {
@@ -1201,7 +1292,7 @@ impl PreparedWriteSet {
                         entity_pk_chunks: journal
                             .chunks
                             .iter()
-                            .map(|chunk| Arc::clone(chunk.entity_pks()))
+                            .map(ImmutableMutationJournalChunk::materialized_entity_pks)
                             .collect(),
                     })
             })
@@ -1467,13 +1558,16 @@ impl TransactionWriteBuffer {
             {
                 return Ok(false);
             }
-            let actual_digest = crate::collection_generation::ordered_single_string_identity_digest(
-                journal
-                    .chunks
-                    .iter()
-                    .flat_map(|chunk| chunk.entity_pks.iter()),
-            );
-            if actual_digest != Some(expected_ordered_identity_digest) {
+            let mut identity_hasher = blake3::Hasher::new();
+            for identity in journal
+                .chunks
+                .iter()
+                .flat_map(|chunk| (0..chunk.len()).map(|index| chunk.identity(index)))
+            {
+                identity_hasher.update(&(identity.len() as u64).to_le_bytes());
+                identity_hasher.update(identity.as_bytes());
+            }
+            if *identity_hasher.finalize().as_bytes() != expected_ordered_identity_digest {
                 return Ok(false);
             }
             let replay_bytes = journal.chunks.iter().try_fold(0_u64, |bytes, chunk| {
@@ -1481,7 +1575,7 @@ impl TransactionWriteBuffer {
                     let row_bytes = chunk
                         .schema_key()
                         .len()
-                        .checked_add(chunk.entity_pk(index).estimated_heap_bytes())
+                        .checked_add(chunk.identity(index).len())
                         .and_then(|value| value.checked_add(128))
                         .and_then(|value| value.checked_add(chunk.snapshot(index).len()))
                         .and_then(|value| u64::try_from(value).ok())
@@ -1562,8 +1656,13 @@ impl TransactionWriteBuffer {
                 && existing
                     .chunks
                     .last()
-                    .and_then(|previous| previous.entity_pks.last())
-                    .zip(chunk.entity_pks.first())
+                    .and_then(|previous| {
+                        previous
+                            .len()
+                            .checked_sub(1)
+                            .map(|index| previous.identity(index))
+                    })
+                    .zip((chunk.len() > 0).then(|| chunk.identity(0)))
                     .is_some_and(|(previous, next)| previous < next);
             if !compatible {
                 return Ok(ImmutableMutationChunkStage::RequiresGeneric(chunk));
@@ -1684,7 +1783,7 @@ impl TransactionWriteBuffer {
                 entity_pk_chunks: journal
                     .chunks
                     .iter()
-                    .map(|chunk| Arc::clone(&chunk.entity_pks))
+                    .map(ImmutableMutationJournalChunk::materialized_entity_pks)
                     .collect(),
                 predecessors_complete: journal
                     .chunks
@@ -3554,16 +3653,18 @@ fn ordered_mutation_journal_row<'a>(
     if file_id.is_some() || journal.branch_id() != branch_id || journal.schema_key() != schema_key {
         return None;
     }
-    let chunk_index = journal.chunks.partition_point(|chunk| {
-        chunk
-            .entity_pks
-            .last()
-            .is_some_and(|last_entity_pk| last_entity_pk < entity_pk)
-    });
+    let entity_pk = entity_pk.as_single_string().ok()?;
+    let chunk_index = journal
+        .chunks
+        .partition_point(|chunk| chunk.len() > 0 && chunk.identity(chunk.len() - 1) < entity_pk);
     let chunk = journal.chunks.get(chunk_index)?;
     chunk
-        .entity_pks
-        .binary_search(entity_pk)
+        .identity_offsets
+        .binary_search_by(|&(start, end)| {
+            std::str::from_utf8(&chunk.identity_arena[start as usize..end as usize])
+                .expect("validated immutable mutation identity UTF-8")
+                .cmp(entity_pk)
+        })
         .ok()
         .map(|index| (chunk, index))
 }
@@ -3593,8 +3694,17 @@ fn push_ordered_mutation_materialized(
             .transpose()?
             .unwrap_or_else(|| chunk.timestamp())
     };
+    let identity = chunk.identity(row_index);
+    let identity =
+        SharedStr::from_utf8_slice(chunk.identity_arena.clone(), identity).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "immutable mutation identity escaped its shared arena",
+            )
+        })?;
+    let entity_pk = EntityPk::from_validated_shared_string(identity);
     let ordinal = output.push_materialized_ref(
-        chunk.entity_pk(row_index),
+        &entity_pk,
         chunk.schema_key(),
         None,
         Some(snapshot),
@@ -4216,6 +4326,36 @@ mod tests {
         ($($row:expr),* $(,)?) => {
             PreparedStateBatch::from_test_rows(vec![$($row),*])
         };
+    }
+
+    #[test]
+    fn immutable_journal_single_string_identities_share_one_arena() {
+        let first_snapshot = r#"{"path":"a","value":1}"#;
+        let second_snapshot = r#"{"path":"b","value":2}"#;
+        let snapshots = format!("{first_snapshot}{second_snapshot}");
+        let chunk = ImmutableMutationJournalChunk::try_new_single_string_identities(
+            SchemaPlanId::for_test(0),
+            "schema".into(),
+            "branch".into(),
+            None,
+            b"ab".to_vec(),
+            vec![(0, 1), (1, 2)],
+            snapshots.into_bytes(),
+            vec![
+                (0, first_snapshot.len()),
+                (
+                    first_snapshot.len(),
+                    first_snapshot.len() + second_snapshot.len(),
+                ),
+            ],
+            None,
+            LixTimestamp::expect_parse("timestamp", "2026-01-01T00:00:00Z"),
+        )
+        .expect("shared identity chunk");
+
+        assert_eq!(chunk.identity(0), "a");
+        assert_eq!(chunk.identity(1), "b");
+        assert_eq!(chunk.identity_arena.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- store ordered scalar UPDATE identities in one journal arena instead of one owned EntityPk per row
- seal borrowed single-string journal columns directly into the content-addressed replacement-part path introduced by #1158
- retain one transaction-local packed-membership cursor across rows instead of reacquiring and mutating the shared cache for every lookup
- remove the boxed future from scalar transaction execute and specialize the certified two-literal UPDATE decoder
- preserve stale and mixed-write semantics through the existing generic lowering boundary

## Performance

Compared with the immediately previous merged PR #1171 using exact preserved release binaries, five samples, 1M scalar UPDATE statements in one explicit transaction:

| adapter | #1171 | this PR | change |
| --- | ---: | ---: | ---: |
| RocksDB | 1.407 s | 1.145 s | -18.6% |
| SlateDB | 1.574 s | 1.240 s | -21.2% |

At 10K rows, RocksDB improves 38.17 to 36.08 ms (-5.5%) and SlateDB improves 38.51 to 36.54 ms (-5.1%).

Isolated-process 1M peak RSS is effectively neutral: RocksDB 3,201,056 to 3,201,244 KiB and SlateDB 3,222,104 to 3,232,332 KiB. Raw SQLite peaks at 838,780 KiB, so #1172 tracks the next ownership-transfer hard cut rather than claiming this PR solves RSS.

## Validation

- cargo test -p lix_engine: 1,837 unit tests, 439 integration tests, and 3 doctests passed
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- targeted escaped-literal, packed read-your-writes, replacement-part byte-equivalence, and mutation-journal tests
- two independent high-rigor reviews: semantic approval; performance review findings recorded in #1172

No changenote.