### PR TITLE
Certify current-state coverage at catalog roots

### DIFF
--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -745,45 +745,7 @@ where
     }
 
     let mut directory_roots = BTreeMap::new();
-    let authority_ids = catalog_entries
-        .values()
-        .map(|set| CommitId::new(uuid::Uuid::from_bytes(set.coverage_anchor_commit_id)))
-        .collect::<BTreeSet<_>>()
-        .into_iter()
-        .collect::<Vec<_>>();
-    let authority_manifests =
-        crate::tracked_state::load_commit_state_manifests(store, &authority_ids).await?;
-    let authority_by_id = authority_ids
-        .into_iter()
-        .zip(authority_manifests)
-        .map(|(authority_id, manifest)| {
-            manifest
-                .map(|manifest| (authority_id, manifest))
-                .ok_or_else(|| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        format!("live current-state catalog references missing coverage authority '{authority_id}'"),
-                    )
-                })
-        })
-        .collect::<Result<BTreeMap<_, _>, _>>()?;
     for set in catalog_entries.values() {
-        let authority = CommitId::new(uuid::Uuid::from_bytes(set.coverage_anchor_commit_id));
-        crate::tracked_state::validate_current_state_catalog_entry_against_authority(
-            set,
-            authority_by_id
-                .get(&authority)
-                .expect("catalog authority was batch loaded"),
-        )?;
-        if !packed.commits.contains_key(&authority) {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "live current-state catalog references missing coverage authority '{authority}'"
-                ),
-            ));
-        }
-        retained_authority_commits.insert(authority);
         if let Some(previous) = directory_roots.insert(set.directory.root_id, set.directory.clone())
         {
             if previous != set.directory {

--- a/packages/engine/src/tracked_state/bench_support.rs
+++ b/packages/engine/src/tracked_state/bench_support.rs
@@ -670,7 +670,7 @@ where
                     )
                     .await
                 } else {
-                    super::storage::load_complete_current_state_values_from_replay_manifest(
+                    super::storage::load_complete_current_state_values_from_published_replay_manifest(
                         &read,
                         &state,
                         std::slice::from_ref(&self.encoded_key),

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -988,7 +988,7 @@ struct PointReplayCommit {
     root_id: Option<TrackedStateRootId>,
     rootless: bool,
     replacement_generation: Option<storage::CommitDeltaReplacementGeneration>,
-    state_manifest: Arc<super::CommitStateManifest>,
+    state_manifest: Arc<storage::AuthenticatedReplayCommitStateManifest>,
 }
 
 /// One immutable first-parent interval shared by every cached suffix view.

--- a/packages/engine/src/tracked_state/current_state_part.rs
+++ b/packages/engine/src/tracked_state/current_state_part.rs
@@ -28,7 +28,7 @@ pub(crate) const CURRENT_STATE_PART_DIRECTORY_SPACE: StorageSpace = StorageSpace
 );
 pub(crate) const CURRENT_STATE_CATALOG_SPACE: StorageSpace = StorageSpace::immutable(
     StorageSpaceId(0x0004_002d),
-    "tracked_state.current_state_catalog.v1",
+    "tracked_state.current_state_catalog.v2",
 );
 
 const DIRECTORY_NODE_RAW_MAGIC: &[u8; 6] = b"LXC2DR";
@@ -36,8 +36,8 @@ const DIRECTORY_NODE_ZSTD_MAGIC: &[u8; 6] = b"LXC2DZ";
 const DIRECTORY_NODE_MAX_DECODED_BYTES: usize = 16 * 1024 * 1024;
 const DIRECTORY_FANOUT: usize = 128;
 const DIRECTORY_HASH_CONTEXT: &str = "lix current-state part directory node v2";
-const CATALOG_NODE_MAGIC: &[u8; 6] = b"LXCSCR";
-const CATALOG_HASH_CONTEXT: &str = "lix current-state catalog node v1";
+const CATALOG_NODE_MAGIC: &[u8; 6] = b"LXCSC2";
+const CATALOG_HASH_CONTEXT: &str = "lix current-state catalog node v2";
 const CURRENT_STATE_LINEAGE_CONTEXT: &str = "lix current-state lineage v2";
 const CATALOG_TRANSITION_CONTEXT: &str = "lix current-state catalog transition v1";
 const CATALOG_LEAF_MAX_ENTRIES: usize = 128;
@@ -103,7 +103,6 @@ pub(crate) fn stage_complete_replacement_current_state_part_set(
         fresh_current_state_lineage_digest(commit_id, generation.integrity_digest, &directory);
     Ok(Some(CurrentStatePartSet {
         scope: generation.scope.clone(),
-        coverage_anchor_commit_id: *commit_id.as_uuid().as_bytes(),
         generation_integrity_digest: generation.integrity_digest,
         state_lineage_digest,
         directory,
@@ -368,7 +367,6 @@ pub(crate) async fn validate_current_state_catalog_transition_root(
             .as_ref()
             .map(|anchor| CurrentStatePartSet {
                 scope: anchor.scope.clone(),
-                coverage_anchor_commit_id: *state.commit_id.as_uuid().as_bytes(),
                 generation_integrity_digest: anchor.generation_integrity_digest,
                 state_lineage_digest: anchor.state_lineage_digest,
                 directory: anchor.directory.clone(),
@@ -1593,7 +1591,6 @@ fn validate_catalog_node(node: &CatalogNode) -> Result<(), LixError> {
                 && entry.directory.part_count > 0
                 && entry.directory.tree_height > 0;
             entry.scope.schema_key.is_empty()
-                || entry.coverage_anchor_commit_id == [0; 16]
                 || entry.generation_integrity_digest == [0; 32]
                 || entry.state_lineage_digest == [0; 32]
                 || !(valid_empty_directory || valid_nonempty_directory)
@@ -3111,7 +3108,6 @@ mod tests {
                 schema_key: format!("schema-{index:05}"),
                 file_id: Some(format!("file-{:03}", index % 100)),
             },
-            coverage_anchor_commit_id: [1; 16],
             generation_integrity_digest: [2; 32],
             state_lineage_digest: [3; 32],
             directory: CurrentStatePartDirectoryRoot {

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -62,9 +62,7 @@ pub(crate) use storage::{
     stage_commit_state_manifest_with_handle, stage_current_state_catalog_from_published_parent,
     stage_current_state_catalog_from_staged_parent, stage_delete_change_locators,
     stage_delete_commit_delta_inventory_entry, stage_ordered_addressable_commit_deltas,
-    stage_ordered_addressable_replacement_parts,
-    validate_current_state_catalog_entry_against_authority,
-    validate_current_state_catalog_parent_manifest,
+    stage_ordered_addressable_replacement_parts, validate_current_state_catalog_parent_manifest,
 };
 #[cfg(feature = "storage-benches")]
 pub(crate) use storage::{

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -746,13 +746,11 @@ fn fresh_replacement_current_state_part_set(
     };
     let set = crate::tracked_state::types::CurrentStatePartSet {
         scope: anchor.scope.clone(),
-        coverage_anchor_commit_id: *manifest.commit_id.as_uuid().as_bytes(),
         generation_integrity_digest: anchor.generation_integrity_digest,
         state_lineage_digest: anchor.state_lineage_digest,
         directory: anchor.directory.clone(),
     };
-    if set.coverage_anchor_commit_id != *manifest.commit_id.as_uuid().as_bytes()
-        || set.generation_integrity_digest != generation.integrity_digest
+    if set.generation_integrity_digest != generation.integrity_digest
         || set.scope != anchor.scope
         || set.generation_integrity_digest != anchor.generation_integrity_digest
         || set.state_lineage_digest != anchor.state_lineage_digest
@@ -770,8 +768,8 @@ fn fresh_replacement_current_state_part_set(
 }
 
 /// Resolves one exact authenticated serving partition from an immutable
-/// published commit manifest. Absence means the scope is not completely
-/// covered; malformed catalog or coverage authority is an error.
+/// published commit manifest. The sealed content-addressed catalog root binds
+/// every exact-scope entry; absence means the scope is not completely covered.
 pub(crate) async fn load_complete_current_state_part_set_from_published_manifest(
     store: &(impl StorageAdapterRead + ?Sized),
     state: &PublishedCommitStateManifest,
@@ -790,11 +788,6 @@ pub(crate) async fn load_complete_current_state_part_set_from_published_manifest
     else {
         return Ok(None);
     };
-    let authority_id = CommitId::new(uuid::Uuid::from_bytes(entry.coverage_anchor_commit_id));
-    let authority = load_published_commit_state_manifest(store, authority_id)
-        .await?
-        .ok_or_else(|| replacement_payload_error("current-state coverage authority is missing"))?;
-    validate_current_state_catalog_entry_against_authority(&entry, &authority)?;
     Ok(Some(entry))
 }
 
@@ -815,9 +808,9 @@ async fn load_complete_current_state_values_encoded_inner(
         return Ok(None);
     };
     if state.replay_debt.depth < MIN_CURRENT_STATE_CATALOG_POINT_READS {
-        // Even the smallest covered lookup reads a catalog node, its coverage
-        // authority, a directory node, and one immutable part. Canonical
-        // replay is cheaper while its bounded manifest interval is shorter.
+        // Even the smallest covered lookup reads a catalog node, a directory
+        // node, and one immutable part. Canonical replay is cheaper while its
+        // bounded manifest interval is shorter.
         return Ok(None);
     }
     let mut scope_keys = BTreeMap::<CommitDeltaReplacementScope, Vec<usize>>::new();
@@ -871,38 +864,6 @@ async fn load_complete_current_state_values_encoded_inner(
     else {
         return Ok(None);
     };
-
-    if validate_publication {
-        let authority_ids = sets
-            .iter()
-            .map(|(set, _)| CommitId::new(uuid::Uuid::from_bytes(set.coverage_anchor_commit_id)))
-            .collect::<BTreeSet<_>>()
-            .into_iter()
-            .collect::<Vec<_>>();
-        let authorities = load_commit_state_manifests(store, &authority_ids).await?;
-        let authority_by_id = authority_ids
-            .into_iter()
-            .zip(authorities)
-            .map(|(authority_id, authority)| {
-                authority
-                    .map(|authority| (authority_id, authority))
-                    .ok_or_else(|| {
-                        replacement_payload_error(
-                            "current-state catalog coverage authority is missing",
-                        )
-                    })
-            })
-            .collect::<Result<BTreeMap<_, _>, _>>()?;
-        for (set, _) in &sets {
-            let authority_id = CommitId::new(uuid::Uuid::from_bytes(set.coverage_anchor_commit_id));
-            validate_current_state_catalog_entry_against_authority(
-                set,
-                authority_by_id
-                    .get(&authority_id)
-                    .expect("unique catalog authority was batch loaded"),
-            )?;
-        }
-    }
 
     let mut routed = BTreeMap::<
         (u8, [u8; 16], u32, [u8; 32], u16),
@@ -1074,13 +1035,22 @@ pub(crate) async fn load_complete_current_state_values_from_published_manifest(
 /// original one-manifest read while any catalog hit is authenticated first.
 pub(crate) async fn load_complete_current_state_values_from_replay_manifest(
     store: &(impl StorageAdapterRead + ?Sized),
-    state: &CommitStateManifest,
+    state: &AuthenticatedReplayCommitStateManifest,
     encoded_keys: &[Bytes],
 ) -> Result<Option<Vec<Option<TrackedStateIndexValue>>>, LixError> {
     // `load_point_replay_commit_state` decoded this exact manifest from the
     // immutable semantic-authority seal, including its certified catalog root.
-    // Re-reading mutable manifests and the original coverage anchor would add
-    // three point I/Os without strengthening that authority.
+    // Re-reading the mutable manifest would add point I/O without
+    // strengthening that authority.
+    load_complete_current_state_values_encoded_inner(store, state, encoded_keys, false, true).await
+}
+
+#[cfg(any(test, feature = "storage-benches"))]
+pub(crate) async fn load_complete_current_state_values_from_published_replay_manifest(
+    store: &(impl StorageAdapterRead + ?Sized),
+    state: &PublishedCommitStateManifest,
+    encoded_keys: &[Bytes],
+) -> Result<Option<Vec<Option<TrackedStateIndexValue>>>, LixError> {
     load_complete_current_state_values_encoded_inner(store, state, encoded_keys, false, true).await
 }
 
@@ -1137,29 +1107,6 @@ pub(crate) fn validate_current_state_catalog_parent_manifest(
     if root.parent_root_id != expected_parent_root {
         return Err(replacement_payload_error(
             "current-state catalog transition disagrees with its graph parent",
-        ));
-    }
-    Ok(())
-}
-
-pub(crate) fn validate_current_state_catalog_entry_against_authority(
-    set: &crate::tracked_state::types::CurrentStatePartSet,
-    origin: &CommitStateManifest,
-) -> Result<(), LixError> {
-    let anchor = origin
-        .current_state_coverage_anchor
-        .as_ref()
-        .ok_or_else(|| {
-            replacement_payload_error("catalog coverage authority omitted its anchor")
-        })?;
-    if set.coverage_anchor_commit_id != *origin.commit_id.as_uuid().as_bytes()
-        || set.scope != anchor.scope
-        || set.generation_integrity_digest != anchor.generation_integrity_digest
-        || (set.state_lineage_digest == anchor.state_lineage_digest
-            && set.directory != anchor.directory)
-    {
-        return Err(replacement_payload_error(
-            "current-state catalog entry disagrees with its coverage anchor",
         ));
     }
     Ok(())
@@ -2055,7 +2002,13 @@ fn decode_commit_state_semantic_authority(bytes: &[u8]) -> Result<CommitStateMan
             "commit-state semantic authority digest is invalid",
         ));
     }
-    storage_codec::decode("commit-state semantic authority", payload)
+    let manifest = storage_codec::decode("commit-state semantic authority", payload)?;
+    // The immutable seal authenticates bytes, while local validation proves
+    // that those bytes describe a structurally valid serving authority. This
+    // is what lets one-read point replay trust a catalog leaf without loading
+    // the historical complete-replacement manifest that first created it.
+    validate_commit_state_manifest(&manifest)?;
+    Ok(manifest)
 }
 
 fn validate_commit_state_semantic_seal(
@@ -2090,6 +2043,14 @@ pub(crate) struct PublishedCommitStateManifest {
     manifest: CommitStateManifest,
 }
 
+/// One-read immutable semantic authority used by point replay. The wrapper
+/// prevents a freely constructed manifest from claiming authoritative catalog
+/// coverage without passing seal and structural validation.
+#[derive(Clone, Debug)]
+pub(crate) struct AuthenticatedReplayCommitStateManifest {
+    manifest: CommitStateManifest,
+}
+
 /// Same-write-set authority produced only after semantic publication. This lets a
 /// later commit in one atomic transaction consume its parent catalog without
 /// treating a freely constructible manifest as provenance.
@@ -2099,6 +2060,14 @@ pub(crate) struct StagedCommitStateManifest {
 }
 
 impl Deref for PublishedCommitStateManifest {
+    type Target = CommitStateManifest;
+
+    fn deref(&self) -> &Self::Target {
+        &self.manifest
+    }
+}
+
+impl Deref for AuthenticatedReplayCommitStateManifest {
     type Target = CommitStateManifest;
 
     fn deref(&self) -> &Self::Target {
@@ -2332,7 +2301,6 @@ pub(crate) async fn stage_sparse_current_state_part_set(
             .as_bytes();
     let rewritten = crate::tracked_state::types::CurrentStatePartSet {
         scope: parent.scope.clone(),
-        coverage_anchor_commit_id: parent.coverage_anchor_commit_id,
         generation_integrity_digest: parent.generation_integrity_digest,
         state_lineage_digest,
         directory,
@@ -2672,13 +2640,15 @@ pub(crate) async fn load_replay_commit_state_manifest(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
 ) -> Result<Option<CommitStateManifest>, LixError> {
-    load_point_replay_commit_state(store, commit_id).await
+    Ok(load_point_replay_commit_state(store, commit_id)
+        .await?
+        .map(|state| state.manifest))
 }
 
 pub(crate) async fn load_point_replay_commit_state(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
-) -> Result<Option<CommitStateManifest>, LixError> {
+) -> Result<Option<AuthenticatedReplayCommitStateManifest>, LixError> {
     #[cfg(feature = "storage-benches")]
     crate::storage_bench::record_crud_replay_manifest_load();
     let Some(authority) = get_one(
@@ -2700,7 +2670,9 @@ pub(crate) async fn load_point_replay_commit_state(
             ),
         ));
     }
-    Ok(Some(state))
+    Ok(Some(AuthenticatedReplayCommitStateManifest {
+        manifest: state,
+    }))
 }
 
 /// Bulk-loads commit authorities in request order.
@@ -10332,9 +10304,9 @@ mod tests {
             entity_pk: &alpha[0].entity_pk,
         }));
         assert!(
-            super::load_complete_current_state_values_from_replay_manifest(
+            super::load_complete_current_state_values_from_published_replay_manifest(
                 &read,
-                &published_touching.manifest,
+                &published_touching,
                 std::slice::from_ref(&updated_key),
             )
             .await
@@ -10342,8 +10314,18 @@ mod tests {
             .is_none(),
             "a key authored by the head must retain the cheaper OLTP replay path"
         );
+        let inherited_manifest_requests = std::sync::Arc::new(AtomicUsize::new(0));
+        let inherited_seal_requests = std::sync::Arc::new(AtomicUsize::new(0));
+        let inherited_read = SealCountingRead {
+            inner: storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("inherited catalog read should open"),
+            manifest_requests: std::sync::Arc::clone(&inherited_manifest_requests),
+            seal_requests: std::sync::Arc::clone(&inherited_seal_requests),
+        };
         let updated = super::load_complete_current_state_values_from_published_manifest(
-            &read,
+            &inherited_read,
             &published_touching,
             std::slice::from_ref(&updated_key),
         )
@@ -10359,6 +10341,33 @@ mod tests {
             Some(created_at),
             "ordinary updates must retain the insertion lifecycle timestamp"
         );
+        assert_eq!(inherited_manifest_requests.load(Ordering::Relaxed), 0);
+        assert_eq!(inherited_seal_requests.load(Ordering::Relaxed), 0);
+
+        let replay_state = super::load_point_replay_commit_state(&inherited_read, touching_id)
+            .await
+            .expect("one-read replay authority should authenticate")
+            .expect("sparse replay authority should exist");
+        assert_eq!(inherited_manifest_requests.load(Ordering::Relaxed), 0);
+        assert_eq!(inherited_seal_requests.load(Ordering::Relaxed), 1);
+        inherited_manifest_requests.store(0, Ordering::Relaxed);
+        inherited_seal_requests.store(0, Ordering::Relaxed);
+        let cold_key = Bytes::from(encode_key_ref(TrackedStateKeyRef {
+            schema_key: &alpha[1].schema_key,
+            file_id: alpha[1].file_id.as_deref(),
+            entity_pk: &alpha[1].entity_pk,
+        }));
+        let cold = super::load_complete_current_state_values_from_replay_manifest(
+            &inherited_read,
+            &replay_state,
+            std::slice::from_ref(&cold_key),
+        )
+        .await
+        .expect("authenticated inherited catalog point should resolve")
+        .expect("inherited scope should remain covered");
+        assert!(cold[0].is_some());
+        assert_eq!(inherited_manifest_requests.load(Ordering::Relaxed), 0);
+        assert_eq!(inherited_seal_requests.load(Ordering::Relaxed), 0);
 
         let mut forged_root = parent_root;
         forged_root.parent_root_id = child
@@ -12902,7 +12911,7 @@ mod tests {
             .await
             .expect("point replay should load immutable semantic authority")
             .expect("semantic authority should exist");
-        assert_eq!(point_state, manifest);
+        assert_eq!(&*point_state, &manifest);
         let change_error = scan_change_records_from_commit_deltas(&read)
             .await
             .expect_err("packed change scans must verify semantic authority");
@@ -13130,7 +13139,7 @@ mod tests {
             .await
             .expect("immutable point authority should load")
             .expect("immutable point authority should exist");
-        assert_eq!(point, original);
+        assert_eq!(&*point, &original);
     }
 
     #[test]

--- a/packages/engine/src/tracked_state/types.rs
+++ b/packages/engine/src/tracked_state/types.rs
@@ -292,10 +292,6 @@ pub(crate) struct CurrentStatePartDirectoryRoot {
 #[musli(packed)]
 pub(crate) struct CurrentStatePartSet {
     pub(crate) scope: CommitDeltaReplacementScope,
-    /// Commit whose complete-replacement certificate created this entry.
-    /// Reused catalog entries retain this identity, so readers can validate
-    /// directly against the immutable origin instead of walking ancestry.
-    pub(crate) coverage_anchor_commit_id: [u8; 16],
     pub(crate) generation_integrity_digest: [u8; 32],
     /// Binds the current post-image to its coverage anchor and every later
     /// sparse rewrite. For a fresh complete replacement this is derived from
@@ -324,9 +320,10 @@ pub(crate) struct CurrentStateCatalogRoot {
     pub(crate) transition_digest: [u8; 32],
 }
 
-/// Historical binding from a complete-replacement mutation certificate to
-/// its optional serving directory. Descendants refer to this immutable anchor
-/// by commit ID, so authoritative misses never trust an unbound catalog leaf.
+/// Publication-time binding from a complete-replacement mutation certificate
+/// to its serving directory. Descendants authenticate inherited coverage
+/// through their sealed content-addressed catalog root, so readers do not
+/// reload the historical replacement manifest.
 #[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
 #[musli(packed)]
 pub(crate) struct CurrentStateCoverageAnchor {


### PR DESCRIPTION
## Summary

Hard-cut current-state catalog leaves so exact-scope coverage is authenticated directly by the sealed content-addressed catalog root.

- Remove the redundant 16-byte `coverage_anchor_commit_id` from every `CurrentStatePartSet` leaf.
- Delete historical origin-manifest/seal reloads from exact part-set resolution, point serving, directory diff, and GC.
- Retain the complete-replacement anchor only as a publication-time certificate against mutation authority.
- Hard-cut catalog CAS namespace, magic, and hash domain to v2; old catalog nodes fail closed.
- Make one-seal point replay structurally validate the immutable authority and carry it in an opaque `AuthenticatedReplayCommitStateManifest` before catalog coverage can be used.
- Preserve partial-catalog semantics: absent scope falls back to replay; exact misses inside a present scope remain authoritative.

Mutation inventory/history authority and payload descriptors are unchanged. This intentionally does not consume the in-progress canonical row-group descriptor contract.

## Performance

Representative authenticated directory diff: 1M rows, 256 scopes, 32 sparse commits, touched scope, 101 interleaved samples.

| Backend | Before (#1185) p50 | After p50 | Change | Before p95 | After p95 | Change |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| RocksDB | 450.687 us | 322.957 us | -28.3% | 459.454 us | 331.062 us | -27.9% |
| SlateDB | 475.754 us | 346.020 us | -27.3% | 485.282 us | 358.443 us | -26.1% |

Point serving did not regress in the same fixture:

- RocksDB p50 73.508 -> 71.334 us (-3.0%), p95 75.311 -> 72.958 us (-3.1%).
- SlateDB p50 92.815 -> 86.803 us (-6.5%), p95 94.558 -> 88.807 us (-6.1%).

Compressed catalog staging shrank 2,775,625 -> 2,525,249 bytes (-9.0%). Sparse written bytes stayed effectively flat (291,323 -> 290,779, -0.2%).

Samply, RocksDB, 10,000 authenticated Merkle comparisons:

- Before: 4,423.371 ms / 4,950 sampled events.
- After: 3,102.280 ms / 3,649 sampled events.
- Elapsed: -29.9%; sampled work: -26.3%.
- Exact result digest unchanged: `726661c040d23c30b16b63ec7748bfe62013676298b68b9a8921545734b754b3`.

The production-wrapper request-count test proves that after its single semantic-authority seal read, an inherited cold catalog point performs zero additional manifest or seal reads.

## Correctness and validation

- `cargo clippy -p lix_engine --all-features --all-targets -- -D warnings`
- `cargo test -p lix_engine --lib` (1,872 passed; 8 ignored)
- `cargo test -p lix_engine --test integration` (440 passed; 2 ignored)
- Focused inherited catalog/point request-count, exact miss, forged transition, corruption, and GC tests.
- `cargo fmt --all -- --check`
- `git diff --check`

Two independent sub-agent reviews covered authority/security/GC/codec semantics and performance/regression risk. Both reported no blockers.