### PR TITLE
Push typed primary keys into bound writes

### DIFF
--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -3965,7 +3965,6 @@ fn bound_entity_pks_from_primary_key_predicate(
                 return None;
             };
             spec.visible_column(column_name)
-                .filter(|column| column.column_type == EntityColumnType::String)
                 .map(|column| column.name.as_str())
         })
         .collect::<Option<Vec<_>>>()?;
@@ -4042,9 +4041,10 @@ impl BoundPrimaryKeyAnalyzer<'_> {
                 if !self.primary_key_columns.contains(&column.name.as_str()) {
                     return None;
                 }
+                let component_type = self.primary_key_component_type(&column.name)?;
                 let values = values
                     .iter()
-                    .map(|value| bound_primary_key_string(value, self.params))
+                    .map(|value| bound_primary_key_external(value, self.params, component_type))
                     .collect::<Option<std::collections::BTreeSet<_>>>()?;
                 if values.is_empty() {
                     return None;
@@ -4072,13 +4072,25 @@ impl BoundPrimaryKeyAnalyzer<'_> {
         if !self.primary_key_columns.contains(&column.name.as_str()) {
             return None;
         }
-        let value = bound_primary_key_string(value_expr, self.params)?;
+        let component_type = self.primary_key_component_type(&column.name)?;
+        let value = bound_primary_key_external(value_expr, self.params, component_type)?;
         Some(BoundPrimaryKeyConstraint::Parts(
             std::collections::BTreeMap::from([(
                 column.name.clone(),
                 std::collections::BTreeSet::from([value]),
             )]),
         ))
+    }
+
+    fn primary_key_component_type(
+        &self,
+        column: &str,
+    ) -> Option<crate::entity_pk::EntityPkComponentType> {
+        self.primary_key_columns
+            .iter()
+            .position(|candidate| *candidate == column)
+            .and_then(|index| self.primary_key_component_types.get(index))
+            .copied()
     }
 }
 
@@ -4152,14 +4164,32 @@ impl BoundPrimaryKeyConstraint {
     }
 }
 
-fn bound_primary_key_string(expr: &BoundExpr, params: &[Value]) -> Option<String> {
-    match expr {
-        BoundExpr::Literal(BoundLiteral::Text(value)) => Some(value.clone()),
-        BoundExpr::Param(param) => match params.get(param.index.saturating_sub(1)) {
-            Some(Value::Text(value)) => Some(value.clone()),
+fn bound_primary_key_external(
+    expr: &BoundExpr,
+    params: &[Value],
+    component_type: crate::entity_pk::EntityPkComponentType,
+) -> Option<String> {
+    use crate::entity_pk::EntityPkComponentType;
+
+    match component_type {
+        EntityPkComponentType::Integer => match expr {
+            BoundExpr::Literal(BoundLiteral::Integer(value)) => Some(value.to_string()),
+            BoundExpr::Param(param) => match params.get(param.index.saturating_sub(1)) {
+                Some(Value::Integer(value)) => Some(value.to_string()),
+                _ => None,
+            },
             _ => None,
         },
-        _ => None,
+        EntityPkComponentType::String
+        | EntityPkComponentType::Uuid
+        | EntityPkComponentType::Bytes => match expr {
+            BoundExpr::Literal(BoundLiteral::Text(value)) => Some(value.clone()),
+            BoundExpr::Param(param) => match params.get(param.index.saturating_sub(1)) {
+                Some(Value::Text(value)) => Some(value.clone()),
+                _ => None,
+            },
+            _ => None,
+        },
     }
 }
 
@@ -7341,6 +7371,60 @@ mod primary_key_route_tests {
                 EntityPk::single("from-param"),
                 EntityPk::single("literal"),
             ])
+        );
+    }
+
+    #[test]
+    fn routes_typed_integer_primary_key_literals_and_parameters() {
+        let component_types = [crate::entity_pk::EntityPkComponentType::Integer];
+        let analyzer = BoundPrimaryKeyAnalyzer {
+            primary_key_columns: vec!["id"],
+            primary_key_component_types: &component_types,
+            params: &[Value::Integer(42)],
+        };
+        let predicate = BoundPredicate::In {
+            expr: column("id"),
+            values: vec![
+                BoundExpr::Literal(BoundLiteral::Integer(7)),
+                BoundExpr::Param(BoundParamRef { index: 1 }),
+            ],
+        };
+        let expected = ["7", "42"]
+            .into_iter()
+            .map(|value| {
+                EntityPk::from_external_parts(vec![value.to_string()], &component_types)
+                    .expect("integer identity should encode")
+            })
+            .collect();
+
+        assert_eq!(
+            analyzer
+                .analyze_conjunctive_constraint(&predicate)
+                .expect("typed integer predicate should route")
+                .into_entity_pks(
+                    &analyzer.primary_key_columns,
+                    analyzer.primary_key_component_types,
+                )
+                .expect("typed integer predicate should be complete"),
+            expected
+        );
+    }
+
+    #[test]
+    fn integer_primary_key_rejects_text_parameter_pushdown() {
+        let analyzer = BoundPrimaryKeyAnalyzer {
+            primary_key_columns: vec!["id"],
+            primary_key_component_types: &[crate::entity_pk::EntityPkComponentType::Integer],
+            params: &[Value::Text("42".to_string())],
+        };
+
+        assert!(
+            analyzer
+                .analyze_conjunctive_constraint(&equals(
+                    column("id"),
+                    BoundExpr::Param(BoundParamRef { index: 1 }),
+                ))
+                .is_none()
         );
     }
 

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -5219,6 +5219,67 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn integer_primary_key_update_and_delete_narrow_candidate_scans() {
+        let branch_id = "01920000-0000-7000-8000-0000000000a1";
+        let component_types = [crate::entity_pk::EntityPkComponentType::Integer];
+        let entity_pk = crate::entity_pk::EntityPk::from_external_parts(
+            vec!["42".to_string()],
+            &component_types,
+        )
+        .expect("integer fixture identity should encode");
+
+        for (sql, params) in [
+            (
+                "UPDATE integer_state_schema SET value = $1 WHERE id = $2",
+                vec![Value::Text("updated".to_string()), Value::Integer(42)],
+            ),
+            (
+                "DELETE FROM integer_state_schema WHERE id = $1",
+                vec![Value::Integer(42)],
+            ),
+        ] {
+            let mut row = live_entity_row("42", branch_id, "before");
+            row.entity_pk = entity_pk.clone();
+            row.schema_key = "integer_state_schema".to_string();
+            row.snapshot_content = Some(json!({ "id": 42, "value": "before" }).to_string().into());
+            let requests = Arc::new(Mutex::new(Vec::new()));
+            let mut ctx = DummySqlWriteExecutionContext {
+                active_branch_id: branch_id,
+                blob_reader: Arc::new(DummyBlobReader),
+                live_state: Arc::new(CapturingRowsLiveStateReader {
+                    rows: vec![row],
+                    requests: Arc::clone(&requests),
+                }),
+                staged_writes: Arc::new(Mutex::new(CapturingStagedWrites::default())),
+                schema_definitions: vec![json!({
+                    "x-lix-key": "integer_state_schema",
+                    "x-lix-primary-key": ["/id"],
+                    "type": "object",
+                    "properties": {
+                        "id": { "type": "integer" },
+                        "value": { "type": "string" }
+                    },
+                    "required": ["id", "value"],
+                    "additionalProperties": false
+                })],
+            };
+
+            let (result, path) =
+                execute_write_sql_trace(&mut ctx, sql, &params, WriteExecutorMode::Auto)
+                    .await
+                    .expect("integer point write should execute");
+
+            assert_eq!(path, WriteExecutorPath::Fast, "{sql}");
+            assert_eq!(result.rows, vec![vec![Value::Integer(1)]], "{sql}");
+            let requests = requests.lock().expect("captured requests lock");
+            let [request] = requests.as_slice() else {
+                panic!("integer point write should issue one candidate scan: {sql}");
+            };
+            assert_eq!(request.filter.entity_pks, vec![entity_pk.clone()], "{sql}");
+        }
+    }
+
+    #[tokio::test]
     async fn execute_sql_file_path_upsert_uses_indexed_conflict_candidates() {
         let requests = Arc::new(Mutex::new(Vec::new()));
         let blob_reader: Arc<dyn BlobDataReader> = Arc::new(StaticBlobReader {


### PR DESCRIPTION
## Summary

- route direct public UPDATE and DELETE candidate reads by typed primary keys
- support integer primary-key literals and parameters alongside string-like keys
- keep unsupported or type-mismatched predicates on the conservative scan path
- verify exact typed candidate requests end to end

## Why

The bound public-write analyzer only recognized string primary keys. Integer-key predicates such as `WHERE id = $1` therefore widened candidate discovery to a full live-state scan. At 100k rows this dominated the Sysbench-derived non-index UPDATE and DELETE workloads.

This generalizes the existing predicate analyzer by deriving the primary-key component type from the schema and converting compatible literals/parameters into the canonical external key representation. It applies uniformly to equality, `IN`, conjunctions, disjunctions, and composite primary keys handled by the existing analyzer.

## Benchmark

Lix + SlateDB, history enabled, 100k rows, one client, 20 fixed events:

| Workload | Before p50 | After p50 | Improvement |
| --- | ---: | ---: | ---: |
| UPDATE non-index column by integer PK | 280.49 ms | 4.08 ms | 68.8x |
| DELETE by integer PK | 291.24 ms | 4.21 ms | 69.2x |

The after figures isolate this commit on top of `main`. A combined audit with #1184 also confirms the provider and bound-write pushdowns compose correctly.

## Qualification

- `cargo fmt --check`
- `cargo test -p lix_engine`
- `cargo test -p lix_engine --features all-simulations`

The final simulation run passed 810 integration tests with 2 ignored and no failures.

Related: #1184 handles the independent typed primary-key provider/read pushdown.
