### PR TITLE
Seal INSERT row groups at typed ingress

### DIFF
--- a/packages/engine/src/sql2/entity_columnar_layout.rs
+++ b/packages/engine/src/sql2/entity_columnar_layout.rs
@@ -29,7 +29,7 @@ pub(crate) const ENTITY_COLUMNAR_LAYOUT_FINGERPRINT_METADATA_KEY: &str =
 pub(crate) const ENTITY_COLUMNAR_BASE_COORDINATES_METADATA_KEY: &str =
     "lix.entity_columnar.base_coordinates.v1";
 pub(crate) const ENTITY_COLUMNAR_ENTITY_PK_FIELD: &str = "lixcol_entity_pk";
-const LOW_CARDINALITY_CLUSTER_MAX_VALUES: usize = 64;
+pub(crate) const LOW_CARDINALITY_CLUSTER_MAX_VALUES: usize = 64;
 const LOW_CARDINALITY_CLUSTER_MAX_BUCKETS: usize = 8;
 const ENTITY_COLUMNAR_MAX_CLUSTER_PARTITIONS: usize = 64;
 
@@ -45,6 +45,7 @@ pub(crate) struct EntityColumnarRowRef<'a> {
     pub(crate) snapshot_value: &'a JsonValue,
 }
 
+#[derive(Clone, Debug)]
 pub(crate) struct EncodedEntityRowGroups {
     encoded: EncodedRowGroupSet,
     pub(crate) input_locations: Vec<RowGroupRowLocation>,
@@ -80,6 +81,101 @@ where
     Ok(optional_derived_row_group_set(
         encode_registered_entity_row_groups_impl(spec, rows),
     ))
+}
+
+/// Encodes frontend-owned Arrow columns without reconstructing them from
+/// canonical snapshot JSON. The fast contract is deliberately limited to
+/// layouts whose established encoder would not reorder rows for clustering;
+/// clustered layouts retain the general encoder and identical physical
+/// behavior.
+pub(crate) fn encode_unclustered_registered_entity_row_groups(
+    spec: &EntitySurfaceSpec,
+    mut columns: Vec<ArrayRef>,
+    entity_pks: ArrayRef,
+) -> Result<Option<EncodedEntityRowGroups>, LixError> {
+    if columns.len() != spec.columns.len() {
+        return Err(entity_columnar_error(
+            "frontend column count does not match the registered schema",
+        ));
+    }
+    let row_count = entity_pks.len();
+    if row_count == 0 || columns.iter().any(|column| column.len() != row_count) {
+        return Err(entity_columnar_error(
+            "frontend columns are empty or have inconsistent row counts",
+        ));
+    }
+    let primary_key_roots = spec
+        .primary_key_paths
+        .iter()
+        .filter_map(|path| path.first().map(String::as_str))
+        .collect::<std::collections::BTreeSet<_>>();
+    for (spec_column, array) in spec.columns.iter().zip(&columns) {
+        if spec_column.column_type == EntityColumnType::Boolean {
+            return Ok(None);
+        }
+        if spec_column.column_type != EntityColumnType::String
+            || primary_key_roots.contains(spec_column.name.as_str())
+        {
+            continue;
+        }
+        let Some(strings) = array.as_any().downcast_ref::<StringArray>() else {
+            return Ok(None);
+        };
+        let mut values = std::collections::BTreeSet::new();
+        for value in strings.iter().flatten() {
+            values.insert(value);
+            if values.len() > LOW_CARDINALITY_CLUSTER_MAX_VALUES {
+                break;
+            }
+        }
+        if (2..=LOW_CARDINALITY_CLUSTER_MAX_VALUES).contains(&values.len()) {
+            return Ok(None);
+        }
+    }
+
+    let mut fields = entity_visible_fields(spec);
+    fields.push(Field::new(
+        ENTITY_COLUMNAR_ENTITY_PK_FIELD,
+        DataType::Utf8,
+        false,
+    ));
+    let mut metadata = HashMap::new();
+    metadata.insert(
+        ENTITY_COLUMNAR_LAYOUT_FINGERPRINT_METADATA_KEY.to_string(),
+        spec.columnar_layout_fingerprint(),
+    );
+    metadata.insert(
+        ENTITY_COLUMNAR_BASE_COORDINATES_METADATA_KEY.to_string(),
+        "true".to_owned(),
+    );
+    let schema = Arc::new(Schema::new_with_metadata(fields, metadata));
+    columns.push(entity_pks);
+    let mut batches = Vec::with_capacity(row_count.div_ceil(ROW_GROUP_MAX_ROWS));
+    let mut input_locations = Vec::with_capacity(row_count);
+    for offset in (0..row_count).step_by(ROW_GROUP_MAX_ROWS) {
+        let len = (row_count - offset).min(ROW_GROUP_MAX_ROWS);
+        let group_index = u32::try_from(batches.len())
+            .map_err(|_| entity_columnar_error("row-group index exceeds u32"))?;
+        input_locations.extend((0..len).map(|row_index| RowGroupRowLocation {
+            group_index,
+            row_index: u32::try_from(row_index).expect("row-group size fits u32"),
+        }));
+        batches.push(
+            RecordBatch::try_new(
+                Arc::clone(&schema),
+                columns
+                    .iter()
+                    .map(|column| column.slice(offset, len))
+                    .collect(),
+            )
+            .map_err(|error| entity_columnar_error(error.to_string()))?,
+        );
+    }
+    let encoded = encode_row_group_set_preserving_batches(&spec.schema_key, schema, &batches)?;
+    Ok(Some(EncodedEntityRowGroups {
+        encoded,
+        input_locations,
+    }))
 }
 
 fn encode_registered_entity_row_groups_impl<'a, I>(
@@ -335,6 +431,152 @@ mod tests {
         assert_eq!(
             identities,
             std::collections::BTreeSet::from([r#"["a",1]"#, r#"["b",2]"#])
+        );
+    }
+
+    #[test]
+    fn frontend_columns_match_canonical_encoding_when_clustering_is_absent() {
+        let spec = derive_entity_surface_spec_from_schema(&json!({
+            "x-lix-key": "direct_columns",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": { "type": "string" }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        }))
+        .expect("schema should derive");
+        let ids = (0..128)
+            .map(|index| format!("id-{index:04}"))
+            .collect::<Vec<_>>();
+        let values = (0..128)
+            .map(|index| format!("value-{index:04}"))
+            .collect::<Vec<_>>();
+        let snapshots = ids
+            .iter()
+            .zip(&values)
+            .map(|(id, value)| json!({"id": id, "value": value}))
+            .collect::<Vec<_>>();
+        let canonical = snapshots
+            .iter()
+            .map(serde_json::to_string)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("snapshots should encode");
+        let identities = ids
+            .iter()
+            .map(|id| EntityPk::from_validated_shared_string(id.as_str().into()))
+            .collect::<Vec<_>>();
+        let canonical_encoding = encode_registered_entity_row_groups(
+            &spec,
+            identities.iter().zip(&snapshots).zip(&canonical).map(
+                |((entity_pk, snapshot), canonical)| EntityColumnarRowRef {
+                    entity_pk,
+                    snapshot_bytes: canonical.as_bytes(),
+                    snapshot_value: snapshot,
+                },
+            ),
+        )
+        .expect("canonical encoding should succeed")
+        .expect("canonical encoding should exist");
+        let direct_encoding = encode_unclustered_registered_entity_row_groups(
+            &spec,
+            vec![
+                Arc::new(StringArray::from(ids.clone())),
+                Arc::new(StringArray::from(values)),
+            ],
+            Arc::new(StringArray::from(
+                identities
+                    .iter()
+                    .map(EntityPk::as_json_array_text)
+                    .collect::<Result<Vec<_>, _>>()
+                    .expect("identities should encode"),
+            )),
+        )
+        .expect("direct encoding should succeed")
+        .expect("high-cardinality values should not cluster");
+        assert_eq!(direct_encoding.manifest, canonical_encoding.manifest);
+        assert_eq!(
+            direct_encoding.input_locations,
+            canonical_encoding.input_locations
+        );
+    }
+
+    #[test]
+    fn frontend_json_columns_match_canonical_path_value_encoding() {
+        let spec = derive_entity_surface_spec_from_schema(&json!({
+            "x-lix-key": "path_value_columns",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" },
+                "value": {
+                    "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+                }
+            },
+            "required": ["path", "value"],
+            "additionalProperties": false
+        }))
+        .expect("schema should derive");
+        let paths = (0..128)
+            .map(|index| format!("/path/{index:04}"))
+            .collect::<Vec<_>>();
+        let json_values = (0..128)
+            .map(|index| json!({"index": index, "nested": [index, index + 1]}))
+            .collect::<Vec<_>>();
+        let snapshots = paths
+            .iter()
+            .zip(&json_values)
+            .map(|(path, value)| json!({"path": path, "value": value}))
+            .collect::<Vec<_>>();
+        let canonical = snapshots
+            .iter()
+            .map(serde_json::to_string)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("snapshots should encode");
+        let identities = paths
+            .iter()
+            .map(|path| EntityPk::from_validated_shared_string(path.as_str().into()))
+            .collect::<Vec<_>>();
+        let canonical_encoding = encode_registered_entity_row_groups(
+            &spec,
+            identities.iter().zip(&snapshots).zip(&canonical).map(
+                |((entity_pk, snapshot), canonical)| EntityColumnarRowRef {
+                    entity_pk,
+                    snapshot_bytes: canonical.as_bytes(),
+                    snapshot_value: snapshot,
+                },
+            ),
+        )
+        .expect("canonical encoding should succeed")
+        .expect("canonical encoding should exist");
+        let direct_encoding = encode_unclustered_registered_entity_row_groups(
+            &spec,
+            vec![
+                Arc::new(StringArray::from(paths.clone())),
+                Arc::new(StringArray::from(
+                    json_values
+                        .iter()
+                        .map(serde_json::to_string)
+                        .collect::<Result<Vec<_>, _>>()
+                        .expect("JSON values should encode"),
+                )),
+            ],
+            Arc::new(StringArray::from(
+                identities
+                    .iter()
+                    .map(EntityPk::as_json_array_text)
+                    .collect::<Result<Vec<_>, _>>()
+                    .expect("identities should encode"),
+            )),
+        )
+        .expect("direct encoding should succeed")
+        .expect("path/value columns should not cluster");
+        assert_eq!(direct_encoding.manifest, canonical_encoding.manifest);
+        assert_eq!(
+            direct_encoding.input_locations,
+            canonical_encoding.input_locations
         );
     }
 

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -1,6 +1,9 @@
 use std::cmp::Ordering;
+use std::sync::Arc;
 
-use datafusion::arrow::array::{Array, BooleanArray, LargeStringArray, StringArray};
+use datafusion::arrow::array::{
+    Array, ArrayRef, BooleanArray, Float64Array, Int64Array, LargeStringArray, StringArray,
+};
 use datafusion::arrow::datatypes::DataType;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::ScalarValue;
@@ -4345,6 +4348,49 @@ struct DirectParameterInsertColumn {
     read_nullable: bool,
 }
 
+fn direct_parameter_batch_needs_clustering(
+    spec: &EntitySurfaceSpec,
+    columns: &[DirectParameterInsertColumn],
+    parameter_batch: EntityInsertParameterBatch<'_>,
+) -> bool {
+    let primary_key_roots = spec
+        .primary_key_paths
+        .iter()
+        .filter_map(|path| path.first().map(String::as_str))
+        .collect::<std::collections::BTreeSet<_>>();
+    for spec_column in &spec.columns {
+        if spec_column.column_type == EntityColumnType::Boolean {
+            return true;
+        }
+        if spec_column.column_type != EntityColumnType::String
+            || primary_key_roots.contains(spec_column.name.as_str())
+        {
+            continue;
+        }
+        let Some(input) = columns
+            .iter()
+            .find(|column| column.name == spec_column.name)
+        else {
+            continue;
+        };
+        let mut values = std::collections::BTreeSet::new();
+        for row_index in 0..parameter_batch.num_rows() {
+            if let DirectParameterValue::String(value) =
+                parameter_batch.value(input.parameter_index, row_index)
+            {
+                values.insert(value);
+                if values.len() > crate::sql2::LOW_CARDINALITY_CLUSTER_MAX_VALUES {
+                    break;
+                }
+            }
+        }
+        if (2..=crate::sql2::LOW_CARDINALITY_CLUSTER_MAX_VALUES).contains(&values.len()) {
+            return true;
+        }
+    }
+    false
+}
+
 fn append_canonical_json_string(output: &mut Vec<u8>, value: &str) -> Result<(), LixError> {
     if value
         .as_bytes()
@@ -4711,13 +4757,81 @@ fn certified_direct_parameter_insert_batch(
         tracked_keys_strictly_ordered,
         complete_collection_replacement: None,
     };
-    let rows = CertifiedParameterInsertBatch::new(
+    let entity_columnar = if use_typed_certified_insert(row_count)
+        && !direct_parameter_batch_needs_clustering(spec, &columns, parameter_batch)
+    {
+        let visible_columns = spec
+            .columns
+            .iter()
+            .map(|spec_column| -> Option<ArrayRef> {
+                let input = columns
+                    .iter()
+                    .find(|column| column.name == spec_column.name);
+                Some(match (spec_column.column_type, input) {
+                    (EntityColumnType::String, Some(input)) => {
+                        Arc::new(StringArray::from_iter((0..row_count).map(|row_index| {
+                            match parameter_batch.value(input.parameter_index, row_index) {
+                                DirectParameterValue::Null => None,
+                                DirectParameterValue::String(value) => Some(value),
+                                DirectParameterValue::Boolean(_) => unreachable!(),
+                            }
+                        })))
+                    }
+                    (EntityColumnType::Boolean, Some(input)) => {
+                        Arc::new(BooleanArray::from_iter((0..row_count).map(|row_index| {
+                            match parameter_batch.value(input.parameter_index, row_index) {
+                                DirectParameterValue::Null => None,
+                                DirectParameterValue::Boolean(value) => Some(value),
+                                DirectParameterValue::String(_) => unreachable!(),
+                            }
+                        })))
+                    }
+                    (EntityColumnType::String | EntityColumnType::Json, None) => {
+                        Arc::new(StringArray::new_null(row_count))
+                    }
+                    (EntityColumnType::Boolean, None) => {
+                        Arc::new(BooleanArray::new_null(row_count))
+                    }
+                    (EntityColumnType::Integer, None) => Arc::new(Int64Array::new_null(row_count)),
+                    (EntityColumnType::Number, None) => Arc::new(Float64Array::new_null(row_count)),
+                    (
+                        EntityColumnType::Json
+                        | EntityColumnType::Integer
+                        | EntityColumnType::Number,
+                        Some(_),
+                    ) => {
+                        return None;
+                    }
+                })
+            })
+            .collect::<Option<Vec<_>>>();
+        visible_columns.and_then(|visible_columns| {
+            let entity_pk_text = entity_pks
+                .iter()
+                .map(EntityPk::as_json_array_text)
+                .collect::<Result<Vec<_>, _>>()
+                .ok()?;
+            crate::sql2::encode_unclustered_registered_entity_row_groups(
+                spec,
+                visible_columns,
+                Arc::new(StringArray::from(entity_pk_text)),
+            )
+            .ok()
+            .flatten()
+        })
+    } else {
+        None
+    };
+    let mut rows = CertifiedParameterInsertBatch::new(
         entity_pks,
         snapshots,
         schema_key,
         branch_id,
         certificate,
     )?;
+    if let Some(entity_columnar) = entity_columnar {
+        rows = rows.with_entity_columnar(entity_columnar);
+    }
     Ok(Some(rows))
 }
 
@@ -4775,6 +4889,7 @@ fn certified_direct_path_value_insert_batch(
     let mut path_offsets = Vec::with_capacity(row_count);
     let mut normalized = Vec::new();
     let mut snapshot_offsets = Vec::with_capacity(row_count);
+    let mut value_offsets = Vec::with_capacity(row_count);
     let mut previous_row = None;
     for statement_index in 0..row_count {
         let DirectParameterValue::String(path) =
@@ -4816,6 +4931,7 @@ fn certified_direct_path_value_insert_batch(
                 statement_index,
             )
         })?;
+        let value_start = normalized.len();
         serde_json::to_writer(&mut normalized, &value).map_err(|error| {
             with_parameter_batch_statement_index(
                 LixError::unknown(format!(
@@ -4824,10 +4940,42 @@ fn certified_direct_path_value_insert_batch(
                 statement_index,
             )
         })?;
+        value_offsets.push((value_start, normalized.len()));
         normalized.push(b'}');
         snapshot_offsets.push((snapshot_start, normalized.len()));
     }
 
+    let entity_columnar = if use_typed_certified_insert(row_count) {
+        let path_values = StringArray::from_iter(path_offsets.iter().map(|&(start, end)| {
+            Some(
+                std::str::from_utf8(&path_arena[start..end])
+                    .expect("certified INSERT path arena is UTF-8"),
+            )
+        }));
+        let json_values = StringArray::from_iter(value_offsets.iter().map(|&(start, end)| {
+            Some(
+                std::str::from_utf8(&normalized[start..end])
+                    .expect("certified INSERT JSON arena is UTF-8"),
+            )
+        }));
+        let entity_pk_values = StringArray::from_iter(path_offsets.iter().map(|&(start, end)| {
+            let path = std::str::from_utf8(&path_arena[start..end])
+                .expect("certified INSERT path arena is UTF-8");
+            Some(format!(
+                "[{}]",
+                serde_json::to_string(path).expect("path should encode")
+            ))
+        }));
+        crate::sql2::encode_unclustered_registered_entity_row_groups(
+            spec,
+            vec![Arc::new(path_values), Arc::new(json_values)],
+            Arc::new(entity_pk_values),
+        )
+        .ok()
+        .flatten()
+    } else {
+        None
+    };
     let path_arena = SharedStr::from_utf8(bytes::Bytes::from(path_arena))
         .map_err(|_| LixError::unknown("certified INSERT path arena is not UTF-8"))?;
     let entity_pks = path_offsets
@@ -4842,7 +4990,7 @@ fn certified_direct_path_value_insert_batch(
         .collect::<Vec<_>>();
     let snapshots =
         TransactionJson::from_certified_row_content_arena(normalized, snapshot_offsets)?;
-    Ok(Some(CertifiedParameterInsertBatch::new(
+    let mut rows = CertifiedParameterInsertBatch::new(
         entity_pks,
         snapshots,
         layout.schema_key.as_str().into(),
@@ -4856,7 +5004,11 @@ fn certified_direct_path_value_insert_batch(
             tracked_keys_strictly_ordered: true,
             complete_collection_replacement: None,
         },
-    )?))
+    )?;
+    if let Some(entity_columnar) = entity_columnar {
+        rows = rows.with_entity_columnar(entity_columnar);
+    }
+    Ok(Some(rows))
 }
 
 fn certified_entity_insert_rows<'a>(

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -50,8 +50,9 @@ pub(crate) use context::{
 pub(crate) use entity_batch::{CurrentEntitySnapshotReader, EntitySnapshotReader};
 pub(crate) use entity_columnar_layout::{
     ENTITY_COLUMNAR_BASE_COORDINATES_METADATA_KEY, ENTITY_COLUMNAR_ENTITY_PK_FIELD,
-    ENTITY_COLUMNAR_LAYOUT_FINGERPRINT_METADATA_KEY, EntityColumnarRowRef,
-    encode_registered_entity_row_groups,
+    ENTITY_COLUMNAR_LAYOUT_FINGERPRINT_METADATA_KEY, EncodedEntityRowGroups, EntityColumnarRowRef,
+    LOW_CARDINALITY_CLUSTER_MAX_VALUES, encode_registered_entity_row_groups,
+    encode_unclustered_registered_entity_row_groups,
 };
 pub(crate) use entity_projection::EntityProjectionDecoder;
 pub(crate) use exec::bound_public_write::PreparedPathValueReplacementProgram;

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -287,8 +287,11 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         deleted_checkpoint_files.remove(&(write.branch_id.clone(), write.file_id.clone()));
     }
     let mut insert_selection = prepared_writes.insert_selection;
-    let entity_columnar_write_sets =
-        prepare_entity_columnar_write_sets(&state_rows, &insert_selection, entity_schema_catalog)?;
+    let entity_columnar_write_sets = prepare_entity_columnar_write_sets(
+        &mut state_rows,
+        &insert_selection,
+        entity_schema_catalog,
+    )?;
     release_validated_canonical_value_columns(&mut state_rows);
     if !prepared_writes.file_content_writes.is_empty() {
         let mut blob_writer = binary_cas.writer_skipping_existing_chunks(&*read, &mut writes);
@@ -4579,7 +4582,7 @@ fn release_validated_canonical_value_columns(state_rows: &mut PreparedStateBatch
 }
 
 fn prepare_entity_columnar_write_sets(
-    state_rows: &PreparedStateBatch,
+    state_rows: &mut PreparedStateBatch,
     insert_selection: &PreparedInsertSelection,
     entity_schema_catalog: Option<&crate::catalog::CatalogSnapshot>,
 ) -> Result<crate::live_state::EntityColumnarWriteSets, LixError> {
@@ -4590,6 +4593,32 @@ fn prepare_entity_columnar_write_sets(
         insert_selection.len() == state_rows.len() && insert_selection.covers_all(state_rows.len());
     if !publishes_ordered_insert {
         return Ok(crate::live_state::EntityColumnarWriteSets::new());
+    }
+    if let Some((commit_id, schema_key, row_groups)) = state_rows.take_dense_entity_columnar() {
+        let layout_is_current = entity_schema_catalog
+            .and_then(|catalog| catalog.schema(&schema_key))
+            .and_then(|schema| crate::sql2::derive_entity_surface_spec_from_schema(schema).ok())
+            .is_some_and(|spec| {
+                row_groups.manifest.namespace == schema_key
+                    && row_groups
+                        .manifest
+                        .metadata
+                        .get(crate::sql2::ENTITY_COLUMNAR_LAYOUT_FINGERPRINT_METADATA_KEY)
+                        .is_some_and(|fingerprint| {
+                            fingerprint == &spec.columnar_layout_fingerprint()
+                        })
+                    && row_groups.input_locations.len() == state_rows.len()
+            });
+        if layout_is_current {
+            let mut encoded =
+                crate::live_state::EntityColumnarWriteSets::with_state_row_count(state_rows.len());
+            let (row_group_set, input_locations) = row_groups.into_parts();
+            for (state_row_index, location) in input_locations.into_iter().enumerate() {
+                encoded.set_state_row_location(state_row_index, location);
+            }
+            encoded.insert((commit_id, schema_key), row_group_set);
+            return Ok(encoded);
+        }
     }
     if let Some((commit_id, schema_key, snapshots)) = state_rows.dense_entity_columnar_input() {
         let Some(schema) = entity_schema_catalog.and_then(|catalog| catalog.schema(schema_key))

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -562,6 +562,7 @@ pub(crate) struct CertifiedParameterBatch {
     schema_key: SharedStr,
     branch_id: SharedStr,
     certificate: CertifiedRawWriteBatchPreparation,
+    entity_columnar: Option<crate::sql2::EncodedEntityRowGroups>,
 }
 
 impl CertifiedParameterBatch {
@@ -590,7 +591,16 @@ impl CertifiedParameterBatch {
             schema_key,
             branch_id,
             certificate,
+            entity_columnar: None,
         })
+    }
+
+    pub(crate) fn with_entity_columnar(
+        mut self,
+        entity_columnar: crate::sql2::EncodedEntityRowGroups,
+    ) -> Self {
+        self.entity_columnar = Some(entity_columnar);
+        self
     }
 
     pub(crate) fn len(&self) -> usize {
@@ -634,6 +644,7 @@ impl CertifiedParameterBatch {
             schema_key,
             branch_id,
             certificate,
+            entity_columnar,
         } = self;
         let row_count = entity_pks.len();
         let (mut strings, schema_key_ordinal, branch_id_ordinal) = if schema_key == branch_id {
@@ -682,6 +693,7 @@ impl CertifiedParameterBatch {
                 commit_id: None,
                 branch_id: branch_id_ordinal,
                 direct_change_ids: None,
+                entity_columnar,
             }),
             entity_pks,
             strings,
@@ -2597,6 +2609,9 @@ struct DenseCertifiedParameterSlots {
     /// Absent until commit-delta publication assigns direct addresses. The
     /// compact segment map derives every UUID without a million-row column.
     direct_change_ids: Option<OrderedAddressableCommitDeltaStage>,
+    /// Frontend-built row groups over the same certified typed columns.
+    /// Topology-changing operations drop this derived accelerator.
+    entity_columnar: Option<crate::sql2::EncodedEntityRowGroups>,
 }
 
 #[derive(Debug, Clone)]
@@ -3087,6 +3102,8 @@ impl PreparedStateBatch {
                     && left.commit_id == right.commit_id
                     && left.direct_change_ids.is_none()
                     && right.direct_change_ids.is_none()
+                    && left.entity_columnar.is_none()
+                    && right.entity_columnar.is_none()
                     && self.durable_predecessors.is_empty()
                     && other.durable_predecessors.is_empty()
                     && self.origins.is_empty()
@@ -3467,6 +3484,19 @@ impl PreparedStateBatch {
             commit_id,
             self.strings[dense.schema_key as usize].as_str(),
             &self.json[..dense.len],
+        ))
+    }
+
+    pub(crate) fn take_dense_entity_columnar(
+        &mut self,
+    ) -> Option<(CommitId, String, crate::sql2::EncodedEntityRowGroups)> {
+        let dense = self.dense_certified_parameter.as_mut()?;
+        let commit_id = dense.commit_id?;
+        let encoded = dense.entity_columnar.take()?;
+        Some((
+            commit_id,
+            self.strings[dense.schema_key as usize].to_string(),
+            encoded,
         ))
     }
 


### PR DESCRIPTION
## What changed

Certified bulk INSERT now seals entity Arrow row groups directly from typed frontend parameters and carries that derived set through the dense transaction journal. Commit consumes those immutable buffers instead of reparsing canonical JSON and rebuilding the same row groups.

The fast lane:
- preserves the existing row-group manifest, statistics, compressed column digests, and input coordinates
- verifies the current catalog layout fingerprint before consumption
- preflights clustered boolean/low-cardinality layouts and leaves them on the established clustered encoder
- falls back to canonical encoding on any derived-accelerator failure
- does not change CommitStateMutationInventory, immutable mutation parts, CommitStateManifest, diff/merge/history, or CurrentStatePartSet contracts

## Why

A 1M INSERT profile attributed the dominant gap to duplicate in-memory representation work: canonical JSON was already validated at ingress, then parsed again at commit to reconstruct Arrow columns. This removes that second parse/copy lifecycle.

## Performance

Five-sample medians against the frozen #1177 binary, with setup excluded:

| 1M INSERT | #1177 | This PR | Change |
|---|---:|---:|---:|
| RocksDB | 4.635 s | 1.838 s | **-60.3%** |
| SlateDB | 4.585 s | 2.043 s | **-55.4%** |

RocksDB allocation/RSS accounting:
- allocated bytes: 3.003 GB → 1.952 GB (**-35.0%**)
- peak RSS: 2.610 GB → 1.838 GB (**-29.6%**)

Paired 1M regression checks retained or improved SELECT and parameterized UPDATE on both adapters. DELETE remained sub-4ms; SlateDB moved by +0.12ms with overlapping sample ranges.

The trace moves commit materialization from roughly 1.91s to 0.93s and removes the former uninstrumented row-group reconstruction gap.

## Validation

- cargo test -p lix_engine --all-features
  - 1866 unit passed / 8 ignored
  - 812 integration passed / 2 ignored
  - doc tests passed
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- direct-vs-canonical tests compare full manifests, per-column digests/statistics, and row coordinates for typed string and path/JSON layouts
- two independent high-effort reviews approved correctness, physical layout, RSS/storage, and #1158/#1178 contract boundaries