### PR TITLE
fix integer primary key inserts

### DIFF
--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -4816,6 +4816,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn public_insert_preserves_declared_integer_primary_key_type() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "x-lix-key": "integer_primary_key_insert_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "integer" },
+                "value": { "type": "string" }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+
+        let inserted = session
+            .execute(
+                "INSERT INTO integer_primary_key_insert_probe (id, value) VALUES ($1, $2)",
+                &[Value::Integer(42), Value::Text("answer".to_string())],
+            )
+            .await
+            .unwrap();
+        assert_eq!(inserted.rows_affected(), 1);
+
+        let result = session
+            .execute(
+                "SELECT id, value FROM integer_primary_key_insert_probe WHERE id = $1",
+                &[Value::Integer(42)],
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.rows()[0].get::<i64>("id").unwrap(), 42);
+        assert_eq!(result.rows()[0].get::<String>("value").unwrap(), "answer");
+    }
+
+    #[tokio::test]
     async fn execute_batch_lowers_distinct_bound_entity_inserts_once() {
         let session = open_session().await;
         let schema = serde_json::json!({

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -5302,18 +5302,20 @@ fn append_entity_insert_row(
         .apply(&mut snapshot, ctx.functions(), &layout.schema_key)?;
     let snapshot = JsonValue::Object(snapshot);
     if !spec.primary_key_paths.is_empty() {
-        let derived_entity_pk =
-            EntityPk::from_primary_key_paths(&snapshot, &spec.primary_key_paths).map_err(
-                |error| {
-                    LixError::new(
-                        LixError::CODE_SCHEMA_VALIDATION,
-                        format!(
-                            "INSERT failed to derive entity primary key for schema '{}': {error}",
-                            layout.schema_key
-                        ),
-                    )
-                },
-            )?;
+        let derived_entity_pk = EntityPk::from_primary_key_plan(
+            &snapshot,
+            &spec.primary_key_paths,
+            &spec.primary_key_component_types,
+        )
+        .map_err(|error| {
+            LixError::new(
+                LixError::CODE_SCHEMA_VALIDATION,
+                format!(
+                    "INSERT failed to derive entity primary key for schema '{}': {error}",
+                    layout.schema_key
+                ),
+            )
+        })?;
         if entity_pk
             .as_ref()
             .is_some_and(|explicit_entity_pk| explicit_entity_pk != &derived_entity_pk)


### PR DESCRIPTION
## What changed

- derive public INSERT entity keys with the schema's declared primary-key component types
- add a regression test covering an integer primary key through the public SQL session

## Root cause

The public INSERT fallback derived keys with `EntityPk::from_primary_key_paths`, which defaults path components to strings. Schemas declaring integer primary keys therefore passed schema validation but failed INSERT key derivation. The bound write specification already carries `primary_key_component_types`; the fallback now uses that typed plan.

## Impact

Public SQL INSERTs into schemas with integer primary keys now preserve the declared key type and can be selected back with integer parameters.

## Validation

`CARGO_TARGET_DIR=/root/projects/lixray/vendor/lix/target cargo test -p lix_engine --lib public_insert_preserves_declared_integer_primary_key_type -- --nocapture`

Result: 1 passed; 0 failed; 1,860 filtered out.
