### PR TITLE
Use Merkle directories for exact current-state diff

### DIFF
--- a/packages/engine-benchmarks/benches/current_state_scope_sharing.rs
+++ b/packages/engine-benchmarks/benches/current_state_scope_sharing.rs
@@ -3,8 +3,8 @@ use std::time::{Duration, Instant};
 
 use lix_engine::storage_adapter::StorageAdapter;
 use lix_engine::tracked_state::bench::{
-    BenchCurrentStatePointFixture, BenchCurrentStatePointMode, BenchCurrentStatePointTarget,
-    BenchCurrentStateSparseShape, seed_current_state_point_fixture,
+    BenchCurrentStateDirectoryDiffMode, BenchCurrentStatePointFixture, BenchCurrentStatePointMode,
+    BenchCurrentStatePointTarget, BenchCurrentStateSparseShape, seed_current_state_point_fixture,
 };
 use lix_rocksdb_storage::RocksDB;
 use lix_slatedb_storage::SlateDB;
@@ -97,6 +97,45 @@ async fn run_backend<S>(
     .await;
     let setup = setup.elapsed();
     let mode = std::env::var("LIX_CURRENT_STATE_MODE").unwrap_or_default();
+    if let Some(diff_mode) = match mode.as_str() {
+        "directory-diff-merkle" => Some(BenchCurrentStateDirectoryDiffMode::Merkle),
+        "directory-diff-flatten" => Some(BenchCurrentStateDirectoryDiffMode::Flatten),
+        _ => None,
+    } {
+        let started = Instant::now();
+        let mut digest = [0; 32];
+        for _ in 0..samples {
+            digest = black_box(fixture.diff_current_state_directory(diff_mode).await);
+        }
+        println!(
+            "current_state_directory_diff_profile,backend={backend},authority=published,mode={diff_mode:?},shape={sparse_shape:?},rows={rows},sparse_commits={sparse_commits},samples={samples},elapsed_ms={:.3},digest={}",
+            millis(started.elapsed()),
+            hex_digest(digest),
+        );
+        return;
+    }
+    if mode == "directory-diff" {
+        assert_eq!(
+            fixture
+                .diff_current_state_directory(BenchCurrentStateDirectoryDiffMode::Merkle)
+                .await,
+            fixture
+                .diff_current_state_directory(BenchCurrentStateDirectoryDiffMode::Flatten)
+                .await,
+            "Merkle and flattened directory comparison must agree",
+        );
+        let (merkle, flatten) = measure_directory_diff_pair(&fixture, warmups, samples).await;
+        println!(
+            "current_state_directory_diff,backend={backend},authority=published,measurement=interleaved,shape={sparse_shape:?},rows={rows},sparse_commits={sparse_commits},merkle_p50_us={:.3},merkle_p95_us={:.3},flatten_p50_us={:.3},flatten_p95_us={:.3},p50_reduction_pct={:.2},p95_reduction_pct={:.2}",
+            micros(merkle.0),
+            micros(merkle.1),
+            micros(flatten.0),
+            micros(flatten.1),
+            reduction_percent(merkle.0, flatten.0),
+            reduction_percent(merkle.1, flatten.1),
+        );
+        return;
+    }
     if mode == "persistent" || mode == "replay" {
         let selected = if mode == "persistent" {
             BenchCurrentStatePointMode::PersistentCatalog
@@ -170,6 +209,64 @@ async fn run_backend<S>(
     );
 }
 
+async fn measure_directory_diff_pair<S>(
+    fixture: &BenchCurrentStatePointFixture<S>,
+    warmups: usize,
+    samples: usize,
+) -> ((Duration, Duration), (Duration, Duration))
+where
+    S: lix_engine::storage::Storage,
+{
+    let expected = fixture
+        .diff_current_state_directory(BenchCurrentStateDirectoryDiffMode::Flatten)
+        .await;
+    for warmup in 0..warmups {
+        for mode in alternating_directory_diff_modes(warmup) {
+            assert_eq!(
+                black_box(fixture.diff_current_state_directory(mode).await),
+                expected
+            );
+        }
+    }
+    let mut merkle = Vec::with_capacity(samples);
+    let mut flatten = Vec::with_capacity(samples);
+    for sample in 0..samples {
+        for mode in alternating_directory_diff_modes(sample) {
+            let started = Instant::now();
+            assert_eq!(
+                black_box(fixture.diff_current_state_directory(mode).await),
+                expected
+            );
+            match mode {
+                BenchCurrentStateDirectoryDiffMode::Merkle => merkle.push(started.elapsed()),
+                BenchCurrentStateDirectoryDiffMode::Flatten => flatten.push(started.elapsed()),
+            }
+        }
+    }
+    (percentiles(merkle), percentiles(flatten))
+}
+
+fn alternating_directory_diff_modes(round: usize) -> [BenchCurrentStateDirectoryDiffMode; 2] {
+    if round.is_multiple_of(2) {
+        [
+            BenchCurrentStateDirectoryDiffMode::Merkle,
+            BenchCurrentStateDirectoryDiffMode::Flatten,
+        ]
+    } else {
+        [
+            BenchCurrentStateDirectoryDiffMode::Flatten,
+            BenchCurrentStateDirectoryDiffMode::Merkle,
+        ]
+    }
+}
+
+fn percentiles(mut timings: Vec<Duration>) -> (Duration, Duration) {
+    timings.sort_unstable();
+    let p50 = timings[timings.len() / 2];
+    let p95 = timings[timings.len().saturating_mul(95).div_ceil(100) - 1];
+    (p50, p95)
+}
+
 async fn measure<S>(
     fixture: &BenchCurrentStatePointFixture<S>,
     mode: BenchCurrentStatePointMode,
@@ -207,6 +304,16 @@ fn micros(duration: Duration) -> f64 {
 
 fn millis(duration: Duration) -> f64 {
     duration.as_secs_f64() * 1_000.0
+}
+
+fn hex_digest(digest: [u8; 32]) -> String {
+    use std::fmt::Write as _;
+
+    let mut encoded = String::with_capacity(64);
+    for byte in digest {
+        write!(encoded, "{byte:02x}").expect("write to string");
+    }
+    encoded
 }
 
 fn reduction_percent(candidate: Duration, baseline: Duration) -> f64 {

--- a/packages/engine/src/tracked_state/bench_support.rs
+++ b/packages/engine/src/tracked_state/bench_support.rs
@@ -73,6 +73,12 @@ pub enum BenchCurrentStatePointMode {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BenchCurrentStateDirectoryDiffMode {
+    Flatten,
+    Merkle,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BenchCurrentStateSparseShape {
     UnrelatedScopes,
     TouchedScope,
@@ -88,6 +94,7 @@ pub enum BenchCurrentStatePointTarget {
 pub struct BenchCurrentStatePointFixture<StorageImpl: Storage> {
     storage: StorageAdapter<StorageImpl>,
     commits: Vec<CommitId>,
+    base_manifest: CommitStateManifest,
     current_manifest: CommitStateManifest,
     encoded_key: bytes::Bytes,
     catalog_entry_count: usize,
@@ -367,6 +374,7 @@ where
         refresh_id
     };
 
+    let base_manifest = current_manifest.clone();
     let mut commits = vec![replay_base_id];
     let mut catalog_manifest_bytes = 0u64;
     let mut replay_manifest_bytes = 0u64;
@@ -533,6 +541,7 @@ where
     BenchCurrentStatePointFixture {
         storage,
         commits,
+        base_manifest,
         current_manifest,
         encoded_key,
         catalog_entry_count,
@@ -679,6 +688,102 @@ where
             }
             BenchCurrentStatePointMode::FirstParentReplay => self.read_point_by_replay(&read).await,
         }
+    }
+
+    pub async fn diff_current_state_directory(
+        &self,
+        mode: BenchCurrentStateDirectoryDiffMode,
+    ) -> [u8; 32] {
+        let read = self
+            .storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("begin benchmark current-state directory diff");
+        let scope = super::types::CommitDeltaReplacementScope {
+            schema_key: "bench_current_state_alpha".to_string(),
+            file_id: None,
+        };
+        let left_state = super::storage::load_published_commit_state_manifest(
+            &read,
+            self.base_manifest.commit_id,
+        )
+        .await
+        .expect("load benchmark base published manifest")
+        .expect("benchmark base published manifest exists");
+        let right_state = super::storage::load_published_commit_state_manifest(
+            &read,
+            self.current_manifest.commit_id,
+        )
+        .await
+        .expect("load benchmark head published manifest")
+        .expect("benchmark head published manifest exists");
+        let left = super::storage::load_complete_current_state_part_set_from_published_manifest(
+            &read,
+            &left_state,
+            &scope,
+        )
+        .await
+        .expect("authenticate benchmark base current-state entry")
+        .expect("benchmark base scope is covered");
+        let right = super::storage::load_complete_current_state_part_set_from_published_manifest(
+            &read,
+            &right_state,
+            &scope,
+        )
+        .await
+        .expect("authenticate benchmark head current-state entry")
+        .expect("benchmark head scope is covered");
+        let windows = match mode {
+            BenchCurrentStateDirectoryDiffMode::Flatten => {
+                let left = super::current_state_part::load_current_state_part_descriptors(
+                    &read,
+                    &left.directory,
+                )
+                .await
+                .expect("flatten benchmark base directory");
+                let right = super::current_state_part::load_current_state_part_descriptors(
+                    &read,
+                    &right.directory,
+                )
+                .await
+                .expect("flatten benchmark head directory");
+                super::current_state_part::diff_current_state_part_descriptor_slices(&left, &right)
+                    .expect("compare flattened benchmark directories")
+            }
+            BenchCurrentStateDirectoryDiffMode::Merkle => {
+                super::current_state_part::diff_current_state_part_descriptors(
+                    &read,
+                    &left.directory,
+                    &right.directory,
+                )
+                .await
+                .expect("Merkle-diff benchmark directories")
+            }
+        };
+        let mut digest = blake3::Hasher::new_derive_key(
+            "lix benchmark current-state descriptor diff windows v1",
+        );
+        for window in windows {
+            digest.update(&(window.first_key.len() as u64).to_be_bytes());
+            digest.update(&window.first_key);
+            digest.update(&(window.last_key.len() as u64).to_be_bytes());
+            digest.update(&window.last_key);
+            let left = crate::storage_codec::encode(
+                "benchmark current-state descriptor diff left window",
+                &window.left,
+            )
+            .expect("encode benchmark left descriptor window");
+            let right = crate::storage_codec::encode(
+                "benchmark current-state descriptor diff right window",
+                &window.right,
+            )
+            .expect("encode benchmark right descriptor window");
+            digest.update(&(left.len() as u64).to_be_bytes());
+            digest.update(&left);
+            digest.update(&(right.len() as u64).to_be_bytes());
+            digest.update(&right);
+        }
+        *digest.finalize().as_bytes()
     }
 
     async fn read_point_by_replay(&self, read: &(impl StorageAdapterRead + ?Sized)) -> usize {

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -2480,7 +2480,17 @@ where
         Ok(records)
     }
 
-    pub(crate) async fn diff_tree_entries_at_commits(
+    pub(crate) async fn diff_semantic_tree_entries_at_commits(
+        &mut self,
+        left_commit_id: &str,
+        right_commit_id: &str,
+        request: &TrackedStateTreeScanRequest,
+    ) -> Result<TrackedStateTreeDiffBatch, LixError> {
+        self.diff_semantic_tree_entries_at_commits_inner(left_commit_id, right_commit_id, request)
+            .await
+    }
+
+    async fn diff_semantic_tree_entries_at_commits_inner(
         &mut self,
         left_commit_id: &str,
         right_commit_id: &str,
@@ -2523,6 +2533,17 @@ where
         {
             entries.swap_sides();
             return Ok(entries);
+        }
+        if self
+            .exact_current_state_scope_has_equal_live_state(
+                left_commit_id,
+                right_commit_id,
+                request,
+            )
+            .await?
+            == Some(true)
+        {
+            return Ok(TrackedStateTreeDiffBatch::default());
         }
         if left_commit_id == right_commit_id {
             return Ok(TrackedStateTreeDiffBatch::default());
@@ -2588,6 +2609,65 @@ where
             }
         }
         entries.finish()
+    }
+
+    /// Proves equal live endpoint state from authenticated serving partitions.
+    ///
+    /// This proof belongs to semantic diff, which normalizes tombstones to
+    /// absence. Raw tree-entry diff must retain tombstone rows for merge and
+    /// history consumers and therefore never calls this helper.
+    pub(crate) async fn exact_current_state_scope_has_equal_live_state(
+        &self,
+        left_commit_id: &str,
+        right_commit_id: &str,
+        request: &TrackedStateTreeScanRequest,
+    ) -> Result<Option<bool>, LixError> {
+        let Some(scope) = exact_current_state_scope(request) else {
+            return Ok(None);
+        };
+        let left_commit_id = CommitId::parse_lix(
+            left_commit_id,
+            "tracked-state current-state diff left commit_id",
+        )?;
+        let right_commit_id = CommitId::parse_lix(
+            right_commit_id,
+            "tracked-state current-state diff right commit_id",
+        )?;
+        let Some(left_state) =
+            storage::load_published_commit_state_manifest(&self.store, left_commit_id).await?
+        else {
+            return Ok(None);
+        };
+        let Some(right_state) =
+            storage::load_published_commit_state_manifest(&self.store, right_commit_id).await?
+        else {
+            return Ok(None);
+        };
+        let Some(left) = storage::load_complete_current_state_part_set_from_published_manifest(
+            &self.store,
+            &left_state,
+            &scope,
+        )
+        .await?
+        else {
+            return Ok(None);
+        };
+        let Some(right) = storage::load_complete_current_state_part_set_from_published_manifest(
+            &self.store,
+            &right_state,
+            &scope,
+        )
+        .await?
+        else {
+            return Ok(None);
+        };
+        let windows = super::current_state_part::diff_current_state_part_descriptors(
+            &self.store,
+            &left.directory,
+            &right.directory,
+        )
+        .await?;
+        Ok(Some(windows.is_empty()))
     }
 
     /// Returns the compact write-set union for an ancestor/descendant
@@ -3619,6 +3699,26 @@ where
         let payloads = self.load_change_payloads(&fallback_ids).await?;
         merge::plan_merge(&target_diff, &source_diff, &payloads)
     }
+}
+
+fn exact_current_state_scope(
+    request: &TrackedStateTreeScanRequest,
+) -> Option<storage::CommitDeltaReplacementScope> {
+    let [schema_key] = request.schema_keys.as_slice() else {
+        return None;
+    };
+    let [file_id] = request.file_ids.as_slice() else {
+        return None;
+    };
+    let file_id = match file_id {
+        NullableKeyFilter::Null => None,
+        NullableKeyFilter::Value(file_id) => Some(file_id.clone()),
+        NullableKeyFilter::Any => return None,
+    };
+    Some(storage::CommitDeltaReplacementScope {
+        schema_key: schema_key.clone(),
+        file_id,
+    })
 }
 
 /// Writer for changelog-backed tracked-state commit roots.
@@ -4731,6 +4831,56 @@ mod tests {
     use crate::storage_adapter::StorageAdapter;
     use crate::storage_adapter::{Memory, StorageReadOptions, StorageWriteOptions};
     use crate::wasm::{WasmCertifiedEntityBatch, WasmCreateContext};
+
+    #[test]
+    fn exact_current_state_diff_scope_requires_one_schema_and_concrete_file_lane() {
+        let request = TrackedStateTreeScanRequest {
+            schema_keys: vec!["alpha".to_string()],
+            file_ids: vec![NullableKeyFilter::Null],
+            entity_pks: vec![EntityPk::single("optional-residual")],
+            ..TrackedStateTreeScanRequest::default()
+        };
+        assert_eq!(
+            exact_current_state_scope(&request),
+            Some(storage::CommitDeltaReplacementScope {
+                schema_key: "alpha".to_string(),
+                file_id: None,
+            })
+        );
+        assert_eq!(
+            exact_current_state_scope(&TrackedStateTreeScanRequest {
+                file_ids: vec![NullableKeyFilter::Value("file".to_string())],
+                ..request.clone()
+            }),
+            Some(storage::CommitDeltaReplacementScope {
+                schema_key: "alpha".to_string(),
+                file_id: Some("file".to_string()),
+            })
+        );
+        for file_ids in [
+            Vec::new(),
+            vec![NullableKeyFilter::Any],
+            vec![
+                NullableKeyFilter::Null,
+                NullableKeyFilter::Value("file".to_string()),
+            ],
+        ] {
+            assert!(
+                exact_current_state_scope(&TrackedStateTreeScanRequest {
+                    file_ids,
+                    ..request.clone()
+                })
+                .is_none()
+            );
+        }
+        assert!(
+            exact_current_state_scope(&TrackedStateTreeScanRequest {
+                schema_keys: Vec::new(),
+                ..request
+            })
+            .is_none()
+        );
+    }
 
     #[test]
     fn point_replay_interval_suffixes_share_one_backing_buffer() {

--- a/packages/engine/src/tracked_state/current_state_part.rs
+++ b/packages/engine/src/tracked_state/current_state_part.rs
@@ -2242,6 +2242,386 @@ pub(crate) async fn load_current_state_part_descriptors(
     Ok(descriptors)
 }
 
+/// One ordered key-range whose immutable current-state descriptors differ.
+///
+/// This is intentionally a physical, source-agnostic result. Consumers decide
+/// whether and how to decode the referenced parts; the directory layer only
+/// proves which descriptor ranges cannot be skipped by Merkle identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CurrentStatePartDescriptorDiffWindow {
+    pub(crate) first_key: Vec<u8>,
+    pub(crate) last_key: Vec<u8>,
+    pub(crate) left: Vec<CurrentStatePartDescriptor>,
+    pub(crate) right: Vec<CurrentStatePartDescriptor>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DirectoryNodeRef {
+    first_key: Vec<u8>,
+    last_key: Vec<u8>,
+    node_id: [u8; 32],
+    row_count: u64,
+    part_count: u32,
+    level: u16,
+}
+
+impl From<DirectoryChild> for DirectoryNodeRef {
+    fn from(child: DirectoryChild) -> Self {
+        Self {
+            first_key: child.first_key,
+            last_key: child.last_key,
+            node_id: child.node_id,
+            row_count: child.row_count,
+            part_count: child.part_count,
+            level: child.level,
+        }
+    }
+}
+
+enum DirectoryDiffWork {
+    Compare(DirectoryNodeRef, DirectoryNodeRef),
+    CollectLeft(DirectoryNodeRef),
+    CollectRight(DirectoryNodeRef),
+}
+
+/// Compares two persistent part directories without interpreting their parts.
+///
+/// Equal node IDs prune complete subtrees. Unequal shapes are aligned by their
+/// certified key ranges, so leaf splits, contractions, and height changes do
+/// not turn into positional comparisons. The returned windows contain only
+/// descriptors that are not byte-identical on both sides.
+pub(crate) async fn diff_current_state_part_descriptors(
+    store: &(impl StorageAdapterRead + ?Sized),
+    left_root: &CurrentStatePartDirectoryRoot,
+    right_root: &CurrentStatePartDirectoryRoot,
+) -> Result<Vec<CurrentStatePartDescriptorDiffWindow>, LixError> {
+    let left_empty = left_root.part_count == 0;
+    let right_empty = right_root.part_count == 0;
+    if left_empty {
+        validate_empty_root(left_root)?;
+    }
+    if right_empty {
+        validate_empty_root(right_root)?;
+    }
+    if left_empty && right_empty {
+        return Ok(Vec::new());
+    }
+
+    let mut cache = std::collections::BTreeMap::<[u8; 32], DirectoryNode>::new();
+    let left = if left_empty {
+        None
+    } else {
+        Some(load_root_ref(store, left_root, &mut cache).await?)
+    };
+    let right = if right_empty {
+        None
+    } else {
+        Some(load_root_ref(store, right_root, &mut cache).await?)
+    };
+    let mut work = match (left, right) {
+        (Some(left), Some(right)) => vec![DirectoryDiffWork::Compare(left, right)],
+        (Some(left), None) => vec![DirectoryDiffWork::CollectLeft(left)],
+        (None, Some(right)) => vec![DirectoryDiffWork::CollectRight(right)],
+        (None, None) => unreachable!("both empty roots returned above"),
+    };
+    let mut left_candidates =
+        std::collections::BTreeMap::<Vec<u8>, CurrentStatePartDescriptor>::new();
+    let mut right_candidates =
+        std::collections::BTreeMap::<Vec<u8>, CurrentStatePartDescriptor>::new();
+
+    while let Some(next) = work.pop() {
+        match next {
+            DirectoryDiffWork::Compare(left, right) => {
+                if left.node_id == right.node_id {
+                    if left != right {
+                        return Err(directory_error(
+                            "equal node identity has conflicting range summaries",
+                        ));
+                    }
+                    continue;
+                }
+                if left.last_key < right.first_key || right.last_key < left.first_key {
+                    work.push(DirectoryDiffWork::CollectLeft(left));
+                    work.push(DirectoryDiffWork::CollectRight(right));
+                    continue;
+                }
+                let left_node = load_node_ref(store, &left, &mut cache).await?;
+                let right_node = load_node_ref(store, &right, &mut cache).await?;
+                match (left_node.kind, right_node.kind) {
+                    (0, 0) => {
+                        insert_descriptor_candidates(&mut left_candidates, left_node.parts)?;
+                        insert_descriptor_candidates(&mut right_candidates, right_node.parts)?;
+                    }
+                    (1, 1) => enqueue_aligned_directory_refs(
+                        left_node.children.into_iter().map(Into::into).collect(),
+                        right_node.children.into_iter().map(Into::into).collect(),
+                        &mut work,
+                    ),
+                    (1, 0) => enqueue_aligned_directory_refs(
+                        left_node.children.into_iter().map(Into::into).collect(),
+                        vec![right],
+                        &mut work,
+                    ),
+                    (0, 1) => enqueue_aligned_directory_refs(
+                        vec![left],
+                        right_node.children.into_iter().map(Into::into).collect(),
+                        &mut work,
+                    ),
+                    _ => unreachable!("validated directory node kind"),
+                }
+            }
+            DirectoryDiffWork::CollectLeft(reference) => {
+                collect_descriptor_candidates(
+                    store,
+                    reference,
+                    &mut cache,
+                    &mut left_candidates,
+                    true,
+                    &mut work,
+                )
+                .await?;
+            }
+            DirectoryDiffWork::CollectRight(reference) => {
+                collect_descriptor_candidates(
+                    store,
+                    reference,
+                    &mut cache,
+                    &mut right_candidates,
+                    false,
+                    &mut work,
+                )
+                .await?;
+            }
+        }
+    }
+
+    remove_shared_descriptors(&mut left_candidates, &mut right_candidates);
+    Ok(descriptor_diff_windows(left_candidates, right_candidates))
+}
+
+/// Pure flatten-and-compare oracle for benchmarks and callers that already
+/// own complete descriptor slices. Its result is identical to the Merkle
+/// walker's result; only descriptor discovery differs.
+pub(crate) fn diff_current_state_part_descriptor_slices(
+    left: &[CurrentStatePartDescriptor],
+    right: &[CurrentStatePartDescriptor],
+) -> Result<Vec<CurrentStatePartDescriptorDiffWindow>, LixError> {
+    if !left.is_empty() {
+        validate_descriptor_slice(left)?;
+    }
+    if !right.is_empty() {
+        validate_descriptor_slice(right)?;
+    }
+    let mut left_candidates = std::collections::BTreeMap::new();
+    let mut right_candidates = std::collections::BTreeMap::new();
+    insert_descriptor_candidates(&mut left_candidates, left.to_vec())?;
+    insert_descriptor_candidates(&mut right_candidates, right.to_vec())?;
+    remove_shared_descriptors(&mut left_candidates, &mut right_candidates);
+    Ok(descriptor_diff_windows(left_candidates, right_candidates))
+}
+
+async fn load_root_ref(
+    store: &(impl StorageAdapterRead + ?Sized),
+    root: &CurrentStatePartDirectoryRoot,
+    cache: &mut std::collections::BTreeMap<[u8; 32], DirectoryNode>,
+) -> Result<DirectoryNodeRef, LixError> {
+    let node = load_cached_directory_node(store, root.root_id, cache).await?;
+    validate_root_summary(root, &node)?;
+    let (first_key, last_key, row_count, part_count) = node_summary(&node)?;
+    Ok(DirectoryNodeRef {
+        first_key,
+        last_key,
+        node_id: root.root_id,
+        row_count,
+        part_count,
+        level: node.level,
+    })
+}
+
+async fn load_node_ref(
+    store: &(impl StorageAdapterRead + ?Sized),
+    reference: &DirectoryNodeRef,
+    cache: &mut std::collections::BTreeMap<[u8; 32], DirectoryNode>,
+) -> Result<DirectoryNode, LixError> {
+    let node = load_cached_directory_node(store, reference.node_id, cache).await?;
+    let (first_key, last_key, row_count, part_count) = node_summary(&node)?;
+    if first_key != reference.first_key
+        || last_key != reference.last_key
+        || row_count != reference.row_count
+        || part_count != reference.part_count
+        || node.level != reference.level
+    {
+        return Err(directory_error("node disagrees with its range summary"));
+    }
+    Ok(node)
+}
+
+async fn load_cached_directory_node(
+    store: &(impl StorageAdapterRead + ?Sized),
+    node_id: [u8; 32],
+    cache: &mut std::collections::BTreeMap<[u8; 32], DirectoryNode>,
+) -> Result<DirectoryNode, LixError> {
+    if let Some(node) = cache.get(&node_id) {
+        return Ok(node.clone());
+    }
+    let node = load_node(store, node_id).await?;
+    cache.insert(node_id, node.clone());
+    Ok(node)
+}
+
+async fn collect_descriptor_candidates(
+    store: &(impl StorageAdapterRead + ?Sized),
+    reference: DirectoryNodeRef,
+    cache: &mut std::collections::BTreeMap<[u8; 32], DirectoryNode>,
+    candidates: &mut std::collections::BTreeMap<Vec<u8>, CurrentStatePartDescriptor>,
+    left: bool,
+    work: &mut Vec<DirectoryDiffWork>,
+) -> Result<(), LixError> {
+    let node = load_node_ref(store, &reference, cache).await?;
+    match node.kind {
+        0 => insert_descriptor_candidates(candidates, node.parts),
+        1 => {
+            for child in node.children.into_iter().rev().map(DirectoryNodeRef::from) {
+                work.push(if left {
+                    DirectoryDiffWork::CollectLeft(child)
+                } else {
+                    DirectoryDiffWork::CollectRight(child)
+                });
+            }
+            Ok(())
+        }
+        _ => unreachable!("validated directory node kind"),
+    }
+}
+
+fn insert_descriptor_candidates(
+    candidates: &mut std::collections::BTreeMap<Vec<u8>, CurrentStatePartDescriptor>,
+    descriptors: Vec<CurrentStatePartDescriptor>,
+) -> Result<(), LixError> {
+    for descriptor in descriptors {
+        match candidates.entry(descriptor.first_key.clone()) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(descriptor);
+            }
+            std::collections::btree_map::Entry::Occupied(entry) if entry.get() == &descriptor => {}
+            std::collections::btree_map::Entry::Occupied(_) => {
+                return Err(directory_error(
+                    "paired traversal found conflicting descriptors for one first key",
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn remove_shared_descriptors(
+    left: &mut std::collections::BTreeMap<Vec<u8>, CurrentStatePartDescriptor>,
+    right: &mut std::collections::BTreeMap<Vec<u8>, CurrentStatePartDescriptor>,
+) {
+    let shared = left
+        .iter()
+        .filter_map(|(first_key, left)| {
+            right
+                .get(first_key)
+                .is_some_and(|right| right == left)
+                .then(|| first_key.clone())
+        })
+        .collect::<Vec<_>>();
+    for first_key in shared {
+        left.remove(&first_key);
+        right.remove(&first_key);
+    }
+}
+
+fn enqueue_aligned_directory_refs(
+    left: Vec<DirectoryNodeRef>,
+    right: Vec<DirectoryNodeRef>,
+    work: &mut Vec<DirectoryDiffWork>,
+) {
+    let mut pending = Vec::new();
+    let mut left_index = 0usize;
+    let mut right_index = 0usize;
+    while left_index < left.len() && right_index < right.len() {
+        let left_ref = &left[left_index];
+        let right_ref = &right[right_index];
+        if left_ref.last_key < right_ref.first_key {
+            pending.push(DirectoryDiffWork::CollectLeft(left_ref.clone()));
+            left_index += 1;
+            continue;
+        }
+        if right_ref.last_key < left_ref.first_key {
+            pending.push(DirectoryDiffWork::CollectRight(right_ref.clone()));
+            right_index += 1;
+            continue;
+        }
+        pending.push(DirectoryDiffWork::Compare(
+            left_ref.clone(),
+            right_ref.clone(),
+        ));
+        match left_ref.last_key.cmp(&right_ref.last_key) {
+            std::cmp::Ordering::Less => left_index += 1,
+            std::cmp::Ordering::Equal => {
+                left_index += 1;
+                right_index += 1;
+            }
+            std::cmp::Ordering::Greater => right_index += 1,
+        }
+    }
+    pending.extend(
+        left[left_index..]
+            .iter()
+            .cloned()
+            .map(DirectoryDiffWork::CollectLeft),
+    );
+    pending.extend(
+        right[right_index..]
+            .iter()
+            .cloned()
+            .map(DirectoryDiffWork::CollectRight),
+    );
+    work.extend(pending.into_iter().rev());
+}
+
+fn descriptor_diff_windows(
+    left: std::collections::BTreeMap<Vec<u8>, CurrentStatePartDescriptor>,
+    right: std::collections::BTreeMap<Vec<u8>, CurrentStatePartDescriptor>,
+) -> Vec<CurrentStatePartDescriptorDiffWindow> {
+    let mut descriptors = left
+        .into_values()
+        .map(|descriptor| (false, descriptor))
+        .chain(right.into_values().map(|descriptor| (true, descriptor)))
+        .collect::<Vec<_>>();
+    descriptors.sort_by(|(left_side, left), (right_side, right)| {
+        left.first_key
+            .cmp(&right.first_key)
+            .then_with(|| left_side.cmp(right_side))
+    });
+    let mut windows = Vec::<CurrentStatePartDescriptorDiffWindow>::new();
+    for (right_side, descriptor) in descriptors {
+        let append = windows
+            .last()
+            .is_some_and(|window| descriptor.first_key <= window.last_key);
+        if !append {
+            windows.push(CurrentStatePartDescriptorDiffWindow {
+                first_key: descriptor.first_key.clone(),
+                last_key: descriptor.last_key.clone(),
+                left: Vec::new(),
+                right: Vec::new(),
+            });
+        }
+        let window = windows.last_mut().expect("a descriptor created a window");
+        if descriptor.last_key > window.last_key {
+            window.last_key.clone_from(&descriptor.last_key);
+        }
+        if right_side {
+            window.right.push(descriptor);
+        } else {
+            window.left.push(descriptor);
+        }
+    }
+    windows
+}
+
 fn stage_node(writes: &mut StorageWriteSet, node: DirectoryNode) -> Result<StagedNode, LixError> {
     stage_node_reusing(writes, node, None)
 }
@@ -2743,6 +3123,299 @@ mod tests {
                 tree_height: 1,
             },
         }
+    }
+
+    #[tokio::test]
+    async fn directory_merkle_diff_skips_an_identical_root_after_validation() {
+        let adapter = StorageAdapter::new(Memory::new());
+        let descriptors = descriptors(DIRECTORY_FANOUT * 2 + 7);
+        let mut writes = adapter.new_write_set();
+        let root = stage_current_state_part_directory(&mut writes, &descriptors)
+            .expect("directory should stage");
+        adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("directory should commit");
+        let batch_sizes = Arc::new(Mutex::new(Vec::new()));
+        let read = CountingDirectoryRead {
+            inner: adapter
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("diff read should open"),
+            directory_batch_sizes: Arc::clone(&batch_sizes),
+            catalog_batch_sizes: Arc::new(Mutex::new(Vec::new())),
+        };
+
+        let windows = diff_current_state_part_descriptors(&read, &root, &root)
+            .await
+            .expect("equal directory should diff");
+
+        assert!(windows.is_empty());
+        assert_eq!(
+            batch_sizes
+                .lock()
+                .expect("directory batch counts lock")
+                .as_slice(),
+            &[1],
+            "the root is validated once and every descendant is pruned"
+        );
+    }
+
+    #[tokio::test]
+    async fn directory_merkle_diff_reads_only_the_changed_leaf_paths() {
+        let adapter = StorageAdapter::new(Memory::new());
+        let descriptors = descriptors(DIRECTORY_FANOUT * 2 + 7);
+        let mut writes = adapter.new_write_set();
+        let root = stage_current_state_part_directory(&mut writes, &descriptors)
+            .expect("directory should stage");
+        adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("directory should commit");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("splice read should open");
+        let mut splice_writes = adapter.new_write_set();
+        let key = Bytes::from_static(b"key-000001-m");
+        let plan = plan_current_state_part_directory_splice(
+            &read,
+            &mut splice_writes,
+            &root,
+            std::slice::from_ref(&key),
+        )
+        .await
+        .expect("one-key splice should plan");
+        let mut replacement = plan.leaf_parts(0).to_vec();
+        replacement[1].content_digest = [7; 32];
+        let rewritten = stage_current_state_part_directory_splice(
+            &read,
+            &mut splice_writes,
+            plan,
+            vec![replacement],
+        )
+        .await
+        .expect("one-leaf splice should stage");
+        drop(read);
+        adapter
+            .commit_write_set(splice_writes, StorageWriteOptions::default())
+            .await
+            .expect("splice should commit");
+
+        let mut expected_descriptors = descriptors.clone();
+        expected_descriptors[1].content_digest = [7; 32];
+        let expected =
+            diff_current_state_part_descriptor_slices(&descriptors, &expected_descriptors)
+                .expect("flat oracle should compare");
+        let batch_sizes = Arc::new(Mutex::new(Vec::new()));
+        let read = CountingDirectoryRead {
+            inner: adapter
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("diff read should open"),
+            directory_batch_sizes: Arc::clone(&batch_sizes),
+            catalog_batch_sizes: Arc::new(Mutex::new(Vec::new())),
+        };
+        let actual = diff_current_state_part_descriptors(&read, &root, &rewritten)
+            .await
+            .expect("rewritten directory should diff");
+
+        assert_eq!(actual, expected);
+        assert_eq!(actual.len(), 1);
+        assert_eq!(actual[0].left, vec![descriptors[1].clone()]);
+        assert_eq!(actual[0].right, vec![expected_descriptors[1].clone()]);
+        assert_eq!(
+            batch_sizes
+                .lock()
+                .expect("directory batch counts lock")
+                .as_slice(),
+            &[1, 1, 1, 1],
+            "only two roots and the unequal leaf pair are read"
+        );
+    }
+
+    #[tokio::test]
+    async fn directory_merkle_diff_aligns_a_leaf_split_without_positional_pairing() {
+        let adapter = StorageAdapter::new(Memory::new());
+        let descriptors = descriptors(DIRECTORY_FANOUT * 2);
+        let mut writes = adapter.new_write_set();
+        let root = stage_current_state_part_directory(&mut writes, &descriptors)
+            .expect("directory should stage");
+        adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("directory should commit");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("splice read should open");
+        let mut splice_writes = adapter.new_write_set();
+        let key = Bytes::from_static(b"key-000000-0");
+        let plan = plan_current_state_part_directory_splice(
+            &read,
+            &mut splice_writes,
+            &root,
+            std::slice::from_ref(&key),
+        )
+        .await
+        .expect("boundary insertion should plan");
+        let mut inserted = descriptors[0].clone();
+        inserted.first_key = b"key-000000-0a".to_vec();
+        inserted.last_key = b"key-000000-0z".to_vec();
+        inserted.content_digest = [8; 32];
+        let mut replacement = Vec::with_capacity(DIRECTORY_FANOUT + 1);
+        replacement.push(inserted.clone());
+        replacement.extend_from_slice(plan.leaf_parts(0));
+        let rewritten = stage_current_state_part_directory_splice(
+            &read,
+            &mut splice_writes,
+            plan,
+            vec![replacement],
+        )
+        .await
+        .expect("overflowing leaf should split");
+        drop(read);
+        adapter
+            .commit_write_set(splice_writes, StorageWriteOptions::default())
+            .await
+            .expect("boundary insertion should commit");
+
+        let mut expected_descriptors = Vec::with_capacity(descriptors.len() + 1);
+        expected_descriptors.push(inserted.clone());
+        expected_descriptors.extend(descriptors.clone());
+        let expected =
+            diff_current_state_part_descriptor_slices(&descriptors, &expected_descriptors)
+                .expect("flat oracle should compare");
+        let batch_sizes = Arc::new(Mutex::new(Vec::new()));
+        let read = CountingDirectoryRead {
+            inner: adapter
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("diff read should open"),
+            directory_batch_sizes: Arc::clone(&batch_sizes),
+            catalog_batch_sizes: Arc::new(Mutex::new(Vec::new())),
+        };
+        let actual = diff_current_state_part_descriptors(&read, &root, &rewritten)
+            .await
+            .expect("split directory should diff");
+
+        assert_eq!(actual, expected);
+        assert_eq!(actual.len(), 1);
+        assert!(actual[0].left.is_empty());
+        assert_eq!(actual[0].right, vec![inserted]);
+        assert_eq!(
+            batch_sizes
+                .lock()
+                .expect("directory batch counts lock")
+                .as_slice(),
+            &[1, 1, 1, 1, 1],
+            "the unchanged sibling leaf is pruned across unequal shapes"
+        );
+    }
+
+    #[tokio::test]
+    async fn directory_merkle_diff_aligns_a_contracted_root_with_unequal_height() {
+        let adapter = StorageAdapter::new(Memory::new());
+        let descriptors = descriptors(DIRECTORY_FANOUT * 2);
+        let mut writes = adapter.new_write_set();
+        let root = stage_current_state_part_directory(&mut writes, &descriptors)
+            .expect("directory should stage");
+        adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("directory should commit");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("splice read should open");
+        let original_root = load_node(&read, root.root_id)
+            .await
+            .expect("root should load");
+        let removed_count = usize::try_from(original_root.children[0].part_count)
+            .expect("fixture part count fits usize");
+        let mut splice_writes = adapter.new_write_set();
+        let key = Bytes::from_static(b"key-000001-m");
+        let plan = plan_current_state_part_directory_splice(
+            &read,
+            &mut splice_writes,
+            &root,
+            std::slice::from_ref(&key),
+        )
+        .await
+        .expect("leaf removal should plan");
+        let rewritten = stage_current_state_part_directory_splice(
+            &read,
+            &mut splice_writes,
+            plan,
+            vec![Vec::new()],
+        )
+        .await
+        .expect("root should contract to its surviving leaf");
+        assert_eq!((root.tree_height, rewritten.tree_height), (2, 1));
+        drop(read);
+        adapter
+            .commit_write_set(splice_writes, StorageWriteOptions::default())
+            .await
+            .expect("contraction should commit");
+
+        let surviving = &descriptors[removed_count..];
+        let expected = diff_current_state_part_descriptor_slices(&descriptors, surviving)
+            .expect("flat oracle should compare");
+        let batch_sizes = Arc::new(Mutex::new(Vec::new()));
+        let read = CountingDirectoryRead {
+            inner: adapter
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("diff read should open"),
+            directory_batch_sizes: Arc::clone(&batch_sizes),
+            catalog_batch_sizes: Arc::new(Mutex::new(Vec::new())),
+        };
+        let actual = diff_current_state_part_descriptors(&read, &root, &rewritten)
+            .await
+            .expect("unequal-height directories should diff");
+
+        assert_eq!(actual, expected);
+        assert_eq!(
+            actual.iter().map(|window| window.left.len()).sum::<usize>(),
+            removed_count
+        );
+        assert!(actual.iter().all(|window| window.right.is_empty()));
+        assert_eq!(
+            batch_sizes
+                .lock()
+                .expect("directory batch counts lock")
+                .as_slice(),
+            &[1, 1, 1],
+            "the surviving contracted leaf is identified by node ID and not reread"
+        );
+    }
+
+    #[tokio::test]
+    async fn directory_merkle_diff_rejects_a_cross_wired_root_summary() {
+        let adapter = StorageAdapter::new(Memory::new());
+        let descriptors = descriptors(3);
+        let mut writes = adapter.new_write_set();
+        let root = stage_current_state_part_directory(&mut writes, &descriptors)
+            .expect("directory should stage");
+        adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("directory should commit");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("diff read should open");
+        let forged = CurrentStatePartDirectoryRoot {
+            row_count: root.row_count + 1,
+            ..root.clone()
+        };
+
+        assert!(
+            diff_current_state_part_descriptors(&read, &root, &forged)
+                .await
+                .is_err(),
+            "both endpoint root summaries must be validated before pruning"
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/tracked_state/diff.rs
+++ b/packages/engine/src/tracked_state/diff.rs
@@ -357,7 +357,7 @@ where
 {
     let scan_request = scan_request_for_diff(request);
     let tree_diff = reader
-        .diff_tree_entries_at_commits(left_commit_id, right_commit_id, &scan_request)
+        .diff_semantic_tree_entries_at_commits(left_commit_id, right_commit_id, &scan_request)
         .await?;
 
     // Validate only rows exposed by the hash-guided tree diff. Whole-root

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -769,6 +769,35 @@ fn fresh_replacement_current_state_part_set(
     Ok(Some(set))
 }
 
+/// Resolves one exact authenticated serving partition from an immutable
+/// published commit manifest. Absence means the scope is not completely
+/// covered; malformed catalog or coverage authority is an error.
+pub(crate) async fn load_complete_current_state_part_set_from_published_manifest(
+    store: &(impl StorageAdapterRead + ?Sized),
+    state: &PublishedCommitStateManifest,
+    scope: &CommitDeltaReplacementScope,
+) -> Result<Option<crate::tracked_state::types::CurrentStatePartSet>, LixError> {
+    if let Some(fresh) = fresh_replacement_current_state_part_set(state)?
+        && fresh.scope == *scope
+    {
+        return Ok(Some(fresh));
+    }
+    let Some(root) = state.current_state_catalog.as_deref() else {
+        return Ok(None);
+    };
+    let Some(entry) =
+        super::current_state_part::load_current_state_catalog_entry(store, root, scope).await?
+    else {
+        return Ok(None);
+    };
+    let authority_id = CommitId::new(uuid::Uuid::from_bytes(entry.coverage_anchor_commit_id));
+    let authority = load_published_commit_state_manifest(store, authority_id)
+        .await?
+        .ok_or_else(|| replacement_payload_error("current-state coverage authority is missing"))?;
+    validate_current_state_catalog_entry_against_authority(&entry, &authority)?;
+    Ok(Some(entry))
+}
+
 /// Resolves a point batch from authoritative complete collection entries in
 /// the persistent catalog. `None` means at least one scope is uncovered and
 /// canonical first-parent replay remains responsible for the whole batch.
@@ -9840,6 +9869,20 @@ mod tests {
         .await
         .expect("replacement catalog should load")
         .expect("replacement should publish a current-state part set");
+        let published = super::load_published_commit_state_manifest(&read, commit_id)
+            .await
+            .expect("published replacement authority should load")
+            .expect("published replacement authority should exist");
+        assert_eq!(
+            super::load_complete_current_state_part_set_from_published_manifest(
+                &read,
+                &published,
+                &state_set.scope,
+            )
+            .await
+            .expect("published exact scope should authenticate"),
+            Some(state_set.clone()),
+        );
         let directory_root = state_set.directory.clone();
         assert_eq!(state_set.directory.part_count, 3);
         let route_key = fixtures[777].key();


### PR DESCRIPTION
## What changed

- add a validated paired Merkle walker for persistent `CurrentStatePartSet` directories
- skip byte-identical subtrees by content identity and align unequal tree heights, splits, and contractions by certified key range
- return source-agnostic, ordered descriptor-difference windows; no mutation payload or row-group interpretation is embedded in the directory layer
- authenticate both endpoint manifests and coverage anchors before trusting a serving partition
- use the proof only for semantic exact-scope endpoint diff, after rooted and first-parent routes; nonempty windows retain canonical replay
- keep raw tombstone/history semantics, merge, checkpoint, SQL execution, transaction ingress, and mutation sealing unchanged

This is intentionally compatible with the next canonical generic-row-group mutation-part cut: the directory compares final serving descriptors and does not assume the old LXCD14 payload shape.

## Why

The existing fallback can flatten both complete serving directories before it can discover that nearly all immutable ranges are shared. A sparse divergent comparison should cost the changed directory paths and boundary leaves, not every descriptor in a million-row state.

## Performance

Authenticated, interleaved release benchmark; 1,000,000 rows, 32 sparse commits, 101 samples:

| backend | Merkle p50 | flatten p50 | p50 | Merkle p95 | flatten p95 | p95 |
|---|---:|---:|---:|---:|---:|---:|
| RocksDB | 450.687 us | 2,171.342 us | **-79.24%** | 459.454 us | 2,184.798 us | **-78.97%** |
| SlateDB | 475.754 us | 2,279.306 us | **-79.13%** | 485.282 us | 2,295.236 us | **-78.86%** |

The benchmark loads sealed `PublishedCommitStateManifest` values, validates coverage authority, hashes the complete ordered output windows, and alternates candidate/baseline order. Both implementations produced the same digest.

Samply profile, RocksDB, 10,000 authenticated comparisons:

- flatten: 21,866.280 ms, 22,395 samples
- Merkle: 4,423.371 ms, 4,950 samples
- elapsed: **-79.77%**
- sampled work: **-77.90%**
- identical output digest: `726661c040d23c30b16b63ec7748bfe62013676298b68b9a8921545734b754b3`

Focused counting-adapter tests prove one shared root reads one node, one changed leaf reads four nodes, split alignment reads five nodes while pruning the shared sibling, and unequal-height contraction reads three nodes.

## Correctness and validation

- `cargo clippy -p lix_engine --all-features --all-targets -- -D warnings`
- `cargo test -p lix_engine --lib` — 1,868 passed, 8 ignored
- `cargo test -p lix_engine --test integration` — 440 passed, 2 ignored
- benchmark crate and release benchmark builds green
- five Merkle differential/forgery/counting tests green
- exact-scope and published coverage-authority tests green
- `cargo fmt --all` and `git diff --check`

Two independent sub-agent reviews challenged production wiring, benchmark equivalence/ordering, authority validation, and tombstone/raw-diff boundaries. All findings were addressed; final reviews report no blockers.
