### PR TITLE
Cut persistent current-state range catalog

### DIFF
--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -125,6 +125,12 @@ harness = false
 required-features = ["storage-benches"]
 
 [[bench]]
+name = "current_state_scope_sharing"
+path = "benches/current_state_scope_sharing.rs"
+harness = false
+required-features = ["storage-benches", "slatedb"]
+
+[[bench]]
 name = "tpch"
 path = "benches/tpch/main.rs"
 harness = false

--- a/packages/engine-benchmarks/benches/current_state_scope_sharing.rs
+++ b/packages/engine-benchmarks/benches/current_state_scope_sharing.rs
@@ -1,0 +1,163 @@
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use lix_engine::storage_adapter::StorageAdapter;
+use lix_engine::tracked_state::bench::{
+    BenchCurrentStatePointFixture, BenchCurrentStatePointMode, seed_current_state_point_fixture,
+};
+use lix_rocksdb_storage::RocksDB;
+use lix_slatedb_storage::SlateDB;
+
+fn main() {
+    let rows = env_usize("LIX_CURRENT_STATE_ROWS", 1_000_000);
+    let sparse_commits = env_usize("LIX_CURRENT_STATE_SPARSE_COMMITS", 32);
+    let scopes = env_usize("LIX_CURRENT_STATE_SCOPES", 256);
+    let warmups = env_usize("LIX_CURRENT_STATE_WARMUPS", 10);
+    let samples = env_usize("LIX_CURRENT_STATE_SAMPLES", 101).max(1);
+    let backend_filter = std::env::var("LIX_CURRENT_STATE_BACKEND").unwrap_or_default();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("create current-state benchmark runtime");
+    runtime.block_on(async {
+        if backend_filter.is_empty() || backend_filter == "rocksdb" {
+            let rocks_dir = tempfile::tempdir().expect("create RocksDB directory");
+            let rocks = StorageAdapter::new(
+                RocksDB::open(rocks_dir.path()).expect("open current-state RocksDB"),
+            );
+            run_backend(
+                "rocksdb",
+                rocks,
+                rows,
+                sparse_commits,
+                scopes,
+                warmups,
+                samples,
+            )
+            .await;
+        }
+        if backend_filter.is_empty() || backend_filter == "slatedb" {
+            let slate_dir = tempfile::tempdir().expect("create SlateDB directory");
+            let slate = StorageAdapter::new(
+                SlateDB::open(slate_dir.path()).expect("open current-state SlateDB"),
+            );
+            run_backend(
+                "slatedb",
+                slate,
+                rows,
+                sparse_commits,
+                scopes,
+                warmups,
+                samples,
+            )
+            .await;
+        }
+    });
+}
+
+async fn run_backend<S>(
+    backend: &str,
+    storage: StorageAdapter<S>,
+    rows: usize,
+    sparse_commits: usize,
+    scopes: usize,
+    warmups: usize,
+    samples: usize,
+) where
+    S: lix_engine::storage::Storage,
+{
+    let setup = Instant::now();
+    let fixture = seed_current_state_point_fixture(storage, rows, sparse_commits, scopes).await;
+    let setup = setup.elapsed();
+    let mode = std::env::var("LIX_CURRENT_STATE_MODE").unwrap_or_default();
+    if mode == "persistent" || mode == "replay" {
+        let selected = if mode == "persistent" {
+            BenchCurrentStatePointMode::PersistentCatalog
+        } else {
+            BenchCurrentStatePointMode::FirstParentReplay
+        };
+        let measured = measure(&fixture, selected, warmups, samples).await;
+        println!(
+            "current_state_scope_sharing,backend={backend},mode={mode},rows={rows},scopes={},sparse_commits={sparse_commits},setup_ms={:.3},catalog_staged_encoded_bytes={},catalog_manifest_bytes={},replay_manifest_bytes={},p50_us={:.3},p95_us={:.3}",
+            fixture.catalog_entry_count(),
+            millis(setup),
+            fixture.catalog_staged_encoded_bytes(),
+            fixture.catalog_manifest_bytes(),
+            fixture.replay_manifest_bytes(),
+            micros(measured.0),
+            micros(measured.1),
+        );
+        return;
+    }
+    let persistent = measure(
+        &fixture,
+        BenchCurrentStatePointMode::PersistentCatalog,
+        warmups,
+        samples,
+    )
+    .await;
+    let replay = measure(
+        &fixture,
+        BenchCurrentStatePointMode::FirstParentReplay,
+        warmups,
+        samples,
+    )
+    .await;
+    println!(
+        "current_state_scope_sharing,backend={backend},rows={rows},scopes={},sparse_commits={sparse_commits},setup_ms={:.3},catalog_staged_encoded_bytes={},catalog_manifest_bytes={},replay_manifest_bytes={},persistent_p50_us={:.3},persistent_p95_us={:.3},replay_p50_us={:.3},replay_p95_us={:.3},p50_reduction_pct={:.2},p95_reduction_pct={:.2}",
+        fixture.catalog_entry_count(),
+        millis(setup),
+        fixture.catalog_staged_encoded_bytes(),
+        fixture.catalog_manifest_bytes(),
+        fixture.replay_manifest_bytes(),
+        micros(persistent.0),
+        micros(persistent.1),
+        micros(replay.0),
+        micros(replay.1),
+        reduction_percent(persistent.0, replay.0),
+        reduction_percent(persistent.1, replay.1),
+    );
+}
+
+async fn measure<S>(
+    fixture: &BenchCurrentStatePointFixture<S>,
+    mode: BenchCurrentStatePointMode,
+    warmups: usize,
+    samples: usize,
+) -> (Duration, Duration)
+where
+    S: lix_engine::storage::Storage,
+{
+    for _ in 0..warmups {
+        black_box(fixture.read_point(mode).await);
+    }
+    let mut timings = Vec::with_capacity(samples);
+    for _ in 0..samples {
+        let started = Instant::now();
+        assert_eq!(black_box(fixture.read_point(mode).await), 1);
+        timings.push(started.elapsed());
+    }
+    timings.sort_unstable();
+    let p50 = timings[timings.len() / 2];
+    let p95 = timings[(timings.len() - 1) * 95 / 100];
+    (p50, p95)
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn micros(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000_000.0
+}
+
+fn millis(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}
+
+fn reduction_percent(candidate: Duration, baseline: Duration) -> f64 {
+    (1.0 - candidate.as_secs_f64() / baseline.as_secs_f64()) * 100.0
+}

--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -944,6 +944,7 @@ fn profile_sql_session_operation(
         };
         maybe_print_profile_rss_phase("after_seed");
         reset_allocation_accounting();
+        let _ = lix_engine::storage_bench::take_crud_current_state_catalog_accounting();
         let start = Instant::now();
         let result = runtime.block_on(run_sql_session_operation(operation, &fixture));
         samples.push(start.elapsed());
@@ -961,6 +962,18 @@ fn profile_sql_session_operation(
         format!("sql_session/{}", profile.name())
     };
     print_profile_samples(&profile_layer, operation, read_many_pk_count, samples);
+    if std::env::var_os("LIX_TRACKED_STATE_CRUD_PROFILE_ROUTE_ACCOUNTING").is_some() {
+        let accounting = lix_engine::storage_bench::take_crud_current_state_catalog_accounting();
+        println!(
+            "tracked_state_crud current-state catalog accounting: attempts={} hits={} errors={} sealed_manifest_loads={} replay_manifest_loads={} ordered_delta_fallbacks={}",
+            accounting.attempts,
+            accounting.hits,
+            accounting.errors,
+            accounting.sealed_manifest_loads,
+            accounting.replay_manifest_loads,
+            accounting.ordered_delta_fallbacks,
+        );
+    }
 }
 
 fn profile_sql_session_bound_updates(

--- a/packages/engine/src/commit_graph/context.rs
+++ b/packages/engine/src/commit_graph/context.rs
@@ -668,7 +668,8 @@ mod tests {
                     bytes: 0,
                 },
                 mutations: CommitStateMutationInventory::default(),
-                current_state_part_sets: Vec::new(),
+                current_state_catalog: None,
+                current_state_coverage_anchor: None,
                 snapshot_root: None,
             },
         )
@@ -720,6 +721,12 @@ mod tests {
                 commit_id.as_uuid().as_bytes(),
             )),
         );
+        writes.delete(
+            crate::tracked_state::TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
+            StorageKey(bytes::Bytes::copy_from_slice(
+                commit_id.as_uuid().as_bytes(),
+            )),
+        );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
@@ -762,7 +769,7 @@ mod tests {
         drop(read);
         manifest.commit_change_id = change_id("different-authority-change");
         let mut writes = storage.new_write_set();
-        stage_commit_state_manifest(&mut writes, &manifest)
+        crate::tracked_state::stage_resealed_commit_state_manifest_for_test(&mut writes, &manifest)
             .expect("drifted but structurally valid authority should stage");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -1072,7 +1079,8 @@ mod tests {
                     bytes: 0,
                 },
                 mutations: staged.mutation_inventory().clone(),
-                current_state_part_sets: Vec::new(),
+                current_state_catalog: None,
+                current_state_coverage_anchor: None,
                 snapshot_root: None,
             },
         )
@@ -1574,7 +1582,8 @@ mod tests {
                     bytes: record.tracked_state_rootless_bytes,
                 },
                 mutations,
-                current_state_part_sets: Vec::new(),
+                current_state_catalog: None,
+                current_state_coverage_anchor: None,
                 snapshot_root: None,
             },
         )

--- a/packages/engine/src/commit_graph/walker.rs
+++ b/packages/engine/src/commit_graph/walker.rs
@@ -250,7 +250,6 @@ mod tests {
     use crate::storage_adapter::{Memory, StorageKey, StorageReadOptions, StorageWriteOptions};
     use crate::tracked_state::{
         CommitStateManifest, CommitStateMutationInventory, CommitStateReplayDebt,
-        stage_commit_state_manifest,
     };
 
     fn ts(value: &str) -> crate::common::LixTimestamp {
@@ -1056,7 +1055,7 @@ mod tests {
         writes: &mut crate::storage_adapter::StorageWriteSet,
         record: &CommitRecord,
     ) -> Result<(), LixError> {
-        stage_commit_state_manifest(
+        crate::tracked_state::stage_resealed_commit_state_manifest_for_test(
             writes,
             &CommitStateManifest {
                 commit_id: record.commit_id,
@@ -1071,7 +1070,8 @@ mod tests {
                     bytes: record.tracked_state_rootless_bytes,
                 },
                 mutations: CommitStateMutationInventory::default(),
-                current_state_part_sets: Vec::new(),
+                current_state_catalog: None,
+                current_state_coverage_anchor: None,
                 snapshot_root: None,
             },
         )

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -236,6 +236,51 @@ pub(crate) async fn load_recovery_refs(
     Ok(refs.into_values().collect())
 }
 
+async fn stage_sweep_unreachable_content_nodes(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    space: StorageSpace,
+    live: &BTreeSet<[u8; 32]>,
+) -> Result<(), LixError> {
+    let plan = ScanPlan::prefix(
+        space,
+        StoragePrefix {
+            bytes: Bytes::new(),
+        },
+    );
+    let mut resume_after = None;
+    loop {
+        let page = plan
+            .collect(
+                store,
+                StorageScanOptions {
+                    resume_after: resume_after.clone(),
+                    ..StorageScanOptions::default()
+                },
+            )
+            .await?;
+        resume_after = page.value.entries.last().map(|entry| entry.key.clone());
+        for entry in page.value.entries {
+            let node_id = <[u8; 32]>::try_from(entry.key.0.as_ref()).map_err(|_| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "content-addressed space '{}' contains a malformed key",
+                        space.name
+                    ),
+                )
+            })?;
+            if !live.contains(&node_id) {
+                writes.delete(space, entry.key);
+            }
+        }
+        if !page.value.has_more {
+            break;
+        }
+    }
+    Ok(())
+}
+
 pub(crate) async fn load_recovery_ref(
     store: &(impl StorageAdapterRead + ?Sized),
     branch_id: &str,
@@ -632,6 +677,146 @@ where
             ));
         }
     }
+    let mut live_catalog_nodes = BTreeSet::<[u8; 32]>::new();
+    let mut live_current_state_directory_nodes = BTreeSet::<[u8; 32]>::new();
+    let mut catalog_roots = BTreeMap::new();
+    let mut live_manifests = BTreeMap::new();
+    let live_commit_ids = live_commits.iter().copied().collect::<Vec<_>>();
+    let loaded_live_manifests =
+        crate::tracked_state::load_commit_state_manifests(store, &live_commit_ids).await?;
+    for (commit_id, manifest) in live_commit_ids.into_iter().zip(loaded_live_manifests) {
+        let manifest = manifest.ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("live commit '{commit_id}' has no commit-state authority"),
+            )
+        })?;
+        live_manifests.insert(commit_id, manifest.clone());
+        let Some(root) = manifest.current_state_catalog.as_ref() else {
+            continue;
+        };
+        if let Some(previous) = catalog_roots.insert(root.root_id, root.clone()) {
+            if previous.entry_count != root.entry_count {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "live current-state catalogs disagree about root '{:?}'",
+                        root.root_id
+                    ),
+                ));
+            }
+        }
+    }
+    for manifest in live_manifests.values() {
+        let parent = manifest
+            .parent_commit_ids
+            .first()
+            .and_then(|parent_id| live_manifests.get(parent_id));
+        crate::tracked_state::validate_current_state_catalog_parent_manifest(manifest, parent)?;
+        crate::tracked_state::validate_current_state_catalog_transition_root(
+            store,
+            manifest,
+            parent.and_then(|parent| parent.current_state_catalog.as_deref()),
+        )
+        .await?;
+    }
+
+    // Catalog roots and immutable directory roots are content addressed and
+    // may be shared by many live commits. Validate each distinct authority and
+    // directory only once; otherwise a long unchanged branch interval turns
+    // GC into O(commits * scopes * directory parts) work.
+    let catalog_root_values = catalog_roots
+        .values()
+        .map(|root| (**root).clone())
+        .collect::<Vec<_>>();
+    let (catalog_nodes, unique_entries) =
+        crate::tracked_state::load_current_state_catalog_reachability_many(
+            store,
+            &catalog_root_values,
+        )
+        .await?;
+    live_catalog_nodes.extend(catalog_nodes);
+    let mut catalog_entries = BTreeMap::new();
+    for set in unique_entries {
+        let identity = storage_codec::encode("GC current-state catalog entry", &set)?;
+        catalog_entries.entry(identity).or_insert(set);
+    }
+
+    let mut directory_roots = BTreeMap::new();
+    let authority_ids = catalog_entries
+        .values()
+        .map(|set| CommitId::new(uuid::Uuid::from_bytes(set.coverage_anchor_commit_id)))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let authority_manifests =
+        crate::tracked_state::load_commit_state_manifests(store, &authority_ids).await?;
+    let authority_by_id = authority_ids
+        .into_iter()
+        .zip(authority_manifests)
+        .map(|(authority_id, manifest)| {
+            manifest
+                .map(|manifest| (authority_id, manifest))
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!("live current-state catalog references missing coverage authority '{authority_id}'"),
+                    )
+                })
+        })
+        .collect::<Result<BTreeMap<_, _>, _>>()?;
+    for set in catalog_entries.values() {
+        let authority = CommitId::new(uuid::Uuid::from_bytes(set.coverage_anchor_commit_id));
+        crate::tracked_state::validate_current_state_catalog_entry_against_authority(
+            set,
+            authority_by_id
+                .get(&authority)
+                .expect("catalog authority was batch loaded"),
+        )?;
+        if !packed.commits.contains_key(&authority) {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "live current-state catalog references missing coverage authority '{authority}'"
+                ),
+            ));
+        }
+        retained_authority_commits.insert(authority);
+        if let Some(previous) = directory_roots.insert(set.directory.root_id, set.directory.clone())
+        {
+            if previous != set.directory {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "live current-state catalogs disagree about directory root '{:?}'",
+                        set.directory.root_id
+                    ),
+                ));
+            }
+        }
+    }
+    let directories = directory_roots.values().cloned().collect::<Vec<_>>();
+    let (directory_nodes, descriptor_sets) =
+        crate::tracked_state::load_current_state_part_directory_reachability_many(
+            store,
+            &directories,
+        )
+        .await?;
+    live_current_state_directory_nodes.extend(directory_nodes);
+    for descriptors in descriptor_sets {
+        for descriptor in descriptors {
+            let owner = CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id));
+            if !packed.commits.contains_key(&owner) {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "live current-state directory references missing immutable-part owner '{owner}'"
+                    ),
+                ));
+            }
+            retained_authority_commits.insert(owner);
+        }
+    }
     if let Some((commit_id, source_commit_id)) = live_commits.iter().find_map(|commit_id| {
         packed
             .commits
@@ -776,22 +961,22 @@ where
         COMMIT_SPACE,
         sweep_commits.iter().map(|commit_id| commit_key(*commit_id)),
     );
+    stage_sweep_unreachable_content_nodes(
+        store,
+        writes,
+        crate::tracked_state::CURRENT_STATE_CATALOG_SPACE,
+        &live_catalog_nodes,
+    )
+    .await?;
+    stage_sweep_unreachable_content_nodes(
+        store,
+        writes,
+        crate::tracked_state::CURRENT_STATE_PART_DIRECTORY_SPACE,
+        &live_current_state_directory_nodes,
+    )
+    .await?;
     for commit_id in &sweep_authority_commits {
         if let Some(entry) = packed.commits.get(commit_id) {
-            if let Some(manifest) =
-                crate::tracked_state::load_commit_state_manifest(store, *commit_id).await?
-            {
-                for set in &manifest.current_state_part_sets {
-                    crate::tracked_state::stage_delete_current_state_part_directory(
-                        store,
-                        writes,
-                        &set.directory,
-                        set.owner_commit_id,
-                        set.mutation_directory_digest,
-                    )
-                    .await?;
-                }
-            }
             let schema_keys = entry
                 .members
                 .iter()
@@ -1004,7 +1189,7 @@ mod tests {
     use crate::live_state::{CurrentStateDeltaRef, TrackedHeadContext, WorkingDiffIndexCoverage};
     use crate::storage_adapter::{
         Memory, PointReadPlan, SharedStorageAdapterRead, StorageAdapter, StorageGetOptions,
-        StorageKey, StorageReadOptions, StorageSpace, StorageWriteOptions,
+        StorageKey, StorageReadOptions, StorageSpace, StorageValue, StorageWriteOptions,
     };
     use crate::tracked_state::{
         CommitStateManifest, CommitStateMutationInventory, CommitStateReplayDebt,
@@ -1093,6 +1278,70 @@ mod tests {
                 .expect("checkpoint GC state should load"),
             expected
         );
+    }
+
+    #[tokio::test]
+    async fn shared_current_state_nodes_are_swept_by_reachability_not_owner() {
+        let storage = StorageAdapter::new(Memory::new());
+        let live_id = [1u8; 32];
+        let dead_id = [2u8; 32];
+        let mut writes = storage.new_write_set();
+        for space in [
+            crate::tracked_state::CURRENT_STATE_CATALOG_SPACE,
+            crate::tracked_state::CURRENT_STATE_PART_DIRECTORY_SPACE,
+        ] {
+            for node_id in [live_id, dead_id] {
+                writes.put(
+                    space,
+                    StorageKey(Bytes::copy_from_slice(&node_id)),
+                    StorageValue {
+                        bytes: Bytes::from_static(b"node"),
+                    },
+                );
+            }
+        }
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("shared-node fixture should commit");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("shared-node read should open");
+        let mut sweep = storage.new_write_set();
+        let live = BTreeSet::from([live_id]);
+        for space in [
+            crate::tracked_state::CURRENT_STATE_CATALOG_SPACE,
+            crate::tracked_state::CURRENT_STATE_PART_DIRECTORY_SPACE,
+        ] {
+            super::stage_sweep_unreachable_content_nodes(&read, &mut sweep, space, &live)
+                .await
+                .expect("content-addressed sweep should stage");
+        }
+        drop(read);
+        storage
+            .commit_write_set(sweep, StorageWriteOptions::default())
+            .await
+            .expect("content-addressed sweep should commit");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("post-sweep read should open");
+        let keys = [
+            StorageKey(Bytes::copy_from_slice(&live_id)),
+            StorageKey(Bytes::copy_from_slice(&dead_id)),
+        ];
+        for space in [
+            crate::tracked_state::CURRENT_STATE_CATALOG_SPACE,
+            crate::tracked_state::CURRENT_STATE_PART_DIRECTORY_SPACE,
+        ] {
+            let loaded = PointReadPlan::new(space, &keys)
+                .materialize(&read, StorageGetOptions::default())
+                .await
+                .expect("post-sweep nodes should load");
+            assert!(loaded.value[0].is_some(), "shared live node must survive");
+            assert!(loaded.value[1].is_none(), "unreachable node must be swept");
+        }
     }
 
     #[tokio::test]
@@ -1405,7 +1654,8 @@ mod tests {
                 bytes: live.tracked_state_rootless_bytes,
             },
             mutations: CommitStateMutationInventory::default(),
-            current_state_part_sets: Vec::new(),
+            current_state_catalog: None,
+            current_state_coverage_anchor: None,
             snapshot_root: None,
         };
         drifted.generation += 1;
@@ -2158,7 +2408,8 @@ mod tests {
                     bytes: record.tracked_state_rootless_bytes,
                 },
                 mutations,
-                current_state_part_sets: Vec::new(),
+                current_state_catalog: None,
+                current_state_coverage_anchor: None,
                 snapshot_root: None,
             },
         )

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -51,7 +51,7 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::mutable(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"commit-state-manifest.v48";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"persistent-current-state-catalog.v49";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately
@@ -395,7 +395,8 @@ where
                 created_at: plan.commit.created_at,
                 replay_debt: CommitStateReplayDebt::default(),
                 mutations: staged_delta.mutation_inventory().clone(),
-                current_state_part_sets: Vec::new(),
+                current_state_catalog: None,
+                current_state_coverage_anchor: None,
                 snapshot_root: Some(snapshot_root),
             },
         )?;

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -2857,7 +2857,8 @@ mod tests {
                     created_at: record.created_at,
                     replay_debt: CommitStateReplayDebt::default(),
                     mutations: Default::default(),
-                    current_state_part_sets: Vec::new(),
+                    current_state_catalog: None,
+                    current_state_coverage_anchor: None,
                     snapshot_root: Some(snapshot_root),
                 },
             )
@@ -3084,7 +3085,8 @@ mod tests {
                         bytes: record.tracked_state_rootless_bytes,
                     },
                     mutations: Default::default(),
-                    current_state_part_sets: Vec::new(),
+                    current_state_catalog: None,
+                    current_state_coverage_anchor: None,
                     snapshot_root: None,
                 },
             )
@@ -3301,7 +3303,8 @@ mod tests {
                     created_at: record.created_at,
                     replay_debt: CommitStateReplayDebt::default(),
                     mutations: mutation_inventory,
-                    current_state_part_sets: Vec::new(),
+                    current_state_catalog: None,
+                    current_state_coverage_anchor: None,
                     snapshot_root: Some(snapshot_root),
                 },
             )?;

--- a/packages/engine/src/storage_adapter/write_set.rs
+++ b/packages/engine/src/storage_adapter/write_set.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::storage::{
     BufferRange, CommitResult, EncodedMutationBatch, Key, KeyRange, PutBatch, PutEntry, SpaceId,
@@ -11,6 +12,11 @@ use bytes::Bytes;
 use tracing::Instrument as _;
 
 type FastHashBuilder = RandomState;
+static NEXT_STORAGE_WRITE_SET_ID: AtomicU64 = AtomicU64::new(1);
+
+fn next_storage_write_set_id() -> u64 {
+    NEXT_STORAGE_WRITE_SET_ID.fetch_add(1, Ordering::Relaxed)
+}
 
 pub trait IntoStorageSpace {
     fn into_storage_space(self) -> StorageSpace;
@@ -71,6 +77,7 @@ impl IntoStorageValue for &[u8] {
 }
 
 pub struct StorageWriteSet {
+    identity: u64,
     groups: Vec<StorageWriteGroup>,
     group_index: HashMap<SpaceId, usize, FastHashBuilder>,
     exclusive_range_deletes: Vec<(StorageSpace, KeyRange)>,
@@ -240,6 +247,7 @@ impl StorageWriteSet {
     /// Creates a canonical write set with capacity hints.
     pub fn with_capacity(_expected_mutations: usize, expected_spaces: usize) -> Self {
         Self {
+            identity: next_storage_write_set_id(),
             groups: Vec::with_capacity(expected_spaces),
             group_index: HashMap::with_capacity_and_hasher(
                 expected_spaces,
@@ -259,6 +267,10 @@ impl StorageWriteSet {
                 .groups
                 .iter()
                 .all(|group| group.puts.is_empty() && group.deletes.is_empty())
+    }
+
+    pub(crate) fn identity(&self) -> u64 {
+        self.identity
     }
 
     /// Conservative encoded-size hint for contiguous backend write batches.
@@ -288,7 +300,7 @@ impl StorageWriteSet {
             })
     }
 
-    #[cfg(any(test, feature = "storage-benches"))]
+    #[cfg(feature = "storage-benches")]
     pub(crate) async fn apply<StorageImpl>(
         self,
         writer: &mut crate::storage_adapter::context::StorageAdapterWriteTransaction<
@@ -589,6 +601,20 @@ impl StorageWriteSet {
             .get(&space.id)
             .and_then(|index| self.groups.get(*index))
             .is_some_and(|group| group.puts.iter().any(|put| group.key_bytes(put.key) == key))
+    }
+
+    /// Returns an exact ordinary staged put value for transaction-local
+    /// immutable read-your-writes. Deferred sources remain final-only.
+    pub(crate) fn staged_value(&self, space: StorageSpace, key: &[u8]) -> Option<Bytes> {
+        let group = self
+            .group_index
+            .get(&space.id)
+            .and_then(|index| self.groups.get(*index))?;
+        let put = group
+            .puts
+            .iter()
+            .find(|put| group.key_bytes(put.key) == key)?;
+        Some(Bytes::copy_from_slice(group.value_bytes(put.value)))
     }
 
     pub fn extend(&mut self, other: Self) {
@@ -983,6 +1009,7 @@ fn validate_sorted_group(group: &StorageWriteGroup) -> Result<(), StorageWriteSe
 impl Default for StorageWriteSet {
     fn default() -> Self {
         Self {
+            identity: next_storage_write_set_id(),
             groups: Vec::new(),
             group_index: HashMap::with_hasher(FastHashBuilder::with_seeds(0, 0, 0, 0)),
             exclusive_range_deletes: Vec::new(),

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -37,7 +37,8 @@ fn stage_bench_commit_deltas(
                 bytes: u64::from(mutations.member_count),
             },
             mutations,
-            current_state_part_sets: Vec::new(),
+            current_state_catalog: None,
+            current_state_coverage_anchor: None,
             snapshot_root: None,
         },
     )?;
@@ -61,7 +62,14 @@ static CRUD_PHYSICAL_DELETES: AtomicU64 = AtomicU64::new(0);
 static CRUD_PHYSICAL_WRITTEN_BYTES: AtomicU64 = AtomicU64::new(0);
 static CRUD_COMMIT_STATE_MANIFEST_BYTES: AtomicU64 = AtomicU64::new(0);
 static CRUD_CURRENT_STATE_DIRECTORY_BYTES: AtomicU64 = AtomicU64::new(0);
+static CRUD_CURRENT_STATE_CATALOG_BYTES: AtomicU64 = AtomicU64::new(0);
 static CRUD_CURRENT_STATE_DIRECTORY_RECOVERIES: AtomicU64 = AtomicU64::new(0);
+static CRUD_CURRENT_STATE_CATALOG_ATTEMPTS: AtomicU64 = AtomicU64::new(0);
+static CRUD_CURRENT_STATE_CATALOG_HITS: AtomicU64 = AtomicU64::new(0);
+static CRUD_CURRENT_STATE_CATALOG_ERRORS: AtomicU64 = AtomicU64::new(0);
+static CRUD_SEALED_MANIFEST_LOADS: AtomicU64 = AtomicU64::new(0);
+static CRUD_REPLAY_MANIFEST_LOADS: AtomicU64 = AtomicU64::new(0);
+static CRUD_ORDERED_DELTA_FALLBACKS: AtomicU64 = AtomicU64::new(0);
 static MEDIA_UPLOAD_MANIFEST_LEAF_ROWS: AtomicU64 = AtomicU64::new(0);
 static MEDIA_UPLOAD_SUMMARIZED_CHUNK_ROWS: AtomicU64 = AtomicU64::new(0);
 static MEDIA_UPLOAD_CHUNK_PAYLOAD_HASH_BYTES: AtomicU64 = AtomicU64::new(0);
@@ -198,12 +206,65 @@ pub fn take_crud_current_state_directory_bytes() -> u64 {
     CRUD_CURRENT_STATE_DIRECTORY_BYTES.swap(0, Ordering::Relaxed)
 }
 
+pub(crate) fn record_crud_current_state_catalog_bytes(bytes: usize) {
+    CRUD_CURRENT_STATE_CATALOG_BYTES.fetch_add(bytes as u64, Ordering::Relaxed);
+}
+
+pub fn take_crud_current_state_catalog_bytes() -> u64 {
+    CRUD_CURRENT_STATE_CATALOG_BYTES.swap(0, Ordering::Relaxed)
+}
+
 pub(crate) fn record_crud_current_state_directory_recovery() {
     CRUD_CURRENT_STATE_DIRECTORY_RECOVERIES.fetch_add(1, Ordering::Relaxed);
 }
 
 pub fn take_crud_current_state_directory_recoveries() -> u64 {
     CRUD_CURRENT_STATE_DIRECTORY_RECOVERIES.swap(0, Ordering::Relaxed)
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CrudCurrentStateCatalogAccounting {
+    pub attempts: u64,
+    pub hits: u64,
+    pub errors: u64,
+    pub sealed_manifest_loads: u64,
+    pub replay_manifest_loads: u64,
+    pub ordered_delta_fallbacks: u64,
+}
+
+pub(crate) fn record_crud_current_state_catalog_attempt() {
+    CRUD_CURRENT_STATE_CATALOG_ATTEMPTS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_crud_current_state_catalog_hit() {
+    CRUD_CURRENT_STATE_CATALOG_HITS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_crud_current_state_catalog_error() {
+    CRUD_CURRENT_STATE_CATALOG_ERRORS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_crud_sealed_manifest_load() {
+    CRUD_SEALED_MANIFEST_LOADS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_crud_replay_manifest_load() {
+    CRUD_REPLAY_MANIFEST_LOADS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_crud_ordered_delta_fallback() {
+    CRUD_ORDERED_DELTA_FALLBACKS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn take_crud_current_state_catalog_accounting() -> CrudCurrentStateCatalogAccounting {
+    CrudCurrentStateCatalogAccounting {
+        attempts: CRUD_CURRENT_STATE_CATALOG_ATTEMPTS.swap(0, Ordering::Relaxed),
+        hits: CRUD_CURRENT_STATE_CATALOG_HITS.swap(0, Ordering::Relaxed),
+        errors: CRUD_CURRENT_STATE_CATALOG_ERRORS.swap(0, Ordering::Relaxed),
+        sealed_manifest_loads: CRUD_SEALED_MANIFEST_LOADS.swap(0, Ordering::Relaxed),
+        replay_manifest_loads: CRUD_REPLAY_MANIFEST_LOADS.swap(0, Ordering::Relaxed),
+        ordered_delta_fallbacks: CRUD_ORDERED_DELTA_FALLBACKS.swap(0, Ordering::Relaxed),
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/packages/engine/src/test_support.rs
+++ b/packages/engine/src/test_support.rs
@@ -469,6 +469,8 @@ pub(crate) async fn stage_tracked_root_from_materialized_with_parents(
             ))
         })?;
         owner_manifest.mutations = owner_mutations;
+        owner_manifest.current_state_catalog = None;
+        owner_manifest.current_state_coverage_anchor = None;
         crate::tracked_state::stage_commit_state_manifest(writes, &owner_manifest)?;
     }
     let mut root_writer = tracked_state.writer(read, writes);
@@ -557,7 +559,8 @@ fn stage_test_commit_state_manifest(
             created_at: record.created_at,
             replay_debt,
             mutations,
-            current_state_part_sets: Vec::new(),
+            current_state_catalog: None,
+            current_state_coverage_anchor: None,
             snapshot_root,
         },
     )

--- a/packages/engine/src/tracked_state/bench_support.rs
+++ b/packages/engine/src/tracked_state/bench_support.rs
@@ -39,7 +39,8 @@ fn stage_bench_commit_deltas(
                 bytes: u64::from(mutations.member_count),
             },
             mutations,
-            current_state_part_sets: Vec::new(),
+            current_state_catalog: None,
+            current_state_coverage_anchor: None,
             snapshot_root: None,
         },
     )?;
@@ -62,6 +63,498 @@ pub struct BenchTrackedFixture<StorageImpl: Storage> {
     rows: Vec<BenchTrackedRow>,
     current_commit_id: Option<String>,
     next_commit_index: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BenchCurrentStatePointMode {
+    PersistentCatalog,
+    FirstParentReplay,
+}
+
+#[expect(missing_debug_implementations)]
+pub struct BenchCurrentStatePointFixture<StorageImpl: Storage> {
+    storage: StorageAdapter<StorageImpl>,
+    commits: Vec<CommitId>,
+    current_manifest: CommitStateManifest,
+    encoded_key: bytes::Bytes,
+    catalog_entry_count: usize,
+    catalog_manifest_bytes: u64,
+    replay_manifest_bytes: u64,
+    catalog_staged_encoded_bytes: u64,
+}
+
+pub async fn seed_current_state_point_fixture<StorageImpl>(
+    storage: StorageAdapter<StorageImpl>,
+    replacement_rows: usize,
+    unrelated_sparse_commits: usize,
+    catalog_entry_count: usize,
+) -> BenchCurrentStatePointFixture<StorageImpl>
+where
+    StorageImpl: Storage,
+{
+    assert!(replacement_rows > 0);
+    assert!(catalog_entry_count > 0);
+    let _ = crate::storage_bench::take_crud_current_state_catalog_bytes();
+    let created_at = crate::common::LixTimestamp::from_unix_millis_utc_lossy(11);
+    let updated_at = crate::common::LixTimestamp::from_unix_millis_utc_lossy(22);
+    let parent_id = bench_addressable_commit_id("persistent-catalog-parent");
+    let entity_pks = (0..replacement_rows)
+        .map(|index| EntityPk::single(format!("entity-{index:09}")))
+        .collect::<Vec<_>>();
+    let parent_rows = entity_pks
+        .iter()
+        .enumerate()
+        .map(|(index, entity_pk)| TrackedStateCommitDeltaRef {
+            delta: TrackedStateDeltaRef {
+                schema_key: "bench_current_state_alpha",
+                file_id: None,
+                entity_pk,
+                change_id: ChangeId::for_test_label(&format!("catalog-parent-{index}")),
+                commit_id: parent_id,
+                deleted: false,
+                created_at,
+                updated_at,
+            },
+            snapshot: JsonSlotRef::Inline("{}"),
+            metadata: JsonSlotRef::None,
+            origin_key: None,
+            base_coordinate: None,
+            authored: true,
+        })
+        .collect::<Vec<_>>();
+    let scope = super::types::CommitDeltaReplacementScope {
+        schema_key: "bench_current_state_alpha".to_string(),
+        file_id: None,
+    };
+    let generation = super::storage::CommitDeltaReplacementGeneration {
+        scope: scope.clone(),
+        fallback_commit_id: None,
+        lifecycle_summary: super::storage::CommitDeltaLifecycleSummary {
+            scope,
+            ordered_identity_digest: [17; 32],
+            uniform_created_at: created_at,
+        },
+    };
+    let mut writes = storage.new_write_set();
+    let parent_stage = super::storage::stage_ordered_addressable_replacement_parts(
+        &mut writes,
+        parent_rows.iter().copied().map(Ok),
+        &generation,
+    )
+    .expect("stage benchmark replacement parts");
+    let mut parent_mutations = parent_stage.mutation_inventory().clone();
+    let parent_publication = super::storage::stage_current_state_catalog_from_published_parent(
+        &storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open benchmark root read"),
+        &mut writes,
+        None,
+        parent_id,
+        &parent_mutations,
+    )
+    .await
+    .expect("certify benchmark parent catalog");
+    let (parent_catalog, parent_anchor) = parent_publication.parts();
+    parent_mutations.parts.clear();
+    let mut current_manifest = bench_current_state_manifest(
+        parent_id,
+        None,
+        1,
+        parent_mutations,
+        parent_catalog,
+        parent_anchor,
+    );
+    super::storage::stage_certified_commit_state_manifest(
+        &mut writes,
+        &current_manifest,
+        &parent_publication,
+    )
+    .expect("stage benchmark parent manifest");
+    storage
+        .commit_write_set(writes, StorageWriteOptions::default())
+        .await
+        .expect("commit benchmark parent");
+
+    for index in 1..catalog_entry_count {
+        let authority_commit_id = bench_addressable_commit_id(&format!("catalog-scope-{index}"));
+        let schema_key = format!("bench_scope_{index:08}");
+        let file_id = format!("file-{:05}", index % 10_000);
+        let entity_pk = EntityPk::single("entity");
+        let scope = super::types::CommitDeltaReplacementScope {
+            schema_key: schema_key.clone(),
+            file_id: Some(file_id.clone()),
+        };
+        let row = TrackedStateCommitDeltaRef {
+            delta: TrackedStateDeltaRef {
+                schema_key: &schema_key,
+                file_id: Some(&file_id),
+                entity_pk: &entity_pk,
+                change_id: ChangeId::for_test_label(&format!("catalog-scope-change-{index}")),
+                commit_id: authority_commit_id,
+                deleted: false,
+                created_at,
+                updated_at,
+            },
+            snapshot: JsonSlotRef::Inline("{}"),
+            metadata: JsonSlotRef::None,
+            origin_key: None,
+            base_coordinate: None,
+            authored: true,
+        };
+        let generation = super::storage::CommitDeltaReplacementGeneration {
+            scope: scope.clone(),
+            fallback_commit_id: None,
+            lifecycle_summary: super::storage::CommitDeltaLifecycleSummary {
+                scope,
+                ordered_identity_digest: *blake3::hash(schema_key.as_bytes()).as_bytes(),
+                uniform_created_at: created_at,
+            },
+        };
+        let mut authority_writes = storage.new_write_set();
+        let staged = super::storage::stage_ordered_addressable_replacement_parts(
+            &mut authority_writes,
+            std::iter::once(Ok(row)),
+            &generation,
+        )
+        .expect("stage valid benchmark scope replacement");
+        let mut mutations = staged.mutation_inventory().clone();
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open benchmark scope parent read");
+        let published_parent =
+            super::storage::load_published_commit_state_manifest(&read, current_manifest.commit_id)
+                .await
+                .expect("load benchmark scope parent authority")
+                .expect("benchmark scope parent authority exists");
+        let publication = super::storage::stage_current_state_catalog_from_published_parent(
+            &read,
+            &mut authority_writes,
+            Some(&published_parent),
+            authority_commit_id,
+            &mutations,
+        )
+        .await
+        .expect("certify benchmark scope catalog");
+        let (catalog, anchor) = publication.parts();
+        mutations.parts.clear();
+        let authority_manifest = bench_current_state_manifest(
+            authority_commit_id,
+            Some(current_manifest.commit_id),
+            u16::try_from(index + 1)
+                .expect("benchmark catalog construction depth fits u16")
+                .min(super::COMMIT_STATE_MAX_REPLAY_DEPTH),
+            mutations,
+            catalog,
+            anchor,
+        );
+        super::storage::stage_certified_commit_state_manifest(
+            &mut authority_writes,
+            &authority_manifest,
+            &publication,
+        )
+        .expect("stage benchmark scope authority");
+        drop(read);
+        storage
+            .commit_write_set(authority_writes, StorageWriteOptions::default())
+            .await
+            .expect("commit benchmark scope authority");
+        current_manifest = authority_manifest;
+    }
+
+    let replay_base_id = if catalog_entry_count == 1 {
+        parent_id
+    } else {
+        let refresh_id = bench_addressable_commit_id("persistent-catalog-alpha-refresh");
+        let refresh_rows = entity_pks
+            .iter()
+            .enumerate()
+            .map(|(index, entity_pk)| TrackedStateCommitDeltaRef {
+                delta: TrackedStateDeltaRef {
+                    schema_key: "bench_current_state_alpha",
+                    file_id: None,
+                    entity_pk,
+                    change_id: ChangeId::for_test_label(&format!("catalog-refresh-{index}")),
+                    commit_id: refresh_id,
+                    deleted: false,
+                    created_at,
+                    updated_at,
+                },
+                snapshot: JsonSlotRef::Inline("{}"),
+                metadata: JsonSlotRef::None,
+                origin_key: None,
+                base_coordinate: None,
+                authored: true,
+            })
+            .collect::<Vec<_>>();
+        let mut refresh_writes = storage.new_write_set();
+        let refresh_stage = super::storage::stage_ordered_addressable_replacement_parts(
+            &mut refresh_writes,
+            refresh_rows.iter().copied().map(Ok),
+            &generation,
+        )
+        .expect("stage benchmark alpha refresh");
+        let mut refresh_mutations = refresh_stage.mutation_inventory().clone();
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open benchmark refresh parent read");
+        let published_parent =
+            super::storage::load_published_commit_state_manifest(&read, current_manifest.commit_id)
+                .await
+                .expect("load benchmark refresh parent authority")
+                .expect("benchmark refresh parent authority exists");
+        let publication = super::storage::stage_current_state_catalog_from_published_parent(
+            &read,
+            &mut refresh_writes,
+            Some(&published_parent),
+            refresh_id,
+            &refresh_mutations,
+        )
+        .await
+        .expect("certify benchmark alpha refresh");
+        let (catalog, anchor) = publication.parts();
+        refresh_mutations.parts.clear();
+        let refresh_manifest = bench_current_state_manifest(
+            refresh_id,
+            Some(current_manifest.commit_id),
+            1,
+            refresh_mutations,
+            catalog,
+            anchor,
+        );
+        super::storage::stage_certified_commit_state_manifest(
+            &mut refresh_writes,
+            &refresh_manifest,
+            &publication,
+        )
+        .expect("stage benchmark alpha refresh authority");
+        drop(read);
+        storage
+            .commit_write_set(refresh_writes, StorageWriteOptions::default())
+            .await
+            .expect("commit benchmark alpha refresh");
+        current_manifest = refresh_manifest;
+        refresh_id
+    };
+
+    let mut commits = vec![replay_base_id];
+    let mut catalog_manifest_bytes = 0u64;
+    let mut replay_manifest_bytes = 0u64;
+    let beta_pk = EntityPk::single("unrelated");
+    for index in 0..unrelated_sparse_commits {
+        let commit_id = bench_addressable_commit_id(&format!("catalog-child-{index}"));
+        let present_scope = catalog_entry_count > 1 && index % 4 == 0;
+        let schema_key = if present_scope {
+            format!("bench_scope_{:08}", 1 + index % (catalog_entry_count - 1))
+        } else {
+            "bench_current_state_beta".to_string()
+        };
+        let file_id = present_scope.then(|| {
+            format!(
+                "file-{:05}",
+                (1 + index % (catalog_entry_count - 1)) % 10_000
+            )
+        });
+        let row = TrackedStateCommitDeltaRef {
+            delta: TrackedStateDeltaRef {
+                schema_key: &schema_key,
+                file_id: file_id.as_deref(),
+                entity_pk: &beta_pk,
+                change_id: ChangeId::for_test_label(&format!("catalog-child-change-{index}")),
+                commit_id,
+                deleted: false,
+                created_at,
+                updated_at,
+            },
+            snapshot: JsonSlotRef::Inline("{}"),
+            metadata: JsonSlotRef::None,
+            origin_key: None,
+            base_coordinate: None,
+            authored: true,
+        };
+        let mut writes = storage.new_write_set();
+        let stage = super::storage::stage_ordered_addressable_commit_deltas(
+            &mut writes,
+            std::iter::once(Ok(row)),
+            true,
+            false,
+        )
+        .expect("stage benchmark sparse mutation")
+        .expect("benchmark sparse mutation is addressable");
+        let mut mutations = stage.mutation_inventory().clone();
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open benchmark parent read");
+        let published_parent =
+            super::storage::load_published_commit_state_manifest(&read, current_manifest.commit_id)
+                .await
+                .expect("load benchmark sparse parent authority")
+                .expect("benchmark sparse parent authority exists");
+        let publication = super::storage::stage_current_state_catalog_from_published_parent(
+            &read,
+            &mut writes,
+            Some(&published_parent),
+            commit_id,
+            &mut mutations,
+        )
+        .await
+        .expect("reuse benchmark persistent catalog");
+        let (catalog, anchor) = publication.parts();
+        drop(read);
+        current_manifest = bench_current_state_manifest(
+            commit_id,
+            commits.last().copied(),
+            u16::try_from(commits.len() + 1)
+                .expect("benchmark replay depth fits u16")
+                .min(super::COMMIT_STATE_MAX_REPLAY_DEPTH),
+            mutations,
+            catalog,
+            anchor,
+        );
+        catalog_manifest_bytes += u64::try_from(bench_manifest_encoded_len(&current_manifest))
+            .expect("benchmark manifest length fits u64");
+        let mut replay_manifest = current_manifest.clone();
+        replay_manifest.current_state_catalog = None;
+        replay_manifest_bytes += u64::try_from(bench_manifest_encoded_len(&replay_manifest))
+            .expect("benchmark manifest length fits u64");
+        super::storage::stage_certified_commit_state_manifest(
+            &mut writes,
+            &current_manifest,
+            &publication,
+        )
+        .expect("stage benchmark sparse manifest");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit benchmark sparse child");
+        commits.push(commit_id);
+    }
+
+    let target = &entity_pks[replacement_rows / 2];
+    let encoded_key = bytes::Bytes::from(super::codec::encode_key_ref(
+        super::types::TrackedStateKeyRef {
+            schema_key: "bench_current_state_alpha",
+            file_id: None,
+            entity_pk: target,
+        },
+    ));
+    BenchCurrentStatePointFixture {
+        storage,
+        commits,
+        current_manifest,
+        encoded_key,
+        catalog_entry_count,
+        catalog_manifest_bytes,
+        replay_manifest_bytes,
+        catalog_staged_encoded_bytes: crate::storage_bench::take_crud_current_state_catalog_bytes(),
+    }
+}
+
+impl<StorageImpl> BenchCurrentStatePointFixture<StorageImpl>
+where
+    StorageImpl: Storage,
+{
+    pub fn catalog_entry_count(&self) -> usize {
+        self.catalog_entry_count
+    }
+
+    pub fn catalog_manifest_bytes(&self) -> u64 {
+        self.catalog_manifest_bytes
+    }
+
+    pub fn replay_manifest_bytes(&self) -> u64 {
+        self.replay_manifest_bytes
+    }
+
+    pub fn catalog_staged_encoded_bytes(&self) -> u64 {
+        self.catalog_staged_encoded_bytes
+    }
+
+    pub async fn read_point(&self, mode: BenchCurrentStatePointMode) -> usize {
+        let read = self
+            .storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("begin benchmark current-state point read");
+        match mode {
+            BenchCurrentStatePointMode::PersistentCatalog => {
+                let state = super::storage::load_published_commit_state_manifest(
+                    &read,
+                    self.current_manifest.commit_id,
+                )
+                .await
+                .expect("load benchmark current-state manifest")
+                .expect("benchmark current-state manifest exists");
+                let values =
+                    super::storage::load_complete_current_state_values_from_published_manifest(
+                        &read,
+                        &state,
+                        std::slice::from_ref(&self.encoded_key),
+                    )
+                    .await
+                    .expect("read benchmark current-state catalog")
+                    .expect("benchmark point is covered");
+                usize::from(values[0].is_some())
+            }
+            BenchCurrentStatePointMode::FirstParentReplay => {
+                for commit_id in self.commits.iter().rev() {
+                    let values = super::storage::load_commit_delta_values_encoded_with_cache(
+                        &read,
+                        *commit_id,
+                        std::slice::from_ref(&self.encoded_key),
+                        None,
+                    )
+                    .await
+                    .expect("replay benchmark commit point");
+                    if values[0].is_some() {
+                        return 1;
+                    }
+                }
+                0
+            }
+        }
+    }
+}
+
+fn bench_manifest_encoded_len(manifest: &CommitStateManifest) -> usize {
+    5 + crate::storage_codec::encode("benchmark commit-state manifest", manifest)
+        .expect("encode benchmark commit-state manifest")
+        .len()
+}
+
+fn bench_addressable_commit_id(label: &str) -> CommitId {
+    let labeled = CommitId::for_test_label(label);
+    CommitId::with_change_address_space(*labeled.as_uuid())
+}
+
+fn bench_current_state_manifest(
+    commit_id: CommitId,
+    parent_commit_id: Option<CommitId>,
+    replay_depth: u16,
+    mutations: super::types::CommitStateMutationInventory,
+    current_state_catalog: Option<Box<super::types::CurrentStateCatalogRoot>>,
+    current_state_coverage_anchor: Option<Box<super::types::CurrentStateCoverageAnchor>>,
+) -> CommitStateManifest {
+    CommitStateManifest {
+        commit_id,
+        generation: 0,
+        parent_commit_ids: parent_commit_id.into_iter().collect(),
+        commit_change_id: ChangeId::for_test_label(&format!("{commit_id}:bench-state")),
+        author_account_ids: Vec::new(),
+        created_at: crate::common::LixTimestamp::from_unix_millis_utc_lossy(0),
+        replay_debt: CommitStateReplayDebt {
+            depth: replay_depth,
+            rows: u64::from(mutations.member_count),
+            bytes: u64::from(mutations.member_count),
+        },
+        mutations,
+        current_state_catalog,
+        current_state_coverage_anchor,
+        snapshot_root: None,
+    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/packages/engine/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/engine/src/tracked_state/commit_root_rebuild.rs
@@ -74,7 +74,7 @@ where
     let staged_roots = writer.staged_commit_roots().cloned().collect::<Vec<_>>();
     drop(writer);
     for snapshot_root in staged_roots {
-        let mut manifest = storage::load_commit_state_manifest(rebuilder.store, snapshot_root.commit_id)
+        let manifest = storage::load_published_commit_state_manifest(rebuilder.store, snapshot_root.commit_id)
             .await?
             .ok_or_else(|| {
                 LixError::new(
@@ -88,8 +88,11 @@ where
         // The rebuilt tree is an optional immutable accelerator. Preserve
         // replay debt: it remains the physical-policy authority projected by
         // the changelog, while readers may serve through this equivalent root.
-        manifest.snapshot_root = Some(snapshot_root);
-        storage::stage_commit_state_manifest(rebuilder.writes, &manifest)?;
+        storage::stage_commit_state_snapshot_root_update(
+            rebuilder.writes,
+            &manifest,
+            Some(snapshot_root),
+        )?;
     }
     Ok(report)
 }

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -988,6 +988,7 @@ struct PointReplayCommit {
     root_id: Option<TrackedStateRootId>,
     rootless: bool,
     replacement_generation: Option<storage::CommitDeltaReplacementGeneration>,
+    state_manifest: Arc<super::CommitStateManifest>,
 }
 
 /// One immutable first-parent interval shared by every cached suffix view.
@@ -3181,6 +3182,42 @@ where
         commit_id: &str,
         keys: &[TrackedStateKey],
     ) -> Result<Vec<Option<TrackedStateIndexValue>>, LixError> {
+        let requested_commit_id =
+            CommitId::parse_lix(commit_id, "rootless point replay commit id")?;
+        let head = self.load_point_replay_commit(requested_commit_id).await?;
+        let mut encoded = TrackedStateKeyBatchBuilder::with_row_capacity(keys.len());
+        for key in keys {
+            encoded.push(TrackedStateKeyRef {
+                schema_key: &key.schema_key,
+                file_id: key.file_id.as_deref(),
+                entity_pk: &key.entity_pk,
+            });
+        }
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_crud_current_state_catalog_attempt();
+        match storage::load_complete_current_state_values_from_replay_manifest(
+            &self.store,
+            &head.state_manifest,
+            &encoded.finish(),
+        )
+        .await
+        {
+            Ok(Some(values)) => {
+                #[cfg(feature = "storage-benches")]
+                crate::storage_bench::record_crud_current_state_catalog_hit();
+                return Ok(values);
+            }
+            Ok(None) => {
+                #[cfg(feature = "storage-benches")]
+                crate::storage_bench::record_crud_current_state_directory_recovery();
+            }
+            Err(_) => {
+                #[cfg(feature = "storage-benches")]
+                crate::storage_bench::record_crud_current_state_catalog_error();
+                #[cfg(feature = "storage-benches")]
+                crate::storage_bench::record_crud_current_state_directory_recovery();
+            }
+        }
         let interval = self.point_replay_interval(commit_id).await?;
         let mut values = if let Some(root_id) = interval.baseline_root.as_ref() {
             self.tree.get_many(&self.store, root_id, keys).await?
@@ -3281,7 +3318,7 @@ where
                 }
             }
         };
-        let manifest = storage::load_commit_state_manifest(&self.store, commit_id)
+        let manifest = storage::load_point_replay_commit_state(&self.store, commit_id)
             .await?
             .ok_or_else(|| {
                 LixError::new(
@@ -3322,13 +3359,11 @@ where
             ));
         }
         let replacement_generation = if rootless && manifest.mutations.member_count != 0 {
-            storage::load_commit_delta_replay_metadata_with_cache(
-                &self.store,
-                commit_id,
-                Some(&self.commit_delta_point_cache),
-            )
-            .await?
-            .and_then(|metadata| metadata.replacement_generation)
+            storage::seed_commit_delta_point_cache_from_replay_manifest(
+                &manifest,
+                &self.commit_delta_point_cache,
+            )?
+            .replacement_generation
         } else {
             None
         };
@@ -3337,6 +3372,7 @@ where
             root_id,
             rootless,
             replacement_generation,
+            state_manifest: Arc::new(manifest),
         };
         self.point_replay_commits
             .insert(commit_id, replay_commit.clone());
@@ -3375,11 +3411,12 @@ where
                 entity_pk: &key.entity_pk,
             });
         }
-        let values = storage::load_commit_delta_values_encoded_with_cache(
+        let replay_commit = self.load_point_replay_commit(commit_id).await?;
+        let values = storage::load_commit_delta_values_encoded_from_replay_manifest(
             &self.store,
-            commit_id,
+            &replay_commit.state_manifest,
             &encoded_keys.finish(),
-            Some(&self.commit_delta_point_cache),
+            &self.commit_delta_point_cache,
         )
         .await?;
         for ((index, key), value) in missing.into_iter().zip(values) {
@@ -4739,7 +4776,8 @@ mod tests {
                 ),
                 replay_debt: Default::default(),
                 mutations: Default::default(),
-                current_state_part_sets: Vec::new(),
+                current_state_catalog: None,
+                current_state_coverage_anchor: None,
                 snapshot_root: Some(snapshot_root),
             },
         )
@@ -6562,6 +6600,10 @@ mod tests {
                     storage::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
                     commit_root_key(commit_id),
                 );
+                writes.delete(
+                    storage::TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
+                    commit_root_key(commit_id),
+                );
             }
             storage
                 .commit_write_set(writes, StorageWriteOptions::default())
@@ -6639,7 +6681,7 @@ mod tests {
                     .expect("commit-b root should load")
                     .expect("commit-b root should exist"),
             }];
-            storage::stage_commit_state_manifest(&mut writes, &manifest)
+            storage::stage_resealed_commit_state_manifest_for_test(&mut writes, &manifest)
                 .expect("corrupt cycle authority should stage");
             writes.put(
                 crate::changelog::COMMIT_SPACE,
@@ -8235,8 +8277,11 @@ mod tests {
         .expect("certified commit delta should stage");
         crate::tracked_state::stage_change_locators(&mut writes, &staged.locators);
         authority.mutations = staged.mutation_inventory().clone();
-        crate::tracked_state::stage_commit_state_manifest(&mut writes, &authority)
-            .expect("certified commit-state authority should update atomically");
+        crate::tracked_state::stage_resealed_commit_state_manifest_for_test(
+            &mut writes,
+            &authority,
+        )
+        .expect("certified commit-state authority should update atomically");
         drop(read);
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -8812,18 +8857,16 @@ mod tests {
             primary_chunk_count: result.chunk_count as u64,
             primary_chunk_bytes: result.chunk_bytes as u64,
         };
-        let mut manifest = storage::load_commit_state_manifest(&read, typed_commit_id)
+        let published = storage::load_published_commit_state_manifest(&read, typed_commit_id)
             .await
             .expect("commit-state authority should load")
             .expect("root fixture should publish commit-state authority");
-        stale_root.parent_roots = manifest
+        stale_root.parent_roots = published
             .snapshot_root
             .as_ref()
             .map(|root| root.parent_roots.clone())
             .unwrap_or_default();
-        manifest.snapshot_root = Some(stale_root);
-        manifest.replay_debt = Default::default();
-        storage::stage_commit_state_manifest(&mut writes, &manifest)
+        storage::stage_commit_state_snapshot_root_update(&mut writes, &published, Some(stale_root))
             .expect("stale authority should encode");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())

--- a/packages/engine/src/tracked_state/current_state_part.rs
+++ b/packages/engine/src/tracked_state/current_state_part.rs
@@ -15,13 +15,20 @@ use crate::storage_adapter::{
     PointReadPlan, StorageAdapterRead, StorageGetOptions, StorageKey, StorageProjectedValue,
     StorageSpace, StorageSpaceId, StorageValue, StorageWriteSet,
 };
-use crate::tracked_state::types::{CommitStateMutationInventory, CurrentStatePartSet};
-use crate::tracked_state::types::{CurrentStatePartDescriptor, CurrentStatePartDirectoryRoot};
+use crate::tracked_state::types::{
+    CommitStateManifest, CommitStateMutationInventory, CurrentStateCatalogRoot,
+    CurrentStateCoverageAnchor, CurrentStatePartDescriptor, CurrentStatePartDirectoryRoot,
+    CurrentStatePartSet,
+};
 use crate::{LixError, storage_codec};
 
 pub(crate) const CURRENT_STATE_PART_DIRECTORY_SPACE: StorageSpace = StorageSpace::immutable(
     StorageSpaceId(0x0004_002c),
     "tracked_state.current_state_part_directory.v1",
+);
+pub(crate) const CURRENT_STATE_CATALOG_SPACE: StorageSpace = StorageSpace::immutable(
+    StorageSpaceId(0x0004_002d),
+    "tracked_state.current_state_catalog.v1",
 );
 
 const DIRECTORY_NODE_RAW_MAGIC: &[u8; 6] = b"LXCSDR";
@@ -29,6 +36,12 @@ const DIRECTORY_NODE_ZSTD_MAGIC: &[u8; 6] = b"LXCSDZ";
 const DIRECTORY_NODE_MAX_DECODED_BYTES: usize = 16 * 1024 * 1024;
 const DIRECTORY_FANOUT: usize = 128;
 const DIRECTORY_HASH_CONTEXT: &str = "lix current-state part directory node v1";
+const CATALOG_NODE_MAGIC: &[u8; 6] = b"LXCSCR";
+const CATALOG_HASH_CONTEXT: &str = "lix current-state catalog node v1";
+const CURRENT_STATE_LINEAGE_CONTEXT: &str = "lix current-state lineage v1";
+const CATALOG_TRANSITION_CONTEXT: &str = "lix current-state catalog transition v1";
+const CATALOG_LEAF_MAX_ENTRIES: usize = 128;
+const CATALOG_MAX_KEY_BYTES: usize = 64 * 1024;
 
 /// Publishes the serving directory for a certified complete replacement.
 /// Ordinary mutation inventories are not state partitions and return `None`.
@@ -37,12 +50,13 @@ pub(crate) fn stage_complete_replacement_current_state_part_set(
     commit_id: CommitId,
     inventory: &CommitStateMutationInventory,
 ) -> Result<Option<CurrentStatePartSet>, LixError> {
-    let Some(generation) = inventory.replacement_generation.as_ref() else {
+    let Some(initial_generation) = inventory.replacement_generation.as_ref() else {
         return Ok(None);
     };
     let authority = inventory.replacement_parts.as_ref().ok_or_else(|| {
         directory_error("replacement generation omitted its immutable part authority")
     })?;
+    let authority_digest = authority.directory_digest;
     if inventory.parts.len() != inventory.direct_part_row_counts.len() || inventory.parts.is_empty()
     {
         return Err(directory_error(
@@ -79,20 +93,1471 @@ pub(crate) fn stage_complete_replacement_current_state_part_set(
         .collect::<Result<Vec<_>, LixError>>()?;
     let directory = stage_current_state_part_directory(writes, &descriptors)?;
     if directory.row_count != u64::from(inventory.member_count)
-        || directory.descriptor_digest != authority.directory_digest
-        || generation.owner_commit_id != *commit_id.as_uuid().as_bytes()
+        || directory.descriptor_digest != authority_digest
+        || initial_generation.owner_commit_id != *commit_id.as_uuid().as_bytes()
     {
         return Err(directory_error(
             "replacement state set disagrees with its commit authority",
         ));
     }
+    let generation = initial_generation.clone();
+    let state_lineage_digest =
+        fresh_current_state_lineage_digest(commit_id, generation.integrity_digest, &directory);
     Ok(Some(CurrentStatePartSet {
         scope: generation.scope.clone(),
-        owner_commit_id: generation.owner_commit_id,
+        coverage_anchor_commit_id: *commit_id.as_uuid().as_bytes(),
         generation_integrity_digest: generation.integrity_digest,
-        mutation_directory_digest: authority.directory_digest,
+        state_lineage_digest,
         directory,
     }))
+}
+
+pub(crate) fn current_state_catalog_transition_digest(
+    commit_id: CommitId,
+    parent_root_id: Option<[u8; 32]>,
+    inventory: &CommitStateMutationInventory,
+    root_id: [u8; 32],
+    entry_count: u32,
+) -> Result<[u8; 32], LixError> {
+    let mut durable_inventory = inventory.clone();
+    if durable_inventory.replacement_generation.is_some() {
+        durable_inventory.parts.clear();
+    }
+    let inventory_bytes = storage_codec::encode(
+        "current-state catalog transition inventory",
+        &durable_inventory,
+    )?;
+    let mut digest = blake3::Hasher::new_derive_key(CATALOG_TRANSITION_CONTEXT);
+    digest.update(commit_id.as_uuid().as_bytes());
+    match parent_root_id {
+        Some(parent_root_id) => {
+            digest.update(&[1]);
+            digest.update(&parent_root_id);
+        }
+        None => {
+            digest.update(&[0]);
+        }
+    }
+    digest.update(&(inventory_bytes.len() as u64).to_be_bytes());
+    digest.update(&inventory_bytes);
+    digest.update(&root_id);
+    digest.update(&entry_count.to_be_bytes());
+    Ok(*digest.finalize().as_bytes())
+}
+
+pub(super) fn attest_catalog_root(
+    mut root: CurrentStateCatalogRoot,
+    parent: Option<&CurrentStateCatalogRoot>,
+    commit_id: CommitId,
+    inventory: &CommitStateMutationInventory,
+) -> Result<CurrentStateCatalogRoot, LixError> {
+    root.parent_root_id = parent.map(|parent| parent.root_id);
+    root.transition_digest = current_state_catalog_transition_digest(
+        commit_id,
+        root.parent_root_id,
+        inventory,
+        root.root_id,
+        root.entry_count,
+    )?;
+    Ok(root)
+}
+
+pub(crate) fn fresh_current_state_lineage_digest(
+    commit_id: CommitId,
+    generation_integrity_digest: [u8; 32],
+    directory: &CurrentStatePartDirectoryRoot,
+) -> [u8; 32] {
+    *blake3::Hasher::new_derive_key(CURRENT_STATE_LINEAGE_CONTEXT)
+        .update(commit_id.as_uuid().as_bytes())
+        .update(&generation_integrity_digest)
+        .update(&directory.root_id)
+        .update(&directory.descriptor_digest)
+        .finalize()
+        .as_bytes()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+struct CatalogChild {
+    #[musli(bytes)]
+    route: Vec<u8>,
+    node_id: [u8; 32],
+    entry_count: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+struct CatalogNode {
+    depth: u32,
+    #[musli(bytes)]
+    sample_key: Vec<u8>,
+    entries: Vec<CurrentStatePartSet>,
+    children: Vec<CatalogChild>,
+}
+
+impl CatalogNode {
+    fn entry_count(&self) -> Result<u32, LixError> {
+        if self.children.is_empty() {
+            u32::try_from(self.entries.len())
+                .map_err(|_| directory_error("catalog entry count overflows u32"))
+        } else {
+            self.children.iter().try_fold(0u32, |total, child| {
+                total
+                    .checked_add(child.entry_count)
+                    .ok_or_else(|| directory_error("catalog entry count overflows u32"))
+            })
+        }
+    }
+}
+
+/// Opaque proof that the serving catalog was produced by the canonical
+/// parent-plus-mutation transition in this module.
+pub(crate) struct CertifiedCurrentStateCatalogPublication {
+    write_set_id: u64,
+    parent_commit_id: Option<CommitId>,
+    root: Option<CurrentStateCatalogRoot>,
+    anchor: Option<CurrentStateCoverageAnchor>,
+}
+
+impl CertifiedCurrentStateCatalogPublication {
+    pub(crate) fn parts(
+        &self,
+    ) -> (
+        Option<Box<CurrentStateCatalogRoot>>,
+        Option<Box<CurrentStateCoverageAnchor>>,
+    ) {
+        (
+            self.root.clone().map(Box::new),
+            self.anchor.clone().map(Box::new),
+        )
+    }
+
+    pub(crate) fn parent_commit_id(&self) -> Option<CommitId> {
+        self.parent_commit_id
+    }
+
+    pub(crate) fn write_set_id(&self) -> u64 {
+        self.write_set_id
+    }
+}
+
+/// Path-copies the collection catalog after one sealed commit inventory.
+/// Unknown/broad mutation scopes deliberately discard the accelerator; replay
+/// remains the semantic fallback and can rebuild the catalog later.
+pub(super) async fn stage_current_state_catalog(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    parent: Option<&CommitStateManifest>,
+    commit_id: CommitId,
+    inventory: &CommitStateMutationInventory,
+) -> Result<CertifiedCurrentStateCatalogPublication, LixError> {
+    let replacement =
+        stage_complete_replacement_current_state_part_set(writes, commit_id, inventory)?;
+    let parent_root = parent.and_then(|parent| parent.current_state_catalog.as_deref());
+    let parent_commit_id = parent.map(|parent| parent.commit_id);
+    let Some(mut touched_scopes) =
+        crate::tracked_state::storage::commit_state_inventory_exact_touched_scopes(
+            commit_id, inventory,
+        )?
+    else {
+        let anchor = replacement.as_ref().map(coverage_anchor_from_entry);
+        let root = replacement
+            .map(|entry| stage_catalog_from_entries(writes, vec![entry]))
+            .transpose()?;
+        let root = root
+            .map(|root| attest_catalog_root(root, parent_root, commit_id, inventory))
+            .transpose()?;
+        return Ok(CertifiedCurrentStateCatalogPublication {
+            write_set_id: writes.identity(),
+            parent_commit_id,
+            root,
+            anchor,
+        });
+    };
+    touched_scopes.sort();
+    touched_scopes.dedup();
+
+    let mut root = parent_root.cloned();
+    let mut staged = std::collections::BTreeMap::<[u8; 32], CatalogNode>::new();
+    for scope in touched_scopes {
+        if replacement
+            .as_ref()
+            .is_some_and(|entry| entry.scope == scope)
+        {
+            continue;
+        }
+        root =
+            update_catalog_entry(store, writes, &mut staged, root.as_ref(), &scope, None).await?;
+    }
+    let anchor = replacement.as_ref().map(coverage_anchor_from_entry);
+    if let Some(entry) = replacement {
+        let scope = entry.scope.clone();
+        root = update_catalog_entry(
+            store,
+            writes,
+            &mut staged,
+            root.as_ref(),
+            &scope,
+            Some(entry),
+        )
+        .await?;
+    }
+    let root = root
+        .map(|root| attest_catalog_root(root, parent_root, commit_id, inventory))
+        .transpose()?;
+    if let Some(root) = root.as_ref() {
+        flush_reachable_staged_catalog_nodes(writes, &staged, root.root_id)?;
+    }
+    Ok(CertifiedCurrentStateCatalogPublication {
+        write_set_id: writes.identity(),
+        parent_commit_id,
+        root,
+        anchor,
+    })
+}
+
+/// Re-derives the complete physical catalog transition from the verified
+/// parent root, the sealed inventory, and the fresh replacement anchor. This
+/// checks untouched scopes without materializing the parent's full catalog.
+pub(crate) async fn validate_current_state_catalog_transition_root(
+    store: &(impl StorageAdapterRead + ?Sized),
+    state: &CommitStateManifest,
+    parent: Option<&CurrentStateCatalogRoot>,
+) -> Result<(), LixError> {
+    if state.current_state_catalog.is_none() {
+        return Ok(());
+    }
+    let replacement =
+        state
+            .current_state_coverage_anchor
+            .as_ref()
+            .map(|anchor| CurrentStatePartSet {
+                scope: anchor.scope.clone(),
+                coverage_anchor_commit_id: *state.commit_id.as_uuid().as_bytes(),
+                generation_integrity_digest: anchor.generation_integrity_digest,
+                state_lineage_digest: anchor.state_lineage_digest,
+                directory: anchor.directory.clone(),
+            });
+    let touched = crate::tracked_state::storage::commit_state_inventory_exact_touched_scopes(
+        state.commit_id,
+        &state.mutations,
+    )?;
+    let mut writes = StorageWriteSet::new();
+    let expected = if let Some(mut touched) = touched {
+        touched.sort();
+        touched.dedup();
+        let mut root = parent.cloned();
+        let mut staged = std::collections::BTreeMap::new();
+        for scope in touched {
+            if replacement
+                .as_ref()
+                .is_some_and(|entry| entry.scope == scope)
+            {
+                continue;
+            }
+            root =
+                update_catalog_entry(store, &mut writes, &mut staged, root.as_ref(), &scope, None)
+                    .await?;
+        }
+        if let Some(entry) = replacement {
+            let scope = entry.scope.clone();
+            root = update_catalog_entry(
+                store,
+                &mut writes,
+                &mut staged,
+                root.as_ref(),
+                &scope,
+                Some(entry),
+            )
+            .await?;
+        }
+        root
+    } else {
+        replacement
+            .map(|entry| stage_catalog_from_entries(&mut writes, vec![entry]))
+            .transpose()?
+    };
+    let actual = state.current_state_catalog.as_ref();
+    if expected
+        .as_ref()
+        .map(|root| (root.root_id, root.entry_count))
+        != actual.map(|root| (root.root_id, root.entry_count))
+    {
+        return Err(directory_error(
+            "catalog result is not the canonical parent mutation transition",
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn coverage_anchor_from_entry(
+    entry: &CurrentStatePartSet,
+) -> CurrentStateCoverageAnchor {
+    CurrentStateCoverageAnchor {
+        scope: entry.scope.clone(),
+        generation_integrity_digest: entry.generation_integrity_digest,
+        state_lineage_digest: entry.state_lineage_digest,
+        directory: entry.directory.clone(),
+    }
+}
+
+pub(crate) fn stage_fresh_current_state_catalog(
+    writes: &mut StorageWriteSet,
+    commit_id: CommitId,
+    inventory: &CommitStateMutationInventory,
+) -> Result<CertifiedCurrentStateCatalogPublication, LixError> {
+    let Some(entry) =
+        stage_complete_replacement_current_state_part_set(writes, commit_id, inventory)?
+    else {
+        return Ok(CertifiedCurrentStateCatalogPublication {
+            write_set_id: writes.identity(),
+            parent_commit_id: None,
+            root: None,
+            anchor: None,
+        });
+    };
+    let anchor = coverage_anchor_from_entry(&entry);
+    let root = attest_catalog_root(
+        stage_catalog_from_entries(writes, vec![entry])?,
+        None,
+        commit_id,
+        inventory,
+    )?;
+    Ok(CertifiedCurrentStateCatalogPublication {
+        write_set_id: writes.identity(),
+        parent_commit_id: None,
+        root: Some(root),
+        anchor: Some(anchor),
+    })
+}
+
+pub(super) fn stage_catalog_from_entries(
+    writes: &mut StorageWriteSet,
+    entries: Vec<CurrentStatePartSet>,
+) -> Result<CurrentStateCatalogRoot, LixError> {
+    let mut staged = std::collections::BTreeMap::new();
+    let child = stage_catalog_subtree(writes, &mut staged, 0, entries)?;
+    flush_reachable_staged_catalog_nodes(writes, &staged, child.node_id)?;
+    Ok(CurrentStateCatalogRoot {
+        root_id: child.node_id,
+        entry_count: child.entry_count,
+        parent_root_id: None,
+        transition_digest: [0; 32],
+    })
+}
+
+async fn update_catalog_entry(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    staged: &mut std::collections::BTreeMap<[u8; 32], CatalogNode>,
+    root: Option<&CurrentStateCatalogRoot>,
+    scope: &crate::tracked_state::types::CommitDeltaReplacementScope,
+    replacement: Option<CurrentStatePartSet>,
+) -> Result<Option<CurrentStateCatalogRoot>, LixError> {
+    let route_key = catalog_scope_key(scope)?;
+    let Some(root) = root else {
+        let Some(entry) = replacement else {
+            return Ok(None);
+        };
+        let child = stage_catalog_subtree(writes, staged, 0, vec![entry])?;
+        return Ok(Some(CurrentStateCatalogRoot {
+            root_id: child.node_id,
+            entry_count: child.entry_count,
+            parent_root_id: None,
+            transition_digest: [0; 32],
+        }));
+    };
+    let mut path = Vec::<(CatalogNode, usize)>::new();
+    let mut node_id = root.root_id;
+    let mut node = load_catalog_node_with_staged(
+        store,
+        staged.get(&node_id).cloned(),
+        writes.staged_value(CURRENT_STATE_CATALOG_SPACE, &node_id),
+        node_id,
+    )
+    .await?;
+    if node.entry_count()? != root.entry_count || node.depth != 0 {
+        return Err(directory_error("catalog root summary mismatch"));
+    }
+    while !node.children.is_empty() {
+        let depth = usize::try_from(node.depth).expect("u32 fits usize");
+        let selector = *route_key
+            .get(depth)
+            .ok_or_else(|| directory_error("catalog exceeds its hash depth"))?;
+        match node
+            .children
+            .binary_search_by_key(&selector, |child| child.route[0])
+        {
+            Ok(child_index) => {
+                let expected = node.children[child_index].clone();
+                if route_key.get(depth..depth + expected.route.len())
+                    != Some(expected.route.as_slice())
+                {
+                    let Some(entry) = replacement else {
+                        return Ok(Some(root.clone()));
+                    };
+                    let existing = load_catalog_node_with_staged(
+                        store,
+                        staged.get(&expected.node_id).cloned(),
+                        writes.staged_value(CURRENT_STATE_CATALOG_SPACE, &expected.node_id),
+                        expected.node_id,
+                    )
+                    .await?;
+                    validate_catalog_child(&node, &expected, &existing)?;
+                    let mismatch = expected
+                        .route
+                        .iter()
+                        .zip(route_key.iter().skip(depth))
+                        .position(|(left, right)| left != right)
+                        .unwrap_or_else(|| expected.route.len().min(route_key.len() - depth));
+                    let divergence = depth + mismatch;
+                    if divergence == depth {
+                        let child =
+                            stage_catalog_subtree(writes, staged, divergence + 1, vec![entry])?;
+                        let child = catalog_child_for_parent(staged, depth, child.node_id)?;
+                        node.children.insert(child_index, child);
+                        node.children.sort_by_key(|child| child.route[0]);
+                        let node_id = stage_catalog_node(writes, staged, node)?;
+                        return rebuild_catalog_path(store, writes, staged, path, Some(node_id))
+                            .await;
+                    }
+                    let mut new_child =
+                        stage_catalog_subtree(writes, staged, divergence + 1, vec![entry])?;
+                    new_child = catalog_child_for_parent(staged, divergence, new_child.node_id)?;
+                    let old_child = catalog_child_for_parent(staged, divergence, expected.node_id)
+                        .or_else(|_| {
+                            let route = existing.sample_key[divergence
+                                ..usize::try_from(existing.depth).expect("u32 fits usize")]
+                                .to_vec();
+                            Ok::<CatalogChild, LixError>(CatalogChild {
+                                route,
+                                node_id: expected.node_id,
+                                entry_count: expected.entry_count,
+                            })
+                        })?;
+                    let mut children = vec![old_child, new_child];
+                    children.sort_by_key(|child| child.route[0]);
+                    let branch = CatalogNode {
+                        depth: u32::try_from(divergence).expect("catalog depth fits u32"),
+                        sample_key: existing.sample_key.clone(),
+                        entries: Vec::new(),
+                        children,
+                    };
+                    let branch_id = stage_catalog_node(writes, staged, branch)?;
+                    node.children[child_index] =
+                        catalog_child_for_parent(staged, depth, branch_id)?;
+                    let node_id = stage_catalog_node(writes, staged, node)?;
+                    return rebuild_catalog_path(store, writes, staged, path, Some(node_id)).await;
+                }
+                path.push((node, child_index));
+                node_id = expected.node_id;
+                node = load_catalog_node_with_staged(
+                    store,
+                    staged.get(&node_id).cloned(),
+                    writes.staged_value(CURRENT_STATE_CATALOG_SPACE, &node_id),
+                    node_id,
+                )
+                .await?;
+                validate_catalog_child(
+                    &path.last().expect("catalog path exists").0,
+                    &expected,
+                    &node,
+                )?;
+            }
+            Err(child_index) => {
+                let Some(entry) = replacement else {
+                    return Ok(Some(root.clone()));
+                };
+                let child = stage_catalog_subtree(writes, staged, depth + 1, vec![entry])?;
+                let child = catalog_child_for_parent(staged, depth, child.node_id)?;
+                node.children.insert(child_index, child);
+                node_id = stage_catalog_node(writes, staged, node)?;
+                return rebuild_catalog_path(store, writes, staged, path, Some(node_id)).await;
+            }
+        }
+    }
+
+    let entry_index = node
+        .entries
+        .binary_search_by(|entry| entry.scope.cmp(scope));
+    match (entry_index, replacement) {
+        (Ok(index), Some(entry)) => node.entries[index] = entry,
+        (Err(index), Some(entry)) => node.entries.insert(index, entry),
+        (Ok(index), None) => {
+            node.entries.remove(index);
+        }
+        (Err(_), None) => return Ok(Some(root.clone())),
+    }
+    let child = if node.entries.is_empty() {
+        None
+    } else {
+        Some(stage_catalog_subtree(
+            writes,
+            staged,
+            usize::try_from(node.depth).expect("u32 fits usize"),
+            node.entries,
+        )?)
+    };
+    rebuild_catalog_path(
+        store,
+        writes,
+        staged,
+        path,
+        child.map(|child| child.node_id),
+    )
+    .await
+}
+
+async fn rebuild_catalog_path(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    staged: &mut std::collections::BTreeMap<[u8; 32], CatalogNode>,
+    mut path: Vec<(CatalogNode, usize)>,
+    mut child_id: Option<[u8; 32]>,
+) -> Result<Option<CurrentStateCatalogRoot>, LixError> {
+    while let Some((mut parent, child_index)) = path.pop() {
+        match child_id {
+            Some(node_id) => {
+                parent.children[child_index] = catalog_child_for_parent_with_store(
+                    store,
+                    staged,
+                    usize::try_from(parent.depth).expect("u32 fits usize"),
+                    node_id,
+                )
+                .await?;
+            }
+            None => {
+                parent.children.remove(child_index);
+            }
+        }
+        child_id = if parent.children.is_empty() {
+            None
+        } else if parent.children.len() == 1 && parent.depth != 0 {
+            Some(parent.children[0].node_id)
+        } else if parent
+            .children
+            .iter()
+            .try_fold(0u32, |total, child| total.checked_add(child.entry_count))
+            .is_some_and(|count| count <= CATALOG_LEAF_MAX_ENTRIES as u32)
+        {
+            let mut entries = Vec::new();
+            let mut pending = parent
+                .children
+                .iter()
+                .map(|child| child.node_id)
+                .collect::<Vec<_>>();
+            while let Some(node_id) = pending.pop() {
+                let mut node = load_catalog_node_with_staged(
+                    store,
+                    staged.get(&node_id).cloned(),
+                    writes.staged_value(CURRENT_STATE_CATALOG_SPACE, &node_id),
+                    node_id,
+                )
+                .await?;
+                if node.children.is_empty() {
+                    entries.append(&mut node.entries);
+                } else {
+                    pending.extend(node.children.into_iter().map(|child| child.node_id));
+                }
+            }
+            Some(
+                stage_catalog_subtree(
+                    writes,
+                    staged,
+                    usize::try_from(parent.depth).expect("catalog depth fits usize"),
+                    entries,
+                )?
+                .node_id,
+            )
+        } else {
+            Some(stage_catalog_node(writes, staged, parent)?)
+        };
+    }
+    let Some(root_id) = child_id else {
+        return Ok(None);
+    };
+    let entry_count = staged
+        .get(&root_id)
+        .ok_or_else(|| directory_error("staged catalog root is missing"))?
+        .entry_count()?;
+    Ok(Some(CurrentStateCatalogRoot {
+        root_id,
+        entry_count,
+        parent_root_id: None,
+        transition_digest: [0; 32],
+    }))
+}
+
+fn stage_catalog_subtree(
+    writes: &mut StorageWriteSet,
+    staged: &mut std::collections::BTreeMap<[u8; 32], CatalogNode>,
+    depth: usize,
+    mut entries: Vec<CurrentStatePartSet>,
+) -> Result<CatalogChild, LixError> {
+    entries.sort_by(|left, right| left.scope.cmp(&right.scope));
+    if entries
+        .windows(2)
+        .any(|pair| pair[0].scope == pair[1].scope)
+    {
+        return Err(directory_error("catalog contains duplicate scopes"));
+    }
+    if entries.len() <= CATALOG_LEAF_MAX_ENTRIES {
+        let sample_key = catalog_scope_key(&entries[0].scope)?;
+        let node = CatalogNode {
+            depth: u32::try_from(depth).expect("catalog depth fits u32"),
+            sample_key,
+            entries,
+            children: Vec::new(),
+        };
+        let entry_count = node.entry_count()?;
+        let node_id = stage_catalog_node(writes, staged, node)?;
+        return Ok(CatalogChild {
+            route: Vec::new(),
+            node_id,
+            entry_count,
+        });
+    }
+    let mut groups = std::collections::BTreeMap::<u8, Vec<CurrentStatePartSet>>::new();
+    for entry in entries {
+        let route_key = catalog_scope_key(&entry.scope)?;
+        let selector = *route_key
+            .get(depth)
+            .ok_or_else(|| directory_error("duplicate canonical catalog scope key"))?;
+        groups.entry(selector).or_default().push(entry);
+    }
+    if groups.len() == 1 {
+        let (selector, entries) = groups
+            .into_iter()
+            .next()
+            .expect("one catalog route group exists");
+        let keys = entries
+            .iter()
+            .map(|entry| catalog_scope_key(&entry.scope))
+            .collect::<Result<Vec<_>, _>>()?;
+        let shortest = keys.iter().map(Vec::len).min().unwrap_or(depth + 1);
+        let mut divergence = depth + 1;
+        while divergence < shortest
+            && keys
+                .iter()
+                .all(|key| key[divergence] == keys[0][divergence])
+        {
+            divergence += 1;
+        }
+        let child = stage_catalog_subtree(writes, staged, divergence, entries)?;
+        let child = catalog_child_for_parent(staged, depth, child.node_id)?;
+        debug_assert_eq!(child.route[0], selector);
+        if depth == 0 {
+            let sample_key = staged
+                .get(&child.node_id)
+                .expect("staged catalog child exists")
+                .sample_key
+                .clone();
+            let root = CatalogNode {
+                depth: 0,
+                sample_key,
+                entries: Vec::new(),
+                children: vec![child],
+            };
+            let entry_count = root.entry_count()?;
+            let node_id = stage_catalog_node(writes, staged, root)?;
+            return Ok(CatalogChild {
+                route: Vec::new(),
+                node_id,
+                entry_count,
+            });
+        }
+        return Ok(child);
+    }
+    let mut children = Vec::with_capacity(groups.len());
+    for (selector, entries) in groups {
+        let child = stage_catalog_subtree(writes, staged, depth + 1, entries)?;
+        let child = catalog_child_for_parent(staged, depth, child.node_id)?;
+        debug_assert_eq!(child.route[0], selector);
+        children.push(child);
+    }
+    let sample_key = staged
+        .get(&children[0].node_id)
+        .expect("staged catalog child exists")
+        .sample_key
+        .clone();
+    let node = CatalogNode {
+        depth: u32::try_from(depth).expect("catalog depth fits u32"),
+        sample_key,
+        entries: Vec::new(),
+        children,
+    };
+    let entry_count = node.entry_count()?;
+    let node_id = stage_catalog_node(writes, staged, node)?;
+    Ok(CatalogChild {
+        route: Vec::new(),
+        node_id,
+        entry_count,
+    })
+}
+
+fn stage_catalog_node(
+    _writes: &mut StorageWriteSet,
+    staged: &mut std::collections::BTreeMap<[u8; 32], CatalogNode>,
+    node: CatalogNode,
+) -> Result<[u8; 32], LixError> {
+    validate_catalog_node(&node)?;
+    let payload = storage_codec::encode("current-state catalog node", &node)?;
+    if payload.len() > DIRECTORY_NODE_MAX_DECODED_BYTES {
+        return Err(directory_error(
+            "catalog node exceeds its decoded size bound",
+        ));
+    }
+    let mut encoded = Vec::with_capacity(CATALOG_NODE_MAGIC.len() + payload.len());
+    encoded.extend_from_slice(CATALOG_NODE_MAGIC);
+    encoded.extend_from_slice(&payload);
+    let bytes = Bytes::from(encoded);
+    let node_id = catalog_node_digest(&bytes);
+    staged.insert(node_id, node);
+    Ok(node_id)
+}
+
+fn flush_reachable_staged_catalog_nodes(
+    writes: &mut StorageWriteSet,
+    staged: &std::collections::BTreeMap<[u8; 32], CatalogNode>,
+    root_id: [u8; 32],
+) -> Result<(), LixError> {
+    let mut pending = vec![root_id];
+    let mut reachable = std::collections::BTreeSet::new();
+    while let Some(node_id) = pending.pop() {
+        if !reachable.insert(node_id) {
+            continue;
+        }
+        let Some(node) = staged.get(&node_id) else {
+            continue;
+        };
+        pending.extend(node.children.iter().map(|child| child.node_id));
+    }
+    for node_id in reachable {
+        let Some(node) = staged.get(&node_id) else {
+            continue;
+        };
+        let payload = storage_codec::encode("current-state catalog node", node)?;
+        let mut encoded = Vec::with_capacity(CATALOG_NODE_MAGIC.len() + payload.len());
+        encoded.extend_from_slice(CATALOG_NODE_MAGIC);
+        encoded.extend_from_slice(&payload);
+        let bytes = Bytes::from(encoded);
+        if catalog_node_digest(&bytes) != node_id {
+            return Err(directory_error("staged catalog node digest drifted"));
+        }
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_crud_current_state_catalog_bytes(bytes.len());
+        writes.put(
+            CURRENT_STATE_CATALOG_SPACE,
+            StorageKey(Bytes::copy_from_slice(&node_id)),
+            StorageValue { bytes },
+        );
+    }
+    Ok(())
+}
+
+fn catalog_child_for_parent(
+    staged: &std::collections::BTreeMap<[u8; 32], CatalogNode>,
+    parent_depth: usize,
+    node_id: [u8; 32],
+) -> Result<CatalogChild, LixError> {
+    let node = staged
+        .get(&node_id)
+        .ok_or_else(|| directory_error("staged catalog child is missing"))?;
+    let child_depth = usize::try_from(node.depth).expect("u32 fits usize");
+    if child_depth <= parent_depth || child_depth > node.sample_key.len() {
+        return Err(directory_error(
+            "catalog child has an invalid compressed route",
+        ));
+    }
+    Ok(CatalogChild {
+        route: node.sample_key[parent_depth..child_depth].to_vec(),
+        node_id,
+        entry_count: node.entry_count()?,
+    })
+}
+
+async fn catalog_child_for_parent_with_store(
+    store: &(impl StorageAdapterRead + ?Sized),
+    staged: &std::collections::BTreeMap<[u8; 32], CatalogNode>,
+    parent_depth: usize,
+    node_id: [u8; 32],
+) -> Result<CatalogChild, LixError> {
+    if staged.contains_key(&node_id) {
+        return catalog_child_for_parent(staged, parent_depth, node_id);
+    }
+    let node = load_catalog_node(store, node_id).await?;
+    let child_depth = usize::try_from(node.depth).expect("u32 fits usize");
+    if child_depth <= parent_depth || child_depth > node.sample_key.len() {
+        return Err(directory_error(
+            "catalog child has an invalid compressed route",
+        ));
+    }
+    Ok(CatalogChild {
+        route: node.sample_key[parent_depth..child_depth].to_vec(),
+        node_id,
+        entry_count: node.entry_count()?,
+    })
+}
+
+fn validate_catalog_child(
+    parent: &CatalogNode,
+    expected: &CatalogChild,
+    child: &CatalogNode,
+) -> Result<(), LixError> {
+    let parent_depth = usize::try_from(parent.depth).expect("u32 fits usize");
+    let child_depth = usize::try_from(child.depth).expect("u32 fits usize");
+    if child.entry_count()? != expected.entry_count
+        || child_depth <= parent_depth
+        || child_depth > child.sample_key.len()
+        || child.sample_key.get(parent_depth..child_depth) != Some(expected.route.as_slice())
+    {
+        return Err(directory_error("catalog child summary mismatch"));
+    }
+    Ok(())
+}
+
+async fn load_catalog_node_with_staged(
+    store: &(impl StorageAdapterRead + ?Sized),
+    staged: Option<CatalogNode>,
+    staged_bytes: Option<Bytes>,
+    node_id: [u8; 32],
+) -> Result<CatalogNode, LixError> {
+    if let Some(node) = staged {
+        return Ok(node);
+    }
+    if let Some(bytes) = staged_bytes {
+        return decode_catalog_node(&bytes, node_id);
+    }
+    load_catalog_node(store, node_id).await
+}
+
+async fn load_catalog_node(
+    store: &(impl StorageAdapterRead + ?Sized),
+    node_id: [u8; 32],
+) -> Result<CatalogNode, LixError> {
+    let key = StorageKey(Bytes::copy_from_slice(&node_id));
+    let result = PointReadPlan::new(CURRENT_STATE_CATALOG_SPACE, &[key])
+        .materialize(store, StorageGetOptions::default())
+        .await?;
+    let value = result
+        .value
+        .into_iter()
+        .next()
+        .flatten()
+        .ok_or_else(|| directory_error("catalog references a missing node"))?;
+    let StorageProjectedValue::FullValue(bytes) = value else {
+        return Err(directory_error("catalog node read omitted its value"));
+    };
+    decode_catalog_node(&bytes, node_id)
+}
+
+fn decode_catalog_node(bytes: &[u8], node_id: [u8; 32]) -> Result<CatalogNode, LixError> {
+    if catalog_node_digest(bytes) != node_id {
+        return Err(directory_error("catalog node content digest mismatch"));
+    }
+    let payload = bytes
+        .strip_prefix(CATALOG_NODE_MAGIC)
+        .ok_or_else(|| directory_error("catalog node has an unsupported format"))?;
+    let node: CatalogNode = storage_codec::decode("current-state catalog node", payload)?;
+    validate_catalog_node(&node)?;
+    Ok(node)
+}
+
+pub(crate) async fn load_current_state_catalog_entry(
+    store: &(impl StorageAdapterRead + ?Sized),
+    root: &CurrentStateCatalogRoot,
+    scope: &crate::tracked_state::types::CommitDeltaReplacementScope,
+) -> Result<Option<CurrentStatePartSet>, LixError> {
+    let route_key = catalog_scope_key(scope)?;
+    let mut expected_count = root.entry_count;
+    let mut minimum_depth = 0u32;
+    let mut expected_route: Option<(usize, Vec<u8>)> = None;
+    let mut node_id = root.root_id;
+    loop {
+        let node = load_catalog_node(store, node_id).await?;
+        if node.entry_count()? != expected_count
+            || node.depth < minimum_depth
+            || (minimum_depth == 0 && node.depth != 0)
+        {
+            return Err(directory_error("catalog node summary mismatch"));
+        }
+        if let Some((parent_depth, route)) = expected_route.take() {
+            let child_depth = usize::try_from(node.depth).expect("u32 fits usize");
+            if child_depth > node.sample_key.len()
+                || node.sample_key.get(parent_depth..child_depth) != Some(route.as_slice())
+            {
+                return Err(directory_error("catalog child route mismatch"));
+            }
+        }
+        if node.children.is_empty() {
+            return Ok(node
+                .entries
+                .binary_search_by(|entry| entry.scope.cmp(scope))
+                .ok()
+                .map(|index| node.entries[index].clone()));
+        }
+        let depth = usize::try_from(node.depth).expect("u32 fits usize");
+        let selector = *route_key
+            .get(depth)
+            .ok_or_else(|| directory_error("catalog exceeds its hash depth"))?;
+        let Ok(index) = node
+            .children
+            .binary_search_by_key(&selector, |child| child.route[0])
+        else {
+            return Ok(None);
+        };
+        let child = &node.children[index];
+        if route_key.get(depth..depth + child.route.len()) != Some(child.route.as_slice()) {
+            return Ok(None);
+        }
+        node_id = child.node_id;
+        expected_count = child.entry_count;
+        minimum_depth = node.depth.saturating_add(1);
+        expected_route = Some((depth, child.route.clone()));
+    }
+}
+
+/// Resolves catalog scopes in caller order while reading each shared trie node
+/// at most once. Each frontier is issued as one storage point-read batch.
+pub(crate) async fn load_current_state_catalog_entries_for_scopes(
+    store: &(impl StorageAdapterRead + ?Sized),
+    root: &CurrentStateCatalogRoot,
+    scopes: &[crate::tracked_state::types::CommitDeltaReplacementScope],
+) -> Result<Vec<Option<CurrentStatePartSet>>, LixError> {
+    let mut loaded =
+        load_current_state_catalog_entries_for_scope_sets(store, &[(root, scopes)]).await?;
+    Ok(loaded.pop().unwrap_or_default())
+}
+
+/// Resolves multiple caller-owned scope batches while reading every shared
+/// catalog node at most once. Results retain request, scope, and duplicate order.
+pub(crate) async fn load_current_state_catalog_entries_for_scope_sets(
+    store: &(impl StorageAdapterRead + ?Sized),
+    requests: &[(
+        &CurrentStateCatalogRoot,
+        &[crate::tracked_state::types::CommitDeltaReplacementScope],
+    )],
+) -> Result<Vec<Vec<Option<CurrentStatePartSet>>>, LixError> {
+    #[derive(Clone)]
+    struct PendingCatalogNode {
+        request_index: usize,
+        expected_count: u32,
+        minimum_depth: u32,
+        expected_route: Option<(usize, Vec<u8>)>,
+        scope_indices: Vec<usize>,
+    }
+
+    let route_keys = requests
+        .iter()
+        .map(|(_, scopes)| {
+            scopes
+                .iter()
+                .map(catalog_scope_key)
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut results = requests
+        .iter()
+        .map(|(_, scopes)| vec![None; scopes.len()])
+        .collect::<Vec<_>>();
+    let mut frontier = std::collections::BTreeMap::<[u8; 32], Vec<PendingCatalogNode>>::new();
+    for (request_index, (root, scopes)) in requests.iter().enumerate() {
+        if !scopes.is_empty() {
+            frontier
+                .entry(root.root_id)
+                .or_default()
+                .push(PendingCatalogNode {
+                    request_index,
+                    expected_count: root.entry_count,
+                    minimum_depth: 0,
+                    expected_route: None,
+                    scope_indices: (0..scopes.len()).collect(),
+                });
+        }
+    }
+    let mut cache = std::collections::BTreeMap::<[u8; 32], CatalogNode>::new();
+    let mut visited = std::collections::BTreeSet::<(usize, [u8; 32])>::new();
+
+    while !frontier.is_empty() {
+        let unseen = frontier
+            .keys()
+            .filter(|node_id| !cache.contains_key(*node_id))
+            .copied()
+            .collect::<Vec<_>>();
+        let storage_keys = unseen
+            .iter()
+            .map(|node_id| StorageKey(Bytes::copy_from_slice(node_id)))
+            .collect::<Vec<_>>();
+        if !storage_keys.is_empty() {
+            let loaded = PointReadPlan::new(CURRENT_STATE_CATALOG_SPACE, &storage_keys)
+                .materialize(store, StorageGetOptions::default())
+                .await?;
+            for (node_id, value) in unseen.into_iter().zip(loaded.value) {
+                let value =
+                    value.ok_or_else(|| directory_error("catalog references a missing node"))?;
+                let StorageProjectedValue::FullValue(bytes) = value else {
+                    return Err(directory_error("catalog node read omitted its value"));
+                };
+                if catalog_node_digest(&bytes) != node_id {
+                    return Err(directory_error("catalog node content digest mismatch"));
+                }
+                let payload = bytes
+                    .strip_prefix(CATALOG_NODE_MAGIC)
+                    .ok_or_else(|| directory_error("catalog node has an unsupported format"))?;
+                let node: CatalogNode =
+                    storage_codec::decode("current-state catalog node", payload)?;
+                validate_catalog_node(&node)?;
+                cache.insert(node_id, node);
+            }
+        }
+        let mut next = std::collections::BTreeMap::<[u8; 32], Vec<PendingCatalogNode>>::new();
+
+        for (node_id, pending_requests) in frontier {
+            let node = cache
+                .get(&node_id)
+                .ok_or_else(|| directory_error("catalog frontier omitted a node"))?;
+            for pending in pending_requests {
+                if !visited.insert((pending.request_index, node_id)) {
+                    return Err(directory_error(
+                        "catalog scoped lookup contains a cycle or duplicate child",
+                    ));
+                }
+                if node.entry_count()? != pending.expected_count
+                    || node.depth < pending.minimum_depth
+                    || (pending.minimum_depth == 0 && node.depth != 0)
+                {
+                    return Err(directory_error("catalog node summary mismatch"));
+                }
+                if let Some((parent_depth, route)) = pending.expected_route {
+                    let child_depth = usize::try_from(node.depth).expect("u32 fits usize");
+                    if child_depth > node.sample_key.len()
+                        || node.sample_key.get(parent_depth..child_depth) != Some(route.as_slice())
+                    {
+                        return Err(directory_error("catalog child route mismatch"));
+                    }
+                }
+
+                if node.children.is_empty() {
+                    let scopes = requests[pending.request_index].1;
+                    for scope_index in pending.scope_indices {
+                        results[pending.request_index][scope_index] = node
+                            .entries
+                            .binary_search_by(|entry| entry.scope.cmp(&scopes[scope_index]))
+                            .ok()
+                            .map(|index| node.entries[index].clone());
+                    }
+                    continue;
+                }
+
+                let depth = usize::try_from(node.depth).expect("u32 fits usize");
+                for scope_index in pending.scope_indices {
+                    let route_key = &route_keys[pending.request_index][scope_index];
+                    let Some(&selector) = route_key.get(depth) else {
+                        // The query cannot lie below this compressed prefix.
+                        continue;
+                    };
+                    let Ok(child_index) = node
+                        .children
+                        .binary_search_by_key(&selector, |child| child.route[0])
+                    else {
+                        continue;
+                    };
+                    let child = &node.children[child_index];
+                    if route_key.get(depth..depth + child.route.len())
+                        != Some(child.route.as_slice())
+                    {
+                        continue;
+                    }
+                    let child_pending = next.entry(child.node_id).or_default();
+                    if let Some(existing) = child_pending
+                        .iter_mut()
+                        .find(|existing| existing.request_index == pending.request_index)
+                    {
+                        if existing.expected_count != child.entry_count
+                            || existing.minimum_depth != node.depth.saturating_add(1)
+                            || existing.expected_route.as_ref()
+                                != Some(&(depth, child.route.clone()))
+                        {
+                            return Err(directory_error(
+                                "catalog shared child has conflicting summaries",
+                            ));
+                        }
+                        existing.scope_indices.push(scope_index);
+                    } else {
+                        child_pending.push(PendingCatalogNode {
+                            request_index: pending.request_index,
+                            expected_count: child.entry_count,
+                            minimum_depth: node.depth.saturating_add(1),
+                            expected_route: Some((depth, child.route.clone())),
+                            scope_indices: vec![scope_index],
+                        });
+                    }
+                }
+            }
+        }
+        frontier = next;
+    }
+
+    Ok(results)
+}
+
+pub(crate) async fn load_current_state_catalog_entries(
+    store: &(impl StorageAdapterRead + ?Sized),
+    root: &CurrentStateCatalogRoot,
+) -> Result<Vec<CurrentStatePartSet>, LixError> {
+    let mut pending = vec![(
+        root.root_id,
+        root.entry_count,
+        0u32,
+        None::<(usize, Vec<u8>)>,
+    )];
+    let mut entries = Vec::with_capacity(root.entry_count as usize);
+    while let Some((node_id, expected_count, minimum_depth, expected_route)) = pending.pop() {
+        let mut node = load_catalog_node(store, node_id).await?;
+        if node.entry_count()? != expected_count
+            || node.depth < minimum_depth
+            || (minimum_depth == 0 && node.depth != 0)
+        {
+            return Err(directory_error("catalog node summary mismatch"));
+        }
+        if let Some((parent_depth, route)) = expected_route {
+            let child_depth = usize::try_from(node.depth).expect("u32 fits usize");
+            if child_depth > node.sample_key.len()
+                || node.sample_key.get(parent_depth..child_depth) != Some(route.as_slice())
+            {
+                return Err(directory_error("catalog child route mismatch"));
+            }
+        }
+        if node.children.is_empty() {
+            entries.append(&mut node.entries);
+        } else {
+            let child_min_depth = node.depth.saturating_add(1);
+            let parent_depth = usize::try_from(node.depth).expect("u32 fits usize");
+            pending.extend(node.children.into_iter().rev().map(|child| {
+                (
+                    child.node_id,
+                    child.entry_count,
+                    child_min_depth,
+                    Some((parent_depth, child.route)),
+                )
+            }));
+        }
+    }
+    if entries.len() != root.entry_count as usize {
+        return Err(directory_error("catalog root entry count mismatch"));
+    }
+    entries.sort_by(|left, right| left.scope.cmp(&right.scope));
+    if entries
+        .windows(2)
+        .any(|pair| pair[0].scope == pair[1].scope)
+    {
+        return Err(directory_error("catalog contains duplicate scopes"));
+    }
+    Ok(entries)
+}
+
+pub(crate) async fn load_current_state_catalog_reachability(
+    store: &(impl StorageAdapterRead + ?Sized),
+    root: &CurrentStateCatalogRoot,
+) -> Result<
+    (
+        std::collections::BTreeSet<[u8; 32]>,
+        Vec<CurrentStatePartSet>,
+    ),
+    LixError,
+> {
+    let (nodes, mut entries) =
+        load_current_state_catalog_reachability_many(store, std::slice::from_ref(root)).await?;
+    entries.sort_by(|left, right| left.scope.cmp(&right.scope));
+    if entries.len() != root.entry_count as usize
+        || entries
+            .windows(2)
+            .any(|pair| pair[0].scope == pair[1].scope)
+    {
+        return Err(directory_error(
+            "catalog reachability count or scope mismatch",
+        ));
+    }
+    Ok((nodes, entries))
+}
+
+pub(crate) async fn load_current_state_catalog_reachability_many(
+    store: &(impl StorageAdapterRead + ?Sized),
+    roots: &[CurrentStateCatalogRoot],
+) -> Result<
+    (
+        std::collections::BTreeSet<[u8; 32]>,
+        Vec<CurrentStatePartSet>,
+    ),
+    LixError,
+> {
+    type ExpectedCatalogNode = (u32, u32, Option<(usize, Vec<u8>)>, bool);
+    let mut pending = std::collections::BTreeMap::<[u8; 32], Vec<ExpectedCatalogNode>>::new();
+    for root in roots {
+        pending
+            .entry(root.root_id)
+            .or_default()
+            .push((root.entry_count, 0, None, true));
+    }
+    let mut node_ids = std::collections::BTreeSet::new();
+    let mut node_cache = std::collections::BTreeMap::<[u8; 32], CatalogNode>::new();
+    let mut entries = Vec::new();
+    while !pending.is_empty() {
+        let frontier = std::mem::take(&mut pending);
+        let unseen = frontier
+            .keys()
+            .filter(|node_id| !node_cache.contains_key(*node_id))
+            .copied()
+            .collect::<Vec<_>>();
+        let storage_keys = unseen
+            .iter()
+            .map(|node_id| StorageKey(Bytes::copy_from_slice(node_id)))
+            .collect::<Vec<_>>();
+        let loaded = PointReadPlan::new(CURRENT_STATE_CATALOG_SPACE, &storage_keys)
+            .materialize(store, StorageGetOptions::default())
+            .await?;
+        for (node_id, value) in unseen.into_iter().zip(loaded.value) {
+            let value =
+                value.ok_or_else(|| directory_error("catalog references a missing node"))?;
+            let StorageProjectedValue::FullValue(bytes) = value else {
+                return Err(directory_error("catalog node read omitted its value"));
+            };
+            if catalog_node_digest(&bytes) != node_id {
+                return Err(directory_error("catalog node content digest mismatch"));
+            }
+            let payload = bytes
+                .strip_prefix(CATALOG_NODE_MAGIC)
+                .ok_or_else(|| directory_error("catalog node has an unsupported format"))?;
+            let node: CatalogNode = storage_codec::decode("current-state catalog node", payload)?;
+            validate_catalog_node(&node)?;
+            node_cache.insert(node_id, node);
+        }
+        for (node_id, expectations) in frontier {
+            let already_expanded = !node_ids.insert(node_id);
+            let node = node_cache
+                .get(&node_id)
+                .ok_or_else(|| directory_error("catalog frontier omitted a node"))?;
+            for (expected_count, expected_depth, expected_route, is_root) in expectations {
+                if node.entry_count()? != expected_count
+                    || node.depth < expected_depth
+                    || (is_root && node.depth != 0)
+                {
+                    return Err(directory_error("catalog child summary mismatch"));
+                }
+                if let Some((parent_depth, route)) = expected_route {
+                    let child_depth = usize::try_from(node.depth).expect("u32 fits usize");
+                    if child_depth > node.sample_key.len()
+                        || node.sample_key.get(parent_depth..child_depth) != Some(route.as_slice())
+                    {
+                        return Err(directory_error("catalog child route mismatch"));
+                    }
+                }
+            }
+            if already_expanded {
+                continue;
+            }
+            if node.children.is_empty() {
+                entries.extend(node.entries.iter().cloned());
+            } else {
+                let child_min_depth = node.depth.saturating_add(1);
+                let parent_depth = usize::try_from(node.depth).expect("u32 fits usize");
+                for child in &node.children {
+                    pending.entry(child.node_id).or_default().push((
+                        child.entry_count,
+                        child_min_depth,
+                        Some((parent_depth, child.route.clone())),
+                        false,
+                    ));
+                }
+            }
+        }
+    }
+    Ok((node_ids, entries))
+}
+
+pub(crate) async fn load_current_state_part_directory_reachability(
+    store: &(impl StorageAdapterRead + ?Sized),
+    root: &CurrentStatePartDirectoryRoot,
+) -> Result<
+    (
+        std::collections::BTreeSet<[u8; 32]>,
+        Vec<CurrentStatePartDescriptor>,
+    ),
+    LixError,
+> {
+    let (nodes, mut descriptor_sets) =
+        load_current_state_part_directory_reachability_many(store, std::slice::from_ref(root))
+            .await?;
+    Ok((nodes, descriptor_sets.pop().unwrap_or_default()))
+}
+
+pub(crate) async fn load_current_state_part_directory_reachability_many(
+    store: &(impl StorageAdapterRead + ?Sized),
+    roots: &[CurrentStatePartDirectoryRoot],
+) -> Result<
+    (
+        std::collections::BTreeSet<[u8; 32]>,
+        Vec<Vec<CurrentStatePartDescriptor>>,
+    ),
+    LixError,
+> {
+    let mut frontier =
+        std::collections::BTreeMap::<[u8; 32], Vec<(usize, Option<DirectoryChild>)>>::new();
+    for (root_index, root) in roots.iter().enumerate() {
+        frontier
+            .entry(root.root_id)
+            .or_default()
+            .push((root_index, None));
+    }
+    let mut node_ids = std::collections::BTreeSet::new();
+    let mut visited = std::collections::BTreeSet::<(usize, [u8; 32])>::new();
+    let mut cache = std::collections::BTreeMap::<[u8; 32], DirectoryNode>::new();
+    let mut descriptor_sets = roots
+        .iter()
+        .map(|root| Vec::with_capacity(root.part_count as usize))
+        .collect::<Vec<_>>();
+    while !frontier.is_empty() {
+        let unseen = frontier
+            .keys()
+            .filter(|node_id| !cache.contains_key(*node_id))
+            .copied()
+            .collect::<Vec<_>>();
+        let loaded = load_directory_nodes(store, &unseen).await?;
+        cache.extend(unseen.into_iter().zip(loaded));
+        let mut next =
+            std::collections::BTreeMap::<[u8; 32], Vec<(usize, Option<DirectoryChild>)>>::new();
+        for (node_id, expectations) in frontier {
+            node_ids.insert(node_id);
+            let node = cache
+                .get(&node_id)
+                .ok_or_else(|| directory_error("directory frontier omitted a node"))?;
+            for (root_index, expected_child) in expectations {
+                if !visited.insert((root_index, node_id)) {
+                    return Err(directory_error(
+                        "part directory contains a cycle or duplicate child",
+                    ));
+                }
+                let root = &roots[root_index];
+                if expected_child.is_none() {
+                    validate_root_summary(root, node)?;
+                }
+                if let Some(expected) = expected_child.as_ref() {
+                    validate_child_summary(expected, node)?;
+                }
+                if node.kind == 0 {
+                    descriptor_sets[root_index].extend(node.parts.iter().cloned());
+                } else {
+                    for child in &node.children {
+                        next.entry(child.node_id)
+                            .or_default()
+                            .push((root_index, Some(child.clone())));
+                    }
+                }
+            }
+        }
+        frontier = next;
+    }
+    for (root, descriptors) in roots.iter().zip(&mut descriptor_sets) {
+        // Frontier batching is content-ID ordered, so normalize the
+        // caller-visible descriptor sequence before semantic validation.
+        descriptors.sort_by(|left, right| left.first_key.cmp(&right.first_key));
+        validate_descriptors(descriptors)?;
+        if descriptors.len() != root.part_count as usize
+            || replacement_directory_digest(descriptors)? != root.descriptor_digest
+        {
+            return Err(directory_error("part directory reachability mismatch"));
+        }
+    }
+    Ok((node_ids, descriptor_sets))
+}
+
+fn validate_catalog_node(node: &CatalogNode) -> Result<(), LixError> {
+    let depth = usize::try_from(node.depth).expect("u32 fits usize");
+    if depth > CATALOG_MAX_KEY_BYTES
+        || node.sample_key.len() > CATALOG_MAX_KEY_BYTES
+        || node.sample_key.len() < depth
+        || node.entries.is_empty() == node.children.is_empty()
+        || (node.children.len() == 1 && node.depth != 0)
+        || (!node.entries.is_empty() && node.entries.len() > CATALOG_LEAF_MAX_ENTRIES)
+        || node
+            .entries
+            .windows(2)
+            .any(|pair| pair[0].scope >= pair[1].scope)
+        || node.entries.iter().any(|entry| {
+            entry.scope.schema_key.is_empty()
+                || entry.coverage_anchor_commit_id == [0; 16]
+                || entry.generation_integrity_digest == [0; 32]
+                || entry.state_lineage_digest == [0; 32]
+                || entry.directory.root_id == [0; 32]
+                || entry.directory.descriptor_digest == [0; 32]
+                || entry.directory.row_count == 0
+                || entry.directory.part_count == 0
+                || entry.directory.tree_height == 0
+        })
+        || node
+            .children
+            .windows(2)
+            .any(|pair| pair[0].route.first() >= pair[1].route.first())
+        || node.children.iter().any(|child| {
+            child.route.is_empty()
+                || child.node_id == [0; 32]
+                || child.entry_count == 0
+                || depth >= CATALOG_MAX_KEY_BYTES
+        })
+        || node.entries.iter().any(|entry| {
+            let Ok(key) = catalog_scope_key(&entry.scope) else {
+                return true;
+            };
+            key.get(..depth) != node.sample_key.get(..depth)
+        })
+    {
+        return Err(directory_error("catalog node is structurally invalid"));
+    }
+    Ok(())
+}
+
+fn catalog_scope_key(
+    scope: &crate::tracked_state::types::CommitDeltaReplacementScope,
+) -> Result<Vec<u8>, LixError> {
+    let file_len = scope.file_id.as_ref().map_or(0, String::len);
+    let capacity = 1usize
+        .checked_add(size_of::<u32>() * 2)
+        .and_then(|value| value.checked_add(file_len))
+        .and_then(|value| value.checked_add(scope.schema_key.len()))
+        .ok_or_else(|| directory_error("catalog scope key length overflows"))?;
+    if capacity > CATALOG_MAX_KEY_BYTES {
+        return Err(directory_error("catalog scope key exceeds its bound"));
+    }
+    let mut encoded = Vec::with_capacity(capacity);
+    match scope.file_id.as_deref() {
+        Some(file_id) => {
+            encoded.push(1);
+            encoded.extend_from_slice(
+                &u32::try_from(file_id.len())
+                    .map_err(|_| directory_error("catalog file id is too long"))?
+                    .to_be_bytes(),
+            );
+            encoded.extend_from_slice(file_id.as_bytes());
+        }
+        None => {
+            encoded.push(0);
+            encoded.extend_from_slice(&0u32.to_be_bytes());
+        }
+    }
+    encoded.extend_from_slice(
+        &u32::try_from(scope.schema_key.len())
+            .map_err(|_| directory_error("catalog schema key is too long"))?
+            .to_be_bytes(),
+    );
+    encoded.extend_from_slice(scope.schema_key.as_bytes());
+    Ok(encoded)
+}
+
+fn catalog_node_digest(bytes: &[u8]) -> [u8; 32] {
+    *blake3::Hasher::new_derive_key(CATALOG_HASH_CONTEXT)
+        .update(bytes)
+        .finalize()
+        .as_bytes()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
@@ -111,28 +1576,22 @@ struct DirectoryChild {
 #[musli(packed)]
 struct DirectoryNode {
     kind: u8,
-    /// The semantic replacement-directory digest for the complete part set.
-    /// Every node carries it so a valid node from another tree cannot turn a
-    /// routing miss into an authoritative absence.
-    set_digest: [u8; 32],
     parts: Vec<CurrentStatePartDescriptor>,
     children: Vec<DirectoryChild>,
 }
 
 impl DirectoryNode {
-    fn leaf(set_digest: [u8; 32], parts: Vec<CurrentStatePartDescriptor>) -> Self {
+    fn leaf(parts: Vec<CurrentStatePartDescriptor>) -> Self {
         Self {
             kind: 0,
-            set_digest,
             parts,
             children: Vec::new(),
         }
     }
 
-    fn internal(set_digest: [u8; 32], children: Vec<DirectoryChild>) -> Self {
+    fn internal(children: Vec<DirectoryChild>) -> Self {
         Self {
             kind: 1,
-            set_digest,
             parts: Vec::new(),
             children,
         }
@@ -156,12 +1615,7 @@ pub(crate) fn stage_current_state_part_directory(
     let descriptor_digest = replacement_directory_digest(descriptors)?;
     let mut level = descriptors
         .chunks(DIRECTORY_FANOUT)
-        .map(|chunk| {
-            stage_node(
-                writes,
-                DirectoryNode::leaf(descriptor_digest, chunk.to_vec()),
-            )
-        })
+        .map(|chunk| stage_node(writes, DirectoryNode::leaf(chunk.to_vec())))
         .collect::<Result<Vec<_>, _>>()?;
     let mut tree_height = 1u16;
     while level.len() > 1 {
@@ -170,10 +1624,7 @@ pub(crate) fn stage_current_state_part_directory(
             .map(|chunk| {
                 stage_node(
                     writes,
-                    DirectoryNode::internal(
-                        descriptor_digest,
-                        chunk.iter().map(|node| node.child.clone()).collect(),
-                    ),
+                    DirectoryNode::internal(chunk.iter().map(|node| node.child.clone()).collect()),
                 )
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -201,10 +1652,14 @@ pub(crate) async fn route_current_state_part(
     encoded_key: &[u8],
 ) -> Result<Option<CurrentStatePartDescriptor>, LixError> {
     let mut node_id = root.root_id;
+    let mut expected_child = None;
     loop {
-        let node = load_node(store, node_id, root.descriptor_digest).await?;
+        let node = load_node(store, node_id).await?;
         if node_id == root.root_id {
             validate_root_summary(root, &node)?;
+        }
+        if let Some(expected) = expected_child.as_ref() {
+            validate_child_summary(expected, &node)?;
         }
         match node.kind {
             0 => {
@@ -226,6 +1681,7 @@ pub(crate) async fn route_current_state_part(
                     return Ok(None);
                 }
                 node_id = child.node_id;
+                expected_child = Some(child.clone());
             }
             _ => unreachable!("validated directory node kind"),
         }
@@ -239,54 +1695,99 @@ pub(crate) async fn route_current_state_parts(
     root: &CurrentStatePartDirectoryRoot,
     encoded_keys: &[Bytes],
 ) -> Result<Vec<Option<CurrentStatePartDescriptor>>, LixError> {
-    let mut routes = vec![None; encoded_keys.len()];
-    let mut pending = vec![(
-        root.root_id,
-        (0..encoded_keys.len()).collect::<Vec<usize>>(),
-    )];
-    while let Some((node_id, key_indices)) = pending.pop() {
-        let node = load_node(store, node_id, root.descriptor_digest).await?;
-        if node_id == root.root_id {
-            validate_root_summary(root, &node)?;
-        }
-        match node.kind {
-            0 => {
-                for key_index in key_indices {
-                    let key = &encoded_keys[key_index];
-                    let index = node
-                        .parts
-                        .partition_point(|part| part.first_key.as_slice() <= key.as_ref());
-                    let Some(part) = index.checked_sub(1).and_then(|index| node.parts.get(index))
-                    else {
-                        continue;
-                    };
-                    if key.as_ref() <= part.last_key.as_slice() {
-                        routes[key_index] = Some(part.clone());
+    let mut routed = route_current_state_part_sets(store, &[(root, encoded_keys)]).await?;
+    Ok(routed.pop().unwrap_or_default())
+}
+
+pub(crate) async fn route_current_state_part_sets(
+    store: &(impl StorageAdapterRead + ?Sized),
+    requests: &[(&CurrentStatePartDirectoryRoot, &[Bytes])],
+) -> Result<Vec<Vec<Option<CurrentStatePartDescriptor>>>, LixError> {
+    type PendingDirectoryRoute = (usize, Option<DirectoryChild>, Vec<usize>);
+    let mut routes = requests
+        .iter()
+        .map(|(_, keys)| vec![None; keys.len()])
+        .collect::<Vec<_>>();
+    let mut frontier = std::collections::BTreeMap::<[u8; 32], Vec<PendingDirectoryRoute>>::new();
+    for (request_index, (root, keys)) in requests.iter().enumerate() {
+        frontier.entry(root.root_id).or_default().push((
+            request_index,
+            None,
+            (0..keys.len()).collect::<Vec<_>>(),
+        ));
+    }
+    let mut cache = std::collections::BTreeMap::<[u8; 32], DirectoryNode>::new();
+    let mut visited = std::collections::BTreeSet::<(usize, [u8; 32])>::new();
+    while !frontier.is_empty() {
+        let unseen = frontier
+            .keys()
+            .filter(|node_id| !cache.contains_key(*node_id))
+            .copied()
+            .collect::<Vec<_>>();
+        let loaded = load_directory_nodes(store, &unseen).await?;
+        cache.extend(unseen.into_iter().zip(loaded));
+        let mut next = std::collections::BTreeMap::<[u8; 32], Vec<PendingDirectoryRoute>>::new();
+        for (node_id, pending_routes) in frontier {
+            let node = cache
+                .get(&node_id)
+                .ok_or_else(|| directory_error("directory frontier omitted a node"))?;
+            for (request_index, expected_child, key_indices) in pending_routes {
+                if !visited.insert((request_index, node_id)) {
+                    return Err(directory_error(
+                        "part directory contains a cycle or duplicate child",
+                    ));
+                }
+                let (root, encoded_keys) = requests[request_index];
+                if expected_child.is_none() {
+                    validate_root_summary(root, node)?;
+                }
+                if let Some(expected) = expected_child.as_ref() {
+                    validate_child_summary(expected, node)?;
+                }
+                match node.kind {
+                    0 => {
+                        for key_index in key_indices {
+                            let key = &encoded_keys[key_index];
+                            let index = node
+                                .parts
+                                .partition_point(|part| part.first_key.as_slice() <= key.as_ref());
+                            let Some(part) =
+                                index.checked_sub(1).and_then(|index| node.parts.get(index))
+                            else {
+                                continue;
+                            };
+                            if key.as_ref() <= part.last_key.as_slice() {
+                                routes[request_index][key_index] = Some(part.clone());
+                            }
+                        }
                     }
+                    1 => {
+                        let mut child_keys = std::collections::BTreeMap::<usize, Vec<usize>>::new();
+                        for key_index in key_indices {
+                            let key = &encoded_keys[key_index];
+                            let upper = node.children.partition_point(|child| {
+                                child.first_key.as_slice() <= key.as_ref()
+                            });
+                            if let Some(child_index) = upper.checked_sub(1)
+                                && key.as_ref() <= node.children[child_index].last_key.as_slice()
+                            {
+                                child_keys.entry(child_index).or_default().push(key_index);
+                            }
+                        }
+                        for (child_index, keys) in child_keys {
+                            let child = node.children[child_index].clone();
+                            next.entry(child.node_id).or_default().push((
+                                request_index,
+                                Some(child),
+                                keys,
+                            ));
+                        }
+                    }
+                    _ => unreachable!("validated directory node kind"),
                 }
             }
-            1 => {
-                let mut child_keys = std::collections::BTreeMap::<usize, Vec<usize>>::new();
-                for key_index in key_indices {
-                    let key = &encoded_keys[key_index];
-                    let upper = node
-                        .children
-                        .partition_point(|child| child.first_key.as_slice() <= key.as_ref());
-                    if let Some(child_index) = upper.checked_sub(1)
-                        && key.as_ref() <= node.children[child_index].last_key.as_slice()
-                    {
-                        child_keys.entry(child_index).or_default().push(key_index);
-                    }
-                }
-                pending.extend(
-                    child_keys
-                        .into_iter()
-                        .rev()
-                        .map(|(child_index, keys)| (node.children[child_index].node_id, keys)),
-                );
-            }
-            _ => unreachable!("validated directory node kind"),
         }
+        frontier = next;
     }
     Ok(routes)
 }
@@ -296,17 +1797,25 @@ pub(crate) async fn load_current_state_part_descriptors(
     store: &(impl StorageAdapterRead + ?Sized),
     root: &CurrentStatePartDirectoryRoot,
 ) -> Result<Vec<CurrentStatePartDescriptor>, LixError> {
-    let mut pending = vec![root.root_id];
+    let mut pending = vec![(root.root_id, None)];
     let mut descriptors = Vec::with_capacity(root.part_count as usize);
-    while let Some(node_id) = pending.pop() {
-        let mut node = load_node(store, node_id, root.descriptor_digest).await?;
+    while let Some((node_id, expected_child)) = pending.pop() {
+        let mut node = load_node(store, node_id).await?;
         if node_id == root.root_id {
             validate_root_summary(root, &node)?;
+        }
+        if let Some(expected) = expected_child.as_ref() {
+            validate_child_summary(expected, &node)?;
         }
         match node.kind {
             0 => descriptors.append(&mut node.parts),
             1 => {
-                pending.extend(node.children.into_iter().rev().map(|child| child.node_id));
+                pending.extend(
+                    node.children
+                        .into_iter()
+                        .rev()
+                        .map(|child| (child.node_id, Some(child))),
+                );
             }
             _ => unreachable!("validated directory node kind"),
         }
@@ -325,40 +1834,6 @@ pub(crate) async fn load_current_state_part_descriptors(
         ));
     }
     Ok(descriptors)
-}
-
-/// Deletes a complete replacement directory. First-slice leaf descriptors bind
-/// every node to one owner commit, so no node can be shared across owners yet.
-/// Sparse structural sharing will replace this with mark/sweep reachability.
-pub(crate) async fn stage_delete_current_state_part_directory(
-    store: &(impl StorageAdapterRead + ?Sized),
-    writes: &mut StorageWriteSet,
-    root: &CurrentStatePartDirectoryRoot,
-    expected_owner_commit_id: [u8; 16],
-    expected_mutation_directory_digest: [u8; 32],
-) -> Result<(), LixError> {
-    let descriptors = load_current_state_part_descriptors(store, root).await?;
-    if root.descriptor_digest != expected_mutation_directory_digest
-        || descriptors
-            .iter()
-            .any(|descriptor| descriptor.owner_commit_id != expected_owner_commit_id)
-    {
-        return Err(directory_error(
-            "refusing to delete a directory not owned by its dead authority",
-        ));
-    }
-    let mut pending = vec![root.root_id];
-    while let Some(node_id) = pending.pop() {
-        let node = load_node(store, node_id, root.descriptor_digest).await?;
-        if node.kind == 1 {
-            pending.extend(node.children.into_iter().map(|child| child.node_id));
-        }
-        writes.delete(
-            CURRENT_STATE_PART_DIRECTORY_SPACE,
-            StorageKey(Bytes::copy_from_slice(&node_id)),
-        );
-    }
-    Ok(())
 }
 
 fn stage_node(writes: &mut StorageWriteSet, node: DirectoryNode) -> Result<StagedNode, LixError> {
@@ -388,7 +1863,6 @@ fn stage_node(writes: &mut StorageWriteSet, node: DirectoryNode) -> Result<Stage
 async fn load_node(
     store: &(impl StorageAdapterRead + ?Sized),
     node_id: [u8; 32],
-    expected_set_digest: [u8; 32],
 ) -> Result<DirectoryNode, LixError> {
     let key = StorageKey(Bytes::copy_from_slice(&node_id));
     let result = PointReadPlan::new(CURRENT_STATE_PART_DIRECTORY_SPACE, &[key])
@@ -406,11 +1880,35 @@ async fn load_node(
     if node_digest(&bytes) != node_id {
         return Err(directory_error("node content digest mismatch"));
     }
-    let node = decode_node(&bytes)?;
-    if node.set_digest != expected_set_digest {
-        return Err(directory_error("node belongs to a different part set"));
-    }
-    Ok(node)
+    decode_node(&bytes)
+}
+
+async fn load_directory_nodes(
+    store: &(impl StorageAdapterRead + ?Sized),
+    node_ids: &[[u8; 32]],
+) -> Result<Vec<DirectoryNode>, LixError> {
+    let keys = node_ids
+        .iter()
+        .map(|node_id| StorageKey(Bytes::copy_from_slice(node_id)))
+        .collect::<Vec<_>>();
+    let result = PointReadPlan::new(CURRENT_STATE_PART_DIRECTORY_SPACE, &keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?;
+    node_ids
+        .iter()
+        .zip(result.value)
+        .map(|(node_id, value)| {
+            let value = value
+                .ok_or_else(|| directory_error("references a missing content-addressed node"))?;
+            let StorageProjectedValue::FullValue(bytes) = value else {
+                return Err(directory_error("node read omitted its value"));
+            };
+            if node_digest(&bytes) != *node_id {
+                return Err(directory_error("node content digest mismatch"));
+            }
+            decode_node(&bytes)
+        })
+        .collect()
 }
 
 fn encode_node(node: &DirectoryNode) -> Result<Bytes, LixError> {
@@ -522,6 +2020,18 @@ fn validate_root_summary(
     Ok(())
 }
 
+fn validate_child_summary(expected: &DirectoryChild, node: &DirectoryNode) -> Result<(), LixError> {
+    let (first_key, last_key, row_count, part_count) = node_summary(node)?;
+    if first_key != expected.first_key
+        || last_key != expected.last_key
+        || row_count != expected.row_count
+        || part_count != expected.part_count
+    {
+        return Err(directory_error("child summary disagrees with its node"));
+    }
+    Ok(())
+}
+
 fn node_summary(node: &DirectoryNode) -> Result<(Vec<u8>, Vec<u8>, u64, u32), LixError> {
     validate_node(node)?;
     match node.kind {
@@ -596,8 +2106,7 @@ fn validate_descriptor_slice(
 ) -> Result<(), LixError> {
     let first = parts.first();
     if first.is_none()
-        || (require_zero_origin
-            && first.is_some_and(|part| part.part_index != 0 || part.first_ordinal != 0))
+        || (require_zero_origin && first.is_some_and(|part| part.first_ordinal != 0))
         || parts.iter().any(|part| {
             part.first_key.is_empty()
                 || part.last_key.is_empty()
@@ -609,11 +2118,7 @@ fn validate_descriptor_slice(
             .windows(2)
             .any(|pair| pair[0].last_key >= pair[1].first_key)
         || parts.windows(2).any(|pair| {
-            pair[1].part_index != pair[0].part_index + 1
-                || pair[1].first_ordinal != pair[0].first_ordinal + u32::from(pair[0].row_count)
-                || pair[1].owner_commit_id != pair[0].owner_commit_id
-                || pair[1].uniform_created_at != pair[0].uniform_created_at
-                || pair[1].uniform_updated_at != pair[0].uniform_updated_at
+            pair[1].first_ordinal != pair[0].first_ordinal + u32::from(pair[0].row_count)
         })
     {
         return Err(directory_error(
@@ -632,10 +2137,61 @@ fn directory_error(message: impl std::fmt::Display) -> LixError {
 
 #[cfg(test)]
 mod tests {
+    use std::future::Future;
+    use std::sync::{Arc, Mutex};
+
     use crate::common::LixTimestamp;
     use crate::storage_adapter::{Memory, StorageAdapter, StorageReadOptions, StorageWriteOptions};
 
     use super::*;
+
+    struct CountingDirectoryRead<R> {
+        inner: R,
+        directory_batch_sizes: Arc<Mutex<Vec<usize>>>,
+        catalog_batch_sizes: Arc<Mutex<Vec<usize>>>,
+    }
+
+    impl<R> StorageAdapterRead for CountingDirectoryRead<R>
+    where
+        R: StorageAdapterRead,
+    {
+        fn snapshot_cache_key(&self) -> Option<u128> {
+            self.inner.snapshot_cache_key()
+        }
+
+        fn get_many(
+            &self,
+            requests: &[crate::storage::GetManyRequest<'_>],
+        ) -> impl Future<
+            Output = Result<crate::storage::GetManyResult, crate::storage::StorageError>,
+        > + Send {
+            for request in requests {
+                if request.space == CURRENT_STATE_PART_DIRECTORY_SPACE {
+                    self.directory_batch_sizes
+                        .lock()
+                        .expect("directory batch counts lock")
+                        .push(request.keys.len());
+                }
+                if request.space == CURRENT_STATE_CATALOG_SPACE {
+                    self.catalog_batch_sizes
+                        .lock()
+                        .expect("catalog batch counts lock")
+                        .push(request.keys.len());
+                }
+            }
+            self.inner.get_many(requests)
+        }
+
+        fn scan(
+            &self,
+            space: StorageSpace,
+            range: crate::storage::KeyRange,
+            opts: crate::storage::ScanOptions,
+        ) -> impl Future<Output = Result<crate::storage::ScanChunk, crate::storage::StorageError>> + Send
+        {
+            self.inner.scan(space, range, opts)
+        }
+    }
 
     fn descriptors(count: usize) -> Vec<CurrentStatePartDescriptor> {
         let timestamp = LixTimestamp::from_unix_millis_utc_lossy(7);
@@ -652,6 +2208,336 @@ mod tests {
                 uniform_updated_at: timestamp,
             })
             .collect()
+    }
+
+    fn catalog_entry(index: usize) -> CurrentStatePartSet {
+        CurrentStatePartSet {
+            scope: crate::tracked_state::types::CommitDeltaReplacementScope {
+                schema_key: format!("schema-{index:05}"),
+                file_id: Some(format!("file-{:03}", index % 100)),
+            },
+            coverage_anchor_commit_id: [1; 16],
+            generation_integrity_digest: [2; 32],
+            state_lineage_digest: [3; 32],
+            directory: CurrentStatePartDirectoryRoot {
+                root_id: *blake3::hash(format!("root-{index}").as_bytes()).as_bytes(),
+                descriptor_digest: *blake3::hash(format!("descriptors-{index}").as_bytes())
+                    .as_bytes(),
+                row_count: 1,
+                part_count: 1,
+                tree_height: 1,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn persistent_catalog_bounds_lookup_and_path_copies_one_leaf() {
+        let adapter = StorageAdapter::new(Memory::new());
+        let entries = (0..10_000).map(catalog_entry).collect::<Vec<_>>();
+        let mut writes = adapter.new_write_set();
+        let root =
+            stage_catalog_from_entries(&mut writes, entries.clone()).expect("catalog should stage");
+        assert_eq!(root.entry_count, 10_000);
+        adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("catalog should commit");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("catalog read should open");
+        for index in [0, 31, 32, 4_999, 9_999] {
+            assert_eq!(
+                load_current_state_catalog_entry(&read, &root, &entries[index].scope)
+                    .await
+                    .expect("catalog lookup should succeed"),
+                Some(entries[index].clone())
+            );
+        }
+        let missing = crate::tracked_state::types::CommitDeltaReplacementScope {
+            schema_key: "missing".to_string(),
+            file_id: Some("file-001".to_string()),
+        };
+        assert!(
+            load_current_state_catalog_entry(&read, &root, &missing)
+                .await
+                .expect("catalog miss should succeed")
+                .is_none()
+        );
+        let requested = vec![
+            entries[9_999].scope.clone(),
+            missing.clone(),
+            entries[0].scope.clone(),
+            entries[9_999].scope.clone(),
+        ];
+        assert_eq!(
+            load_current_state_catalog_entries_for_scopes(&read, &root, &requested)
+                .await
+                .expect("batched catalog lookup should succeed"),
+            vec![
+                Some(entries[9_999].clone()),
+                None,
+                Some(entries[0].clone()),
+                Some(entries[9_999].clone()),
+            ],
+            "batched lookup must preserve caller order and duplicate scopes"
+        );
+        let (reachable, loaded) = load_current_state_catalog_reachability(&read, &root)
+            .await
+            .expect("catalog reachability should validate");
+        assert!(
+            reachable.len() < 1_000,
+            "adaptive buckets must remain shallow; got {} nodes",
+            reachable.len()
+        );
+        assert_eq!(loaded.len(), entries.len());
+
+        let removed = entries[4_999].scope.clone();
+        let mut rewrite = adapter.new_write_set();
+        let mut staged = std::collections::BTreeMap::new();
+        let rewritten = update_catalog_entry(
+            &read,
+            &mut rewrite,
+            &mut staged,
+            Some(&root),
+            &removed,
+            None,
+        )
+        .await
+        .expect("catalog delete should path-copy")
+        .expect("catalog should remain non-empty");
+        assert_eq!(rewritten.entry_count, root.entry_count - 1);
+        assert_ne!(rewritten.root_id, root.root_id);
+        assert!(staged.len() < 16, "one update must rewrite a bounded path");
+        flush_reachable_staged_catalog_nodes(&mut rewrite, &staged, rewritten.root_id)
+            .expect("reachable path copy should flush");
+        adapter
+            .commit_write_set(rewrite, StorageWriteOptions::default())
+            .await
+            .expect("catalog rewrite should commit");
+        let rewritten_read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("rewritten catalog read should open");
+        assert!(
+            load_current_state_catalog_entry(&rewritten_read, &rewritten, &removed)
+                .await
+                .expect("removed scope lookup should succeed")
+                .is_none()
+        );
+        assert_eq!(
+            load_current_state_catalog_entry(&rewritten_read, &rewritten, &entries[5_000].scope)
+                .await
+                .expect("untouched scope lookup should succeed"),
+            Some(entries[5_000].clone())
+        );
+    }
+
+    #[tokio::test]
+    async fn catalog_scope_sets_read_shared_root_frontiers_once() {
+        let adapter = StorageAdapter::new(Memory::new());
+        let entries = (0..10_000).map(catalog_entry).collect::<Vec<_>>();
+        let mut writes = adapter.new_write_set();
+        let root =
+            stage_catalog_from_entries(&mut writes, entries.clone()).expect("catalog should stage");
+        adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("catalog should commit");
+
+        let catalog_batch_sizes = Arc::new(Mutex::new(Vec::new()));
+        let read = CountingDirectoryRead {
+            inner: adapter
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("catalog read should open"),
+            directory_batch_sizes: Arc::new(Mutex::new(Vec::new())),
+            catalog_batch_sizes: Arc::clone(&catalog_batch_sizes),
+        };
+        let first = vec![
+            entries[9_999].scope.clone(),
+            entries[0].scope.clone(),
+            entries[9_999].scope.clone(),
+        ];
+        let second = vec![entries[5_000].scope.clone(), entries[31].scope.clone()];
+
+        let single =
+            load_current_state_catalog_entries_for_scope_sets(&read, &[(&root, first.as_slice())])
+                .await
+                .expect("single catalog request should route");
+        let single_batches = std::mem::take(
+            &mut *catalog_batch_sizes
+                .lock()
+                .expect("catalog batch counts lock"),
+        );
+
+        let shared = load_current_state_catalog_entries_for_scope_sets(
+            &read,
+            &[
+                (&root, first.as_slice()),
+                (&root, second.as_slice()),
+                (&root, first.as_slice()),
+            ],
+        )
+        .await
+        .expect("shared-root catalog requests should route");
+        assert_eq!(shared[0], single[0]);
+        assert_eq!(shared[2], single[0]);
+        assert_eq!(
+            shared[1],
+            vec![Some(entries[5_000].clone()), Some(entries[31].clone())]
+        );
+
+        let shared_batches = catalog_batch_sizes
+            .lock()
+            .expect("catalog batch counts lock")
+            .clone();
+        assert_eq!(shared_batches.len(), single_batches.len());
+        assert_eq!(shared_batches[0], 1, "shared root must be read once");
+        assert!(shared_batches.iter().any(|&size| size > 1));
+        assert!(
+            shared_batches.iter().sum::<usize>() < single_batches.iter().sum::<usize>() * 3,
+            "three requests must share physical node reads"
+        );
+    }
+
+    #[tokio::test]
+    async fn compressed_catalog_root_handles_short_misses_and_prefix_divergence() {
+        let adapter = StorageAdapter::new(Memory::new());
+        let mut entries = (0..129).map(catalog_entry).collect::<Vec<_>>();
+        for (index, entry) in entries.iter_mut().enumerate() {
+            entry.scope.file_id = Some(format!("shared-prefix-{index:04}"));
+            entry.scope.schema_key = "shared-schema".to_string();
+        }
+        let mut writes = adapter.new_write_set();
+        let root = stage_catalog_from_entries(&mut writes, entries.clone())
+            .expect("compressed catalog should stage");
+        adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("compressed catalog should commit");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("compressed catalog read should open");
+        let short_scope = crate::tracked_state::types::CommitDeltaReplacementScope {
+            schema_key: "x".to_string(),
+            file_id: None,
+        };
+        let mut no_op_writes = adapter.new_write_set();
+        let mut no_op_staged = std::collections::BTreeMap::new();
+        let unchanged = update_catalog_entry(
+            &read,
+            &mut no_op_writes,
+            &mut no_op_staged,
+            Some(&root),
+            &short_scope,
+            None,
+        )
+        .await
+        .expect("short absent scope must be a no-op")
+        .expect("catalog should remain present");
+        assert_eq!(unchanged.root_id, root.root_id);
+        assert!(no_op_staged.is_empty());
+
+        let mut inserted = catalog_entry(10_000);
+        inserted.scope = short_scope.clone();
+        let mut insert_writes = adapter.new_write_set();
+        let mut insert_staged = std::collections::BTreeMap::new();
+        let rewritten = update_catalog_entry(
+            &read,
+            &mut insert_writes,
+            &mut insert_staged,
+            Some(&root),
+            &short_scope,
+            Some(inserted.clone()),
+        )
+        .await
+        .expect("prefix-divergent insertion should stage")
+        .expect("catalog should remain present");
+        flush_reachable_staged_catalog_nodes(&mut insert_writes, &insert_staged, rewritten.root_id)
+            .expect("rewritten catalog should flush");
+        drop(read);
+        adapter
+            .commit_write_set(insert_writes, StorageWriteOptions::default())
+            .await
+            .expect("prefix-divergent insertion should commit");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("rewritten catalog read should open");
+        assert_eq!(
+            load_current_state_catalog_entry(&read, &rewritten, &short_scope)
+                .await
+                .expect("inserted scope should route"),
+            Some(inserted)
+        );
+        assert_eq!(
+            load_current_state_catalog_entry(&read, &rewritten, &entries[64].scope)
+                .await
+                .expect("old compressed scope should still route"),
+            Some(entries[64].clone())
+        );
+    }
+
+    #[tokio::test]
+    async fn catalog_delete_collapses_to_an_unstaged_shared_subtree() {
+        let adapter = StorageAdapter::new(Memory::new());
+        let mut entries = (0..130).map(catalog_entry).collect::<Vec<_>>();
+        for (index, entry) in entries.iter_mut().take(129).enumerate() {
+            entry.scope.file_id = Some(format!("shared-A-{index:04}"));
+            entry.scope.schema_key = "schema".to_string();
+        }
+        entries[129].scope.file_id = Some("shared-B".to_string());
+        entries[129].scope.schema_key = "schema".to_string();
+        let removed = entries[129].scope.clone();
+        let mut writes = adapter.new_write_set();
+        let root = stage_catalog_from_entries(&mut writes, entries.clone())
+            .expect("branching catalog should stage");
+        adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("branching catalog should commit");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("branching catalog read should open");
+        let mut rewrite = adapter.new_write_set();
+        let mut staged = std::collections::BTreeMap::new();
+        let rewritten = update_catalog_entry(
+            &read,
+            &mut rewrite,
+            &mut staged,
+            Some(&root),
+            &removed,
+            None,
+        )
+        .await
+        .expect("singleton branch deletion should collapse")
+        .expect("shared subtree should remain");
+        flush_reachable_staged_catalog_nodes(&mut rewrite, &staged, rewritten.root_id)
+            .expect("collapsed root should flush");
+        drop(read);
+        adapter
+            .commit_write_set(rewrite, StorageWriteOptions::default())
+            .await
+            .expect("collapsed catalog should commit");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("collapsed catalog read should open");
+        assert!(
+            load_current_state_catalog_entry(&read, &rewritten, &removed)
+                .await
+                .expect("removed branch should miss")
+                .is_none()
+        );
+        assert_eq!(
+            load_current_state_catalog_entry(&read, &rewritten, &entries[64].scope)
+                .await
+                .expect("shared surviving subtree should route"),
+            Some(entries[64].clone())
+        );
     }
 
     #[tokio::test]
@@ -712,53 +2598,102 @@ mod tests {
             root_id: foreign_root.root_id,
             ..root.clone()
         };
-        assert!(
-            route_current_state_part(&read, &forged_root, b"key-000000-m")
+        let routed = route_current_state_part(&read, &forged_root, b"key-000000-m")
+            .await
+            .expect("content-addressed foreign root remains structurally readable")
+            .expect("foreign range should route");
+        assert_ne!(routed.content_digest, descriptors[0].content_digest);
+    }
+
+    #[tokio::test]
+    async fn directory_routing_and_reachability_batch_each_tree_frontier() {
+        let adapter = StorageAdapter::new(Memory::new());
+        let descriptors = descriptors(DIRECTORY_FANOUT * DIRECTORY_FANOUT + 1);
+        let mut writes = adapter.new_write_set();
+        let root = stage_current_state_part_directory(&mut writes, &descriptors)
+            .expect("multi-level directory should stage");
+        assert!(root.tree_height >= 3);
+        adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("multi-level directory should commit");
+
+        let batch_sizes = Arc::new(Mutex::new(Vec::new()));
+        let read = CountingDirectoryRead {
+            inner: adapter
+                .begin_read(StorageReadOptions::default())
                 .await
-                .is_err(),
-            "a valid root from another certified set must not authorize a miss"
+                .expect("directory read should open"),
+            directory_batch_sizes: Arc::clone(&batch_sizes),
+            catalog_batch_sizes: Arc::new(Mutex::new(Vec::new())),
+        };
+        let keys = descriptors
+            .iter()
+            .map(|descriptor| Bytes::copy_from_slice(&descriptor.first_key))
+            .collect::<Vec<_>>();
+        let routed = route_current_state_parts(&read, &root, &keys)
+            .await
+            .expect("multi-level batch should route");
+        assert_eq!(
+            routed,
+            descriptors.iter().cloned().map(Some).collect::<Vec<_>>()
+        );
+        let routing_batches =
+            std::mem::take(&mut *batch_sizes.lock().expect("directory batch counts lock"));
+        assert_eq!(routing_batches.len(), usize::from(root.tree_height));
+        assert!(routing_batches.iter().any(|&size| size > 1));
+
+        let (node_ids, loaded) = load_current_state_part_directory_reachability(&read, &root)
+            .await
+            .expect("multi-level reachability should load");
+        assert!(node_ids.len() > usize::from(root.tree_height));
+        assert_eq!(loaded, descriptors);
+        let reachability_batches = batch_sizes
+            .lock()
+            .expect("directory batch counts lock")
+            .clone();
+        assert_eq!(reachability_batches.len(), usize::from(root.tree_height));
+        assert!(reachability_batches.iter().any(|&size| size > 1));
+
+        batch_sizes
+            .lock()
+            .expect("directory batch counts lock")
+            .clear();
+        let requests = [(&root, keys.as_slice()), (&root, keys.as_slice())];
+        let routed_sets = route_current_state_part_sets(&read, &requests)
+            .await
+            .expect("shared directory roots should route in one traversal");
+        assert_eq!(routed_sets[0], routed_sets[1]);
+        assert_eq!(
+            batch_sizes
+                .lock()
+                .expect("directory batch counts lock")
+                .len(),
+            usize::from(root.tree_height)
         );
 
-        let mut deletes = adapter.new_write_set();
-        assert!(
-            stage_delete_current_state_part_directory(
-                &read,
-                &mut deletes,
-                &root,
-                [8; 16],
-                root.descriptor_digest,
-            )
-            .await
-            .is_err(),
-            "GC must fail closed when a dead manifest is cross-wired"
-        );
-        stage_delete_current_state_part_directory(
+        batch_sizes
+            .lock()
+            .expect("directory batch counts lock")
+            .clear();
+        let (_, loaded_sets) = load_current_state_part_directory_reachability_many(
             &read,
-            &mut deletes,
-            &root,
-            [9; 16],
-            root.descriptor_digest,
+            &[root.clone(), root.clone()],
         )
         .await
-        .expect("directory deletion should stage");
-        drop(read);
-        adapter
-            .commit_write_set(deletes, StorageWriteOptions::default())
-            .await
-            .expect("directory deletion should commit");
-        let read = adapter
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("post-delete read should open");
-        assert!(
-            route_current_state_part(&read, &root, b"key-000000-m")
-                .await
-                .is_err()
+        .expect("shared directory roots should traverse once");
+        assert_eq!(loaded_sets, vec![descriptors.clone(), descriptors.clone()]);
+        assert_eq!(
+            batch_sizes
+                .lock()
+                .expect("directory batch counts lock")
+                .len(),
+            usize::from(root.tree_height)
         );
     }
 
     #[test]
-    fn directory_rejects_overlap_and_owner_drift() {
+    fn directory_rejects_overlap_and_ordinal_drift_but_allows_mixed_owners() {
         let adapter = StorageAdapter::new(Memory::new());
         let mut overlapping = descriptors(2);
         overlapping[1].first_key = overlapping[0].last_key.clone();
@@ -768,7 +2703,13 @@ mod tests {
         let mut owner_drift = descriptors(2);
         owner_drift[1].owner_commit_id = [8; 16];
         assert!(
-            stage_current_state_part_directory(&mut adapter.new_write_set(), &owner_drift).is_err()
+            stage_current_state_part_directory(&mut adapter.new_write_set(), &owner_drift).is_ok()
+        );
+        let mut ordinal_drift = descriptors(2);
+        ordinal_drift[1].first_ordinal += 1;
+        assert!(
+            stage_current_state_part_directory(&mut adapter.new_write_set(), &ordinal_drift)
+                .is_err()
         );
 
         let mut oversized = descriptors(1);

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -21,7 +21,10 @@ pub(crate) use context::{
     TrackedStateContext, TrackedStateStoreReader, descriptor_dependency_cascade_file_ids,
 };
 pub(crate) use current_state_part::{
-    stage_complete_replacement_current_state_part_set, stage_delete_current_state_part_directory,
+    CURRENT_STATE_CATALOG_SPACE, CURRENT_STATE_PART_DIRECTORY_SPACE,
+    load_current_state_catalog_reachability_many,
+    load_current_state_part_directory_reachability_many,
+    validate_current_state_catalog_transition_root,
 };
 pub(crate) use diff::{
     TrackedStateDiff, TrackedStateDiffEntry, TrackedStateDiffIdentity, TrackedStateDiffKind,
@@ -45,12 +48,18 @@ pub(crate) use storage::{
     load_commit_delta_members_with_payloads, load_commit_delta_members_with_payloads_for_schemas,
     load_commit_delta_replay_metadata, load_commit_delta_selection_certificate,
     load_commit_state_manifest, load_commit_state_manifests, load_owned_commit_delta_entries,
-    load_owned_commit_delta_entries_one_ordered_ref, scan_change_records_from_commit_deltas,
-    scan_commit_delta_inventory, scan_commit_delta_values, selected_change_selection_fingerprint,
-    stage_addressable_commit_deltas, stage_addressable_commit_deltas_with_selected_source,
-    stage_change_locators, stage_commit_deltas_for_commit_state, stage_commit_state_manifest,
-    stage_delete_change_locators, stage_delete_commit_delta_inventory_entry,
-    stage_ordered_addressable_commit_deltas, stage_ordered_addressable_replacement_parts,
+    load_owned_commit_delta_entries_one_ordered_ref, load_published_commit_state_manifest,
+    scan_change_records_from_commit_deltas, scan_commit_delta_inventory, scan_commit_delta_values,
+    selected_change_selection_fingerprint, stage_addressable_commit_deltas,
+    stage_addressable_commit_deltas_with_selected_source,
+    stage_certified_commit_state_manifest_with_handle, stage_change_locators,
+    stage_commit_deltas_for_commit_state, stage_commit_state_manifest,
+    stage_commit_state_manifest_with_handle, stage_current_state_catalog_from_published_parent,
+    stage_current_state_catalog_from_staged_parent, stage_delete_change_locators,
+    stage_delete_commit_delta_inventory_entry, stage_ordered_addressable_commit_deltas,
+    stage_ordered_addressable_replacement_parts,
+    validate_current_state_catalog_entry_against_authority,
+    validate_current_state_catalog_parent_manifest,
 };
 #[cfg(feature = "storage-benches")]
 pub(crate) use storage::{
@@ -64,7 +73,9 @@ pub(crate) use storage::{
 };
 #[cfg(test)]
 pub(crate) use storage::{
-    load_authoritative_commit_root, load_commit_delta_change_ids, scan_commit_delta_members,
+    TRACKED_STATE_COMMIT_STATE_SEAL_SPACE, load_authoritative_commit_root,
+    load_commit_delta_change_ids, scan_commit_delta_members,
+    stage_resealed_commit_state_manifest_for_test,
 };
 pub(crate) use types::{COMMIT_STATE_MAX_REPLAY_BYTES, COMMIT_STATE_MAX_REPLAY_DEPTH};
 pub(crate) use types::{

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -47,6 +47,9 @@ pub(crate) const TRACKED_STATE_COMMIT_DELTA_SEGMENT_NAMESPACE: &str =
 pub(crate) const TRACKED_STATE_CHANGE_LOCATOR_NAMESPACE: &str = "tracked_state.change_locator.v2";
 pub(crate) const TRACKED_STATE_COMMIT_STATE_MANIFEST_NAMESPACE: &str =
     "tracked_state.commit_state_manifest.v1";
+pub(crate) const TRACKED_STATE_COMMIT_STATE_SEAL_NAMESPACE: &str =
+    "tracked_state.commit_state_semantic_authority.v1";
+const MIN_CURRENT_STATE_CATALOG_POINT_READS: u16 = 4;
 pub(crate) const TRACKED_STATE_TREE_CHUNK_SPACE: StorageSpace = StorageSpace::mutable(
     StorageSpaceId(0x0004_0001),
     TRACKED_STATE_TREE_CHUNK_NAMESPACE,
@@ -72,6 +75,10 @@ pub(crate) const TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE: StorageSpace = Stora
     StorageSpaceId(0x0004_002b),
     TRACKED_STATE_COMMIT_STATE_MANIFEST_NAMESPACE,
 );
+pub(crate) const TRACKED_STATE_COMMIT_STATE_SEAL_SPACE: StorageSpace = StorageSpace::immutable(
+    StorageSpaceId(0x0004_002e),
+    TRACKED_STATE_COMMIT_STATE_SEAL_NAMESPACE,
+);
 
 const COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 512;
 const GENERIC_COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 128;
@@ -81,7 +88,8 @@ const ORDERED_COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 64 * 1024;
 // replacements authoritative through their immutable part manifest. The
 // payload-less certified-reference encoding is intentionally rejected.
 const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD14";
-const COMMIT_STATE_MANIFEST_FORMAT_MAGIC: &[u8] = b"LXCS2";
+const COMMIT_STATE_SEMANTIC_AUTHORITY_MAGIC: &[u8] = b"LXSA1";
+const COMMIT_STATE_MANIFEST_FORMAT_MAGIC: &[u8] = b"LXCS3";
 const COMMIT_DELTA_PAYLOAD_OFFSET_BYTES: usize = size_of::<u32>();
 #[cfg(not(test))]
 const COMMIT_DELTA_MAX_SIDECAR_BYTES: usize = 64 * 1024 * 1024;
@@ -615,6 +623,60 @@ fn commit_delta_manifest_from_commit_state(manifest: &CommitStateManifest) -> Co
     commit_delta_manifest_from_inventory(&manifest.mutations)
 }
 
+/// Returns the exact collection scopes touched by a sealed mutation inventory.
+/// `None` means bounds or implicit cascades may affect another scope, in which
+/// case an inherited serving catalog must be discarded fail-closed.
+pub(crate) fn commit_state_inventory_exact_touched_scopes(
+    commit_id: CommitId,
+    inventory: &CommitStateMutationInventory,
+) -> Result<Option<Vec<CommitDeltaReplacementScope>>, LixError> {
+    if inventory.selected_source_commit_id.is_some() {
+        return Ok(None);
+    }
+    if inventory.member_count == 0 {
+        return Ok(Some(Vec::new()));
+    }
+    if !inventory.replacement_part_digests.is_empty() {
+        return Ok(inventory.single_partition.clone().map(|scope| vec![scope]));
+    }
+
+    let mut scopes = BTreeSet::new();
+    for part in &inventory.parts {
+        let first = decode_key(&part.first_key)?;
+        let last = decode_key(&part.last_key)?;
+        if first.schema_key != last.schema_key || first.file_id != last.file_id {
+            return Ok(None);
+        }
+        if first.schema_key == "lix_file_descriptor" {
+            return Ok(None);
+        }
+        scopes.insert(CommitDeltaReplacementScope {
+            schema_key: first.schema_key,
+            file_id: first.file_id,
+        });
+    }
+    if !inventory.inline_part.is_empty() {
+        let leaf = decode_commit_delta_segment(&inventory.inline_part, None, commit_id)?;
+        let mut has_cascade = false;
+        visit_commit_delta_leaf(&leaf, commit_id, |_, encoded_key, _| {
+            let key = decode_key(encoded_key)?;
+            if key.schema_key == "lix_file_descriptor" {
+                has_cascade = true;
+            } else {
+                scopes.insert(CommitDeltaReplacementScope {
+                    schema_key: key.schema_key,
+                    file_id: key.file_id,
+                });
+            }
+            Ok(())
+        })?;
+        if has_cascade {
+            return Ok(None);
+        }
+    }
+    Ok(Some(scopes.into_iter().collect()))
+}
+
 async fn expanded_commit_delta_manifest_from_commit_state(
     store: &(impl StorageAdapterRead + ?Sized),
     manifest: &CommitStateManifest,
@@ -623,7 +685,8 @@ async fn expanded_commit_delta_manifest_from_commit_state(
     if manifest.mutations.replacement_part_digests.is_empty() {
         return Ok(expanded);
     }
-    let descriptors = match manifest.current_state_part_sets.first() {
+    let fresh_set = fresh_replacement_current_state_part_set(manifest)?;
+    let descriptors = match fresh_set.as_ref() {
         Some(set) => match super::current_state_part::load_current_state_part_descriptors(
             store,
             &set.directory,
@@ -668,6 +731,316 @@ async fn expanded_commit_delta_manifest_from_commit_state(
         None => recover_replacement_segment_bounds(store, manifest).await?,
     };
     Ok(expanded)
+}
+
+fn fresh_replacement_current_state_part_set(
+    manifest: &CommitStateManifest,
+) -> Result<Option<crate::tracked_state::types::CurrentStatePartSet>, LixError> {
+    let (Some(_root), Some(generation), Some(authority), Some(anchor)) = (
+        manifest.current_state_catalog.as_ref(),
+        manifest.mutations.replacement_generation.as_ref(),
+        manifest.mutations.replacement_parts.as_ref(),
+        manifest.current_state_coverage_anchor.as_ref(),
+    ) else {
+        return Ok(None);
+    };
+    let set = crate::tracked_state::types::CurrentStatePartSet {
+        scope: anchor.scope.clone(),
+        coverage_anchor_commit_id: *manifest.commit_id.as_uuid().as_bytes(),
+        generation_integrity_digest: anchor.generation_integrity_digest,
+        state_lineage_digest: anchor.state_lineage_digest,
+        directory: anchor.directory.clone(),
+    };
+    if set.coverage_anchor_commit_id != *manifest.commit_id.as_uuid().as_bytes()
+        || set.generation_integrity_digest != generation.integrity_digest
+        || set.scope != anchor.scope
+        || set.generation_integrity_digest != anchor.generation_integrity_digest
+        || set.state_lineage_digest != anchor.state_lineage_digest
+        || set.directory != anchor.directory
+        || set.directory.descriptor_digest != authority.directory_digest
+        || set.directory.row_count != u64::from(manifest.mutations.member_count)
+        || set.directory.part_count as usize != manifest.mutations.part_count()
+        || set.directory.root_id == [0; 32]
+        || set.directory.tree_height == 0
+    {
+        return Err(replacement_payload_error(
+            "current-state catalog entry disagrees with its replacement authority",
+        ));
+    }
+    Ok(Some(set))
+}
+
+/// Resolves a point batch from authoritative complete collection entries in
+/// the persistent catalog. `None` means at least one scope is uncovered and
+/// canonical first-parent replay remains responsible for the whole batch.
+async fn load_complete_current_state_values_encoded_inner(
+    store: &(impl StorageAdapterRead + ?Sized),
+    state: &CommitStateManifest,
+    encoded_keys: &[Bytes],
+    validate_publication: bool,
+) -> Result<Option<Vec<Option<TrackedStateIndexValue>>>, LixError> {
+    if encoded_keys.is_empty() {
+        return Ok(Some(Vec::new()));
+    }
+    let Some(root) = state.current_state_catalog.as_ref() else {
+        return Ok(None);
+    };
+    if state.replay_debt.depth < MIN_CURRENT_STATE_CATALOG_POINT_READS {
+        // Even the smallest covered lookup reads a catalog node, its coverage
+        // authority, a directory node, and one immutable part. Canonical
+        // replay is cheaper while its bounded manifest interval is shorter.
+        return Ok(None);
+    }
+    let mut scope_keys = BTreeMap::<CommitDeltaReplacementScope, Vec<usize>>::new();
+    for (index, encoded_key) in encoded_keys.iter().enumerate() {
+        let key = decode_key_shared(encoded_key.clone())?;
+        scope_keys
+            .entry(CommitDeltaReplacementScope {
+                schema_key: key.schema_key.to_string(),
+                file_id: key.file_id.map(|file_id| file_id.to_string()),
+            })
+            .or_default()
+            .push(index);
+    }
+    let Some(touched_scopes) =
+        commit_state_inventory_exact_touched_scopes(state.commit_id, &state.mutations)?
+    else {
+        return Ok(None);
+    };
+    if scope_keys
+        .keys()
+        .any(|scope| touched_scopes.binary_search(scope).is_ok())
+    {
+        return Ok(None);
+    }
+    if state
+        .current_state_coverage_anchor
+        .as_ref()
+        .is_some_and(|anchor| scope_keys.keys().all(|scope| scope == &anchor.scope))
+    {
+        // The current manifest's complete-replacement authority already has a
+        // direct bounded-part route for this scope. Prefer it over resolving
+        // the same directory through the inherited-serving catalog.
+        return Ok(None);
+    }
+
+    let scoped_keys = scope_keys.into_iter().collect::<Vec<_>>();
+    let scopes = scoped_keys
+        .iter()
+        .map(|(scope, _)| scope.clone())
+        .collect::<Vec<_>>();
+    let loaded_sets = super::current_state_part::load_current_state_catalog_entries_for_scopes(
+        store, root, &scopes,
+    )
+    .await?;
+    if validate_publication {
+        validate_current_state_catalog_requested_scopes(store, state, &scopes, &loaded_sets)
+            .await?;
+    }
+    let Some(sets) = loaded_sets
+        .into_iter()
+        .zip(scoped_keys)
+        .map(|(set, (_, key_indices))| set.map(|set| (set, key_indices)))
+        .collect::<Option<Vec<_>>>()
+    else {
+        return Ok(None);
+    };
+
+    if validate_publication {
+        let authority_ids = sets
+            .iter()
+            .map(|(set, _)| CommitId::new(uuid::Uuid::from_bytes(set.coverage_anchor_commit_id)))
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let authorities = load_commit_state_manifests(store, &authority_ids).await?;
+        let authority_by_id = authority_ids
+            .into_iter()
+            .zip(authorities)
+            .map(|(authority_id, authority)| {
+                authority
+                    .map(|authority| (authority_id, authority))
+                    .ok_or_else(|| {
+                        replacement_payload_error(
+                            "current-state catalog coverage authority is missing",
+                        )
+                    })
+            })
+            .collect::<Result<BTreeMap<_, _>, _>>()?;
+        for (set, _) in &sets {
+            let authority_id = CommitId::new(uuid::Uuid::from_bytes(set.coverage_anchor_commit_id));
+            validate_current_state_catalog_entry_against_authority(
+                set,
+                authority_by_id
+                    .get(&authority_id)
+                    .expect("unique catalog authority was batch loaded"),
+            )?;
+        }
+    }
+
+    let mut routed = BTreeMap::<([u8; 16], u32), (CurrentStatePartDescriptor, Vec<usize>)>::new();
+    let mut values = vec![None; encoded_keys.len()];
+    let directory_keys = sets
+        .iter()
+        .map(|(_, key_indices)| {
+            key_indices
+                .iter()
+                .map(|&index| encoded_keys[index].clone())
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let directory_requests = sets
+        .iter()
+        .zip(&directory_keys)
+        .map(|((set, _), keys)| (&set.directory, keys.as_slice()))
+        .collect::<Vec<_>>();
+    let directory_routes =
+        super::current_state_part::route_current_state_part_sets(store, &directory_requests)
+            .await?;
+    for ((_, key_indices), routes) in sets.into_iter().zip(directory_routes) {
+        for (output_index, descriptor) in key_indices.into_iter().zip(routes) {
+            let Some(descriptor) = descriptor else {
+                continue;
+            };
+            routed
+                .entry((descriptor.owner_commit_id, descriptor.part_index))
+                .or_insert_with(|| (descriptor, Vec::new()))
+                .1
+                .push(output_index);
+        }
+    }
+
+    let storage_keys = routed
+        .values()
+        .map(|(descriptor, _)| {
+            let owner = CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id));
+            let mut key = commit_delta_segment_key(owner, descriptor.part_index as usize)?;
+            key.extend_from_slice(&descriptor.content_digest);
+            Ok(StorageKey(Bytes::from(key)))
+        })
+        .collect::<Result<Vec<_>, LixError>>()?;
+    let loaded = PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, &storage_keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?;
+    for ((_, (descriptor, output_indices)), value) in routed.into_iter().zip(loaded.value) {
+        let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
+            replacement_payload_error("current-state directory references a missing part")
+        })?;
+        let owner = CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id));
+        let bounds = CommitDeltaSegmentBounds {
+            first_key: descriptor.first_key,
+            last_key: descriptor.last_key,
+            replacement_part: Some(StoredReplacementPart {
+                content_digest: descriptor.content_digest,
+                owner_commit_id: descriptor.owner_commit_id,
+                first_address: descriptor.part_index.saturating_mul(
+                    u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS)
+                        .expect("replacement row bound fits u32"),
+                ),
+                uniform_created_at: descriptor.uniform_created_at,
+                uniform_updated_at: descriptor.uniform_updated_at,
+            }),
+        };
+        let leaf = decode_commit_delta_segment(&bytes, Some(&bounds), owner)?;
+        for output_index in output_indices {
+            values[output_index] =
+                find_commit_delta_value(&leaf, &encoded_keys[output_index], owner)?;
+        }
+    }
+    Ok(Some(values))
+}
+
+#[cfg(test)]
+pub(crate) async fn load_complete_current_state_values_encoded(
+    store: &(impl StorageAdapterRead + ?Sized),
+    state: &CommitStateManifest,
+    encoded_keys: &[Bytes],
+) -> Result<Option<Vec<Option<TrackedStateIndexValue>>>, LixError> {
+    load_complete_current_state_values_encoded_inner(store, state, encoded_keys, true).await
+}
+
+/// Uses a manifest returned by [`load_commit_state_manifest`] or
+/// [`load_commit_state_manifests`]. The opaque handle proves that the mutable
+/// manifest matched its immutable semantic authority in the caller's coherent
+/// read.
+#[cfg(feature = "storage-benches")]
+pub(crate) async fn load_complete_current_state_values_from_published_manifest(
+    store: &(impl StorageAdapterRead + ?Sized),
+    state: &PublishedCommitStateManifest,
+    encoded_keys: &[Bytes],
+) -> Result<Option<Vec<Option<TrackedStateIndexValue>>>, LixError> {
+    load_complete_current_state_values_encoded_inner(store, &state.manifest, encoded_keys, false)
+        .await
+}
+
+/// Tries the serving catalog from a one-read replay manifest. The inner cost
+/// gates run before publication validation, so shallow OLTP replay retains its
+/// original one-manifest read while any catalog hit is authenticated first.
+pub(crate) async fn load_complete_current_state_values_from_replay_manifest(
+    store: &(impl StorageAdapterRead + ?Sized),
+    state: &CommitStateManifest,
+    encoded_keys: &[Bytes],
+) -> Result<Option<Vec<Option<TrackedStateIndexValue>>>, LixError> {
+    load_complete_current_state_values_encoded_inner(store, state, encoded_keys, true).await
+}
+
+pub(crate) async fn validate_current_state_catalog_requested_scopes(
+    store: &(impl StorageAdapterRead + ?Sized),
+    state: &CommitStateManifest,
+    _scopes: &[CommitDeltaReplacementScope],
+    _current_entries: &[Option<crate::tracked_state::types::CurrentStatePartSet>],
+) -> Result<(), LixError> {
+    if load_commit_state_manifest(store, state.commit_id)
+        .await?
+        .as_ref()
+        != Some(state)
+    {
+        return Err(replacement_payload_error(
+            "current-state catalog was not loaded from its immutable commit authority",
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_current_state_catalog_parent_manifest(
+    state: &CommitStateManifest,
+    parent: Option<&CommitStateManifest>,
+) -> Result<(), LixError> {
+    let Some(root) = state.current_state_catalog.as_ref() else {
+        return Ok(());
+    };
+    let expected_parent_root = parent
+        .and_then(|parent| parent.current_state_catalog.as_ref())
+        .map(|parent| parent.root_id);
+    if root.parent_root_id != expected_parent_root {
+        return Err(replacement_payload_error(
+            "current-state catalog transition disagrees with its graph parent",
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_current_state_catalog_entry_against_authority(
+    set: &crate::tracked_state::types::CurrentStatePartSet,
+    origin: &CommitStateManifest,
+) -> Result<(), LixError> {
+    let anchor = origin
+        .current_state_coverage_anchor
+        .as_ref()
+        .ok_or_else(|| {
+            replacement_payload_error("catalog coverage authority omitted its anchor")
+        })?;
+    if set.coverage_anchor_commit_id != *origin.commit_id.as_uuid().as_bytes()
+        || set.scope != anchor.scope
+        || set.generation_integrity_digest != anchor.generation_integrity_digest
+        || set.state_lineage_digest != anchor.state_lineage_digest
+        || set.directory != anchor.directory
+    {
+        return Err(replacement_payload_error(
+            "current-state catalog entry disagrees with its coverage anchor",
+        ));
+    }
+    Ok(())
 }
 
 async fn recover_replacement_segment_bounds(
@@ -1471,6 +1844,138 @@ fn commit_state_manifest_key(commit_id: CommitId) -> Vec<u8> {
     commit_id.as_uuid().as_bytes().to_vec()
 }
 
+fn commit_state_semantic_seal(manifest: &CommitStateManifest) -> Result<Vec<u8>, LixError> {
+    // Retain the root published with the commit so one-read point replay can
+    // stop at its original baseline. A later rebuilt root may change only the
+    // mutable manifest; semantic comparison intentionally ignores that field.
+    let payload = storage_codec::encode("commit-state semantic authority", manifest)?;
+    let digest = blake3::Hasher::new_derive_key("lix.commit-state.semantic-authority.v1")
+        .update(&payload)
+        .finalize();
+    let mut encoded = Vec::with_capacity(
+        COMMIT_STATE_SEMANTIC_AUTHORITY_MAGIC.len() + TRACKED_STATE_HASH_BYTES + payload.len(),
+    );
+    encoded.extend_from_slice(COMMIT_STATE_SEMANTIC_AUTHORITY_MAGIC);
+    encoded.extend_from_slice(digest.as_bytes());
+    encoded.extend_from_slice(&payload);
+    Ok(encoded)
+}
+
+fn decode_commit_state_semantic_authority(bytes: &[u8]) -> Result<CommitStateManifest, LixError> {
+    let payload = bytes
+        .strip_prefix(COMMIT_STATE_SEMANTIC_AUTHORITY_MAGIC)
+        .ok_or_else(|| {
+            replacement_payload_error("commit-state semantic authority has an unsupported format")
+        })?;
+    let (expected_digest, payload) = payload
+        .split_at_checked(TRACKED_STATE_HASH_BYTES)
+        .ok_or_else(|| replacement_payload_error("commit-state semantic authority is truncated"))?;
+    let actual_digest = blake3::Hasher::new_derive_key("lix.commit-state.semantic-authority.v1")
+        .update(payload)
+        .finalize();
+    if expected_digest != actual_digest.as_bytes() {
+        return Err(replacement_payload_error(
+            "commit-state semantic authority digest is invalid",
+        ));
+    }
+    storage_codec::decode("commit-state semantic authority", payload)
+}
+
+fn validate_commit_state_semantic_seal(
+    manifest: &CommitStateManifest,
+    seal: &[u8],
+) -> Result<(), LixError> {
+    let authority = decode_commit_state_semantic_authority(seal)?;
+    validate_commit_state_semantic_projection(manifest, &authority)
+}
+
+fn validate_commit_state_semantic_projection(
+    manifest: &CommitStateManifest,
+    authority: &CommitStateManifest,
+) -> Result<(), LixError> {
+    let mut manifest_semantics = manifest.clone();
+    manifest_semantics.snapshot_root = None;
+    let mut authority_semantics = authority.clone();
+    authority_semantics.snapshot_root = None;
+    if authority_semantics != manifest_semantics {
+        return Err(replacement_payload_error(
+            "commit-state manifest disagrees with its immutable semantic authority",
+        ));
+    }
+    Ok(())
+}
+
+/// Commit authority loaded from the mutable manifest plane after its
+/// immutable semantic authority was verified. Only this opaque handle may bypass
+/// publication-time catalog re-derivation.
+#[derive(Clone, Debug)]
+pub(crate) struct PublishedCommitStateManifest {
+    manifest: CommitStateManifest,
+}
+
+/// Same-write-set authority produced only after semantic publication. This lets a
+/// later commit in one atomic transaction consume its parent catalog without
+/// treating a freely constructible manifest as provenance.
+pub(crate) struct StagedCommitStateManifest {
+    manifest: CommitStateManifest,
+    write_set_id: u64,
+}
+
+impl Deref for PublishedCommitStateManifest {
+    type Target = CommitStateManifest;
+
+    fn deref(&self) -> &Self::Target {
+        &self.manifest
+    }
+}
+
+impl Deref for StagedCommitStateManifest {
+    type Target = CommitStateManifest;
+
+    fn deref(&self) -> &Self::Target {
+        &self.manifest
+    }
+}
+
+pub(crate) async fn stage_current_state_catalog_from_published_parent(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    parent: Option<&PublishedCommitStateManifest>,
+    commit_id: CommitId,
+    inventory: &CommitStateMutationInventory,
+) -> Result<super::current_state_part::CertifiedCurrentStateCatalogPublication, LixError> {
+    super::current_state_part::stage_current_state_catalog(
+        store,
+        writes,
+        parent.map(|parent| &parent.manifest),
+        commit_id,
+        inventory,
+    )
+    .await
+}
+
+pub(crate) async fn stage_current_state_catalog_from_staged_parent(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    parent: &StagedCommitStateManifest,
+    commit_id: CommitId,
+    inventory: &CommitStateMutationInventory,
+) -> Result<super::current_state_part::CertifiedCurrentStateCatalogPublication, LixError> {
+    if parent.write_set_id != writes.identity() {
+        return Err(replacement_payload_error(
+            "staged catalog parent belongs to a different storage write set",
+        ));
+    }
+    super::current_state_part::stage_current_state_catalog(
+        store,
+        writes,
+        Some(&parent.manifest),
+        commit_id,
+        inventory,
+    )
+    .await
+}
+
 fn commit_delta_segment_key(
     commit_id: CommitId,
     segment_index: usize,
@@ -1503,15 +2008,35 @@ pub(crate) async fn load_commit_state_manifest(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
 ) -> Result<Option<CommitStateManifest>, LixError> {
-    let Some(bytes) = get_one(
-        store,
-        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
-        commit_state_manifest_key(commit_id),
-    )
-    .await?
-    else {
+    #[cfg(feature = "storage-benches")]
+    crate::storage_bench::record_crud_sealed_manifest_load();
+    let key = StorageKey(Bytes::from(commit_state_manifest_key(commit_id)));
+    let requests = [
+        StorageGetManyRequest {
+            space: TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+            keys: std::slice::from_ref(&key),
+            opts: StorageGetOptions::default(),
+        },
+        StorageGetManyRequest {
+            space: TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
+            keys: std::slice::from_ref(&key),
+            opts: StorageGetOptions::default(),
+        },
+    ];
+    let mut values = exact_get_many(store, &requests).await?.values.into_iter();
+    let manifest_bytes = values.next().flatten().and_then(full_value_bytes);
+    let seal = values.next().flatten().and_then(full_value_bytes);
+    let Some(bytes) = manifest_bytes else {
+        if seal.is_some() {
+            return Err(replacement_payload_error(
+                "commit-state semantic authority has no mutable manifest",
+            ));
+        }
         return Ok(None);
     };
+    let seal = seal.ok_or_else(|| {
+        replacement_payload_error("commit-state manifest omitted its immutable semantic authority")
+    })?;
     let manifest = decode_commit_state_manifest(&bytes)?;
     if manifest.commit_id != commit_id {
         return Err(LixError::new(
@@ -1522,7 +2047,53 @@ pub(crate) async fn load_commit_state_manifest(
             ),
         ));
     }
+    validate_commit_state_semantic_seal(&manifest, &seal)?;
     Ok(Some(manifest))
+}
+
+pub(crate) async fn load_published_commit_state_manifest(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+) -> Result<Option<PublishedCommitStateManifest>, LixError> {
+    Ok(load_commit_state_manifest(store, commit_id)
+        .await?
+        .map(|manifest| PublishedCommitStateManifest { manifest }))
+}
+
+/// Loads the replay projection after verifying immutable semantic authority.
+pub(crate) async fn load_replay_commit_state_manifest(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+) -> Result<Option<CommitStateManifest>, LixError> {
+    load_point_replay_commit_state(store, commit_id).await
+}
+
+pub(crate) async fn load_point_replay_commit_state(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+) -> Result<Option<CommitStateManifest>, LixError> {
+    #[cfg(feature = "storage-benches")]
+    crate::storage_bench::record_crud_replay_manifest_load();
+    let Some(authority) = get_one(
+        store,
+        TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
+        commit_state_manifest_key(commit_id),
+    )
+    .await?
+    else {
+        return Ok(None);
+    };
+    let state = decode_commit_state_semantic_authority(&authority)?;
+    if state.commit_id != commit_id {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "tracked_state semantic authority key for commit '{commit_id}' contains authority for commit '{}'",
+                state.commit_id
+            ),
+        ));
+    }
+    Ok(Some(state))
 }
 
 /// Bulk-loads commit authorities in request order.
@@ -1534,17 +2105,41 @@ pub(crate) async fn load_commit_state_manifests(
         .iter()
         .map(|commit_id| StorageKey(Bytes::from(commit_state_manifest_key(*commit_id))))
         .collect::<Vec<_>>();
-    let values = PointReadPlan::new(TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE, &keys)
-        .materialize(store, StorageGetOptions::default())
-        .await?;
+    let requests = [
+        StorageGetManyRequest {
+            space: TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+            keys: &keys,
+            opts: StorageGetOptions::default(),
+        },
+        StorageGetManyRequest {
+            space: TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
+            keys: &keys,
+            opts: StorageGetOptions::default(),
+        },
+    ];
+    let mut values = exact_get_many(store, &requests).await?.values.into_iter();
+    let manifests = values.by_ref().take(keys.len()).collect::<Vec<_>>();
+    let seals = values.collect::<Vec<_>>();
     commit_ids
         .iter()
         .copied()
-        .zip(values.value)
-        .map(|(commit_id, value)| {
-            let Some(bytes) = value.and_then(full_value_bytes) else {
+        .zip(manifests.into_iter().zip(seals))
+        .map(|(commit_id, (manifest_value, seal_value))| {
+            let manifest_bytes = manifest_value.and_then(full_value_bytes);
+            let seal = seal_value.and_then(full_value_bytes);
+            let Some(bytes) = manifest_bytes else {
+                if seal.is_some() {
+                    return Err(replacement_payload_error(
+                        "commit-state semantic authority has no mutable manifest",
+                    ));
+                }
                 return Ok(None);
             };
+            let seal = seal.ok_or_else(|| {
+                replacement_payload_error(
+                    "commit-state manifest omitted its immutable semantic authority",
+                )
+            })?;
             let manifest = decode_commit_state_manifest(&bytes)?;
             if manifest.commit_id != commit_id {
                 return Err(LixError::new(
@@ -1555,6 +2150,7 @@ pub(crate) async fn load_commit_state_manifests(
                     ),
                 ));
             }
+            validate_commit_state_semantic_seal(&manifest, &seal)?;
             Ok(Some(manifest))
         })
         .collect()
@@ -1611,13 +2207,112 @@ async fn load_commit_delta_manifests(
 /// optional snapshot metadata are final. Publishing a partially populated
 /// manifest and patching it later would make an intermediate representation
 /// authoritative to read-your-writes consumers.
-pub(crate) fn stage_commit_state_manifest(
+fn stage_commit_state_manifest_bytes(
     writes: &mut StorageWriteSet,
     manifest: &CommitStateManifest,
 ) -> Result<(), LixError> {
     let encoded = encode_commit_state_manifest(manifest)?;
+    let seal = commit_state_semantic_seal(manifest)?;
     #[cfg(feature = "storage-benches")]
     crate::storage_bench::record_crud_commit_state_manifest_bytes(encoded.len());
+    writes.put(
+        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+        key(commit_state_manifest_key(manifest.commit_id)),
+        value(encoded),
+    );
+    writes.put(
+        TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
+        key(commit_state_manifest_key(manifest.commit_id)),
+        value(seal.to_vec()),
+    );
+    Ok(())
+}
+
+/// Stages authority that carries no serving catalog. Catalog-bearing
+/// authorities require the opaque canonical transition proof returned by
+/// `stage_current_state_catalog`.
+pub(crate) fn stage_commit_state_manifest(
+    writes: &mut StorageWriteSet,
+    manifest: &CommitStateManifest,
+) -> Result<(), LixError> {
+    if manifest.current_state_catalog.is_some() || manifest.current_state_coverage_anchor.is_some()
+    {
+        return Err(replacement_payload_error(
+            "current-state catalogs require canonical publication certification",
+        ));
+    }
+    stage_commit_state_manifest_bytes(writes, manifest)
+}
+
+pub(crate) fn stage_commit_state_manifest_with_handle(
+    writes: &mut StorageWriteSet,
+    manifest: &CommitStateManifest,
+) -> Result<StagedCommitStateManifest, LixError> {
+    stage_commit_state_manifest(writes, manifest)?;
+    Ok(StagedCommitStateManifest {
+        manifest: manifest.clone(),
+        write_set_id: writes.identity(),
+    })
+}
+
+/// Publishes a catalog only when the exact opaque proof from its canonical
+/// staging transition accompanies the manifest.
+pub(crate) fn stage_certified_commit_state_manifest(
+    writes: &mut StorageWriteSet,
+    manifest: &CommitStateManifest,
+    publication: &super::current_state_part::CertifiedCurrentStateCatalogPublication,
+) -> Result<(), LixError> {
+    if writes.identity() != publication.write_set_id() {
+        return Err(replacement_payload_error(
+            "catalog publication proof belongs to a different storage write set",
+        ));
+    }
+    let (root, anchor) = publication.parts();
+    let declared_parent_id = match manifest.parent_commit_ids.as_slice() {
+        [] => None,
+        [parent_id] => Some(*parent_id),
+        _ => {
+            return Err(replacement_payload_error(
+                "certified current-state catalogs cannot have multiple graph parents",
+            ));
+        }
+    };
+    if declared_parent_id != publication.parent_commit_id() {
+        return Err(replacement_payload_error(
+            "commit manifest graph parent disagrees with its catalog publication proof",
+        ));
+    }
+    if manifest.current_state_catalog != root || manifest.current_state_coverage_anchor != anchor {
+        return Err(replacement_payload_error(
+            "commit manifest disagrees with its canonical catalog publication proof",
+        ));
+    }
+    stage_commit_state_manifest_bytes(writes, manifest)
+}
+
+pub(crate) fn stage_certified_commit_state_manifest_with_handle(
+    writes: &mut StorageWriteSet,
+    manifest: &CommitStateManifest,
+    publication: &super::current_state_part::CertifiedCurrentStateCatalogPublication,
+) -> Result<StagedCommitStateManifest, LixError> {
+    stage_certified_commit_state_manifest(writes, manifest, publication)?;
+    Ok(StagedCommitStateManifest {
+        manifest: manifest.clone(),
+        write_set_id: writes.identity(),
+    })
+}
+
+/// Updates only the rebuildable snapshot accelerator of an already sealed
+/// authority. All semantic fields come from the opaque published handle and
+/// therefore retain the exact same immutable authority.
+pub(crate) fn stage_commit_state_snapshot_root_update(
+    writes: &mut StorageWriteSet,
+    published: &PublishedCommitStateManifest,
+    snapshot_root: Option<TrackedStateCommitRoot>,
+) -> Result<(), LixError> {
+    let mut manifest = published.manifest.clone();
+    manifest.snapshot_root = snapshot_root;
+    let encoded = encode_commit_state_manifest(&manifest)?;
     writes.put(
         TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
         key(commit_state_manifest_key(manifest.commit_id)),
@@ -1641,6 +2336,32 @@ pub(crate) fn stage_unchecked_commit_state_manifest_for_test(
         TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
         key(commit_state_manifest_key(manifest.commit_id)),
         value(encoded),
+    );
+    Ok(())
+}
+
+/// Replaces both mutable manifest bytes and the normally immutable seal for a
+/// corruption/test-fixture scenario. Production code cannot compile a call to
+/// this bypass.
+#[cfg(test)]
+pub(crate) fn stage_resealed_commit_state_manifest_for_test(
+    writes: &mut StorageWriteSet,
+    manifest: &CommitStateManifest,
+) -> Result<(), LixError> {
+    let encoded = encode_commit_state_manifest(manifest)?;
+    let seal = commit_state_semantic_seal(manifest)?;
+    writes.put(
+        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+        key(commit_state_manifest_key(manifest.commit_id)),
+        value(encoded),
+    );
+    writes.put(
+        StorageSpace::mutable(
+            TRACKED_STATE_COMMIT_STATE_SEAL_SPACE.id,
+            TRACKED_STATE_COMMIT_STATE_SEAL_NAMESPACE,
+        ),
+        key(commit_state_manifest_key(manifest.commit_id)),
+        value(seal.to_vec()),
     );
     Ok(())
 }
@@ -2234,13 +2955,13 @@ fn stored_replacement_generation(
     stored
 }
 
-fn replacement_generation_integrity_digest(
+pub(crate) fn replacement_generation_integrity_digest(
     generation: &StoredCommitDeltaReplacementGeneration,
     lifecycle_summary: &CommitDeltaLifecycleSummary,
     replacement_parts: &StoredReplacementPartsAuthority,
 ) -> [u8; 32] {
     let mut digest =
-        blake3::Hasher::new_derive_key("lix tracked-state replacement generation certificate v1");
+        blake3::Hasher::new_derive_key("lix tracked-state replacement generation certificate v2");
     digest.update(&generation.owner_commit_id);
     digest.update(&(generation.scope.schema_key.len() as u64).to_be_bytes());
     digest.update(generation.scope.schema_key.as_bytes());
@@ -3368,7 +4089,7 @@ pub(crate) async fn load_commit_delta_values_encoded_with_cache(
     let manifest = match cached_manifest {
         Some(manifest) => manifest,
         None => {
-            let Some(state) = load_commit_state_manifest(store, commit_id).await? else {
+            let Some(state) = load_replay_commit_state_manifest(store, commit_id).await? else {
                 return Ok(vec![None; encoded_keys.len()]);
             };
             if !state.mutations.replacement_part_digests.is_empty() {
@@ -3392,7 +4113,7 @@ pub(crate) async fn load_commit_delta_values_encoded_with_cache(
         return load_local_commit_delta_values_encoded(store, commit_id, encoded_keys, &manifest)
             .await;
     };
-    if load_commit_state_manifest(store, source_commit_id)
+    if load_replay_commit_state_manifest(store, source_commit_id)
         .await?
         .is_none()
     {
@@ -3429,6 +4150,39 @@ pub(crate) async fn load_commit_delta_values_encoded_with_cache(
     Ok(values)
 }
 
+/// Replays deltas from the one-read manifest already validated against the
+/// changelog projection. Compact replacements route directly through their
+/// immutable parts; ordinary manifests seed and reuse the point cache.
+pub(crate) async fn load_commit_delta_values_encoded_from_replay_manifest(
+    store: &(impl StorageAdapterRead + ?Sized),
+    state: &CommitStateManifest,
+    encoded_keys: &[Bytes],
+    point_cache: &CommitDeltaPointReadCache,
+) -> Result<Vec<Option<TrackedStateIndexValue>>, LixError> {
+    if !state.mutations.replacement_part_digests.is_empty() {
+        return load_compact_replacement_values_encoded(
+            store,
+            state.commit_id,
+            encoded_keys,
+            state,
+        )
+        .await;
+    }
+    if point_cache.manifest(state.commit_id)?.is_none() {
+        point_cache.remember_manifest(
+            state.commit_id,
+            Arc::new(commit_delta_manifest_from_commit_state(state)),
+        )?;
+    }
+    load_commit_delta_values_encoded_with_cache(
+        store,
+        state.commit_id,
+        encoded_keys,
+        Some(point_cache),
+    )
+    .await
+}
+
 async fn load_compact_replacement_values_encoded(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
@@ -3438,7 +4192,7 @@ async fn load_compact_replacement_values_encoded(
     if encoded_keys.is_empty() {
         return Ok(Vec::new());
     }
-    let Some(set) = state.current_state_part_sets.first() else {
+    let Some(set) = fresh_replacement_current_state_part_set(state)? else {
         let expanded = expanded_commit_delta_manifest_from_commit_state(store, state).await?;
         return load_local_commit_delta_values_encoded(store, commit_id, encoded_keys, &expanded)
             .await;
@@ -3483,12 +4237,22 @@ async fn load_compact_replacement_values_encoded(
         let Some(descriptor) = descriptor else {
             continue;
         };
+        let part_index = descriptor.part_index as usize;
         let expected_digest = state
             .mutations
             .replacement_part_digests
-            .get(descriptor.part_index as usize)
+            .get(part_index)
+            .copied()
+            .or_else(|| {
+                state
+                    .mutations
+                    .parts
+                    .get(part_index)
+                    .and_then(|part| part.replacement_part.as_ref())
+                    .map(|part| part.content_digest)
+            })
             .ok_or_else(|| replacement_payload_error("directory part index is out of bounds"))?;
-        if descriptor.content_digest != *expected_digest
+        if descriptor.content_digest != expected_digest
             || state
                 .mutations
                 .direct_part_row_counts
@@ -3979,6 +4743,8 @@ pub(crate) async fn load_owned_commit_delta_entries_one_ordered_ref(
             return Ok(output);
         }
     }
+    #[cfg(feature = "storage-benches")]
+    crate::storage_bench::record_crud_ordered_delta_fallback();
     let requests = keys
         .iter()
         .map(|key| {
@@ -4132,6 +4898,206 @@ async fn load_local_owned_commit_delta_entries(
     Ok(output)
 }
 
+async fn load_compact_replacement_entries_one_ordered(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+    keys: &[TrackedStateKeyRef<'_>],
+    state: &CommitStateManifest,
+) -> Result<Vec<Option<LoadedCommitDeltaEntry>>, LixError> {
+    let Some(set) = fresh_replacement_current_state_part_set(state)? else {
+        return Err(replacement_payload_error(
+            "compact replacement omitted its direct current-state route",
+        ));
+    };
+    let generation = state
+        .mutations
+        .replacement_generation
+        .as_ref()
+        .ok_or_else(|| replacement_payload_error("compact state omitted its generation"))?;
+    let lifecycle =
+        state.mutations.lifecycle_summary.as_ref().ok_or_else(|| {
+            replacement_payload_error("compact state omitted lifecycle authority")
+        })?;
+    let authority = state
+        .mutations
+        .replacement_parts
+        .as_ref()
+        .ok_or_else(|| replacement_payload_error("compact state omitted part authority"))?;
+    let encoded_keys = keys
+        .iter()
+        .map(|&key| Bytes::from(encode_key_ref(key)))
+        .collect::<Vec<_>>();
+    let routes =
+        super::current_state_part::route_current_state_parts(store, &set.directory, &encoded_keys)
+            .await?;
+    let mut grouped = BTreeMap::<u32, (CurrentStatePartDescriptor, Vec<usize>)>::new();
+    for (output_index, descriptor) in routes.into_iter().enumerate() {
+        let Some(descriptor) = descriptor else {
+            continue;
+        };
+        let expected_digest = state
+            .mutations
+            .replacement_part_digests
+            .get(descriptor.part_index as usize)
+            .ok_or_else(|| replacement_payload_error("directory part index is out of bounds"))?;
+        if descriptor.content_digest != *expected_digest
+            || state
+                .mutations
+                .direct_part_row_counts
+                .get(descriptor.part_index as usize)
+                != Some(&descriptor.row_count)
+            || descriptor.owner_commit_id != generation.owner_commit_id
+            || descriptor.uniform_created_at != lifecycle.uniform_created_at
+            || descriptor.uniform_updated_at != authority.uniform_updated_at
+        {
+            return Err(replacement_payload_error(
+                "directory descriptor disagrees with compact mutation authority",
+            ));
+        }
+        grouped
+            .entry(descriptor.part_index)
+            .or_insert_with(|| (descriptor, Vec::new()))
+            .1
+            .push(output_index);
+    }
+    let storage_keys = grouped
+        .values()
+        .map(|(descriptor, _)| {
+            let mut key = commit_delta_segment_key(commit_id, descriptor.part_index as usize)?;
+            key.extend_from_slice(&descriptor.content_digest);
+            Ok(StorageKey(Bytes::from(key)))
+        })
+        .collect::<Result<Vec<_>, LixError>>()?;
+    let loaded = PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, &storage_keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?;
+    let mut output = (0..keys.len()).map(|_| None).collect::<Vec<_>>();
+    for ((_, (descriptor, output_indices)), value) in grouped.into_iter().zip(loaded.value) {
+        let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
+            replacement_payload_error("directory references a missing immutable state part")
+        })?;
+        let bounds = CommitDeltaSegmentBounds {
+            first_key: descriptor.first_key,
+            last_key: descriptor.last_key,
+            replacement_part: Some(StoredReplacementPart {
+                content_digest: descriptor.content_digest,
+                owner_commit_id: descriptor.owner_commit_id,
+                first_address: descriptor.part_index.saturating_mul(
+                    u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS)
+                        .expect("replacement row bound fits u32"),
+                ),
+                uniform_created_at: descriptor.uniform_created_at,
+                uniform_updated_at: descriptor.uniform_updated_at,
+            }),
+        };
+        let (leaf, payloads) = decode_commit_delta_with_payloads(&bytes, Some(&bounds))?;
+        for output_index in output_indices {
+            output[output_index] = find_loaded_commit_delta_entry(
+                &leaf,
+                &payloads,
+                &encoded_keys[output_index],
+                commit_id,
+            )?;
+        }
+    }
+    hydrate_selected_loaded_entries(store, &mut output).await?;
+    Ok(output)
+}
+
+async fn load_inventory_part_entries_one_ordered(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+    keys: &[TrackedStateKeyRef<'_>],
+    state: &CommitStateManifest,
+) -> Result<Vec<Option<LoadedCommitDeltaEntry>>, LixError> {
+    let inventory = &state.mutations;
+    if !inventory_parts_support_direct_route(inventory) {
+        return Err(replacement_payload_error(
+            "ordered mutation inventory has invalid part bounds",
+        ));
+    }
+    let mut encoded_keys = Vec::new();
+    let mut grouped = BTreeMap::<usize, Vec<(usize, Range<usize>)>>::new();
+    for (output_index, &key) in keys.iter().enumerate() {
+        let encoded = encode_key_ref_into(&mut encoded_keys, key);
+        let key_bytes = &encoded_keys[encoded.clone()];
+        let mut lower = 0usize;
+        let mut upper = inventory.parts.len();
+        while lower < upper {
+            let middle = lower + (upper - lower) / 2;
+            if inventory.parts[middle].first_key.as_slice() <= key_bytes {
+                lower = middle + 1;
+            } else {
+                upper = middle;
+            }
+        }
+        let Some(part_index) = lower.checked_sub(1) else {
+            continue;
+        };
+        if key_bytes <= inventory.parts[part_index].last_key.as_slice() {
+            grouped
+                .entry(part_index)
+                .or_default()
+                .push((output_index, encoded));
+        }
+    }
+    let storage_keys = grouped
+        .keys()
+        .map(|&part_index| {
+            let bounds = &inventory.parts[part_index];
+            commit_delta_segment_key_for_bounds(
+                commit_id,
+                part_index,
+                &CommitDeltaSegmentBounds {
+                    first_key: bounds.first_key.clone(),
+                    last_key: bounds.last_key.clone(),
+                    replacement_part: bounds.replacement_part.clone(),
+                },
+            )
+            .map(|key| StorageKey(Bytes::from(key)))
+        })
+        .collect::<Result<Vec<_>, LixError>>()?;
+    let loaded = PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, &storage_keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?;
+    let mut output = (0..keys.len()).map(|_| None).collect::<Vec<_>>();
+    for ((part_index, requests), value) in grouped.into_iter().zip(loaded.value) {
+        let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
+            replacement_payload_error("mutation inventory references a missing immutable part")
+        })?;
+        let part = &inventory.parts[part_index];
+        let bounds = CommitDeltaSegmentBounds {
+            first_key: part.first_key.clone(),
+            last_key: part.last_key.clone(),
+            replacement_part: part.replacement_part.clone(),
+        };
+        let (leaf, payloads) = decode_commit_delta_with_payloads(&bytes, Some(&bounds))?;
+        for (output_index, encoded) in requests {
+            output[output_index] = find_loaded_commit_delta_entry(
+                &leaf,
+                &payloads,
+                &encoded_keys[encoded],
+                commit_id,
+            )?;
+        }
+    }
+    Ok(output)
+}
+
+fn inventory_parts_support_direct_route(inventory: &CommitStateMutationInventory) -> bool {
+    !(inventory.selected_source_commit_id.is_some()
+        || !inventory.inline_part.is_empty()
+        || inventory.parts.is_empty()
+        || inventory.parts.len() != inventory.direct_part_row_counts.len()
+        || inventory.parts.iter().any(|part| {
+            part.first_key.is_empty() || part.last_key.is_empty() || part.first_key > part.last_key
+        })
+        || inventory
+            .parts
+            .windows(2)
+            .any(|pair| pair[0].last_key >= pair[1].first_key))
+}
+
 /// Fast path for one physical owner and an already ordered exact-key batch.
 ///
 /// Dense current-state replacement reads naturally have this shape. Route the
@@ -4150,9 +5116,39 @@ async fn load_local_owned_commit_delta_entries_one_ordered(
     {
         Some(manifest) => PointReadCommitDeltaManifest::Cached(manifest),
         None => {
-            let Some(manifest) = load_commit_delta_manifest(store, commit_id).await? else {
+            let Some(state) = load_point_replay_commit_state(store, commit_id).await? else {
                 return Ok((0..keys.len()).map(|_| None).collect());
             };
+            if state.mutations.replacement_generation.is_some()
+                && state.current_state_coverage_anchor.is_some()
+            {
+                let output =
+                    load_compact_replacement_entries_one_ordered(store, commit_id, keys, &state)
+                        .await?;
+                remember_expanded_point_manifest(store, &state, point_cache).await?;
+                return Ok(output);
+            }
+            if keys.len() <= DECODED_COMMIT_DELTA_CACHE_MAX_POINT_KEYS
+                && inventory_parts_support_direct_route(&state.mutations)
+            {
+                let output =
+                    load_inventory_part_entries_one_ordered(store, commit_id, keys, &state).await?;
+                remember_expanded_point_manifest(store, &state, point_cache).await?;
+                return Ok(output);
+            }
+            let manifest = expanded_commit_delta_manifest_from_commit_state(store, &state).await?;
+            validate_commit_delta_manifest(&manifest)?;
+            if manifest
+                .replacement_generation
+                .as_ref()
+                .is_some_and(|generation| {
+                    generation.owner_commit_id != *commit_id.as_uuid().as_bytes()
+                })
+            {
+                return Err(replacement_payload_error(
+                    "replacement generation does not belong to its commit",
+                ));
+            }
             match point_cache {
                 Some(cache) => {
                     let manifest = Arc::new(manifest);
@@ -4460,6 +5456,19 @@ async fn load_local_owned_commit_delta_entries_one_ordered(
     }
     hydrate_selected_loaded_entries(store, &mut output).await?;
     Ok(output)
+}
+
+async fn remember_expanded_point_manifest(
+    store: &(impl StorageAdapterRead + ?Sized),
+    state: &CommitStateManifest,
+    point_cache: Option<&CommitDeltaPointReadCache>,
+) -> Result<(), LixError> {
+    let Some(point_cache) = point_cache else {
+        return Ok(());
+    };
+    let manifest = expanded_commit_delta_manifest_from_commit_state(store, state).await?;
+    validate_commit_delta_manifest(&manifest)?;
+    point_cache.remember_manifest(state.commit_id, Arc::new(manifest))
 }
 
 async fn hydrate_selected_loaded_entries(
@@ -4780,7 +5789,19 @@ pub(crate) async fn visit_change_records_from_commit_deltas(
                 },
             )
             .await?;
-        for entry in &page.value.entries {
+        let seal_keys = page
+            .value
+            .entries
+            .iter()
+            .map(|entry| entry.key.clone())
+            .collect::<Vec<_>>();
+        let seal_request = [StorageGetManyRequest {
+            space: TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
+            keys: &seal_keys,
+            opts: StorageGetOptions::default(),
+        }];
+        let seals = exact_get_many(store, &seal_request).await?.values;
+        for (entry, seal) in page.value.entries.iter().zip(seals) {
             if entry.key.0.len() != 16 {
                 return Err(LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
@@ -4798,6 +5819,12 @@ pub(crate) async fn visit_change_records_from_commit_deltas(
                     "tracked_state commit-state scan key and manifest commit disagree",
                 ));
             }
+            let seal = seal.and_then(full_value_bytes).ok_or_else(|| {
+                replacement_payload_error(
+                    "commit-state scan found a manifest without its immutable semantic authority",
+                )
+            })?;
+            validate_commit_state_semantic_seal(&state, &seal)?;
             let manifest = expanded_commit_delta_manifest_from_commit_state(store, &state).await?;
             let members =
                 load_commit_delta_members_from_manifest(store, commit_id, &manifest, &[]).await?;
@@ -5082,11 +6109,23 @@ async fn scan_commit_delta_plane(
 ) -> Result<CommitDeltaPlane, LixError> {
     let commit_state_rows =
         scan_full_space(store, TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE).await?;
+    let commit_state_seals = scan_full_space(store, TRACKED_STATE_COMMIT_STATE_SEAL_SPACE).await?;
     let segment_rows = scan_full_space(store, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE).await?;
+
+    if commit_state_rows.len() != commit_state_seals.len()
+        || commit_state_rows
+            .iter()
+            .zip(&commit_state_seals)
+            .any(|((manifest_key, _), (seal_key, _))| manifest_key != seal_key)
+    {
+        return Err(replacement_payload_error(
+            "commit-state inventory found an orphan manifest or semantic authority",
+        ));
+    }
 
     let mut manifests = BTreeMap::<CommitId, CommitDeltaManifest>::new();
     let mut authorities = BTreeMap::<CommitId, CommitStateTopologyProjection>::new();
-    for (key, bytes) in commit_state_rows {
+    for ((key, bytes), (_, seal)) in commit_state_rows.into_iter().zip(commit_state_seals) {
         if key.0.len() != 16 {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
@@ -5103,6 +6142,7 @@ async fn scan_commit_delta_plane(
                 ),
             ));
         }
+        validate_commit_state_semantic_seal(&manifest, &seal)?;
         authorities.insert(
             commit_id,
             CommitStateTopologyProjection {
@@ -5224,6 +6264,10 @@ pub(crate) fn stage_delete_commit_delta_inventory_entry(
 ) -> Result<(), LixError> {
     writes.delete(
         TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+        key(commit_state_manifest_key(commit_id)),
+    );
+    writes.delete(
+        TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
         key(commit_state_manifest_key(commit_id)),
     );
     for segment_key in &entry.physical_segment_keys {
@@ -5481,9 +6525,28 @@ pub(crate) async fn load_commit_delta_replay_metadata_with_cache(
     {
         return Ok(Some(commit_delta_replay_metadata(&manifest)));
     }
-    Ok(load_commit_state_manifest(store, commit_id)
+    Ok(load_replay_commit_state_manifest(store, commit_id)
         .await?
         .map(|manifest| commit_delta_replay_metadata_from_inventory(&manifest.mutations)))
+}
+
+/// Seeds the snapshot-local delta cache from the seal-verified replay manifest
+/// already read by point traversal, avoiding a second authority read.
+pub(crate) fn seed_commit_delta_point_cache_from_replay_manifest(
+    state: &CommitStateManifest,
+    point_cache: &CommitDeltaPointReadCache,
+) -> Result<CommitDeltaReplayMetadata, LixError> {
+    if let Some(manifest) = point_cache.manifest(state.commit_id)? {
+        return Ok(commit_delta_replay_metadata(&manifest));
+    }
+    let metadata = commit_delta_replay_metadata_from_inventory(&state.mutations);
+    if state.mutations.replacement_part_digests.is_empty() {
+        point_cache.remember_manifest(
+            state.commit_id,
+            Arc::new(commit_delta_manifest_from_commit_state(state)),
+        )?;
+    }
+    Ok(metadata)
 }
 
 fn commit_delta_replay_metadata(manifest: &CommitDeltaManifest) -> CommitDeltaReplayMetadata {
@@ -5532,7 +6595,7 @@ async fn load_commit_delta_manifest(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
 ) -> Result<Option<CommitDeltaManifest>, LixError> {
-    let Some(state) = load_commit_state_manifest(store, commit_id).await? else {
+    let Some(state) = load_point_replay_commit_state(store, commit_id).await? else {
         return Ok(None);
     };
     let manifest = expanded_commit_delta_manifest_from_commit_state(store, &state).await?;
@@ -6874,6 +7937,7 @@ pub(crate) struct TrackedStateStagedRead<'a, S: ?Sized> {
     store: &'a S,
     chunks: &'a TrackedStateChunkOverlay,
     commit_states: HashMap<Vec<u8>, Bytes>,
+    commit_state_seals: HashMap<Vec<u8>, Bytes>,
 }
 
 impl<'a, S> TrackedStateStagedRead<'a, S>
@@ -6885,6 +7949,7 @@ where
             store,
             chunks,
             commit_states: HashMap::new(),
+            commit_state_seals: HashMap::new(),
         }
     }
 
@@ -6893,12 +7958,22 @@ where
         chunks: &'a TrackedStateChunkOverlay,
         manifests: impl IntoIterator<Item = CommitStateManifest>,
     ) -> Result<Self, LixError> {
+        let manifests = manifests.into_iter().collect::<Vec<_>>();
         let commit_states = manifests
-            .into_iter()
+            .iter()
             .map(|manifest| {
                 Ok((
                     commit_state_manifest_key(manifest.commit_id),
-                    Bytes::from(encode_commit_state_manifest(&manifest)?),
+                    Bytes::from(encode_commit_state_manifest(manifest)?),
+                ))
+            })
+            .collect::<Result<HashMap<_, _>, LixError>>()?;
+        let commit_state_seals = manifests
+            .iter()
+            .map(|manifest| {
+                Ok((
+                    commit_state_manifest_key(manifest.commit_id),
+                    Bytes::copy_from_slice(&commit_state_semantic_seal(manifest)?),
                 ))
             })
             .collect::<Result<HashMap<_, _>, LixError>>()?;
@@ -6906,6 +7981,7 @@ where
             store,
             chunks,
             commit_states,
+            commit_state_seals,
         })
     }
 
@@ -6916,6 +7992,9 @@ where
         }
         if space == TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE.id {
             return self.commit_states.get(key.0.as_ref()).cloned();
+        }
+        if space == TRACKED_STATE_COMMIT_STATE_SEAL_SPACE.id {
+            return self.commit_state_seals.get(key.0.as_ref()).cloned();
         }
         None
     }
@@ -6988,6 +8067,13 @@ fn encode_commit_state_manifest(manifest: &CommitStateManifest) -> Result<Vec<u8
 }
 
 fn decode_commit_state_manifest(bytes: &[u8]) -> Result<CommitStateManifest, LixError> {
+    decode_commit_state_manifest_with_catalog_attestation(bytes, true)
+}
+
+fn decode_commit_state_manifest_with_catalog_attestation(
+    bytes: &[u8],
+    validate_catalog_attestation: bool,
+) -> Result<CommitStateManifest, LixError> {
     let Some(payload) = bytes.strip_prefix(COMMIT_STATE_MANIFEST_FORMAT_MAGIC) else {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
@@ -6995,11 +8081,18 @@ fn decode_commit_state_manifest(bytes: &[u8]) -> Result<CommitStateManifest, Lix
         ));
     };
     let manifest = storage_codec::decode("tracked_state commit_state_manifest", payload)?;
-    validate_commit_state_manifest(&manifest)?;
+    validate_commit_state_manifest_inner(&manifest, validate_catalog_attestation)?;
     Ok(manifest)
 }
 
 fn validate_commit_state_manifest(manifest: &CommitStateManifest) -> Result<(), LixError> {
+    validate_commit_state_manifest_inner(manifest, true)
+}
+
+fn validate_commit_state_manifest_inner(
+    manifest: &CommitStateManifest,
+    validate_catalog_attestation: bool,
+) -> Result<(), LixError> {
     let mut parents = BTreeSet::new();
     for parent in &manifest.parent_commit_ids {
         if *parent == manifest.commit_id || !parents.insert(*parent) {
@@ -7057,60 +8150,78 @@ fn validate_commit_state_manifest(manifest: &CommitStateManifest) -> Result<(), 
     }
 
     validate_commit_state_mutation_inventory(manifest.commit_id, &manifest.mutations)?;
-    validate_current_state_part_sets(manifest)
+    validate_current_state_catalog(manifest, validate_catalog_attestation)
 }
 
-fn validate_current_state_part_sets(manifest: &CommitStateManifest) -> Result<(), LixError> {
-    if manifest.current_state_part_sets.is_empty() {
-        return Ok(());
-    }
-    // The first publication slice covers the one certified replacement scope
-    // carried by the current mutation inventory. Sparse commits will publish
-    // multiple structurally shared scopes in the subsequent range-rewrite cut.
-    if manifest.current_state_part_sets.len() != 1 {
+fn validate_current_state_catalog(
+    manifest: &CommitStateManifest,
+    validate_catalog_attestation: bool,
+) -> Result<(), LixError> {
+    if manifest.current_state_catalog.as_ref().is_some_and(|root| {
+        root.root_id == [0; 32]
+            || root.entry_count == 0
+            || root.transition_digest == [0; 32]
+            || manifest.parent_commit_ids.len() > 1
+            || manifest.mutations.selected_source_commit_id.is_some()
+    }) {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
-            "tracked_state commit_state_manifest has multiple current-state part sets before sparse range rewrite",
+            "tracked_state commit_state_manifest has an invalid current-state catalog root",
         ));
     }
-    let set = &manifest.current_state_part_sets[0];
-    let generation = manifest
-        .mutations
-        .replacement_generation
-        .as_ref()
-        .ok_or_else(|| {
-            LixError::new(
+    if validate_catalog_attestation && let Some(root) = manifest.current_state_catalog.as_ref() {
+        let expected = super::current_state_part::current_state_catalog_transition_digest(
+            manifest.commit_id,
+            root.parent_root_id,
+            &manifest.mutations,
+            root.root_id,
+            root.entry_count,
+        )?;
+        if root.transition_digest != expected
+            || (manifest.parent_commit_ids.is_empty() && root.parent_root_id.is_some())
+        {
+            return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
-                "tracked_state current-state part set has no replacement-generation authority",
-            )
-        })?;
-    let authority = manifest
-        .mutations
-        .replacement_parts
-        .as_ref()
-        .ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                "tracked_state current-state part set has no immutable-part authority",
-            )
-        })?;
-    if set.scope != generation.scope
-        || set.owner_commit_id != *manifest.commit_id.as_uuid().as_bytes()
-        || set.owner_commit_id != generation.owner_commit_id
-        || set.generation_integrity_digest != generation.integrity_digest
-        || set.mutation_directory_digest != authority.directory_digest
-        || set.directory.descriptor_digest != authority.directory_digest
-        || set.directory.root_id == [0; 32]
-        || set.directory.descriptor_digest == [0; 32]
-        || set.directory.part_count == 0
-        || set.directory.row_count != u64::from(manifest.mutations.member_count)
-        || set.directory.part_count as usize != manifest.mutations.part_count()
-        || set.directory.tree_height == 0
+                "tracked_state current-state catalog transition is not bound to this commit",
+            ));
+        }
+    }
+    if manifest.current_state_catalog.is_none() && manifest.current_state_coverage_anchor.is_some()
     {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
-            "tracked_state current-state part set disagrees with its replacement authority",
+            "tracked_state commit_state_manifest has a coverage anchor without a catalog",
         ));
+    }
+    if let Some(anchor) = manifest.current_state_coverage_anchor.as_ref() {
+        let (Some(generation), Some(authority)) = (
+            manifest.mutations.replacement_generation.as_ref(),
+            manifest.mutations.replacement_parts.as_ref(),
+        ) else {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state current-state coverage anchor has no replacement authority",
+            ));
+        };
+        if anchor.scope != generation.scope
+            || anchor.generation_integrity_digest != generation.integrity_digest
+            || anchor.directory.descriptor_digest != authority.directory_digest
+            || anchor.directory.row_count != u64::from(manifest.mutations.member_count)
+            || anchor.directory.part_count as usize != manifest.mutations.part_count()
+            || anchor.directory.root_id == [0; 32]
+            || anchor.directory.tree_height == 0
+            || anchor.state_lineage_digest
+                != super::current_state_part::fresh_current_state_lineage_digest(
+                    manifest.commit_id,
+                    generation.integrity_digest,
+                    &anchor.directory,
+                )
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state current-state coverage anchor disagrees with replacement authority",
+            ));
+        }
     }
     Ok(())
 }
@@ -7260,7 +8371,9 @@ fn validate_compact_replacement_inventory(
 mod tests {
     use std::collections::BTreeMap;
     use std::fs;
+    use std::future::Future;
     use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use bytes::Bytes;
 
@@ -7282,7 +8395,7 @@ mod tests {
         HOT_DIFF_SPACE, HOT_FILE_SPACE, HOT_ROW_SPACE, TRACKED_WORKING_DIFF_MARKER_SPACE,
     };
     use crate::storage_adapter::{
-        Memory, StorageAdapter, StorageKey, StorageReadOptions, StorageWriteOptions,
+        Memory, StorageAdapter, StorageKey, StorageReadOptions, StorageSpace, StorageWriteOptions,
         StorageWriteSet,
     };
     use crate::tracked_state::codec::{
@@ -7290,8 +8403,8 @@ mod tests {
         encode_key_ref, encode_value_ref, hash_bytes,
     };
     use crate::tracked_state::current_state_part::{
-        CURRENT_STATE_PART_DIRECTORY_SPACE, route_current_state_part,
-        stage_complete_replacement_current_state_part_set,
+        CURRENT_STATE_PART_DIRECTORY_SPACE, load_current_state_catalog_entry,
+        route_current_state_part, stage_fresh_current_state_catalog,
     };
     use crate::tracked_state::types::{
         CommitStateManifest, CommitStateMutationInventory, CommitStateReplayDebt,
@@ -7318,6 +8431,48 @@ mod tests {
         stage_delete_commit_delta_inventory_entry, value,
     };
 
+    struct SealCountingRead<R> {
+        inner: R,
+        manifest_requests: std::sync::Arc<AtomicUsize>,
+        seal_requests: std::sync::Arc<AtomicUsize>,
+    }
+
+    impl<R> crate::storage_adapter::StorageAdapterRead for SealCountingRead<R>
+    where
+        R: crate::storage_adapter::StorageAdapterRead,
+    {
+        fn snapshot_cache_key(&self) -> Option<u128> {
+            self.inner.snapshot_cache_key()
+        }
+
+        fn get_many(
+            &self,
+            requests: &[crate::storage::GetManyRequest<'_>],
+        ) -> impl Future<
+            Output = Result<crate::storage::GetManyResult, crate::storage::StorageError>,
+        > + Send {
+            for request in requests {
+                if request.space == super::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE {
+                    self.manifest_requests.fetch_add(1, Ordering::Relaxed);
+                }
+                if request.space == super::TRACKED_STATE_COMMIT_STATE_SEAL_SPACE {
+                    self.seal_requests.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+            self.inner.get_many(requests)
+        }
+
+        fn scan(
+            &self,
+            space: StorageSpace,
+            range: crate::storage::KeyRange,
+            opts: crate::storage::ScanOptions,
+        ) -> impl Future<Output = Result<crate::storage::ScanChunk, crate::storage::StorageError>> + Send
+        {
+            self.inner.scan(space, range, opts)
+        }
+    }
+
     fn fixture_commit_state_manifest(
         commit_id: CommitId,
         mutations: CommitStateMutationInventory,
@@ -7335,7 +8490,8 @@ mod tests {
                 bytes: u64::from(mutations.member_count),
             },
             mutations,
-            current_state_part_sets: Vec::new(),
+            current_state_catalog: None,
+            current_state_coverage_anchor: None,
             snapshot_root: None,
         }
     }
@@ -7347,15 +8503,16 @@ mod tests {
     ) -> Result<(), LixError> {
         let mut compact_mutations = mutations.clone();
         let mut manifest = fixture_commit_state_manifest(commit_id, compact_mutations.clone());
-        manifest.current_state_part_sets =
-            stage_complete_replacement_current_state_part_set(writes, commit_id, mutations)?
-                .into_iter()
-                .collect();
-        if !manifest.current_state_part_sets.is_empty() {
+        let publication =
+            stage_fresh_current_state_catalog(writes, commit_id, &mut compact_mutations)?;
+        let (catalog, anchor) = publication.parts();
+        manifest.current_state_catalog = catalog;
+        manifest.current_state_coverage_anchor = anchor;
+        if manifest.current_state_catalog.is_some() {
             compact_mutations.parts.clear();
             manifest.mutations = compact_mutations;
         }
-        stage_commit_state_manifest(writes, &manifest)
+        super::stage_certified_commit_state_manifest(writes, &manifest, &publication)
     }
 
     fn stage_commit_deltas(
@@ -8091,10 +9248,21 @@ mod tests {
             .await
             .expect("replacement authority should load")
             .expect("replacement authority should exist");
-        let state_set = authority
-            .current_state_part_sets
-            .first()
-            .expect("replacement should publish a current-state part set");
+        let state_set = load_current_state_catalog_entry(
+            &read,
+            authority
+                .current_state_catalog
+                .as_ref()
+                .expect("replacement should publish a current-state catalog"),
+            &authority
+                .current_state_coverage_anchor
+                .as_ref()
+                .expect("replacement should publish a coverage anchor")
+                .scope,
+        )
+        .await
+        .expect("replacement catalog should load")
+        .expect("replacement should publish a current-state part set");
         let directory_root = state_set.directory.clone();
         assert_eq!(state_set.directory.part_count, 3);
         let route_key = fixtures[777].key();
@@ -8169,6 +9337,257 @@ mod tests {
                 .await
                 .expect("historical authority should survive directory loss")
                 .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn persistent_catalog_reuses_untouched_scope_and_invalidates_touched_scope() {
+        let storage = StorageAdapter::new(Memory::new());
+        let parent_id = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x0199_2000_0000_7000_8000_0000_0000_0000,
+        ));
+        let child_id = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x0199_2000_0000_7000_8000_0001_0000_0000,
+        ));
+        let created_at = LixTimestamp::from_unix_millis_utc_lossy(11);
+        let updated_at = LixTimestamp::from_unix_millis_utc_lossy(22);
+        let alpha = (0..3)
+            .map(|index| CommitDeltaFixture {
+                schema_key: "alpha".to_string(),
+                file_id: None,
+                entity_pk: EntityPk::single(format!("entity-{index}")),
+                change_id: ChangeId::for_test_label(&format!("catalog-alpha-{index}")),
+                deleted: false,
+                created_at,
+                updated_at,
+            })
+            .collect::<Vec<_>>();
+        let mut parent_deltas = commit_delta_refs(parent_id, &alpha);
+        for delta in &mut parent_deltas {
+            delta.snapshot = crate::json_store::JsonSlotRef::Inline("{}");
+        }
+        let scope = super::CommitDeltaReplacementScope {
+            schema_key: "alpha".to_string(),
+            file_id: None,
+        };
+        let generation = super::CommitDeltaReplacementGeneration {
+            scope: scope.clone(),
+            fallback_commit_id: None,
+            lifecycle_summary: super::CommitDeltaLifecycleSummary {
+                scope: scope.clone(),
+                ordered_identity_digest: [7; 32],
+                uniform_created_at: created_at,
+            },
+        };
+        let mut writes = storage.new_write_set();
+        let parent_stage = super::stage_ordered_addressable_replacement_parts(
+            &mut writes,
+            parent_deltas.iter().copied().map(Ok),
+            &generation,
+        )
+        .expect("parent replacement should stage");
+        stage_fixture_manifest(&mut writes, parent_id, parent_stage.mutation_inventory())
+            .expect("parent manifest should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("parent replacement should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("parent read should open");
+        let parent = super::load_published_commit_state_manifest(&read, parent_id)
+            .await
+            .expect("parent manifest should load")
+            .expect("parent manifest should exist");
+        let parent_root = parent
+            .current_state_catalog
+            .clone()
+            .expect("parent should publish a catalog");
+        let beta = CommitDeltaFixture {
+            schema_key: "beta".to_string(),
+            file_id: None,
+            entity_pk: EntityPk::single("other"),
+            change_id: ChangeId::for_test_label("catalog-beta-child"),
+            deleted: false,
+            created_at,
+            updated_at,
+        };
+        let child_deltas = commit_delta_refs(child_id, std::slice::from_ref(&beta));
+        let mut child_writes = storage.new_write_set();
+        let child_stage = super::stage_ordered_addressable_commit_deltas(
+            &mut child_writes,
+            child_deltas.iter().copied().map(Ok),
+            true,
+            false,
+        )
+        .expect("child mutation should stage")
+        .expect("child mutation should be addressable");
+        let mut child_inventory = child_stage.mutation_inventory().clone();
+        let child_publication = super::stage_current_state_catalog_from_published_parent(
+            &read,
+            &mut child_writes,
+            Some(&parent),
+            child_id,
+            &mut child_inventory,
+        )
+        .await
+        .expect("child catalog should path-copy");
+        let (child_catalog, child_anchor) = child_publication.parts();
+        let child_catalog = child_catalog.expect("child should retain inherited catalog");
+        assert_eq!(child_catalog.root_id, parent_root.root_id);
+        assert_eq!(child_catalog.parent_root_id, Some(parent_root.root_id));
+        assert!(child_anchor.is_none());
+        let mut child = fixture_commit_state_manifest(child_id, child_inventory);
+        child.parent_commit_ids = vec![parent_id];
+        child.replay_debt.depth = super::MIN_CURRENT_STATE_CATALOG_POINT_READS;
+        child.current_state_catalog = Some(child_catalog);
+        let mut cross_wired_child = child.clone();
+        cross_wired_child.parent_commit_ids = vec![CommitId::for_test_label("foreign-parent")];
+        assert!(
+            super::stage_certified_commit_state_manifest(
+                &mut child_writes,
+                &cross_wired_child,
+                &child_publication,
+            )
+            .is_err(),
+            "catalog proof must bind the exact graph parent commit"
+        );
+        let mut foreign_writes = storage.new_write_set();
+        assert!(
+            super::stage_certified_commit_state_manifest(
+                &mut foreign_writes,
+                &child,
+                &child_publication,
+            )
+            .is_err(),
+            "catalog proof must bind the write set containing its physical nodes"
+        );
+        super::stage_certified_commit_state_manifest(&mut child_writes, &child, &child_publication)
+            .expect("child manifest should stage");
+        drop(read);
+        storage
+            .commit_write_set(child_writes, StorageWriteOptions::default())
+            .await
+            .expect("child should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("child read should open");
+        let child = super::load_published_commit_state_manifest(&read, child_id)
+            .await
+            .expect("child manifest should load")
+            .expect("child manifest should exist");
+        let mut encoded = TrackedStateKeyBatchBuilder::with_row_capacity(2);
+        for key in [
+            alpha[1].key(),
+            TrackedStateKey {
+                schema_key: "alpha".to_string(),
+                file_id: None,
+                entity_pk: EntityPk::single("missing"),
+            },
+        ] {
+            encoded.push(TrackedStateKeyRef {
+                schema_key: &key.schema_key,
+                file_id: key.file_id.as_deref(),
+                entity_pk: &key.entity_pk,
+            });
+        }
+        let resolved =
+            super::load_complete_current_state_values_encoded(&read, &child, &encoded.finish())
+                .await
+                .expect("catalog points should resolve")
+                .expect("alpha is covered");
+        assert!(resolved[0].is_some());
+        assert!(resolved[1].is_none(), "covered miss must be authoritative");
+
+        let mut forged = (*child).clone();
+        forged.current_state_catalog = Some(parent_root.clone());
+        let mut forged_writes = storage.new_write_set();
+        assert!(
+            stage_commit_state_manifest(&mut forged_writes, &forged).is_err(),
+            "an ancestor catalog root must not be cross-wired into a descendant manifest"
+        );
+
+        let touching_id = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x0199_2000_0000_7000_8000_0002_0000_0000,
+        ));
+        let touching_deltas = commit_delta_refs(touching_id, std::slice::from_ref(&alpha[0]));
+        let mut touching_writes = storage.new_write_set();
+        let touching_stage = super::stage_ordered_addressable_commit_deltas(
+            &mut touching_writes,
+            touching_deltas.iter().copied().map(Ok),
+            true,
+            false,
+        )
+        .expect("same-scope mutation should stage")
+        .expect("same-scope mutation should be addressable");
+        let mut touching_inventory = touching_stage.mutation_inventory().clone();
+        let touching_publication = super::stage_current_state_catalog_from_published_parent(
+            &read,
+            &mut touching_writes,
+            Some(&child),
+            touching_id,
+            &mut touching_inventory,
+        )
+        .await
+        .expect("same-scope invalidation should succeed");
+        let (touching_catalog, _) = touching_publication.parts();
+        assert!(touching_catalog.is_none(), "touched scope must be removed");
+
+        let mut forged_root = parent_root;
+        forged_root.parent_root_id = child
+            .current_state_catalog
+            .as_ref()
+            .map(|root| root.root_id);
+        forged_root.transition_digest =
+            crate::tracked_state::current_state_part::current_state_catalog_transition_digest(
+                touching_id,
+                forged_root.parent_root_id,
+                &touching_inventory,
+                forged_root.root_id,
+                forged_root.entry_count,
+            )
+            .expect("forged transition digest should compute");
+        let mut forged_touching = fixture_commit_state_manifest(touching_id, touching_inventory);
+        forged_touching.parent_commit_ids = vec![child_id];
+        forged_touching.current_state_catalog = Some(forged_root);
+        let mut forged_writes = storage.new_write_set();
+        assert!(
+            stage_commit_state_manifest(&mut forged_writes, &forged_touching).is_err(),
+            "catalog authority cannot bypass canonical publication certification"
+        );
+        assert!(
+            super::stage_certified_commit_state_manifest(
+                &mut forged_writes,
+                &forged_touching,
+                &touching_publication,
+            )
+            .is_err(),
+            "the canonical touched-scope proof must reject a stale catalog root"
+        );
+        let forged_entry = load_current_state_catalog_entry(
+            &read,
+            forged_touching
+                .current_state_catalog
+                .as_ref()
+                .expect("forged catalog exists"),
+            &scope,
+        )
+        .await
+        .expect("forged stale scope should be structurally readable");
+        assert!(forged_entry.is_some());
+        assert!(
+            crate::tracked_state::current_state_part::validate_current_state_catalog_transition_root(
+                &read,
+                &forged_touching,
+                child.current_state_catalog.as_deref(),
+            )
+            .await
+            .is_err(),
+            "recomputed attestation must not authorize a stale touched scope"
         );
     }
 
@@ -9011,8 +10430,8 @@ mod tests {
         stage_commit_deltas(&mut writes, &deltas).expect("packed deltas should stage");
         assert_eq!(
             writes.stats().staged_puts,
-            4,
-            "generic history keeps 300 compact rows in three read-friendly segments plus its commit-state authority"
+            5,
+            "generic history keeps 300 compact rows in three read-friendly segments plus its commit-state authority and immutable seal"
         );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -9207,8 +10626,8 @@ mod tests {
             .expect("individually valid rows should split below the sidecar limit");
         assert_eq!(
             writes.stats().staged_puts,
-            3,
-            "the oversized four-row candidate should become two segments plus its commit-state authority"
+            4,
+            "the oversized four-row candidate should become two segments plus its commit-state authority and immutable seal"
         );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -10001,6 +11420,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn shallow_point_replay_reads_one_immutable_semantic_authority() {
+        let storage = StorageAdapter::new(Memory::new());
+        let commit_id = CommitId::for_test_label("one-read-shallow-point-replay");
+        let fixture = packed_commit_delta_fixtures()
+            .into_iter()
+            .next()
+            .expect("fixture should contain one row");
+        let delta = commit_delta_ref(
+            commit_id,
+            &fixture,
+            crate::json_store::JsonSlotRef::None,
+            crate::json_store::JsonSlotRef::None,
+            None,
+        );
+        let mut writes = storage.new_write_set();
+        stage_commit_deltas(&mut writes, &[delta]).expect("ordinary delta should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("ordinary delta should commit");
+
+        let manifest_requests = std::sync::Arc::new(AtomicUsize::new(0));
+        let seal_requests = std::sync::Arc::new(AtomicUsize::new(0));
+        let read = SealCountingRead {
+            inner: storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("point read should open"),
+            manifest_requests: std::sync::Arc::clone(&manifest_requests),
+            seal_requests: std::sync::Arc::clone(&seal_requests),
+        };
+        let state = super::load_replay_commit_state_manifest(&read, commit_id)
+            .await
+            .expect("replay manifest should load")
+            .expect("replay manifest should exist");
+        let cache = super::CommitDeltaPointReadCache::default();
+        super::seed_commit_delta_point_cache_from_replay_manifest(&state, &cache)
+            .expect("replay manifest should seed the point cache");
+        let encoded_key = Bytes::from(encode_key_ref(TrackedStateKeyRef {
+            schema_key: &fixture.schema_key,
+            file_id: fixture.file_id.as_deref(),
+            entity_pk: &fixture.entity_pk,
+        }));
+        let values = super::load_commit_delta_values_encoded_with_cache(
+            &read,
+            commit_id,
+            &[encoded_key],
+            Some(&cache),
+        )
+        .await
+        .expect("cached shallow point replay should load");
+        assert_eq!(values, vec![Some(fixture.value(commit_id))]);
+        assert_eq!(manifest_requests.load(Ordering::Relaxed), 0);
+        assert_eq!(seal_requests.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
     async fn single_segment_commit_delta_stays_inline() {
         let storage = StorageAdapter::new(Memory::new());
         let commit_id = CommitId::for_test_label("inline-packed-delta-commit");
@@ -10019,8 +11495,8 @@ mod tests {
         stage_commit_deltas(&mut writes, &[delta]).expect("inline delta should stage");
         assert_eq!(
             writes.stats().staged_puts,
-            1,
-            "a one-segment commit should remain inline in its commit-state authority"
+            2,
+            "a one-segment commit should remain inline in its commit-state authority plus immutable seal"
         );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -10061,8 +11537,8 @@ mod tests {
         .expect("inline delta should stage for deletion");
         assert_eq!(
             deletes.stats().staged_deletes,
-            1,
-            "GC should delete the inline commit-state authority"
+            2,
+            "GC should delete the inline commit-state authority and immutable seal"
         );
     }
 
@@ -10201,7 +11677,7 @@ mod tests {
                 .get(&commit_id)
                 .expect("packed commit should be inventoried")
                 .segment_count
-                + 1,
+                + 2,
         )
         .expect("test segment count fits u64");
         assert_eq!(deletes.stats().staged_deletes, expected_deletes);
@@ -10254,7 +11730,7 @@ mod tests {
         let inline_deltas = commit_delta_refs(inline_commit_id, &fixtures[..128]);
         stage_commit_deltas(&mut inline_writes, &inline_deltas)
             .expect("128 generic deltas should fit the history read boundary");
-        assert_eq!(inline_writes.stats().staged_puts, 1);
+        assert_eq!(inline_writes.stats().staged_puts, 2);
         storage
             .commit_write_set(inline_writes, StorageWriteOptions::default())
             .await
@@ -10264,7 +11740,7 @@ mod tests {
         let indexed_deltas = commit_delta_refs(indexed_commit_id, &fixtures);
         stage_commit_deltas(&mut indexed_writes, &indexed_deltas)
             .expect("129 generic deltas should use indexed segments");
-        assert_eq!(indexed_writes.stats().staged_puts, 3);
+        assert_eq!(indexed_writes.stats().staged_puts, 4);
         storage
             .commit_write_set(indexed_writes, StorageWriteOptions::default())
             .await
@@ -10439,7 +11915,8 @@ mod tests {
                 inline_part: encode_commit_delta_segment(&[entry]),
                 parts: Vec::new(),
             },
-            current_state_part_sets: Vec::new(),
+            current_state_catalog: None,
+            current_state_coverage_anchor: None,
             snapshot_root: None,
         }
     }
@@ -10474,6 +11951,134 @@ mod tests {
                 .await
                 .expect("manifest should load"),
             Some(expected)
+        );
+    }
+
+    #[tokio::test]
+    async fn semantic_authority_is_the_point_source_and_guards_manifest_scans() {
+        let storage = StorageAdapter::new(Memory::new());
+        let manifest = commit_state_manifest_fixture();
+        let mut writes = storage.new_write_set();
+        stage_commit_state_manifest(&mut writes, &manifest).expect("authority should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("authority should commit");
+
+        let mut forged = manifest.clone();
+        forged.generation += 1;
+        let mut writes = storage.new_write_set();
+        super::stage_unchecked_commit_state_manifest_for_test(&mut writes, &forged)
+            .expect("mutable manifest corruption should stage without replacing authority");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("mutable manifest corruption should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("corrupt read should open");
+        let point_state = super::load_point_replay_commit_state(&read, manifest.commit_id)
+            .await
+            .expect("point replay should load immutable semantic authority")
+            .expect("semantic authority should exist");
+        assert_eq!(point_state, manifest);
+        let change_error = scan_change_records_from_commit_deltas(&read)
+            .await
+            .expect_err("packed change scans must verify semantic authority");
+        assert!(change_error.message.contains("semantic authority"));
+        let inventory_error = scan_commit_delta_inventory(&read)
+            .await
+            .expect_err("GC inventory must verify semantic authority");
+        assert!(inventory_error.message.contains("semantic authority"));
+
+        let mut corrupted_authority =
+            super::commit_state_semantic_seal(&manifest).expect("semantic authority should encode");
+        *corrupted_authority
+            .last_mut()
+            .expect("semantic authority should not be empty") ^= 0xff;
+        let mut writes = storage.new_write_set();
+        writes.put(
+            StorageSpace::mutable(
+                super::TRACKED_STATE_COMMIT_STATE_SEAL_SPACE.id,
+                super::TRACKED_STATE_COMMIT_STATE_SEAL_NAMESPACE,
+            ),
+            key(super::commit_state_manifest_key(manifest.commit_id)),
+            value(corrupted_authority),
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("authority corruption should commit through the test-only mutable alias");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("corrupt authority read should open");
+        let error = super::load_point_replay_commit_state(&read, manifest.commit_id)
+            .await
+            .expect_err("point replay must reject corrupt immutable authority bytes");
+        assert!(error.message.contains("authority digest"));
+    }
+
+    #[tokio::test]
+    async fn gc_inventory_rejects_missing_and_orphan_semantic_authority() {
+        let missing_storage = StorageAdapter::new(Memory::new());
+        let manifest = commit_state_manifest_fixture();
+        let mut writes = missing_storage.new_write_set();
+        stage_commit_state_manifest(&mut writes, &manifest).expect("authority should stage");
+        missing_storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("authority should commit");
+        let mut deletes = missing_storage.new_write_set();
+        deletes.delete(
+            super::TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
+            key(super::commit_state_manifest_key(manifest.commit_id)),
+        );
+        missing_storage
+            .commit_write_set(deletes, StorageWriteOptions::default())
+            .await
+            .expect("seal deletion should commit");
+        let read = missing_storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("missing-seal read should open");
+        let error = scan_commit_delta_inventory(&read)
+            .await
+            .expect_err("GC inventory must reject a missing seal");
+        assert!(
+            error
+                .message
+                .contains("orphan manifest or semantic authority")
+        );
+
+        let orphan_storage = StorageAdapter::new(Memory::new());
+        let mut writes = orphan_storage.new_write_set();
+        writes.put(
+            super::TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
+            key(super::commit_state_manifest_key(manifest.commit_id)),
+            value(
+                super::commit_state_semantic_seal(&manifest)
+                    .unwrap()
+                    .to_vec(),
+            ),
+        );
+        orphan_storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("orphan seal should commit");
+        let read = orphan_storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("orphan-seal read should open");
+        let error = scan_commit_delta_inventory(&read)
+            .await
+            .expect_err("GC inventory must reject an orphan seal");
+        assert!(
+            error
+                .message
+                .contains("orphan manifest or semantic authority")
         );
     }
 
@@ -10522,7 +12127,7 @@ mod tests {
             bytes: 64,
         };
         let mut writes = storage.new_write_set();
-        stage_commit_state_manifest(&mut writes, &manifest)
+        super::stage_resealed_commit_state_manifest_for_test(&mut writes, &manifest)
             .expect("rootless authority should stage");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -10539,6 +12144,74 @@ mod tests {
                 .is_none(),
             "a stale derived root must not override rootless authority"
         );
+    }
+
+    #[tokio::test]
+    async fn rootless_rebuild_updates_only_the_mutable_snapshot_accelerator() {
+        let storage = StorageAdapter::new(Memory::new());
+        let mut original = commit_state_manifest_fixture();
+        original.snapshot_root = None;
+        original.replay_debt = CommitStateReplayDebt {
+            depth: 1,
+            rows: 1,
+            bytes: 64,
+        };
+        let mut writes = storage.new_write_set();
+        stage_commit_state_manifest(&mut writes, &original)
+            .expect("rootless authority should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("rootless authority should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("published authority read should open");
+        let published = super::load_published_commit_state_manifest(&read, original.commit_id)
+            .await
+            .expect("published authority should load")
+            .expect("published authority should exist");
+        let rebuilt = TrackedStateCommitRoot {
+            commit_id: original.commit_id,
+            root_id: TrackedStateRootId::new([9; 32]),
+            parent_roots: vec![crate::tracked_state::types::TrackedStateCommitRootParent {
+                commit_id: original.parent_commit_ids[0],
+                root_id: TrackedStateRootId::new([8; 32]),
+            }],
+            changed_key_count: 1,
+            row_count_estimate: 1,
+            tree_height: 1,
+            primary_chunk_count: 1,
+            primary_chunk_bytes: 64,
+        };
+        let mut writes = storage.new_write_set();
+        super::stage_commit_state_snapshot_root_update(
+            &mut writes,
+            &published,
+            Some(rebuilt.clone()),
+        )
+        .expect("snapshot accelerator update should stage");
+        drop(read);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("snapshot rebuild must not rewrite immutable authority");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("rebuilt authority read should open");
+        let loaded = load_commit_state_manifest(&read, original.commit_id)
+            .await
+            .expect("rebuilt manifest should load")
+            .expect("rebuilt manifest should exist");
+        assert_eq!(loaded.snapshot_root, Some(rebuilt));
+        let point = super::load_point_replay_commit_state(&read, original.commit_id)
+            .await
+            .expect("immutable point authority should load")
+            .expect("immutable point authority should exist");
+        assert_eq!(point, original);
     }
 
     #[test]

--- a/packages/engine/src/tracked_state/types.rs
+++ b/packages/engine/src/tracked_state/types.rs
@@ -283,9 +283,47 @@ pub(crate) struct CurrentStatePartDirectoryRoot {
 #[musli(packed)]
 pub(crate) struct CurrentStatePartSet {
     pub(crate) scope: CommitDeltaReplacementScope,
-    pub(crate) owner_commit_id: [u8; 16],
+    /// Commit whose complete-replacement certificate created this entry.
+    /// Reused catalog entries retain this identity, so readers can validate
+    /// directly against the immutable origin instead of walking ancestry.
+    pub(crate) coverage_anchor_commit_id: [u8; 16],
     pub(crate) generation_integrity_digest: [u8; 32],
-    pub(crate) mutation_directory_digest: [u8; 32],
+    /// Binds the current post-image to its coverage anchor and every later
+    /// sparse rewrite. For a fresh complete replacement this is derived from
+    /// the replacement certificate and directory root.
+    pub(crate) state_lineage_digest: [u8; 32],
+    pub(crate) directory: CurrentStatePartDirectoryRoot,
+}
+
+/// Content-addressed root of the persistent collection-to-state-part catalog.
+///
+/// One root in each commit manifest replaces an O(collections) copied vector.
+/// Unchanged commits reuse the exact root; updates rewrite only the bounded
+/// radix path for affected collections.
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+pub(crate) struct CurrentStateCatalogRoot {
+    pub(crate) root_id: [u8; 32],
+    pub(crate) entry_count: u32,
+    /// Root inherited from the sole parent before applying this commit. This
+    /// is serving-layout lineage, not commit-graph ancestry.
+    #[musli(with = crate::storage_codec::option)]
+    pub(crate) parent_root_id: Option<[u8; 32]>,
+    /// Binds this commit, its sealed mutation inventory, the inherited root,
+    /// and the resulting root. Cross-wiring an ancestor root into a newer
+    /// manifest therefore fails before an authoritative read.
+    pub(crate) transition_digest: [u8; 32],
+}
+
+/// Historical binding from a complete-replacement mutation certificate to
+/// its optional serving directory. Descendants refer to this immutable anchor
+/// by commit ID, so authoritative misses never trust an unbound catalog leaf.
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+pub(crate) struct CurrentStateCoverageAnchor {
+    pub(crate) scope: CommitDeltaReplacementScope,
+    pub(crate) generation_integrity_digest: [u8; 32],
+    pub(crate) state_lineage_digest: [u8; 32],
     pub(crate) directory: CurrentStatePartDirectoryRoot,
 }
 
@@ -358,7 +396,10 @@ pub(crate) struct CommitStateManifest {
     pub(crate) created_at: LixTimestamp,
     pub(crate) replay_debt: CommitStateReplayDebt,
     pub(crate) mutations: CommitStateMutationInventory,
-    pub(crate) current_state_part_sets: Vec<CurrentStatePartSet>,
+    #[musli(with = crate::storage_codec::option)]
+    pub(crate) current_state_catalog: Option<Box<CurrentStateCatalogRoot>>,
+    #[musli(with = crate::storage_codec::option)]
+    pub(crate) current_state_coverage_anchor: Option<Box<CurrentStateCoverageAnchor>>,
     #[musli(with = crate::storage_codec::option)]
     pub(crate) snapshot_root: Option<TrackedStateCommitRoot>,
 }

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -30,6 +30,8 @@ use crate::live_state::{
     stage_tracked_working_diff_epoch,
 };
 use crate::storage_adapter::{StorageAdapterRead, StoragePrecondition, StorageWriteSet};
+#[cfg(test)]
+use crate::tracked_state::stage_commit_state_manifest;
 use crate::tracked_state::{
     CommitDeltaReplacementGeneration, CommitDeltaReplacementScope, CommitStateManifest,
     CommitStateMutationInventory, CommitStateReplayDebt, MaterializedTrackedStateRow,
@@ -37,7 +39,7 @@ use crate::tracked_state::{
     TrackedStateFilter, TrackedStateKey, TrackedStateKeyRef, TrackedStateReadColumns,
     TrackedStateRootMutationRef, TrackedStateScanRequest, TrackedStateSingleStringReplacementRef,
     encode_key_ref, load_commit_delta_change_records, load_commit_delta_replay_metadata,
-    stage_addressable_commit_deltas, stage_change_locators, stage_commit_state_manifest,
+    stage_addressable_commit_deltas, stage_change_locators,
     stage_ordered_addressable_commit_deltas,
 };
 use crate::transaction::staging::{
@@ -50,6 +52,7 @@ use crate::transaction::types::{
     StagedCommitChangeRefs,
 };
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::future::Future;
 use std::sync::Arc;
 use tracing::Instrument as _;
 
@@ -538,7 +541,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         }
     }
 
-    let staged_delta_index = stage_tracked_commit_delta_index(
+    let staged_delta_index = Box::pin(stage_tracked_commit_delta_index(
         read,
         &mut writes,
         &mut state_rows,
@@ -552,7 +555,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &insert_selection,
         &replacement_generations,
         &ordered_replacements,
-    )
+    ))
     .await?;
 
     let mut rootless_ordered_commits = select_new_rootless_ordered_commits(
@@ -570,28 +573,32 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         .collect::<BTreeSet<_>>();
     let mut durable_root_rebuild_parents = BTreeSet::new();
     let mut staged_root_rebuild_commits = BTreeSet::new();
+    let mut external_parent_manifests = BTreeMap::new();
 
-    let staged_commits = stage_changelog_commits(
-        read,
-        &mut writes,
-        &state_rows,
-        &branch_head_changes,
-        &engine_rows,
-        &[],
-        &mut rootless_ordered_commits,
-        &replacement_generation_commits,
-        &mut durable_root_rebuild_parents,
-        &mut staged_root_rebuild_commits,
-        &row_index.tracked_row_indices_by_commit,
-        &commit_rows,
-        &certified_packet_root_rows,
-        &staged_delta_index.inventories,
-        &ordered_replacements,
+    let staged_commits = Box::pin(
+        stage_changelog_commits(
+            read,
+            &mut writes,
+            &state_rows,
+            &branch_head_changes,
+            &engine_rows,
+            &[],
+            &mut rootless_ordered_commits,
+            &replacement_generation_commits,
+            &mut durable_root_rebuild_parents,
+            &mut staged_root_rebuild_commits,
+            &row_index.tracked_row_indices_by_commit,
+            &commit_rows,
+            &certified_packet_root_rows,
+            &staged_delta_index.inventories,
+            &ordered_replacements,
+            &mut external_parent_manifests,
+        )
+        .instrument(tracing::debug_span!(
+            target: "lix_perf",
+            "lix.perf.materialization.changelog"
+        )),
     )
-    .instrument(tracing::debug_span!(
-        target: "lix_perf",
-        "lix.perf.materialization.changelog"
-    ))
     .await?;
 
     ensure_explicit_branch_ref_targets_exist(read, &explicit_branch_targets, &staged_commits)
@@ -633,34 +640,39 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     )
     .await?;
 
-    let staged_snapshot_roots = stage_tracked_roots(
-        tracked_state,
-        read,
-        &mut writes,
-        &state_rows,
-        &row_index.tracked_row_indices_by_commit,
-        &tracked_roots,
-        &rootless_ordered_commits,
-        &durable_root_rebuild_parents,
-        &staged_root_rebuild_commits,
-        &staged_commits,
-        &insert_selection,
-        &certified_packet_root_rows,
-        &certified_replacement_markers,
+    let staged_snapshot_roots = Box::pin(
+        stage_tracked_roots(
+            tracked_state,
+            read,
+            &mut writes,
+            &state_rows,
+            &row_index.tracked_row_indices_by_commit,
+            &tracked_roots,
+            &rootless_ordered_commits,
+            &durable_root_rebuild_parents,
+            &staged_root_rebuild_commits,
+            &staged_commits,
+            &insert_selection,
+            &certified_packet_root_rows,
+            &certified_replacement_markers,
+        )
+        .instrument(tracing::debug_span!(
+            target: "lix_perf",
+            "lix.perf.materialization.tracked_roots"
+        )),
     )
-    .instrument(tracing::debug_span!(
-        target: "lix_perf",
-        "lix.perf.materialization.tracked_roots"
-    ))
     .await?;
     stage_commit_state_manifests(
+        read,
         &mut writes,
         &commit_rows,
         &staged_delta_index.inventories,
         &rootless_ordered_commits,
         &staged_commits,
         &staged_snapshot_roots,
-    )?;
+        &external_parent_manifests,
+    )
+    .await?;
     // HOT publication has adapter-specific checkpoint, packed-base, and
     // point-row futures. Keep their combined async state out of the parent
     // commit future so an inactive bulk branch cannot inflate every ordinary
@@ -1074,6 +1086,7 @@ async fn stage_changelog_commits(
     certified_packet_root_rows: &BTreeMap<CommitId, Vec<MaterializedLiveStateRow>>,
     mutation_inventories: &BTreeMap<CommitId, CommitStateMutationInventory>,
     ordered_replacements: &BTreeMap<CommitId, Arc<OrderedMutationJournal>>,
+    external_parent_manifests: &mut BTreeMap<CommitId, CommitStateManifest>,
 ) -> Result<BTreeMap<CommitId, StagedChangelogCommit>, LixError> {
     let mut commits = Vec::with_capacity(commit_rows.len());
     let staged_commit_ids = commit_rows
@@ -1118,6 +1131,7 @@ async fn stage_changelog_commits(
                     format!("commit '{commit_id}' has no commit-state authority"),
                 )
             })?;
+        external_parent_manifests.insert(*commit_id, manifest.clone());
         // Replay debt is the durable layout authority. A rootless commit may
         // later gain an immutable snapshot accelerator without changing its
         // changelog topology projection.
@@ -5016,54 +5030,116 @@ async fn stage_tracked_roots(
         .collect())
 }
 
-fn stage_commit_state_manifests(
-    writes: &mut StorageWriteSet,
-    commit_rows: &[FinalizedCommitRow],
-    mutation_inventories: &BTreeMap<CommitId, CommitStateMutationInventory>,
-    rootless_commit_ids: &BTreeSet<CommitId>,
-    staged_commits: &BTreeMap<CommitId, StagedChangelogCommit>,
-    snapshot_roots: &BTreeMap<CommitId, TrackedStateCommitRoot>,
-) -> Result<(), LixError> {
-    for commit in commit_rows {
-        let staged = staged_commits.get(&commit.commit_id).ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "commit '{}' has no staged topology projection for commit-state publication",
-                    commit.commit_id
-                ),
-            )
-        })?;
-        let record = &staged.record;
-        let rootless = rootless_commit_ids.contains(&commit.commit_id);
-        let snapshot_root = snapshot_roots.get(&commit.commit_id).cloned();
-        if rootless == snapshot_root.is_some() {
+fn stage_commit_state_manifests<'a, S>(
+    read: &'a S,
+    writes: &'a mut StorageWriteSet,
+    commit_rows: &'a [FinalizedCommitRow],
+    mutation_inventories: &'a BTreeMap<CommitId, CommitStateMutationInventory>,
+    rootless_commit_ids: &'a BTreeSet<CommitId>,
+    staged_commits: &'a BTreeMap<CommitId, StagedChangelogCommit>,
+    snapshot_roots: &'a BTreeMap<CommitId, TrackedStateCommitRoot>,
+    external_parent_manifests: &'a BTreeMap<CommitId, CommitStateManifest>,
+) -> std::pin::Pin<Box<dyn Future<Output = Result<(), LixError>> + Send + 'a>>
+where
+    S: StorageAdapterRead + ?Sized + 'a,
+{
+    Box::pin(async move {
+        let mut published_manifests = BTreeMap::new();
+        if staged_commits.len() != commit_rows.len()
+            || commit_rows
+                .iter()
+                .any(|commit| !staged_commits.contains_key(&commit.commit_id))
+        {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "commit '{}' has inconsistent mutation-journal and snapshot-root publication",
-                    commit.commit_id
-                ),
+                "commit-state publication is missing a staged topology projection",
             ));
         }
-        let mut mutations = mutation_inventories
-            .get(&commit.commit_id)
-            .cloned()
-            .unwrap_or_default();
-        let current_state_part_sets: Vec<_> =
-            crate::tracked_state::stage_complete_replacement_current_state_part_set(
-                writes,
-                record.commit_id,
-                &mutations,
-            )?
-            .into_iter()
-            .collect();
-        if !current_state_part_sets.is_empty() {
-            mutations.parts.clear();
-        }
-        stage_commit_state_manifest(
-            writes,
-            &CommitStateManifest {
+        let mut publication_order = staged_commits.values().collect::<Vec<_>>();
+        publication_order
+            .sort_unstable_by_key(|staged| (staged.record.generation, staged.record.commit_id));
+        for staged in publication_order {
+            let record = &staged.record;
+            let rootless = rootless_commit_ids.contains(&record.commit_id);
+            let snapshot_root = snapshot_roots.get(&record.commit_id).cloned();
+            if rootless == snapshot_root.is_some() {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "commit '{}' has inconsistent mutation-journal and snapshot-root publication",
+                        record.commit_id
+                    ),
+                ));
+            }
+            let mut mutations = mutation_inventories
+                .get(&record.commit_id)
+                .cloned()
+                .unwrap_or_default();
+            let first_parent =
+                (record.parent_commit_ids.len() == 1).then(|| record.parent_commit_ids[0]);
+            let staged_parent =
+                first_parent.and_then(|parent_id| published_manifests.get(&parent_id));
+            let external_parent = if staged_parent.is_none() {
+                match first_parent {
+                    Some(parent_id) => {
+                        let published = crate::tracked_state::load_published_commit_state_manifest(
+                            read, parent_id,
+                        )
+                        .await?
+                        .ok_or_else(|| {
+                            LixError::new(
+                                LixError::CODE_INTERNAL_ERROR,
+                                format!(
+                                    "commit '{}' has no published parent authority",
+                                    record.commit_id
+                                ),
+                            )
+                        })?;
+                        if external_parent_manifests.get(&parent_id) != Some(&*published) {
+                            return Err(LixError::new(
+                                LixError::CODE_INTERNAL_ERROR,
+                                "published parent authority changed during commit staging",
+                            ));
+                        }
+                        Some(published)
+                    }
+                    None => None,
+                }
+            } else {
+                None
+            };
+            let catalog_publication = if record.parent_commit_ids.len() <= 1
+                && mutations.selected_source_commit_id.is_none()
+            {
+                Some(if let Some(parent) = staged_parent {
+                    crate::tracked_state::stage_current_state_catalog_from_staged_parent(
+                        read,
+                        writes,
+                        parent,
+                        record.commit_id,
+                        &mutations,
+                    )
+                    .await?
+                } else {
+                    crate::tracked_state::stage_current_state_catalog_from_published_parent(
+                        read,
+                        writes,
+                        external_parent.as_ref(),
+                        record.commit_id,
+                        &mutations,
+                    )
+                    .await?
+                })
+            } else {
+                None
+            };
+            let (current_state_catalog, current_state_coverage_anchor) = catalog_publication
+                .as_ref()
+                .map_or((None, None), |publication| publication.parts());
+            if mutations.replacement_generation.is_some() {
+                mutations.parts.clear();
+            }
+            let manifest = CommitStateManifest {
                 commit_id: record.commit_id,
                 generation: record.generation,
                 parent_commit_ids: record.parent_commit_ids.clone(),
@@ -5080,12 +5156,23 @@ fn stage_commit_state_manifests(
                     CommitStateReplayDebt::default()
                 },
                 mutations,
-                current_state_part_sets,
+                current_state_catalog,
+                current_state_coverage_anchor,
                 snapshot_root,
-            },
-        )?;
-    }
-    Ok(())
+            };
+            let staged_manifest = if let Some(publication) = catalog_publication.as_ref() {
+                crate::tracked_state::stage_certified_commit_state_manifest_with_handle(
+                    writes,
+                    &manifest,
+                    publication,
+                )?
+            } else {
+                crate::tracked_state::stage_commit_state_manifest_with_handle(writes, &manifest)?
+            };
+            published_manifests.insert(record.commit_id, staged_manifest);
+        }
+        Ok(())
+    })
 }
 
 /// Every current-protocol commit is a root fence.
@@ -6095,7 +6182,8 @@ mod tests {
                     .get(&commit_id)
                     .cloned()
                     .expect("mixed certified inventory should stage"),
-                current_state_part_sets: Vec::new(),
+                current_state_catalog: None,
+                current_state_coverage_anchor: None,
                 snapshot_root: None,
             },
         )
@@ -7972,7 +8060,8 @@ mod tests {
         let mut rootless_commit_ids = BTreeSet::from([CommitId::for_test_label("parent-commit")]);
         let mut durable_root_rebuild_parents = BTreeSet::new();
         let mut staged_root_rebuild_commits = BTreeSet::new();
-        stage_changelog_commits(
+        let mut external_parent_manifests = BTreeMap::new();
+        let staged = stage_changelog_commits(
             &mut read,
             &mut writes,
             &prepared_rows![parent_row, child_row],
@@ -7991,9 +8080,26 @@ mod tests {
             &BTreeMap::new(),
             &BTreeMap::new(),
             &BTreeMap::new(),
+            &mut external_parent_manifests,
         )
         .await
         .expect("child-before-parent input should still stage parent first");
+        let mutation_inventories = commits
+            .iter()
+            .map(|commit| (commit.commit_id, CommitStateMutationInventory::default()))
+            .collect::<BTreeMap<_, _>>();
+        stage_commit_state_manifests(
+            &read,
+            &mut writes,
+            &commits,
+            &mutation_inventories,
+            &rootless_commit_ids,
+            &staged,
+            &BTreeMap::new(),
+            &external_parent_manifests,
+        )
+        .await
+        .expect("child-before-parent manifests should publish parent authority first");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
@@ -8088,6 +8194,7 @@ mod tests {
         let mut rootless_commit_ids = BTreeSet::from([commit_ids[0]]);
         let mut durable_root_rebuild_parents = BTreeSet::new();
         let mut staged_root_rebuild_commits = BTreeSet::new();
+        let mut external_parent_manifests = BTreeMap::new();
 
         let staged = stage_changelog_commits(
             &mut read,
@@ -8105,6 +8212,7 @@ mod tests {
             &BTreeMap::new(),
             &BTreeMap::new(),
             &BTreeMap::new(),
+            &mut external_parent_manifests,
         )
         .await
         .expect("depth fence should close a fully staged interval");


### PR DESCRIPTION
## Outcome

Hard-cuts protocol v49 to add a persistent, content-addressed current-state catalog over immutable ordered, non-overlapping range parts. Commit mutation inventory remains the historical authority; the catalog is a rebuildable serving accelerator.

This is generic tracked-state physical layout. It introduces no SQL shape recognizers or workload policy, and leaves SQL semantics in the existing execution paths/DataFusion.

## Physical layout and semantics

- Adds `CurrentStatePartSet` descriptors and a structurally shared radix catalog keyed by collection scope.
- Publishes complete replacement/checkpoint generations as exact covered current state.
- Makes an exact miss authoritative only inside certified coverage; incomplete scopes retain bounded historical fallback.
- Separates the mutable rebuildable manifest from one immutable semantic authority containing the original snapshot baseline.
- Point replay reads that immutable authority directly, eliminating the mutable-manifest round trip while retaining corruption detection.
- Extends GC, rebuild, history traversal, codecs, and commit validation for the catalog/part graph.
- Preserves graph parents separately from serving fallback and mutation history.
- No backward compatibility: repository protocol advances to v49.

## Performance

Matched release runs against `d993bcf0c` on 1,000,000 rows.

| Workload | Backend | Before | After | Change |
|---|---:|---:|---:|---:|
| Public SQL point read, median (10) | RocksDB | 739.960 us | 555.403 us | **-24.9%** |
| Public SQL point read, median (10) | SlateDB | 1,375.094 us | 943.653 us | **-31.4%** |
| 32-commit scope point resolution, p50 (101) | RocksDB | 225.194 us | 116.078 us | **-48.5%** |
| 32-commit scope point resolution, p95 (101) | RocksDB | 227.518 us | 118.283 us | **-48.0%** |
| 32-commit scope point resolution, p50 (101) | SlateDB | 317.667 us | 133.842 us | **-57.9%** |
| 32-commit scope point resolution, p95 (101) | SlateDB | 321.575 us | 136.156 us | **-57.7%** |

Regression gates from matched 1M runs:

- full public read: RocksDB +2.03%, SlateDB +0.37%
- bound UPDATE: RocksDB -0.75%, SlateDB +0.35%

The catalog deliberately spends storage to remove replay. In the representative 256-scope/32-commit fixture it stages 2,906,829 encoded catalog bytes; catalog manifest bytes are 11,320 versus 8,056 replay-manifest bytes. That is an explicit current-state acceleration tradeoff, not a storage win.

Samply profiles over 100k RocksDB point operations recorded 12,233 main-thread samples with the persistent route versus 23,390 for replay: 47.7% fewer sampled wall-time events. Mold is used for linking.

## Validation

- `cargo test -p lix_engine --features all-simulations`: 1,856 unit tests + 808 integration tests green (10 ignored)
- 3 doctests green
- `cargo clippy -p lix_engine --all-targets --features all-simulations,storage-benches -- -D warnings`
- release compilation for `current_state_scope_sharing` and `tracked_state_crud`
- focused corruption, exact-miss, fallback, rebuild, GC, history, diff/merge, branch, checkpoint, and stack regressions
- independent sub-agent reviews: final storage review approved with no blockers after the immutable-authority rebuild fix

## Next cut

After this lands, sparse commits can consume the same contract through bounded copy-on-write range rewrite: structurally reuse untouched parent state parts and rewrite only touched ranges.