### PR TITLE
Splice persistent current-state range directories

### DIFF
--- a/packages/engine-benchmarks/benches/current_state_scope_sharing.rs
+++ b/packages/engine-benchmarks/benches/current_state_scope_sharing.rs
@@ -105,13 +105,19 @@ async fn run_backend<S>(
         };
         let measured = measure(&fixture, selected, warmups, samples).await;
         println!(
-            "current_state_scope_sharing,backend={backend},mode={mode},shape={sparse_shape:?},target={point_target:?},rows={rows},scopes={},sparse_commits={sparse_commits},setup_ms={:.3},catalog_staged_encoded_bytes={},directory_staged_encoded_bytes={},sparse_staged_puts={},sparse_written_bytes={},first_sparse_ms={:.3},first_sparse_staged_puts={},first_sparse_written_bytes={},catalog_manifest_bytes={},replay_manifest_bytes={},p50_us={:.3},p95_us={:.3}",
+            "current_state_scope_sharing,backend={backend},mode={mode},shape={sparse_shape:?},target={point_target:?},rows={rows},scopes={},sparse_commits={sparse_commits},setup_ms={:.3},catalog_staged_encoded_bytes={},directory_staged_encoded_bytes={},sparse_directory_staged_encoded_bytes={},sparse_staged_puts={},sparse_written_bytes={},sparse_directory_nodes_loaded={},sparse_directory_descriptors_visited={},sparse_directory_nodes_encoded={},sparse_publication_p50_us={:.3},sparse_publication_p95_us={:.3},first_sparse_ms={:.3},first_sparse_staged_puts={},first_sparse_written_bytes={},catalog_manifest_bytes={},replay_manifest_bytes={},p50_us={:.3},p95_us={:.3}",
             fixture.catalog_entry_count(),
             millis(setup),
             fixture.catalog_staged_encoded_bytes(),
             fixture.directory_staged_encoded_bytes(),
+            fixture.sparse_directory_staged_encoded_bytes(),
             fixture.sparse_staged_puts(),
             fixture.sparse_written_bytes(),
+            fixture.sparse_directory_nodes_loaded(),
+            fixture.sparse_directory_descriptors_visited(),
+            fixture.sparse_directory_nodes_encoded(),
+            fixture.sparse_publication_p50_nanos() as f64 / 1_000.0,
+            fixture.sparse_publication_p95_nanos() as f64 / 1_000.0,
             fixture.first_sparse_elapsed_nanos() as f64 / 1_000_000.0,
             fixture.first_sparse_staged_puts(),
             fixture.first_sparse_written_bytes(),
@@ -137,13 +143,19 @@ async fn run_backend<S>(
     )
     .await;
     println!(
-        "current_state_scope_sharing,backend={backend},shape={sparse_shape:?},target={point_target:?},rows={rows},scopes={},sparse_commits={sparse_commits},setup_ms={:.3},catalog_staged_encoded_bytes={},directory_staged_encoded_bytes={},sparse_staged_puts={},sparse_written_bytes={},first_sparse_ms={:.3},first_sparse_staged_puts={},first_sparse_written_bytes={},catalog_manifest_bytes={},replay_manifest_bytes={},serving_p50_us={:.3},serving_p95_us={:.3},replay_p50_us={:.3},replay_p95_us={:.3},p50_reduction_pct={:.2},p95_reduction_pct={:.2}",
+        "current_state_scope_sharing,backend={backend},shape={sparse_shape:?},target={point_target:?},rows={rows},scopes={},sparse_commits={sparse_commits},setup_ms={:.3},catalog_staged_encoded_bytes={},directory_staged_encoded_bytes={},sparse_directory_staged_encoded_bytes={},sparse_staged_puts={},sparse_written_bytes={},sparse_directory_nodes_loaded={},sparse_directory_descriptors_visited={},sparse_directory_nodes_encoded={},sparse_publication_p50_us={:.3},sparse_publication_p95_us={:.3},first_sparse_ms={:.3},first_sparse_staged_puts={},first_sparse_written_bytes={},catalog_manifest_bytes={},replay_manifest_bytes={},serving_p50_us={:.3},serving_p95_us={:.3},replay_p50_us={:.3},replay_p95_us={:.3},p50_reduction_pct={:.2},p95_reduction_pct={:.2}",
         fixture.catalog_entry_count(),
         millis(setup),
         fixture.catalog_staged_encoded_bytes(),
         fixture.directory_staged_encoded_bytes(),
+        fixture.sparse_directory_staged_encoded_bytes(),
         fixture.sparse_staged_puts(),
         fixture.sparse_written_bytes(),
+        fixture.sparse_directory_nodes_loaded(),
+        fixture.sparse_directory_descriptors_visited(),
+        fixture.sparse_directory_nodes_encoded(),
+        fixture.sparse_publication_p50_nanos() as f64 / 1_000.0,
+        fixture.sparse_publication_p95_nanos() as f64 / 1_000.0,
         fixture.first_sparse_elapsed_nanos() as f64 / 1_000_000.0,
         fixture.first_sparse_staged_puts(),
         fixture.first_sparse_written_bytes(),
@@ -178,7 +190,7 @@ where
     }
     timings.sort_unstable();
     let p50 = timings[timings.len() / 2];
-    let p95 = timings[(timings.len() - 1) * 95 / 100];
+    let p95 = timings[timings.len().saturating_mul(95).div_ceil(100) - 1];
     (p50, p95)
 }
 

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -51,7 +51,7 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::mutable(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"sparse-current-state-parts.v50";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"persistent-current-state-range-splice.v51";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -62,6 +62,9 @@ static CRUD_PHYSICAL_DELETES: AtomicU64 = AtomicU64::new(0);
 static CRUD_PHYSICAL_WRITTEN_BYTES: AtomicU64 = AtomicU64::new(0);
 static CRUD_COMMIT_STATE_MANIFEST_BYTES: AtomicU64 = AtomicU64::new(0);
 static CRUD_CURRENT_STATE_DIRECTORY_BYTES: AtomicU64 = AtomicU64::new(0);
+static CRUD_CURRENT_STATE_DIRECTORY_NODES_LOADED: AtomicU64 = AtomicU64::new(0);
+static CRUD_CURRENT_STATE_DIRECTORY_DESCRIPTORS_VISITED: AtomicU64 = AtomicU64::new(0);
+static CRUD_CURRENT_STATE_DIRECTORY_NODES_ENCODED: AtomicU64 = AtomicU64::new(0);
 static CRUD_CURRENT_STATE_CATALOG_BYTES: AtomicU64 = AtomicU64::new(0);
 static CRUD_CURRENT_STATE_DIRECTORY_RECOVERIES: AtomicU64 = AtomicU64::new(0);
 static CRUD_CURRENT_STATE_CATALOG_ATTEMPTS: AtomicU64 = AtomicU64::new(0);
@@ -204,6 +207,34 @@ pub(crate) fn record_crud_current_state_directory_bytes(bytes: usize) {
 
 pub fn take_crud_current_state_directory_bytes() -> u64 {
     CRUD_CURRENT_STATE_DIRECTORY_BYTES.swap(0, Ordering::Relaxed)
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CrudCurrentStateDirectoryAccounting {
+    pub nodes_loaded: u64,
+    pub descriptors_visited: u64,
+    pub nodes_encoded: u64,
+}
+
+pub(crate) fn record_crud_current_state_directory_node_loaded() {
+    CRUD_CURRENT_STATE_DIRECTORY_NODES_LOADED.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_crud_current_state_directory_descriptors_visited(count: usize) {
+    CRUD_CURRENT_STATE_DIRECTORY_DESCRIPTORS_VISITED.fetch_add(count as u64, Ordering::Relaxed);
+}
+
+pub(crate) fn record_crud_current_state_directory_node_encoded() {
+    CRUD_CURRENT_STATE_DIRECTORY_NODES_ENCODED.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn take_crud_current_state_directory_accounting() -> CrudCurrentStateDirectoryAccounting {
+    CrudCurrentStateDirectoryAccounting {
+        nodes_loaded: CRUD_CURRENT_STATE_DIRECTORY_NODES_LOADED.swap(0, Ordering::Relaxed),
+        descriptors_visited: CRUD_CURRENT_STATE_DIRECTORY_DESCRIPTORS_VISITED
+            .swap(0, Ordering::Relaxed),
+        nodes_encoded: CRUD_CURRENT_STATE_DIRECTORY_NODES_ENCODED.swap(0, Ordering::Relaxed),
+    }
 }
 
 pub(crate) fn record_crud_current_state_catalog_bytes(bytes: usize) {

--- a/packages/engine/src/tracked_state/bench_support.rs
+++ b/packages/engine/src/tracked_state/bench_support.rs
@@ -95,8 +95,14 @@ pub struct BenchCurrentStatePointFixture<StorageImpl: Storage> {
     replay_manifest_bytes: u64,
     catalog_staged_encoded_bytes: u64,
     directory_staged_encoded_bytes: u64,
+    sparse_directory_staged_encoded_bytes: u64,
     sparse_staged_puts: u64,
     sparse_written_bytes: u64,
+    sparse_directory_nodes_loaded: u64,
+    sparse_directory_descriptors_visited: u64,
+    sparse_directory_nodes_encoded: u64,
+    sparse_publication_p50_nanos: u64,
+    sparse_publication_p95_nanos: u64,
     first_sparse_elapsed_nanos: u64,
     first_sparse_staged_puts: u64,
     first_sparse_written_bytes: u64,
@@ -366,9 +372,16 @@ where
     let mut replay_manifest_bytes = 0u64;
     let mut sparse_staged_puts = 0u64;
     let mut sparse_written_bytes = 0u64;
+    let mut sparse_directory_nodes_loaded = 0u64;
+    let mut sparse_directory_descriptors_visited = 0u64;
+    let mut sparse_directory_nodes_encoded = 0u64;
+    let mut sparse_publication_nanos = Vec::with_capacity(unrelated_sparse_commits);
     let mut first_sparse_elapsed_nanos = 0u64;
     let mut first_sparse_staged_puts = 0u64;
     let mut first_sparse_written_bytes = 0u64;
+    let _ = crate::storage_bench::take_crud_current_state_directory_accounting();
+    let base_directory_staged_encoded_bytes =
+        crate::storage_bench::take_crud_current_state_directory_bytes();
     let beta_pk = EntityPk::single("unrelated");
     for index in 0..unrelated_sparse_commits {
         let sparse_started = Instant::now();
@@ -429,6 +442,7 @@ where
                 .await
                 .expect("load benchmark sparse parent authority")
                 .expect("benchmark sparse parent authority exists");
+        let publication_started = Instant::now();
         let publication = super::storage::stage_current_state_catalog_from_published_parent(
             &read,
             &mut writes,
@@ -438,6 +452,8 @@ where
         )
         .await
         .expect("reuse benchmark persistent catalog");
+        sparse_publication_nanos
+            .push(u64::try_from(publication_started.elapsed().as_nanos()).unwrap_or(u64::MAX));
         let (catalog, anchor) = publication.parts();
         drop(read);
         current_manifest = bench_current_state_manifest(
@@ -468,6 +484,11 @@ where
             .expect("commit benchmark sparse child");
         sparse_staged_puts += stats.staged_puts;
         sparse_written_bytes += stats.written_bytes;
+        let directory_accounting =
+            crate::storage_bench::take_crud_current_state_directory_accounting();
+        sparse_directory_nodes_loaded += directory_accounting.nodes_loaded;
+        sparse_directory_descriptors_visited += directory_accounting.descriptors_visited;
+        sparse_directory_nodes_encoded += directory_accounting.nodes_encoded;
         if index == 0 {
             first_sparse_elapsed_nanos =
                 u64::try_from(sparse_started.elapsed().as_nanos()).unwrap_or(u64::MAX);
@@ -476,6 +497,23 @@ where
         }
         commits.push(commit_id);
     }
+    sparse_publication_nanos.sort_unstable();
+    let sparse_publication_p50_nanos = sparse_publication_nanos
+        .get(sparse_publication_nanos.len() / 2)
+        .copied()
+        .unwrap_or_default();
+    let sparse_publication_p95_nanos = sparse_publication_nanos
+        .get(
+            sparse_publication_nanos
+                .len()
+                .saturating_mul(95)
+                .div_ceil(100)
+                .saturating_sub(1),
+        )
+        .copied()
+        .unwrap_or_default();
+    let sparse_directory_staged_encoded_bytes =
+        crate::storage_bench::take_crud_current_state_directory_bytes();
 
     let target_index = if sparse_shape == BenchCurrentStateSparseShape::TouchedScope
         && point_target == BenchCurrentStatePointTarget::HotMutated
@@ -501,10 +539,16 @@ where
         catalog_manifest_bytes,
         replay_manifest_bytes,
         catalog_staged_encoded_bytes: crate::storage_bench::take_crud_current_state_catalog_bytes(),
-        directory_staged_encoded_bytes:
-            crate::storage_bench::take_crud_current_state_directory_bytes(),
+        directory_staged_encoded_bytes: base_directory_staged_encoded_bytes
+            .saturating_add(sparse_directory_staged_encoded_bytes),
+        sparse_directory_staged_encoded_bytes,
         sparse_staged_puts,
         sparse_written_bytes,
+        sparse_directory_nodes_loaded,
+        sparse_directory_descriptors_visited,
+        sparse_directory_nodes_encoded,
+        sparse_publication_p50_nanos,
+        sparse_publication_p95_nanos,
         first_sparse_elapsed_nanos,
         first_sparse_staged_puts,
         first_sparse_written_bytes,
@@ -535,12 +579,36 @@ where
         self.directory_staged_encoded_bytes
     }
 
+    pub fn sparse_directory_staged_encoded_bytes(&self) -> u64 {
+        self.sparse_directory_staged_encoded_bytes
+    }
+
     pub fn sparse_staged_puts(&self) -> u64 {
         self.sparse_staged_puts
     }
 
     pub fn sparse_written_bytes(&self) -> u64 {
         self.sparse_written_bytes
+    }
+
+    pub fn sparse_directory_nodes_loaded(&self) -> u64 {
+        self.sparse_directory_nodes_loaded
+    }
+
+    pub fn sparse_directory_descriptors_visited(&self) -> u64 {
+        self.sparse_directory_descriptors_visited
+    }
+
+    pub fn sparse_directory_nodes_encoded(&self) -> u64 {
+        self.sparse_directory_nodes_encoded
+    }
+
+    pub fn sparse_publication_p50_nanos(&self) -> u64 {
+        self.sparse_publication_p50_nanos
+    }
+
+    pub fn sparse_publication_p95_nanos(&self) -> u64 {
+        self.sparse_publication_p95_nanos
     }
 
     pub fn first_sparse_elapsed_nanos(&self) -> u64 {

--- a/packages/engine/src/tracked_state/current_state_part.rs
+++ b/packages/engine/src/tracked_state/current_state_part.rs
@@ -24,25 +24,24 @@ use crate::{LixError, storage_codec};
 
 pub(crate) const CURRENT_STATE_PART_DIRECTORY_SPACE: StorageSpace = StorageSpace::immutable(
     StorageSpaceId(0x0004_002c),
-    "tracked_state.current_state_part_directory.v1",
+    "tracked_state.current_state_part_directory.v2",
 );
 pub(crate) const CURRENT_STATE_CATALOG_SPACE: StorageSpace = StorageSpace::immutable(
     StorageSpaceId(0x0004_002d),
     "tracked_state.current_state_catalog.v1",
 );
 
-const DIRECTORY_NODE_RAW_MAGIC: &[u8; 6] = b"LXCSDR";
-const DIRECTORY_NODE_ZSTD_MAGIC: &[u8; 6] = b"LXCSDZ";
+const DIRECTORY_NODE_RAW_MAGIC: &[u8; 6] = b"LXC2DR";
+const DIRECTORY_NODE_ZSTD_MAGIC: &[u8; 6] = b"LXC2DZ";
 const DIRECTORY_NODE_MAX_DECODED_BYTES: usize = 16 * 1024 * 1024;
 const DIRECTORY_FANOUT: usize = 128;
-const DIRECTORY_HASH_CONTEXT: &str = "lix current-state part directory node v1";
+const DIRECTORY_HASH_CONTEXT: &str = "lix current-state part directory node v2";
 const CATALOG_NODE_MAGIC: &[u8; 6] = b"LXCSCR";
 const CATALOG_HASH_CONTEXT: &str = "lix current-state catalog node v1";
-const CURRENT_STATE_LINEAGE_CONTEXT: &str = "lix current-state lineage v1";
+const CURRENT_STATE_LINEAGE_CONTEXT: &str = "lix current-state lineage v2";
 const CATALOG_TRANSITION_CONTEXT: &str = "lix current-state catalog transition v1";
 const CATALOG_LEAF_MAX_ENTRIES: usize = 128;
 const CATALOG_MAX_KEY_BYTES: usize = 64 * 1024;
-const CURRENT_STATE_DESCRIPTOR_DIGEST_CONTEXT: &str = "lix current-state descriptor set v1";
 
 /// Publishes the serving directory for a certified complete replacement.
 /// Ordinary mutation inventories are not state partitions and return `None`.
@@ -90,7 +89,7 @@ pub(crate) fn stage_complete_replacement_current_state_part_set(
             Ok(descriptor)
         })
         .collect::<Result<Vec<_>, LixError>>()?;
-    let mut directory = stage_current_state_part_directory(writes, &descriptors)?;
+    let directory = stage_current_state_part_directory(writes, &descriptors)?;
     if directory.row_count != u64::from(inventory.member_count)
         || replacement_directory_digest(&descriptors)? != authority_digest
         || initial_generation.owner_commit_id != *commit_id.as_uuid().as_bytes()
@@ -99,10 +98,6 @@ pub(crate) fn stage_complete_replacement_current_state_part_set(
             "replacement state set disagrees with its commit authority",
         ));
     }
-    // The first complete generation retains the historical replacement
-    // certificate digest. Sparse descendants use the generic descriptor-set
-    // digest because they may mix replacement and native sources.
-    directory.descriptor_digest = authority_digest;
     let generation = initial_generation.clone();
     let state_lineage_digest =
         fresh_current_state_lineage_digest(commit_id, generation.integrity_digest, &directory);
@@ -174,7 +169,7 @@ pub(crate) fn fresh_current_state_lineage_digest(
         .update(commit_id.as_uuid().as_bytes())
         .update(&generation_integrity_digest)
         .update(&directory.root_id)
-        .update(&directory.descriptor_digest)
+        .update(&directory.directory_digest)
         .finalize()
         .as_bytes()
 }
@@ -1487,66 +1482,6 @@ pub(crate) async fn load_current_state_part_directory_reachability(
     Ok((nodes, descriptor_sets.pop().unwrap_or_default()))
 }
 
-pub(crate) async fn load_current_state_part_directory_reachability_for_write(
-    store: &(impl StorageAdapterRead + ?Sized),
-    writes: &mut StorageWriteSet,
-    root: &CurrentStatePartDirectoryRoot,
-) -> Result<
-    (
-        std::collections::BTreeSet<[u8; 32]>,
-        Vec<CurrentStatePartDescriptor>,
-    ),
-    LixError,
-> {
-    if root.part_count == 0 {
-        validate_empty_root(root)?;
-        return Ok((std::collections::BTreeSet::new(), Vec::new()));
-    }
-    let mut pending = vec![(root.root_id, None)];
-    let mut node_ids = std::collections::BTreeSet::new();
-    let mut descriptors = Vec::with_capacity(root.part_count as usize);
-    while let Some((node_id, expected_child)) = pending.pop() {
-        if !node_ids.insert(node_id) {
-            return Err(directory_error(
-                "part directory contains a cycle or duplicate child",
-            ));
-        }
-        let staged = writes.staged_value(CURRENT_STATE_PART_DIRECTORY_SPACE, &node_id);
-        let node = if let Some(bytes) = staged {
-            if node_digest(&bytes) != node_id {
-                return Err(directory_error("node content digest mismatch"));
-            }
-            decode_node(&bytes)?
-        } else {
-            load_node(store, node_id).await?
-        };
-        if expected_child.is_none() {
-            validate_root_summary(root, &node)?;
-        }
-        if let Some(expected) = expected_child.as_ref() {
-            validate_child_summary(expected, &node)?;
-        }
-        if node.kind == 0 {
-            descriptors.extend(node.parts);
-        } else {
-            pending.extend(
-                node.children
-                    .into_iter()
-                    .rev()
-                    .map(|child| (child.node_id, Some(child))),
-            );
-        }
-    }
-    descriptors.sort_by(|left, right| left.first_key.cmp(&right.first_key));
-    validate_descriptors(&descriptors)?;
-    if descriptors.len() != root.part_count as usize
-        || !descriptor_digest_matches(root, &descriptors)?
-    {
-        return Err(directory_error("part directory reachability mismatch"));
-    }
-    Ok((node_ids, descriptors))
-}
-
 pub(crate) async fn load_current_state_part_directory_reachability_many(
     store: &(impl StorageAdapterRead + ?Sized),
     roots: &[CurrentStatePartDirectoryRoot],
@@ -1626,9 +1561,7 @@ pub(crate) async fn load_current_state_part_directory_reachability_many(
         // caller-visible descriptor sequence before semantic validation.
         descriptors.sort_by(|left, right| left.first_key.cmp(&right.first_key));
         validate_descriptors(descriptors)?;
-        if descriptors.len() != root.part_count as usize
-            || !descriptor_digest_matches(root, descriptors)?
-        {
+        if descriptors.len() != root.part_count as usize || !directory_digest_matches(root) {
             return Err(directory_error("part directory reachability mismatch"));
         }
     }
@@ -1637,7 +1570,7 @@ pub(crate) async fn load_current_state_part_directory_reachability_many(
 
 fn validate_catalog_node(node: &CatalogNode) -> Result<(), LixError> {
     let depth = usize::try_from(node.depth).expect("u32 fits usize");
-    let empty_descriptor_digest = current_state_descriptor_digest(&[])?;
+    let empty_directory_digest = empty_current_state_directory_digest();
     if depth > CATALOG_MAX_KEY_BYTES
         || node.sample_key.len() > CATALOG_MAX_KEY_BYTES
         || node.sample_key.len() < depth
@@ -1650,12 +1583,12 @@ fn validate_catalog_node(node: &CatalogNode) -> Result<(), LixError> {
             .any(|pair| pair[0].scope >= pair[1].scope)
         || node.entries.iter().any(|entry| {
             let valid_empty_directory = entry.directory.root_id == [0; 32]
-                && entry.directory.descriptor_digest == empty_descriptor_digest
+                && entry.directory.directory_digest == empty_directory_digest
                 && entry.directory.row_count == 0
                 && entry.directory.part_count == 0
                 && entry.directory.tree_height == 0;
             let valid_nonempty_directory = entry.directory.root_id != [0; 32]
-                && entry.directory.descriptor_digest != [0; 32]
+                && entry.directory.directory_digest != [0; 32]
                 && entry.directory.row_count > 0
                 && entry.directory.part_count > 0
                 && entry.directory.tree_height > 0;
@@ -1741,12 +1674,14 @@ struct DirectoryChild {
     node_id: [u8; 32],
     row_count: u64,
     part_count: u32,
+    level: u16,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
 #[musli(packed)]
 struct DirectoryNode {
     kind: u8,
+    level: u16,
     parts: Vec<CurrentStatePartDescriptor>,
     children: Vec<DirectoryChild>,
 }
@@ -1755,14 +1690,20 @@ impl DirectoryNode {
     fn leaf(parts: Vec<CurrentStatePartDescriptor>) -> Self {
         Self {
             kind: 0,
+            level: 0,
             parts,
             children: Vec::new(),
         }
     }
 
     fn internal(children: Vec<DirectoryChild>) -> Self {
+        let level = children
+            .first()
+            .map(|child| child.level.saturating_add(1))
+            .unwrap_or(1);
         Self {
             kind: 1,
+            level,
             parts: Vec::new(),
             children,
         }
@@ -1774,58 +1715,80 @@ struct StagedNode {
     child: DirectoryChild,
 }
 
+fn balanced_directory_chunks<T>(values: &[T]) -> Vec<&[T]> {
+    if values.is_empty() {
+        return Vec::new();
+    }
+    let group_count = values.len().div_ceil(DIRECTORY_FANOUT);
+    let base = values.len() / group_count;
+    let remainder = values.len() % group_count;
+    let mut chunks = Vec::with_capacity(group_count);
+    let mut start = 0usize;
+    for group_index in 0..group_count {
+        let length = base + usize::from(group_index < remainder);
+        chunks.push(&values[start..start + length]);
+        start += length;
+    }
+    chunks
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CurrentStateDirectorySplicePlan {
+    write_set_id: u64,
+    root: CurrentStatePartDirectoryRoot,
+    leaves: Vec<DirectorySpliceLeaf>,
+    internal_by_depth: Vec<std::collections::BTreeMap<[u8; 32], DirectoryNode>>,
+}
+
+#[derive(Debug, Clone)]
+struct DirectorySpliceLeaf {
+    node_id: [u8; 32],
+    parts: Vec<CurrentStatePartDescriptor>,
+    key_indices: Vec<usize>,
+}
+
+impl CurrentStateDirectorySplicePlan {
+    pub(crate) fn leaf_count(&self) -> usize {
+        self.leaves.len()
+    }
+
+    pub(crate) fn leaf_parts(&self, index: usize) -> &[CurrentStatePartDescriptor] {
+        &self.leaves[index].parts
+    }
+
+    pub(crate) fn leaf_key_indices(&self, index: usize) -> &[usize] {
+        &self.leaves[index].key_indices
+    }
+}
+
 /// Stages one complete ordered post-image part set as a bounded persistent
 /// range directory. Equal nodes naturally share storage across generations.
 pub(crate) fn stage_current_state_part_directory(
     writes: &mut StorageWriteSet,
     descriptors: &[CurrentStatePartDescriptor],
 ) -> Result<CurrentStatePartDirectoryRoot, LixError> {
-    stage_current_state_part_directory_reusing(
-        writes,
-        descriptors,
-        &std::collections::BTreeSet::new(),
-    )
-}
-
-/// Rebuilds the logical directory while retaining all content-identical nodes
-/// already reachable from the parent root. When descriptor cardinality stays
-/// stable, leaf chunking stages only changed leaves and their ancestors. A
-/// fully key-addressed range splice is deliberately left to the next cut.
-pub(crate) fn stage_current_state_part_directory_reusing(
-    writes: &mut StorageWriteSet,
-    descriptors: &[CurrentStatePartDescriptor],
-    reusable_node_ids: &std::collections::BTreeSet<[u8; 32]>,
-) -> Result<CurrentStatePartDirectoryRoot, LixError> {
     if descriptors.is_empty() {
         return Ok(CurrentStatePartDirectoryRoot {
             root_id: [0; 32],
-            descriptor_digest: current_state_descriptor_digest(descriptors)?,
+            directory_digest: empty_current_state_directory_digest(),
             row_count: 0,
             part_count: 0,
             tree_height: 0,
         });
     }
     validate_descriptors(descriptors)?;
-    let descriptor_digest = current_state_descriptor_digest(descriptors)?;
-    let mut level = descriptors
-        .chunks(DIRECTORY_FANOUT)
-        .map(|chunk| {
-            stage_node_reusing(
-                writes,
-                DirectoryNode::leaf(chunk.to_vec()),
-                reusable_node_ids,
-            )
-        })
+    let mut level = balanced_directory_chunks(descriptors)
+        .into_iter()
+        .map(|chunk| stage_node(writes, DirectoryNode::leaf(chunk.to_vec())))
         .collect::<Result<Vec<_>, _>>()?;
     let mut tree_height = 1u16;
     while level.len() > 1 {
-        level = level
-            .chunks(DIRECTORY_FANOUT)
+        level = balanced_directory_chunks(&level)
+            .into_iter()
             .map(|chunk| {
-                stage_node_reusing(
+                stage_node(
                     writes,
                     DirectoryNode::internal(chunk.iter().map(|node| node.child.clone()).collect()),
-                    reusable_node_ids,
                 )
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -1839,7 +1802,237 @@ pub(crate) fn stage_current_state_part_directory_reusing(
         .ok_or_else(|| directory_error("cannot stage an empty part set"))?;
     Ok(CurrentStatePartDirectoryRoot {
         root_id: root.child.node_id,
-        descriptor_digest,
+        directory_digest: current_state_directory_digest(
+            root.child.node_id,
+            root.child.row_count,
+            root.child.part_count,
+            tree_height,
+        ),
+        row_count: root.child.row_count,
+        part_count: root.child.part_count,
+        tree_height,
+    })
+}
+
+/// Loads only the immutable search paths and boundary leaves needed to apply
+/// an ordered key batch. Keys in gaps are assigned to the preceding leaf (or
+/// the first leaf before the directory's minimum), so inserts and exact
+/// misses never require flattening the complete descriptor set.
+pub(crate) async fn plan_current_state_part_directory_splice(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    root: &CurrentStatePartDirectoryRoot,
+    encoded_keys: &[Bytes],
+) -> Result<CurrentStateDirectorySplicePlan, LixError> {
+    if root.part_count == 0 {
+        validate_empty_root(root)?;
+        return Ok(CurrentStateDirectorySplicePlan {
+            write_set_id: writes.identity(),
+            root: root.clone(),
+            leaves: Vec::new(),
+            internal_by_depth: Vec::new(),
+        });
+    }
+    if encoded_keys.windows(2).any(|pair| pair[0] >= pair[1]) {
+        return Err(directory_error(
+            "splice keys are empty, duplicate, or unordered",
+        ));
+    }
+    if encoded_keys.is_empty() {
+        return Err(directory_error("splice key batch is empty"));
+    }
+    let mut cache = std::collections::BTreeMap::<[u8; 32], DirectoryNode>::new();
+    let mut internal_by_depth = (0..root.tree_height.saturating_sub(1))
+        .map(|_| std::collections::BTreeMap::new())
+        .collect::<Vec<_>>();
+    let mut leaves = std::collections::BTreeMap::<[u8; 32], DirectorySpliceLeaf>::new();
+    for (key_index, encoded_key) in encoded_keys.iter().enumerate() {
+        let mut node_id = root.root_id;
+        let mut expected_child = None;
+        let mut depth = 0usize;
+        loop {
+            let node = if let Some(node) = cache.get(&node_id) {
+                node.clone()
+            } else {
+                let node = load_node_for_write(store, writes, node_id).await?;
+                #[cfg(feature = "storage-benches")]
+                crate::storage_bench::record_crud_current_state_directory_node_loaded();
+                cache.insert(node_id, node.clone());
+                node
+            };
+            if depth == 0 {
+                validate_root_summary(root, &node)?;
+            }
+            if let Some(expected) = expected_child.as_ref() {
+                validate_child_summary(expected, &node)?;
+            }
+            match node.kind {
+                0 => {
+                    #[cfg(feature = "storage-benches")]
+                    if !leaves.contains_key(&node_id) {
+                        crate::storage_bench::record_crud_current_state_directory_descriptors_visited(
+                            node.parts.len(),
+                        );
+                    }
+                    leaves
+                        .entry(node_id)
+                        .or_insert_with(|| DirectorySpliceLeaf {
+                            node_id,
+                            parts: node.parts,
+                            key_indices: Vec::new(),
+                        })
+                        .key_indices
+                        .push(key_index);
+                    break;
+                }
+                1 => {
+                    let upper = node.children.partition_point(|child| {
+                        child.first_key.as_slice() <= encoded_key.as_ref()
+                    });
+                    let child_index = upper.saturating_sub(1);
+                    let child = node.children.get(child_index).cloned().ok_or_else(|| {
+                        directory_error("splice path reached an empty internal node")
+                    })?;
+                    internal_by_depth
+                        .get_mut(depth)
+                        .ok_or_else(|| directory_error("splice path exceeds root height"))?
+                        .insert(node_id, node);
+                    node_id = child.node_id;
+                    expected_child = Some(child);
+                    depth += 1;
+                }
+                _ => unreachable!("validated directory node kind"),
+            }
+        }
+    }
+    let leaves = leaves.into_values().collect::<Vec<_>>();
+    Ok(CurrentStateDirectorySplicePlan {
+        write_set_id: writes.identity(),
+        root: root.clone(),
+        leaves,
+        internal_by_depth,
+    })
+}
+
+/// Applies leaf replacements to a previously planned immutable search-path
+/// frontier. Only changed leaves and their ancestor closure are staged.
+pub(crate) async fn stage_current_state_part_directory_splice(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    plan: CurrentStateDirectorySplicePlan,
+    replacements: Vec<Vec<CurrentStatePartDescriptor>>,
+) -> Result<CurrentStatePartDirectoryRoot, LixError> {
+    if plan.write_set_id != writes.identity() {
+        return Err(directory_error(
+            "splice plan belongs to a different storage write set",
+        ));
+    }
+    if replacements.len() != plan.leaves.len() {
+        return Err(directory_error("splice replacement cardinality mismatch"));
+    }
+    if plan.root.part_count == 0 {
+        if replacements.is_empty() {
+            return Ok(plan.root);
+        }
+        return Err(directory_error("empty directory splice cannot name leaves"));
+    }
+    let mut changes = std::collections::BTreeMap::<[u8; 32], Vec<StagedNode>>::new();
+    for (leaf, parts) in plan.leaves.into_iter().zip(replacements) {
+        if !parts.is_empty() {
+            validate_descriptor_slice(&parts)?;
+        }
+        let chunks = balanced_directory_chunks(&parts);
+        let reuse = (chunks.len() == 1).then_some(leaf.node_id);
+        let staged = chunks
+            .into_iter()
+            .map(|chunk| stage_node_reusing(writes, DirectoryNode::leaf(chunk.to_vec()), reuse))
+            .collect::<Result<Vec<_>, _>>()?;
+        changes.insert(leaf.node_id, staged);
+    }
+    for level in plan.internal_by_depth.into_iter().rev() {
+        for (node_id, node) in level {
+            let mut children = Vec::with_capacity(node.children.len() + DIRECTORY_FANOUT);
+            for child in node.children {
+                if let Some(replacement) = changes.remove(&child.node_id) {
+                    children.extend(replacement.into_iter().map(|node| node.child));
+                } else {
+                    children.push(child);
+                }
+            }
+            if node_id == plan.root.root_id && children.len() == 1 {
+                changes.insert(
+                    node_id,
+                    vec![StagedNode {
+                        child: children.pop().expect("one-child root has one child"),
+                    }],
+                );
+                continue;
+            }
+            let chunks = balanced_directory_chunks(&children);
+            let reuse = (chunks.len() == 1).then_some(node_id);
+            let staged = chunks
+                .into_iter()
+                .map(|chunk| {
+                    stage_node_reusing(writes, DirectoryNode::internal(chunk.to_vec()), reuse)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            changes.insert(node_id, staged);
+        }
+    }
+    let mut roots = changes.remove(&plan.root.root_id).ok_or_else(|| {
+        directory_error("splice plan did not rewrite the root search-path closure")
+    })?;
+    if !changes.is_empty() {
+        return Err(directory_error(
+            "splice plan retained disconnected node changes",
+        ));
+    }
+    if roots.is_empty() {
+        return Ok(CurrentStatePartDirectoryRoot {
+            root_id: [0; 32],
+            directory_digest: empty_current_state_directory_digest(),
+            row_count: 0,
+            part_count: 0,
+            tree_height: 0,
+        });
+    }
+    while roots.len() > 1 {
+        roots = balanced_directory_chunks(&roots)
+            .into_iter()
+            .map(|chunk| {
+                stage_node(
+                    writes,
+                    DirectoryNode::internal(chunk.iter().map(|node| node.child.clone()).collect()),
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+    }
+    let mut root = roots.pop().expect("non-empty roots have one final node");
+    while root.child.level > 0 {
+        let node = load_node_for_write(store, writes, root.child.node_id).await?;
+        validate_child_summary(&root.child, &node)?;
+        if node.children.len() != 1 {
+            break;
+        }
+        root.child = node
+            .children
+            .into_iter()
+            .next()
+            .expect("validated one-child internal node has one child");
+    }
+    let tree_height = root
+        .child
+        .level
+        .checked_add(1)
+        .ok_or_else(|| directory_error("tree height overflows"))?;
+    Ok(CurrentStatePartDirectoryRoot {
+        root_id: root.child.node_id,
+        directory_digest: current_state_directory_digest(
+            root.child.node_id,
+            root.child.row_count,
+            root.child.part_count,
+            tree_height,
+        ),
         row_count: root.child.row_count,
         part_count: root.child.part_count,
         tree_height,
@@ -2040,7 +2233,7 @@ pub(crate) async fn load_current_state_part_descriptors(
             .map(|part| u64::from(part.row_count))
             .sum::<u64>()
             != root.row_count
-        || !descriptor_digest_matches(root, &descriptors)?
+        || !directory_digest_matches(root)
     {
         return Err(directory_error(
             "root summary does not match its descriptor set",
@@ -2049,15 +2242,27 @@ pub(crate) async fn load_current_state_part_descriptors(
     Ok(descriptors)
 }
 
+fn stage_node(writes: &mut StorageWriteSet, node: DirectoryNode) -> Result<StagedNode, LixError> {
+    stage_node_reusing(writes, node, None)
+}
+
 fn stage_node_reusing(
     writes: &mut StorageWriteSet,
     node: DirectoryNode,
-    reusable_node_ids: &std::collections::BTreeSet<[u8; 32]>,
+    reusable_node_id: Option<[u8; 32]>,
 ) -> Result<StagedNode, LixError> {
+    #[cfg(feature = "storage-benches")]
+    crate::storage_bench::record_crud_current_state_directory_node_encoded();
     let (first_key, last_key, row_count, part_count) = node_summary(&node)?;
     let bytes = encode_node(&node)?;
     let node_id = node_digest(&bytes);
-    if !reusable_node_ids.contains(&node_id) {
+    if let Some(staged) = writes.staged_value(CURRENT_STATE_PART_DIRECTORY_SPACE, &node_id) {
+        if staged != bytes {
+            return Err(directory_error(
+                "content-addressed node identity has conflicting staged bytes",
+            ));
+        }
+    } else if reusable_node_id != Some(node_id) {
         #[cfg(feature = "storage-benches")]
         crate::storage_bench::record_crud_current_state_directory_bytes(bytes.len());
         writes.put(
@@ -2075,8 +2280,24 @@ fn stage_node_reusing(
             node_id,
             row_count,
             part_count,
+            level: node.level,
         },
     })
+}
+
+async fn load_node_for_write(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    node_id: [u8; 32],
+) -> Result<DirectoryNode, LixError> {
+    if let Some(bytes) = writes.staged_value(CURRENT_STATE_PART_DIRECTORY_SPACE, &node_id) {
+        if node_digest(&bytes) != node_id {
+            return Err(directory_error("node content digest mismatch"));
+        }
+        decode_node(&bytes)
+    } else {
+        load_node(store, node_id).await
+    }
 }
 
 async fn load_node(
@@ -2233,32 +2454,33 @@ fn replacement_directory_digest(
     .digest()
 }
 
-fn current_state_descriptor_digest(
-    descriptors: &[CurrentStatePartDescriptor],
-) -> Result<[u8; 32], LixError> {
-    let encoded = storage_codec::encode("current-state descriptor set", &descriptors)?;
-    Ok(
-        *blake3::Hasher::new_derive_key(CURRENT_STATE_DESCRIPTOR_DIGEST_CONTEXT)
-            .update(&encoded)
-            .finalize()
-            .as_bytes(),
-    )
+fn current_state_directory_digest(
+    root_id: [u8; 32],
+    row_count: u64,
+    part_count: u32,
+    tree_height: u16,
+) -> [u8; 32] {
+    *blake3::Hasher::new_derive_key("lix current-state merkle directory v2")
+        .update(&root_id)
+        .update(&row_count.to_be_bytes())
+        .update(&part_count.to_be_bytes())
+        .update(&tree_height.to_be_bytes())
+        .finalize()
+        .as_bytes()
 }
 
-fn descriptor_digest_matches(
-    root: &CurrentStatePartDirectoryRoot,
-    descriptors: &[CurrentStatePartDescriptor],
-) -> Result<bool, LixError> {
-    if current_state_descriptor_digest(descriptors)? == root.descriptor_digest {
-        return Ok(true);
-    }
-    if descriptors
-        .iter()
-        .all(|part| part.source_kind == 0 && part.source_row_offset == 0)
-    {
-        return Ok(replacement_directory_digest(descriptors)? == root.descriptor_digest);
-    }
-    Ok(false)
+fn empty_current_state_directory_digest() -> [u8; 32] {
+    current_state_directory_digest([0; 32], 0, 0, 0)
+}
+
+fn directory_digest_matches(root: &CurrentStatePartDirectoryRoot) -> bool {
+    root.directory_digest
+        == current_state_directory_digest(
+            root.root_id,
+            root.row_count,
+            root.part_count,
+            root.tree_height,
+        )
 }
 
 fn validate_root_summary(
@@ -2266,7 +2488,17 @@ fn validate_root_summary(
     node: &DirectoryNode,
 ) -> Result<(), LixError> {
     let (_, _, row_count, part_count) = node_summary(node)?;
-    if row_count != root.row_count || part_count != root.part_count {
+    if row_count != root.row_count
+        || part_count != root.part_count
+        || node.level.checked_add(1) != Some(root.tree_height)
+        || root.directory_digest
+            != current_state_directory_digest(
+                root.root_id,
+                root.row_count,
+                root.part_count,
+                root.tree_height,
+            )
+    {
         return Err(directory_error("root summary disagrees with its node"));
     }
     Ok(())
@@ -2274,7 +2506,7 @@ fn validate_root_summary(
 
 fn validate_empty_root(root: &CurrentStatePartDirectoryRoot) -> Result<(), LixError> {
     if root.root_id != [0; 32]
-        || root.descriptor_digest != current_state_descriptor_digest(&[])?
+        || root.directory_digest != empty_current_state_directory_digest()
         || root.row_count != 0
         || root.part_count != 0
         || root.tree_height != 0
@@ -2290,6 +2522,7 @@ fn validate_child_summary(expected: &DirectoryChild, node: &DirectoryNode) -> Re
         || last_key != expected.last_key
         || row_count != expected.row_count
         || part_count != expected.part_count
+        || node.level != expected.level
     {
         return Err(directory_error("child summary disagrees with its node"));
     }
@@ -2312,16 +2545,26 @@ fn node_summary(node: &DirectoryNode) -> Result<(Vec<u8>, Vec<u8>, u64, u32), Li
                 .sum(),
             u32::try_from(node.parts.len()).map_err(|_| directory_error("part count overflows"))?,
         )),
-        1 => Ok((
-            node.children[0].first_key.clone(),
-            node.children
-                .last()
-                .expect("validated internal node is non-empty")
-                .last_key
-                .clone(),
-            node.children.iter().map(|child| child.row_count).sum(),
-            node.children.iter().map(|child| child.part_count).sum(),
-        )),
+        1 => {
+            let row_count = node.children.iter().try_fold(0u64, |sum, child| {
+                sum.checked_add(child.row_count)
+                    .ok_or_else(|| directory_error("directory row count overflows"))
+            })?;
+            let part_count = node.children.iter().try_fold(0u32, |sum, child| {
+                sum.checked_add(child.part_count)
+                    .ok_or_else(|| directory_error("directory part count overflows"))
+            })?;
+            Ok((
+                node.children[0].first_key.clone(),
+                node.children
+                    .last()
+                    .expect("validated internal node is non-empty")
+                    .last_key
+                    .clone(),
+                row_count,
+                part_count,
+            ))
+        }
         _ => unreachable!("validated directory node kind"),
     }
 }
@@ -2329,7 +2572,7 @@ fn node_summary(node: &DirectoryNode) -> Result<(Vec<u8>, Vec<u8>, u64, u32), Li
 fn validate_node(node: &DirectoryNode) -> Result<(), LixError> {
     match node.kind {
         0 => {
-            if !node.children.is_empty() || node.parts.len() > DIRECTORY_FANOUT {
+            if node.level != 0 || !node.children.is_empty() || node.parts.len() > DIRECTORY_FANOUT {
                 return Err(directory_error("leaf exceeds bounded fanout"));
             }
             validate_descriptor_slice(&node.parts)
@@ -2344,6 +2587,7 @@ fn validate_node(node: &DirectoryNode) -> Result<(), LixError> {
                         || child.first_key > child.last_key
                         || child.row_count == 0
                         || child.part_count == 0
+                        || child.level.checked_add(1) != Some(node.level)
                 })
                 || node
                     .children
@@ -2492,7 +2736,7 @@ mod tests {
             state_lineage_digest: [3; 32],
             directory: CurrentStatePartDirectoryRoot {
                 root_id: *blake3::hash(format!("root-{index}").as_bytes()).as_bytes(),
-                descriptor_digest: *blake3::hash(format!("descriptors-{index}").as_bytes())
+                directory_digest: *blake3::hash(format!("descriptors-{index}").as_bytes())
                     .as_bytes(),
                 row_count: 1,
                 part_count: 1,
@@ -2869,11 +3113,494 @@ mod tests {
             root_id: foreign_root.root_id,
             ..root.clone()
         };
-        let routed = route_current_state_part(&read, &forged_root, b"key-000000-m")
+        assert!(
+            route_current_state_part(&read, &forged_root, b"key-000000-m")
+                .await
+                .is_err(),
+            "the Merkle directory digest must reject a cross-wired foreign root"
+        );
+    }
+
+    #[tokio::test]
+    async fn directory_splice_reads_and_rewrites_only_one_search_path() {
+        let adapter = StorageAdapter::new(Memory::new());
+        let descriptors = descriptors(DIRECTORY_FANOUT * 2 + 7);
+        let mut writes = adapter.new_write_set();
+        let root = stage_current_state_part_directory(&mut writes, &descriptors)
+            .expect("directory should stage");
+        adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
             .await
-            .expect("content-addressed foreign root remains structurally readable")
-            .expect("foreign range should route");
-        assert_ne!(routed.content_digest, descriptors[0].content_digest);
+            .expect("directory should commit");
+
+        let batch_sizes = Arc::new(Mutex::new(Vec::new()));
+        let read = CountingDirectoryRead {
+            inner: adapter
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("splice read should open"),
+            directory_batch_sizes: Arc::clone(&batch_sizes),
+            catalog_batch_sizes: Arc::new(Mutex::new(Vec::new())),
+        };
+        let key = Bytes::from_static(b"key-000001-m");
+        let mut splice_writes = adapter.new_write_set();
+        let plan = plan_current_state_part_directory_splice(
+            &read,
+            &mut splice_writes,
+            &root,
+            std::slice::from_ref(&key),
+        )
+        .await
+        .expect("one-key splice should plan");
+        assert_eq!(plan.leaf_count(), 1);
+        let first_leaf_len = descriptors.len().div_ceil(3);
+        assert_eq!(plan.leaf_parts(0), &descriptors[..first_leaf_len]);
+        let mut replacement = plan.leaf_parts(0).to_vec();
+        replacement[1].content_digest = [7; 32];
+        let mut foreign_writes = adapter.new_write_set();
+        assert!(
+            stage_current_state_part_directory_splice(
+                &read,
+                &mut foreign_writes,
+                plan.clone(),
+                vec![replacement.clone()],
+            )
+            .await
+            .is_err(),
+            "a splice plan cannot move staged-only authority into another write set"
+        );
+        let rewritten = stage_current_state_part_directory_splice(
+            &read,
+            &mut splice_writes,
+            plan,
+            vec![replacement],
+        )
+        .await
+        .expect("one-leaf splice should stage");
+        assert_eq!(
+            batch_sizes
+                .lock()
+                .expect("directory batch counts lock")
+                .as_slice(),
+            &[1, 1],
+            "a two-level directory splice must read only root and one leaf"
+        );
+        assert_eq!(
+            splice_writes.stats().staged_puts,
+            2,
+            "one update must stage one leaf and its root"
+        );
+        adapter
+            .commit_write_set(splice_writes, StorageWriteOptions::default())
+            .await
+            .expect("splice should commit");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("rewritten read should open");
+        let mut expected = descriptors;
+        expected[1].content_digest = [7; 32];
+        assert_eq!(
+            load_current_state_part_descriptors(&read, &rewritten)
+                .await
+                .expect("rewritten directory should flatten"),
+            expected
+        );
+    }
+
+    #[tokio::test]
+    async fn directory_splice_splits_boundary_leaf_and_preserves_distant_subtrees() {
+        let adapter = StorageAdapter::new(Memory::new());
+        let descriptors = descriptors(DIRECTORY_FANOUT * 2);
+        let mut writes = adapter.new_write_set();
+        let root = stage_current_state_part_directory(&mut writes, &descriptors)
+            .expect("directory should stage");
+        adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("directory should commit");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("splice read should open");
+        let original_root = load_node(&read, root.root_id)
+            .await
+            .expect("root should load");
+        let untouched_middle = original_root.children[1].clone();
+
+        let key = Bytes::from_static(b"key-000000-0");
+        let mut splice_writes = adapter.new_write_set();
+        let plan = plan_current_state_part_directory_splice(
+            &read,
+            &mut splice_writes,
+            &root,
+            std::slice::from_ref(&key),
+        )
+        .await
+        .expect("boundary insertion should plan");
+        let mut inserted = descriptors[0].clone();
+        inserted.first_key = b"key-000000-0a".to_vec();
+        inserted.last_key = b"key-000000-0z".to_vec();
+        inserted.content_digest = [8; 32];
+        let mut replacement = Vec::with_capacity(DIRECTORY_FANOUT + 1);
+        replacement.push(inserted.clone());
+        replacement.extend_from_slice(plan.leaf_parts(0));
+        let rewritten = stage_current_state_part_directory_splice(
+            &read,
+            &mut splice_writes,
+            plan,
+            vec![replacement],
+        )
+        .await
+        .expect("overflowing leaf should split");
+        assert_eq!(
+            splice_writes.stats().staged_puts,
+            3,
+            "one overflowing leaf stages two leaves and one root"
+        );
+        adapter
+            .commit_write_set(splice_writes, StorageWriteOptions::default())
+            .await
+            .expect("boundary insertion should commit");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("rewritten read should open");
+        let rewritten_root = load_node(&read, rewritten.root_id)
+            .await
+            .expect("rewritten root should load");
+        assert_eq!(rewritten_root.children[0].part_count, 65);
+        assert_eq!(rewritten_root.children[1].part_count, 64);
+        assert!(
+            rewritten_root
+                .children
+                .iter()
+                .any(|child| child == &untouched_middle),
+            "the distant middle subtree must remain byte-identical"
+        );
+        let mut expected = Vec::with_capacity(descriptors.len() + 1);
+        expected.push(inserted);
+        expected.extend(descriptors);
+        assert_eq!(
+            load_current_state_part_descriptors(&read, &rewritten)
+                .await
+                .expect("split directory should flatten"),
+            expected
+        );
+    }
+
+    #[tokio::test]
+    async fn directory_splice_removes_empty_leaf_without_rewriting_siblings() {
+        let adapter = StorageAdapter::new(Memory::new());
+        let descriptors = descriptors(DIRECTORY_FANOUT * 2);
+        let mut writes = adapter.new_write_set();
+        let root = stage_current_state_part_directory(&mut writes, &descriptors)
+            .expect("directory should stage");
+        adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("directory should commit");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("splice read should open");
+        let original_root = load_node(&read, root.root_id)
+            .await
+            .expect("root should load");
+        let removed_count = usize::try_from(original_root.children[0].part_count).unwrap();
+        let surviving_child = original_root.children[1].clone();
+        let key = Bytes::from_static(b"key-000001-m");
+        let mut splice_writes = adapter.new_write_set();
+        let plan = plan_current_state_part_directory_splice(
+            &read,
+            &mut splice_writes,
+            &root,
+            std::slice::from_ref(&key),
+        )
+        .await
+        .expect("leaf removal should plan");
+        let rewritten = stage_current_state_part_directory_splice(
+            &read,
+            &mut splice_writes,
+            plan,
+            vec![Vec::new()],
+        )
+        .await
+        .expect("empty leaf should be removed");
+        assert_eq!(
+            splice_writes.stats().staged_puts,
+            0,
+            "contracting to an immutable sibling stages no directory node"
+        );
+        assert_eq!(rewritten.root_id, surviving_child.node_id);
+        assert_eq!(rewritten.tree_height, 1);
+        adapter
+            .commit_write_set(splice_writes, StorageWriteOptions::default())
+            .await
+            .expect("leaf removal should commit");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("rewritten read should open");
+        assert_eq!(
+            load_current_state_part_descriptors(&read, &rewritten)
+                .await
+                .expect("rewritten directory should flatten"),
+            descriptors[removed_count..]
+        );
+    }
+
+    #[tokio::test]
+    async fn directory_splice_recursively_contracts_a_height_three_root() {
+        let adapter = StorageAdapter::new(Memory::new());
+        let descriptors = descriptors(DIRECTORY_FANOUT * DIRECTORY_FANOUT + 1);
+        let survivor = descriptors
+            .last()
+            .expect("descriptors are non-empty")
+            .clone();
+        let mut writes = adapter.new_write_set();
+        let root = stage_current_state_part_directory(&mut writes, &descriptors)
+            .expect("height-three directory should stage");
+        assert_eq!(root.tree_height, 3);
+        adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("height-three directory should commit");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("splice read should open");
+        let deleted_keys = descriptors[..descriptors.len() - 1]
+            .iter()
+            .map(|descriptor| Bytes::copy_from_slice(&descriptor.first_key))
+            .collect::<Vec<_>>();
+        let mut splice_writes = adapter.new_write_set();
+        let plan = plan_current_state_part_directory_splice(
+            &read,
+            &mut splice_writes,
+            &root,
+            &deleted_keys,
+        )
+        .await
+        .expect("mass-delete splice should plan");
+        let replacements = (0..plan.leaf_count())
+            .map(|leaf_index| {
+                plan.leaf_parts(leaf_index)
+                    .iter()
+                    .filter(|part| part.first_key == survivor.first_key)
+                    .cloned()
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        let rewritten = stage_current_state_part_directory_splice(
+            &read,
+            &mut splice_writes,
+            plan,
+            replacements,
+        )
+        .await
+        .expect("mass delete should recursively contract");
+        assert_eq!(rewritten.tree_height, 1);
+        assert_eq!(rewritten.part_count, 1);
+        adapter
+            .commit_write_set(splice_writes, StorageWriteOptions::default())
+            .await
+            .expect("contracted directory should commit");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("contracted read should open");
+        assert_eq!(
+            load_current_state_part_descriptors(&read, &rewritten)
+                .await
+                .expect("contracted directory should flatten"),
+            vec![survivor]
+        );
+    }
+
+    #[tokio::test]
+    async fn directory_splice_coalesces_staged_parent_noop() {
+        let adapter = StorageAdapter::new(Memory::new());
+        let descriptors = descriptors(DIRECTORY_FANOUT + 1);
+        let mut writes = adapter.new_write_set();
+        let root = stage_current_state_part_directory(&mut writes, &descriptors)
+            .expect("staged parent should build");
+        let puts_before = writes.stats().staged_puts;
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("empty backing read should open");
+        let key = Bytes::from_static(b"key-000001-m");
+        let plan = plan_current_state_part_directory_splice(
+            &read,
+            &mut writes,
+            &root,
+            std::slice::from_ref(&key),
+        )
+        .await
+        .expect("staged parent should be readable");
+        let unchanged = plan.leaf_parts(0).to_vec();
+        let rewritten =
+            stage_current_state_part_directory_splice(&read, &mut writes, plan, vec![unchanged])
+                .await
+                .expect("identical staged nodes should coalesce");
+        assert_eq!(rewritten, root);
+        assert_eq!(
+            writes.stats().staged_puts,
+            puts_before,
+            "no-op path copying must not stage duplicate immutable puts"
+        );
+        writes
+            .validate()
+            .expect("coalesced staged-parent write set must validate");
+    }
+
+    #[tokio::test]
+    async fn directory_splice_coalesces_two_distant_multilevel_paths() {
+        let adapter = StorageAdapter::new(Memory::new());
+        let descriptors = descriptors(DIRECTORY_FANOUT * DIRECTORY_FANOUT + 1);
+        let mut writes = adapter.new_write_set();
+        let root = stage_current_state_part_directory(&mut writes, &descriptors)
+            .expect("multilevel directory should stage");
+        assert_eq!(root.tree_height, 3);
+        adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("multilevel directory should commit");
+        let batch_sizes = Arc::new(Mutex::new(Vec::new()));
+        let read = CountingDirectoryRead {
+            inner: adapter
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("splice read should open"),
+            directory_batch_sizes: Arc::clone(&batch_sizes),
+            catalog_batch_sizes: Arc::new(Mutex::new(Vec::new())),
+        };
+        let keys = [
+            Bytes::from_static(b"key-000001-m"),
+            Bytes::from(format!("key-{:06}-m", descriptors.len() - 1)),
+        ];
+        let mut splice_writes = adapter.new_write_set();
+        let plan =
+            plan_current_state_part_directory_splice(&read, &mut splice_writes, &root, &keys)
+                .await
+                .expect("distant splice should plan");
+        assert_eq!(plan.leaf_count(), 2);
+        let mut changed_keys = Vec::new();
+        let replacements = (0..plan.leaf_count())
+            .map(|leaf_index| {
+                let mut parts = plan.leaf_parts(leaf_index).to_vec();
+                changed_keys.push(parts[0].first_key.clone());
+                parts[0].content_digest = [u8::try_from(10 + leaf_index).unwrap(); 32];
+                parts
+            })
+            .collect::<Vec<_>>();
+        let rewritten = stage_current_state_part_directory_splice(
+            &read,
+            &mut splice_writes,
+            plan,
+            replacements,
+        )
+        .await
+        .expect("distant paths should splice");
+        assert_eq!(
+            batch_sizes
+                .lock()
+                .expect("directory batch counts lock")
+                .len(),
+            5,
+            "two height-three paths share the root and read five nodes"
+        );
+        assert_eq!(
+            splice_writes.stats().staged_puts,
+            5,
+            "two distant leaves stage their two parents and shared root"
+        );
+        adapter
+            .commit_write_set(splice_writes, StorageWriteOptions::default())
+            .await
+            .expect("distant splice should commit");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("rewritten read should open");
+        let loaded = load_current_state_part_descriptors(&read, &rewritten)
+            .await
+            .expect("rewritten directory should flatten");
+        for key in changed_keys {
+            assert_ne!(
+                loaded
+                    .iter()
+                    .find(|part| part.first_key == key)
+                    .expect("changed descriptor remains present")
+                    .content_digest,
+                descriptors
+                    .iter()
+                    .find(|part| part.first_key == key)
+                    .expect("original descriptor exists")
+                    .content_digest
+            );
+        }
+    }
+
+    #[test]
+    fn directory_nodes_reject_mixed_or_forged_levels() {
+        let leaf = DirectoryNode::leaf(descriptors(1));
+        let child = StagedNode {
+            child: DirectoryChild {
+                first_key: b"a".to_vec(),
+                last_key: b"z".to_vec(),
+                node_id: [1; 32],
+                row_count: 1,
+                part_count: 1,
+                level: 0,
+            },
+        };
+        let mut internal = DirectoryNode::internal(vec![child.child]);
+        assert!(validate_node(&leaf).is_ok());
+        assert!(validate_node(&internal).is_ok());
+        internal.level = 2;
+        assert!(validate_node(&internal).is_err());
+
+        let overflowing_rows = DirectoryNode::internal(vec![
+            DirectoryChild {
+                first_key: b"a".to_vec(),
+                last_key: b"b".to_vec(),
+                node_id: [2; 32],
+                row_count: u64::MAX,
+                part_count: 1,
+                level: 0,
+            },
+            DirectoryChild {
+                first_key: b"c".to_vec(),
+                last_key: b"d".to_vec(),
+                node_id: [3; 32],
+                row_count: 1,
+                part_count: 1,
+                level: 0,
+            },
+        ]);
+        assert!(node_summary(&overflowing_rows).is_err());
+
+        let overflowing_parts = DirectoryNode::internal(vec![
+            DirectoryChild {
+                first_key: b"a".to_vec(),
+                last_key: b"b".to_vec(),
+                node_id: [4; 32],
+                row_count: 1,
+                part_count: u32::MAX,
+                level: 0,
+            },
+            DirectoryChild {
+                first_key: b"c".to_vec(),
+                last_key: b"d".to_vec(),
+                node_id: [5; 32],
+                row_count: 1,
+                part_count: 1,
+                level: 0,
+            },
+        ]);
+        assert!(node_summary(&overflowing_parts).is_err());
     }
 
     #[tokio::test]

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -736,7 +736,7 @@ async fn expanded_commit_delta_manifest_from_commit_state(
 fn fresh_replacement_current_state_part_set(
     manifest: &CommitStateManifest,
 ) -> Result<Option<crate::tracked_state::types::CurrentStatePartSet>, LixError> {
-    let (Some(_root), Some(generation), Some(authority), Some(anchor)) = (
+    let (Some(_root), Some(generation), Some(_authority), Some(anchor)) = (
         manifest.current_state_catalog.as_ref(),
         manifest.mutations.replacement_generation.as_ref(),
         manifest.mutations.replacement_parts.as_ref(),
@@ -757,7 +757,6 @@ fn fresh_replacement_current_state_part_set(
         || set.generation_integrity_digest != anchor.generation_integrity_digest
         || set.state_lineage_digest != anchor.state_lineage_digest
         || set.directory != anchor.directory
-        || set.directory.descriptor_digest != authority.directory_digest
         || set.directory.row_count != u64::from(manifest.mutations.member_count)
         || set.directory.part_count as usize != manifest.mutations.part_count()
         || set.directory.root_id == [0; 32]
@@ -2179,83 +2178,127 @@ pub(crate) async fn stage_sparse_current_state_part_set(
         return Ok(Some(parent.clone()));
     }
 
-    let (reusable_directory_nodes, parent_descriptors) =
-        super::current_state_part::load_current_state_part_directory_reachability_for_write(
+    let mut mutation_rows = mutations.into_iter().map(Some).collect::<Vec<_>>();
+    let directory = if parent.directory.part_count == 0 {
+        let rows = mutation_rows
+            .into_iter()
+            .flatten()
+            .filter_map(|(_, row)| row)
+            .collect::<Vec<_>>();
+        let mut output = Vec::new();
+        stage_native_current_state_rows(writes, &rows, &mut output)?;
+        super::current_state_part::stage_current_state_part_directory(writes, &output)?
+    } else {
+        let encoded_keys = mutation_rows
+            .iter()
+            .map(|entry| {
+                Bytes::copy_from_slice(
+                    &entry
+                        .as_ref()
+                        .expect("sparse mutation has not been assigned")
+                        .0,
+                )
+            })
+            .collect::<Vec<_>>();
+        let splice = super::current_state_part::plan_current_state_part_directory_splice(
             store,
             writes,
             &parent.directory,
+            &encoded_keys,
         )
         .await?;
-    let mut output = Vec::with_capacity(parent_descriptors.len() + mutations.len());
-    let mut pending = mutations.into_iter().peekable();
-    for descriptor in parent_descriptors {
-        let mut gap = Vec::new();
-        while pending
-            .peek()
-            .is_some_and(|(key, _)| key.as_slice() < descriptor.first_key.as_slice())
-        {
-            let (_, row) = pending.next().expect("peeked sparse mutation");
-            if let Some(row) = row {
-                gap.push(row);
-            }
-        }
-        stage_native_current_state_rows(writes, &gap, &mut output)?;
-
-        let touches_descriptor = pending
-            .peek()
-            .is_some_and(|(key, _)| key.as_slice() <= descriptor.last_key.as_slice());
-        if !touches_descriptor {
-            output.push(descriptor);
-            continue;
-        }
-        let mut rows = load_current_state_descriptor_rows(store, writes, &descriptor)
-            .await?
-            .into_iter()
-            .map(|row| (row.encoded_key.clone(), row))
-            .collect::<BTreeMap<_, _>>();
-        while pending
-            .peek()
-            .is_some_and(|(key, _)| key.as_slice() <= descriptor.last_key.as_slice())
-        {
-            let (key, row) = pending.next().expect("peeked sparse mutation");
-            match row {
-                Some(mut row) => {
-                    if let Some(previous) = rows.get(&key) {
-                        row.value.created_at = previous.value.created_at;
+        let mut replacements = Vec::with_capacity(splice.leaf_count());
+        for leaf_index in 0..splice.leaf_count() {
+            let leaf_key_indices = splice.leaf_key_indices(leaf_index).to_vec();
+            let leaf_parts = splice.leaf_parts(leaf_index).to_vec();
+            let mut pending = leaf_key_indices
+                .iter()
+                .map(|&key_index| {
+                    mutation_rows[key_index]
+                        .take()
+                        .expect("each sparse mutation is assigned to one leaf")
+                })
+                .collect::<Vec<_>>()
+                .into_iter()
+                .peekable();
+            let mut output = Vec::with_capacity(leaf_parts.len() + leaf_key_indices.len());
+            for descriptor in &leaf_parts {
+                let mut gap = Vec::new();
+                while pending
+                    .peek()
+                    .is_some_and(|(key, _)| key.as_slice() < descriptor.first_key.as_slice())
+                {
+                    let (_, row) = pending.next().expect("peeked sparse mutation");
+                    if let Some(row) = row {
+                        gap.push(row);
                     }
-                    rows.insert(key, row);
                 }
-                None => {
-                    rows.remove(&key);
-                }
-            }
-        }
-        stage_native_current_state_rows(
-            writes,
-            &rows.into_values().collect::<Vec<_>>(),
-            &mut output,
-        )?;
-    }
-    let tail = pending
-        .filter_map(|(_, row)| row)
-        .collect::<Vec<CurrentStateDataRow>>();
-    stage_native_current_state_rows(writes, &tail, &mut output)?;
+                stage_native_current_state_rows(writes, &gap, &mut output)?;
 
-    let directory = super::current_state_part::stage_current_state_part_directory_reusing(
-        writes,
-        &output,
-        &reusable_directory_nodes,
-    )?;
+                let touches_descriptor = pending
+                    .peek()
+                    .is_some_and(|(key, _)| key.as_slice() <= descriptor.last_key.as_slice());
+                if !touches_descriptor {
+                    output.push(descriptor.clone());
+                    continue;
+                }
+                let mut rows = load_current_state_descriptor_rows(store, writes, descriptor)
+                    .await?
+                    .into_iter()
+                    .map(|row| (row.encoded_key.clone(), row))
+                    .collect::<BTreeMap<_, _>>();
+                while pending
+                    .peek()
+                    .is_some_and(|(key, _)| key.as_slice() <= descriptor.last_key.as_slice())
+                {
+                    let (key, row) = pending.next().expect("peeked sparse mutation");
+                    match row {
+                        Some(mut row) => {
+                            if let Some(previous) = rows.get(&key) {
+                                row.value.created_at = previous.value.created_at;
+                            }
+                            rows.insert(key, row);
+                        }
+                        None => {
+                            rows.remove(&key);
+                        }
+                    }
+                }
+                stage_native_current_state_rows(
+                    writes,
+                    &rows.into_values().collect::<Vec<_>>(),
+                    &mut output,
+                )?;
+            }
+            let tail = pending
+                .filter_map(|(_, row)| row)
+                .collect::<Vec<CurrentStateDataRow>>();
+            stage_native_current_state_rows(writes, &tail, &mut output)?;
+            replacements.push(output);
+        }
+        if mutation_rows.iter().any(Option::is_some) {
+            return Err(replacement_payload_error(
+                "sparse current-state splice did not assign every mutation",
+            ));
+        }
+        super::current_state_part::stage_current_state_part_directory_splice(
+            store,
+            writes,
+            splice,
+            replacements,
+        )
+        .await?
+    };
     let inventory_bytes =
         storage_codec::encode("sparse current-state lineage inventory", inventory)?;
     let state_lineage_digest =
-        *blake3::Hasher::new_derive_key("lix sparse current-state lineage v1")
+        *blake3::Hasher::new_derive_key("lix sparse current-state lineage v2")
             .update(&parent.state_lineage_digest)
             .update(commit_id.as_uuid().as_bytes())
             .update(&(inventory_bytes.len() as u64).to_be_bytes())
             .update(&inventory_bytes)
             .update(&directory.root_id)
-            .update(&directory.descriptor_digest)
+            .update(&directory.directory_digest)
             .finalize()
             .as_bytes();
     let rewritten = crate::tracked_state::types::CurrentStatePartSet {
@@ -2276,16 +2319,18 @@ pub(crate) async fn stage_sparse_current_state_part_set(
         }
         let timestamp = crate::common::LixTimestamp::from_unix_millis_utc_lossy(0);
         for part in encode_bounded_current_state_data_parts(rows)? {
-            writes.put(
+            stage_content_addressed_current_state_bytes(
+                writes,
                 CURRENT_STATE_DATA_PART_SPACE,
-                key(part.digest.to_vec()),
-                value(part.bytes.to_vec()),
-            );
-            writes.put(
+                part.digest,
+                &part.bytes,
+            )?;
+            stage_content_addressed_current_state_bytes(
+                writes,
                 CURRENT_STATE_DATA_PART_REFS_SPACE,
-                key(part.digest.to_vec()),
-                value(part.refs_bytes.to_vec()),
-            );
+                part.digest,
+                &part.refs_bytes,
+            )?;
             output.push(CurrentStatePartDescriptor {
                 first_key: part.first_key,
                 last_key: part.last_key,
@@ -2300,6 +2345,24 @@ pub(crate) async fn stage_sparse_current_state_part_set(
                 uniform_updated_at: timestamp,
             });
         }
+        Ok(())
+    }
+
+    fn stage_content_addressed_current_state_bytes(
+        writes: &mut StorageWriteSet,
+        space: StorageSpace,
+        digest: [u8; 32],
+        bytes: &[u8],
+    ) -> Result<(), LixError> {
+        if let Some(staged) = writes.staged_value(space, &digest) {
+            if staged.as_ref() != bytes {
+                return Err(replacement_payload_error(
+                    "current-state content digest has conflicting staged bytes",
+                ));
+            }
+            return Ok(());
+        }
+        writes.put(space, key(digest.to_vec()), value(bytes.to_vec()));
         Ok(())
     }
 
@@ -8709,7 +8772,7 @@ fn validate_current_state_catalog(
         ));
     }
     if let Some(anchor) = manifest.current_state_coverage_anchor.as_ref() {
-        let (Some(generation), Some(authority)) = (
+        let (Some(generation), Some(_authority)) = (
             manifest.mutations.replacement_generation.as_ref(),
             manifest.mutations.replacement_parts.as_ref(),
         ) else {
@@ -8720,7 +8783,6 @@ fn validate_current_state_catalog(
         };
         if anchor.scope != generation.scope
             || anchor.generation_integrity_digest != generation.integrity_digest
-            || anchor.directory.descriptor_digest != authority.directory_digest
             || anchor.directory.row_count != u64::from(manifest.mutations.member_count)
             || anchor.directory.part_count as usize != manifest.mutations.part_count()
             || anchor.directory.root_id == [0; 32]
@@ -10155,12 +10217,59 @@ mod tests {
         staged_child.parent_commit_ids = vec![touching_id];
         staged_child.replay_debt.depth = super::MIN_CURRENT_STATE_CATALOG_POINT_READS;
         staged_child.current_state_catalog = staged_child_catalog;
-        super::stage_certified_commit_state_manifest(
+        let staged_staged_child = super::stage_certified_commit_state_manifest_with_handle(
             &mut touching_writes,
             &staged_child,
             &staged_child_publication,
         )
         .expect("staged child manifest should stage in the same write set");
+        let absent_delete_id = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x0199_2000_0000_7000_8000_0002_2000_0000,
+        ));
+        let absent_delete = CommitDeltaFixture {
+            schema_key: "alpha".to_string(),
+            file_id: None,
+            entity_pk: EntityPk::single("absent-staged-child-key"),
+            change_id: ChangeId::for_test_label("catalog-staged-child-absent-delete"),
+            deleted: true,
+            created_at,
+            updated_at,
+        };
+        let absent_delete_deltas =
+            commit_delta_refs(absent_delete_id, std::slice::from_ref(&absent_delete));
+        let absent_delete_stage = super::stage_ordered_addressable_commit_deltas(
+            &mut touching_writes,
+            absent_delete_deltas.iter().copied().map(Ok),
+            true,
+            false,
+        )
+        .expect("absent delete should stage")
+        .expect("absent delete should be addressable");
+        let absent_delete_inventory = absent_delete_stage.mutation_inventory().clone();
+        let absent_delete_publication = super::stage_current_state_catalog_from_staged_parent(
+            &read,
+            &mut touching_writes,
+            &staged_staged_child,
+            absent_delete_id,
+            &absent_delete_inventory,
+        )
+        .await
+        .expect("absent delete should reuse identical staged current-state parts");
+        let (absent_delete_catalog, _) = absent_delete_publication.parts();
+        let mut absent_delete_manifest =
+            fixture_commit_state_manifest(absent_delete_id, absent_delete_inventory);
+        absent_delete_manifest.parent_commit_ids = vec![staged_child_id];
+        absent_delete_manifest.replay_debt.depth = super::MIN_CURRENT_STATE_CATALOG_POINT_READS;
+        absent_delete_manifest.current_state_catalog = absent_delete_catalog;
+        super::stage_certified_commit_state_manifest(
+            &mut touching_writes,
+            &absent_delete_manifest,
+            &absent_delete_publication,
+        )
+        .expect("absent-delete child manifest should coalesce in the same write set");
+        touching_writes
+            .validate()
+            .expect("two staged children must retain one immutable data-part put per digest");
         drop(read);
         storage
             .commit_write_set(touching_writes, StorageWriteOptions::default())

--- a/packages/engine/src/tracked_state/types.rs
+++ b/packages/engine/src/tracked_state/types.rs
@@ -276,7 +276,7 @@ pub(crate) struct CurrentStatePartDescriptor {
 #[musli(packed)]
 pub(crate) struct CurrentStatePartDirectoryRoot {
     pub(crate) root_id: [u8; 32],
-    pub(crate) descriptor_digest: [u8; 32],
+    pub(crate) directory_digest: [u8; 32],
     pub(crate) row_count: u64,
     pub(crate) part_count: u32,
     pub(crate) tree_height: u16,
@@ -284,9 +284,10 @@ pub(crate) struct CurrentStatePartDirectoryRoot {
 
 /// One authoritative current-state collection generation.
 ///
-/// The mutation-directory digest binds this rebuildable serving projection to
-/// the commit's historical replacement certificate without making the serving
-/// directory part of commit semantics.
+/// The generation digest binds this rebuildable serving projection to the
+/// historical replacement certificate. Sparse lineage then binds each later
+/// post-image directory root without making that serving directory historical
+/// commit authority.
 #[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
 #[musli(packed)]
 pub(crate) struct CurrentStatePartSet {


### PR DESCRIPTION
## What changed

- Replace whole-directory flatten/sort/hash/rechunk on sparse current-state publication with a persistent key/range-addressed copy-on-write splice.
- Read only mutation search paths and touched leaves, then rewrite only changed leaves and their ancestor closure.
- Bind directory nodes and roots with explicit levels and a root-bound Merkle summary.
- Balance overflow splits, recursively contract one-child roots, and coalesce identical staged directory/data/ref content.
- Keep `CommitStateMutationInventory` as historical authority; the `CurrentStatePartSet` directory remains a certified, rebuildable serving accelerator.
- Hard-cut the physical protocol to `persistent-current-state-range-splice.v51`; backward compatibility is intentionally not retained.

This does not change transaction ingress, typed journals, sealed mutation parts, SQL policy, or DataFusion execution.

## Why

The previous sparse path loaded every directory node, flattened every descriptor, sorted and hashed the full vector, and rebuilt the whole tree for a one-row change. At 1M rows that made publication proportional to the complete current-state descriptor set rather than the touched key ranges.

The new path makes sparse publication proportional to `O(touched leaves × tree height)` while preserving exact-miss authority, read-your-writes, history/diff/merge/checkpoint semantics, and point-read routing.

## Performance

Exact release benchmark: 1M rows, 256 scopes, 32 touched-scope sparse commits, 20 warmups, 201 point-read samples.

| Backend | Metric | Before | After | Change |
|---|---:|---:|---:|---:|
| RocksDB | sparse publication p50 | 1,437.1 us | 313.3 us | -78.2% |
| RocksDB | sparse publication p95 | 1,458.0 us | 331.9 us | -77.2% |
| SlateDB | sparse publication p50 | 1,574.4 us | 362.2 us | -77.0% |
| SlateDB | sparse publication p95 | 1,613.6 us | 783.2 us | -51.5% |
| Both | directory nodes loaded/encoded across 32 commits | 544 | 64 | -88.2% |
| Both | descriptors visited across 32 commits | 62,528 | 3,904 | -93.8% |
| Both | sparse written bytes | 301,904 | 291,323 | -3.5% |

Point-query performance is preserved. A 1,001-sample hot-point run remained within 2.1% of replay on both adapters. The cold serving read changed by less than 1% versus the merged baseline (RocksDB 73.18→73.82 us; SlateDB 91.78→92.37 us).

RocksDB `perf record` over 1M rows and 1,000 sparse publications:

- profile duration: 1.902 s → 0.813 s (-57.3%)
- full `CurrentStatePartDescriptor` vector encoding: 8.49% self → no samples
- `DirectoryNode` encoding: 3.53% self → 0.87% (-75.4% relative)
- zstd block compression: 4.46% self → 1.71% (-61.7% relative)

## Correctness and validation

- `cargo test -p lix_engine --lib`: 1,859 passed, 8 ignored, 0 failed
- `cargo test -p lix_engine --test integration`: 440 passed, 2 ignored, 0 failed
- `cargo clippy -p lix_engine --all-features --all-targets -- -D warnings`
- `cargo check -p lix_engine --all-features --all-targets`
- `cargo fmt --all --check`
- direct regressions cover bounded path reads, balanced 65/64 splits, distant multi-path closure, recursive height-3 root contraction, foreign write-set rejection, staged-parent absent deletes, content-addressed conflicts, forged levels/count overflows, exact misses, and catalog authority validation

Two independent sub-agent reviews completed with no remaining blockers.
