### PR TITLE
Publish sparse immutable current-state parts

### DIFF
--- a/packages/engine-benchmarks/benches/current_state_scope_sharing.rs
+++ b/packages/engine-benchmarks/benches/current_state_scope_sharing.rs
@@ -3,7 +3,8 @@ use std::time::{Duration, Instant};
 
 use lix_engine::storage_adapter::StorageAdapter;
 use lix_engine::tracked_state::bench::{
-    BenchCurrentStatePointFixture, BenchCurrentStatePointMode, seed_current_state_point_fixture,
+    BenchCurrentStatePointFixture, BenchCurrentStatePointMode, BenchCurrentStatePointTarget,
+    BenchCurrentStateSparseShape, seed_current_state_point_fixture,
 };
 use lix_rocksdb_storage::RocksDB;
 use lix_slatedb_storage::SlateDB;
@@ -15,6 +16,18 @@ fn main() {
     let warmups = env_usize("LIX_CURRENT_STATE_WARMUPS", 10);
     let samples = env_usize("LIX_CURRENT_STATE_SAMPLES", 101).max(1);
     let backend_filter = std::env::var("LIX_CURRENT_STATE_BACKEND").unwrap_or_default();
+    let sparse_shape = match std::env::var("LIX_CURRENT_STATE_SPARSE_SHAPE").as_deref() {
+        Ok("unrelated") => BenchCurrentStateSparseShape::UnrelatedScopes,
+        Ok("touched") | Err(_) => BenchCurrentStateSparseShape::TouchedScope,
+        Ok(other) => panic!(
+            "unknown LIX_CURRENT_STATE_SPARSE_SHAPE '{other}'; expected touched or unrelated"
+        ),
+    };
+    let point_target = match std::env::var("LIX_CURRENT_STATE_TARGET").as_deref() {
+        Ok("hot") => BenchCurrentStatePointTarget::HotMutated,
+        Ok("cold") | Err(_) => BenchCurrentStatePointTarget::ColdUntouched,
+        Ok(other) => panic!("unknown LIX_CURRENT_STATE_TARGET '{other}'; expected hot or cold"),
+    };
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -33,6 +46,8 @@ fn main() {
                 scopes,
                 warmups,
                 samples,
+                sparse_shape,
+                point_target,
             )
             .await;
         }
@@ -49,6 +64,8 @@ fn main() {
                 scopes,
                 warmups,
                 samples,
+                sparse_shape,
+                point_target,
             )
             .await;
         }
@@ -63,11 +80,21 @@ async fn run_backend<S>(
     scopes: usize,
     warmups: usize,
     samples: usize,
+    sparse_shape: BenchCurrentStateSparseShape,
+    point_target: BenchCurrentStatePointTarget,
 ) where
     S: lix_engine::storage::Storage,
 {
     let setup = Instant::now();
-    let fixture = seed_current_state_point_fixture(storage, rows, sparse_commits, scopes).await;
+    let fixture = seed_current_state_point_fixture(
+        storage,
+        rows,
+        sparse_commits,
+        scopes,
+        sparse_shape,
+        point_target,
+    )
+    .await;
     let setup = setup.elapsed();
     let mode = std::env::var("LIX_CURRENT_STATE_MODE").unwrap_or_default();
     if mode == "persistent" || mode == "replay" {
@@ -78,10 +105,16 @@ async fn run_backend<S>(
         };
         let measured = measure(&fixture, selected, warmups, samples).await;
         println!(
-            "current_state_scope_sharing,backend={backend},mode={mode},rows={rows},scopes={},sparse_commits={sparse_commits},setup_ms={:.3},catalog_staged_encoded_bytes={},catalog_manifest_bytes={},replay_manifest_bytes={},p50_us={:.3},p95_us={:.3}",
+            "current_state_scope_sharing,backend={backend},mode={mode},shape={sparse_shape:?},target={point_target:?},rows={rows},scopes={},sparse_commits={sparse_commits},setup_ms={:.3},catalog_staged_encoded_bytes={},directory_staged_encoded_bytes={},sparse_staged_puts={},sparse_written_bytes={},first_sparse_ms={:.3},first_sparse_staged_puts={},first_sparse_written_bytes={},catalog_manifest_bytes={},replay_manifest_bytes={},p50_us={:.3},p95_us={:.3}",
             fixture.catalog_entry_count(),
             millis(setup),
             fixture.catalog_staged_encoded_bytes(),
+            fixture.directory_staged_encoded_bytes(),
+            fixture.sparse_staged_puts(),
+            fixture.sparse_written_bytes(),
+            fixture.first_sparse_elapsed_nanos() as f64 / 1_000_000.0,
+            fixture.first_sparse_staged_puts(),
+            fixture.first_sparse_written_bytes(),
             fixture.catalog_manifest_bytes(),
             fixture.replay_manifest_bytes(),
             micros(measured.0),
@@ -91,7 +124,7 @@ async fn run_backend<S>(
     }
     let persistent = measure(
         &fixture,
-        BenchCurrentStatePointMode::PersistentCatalog,
+        BenchCurrentStatePointMode::CatalogThenReplay,
         warmups,
         samples,
     )
@@ -104,10 +137,16 @@ async fn run_backend<S>(
     )
     .await;
     println!(
-        "current_state_scope_sharing,backend={backend},rows={rows},scopes={},sparse_commits={sparse_commits},setup_ms={:.3},catalog_staged_encoded_bytes={},catalog_manifest_bytes={},replay_manifest_bytes={},persistent_p50_us={:.3},persistent_p95_us={:.3},replay_p50_us={:.3},replay_p95_us={:.3},p50_reduction_pct={:.2},p95_reduction_pct={:.2}",
+        "current_state_scope_sharing,backend={backend},shape={sparse_shape:?},target={point_target:?},rows={rows},scopes={},sparse_commits={sparse_commits},setup_ms={:.3},catalog_staged_encoded_bytes={},directory_staged_encoded_bytes={},sparse_staged_puts={},sparse_written_bytes={},first_sparse_ms={:.3},first_sparse_staged_puts={},first_sparse_written_bytes={},catalog_manifest_bytes={},replay_manifest_bytes={},serving_p50_us={:.3},serving_p95_us={:.3},replay_p50_us={:.3},replay_p95_us={:.3},p50_reduction_pct={:.2},p95_reduction_pct={:.2}",
         fixture.catalog_entry_count(),
         millis(setup),
         fixture.catalog_staged_encoded_bytes(),
+        fixture.directory_staged_encoded_bytes(),
+        fixture.sparse_staged_puts(),
+        fixture.sparse_written_bytes(),
+        fixture.first_sparse_elapsed_nanos() as f64 / 1_000_000.0,
+        fixture.first_sparse_staged_puts(),
+        fixture.first_sparse_written_bytes(),
         fixture.catalog_manifest_bytes(),
         fixture.replay_manifest_bytes(),
         micros(persistent.0),

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -21,9 +21,9 @@ use crate::json_store::{
 };
 use crate::live_state::{TrackedHeadContext, stage_collect_stale_working_diff_indexes};
 use crate::storage_adapter::{
-    PointReadPlan, ScanPlan, StorageAdapterRead, StorageGetOptions, StorageKey, StoragePrefix,
-    StorageProjectedValue, StorageScanOptions, StorageSpace, StorageSpaceId, StorageValue,
-    StorageWriteSet,
+    PointReadPlan, ScanPlan, StorageAdapterRead, StorageCoreProjection, StorageGetOptions,
+    StorageKey, StoragePrefix, StorageProjectedValue, StorageScanOptions, StorageSpace,
+    StorageSpaceId, StorageValue, StorageWriteSet,
 };
 use crate::{LixError, storage_codec};
 
@@ -254,6 +254,7 @@ async fn stage_sweep_unreachable_content_nodes(
             .collect(
                 store,
                 StorageScanOptions {
+                    projection: StorageCoreProjection::KeyOnly,
                     resume_after: resume_after.clone(),
                     ..StorageScanOptions::default()
                 },
@@ -679,6 +680,9 @@ where
     }
     let mut live_catalog_nodes = BTreeSet::<[u8; 32]>::new();
     let mut live_current_state_directory_nodes = BTreeSet::<[u8; 32]>::new();
+    let mut live_current_state_data_parts = BTreeSet::<[u8; 32]>::new();
+    let mut live_current_state_ref_summaries = BTreeMap::<[u8; 32], [u8; 32]>::new();
+    let mut live_current_state_payload_hashes = BTreeSet::<[u8; 32]>::new();
     let mut catalog_roots = BTreeMap::new();
     let mut live_manifests = BTreeMap::new();
     let live_commit_ids = live_commits.iter().copied().collect::<Vec<_>>();
@@ -714,9 +718,7 @@ where
             .and_then(|parent_id| live_manifests.get(parent_id));
         crate::tracked_state::validate_current_state_catalog_parent_manifest(manifest, parent)?;
         crate::tracked_state::validate_current_state_catalog_transition_root(
-            store,
-            manifest,
-            parent.and_then(|parent| parent.current_state_catalog.as_deref()),
+            store, manifest, parent,
         )
         .await?;
     }
@@ -805,17 +807,87 @@ where
     live_current_state_directory_nodes.extend(directory_nodes);
     for descriptors in descriptor_sets {
         for descriptor in descriptors {
-            let owner = CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id));
-            if !packed.commits.contains_key(&owner) {
+            match descriptor.source_kind {
+                0 => {
+                    let owner = CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id));
+                    if !packed.commits.contains_key(&owner) {
+                        return Err(LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            format!(
+                                "live current-state directory references missing immutable-part owner '{owner}'"
+                            ),
+                        ));
+                    }
+                    retained_authority_commits.insert(owner);
+                }
+                1 => {
+                    live_current_state_data_parts.insert(descriptor.content_digest);
+                    if let Some(previous) = live_current_state_ref_summaries
+                        .insert(descriptor.content_digest, descriptor.payload_refs_digest)
+                        && previous != descriptor.payload_refs_digest
+                    {
+                        return Err(LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            "native current-state descriptors disagree about payload refs",
+                        ));
+                    }
+                }
+                _ => {
+                    return Err(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "live current-state directory contains an unknown part source",
+                    ));
+                }
+            }
+        }
+    }
+    let native_keys = live_current_state_ref_summaries
+        .keys()
+        .map(|digest| StorageKey(Bytes::copy_from_slice(digest)))
+        .collect::<Vec<_>>();
+    let native_refs = PointReadPlan::new(
+        crate::tracked_state::CURRENT_STATE_DATA_PART_REFS_SPACE,
+        &native_keys,
+    )
+    .materialize(store, StorageGetOptions::default())
+    .await?;
+    for ((_, refs_digest), value) in live_current_state_ref_summaries
+        .iter()
+        .zip(native_refs.value)
+    {
+        let bytes = match value {
+            Some(StorageProjectedValue::FullValue(bytes)) => bytes,
+            Some(StorageProjectedValue::KeyOnly) | None => {
                 return Err(LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
-                    format!(
-                        "live current-state directory references missing immutable-part owner '{owner}'"
-                    ),
+                    "live current-state directory references a missing payload-ref summary",
                 ));
             }
-            retained_authority_commits.insert(owner);
-        }
+        };
+        live_current_state_payload_hashes.extend(
+            crate::tracked_state::decode_current_state_data_part_refs(refs_digest, &bytes)?,
+        );
+    }
+    let native_part_presence = PointReadPlan::new(
+        crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
+        &native_keys,
+    )
+    .materialize(
+        store,
+        StorageGetOptions {
+            projection: StorageCoreProjection::KeyOnly,
+        },
+    )
+    .await?;
+    if native_part_presence
+        .value
+        .into_iter()
+        .any(|value| !matches!(value, Some(StorageProjectedValue::KeyOnly)))
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "live current-state directory references a missing native data part",
+        ));
     }
     if let Some((commit_id, source_commit_id)) = live_commits.iter().find_map(|commit_id| {
         packed
@@ -864,6 +936,7 @@ where
             GcRoot::BranchHead(_) | GcRoot::StandaloneChange(_) => None,
         })
         .collect::<BTreeSet<_>>();
+    live_payload_hashes.extend(live_current_state_payload_hashes);
     for change_id in &standalone_root_ids {
         collect_change_payload_hashes(
             standalone_changes
@@ -971,8 +1044,22 @@ where
     stage_sweep_unreachable_content_nodes(
         store,
         writes,
+        crate::tracked_state::CURRENT_STATE_DATA_PART_REFS_SPACE,
+        &live_current_state_data_parts,
+    )
+    .await?;
+    stage_sweep_unreachable_content_nodes(
+        store,
+        writes,
         crate::tracked_state::CURRENT_STATE_PART_DIRECTORY_SPACE,
         &live_current_state_directory_nodes,
+    )
+    .await?;
+    stage_sweep_unreachable_content_nodes(
+        store,
+        writes,
+        crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
+        &live_current_state_data_parts,
     )
     .await?;
     for commit_id in &sweep_authority_commits {
@@ -1289,6 +1376,8 @@ mod tests {
         for space in [
             crate::tracked_state::CURRENT_STATE_CATALOG_SPACE,
             crate::tracked_state::CURRENT_STATE_PART_DIRECTORY_SPACE,
+            crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
+            crate::tracked_state::CURRENT_STATE_DATA_PART_REFS_SPACE,
         ] {
             for node_id in [live_id, dead_id] {
                 writes.put(
@@ -1313,6 +1402,8 @@ mod tests {
         for space in [
             crate::tracked_state::CURRENT_STATE_CATALOG_SPACE,
             crate::tracked_state::CURRENT_STATE_PART_DIRECTORY_SPACE,
+            crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
+            crate::tracked_state::CURRENT_STATE_DATA_PART_REFS_SPACE,
         ] {
             super::stage_sweep_unreachable_content_nodes(&read, &mut sweep, space, &live)
                 .await
@@ -1334,6 +1425,8 @@ mod tests {
         for space in [
             crate::tracked_state::CURRENT_STATE_CATALOG_SPACE,
             crate::tracked_state::CURRENT_STATE_PART_DIRECTORY_SPACE,
+            crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
+            crate::tracked_state::CURRENT_STATE_DATA_PART_REFS_SPACE,
         ] {
             let loaded = PointReadPlan::new(space, &keys)
                 .materialize(&read, StorageGetOptions::default())

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -51,7 +51,7 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::mutable(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"persistent-current-state-catalog.v49";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"sparse-current-state-parts.v50";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately

--- a/packages/engine/src/json_store/types.rs
+++ b/packages/engine/src/json_store/types.rs
@@ -248,6 +248,13 @@ pub(crate) mod json_slot_storage {
 
     use super::{JsonRef, JsonSlot};
 
+    pub(crate) fn encode<E>(value: &JsonSlot, encoder: E) -> Result<(), E::Error>
+    where
+        E: musli::Encoder,
+    {
+        super::json_slot_storage_ref::encode(&value.as_ref_slot(), encoder)
+    }
+
     pub(crate) fn decode<'de, D>(decoder: D) -> Result<JsonSlot, D::Error>
     where
         D: musli::Decoder<'de>,

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -7640,6 +7640,29 @@ mod tests {
             )
             .await
             .unwrap();
+        let mixed_hot_cold = session
+            .execute(
+                "SELECT path, value FROM packed_replacement_probe \
+                 WHERE path IN ('/00000', '/16000') ORDER BY path",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(mixed_hot_cold.len(), 2);
+        assert_eq!(
+            mixed_hot_cold.rows()[0]
+                .get::<serde_json::Value>("value")
+                .unwrap(),
+            serde_json::json!({"overlay": true}),
+            "a mixed exact batch must retain the head-delta hit"
+        );
+        assert_eq!(
+            mixed_hot_cold.rows()[1]
+                .get::<serde_json::Value>("value")
+                .unwrap(),
+            serde_json::json!({"second": 16_000}),
+            "a mixed exact batch must resolve its cold key from inherited current state"
+        );
         session
             .execute(
                 "DELETE FROM packed_replacement_probe WHERE path = '/32767'",
@@ -7752,6 +7775,60 @@ mod tests {
                 .created_at(),
             reinserted_created_at,
             "full updates must preserve the newer lifecycle of a reinserted identity"
+        );
+
+        let read = session
+            .storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .unwrap();
+        let native = crate::storage_adapter::ScanPlan::prefix(
+            crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
+            crate::storage_adapter::StoragePrefix {
+                bytes: bytes::Bytes::new(),
+            },
+        )
+        .collect(
+            &read,
+            crate::storage_adapter::StorageScanOptions {
+                projection: crate::storage_adapter::StorageCoreProjection::KeyOnly,
+                limit_rows: 1,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let native_key = native
+            .value
+            .entries
+            .first()
+            .expect("sparse descendants must publish a native current-state part")
+            .key
+            .clone();
+        drop(read);
+        let mut corrupt = session.storage.new_write_set();
+        corrupt.delete(
+            crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
+            native_key,
+        );
+        session
+            .storage
+            .commit_write_set(corrupt, StorageWriteOptions::default())
+            .await
+            .unwrap();
+        let read = SharedStorageAdapterRead::new(
+            session
+                .storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .unwrap(),
+        );
+        let mut gc_writes = session.storage.new_write_set();
+        assert!(
+            crate::gc::stage_repository_gc(read, &mut gc_writes)
+                .await
+                .is_err(),
+            "GC must fail closed before sweeping when a live native part is missing"
         );
     }
 

--- a/packages/engine/src/tracked_state/bench_support.rs
+++ b/packages/engine/src/tracked_state/bench_support.rs
@@ -5,8 +5,8 @@ use crate::json_store::{
 };
 use crate::storage_adapter::Storage;
 use crate::storage_adapter::{
-    SharedStorageAdapterRead, StorageAdapter, StorageReadOptions, StorageWriteOptions,
-    StorageWriteSet, StorageWriteSetStats,
+    SharedStorageAdapterRead, StorageAdapter, StorageAdapterRead, StorageReadOptions,
+    StorageWriteOptions, StorageWriteSet, StorageWriteSetStats,
 };
 use crate::tracked_state::{
     CommitStateManifest, CommitStateReplayDebt, TrackedStateCommitDeltaRef, TrackedStateContext,
@@ -68,7 +68,20 @@ pub struct BenchTrackedFixture<StorageImpl: Storage> {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BenchCurrentStatePointMode {
     PersistentCatalog,
+    CatalogThenReplay,
     FirstParentReplay,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BenchCurrentStateSparseShape {
+    UnrelatedScopes,
+    TouchedScope,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BenchCurrentStatePointTarget {
+    ColdUntouched,
+    HotMutated,
 }
 
 #[expect(missing_debug_implementations)]
@@ -81,6 +94,12 @@ pub struct BenchCurrentStatePointFixture<StorageImpl: Storage> {
     catalog_manifest_bytes: u64,
     replay_manifest_bytes: u64,
     catalog_staged_encoded_bytes: u64,
+    directory_staged_encoded_bytes: u64,
+    sparse_staged_puts: u64,
+    sparse_written_bytes: u64,
+    first_sparse_elapsed_nanos: u64,
+    first_sparse_staged_puts: u64,
+    first_sparse_written_bytes: u64,
 }
 
 pub async fn seed_current_state_point_fixture<StorageImpl>(
@@ -88,6 +107,8 @@ pub async fn seed_current_state_point_fixture<StorageImpl>(
     replacement_rows: usize,
     unrelated_sparse_commits: usize,
     catalog_entry_count: usize,
+    sparse_shape: BenchCurrentStateSparseShape,
+    point_target: BenchCurrentStatePointTarget,
 ) -> BenchCurrentStatePointFixture<StorageImpl>
 where
     StorageImpl: Storage,
@@ -95,6 +116,7 @@ where
     assert!(replacement_rows > 0);
     assert!(catalog_entry_count > 0);
     let _ = crate::storage_bench::take_crud_current_state_catalog_bytes();
+    let _ = crate::storage_bench::take_crud_current_state_directory_bytes();
     let created_at = crate::common::LixTimestamp::from_unix_millis_utc_lossy(11);
     let updated_at = crate::common::LixTimestamp::from_unix_millis_utc_lossy(22);
     let parent_id = bench_addressable_commit_id("persistent-catalog-parent");
@@ -342,11 +364,20 @@ where
     let mut commits = vec![replay_base_id];
     let mut catalog_manifest_bytes = 0u64;
     let mut replay_manifest_bytes = 0u64;
+    let mut sparse_staged_puts = 0u64;
+    let mut sparse_written_bytes = 0u64;
+    let mut first_sparse_elapsed_nanos = 0u64;
+    let mut first_sparse_staged_puts = 0u64;
+    let mut first_sparse_written_bytes = 0u64;
     let beta_pk = EntityPk::single("unrelated");
     for index in 0..unrelated_sparse_commits {
+        let sparse_started = Instant::now();
         let commit_id = bench_addressable_commit_id(&format!("catalog-child-{index}"));
-        let present_scope = catalog_entry_count > 1 && index % 4 == 0;
-        let schema_key = if present_scope {
+        let touches_alpha = sparse_shape == BenchCurrentStateSparseShape::TouchedScope;
+        let present_scope = !touches_alpha && catalog_entry_count > 1 && index % 4 == 0;
+        let schema_key = if touches_alpha {
+            "bench_current_state_alpha".to_string()
+        } else if present_scope {
             format!("bench_scope_{:08}", 1 + index % (catalog_entry_count - 1))
         } else {
             "bench_current_state_beta".to_string()
@@ -357,11 +388,16 @@ where
                 (1 + index % (catalog_entry_count - 1)) % 10_000
             )
         });
+        let sparse_pk = if touches_alpha {
+            &entity_pks[replacement_rows / 4]
+        } else {
+            &beta_pk
+        };
         let row = TrackedStateCommitDeltaRef {
             delta: TrackedStateDeltaRef {
                 schema_key: &schema_key,
                 file_id: file_id.as_deref(),
-                entity_pk: &beta_pk,
+                entity_pk: sparse_pk,
                 change_id: ChangeId::for_test_label(&format!("catalog-child-change-{index}")),
                 commit_id,
                 deleted: false,
@@ -426,14 +462,29 @@ where
             &publication,
         )
         .expect("stage benchmark sparse manifest");
-        storage
+        let (_, stats) = storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
             .expect("commit benchmark sparse child");
+        sparse_staged_puts += stats.staged_puts;
+        sparse_written_bytes += stats.written_bytes;
+        if index == 0 {
+            first_sparse_elapsed_nanos =
+                u64::try_from(sparse_started.elapsed().as_nanos()).unwrap_or(u64::MAX);
+            first_sparse_staged_puts = stats.staged_puts;
+            first_sparse_written_bytes = stats.written_bytes;
+        }
         commits.push(commit_id);
     }
 
-    let target = &entity_pks[replacement_rows / 2];
+    let target_index = if sparse_shape == BenchCurrentStateSparseShape::TouchedScope
+        && point_target == BenchCurrentStatePointTarget::HotMutated
+    {
+        replacement_rows / 4
+    } else {
+        replacement_rows / 2
+    };
+    let target = &entity_pks[target_index];
     let encoded_key = bytes::Bytes::from(super::codec::encode_key_ref(
         super::types::TrackedStateKeyRef {
             schema_key: "bench_current_state_alpha",
@@ -450,6 +501,13 @@ where
         catalog_manifest_bytes,
         replay_manifest_bytes,
         catalog_staged_encoded_bytes: crate::storage_bench::take_crud_current_state_catalog_bytes(),
+        directory_staged_encoded_bytes:
+            crate::storage_bench::take_crud_current_state_directory_bytes(),
+        sparse_staged_puts,
+        sparse_written_bytes,
+        first_sparse_elapsed_nanos,
+        first_sparse_staged_puts,
+        first_sparse_written_bytes,
     }
 }
 
@@ -473,6 +531,30 @@ where
         self.catalog_staged_encoded_bytes
     }
 
+    pub fn directory_staged_encoded_bytes(&self) -> u64 {
+        self.directory_staged_encoded_bytes
+    }
+
+    pub fn sparse_staged_puts(&self) -> u64 {
+        self.sparse_staged_puts
+    }
+
+    pub fn sparse_written_bytes(&self) -> u64 {
+        self.sparse_written_bytes
+    }
+
+    pub fn first_sparse_elapsed_nanos(&self) -> u64 {
+        self.first_sparse_elapsed_nanos
+    }
+
+    pub fn first_sparse_staged_puts(&self) -> u64 {
+        self.first_sparse_staged_puts
+    }
+
+    pub fn first_sparse_written_bytes(&self) -> u64 {
+        self.first_sparse_written_bytes
+    }
+
     pub async fn read_point(&self, mode: BenchCurrentStatePointMode) -> usize {
         let read = self
             .storage
@@ -480,7 +562,22 @@ where
             .await
             .expect("begin benchmark current-state point read");
         match mode {
-            BenchCurrentStatePointMode::PersistentCatalog => {
+            BenchCurrentStatePointMode::PersistentCatalog
+            | BenchCurrentStatePointMode::CatalogThenReplay => {
+                if mode == BenchCurrentStatePointMode::CatalogThenReplay {
+                    let head = *self.commits.last().expect("benchmark has a head commit");
+                    let values = super::storage::load_commit_delta_values_encoded_with_cache(
+                        &read,
+                        head,
+                        std::slice::from_ref(&self.encoded_key),
+                        None,
+                    )
+                    .await
+                    .expect("probe benchmark head delta");
+                    if values[0].is_some() {
+                        return 1;
+                    }
+                }
                 let state = super::storage::load_published_commit_state_manifest(
                     &read,
                     self.current_manifest.commit_id,
@@ -488,34 +585,49 @@ where
                 .await
                 .expect("load benchmark current-state manifest")
                 .expect("benchmark current-state manifest exists");
-                let values =
+                let values = if mode == BenchCurrentStatePointMode::PersistentCatalog {
                     super::storage::load_complete_current_state_values_from_published_manifest(
                         &read,
                         &state,
                         std::slice::from_ref(&self.encoded_key),
                     )
                     .await
-                    .expect("read benchmark current-state catalog")
-                    .expect("benchmark point is covered");
-                usize::from(values[0].is_some())
-            }
-            BenchCurrentStatePointMode::FirstParentReplay => {
-                for commit_id in self.commits.iter().rev() {
-                    let values = super::storage::load_commit_delta_values_encoded_with_cache(
+                } else {
+                    super::storage::load_complete_current_state_values_from_replay_manifest(
                         &read,
-                        *commit_id,
+                        &state,
                         std::slice::from_ref(&self.encoded_key),
-                        None,
                     )
                     .await
-                    .expect("replay benchmark commit point");
-                    if values[0].is_some() {
-                        return 1;
-                    }
                 }
-                0
+                .expect("read benchmark current-state catalog");
+                if let Some(values) = values {
+                    return usize::from(values[0].is_some());
+                }
+                if mode == BenchCurrentStatePointMode::PersistentCatalog {
+                    panic!("benchmark point is not covered");
+                }
+                self.read_point_by_replay(&read).await
+            }
+            BenchCurrentStatePointMode::FirstParentReplay => self.read_point_by_replay(&read).await,
+        }
+    }
+
+    async fn read_point_by_replay(&self, read: &(impl StorageAdapterRead + ?Sized)) -> usize {
+        for commit_id in self.commits.iter().rev() {
+            let values = super::storage::load_commit_delta_values_encoded_with_cache(
+                read,
+                *commit_id,
+                std::slice::from_ref(&self.encoded_key),
+                None,
+            )
+            .await
+            .expect("replay benchmark commit point");
+            if values[0].is_some() {
+                return 1;
             }
         }
+        0
     }
 }
 
@@ -1373,3 +1485,4 @@ fn row_key(row: &BenchTrackedRow) -> TrackedStateKey {
         file_id: row.file_id.clone(),
     }
 }
+use std::time::Instant;

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -3193,15 +3193,78 @@ where
                 entity_pk: &key.entity_pk,
             });
         }
-        #[cfg(feature = "storage-benches")]
-        crate::storage_bench::record_crud_current_state_catalog_attempt();
-        match storage::load_complete_current_state_values_from_replay_manifest(
-            &self.store,
-            &head.state_manifest,
-            &encoded.finish(),
-        )
-        .await
-        {
+        let encoded = encoded.finish();
+        // The newest delta is the cheapest and most likely OLTP hit. Probe it
+        // once before the persistent post-image so hot keys never pay a
+        // catalog traversal, and retain the result for canonical replay.
+        let head_values = self
+            .load_replayed_commit_delta_values(requested_commit_id, keys)
+            .await?;
+        let cold_indices = head_values
+            .iter()
+            .enumerate()
+            .filter_map(|(index, value)| value.is_none().then_some(index))
+            .collect::<Vec<_>>();
+        if !cold_indices.is_empty() && cold_indices.len() != keys.len() {
+            let cold_encoded = cold_indices
+                .iter()
+                .map(|&index| encoded[index].clone())
+                .collect::<Vec<_>>();
+            #[cfg(feature = "storage-benches")]
+            crate::storage_bench::record_crud_current_state_catalog_attempt();
+            let cold_catalog = storage::load_complete_current_state_values_from_replay_manifest(
+                &self.store,
+                &head.state_manifest,
+                &cold_encoded,
+            )
+            .await;
+            #[cfg(feature = "storage-benches")]
+            let cold_catalog_error = cold_catalog.is_err();
+            if let Ok(Some(cold_values)) = cold_catalog {
+                let hot_indices = head_values
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(index, value)| value.is_some().then_some(index))
+                    .collect::<Vec<_>>();
+                let hot_keys = hot_indices
+                    .iter()
+                    .map(|&index| keys[index].clone())
+                    .collect::<Vec<_>>();
+                // Box the hot-only recursion so this async function keeps a
+                // finite future type. The recursive call cannot re-enter this
+                // mixed branch because every hot key matched the head delta.
+                let hot_values =
+                    Box::pin(self.resolve_rootless_index_values_at_commit(commit_id, &hot_keys))
+                        .await?;
+                let mut values = vec![None; keys.len()];
+                for (index, value) in cold_indices.into_iter().zip(cold_values) {
+                    values[index] = value;
+                }
+                for (index, value) in hot_indices.into_iter().zip(hot_values) {
+                    values[index] = value;
+                }
+                #[cfg(feature = "storage-benches")]
+                crate::storage_bench::record_crud_current_state_catalog_hit();
+                return Ok(values);
+            }
+            #[cfg(feature = "storage-benches")]
+            if cold_catalog_error {
+                crate::storage_bench::record_crud_current_state_catalog_error();
+            }
+        }
+        let catalog = if head_values.iter().all(Option::is_none) {
+            #[cfg(feature = "storage-benches")]
+            crate::storage_bench::record_crud_current_state_catalog_attempt();
+            storage::load_complete_current_state_values_from_replay_manifest(
+                &self.store,
+                &head.state_manifest,
+                &encoded,
+            )
+            .await
+        } else {
+            Ok(None)
+        };
+        match catalog {
             Ok(Some(values)) => {
                 #[cfg(feature = "storage-benches")]
                 crate::storage_bench::record_crud_current_state_catalog_hit();
@@ -3238,9 +3301,12 @@ where
         // generations instead carry their lifecycle timestamp explicitly.
         for &current_commit_id in interval.commits().iter().rev() {
             let replay_commit = self.load_point_replay_commit(current_commit_id).await?;
-            let deltas = self
-                .load_replayed_commit_delta_values(current_commit_id, keys)
-                .await?;
+            let deltas = if current_commit_id == requested_commit_id {
+                head_values.clone()
+            } else {
+                self.load_replayed_commit_delta_values(current_commit_id, keys)
+                    .await?
+            };
             let descriptor_deltas = self
                 .load_replayed_commit_delta_values(current_commit_id, &descriptor_keys)
                 .await?;

--- a/packages/engine/src/tracked_state/current_state_data_part.rs
+++ b/packages/engine/src/tracked_state/current_state_data_part.rs
@@ -1,0 +1,324 @@
+//! Content-addressed immutable post-image parts for sparse current-state rewrites.
+//!
+//! Unlike complete-replacement parts, these rows retain exact per-row provenance
+//! and lifecycle timestamps because a sparse post-image may mix many authoring
+//! commits. Mutation inventory remains the historical authority; this payload is
+//! a rebuildable serving accelerator.
+
+use std::borrow::Cow;
+
+use bytes::Bytes;
+
+use crate::json_store::JsonSlot;
+use crate::storage_adapter::{StorageSpace, StorageSpaceId};
+use crate::tracked_state::codec::decode_value;
+use crate::tracked_state::types::TrackedStateIndexValue;
+use crate::{LixError, storage_codec};
+
+pub(crate) const CURRENT_STATE_DATA_PART_SPACE: StorageSpace = StorageSpace::immutable(
+    StorageSpaceId(0x0004_002f),
+    "tracked_state.current_state_data_part.v1",
+);
+pub(crate) const CURRENT_STATE_DATA_PART_REFS_SPACE: StorageSpace = StorageSpace::immutable(
+    StorageSpaceId(0x0004_0030),
+    "tracked_state.current_state_data_part_refs.v1",
+);
+
+pub(crate) const CURRENT_STATE_DATA_PART_MAX_ROWS: usize = 512;
+pub(crate) const CURRENT_STATE_DATA_PART_TARGET_BYTES: usize = 64 * 1024;
+const CURRENT_STATE_DATA_PART_MAX_BYTES: usize = 4 * 1024 * 1024;
+const CURRENT_STATE_DATA_PART_MAX_DECODED_BYTES: usize = 16 * 1024 * 1024;
+const RAW_MAGIC: &[u8; 7] = b"LXCSP01";
+const ZSTD_MAGIC: &[u8; 7] = b"LXCSPZ1";
+const DIGEST_CONTEXT: &str = "lix native current-state data part v1";
+const REFS_DIGEST_CONTEXT: &str = "lix native current-state data part refs v1";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CurrentStateDataRow {
+    pub(crate) encoded_key: Vec<u8>,
+    pub(crate) value: TrackedStateIndexValue,
+    pub(crate) snapshot: JsonSlot,
+    pub(crate) metadata: JsonSlot,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+struct StoredCurrentStateDataRow {
+    #[musli(bytes)]
+    encoded_key: Vec<u8>,
+    #[musli(bytes)]
+    encoded_value: Vec<u8>,
+    #[musli(with = crate::json_store::json_slot_storage)]
+    snapshot: JsonSlot,
+    #[musli(with = crate::json_store::json_slot_storage)]
+    metadata: JsonSlot,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct EncodedCurrentStateDataPart {
+    pub(crate) digest: [u8; 32],
+    pub(crate) bytes: Bytes,
+    pub(crate) first_key: Vec<u8>,
+    pub(crate) last_key: Vec<u8>,
+    pub(crate) row_count: u16,
+    pub(crate) refs_digest: [u8; 32],
+    pub(crate) refs_bytes: Bytes,
+}
+
+pub(crate) fn encode_current_state_data_part(
+    rows: &[CurrentStateDataRow],
+    compressor: &mut Option<crate::compression::ZstdLevel1Compressor>,
+) -> Result<EncodedCurrentStateDataPart, LixError> {
+    validate_rows(rows)?;
+    let stored = rows
+        .iter()
+        .map(|row| StoredCurrentStateDataRow {
+            encoded_key: row.encoded_key.clone(),
+            encoded_value: super::codec::encode_value_ref(
+                super::types::TrackedStateIndexValueRef {
+                    change_id: row.value.change_id,
+                    commit_id: row.value.commit_id,
+                    deleted: row.value.deleted,
+                    created_at: row.value.created_at,
+                    updated_at: row.value.updated_at,
+                },
+            ),
+            snapshot: row.snapshot.clone(),
+            metadata: row.metadata.clone(),
+        })
+        .collect::<Vec<_>>();
+    let payload = storage_codec::encode("native current-state data part", &stored)?;
+    if payload.len() > CURRENT_STATE_DATA_PART_MAX_DECODED_BYTES {
+        return Err(part_error("decoded payload exceeds its bound"));
+    }
+    let mut encoded = Vec::with_capacity(RAW_MAGIC.len() + payload.len());
+    encoded.extend_from_slice(RAW_MAGIC);
+    encoded.extend_from_slice(&payload);
+    if payload.len() >= 512 {
+        if compressor.is_none() {
+            *compressor = Some(
+                crate::compression::ZstdLevel1Compressor::new()
+                    .map_err(|error| part_error(format!("compressor init failed: {error}")))?,
+            );
+        }
+        let compressed = compressor
+            .as_mut()
+            .expect("compressor was initialized")
+            .compress(&payload)
+            .map_err(|error| part_error(format!("compression failed: {error}")))?;
+        let mut physical = Vec::with_capacity(ZSTD_MAGIC.len() + 4 + compressed.len());
+        physical.extend_from_slice(ZSTD_MAGIC);
+        physical.extend_from_slice(
+            &u32::try_from(payload.len())
+                .map_err(|_| part_error("decoded length exceeds u32"))?
+                .to_be_bytes(),
+        );
+        physical.extend_from_slice(&compressed);
+        if physical.len() < encoded.len() {
+            encoded = physical;
+        }
+    }
+    if encoded.len() > CURRENT_STATE_DATA_PART_MAX_BYTES {
+        return Err(part_error("physical payload exceeds its bound"));
+    }
+    let digest = digest(&encoded);
+    let mut refs = rows
+        .iter()
+        .flat_map(|row| [&row.snapshot, &row.metadata])
+        .filter_map(|slot| match slot {
+            JsonSlot::Ref(reference) => Some(*reference.as_hash_array()),
+            JsonSlot::None | JsonSlot::Inline(_) => None,
+        })
+        .collect::<Vec<_>>();
+    refs.sort_unstable();
+    refs.dedup();
+    let refs_bytes = storage_codec::encode("native current-state data part refs", &refs)?;
+    let refs_digest = refs_digest(&refs_bytes);
+    Ok(EncodedCurrentStateDataPart {
+        digest,
+        bytes: Bytes::from(encoded),
+        first_key: rows.first().expect("validated rows").encoded_key.clone(),
+        last_key: rows.last().expect("validated rows").encoded_key.clone(),
+        row_count: u16::try_from(rows.len()).expect("native part row count is bounded"),
+        refs_digest,
+        refs_bytes: Bytes::from(refs_bytes),
+    })
+}
+
+pub(crate) fn decode_current_state_data_part_refs(
+    expected_digest: &[u8; 32],
+    encoded: &[u8],
+) -> Result<Vec<[u8; 32]>, LixError> {
+    if &refs_digest(encoded) != expected_digest {
+        return Err(part_error("payload-ref summary digest is invalid"));
+    }
+    let refs: Vec<[u8; 32]> =
+        storage_codec::decode("native current-state data part refs", encoded)?;
+    if refs.len() > CURRENT_STATE_DATA_PART_MAX_ROWS * 2
+        || refs.windows(2).any(|pair| pair[0] >= pair[1])
+    {
+        return Err(part_error("payload-ref summary is oversized or unordered"));
+    }
+    Ok(refs)
+}
+
+pub(crate) fn encode_bounded_current_state_data_parts(
+    rows: &[CurrentStateDataRow],
+) -> Result<Vec<EncodedCurrentStateDataPart>, LixError> {
+    let mut compressor = None;
+    let mut encoded = Vec::new();
+    let mut offset = 0usize;
+    while offset < rows.len() {
+        let mut count = (rows.len() - offset).min(CURRENT_STATE_DATA_PART_MAX_ROWS);
+        let part = loop {
+            let part =
+                encode_current_state_data_part(&rows[offset..offset + count], &mut compressor)?;
+            if part.bytes.len() <= CURRENT_STATE_DATA_PART_TARGET_BYTES || count == 1 {
+                break part;
+            }
+            count = count.div_ceil(2);
+        };
+        encoded.push(part);
+        offset += count;
+    }
+    Ok(encoded)
+}
+
+pub(crate) fn decode_current_state_data_part(
+    expected_digest: &[u8; 32],
+    encoded: &[u8],
+) -> Result<Vec<CurrentStateDataRow>, LixError> {
+    if encoded.len() > CURRENT_STATE_DATA_PART_MAX_BYTES || &digest(encoded) != expected_digest {
+        return Err(part_error("content digest or physical bound is invalid"));
+    }
+    let payload: Cow<'_, [u8]> = if let Some(payload) = encoded.strip_prefix(RAW_MAGIC) {
+        Cow::Borrowed(payload)
+    } else if let Some(body) = encoded.strip_prefix(ZSTD_MAGIC) {
+        let (decoded_len, compressed) = body
+            .split_at_checked(4)
+            .ok_or_else(|| part_error("compressed payload is truncated"))?;
+        let decoded_len = usize::try_from(u32::from_be_bytes(
+            decoded_len.try_into().expect("fixed decoded length"),
+        ))
+        .expect("u32 fits usize");
+        if decoded_len > CURRENT_STATE_DATA_PART_MAX_DECODED_BYTES {
+            return Err(part_error("compressed payload exceeds its decoded bound"));
+        }
+        Cow::Owned(
+            crate::compression::decompress_zstd(compressed, decoded_len)
+                .map_err(|error| part_error(format!("decompression failed: {error}")))?,
+        )
+    } else {
+        return Err(part_error("unsupported format; recreate the repository"));
+    };
+    let stored: Vec<StoredCurrentStateDataRow> =
+        storage_codec::decode("native current-state data part", &payload)?;
+    let rows = stored
+        .into_iter()
+        .map(|row| {
+            Ok(CurrentStateDataRow {
+                encoded_key: row.encoded_key,
+                value: decode_value(&row.encoded_value)?,
+                snapshot: row.snapshot,
+                metadata: row.metadata,
+            })
+        })
+        .collect::<Result<Vec<_>, LixError>>()?;
+    validate_rows(&rows)?;
+    Ok(rows)
+}
+
+fn validate_rows(rows: &[CurrentStateDataRow]) -> Result<(), LixError> {
+    if rows.is_empty()
+        || rows.len() > CURRENT_STATE_DATA_PART_MAX_ROWS
+        || rows
+            .iter()
+            .any(|row| row.encoded_key.is_empty() || row.value.deleted || row.snapshot.is_none())
+        || rows
+            .windows(2)
+            .any(|pair| pair[0].encoded_key >= pair[1].encoded_key)
+    {
+        return Err(part_error(
+            "rows are empty, deleted, oversized, or unordered",
+        ));
+    }
+    Ok(())
+}
+
+fn digest(encoded: &[u8]) -> [u8; 32] {
+    *blake3::Hasher::new_derive_key(DIGEST_CONTEXT)
+        .update(encoded)
+        .finalize()
+        .as_bytes()
+}
+
+fn refs_digest(encoded: &[u8]) -> [u8; 32] {
+    *blake3::Hasher::new_derive_key(REFS_DIGEST_CONTEXT)
+        .update(encoded)
+        .finalize()
+        .as_bytes()
+}
+
+fn part_error(message: impl std::fmt::Display) -> LixError {
+    LixError::new(
+        LixError::CODE_INTERNAL_ERROR,
+        format!("tracked_state native current-state data part {message}"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::changelog::{ChangeId, CommitId};
+    use crate::common::LixTimestamp;
+
+    fn row(index: usize) -> CurrentStateDataRow {
+        CurrentStateDataRow {
+            encoded_key: format!("key-{index:04}").into_bytes(),
+            value: TrackedStateIndexValue {
+                change_id: ChangeId::for_test_label(&format!("native-change-{index}")),
+                commit_id: CommitId::for_test_label(&format!("native-commit-{index}")),
+                deleted: false,
+                created_at: LixTimestamp::from_unix_millis_utc_lossy(index as i64),
+                updated_at: LixTimestamp::from_unix_millis_utc_lossy(index as i64 + 1),
+            },
+            snapshot: JsonSlot::Inline(format!(r#"{{"index":{index}}}"#).into()),
+            metadata: JsonSlot::None,
+        }
+    }
+
+    #[test]
+    fn native_parts_round_trip_exact_provenance_and_reject_corruption() {
+        let mut rows = (0..513).map(row).collect::<Vec<_>>();
+        let referenced = crate::json_store::JsonRef::for_content(b"native referenced metadata");
+        rows[0].metadata = JsonSlot::Ref(referenced);
+        let parts = encode_bounded_current_state_data_parts(&rows).expect("parts should encode");
+        assert_eq!(parts.len(), 2, "row bound must split the post-image");
+        let decoded = parts
+            .iter()
+            .flat_map(|part| {
+                decode_current_state_data_part(&part.digest, &part.bytes)
+                    .expect("part should decode")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(decoded, rows);
+        assert_eq!(
+            decode_current_state_data_part_refs(&parts[0].refs_digest, &parts[0].refs_bytes)
+                .expect("payload refs should decode"),
+            vec![*referenced.as_hash_array()]
+        );
+
+        let mut corrupt = parts[0].bytes.to_vec();
+        *corrupt.last_mut().expect("encoded part is non-empty") ^= 1;
+        assert!(decode_current_state_data_part(&parts[0].digest, &corrupt).is_err());
+    }
+
+    #[test]
+    fn native_parts_reject_tombstones_and_unordered_rows() {
+        let mut rows = vec![row(1), row(0)];
+        assert!(encode_bounded_current_state_data_parts(&rows).is_err());
+        rows.sort_by(|left, right| left.encoded_key.cmp(&right.encoded_key));
+        rows[0].value.deleted = true;
+        assert!(encode_bounded_current_state_data_parts(&rows).is_err());
+    }
+}

--- a/packages/engine/src/tracked_state/current_state_part.rs
+++ b/packages/engine/src/tracked_state/current_state_part.rs
@@ -42,6 +42,7 @@ const CURRENT_STATE_LINEAGE_CONTEXT: &str = "lix current-state lineage v1";
 const CATALOG_TRANSITION_CONTEXT: &str = "lix current-state catalog transition v1";
 const CATALOG_LEAF_MAX_ENTRIES: usize = 128;
 const CATALOG_MAX_KEY_BYTES: usize = 64 * 1024;
+const CURRENT_STATE_DESCRIPTOR_DIGEST_CONTEXT: &str = "lix current-state descriptor set v1";
 
 /// Publishes the serving directory for a certified complete replacement.
 /// Ordinary mutation inventories are not state partitions and return `None`.
@@ -63,7 +64,6 @@ pub(crate) fn stage_complete_replacement_current_state_part_set(
             "replacement generation has no complete directly-addressable part set",
         ));
     }
-    let mut first_ordinal = 0u32;
     let descriptors = inventory
         .parts
         .iter()
@@ -77,29 +77,32 @@ pub(crate) fn stage_complete_replacement_current_state_part_set(
                 first_key: bounds.first_key.clone(),
                 last_key: bounds.last_key.clone(),
                 content_digest: part.content_digest,
+                payload_refs_digest: [0; 32],
+                source_kind: 0,
                 owner_commit_id: part.owner_commit_id,
                 part_index: u32::try_from(part_index)
                     .map_err(|_| directory_error("part index overflows u32"))?,
-                first_ordinal,
+                source_row_offset: 0,
                 row_count,
                 uniform_created_at: part.uniform_created_at,
                 uniform_updated_at: part.uniform_updated_at,
             };
-            first_ordinal = first_ordinal
-                .checked_add(u32::from(row_count))
-                .ok_or_else(|| directory_error("row ordinal overflows u32"))?;
             Ok(descriptor)
         })
         .collect::<Result<Vec<_>, LixError>>()?;
-    let directory = stage_current_state_part_directory(writes, &descriptors)?;
+    let mut directory = stage_current_state_part_directory(writes, &descriptors)?;
     if directory.row_count != u64::from(inventory.member_count)
-        || directory.descriptor_digest != authority_digest
+        || replacement_directory_digest(&descriptors)? != authority_digest
         || initial_generation.owner_commit_id != *commit_id.as_uuid().as_bytes()
     {
         return Err(directory_error(
             "replacement state set disagrees with its commit authority",
         ));
     }
+    // The first complete generation retains the historical replacement
+    // certificate digest. Sparse descendants use the generic descriptor-set
+    // digest because they may mix replacement and native sources.
+    directory.descriptor_digest = authority_digest;
     let generation = initial_generation.clone();
     let state_lineage_digest =
         fresh_current_state_lineage_digest(commit_id, generation.integrity_digest, &directory);
@@ -286,8 +289,27 @@ pub(super) async fn stage_current_state_catalog(
         {
             continue;
         }
-        root =
-            update_catalog_entry(store, writes, &mut staged, root.as_ref(), &scope, None).await?;
+        let rewritten = if let Some(parent_root) = parent_root {
+            match load_current_state_catalog_entry_for_write(store, writes, parent_root, &scope)
+                .await?
+            {
+                Some(parent_entry) => {
+                    crate::tracked_state::storage::stage_sparse_current_state_part_set(
+                        store,
+                        writes,
+                        &parent_entry,
+                        commit_id,
+                        inventory,
+                    )
+                    .await?
+                }
+                None => None,
+            }
+        } else {
+            None
+        };
+        root = update_catalog_entry(store, writes, &mut staged, root.as_ref(), &scope, rewritten)
+            .await?;
     }
     let anchor = replacement.as_ref().map(coverage_anchor_from_entry);
     if let Some(entry) = replacement {
@@ -322,11 +344,29 @@ pub(super) async fn stage_current_state_catalog(
 pub(crate) async fn validate_current_state_catalog_transition_root(
     store: &(impl StorageAdapterRead + ?Sized),
     state: &CommitStateManifest,
-    parent: Option<&CurrentStateCatalogRoot>,
+    parent: Option<&CommitStateManifest>,
 ) -> Result<(), LixError> {
     if state.current_state_catalog.is_none() {
         return Ok(());
     }
+    if state.current_state_coverage_anchor.is_none() {
+        let mut writes = StorageWriteSet::new();
+        let expected = stage_current_state_catalog(
+            store,
+            &mut writes,
+            parent,
+            state.commit_id,
+            &state.mutations,
+        )
+        .await?;
+        if expected.root.as_ref() != state.current_state_catalog.as_deref() {
+            return Err(directory_error(
+                "sparse catalog result is not the canonical parent mutation transition",
+            ));
+        }
+        return Ok(());
+    }
+    let parent = parent.and_then(|parent| parent.current_state_catalog.as_deref());
     let replacement =
         state
             .current_state_coverage_anchor
@@ -1017,6 +1057,62 @@ pub(crate) async fn load_current_state_catalog_entry(
     }
 }
 
+async fn load_current_state_catalog_entry_for_write(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    root: &CurrentStateCatalogRoot,
+    scope: &crate::tracked_state::types::CommitDeltaReplacementScope,
+) -> Result<Option<CurrentStatePartSet>, LixError> {
+    let route_key = catalog_scope_key(scope)?;
+    let mut expected_count = root.entry_count;
+    let mut minimum_depth = 0u32;
+    let mut expected_route: Option<(usize, Vec<u8>)> = None;
+    let mut node_id = root.root_id;
+    loop {
+        let staged = writes.staged_value(CURRENT_STATE_CATALOG_SPACE, &node_id);
+        let node = load_catalog_node_with_staged(store, None, staged, node_id).await?;
+        if node.entry_count()? != expected_count
+            || node.depth < minimum_depth
+            || (minimum_depth == 0 && node.depth != 0)
+        {
+            return Err(directory_error("catalog node summary mismatch"));
+        }
+        if let Some((parent_depth, route)) = expected_route.take() {
+            let child_depth = usize::try_from(node.depth).expect("u32 fits usize");
+            if child_depth > node.sample_key.len()
+                || node.sample_key.get(parent_depth..child_depth) != Some(route.as_slice())
+            {
+                return Err(directory_error("catalog child route mismatch"));
+            }
+        }
+        if node.children.is_empty() {
+            return Ok(node
+                .entries
+                .binary_search_by(|entry| entry.scope.cmp(scope))
+                .ok()
+                .map(|index| node.entries[index].clone()));
+        }
+        let depth = usize::try_from(node.depth).expect("u32 fits usize");
+        let selector = *route_key
+            .get(depth)
+            .ok_or_else(|| directory_error("catalog exceeds its hash depth"))?;
+        let Ok(index) = node
+            .children
+            .binary_search_by_key(&selector, |child| child.route[0])
+        else {
+            return Ok(None);
+        };
+        let child = &node.children[index];
+        if route_key.get(depth..depth + child.route.len()) != Some(child.route.as_slice()) {
+            return Ok(None);
+        }
+        node_id = child.node_id;
+        expected_count = child.entry_count;
+        minimum_depth = node.depth.saturating_add(1);
+        expected_route = Some((depth, child.route.clone()));
+    }
+}
+
 /// Resolves catalog scopes in caller order while reading each shared trie node
 /// at most once. Each frontier is issued as one storage point-read batch.
 pub(crate) async fn load_current_state_catalog_entries_for_scopes(
@@ -1391,6 +1487,66 @@ pub(crate) async fn load_current_state_part_directory_reachability(
     Ok((nodes, descriptor_sets.pop().unwrap_or_default()))
 }
 
+pub(crate) async fn load_current_state_part_directory_reachability_for_write(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    root: &CurrentStatePartDirectoryRoot,
+) -> Result<
+    (
+        std::collections::BTreeSet<[u8; 32]>,
+        Vec<CurrentStatePartDescriptor>,
+    ),
+    LixError,
+> {
+    if root.part_count == 0 {
+        validate_empty_root(root)?;
+        return Ok((std::collections::BTreeSet::new(), Vec::new()));
+    }
+    let mut pending = vec![(root.root_id, None)];
+    let mut node_ids = std::collections::BTreeSet::new();
+    let mut descriptors = Vec::with_capacity(root.part_count as usize);
+    while let Some((node_id, expected_child)) = pending.pop() {
+        if !node_ids.insert(node_id) {
+            return Err(directory_error(
+                "part directory contains a cycle or duplicate child",
+            ));
+        }
+        let staged = writes.staged_value(CURRENT_STATE_PART_DIRECTORY_SPACE, &node_id);
+        let node = if let Some(bytes) = staged {
+            if node_digest(&bytes) != node_id {
+                return Err(directory_error("node content digest mismatch"));
+            }
+            decode_node(&bytes)?
+        } else {
+            load_node(store, node_id).await?
+        };
+        if expected_child.is_none() {
+            validate_root_summary(root, &node)?;
+        }
+        if let Some(expected) = expected_child.as_ref() {
+            validate_child_summary(expected, &node)?;
+        }
+        if node.kind == 0 {
+            descriptors.extend(node.parts);
+        } else {
+            pending.extend(
+                node.children
+                    .into_iter()
+                    .rev()
+                    .map(|child| (child.node_id, Some(child))),
+            );
+        }
+    }
+    descriptors.sort_by(|left, right| left.first_key.cmp(&right.first_key));
+    validate_descriptors(&descriptors)?;
+    if descriptors.len() != root.part_count as usize
+        || !descriptor_digest_matches(root, &descriptors)?
+    {
+        return Err(directory_error("part directory reachability mismatch"));
+    }
+    Ok((node_ids, descriptors))
+}
+
 pub(crate) async fn load_current_state_part_directory_reachability_many(
     store: &(impl StorageAdapterRead + ?Sized),
     roots: &[CurrentStatePartDirectoryRoot],
@@ -1404,6 +1560,10 @@ pub(crate) async fn load_current_state_part_directory_reachability_many(
     let mut frontier =
         std::collections::BTreeMap::<[u8; 32], Vec<(usize, Option<DirectoryChild>)>>::new();
     for (root_index, root) in roots.iter().enumerate() {
+        if root.part_count == 0 {
+            validate_empty_root(root)?;
+            continue;
+        }
         frontier
             .entry(root.root_id)
             .or_default()
@@ -1458,12 +1618,16 @@ pub(crate) async fn load_current_state_part_directory_reachability_many(
         frontier = next;
     }
     for (root, descriptors) in roots.iter().zip(&mut descriptor_sets) {
+        if root.part_count == 0 {
+            validate_empty_root(root)?;
+            continue;
+        }
         // Frontier batching is content-ID ordered, so normalize the
         // caller-visible descriptor sequence before semantic validation.
         descriptors.sort_by(|left, right| left.first_key.cmp(&right.first_key));
         validate_descriptors(descriptors)?;
         if descriptors.len() != root.part_count as usize
-            || replacement_directory_digest(descriptors)? != root.descriptor_digest
+            || !descriptor_digest_matches(root, descriptors)?
         {
             return Err(directory_error("part directory reachability mismatch"));
         }
@@ -1473,6 +1637,7 @@ pub(crate) async fn load_current_state_part_directory_reachability_many(
 
 fn validate_catalog_node(node: &CatalogNode) -> Result<(), LixError> {
     let depth = usize::try_from(node.depth).expect("u32 fits usize");
+    let empty_descriptor_digest = current_state_descriptor_digest(&[])?;
     if depth > CATALOG_MAX_KEY_BYTES
         || node.sample_key.len() > CATALOG_MAX_KEY_BYTES
         || node.sample_key.len() < depth
@@ -1484,15 +1649,21 @@ fn validate_catalog_node(node: &CatalogNode) -> Result<(), LixError> {
             .windows(2)
             .any(|pair| pair[0].scope >= pair[1].scope)
         || node.entries.iter().any(|entry| {
+            let valid_empty_directory = entry.directory.root_id == [0; 32]
+                && entry.directory.descriptor_digest == empty_descriptor_digest
+                && entry.directory.row_count == 0
+                && entry.directory.part_count == 0
+                && entry.directory.tree_height == 0;
+            let valid_nonempty_directory = entry.directory.root_id != [0; 32]
+                && entry.directory.descriptor_digest != [0; 32]
+                && entry.directory.row_count > 0
+                && entry.directory.part_count > 0
+                && entry.directory.tree_height > 0;
             entry.scope.schema_key.is_empty()
                 || entry.coverage_anchor_commit_id == [0; 16]
                 || entry.generation_integrity_digest == [0; 32]
                 || entry.state_lineage_digest == [0; 32]
-                || entry.directory.root_id == [0; 32]
-                || entry.directory.descriptor_digest == [0; 32]
-                || entry.directory.row_count == 0
-                || entry.directory.part_count == 0
-                || entry.directory.tree_height == 0
+                || !(valid_empty_directory || valid_nonempty_directory)
         })
         || node
             .children
@@ -1609,22 +1780,52 @@ pub(crate) fn stage_current_state_part_directory(
     writes: &mut StorageWriteSet,
     descriptors: &[CurrentStatePartDescriptor],
 ) -> Result<CurrentStatePartDirectoryRoot, LixError> {
+    stage_current_state_part_directory_reusing(
+        writes,
+        descriptors,
+        &std::collections::BTreeSet::new(),
+    )
+}
+
+/// Rebuilds the logical directory while retaining all content-identical nodes
+/// already reachable from the parent root. When descriptor cardinality stays
+/// stable, leaf chunking stages only changed leaves and their ancestors. A
+/// fully key-addressed range splice is deliberately left to the next cut.
+pub(crate) fn stage_current_state_part_directory_reusing(
+    writes: &mut StorageWriteSet,
+    descriptors: &[CurrentStatePartDescriptor],
+    reusable_node_ids: &std::collections::BTreeSet<[u8; 32]>,
+) -> Result<CurrentStatePartDirectoryRoot, LixError> {
+    if descriptors.is_empty() {
+        return Ok(CurrentStatePartDirectoryRoot {
+            root_id: [0; 32],
+            descriptor_digest: current_state_descriptor_digest(descriptors)?,
+            row_count: 0,
+            part_count: 0,
+            tree_height: 0,
+        });
+    }
     validate_descriptors(descriptors)?;
-    // Reuse the historical replacement-directory certificate rather than
-    // inventing a second digest vocabulary for the same immutable part set.
-    let descriptor_digest = replacement_directory_digest(descriptors)?;
+    let descriptor_digest = current_state_descriptor_digest(descriptors)?;
     let mut level = descriptors
         .chunks(DIRECTORY_FANOUT)
-        .map(|chunk| stage_node(writes, DirectoryNode::leaf(chunk.to_vec())))
+        .map(|chunk| {
+            stage_node_reusing(
+                writes,
+                DirectoryNode::leaf(chunk.to_vec()),
+                reusable_node_ids,
+            )
+        })
         .collect::<Result<Vec<_>, _>>()?;
     let mut tree_height = 1u16;
     while level.len() > 1 {
         level = level
             .chunks(DIRECTORY_FANOUT)
             .map(|chunk| {
-                stage_node(
+                stage_node_reusing(
                     writes,
                     DirectoryNode::internal(chunk.iter().map(|node| node.child.clone()).collect()),
+                    reusable_node_ids,
                 )
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -1651,6 +1852,10 @@ pub(crate) async fn route_current_state_part(
     root: &CurrentStatePartDirectoryRoot,
     encoded_key: &[u8],
 ) -> Result<Option<CurrentStatePartDescriptor>, LixError> {
+    if root.part_count == 0 {
+        validate_empty_root(root)?;
+        return Ok(None);
+    }
     let mut node_id = root.root_id;
     let mut expected_child = None;
     loop {
@@ -1710,6 +1915,10 @@ pub(crate) async fn route_current_state_part_sets(
         .collect::<Vec<_>>();
     let mut frontier = std::collections::BTreeMap::<[u8; 32], Vec<PendingDirectoryRoute>>::new();
     for (request_index, (root, keys)) in requests.iter().enumerate() {
+        if root.part_count == 0 {
+            validate_empty_root(root)?;
+            continue;
+        }
         frontier.entry(root.root_id).or_default().push((
             request_index,
             None,
@@ -1797,6 +2006,10 @@ pub(crate) async fn load_current_state_part_descriptors(
     store: &(impl StorageAdapterRead + ?Sized),
     root: &CurrentStatePartDirectoryRoot,
 ) -> Result<Vec<CurrentStatePartDescriptor>, LixError> {
+    if root.part_count == 0 {
+        validate_empty_root(root)?;
+        return Ok(Vec::new());
+    }
     let mut pending = vec![(root.root_id, None)];
     let mut descriptors = Vec::with_capacity(root.part_count as usize);
     while let Some((node_id, expected_child)) = pending.pop() {
@@ -1827,7 +2040,7 @@ pub(crate) async fn load_current_state_part_descriptors(
             .map(|part| u64::from(part.row_count))
             .sum::<u64>()
             != root.row_count
-        || replacement_directory_digest(&descriptors)? != root.descriptor_digest
+        || !descriptor_digest_matches(root, &descriptors)?
     {
         return Err(directory_error(
             "root summary does not match its descriptor set",
@@ -1836,19 +2049,25 @@ pub(crate) async fn load_current_state_part_descriptors(
     Ok(descriptors)
 }
 
-fn stage_node(writes: &mut StorageWriteSet, node: DirectoryNode) -> Result<StagedNode, LixError> {
+fn stage_node_reusing(
+    writes: &mut StorageWriteSet,
+    node: DirectoryNode,
+    reusable_node_ids: &std::collections::BTreeSet<[u8; 32]>,
+) -> Result<StagedNode, LixError> {
     let (first_key, last_key, row_count, part_count) = node_summary(&node)?;
     let bytes = encode_node(&node)?;
-    #[cfg(feature = "storage-benches")]
-    crate::storage_bench::record_crud_current_state_directory_bytes(bytes.len());
     let node_id = node_digest(&bytes);
-    writes.put(
-        CURRENT_STATE_PART_DIRECTORY_SPACE,
-        StorageKey(Bytes::copy_from_slice(&node_id)),
-        StorageValue {
-            bytes: bytes.clone(),
-        },
-    );
+    if !reusable_node_ids.contains(&node_id) {
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_crud_current_state_directory_bytes(bytes.len());
+        writes.put(
+            CURRENT_STATE_PART_DIRECTORY_SPACE,
+            StorageKey(Bytes::copy_from_slice(&node_id)),
+            StorageValue {
+                bytes: bytes.clone(),
+            },
+        );
+    }
     Ok(StagedNode {
         child: DirectoryChild {
             first_key,
@@ -1984,16 +2203,21 @@ fn node_digest(bytes: &[u8]) -> [u8; 32] {
 fn replacement_directory_digest(
     descriptors: &[CurrentStatePartDescriptor],
 ) -> Result<[u8; 32], LixError> {
+    let mut first_ordinal = 0u32;
     let entries = descriptors
         .iter()
         .map(|descriptor| {
-            crate::tracked_state::replacement_part::ReplacementPartDirectoryEntry::new(
+            let entry = crate::tracked_state::replacement_part::ReplacementPartDirectoryEntry::new(
                 descriptor.content_digest,
                 &descriptor.first_key,
                 &descriptor.last_key,
-                descriptor.first_ordinal,
+                first_ordinal,
                 descriptor.row_count,
-            )
+            );
+            first_ordinal = first_ordinal
+                .checked_add(u32::from(descriptor.row_count))
+                .expect("validated replacement row count fits u32");
+            entry
         })
         .collect();
     crate::tracked_state::replacement_part::ReplacementPartDirectory::try_new(
@@ -2009,6 +2233,34 @@ fn replacement_directory_digest(
     .digest()
 }
 
+fn current_state_descriptor_digest(
+    descriptors: &[CurrentStatePartDescriptor],
+) -> Result<[u8; 32], LixError> {
+    let encoded = storage_codec::encode("current-state descriptor set", &descriptors)?;
+    Ok(
+        *blake3::Hasher::new_derive_key(CURRENT_STATE_DESCRIPTOR_DIGEST_CONTEXT)
+            .update(&encoded)
+            .finalize()
+            .as_bytes(),
+    )
+}
+
+fn descriptor_digest_matches(
+    root: &CurrentStatePartDirectoryRoot,
+    descriptors: &[CurrentStatePartDescriptor],
+) -> Result<bool, LixError> {
+    if current_state_descriptor_digest(descriptors)? == root.descriptor_digest {
+        return Ok(true);
+    }
+    if descriptors
+        .iter()
+        .all(|part| part.source_kind == 0 && part.source_row_offset == 0)
+    {
+        return Ok(replacement_directory_digest(descriptors)? == root.descriptor_digest);
+    }
+    Ok(false)
+}
+
 fn validate_root_summary(
     root: &CurrentStatePartDirectoryRoot,
     node: &DirectoryNode,
@@ -2016,6 +2268,18 @@ fn validate_root_summary(
     let (_, _, row_count, part_count) = node_summary(node)?;
     if row_count != root.row_count || part_count != root.part_count {
         return Err(directory_error("root summary disagrees with its node"));
+    }
+    Ok(())
+}
+
+fn validate_empty_root(root: &CurrentStatePartDirectoryRoot) -> Result<(), LixError> {
+    if root.root_id != [0; 32]
+        || root.descriptor_digest != current_state_descriptor_digest(&[])?
+        || root.row_count != 0
+        || root.part_count != 0
+        || root.tree_height != 0
+    {
+        return Err(directory_error("empty root summary is invalid"));
     }
     Ok(())
 }
@@ -2068,7 +2332,7 @@ fn validate_node(node: &DirectoryNode) -> Result<(), LixError> {
             if !node.children.is_empty() || node.parts.len() > DIRECTORY_FANOUT {
                 return Err(directory_error("leaf exceeds bounded fanout"));
             }
-            validate_descriptor_slice(&node.parts, false)
+            validate_descriptor_slice(&node.parts)
         }
         1 => {
             if !node.parts.is_empty()
@@ -2097,29 +2361,34 @@ fn validate_node(node: &DirectoryNode) -> Result<(), LixError> {
 }
 
 fn validate_descriptors(parts: &[CurrentStatePartDescriptor]) -> Result<(), LixError> {
-    validate_descriptor_slice(parts, true)
+    validate_descriptor_slice(parts)
 }
 
-fn validate_descriptor_slice(
-    parts: &[CurrentStatePartDescriptor],
-    require_zero_origin: bool,
-) -> Result<(), LixError> {
+fn validate_descriptor_slice(parts: &[CurrentStatePartDescriptor]) -> Result<(), LixError> {
     let first = parts.first();
     if first.is_none()
-        || (require_zero_origin && first.is_some_and(|part| part.first_ordinal != 0))
         || parts.iter().any(|part| {
             part.first_key.is_empty()
-                || part.last_key.is_empty()
-                || part.first_key > part.last_key
-                || part.row_count == 0
-                || part.content_digest == [0; 32]
+            || part.last_key.is_empty()
+            || part.first_key > part.last_key
+            || part.row_count == 0
+            || u32::from(part.source_row_offset) + u32::from(part.row_count)
+                > crate::tracked_state::current_state_data_part::CURRENT_STATE_DATA_PART_MAX_ROWS
+                    as u32
+            || part.content_digest == [0; 32]
+            || part.source_kind > 1
+            || (part.source_kind == 0
+                && (part.owner_commit_id == [0; 16] || part.payload_refs_digest != [0; 32]))
+            || (part.source_kind == 1
+                && (part.owner_commit_id != [0; 16]
+                    || part.part_index != 0
+                    || part.payload_refs_digest == [0; 32]
+                    || part.uniform_created_at.packed() != 0
+                    || part.uniform_updated_at.packed() != 0))
         })
         || parts
             .windows(2)
             .any(|pair| pair[0].last_key >= pair[1].first_key)
-        || parts.windows(2).any(|pair| {
-            pair[1].first_ordinal != pair[0].first_ordinal + u32::from(pair[0].row_count)
-        })
     {
         return Err(directory_error(
             "descriptor set is empty, unordered, or overlapping",
@@ -2200,9 +2469,11 @@ mod tests {
                 first_key: format!("key-{index:06}-a").into_bytes(),
                 last_key: format!("key-{index:06}-z").into_bytes(),
                 content_digest: *blake3::hash(&index.to_be_bytes()).as_bytes(),
+                payload_refs_digest: [0; 32],
+                source_kind: 0,
                 owner_commit_id: [9; 16],
                 part_index: u32::try_from(index).expect("fixture index fits u32"),
-                first_ordinal: u32::try_from(index * 10).expect("fixture ordinal fits u32"),
+                source_row_offset: 0,
                 row_count: 10,
                 uniform_created_at: timestamp,
                 uniform_updated_at: timestamp,
@@ -2693,7 +2964,7 @@ mod tests {
     }
 
     #[test]
-    fn directory_rejects_overlap_and_ordinal_drift_but_allows_mixed_owners() {
+    fn directory_rejects_overlap_and_unknown_sources_but_allows_mixed_owners() {
         let adapter = StorageAdapter::new(Memory::new());
         let mut overlapping = descriptors(2);
         overlapping[1].first_key = overlapping[0].last_key.clone();
@@ -2705,10 +2976,10 @@ mod tests {
         assert!(
             stage_current_state_part_directory(&mut adapter.new_write_set(), &owner_drift).is_ok()
         );
-        let mut ordinal_drift = descriptors(2);
-        ordinal_drift[1].first_ordinal += 1;
+        let mut invalid_source = descriptors(2);
+        invalid_source[1].source_kind = 2;
         assert!(
-            stage_current_state_part_directory(&mut adapter.new_write_set(), &ordinal_drift)
+            stage_current_state_part_directory(&mut adapter.new_write_set(), &invalid_source)
                 .is_err()
         );
 

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -3,6 +3,7 @@ mod bench_support;
 mod codec;
 mod commit_root_rebuild;
 mod context;
+mod current_state_data_part;
 mod current_state_part;
 mod diff;
 mod diff_id;
@@ -19,6 +20,10 @@ pub(crate) use commit_root_rebuild::{
 };
 pub(crate) use context::{
     TrackedStateContext, TrackedStateStoreReader, descriptor_dependency_cascade_file_ids,
+};
+pub(crate) use current_state_data_part::{
+    CURRENT_STATE_DATA_PART_REFS_SPACE, CURRENT_STATE_DATA_PART_SPACE,
+    decode_current_state_data_part_refs,
 };
 pub(crate) use current_state_part::{
     CURRENT_STATE_CATALOG_SPACE, CURRENT_STATE_PART_DIRECTORY_SPACE,

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -778,6 +778,7 @@ async fn load_complete_current_state_values_encoded_inner(
     state: &CommitStateManifest,
     encoded_keys: &[Bytes],
     validate_publication: bool,
+    prefer_recent_replay: bool,
 ) -> Result<Option<Vec<Option<TrackedStateIndexValue>>>, LixError> {
     if encoded_keys.is_empty() {
         return Ok(Some(Vec::new()));
@@ -802,15 +803,12 @@ async fn load_complete_current_state_values_encoded_inner(
             .or_default()
             .push(index);
     }
-    let Some(touched_scopes) =
+    let Some(_touched_scopes) =
         commit_state_inventory_exact_touched_scopes(state.commit_id, &state.mutations)?
     else {
         return Ok(None);
     };
-    if scope_keys
-        .keys()
-        .any(|scope| touched_scopes.binary_search(scope).is_ok())
-    {
+    if prefer_recent_replay && current_inventory_may_contain_any_key(state, encoded_keys)? {
         return Ok(None);
     }
     if state
@@ -878,7 +876,10 @@ async fn load_complete_current_state_values_encoded_inner(
         }
     }
 
-    let mut routed = BTreeMap::<([u8; 16], u32), (CurrentStatePartDescriptor, Vec<usize>)>::new();
+    let mut routed = BTreeMap::<
+        (u8, [u8; 16], u32, [u8; 32], u16),
+        (CurrentStatePartDescriptor, Vec<usize>),
+    >::new();
     let mut values = vec![None; encoded_keys.len()];
     let directory_keys = sets
         .iter()
@@ -903,16 +904,26 @@ async fn load_complete_current_state_values_encoded_inner(
                 continue;
             };
             routed
-                .entry((descriptor.owner_commit_id, descriptor.part_index))
+                .entry((
+                    descriptor.source_kind,
+                    descriptor.owner_commit_id,
+                    descriptor.part_index,
+                    descriptor.content_digest,
+                    descriptor.source_row_offset,
+                ))
                 .or_insert_with(|| (descriptor, Vec::new()))
                 .1
                 .push(output_index);
         }
     }
 
-    let storage_keys = routed
-        .values()
-        .map(|(descriptor, _)| {
+    let replacement = routed
+        .iter()
+        .filter(|(_, (descriptor, _))| descriptor.source_kind == 0)
+        .collect::<Vec<_>>();
+    let storage_keys = replacement
+        .iter()
+        .map(|(_, (descriptor, _))| {
             let owner = CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id));
             let mut key = commit_delta_segment_key(owner, descriptor.part_index as usize)?;
             key.extend_from_slice(&descriptor.content_digest);
@@ -922,29 +933,80 @@ async fn load_complete_current_state_values_encoded_inner(
     let loaded = PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, &storage_keys)
         .materialize(store, StorageGetOptions::default())
         .await?;
-    for ((_, (descriptor, output_indices)), value) in routed.into_iter().zip(loaded.value) {
+    for ((_, (descriptor, output_indices)), value) in replacement.into_iter().zip(loaded.value) {
         let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
             replacement_payload_error("current-state directory references a missing part")
         })?;
         let owner = CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id));
-        let bounds = CommitDeltaSegmentBounds {
-            first_key: descriptor.first_key,
-            last_key: descriptor.last_key,
-            replacement_part: Some(StoredReplacementPart {
-                content_digest: descriptor.content_digest,
-                owner_commit_id: descriptor.owner_commit_id,
-                first_address: descriptor.part_index.saturating_mul(
-                    u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS)
-                        .expect("replacement row bound fits u32"),
-                ),
-                uniform_created_at: descriptor.uniform_created_at,
-                uniform_updated_at: descriptor.uniform_updated_at,
-            }),
-        };
-        let leaf = decode_commit_delta_segment(&bytes, Some(&bounds), owner)?;
+        let decoded = crate::tracked_state::replacement_part::decode_replacement_part(
+            &descriptor.content_digest,
+            &bytes,
+        )?;
         for output_index in output_indices {
-            values[output_index] =
-                find_commit_delta_value(&leaf, &encoded_keys[output_index], owner)?;
+            let Some(found) = decoded.find(&encoded_keys[*output_index])? else {
+                continue;
+            };
+            let physical_ordinal = u32::from(found.ordinal);
+            let slice_start = u32::from(descriptor.source_row_offset);
+            if physical_ordinal < slice_start
+                || physical_ordinal >= slice_start + u32::from(descriptor.row_count)
+            {
+                return Err(replacement_payload_error(
+                    "replacement current-state route escaped its source slice",
+                ));
+            }
+            let packed = descriptor
+                .part_index
+                .checked_mul(
+                    u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS).expect("row bound fits u32"),
+                )
+                .and_then(|base| base.checked_add(physical_ordinal))
+                .and_then(|address| address.checked_add(1))
+                .ok_or_else(|| replacement_payload_error("replacement address overflows"))?;
+            values[*output_index] = Some(TrackedStateIndexValue {
+                change_id: change_id_from_packed_address(owner, packed),
+                commit_id: owner,
+                deleted: false,
+                created_at: descriptor.uniform_created_at,
+                updated_at: descriptor.uniform_updated_at,
+            });
+        }
+    }
+    let native = routed
+        .iter()
+        .filter(|(_, (descriptor, _))| descriptor.source_kind == 1)
+        .collect::<Vec<_>>();
+    let native_keys = native
+        .iter()
+        .map(|(_, (descriptor, _))| StorageKey(Bytes::copy_from_slice(&descriptor.content_digest)))
+        .collect::<Vec<_>>();
+    let loaded = PointReadPlan::new(
+        crate::tracked_state::current_state_data_part::CURRENT_STATE_DATA_PART_SPACE,
+        &native_keys,
+    )
+    .materialize(store, StorageGetOptions::default())
+    .await?;
+    for ((_, (descriptor, output_indices)), value) in native.into_iter().zip(loaded.value) {
+        let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
+            replacement_payload_error("current-state directory references a missing native part")
+        })?;
+        let rows = crate::tracked_state::current_state_data_part::decode_current_state_data_part(
+            &descriptor.content_digest,
+            &bytes,
+        )?;
+        let start = usize::from(descriptor.source_row_offset);
+        let end = start + usize::from(descriptor.row_count);
+        let rows = rows.get(start..end).ok_or_else(|| {
+            replacement_payload_error("native current-state source slice is out of bounds")
+        })?;
+        for output_index in output_indices {
+            if let Ok(index) = rows.binary_search_by(|row| {
+                row.encoded_key
+                    .as_slice()
+                    .cmp(encoded_keys[*output_index].as_ref())
+            }) {
+                values[*output_index] = Some(rows[index].value.clone());
+            }
         }
     }
     Ok(Some(values))
@@ -956,21 +1018,27 @@ pub(crate) async fn load_complete_current_state_values_encoded(
     state: &CommitStateManifest,
     encoded_keys: &[Bytes],
 ) -> Result<Option<Vec<Option<TrackedStateIndexValue>>>, LixError> {
-    load_complete_current_state_values_encoded_inner(store, state, encoded_keys, true).await
+    load_complete_current_state_values_encoded_inner(store, state, encoded_keys, true, true).await
 }
 
 /// Uses a manifest returned by [`load_commit_state_manifest`] or
 /// [`load_commit_state_manifests`]. The opaque handle proves that the mutable
 /// manifest matched its immutable semantic authority in the caller's coherent
 /// read.
-#[cfg(feature = "storage-benches")]
+#[cfg(any(test, feature = "storage-benches"))]
 pub(crate) async fn load_complete_current_state_values_from_published_manifest(
     store: &(impl StorageAdapterRead + ?Sized),
     state: &PublishedCommitStateManifest,
     encoded_keys: &[Bytes],
 ) -> Result<Option<Vec<Option<TrackedStateIndexValue>>>, LixError> {
-    load_complete_current_state_values_encoded_inner(store, &state.manifest, encoded_keys, false)
-        .await
+    load_complete_current_state_values_encoded_inner(
+        store,
+        &state.manifest,
+        encoded_keys,
+        false,
+        false,
+    )
+    .await
 }
 
 /// Tries the serving catalog from a one-read replay manifest. The inner cost
@@ -981,7 +1049,33 @@ pub(crate) async fn load_complete_current_state_values_from_replay_manifest(
     state: &CommitStateManifest,
     encoded_keys: &[Bytes],
 ) -> Result<Option<Vec<Option<TrackedStateIndexValue>>>, LixError> {
-    load_complete_current_state_values_encoded_inner(store, state, encoded_keys, true).await
+    // `load_point_replay_commit_state` decoded this exact manifest from the
+    // immutable semantic-authority seal, including its certified catalog root.
+    // Re-reading mutable manifests and the original coverage anchor would add
+    // three point I/Os without strengthening that authority.
+    load_complete_current_state_values_encoded_inner(store, state, encoded_keys, false, true).await
+}
+
+fn current_inventory_may_contain_any_key(
+    state: &CommitStateManifest,
+    encoded_keys: &[Bytes],
+) -> Result<bool, LixError> {
+    let manifest = commit_delta_manifest_from_inventory(&state.mutations);
+    if let Some(inline) = manifest.inline_segment() {
+        let leaf = decode_commit_delta_segment(inline, None, state.commit_id)?;
+        for encoded_key in encoded_keys {
+            if find_commit_delta_entry_index(&leaf, encoded_key)?.is_some() {
+                return Ok(true);
+            }
+        }
+        return Ok(false);
+    }
+    Ok(encoded_keys.iter().any(|encoded_key| {
+        manifest.segments.iter().any(|segment| {
+            segment.first_key.as_slice() <= encoded_key.as_ref()
+                && encoded_key.as_ref() <= segment.last_key.as_slice()
+        })
+    }))
 }
 
 pub(crate) async fn validate_current_state_catalog_requested_scopes(
@@ -1033,8 +1127,8 @@ pub(crate) fn validate_current_state_catalog_entry_against_authority(
     if set.coverage_anchor_commit_id != *origin.commit_id.as_uuid().as_bytes()
         || set.scope != anchor.scope
         || set.generation_integrity_digest != anchor.generation_integrity_digest
-        || set.state_lineage_digest != anchor.state_lineage_digest
-        || set.directory != anchor.directory
+        || (set.state_lineage_digest == anchor.state_lineage_digest
+            && set.directory != anchor.directory)
     {
         return Err(replacement_payload_error(
             "current-state catalog entry disagrees with its coverage anchor",
@@ -2029,6 +2123,372 @@ pub(crate) async fn stage_current_state_catalog_from_staged_parent(
         inventory,
     )
     .await
+}
+
+/// Rewrites one exactly scoped current-state partition from its certified
+/// parent post-image and the current commit's sealed mutation parts. Untouched
+/// parent descriptors are reused byte-for-byte; only intersecting bounded
+/// parts and insertion gaps become native current-state data parts.
+pub(crate) async fn stage_sparse_current_state_part_set(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    parent: &crate::tracked_state::types::CurrentStatePartSet,
+    commit_id: CommitId,
+    inventory: &CommitStateMutationInventory,
+) -> Result<Option<crate::tracked_state::types::CurrentStatePartSet>, LixError> {
+    use crate::tracked_state::current_state_data_part::{
+        CURRENT_STATE_DATA_PART_REFS_SPACE, CURRENT_STATE_DATA_PART_SPACE, CurrentStateDataRow,
+        decode_current_state_data_part, encode_bounded_current_state_data_parts,
+    };
+
+    let staged_segments = staged_commit_delta_segment_bytes(writes, commit_id, inventory)?;
+    let members = staged_commit_delta_members(store, commit_id, inventory, staged_segments).await?;
+    if members.iter().any(|member| {
+        member.key.schema_key == parent.scope.schema_key
+            && member.key.file_id == parent.scope.file_id
+            && !member.value.deleted
+            && member.change.snapshot == crate::json_store::JsonSlot::None
+    }) {
+        // Selected/reference rows may intentionally omit their payload from
+        // the local mutation part. Until that authority is available through
+        // the same read-your-writes view, drop only this rebuildable serving
+        // entry and leave canonical replay responsible for the scope.
+        return Ok(None);
+    }
+    let mut mutations = BTreeMap::<Vec<u8>, Option<CurrentStateDataRow>>::new();
+    for member in members {
+        if member.key.schema_key != parent.scope.schema_key
+            || member.key.file_id != parent.scope.file_id
+        {
+            continue;
+        }
+        let encoded_key = crate::tracked_state::codec::encode_key(&member.key);
+        let row = (!member.value.deleted).then(|| CurrentStateDataRow {
+            encoded_key: encoded_key.clone(),
+            value: member.value,
+            snapshot: member.change.snapshot,
+            metadata: member.change.metadata,
+        });
+        if mutations.insert(encoded_key, row).is_some() {
+            return Err(replacement_payload_error(
+                "sparse current-state rewrite contains a duplicate identity",
+            ));
+        }
+    }
+    if mutations.is_empty() {
+        return Ok(Some(parent.clone()));
+    }
+
+    let (reusable_directory_nodes, parent_descriptors) =
+        super::current_state_part::load_current_state_part_directory_reachability_for_write(
+            store,
+            writes,
+            &parent.directory,
+        )
+        .await?;
+    let mut output = Vec::with_capacity(parent_descriptors.len() + mutations.len());
+    let mut pending = mutations.into_iter().peekable();
+    for descriptor in parent_descriptors {
+        let mut gap = Vec::new();
+        while pending
+            .peek()
+            .is_some_and(|(key, _)| key.as_slice() < descriptor.first_key.as_slice())
+        {
+            let (_, row) = pending.next().expect("peeked sparse mutation");
+            if let Some(row) = row {
+                gap.push(row);
+            }
+        }
+        stage_native_current_state_rows(writes, &gap, &mut output)?;
+
+        let touches_descriptor = pending
+            .peek()
+            .is_some_and(|(key, _)| key.as_slice() <= descriptor.last_key.as_slice());
+        if !touches_descriptor {
+            output.push(descriptor);
+            continue;
+        }
+        let mut rows = load_current_state_descriptor_rows(store, writes, &descriptor)
+            .await?
+            .into_iter()
+            .map(|row| (row.encoded_key.clone(), row))
+            .collect::<BTreeMap<_, _>>();
+        while pending
+            .peek()
+            .is_some_and(|(key, _)| key.as_slice() <= descriptor.last_key.as_slice())
+        {
+            let (key, row) = pending.next().expect("peeked sparse mutation");
+            match row {
+                Some(mut row) => {
+                    if let Some(previous) = rows.get(&key) {
+                        row.value.created_at = previous.value.created_at;
+                    }
+                    rows.insert(key, row);
+                }
+                None => {
+                    rows.remove(&key);
+                }
+            }
+        }
+        stage_native_current_state_rows(
+            writes,
+            &rows.into_values().collect::<Vec<_>>(),
+            &mut output,
+        )?;
+    }
+    let tail = pending
+        .filter_map(|(_, row)| row)
+        .collect::<Vec<CurrentStateDataRow>>();
+    stage_native_current_state_rows(writes, &tail, &mut output)?;
+
+    let directory = super::current_state_part::stage_current_state_part_directory_reusing(
+        writes,
+        &output,
+        &reusable_directory_nodes,
+    )?;
+    let inventory_bytes =
+        storage_codec::encode("sparse current-state lineage inventory", inventory)?;
+    let state_lineage_digest =
+        *blake3::Hasher::new_derive_key("lix sparse current-state lineage v1")
+            .update(&parent.state_lineage_digest)
+            .update(commit_id.as_uuid().as_bytes())
+            .update(&(inventory_bytes.len() as u64).to_be_bytes())
+            .update(&inventory_bytes)
+            .update(&directory.root_id)
+            .update(&directory.descriptor_digest)
+            .finalize()
+            .as_bytes();
+    let rewritten = crate::tracked_state::types::CurrentStatePartSet {
+        scope: parent.scope.clone(),
+        coverage_anchor_commit_id: parent.coverage_anchor_commit_id,
+        generation_integrity_digest: parent.generation_integrity_digest,
+        state_lineage_digest,
+        directory,
+    };
+
+    fn stage_native_current_state_rows(
+        writes: &mut StorageWriteSet,
+        rows: &[CurrentStateDataRow],
+        output: &mut Vec<CurrentStatePartDescriptor>,
+    ) -> Result<(), LixError> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+        let timestamp = crate::common::LixTimestamp::from_unix_millis_utc_lossy(0);
+        for part in encode_bounded_current_state_data_parts(rows)? {
+            writes.put(
+                CURRENT_STATE_DATA_PART_SPACE,
+                key(part.digest.to_vec()),
+                value(part.bytes.to_vec()),
+            );
+            writes.put(
+                CURRENT_STATE_DATA_PART_REFS_SPACE,
+                key(part.digest.to_vec()),
+                value(part.refs_bytes.to_vec()),
+            );
+            output.push(CurrentStatePartDescriptor {
+                first_key: part.first_key,
+                last_key: part.last_key,
+                content_digest: part.digest,
+                payload_refs_digest: part.refs_digest,
+                source_kind: 1,
+                owner_commit_id: [0; 16],
+                part_index: 0,
+                source_row_offset: 0,
+                row_count: part.row_count,
+                uniform_created_at: timestamp,
+                uniform_updated_at: timestamp,
+            });
+        }
+        Ok(())
+    }
+
+    async fn load_current_state_descriptor_rows(
+        store: &(impl StorageAdapterRead + ?Sized),
+        writes: &mut StorageWriteSet,
+        descriptor: &CurrentStatePartDescriptor,
+    ) -> Result<Vec<CurrentStateDataRow>, LixError> {
+        let rows = match descriptor.source_kind {
+            0 => {
+                let owner = CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id));
+                let mut physical_key =
+                    commit_delta_segment_key(owner, descriptor.part_index as usize)?;
+                physical_key.extend_from_slice(&descriptor.content_digest);
+                let staged =
+                    writes.staged_value(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, &physical_key);
+                let bytes = if let Some(bytes) = staged {
+                    bytes
+                } else {
+                    get_one(
+                        store,
+                        TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
+                        physical_key,
+                    )
+                    .await?
+                    .ok_or_else(|| {
+                        replacement_payload_error("current-state source part is missing")
+                    })?
+                };
+                let decoded = crate::tracked_state::replacement_part::decode_replacement_part(
+                    &descriptor.content_digest,
+                    &bytes,
+                )?;
+                let start = usize::from(descriptor.source_row_offset);
+                let end = start + usize::from(descriptor.row_count);
+                if end > decoded.len() {
+                    return Err(replacement_payload_error(
+                        "current-state source slice is out of bounds",
+                    ));
+                }
+                (start..end)
+                    .map(|ordinal| {
+                        let encoded_key = decoded.key(ordinal)?.ok_or_else(|| {
+                            replacement_payload_error("replacement source omitted a key")
+                        })?;
+                        let packed = descriptor
+                            .part_index
+                            .checked_mul(
+                                u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS)
+                                    .expect("row bound fits u32"),
+                            )
+                            .and_then(|base| {
+                                base.checked_add(u32::try_from(ordinal).expect("ordinal fits u32"))
+                            })
+                            .and_then(|address| address.checked_add(1))
+                            .ok_or_else(|| {
+                                replacement_payload_error("replacement source address overflows")
+                            })?;
+                        Ok(CurrentStateDataRow {
+                            encoded_key: encoded_key.to_vec(),
+                            value: TrackedStateIndexValue {
+                                change_id: change_id_from_packed_address(owner, packed),
+                                commit_id: owner,
+                                deleted: false,
+                                created_at: descriptor.uniform_created_at,
+                                updated_at: descriptor.uniform_updated_at,
+                            },
+                            snapshot: owned_json_slot(decoded.snapshot(ordinal)?.ok_or_else(
+                                || replacement_payload_error("replacement source omitted snapshot"),
+                            )?),
+                            metadata: owned_json_slot(decoded.metadata(ordinal)?.ok_or_else(
+                                || replacement_payload_error("replacement source omitted metadata"),
+                            )?),
+                        })
+                    })
+                    .collect::<Result<Vec<_>, LixError>>()?
+            }
+            1 => {
+                let physical_key = descriptor.content_digest.to_vec();
+                let staged = writes.staged_value(CURRENT_STATE_DATA_PART_SPACE, &physical_key);
+                let bytes = if let Some(bytes) = staged {
+                    bytes
+                } else {
+                    get_one(store, CURRENT_STATE_DATA_PART_SPACE, physical_key)
+                        .await?
+                        .ok_or_else(|| {
+                            replacement_payload_error("native current-state part is missing")
+                        })?
+                };
+                let decoded = decode_current_state_data_part(&descriptor.content_digest, &bytes)?;
+                let start = usize::from(descriptor.source_row_offset);
+                let end = start + usize::from(descriptor.row_count);
+                decoded
+                    .get(start..end)
+                    .ok_or_else(|| {
+                        replacement_payload_error("native current-state slice is out of bounds")
+                    })?
+                    .to_vec()
+            }
+            _ => {
+                return Err(replacement_payload_error(
+                    "current-state descriptor has unknown source",
+                ));
+            }
+        };
+        if rows.first().map(|row| row.encoded_key.as_slice())
+            != Some(descriptor.first_key.as_slice())
+            || rows.last().map(|row| row.encoded_key.as_slice())
+                != Some(descriptor.last_key.as_slice())
+        {
+            return Err(replacement_payload_error(
+                "current-state source slice disagrees with descriptor bounds",
+            ));
+        }
+        Ok(rows)
+    }
+
+    fn owned_json_slot(slot: crate::json_store::JsonSlotRef<'_>) -> crate::json_store::JsonSlot {
+        match slot {
+            crate::json_store::JsonSlotRef::None => crate::json_store::JsonSlot::None,
+            crate::json_store::JsonSlotRef::Ref(reference) => {
+                crate::json_store::JsonSlot::Ref(reference.clone())
+            }
+            crate::json_store::JsonSlotRef::Inline(json) => {
+                crate::json_store::JsonSlot::Inline(json.into())
+            }
+        }
+    }
+    Ok(Some(rewritten))
+}
+
+fn staged_commit_delta_segment_bytes(
+    writes: &StorageWriteSet,
+    commit_id: CommitId,
+    inventory: &CommitStateMutationInventory,
+) -> Result<Vec<Option<Bytes>>, LixError> {
+    let manifest = commit_delta_manifest_from_inventory(inventory);
+    manifest
+        .segments
+        .iter()
+        .enumerate()
+        .map(|(segment_index, bounds)| {
+            let physical_key =
+                commit_delta_segment_key_for_bounds(commit_id, segment_index, bounds)?;
+            Ok(writes.staged_value(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, &physical_key))
+        })
+        .collect()
+}
+
+async fn staged_commit_delta_members(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+    inventory: &CommitStateMutationInventory,
+    staged_segments: Vec<Option<Bytes>>,
+) -> Result<Vec<CommitDeltaMember>, LixError> {
+    let manifest = commit_delta_manifest_from_inventory(inventory);
+    let mut members = Vec::with_capacity(inventory.member_count as usize);
+    if let Some(inline) = manifest.inline_segment() {
+        collect_strict_commit_delta_members(inline, None, commit_id, 0, &mut members)?;
+    } else {
+        for ((segment_index, bounds), staged) in
+            manifest.segments.iter().enumerate().zip(staged_segments)
+        {
+            let physical_key =
+                commit_delta_segment_key_for_bounds(commit_id, segment_index, bounds)?;
+            let bytes = if let Some(bytes) = staged {
+                bytes
+            } else {
+                get_one(
+                    store,
+                    TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
+                    physical_key,
+                )
+                .await?
+                .ok_or_else(|| {
+                    replacement_payload_error("sparse rewrite cannot read its mutation part")
+                })?
+            };
+            collect_strict_commit_delta_members(
+                &bytes,
+                Some(bounds),
+                commit_id,
+                u32::try_from(segment_index).expect("segment index fits u32"),
+                &mut members,
+            )?;
+        }
+    }
+    validate_commit_delta_member_order_and_ids(commit_id, &members)?;
+    Ok(members)
 }
 
 fn commit_delta_segment_key(
@@ -9418,7 +9878,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn persistent_catalog_reuses_untouched_scope_and_invalidates_touched_scope() {
+    async fn persistent_catalog_reuses_untouched_scope_and_rewrites_touched_scope() {
         let storage = StorageAdapter::new(Memory::new());
         let parent_id = CommitId::with_change_address_space(uuid::Uuid::from_u128(
             0x0199_2000_0000_7000_8000_0000_0000_0000,
@@ -9482,6 +9942,36 @@ mod tests {
             .current_state_catalog
             .clone()
             .expect("parent should publish a catalog");
+        let selected_id = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x0199_2000_0000_7000_8000_0000_1000_0000,
+        ));
+        let mut selected_delta = commit_delta_refs(selected_id, std::slice::from_ref(&alpha[0]));
+        selected_delta[0].delta.change_id = parent_stage
+            .change_id_at(0)
+            .expect("replacement row should have an address");
+        selected_delta[0].authored = false;
+        let mut selected_writes = storage.new_write_set();
+        let selected_stage = super::stage_ordered_addressable_commit_deltas(
+            &mut selected_writes,
+            selected_delta.iter().copied().map(Ok),
+            true,
+            false,
+        )
+        .expect("selected mutation should stage")
+        .expect("selected mutation should be addressable");
+        let selected_publication = super::stage_current_state_catalog_from_published_parent(
+            &read,
+            &mut selected_writes,
+            Some(&parent),
+            selected_id,
+            selected_stage.mutation_inventory(),
+        )
+        .await
+        .expect("omitted selected payload must not fail commit publication");
+        assert!(
+            selected_publication.parts().0.is_none(),
+            "only the unsupported serving entry should be dropped"
+        );
         let beta = CommitDeltaFixture {
             schema_key: "beta".to_string(),
             file_id: None,
@@ -9591,7 +10081,9 @@ mod tests {
         let touching_id = CommitId::with_change_address_space(uuid::Uuid::from_u128(
             0x0199_2000_0000_7000_8000_0002_0000_0000,
         ));
-        let touching_deltas = commit_delta_refs(touching_id, std::slice::from_ref(&alpha[0]));
+        let mut touching_deltas = commit_delta_refs(touching_id, std::slice::from_ref(&alpha[0]));
+        touching_deltas[0].delta.created_at = LixTimestamp::from_unix_millis_utc_lossy(999);
+        touching_deltas[0].snapshot = crate::json_store::JsonSlotRef::Inline("{\"updated\":true}");
         let mut touching_writes = storage.new_write_set();
         let touching_stage = super::stage_ordered_addressable_commit_deltas(
             &mut touching_writes,
@@ -9610,9 +10102,111 @@ mod tests {
             &mut touching_inventory,
         )
         .await
-        .expect("same-scope invalidation should succeed");
+        .expect("same-scope sparse rewrite should succeed");
         let (touching_catalog, _) = touching_publication.parts();
-        assert!(touching_catalog.is_none(), "touched scope must be removed");
+        let touching_catalog = touching_catalog.expect("touched scope should remain served");
+        assert_ne!(
+            touching_catalog.root_id,
+            child
+                .current_state_catalog
+                .as_ref()
+                .expect("child catalog exists")
+                .root_id,
+            "touched scope must publish a new post-image catalog"
+        );
+        let mut touching = fixture_commit_state_manifest(touching_id, touching_inventory.clone());
+        touching.parent_commit_ids = vec![child_id];
+        touching.replay_debt.depth = super::MIN_CURRENT_STATE_CATALOG_POINT_READS;
+        touching.current_state_catalog = Some(touching_catalog.clone());
+        let staged_touching = super::stage_certified_commit_state_manifest_with_handle(
+            &mut touching_writes,
+            &touching,
+            &touching_publication,
+        )
+        .expect("sparse post-image manifest should stage");
+        let staged_child_id = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x0199_2000_0000_7000_8000_0002_1000_0000,
+        ));
+        let mut staged_child_deltas =
+            commit_delta_refs(staged_child_id, std::slice::from_ref(&alpha[2]));
+        staged_child_deltas[0].snapshot =
+            crate::json_store::JsonSlotRef::Inline("{\"staged_child\":true}");
+        let staged_child_stage = super::stage_ordered_addressable_commit_deltas(
+            &mut touching_writes,
+            staged_child_deltas.iter().copied().map(Ok),
+            true,
+            false,
+        )
+        .expect("staged child mutation should stage")
+        .expect("staged child mutation should be addressable");
+        let staged_child_inventory = staged_child_stage.mutation_inventory().clone();
+        let staged_child_publication = super::stage_current_state_catalog_from_staged_parent(
+            &read,
+            &mut touching_writes,
+            &staged_touching,
+            staged_child_id,
+            &staged_child_inventory,
+        )
+        .await
+        .expect("staged child should read parent catalog, directory, and data parts");
+        let (staged_child_catalog, _) = staged_child_publication.parts();
+        let mut staged_child =
+            fixture_commit_state_manifest(staged_child_id, staged_child_inventory);
+        staged_child.parent_commit_ids = vec![touching_id];
+        staged_child.replay_debt.depth = super::MIN_CURRENT_STATE_CATALOG_POINT_READS;
+        staged_child.current_state_catalog = staged_child_catalog;
+        super::stage_certified_commit_state_manifest(
+            &mut touching_writes,
+            &staged_child,
+            &staged_child_publication,
+        )
+        .expect("staged child manifest should stage in the same write set");
+        drop(read);
+        storage
+            .commit_write_set(touching_writes, StorageWriteOptions::default())
+            .await
+            .expect("sparse post-image should commit atomically");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("sparse post-image read should open");
+        let published_touching = super::load_published_commit_state_manifest(&read, touching_id)
+            .await
+            .expect("sparse manifest should load")
+            .expect("sparse manifest should exist");
+        let updated_key = Bytes::from(encode_key_ref(TrackedStateKeyRef {
+            schema_key: &alpha[0].schema_key,
+            file_id: alpha[0].file_id.as_deref(),
+            entity_pk: &alpha[0].entity_pk,
+        }));
+        assert!(
+            super::load_complete_current_state_values_from_replay_manifest(
+                &read,
+                &published_touching.manifest,
+                std::slice::from_ref(&updated_key),
+            )
+            .await
+            .expect("hot-key replay preference should resolve")
+            .is_none(),
+            "a key authored by the head must retain the cheaper OLTP replay path"
+        );
+        let updated = super::load_complete_current_state_values_from_published_manifest(
+            &read,
+            &published_touching,
+            std::slice::from_ref(&updated_key),
+        )
+        .await
+        .expect("sparse point should resolve")
+        .expect("sparse scope should remain covered");
+        assert_eq!(
+            updated[0].as_ref().map(|value| value.commit_id),
+            Some(touching_id)
+        );
+        assert_eq!(
+            updated[0].as_ref().map(|value| value.created_at),
+            Some(created_at),
+            "ordinary updates must retain the insertion lifecycle timestamp"
+        );
 
         let mut forged_root = parent_root;
         forged_root.parent_root_id = child
@@ -9660,12 +10254,108 @@ mod tests {
             crate::tracked_state::current_state_part::validate_current_state_catalog_transition_root(
                 &read,
                 &forged_touching,
-                child.current_state_catalog.as_deref(),
+                Some(&child),
             )
             .await
             .is_err(),
             "recomputed attestation must not authorize a stale touched scope"
         );
+
+        let insert_delete_id = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x0199_2000_0000_7000_8000_0003_0000_0000,
+        ));
+        let delete = CommitDeltaFixture {
+            change_id: ChangeId::for_test_label("catalog-alpha-delete"),
+            deleted: true,
+            ..alpha[1].clone()
+        };
+        let insert = CommitDeltaFixture {
+            schema_key: "alpha".to_string(),
+            file_id: None,
+            entity_pk: EntityPk::single("entity-inserted"),
+            change_id: ChangeId::for_test_label("catalog-alpha-insert"),
+            deleted: false,
+            created_at,
+            updated_at,
+        };
+        let sparse_fixtures = [delete, insert];
+        let mut sparse_deltas = commit_delta_refs(insert_delete_id, &sparse_fixtures);
+        sparse_deltas[1].snapshot = crate::json_store::JsonSlotRef::Inline("{\"inserted\":true}");
+        let mut sparse_writes = storage.new_write_set();
+        let sparse_stage = super::stage_ordered_addressable_commit_deltas(
+            &mut sparse_writes,
+            sparse_deltas.iter().copied().map(Ok),
+            true,
+            false,
+        )
+        .expect("insert/delete mutation should stage")
+        .expect("insert/delete mutation should be addressable");
+        let mut sparse_inventory = sparse_stage.mutation_inventory().clone();
+        let sparse_publication = super::stage_current_state_catalog_from_published_parent(
+            &read,
+            &mut sparse_writes,
+            Some(&published_touching),
+            insert_delete_id,
+            &mut sparse_inventory,
+        )
+        .await
+        .expect("insert/delete post-image should stage");
+        let (sparse_catalog, _) = sparse_publication.parts();
+        let mut sparse = fixture_commit_state_manifest(insert_delete_id, sparse_inventory);
+        sparse.parent_commit_ids = vec![touching_id];
+        sparse.replay_debt.depth = super::MIN_CURRENT_STATE_CATALOG_POINT_READS;
+        sparse.current_state_catalog = sparse_catalog;
+        super::stage_certified_commit_state_manifest(
+            &mut sparse_writes,
+            &sparse,
+            &sparse_publication,
+        )
+        .expect("insert/delete manifest should stage");
+        drop(read);
+        storage
+            .commit_write_set(sparse_writes, StorageWriteOptions::default())
+            .await
+            .expect("insert/delete post-image should commit");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("insert/delete read should open");
+        let published_sparse = super::load_published_commit_state_manifest(&read, insert_delete_id)
+            .await
+            .expect("insert/delete manifest should load")
+            .expect("insert/delete manifest should exist");
+        let mut keys = TrackedStateKeyBatchBuilder::with_row_capacity(4);
+        for key in [
+            alpha[0].key(),
+            alpha[1].key(),
+            sparse_fixtures[1].key(),
+            TrackedStateKey {
+                schema_key: "alpha".to_string(),
+                file_id: None,
+                entity_pk: EntityPk::single("authoritative-miss"),
+            },
+        ] {
+            keys.push(TrackedStateKeyRef {
+                schema_key: &key.schema_key,
+                file_id: key.file_id.as_deref(),
+                entity_pk: &key.entity_pk,
+            });
+        }
+        let resolved = super::load_complete_current_state_values_from_published_manifest(
+            &read,
+            &published_sparse,
+            &keys.finish(),
+        )
+        .await
+        .expect("insert/delete points should resolve")
+        .expect("insert/delete scope should remain covered");
+        assert!(resolved[0].is_some(), "untouched row must survive");
+        assert!(resolved[1].is_none(), "delete must be authoritative");
+        assert_eq!(
+            resolved[2].as_ref().map(|value| value.commit_id),
+            Some(insert_delete_id)
+        );
+        assert!(resolved[3].is_none(), "exact miss must be authoritative");
     }
 
     #[tokio::test]

--- a/packages/engine/src/tracked_state/types.rs
+++ b/packages/engine/src/tracked_state/types.rs
@@ -255,9 +255,17 @@ pub(crate) struct CurrentStatePartDescriptor {
     #[musli(bytes)]
     pub(crate) last_key: Vec<u8>,
     pub(crate) content_digest: [u8; 32],
+    /// Digest of the native part's compact JSON-reference summary. Zero for
+    /// complete-replacement sources whose history authority owns reachability.
+    pub(crate) payload_refs_digest: [u8; 32],
+    /// 0 references an immutable complete-replacement mutation part; 1
+    /// references a native content-addressed current-state data part.
+    pub(crate) source_kind: u8,
     pub(crate) owner_commit_id: [u8; 16],
     pub(crate) part_index: u32,
-    pub(crate) first_ordinal: u32,
+    /// First physical row selected from the source part. Descriptor slicing
+    /// allows sparse deletes and updates to retain untouched source bytes.
+    pub(crate) source_row_offset: u16,
     pub(crate) row_count: u16,
     pub(crate) uniform_created_at: LixTimestamp,
     pub(crate) uniform_updated_at: LixTimestamp,
@@ -335,6 +343,9 @@ pub(crate) struct CurrentStateCoverageAnchor {
 #[derive(Debug, Clone, Default, PartialEq, Eq, musli::Encode, musli::Decode)]
 #[musli(packed)]
 pub(crate) struct CommitStateMutationInventory {
+    /// Certified whole-source alias authority. This is never used for a
+    /// finite exact selection: when present, the selected source supplies the
+    /// complete inherited state and authored members overlay it during replay.
     #[musli(with = crate::storage_codec::option)]
     pub(crate) selected_source_commit_id: Option<[u8; 16]>,
     pub(crate) member_count: u32,

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -120,8 +120,7 @@ use crate::transaction::types::{
     StagedCommitChangeBatch, StagedCommitChangeBatchBuilder, TransactionFileContent,
     TransactionJson, TransactionWrite, TransactionWriteMode, TransactionWriteOperation,
     TransactionWriteOrigin, TransactionWriteOutcome, TransactionWriteRow,
-    TypedMutationJournalBatch,
-    canonicalize_transaction_json_batch, stage_json_from_value,
+    TypedMutationJournalBatch, canonicalize_transaction_json_batch, stage_json_from_value,
 };
 
 pub(crate) struct CertifiedHistoryStoreReader<S> {


### PR DESCRIPTION
## What changed

- Add immutable native current-state data parts for sparse post-images, including exact key/value/lifecycle fields and digest-bound JSON reference sidecars.
- Publish a distinct `CurrentStatePartSet` serving view: untouched parent descriptors are retained, touched collection scopes are rewritten into sorted non-overlapping post-image parts, and content-identical directory nodes are reused.
- Route current-state point reads through the post-image catalog for cold keys while probing the head mutation inventory first so hot CRUD keys keep the replay fast path.
- Keep `CommitStateMutationInventory` as history authority. The catalog remains a validated, rebuildable serving accelerator and fails back to canonical replay on missing/corrupt data.
- Extend GC reachability and corruption validation to native parts and their JSON reference sidecars.
- Hard-cut the repository protocol to `sparse-current-state-parts.v50`; no backward compatibility.

This is deliberately workload-neutral physical layout. It consumes the sealed mutation inventory from #1158/#1177 and does not add SQL query recognizers, density policy, or OLAP-specific schema controls.

## Why

Before this cut, touching a scope behind a replacement generation removed that scope from the serving catalog. A cold point read then replayed all sparse commits. The new layout materializes the bounded post-image range once and makes later exact reads independent of replay depth, without moving historical authority out of the commit mutation inventory.

## Performance

1M rows, 256 scopes, 32 sparse commits touching the queried scope, 20 warmups / 201 samples:

| backend | path | p50 | p95 | p50 change | p95 change |
| --- | ---: | ---: | ---: | ---: | ---: |
| RocksDB | canonical replay | 234.852 us | 237.206 us | — | — |
| RocksDB | current-state catalog | 73.368 us | 74.971 us | **-68.76%** | **-68.39%** |
| SlateDB | canonical replay | 323.729 us | 327.145 us | — | — |
| SlateDB | current-state catalog | 92.023 us | 94.358 us | **-71.57%** | **-71.16%** |

Hot-key control, 100 warmups / 1,001 samples, uses the public catalog-then-replay route:

| backend | serving vs replay p50 | serving vs replay p95 |
| --- | ---: | ---: |
| RocksDB | +1.94% | +2.38% |
| SlateDB | -2.54% | +3.35% |

The first sparse publication stages 8 puts / 9,433 bytes. Across 32 sparse commits it stages 256 puts / 301,904 bytes. Compared with the initial eager full-directory rewrite prototype (704 puts / 2,858,966 bytes), content-identical node reuse removes **63.6% of puts** and **89.4% of staged bytes**.

Paired `perf record -F 999 -g` profiles reproduce the RocksDB cold-read reduction (227.718 us replay to 69.812 us catalog, **-69.3%**). Canonical replay spends 18.27% self time decoding inventory digests, 7.70% in BLAKE3 compression, and 3.16% rebuilding leaf references; bounded catalog lookup reduces those stacks to 7.19%, 5.55%, and below the 0.5% report threshold respectively. The remaining candidate cost is direct packed replacement-part decode/materialization.

## Validation

- `cargo check -p lix_engine --all-features --all-targets`
- `cargo test -p lix_engine --lib` — 1,852 passed, 8 ignored
- `cargo test -p lix_engine --test integration` — 440 passed, 2 ignored
- `cargo clippy -p lix_engine --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- Comprehensive replacement/sparse update/delete/reinsert, branch, diff, merge, history, root rebuild, mixed hot+cold point read, GC corruption regression
- Independent subagent reviews: authority/GC/catalog semantics approved; mixed-batch failover issue found, fixed, and re-reviewed with no remaining blocker

## Follow-up cut

This PR reuses content-identical nodes but still flattens the parent descriptor set and can positionally rechunk a suffix. The next physical cut is a persistent key/range-addressed directory splice that loads and rewrites only affected search paths and boundary leaves.
