### PR TITLE
Stream packed UPDATE membership across immutable parts

### DIFF
--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -1994,8 +1994,9 @@ pub(crate) struct PackedIdentityMembership {
 }
 
 impl PackedIdentityMembership {
-    pub(crate) fn contains_single_string(
+    pub(crate) async fn contains_single_string(
         &mut self,
+        store: &(impl StorageAdapterRead + ?Sized),
         entity_pk: &str,
     ) -> Result<Option<bool>, LixError> {
         self.encoded_key.clear();
@@ -2006,7 +2007,12 @@ impl PackedIdentityMembership {
             entity_pk,
         );
         self.cursor
-            .cached_live_member(&self.cache.commit_delta_points, &self.encoded_key[encoded])
+            .live_member(
+                store,
+                &self.cache.commit_delta_points,
+                &self.encoded_key[encoded],
+            )
+            .await
     }
 
     pub(crate) fn complete_generation(&self) -> (u64, [u8; 32]) {

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -989,22 +989,36 @@ impl CommitDeltaPointReadCache {
 }
 
 impl CommitDeltaLiveMembershipCursor {
-    pub(crate) fn cached_live_member(
+    /// Resolves one key through a monotonically consumed immutable generation.
+    ///
+    /// The shared point cache is only an opportunistic source. An ordered
+    /// transaction must not fall back to the generic live-state point reader
+    /// merely because the next physical part has not been observed twice yet:
+    /// load that one bounded part directly and retain it until the cursor
+    /// crosses the next range boundary.
+    pub(crate) async fn live_member(
         &mut self,
+        store: &(impl StorageAdapterRead + ?Sized),
         cache: &CommitDeltaPointReadCache,
         encoded_key: &[u8],
     ) -> Result<Option<bool>, LixError> {
         if self.manifest.is_none() {
-            self.manifest = cache.manifest(self.commit_id)?;
+            self.manifest =
+                load_commit_delta_manifest_cached(store, self.commit_id, Some(cache)).await?;
         }
         let Some(manifest) = self.manifest.as_ref() else {
             return Ok(None);
         };
-        if manifest.selected_source_commit_id.is_some() || manifest.inline_segment().is_some() {
+        if manifest.selected_source_commit_id.is_some() {
             return Ok(None);
         }
-        let Some(segment_index) = commit_delta_segment_for_key(&manifest, encoded_key) else {
-            return Ok(Some(false));
+        let segment_index = if manifest.inline_segment().is_some() {
+            0
+        } else {
+            let Some(segment_index) = commit_delta_segment_for_key(manifest, encoded_key) else {
+                return Ok(Some(false));
+            };
+            segment_index
         };
         if self.segment_index != Some(segment_index) || self.segment.is_none() {
             self.segment = cache.segment(
@@ -1012,11 +1026,52 @@ impl CommitDeltaLiveMembershipCursor {
                 segment_index,
                 manifest.segments.get(segment_index),
             )?;
+            if self.segment.is_none() {
+                let decoded = if let Some(inline_segment) = manifest.inline_segment() {
+                    decode_owned_commit_delta_segment(inline_segment, None)?
+                } else {
+                    let bounds = manifest.segments.get(segment_index).ok_or_else(|| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            format!(
+                                "tracked_state commit_delta manifest for commit '{}' has no segment {segment_index}",
+                                self.commit_id
+                            ),
+                        )
+                    })?;
+                    let storage_key =
+                        commit_delta_segment_key_for_bounds(self.commit_id, segment_index, bounds)?;
+                    let loaded = PointReadPlan::new(
+                        TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
+                        &[StorageKey(Bytes::from(storage_key))],
+                    )
+                    .materialize(store, StorageGetOptions::default())
+                    .await?;
+                    let bytes = loaded
+                        .value
+                        .into_iter()
+                        .next()
+                        .flatten()
+                        .and_then(full_value_bytes)
+                        .ok_or_else(|| {
+                            LixError::new(
+                                LixError::CODE_INTERNAL_ERROR,
+                                format!(
+                                    "tracked_state commit_delta manifest for commit '{}' references missing segment {segment_index}",
+                                    self.commit_id
+                                ),
+                            )
+                        })?;
+                    decode_owned_commit_delta_segment(&bytes, Some(bounds))?
+                };
+                self.segment = Some(decoded);
+            }
             self.segment_index = Some(segment_index);
         }
-        let Some(segment) = self.segment.as_ref() else {
-            return Ok(None);
-        };
+        let segment = self
+            .segment
+            .as_ref()
+            .expect("membership cursor loaded its current immutable part");
         Ok(Some(
             find_commit_delta_value(&segment.leaf, encoded_key, self.commit_id)?
                 .is_some_and(|value| !value.deleted),
@@ -8130,6 +8185,28 @@ mod tests {
             .await
             .expect("replacement point replay should load");
         assert!(values.iter().all(Option::is_some));
+        let point_cache = super::CommitDeltaPointReadCache::default();
+        let mut membership = point_cache.live_membership_cursor(commit_id);
+        let mut encoded_key = Vec::new();
+        for fixture_index in [0, 777, 1_024] {
+            encoded_key.clear();
+            crate::tracked_state::encode_single_string_key_ref_into(
+                &mut encoded_key,
+                "alpha",
+                None,
+                fixtures[fixture_index]
+                    .entity_pk
+                    .as_single_string()
+                    .expect("fixture identity is one string"),
+            );
+            assert_eq!(
+                membership
+                    .live_member(&read, &point_cache, &encoded_key)
+                    .await
+                    .expect("cold monotonic membership should load its bounded part"),
+                Some(true)
+            );
+        }
         let change_id = staged
             .change_id_at(777)
             .expect("replacement row has a direct address");

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -6434,9 +6434,12 @@ where
             }
             self.prepared_mutation_overlay_empty = !self.staged_writes.has_staged_state_rows()?;
         }
+        let opening_read = self.opening_read();
         let cached_membership = match &mut self.prepared_mutation_membership {
             PreparedMutationMembership::Packed(membership) => {
-                membership.contains_single_string(primary_key)?
+                membership
+                    .contains_single_string(&opening_read, primary_key)
+                    .await?
             }
             PreparedMutationMembership::Unprepared | PreparedMutationMembership::Unavailable => {
                 None
@@ -6569,11 +6572,15 @@ where
             }
             self.prepared_mutation_overlay_empty = !self.staged_writes.has_staged_state_rows()?;
         }
+        let opening_read = self.opening_read();
         let PreparedMutationMembership::Packed(membership) = &mut self.prepared_mutation_membership
         else {
             unreachable!("packed literal mutation membership was checked above")
         };
-        match membership.contains_single_string(primary_key)? {
+        match membership
+            .contains_single_string(&opening_read, primary_key)
+            .await?
+        {
             Some(false) => return Ok(Some(crate::sql2::SqlWriteResult::affected(0))),
             Some(true) => {}
             None => return Ok(None),


### PR DESCRIPTION
## Summary\n\n- stream ordered UPDATE membership across cold immutable replacement parts\n- load only the bounded part selected by the commit manifest and retain it until the monotonic cursor crosses a part boundary\n- preserve selected-source fallback and transaction opening-snapshot semantics\n- add cold multi-part cursor coverage\n\n## Root cause\n\nThe packed UPDATE cursor treated the shared point cache as authoritative. At every uncached part boundary it returned unavailable, forcing the ordered transaction path back through the generic live-state point reader. A 1M UPDATE therefore repeated point-read planning and allocation work even though the immutable replacement manifest already supplied exact bounded routing.\n\nThis cut makes the cursor own one decoded immutable part and refill it directly from the opening snapshot. It does not rebuild the transaction or add a compatibility layout.\n\n## Performance\n\nImmediate predecessor baseline: merged PR #1173 at d993bcf0cd9e275307d11982d88dc09b64d1fcbd. Measurements use the same tracked-state SQL UPDATE fixture and release binaries.\n\n| Metric | #1173 | This PR | Change |\n| --- | ---: | ---: | ---: |\n| RocksDB 10K allocated bytes | 27,730,557 | 19,719,374 | -28.9% |\n| RocksDB 1M allocated bytes | 1,431,523,647 | 1,017,435,767 | -28.9% |\n| SlateDB 1M latency | 1.2789 s | 1.1508 s | -10.0% |\n\nRocksDB latency was low-single-digit in the isolated cursor-only run and global peak RSS stayed effectively neutral because fixture seeding/current-state layout remains the process peak. The PR gate is the repeatable 28.9% reduction in UPDATE allocation traffic at both scales.\n\n## Validation\n\n- cargo fmt --all -- --check\n- cargo clippy --workspace --all-targets --all-features -- -D warnings\n- cargo test -p lix_engine --no-fail-fast\n- targeted cold replacement-part membership, direct journal sealing, and read-your-writes tests\n- independent correctness review covering RocksDB, SlateDB, diff, merge, branch, checkpoint, and history simulations\n- independent performance review against the exact #1173 binary\n\nNo changenote.