### PR TITLE
Seal complete updates as typed mutation journals

### DIFF
--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -5941,6 +5941,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ordered_batch_update_preserves_non_uniform_lifecycle_without_journal_admission() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "x-lix-key": "non_uniform_journal_admission_probe",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "required": ["path", "value"],
+            "properties": {
+                "path": { "type": "string" },
+                "value": { "type": "string" }
+            },
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+        for path in ["a", "b"] {
+            session
+                .execute(
+                    "INSERT INTO non_uniform_journal_admission_probe (path, value) VALUES ($1, $2)",
+                    &[
+                        Value::Text(path.to_string()),
+                        Value::Text("base".to_string()),
+                    ],
+                )
+                .await
+                .unwrap();
+        }
+        let before = session
+            .execute(
+                "SELECT path, lixcol_created_at FROM non_uniform_journal_admission_probe ORDER BY path",
+                &[],
+            )
+            .await
+            .unwrap();
+        let update_sql =
+            "UPDATE non_uniform_journal_admission_probe SET value = $1 WHERE path = $2";
+        for version in ["first", "second"] {
+            session
+                .execute_batch(&[
+                    ExecuteBatchStatement {
+                        sql: update_sql.to_string(),
+                        params: vec![
+                            Value::Text(version.to_string()),
+                            Value::Text("a".to_string()),
+                        ],
+                    },
+                    ExecuteBatchStatement {
+                        sql: update_sql.to_string(),
+                        params: vec![
+                            Value::Text(version.to_string()),
+                            Value::Text("b".to_string()),
+                        ],
+                    },
+                ])
+                .await
+                .unwrap();
+        }
+        let after = session
+            .execute(
+                "SELECT path, lixcol_created_at FROM non_uniform_journal_admission_probe ORDER BY path",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(before.rows(), after.rows());
+    }
+
+    #[tokio::test]
     async fn certified_parameter_batch_revalidates_after_staged_schema_amendment() {
         // Keep this at the production typed-transport boundary. A separate
         // route-selection unit test pins the threshold itself.
@@ -5979,7 +6052,9 @@ mod tests {
             "required": ["id", "value"],
             "additionalProperties": false
         });
-        crate::transaction::take_direct_journal_replacement_publications();
+        crate::transaction::take_direct_journal_replacement_publications(
+            "amended_parameter_insert_probe",
+        );
         let mut transaction = session.begin_transaction().await.unwrap();
         transaction
             .execute(
@@ -9280,7 +9355,9 @@ mod tests {
             assert_eq!(result.rows_affected(), 1);
         }
         assert_eq!(
-            crate::transaction::take_direct_journal_replacement_publications(),
+            crate::transaction::take_direct_journal_replacement_publications(
+                "direct_journal_seal_probe",
+            ),
             0
         );
         let visible = transaction
@@ -9304,7 +9381,9 @@ mod tests {
             .await
             .expect("direct journal should commit");
         assert_eq!(
-            crate::transaction::take_direct_journal_replacement_publications(),
+            crate::transaction::take_direct_journal_replacement_publications(
+                "direct_journal_seal_probe",
+            ),
             1,
             "the complete scalar generation must seal without PreparedStateBatch"
         );
@@ -9333,7 +9412,9 @@ mod tests {
             .await
             .expect("identical replacement generation should commit");
         assert_eq!(
-            crate::transaction::take_direct_journal_replacement_publications(),
+            crate::transaction::take_direct_journal_replacement_publications(
+                "direct_journal_seal_probe",
+            ),
             1
         );
     }
@@ -9425,7 +9506,9 @@ mod tests {
         }
         transaction.commit().await.unwrap();
         assert_eq!(
-            crate::transaction::take_direct_journal_replacement_publications(),
+            crate::transaction::take_direct_journal_replacement_publications(
+                "journal_read_your_writes_probe",
+            ),
             1,
             "an intervening read must not reconstruct the immutable journal"
         );
@@ -9560,7 +9643,9 @@ mod tests {
             .clone();
         session.create_checkpoint().await.unwrap();
 
-        crate::transaction::take_direct_journal_replacement_publications();
+        crate::transaction::take_direct_journal_replacement_publications(
+            "rooted_journal_parent_probe",
+        );
         let mut transaction = session.begin_transaction().await.unwrap();
         let update_sql =
             "UPDATE rooted_journal_parent_probe SET value = lix_json($1) WHERE path = $2";
@@ -9593,7 +9678,9 @@ mod tests {
             .await
             .expect("a parent without collection lifecycle authority must use the safe lane");
         assert_eq!(
-            crate::transaction::take_direct_journal_replacement_publications(),
+            crate::transaction::take_direct_journal_replacement_publications(
+                "rooted_journal_parent_probe",
+            ),
             0
         );
         let committed_created_at = session

--- a/packages/engine/src/sql2/context.rs
+++ b/packages/engine/src/sql2/context.rs
@@ -26,7 +26,7 @@ use crate::storage_adapter::StorageAdapterRead;
 use crate::tracked_state::TrackedStateScanRequest;
 use crate::transaction::types::{
     CertifiedParameterInsertBatch, CertifiedParameterReplacementBatch, RawWriteBatch,
-    TransactionWrite, TransactionWriteMode, TransactionWriteOutcome,
+    TransactionWrite, TransactionWriteMode, TransactionWriteOutcome, TypedMutationJournalBatch,
 };
 use crate::wasm::UnsupportedWasmRuntime;
 
@@ -255,6 +255,18 @@ pub(crate) trait SqlWriteExecutionContext: Send {
     ) -> Result<TransactionWriteOutcome, LixError> {
         self.stage_parameter_batch_replace(rows.into_raw()?).await
     }
+
+    async fn stage_typed_mutation_journal_replace(
+        &mut self,
+        rows: TypedMutationJournalBatch,
+    ) -> Result<TransactionWriteOutcome, LixError>;
+
+    async fn can_stage_typed_mutation_journal_replace(
+        &mut self,
+        schema_key: &str,
+        live_count: u64,
+        ordered_identity_digest: [u8; 32],
+    ) -> Result<bool, LixError>;
 
     async fn execute_diff_command(
         &mut self,

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -34,6 +34,7 @@ use crate::transaction::types::{
     CertifiedParameterInsertBatch, CertifiedParameterReplacementBatch,
     CertifiedRawWriteBatchPreparation, CompleteCollectionReplacementProof, PreparedRowFacts,
     RawWriteBatch, RawWriteRowRef, TransactionJson, TransactionWrite, TransactionWriteMode,
+    TypedMutationJournalBatch,
 };
 use crate::wasm::WasmEntityKey;
 use crate::{LixError, NullableKeyFilter, Value, parse_row_metadata_value};
@@ -810,6 +811,7 @@ async fn try_execute_direct_path_value_replacement_batch(
     let mut primary_key_offsets = Vec::with_capacity(row_count);
     let mut previous_row = None;
     let mut primary_keys_strictly_ordered = true;
+    let mut parameter_identity_hasher = blake3::Hasher::new();
     for statement_index in 0..row_count {
         let DirectParameterValue::String(primary_key) =
             parameter_batch.value(primary_key_param_index, statement_index)
@@ -825,9 +827,110 @@ async fn try_execute_direct_path_value_replacement_batch(
             primary_keys_strictly_ordered &= previous < primary_key;
         }
         previous_row = Some(statement_index);
+        parameter_identity_hasher.update(&(primary_key.len() as u64).to_le_bytes());
+        parameter_identity_hasher.update(primary_key.as_bytes());
         let start = primary_key_arena.len();
         primary_key_arena.extend_from_slice(primary_key.as_bytes());
         primary_key_offsets.push((start, primary_key_arena.len()));
+    }
+    let parameter_identity_digest = *parameter_identity_hasher.finalize().as_bytes();
+    let active_branch_id = ctx.active_branch_id().to_owned();
+    let scope = crate::collection_generation::CollectionScopeRef {
+        schema_key: &spec.schema_key,
+        file_id: None,
+    };
+    // Generation controls describe committed HOT state. Any staged member can
+    // change the effective identity set, so it must force the overlay-aware
+    // candidate scan instead of certifying the committed digest.
+    let has_staged_collection_rows = ctx.has_staged_collection_rows(&active_branch_id, scope)?;
+    let collection_generation = ctx
+        .load_collection_generation(&active_branch_id, scope)
+        .await?;
+    let certified_ordered_generation = primary_keys_strictly_ordered
+        && !has_staged_collection_rows
+        && collection_generation.is_some_and(|generation| {
+            generation.live_count == row_count as u64
+                && generation.ordered_identity_digest == Some(parameter_identity_digest)
+        });
+    let typed_journal_admitted = if certified_ordered_generation {
+        ctx.can_stage_typed_mutation_journal_replace(
+            &spec.schema_key,
+            row_count as u64,
+            parameter_identity_digest,
+        )
+        .await?
+    } else {
+        false
+    };
+    if typed_journal_admitted {
+        let mut snapshots = Vec::with_capacity(
+            primary_key_arena
+                .len()
+                .saturating_add(row_count.saturating_mul(32)),
+        );
+        let mut snapshot_offsets = Vec::with_capacity(row_count);
+        for (statement_index, &(identity_start, identity_end)) in
+            primary_key_offsets.iter().enumerate()
+        {
+            let primary_key = std::str::from_utf8(&primary_key_arena[identity_start..identity_end])
+                .expect("borrowed SQL text remains UTF-8 in its mutation arena");
+            let snapshot_start = snapshots.len();
+            snapshots.extend_from_slice(b"{\"path\":");
+            append_canonical_json_string(&mut snapshots, primary_key)
+                .map_err(|error| with_parameter_batch_statement_index(error, statement_index))?;
+            snapshots.extend_from_slice(b",\"value\":");
+            match parameter_batch.value(replacement.value_param_index, statement_index) {
+                DirectParameterValue::Null => snapshots.extend_from_slice(b"null"),
+                DirectParameterValue::String(raw) => {
+                    append_canonical_json_parameter(&mut snapshots, raw).map_err(|error| {
+                        with_parameter_batch_statement_index(error, statement_index)
+                    })?;
+                }
+                DirectParameterValue::Boolean(_) => {
+                    unreachable!("the certified replacement value parameter is text")
+                }
+            }
+            snapshots.push(b'}');
+            snapshot_offsets.push((snapshot_start, snapshots.len()));
+        }
+        let journal = TypedMutationJournalBatch::new(
+            schema_plan_id,
+            spec.schema_key.as_str().into(),
+            active_branch_id.into(),
+            primary_key_arena,
+            primary_key_offsets,
+            snapshots,
+            snapshot_offsets,
+            parameter_identity_digest,
+        )?;
+        ctx.stage_typed_mutation_journal_replace(journal)
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.entity_update_value_batch.stage_typed_journal",
+                row_count
+            ))
+            .await?;
+        #[cfg(test)]
+        {
+            ENTITY_UPDATE_PARAMETER_BATCH_EXECUTIONS.with(|executions| {
+                executions.set(executions.get().saturating_add(1));
+            });
+            CERTIFIED_REPLACEMENT_PARAMETER_BATCH_EXECUTIONS.with(|executions| {
+                executions.set(executions.get().saturating_add(1));
+            });
+            CERTIFIED_GENERATION_IDENTITY_REPLACEMENTS.with(|executions| {
+                executions.set(executions.get().saturating_add(1));
+            });
+        }
+        #[cfg(feature = "storage-benches")]
+        if record_value_certificate {
+            crate::storage_bench::record_certified_entity_update_value_batch_hit(row_count);
+        }
+        return Ok(Some(
+            (0..row_count)
+                .map(|_| SqlWriteResult::affected(1))
+                .collect(),
+        ));
     }
     let primary_key_arena = SharedStr::from_utf8(bytes::Bytes::from(primary_key_arena))
         .map_err(|_| LixError::unknown("certified replacement primary-key arena is not UTF-8"))?;
@@ -872,18 +975,6 @@ async fn try_execute_direct_path_value_replacement_batch(
         .as_deref()
         .unwrap_or(entity_pks.as_slice());
     let unique_row_count = unique_entity_pks.len();
-    let active_branch_id = ctx.active_branch_id().to_owned();
-    let scope = crate::collection_generation::CollectionScopeRef {
-        schema_key: &spec.schema_key,
-        file_id: None,
-    };
-    // Generation controls describe committed HOT state. Any staged member can
-    // change the effective identity set, so it must force the overlay-aware
-    // candidate scan instead of certifying the committed digest.
-    let has_staged_collection_rows = ctx.has_staged_collection_rows(&active_branch_id, scope)?;
-    let collection_generation = ctx
-        .load_collection_generation(&active_branch_id, scope)
-        .await?;
     let ordered_identity_digest =
         crate::collection_generation::ordered_single_string_identity_digest(
             unique_entity_pks.iter(),

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -2834,6 +2834,25 @@ mod tests {
             Ok(TransactionWriteOutcome { count })
         }
 
+        async fn stage_typed_mutation_journal_replace(
+            &mut self,
+            _rows: crate::transaction::types::TypedMutationJournalBatch,
+        ) -> Result<TransactionWriteOutcome, LixError> {
+            Err(LixError::new(
+                LixError::CODE_UNSUPPORTED_SQL,
+                "DataFusion test context does not stage transaction journals",
+            ))
+        }
+
+        async fn can_stage_typed_mutation_journal_replace(
+            &mut self,
+            _schema_key: &str,
+            _live_count: u64,
+            _ordered_identity_digest: [u8; 32],
+        ) -> Result<bool, LixError> {
+            Ok(false)
+        }
+
         async fn execute_diff_command(
             &mut self,
             _command: crate::sql2::DiffCommand,
@@ -2902,6 +2921,28 @@ mod tests {
             write: TransactionWrite,
         ) -> Result<TransactionWriteOutcome, LixError> {
             self.inner.stage_write(write).await
+        }
+
+        async fn stage_typed_mutation_journal_replace(
+            &mut self,
+            rows: crate::transaction::types::TypedMutationJournalBatch,
+        ) -> Result<TransactionWriteOutcome, LixError> {
+            self.inner.stage_typed_mutation_journal_replace(rows).await
+        }
+
+        async fn can_stage_typed_mutation_journal_replace(
+            &mut self,
+            schema_key: &str,
+            live_count: u64,
+            ordered_identity_digest: [u8; 32],
+        ) -> Result<bool, LixError> {
+            self.inner
+                .can_stage_typed_mutation_journal_replace(
+                    schema_key,
+                    live_count,
+                    ordered_identity_digest,
+                )
+                .await
         }
     }
 

--- a/packages/engine/src/sql2/providers/directory.rs
+++ b/packages/engine/src/sql2/providers/directory.rs
@@ -2676,6 +2676,25 @@ mod tests {
             self.writes.push(write);
             Ok(TransactionWriteOutcome { count: 0 })
         }
+
+        async fn stage_typed_mutation_journal_replace(
+            &mut self,
+            _rows: crate::transaction::types::TypedMutationJournalBatch,
+        ) -> Result<TransactionWriteOutcome, LixError> {
+            Err(LixError::new(
+                LixError::CODE_UNSUPPORTED_SQL,
+                "directory provider test context does not stage transaction journals",
+            ))
+        }
+
+        async fn can_stage_typed_mutation_journal_replace(
+            &mut self,
+            _schema_key: &str,
+            _live_count: u64,
+            _ordered_identity_digest: [u8; 32],
+        ) -> Result<bool, LixError> {
+            Ok(false)
+        }
     }
 
     fn live_row(

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -3155,6 +3155,22 @@ mod tests {
         ) -> Result<crate::transaction::types::TransactionWriteOutcome, LixError> {
             panic!("raw DataFusion entity INSERT must never stage writes");
         }
+
+        async fn stage_typed_mutation_journal_replace(
+            &mut self,
+            _rows: crate::transaction::types::TypedMutationJournalBatch,
+        ) -> Result<crate::transaction::types::TransactionWriteOutcome, LixError> {
+            panic!("raw DataFusion entity INSERT must never stage transaction journals");
+        }
+
+        async fn can_stage_typed_mutation_journal_replace(
+            &mut self,
+            _schema_key: &str,
+            _live_count: u64,
+            _ordered_identity_digest: [u8; 32],
+        ) -> Result<bool, LixError> {
+            Ok(false)
+        }
     }
 
     // Guards the plan-time phase of the entity INSERT rejection: validate-only

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -8642,6 +8642,25 @@ mod tests {
             self.writes.push(write);
             Ok(TransactionWriteOutcome { count: 0 })
         }
+
+        async fn stage_typed_mutation_journal_replace(
+            &mut self,
+            _rows: crate::transaction::types::TypedMutationJournalBatch,
+        ) -> Result<TransactionWriteOutcome, LixError> {
+            Err(LixError::new(
+                LixError::CODE_UNSUPPORTED_SQL,
+                "file provider test context does not stage transaction journals",
+            ))
+        }
+
+        async fn can_stage_typed_mutation_journal_replace(
+            &mut self,
+            _schema_key: &str,
+            _live_count: u64,
+            _ordered_identity_digest: [u8; 32],
+        ) -> Result<bool, LixError> {
+            Ok(false)
+        }
     }
 
     #[async_trait]
@@ -8731,6 +8750,25 @@ mod tests {
             };
             self.writes.push(write);
             Ok(TransactionWriteOutcome { count })
+        }
+
+        async fn stage_typed_mutation_journal_replace(
+            &mut self,
+            _rows: crate::transaction::types::TypedMutationJournalBatch,
+        ) -> Result<TransactionWriteOutcome, LixError> {
+            Err(LixError::new(
+                LixError::CODE_UNSUPPORTED_SQL,
+                "indexed file test context does not stage transaction journals",
+            ))
+        }
+
+        async fn can_stage_typed_mutation_journal_replace(
+            &mut self,
+            _schema_key: &str,
+            _live_count: u64,
+            _ordered_identity_digest: [u8; 32],
+        ) -> Result<bool, LixError> {
+            Ok(false)
         }
     }
 

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -93,8 +93,9 @@ std::thread_local! {
 }
 
 #[cfg(test)]
-static DIRECT_JOURNAL_REPLACEMENT_PUBLICATIONS: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
+static DIRECT_JOURNAL_REPLACEMENT_PUBLICATIONS: std::sync::LazyLock<
+    std::sync::Mutex<BTreeMap<String, usize>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(BTreeMap::new()));
 
 #[cfg(test)]
 pub(crate) fn take_ordered_packed_current_base_publications() -> usize {
@@ -118,8 +119,12 @@ pub(crate) fn take_rootless_replacement_generation_publications() -> usize {
 }
 
 #[cfg(test)]
-pub(crate) fn take_direct_journal_replacement_publications() -> usize {
-    DIRECT_JOURNAL_REPLACEMENT_PUBLICATIONS.swap(0, std::sync::atomic::Ordering::Relaxed)
+pub(crate) fn take_direct_journal_replacement_publications(schema_key: &str) -> usize {
+    DIRECT_JOURNAL_REPLACEMENT_PUBLICATIONS
+        .lock()
+        .expect("direct journal publication counters")
+        .remove(schema_key)
+        .unwrap_or_default()
 }
 
 /// Commits prepared transaction rows into tracked history and unified current
@@ -1982,8 +1987,13 @@ async fn stage_tracked_commit_delta_index(
     for root in tracked_roots {
         if let Some(journal) = ordered_replacements.get(&root.commit_id) {
             #[cfg(test)]
-            DIRECT_JOURNAL_REPLACEMENT_PUBLICATIONS
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            {
+                let mut counts = DIRECT_JOURNAL_REPLACEMENT_PUBLICATIONS
+                    .lock()
+                    .expect("direct journal publication counters");
+                let count = counts.entry(journal.schema_key().to_owned()).or_default();
+                *count = count.saturating_add(1);
+            }
             if !state_rows.is_empty()
                 || certified_packet_root_rows
                     .get(&root.commit_id)
@@ -3401,6 +3411,10 @@ async fn stage_tracked_head(
                     "immutable replacement journal entered an incompatible HOT publication lane",
                 ));
             }
+            #[cfg(test)]
+            COMPLETE_REPLACEMENT_PACKED_CURRENT_BASE_PUBLICATIONS.with(|publications| {
+                publications.set(publications.get().saturating_add(1));
+            });
             let (generation, _retired_predecessor_bases) = tracked_head
                 .writer(read, writes)
                 .stage_complete_collection_replacement_current_base(
@@ -3418,6 +3432,12 @@ async fn stage_tracked_head(
                     "lix.perf.materialization.tracked_head.stage_direct_replacement_parts"
                 ))
                 .await?;
+            #[cfg(test)]
+            if _retired_predecessor_bases {
+                COMPLETE_REPLACEMENT_PACKED_CURRENT_BASE_RETIREMENTS.with(|retirements| {
+                    retirements.set(retirements.get().saturating_add(1));
+                });
+            }
             if let Some(epoch) = working_diff_epoch {
                 let next_epoch = TrackedWorkingDiffEpoch {
                     checkpoint_commit_id: epoch.checkpoint_commit_id,

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -120,6 +120,7 @@ use crate::transaction::types::{
     StagedCommitChangeBatch, StagedCommitChangeBatchBuilder, TransactionFileContent,
     TransactionJson, TransactionWrite, TransactionWriteMode, TransactionWriteOperation,
     TransactionWriteOrigin, TransactionWriteOutcome, TransactionWriteRow,
+    TypedMutationJournalBatch,
     canonicalize_transaction_json_batch, stage_json_from_value,
 };
 
@@ -8799,6 +8800,123 @@ where
                     })
             },
         )
+    }
+
+    async fn stage_typed_mutation_journal_replace(
+        &mut self,
+        rows: TypedMutationJournalBatch,
+    ) -> Result<TransactionWriteOutcome, LixError> {
+        let row_count = rows.len();
+        if row_count == 0 {
+            return Ok(TransactionWriteOutcome { count: 0 });
+        }
+        self.ensure_plugin_generation_read_guard().await;
+        let domain = Domain::schema_catalog(rows.branch_id.to_string(), false);
+        if self.origin_key.is_some()
+            || self
+                .staged_writes
+                .has_staged_schema_catalog_change(&domain)?
+        {
+            return Err(LixError::new(
+                LixError::CODE_TRANSACTION_CONFLICT,
+                "typed mutation journals require a stable schema and direct transaction origin",
+            ));
+        }
+        if opening_parent_complete_lifecycle_created_at(
+            &self.opening_read(),
+            self.opening_active_branch_head,
+            rows.schema_key.as_str(),
+            u64::try_from(row_count).map_err(|_| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "typed mutation journal row count exceeds u64",
+                )
+            })?,
+            rows.expected_ordered_identity_digest,
+        )
+        .await?
+        .is_none()
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "typed mutation journal lacks complete parent lifecycle authority",
+            ));
+        }
+
+        #[cfg(feature = "storage-benches")]
+        {
+            crate::storage_bench::record_transaction_rows_staged(row_count);
+            crate::storage_bench::record_transaction_untracked_rows(0);
+        }
+        let expected_ordered_identity_digest = rows.expected_ordered_identity_digest;
+        let schema_key = rows.schema_key.clone();
+        let branch_id = rows.branch_id.clone();
+        let chunk = ImmutableMutationJournalChunk::try_new_single_string_identities(
+            rows.schema_plan_id,
+            rows.schema_key,
+            rows.branch_id,
+            None,
+            rows.identity_arena,
+            rows.identity_offsets,
+            rows.snapshot_arena,
+            rows.snapshot_offsets,
+            None,
+            self.functions.call_timestamp(),
+        )?;
+        match self.staged_writes.stage_immutable_mutation_chunk(chunk)? {
+            ImmutableMutationChunkStage::Staged => {
+                if !self.staged_writes.certify_complete_collection_replacement(
+                    schema_key.as_str(),
+                    branch_id.as_str(),
+                    u64::try_from(row_count).map_err(|_| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            "typed mutation journal row count exceeds u64",
+                        )
+                    })?,
+                    expected_ordered_identity_digest,
+                )? {
+                    return Err(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "typed mutation journal lost its complete replacement scope",
+                    ));
+                }
+            }
+            ImmutableMutationChunkStage::RequiresGeneric(_) => {
+                return Err(LixError::new(
+                    LixError::CODE_TRANSACTION_CONFLICT,
+                    "typed mutation journal overlaps an existing transaction mutation lane",
+                ));
+            }
+        }
+        Ok(TransactionWriteOutcome {
+            count: u64::try_from(row_count).expect("typed mutation journal row count fits u64"),
+        })
+    }
+
+    async fn can_stage_typed_mutation_journal_replace(
+        &mut self,
+        schema_key: &str,
+        live_count: u64,
+        ordered_identity_digest: [u8; 32],
+    ) -> Result<bool, LixError> {
+        let domain = Domain::schema_catalog(self.active_branch_id.clone(), false);
+        if self.origin_key.is_some()
+            || self
+                .staged_writes
+                .has_staged_schema_catalog_change(&domain)?
+        {
+            return Ok(false);
+        }
+        opening_parent_complete_lifecycle_created_at(
+            &self.opening_read(),
+            self.opening_active_branch_head,
+            schema_key,
+            live_count,
+            ordered_identity_digest,
+        )
+        .await
+        .map(|created_at| created_at.is_some())
     }
 
     async fn execute_diff_command(

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -95,7 +95,7 @@ pub(crate) struct ImmutableMutationJournalChunk {
     identity_offsets: Arc<[(u32, u32)]>,
     snapshot_arena: Bytes,
     snapshot_offsets: Arc<[(u32, u32)]>,
-    large_snapshot_refs: Arc<[(u16, crate::json_store::JsonRef)]>,
+    large_snapshot_refs: Arc<[(u32, crate::json_store::JsonRef)]>,
     durable_predecessors: Option<Arc<[CertifiedCurrentStatePredecessor]>>,
     timestamp: LixTimestamp,
 }
@@ -290,8 +290,8 @@ impl ImmutableMutationJournalChunk {
                 let bytes = &snapshot_arena[start as usize..end as usize];
                 (bytes.len() > crate::json_store::JSON_INLINE_MAX_BYTES).then(|| {
                     (
-                        u16::try_from(index)
-                            .expect("immutable mutation chunk row ordinal fits u16"),
+                        u32::try_from(index)
+                            .expect("immutable mutation chunk row ordinal fits u32"),
                         crate::json_store::JsonRef::for_content(bytes),
                     )
                 })
@@ -361,7 +361,7 @@ impl ImmutableMutationJournalChunk {
         if snapshot.len() <= crate::json_store::JSON_INLINE_MAX_BYTES {
             return crate::json_store::JsonSlotRef::Inline(snapshot);
         }
-        let index = u16::try_from(index).expect("immutable mutation chunk row ordinal fits u16");
+        let index = u32::try_from(index).expect("immutable mutation chunk row ordinal fits u32");
         let position = self
             .large_snapshot_refs
             .binary_search_by_key(&index, |(ordinal, _)| *ordinal)
@@ -4359,6 +4359,50 @@ mod tests {
         assert_eq!(chunk.identity(0), "a");
         assert_eq!(chunk.identity(1), "b");
         assert_eq!(chunk.identity_arena.len(), 2);
+    }
+
+    #[test]
+    fn immutable_journal_large_snapshot_refs_support_more_than_u16_rows() {
+        const ROW_COUNT: usize = 65_537;
+        let mut identities = Vec::with_capacity(ROW_COUNT * 6);
+        let mut identity_offsets = Vec::with_capacity(ROW_COUNT);
+        let mut snapshots = Vec::with_capacity(ROW_COUNT * 2 + 512);
+        let mut snapshot_offsets = Vec::with_capacity(ROW_COUNT);
+        for row in 0..ROW_COUNT {
+            let start = identities.len();
+            identities.extend_from_slice(format!("{row:06}").as_bytes());
+            identity_offsets.push((start, identities.len()));
+
+            let start = snapshots.len();
+            if row + 1 == ROW_COUNT {
+                snapshots.extend(std::iter::repeat_n(
+                    b'x',
+                    crate::json_store::JSON_INLINE_MAX_BYTES + 1,
+                ));
+            } else {
+                snapshots.extend_from_slice(b"{}");
+            }
+            snapshot_offsets.push((start, snapshots.len()));
+        }
+
+        let chunk = ImmutableMutationJournalChunk::try_new_single_string_identities(
+            SchemaPlanId::for_test(0),
+            "schema".into(),
+            "branch".into(),
+            None,
+            identities,
+            identity_offsets,
+            snapshots,
+            snapshot_offsets,
+            None,
+            LixTimestamp::expect_parse("timestamp", "2026-01-01T00:00:00Z"),
+        )
+        .expect("journal chunk above the u16 row boundary");
+
+        assert!(matches!(
+            chunk.snapshot_slot(ROW_COUNT - 1),
+            crate::json_store::JsonSlotRef::Ref(_)
+        ));
     }
 
     #[test]

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -496,6 +496,59 @@ pub(crate) struct CompleteCollectionReplacementProof {
     pub(crate) replay_bytes: u64,
 }
 
+/// Frontend-neutral columns for one certified ordered replacement journal.
+///
+/// SQL, plugins, and programmatic APIs can produce this carrier without
+/// allocating row-owned transaction DTOs. The transaction assigns lifecycle
+/// and commit identity while retaining these arenas as its immutable journal.
+/// Mixed mutation lanes are rejected instead of lowering this representation
+/// into generic prepared rows.
+pub(crate) struct TypedMutationJournalBatch {
+    pub(crate) schema_plan_id: SchemaPlanId,
+    pub(crate) schema_key: SharedStr,
+    pub(crate) branch_id: SharedStr,
+    pub(crate) identity_arena: Vec<u8>,
+    pub(crate) identity_offsets: Vec<(usize, usize)>,
+    pub(crate) snapshot_arena: Vec<u8>,
+    pub(crate) snapshot_offsets: Vec<(usize, usize)>,
+    pub(crate) expected_ordered_identity_digest: [u8; 32],
+}
+
+impl TypedMutationJournalBatch {
+    #[expect(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        schema_plan_id: SchemaPlanId,
+        schema_key: SharedStr,
+        branch_id: SharedStr,
+        identity_arena: Vec<u8>,
+        identity_offsets: Vec<(usize, usize)>,
+        snapshot_arena: Vec<u8>,
+        snapshot_offsets: Vec<(usize, usize)>,
+        expected_ordered_identity_digest: [u8; 32],
+    ) -> Result<Self, LixError> {
+        if identity_offsets.is_empty() || identity_offsets.len() != snapshot_offsets.len() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "typed mutation journal columns are empty or misaligned",
+            ));
+        }
+        Ok(Self {
+            schema_plan_id,
+            schema_key,
+            branch_id,
+            identity_arena,
+            identity_offsets,
+            snapshot_arena,
+            snapshot_offsets,
+            expected_ordered_identity_digest,
+        })
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.identity_offsets.len()
+    }
+}
+
 /// Dense, typed columns produced by certified SQL parameter-batch paths.
 ///
 /// Keeping this transport separate from [`RawWriteBatch`] avoids allocating


### PR DESCRIPTION
## What changed

- routes complete, strictly ordered bound SQL UPDATE batches into a typed columnar mutation journal
- makes journal staging a required first-class write-context contract with no reverse conversion, trait default, or PreparedStateBatch fallback beneath this path
- seals the journal through the existing #1158 immutable mutation-part and CommitStateManifest authority
- binds replacement certification to the journal identity and snapshot contents
- admits the replacement lane only with exact opening-parent lifecycle authority; origin, staged-schema, and non-uniform lifecycle cases keep their established semantic lane
- expands large-snapshot row ordinals to u32 for 1M-row journals

## Why

The previous complete UPDATE path allocated row-owned EntityPk/TransactionJson transports, reconstructed PreparedStateBatch, and then dismantled it again while sealing immutable parts. This hard cut retains the identity and canonical snapshot arenas through commit publication.

## Performance

Setup-excluded medians, 3 samples, versus immediately previous merged PR #1174:

| UPDATE | #1174 | This PR | Change |
|---|---:|---:|---:|
| RocksDB 10K | 17.327 ms | 14.685 ms | -15.2% |
| SlateDB 10K | 18.702 ms | 15.743 ms | -15.8% |
| RocksDB 1M | 992.319 ms | 554.023 ms | -44.2% |
| SlateDB 1M | 1.038 s | 551.355 ms | -46.9% |

Raw SQLite 1M UPDATE is 873.643 ms on the same fixture, so RocksDB and SlateDB are both about 0.63x SQLite latency.

## Validation

- cargo test -p lix_engine --all-features: 1,861 unit tests and 810 integration tests green; doc tests green
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- focused non-uniform lifecycle, read-your-writes, packed publication, out-of-order semantics, and >65,535-row large-snapshot tests
- two independent Luna extra-high reviews; no remaining correctness P1 in this lane and no #1158 durable contract changes

No changenote.