### PR TITLE
Use sealed column pages as mutation authority

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -241,6 +241,18 @@ fn profile_bound_update_spread() -> bool {
 /// `read_many`, `LIX_TRACKED_STATE_CRUD_PROFILE_READ_MANY_PK_COUNT` selects
 /// the setup-excluded multi-point query shape.
 fn profile_operation(runtime: &tokio::runtime::Runtime, rows: &[WorkloadRow]) {
+    if let Ok(operation @ ("columnar_history" | "columnar_diff")) =
+        std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_OP").as_deref()
+    {
+        profile_columnar_semantic_operation(
+            runtime,
+            rows,
+            operation,
+            profile_sample_count(),
+            profile_sql_session_storage(),
+        );
+        return;
+    }
     let operation = match std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_OP").as_deref() {
         Ok("insert_all") => TransactionBenchOp::InsertAll,
         Ok("read_one") => TransactionBenchOp::ReadOneByPk,
@@ -407,6 +419,44 @@ fn profile_operation(runtime: &tokio::runtime::Runtime, rows: &[WorkloadRow]) {
             "unknown LIX_TRACKED_STATE_CRUD_PROFILE_LAYER '{other}'; expected transaction, sql_session, sql_session_bound, kv_layout, raw_sqlite, or raw_sqlite_literal"
         ),
     }
+}
+
+fn profile_columnar_semantic_operation(
+    runtime: &tokio::runtime::Runtime,
+    rows: &[WorkloadRow],
+    operation: &str,
+    sample_count: usize,
+    profile: StorageProfile,
+) {
+    let mut samples = Vec::with_capacity(sample_count);
+    for _ in 0..sample_count {
+        let fixture = runtime.block_on(sql_session::empty_fixture_with_read_many_pk_count(
+            profile,
+            rows,
+            READ_MANY_PK_COUNT.min(rows.len()),
+        ));
+        let baseline = runtime.block_on(fixture.active_commit_id());
+        runtime.block_on(fixture.insert_all());
+        let head = runtime.block_on(fixture.active_commit_id());
+        let start = Instant::now();
+        let result = match operation {
+            "columnar_history" => runtime.block_on(fixture.columnar_history_count(&head)),
+            "columnar_diff" => runtime.block_on(fixture.columnar_diff_count(&baseline, &head)),
+            _ => unreachable!("columnar semantic operation was validated"),
+        };
+        samples.push(start.elapsed());
+        black_box(result);
+    }
+    let mut sorted = samples.clone();
+    sorted.sort_unstable();
+    println!(
+        "tracked_state_crud profile: sql_session/{}/{operation}/{} samples: median={:?} min={:?} max={:?}",
+        profile.name(),
+        sample_count,
+        sorted[sorted.len() / 2],
+        sorted[0],
+        sorted[sorted.len() - 1],
+    );
 }
 
 fn profile_read_many_pk_count(operation: TransactionBenchOp, row_count: usize) -> usize {
@@ -945,12 +995,31 @@ fn profile_sql_session_operation(
         maybe_print_profile_rss_phase("after_seed");
         reset_allocation_accounting();
         let _ = lix_engine::storage_bench::take_crud_current_state_catalog_accounting();
+        if std::env::var_os("LIX_TRACKED_STATE_CRUD_PROFILE_WRITE_ACCOUNTING").is_some() {
+            let _ = lix_engine::storage_bench::take_crud_physical_write_accounting();
+            let _ = lix_engine::storage_bench::take_crud_commit_state_manifest_bytes();
+            let _ = lix_engine::storage_bench::take_crud_current_state_directory_bytes();
+        }
         let start = Instant::now();
         let result = runtime.block_on(run_sql_session_operation(operation, &fixture));
         samples.push(start.elapsed());
         black_box(result);
         maybe_print_profile_rss_phase("after_operation");
         print_allocation_accounting("operation");
+        if std::env::var_os("LIX_TRACKED_STATE_CRUD_PROFILE_WRITE_ACCOUNTING").is_some() {
+            let physical = lix_engine::storage_bench::take_crud_physical_write_accounting();
+            let manifest_bytes = lix_engine::storage_bench::take_crud_commit_state_manifest_bytes();
+            let directory_bytes =
+                lix_engine::storage_bench::take_crud_current_state_directory_bytes();
+            println!(
+                "tracked_state_crud write accounting: staged_puts={} staged_deletes={} staged_value_bytes={} commit_state_manifest_value_bytes={} current_state_directory_value_bytes={}",
+                physical.puts,
+                physical.deletes,
+                physical.written_bytes,
+                manifest_bytes,
+                directory_bytes,
+            );
+        }
     }
     let profile_layer = if matches!(operation, TransactionBenchOp::ReadAll) {
         format!(

--- a/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
@@ -382,6 +382,33 @@ impl SqlFixture {
         }
     }
 
+    pub(crate) async fn active_commit_id(&self) -> String {
+        match self {
+            Self::SQLite(fixture) => fixture.active_commit_id().await,
+            Self::RocksDB(fixture) => fixture.active_commit_id().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.active_commit_id().await,
+        }
+    }
+
+    pub(crate) async fn columnar_history_count(&self, commit_id: &str) -> usize {
+        match self {
+            Self::SQLite(fixture) => fixture.columnar_history_count(commit_id).await,
+            Self::RocksDB(fixture) => fixture.columnar_history_count(commit_id).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.columnar_history_count(commit_id).await,
+        }
+    }
+
+    pub(crate) async fn columnar_diff_count(&self, before: &str, after: &str) -> usize {
+        match self {
+            Self::SQLite(fixture) => fixture.columnar_diff_count(before, after).await,
+            Self::RocksDB(fixture) => fixture.columnar_diff_count(before, after).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.columnar_diff_count(before, after).await,
+        }
+    }
+
     async fn seed_rows(&self) {
         match self {
             Self::SQLite(fixture) => fixture.seed_rows().await,
@@ -670,6 +697,50 @@ where
             "tracked-state CRUD insert benchmark must execute one certified parameter batch"
         );
         affected as usize
+    }
+
+    async fn active_commit_id(&self) -> String {
+        let result = execute(&self.session, "SELECT lix_active_branch_commit_id()").await;
+        match result.rows()[0].get_index(0) {
+            Some(Value::Text(commit_id)) => commit_id.clone(),
+            value => panic!("active commit id should be text, got {value:?}"),
+        }
+    }
+
+    async fn columnar_history_count(&self, commit_id: &str) -> usize {
+        let result = execute(
+            &self.session,
+            &format!(
+                "SELECT COUNT(*) AS entries FROM tracked_crud_insert_history('{commit_id}') \
+                 WHERE lixcol_is_deleted = false"
+            ),
+        )
+        .await;
+        assert_eq!(
+            result.rows()[0].get_index(0),
+            Some(&Value::Integer(
+                i64::try_from(self.row_count).expect("benchmark row count fits i64"),
+            ))
+        );
+        self.row_count
+    }
+
+    async fn columnar_diff_count(&self, before: &str, after: &str) -> usize {
+        let result = execute(
+            &self.session,
+            &format!(
+                "SELECT COUNT(*) AS entries FROM lix_diff('{before}', '{after}') \
+                 WHERE schema_key = 'tracked_crud_insert' AND diff_type = 'added'"
+            ),
+        )
+        .await;
+        assert_eq!(
+            result.rows()[0].get_index(0),
+            Some(&Value::Integer(
+                i64::try_from(self.row_count).expect("benchmark row count fits i64"),
+            ))
+        );
+        self.row_count
     }
 
     async fn seed_rows(&self) {

--- a/packages/engine/src/columnar_row_group.rs
+++ b/packages/engine/src/columnar_row_group.rs
@@ -18,17 +18,20 @@ use datafusion::arrow::array::{
     Array, ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray,
 };
 use datafusion::arrow::buffer::{BooleanBuffer, Buffer, NullBuffer, OffsetBuffer, ScalarBuffer};
-use datafusion::arrow::compute::concat_batches;
+use datafusion::arrow::compute::{concat, concat_batches};
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::record_batch::{RecordBatch, RecordBatchOptions};
 
 use crate::LixError;
 use crate::storage_adapter::{
-    PointReadPlan, StorageAdapterRead, StorageGetOptions, StorageKey, StorageProjectedValue,
-    StorageSpace, StorageSpaceId, StorageValue, StorageWriteSet,
+    BufferRange, EncodedMutationBatch, EncodedPut, PointReadPlan, StorageAdapterRead,
+    StorageGetOptions, StorageKey, StorageProjectedValue, StorageSpace, StorageSpaceId,
+    StorageValue, StorageWriteSet,
 };
 
 pub(crate) const ROW_GROUP_MAX_ROWS: usize = 64 * 1024;
+/// Independently compressed point-read unit inside a scan-oriented row group.
+pub(crate) const ROW_GROUP_PAGE_ROWS: usize = 2 * 1024;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct RowGroupRowLocation {
@@ -44,7 +47,7 @@ pub(crate) const ROW_GROUP_COLUMN_SPACE: StorageSpace = StorageSpace::immutable(
     "entity.columnar_row_group_column.v1",
 );
 
-const MANIFEST_MAGIC: &[u8; 8] = b"LXRGM003";
+const MANIFEST_MAGIC: &[u8; 8] = b"LXRGM004";
 const COLUMN_MAGIC: &[u8; 8] = b"LXRGC001";
 const COMPRESSED_MAGIC: &[u8; 8] = b"LXRGZ001";
 const BLAKE3_DIGEST_LEN: usize = 32;
@@ -66,14 +69,22 @@ impl RowGroupSetId {
         StorageKey(Bytes::copy_from_slice(&self.0))
     }
 
-    fn column_key(self, group_index: usize, column_index: usize) -> Result<StorageKey, LixError> {
+    fn column_key(
+        self,
+        group_index: usize,
+        page_index: usize,
+        column_index: usize,
+    ) -> Result<StorageKey, LixError> {
         let group_index = u32::try_from(group_index)
             .map_err(|_| row_group_error("row-group index exceeds u32"))?;
         let column_index = u16::try_from(column_index)
             .map_err(|_| row_group_error("row-group column index exceeds u16"))?;
-        let mut key = Vec::with_capacity(22);
+        let page_index = u16::try_from(page_index)
+            .map_err(|_| row_group_error("row-group page index exceeds u16"))?;
+        let mut key = Vec::with_capacity(24);
         key.extend_from_slice(&self.0);
         key.extend_from_slice(&group_index.to_be_bytes());
+        key.extend_from_slice(&page_index.to_be_bytes());
         key.extend_from_slice(&column_index.to_be_bytes());
         Ok(StorageKey(Bytes::from(key)))
     }
@@ -157,7 +168,7 @@ pub(crate) struct RowGroupColumnStatistics {
 pub(crate) struct RowGroupStatistics {
     pub(crate) row_count: u32,
     pub(crate) columns: Vec<RowGroupColumnStatistics>,
-    column_digests: Vec<[u8; BLAKE3_DIGEST_LEN]>,
+    column_page_digests: Vec<Vec<[u8; BLAKE3_DIGEST_LEN]>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -174,6 +185,7 @@ pub(crate) struct RowGroupManifest {
     pub(crate) metadata: HashMap<String, String>,
     pub(crate) fields: Vec<RowGroupField>,
     pub(crate) groups: Vec<RowGroupStatistics>,
+    pub(crate) encoded_digest: [u8; BLAKE3_DIGEST_LEN],
 }
 
 impl RowGroupManifest {
@@ -181,6 +193,9 @@ impl RowGroupManifest {
     /// column digest. Decoded-column caches use this in addition to the set
     /// identifier so corrupted or replaced manifests can never alias.
     pub(crate) fn content_digest(&self) -> Result<[u8; BLAKE3_DIGEST_LEN], LixError> {
+        if self.encoded_digest != [0; BLAKE3_DIGEST_LEN] {
+            return Ok(self.encoded_digest);
+        }
         Ok(*blake3::hash(&encode_manifest(self)?).as_bytes())
     }
 
@@ -261,9 +276,21 @@ impl RowGroupManifest {
                             .saturating_mul(size_of::<RowGroupColumnStatistics>())
                             .saturating_add(
                                 group
-                                    .column_digests
+                                    .column_page_digests
                                     .capacity()
-                                    .saturating_mul(size_of::<[u8; BLAKE3_DIGEST_LEN]>()),
+                                    .saturating_mul(size_of::<Vec<[u8; BLAKE3_DIGEST_LEN]>>())
+                                    .saturating_add(
+                                        group
+                                            .column_page_digests
+                                            .iter()
+                                            .map(|digests| {
+                                                digests.capacity().saturating_mul(size_of::<
+                                                    [u8; BLAKE3_DIGEST_LEN],
+                                                >(
+                                                ))
+                                            })
+                                            .sum(),
+                                    ),
                             )
                             .saturating_add(
                                 group
@@ -285,8 +312,9 @@ impl RowGroupManifest {
 #[derive(Clone, Debug)]
 struct EncodedColumn {
     group_index: usize,
+    page_index: usize,
     column_index: usize,
-    bytes: Bytes,
+    value: BufferRange,
 }
 
 #[derive(Clone, Debug)]
@@ -294,6 +322,14 @@ pub(crate) struct EncodedRowGroupSet {
     pub(crate) manifest: RowGroupManifest,
     manifest_bytes: Bytes,
     columns: Vec<EncodedColumn>,
+    column_values: Bytes,
+}
+
+impl EncodedRowGroupSet {
+    fn column_bytes(&self, column: &EncodedColumn) -> &[u8] {
+        let start = column.value.offset();
+        &self.column_values[start..start + column.value.len()]
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -346,39 +382,51 @@ fn encode_row_group_set_impl(
     let row_groups = partition_batches(&schema, batches, preserve_batch_boundaries)?;
     let mut groups = Vec::with_capacity(row_groups.len());
     let mut columns = Vec::with_capacity(row_groups.len().saturating_mul(fields.len()));
+    let mut column_values = Vec::new();
     for (group_index, batch) in row_groups.iter().enumerate() {
         let row_count = u32::try_from(batch.num_rows())
             .map_err(|_| row_group_error("row-group row count exceeds u32"))?;
         let mut statistics = Vec::with_capacity(fields.len());
-        let mut column_digests = Vec::with_capacity(fields.len());
+        let mut column_page_digests = Vec::with_capacity(fields.len());
         for (column_index, (array, field)) in batch.columns().iter().zip(&fields).enumerate() {
             let stats = column_statistics(array, field.data_type)?;
-            let encoded = encode_column(array, field.data_type)?;
             statistics.push(stats);
-            column_digests.push(*blake3::hash(&encoded).as_bytes());
-            columns.push(EncodedColumn {
-                group_index,
-                column_index,
-                bytes: Bytes::from(encoded),
-            });
+            let mut page_digests = Vec::with_capacity(array.len().div_ceil(ROW_GROUP_PAGE_ROWS));
+            for (page_index, offset) in (0..array.len()).step_by(ROW_GROUP_PAGE_ROWS).enumerate() {
+                let page = array.slice(offset, ROW_GROUP_PAGE_ROWS.min(array.len() - offset));
+                let encoded = encode_column(&page, field.data_type)?;
+                page_digests.push(*blake3::hash(&encoded).as_bytes());
+                let value = BufferRange::new(column_values.len(), encoded.len());
+                column_values.extend_from_slice(&encoded);
+                columns.push(EncodedColumn {
+                    group_index,
+                    page_index,
+                    column_index,
+                    value,
+                });
+            }
+            column_page_digests.push(page_digests);
         }
         groups.push(RowGroupStatistics {
             row_count,
             columns: statistics,
-            column_digests,
+            column_page_digests,
         });
     }
-    let manifest = RowGroupManifest {
+    let mut manifest = RowGroupManifest {
         namespace,
         metadata: schema.metadata().clone(),
         fields,
         groups,
+        encoded_digest: [0; BLAKE3_DIGEST_LEN],
     };
     let manifest_bytes = Bytes::from(encode_manifest(&manifest)?);
+    manifest.encoded_digest = *blake3::hash(&manifest_bytes).as_bytes();
     Ok(EncodedRowGroupSet {
         manifest,
         manifest_bytes,
         columns,
+        column_values: Bytes::from(column_values),
     })
 }
 
@@ -388,16 +436,27 @@ pub(crate) fn stage_row_group_set(
     encoded: &EncodedRowGroupSet,
 ) -> Result<(), LixError> {
     writes.reserve_space(ROW_GROUP_MANIFEST_SPACE, 1, 0);
-    writes.reserve_space(ROW_GROUP_COLUMN_SPACE, encoded.columns.len(), 0);
+    let mut key_bytes = Vec::with_capacity(encoded.columns.len().saturating_mul(24));
+    let mut puts = Vec::with_capacity(encoded.columns.len());
     for column in &encoded.columns {
-        writes.put(
-            ROW_GROUP_COLUMN_SPACE,
-            id.column_key(column.group_index, column.column_index)?,
-            StorageValue {
-                bytes: column.bytes.clone(),
-            },
-        );
+        let key = id.column_key(column.group_index, column.page_index, column.column_index)?;
+        let key_range = BufferRange::new(key_bytes.len(), key.0.len());
+        key_bytes.extend_from_slice(&key.0);
+        puts.push(EncodedPut {
+            key: key_range,
+            value: column.value,
+        });
     }
+    writes.stage_encoded_batch(
+        ROW_GROUP_COLUMN_SPACE,
+        EncodedMutationBatch::try_new(
+            Bytes::from(key_bytes),
+            encoded.column_values.clone(),
+            puts,
+            Vec::new(),
+        )
+        .map_err(|error| row_group_error(error.to_string()))?,
+    );
     writes.put(
         ROW_GROUP_MANIFEST_SPACE,
         id.manifest_key(),
@@ -437,11 +496,15 @@ pub(crate) async fn stage_delete_row_group_set(
     };
     writes.delete(ROW_GROUP_MANIFEST_SPACE, id.manifest_key());
     for group_index in 0..manifest.groups.len() {
-        for column_index in 0..manifest.fields.len() {
-            writes.delete(
-                ROW_GROUP_COLUMN_SPACE,
-                id.column_key(group_index, column_index)?,
-            );
+        let page_count =
+            (manifest.groups[group_index].row_count as usize).div_ceil(ROW_GROUP_PAGE_ROWS);
+        for page_index in 0..page_count {
+            for column_index in 0..manifest.fields.len() {
+                writes.delete(
+                    ROW_GROUP_COLUMN_SPACE,
+                    id.column_key(group_index, page_index, column_index)?,
+                );
+            }
         }
     }
     Ok(())
@@ -515,9 +578,13 @@ pub(crate) async fn load_row_group_columns(
     if projection.is_empty() {
         return Ok(Vec::new());
     }
+    let page_count = (group.row_count as usize).div_ceil(ROW_GROUP_PAGE_ROWS);
     let keys = projection
         .iter()
-        .map(|&column_index| id.column_key(group_index, column_index))
+        .flat_map(|&column_index| {
+            (0..page_count)
+                .map(move |page_index| id.column_key(group_index, page_index, column_index))
+        })
         .collect::<Result<Vec<_>, _>>()?;
     let values = PointReadPlan::from_unique_keys(ROW_GROUP_COLUMN_SPACE, keys)
         .materialize(store, StorageGetOptions::default())
@@ -526,22 +593,28 @@ pub(crate) async fn load_row_group_columns(
     let mut values = values.into_iter();
     let mut arrays = Vec::with_capacity(projection.len());
     for &column_index in projection {
-        let value = values.next().flatten().ok_or_else(|| {
-            row_group_error(format!(
-                "row-group {group_index} column {column_index} is missing"
-            ))
-        })?;
-        let StorageProjectedValue::FullValue(bytes) = value else {
-            return Err(row_group_error("row-group column read omitted its value"));
-        };
         let field = &manifest.fields[column_index];
-        let array = decode_verified_column(
-            &bytes,
-            group.column_digests[column_index],
-            field.data_type,
-            group.row_count as usize,
-        )?;
-        arrays.push(array);
+        let mut pages = Vec::with_capacity(page_count);
+        for page_index in 0..page_count {
+            let value = values.next().flatten().ok_or_else(|| {
+                row_group_error(format!(
+                    "row-group {group_index} page {page_index} column {column_index} is missing"
+                ))
+            })?;
+            let StorageProjectedValue::FullValue(bytes) = value else {
+                return Err(row_group_error("row-group column read omitted its value"));
+            };
+            let page_rows = ROW_GROUP_PAGE_ROWS
+                .min(group.row_count as usize - page_index.saturating_mul(ROW_GROUP_PAGE_ROWS));
+            pages.push(decode_verified_column(
+                &bytes,
+                group.column_page_digests[column_index][page_index],
+                field.data_type,
+                page_rows,
+            )?);
+        }
+        let page_refs = pages.iter().map(|page| page.as_ref()).collect::<Vec<_>>();
+        arrays.push(concat(&page_refs).map_err(|error| row_group_error(error.to_string()))?);
     }
     if values.next().is_some() {
         return Err(row_group_error(
@@ -549,6 +622,59 @@ pub(crate) async fn load_row_group_columns(
         ));
     }
     Ok(arrays)
+}
+
+/// Loads one independently compressed page from one logical scan group.
+pub(crate) async fn load_row_group_page(
+    store: &(impl StorageAdapterRead + ?Sized),
+    id: RowGroupSetId,
+    manifest: &RowGroupManifest,
+    group_index: usize,
+    page_index: usize,
+    projection: &[usize],
+) -> Result<RecordBatch, LixError> {
+    validate_projection(manifest, projection)?;
+    let group = manifest.groups.get(group_index).ok_or_else(|| {
+        row_group_error(format!(
+            "row-group index {group_index} is outside the manifest"
+        ))
+    })?;
+    let page_count = (group.row_count as usize).div_ceil(ROW_GROUP_PAGE_ROWS);
+    if page_index >= page_count {
+        return Err(row_group_error(format!(
+            "row-group page index {page_index} is outside {page_count} pages"
+        )));
+    }
+    let page_rows = ROW_GROUP_PAGE_ROWS
+        .min(group.row_count as usize - page_index.saturating_mul(ROW_GROUP_PAGE_ROWS));
+    let keys = projection
+        .iter()
+        .map(|&column_index| id.column_key(group_index, page_index, column_index))
+        .collect::<Result<Vec<_>, _>>()?;
+    let loaded = PointReadPlan::from_unique_keys(ROW_GROUP_COLUMN_SPACE, keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?;
+    let mut arrays = Vec::with_capacity(projection.len());
+    for (&column_index, value) in projection.iter().zip(loaded.value) {
+        let bytes = value
+            .and_then(|value| match value {
+                StorageProjectedValue::FullValue(bytes) => Some(bytes),
+                StorageProjectedValue::KeyOnly => None,
+            })
+            .ok_or_else(|| {
+                row_group_error(format!(
+                    "row-group {group_index} page {page_index} column {column_index} is missing"
+                ))
+            })?;
+        arrays.push(decode_verified_column(
+            &bytes,
+            group.column_page_digests[column_index][page_index],
+            manifest.fields[column_index].data_type,
+            page_rows,
+        )?);
+    }
+    RecordBatch::try_new(projected_schema(manifest, projection), arrays)
+        .map_err(|error| row_group_error(error.to_string()))
 }
 
 pub(crate) fn row_group_projected_schema(
@@ -1004,7 +1130,7 @@ pub(crate) fn exact_record_batch_statistics(
         .collect::<Result<Vec<_>, LixError>>()?;
     Ok(RowGroupStatistics {
         row_count,
-        column_digests: vec![[0; BLAKE3_DIGEST_LEN]; columns.len()],
+        column_page_digests: vec![Vec::new(); columns.len()],
         columns,
     })
 }
@@ -1064,18 +1190,26 @@ fn encode_manifest(manifest: &RowGroupManifest) -> Result<Vec<u8>, LixError> {
                 "manifest statistics width does not match its schema",
             ));
         }
-        if group.column_digests.len() != manifest.fields.len() {
+        if group.column_page_digests.len() != manifest.fields.len() {
             return Err(row_group_error(
                 "manifest column digest width does not match its schema",
             ));
         }
-        for ((stats, digest), field) in group
+        let page_count = (group.row_count as usize).div_ceil(ROW_GROUP_PAGE_ROWS);
+        for ((stats, page_digests), field) in group
             .columns
             .iter()
-            .zip(&group.column_digests)
+            .zip(&group.column_page_digests)
             .zip(&manifest.fields)
         {
-            output.extend_from_slice(digest);
+            if page_digests.len() != page_count {
+                return Err(row_group_error(
+                    "manifest column page digest count disagrees with its row count",
+                ));
+            }
+            for digest in page_digests {
+                output.extend_from_slice(digest);
+            }
             output.extend_from_slice(&stats.null_count.to_le_bytes());
             put_optional_scalar(&mut output, stats.min.as_ref(), field.data_type)?;
             put_optional_scalar(&mut output, stats.max.as_ref(), field.data_type)?;
@@ -1101,7 +1235,10 @@ fn decode_manifest(encoded: &[u8]) -> Result<RowGroupManifest, LixError> {
     let namespace = cursor.string()?;
     let metadata = cursor.metadata()?;
     let field_count = cursor.u16_le()? as usize;
-    let mut fields = Vec::with_capacity(field_count);
+    // Counts are encoded inside storage-controlled bytes. Do not turn a forged,
+    // self-checksummed count into an unbounded allocation before the decoder has
+    // established that the corresponding entries actually exist.
+    let mut fields = Vec::with_capacity(field_count.min(1_024));
     for _ in 0..field_count {
         let name = cursor.string()?;
         let data_type = RowGroupDataType::decode(cursor.u8()?)?;
@@ -1118,7 +1255,7 @@ fn decode_manifest(encoded: &[u8]) -> Result<RowGroupManifest, LixError> {
         });
     }
     let group_count = cursor.u32_le()? as usize;
-    let mut groups = Vec::with_capacity(group_count);
+    let mut groups = Vec::with_capacity(group_count.min(1_024));
     for _ in 0..group_count {
         let row_count = cursor.u32_le()?;
         if row_count == 0 || row_count as usize > ROW_GROUP_MAX_ROWS {
@@ -1127,10 +1264,17 @@ fn decode_manifest(encoded: &[u8]) -> Result<RowGroupManifest, LixError> {
             ));
         }
         let mut columns = Vec::with_capacity(field_count);
-        let mut column_digests = Vec::with_capacity(field_count);
+        let page_count = (row_count as usize).div_ceil(ROW_GROUP_PAGE_ROWS);
+        let mut column_page_digests = Vec::with_capacity(field_count);
         for field in &fields {
-            let digest = <[u8; BLAKE3_DIGEST_LEN]>::try_from(cursor.bytes(BLAKE3_DIGEST_LEN)?)
-                .map_err(|_| row_group_error("row-group column digest has an invalid length"))?;
+            let mut page_digests = Vec::with_capacity(page_count);
+            for _ in 0..page_count {
+                page_digests.push(
+                    <[u8; BLAKE3_DIGEST_LEN]>::try_from(cursor.bytes(BLAKE3_DIGEST_LEN)?).map_err(
+                        |_| row_group_error("row-group column digest has an invalid length"),
+                    )?,
+                );
+            }
             let null_count = cursor.u32_le()?;
             if null_count > row_count {
                 return Err(row_group_error(
@@ -1151,12 +1295,12 @@ fn decode_manifest(encoded: &[u8]) -> Result<RowGroupManifest, LixError> {
                 max,
                 sum,
             });
-            column_digests.push(digest);
+            column_page_digests.push(page_digests);
         }
         groups.push(RowGroupStatistics {
             row_count,
             columns,
-            column_digests,
+            column_page_digests,
         });
     }
     if !cursor.is_empty() {
@@ -1167,6 +1311,7 @@ fn decode_manifest(encoded: &[u8]) -> Result<RowGroupManifest, LixError> {
         metadata,
         fields,
         groups,
+        encoded_digest: *blake3::hash(encoded).as_bytes(),
     })
 }
 
@@ -1420,11 +1565,16 @@ mod tests {
         for column in &encoded.columns {
             let group = &encoded.manifest.groups[column.group_index];
             let field = &encoded.manifest.fields[column.column_index];
-            let decoded = decode_column(&column.bytes, field.data_type, group.row_count as usize)
-                .expect("decode column");
+            let page_rows = ROW_GROUP_PAGE_ROWS.min(
+                group.row_count as usize - column.page_index.saturating_mul(ROW_GROUP_PAGE_ROWS),
+            );
+            let column_bytes = encoded.column_bytes(column);
+            let decoded =
+                decode_column(column_bytes, field.data_type, page_rows).expect("decode column");
+            assert_eq!(decoded.len(), page_rows);
             assert_eq!(
-                column_statistics(&decoded, field.data_type).expect("decoded stats"),
-                group.columns[column.column_index]
+                *blake3::hash(column_bytes).as_bytes(),
+                group.column_page_digests[column.column_index][column.page_index]
             );
         }
     }
@@ -1525,7 +1675,7 @@ mod tests {
             .columns
             .iter()
             .map(|column| {
-                id.column_key(column.group_index, column.column_index)
+                id.column_key(column.group_index, column.page_index, column.column_index)
                     .expect("key")
             })
             .collect::<Vec<_>>();
@@ -1554,7 +1704,7 @@ mod tests {
         bad_manifest_checksum[checksum_index] ^= 0xff;
         assert!(decode_manifest(&bad_manifest_checksum).is_err());
 
-        let mut truncated = encoded.columns[0].bytes.to_vec();
+        let mut truncated = encoded.column_bytes(&encoded.columns[0]).to_vec();
         truncated.truncate(truncated.len() / 2);
         assert!(decode_column(&truncated, RowGroupDataType::String, 32).is_err());
 
@@ -1562,6 +1712,15 @@ mod tests {
         oversized.extend_from_slice(&u32::MAX.to_le_bytes());
         oversized.extend_from_slice(b"not-zstd");
         assert!(decode_column(&oversized, RowGroupDataType::String, 32).is_err());
+
+        let mut forged_count = Vec::from(MANIFEST_MAGIC);
+        forged_count.extend_from_slice(&0_u32.to_le_bytes()); // namespace
+        forged_count.extend_from_slice(&0_u16.to_le_bytes()); // metadata
+        forged_count.extend_from_slice(&0_u16.to_le_bytes()); // fields
+        forged_count.extend_from_slice(&u32::MAX.to_le_bytes()); // groups
+        let checksum = blake3::hash(&forged_count);
+        forged_count.extend_from_slice(checksum.as_bytes());
+        assert!(decode_manifest(&forged_count).is_err());
     }
 
     #[test]
@@ -1583,10 +1742,11 @@ mod tests {
         let (schema, batches) = fixture(32);
         let mut encoded = encode_row_group_set("fixture", schema, &batches).expect("encode");
 
-        let mut corrupt_column = encoded.columns[0].bytes.to_vec();
-        let corrupt_index = corrupt_column.len() - 1;
-        corrupt_column[corrupt_index] ^= 0xff;
-        encoded.columns[0].bytes = Bytes::from(corrupt_column);
+        let corrupt_range = encoded.columns[0].value;
+        let mut column_values = encoded.column_values.to_vec();
+        let corrupt_index = corrupt_range.offset() + corrupt_range.len() - 1;
+        column_values[corrupt_index] ^= 0xff;
+        encoded.column_values = Bytes::from(column_values);
 
         let adapter = StorageAdapter::new(Memory::new());
         let id = RowGroupSetId::new(*b"row-group-set-02");

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -1675,6 +1675,7 @@ mod tests {
             metadata: std::collections::HashMap::new(),
             fields: Vec::new(),
             groups: Vec::new(),
+            encoded_digest: [0; 32],
         }
     }
 

--- a/packages/engine/src/live_state/entity_columnar.rs
+++ b/packages/engine/src/live_state/entity_columnar.rs
@@ -7,21 +7,41 @@ use crate::columnar_row_group::{RowGroupRowLocation, RowGroupSetId};
 
 pub(crate) struct EntityColumnarWriteSets {
     sets: BTreeMap<(CommitId, String), crate::columnar_row_group::EncodedRowGroupSet>,
-    state_row_locations: Vec<Option<RowGroupRowLocation>>,
+    state_row_locations: StateRowLocations,
+}
+
+enum StateRowLocations {
+    None,
+    Dense { row_count: usize },
+    Explicit(Vec<Option<RowGroupRowLocation>>),
 }
 
 impl EntityColumnarWriteSets {
     pub(crate) fn new() -> Self {
         Self {
             sets: BTreeMap::new(),
-            state_row_locations: Vec::new(),
+            state_row_locations: StateRowLocations::None,
         }
     }
 
     pub(crate) fn with_state_row_count(row_count: usize) -> Self {
         Self {
             sets: BTreeMap::new(),
-            state_row_locations: vec![None; row_count],
+            state_row_locations: StateRowLocations::Explicit(vec![None; row_count]),
+        }
+    }
+
+    pub(crate) fn with_dense_state_rows(row_count: usize) -> Self {
+        Self {
+            sets: BTreeMap::new(),
+            state_row_locations: StateRowLocations::Dense { row_count },
+        }
+    }
+
+    pub(crate) fn dense_state_row_count(&self) -> Option<usize> {
+        match &self.state_row_locations {
+            StateRowLocations::Dense { row_count } => Some(*row_count),
+            StateRowLocations::None | StateRowLocations::Explicit(_) => None,
         }
     }
 
@@ -30,6 +50,13 @@ impl EntityColumnarWriteSets {
         key: &(CommitId, String),
     ) -> Option<&crate::columnar_row_group::EncodedRowGroupSet> {
         self.sets.get(key)
+    }
+
+    pub(crate) fn take(
+        &mut self,
+        key: &(CommitId, String),
+    ) -> Option<crate::columnar_row_group::EncodedRowGroupSet> {
+        self.sets.remove(key)
     }
 
     pub(crate) fn insert(
@@ -45,14 +72,36 @@ impl EntityColumnarWriteSets {
         state_row_index: usize,
         location: RowGroupRowLocation,
     ) {
-        self.state_row_locations[state_row_index] = Some(location);
+        match &mut self.state_row_locations {
+            StateRowLocations::Explicit(locations) => {
+                locations[state_row_index] = Some(location);
+            }
+            StateRowLocations::None | StateRowLocations::Dense { .. } => {
+                panic!("explicit entity row location requires an explicit location column")
+            }
+        }
     }
 
     pub(crate) fn state_row_location(&self, state_row_index: usize) -> Option<RowGroupRowLocation> {
-        self.state_row_locations
-            .get(state_row_index)
-            .copied()
-            .flatten()
+        match &self.state_row_locations {
+            StateRowLocations::None => None,
+            StateRowLocations::Dense { row_count } if state_row_index < *row_count => {
+                Some(RowGroupRowLocation {
+                    group_index: u32::try_from(
+                        state_row_index / crate::columnar_row_group::ROW_GROUP_MAX_ROWS,
+                    )
+                    .ok()?,
+                    row_index: u32::try_from(
+                        state_row_index % crate::columnar_row_group::ROW_GROUP_MAX_ROWS,
+                    )
+                    .ok()?,
+                })
+            }
+            StateRowLocations::Dense { .. } => None,
+            StateRowLocations::Explicit(locations) => {
+                locations.get(state_row_index).copied().flatten()
+            }
+        }
     }
 }
 

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -4145,10 +4145,10 @@ mod tests {
 
     async fn assert_columnar_lifecycle_current(
         session: &SessionContext<Memory>,
+        row_count: usize,
         first: &str,
-        last: &str,
+        sample: &str,
     ) {
-        const ROW_COUNT: usize = 1_024;
         let rows = session
             .execute(
                 "SELECT id, value FROM columnar_lifecycle_probe ORDER BY id",
@@ -4156,17 +4156,11 @@ mod tests {
             )
             .await
             .expect("typed lifecycle scan should succeed");
-        assert_eq!(rows.len(), ROW_COUNT);
-        assert_eq!(rows.rows()[0].get::<String>("id").unwrap(), "0000");
+        assert_eq!(rows.len(), row_count);
+        assert_eq!(rows.rows()[0].get::<String>("id").unwrap(), "00000");
         assert_eq!(rows.rows()[0].get::<String>("value").unwrap(), first);
-        assert_eq!(
-            rows.rows()[ROW_COUNT - 1].get::<String>("id").unwrap(),
-            "1023"
-        );
-        assert_eq!(
-            rows.rows()[ROW_COUNT - 1].get::<String>("value").unwrap(),
-            last
-        );
+        assert_eq!(rows.rows()[1_023].get::<String>("id").unwrap(), "01023");
+        assert_eq!(rows.rows()[1_023].get::<String>("value").unwrap(), sample);
     }
 
     async fn assert_columnar_layout_selected(
@@ -5550,17 +5544,83 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn successive_columnar_inserts_preserve_the_existing_schema_base() {
+        const BATCH_ROWS: usize = 1_024;
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "x-lix-key": "successive_columnar_insert_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": { "type": "string" }
+            },
+            "required": ["id", "value"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .expect("successive insert schema should register");
+
+        let sql = "INSERT INTO successive_columnar_insert_probe (id, value) VALUES ($1, $2)";
+        for generation in 0..2 {
+            let first = generation * BATCH_ROWS;
+            let inserts = (first..first + BATCH_ROWS)
+                .map(|row_index| ExecuteBatchStatement {
+                    sql: sql.to_owned(),
+                    params: vec![
+                        Value::Text(format!("{row_index:04}")),
+                        Value::Text(format!("generation-{generation}")),
+                    ],
+                })
+                .collect::<Vec<_>>();
+            let inserted = session
+                .execute_batch(&inserts)
+                .await
+                .expect("each ordered insert generation should commit")
+                .iter()
+                .map(ExecuteResult::rows_affected)
+                .sum::<u64>();
+            assert_eq!(inserted, BATCH_ROWS as u64);
+        }
+
+        let rows = session
+            .execute(
+                "SELECT id, value FROM successive_columnar_insert_probe ORDER BY id",
+                &[],
+            )
+            .await
+            .expect("the second generation must retain the first columnar base");
+        assert_eq!(rows.len(), BATCH_ROWS * 2);
+        assert_eq!(rows.rows()[0].get::<String>("id").unwrap(), "0000");
+        assert_eq!(
+            rows.rows()[0].get::<String>("value").unwrap(),
+            "generation-0"
+        );
+        assert_eq!(rows.rows()[BATCH_ROWS].get::<String>("id").unwrap(), "1024");
+        assert_eq!(
+            rows.rows()[BATCH_ROWS].get::<String>("value").unwrap(),
+            "generation-1"
+        );
+    }
+
+    #[tokio::test]
     async fn typed_columnar_base_preserves_current_diff_and_history_across_lifecycle_changes() {
-        const ROW_COUNT: usize = 1_024;
+        const ROW_COUNT: usize = 65_537;
         let storage = Memory::default();
         Engine::initialize(storage.clone())
             .await
             .expect("storage should initialize");
-        let engine = Engine::new(storage)
+        let engine = Engine::new(storage.clone())
             .await
             .expect("initialized storage should create engine");
         let main = engine
-            .open_workspace_session()
+            .open_workspace_session_with_account(crate::SYSTEM_ACCOUNT_ID)
             .await
             .expect("workspace session should open");
         let main_branch_id = main
@@ -5597,7 +5657,7 @@ mod tests {
             .map(|row_index| ExecuteBatchStatement {
                 sql: insert_sql.to_owned(),
                 params: vec![
-                    Value::Text(format!("{row_index:04}")),
+                    Value::Text(format!("{row_index:05}")),
                     Value::Text(format!("base-{row_index:04}")),
                 ],
             })
@@ -5620,8 +5680,8 @@ mod tests {
             .await
             .expect("insert head should load")
             .expect("insert head should exist");
-        let storage = engine.storage();
-        let read = storage
+        let adapter = engine.storage();
+        let read = adapter
             .begin_read(StorageReadOptions::default())
             .await
             .expect("sidecar read scope should open");
@@ -5635,8 +5695,38 @@ mod tests {
             .expect("typed lifecycle sidecar manifest should load")
             .expect("fixture must publish a typed columnar sidecar");
         assert_eq!(manifest.row_count(), ROW_COUNT as u64);
+        assert_eq!(
+            manifest
+                .groups
+                .iter()
+                .map(|group| group.row_count)
+                .collect::<Vec<_>>(),
+            vec![65_536, 1],
+            "fixture must cross both column-page and logical-group boundaries"
+        );
+        let commit_state = crate::tracked_state::load_commit_state_manifest(
+            &read,
+            crate::changelog::CommitId::parse_lix(
+                &inserted_head,
+                "typed lifecycle mutation authority",
+            )
+            .expect("insert head should be canonical"),
+        )
+        .await
+        .expect("typed mutation authority should load")
+        .expect("typed mutation authority should exist");
+        let columnar_parts = commit_state
+            .mutations
+            .columnar_parts
+            .as_ref()
+            .expect("fixture must publish column pages as sole mutation authority");
+        assert_eq!(commit_state.account_id, crate::SYSTEM_ACCOUNT_ID);
+        assert!(commit_state.mutations.inline_part.is_empty());
+        assert!(commit_state.mutations.parts.is_empty());
+        assert_eq!(columnar_parts.page_first_keys.len(), 33);
+        drop(read);
 
-        assert_columnar_lifecycle_current(&main, "base-0000", "base-1023").await;
+        assert_columnar_lifecycle_current(&main, ROW_COUNT, "base-0000", "base-1023").await;
 
         let inserted_diff = main
             .execute(
@@ -5668,9 +5758,34 @@ mod tests {
             inserted_history.rows()[0].get::<i64>("entries").unwrap(),
             ROW_COUNT as i64
         );
+        let attributed_changes = main
+            .execute(
+                "SELECT COUNT(*) AS entries FROM lix_change \
+                 WHERE schema_key = 'columnar_lifecycle_probe' AND account_id = $1",
+                &[Value::Text(crate::SYSTEM_ACCOUNT_ID.to_owned())],
+            )
+            .await
+            .expect("columnar mutation history must retain commit account attribution");
+        assert_eq!(
+            attributed_changes.rows()[0].get::<i64>("entries").unwrap(),
+            ROW_COUNT as i64
+        );
+        let boundary_history = main
+            .execute(
+                &format!(
+                    "SELECT COUNT(DISTINCT id) AS entries \
+                     FROM columnar_lifecycle_probe_history('{inserted_head}') \
+                     WHERE id IN ('02047', '02048', '65535', '65536') \
+                       AND lixcol_is_deleted = false"
+                ),
+                &[],
+            )
+            .await
+            .expect("history must address rows on both sides of page and group boundaries");
+        assert_eq!(boundary_history.rows()[0].get::<i64>("entries").unwrap(), 4);
 
         main.execute(
-            "UPDATE columnar_lifecycle_probe SET value = 'sparse-0512' WHERE id = '0512'",
+            "UPDATE columnar_lifecycle_probe SET value = 'sparse-0512' WHERE id = '00512'",
             &[],
         )
         .await
@@ -5685,8 +5800,8 @@ mod tests {
             .await
             .expect("DataFusion LIMIT should remain above the columnar scan");
         assert_eq!(limited.len(), 3);
-        assert_eq!(limited.rows()[0].get::<String>("id").unwrap(), "0000");
-        assert_eq!(limited.rows()[2].get::<String>("id").unwrap(), "0002");
+        assert_eq!(limited.rows()[0].get::<String>("id").unwrap(), "00000");
+        assert_eq!(limited.rows()[2].get::<String>("id").unwrap(), "00002");
         let zero = main
             .execute(
                 "SELECT id FROM columnar_lifecycle_probe ORDER BY id LIMIT 0",
@@ -5707,7 +5822,10 @@ mod tests {
             .await
             .expect("pruned columnar scan should retain matching overlay winner");
         assert_eq!(overlay_match.len(), 1);
-        assert_eq!(overlay_match.rows()[0].get::<String>("id").unwrap(), "0512");
+        assert_eq!(
+            overlay_match.rows()[0].get::<String>("id").unwrap(),
+            "00512"
+        );
         let no_match = main
             .execute(
                 "SELECT id FROM columnar_lifecycle_probe \
@@ -5719,7 +5837,7 @@ mod tests {
         assert!(no_match.is_empty());
 
         main.execute(
-            "UPDATE columnar_lifecycle_probe SET value = 'base-0512' WHERE id = '0512'",
+            "UPDATE columnar_lifecycle_probe SET value = 'base-0512' WHERE id = '00512'",
             &[],
         )
         .await
@@ -5743,7 +5861,7 @@ mod tests {
             .expect("draft session should open");
         draft_session
             .execute(
-                "UPDATE columnar_lifecycle_probe SET value = 'draft-0000' WHERE id = '0000'",
+                "UPDATE columnar_lifecycle_probe SET value = 'draft-0000' WHERE id = '00000'",
                 &[],
             )
             .await
@@ -5752,14 +5870,15 @@ mod tests {
             .undo()
             .await
             .expect("draft update should undo");
-        assert_columnar_lifecycle_current(&draft_session, "base-0000", "base-1023").await;
+        assert_columnar_lifecycle_current(&draft_session, ROW_COUNT, "base-0000", "base-1023")
+            .await;
         draft_session
             .redo()
             .await
             .expect("draft update should redo");
 
         main.execute(
-            "UPDATE columnar_lifecycle_probe SET value = 'main-1023' WHERE id = '1023'",
+            "UPDATE columnar_lifecycle_probe SET value = 'main-1023' WHERE id = '01023'",
             &[],
         )
         .await
@@ -5771,7 +5890,7 @@ mod tests {
             .await
             .expect("disjoint typed updates should merge");
         assert_eq!(merge.outcome, crate::MergeBranchOutcome::MergeCommitted);
-        assert_columnar_lifecycle_current(&main, "draft-0000", "main-1023").await;
+        assert_columnar_lifecycle_current(&main, ROW_COUNT, "draft-0000", "main-1023").await;
 
         let merged_head = engine
             .load_branch_head_commit_id(&main_branch_id)
@@ -5795,7 +5914,7 @@ mod tests {
                 &format!(
                     "SELECT value, lixcol_depth \
                      FROM columnar_lifecycle_probe_history('{merged_head}') \
-                     WHERE id = '0000' ORDER BY lixcol_depth"
+                     WHERE id = '00000' ORDER BY lixcol_depth"
                 ),
                 &[],
             )
@@ -5813,7 +5932,7 @@ mod tests {
         );
 
         main.execute(
-            "UPDATE columnar_lifecycle_probe SET value = 'temporary' WHERE id = '0512'",
+            "UPDATE columnar_lifecycle_probe SET value = 'temporary' WHERE id = '00512'",
             &[],
         )
         .await
@@ -5821,7 +5940,7 @@ mod tests {
         main.undo().await.expect("post-merge update should undo");
         let restored = main
             .execute(
-                "SELECT value FROM columnar_lifecycle_probe WHERE id = '0512'",
+                "SELECT value FROM columnar_lifecycle_probe WHERE id = '00512'",
                 &[],
             )
             .await
@@ -5830,7 +5949,40 @@ mod tests {
             restored.rows()[0].get::<String>("value").unwrap(),
             "base-0512"
         );
-        assert_columnar_lifecycle_current(&main, "draft-0000", "main-1023").await;
+        assert_columnar_lifecycle_current(&main, ROW_COUNT, "draft-0000", "main-1023").await;
+
+        let mut corrupt = engine.storage().new_write_set();
+        corrupt.delete(
+            crate::columnar_row_group::ROW_GROUP_MANIFEST_SPACE,
+            crate::storage_adapter::StorageKey(bytes::Bytes::copy_from_slice(
+                &row_group_id.as_bytes(),
+            )),
+        );
+        engine
+            .storage()
+            .commit_write_set(corrupt, StorageWriteOptions::default())
+            .await
+            .expect("test corruption should commit");
+        let reopened = Engine::new(storage)
+            .await
+            .expect("corrupt storage should still open structurally");
+        let reopened_session = reopened
+            .open_workspace_session()
+            .await
+            .expect("corrupt storage session should open");
+        assert!(
+            reopened_session
+                .execute(
+                    &format!(
+                        "SELECT value FROM columnar_lifecycle_probe_history('{inserted_head}') \
+                         WHERE id = '65536'"
+                    ),
+                    &[],
+                )
+                .await
+                .is_err(),
+            "missing authoritative columnar manifests must fail closed"
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/sql2/catalog/entity_surface.rs
+++ b/packages/engine/src/sql2/catalog/entity_surface.rs
@@ -55,6 +55,10 @@ pub(crate) struct EntitySurfaceSpec {
     /// This exact schema shape proves that replacing `value` while preserving
     /// the already-valid string `path` produces complete valid row content.
     pub(crate) certifies_path_value_replacement: bool,
+    /// Every accepted snapshot is exactly the declared, required top-level
+    /// columns, so typed Arrow values can reconstruct canonical JSON without
+    /// a second persisted snapshot payload.
+    pub(crate) columnar_snapshot_bijective: bool,
 }
 
 impl EntitySurfaceSpec {
@@ -205,6 +209,18 @@ pub(crate) fn derive_entity_surface_spec_from_schema(
     columns.sort_by(|left, right| left.name.cmp(&right.name));
 
     let certifies_path_value_replacement = certifies_path_value_replacement(schema);
+    let columnar_snapshot_bijective = schema.get("additionalProperties")
+        == Some(&JsonValue::Bool(false))
+        && properties.len() == columns.len()
+        && columns.iter().all(|column| {
+            column.insert_required
+                && matches!(
+                    column.column_type,
+                    EntityColumnType::String
+                        | EntityColumnType::Integer
+                        | EntityColumnType::Boolean
+                )
+        });
     Ok(EntitySurfaceSpec {
         schema_key: schema_key.to_string(),
         primary_key_paths,
@@ -220,6 +236,7 @@ pub(crate) fn derive_entity_surface_spec_from_schema(
             },
         ),
         certifies_path_value_replacement,
+        columnar_snapshot_bijective,
     })
 }
 
@@ -616,6 +633,28 @@ mod tests {
         .expect("schema should derive");
 
         assert!(spec.certifies_path_value_replacement);
+    }
+
+    #[test]
+    fn columnar_snapshot_certificate_requires_exact_reversible_columns() {
+        let strings = derive_entity_surface_spec_from_schema(&path_value_schema(json!({
+            "type": "string"
+        })))
+        .expect("string schema should derive");
+        assert!(strings.columnar_snapshot_bijective);
+
+        let numbers = derive_entity_surface_spec_from_schema(&path_value_schema(json!({
+            "type": "number"
+        })))
+        .expect("number schema should derive");
+        assert!(!numbers.columnar_snapshot_bijective);
+
+        let mut reserved = path_value_schema(json!({ "type": "string" }));
+        reserved["properties"]["lixcol_user_value"] = json!({ "type": "string" });
+        reserved["required"] = json!(["path", "value", "lixcol_user_value"]);
+        let reserved = derive_entity_surface_spec_from_schema(&reserved)
+            .expect("reserved-name schema should still derive");
+        assert!(!reserved.columnar_snapshot_bijective);
     }
 
     #[test]

--- a/packages/engine/src/sql2/entity_batch.rs
+++ b/packages/engine/src/sql2/entity_batch.rs
@@ -480,6 +480,7 @@ mod tests {
                 metadata: std::collections::HashMap::new(),
                 fields: Vec::new(),
                 groups: Vec::new(),
+                encoded_digest: [0; 32],
             }),
             manifest_digest: [42; 32],
             overlay: Arc::new(Vec::new()),

--- a/packages/engine/src/sql2/entity_columnar_layout.rs
+++ b/packages/engine/src/sql2/entity_columnar_layout.rs
@@ -28,6 +28,8 @@ pub(crate) const ENTITY_COLUMNAR_LAYOUT_FINGERPRINT_METADATA_KEY: &str =
     "lix.entity_columnar.layout_fingerprint.v1";
 pub(crate) const ENTITY_COLUMNAR_BASE_COORDINATES_METADATA_KEY: &str =
     "lix.entity_columnar.base_coordinates.v1";
+pub(crate) const ENTITY_COLUMNAR_LOSSLESS_SNAPSHOT_METADATA_KEY: &str =
+    "lix.entity_columnar.lossless_snapshot.v1";
 pub(crate) const ENTITY_COLUMNAR_ENTITY_PK_FIELD: &str = "lixcol_entity_pk";
 pub(crate) const LOW_CARDINALITY_CLUSTER_MAX_VALUES: usize = 64;
 const LOW_CARDINALITY_CLUSTER_MAX_BUCKETS: usize = 8;
@@ -48,8 +50,54 @@ pub(crate) struct EntityColumnarRowRef<'a> {
 #[derive(Clone, Debug)]
 pub(crate) struct EncodedEntityRowGroups {
     encoded: EncodedRowGroupSet,
-    pub(crate) input_locations: Vec<RowGroupRowLocation>,
+    pub(crate) input_locations: EntityRowGroupLocations,
 }
+
+/// Input-row to physical-row mapping for one sealed entity generation.
+///
+/// Identity-preserving batches use arithmetic coordinates and retain no
+/// row-cardinal location column. Clustered layouts keep the explicit
+/// permutation required to map their reordered rows back to statement order.
+#[derive(Clone, Debug)]
+pub(crate) enum EntityRowGroupLocations {
+    Dense { row_count: usize },
+    Explicit(Vec<RowGroupRowLocation>),
+}
+
+impl EntityRowGroupLocations {
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            Self::Dense { row_count } => *row_count,
+            Self::Explicit(locations) => locations.len(),
+        }
+    }
+
+    pub(crate) fn location(&self, input_index: usize) -> Option<RowGroupRowLocation> {
+        match self {
+            Self::Dense { row_count } if input_index < *row_count => Some(RowGroupRowLocation {
+                group_index: u32::try_from(input_index / ROW_GROUP_MAX_ROWS).ok()?,
+                row_index: u32::try_from(input_index % ROW_GROUP_MAX_ROWS).ok()?,
+            }),
+            Self::Dense { .. } => None,
+            Self::Explicit(locations) => locations.get(input_index).copied(),
+        }
+    }
+
+    pub(crate) fn iter(&self) -> impl ExactSizeIterator<Item = RowGroupRowLocation> + '_ {
+        (0..self.len()).map(|input_index| {
+            self.location(input_index)
+                .expect("entity row-group location covers every input row")
+        })
+    }
+}
+
+impl PartialEq for EntityRowGroupLocations {
+    fn eq(&self, other: &Self) -> bool {
+        self.len() == other.len() && self.iter().eq(other.iter())
+    }
+}
+
+impl Eq for EntityRowGroupLocations {}
 
 impl Deref for EncodedEntityRowGroups {
     type Target = EncodedRowGroupSet;
@@ -60,7 +108,7 @@ impl Deref for EncodedEntityRowGroups {
 }
 
 impl EncodedEntityRowGroups {
-    pub(crate) fn into_parts(self) -> (EncodedRowGroupSet, Vec<RowGroupRowLocation>) {
+    pub(crate) fn into_parts(self) -> (EncodedRowGroupSet, EntityRowGroupLocations) {
         (self.encoded, self.input_locations)
     }
 }
@@ -139,27 +187,12 @@ pub(crate) fn encode_unclustered_registered_entity_row_groups(
         DataType::Utf8,
         false,
     ));
-    let mut metadata = HashMap::new();
-    metadata.insert(
-        ENTITY_COLUMNAR_LAYOUT_FINGERPRINT_METADATA_KEY.to_string(),
-        spec.columnar_layout_fingerprint(),
-    );
-    metadata.insert(
-        ENTITY_COLUMNAR_BASE_COORDINATES_METADATA_KEY.to_string(),
-        "true".to_owned(),
-    );
+    let metadata = entity_columnar_metadata(spec);
     let schema = Arc::new(Schema::new_with_metadata(fields, metadata));
     columns.push(entity_pks);
     let mut batches = Vec::with_capacity(row_count.div_ceil(ROW_GROUP_MAX_ROWS));
-    let mut input_locations = Vec::with_capacity(row_count);
     for offset in (0..row_count).step_by(ROW_GROUP_MAX_ROWS) {
         let len = (row_count - offset).min(ROW_GROUP_MAX_ROWS);
-        let group_index = u32::try_from(batches.len())
-            .map_err(|_| entity_columnar_error("row-group index exceeds u32"))?;
-        input_locations.extend((0..len).map(|row_index| RowGroupRowLocation {
-            group_index,
-            row_index: u32::try_from(row_index).expect("row-group size fits u32"),
-        }));
         batches.push(
             RecordBatch::try_new(
                 Arc::clone(&schema),
@@ -174,7 +207,7 @@ pub(crate) fn encode_unclustered_registered_entity_row_groups(
     let encoded = encode_row_group_set_preserving_batches(&spec.schema_key, schema, &batches)?;
     Ok(Some(EncodedEntityRowGroups {
         encoded,
-        input_locations,
+        input_locations: EntityRowGroupLocations::Dense { row_count },
     }))
 }
 
@@ -191,15 +224,7 @@ where
         DataType::Utf8,
         false,
     ));
-    let mut metadata = HashMap::new();
-    metadata.insert(
-        ENTITY_COLUMNAR_LAYOUT_FINGERPRINT_METADATA_KEY.to_string(),
-        spec.columnar_layout_fingerprint(),
-    );
-    metadata.insert(
-        ENTITY_COLUMNAR_BASE_COORDINATES_METADATA_KEY.to_string(),
-        "true".to_owned(),
-    );
+    let metadata = entity_columnar_metadata(spec);
     let schema = Arc::new(Schema::new_with_metadata(fields, metadata));
     let decoder =
         EntityProjectionDecoder::new(spec, spec.columns.iter().map(|column| column.name.as_str()))?;
@@ -324,10 +349,14 @@ where
     let encoded = encode_row_group_set_preserving_batches(&spec.schema_key, schema, &batches)?;
     Ok(EncodedEntityRowGroups {
         encoded,
-        input_locations: input_locations
-            .into_iter()
-            .collect::<Option<Vec<_>>>()
-            .ok_or_else(|| entity_columnar_error("row-group permutation omitted an input row"))?,
+        input_locations: EntityRowGroupLocations::Explicit(
+            input_locations
+                .into_iter()
+                .collect::<Option<Vec<_>>>()
+                .ok_or_else(|| {
+                    entity_columnar_error("row-group permutation omitted an input row")
+                })?,
+        ),
     })
 }
 
@@ -335,6 +364,26 @@ fn optional_derived_row_group_set(
     encoded: Result<EncodedEntityRowGroups, LixError>,
 ) -> Option<EncodedEntityRowGroups> {
     encoded.ok()
+}
+
+fn entity_columnar_metadata(spec: &EntitySurfaceSpec) -> HashMap<String, String> {
+    let mut metadata = HashMap::from([
+        (
+            ENTITY_COLUMNAR_LAYOUT_FINGERPRINT_METADATA_KEY.to_string(),
+            spec.columnar_layout_fingerprint(),
+        ),
+        (
+            ENTITY_COLUMNAR_BASE_COORDINATES_METADATA_KEY.to_string(),
+            "true".to_owned(),
+        ),
+    ]);
+    if spec.columnar_snapshot_bijective {
+        metadata.insert(
+            ENTITY_COLUMNAR_LOSSLESS_SNAPSHOT_METADATA_KEY.to_string(),
+            "true".to_owned(),
+        );
+    }
+    metadata
 }
 
 fn entity_columnar_error(message: impl Into<String>) -> LixError {
@@ -496,6 +545,10 @@ mod tests {
         )
         .expect("direct encoding should succeed")
         .expect("high-cardinality values should not cluster");
+        assert!(matches!(
+            &direct_encoding.input_locations,
+            EntityRowGroupLocations::Dense { row_count: 128 }
+        ));
         assert_eq!(direct_encoding.manifest, canonical_encoding.manifest);
         assert_eq!(
             direct_encoding.input_locations,
@@ -628,8 +681,16 @@ mod tests {
 
         assert_eq!(encoded.input_locations.len(), identities.len());
         assert_ne!(
-            encoded.input_locations[0].group_index,
-            encoded.input_locations[1].group_index
+            encoded
+                .input_locations
+                .location(0)
+                .expect("first input coordinate")
+                .group_index,
+            encoded
+                .input_locations
+                .location(1)
+                .expect("second input coordinate")
+                .group_index
         );
         for (input_index, location) in encoded.input_locations.iter().enumerate() {
             let group = &encoded.manifest.groups[location.group_index as usize];

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -50,9 +50,10 @@ pub(crate) use context::{
 pub(crate) use entity_batch::{CurrentEntitySnapshotReader, EntitySnapshotReader};
 pub(crate) use entity_columnar_layout::{
     ENTITY_COLUMNAR_BASE_COORDINATES_METADATA_KEY, ENTITY_COLUMNAR_ENTITY_PK_FIELD,
-    ENTITY_COLUMNAR_LAYOUT_FINGERPRINT_METADATA_KEY, EncodedEntityRowGroups, EntityColumnarRowRef,
-    LOW_CARDINALITY_CLUSTER_MAX_VALUES, encode_registered_entity_row_groups,
-    encode_unclustered_registered_entity_row_groups,
+    ENTITY_COLUMNAR_LAYOUT_FINGERPRINT_METADATA_KEY,
+    ENTITY_COLUMNAR_LOSSLESS_SNAPSHOT_METADATA_KEY, EncodedEntityRowGroups, EntityColumnarRowRef,
+    EntityRowGroupLocations, LOW_CARDINALITY_CLUSTER_MAX_VALUES,
+    encode_registered_entity_row_groups, encode_unclustered_registered_entity_row_groups,
 };
 pub(crate) use entity_projection::EntityProjectionDecoder;
 pub(crate) use exec::bound_public_write::PreparedPathValueReplacementProgram;

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -4927,7 +4927,10 @@ mod tests {
         .expect("encode")
         .expect("registered sidecar");
         let base_commit_id = CommitId::for_test_label("coordinate-base");
-        let location = encoded.input_locations[0];
+        let location = encoded
+            .input_locations
+            .location(0)
+            .expect("encoded entity row has an input coordinate");
         let layout = crate::sql2::entity_batch::EntityColumnarScanLayout {
             id: crate::live_state::entity_row_group_set_id(base_commit_id, &spec.schema_key),
             manifest: Arc::new(encoded.manifest.clone()),
@@ -4985,6 +4988,7 @@ mod tests {
                 metadata: HashMap::new(),
                 fields: Vec::new(),
                 groups: Vec::new(),
+                encoded_digest: [0; 32],
             }),
             manifest_digest: [24; 32],
             overlay: Arc::new(Vec::new()),

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -62,7 +62,8 @@ pub(crate) use storage::{
     stage_commit_state_manifest_with_handle, stage_current_state_catalog_from_published_parent,
     stage_current_state_catalog_from_staged_parent, stage_delete_change_locators,
     stage_delete_commit_delta_inventory_entry, stage_ordered_addressable_commit_deltas,
-    stage_ordered_addressable_replacement_parts, validate_current_state_catalog_parent_manifest,
+    stage_ordered_addressable_replacement_parts, stage_ordered_columnar_mutations,
+    validate_current_state_catalog_parent_manifest,
 };
 #[cfg(feature = "storage-benches")]
 pub(crate) use storage::{
@@ -82,11 +83,11 @@ pub(crate) use storage::{
 };
 pub(crate) use types::{COMMIT_STATE_MAX_REPLAY_BYTES, COMMIT_STATE_MAX_REPLAY_DEPTH};
 pub(crate) use types::{
-    CommitStateManifest, CommitStateMutationInventory, CommitStateReplayDebt,
-    MaterializedTrackedStateRow, TrackedStateBaseCoordinate, TrackedStateCommitDeltaRef,
-    TrackedStateCommitRoot, TrackedStateDeltaRef, TrackedStateFilter, TrackedStateIndexValue,
-    TrackedStateReadColumns, TrackedStateRootMutationRef, TrackedStateScanRequest,
-    TrackedStateSingleStringReplacementRef,
+    ColumnarMutationPartSet, CommitStateManifest, CommitStateMutationInventory,
+    CommitStateReplayDebt, MaterializedTrackedStateRow, TrackedStateBaseCoordinate,
+    TrackedStateCommitDeltaRef, TrackedStateCommitRoot, TrackedStateDeltaRef, TrackedStateFilter,
+    TrackedStateIndexValue, TrackedStateReadColumns, TrackedStateRootMutationRef,
+    TrackedStateScanRequest, TrackedStateSingleStringReplacementRef,
 };
 pub(crate) use types::{TrackedStateKey, TrackedStateKeyRef};
 #[cfg(feature = "storage-benches")]

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -13,6 +13,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::changelog::CommitId;
 use crate::common::SharedStr;
+use crate::entity_pk::EntityPk;
 use crate::storage_adapter::{
     BufferRange, EncodedMutationBatch, EncodedPut, PointReadPlan, ScanPlan, StorageAdapterRead,
     StorageCoreProjection, StorageError, StorageGetManyRequest, StorageGetManyResult,
@@ -89,7 +90,10 @@ const ORDERED_COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 64 * 1024;
 // payload-less certified-reference encoding is intentionally rejected.
 const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD14";
 const COMMIT_STATE_SEMANTIC_AUTHORITY_MAGIC: &[u8] = b"LXSA1";
-const COMMIT_STATE_MANIFEST_FORMAT_MAGIC: &[u8] = b"LXCS3";
+// Version 4 makes lossless columnar mutation parts a first-class, exclusive
+// commit payload. LXCS3 repositories are intentionally rejected: there is no
+// compatibility decoder beneath the new authority.
+const COMMIT_STATE_MANIFEST_FORMAT_MAGIC: &[u8] = b"LXCS4";
 const COMMIT_DELTA_PAYLOAD_OFFSET_BYTES: usize = size_of::<u32>();
 #[cfg(not(test))]
 const COMMIT_DELTA_MAX_SIDECAR_BYTES: usize = 64 * 1024 * 1024;
@@ -544,6 +548,8 @@ struct CommitDeltaManifest {
     replacement_generation: Option<StoredCommitDeltaReplacementGeneration>,
     #[musli(with = storage_codec::option)]
     replacement_parts: Option<StoredReplacementPartsAuthority>,
+    #[musli(with = storage_codec::option)]
+    columnar_parts: Option<crate::tracked_state::types::ColumnarMutationPartSet>,
     /// A complete leaf payload for a commit that fits in one segment. Keeping
     /// it in the directory preserves the one-record shape of tiny commits;
     /// larger commits use the indexed segment list below.
@@ -607,6 +613,7 @@ fn commit_state_inventory_from_delta_manifest(
         lifecycle_summary: manifest.lifecycle_summary.clone(),
         replacement_generation: manifest.replacement_generation.clone(),
         replacement_parts: manifest.replacement_parts.clone(),
+        columnar_parts: manifest.columnar_parts.clone(),
         inline_part: manifest.inline_segment.clone(),
         parts: manifest
             .segments
@@ -638,6 +645,11 @@ pub(crate) fn commit_state_inventory_exact_touched_scopes(
     }
     if inventory.member_count == 0 {
         return Ok(Some(Vec::new()));
+    }
+    if inventory.columnar_parts.is_some() {
+        // The catalog rewrite path does not yet consume typed column pages.
+        // Discard inherited serving state rather than publishing stale misses.
+        return Ok(None);
     }
     if !inventory.replacement_part_digests.is_empty() {
         return Ok(inventory.single_partition.clone().map(|scope| vec![scope]));
@@ -1062,6 +1074,11 @@ fn current_inventory_may_contain_any_key(
     encoded_keys: &[Bytes],
 ) -> Result<bool, LixError> {
     let manifest = commit_delta_manifest_from_inventory(&state.mutations);
+    if let Some(parts) = manifest.columnar_parts.as_ref() {
+        return Ok(encoded_keys.iter().any(|key| {
+            parts.first_key.as_slice() <= key.as_ref() && key.as_ref() <= parts.last_key.as_slice()
+        }));
+    }
     if let Some(inline) = manifest.inline_segment() {
         let leaf = decode_commit_delta_segment(inline, None, state.commit_id)?;
         for encoded_key in encoded_keys {
@@ -1244,6 +1261,7 @@ fn commit_delta_manifest_from_inventory(
         lifecycle_summary: inventory.lifecycle_summary.clone(),
         replacement_generation: inventory.replacement_generation.clone(),
         replacement_parts: inventory.replacement_parts.clone(),
+        columnar_parts: inventory.columnar_parts.clone(),
         inline_segment: inventory.inline_part.clone(),
         segments: inventory
             .parts
@@ -1706,6 +1724,7 @@ const COMMIT_DELTA_SMALL_STRING_DICTIONARY_LIMIT: usize = 32;
 #[derive(Debug, Default)]
 pub(crate) struct DecodedCommitDeltaBatch {
     arenas: Vec<DecodedLeafNodeRef>,
+    columnar_keys: Bytes,
     schema_keys: Vec<SharedStr>,
     file_ids: Vec<SharedStr>,
     rows: Vec<DecodedCommitDeltaRow>,
@@ -1716,10 +1735,11 @@ pub(crate) struct DecodedCommitDeltaBatch {
 struct DecodedCommitDeltaRow {
     arena_ordinal: u32,
     entry_ordinal: u16,
+    columnar_key: Option<BufferRange>,
     schema_key_ordinal: u32,
     /// `u32::MAX` is the null file-id sentinel.
     file_id_ordinal: u32,
-    entity_pk: crate::entity_pk::EntityPk,
+    entity_pk: EntityPk,
 }
 
 #[derive(Clone, Copy)]
@@ -1780,6 +1800,12 @@ impl<'a> DecodedCommitDeltaRowRef<'a> {
     #[cfg(test)]
     pub(crate) fn encoded_key(&self) -> Bytes {
         let row = &self.batch.rows[self.ordinal];
+        if let Some(range) = row.columnar_key {
+            return self
+                .batch
+                .columnar_keys
+                .slice(range.offset()..range.offset() + range.len());
+        }
         self.batch.arenas[row.arena_ordinal as usize]
             .entry_owned(row.entry_ordinal as usize)
             .expect("decoded commit-delta row references an existing leaf entry")
@@ -1792,6 +1818,9 @@ impl<'a> DecodedCommitDeltaRowRef<'a> {
     /// so it does not need a `Bytes` clone for every discovered mutation.
     pub(crate) fn encoded_key_ref(&self) -> &[u8] {
         let row = &self.batch.rows[self.ordinal];
+        if let Some(range) = row.columnar_key {
+            return &self.batch.columnar_keys[range.offset()..range.offset() + range.len()];
+        }
         self.batch.arenas[row.arena_ordinal as usize]
             .key(row.entry_ordinal as usize)
             .expect("decoded commit-delta key lookup cannot fail")
@@ -1848,6 +1877,7 @@ impl CommitDeltaStringInterner {
 
 struct DecodedCommitDeltaBatchBuilder {
     arenas: Vec<DecodedLeafNodeRef>,
+    columnar_keys: Vec<u8>,
     schema_keys: CommitDeltaStringInterner,
     file_ids: CommitDeltaStringInterner,
     rows: Vec<DecodedCommitDeltaRow>,
@@ -1858,6 +1888,7 @@ impl DecodedCommitDeltaBatchBuilder {
     fn with_capacity(row_capacity: usize, arena_capacity: usize) -> Self {
         Self {
             arenas: Vec::with_capacity(arena_capacity),
+            columnar_keys: Vec::new(),
             schema_keys: CommitDeltaStringInterner::new(row_capacity),
             file_ids: CommitDeltaStringInterner::new(row_capacity),
             rows: Vec::with_capacity(row_capacity),
@@ -1901,6 +1932,7 @@ impl DecodedCommitDeltaBatchBuilder {
             self.rows.push(DecodedCommitDeltaRow {
                 arena_ordinal,
                 entry_ordinal,
+                columnar_key: None,
                 schema_key_ordinal,
                 file_id_ordinal,
                 entity_pk: key.entity_pk,
@@ -1914,9 +1946,39 @@ impl DecodedCommitDeltaBatchBuilder {
         Ok(())
     }
 
+    fn push_columnar_row(
+        &mut self,
+        schema_key: &str,
+        entity_pk: EntityPk,
+        value: TrackedStateIndexValue,
+    ) -> Result<(), LixError> {
+        let schema_key_ordinal = self.schema_keys.intern(SharedStr::from(schema_key))?;
+        let start = self.columnar_keys.len();
+        encode_key_ref_into(
+            &mut self.columnar_keys,
+            TrackedStateKeyRef {
+                schema_key,
+                file_id: None,
+                entity_pk: &entity_pk,
+            },
+        );
+        let columnar_key = BufferRange::new(start, self.columnar_keys.len() - start);
+        self.rows.push(DecodedCommitDeltaRow {
+            arena_ordinal: u32::MAX,
+            entry_ordinal: 0,
+            columnar_key: Some(columnar_key),
+            schema_key_ordinal,
+            file_id_ordinal: u32::MAX,
+            entity_pk,
+        });
+        self.values.push(value);
+        Ok(())
+    }
+
     fn finish(self) -> DecodedCommitDeltaBatch {
         DecodedCommitDeltaBatch {
             arenas: self.arenas,
+            columnar_keys: Bytes::from(self.columnar_keys),
             schema_keys: self.schema_keys.values,
             file_ids: self.file_ids.values,
             rows: self.rows,
@@ -3084,6 +3146,7 @@ where
         lifecycle_summary,
         replacement_generation: None,
         replacement_parts: None,
+        columnar_parts: None,
         inline_segment: Vec::new(),
         segments: Vec::with_capacity(row_count.div_ceil(COMMIT_DELTA_SEGMENT_MAX_ROWS)),
     };
@@ -3210,6 +3273,70 @@ where
         row_count,
         mutation_inventory: commit_state_inventory_from_delta_manifest(&manifest),
     }))
+}
+
+/// Publishes a lossless identity-ordered entity generation as the commit's
+/// authored mutation payload without encoding a second LXCD JSON sidecar.
+/// The row-group set is staged by the current-state publisher in the same
+/// atomic write set; this function seals only its historical authority.
+pub(crate) fn stage_ordered_columnar_mutations(
+    commit_id: CommitId,
+    parts: crate::tracked_state::types::ColumnarMutationPartSet,
+    ordered_identity_digest: [u8; 32],
+) -> Result<OrderedAddressableCommitDeltaStage, LixError> {
+    let row_count = usize::try_from(parts.row_count).expect("u32 row count fits usize");
+    if row_count == 0
+        || parts.group_row_counts.is_empty()
+        || parts
+            .group_row_counts
+            .iter()
+            .map(|&count| u64::from(count))
+            .sum::<u64>()
+            != u64::from(parts.row_count)
+        || (row_count == 1 && parts.first_key != parts.last_key)
+        || (row_count > 1 && parts.first_key >= parts.last_key)
+        || parts.page_first_keys.len()
+            != row_count.div_ceil(crate::columnar_row_group::ROW_GROUP_PAGE_ROWS)
+        || parts.page_first_keys.len() != parts.page_last_keys.len()
+    {
+        return Err(replacement_payload_error(
+            "columnar mutation inventory has invalid row topology",
+        ));
+    }
+    let direct_part_row_counts = (0..row_count)
+        .step_by(COMMIT_DELTA_SEGMENT_MAX_ROWS)
+        .map(|offset| {
+            u16::try_from((row_count - offset).min(COMMIT_DELTA_SEGMENT_MAX_ROWS))
+                .expect("direct mutation segment row count fits u16")
+        })
+        .collect::<Vec<_>>();
+    let lifecycle_summary = CommitDeltaLifecycleSummary {
+        scope: CommitDeltaReplacementScope {
+            schema_key: parts.schema_key.clone(),
+            file_id: None,
+        },
+        ordered_identity_digest,
+        uniform_created_at: parts.uniform_created_at,
+    };
+    Ok(OrderedAddressableCommitDeltaStage {
+        commit_id,
+        change_addresses: OrderedChangeAddresses::Dense,
+        row_count,
+        mutation_inventory: CommitStateMutationInventory {
+            selected_source_commit_id: None,
+            member_count: parts.row_count,
+            selection_fingerprint: [0; 32],
+            direct_part_row_counts,
+            replacement_part_digests: Vec::new(),
+            single_partition: Some(lifecycle_summary.scope.clone()),
+            lifecycle_summary: Some(lifecycle_summary),
+            replacement_generation: None,
+            replacement_parts: None,
+            columnar_parts: Some(parts),
+            inline_part: Vec::new(),
+            parts: Vec::new(),
+        },
+    })
 }
 
 /// Publishes a complete replacement as compact immutable identity parts.
@@ -3427,6 +3554,7 @@ where
             commit_id, generation, &authority,
         )),
         replacement_parts: Some(authority),
+        columnar_parts: None,
         inline_segment: Vec::new(),
         segments: Vec::with_capacity(parts.len()),
     };
@@ -3868,6 +3996,7 @@ fn stage_commit_deltas_inner(
             lifecycle_summary: None,
             replacement_generation: None,
             replacement_parts: None,
+            columnar_parts: None,
             inline_segment,
             segments: Vec::new(),
         };
@@ -3894,6 +4023,7 @@ fn stage_commit_deltas_inner(
         lifecycle_summary: None,
         replacement_generation: None,
         replacement_parts: None,
+        columnar_parts: None,
         inline_segment: Vec::new(),
         segments: Vec::with_capacity(segment_count),
     };
@@ -4166,7 +4296,9 @@ async fn load_change_records_by_ids(
         // per selected change. Address-shaped explicit IDs are rare and keep
         // the established locator fallback below if candidate validation
         // rejects the direct route.
-        if let Ok(records) = load_change_records_at_locators(store, &direct_locators).await {
+        if let Ok(records) =
+            Box::pin(load_change_records_at_locators(store, &direct_locators)).await
+        {
             return Ok(records);
         }
     }
@@ -4215,7 +4347,7 @@ async fn load_change_records_by_ids(
             decode_change_locator(change_id, &bytes)
         })
         .collect::<Result<Vec<_>, _>>()?;
-    load_change_records_at_locators(store, &locators).await
+    Box::pin(load_change_records_at_locators(store, &locators)).await
 }
 
 fn load_change_record_by_id_boxed<'a, S>(
@@ -4257,11 +4389,87 @@ async fn load_change_records_at_locators(
         })
         .collect::<Result<BTreeMap<_, _>, LixError>>()?;
 
+    let mut loaded = (0..locators.len()).map(|_| None).collect::<Vec<_>>();
+    let mut columnar_by_commit = BTreeMap::<CommitId, Vec<usize>>::new();
+    for (locator_index, locator) in locators.iter().enumerate() {
+        if manifests[&locator.commit_id].columnar_parts.is_some() {
+            columnar_by_commit
+                .entry(locator.commit_id)
+                .or_default()
+                .push(locator_index);
+        }
+    }
+    for (commit_id, locator_indices) in columnar_by_commit {
+        let parts = manifests[&commit_id]
+            .columnar_parts
+            .as_ref()
+            .expect("columnar locator group was selected from this manifest");
+        let id = crate::columnar_row_group::RowGroupSetId::new(parts.row_group_set_id);
+        let row_group_manifest = crate::columnar_row_group::load_row_group_manifest(store, id)
+            .await?
+            .ok_or_else(|| replacement_payload_error("columnar mutation manifest is missing"))?;
+        validate_columnar_mutation_manifest(&row_group_manifest, parts)?;
+        let projection = (0..row_group_manifest.fields.len()).collect::<Vec<_>>();
+        let mut page_groups = BTreeMap::<(usize, usize), Vec<(usize, usize)>>::new();
+        for locator_index in locator_indices {
+            let locator = locators[locator_index];
+            let logical_ordinal = usize::try_from(locator.segment_index)
+                .expect("u32 segment fits usize")
+                .checked_mul(COMMIT_DELTA_SEGMENT_MAX_ROWS)
+                .and_then(|base| base.checked_add(usize::from(locator.ordinal)))
+                .ok_or_else(|| replacement_payload_error("columnar mutation address overflows"))?;
+            if logical_ordinal >= parts.row_count as usize {
+                return Err(replacement_payload_error(
+                    "columnar mutation locator is outside its inventory",
+                ));
+            }
+            let packed = u32::try_from(logical_ordinal)
+                .map_err(|_| replacement_payload_error("columnar mutation address exceeds u32"))?
+                .checked_add(1)
+                .ok_or_else(|| replacement_payload_error("columnar mutation address overflows"))?;
+            if locator.change_id != change_id_from_packed_address(commit_id, packed) {
+                return Err(replacement_payload_error(
+                    "columnar mutation locator change id disagrees with its ordinal",
+                ));
+            }
+            let group_index = logical_ordinal / crate::columnar_row_group::ROW_GROUP_MAX_ROWS;
+            let row_in_group = logical_ordinal % crate::columnar_row_group::ROW_GROUP_MAX_ROWS;
+            let page_index = row_in_group / crate::columnar_row_group::ROW_GROUP_PAGE_ROWS;
+            let row_in_page = row_in_group % crate::columnar_row_group::ROW_GROUP_PAGE_ROWS;
+            page_groups
+                .entry((group_index, page_index))
+                .or_default()
+                .push((locator_index, row_in_page));
+        }
+        for ((group_index, page_index), page_locators) in page_groups {
+            let batch = crate::columnar_row_group::load_row_group_page(
+                store,
+                id,
+                &row_group_manifest,
+                group_index,
+                page_index,
+                &projection,
+            )
+            .await?;
+            for (locator_index, row_in_page) in page_locators {
+                let locator = locators[locator_index];
+                loaded[locator_index] = Some(decode_columnar_change_record(
+                    &row_group_manifest,
+                    &batch,
+                    row_in_page,
+                    parts,
+                    locator.change_id,
+                    &manifests[&commit_id].account_id,
+                )?);
+            }
+        }
+    }
+
     let routes = locators
         .iter()
         .filter_map(|locator| {
             let manifest = &manifests[&locator.commit_id];
-            manifest.inline_segment().is_none().then_some((
+            (manifest.columnar_parts.is_none() && manifest.inline_segment().is_none()).then_some((
                 locator.commit_id,
                 usize::try_from(locator.segment_index).expect("u32 fits usize"),
             ))
@@ -4313,6 +4521,9 @@ async fn load_change_records_at_locators(
 
     let mut locator_groups = BTreeMap::<(CommitId, usize), Vec<usize>>::new();
     for (locator_index, locator) in locators.iter().enumerate() {
+        if manifests[&locator.commit_id].columnar_parts.is_some() {
+            continue;
+        }
         locator_groups
             .entry((
                 locator.commit_id,
@@ -4321,7 +4532,6 @@ async fn load_change_records_at_locators(
             .or_default()
             .push(locator_index);
     }
-    let mut loaded = (0..locators.len()).map(|_| None).collect::<Vec<_>>();
     for ((commit_id, segment_index), locator_indices) in locator_groups {
         let manifest = &manifests[&commit_id];
         let (bytes, bounds) = if let Some(inline) = manifest.inline_segment() {
@@ -4344,18 +4554,21 @@ async fn load_change_records_at_locators(
         let (leaf, payloads) = decode_commit_delta_with_payloads(bytes, bounds)?;
         for locator_index in locator_indices {
             let locator = locators[locator_index];
-            loaded[locator_index] = Some(decode_change_at_locator_from_decoded(
-                &leaf,
-                &payloads,
-                locator,
-                &manifest.account_id,
-            )?);
+            loaded[locator_index] = Some(
+                decode_change_at_locator_from_decoded(
+                    &leaf,
+                    &payloads,
+                    locator,
+                    &manifest.account_id,
+                )?
+                .change_record,
+            );
         }
     }
     loaded
         .into_iter()
         .map(|entry| {
-            entry.map(|entry| entry.change_record).ok_or_else(|| {
+            entry.ok_or_else(|| {
                 LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
                     "tracked_state authoritative change unexpectedly disappeared",
@@ -4477,6 +4690,11 @@ async fn try_load_change_record_at_locator_in_manifest(
     locator: CommitDeltaChangeLocator,
     manifest: &CommitDeltaManifest,
 ) -> Result<Option<crate::changelog::ChangeRecord>, LixError> {
+    if let Some(parts) = manifest.columnar_parts.as_ref() {
+        return load_columnar_change_record_at_locator(store, locator, parts, &manifest.account_id)
+            .await
+            .map(Some);
+    }
     let change_id = locator.change_id;
     let (segment, bounds) = if let Some(inline) = manifest.inline_segment() {
         if locator.segment_index != 0 {
@@ -4530,6 +4748,199 @@ async fn try_load_change_record_at_locator_in_manifest(
     Ok(Some(
         decode_change_at_locator(&segment, bounds, locator, &manifest.account_id)?.change_record,
     ))
+}
+
+async fn load_columnar_change_record_at_locator(
+    store: &(impl StorageAdapterRead + ?Sized),
+    locator: CommitDeltaChangeLocator,
+    parts: &crate::tracked_state::types::ColumnarMutationPartSet,
+    account_id: &str,
+) -> Result<crate::changelog::ChangeRecord, LixError> {
+    let logical_ordinal = usize::try_from(locator.segment_index)
+        .expect("u32 segment fits usize")
+        .checked_mul(COMMIT_DELTA_SEGMENT_MAX_ROWS)
+        .and_then(|base| base.checked_add(usize::from(locator.ordinal)))
+        .ok_or_else(|| replacement_payload_error("columnar mutation address overflows"))?;
+    if logical_ordinal >= parts.row_count as usize {
+        return Err(replacement_payload_error(
+            "columnar mutation address is outside its inventory",
+        ));
+    }
+    let expected_change_id = change_id_from_packed_address(
+        locator.commit_id,
+        u32::try_from(logical_ordinal)
+            .map_err(|_| replacement_payload_error("columnar mutation address exceeds u32"))?
+            .checked_add(1)
+            .ok_or_else(|| replacement_payload_error("columnar mutation address overflows"))?,
+    );
+    if locator.change_id != expected_change_id {
+        return Err(replacement_payload_error(
+            "columnar mutation locator change id disagrees with its ordinal",
+        ));
+    }
+    let mut group_base = 0usize;
+    let (group_index, row_index) = parts
+        .group_row_counts
+        .iter()
+        .enumerate()
+        .find_map(|(group_index, &row_count)| {
+            let group_end = group_base + row_count as usize;
+            let result = (logical_ordinal < group_end)
+                .then_some((group_index, logical_ordinal - group_base));
+            group_base = group_end;
+            result
+        })
+        .ok_or_else(|| replacement_payload_error("columnar mutation group is missing"))?;
+    let id = crate::columnar_row_group::RowGroupSetId::new(parts.row_group_set_id);
+    let manifest = crate::columnar_row_group::load_row_group_manifest(store, id)
+        .await?
+        .ok_or_else(|| replacement_payload_error("columnar mutation manifest is missing"))?;
+    validate_columnar_mutation_manifest(&manifest, parts)?;
+    let projection = (0..manifest.fields.len()).collect::<Vec<_>>();
+    let page_index = row_index / crate::columnar_row_group::ROW_GROUP_PAGE_ROWS;
+    let page_row_index = row_index % crate::columnar_row_group::ROW_GROUP_PAGE_ROWS;
+    let batch = crate::columnar_row_group::load_row_group_page(
+        store,
+        id,
+        &manifest,
+        group_index,
+        page_index,
+        &projection,
+    )
+    .await?;
+    decode_columnar_change_record(
+        &manifest,
+        &batch,
+        page_row_index,
+        parts,
+        locator.change_id,
+        account_id,
+    )
+}
+
+fn validate_columnar_mutation_manifest(
+    manifest: &crate::columnar_row_group::RowGroupManifest,
+    parts: &crate::tracked_state::types::ColumnarMutationPartSet,
+) -> Result<(), LixError> {
+    let owner = CommitId::new(uuid::Uuid::from_bytes(parts.owner_commit_id));
+    if crate::live_state::entity_row_group_set_id(owner, &parts.schema_key).as_bytes()
+        != parts.row_group_set_id
+        || manifest.content_digest()? != parts.manifest_digest
+        || manifest.namespace != parts.schema_key
+        || manifest
+            .metadata
+            .get(crate::sql2::ENTITY_COLUMNAR_LOSSLESS_SNAPSHOT_METADATA_KEY)
+            .map(String::as_str)
+            != Some("true")
+        || manifest
+            .groups
+            .iter()
+            .map(|group| group.row_count)
+            .collect::<Vec<_>>()
+            != parts.group_row_counts
+        || manifest.fields.last().map(|field| field.name.as_str())
+            != Some(crate::sql2::ENTITY_COLUMNAR_ENTITY_PK_FIELD)
+    {
+        return Err(replacement_payload_error(
+            "columnar mutation manifest disagrees with commit authority",
+        ));
+    }
+    Ok(())
+}
+
+fn decode_columnar_change_record(
+    manifest: &crate::columnar_row_group::RowGroupManifest,
+    batch: &datafusion::arrow::record_batch::RecordBatch,
+    row_index: usize,
+    parts: &crate::tracked_state::types::ColumnarMutationPartSet,
+    change_id: crate::changelog::ChangeId,
+    account_id: &str,
+) -> Result<crate::changelog::ChangeRecord, LixError> {
+    use datafusion::arrow::array::{Array, BooleanArray, Float64Array, Int64Array, StringArray};
+
+    let identity_column = batch
+        .column(batch.num_columns() - 1)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| replacement_payload_error("columnar mutation identity is not UTF-8"))?;
+    if identity_column.is_null(row_index) {
+        return Err(replacement_payload_error(
+            "columnar mutation identity is null",
+        ));
+    }
+    let entity_pk = EntityPk::from_json_array_text(identity_column.value(row_index))
+        .map_err(|error| replacement_payload_error(&error.to_string()))?;
+    let mut snapshot = serde_json::Map::new();
+    for (column_index, field) in manifest
+        .fields
+        .iter()
+        .take(manifest.fields.len() - 1)
+        .enumerate()
+    {
+        let column = batch.column(column_index);
+        let value = if column.is_null(row_index) {
+            serde_json::Value::Null
+        } else {
+            match field.data_type {
+                crate::columnar_row_group::RowGroupDataType::String => {
+                    let value = column
+                        .as_any()
+                        .downcast_ref::<StringArray>()
+                        .ok_or_else(|| replacement_payload_error("columnar string type drift"))?
+                        .value(row_index);
+                    if field.metadata.get("lix.value_type").map(String::as_str) == Some("json") {
+                        serde_json::from_str(value).map_err(|error| {
+                            replacement_payload_error(&format!(
+                                "columnar JSON value is invalid: {error}"
+                            ))
+                        })?
+                    } else {
+                        serde_json::Value::String(value.to_owned())
+                    }
+                }
+                crate::columnar_row_group::RowGroupDataType::Int64 => serde_json::Value::Number(
+                    column
+                        .as_any()
+                        .downcast_ref::<Int64Array>()
+                        .ok_or_else(|| replacement_payload_error("columnar integer type drift"))?
+                        .value(row_index)
+                        .into(),
+                ),
+                crate::columnar_row_group::RowGroupDataType::Float64 => {
+                    let value = column
+                        .as_any()
+                        .downcast_ref::<Float64Array>()
+                        .ok_or_else(|| replacement_payload_error("columnar number type drift"))?
+                        .value(row_index);
+                    serde_json::Number::from_f64(value)
+                        .map(serde_json::Value::Number)
+                        .ok_or_else(|| replacement_payload_error("columnar number is non-finite"))?
+                }
+                crate::columnar_row_group::RowGroupDataType::Boolean => serde_json::Value::Bool(
+                    column
+                        .as_any()
+                        .downcast_ref::<BooleanArray>()
+                        .ok_or_else(|| replacement_payload_error("columnar boolean type drift"))?
+                        .value(row_index),
+                ),
+            }
+        };
+        snapshot.insert(field.name.clone(), value);
+    }
+    let snapshot = serde_json::to_string(&snapshot)
+        .map_err(|error| replacement_payload_error(&error.to_string()))?;
+    Ok(crate::changelog::ChangeRecord {
+        account_id: account_id.to_string(),
+        format_version: 2,
+        change_id,
+        schema_key: parts.schema_key.clone(),
+        entity_pk,
+        file_id: None,
+        snapshot: crate::json_store::JsonSlot::from_json(&snapshot),
+        metadata: crate::json_store::JsonSlot::None,
+        created_at: parts.uniform_updated_at,
+        origin_key: parts.origin_key.clone(),
+    })
 }
 
 pub(crate) fn decode_change_locator(
@@ -4922,6 +5333,15 @@ async fn load_local_commit_delta_values_encoded(
     if encoded_keys.is_empty() {
         return Ok(Vec::new());
     }
+    if let Some(parts) = manifest.columnar_parts.as_ref() {
+        return Box::pin(load_columnar_mutation_values_encoded(
+            store,
+            commit_id,
+            encoded_keys,
+            parts,
+        ))
+        .await;
+    }
     let mut values = vec![None; encoded_keys.len()];
     if let Some(inline_segment) = manifest.inline_segment() {
         let leaf = decode_commit_delta_segment(inline_segment, None, commit_id)?;
@@ -4994,6 +5414,223 @@ async fn load_local_commit_delta_values_encoded(
         }
     }
     Ok(values)
+}
+
+async fn load_columnar_mutation_values_encoded(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+    encoded_keys: &[Bytes],
+    parts: &crate::tracked_state::types::ColumnarMutationPartSet,
+) -> Result<Vec<Option<TrackedStateIndexValue>>, LixError> {
+    use datafusion::arrow::array::{Array, StringArray};
+
+    let id = crate::columnar_row_group::RowGroupSetId::new(parts.row_group_set_id);
+    let manifest = crate::columnar_row_group::load_row_group_manifest(store, id)
+        .await?
+        .ok_or_else(|| replacement_payload_error("columnar mutation manifest is missing"))?;
+    validate_columnar_mutation_manifest(&manifest, parts)?;
+    let identity_column_index = manifest.fields.len() - 1;
+    let identities = encoded_keys
+        .iter()
+        .map(|encoded| {
+            let key = decode_key(encoded)?;
+            if key.schema_key != parts.schema_key || key.file_id.is_some() {
+                return Ok(None);
+            }
+            key.entity_pk.as_json_array_text().map(Some)
+        })
+        .collect::<Result<Vec<_>, LixError>>()?;
+    let mut grouped = BTreeMap::<(usize, usize), Vec<(usize, &str)>>::new();
+    for (output_index, identity) in identities.iter().enumerate() {
+        let Some(identity) = identity.as_deref() else {
+            continue;
+        };
+        if let Some((group_index, page_index, _global_page)) =
+            columnar_mutation_page_for_key(parts, &encoded_keys[output_index])
+        {
+            grouped
+                .entry((group_index, page_index))
+                .or_default()
+                .push((output_index, identity));
+        }
+    }
+    let mut output = vec![None; encoded_keys.len()];
+    for ((group_index, page_index), requests) in grouped {
+        let batch = crate::columnar_row_group::load_row_group_page(
+            store,
+            id,
+            &manifest,
+            group_index,
+            page_index,
+            &[identity_column_index],
+        )
+        .await?;
+        let column = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| replacement_payload_error("columnar mutation identity type drift"))?;
+        if column.null_count() != 0 {
+            return Err(replacement_payload_error(
+                "columnar mutation identity contains nulls",
+            ));
+        }
+        let row_by_identity = (requests.len() > 8).then(|| {
+            (0..column.len())
+                .map(|row_index| (column.value(row_index), row_index))
+                .collect::<HashMap<_, _>>()
+        });
+        for (output_index, identity) in requests {
+            let row_index = match &row_by_identity {
+                Some(rows) => rows.get(identity).copied(),
+                None => (0..column.len()).find(|&row_index| column.value(row_index) == identity),
+            };
+            let Some(row_index) = row_index else {
+                continue;
+            };
+            let global_ordinal = group_index
+                .saturating_mul(crate::columnar_row_group::ROW_GROUP_MAX_ROWS)
+                .saturating_add(
+                    page_index.saturating_mul(crate::columnar_row_group::ROW_GROUP_PAGE_ROWS),
+                )
+                .saturating_add(row_index);
+            let packed = u32::try_from(global_ordinal)
+                .map_err(|_| replacement_payload_error("columnar mutation address exceeds u32"))?
+                + 1;
+            output[output_index] = Some(TrackedStateIndexValue {
+                change_id: change_id_from_packed_address(commit_id, packed),
+                commit_id,
+                deleted: false,
+                created_at: parts.uniform_created_at,
+                updated_at: parts.uniform_updated_at,
+            });
+        }
+    }
+    Ok(output)
+}
+
+fn columnar_mutation_page_for_key(
+    parts: &crate::tracked_state::types::ColumnarMutationPartSet,
+    encoded_key: &[u8],
+) -> Option<(usize, usize, usize)> {
+    let global_page = parts
+        .page_first_keys
+        .partition_point(|first| first.as_slice() <= encoded_key)
+        .checked_sub(1)?;
+    if encoded_key > parts.page_last_keys[global_page].as_slice() {
+        return None;
+    }
+    let pages_per_group = crate::columnar_row_group::ROW_GROUP_MAX_ROWS
+        / crate::columnar_row_group::ROW_GROUP_PAGE_ROWS;
+    Some((
+        global_page / pages_per_group,
+        global_page % pages_per_group,
+        global_page,
+    ))
+}
+
+async fn load_columnar_owned_entries(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+    keys: &[TrackedStateKeyRef<'_>],
+    parts: &crate::tracked_state::types::ColumnarMutationPartSet,
+    account_id: &str,
+) -> Result<Vec<Option<LoadedCommitDeltaEntry>>, LixError> {
+    use datafusion::arrow::array::{Array, StringArray};
+
+    let id = crate::columnar_row_group::RowGroupSetId::new(parts.row_group_set_id);
+    let manifest = crate::columnar_row_group::load_row_group_manifest(store, id)
+        .await?
+        .ok_or_else(|| replacement_payload_error("columnar mutation manifest is missing"))?;
+    validate_columnar_mutation_manifest(&manifest, parts)?;
+    let identity_column_index = manifest.fields.len() - 1;
+    let mut grouped = BTreeMap::<(usize, usize), Vec<(usize, String)>>::new();
+    for (output_index, key) in keys.iter().enumerate() {
+        if key.schema_key != parts.schema_key || key.file_id.is_some() {
+            continue;
+        }
+        let identity = key.entity_pk.as_json_array_text()?;
+        let encoded_key = encode_key_ref(*key);
+        if let Some((group_index, page_index, _global_page)) =
+            columnar_mutation_page_for_key(parts, &encoded_key)
+        {
+            grouped
+                .entry((group_index, page_index))
+                .or_default()
+                .push((output_index, identity));
+        }
+    }
+    let projection = (0..manifest.fields.len()).collect::<Vec<_>>();
+    let mut output = (0..keys.len()).map(|_| None).collect::<Vec<_>>();
+    for ((group_index, page_index), requests) in grouped {
+        let batch = crate::columnar_row_group::load_row_group_page(
+            store,
+            id,
+            &manifest,
+            group_index,
+            page_index,
+            &projection,
+        )
+        .await?;
+        let identities = batch
+            .column(identity_column_index)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| replacement_payload_error("columnar mutation identity type drift"))?;
+        if identities.null_count() != 0 {
+            return Err(replacement_payload_error(
+                "columnar mutation identity contains nulls",
+            ));
+        }
+        let row_by_identity = (requests.len() > 8).then(|| {
+            (0..identities.len())
+                .map(|row_index| (identities.value(row_index), row_index))
+                .collect::<HashMap<_, _>>()
+        });
+        for (output_index, identity) in requests {
+            let row_index = match &row_by_identity {
+                Some(rows) => rows.get(identity.as_str()).copied(),
+                None => {
+                    (0..identities.len()).find(|&row_index| identities.value(row_index) == identity)
+                }
+            };
+            let Some(row_index) = row_index else {
+                continue;
+            };
+            let row_index_in_group = page_index
+                .saturating_mul(crate::columnar_row_group::ROW_GROUP_PAGE_ROWS)
+                .saturating_add(row_index);
+            let global_ordinal = group_index
+                .saturating_mul(crate::columnar_row_group::ROW_GROUP_MAX_ROWS)
+                .saturating_add(row_index_in_group);
+            let packed = u32::try_from(global_ordinal)
+                .map_err(|_| replacement_payload_error("columnar mutation address exceeds u32"))?
+                .checked_add(1)
+                .ok_or_else(|| replacement_payload_error("columnar mutation address overflows"))?;
+            let change_id = change_id_from_packed_address(commit_id, packed);
+            output[output_index] = Some(LoadedCommitDeltaEntry {
+                value: TrackedStateIndexValue {
+                    change_id,
+                    commit_id,
+                    deleted: false,
+                    created_at: parts.uniform_created_at,
+                    updated_at: parts.uniform_updated_at,
+                },
+                change_record: decode_columnar_change_record(
+                    &manifest, &batch, row_index, parts, change_id, account_id,
+                )?,
+                base_coordinate: Some(TrackedStateBaseCoordinate {
+                    base_commit_id: commit_id,
+                    group_index: u32::try_from(group_index)
+                        .expect("columnar mutation group fits u32"),
+                    row_index: u32::try_from(row_index_in_group)
+                        .expect("columnar mutation row fits u32"),
+                }),
+                selected_ref: false,
+            });
+        }
+    }
+    Ok(output)
 }
 
 /// Loads authoritative change records for exact identities in one physical
@@ -5133,6 +5770,13 @@ async fn load_commit_delta_members_from_manifest(
     manifest: &CommitDeltaManifest,
     schema_keys: &[String],
 ) -> Result<Vec<CommitDeltaMember>, LixError> {
+    if let Some(parts) = manifest.columnar_parts.as_ref() {
+        if !schema_keys.is_empty() && !schema_keys.iter().any(|schema| schema == &parts.schema_key)
+        {
+            return Ok(Vec::new());
+        }
+        return load_columnar_mutation_members(store, commit_id, parts, &manifest.account_id).await;
+    }
     let requested_schemas = schema_keys
         .iter()
         .map(String::as_str)
@@ -5186,6 +5830,77 @@ async fn load_commit_delta_members_from_manifest(
         members.retain(|member| requested_schemas.contains(member.key.schema_key.as_str()));
     }
     hydrate_selected_members(store, &mut members).await?;
+    validate_commit_delta_member_order_and_ids(commit_id, &members)?;
+    Ok(members)
+}
+
+async fn load_columnar_mutation_members(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+    parts: &crate::tracked_state::types::ColumnarMutationPartSet,
+    account_id: &str,
+) -> Result<Vec<CommitDeltaMember>, LixError> {
+    let id = crate::columnar_row_group::RowGroupSetId::new(parts.row_group_set_id);
+    let manifest = crate::columnar_row_group::load_row_group_manifest(store, id)
+        .await?
+        .ok_or_else(|| replacement_payload_error("columnar mutation manifest is missing"))?;
+    validate_columnar_mutation_manifest(&manifest, parts)?;
+    let projection = (0..manifest.fields.len()).collect::<Vec<_>>();
+    let mut members = Vec::with_capacity(parts.row_count as usize);
+    for group_index in 0..manifest.groups.len() {
+        let batch = crate::columnar_row_group::load_row_group_batch(
+            store,
+            id,
+            &manifest,
+            group_index,
+            &projection,
+        )
+        .await?;
+        for row_index in 0..batch.num_rows() {
+            let global_ordinal = members.len();
+            let packed = u32::try_from(global_ordinal)
+                .map_err(|_| replacement_payload_error("columnar mutation address exceeds u32"))?
+                .checked_add(1)
+                .ok_or_else(|| replacement_payload_error("columnar mutation address overflows"))?;
+            let change_id = change_id_from_packed_address(commit_id, packed);
+            let change = decode_columnar_change_record(
+                &manifest, &batch, row_index, parts, change_id, account_id,
+            )?;
+            let key = TrackedStateKey {
+                schema_key: parts.schema_key.clone(),
+                file_id: None,
+                entity_pk: change.entity_pk.clone(),
+            };
+            members.push(CommitDeltaMember {
+                key,
+                value: TrackedStateIndexValue {
+                    change_id,
+                    commit_id,
+                    deleted: false,
+                    created_at: parts.uniform_created_at,
+                    updated_at: parts.uniform_updated_at,
+                },
+                change,
+                segment_index: u32::try_from(global_ordinal / COMMIT_DELTA_SEGMENT_MAX_ROWS)
+                    .expect("columnar mutation segment fits u32"),
+                ordinal: u32::try_from(global_ordinal % COMMIT_DELTA_SEGMENT_MAX_ROWS)
+                    .expect("columnar mutation ordinal fits u32"),
+                authored: true,
+                base_coordinate: Some(TrackedStateBaseCoordinate {
+                    base_commit_id: commit_id,
+                    group_index: u32::try_from(group_index)
+                        .expect("columnar mutation group fits u32"),
+                    row_index: u32::try_from(row_index).expect("columnar mutation row fits u32"),
+                }),
+                selected_tombstone: false,
+            });
+        }
+    }
+    if members.len() != parts.row_count as usize {
+        return Err(replacement_payload_error(
+            "columnar mutation rows disagree with commit authority",
+        ));
+    }
     validate_commit_delta_member_order_and_ids(commit_id, &members)?;
     Ok(members)
 }
@@ -5425,6 +6140,32 @@ async fn load_local_owned_commit_delta_entries(
         let request_indices = request_indices_by_commit
             .get(&commit_id)
             .expect("manifest commit came from the requested commit set");
+        if let Some(parts) = manifest.columnar_parts.as_ref() {
+            let keys = request_indices
+                .iter()
+                .map(|&request_index| {
+                    let key = &requests[request_index].1;
+                    TrackedStateKeyRef {
+                        schema_key: &key.schema_key,
+                        file_id: key.file_id.as_deref(),
+                        entity_pk: &key.entity_pk,
+                    }
+                })
+                .collect::<Vec<_>>();
+            for (&request_index, entry) in request_indices.iter().zip(
+                Box::pin(load_columnar_owned_entries(
+                    store,
+                    commit_id,
+                    &keys,
+                    parts,
+                    &manifest.account_id,
+                ))
+                .await?,
+            ) {
+                output[request_index] = entry;
+            }
+            continue;
+        }
         if let Some(inline_segment) = manifest.inline_segment() {
             let (leaf, payloads) = decode_commit_delta_with_payloads(inline_segment, None)?;
             for &request_index in request_indices {
@@ -5782,6 +6523,16 @@ async fn load_local_owned_commit_delta_entries_one_ordered(
             }
         }
     };
+    if let Some(parts) = manifest.columnar_parts.as_ref() {
+        return Box::pin(load_columnar_owned_entries(
+            store,
+            commit_id,
+            keys,
+            parts,
+            &manifest.account_id,
+        ))
+        .await;
+    }
     let mut output = (0..keys.len()).map(|_| None).collect::<Vec<_>>();
     if let Some(inline_segment) = manifest.inline_segment() {
         if keys.len() <= DECODED_COMMIT_DELTA_CACHE_MAX_POINT_KEYS
@@ -6207,6 +6958,12 @@ async fn scan_local_commit_delta_values(
         .iter()
         .map(String::as_str)
         .collect::<BTreeSet<_>>();
+    if let Some(parts) = manifest.columnar_parts.as_ref() {
+        if !requested_schemas.is_empty() && !requested_schemas.contains(parts.schema_key.as_str()) {
+            return Ok(DecodedCommitDeltaBatch::default());
+        }
+        return scan_columnar_mutation_values(store, commit_id, parts).await;
+    }
     if let Some(inline_segment) = manifest.inline_segment() {
         let leaf = decode_commit_delta_leaf(inline_segment, None)?;
         let mut batch = DecodedCommitDeltaBatchBuilder::with_capacity(leaf.len(), 1);
@@ -6254,6 +7011,67 @@ async fn scan_local_commit_delta_values(
     Ok(batch.finish())
 }
 
+async fn scan_columnar_mutation_values(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+    parts: &crate::tracked_state::types::ColumnarMutationPartSet,
+) -> Result<DecodedCommitDeltaBatch, LixError> {
+    use datafusion::arrow::array::{Array, StringArray};
+
+    let id = crate::columnar_row_group::RowGroupSetId::new(parts.row_group_set_id);
+    let manifest = crate::columnar_row_group::load_row_group_manifest(store, id)
+        .await?
+        .ok_or_else(|| replacement_payload_error("columnar mutation manifest is missing"))?;
+    validate_columnar_mutation_manifest(&manifest, parts)?;
+    let identity_column_index = manifest.fields.len() - 1;
+    let mut builder = DecodedCommitDeltaBatchBuilder::with_capacity(
+        parts.row_count as usize,
+        (parts.row_count as usize).div_ceil(COMMIT_DELTA_SEGMENT_MAX_ROWS),
+    );
+    let mut global_ordinal = 0usize;
+    for group_index in 0..manifest.groups.len() {
+        let batch = crate::columnar_row_group::load_row_group_batch(
+            store,
+            id,
+            &manifest,
+            group_index,
+            &[identity_column_index],
+        )
+        .await?;
+        let identities = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| replacement_payload_error("columnar mutation identity type drift"))?;
+        for row_index in 0..identities.len() {
+            let entity_pk = EntityPk::from_json_array_text(identities.value(row_index))
+                .map_err(|error| replacement_payload_error(&error.to_string()))?;
+            let packed = u32::try_from(global_ordinal)
+                .map_err(|_| replacement_payload_error("columnar mutation address exceeds u32"))?
+                .checked_add(1)
+                .ok_or_else(|| replacement_payload_error("columnar mutation address overflows"))?;
+            builder.push_columnar_row(
+                &parts.schema_key,
+                entity_pk,
+                TrackedStateIndexValue {
+                    change_id: change_id_from_packed_address(commit_id, packed),
+                    commit_id,
+                    deleted: false,
+                    created_at: parts.uniform_created_at,
+                    updated_at: parts.uniform_updated_at,
+                },
+            )?;
+            global_ordinal += 1;
+        }
+    }
+    if global_ordinal != parts.row_count as usize {
+        return Err(replacement_payload_error(
+            "columnar mutation rows disagree with commit authority",
+        ));
+    }
+    Ok(builder.finish())
+}
+
 fn merge_selected_source_batches(
     mut source: DecodedCommitDeltaBatch,
     mut local: DecodedCommitDeltaBatch,
@@ -6277,36 +7095,39 @@ fn merge_selected_source_batches(
             "selected-source commit delta has too many file ids",
         )
     })?;
+    let columnar_key_offset = source.columnar_keys.len();
     let mut entries = BTreeMap::<Vec<u8>, (DecodedCommitDeltaRow, TrackedStateIndexValue)>::new();
-    for (row, mut value) in source.rows.drain(..).zip(source.values.drain(..)) {
-        let key = source.arenas[row.arena_ordinal as usize]
-            .key(row.entry_ordinal as usize)?
-            .ok_or_else(|| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "selected-source commit delta references a missing source key",
-                )
-            })?
-            .to_vec();
+    let source_rows = std::mem::take(&mut source.rows);
+    let source_values = std::mem::take(&mut source.values);
+    for (row, mut value) in source_rows.into_iter().zip(source_values) {
+        let key = decoded_commit_delta_row_key(&source, &row)?.to_vec();
         value.commit_id = commit_id;
         entries.insert(key, (row, value));
     }
-    for (mut row, value) in local.rows.drain(..).zip(local.values.drain(..)) {
-        let key = local.arenas[row.arena_ordinal as usize]
-            .key(row.entry_ordinal as usize)?
-            .ok_or_else(|| {
+    let local_rows = std::mem::take(&mut local.rows);
+    let local_values = std::mem::take(&mut local.values);
+    for (mut row, value) in local_rows.into_iter().zip(local_values) {
+        let key = decoded_commit_delta_row_key(&local, &row)?.to_vec();
+        if let Some(range) = row.columnar_key {
+            let shifted_offset =
+                range
+                    .offset()
+                    .checked_add(columnar_key_offset)
+                    .ok_or_else(|| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            "commit delta columnar key offset overflow",
+                        )
+                    })?;
+            row.columnar_key = Some(BufferRange::new(shifted_offset, range.len()));
+        } else {
+            row.arena_ordinal = row.arena_ordinal.checked_add(arena_offset).ok_or_else(|| {
                 LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
-                    "selected-source commit delta references a missing local key",
+                    "commit delta arena ordinal overflow",
                 )
-            })?
-            .to_vec();
-        row.arena_ordinal = row.arena_ordinal.checked_add(arena_offset).ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                "commit delta arena ordinal overflow",
-            )
-        })?;
+            })?;
+        }
         row.schema_key_ordinal = row
             .schema_key_ordinal
             .checked_add(schema_offset)
@@ -6329,6 +7150,15 @@ fn merge_selected_source_batches(
         }
         entries.insert(key, (row, value));
     }
+    let mut columnar_keys = Vec::with_capacity(
+        source
+            .columnar_keys
+            .len()
+            .saturating_add(local.columnar_keys.len()),
+    );
+    columnar_keys.extend_from_slice(&source.columnar_keys);
+    columnar_keys.extend_from_slice(&local.columnar_keys);
+    source.columnar_keys = Bytes::from(columnar_keys);
     source.arenas.append(&mut local.arenas);
     source.schema_keys.append(&mut local.schema_keys);
     source.file_ids.append(&mut local.file_ids);
@@ -6337,6 +7167,34 @@ fn merge_selected_source_batches(
         source.values.push(value);
     }
     Ok(source)
+}
+
+fn decoded_commit_delta_row_key<'a>(
+    batch: &'a DecodedCommitDeltaBatch,
+    row: &DecodedCommitDeltaRow,
+) -> Result<&'a [u8], LixError> {
+    if let Some(range) = row.columnar_key {
+        return batch
+            .columnar_keys
+            .get(range.offset()..range.offset().saturating_add(range.len()))
+            .ok_or_else(|| replacement_payload_error("columnar mutation key range is invalid"));
+    }
+    batch
+        .arenas
+        .get(row.arena_ordinal as usize)
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "selected-source commit delta references a missing arena",
+            )
+        })?
+        .key(row.entry_ordinal as usize)?
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "selected-source commit delta references a missing key",
+            )
+        })
 }
 
 /// Answers schema membership from the packed commit directory.
@@ -6368,6 +7226,9 @@ async fn local_commit_delta_contains_schema(
     let Some(manifest) = load_commit_delta_manifest(store, commit_id).await? else {
         return Ok(false);
     };
+    if let Some(parts) = manifest.columnar_parts.as_ref() {
+        return Ok(parts.schema_key == schema_key);
+    }
     if let Some(inline_segment) = manifest.inline_segment() {
         let leaf = decode_commit_delta_leaf(inline_segment, None)?;
         let mut found = false;
@@ -6471,6 +7332,19 @@ pub(crate) async fn visit_change_records_from_commit_deltas(
             })?;
             validate_commit_state_semantic_seal(&state, &seal)?;
             let manifest = expanded_commit_delta_manifest_from_commit_state(store, &state).await?;
+            if let Some(parts) = manifest.columnar_parts.as_ref() {
+                emitted = emitted.saturating_add(
+                    visit_columnar_mutation_change_records(
+                        store,
+                        commit_id,
+                        parts,
+                        &manifest.account_id,
+                        &mut visit,
+                    )
+                    .await?,
+                );
+                continue;
+            }
             let members =
                 load_commit_delta_members_from_manifest(store, commit_id, &manifest, &[]).await?;
             for member in members {
@@ -6518,6 +7392,58 @@ pub(crate) async fn visit_change_records_from_commit_deltas(
     }
     validate_no_orphan_commit_delta_segments(store).await?;
     Ok(emitted)
+}
+
+async fn visit_columnar_mutation_change_records(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+    parts: &crate::tracked_state::types::ColumnarMutationPartSet,
+    account_id: &str,
+    visit: &mut impl FnMut(crate::changelog::ChangeRecord) -> Result<(), LixError>,
+) -> Result<usize, LixError> {
+    let id = crate::columnar_row_group::RowGroupSetId::new(parts.row_group_set_id);
+    let manifest = crate::columnar_row_group::load_row_group_manifest(store, id)
+        .await?
+        .ok_or_else(|| replacement_payload_error("columnar mutation manifest is missing"))?;
+    validate_columnar_mutation_manifest(&manifest, parts)?;
+    let projection = (0..manifest.fields.len()).collect::<Vec<_>>();
+    let mut global_ordinal = 0usize;
+    for (group_index, group) in manifest.groups.iter().enumerate() {
+        let page_count =
+            (group.row_count as usize).div_ceil(crate::columnar_row_group::ROW_GROUP_PAGE_ROWS);
+        for page_index in 0..page_count {
+            let batch = crate::columnar_row_group::load_row_group_page(
+                store,
+                id,
+                &manifest,
+                group_index,
+                page_index,
+                &projection,
+            )
+            .await?;
+            for row_index in 0..batch.num_rows() {
+                let packed = u32::try_from(global_ordinal)
+                    .map_err(|_| {
+                        replacement_payload_error("columnar mutation address exceeds u32")
+                    })?
+                    .checked_add(1)
+                    .ok_or_else(|| {
+                        replacement_payload_error("columnar mutation address overflows")
+                    })?;
+                let change_id = change_id_from_packed_address(commit_id, packed);
+                visit(decode_columnar_change_record(
+                    &manifest, &batch, row_index, parts, change_id, account_id,
+                )?)?;
+                global_ordinal += 1;
+            }
+        }
+    }
+    if global_ordinal != parts.row_count as usize {
+        return Err(replacement_payload_error(
+            "columnar mutation rows disagree with commit authority",
+        ));
+    }
+    Ok(global_ordinal)
 }
 
 async fn validate_no_orphan_commit_delta_segments(
@@ -6626,9 +7552,17 @@ pub(crate) async fn scan_commit_delta_inventory(
     for (&commit_id, manifest) in &manifests {
         let physical_segments = segments.remove(&commit_id).unwrap_or_default();
         let physical_segment_keys = segment_keys.remove(&commit_id).unwrap_or_default();
-        let segment_count = manifest.segments.len();
         let mut members = Vec::new();
-        if let Some(inline_segment) = manifest.inline_segment() {
+        let segment_count = if let Some(parts) = manifest.columnar_parts.as_ref() {
+            if !physical_segments.is_empty() {
+                return Err(replacement_payload_error(
+                    "columnar mutation inventory has legacy external segments",
+                ));
+            }
+            members = load_columnar_mutation_members(store, commit_id, parts, &manifest.account_id)
+                .await?;
+            parts.group_row_counts.len()
+        } else if let Some(inline_segment) = manifest.inline_segment() {
             if !physical_segments.is_empty() {
                 return Err(LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
@@ -6645,6 +7579,7 @@ pub(crate) async fn scan_commit_delta_inventory(
                 &manifest.account_id,
                 &mut members,
             )?;
+            1
         } else {
             validate_physical_commit_delta_segments(
                 commit_id,
@@ -6662,7 +7597,8 @@ pub(crate) async fn scan_commit_delta_inventory(
                     &mut members,
                 )?;
             }
-        }
+            manifest.segments.len()
+        };
         hydrate_selected_members(store, &mut members).await?;
         validate_commit_delta_member_order_and_ids(commit_id, &members)?;
         inventory.commits.insert(
@@ -7443,7 +8379,9 @@ fn validate_commit_delta_manifest(manifest: &CommitDeltaManifest) -> Result<(), 
                 "tracked_state commit_delta manifest has an invalid dense address inventory",
             ));
         }
-        let expected_segment_count = if manifest.inline_segment.is_empty() {
+        let expected_segment_count = if manifest.columnar_parts.is_some() {
+            manifest.direct_segment_row_counts.len()
+        } else if manifest.inline_segment.is_empty() {
             manifest.segments.len()
         } else {
             1
@@ -7454,6 +8392,16 @@ fn validate_commit_delta_manifest(manifest: &CommitDeltaManifest) -> Result<(), 
                 "tracked_state commit_delta dense address inventory does not match its segments",
             ));
         }
+    }
+    if let Some(parts) = manifest.columnar_parts.as_ref() {
+        let actual_single_partition =
+            single_partition_from_bounds(&parts.first_key, &parts.last_key)?;
+        if manifest.single_partition != actual_single_partition {
+            return Err(replacement_payload_error(
+                "columnar mutation partition certificate does not match its bounds",
+            ));
+        }
+        return Ok(());
     }
     if !manifest.inline_segment.is_empty() {
         if !manifest.segments.is_empty() {
@@ -8894,6 +9842,64 @@ fn validate_commit_state_mutation_inventory(
             "tracked_state commit_state_manifest selects itself as a mutation source",
         ));
     }
+    if let Some(columnar) = inventory.columnar_parts.as_ref() {
+        if inventory.selected_source_commit_id.is_some()
+            || !inventory.inline_part.is_empty()
+            || !inventory.parts.is_empty()
+            || !inventory.replacement_part_digests.is_empty()
+            || inventory.replacement_generation.is_some()
+            || inventory.replacement_parts.is_some()
+            || inventory.single_partition.as_ref().is_none_or(|scope| {
+                scope.schema_key != columnar.schema_key || scope.file_id.is_some()
+            })
+            || columnar.owner_commit_id != *commit_id.as_uuid().as_bytes()
+            || columnar.row_group_set_id
+                != crate::live_state::entity_row_group_set_id(commit_id, &columnar.schema_key)
+                    .as_bytes()
+            || columnar.manifest_digest == [0; 32]
+            || columnar.schema_key.is_empty()
+            || columnar.row_count != inventory.member_count
+            || columnar.group_row_counts.is_empty()
+            || columnar.group_row_counts.iter().any(|&rows| {
+                rows == 0 || rows as usize > crate::columnar_row_group::ROW_GROUP_MAX_ROWS
+            })
+            || columnar
+                .group_row_counts
+                .iter()
+                .map(|&rows| u64::from(rows))
+                .sum::<u64>()
+                != u64::from(columnar.row_count)
+            || columnar.first_key.is_empty()
+            || columnar.last_key.is_empty()
+            || columnar.first_key > columnar.last_key
+            || columnar.page_first_keys.len()
+                != (columnar.row_count as usize)
+                    .div_ceil(crate::columnar_row_group::ROW_GROUP_PAGE_ROWS)
+            || columnar.page_first_keys.len() != columnar.page_last_keys.len()
+            || columnar
+                .page_first_keys
+                .iter()
+                .zip(&columnar.page_last_keys)
+                .any(|(first, last)| first.is_empty() || first > last)
+            || columnar
+                .page_last_keys
+                .iter()
+                .zip(columnar.page_first_keys.iter().skip(1))
+                .any(|(last, first)| last >= first)
+            || columnar.page_first_keys.first() != Some(&columnar.first_key)
+            || columnar.page_last_keys.last() != Some(&columnar.last_key)
+            || inventory.lifecycle_summary.as_ref().is_none_or(|summary| {
+                summary.scope.schema_key != columnar.schema_key
+                    || summary.scope.file_id.is_some()
+                    || summary.uniform_created_at != columnar.uniform_created_at
+            })
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state commit_state_manifest has an invalid columnar mutation inventory",
+            ));
+        }
+    }
     if !inventory.inline_part.is_empty()
         && (!inventory.parts.is_empty() || !inventory.replacement_part_digests.is_empty())
     {
@@ -8939,7 +9945,7 @@ fn validate_commit_state_mutation_inventory(
     }
     if !inventory.direct_part_row_counts.is_empty() {
         let direct_rows = &inventory.direct_part_row_counts;
-        if direct_rows.len() != inventory.part_count()
+        if (inventory.columnar_parts.is_none() && direct_rows.len() != inventory.part_count())
             || direct_rows
                 .iter()
                 .any(|&rows| rows == 0 || usize::from(rows) > COMMIT_DELTA_SEGMENT_MAX_ROWS)
@@ -8959,11 +9965,12 @@ fn validate_commit_state_mutation_inventory(
         && inventory.lifecycle_summary.is_none()
         && inventory.replacement_generation.is_none()
         && inventory.replacement_parts.is_none()
+        && inventory.columnar_parts.is_none()
         && inventory.replacement_part_digests.is_empty()
         && inventory.inline_part.is_empty()
         && inventory.parts.is_empty();
     if !is_empty {
-        if inventory.replacement_part_digests.is_empty() {
+        if inventory.replacement_part_digests.is_empty() && inventory.columnar_parts.is_none() {
             validate_commit_delta_manifest(&commit_delta_manifest_from_inventory(inventory))?;
         }
         if inventory
@@ -11359,6 +12366,65 @@ mod tests {
         assert_eq!(canonical.len(), 3);
     }
 
+    #[test]
+    fn selected_source_merge_preserves_columnar_key_arenas() {
+        let source_commit = CommitId::for_test_label("columnar-selected-source");
+        let alias_commit = CommitId::for_test_label("columnar-selected-alias");
+        let timestamp = LixTimestamp::from_unix_millis_utc_lossy(7);
+        let mut source = super::DecodedCommitDeltaBatchBuilder::with_capacity(2, 0);
+        for identity in ["a", "c"] {
+            source
+                .push_columnar_row(
+                    "columnar-selected-schema",
+                    EntityPk::single(identity),
+                    TrackedStateIndexValue {
+                        change_id: ChangeId::for_test_label(&format!("source-{identity}")),
+                        commit_id: source_commit,
+                        deleted: false,
+                        created_at: timestamp,
+                        updated_at: timestamp,
+                    },
+                )
+                .expect("source columnar row should append");
+        }
+        let mut local = super::DecodedCommitDeltaBatchBuilder::with_capacity(2, 0);
+        for identity in ["b", "c"] {
+            local
+                .push_columnar_row(
+                    "columnar-selected-schema",
+                    EntityPk::single(identity),
+                    TrackedStateIndexValue {
+                        change_id: ChangeId::for_test_label(&format!("local-{identity}")),
+                        commit_id: alias_commit,
+                        deleted: false,
+                        created_at: timestamp,
+                        updated_at: timestamp,
+                    },
+                )
+                .expect("local columnar row should append");
+        }
+
+        let merged =
+            super::merge_selected_source_batches(source.finish(), local.finish(), alias_commit)
+                .expect("selected-source merge should preserve both columnar key arenas");
+        let rows = decoded_commit_delta_rows(&merged);
+        assert_eq!(
+            rows.iter()
+                .map(|(key, _)| key.entity_pk.as_single_string().unwrap())
+                .collect::<Vec<_>>(),
+            vec!["a", "b", "c"]
+        );
+        assert!(
+            rows.iter()
+                .all(|(_, value)| value.commit_id == alias_commit)
+        );
+        assert_eq!(
+            rows[2].1.change_id,
+            ChangeId::for_test_label("local-c"),
+            "local mutations must override selected-source identities"
+        );
+    }
+
     fn decoded_commit_delta_rows(
         batch: &DecodedCommitDeltaBatch,
     ) -> Vec<(TrackedStateKey, TrackedStateIndexValue)> {
@@ -11714,6 +12780,7 @@ mod tests {
             lifecycle_summary: None,
             replacement_generation: None,
             replacement_parts: None,
+            columnar_parts: None,
             inline_segment: segment,
             segments: Vec::new(),
         };
@@ -12612,6 +13679,7 @@ mod tests {
             lifecycle_summary: None,
             replacement_generation: None,
             replacement_parts: None,
+            columnar_parts: None,
             inline_segment: encode_commit_delta_segment(&entries),
             segments: Vec::new(),
         };
@@ -12928,6 +13996,7 @@ mod tests {
                 lifecycle_summary: None,
                 replacement_generation: None,
                 replacement_parts: None,
+                columnar_parts: None,
                 inline_part: encode_commit_delta_segment(&[entry]),
                 parts: Vec::new(),
             },

--- a/packages/engine/src/tracked_state/types.rs
+++ b/packages/engine/src/tracked_state/types.rs
@@ -196,6 +196,33 @@ pub(crate) struct CommitStateMutationPart {
     pub(crate) replacement_part: Option<StoredReplacementPart>,
 }
 
+/// One lossless entity-columnar generation used directly as authored history.
+///
+/// The row-group manifest binds every column digest. Uniform lifecycle and
+/// origin metadata remain in the commit authority instead of being repeated
+/// in every row. Direct change addresses retain their established 512-row
+/// logical slots and translate to these larger physical groups by ordinal.
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+pub(crate) struct ColumnarMutationPartSet {
+    pub(crate) owner_commit_id: [u8; 16],
+    pub(crate) row_group_set_id: [u8; 16],
+    pub(crate) manifest_digest: [u8; 32],
+    pub(crate) schema_key: String,
+    pub(crate) row_count: u32,
+    pub(crate) group_row_counts: Vec<u32>,
+    #[musli(bytes)]
+    pub(crate) first_key: Vec<u8>,
+    #[musli(bytes)]
+    pub(crate) last_key: Vec<u8>,
+    pub(crate) page_first_keys: Vec<Vec<u8>>,
+    pub(crate) page_last_keys: Vec<Vec<u8>>,
+    pub(crate) uniform_created_at: LixTimestamp,
+    pub(crate) uniform_updated_at: LixTimestamp,
+    #[musli(with = crate::storage_codec::option)]
+    pub(crate) origin_key: Option<String>,
+}
+
 /// One collection partition replaced by a certified immutable generation.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, musli::Encode, musli::Decode)]
 #[musli(packed)]
@@ -365,6 +392,11 @@ pub(crate) struct CommitStateMutationInventory {
     pub(crate) replacement_generation: Option<StoredCommitDeltaReplacementGeneration>,
     #[musli(with = crate::storage_codec::option)]
     pub(crate) replacement_parts: Option<StoredReplacementPartsAuthority>,
+    /// Lossless typed post-images that are both the authored mutation payload
+    /// and the serving columnar source. When present, legacy LXCD parts are
+    /// forbidden rather than retained as a compatibility copy.
+    #[musli(with = crate::storage_codec::option)]
+    pub(crate) columnar_parts: Option<ColumnarMutationPartSet>,
     /// Tiny commits retain their only part inline so an exact history lookup
     /// remains one backend point read.
     #[musli(bytes)]
@@ -379,7 +411,10 @@ impl CommitStateMutationInventory {
     }
 
     pub(crate) fn part_count(&self) -> usize {
-        usize::from(!self.inline_part.is_empty())
+        self.columnar_parts
+            .as_ref()
+            .map_or(0, |parts| parts.group_row_counts.len())
+            + usize::from(!self.inline_part.is_empty())
             + if self.replacement_part_digests.is_empty() {
                 self.parts.len()
             } else {

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -302,7 +302,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         deleted_checkpoint_files.remove(&(write.branch_id.clone(), write.file_id.clone()));
     }
     let mut insert_selection = prepared_writes.insert_selection;
-    let entity_columnar_write_sets = prepare_entity_columnar_write_sets(
+    let mut entity_columnar_write_sets = prepare_entity_columnar_write_sets(
         &mut state_rows,
         &insert_selection,
         entity_schema_catalog,
@@ -569,7 +569,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         read,
         &mut writes,
         &mut state_rows,
-        &entity_columnar_write_sets,
+        &mut entity_columnar_write_sets,
         &row_index.tracked_row_indices_by_commit,
         &tracked_roots,
         &commit_rows,
@@ -2005,7 +2005,7 @@ async fn stage_tracked_commit_delta_index(
     read: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
     state_rows: &mut PreparedStateBatch,
-    entity_columnar_write_sets: &crate::live_state::EntityColumnarWriteSets,
+    entity_columnar_write_sets: &mut crate::live_state::EntityColumnarWriteSets,
     tracked_row_indices_by_commit: &BTreeMap<CommitId, Vec<RowIndex>>,
     tracked_roots: &[PendingTrackedRoot],
     commit_rows: &[FinalizedCommitRow],
@@ -2134,58 +2134,71 @@ async fn stage_tracked_commit_delta_index(
                 )
                 .entered();
                 let state_rows = &*state_rows;
-                let make_delta = |row_index| {
-                    let row = state_rows.row(row_index);
-                    let mut delta = tracked_commit_delta_from_state_row(row)?;
-                    if let Some(created_at) = lifecycle_created_at {
-                        delta.delta.created_at = created_at;
-                    }
-                    delta.base_coordinate = entity_columnar_write_sets
-                        .state_row_location(row_index)
-                        .map(
-                            |location| crate::tracked_state::TrackedStateBaseCoordinate {
-                                base_commit_id: root.commit_id,
-                                group_index: location.group_index,
-                                row_index: location.row_index,
-                            },
-                        );
-                    Ok(delta)
-                };
                 let order_certified = state_rows.certified_tracked_keys_strictly_ordered()
                     && state_row_indices.len() == state_rows.len()
                     && state_row_indices
                         .iter()
                         .enumerate()
                         .all(|(index, &row_index)| index == row_index);
-                let replacement_stage = if let Some(generation) = replacement_generation {
-                    if !order_certified {
-                        return Err(LixError::new(
-                            LixError::CODE_INTERNAL_ERROR,
-                            "complete replacement generation is not in canonical identity order",
-                        ));
-                    }
-                    Some(
-                        crate::tracked_state::stage_ordered_addressable_replacement_parts(
+                if replacement_generation.is_none()
+                    && order_certified
+                    && let Some(stage) = try_stage_lossless_columnar_mutations(
+                        writes,
+                        root.commit_id,
+                        state_rows,
+                        state_row_indices,
+                        entity_columnar_write_sets,
+                    )?
+                {
+                    Some(stage)
+                } else {
+                    let make_delta = |row_index| {
+                        let row = state_rows.row(row_index);
+                        let mut delta = tracked_commit_delta_from_state_row(row)?;
+                        if let Some(created_at) = lifecycle_created_at {
+                            delta.delta.created_at = created_at;
+                        }
+                        delta.base_coordinate = entity_columnar_write_sets
+                            .state_row_location(row_index)
+                            .map(
+                                |location| crate::tracked_state::TrackedStateBaseCoordinate {
+                                    base_commit_id: root.commit_id,
+                                    group_index: location.group_index,
+                                    row_index: location.row_index,
+                                },
+                            );
+                        Ok(delta)
+                    };
+                    let replacement_stage = if let Some(generation) = replacement_generation {
+                        if !order_certified {
+                            return Err(LixError::new(
+                                LixError::CODE_INTERNAL_ERROR,
+                                "complete replacement generation is not in canonical identity order",
+                            ));
+                        }
+                        Some(
+                            crate::tracked_state::stage_ordered_addressable_replacement_parts(
+                                writes,
+                                state_row_indices
+                                    .iter()
+                                    .map(|&row_index| make_delta(row_index)),
+                                generation,
+                            )?,
+                        )
+                    } else {
+                        None
+                    };
+                    match replacement_stage {
+                        Some(stage) => Some(stage),
+                        None => stage_ordered_addressable_commit_deltas(
                             writes,
                             state_row_indices
                                 .iter()
                                 .map(|&row_index| make_delta(row_index)),
-                            generation,
+                            order_certified,
+                            publish_lifecycle_summary,
                         )?,
-                    )
-                } else {
-                    None
-                };
-                match replacement_stage {
-                    Some(stage) => Some(stage),
-                    None => stage_ordered_addressable_commit_deltas(
-                        writes,
-                        state_row_indices
-                            .iter()
-                            .map(|&row_index| make_delta(row_index)),
-                        order_certified,
-                        publish_lifecycle_summary,
-                    )?,
+                    }
                 }
             };
             if let Some(ordered_stage) = ordered_stage {
@@ -2380,6 +2393,126 @@ async fn stage_tracked_commit_delta_index(
         ordered_addressable_commits,
         inventories,
     })
+}
+
+fn try_stage_lossless_columnar_mutations(
+    writes: &mut StorageWriteSet,
+    commit_id: CommitId,
+    state_rows: &PreparedStateBatch,
+    state_row_indices: &[RowIndex],
+    entity_columnar_write_sets: &mut crate::live_state::EntityColumnarWriteSets,
+) -> Result<Option<crate::tracked_state::OrderedAddressableCommitDeltaStage>, LixError> {
+    if state_row_indices.is_empty()
+        || entity_columnar_write_sets.dense_state_row_count() != Some(state_row_indices.len())
+    {
+        return Ok(None);
+    }
+    let first = state_rows.row(state_row_indices[0]);
+    let Some(encoded) = entity_columnar_write_sets.get(&(commit_id, first.schema_key.to_string()))
+    else {
+        return Ok(None);
+    };
+    if encoded
+        .manifest
+        .metadata
+        .get(crate::sql2::ENTITY_COLUMNAR_LOSSLESS_SNAPSHOT_METADATA_KEY)
+        .map(String::as_str)
+        != Some("true")
+        || encoded.manifest.row_count()
+            != u64::try_from(state_row_indices.len()).expect("row count fits u64")
+    {
+        return Ok(None);
+    }
+    let mut identity_digest = blake3::Hasher::new();
+    for &row_index in state_row_indices {
+        let row = state_rows.row(row_index);
+        if row.schema_key != first.schema_key
+            || row.file_id.is_some()
+            || row.snapshot.is_none()
+            || row.metadata.is_some()
+            || row.created_at != first.created_at
+            || row.updated_at != first.updated_at
+            || row.origin_key != first.origin_key
+            || row.commit_id != Some(commit_id)
+            || row.untracked
+            || row.global
+        {
+            return Ok(None);
+        }
+        let Ok(identity) = row.entity_pk.as_single_string() else {
+            return Ok(None);
+        };
+        identity_digest.update(&(identity.len() as u64).to_le_bytes());
+        identity_digest.update(identity.as_bytes());
+    }
+    let last = state_rows.row(*state_row_indices.last().expect("non-empty rows"));
+    let mut page_first_keys = Vec::new();
+    let mut page_last_keys = Vec::new();
+    for page in state_row_indices.chunks(crate::columnar_row_group::ROW_GROUP_PAGE_ROWS) {
+        let page_first = state_rows.row(page[0]);
+        let page_last = state_rows.row(*page.last().expect("non-empty mutation page"));
+        page_first_keys.push(encode_key_ref(TrackedStateKeyRef {
+            schema_key: page_first.schema_key.as_str(),
+            file_id: None,
+            entity_pk: page_first.entity_pk,
+        }));
+        page_last_keys.push(encode_key_ref(TrackedStateKeyRef {
+            schema_key: page_last.schema_key.as_str(),
+            file_id: None,
+            entity_pk: page_last.entity_pk,
+        }));
+    }
+    let parts = crate::tracked_state::ColumnarMutationPartSet {
+        owner_commit_id: *commit_id.as_uuid().as_bytes(),
+        row_group_set_id: crate::live_state::entity_row_group_set_id(
+            commit_id,
+            first.schema_key.as_str(),
+        )
+        .as_bytes(),
+        manifest_digest: encoded.manifest.content_digest()?,
+        schema_key: first.schema_key.to_string(),
+        row_count: u32::try_from(state_row_indices.len()).map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "columnar mutation row count exceeds u32",
+            )
+        })?,
+        group_row_counts: encoded
+            .manifest
+            .groups
+            .iter()
+            .map(|group| group.row_count)
+            .collect(),
+        first_key: encode_key_ref(TrackedStateKeyRef {
+            schema_key: first.schema_key.as_str(),
+            file_id: None,
+            entity_pk: first.entity_pk,
+        }),
+        last_key: encode_key_ref(TrackedStateKeyRef {
+            schema_key: last.schema_key.as_str(),
+            file_id: None,
+            entity_pk: last.entity_pk,
+        }),
+        page_first_keys,
+        page_last_keys,
+        uniform_created_at: first.created_at,
+        uniform_updated_at: first.updated_at,
+        origin_key: first.origin_key.map(ToString::to_string),
+    };
+    let encoded = entity_columnar_write_sets
+        .take(&(commit_id, first.schema_key.to_string()))
+        .expect("qualified columnar mutation set remains staged exactly once");
+    crate::columnar_row_group::stage_row_group_set(
+        writes,
+        crate::columnar_row_group::RowGroupSetId::new(parts.row_group_set_id),
+        &encoded,
+    )?;
+    crate::tracked_state::stage_ordered_columnar_mutations(
+        commit_id,
+        parts,
+        *identity_digest.finalize().as_bytes(),
+    )
+    .map(Some)
 }
 
 async fn certify_complete_replacement_generations(
@@ -4645,12 +4778,22 @@ fn prepare_entity_columnar_write_sets(
                     && row_groups.input_locations.len() == state_rows.len()
             });
         if layout_is_current {
-            let mut encoded =
-                crate::live_state::EntityColumnarWriteSets::with_state_row_count(state_rows.len());
             let (row_group_set, input_locations) = row_groups.into_parts();
-            for (state_row_index, location) in input_locations.into_iter().enumerate() {
-                encoded.set_state_row_location(state_row_index, location);
-            }
+            let mut encoded = match input_locations {
+                crate::sql2::EntityRowGroupLocations::Dense { row_count } => {
+                    crate::live_state::EntityColumnarWriteSets::with_dense_state_rows(row_count)
+                }
+                crate::sql2::EntityRowGroupLocations::Explicit(locations) => {
+                    let mut encoded =
+                        crate::live_state::EntityColumnarWriteSets::with_state_row_count(
+                            state_rows.len(),
+                        );
+                    for (state_row_index, location) in locations.into_iter().enumerate() {
+                        encoded.set_state_row_location(state_row_index, location);
+                    }
+                    encoded
+                }
+            };
             encoded.insert((commit_id, schema_key), row_group_set);
             return Ok(encoded);
         }
@@ -4674,7 +4817,7 @@ fn prepare_entity_columnar_write_sets(
             crate::live_state::EntityColumnarWriteSets::with_state_row_count(state_rows.len());
         if let Some(row_groups) = crate::sql2::encode_registered_entity_row_groups(&spec, rows)? {
             let (row_group_set, input_locations) = row_groups.into_parts();
-            for (state_row_index, location) in input_locations.into_iter().enumerate() {
+            for (state_row_index, location) in input_locations.iter().enumerate() {
                 encoded.set_state_row_location(state_row_index, location);
             }
             encoded.insert((commit_id, schema_key.to_string()), row_group_set);
@@ -4723,7 +4866,7 @@ fn prepare_entity_columnar_write_sets(
         });
         if let Some(row_groups) = crate::sql2::encode_registered_entity_row_groups(&spec, rows)? {
             let (row_group_set, input_locations) = row_groups.into_parts();
-            for (&state_row_index, location) in row_indices.iter().zip(input_locations) {
+            for (&state_row_index, location) in row_indices.iter().zip(input_locations.iter()) {
                 encoded.set_state_row_location(state_row_index, location);
             }
             encoded.insert((commit_id, schema_key), row_group_set);
@@ -6418,11 +6561,12 @@ mod tests {
         let large_snapshot_ref = certified_json_refs[&commit_id][0]
             .snapshot
             .expect("large certified snapshot should use a JSON ref");
+        let mut entity_columnar_write_sets = crate::live_state::EntityColumnarWriteSets::new();
         let staged_index = stage_tracked_commit_delta_index(
             &read,
             &mut writes,
             &mut state_rows,
-            &crate::live_state::EntityColumnarWriteSets::new(),
+            &mut entity_columnar_write_sets,
             &BTreeMap::from([(commit_id, vec![0])]),
             &roots,
             &commits,


### PR DESCRIPTION
## What changed

Hard-cut the tracked mutation format so large lossless ordered entity INSERTs publish their already-sealed column pages as the sole authored mutation payload.

- adds `ColumnarMutationPartSet` to the authoritative `CommitStateMutationInventory`
- seals 64K logical row groups as independently compressed 2K-row pages with authenticated page fences and digests
- routes exact reads, schema scans, history, diff, change lookup, replay, and GC directly through those pages
- reuses the same row-group bytes for current state and mutation history instead of reconstructing a second LXCD JSON sidecar
- streams canonical history page-by-page and carries encoded identity keys in one shared arena
- hard-cuts the durable codec to LXCS4/LXRGM004; no compatibility decoder is retained
- preserves selected-source, account-attribution, and successive-generation semantics across columnar inventories

## Why

The profiled bottleneck was duplicate commit preparation: a typed INSERT first encoded columnar current-state pages, then rebuilt the same million rows into generic mutation segments and decoded those segments again for history and scans. The immutable column pages are now the content-addressed mutation authority, so commit publication stages one payload and one atomic manifest.

## Performance

Exact previous-PR baseline: `origin/main` at `a002f2ece`; median release measurements.

| 1M rows | Previous | This PR | Change |
|---|---:|---:|---:|
| RocksDB INSERT | 2.088 s | 1.065 s | **-49.0%** |
| SlateDB INSERT | 1.501 s | 1.066 s | **-29.0%** |
| RocksDB SELECT all | 840.8 ms | 420.1 ms | **-50.0%** |
| SlateDB SELECT all | 983.0 ms | 444.6 ms | **-54.8%** |
| RocksDB history | 4.418 s | 1.756 s | **-60.3%** |
| SlateDB history | 4.799 s | 1.685 s | **-64.9%** |
| RocksDB diff | 2.767 s | 2.060 s | **-25.6%** |
| SlateDB diff | 2.831 s | 2.065 s | **-27.0%** |

At 10K, INSERT, history, and diff remain within ±2.2% of the exact baseline. Single-row SELECT remains within the 5% no-regression gate: RocksDB +2.0%, SlateDB +4.7%.

For 1M INSERT:

- staged puts: 2,051 → 1,516 (**-26.1%**)
- staged value bytes: 42.217 MB → 12.025 MB (**-71.5%**)
- allocated bytes: RocksDB **-35.9%**, SlateDB **-35.9%**
- peak RSS: RocksDB -0.02%, SlateDB -0.4%

## Validation

- `RUST_MIN_STACK=8388608 cargo test -p lix_engine --lib` — 1,878 passed
- `cargo test -p lix_engine --test integration` — 440 passed
- `cargo clippy -p lix_engine --features storage-benches --all-targets -- -D warnings`
- `cargo clippy -p lix_engine_benchmarks --bench tracked_state_crud --features storage-benches,slatedb -- -D warnings`
- 65,537-row attributed lifecycle regression crosses page and logical-group boundaries and covers current state, diff, history, sparse updates, checkpoint, branch, undo/redo, merge, and fail-closed missing authority
- selected-source columnar arena merge and two successive 1,024-row columnar INSERT generations are covered

Current main independently overflows the default local test-harness stack in one whole-collection delete test; reproduced on a clean `895e4456d` worktree and tracked in #1189. The test and full suite pass with the bounded 8 MiB harness stack above.

No changenote: this is an internal no-backward-compat storage-layout cut.