### PR TITLE
add Sysbench-derived CRUD comparison

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,7 +893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
- "phf",
+ "phf 0.12.1",
 ]
 
 [[package]]
@@ -2097,6 +2097,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -2146,7 +2147,7 @@ dependencies = [
  "arrow",
  "cast",
  "comfy-table",
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink 0.10.0",
  "libduckdb-sys",
@@ -2242,6 +2243,12 @@ dependencies = [
  "rand 0.9.2",
  "tokio",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fallible-iterator"
@@ -2525,7 +2532,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -2673,6 +2680,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder",
+ "crossbeam-channel",
+ "flate2",
+ "nom 7.1.3",
+ "num-traits",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2695,6 +2716,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -3417,12 +3447,14 @@ dependencies = [
  "datafusion",
  "duckdb",
  "futures-util",
+ "hdrhistogram",
  "lix_engine",
  "lix_rocksdb_storage",
  "lix_slatedb_storage",
  "lix_sqlite_storage",
  "mimalloc",
  "object_store 0.14.0",
+ "postgres",
  "rusqlite",
  "rustc-hash",
  "serde",
@@ -3731,6 +3763,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3784,7 +3826,7 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -4109,6 +4151,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4298,7 +4349,17 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -4306,6 +4367,15 @@ name = "phf_shared"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -4439,6 +4509,49 @@ dependencies = [
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
  "serde",
+]
+
+[[package]]
+name = "postgres"
+version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c48ece1c6cda0db61b058c1721378da76855140e9214339fa1317decacb176"
+dependencies = [
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-util",
+ "log",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee9dd5fe15055d2b6806f4736aa0c9637217074e224bbec46d4041b91bb9491"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand 0.9.2",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b858f82211e84682fecd373f68e1ceae642d8d751a1ebd13f33de6257b3e20"
+dependencies = [
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "postgres-protocol",
 ]
 
 [[package]]
@@ -4710,7 +4823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
  "bitflags",
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink 0.9.1",
  "libsqlite3-sys",
@@ -5204,6 +5317,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5432,6 +5556,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5456,6 +5595,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcea47c8f71744367793f16c2db1f11cb859d28f436bdb4ca9193eb1f787ee42"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf 0.13.1",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.9.2",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami",
 ]
 
 [[package]]
@@ -5732,10 +5897,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -5883,6 +6069,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5898,6 +6093,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -6370,6 +6574,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]

--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -19,6 +19,7 @@ sqlite = ["dep:lix_sqlite_storage", "dep:rusqlite"]
 slatedb = ["dep:lix_slatedb_storage", "dep:object_store", "dep:slatedb", "dep:ulid"]
 storage-benches = ["lix_engine/storage-benches", "rocksdb", "sqlite"]
 tpch = ["dep:duckdb", "dep:tpchgen"]
+postgres = ["dep:postgres"]
 # Opt-in profiling build that routes Rust allocations through libc so tools
 # such as heaptrack can attribute transient allocation churn to call stacks.
 # Normal tracked-CRUD builds wrap mimalloc with byte accounting so latency
@@ -37,6 +38,7 @@ ulid = { version = "1.2.1", optional = true }
 rusqlite = { version = "0.32", features = ["bundled"], optional = true }
 duckdb = { version = "=1.10505.0", features = ["bundled"], optional = true }
 tpchgen = { version = "=3.0.0", optional = true }
+postgres = { version = "0.19", optional = true }
 zstd = "0.13"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
@@ -58,6 +60,7 @@ tempfile = "3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
+hdrhistogram = "7"
 
 [[example]]
 name = "storage_layout"
@@ -68,6 +71,11 @@ required-features = ["storage-benches", "slatedb"]
 name = "revision_pack_oracle"
 path = "examples/revision_pack_oracle.rs"
 required-features = ["storage-benches", "slatedb"]
+
+[[example]]
+name = "sysbench_crud"
+path = "examples/sysbench_crud.rs"
+required-features = ["sqlite", "slatedb", "postgres"]
 
 [[test]]
 name = "exact_file_read_benchmark"

--- a/packages/engine-benchmarks/SYSBENCH_PROFILE.md
+++ b/packages/engine-benchmarks/SYSBENCH_PROFILE.md
@@ -1,0 +1,99 @@
+# Sysbench-derived OLTP comparison profile
+
+Status: benchmark contract. The existing `tracked_state_crud` benchmark is a
+component-level qualification harness; results from it must not be presented as
+Sysbench results.
+
+## Claim boundary
+
+The suite compares current-state SQL performance in Lix with always-on tracked
+history against conventional SQLite and PostgreSQL current-state tables. It is
+described as **Sysbench 1.0.20 OLTP-derived, common-feature profile**. It is not
+an official or unmodified Sysbench result because Sysbench has no Lix driver
+and the common profile deliberately removes features unavailable in Lix.
+
+The first publication does not claim feature-equivalent version control for
+SQLite or PostgreSQL. A later suite measures branching, diff, merge, rollback,
+and historical queries separately.
+
+## Systems under test
+
+- `lix-slatedb`: the public Lix SQL session backed by local durable SlateDB;
+  tracked history and normal commit semantics remain enabled.
+- `sqlite`: standalone SQLite in WAL mode through its in-process driver.
+- `postgres`: PostgreSQL through a loopback client connection.
+
+All three are driven from the same benchmark process. The embedded versus
+client/server boundary is part of the measured system and must be stated beside
+published charts. Remote object-store latency and the Lix HTTP protocol are
+separate product benchmarks and are not mixed into this engine comparison.
+
+## Common schema
+
+The logical schema follows Sysbench's `sbtest` table:
+
+```sql
+CREATE TABLE sbtest1 (
+  id BIGINT NOT NULL PRIMARY KEY,
+  k BIGINT NOT NULL,
+  c VARCHAR(120) NOT NULL,
+  pad VARCHAR(60) NOT NULL
+);
+```
+
+The profile corresponds to `--auto-inc=off --create-secondary=off`. Secondary
+index maintenance cannot be compared until Lix exposes a corresponding public
+index feature. Every engine receives identical deterministic values and row
+order. Load, schema registration, connection setup, and warmup are outside the
+measurement interval. PostgreSQL uses reusable prepared statements, SQLite uses
+its prepared-statement cache, and Lix includes the per-event parse/plan costs
+imposed by its public SQL API. That difference is recorded as part of the tested
+system.
+
+## Workloads
+
+The initial CRUD publication includes the operation definitions from Sysbench
+1.0.20:
+
+- `oltp_point_select`: one primary-key point select per event.
+- `oltp_insert`: one insert per event into a reserved, non-colliding key range.
+- `oltp_update_index`: `UPDATE ... SET k=k+1 WHERE id=?`.
+- `oltp_update_non_index`: replace `c` by primary key.
+- `oltp_delete`: one primary-key delete per event from an independently seeded
+  disposable key range.
+
+The follow-up mixed suite adds the exact read-only, write-only, and read/write
+transaction composition: ten point reads; one each of simple, sum, ordered,
+and distinct range reads; one indexed-column update; one non-indexed-column
+update; and one delete/insert pair where applicable.
+
+## Fixed publication matrix
+
+- Sysbench reference: tag `1.0.20`.
+- Table size: 1,000 for automated qualification; 100,000 and 1,000,000 for
+  publication.
+- Access distribution: uniform with a recorded 64-bit seed.
+- Clients: 1, 4, and 16.
+- Warmup: 15 seconds.
+- Measurement: 60 seconds.
+- Repetitions: at least five fresh, independently loaded databases per point,
+  run in counterbalanced engine order.
+- Durability: defaults are retained and recorded; no `fsync` or synchronous
+  commit relaxation is allowed.
+
+Each event is atomic. The runner performs no automatic retries; failed or
+conflicted events are counted and reported rather than silently removed.
+
+## Required report fields
+
+Every machine-readable result records engine and library versions, Git
+revision and dirty state, database configuration, workload parameters, seed,
+start/end Unix timestamps, successful and failed events, retries, throughput,
+p50/p95/p99/max latency, logical row count, retained history/commit count where
+available, and physical storage bytes before and after the run. The matrix
+manifest records OS/kernel, CPU, memory, block devices, filesystem, invocation,
+run order, and the exact result files.
+
+Publication charts use absolute values with uncertainty across independent
+repetitions. Relative multipliers are secondary annotations. Raw JSON results,
+runner source, and the exact reproduction command ship with the post.

--- a/packages/engine-benchmarks/benches/tracked_state_crud/README.md
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/README.md
@@ -1,0 +1,89 @@
+# Tracked-state CRUD benchmark
+
+This benchmark compares the same deterministic CRUD operations through Lix,
+standalone SQLite, and optionally PostgreSQL. Lix keeps its normal tracked
+commit history enabled. The conventional database controls retain only current
+state; that asymmetry is intentional for measuring the cost of Lix's always-on
+history and must be disclosed with published results.
+
+This is a neutral direct-driver benchmark, not a database wire protocol and not
+an official Sysbench result. Sysbench provides database drivers and Lua
+workloads; it does not define a "Sysbench protocol." The operation names here
+are suitable prerequisites for a later Sysbench-derived mixed-workload runner.
+
+Run Lix and SQLite with:
+
+```sh
+cargo bench -p lix_engine_benchmarks --bench tracked_state_crud \
+  --features storage-benches
+```
+
+Add PostgreSQL by enabling the feature and supplying a dedicated benchmark
+database. Each sample uses a connection-local temporary table, so the runner
+does not modify persistent schemas:
+
+```sh
+LIX_TRACKED_STATE_CRUD_POSTGRES_URL='postgresql://bench:bench@127.0.0.1/bench' \
+  cargo bench -p lix_engine_benchmarks --bench tracked_state_crud \
+  --features storage-benches,postgres
+```
+
+The common matrix covers bulk insert, full scan, one- and ten-key reads, bulk
+and point updates, and bulk and point deletes at 1,000 and 10,000 rows. Fixture
+creation, connection establishment, table creation, seeding, and statement
+preparation are outside each timed sample. Query execution and complete result
+transfer into the benchmark process are inside it.
+
+For publishable comparisons, pin engine versions and configuration, use the
+same machine and durability policy, retain raw Criterion output, and report
+median plus tail latency rather than only relative multipliers. Embedded
+SQLite and Lix avoid a network hop while PostgreSQL uses its normal client/server
+boundary; state that boundary explicitly in the post.
+
+## Sysbench-derived publication runner
+
+The separate `sysbench_crud` example implements the point-CRUD event shapes
+from Sysbench 1.0.20 with one shared generator and timing loop for Lix/SlateDB,
+SQLite, and PostgreSQL. Build it without unrelated default storage adapters:
+
+```sh
+cargo build -p lix_engine_benchmarks --release \
+  --example sysbench_crud --no-default-features \
+  --features sqlite,slatedb,postgres
+```
+
+Run a fixed-event qualification point directly:
+
+```sh
+target/release/examples/sysbench_crud \
+  --engine lix-slatedb \
+  --workload point-select \
+  --table-size 1000 \
+  --clients 2 \
+  --events-per-client 20 \
+  --seed 42
+```
+
+The orchestrator builds release mode, runs every CRUD shape against all three
+engines in counterbalanced order, records host and revision metadata, validates
+each result, and retains the raw JSON:
+
+```sh
+node packages/engine-benchmarks/scripts/run-sysbench-crud.mjs \
+  --qualify \
+  --postgres-url 'postgresql://bench:bench@127.0.0.1:5432/bench'
+
+node packages/engine-benchmarks/scripts/run-sysbench-crud.mjs \
+  --postgres-url 'postgresql://bench:bench@127.0.0.1:5432/bench' \
+  --output-dir target/sysbench-results/publication-1
+```
+
+The publication profile is intentionally long: five workloads, two table
+sizes, three client counts, three engines, and five independent repetitions,
+each with a 15-second warmup and 60-second measurement. Use `--sizes`,
+`--clients`, `--repetitions`, `--warmup-seconds`, and `--time-seconds` only for
+explicitly labeled exploratory profiles. Never mix those results into the
+fixed publication cohort.
+
+The exact claim and fairness boundary are defined in
+`packages/engine-benchmarks/SYSBENCH_PROFILE.md`.

--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -112,6 +112,8 @@ fn print_allocation_accounting(_phase: &str) {}
 mod accounting;
 mod io_stats;
 mod kv_layout;
+#[cfg(feature = "postgres")]
+mod raw_postgres;
 mod raw_sqlite;
 mod sql_session;
 mod storage;
@@ -159,6 +161,10 @@ fn tracked_state_crud_benches(c: &mut Criterion) {
 
     for (label, row_count) in [("smoke", SMOKE_ROWS), ("real_workload", REAL_WORKLOAD_ROWS)] {
         bench_raw_sqlite(c, &rows[..row_count], label);
+        #[cfg(feature = "postgres")]
+        if let Some(url) = raw_postgres::configured_url() {
+            bench_raw_postgres(c, &rows[..row_count], label, &url);
+        }
         for &profile in KV_STORAGE_PROFILES {
             bench_kv_layout(c, &runtime, profile, &rows[..row_count], label);
         }
@@ -1214,6 +1220,71 @@ fn bench_raw_sqlite(c: &mut Criterion, rows: &[WorkloadRow], label: &str) {
     group.bench_function(format!("delete_one_by_pk/{}", row_label(rows.len())), |b| {
         b.iter_batched_ref(
             || raw_sqlite::seeded_fixture(&rows),
+            |fixture| black_box(fixture.delete_one_by_pk()),
+            BatchSize::LargeInput,
+        );
+    });
+    group.finish();
+}
+
+#[cfg(feature = "postgres")]
+fn bench_raw_postgres(c: &mut Criterion, rows: &[WorkloadRow], label: &str, url: &str) {
+    let mut group = c.benchmark_group(format!("tracked_state_crud/raw_postgres/{label}"));
+    configure_group(&mut group, rows.len());
+    let rows = rows.to_vec();
+
+    group.bench_function(format!("insert_all_rows/{}", row_label(rows.len())), |b| {
+        b.iter_batched_ref(
+            || raw_postgres::empty_fixture(url, &rows),
+            |fixture| black_box(fixture.insert_all()),
+            BatchSize::LargeInput,
+        );
+    });
+    group.bench_function(format!("read_all_rows/{}", row_label(rows.len())), |b| {
+        b.iter_batched_ref(
+            || raw_postgres::seeded_fixture(url, &rows),
+            |fixture| black_box(fixture.read_all()),
+            BatchSize::LargeInput,
+        );
+    });
+    group.bench_function(format!("read_one_by_pk/{}", row_label(rows.len())), |b| {
+        b.iter_batched_ref(
+            || raw_postgres::seeded_fixture(url, &rows),
+            |fixture| black_box(fixture.read_one_by_pk()),
+            BatchSize::LargeInput,
+        );
+    });
+    group.bench_function(format!("read_many_by_pk/{READ_MANY_PK_COUNT}"), |b| {
+        b.iter_batched_ref(
+            || raw_postgres::seeded_fixture(url, &rows),
+            |fixture| black_box(fixture.read_many_by_pk(READ_MANY_PK_COUNT)),
+            BatchSize::LargeInput,
+        );
+    });
+    group.bench_function(format!("update_all_rows/{}", row_label(rows.len())), |b| {
+        b.iter_batched_ref(
+            || raw_postgres::seeded_fixture(url, &rows),
+            |fixture| black_box(fixture.update_all()),
+            BatchSize::LargeInput,
+        );
+    });
+    group.bench_function(format!("update_one_by_pk/{}", row_label(rows.len())), |b| {
+        b.iter_batched_ref(
+            || raw_postgres::seeded_fixture(url, &rows),
+            |fixture| black_box(fixture.update_one_by_pk()),
+            BatchSize::LargeInput,
+        );
+    });
+    group.bench_function(format!("delete_all_rows/{}", row_label(rows.len())), |b| {
+        b.iter_batched_ref(
+            || raw_postgres::seeded_fixture(url, &rows),
+            |fixture| black_box(fixture.delete_all()),
+            BatchSize::LargeInput,
+        );
+    });
+    group.bench_function(format!("delete_one_by_pk/{}", row_label(rows.len())), |b| {
+        b.iter_batched_ref(
+            || raw_postgres::seeded_fixture(url, &rows),
             |fixture| black_box(fixture.delete_one_by_pk()),
             BatchSize::LargeInput,
         );

--- a/packages/engine-benchmarks/benches/tracked_state_crud/raw_postgres.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/raw_postgres.rs
@@ -1,0 +1,218 @@
+use postgres::{Client, NoTls, Statement};
+
+use crate::workload::WorkloadRow;
+
+const URL_ENV: &str = "LIX_TRACKED_STATE_CRUD_POSTGRES_URL";
+
+pub(crate) struct RawPostgresFixture {
+    client: Client,
+    rows: Vec<WorkloadRow>,
+    read_many_by_pk_count: usize,
+    insert: Statement,
+    read_all_statement: Statement,
+    read_one_statement: Statement,
+    read_many_statement: Statement,
+    update: Statement,
+    delete_all_statement: Statement,
+    delete_one_statement: Statement,
+}
+
+pub(crate) fn configured_url() -> Option<String> {
+    std::env::var(URL_ENV)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+}
+
+pub(crate) fn empty_fixture(url: &str, rows: &[WorkloadRow]) -> RawPostgresFixture {
+    empty_fixture_with_read_many_pk_count(url, rows, crate::READ_MANY_PK_COUNT)
+}
+
+fn empty_fixture_with_read_many_pk_count(
+    url: &str,
+    rows: &[WorkloadRow],
+    read_many_by_pk_count: usize,
+) -> RawPostgresFixture {
+    assert!(
+        (1..=rows.len()).contains(&read_many_by_pk_count),
+        "read-many primary-key count must be between 1 and {}, got {read_many_by_pk_count}",
+        rows.len()
+    );
+    let mut client = Client::connect(url, NoTls)
+        .unwrap_or_else(|error| panic!("connect to PostgreSQL from {URL_ENV}: {error}"));
+    client
+        .batch_execute(
+            "CREATE TEMP TABLE json_pointer (
+                 path TEXT PRIMARY KEY NOT NULL,
+                 value TEXT NOT NULL
+             );",
+        )
+        .expect("initialize raw PostgreSQL benchmark table");
+
+    let insert = client
+        .prepare("INSERT INTO json_pointer (path, value) VALUES ($1, $2)")
+        .expect("prepare raw PostgreSQL insert");
+    let read_all_statement = client
+        .prepare("SELECT path, value FROM json_pointer ORDER BY path")
+        .expect("prepare raw PostgreSQL read all");
+    let read_one_statement = client
+        .prepare("SELECT path, value FROM json_pointer WHERE path = $1")
+        .expect("prepare raw PostgreSQL point read");
+    let read_many_statement = client
+        .prepare(&select_many_by_pk_sql(read_many_by_pk_count))
+        .expect("prepare raw PostgreSQL multi-point read");
+    let update = client
+        .prepare("UPDATE json_pointer SET value = $1 WHERE path = $2")
+        .expect("prepare raw PostgreSQL update");
+    let delete_all_statement = client
+        .prepare("DELETE FROM json_pointer")
+        .expect("prepare raw PostgreSQL delete all");
+    let delete_one_statement = client
+        .prepare("DELETE FROM json_pointer WHERE path = $1")
+        .expect("prepare raw PostgreSQL point delete");
+
+    RawPostgresFixture {
+        client,
+        rows: rows.to_vec(),
+        read_many_by_pk_count,
+        insert,
+        read_all_statement,
+        read_one_statement,
+        read_many_statement,
+        update,
+        delete_all_statement,
+        delete_one_statement,
+    }
+}
+
+pub(crate) fn seeded_fixture(url: &str, rows: &[WorkloadRow]) -> RawPostgresFixture {
+    let mut fixture = empty_fixture(url, rows);
+    fixture.insert_all();
+    fixture
+}
+
+impl RawPostgresFixture {
+    pub(crate) fn insert_all(&mut self) -> usize {
+        let statement = self.insert.clone();
+        let mut transaction = self
+            .client
+            .transaction()
+            .expect("begin raw PostgreSQL insert transaction");
+        let mut affected = 0_u64;
+        for row in &self.rows {
+            affected += transaction
+                .execute(&statement, &[&row.path, &row.value_json])
+                .expect("insert raw PostgreSQL row");
+        }
+        transaction
+            .commit()
+            .expect("commit raw PostgreSQL insert transaction");
+        assert_eq!(affected as usize, self.rows.len());
+        affected as usize
+    }
+
+    pub(crate) fn read_all(&mut self) -> usize {
+        let results = self
+            .client
+            .query(&self.read_all_statement, &[])
+            .expect("query all raw PostgreSQL rows");
+        for result in &results {
+            let _: &str = result.get(0);
+            let _: &str = result.get(1);
+        }
+        assert_eq!(results.len(), self.rows.len());
+        results.len()
+    }
+
+    pub(crate) fn read_one_by_pk(&mut self) -> usize {
+        let row = &self.rows[self.rows.len() / 2];
+        let results = self
+            .client
+            .query(&self.read_one_statement, &[&row.path])
+            .expect("query raw PostgreSQL point row");
+        assert_eq!(results.len(), 1);
+        let _: &str = results[0].get(0);
+        let _: &str = results[0].get(1);
+        results.len()
+    }
+
+    pub(crate) fn read_many_by_pk(&mut self, count: usize) -> usize {
+        assert_eq!(
+            count, self.read_many_by_pk_count,
+            "read-many benchmark must use the fixture's setup-excluded query shape"
+        );
+        let parameters = self.rows[..count]
+            .iter()
+            .map(|row| {
+                let parameter: &(dyn postgres::types::ToSql + Sync) = &row.path;
+                parameter
+            })
+            .collect::<Vec<_>>();
+        let results = self
+            .client
+            .query(&self.read_many_statement, &parameters)
+            .expect("query raw PostgreSQL multi-point rows");
+        for result in &results {
+            let _: &str = result.get(0);
+            let _: &str = result.get(1);
+        }
+        assert_eq!(results.len(), count);
+        results.len()
+    }
+
+    pub(crate) fn update_all(&mut self) -> usize {
+        let statement = self.update.clone();
+        let mut transaction = self
+            .client
+            .transaction()
+            .expect("begin raw PostgreSQL update transaction");
+        let mut affected = 0_u64;
+        for row in &self.rows {
+            affected += transaction
+                .execute(&statement, &[&row.updated_value_json, &row.path])
+                .expect("update raw PostgreSQL row");
+        }
+        transaction
+            .commit()
+            .expect("commit raw PostgreSQL update transaction");
+        assert_eq!(affected as usize, self.rows.len());
+        affected as usize
+    }
+
+    pub(crate) fn update_one_by_pk(&mut self) -> usize {
+        let row = &self.rows[self.rows.len() / 2];
+        let affected = self
+            .client
+            .execute(&self.update, &[&row.updated_value_json, &row.path])
+            .expect("update one raw PostgreSQL row");
+        assert_eq!(affected, 1);
+        affected as usize
+    }
+
+    pub(crate) fn delete_all(&mut self) -> usize {
+        let affected = self
+            .client
+            .execute(&self.delete_all_statement, &[])
+            .expect("delete all raw PostgreSQL rows");
+        assert_eq!(affected as usize, self.rows.len());
+        affected as usize
+    }
+
+    pub(crate) fn delete_one_by_pk(&mut self) -> usize {
+        let row = &self.rows[self.rows.len() / 2];
+        let affected = self
+            .client
+            .execute(&self.delete_one_statement, &[&row.path])
+            .expect("delete one raw PostgreSQL row");
+        assert_eq!(affected, 1);
+        affected as usize
+    }
+}
+
+fn select_many_by_pk_sql(count: usize) -> String {
+    assert!(count > 0, "read-many benchmark requires at least one row");
+    let placeholders = (1..=count)
+        .map(|index| format!("${index}"))
+        .collect::<Vec<_>>()
+        .join(",");
+    format!("SELECT path, value FROM json_pointer WHERE path IN ({placeholders}) ORDER BY path")
+}

--- a/packages/engine-benchmarks/examples/sysbench_crud.rs
+++ b/packages/engine-benchmarks/examples/sysbench_crud.rs
@@ -1,0 +1,1389 @@
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Barrier, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use hdrhistogram::Histogram;
+use lix_engine::{Engine, ExecuteBatchStatement, SessionContext, Value};
+use lix_slatedb_storage::SlateDB;
+use postgres::{Client, NoTls, Statement};
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::Serialize;
+use tempfile::TempDir;
+
+const INSERT_SQL: &str = "INSERT INTO sbtest1 (id, k, c, pad) VALUES ($1, $2, $3, $4)";
+const POINT_SELECT_SQL: &str = "SELECT c FROM sbtest1 WHERE id = $1";
+const UPDATE_INDEX_SQL: &str = "UPDATE sbtest1 SET k = k + 1 WHERE id = $1";
+const UPDATE_NON_INDEX_SQL: &str = "UPDATE sbtest1 SET c = $1 WHERE id = $2";
+const DELETE_SQL: &str = "DELETE FROM sbtest1 WHERE id = $1";
+const SYSBENCH_VERSION: &str = "1.0.20";
+const PROFILE_NAME: &str = "sysbench-1.0.20-oltp-derived-common-feature";
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum EngineKind {
+    LixSlatedb,
+    Sqlite,
+    Postgres,
+}
+
+impl FromStr for EngineKind {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "lix-slatedb" => Ok(Self::LixSlatedb),
+            "sqlite" => Ok(Self::Sqlite),
+            "postgres" => Ok(Self::Postgres),
+            _ => Err(format!(
+                "unknown engine '{value}'; expected lix-slatedb, sqlite, or postgres"
+            )),
+        }
+    }
+}
+
+impl fmt::Display for EngineKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::LixSlatedb => formatter.write_str("lix-slatedb"),
+            Self::Sqlite => formatter.write_str("sqlite"),
+            Self::Postgres => formatter.write_str("postgres"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum Workload {
+    PointSelect,
+    Insert,
+    UpdateIndex,
+    UpdateNonIndex,
+    Delete,
+}
+
+impl Workload {
+    fn needs_seed(self) -> bool {
+        !matches!(self, Self::Insert)
+    }
+}
+
+impl FromStr for Workload {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "point-select" => Ok(Self::PointSelect),
+            "insert" => Ok(Self::Insert),
+            "update-index" => Ok(Self::UpdateIndex),
+            "update-non-index" => Ok(Self::UpdateNonIndex),
+            "delete" => Ok(Self::Delete),
+            _ => Err(format!(
+                "unknown workload '{value}'; expected point-select, insert, update-index, update-non-index, or delete"
+            )),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Config {
+    engine: EngineKind,
+    workload: Workload,
+    table_size: u32,
+    clients: usize,
+    warmup: Duration,
+    measurement: Duration,
+    events_per_client: Option<u64>,
+    seed: u64,
+    load_batch_size: usize,
+    settle: Duration,
+    database_path: Option<PathBuf>,
+    postgres_url: Option<String>,
+    output: Option<PathBuf>,
+    target_revision: Option<String>,
+    target_dirty: bool,
+}
+
+impl Config {
+    fn parse() -> Result<Self, String> {
+        let mut engine = None;
+        let mut workload = None;
+        let mut table_size = 10_000_u32;
+        let mut clients = 1_usize;
+        let mut warmup_seconds = 15_u64;
+        let mut time_seconds = 60_u64;
+        let mut events_per_client = None;
+        let mut seed = 1_u64;
+        let mut load_batch_size = 10_000_usize;
+        let mut settle_ms = 1_000_u64;
+        let mut database_path = None;
+        let mut postgres_url = None;
+        let mut output = None;
+        let mut target_revision = None;
+        let mut target_dirty = false;
+        let mut arguments = std::env::args().skip(1);
+        while let Some(flag) = arguments.next() {
+            let mut value = || {
+                arguments
+                    .next()
+                    .ok_or_else(|| format!("{flag} requires a value"))
+            };
+            match flag.as_str() {
+                "--engine" => engine = Some(value()?.parse()?),
+                "--workload" => workload = Some(value()?.parse()?),
+                "--table-size" => table_size = parse_positive(&flag, &value()?)?,
+                "--clients" => clients = parse_positive(&flag, &value()?)?,
+                "--warmup-seconds" => warmup_seconds = parse_number(&flag, &value()?)?,
+                "--time-seconds" => time_seconds = parse_number(&flag, &value()?)?,
+                "--events-per-client" => {
+                    events_per_client = Some(parse_positive(&flag, &value()?)?)
+                }
+                "--seed" => seed = parse_number(&flag, &value()?)?,
+                "--load-batch-size" => load_batch_size = parse_positive(&flag, &value()?)?,
+                "--settle-ms" => settle_ms = parse_number(&flag, &value()?)?,
+                "--database-path" => database_path = Some(PathBuf::from(value()?)),
+                "--postgres-url" => postgres_url = Some(value()?),
+                "--output" => output = Some(PathBuf::from(value()?)),
+                "--target-revision" => target_revision = Some(value()?),
+                "--target-dirty" => target_dirty = parse_number(&flag, &value()?)?,
+                "--help" | "-h" => return Err(usage()),
+                _ => return Err(format!("unknown argument '{flag}'\n\n{}", usage())),
+            }
+        }
+        let engine = engine.ok_or_else(|| format!("--engine is required\n\n{}", usage()))?;
+        let workload = workload.ok_or_else(|| format!("--workload is required\n\n{}", usage()))?;
+        if events_per_client.is_none() && time_seconds == 0 {
+            return Err("--time-seconds must be positive unless --events-per-client is set".into());
+        }
+        if events_per_client.is_some() {
+            warmup_seconds = 0;
+            time_seconds = 0;
+        }
+        if matches!(engine, EngineKind::Postgres) && postgres_url.is_none() {
+            return Err("--postgres-url is required for the postgres engine".into());
+        }
+        Ok(Self {
+            engine,
+            workload,
+            table_size,
+            clients,
+            warmup: Duration::from_secs(warmup_seconds),
+            measurement: Duration::from_secs(time_seconds),
+            events_per_client,
+            seed,
+            load_batch_size,
+            settle: Duration::from_millis(settle_ms),
+            database_path,
+            postgres_url,
+            output,
+            target_revision,
+            target_dirty,
+        })
+    }
+}
+
+fn parse_number<T>(flag: &str, value: &str) -> Result<T, String>
+where
+    T: FromStr,
+    T::Err: fmt::Display,
+{
+    value
+        .parse()
+        .map_err(|error| format!("invalid value for {flag}: {error}"))
+}
+
+fn parse_positive<T>(flag: &str, value: &str) -> Result<T, String>
+where
+    T: FromStr + Default + PartialOrd,
+    T::Err: fmt::Display,
+{
+    let parsed = parse_number(flag, value)?;
+    if parsed <= T::default() {
+        return Err(format!("{flag} must be positive"));
+    }
+    Ok(parsed)
+}
+
+fn usage() -> String {
+    r#"Usage: sysbench_crud --engine <lix-slatedb|sqlite|postgres> \
+  --workload <point-select|insert|update-index|update-non-index|delete> [options]
+
+Options:
+  --table-size N            Seed rows (default 10000)
+  --clients N               Concurrent clients (default 1)
+  --warmup-seconds N        Warmup duration (default 15)
+  --time-seconds N          Measurement duration (default 60)
+  --events-per-client N     Fixed-event qualification mode; disables warmup
+  --seed N                  Deterministic 64-bit seed (default 1)
+  --load-batch-size N       Rows committed per load transaction (default 10000)
+  --database-path PATH      Fresh SQLite file or Lix SlateDB directory
+  --postgres-url URL        Dedicated PostgreSQL benchmark database
+  --output PATH             Write JSON report to a new file
+  --target-revision REV     Revision recorded in the report
+  --settle-ms N             Settle before storage snapshots (default 1000)
+  --target-dirty BOOL       Dirty checkout state recorded in the report"#
+        .to_string()
+}
+
+#[derive(Clone)]
+enum WorkerFactory {
+    Lix(Arc<Engine<SlateDB>>),
+    Sqlite(PathBuf),
+    Postgres { url: String, schema: String },
+}
+
+enum Worker {
+    Lix {
+        runtime: tokio::runtime::Runtime,
+        session: SessionContext<SlateDB>,
+    },
+    Sqlite(Connection),
+    Postgres {
+        client: Client,
+        statements: PostgresStatements,
+    },
+}
+
+struct PostgresStatements {
+    point_select: Statement,
+    insert: Statement,
+    update_index: Statement,
+    update_non_index: Statement,
+    delete: Statement,
+}
+
+impl WorkerFactory {
+    fn worker(&self) -> Result<Worker, String> {
+        match self {
+            Self::Lix(engine) => {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|error| format!("create Lix worker runtime: {error}"))?;
+                let session = runtime
+                    .block_on(engine.open_workspace_session())
+                    .map_err(|error| format!("open Lix worker session: {error}"))?;
+                Ok(Worker::Lix { runtime, session })
+            }
+            Self::Sqlite(path) => {
+                let connection = Connection::open(path)
+                    .map_err(|error| format!("open SQLite worker connection: {error}"))?;
+                configure_sqlite(&connection)?;
+                connection.set_prepared_statement_cache_capacity(16);
+                Ok(Worker::Sqlite(connection))
+            }
+            Self::Postgres { url, schema } => {
+                let mut client = Client::connect(url, NoTls)
+                    .map_err(|error| format!("open PostgreSQL worker connection: {error}"))?;
+                set_postgres_schema(&mut client, schema)?;
+                let statements = PostgresStatements {
+                    point_select: client
+                        .prepare(POINT_SELECT_SQL)
+                        .map_err(|error| format!("prepare PostgreSQL point select: {error}"))?,
+                    insert: client
+                        .prepare(INSERT_SQL)
+                        .map_err(|error| format!("prepare PostgreSQL insert: {error}"))?,
+                    update_index: client
+                        .prepare(UPDATE_INDEX_SQL)
+                        .map_err(|error| format!("prepare PostgreSQL indexed update: {error}"))?,
+                    update_non_index: client
+                        .prepare(UPDATE_NON_INDEX_SQL)
+                        .map_err(|error| format!("prepare PostgreSQL non-index update: {error}"))?,
+                    delete: client
+                        .prepare(DELETE_SQL)
+                        .map_err(|error| format!("prepare PostgreSQL delete: {error}"))?,
+                };
+                Ok(Worker::Postgres { client, statements })
+            }
+        }
+    }
+}
+
+impl Worker {
+    fn event(
+        &mut self,
+        workload: Workload,
+        id: i64,
+        k: i64,
+        c: &str,
+        pad: &str,
+    ) -> Result<(), String> {
+        match self {
+            Self::Lix { runtime, session } => runtime.block_on(async {
+                let result = match workload {
+                    Workload::PointSelect => {
+                        session
+                            .execute(POINT_SELECT_SQL, &[Value::Integer(id)])
+                            .await
+                    }
+                    Workload::Insert => {
+                        session
+                            .execute(
+                                INSERT_SQL,
+                                &[
+                                    Value::Integer(id),
+                                    Value::Integer(k),
+                                    Value::Text(c.to_string()),
+                                    Value::Text(pad.to_string()),
+                                ],
+                            )
+                            .await
+                    }
+                    Workload::UpdateIndex => {
+                        session
+                            .execute(UPDATE_INDEX_SQL, &[Value::Integer(id)])
+                            .await
+                    }
+                    Workload::UpdateNonIndex => {
+                        session
+                            .execute(
+                                UPDATE_NON_INDEX_SQL,
+                                &[Value::Text(c.to_string()), Value::Integer(id)],
+                            )
+                            .await
+                    }
+                    Workload::Delete => session.execute(DELETE_SQL, &[Value::Integer(id)]).await,
+                }
+                .map_err(|error| error.to_string())?;
+                if matches!(workload, Workload::PointSelect) && result.rows().len() != 1 {
+                    return Err(format!(
+                        "point select returned {} rows instead of one",
+                        result.rows().len()
+                    ));
+                }
+                Ok(())
+            }),
+            Self::Sqlite(connection) => {
+                match workload {
+                    Workload::PointSelect => {
+                        let mut statement = connection
+                            .prepare_cached("SELECT c FROM sbtest1 WHERE id = ?1")
+                            .map_err(|error| error.to_string())?;
+                        let value = statement
+                            .query_row(params![id], |row| row.get::<_, String>(0))
+                            .optional()
+                            .map_err(|error| error.to_string())?;
+                        if value.is_none() {
+                            return Err("point select returned no row".into());
+                        }
+                    }
+                    Workload::Insert => {
+                        connection
+                            .prepare_cached(
+                                "INSERT INTO sbtest1 (id, k, c, pad) VALUES (?1, ?2, ?3, ?4)",
+                            )
+                            .map_err(|error| error.to_string())?
+                            .execute(params![id, k, c, pad])
+                            .map_err(|error| error.to_string())?;
+                    }
+                    Workload::UpdateIndex => {
+                        connection
+                            .prepare_cached("UPDATE sbtest1 SET k = k + 1 WHERE id = ?1")
+                            .map_err(|error| error.to_string())?
+                            .execute(params![id])
+                            .map_err(|error| error.to_string())?;
+                    }
+                    Workload::UpdateNonIndex => {
+                        connection
+                            .prepare_cached("UPDATE sbtest1 SET c = ?1 WHERE id = ?2")
+                            .map_err(|error| error.to_string())?
+                            .execute(params![c, id])
+                            .map_err(|error| error.to_string())?;
+                    }
+                    Workload::Delete => {
+                        connection
+                            .prepare_cached("DELETE FROM sbtest1 WHERE id = ?1")
+                            .map_err(|error| error.to_string())?
+                            .execute(params![id])
+                            .map_err(|error| error.to_string())?;
+                    }
+                }
+                Ok(())
+            }
+            Self::Postgres { client, statements } => {
+                match workload {
+                    Workload::PointSelect => {
+                        let rows = client
+                            .query(&statements.point_select, &[&id])
+                            .map_err(|error| error.to_string())?;
+                        if rows.len() != 1 {
+                            return Err(format!(
+                                "point select returned {} rows instead of one",
+                                rows.len()
+                            ));
+                        }
+                        let _: &str = rows[0].get(0);
+                    }
+                    Workload::Insert => {
+                        client
+                            .execute(&statements.insert, &[&id, &k, &c, &pad])
+                            .map_err(|error| error.to_string())?;
+                    }
+                    Workload::UpdateIndex => {
+                        client
+                            .execute(&statements.update_index, &[&id])
+                            .map_err(|error| error.to_string())?;
+                    }
+                    Workload::UpdateNonIndex => {
+                        client
+                            .execute(&statements.update_non_index, &[&c, &id])
+                            .map_err(|error| error.to_string())?;
+                    }
+                    Workload::Delete => {
+                        client
+                            .execute(&statements.delete, &[&id])
+                            .map_err(|error| error.to_string())?;
+                    }
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+struct Resources {
+    factory: WorkerFactory,
+    lix_storage: Option<SlateDB>,
+    database_path: Option<PathBuf>,
+    _temp_dir: Option<TempDir>,
+    postgres_schema: Option<String>,
+    engine_version: String,
+    storage_bytes_before: u64,
+    initial_history_commits: Option<i64>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Window {
+    measurement_start: Instant,
+    end: Instant,
+}
+
+struct WorkerResult {
+    successes: u64,
+    failures: u64,
+    histogram: Histogram<u64>,
+    first_error: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Report {
+    schema_version: u32,
+    suite: &'static str,
+    sysbench_reference_version: &'static str,
+    engine: EngineKind,
+    engine_version: String,
+    workload: Workload,
+    table_size: u32,
+    clients: usize,
+    warmup_seconds: f64,
+    requested_measurement_seconds: f64,
+    actual_measurement_seconds: f64,
+    events_per_client: Option<u64>,
+    seed: u64,
+    load_batch_size: usize,
+    successful_events: u64,
+    failed_events: u64,
+    retried_events: u64,
+    first_error: Option<String>,
+    events_per_second: f64,
+    latency_ns: Latency,
+    initial_rows: u64,
+    final_rows: u64,
+    initial_history_commits: Option<i64>,
+    final_history_commits: Option<i64>,
+    storage_bytes_before: u64,
+    storage_bytes_after: u64,
+    postgres_schema: Option<String>,
+    target_revision: Option<String>,
+    target_dirty: bool,
+    started_at_unix_ms: u128,
+    finished_at_unix_ms: u128,
+    durability: &'static str,
+    auto_increment: bool,
+    secondary_index: bool,
+    access_distribution: &'static str,
+    settle_ms: u64,
+    storage_measurement: &'static str,
+    storage_scope: &'static str,
+    retry_policy: &'static str,
+}
+
+#[derive(Serialize)]
+struct Latency {
+    min: u64,
+    p50: u64,
+    p95: u64,
+    p99: u64,
+    max: u64,
+    mean: f64,
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("sysbench_crud: {error}");
+        std::process::exit(2);
+    }
+}
+
+fn run() -> Result<(), String> {
+    let config = Config::parse()?;
+    validate_fresh_paths(&config)?;
+    let started_at_unix_ms = unix_ms();
+    let mut resources = setup(&config)?;
+    thread::sleep(config.settle);
+    resources.storage_bytes_before = storage_bytes(&resources)?;
+    let initial_rows = row_count(&resources)?;
+    let expected_initial_rows = if config.workload.needs_seed() {
+        u64::from(config.table_size)
+    } else {
+        0
+    };
+    if initial_rows != expected_initial_rows {
+        return Err(format!(
+            "qualification failed: expected {expected_initial_rows} initial rows, found {initial_rows}"
+        ));
+    }
+
+    let ready = Arc::new(Barrier::new(config.clients + 1));
+    let start = Arc::new(Barrier::new(config.clients + 1));
+    let window = Arc::new(OnceLock::new());
+    let abort = Arc::new(AtomicBool::new(false));
+    let mut handles = Vec::with_capacity(config.clients);
+    for client_id in 0..config.clients {
+        let factory = resources.factory.clone();
+        let ready = Arc::clone(&ready);
+        let start = Arc::clone(&start);
+        let window = Arc::clone(&window);
+        let abort = Arc::clone(&abort);
+        let workload = config.workload;
+        let table_size = config.table_size;
+        let clients = config.clients;
+        let seed = config.seed;
+        let events_per_client = config.events_per_client;
+        handles.push(thread::spawn(move || {
+            let mut worker = match factory.worker() {
+                Ok(worker) => worker,
+                Err(error) => {
+                    abort.store(true, Ordering::Release);
+                    ready.wait();
+                    start.wait();
+                    return failed_worker(error);
+                }
+            };
+            ready.wait();
+            start.wait();
+            let window = *window.get().expect("coordinator installs benchmark window");
+            run_worker(
+                &mut worker,
+                workload,
+                table_size,
+                clients,
+                client_id,
+                seed,
+                events_per_client,
+                window,
+                &abort,
+            )
+        }));
+    }
+
+    ready.wait();
+    if abort.load(Ordering::Acquire) {
+        window
+            .set(Window {
+                measurement_start: Instant::now(),
+                end: Instant::now(),
+            })
+            .expect("install failed benchmark window");
+    } else {
+        let now = Instant::now();
+        window
+            .set(Window {
+                measurement_start: now + config.warmup,
+                end: now + config.warmup + config.measurement,
+            })
+            .expect("install benchmark window");
+    }
+    let measurement_wall_start = Instant::now() + config.warmup;
+    start.wait();
+
+    let mut successes = 0_u64;
+    let mut failures = 0_u64;
+    let mut histogram = latency_histogram()?;
+    let mut first_error = None;
+    for handle in handles {
+        let result = handle
+            .join()
+            .map_err(|_| "benchmark worker panicked".to_string())?;
+        successes += result.successes;
+        failures += result.failures;
+        histogram
+            .add(&result.histogram)
+            .map_err(|error| format!("merge latency histogram: {error}"))?;
+        if first_error.is_none() {
+            first_error = result.first_error;
+        }
+    }
+    let actual_measurement = Instant::now().saturating_duration_since(measurement_wall_start);
+    let final_rows = row_count(&resources)?;
+    let final_history_commits = history_count(&resources)?;
+    thread::sleep(config.settle);
+    let storage_bytes_after = storage_bytes(&resources)?;
+    let finished_at_unix_ms = unix_ms();
+    let report = Report {
+        schema_version: 1,
+        suite: PROFILE_NAME,
+        sysbench_reference_version: SYSBENCH_VERSION,
+        engine: config.engine,
+        engine_version: resources.engine_version.clone(),
+        workload: config.workload,
+        table_size: config.table_size,
+        clients: config.clients,
+        warmup_seconds: config.warmup.as_secs_f64(),
+        requested_measurement_seconds: config.measurement.as_secs_f64(),
+        actual_measurement_seconds: actual_measurement.as_secs_f64(),
+        events_per_client: config.events_per_client,
+        seed: config.seed,
+        load_batch_size: config.load_batch_size,
+        successful_events: successes,
+        failed_events: failures,
+        retried_events: 0,
+        first_error,
+        events_per_second: successes as f64 / actual_measurement.as_secs_f64().max(f64::EPSILON),
+        latency_ns: summarize_latency(&histogram),
+        initial_rows,
+        final_rows,
+        initial_history_commits: resources.initial_history_commits,
+        final_history_commits,
+        storage_bytes_before: resources.storage_bytes_before,
+        storage_bytes_after,
+        postgres_schema: resources.postgres_schema.clone(),
+        target_revision: config.target_revision,
+        target_dirty: config.target_dirty,
+        started_at_unix_ms,
+        finished_at_unix_ms,
+        durability: match config.engine {
+            EngineKind::LixSlatedb => "lix/slatedb defaults; no relaxation",
+            EngineKind::Sqlite => "WAL, synchronous=FULL",
+            EngineKind::Postgres => {
+                "fsync=on, full_page_writes=on, synchronous_commit=on; all verified"
+            }
+        },
+        auto_increment: false,
+        secondary_index: false,
+        access_distribution: "uniform",
+        settle_ms: config.settle.as_millis() as u64,
+        storage_measurement: "settled live storage snapshot; database remains open",
+        storage_scope: match config.engine {
+            EngineKind::LixSlatedb => "complete SlateDB database directory",
+            EngineKind::Sqlite => "database file plus WAL and shared-memory sidecars",
+            EngineKind::Postgres => "pg_total_relation_size(sbtest1); excludes server WAL",
+        },
+        retry_policy: "none; failures are reported",
+    };
+    let json = serde_json::to_string_pretty(&report)
+        .map_err(|error| format!("serialize report: {error}"))?;
+    if let Some(path) = &config.output {
+        if path.exists() {
+            return Err(format!("refusing to overwrite output {}", path.display()));
+        }
+        fs::write(path, format!("{json}\n"))
+            .map_err(|error| format!("write {}: {error}", path.display()))?;
+    }
+    println!("{json}");
+    cleanup_postgres(&mut resources)?;
+    if failures > 0 {
+        return Err(format!("benchmark completed with {failures} failed events"));
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_worker(
+    worker: &mut Worker,
+    workload: Workload,
+    table_size: u32,
+    clients: usize,
+    client_id: usize,
+    seed: u64,
+    events_per_client: Option<u64>,
+    window: Window,
+    abort: &AtomicBool,
+) -> WorkerResult {
+    let mut rng = SplitMix64::new(seed ^ (client_id as u64).wrapping_mul(0x9e3779b97f4a7c15));
+    let mut histogram = latency_histogram().expect("valid histogram bounds");
+    let mut successes = 0_u64;
+    let mut failures = 0_u64;
+    let mut first_error = None;
+    let mut event_index = 0_u64;
+    loop {
+        if abort.load(Ordering::Acquire) {
+            break;
+        }
+        let now = Instant::now();
+        let measuring = now >= window.measurement_start;
+        if let Some(limit) = events_per_client {
+            if measuring && successes + failures >= limit {
+                break;
+            }
+        } else if now >= window.end {
+            break;
+        }
+        let event_start = Instant::now();
+        let id = if matches!(workload, Workload::Insert) {
+            i64::from(i32::MIN)
+                + i64::try_from(client_id).expect("client id fits i64")
+                + i64::try_from(event_index).expect("event index fits i64")
+                    * i64::try_from(clients).expect("client count fits i64")
+        } else {
+            i64::from(rng.uniform_u32(1, table_size))
+        };
+        let k = if matches!(workload, Workload::Insert) {
+            i64::from(rng.uniform_u32(1, table_size))
+        } else {
+            0
+        };
+        let c = if matches!(workload, Workload::Insert | Workload::UpdateNonIndex) {
+            sysbench_string(&mut rng, 10)
+        } else {
+            String::new()
+        };
+        let pad = if matches!(workload, Workload::Insert) {
+            sysbench_string(&mut rng, 5)
+        } else {
+            String::new()
+        };
+        let outcome = worker.event(workload, id, k, &c, &pad);
+        let elapsed = event_start.elapsed();
+        if measuring {
+            let nanos = u64::try_from(elapsed.as_nanos()).unwrap_or(u64::MAX);
+            histogram
+                .record(nanos.max(1))
+                .expect("latency is in histogram range");
+            match outcome {
+                Ok(()) => successes += 1,
+                Err(error) => {
+                    failures += 1;
+                    if first_error.is_none() {
+                        first_error = Some(error);
+                    }
+                }
+            }
+        } else if let Err(error) = outcome {
+            abort.store(true, Ordering::Release);
+            first_error = Some(format!("warmup failed: {error}"));
+            failures += 1;
+            break;
+        }
+        event_index += 1;
+    }
+    WorkerResult {
+        successes,
+        failures,
+        histogram,
+        first_error,
+    }
+}
+
+fn failed_worker(error: String) -> WorkerResult {
+    WorkerResult {
+        successes: 0,
+        failures: 1,
+        histogram: latency_histogram().expect("valid histogram bounds"),
+        first_error: Some(error),
+    }
+}
+
+fn latency_histogram() -> Result<Histogram<u64>, String> {
+    Histogram::new_with_bounds(1, 300_000_000_000, 3)
+        .map_err(|error| format!("create latency histogram: {error}"))
+}
+
+fn summarize_latency(histogram: &Histogram<u64>) -> Latency {
+    if histogram.is_empty() {
+        return Latency {
+            min: 0,
+            p50: 0,
+            p95: 0,
+            p99: 0,
+            max: 0,
+            mean: 0.0,
+        };
+    }
+    Latency {
+        min: histogram.min(),
+        p50: histogram.value_at_quantile(0.50),
+        p95: histogram.value_at_quantile(0.95),
+        p99: histogram.value_at_quantile(0.99),
+        max: histogram.max(),
+        mean: histogram.mean(),
+    }
+}
+
+fn validate_fresh_paths(config: &Config) -> Result<(), String> {
+    if let Some(path) = &config.database_path
+        && path.exists()
+    {
+        return Err(format!(
+            "refusing to reuse database path {}; provide a fresh path",
+            path.display()
+        ));
+    }
+    if let Some(path) = &config.output
+        && path.exists()
+    {
+        return Err(format!("refusing to overwrite output {}", path.display()));
+    }
+    Ok(())
+}
+
+fn setup(config: &Config) -> Result<Resources, String> {
+    match config.engine {
+        EngineKind::LixSlatedb => setup_lix(config),
+        EngineKind::Sqlite => setup_sqlite(config),
+        EngineKind::Postgres => setup_postgres(config),
+    }
+}
+
+fn setup_path(config: &Config, leaf: &str) -> Result<(PathBuf, Option<TempDir>), String> {
+    if let Some(path) = &config.database_path {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|error| format!("create {}: {error}", parent.display()))?;
+        }
+        return Ok((path.clone(), None));
+    }
+    let temp_dir =
+        tempfile::tempdir().map_err(|error| format!("create temporary path: {error}"))?;
+    let path = temp_dir.path().join(leaf);
+    Ok((path, Some(temp_dir)))
+}
+
+fn setup_lix(config: &Config) -> Result<Resources, String> {
+    let (path, temp_dir) = setup_path(config, "lix-slatedb")?;
+    let storage = SlateDB::open(&path).map_err(|error| format!("open SlateDB: {error}"))?;
+    let accounting_storage = storage.clone();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| format!("create Lix setup runtime: {error}"))?;
+    let engine = runtime.block_on(async {
+        Engine::initialize(storage.clone())
+            .await
+            .map_err(|error| format!("initialize Lix: {error}"))?;
+        let engine = Engine::new(storage)
+            .await
+            .map_err(|error| format!("open Lix engine: {error}"))?;
+        let session = engine
+            .open_workspace_session()
+            .await
+            .map_err(|error| format!("open Lix setup session: {error}"))?;
+        register_lix_schema(&session).await?;
+        if config.workload.needs_seed() {
+            seed_lix(&session, config).await?;
+        }
+        Ok::<_, String>(engine)
+    })?;
+    let engine = Arc::new(engine);
+    let session = runtime
+        .block_on(engine.open_workspace_session())
+        .map_err(|error| format!("open Lix accounting session: {error}"))?;
+    let initial_history_commits = runtime.block_on(lix_count(&session, "lix_commit"))?;
+    let storage_bytes_before = path_size(&path)?;
+    Ok(Resources {
+        factory: WorkerFactory::Lix(engine),
+        lix_storage: Some(accounting_storage),
+        database_path: Some(path),
+        _temp_dir: temp_dir,
+        postgres_schema: None,
+        engine_version: format!("lix {}; slatedb 0.14.1", env!("CARGO_PKG_VERSION")),
+        storage_bytes_before,
+        initial_history_commits: Some(initial_history_commits),
+    })
+}
+
+async fn register_lix_schema(session: &SessionContext<SlateDB>) -> Result<(), String> {
+    let schema = serde_json::json!({
+        "x-lix-key": "sbtest1",
+        "x-lix-primary-key": ["/id"],
+        "type": "object",
+        "required": ["id", "k", "c", "pad"],
+        "properties": {
+            "id": { "type": "integer" },
+            "k": { "type": "integer" },
+            "c": { "type": "string" },
+            "pad": { "type": "string" }
+        },
+        "additionalProperties": false
+    });
+    let result = session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .map_err(|error| format!("register Lix sbtest schema: {error}"))?;
+    if result.rows_affected() != 1 {
+        return Err("registering Lix sbtest schema did not affect one row".into());
+    }
+    Ok(())
+}
+
+async fn seed_lix(session: &SessionContext<SlateDB>, config: &Config) -> Result<(), String> {
+    for start in (1..=config.table_size).step_by(config.load_batch_size) {
+        let end = config
+            .table_size
+            .min(start + u32::try_from(config.load_batch_size).unwrap_or(u32::MAX) - 1);
+        let statements = (start..=end)
+            .map(|id| {
+                let row = seed_row(config.seed, id);
+                ExecuteBatchStatement {
+                    // Setup is outside the timer. Distinct literals avoid the
+                    // homogeneous string-PK fast path so integer primary keys
+                    // retain their declared type during bulk qualification.
+                    sql: format!(
+                        "INSERT INTO sbtest1 (id, k, c, pad) VALUES ({id}, {}, '{}', '{}')",
+                        row.k, row.c, row.pad
+                    ),
+                    params: Vec::new(),
+                }
+            })
+            .collect::<Vec<_>>();
+        let results = session
+            .execute_batch(&statements)
+            .await
+            .map_err(|error| format!("seed Lix rows {start}..={end}: {error}"))?;
+        if results.len() != usize::try_from(end - start + 1).expect("batch size fits usize") {
+            return Err(format!(
+                "Lix seed returned wrong result count for {start}..={end}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn setup_sqlite(config: &Config) -> Result<Resources, String> {
+    let (path, temp_dir) = setup_path(config, "sysbench.sqlite")?;
+    let mut connection = Connection::open(&path)
+        .map_err(|error| format!("open SQLite setup connection: {error}"))?;
+    configure_sqlite(&connection)?;
+    connection
+        .execute_batch(
+            "CREATE TABLE sbtest1 (
+                id INTEGER NOT NULL PRIMARY KEY,
+                k INTEGER NOT NULL,
+                c TEXT NOT NULL,
+                pad TEXT NOT NULL
+            );",
+        )
+        .map_err(|error| format!("create SQLite sbtest table: {error}"))?;
+    if config.workload.needs_seed() {
+        seed_sqlite(&mut connection, config)?;
+    }
+    drop(connection);
+    Ok(Resources {
+        factory: WorkerFactory::Sqlite(path.clone()),
+        lix_storage: None,
+        database_path: Some(path.clone()),
+        _temp_dir: temp_dir,
+        postgres_schema: None,
+        engine_version: rusqlite::version().to_string(),
+        storage_bytes_before: sqlite_storage_bytes(&path)?,
+        initial_history_commits: None,
+    })
+}
+
+fn configure_sqlite(connection: &Connection) -> Result<(), String> {
+    connection
+        .execute_batch(
+            "PRAGMA journal_mode=WAL;
+             PRAGMA synchronous=FULL;
+             PRAGMA busy_timeout=30000;
+             PRAGMA foreign_keys=ON;",
+        )
+        .map_err(|error| format!("configure SQLite: {error}"))?;
+    let journal_mode: String = connection
+        .query_row("PRAGMA journal_mode", [], |row| row.get(0))
+        .map_err(|error| format!("verify SQLite journal_mode: {error}"))?;
+    let synchronous: i64 = connection
+        .query_row("PRAGMA synchronous", [], |row| row.get(0))
+        .map_err(|error| format!("verify SQLite synchronous: {error}"))?;
+    let busy_timeout: i64 = connection
+        .query_row("PRAGMA busy_timeout", [], |row| row.get(0))
+        .map_err(|error| format!("verify SQLite busy_timeout: {error}"))?;
+    if !journal_mode.eq_ignore_ascii_case("wal") || synchronous != 2 || busy_timeout != 30_000 {
+        return Err(format!(
+            "SQLite durability verification failed: journal_mode={journal_mode}, synchronous={synchronous}, busy_timeout={busy_timeout}"
+        ));
+    }
+    Ok(())
+}
+
+fn seed_sqlite(connection: &mut Connection, config: &Config) -> Result<(), String> {
+    for start in (1..=config.table_size).step_by(config.load_batch_size) {
+        let end = config
+            .table_size
+            .min(start + u32::try_from(config.load_batch_size).unwrap_or(u32::MAX) - 1);
+        let transaction = connection
+            .transaction()
+            .map_err(|error| format!("begin SQLite load transaction: {error}"))?;
+        {
+            let mut statement = transaction
+                .prepare("INSERT INTO sbtest1 (id, k, c, pad) VALUES (?1, ?2, ?3, ?4)")
+                .map_err(|error| format!("prepare SQLite load insert: {error}"))?;
+            for id in start..=end {
+                let row = seed_row(config.seed, id);
+                statement
+                    .execute(params![id, row.k, row.c, row.pad])
+                    .map_err(|error| format!("seed SQLite row {id}: {error}"))?;
+            }
+        }
+        transaction
+            .commit()
+            .map_err(|error| format!("commit SQLite load transaction: {error}"))?;
+    }
+    Ok(())
+}
+
+fn setup_postgres(config: &Config) -> Result<Resources, String> {
+    let url = config
+        .postgres_url
+        .as_ref()
+        .expect("validated PostgreSQL URL");
+    let schema = format!(
+        "lix_sysbench_{:016x}_{}_{}",
+        config.seed,
+        std::process::id(),
+        unix_ms()
+    );
+    let mut client = Client::connect(url, NoTls)
+        .map_err(|error| format!("open PostgreSQL setup connection: {error}"))?;
+    for setting in ["fsync", "full_page_writes", "synchronous_commit"] {
+        let value: String = client
+            .query_one(&format!("SHOW {setting}"), &[])
+            .map_err(|error| format!("read PostgreSQL {setting}: {error}"))?
+            .get(0);
+        if value != "on" {
+            return Err(format!("PostgreSQL {setting} must be on, got '{value}'"));
+        }
+    }
+    client
+        .batch_execute(&format!(
+            "CREATE SCHEMA {schema}; SET search_path TO {schema};
+             CREATE TABLE sbtest1 (
+                id BIGINT NOT NULL PRIMARY KEY,
+                k BIGINT NOT NULL,
+                c VARCHAR(120) NOT NULL,
+                pad VARCHAR(60) NOT NULL
+             );"
+        ))
+        .map_err(|error| format!("create PostgreSQL benchmark schema: {error}"))?;
+    if config.workload.needs_seed() {
+        seed_postgres(&mut client, config)?;
+    }
+    let engine_version: String = client
+        .query_one("SHOW server_version", &[])
+        .map_err(|error| format!("read PostgreSQL version: {error}"))?
+        .get(0);
+    let storage_bytes_before = postgres_storage_bytes(&mut client)?;
+    Ok(Resources {
+        factory: WorkerFactory::Postgres {
+            url: url.clone(),
+            schema: schema.clone(),
+        },
+        lix_storage: None,
+        database_path: None,
+        _temp_dir: None,
+        postgres_schema: Some(schema),
+        engine_version,
+        storage_bytes_before,
+        initial_history_commits: None,
+    })
+}
+
+fn set_postgres_schema(client: &mut Client, schema: &str) -> Result<(), String> {
+    client
+        .batch_execute(&format!("SET search_path TO {schema}"))
+        .map_err(|error| format!("select PostgreSQL benchmark schema: {error}"))
+}
+
+fn seed_postgres(client: &mut Client, config: &Config) -> Result<(), String> {
+    let statement = client
+        .prepare(INSERT_SQL)
+        .map_err(|error| format!("prepare PostgreSQL load insert: {error}"))?;
+    for start in (1..=config.table_size).step_by(config.load_batch_size) {
+        let end = config
+            .table_size
+            .min(start + u32::try_from(config.load_batch_size).unwrap_or(u32::MAX) - 1);
+        let mut transaction = client
+            .transaction()
+            .map_err(|error| format!("begin PostgreSQL load transaction: {error}"))?;
+        for id in start..=end {
+            let row = seed_row(config.seed, id);
+            transaction
+                .execute(
+                    &statement,
+                    &[&i64::from(id), &i64::from(row.k), &row.c, &row.pad],
+                )
+                .map_err(|error| format!("seed PostgreSQL row {id}: {error}"))?;
+        }
+        transaction
+            .commit()
+            .map_err(|error| format!("commit PostgreSQL load transaction: {error}"))?;
+    }
+    Ok(())
+}
+
+fn row_count(resources: &Resources) -> Result<u64, String> {
+    match &resources.factory {
+        WorkerFactory::Lix(engine) => {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|error| format!("create Lix accounting runtime: {error}"))?;
+            let session = runtime
+                .block_on(engine.open_workspace_session())
+                .map_err(|error| format!("open Lix accounting session: {error}"))?;
+            runtime
+                .block_on(lix_count(&session, "sbtest1"))
+                .map(|value| value as u64)
+        }
+        WorkerFactory::Sqlite(path) => {
+            let connection = Connection::open(path)
+                .map_err(|error| format!("open SQLite accounting connection: {error}"))?;
+            let count: i64 = connection
+                .query_row("SELECT COUNT(*) FROM sbtest1", [], |row| row.get(0))
+                .map_err(|error| format!("count SQLite rows: {error}"))?;
+            Ok(count as u64)
+        }
+        WorkerFactory::Postgres { url, schema } => {
+            let mut client = Client::connect(url, NoTls)
+                .map_err(|error| format!("open PostgreSQL accounting connection: {error}"))?;
+            set_postgres_schema(&mut client, schema)?;
+            let count: i64 = client
+                .query_one("SELECT COUNT(*) FROM sbtest1", &[])
+                .map_err(|error| format!("count PostgreSQL rows: {error}"))?
+                .get(0);
+            Ok(count as u64)
+        }
+    }
+}
+
+fn history_count(resources: &Resources) -> Result<Option<i64>, String> {
+    let WorkerFactory::Lix(engine) = &resources.factory else {
+        return Ok(None);
+    };
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| format!("create Lix history runtime: {error}"))?;
+    let session = runtime
+        .block_on(engine.open_workspace_session())
+        .map_err(|error| format!("open Lix history session: {error}"))?;
+    runtime
+        .block_on(lix_count(&session, "lix_commit"))
+        .map(Some)
+}
+
+async fn lix_count(session: &SessionContext<SlateDB>, table: &str) -> Result<i64, String> {
+    let result = session
+        .execute(&format!("SELECT COUNT(*) AS count FROM {table}"), &[])
+        .await
+        .map_err(|error| format!("count Lix {table}: {error}"))?;
+    result.rows()[0]
+        .get::<i64>("count")
+        .map_err(|error| format!("Lix {table} count was not an integer: {error}"))
+}
+
+fn storage_bytes(resources: &Resources) -> Result<u64, String> {
+    match &resources.factory {
+        WorkerFactory::Postgres { url, schema } => {
+            let mut client = Client::connect(url, NoTls)
+                .map_err(|error| format!("open PostgreSQL storage connection: {error}"))?;
+            set_postgres_schema(&mut client, schema)?;
+            postgres_storage_bytes(&mut client)
+        }
+        WorkerFactory::Sqlite(_) => sqlite_storage_bytes(
+            resources
+                .database_path
+                .as_ref()
+                .expect("SQLite has a database path"),
+        ),
+        WorkerFactory::Lix(_) => path_size({
+            let storage = resources
+                .lix_storage
+                .as_ref()
+                .expect("Lix has a SlateDB storage handle");
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|error| format!("create Lix storage accounting runtime: {error}"))?;
+            runtime
+                .block_on(storage.flush())
+                .map_err(|error| format!("flush Lix storage before accounting: {error}"))?;
+            resources
+                .database_path
+                .as_ref()
+                .expect("Lix has a database path")
+        }),
+    }
+}
+
+fn sqlite_storage_bytes(path: &Path) -> Result<u64, String> {
+    let mut bytes = path_size(path)?;
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| format!("SQLite path has no file name: {}", path.display()))?
+        .to_string_lossy();
+    for suffix in ["-wal", "-shm"] {
+        bytes += path_size(&path.with_file_name(format!("{file_name}{suffix}")))?;
+    }
+    Ok(bytes)
+}
+
+fn postgres_storage_bytes(client: &mut Client) -> Result<u64, String> {
+    let bytes: i64 = client
+        .query_one("SELECT pg_total_relation_size('sbtest1')", &[])
+        .map_err(|error| format!("measure PostgreSQL relation size: {error}"))?
+        .get(0);
+    Ok(bytes as u64)
+}
+
+fn cleanup_postgres(resources: &mut Resources) -> Result<(), String> {
+    let WorkerFactory::Postgres { url, schema } = &resources.factory else {
+        return Ok(());
+    };
+    let mut client = Client::connect(url, NoTls)
+        .map_err(|error| format!("open PostgreSQL cleanup connection: {error}"))?;
+    client
+        .batch_execute(&format!("DROP SCHEMA {schema} CASCADE"))
+        .map_err(|error| format!("drop PostgreSQL benchmark schema: {error}"))
+}
+
+fn path_size(path: &Path) -> Result<u64, String> {
+    if path.is_file() {
+        return fs::metadata(path)
+            .map(|metadata| metadata.len())
+            .map_err(|error| format!("stat {}: {error}", path.display()));
+    }
+    if !path.exists() {
+        return Ok(0);
+    }
+    let mut bytes = 0_u64;
+    for entry in fs::read_dir(path).map_err(|error| format!("read {}: {error}", path.display()))? {
+        let entry = entry.map_err(|error| format!("read {} entry: {error}", path.display()))?;
+        let entry_path = entry.path();
+        if entry_path.is_dir() {
+            bytes += path_size(&entry_path)?;
+        } else {
+            bytes += entry
+                .metadata()
+                .map_err(|error| format!("stat {}: {error}", entry_path.display()))?
+                .len();
+        }
+    }
+    Ok(bytes)
+}
+
+struct SeedRow {
+    k: u32,
+    c: String,
+    pad: String,
+}
+
+fn seed_row(seed: u64, id: u32) -> SeedRow {
+    let mut rng = SplitMix64::new(seed ^ u64::from(id).wrapping_mul(0x9e3779b97f4a7c15));
+    SeedRow {
+        k: rng.uniform_u32(1, u32::MAX),
+        c: sysbench_string(&mut rng, 10),
+        pad: sysbench_string(&mut rng, 5),
+    }
+}
+
+fn sysbench_string(rng: &mut SplitMix64, groups: usize) -> String {
+    let mut value = String::with_capacity(groups * 11 + groups.saturating_sub(1));
+    for group in 0..groups {
+        if group > 0 {
+            value.push('-');
+        }
+        for _ in 0..11 {
+            value.push(char::from(b'0' + rng.uniform_u32(0, 9) as u8));
+        }
+    }
+    value
+}
+
+struct SplitMix64(u64);
+
+impl SplitMix64 {
+    fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9e3779b97f4a7c15);
+        let mut value = self.0;
+        value = (value ^ (value >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
+        value = (value ^ (value >> 27)).wrapping_mul(0x94d049bb133111eb);
+        value ^ (value >> 31)
+    }
+
+    fn uniform_u32(&mut self, min: u32, max: u32) -> u32 {
+        assert!(min <= max);
+        let width = u64::from(max) - u64::from(min) + 1;
+        (u64::from(min) + self.next() % width) as u32
+    }
+}
+
+fn unix_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time is after Unix epoch")
+        .as_millis()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SplitMix64, seed_row, sysbench_string};
+
+    #[test]
+    fn sysbench_strings_preserve_template_shape() {
+        let mut rng = SplitMix64::new(42);
+        let c = sysbench_string(&mut rng, 10);
+        let pad = sysbench_string(&mut rng, 5);
+        assert_eq!(c.len(), 119);
+        assert_eq!(pad.len(), 59);
+        assert!(c.bytes().enumerate().all(|(index, byte)| {
+            if (index + 1) % 12 == 0 {
+                byte == b'-'
+            } else {
+                byte.is_ascii_digit()
+            }
+        }));
+    }
+
+    #[test]
+    fn seed_rows_are_deterministic_and_identity_specific() {
+        let first = seed_row(7, 11);
+        let repeated = seed_row(7, 11);
+        let next = seed_row(7, 12);
+        assert_eq!(first.k, repeated.k);
+        assert_eq!(first.c, repeated.c);
+        assert_eq!(first.pad, repeated.pad);
+        assert_ne!(first.c, next.c);
+    }
+
+    #[test]
+    fn uniform_generator_honors_closed_bounds() {
+        let mut rng = SplitMix64::new(9);
+        for _ in 0..1_000 {
+            assert!((3..=7).contains(&rng.uniform_u32(3, 7)));
+        }
+        assert_eq!(rng.uniform_u32(5, 5), 5);
+    }
+}

--- a/packages/engine-benchmarks/scripts/run-sysbench-crud.mjs
+++ b/packages/engine-benchmarks/scripts/run-sysbench-crud.mjs
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const workspace = resolve(scriptDir, "../../..");
+const options = parseArgs(process.argv.slice(2));
+const qualification = options.has("qualify");
+const postgresUrl = options.get("postgres-url");
+if (!postgresUrl) fail("--postgres-url is required");
+
+const timestamp = new Date().toISOString().replaceAll(":", "-");
+const outputDir = resolve(
+  workspace,
+  options.get("output-dir") ?? `target/sysbench-results/${timestamp}`,
+);
+if (existsSync(outputDir)) fail(`refusing to reuse output directory: ${outputDir}`);
+mkdirSync(outputDir, { recursive: true });
+
+run("cargo", [
+  "build",
+  "-p",
+  "lix_engine_benchmarks",
+  "--release",
+  "--example",
+  "sysbench_crud",
+  "--no-default-features",
+  "--features",
+  "sqlite,slatedb,postgres",
+]);
+
+const binary = resolve(workspace, "target/release/examples/sysbench_crud");
+const revision = capture("git", ["rev-parse", "HEAD"]);
+const dirty = capture("git", ["status", "--porcelain"]).length > 0;
+const profile = qualification
+  ? {
+      name: "qualification",
+      sizes: [1_000],
+      clients: [1, 2],
+      repetitions: 1,
+      eventsPerClient: 20,
+      warmupSeconds: 0,
+      timeSeconds: 0,
+      settleMs: 100,
+    }
+  : {
+      name: "publication",
+      sizes: parseList(options.get("sizes") ?? "100000,1000000"),
+      clients: parseList(options.get("clients") ?? "1,4,16"),
+      repetitions: Number(options.get("repetitions") ?? "5"),
+      eventsPerClient: null,
+      warmupSeconds: Number(options.get("warmup-seconds") ?? "15"),
+      timeSeconds: Number(options.get("time-seconds") ?? "60"),
+      settleMs: Number(options.get("settle-ms") ?? "1000"),
+    };
+validateProfile(profile);
+
+const engines = ["lix-slatedb", "sqlite", "postgres"];
+const workloads = [
+  "point-select",
+  "insert",
+  "update-index",
+  "update-non-index",
+  "delete",
+];
+const counterbalancedOrders = [
+  ["lix-slatedb", "sqlite", "postgres"],
+  ["postgres", "sqlite", "lix-slatedb"],
+  ["sqlite", "postgres", "lix-slatedb"],
+  ["lix-slatedb", "postgres", "sqlite"],
+  ["postgres", "lix-slatedb", "sqlite"],
+  ["sqlite", "lix-slatedb", "postgres"],
+];
+
+const manifest = {
+  schemaVersion: 1,
+  suite: "sysbench-1.0.20-oltp-derived-common-feature",
+  profile,
+  revision,
+  dirty,
+  startedAt: new Date().toISOString(),
+  host: hostMetadata(),
+  runnerArguments: redactArguments(process.argv.slice(2)),
+  binarySha256: sha256(binary),
+  cargoLockSha256: sha256(resolve(workspace, "Cargo.lock")),
+  engineOrder: [],
+  resultFiles: [],
+};
+writeJson(resolve(outputDir, "manifest.in-progress.json"), manifest);
+
+let matrixOrdinal = 0;
+for (const tableSize of profile.sizes) {
+  for (const clients of profile.clients) {
+    for (const workload of workloads) {
+      for (let repetition = 0; repetition < profile.repetitions; repetition++) {
+        const engineOrder =
+          counterbalancedOrders[(matrixOrdinal + repetition) % counterbalancedOrders.length];
+        const seed = deterministicSeed(matrixOrdinal, repetition);
+        manifest.engineOrder.push({
+          tableSize,
+          clients,
+          workload,
+          repetition: repetition + 1,
+          seed,
+          engines: engineOrder,
+        });
+        for (const engine of engineOrder) {
+          if (!engines.includes(engine)) fail(`invalid engine order entry: ${engine}`);
+          const filename = [
+            engine,
+            workload,
+            `n${tableSize}`,
+            `c${clients}`,
+            `r${repetition + 1}`,
+          ].join("-") + ".json";
+          const output = resolve(outputDir, filename);
+          const args = [
+            "--engine",
+            engine,
+            "--workload",
+            workload,
+            "--table-size",
+            String(tableSize),
+            "--clients",
+            String(clients),
+            "--seed",
+            String(seed),
+            "--load-batch-size",
+            "10000",
+            "--settle-ms",
+            String(profile.settleMs),
+            "--target-revision",
+            revision,
+            "--target-dirty",
+            String(dirty),
+            "--output",
+            output,
+          ];
+          if (profile.eventsPerClient !== null) {
+            args.push("--events-per-client", String(profile.eventsPerClient));
+          } else {
+            args.push(
+              "--warmup-seconds",
+              String(profile.warmupSeconds),
+              "--time-seconds",
+              String(profile.timeSeconds),
+            );
+          }
+          if (engine === "postgres") {
+            args.push("--postgres-url", postgresUrl);
+          }
+          run(binary, args);
+          const result = JSON.parse(readFileSync(output, "utf8"));
+          validateResult(result, { engine, workload, tableSize, clients, seed });
+          manifest.resultFiles.push(filename);
+          writeJson(resolve(outputDir, "manifest.in-progress.json"), manifest);
+        }
+      }
+      matrixOrdinal++;
+    }
+  }
+}
+
+manifest.finishedAt = new Date().toISOString();
+writeJson(resolve(outputDir, "manifest.json"), manifest, true);
+console.log(`Completed ${manifest.resultFiles.length} runs in ${outputDir}`);
+
+function parseArgs(args) {
+  const parsed = new Map();
+  for (let index = 0; index < args.length; index++) {
+    const flag = args[index];
+    if (!flag.startsWith("--")) fail(`unexpected argument: ${flag}`);
+    const name = flag.slice(2);
+    if (name === "qualify") {
+      parsed.set(name, true);
+      continue;
+    }
+    const value = args[++index];
+    if (value === undefined) fail(`${flag} requires a value`);
+    parsed.set(name, value);
+  }
+  return parsed;
+}
+
+function parseList(value) {
+  return value.split(",").map((item) => Number(item));
+}
+
+function validateProfile(value) {
+  for (const [name, values] of [
+    ["sizes", value.sizes],
+    ["clients", value.clients],
+  ]) {
+    if (values.length === 0 || values.some((item) => !Number.isInteger(item) || item <= 0)) {
+      fail(`${name} must contain positive integers`);
+    }
+  }
+  if (!Number.isInteger(value.repetitions) || value.repetitions <= 0) {
+    fail("repetitions must be a positive integer");
+  }
+}
+
+function validateResult(result, expected) {
+  for (const [field, value] of Object.entries(expected)) {
+    if (result[field] !== value) {
+      fail(`result qualification failed: ${field}=${result[field]} expected ${value}`);
+    }
+  }
+  if (result.failedEvents !== 0 || result.successfulEvents <= 0) {
+    fail(`result qualification failed for ${expected.engine}/${expected.workload}`);
+  }
+  if (result.targetRevision !== revision || result.targetDirty !== dirty) {
+    fail("result revision attestation does not match the orchestrator");
+  }
+}
+
+function deterministicSeed(matrixOrdinal, repetition) {
+  return 1_000_003 + matrixOrdinal * 10_007 + repetition * 101;
+}
+
+function hostMetadata() {
+  return {
+    uname: safeCapture("uname", ["-a"]),
+    cpuModel: firstMatchingLine("/proc/cpuinfo", "model name"),
+    memory: firstMatchingLine("/proc/meminfo", "MemTotal"),
+    blockDevices: safeCapture("lsblk", [
+      "--output",
+      "NAME,MODEL,TYPE,SIZE,ROTA,MOUNTPOINTS",
+    ]),
+    filesystem: safeCapture("findmnt", [
+      "--target",
+      workspace,
+      "--output",
+      "TARGET,SOURCE,FSTYPE,OPTIONS",
+      "--noheadings",
+    ]),
+    rustc: safeCapture("rustc", ["--version"]),
+    cargo: safeCapture("cargo", ["--version"]),
+    node: process.version,
+  };
+}
+
+function redactArguments(args) {
+  const redacted = [...args];
+  const urlIndex = redacted.indexOf("--postgres-url");
+  if (urlIndex !== -1 && urlIndex + 1 < redacted.length) redacted[urlIndex + 1] = "<redacted>";
+  return redacted;
+}
+
+function sha256(path) {
+  return capture("sha256sum", [path]).split(/\s+/, 1)[0];
+}
+
+function firstMatchingLine(path, prefix) {
+  try {
+    return readFileSync(path, "utf8")
+      .split("\n")
+      .find((line) => line.startsWith(prefix)) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, { cwd: workspace, stdio: "inherit" });
+  if (result.error) fail(`${command} failed to start: ${result.error.message}`);
+  if (result.status !== 0) fail(`${command} exited with status ${result.status}`);
+}
+
+function capture(command, args) {
+  return execFileSync(command, args, { cwd: workspace, encoding: "utf8" }).trim();
+}
+
+function safeCapture(command, args) {
+  try {
+    return capture(command, args);
+  } catch {
+    return null;
+  }
+}
+
+function writeJson(path, value, exclusive = false) {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, {
+    flag: exclusive ? "wx" : "w",
+  });
+}
+
+function fail(message) {
+  console.error(`run-sysbench-crud: ${message}`);
+  process.exit(2);
+}


### PR DESCRIPTION
## What changed

- add a Sysbench 1.0.20 OLTP-derived common-feature CRUD runner for Lix/SlateDB, SQLite, and PostgreSQL
- cover point select, insert, indexed-column update, non-indexed-column update, and delete with one deterministic generator and timing loop
- emit raw JSON with HDR latency percentiles, throughput, failures/retries, row counts, Lix history commits, storage growth, revision state, durability, and engine versions
- add a publication orchestrator with fresh databases, fixed parameters, counterbalanced engine order, five repetitions, host metadata, hashes, and fail-closed result validation
- add an optional direct PostgreSQL arm to the existing tracked-state Criterion benchmark
- document the fairness and marketing claim boundary

## Claim boundary

This is named `Sysbench 1.0.20 OLTP-derived, common-feature profile`. It is intentionally not presented as official or unmodified Sysbench because Sysbench has no Lix driver. Lix runs with tracked history enabled. SQLite and PostgreSQL retain only current state; that asymmetry is explicit in the contract.

## Durability and accounting

- Lix uses normal SlateDB defaults and is flushed before storage snapshots.
- SQLite verifies WAL, `synchronous=FULL`, and the configured busy timeout; storage includes WAL/SHM sidecars.
- PostgreSQL verifies `fsync=on`, `full_page_writes=on`, and `synchronous_commit=on`; relation storage explicitly excludes server WAL.
- The runner performs no silent retries and rejects result failures.

## Validation

- `cargo check -p lix_engine_benchmarks --example sysbench_crud --no-default-features --features sqlite,slatedb,postgres`
- `cargo check -p lix_engine_benchmarks --bench tracked_state_crud --features storage-benches,slatedb,postgres`
- runner unit tests: 3 passed
- clean release qualification matrix: 30/30 result files, 900 successful events, 0 failed events
- Lix write qualification: 240 successful writes and 240 retained history commits
- PostgreSQL cleanup audit: 0 leftover `lix_sysbench_*` schemas
- qualification revision: `d03c2ace69678882a0e34dbffe2c80ba1bddb575`, `dirty: false`

## Stack

This PR is based on #1179 because the insert workload uses integer primary keys and exposed that engine bug. The benchmark diff is isolated from the fix and can be retargeted to `main` after #1179 merges.
