### PR TITLE
Make ordered update membership linear

### DIFF
--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -2587,12 +2587,14 @@ where
                     .as_ref()
                     .and_then(|transaction| transaction.prepared_literal_mutation_shape())
             {
-                if let Some(decoded_values) =
-                    self.sql_planning_cache.decode_update_literals_for_shape(
+                if let Some(decoded_values) = self
+                    .sql_planning_cache
+                    .decode_update_literals_for_cached_shape(
                         sql,
                         normalized_shape,
                         parameter_count,
                         &mut self.prepared_literal_escape_scratch,
+                        &mut self.prepared_literal_shape,
                     )
                 {
                     let transaction = self
@@ -9192,18 +9194,18 @@ mod tests {
             .expect("transaction should begin");
         let first = transaction
             .execute(
-                "UPDATE lix_key_value SET value = 'first''s value' WHERE key = 'auto''one'",
+                "UPDATE lix_key_value SET value = 'second''s value' WHERE key = 'auto''two'",
                 &[],
             )
             .await
             .expect("first literal update should stage");
         let second = transaction
             .execute(
-                "UPDATE lix_key_value SET value = 'second''s value' WHERE key = 'auto''two'",
+                "UPDATE lix_key_value SET value = 'first''s value' WHERE key = 'auto''one'",
                 &[],
             )
             .await
-            .expect("second literal update should reuse the statement shape");
+            .expect("descending literal update should cross the order barrier");
         assert_eq!(first.rows_affected(), 1);
         assert_eq!(second.rows_affected(), 1);
         transaction
@@ -9229,6 +9231,59 @@ mod tests {
         assert_eq!(
             values.rows()[1].get::<serde_json::Value>("value").unwrap(),
             serde_json::json!("second's value")
+        );
+    }
+
+    #[tokio::test]
+    async fn explicit_transaction_parameter_updates_reset_membership_on_descending_keys() {
+        let session = open_session().await;
+        for key in ["parameter-a", "parameter-z"] {
+            session
+                .execute(
+                    "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
+                    &[
+                        Value::Text(key.to_string()),
+                        Value::Text("seed".to_string()),
+                    ],
+                )
+                .await
+                .expect("seed row should commit");
+        }
+
+        let mut transaction = session.begin_transaction().await.unwrap();
+        let sql = "UPDATE lix_key_value SET value = $1 WHERE key = $2";
+        for (key, value) in [("parameter-z", "updated-z"), ("parameter-a", "updated-a")] {
+            assert_eq!(
+                transaction
+                    .execute(
+                        sql,
+                        &[Value::Text(value.to_string()), Value::Text(key.to_string()),],
+                    )
+                    .await
+                    .expect("descending parameter update should stage")
+                    .rows_affected(),
+                1
+            );
+        }
+        transaction.commit().await.unwrap();
+
+        let values = session
+            .execute(
+                "SELECT key, value FROM lix_key_value WHERE key IN ($1, $2) ORDER BY key",
+                &[
+                    Value::Text("parameter-a".to_string()),
+                    Value::Text("parameter-z".to_string()),
+                ],
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            values.rows()[0].get::<serde_json::Value>("value").unwrap(),
+            serde_json::json!("updated-a")
+        );
+        assert_eq!(
+            values.rows()[1].get::<serde_json::Value>("value").unwrap(),
+            serde_json::json!("updated-z")
         );
     }
 

--- a/packages/engine/src/session/transaction.rs
+++ b/packages/engine/src/session/transaction.rs
@@ -37,6 +37,7 @@ pub struct SessionTransaction<StorageImpl: Storage + 'static = Memory> {
     /// Reusable storage only for SQL literals containing doubled quote
     /// escapes. Ordinary warm literals continue to borrow the SQL text.
     pub(super) prepared_literal_escape_scratch: SmallVec<[String; 4]>,
+    pub(super) prepared_literal_shape: crate::sql2::CachedUpdateLiteralShape,
 }
 
 impl<StorageImpl> SessionContext<StorageImpl>
@@ -97,6 +98,7 @@ where
             telemetry: self.telemetry.clone(),
             has_started_statement: false,
             prepared_literal_escape_scratch: SmallVec::new(),
+            prepared_literal_shape: crate::sql2::CachedUpdateLiteralShape::default(),
         })
     }
 }

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -86,7 +86,7 @@ pub(crate) use file_view::{
 };
 pub(crate) use parse::parse_statement;
 pub(crate) use plan::plan_write;
-pub(crate) use planning_cache::{CachedReadPlan, SqlPlanningCache};
+pub(crate) use planning_cache::{CachedReadPlan, CachedUpdateLiteralShape, SqlPlanningCache};
 pub(crate) use providers::{
     ExactLixFileReadColumn, ExactLixFileReadSelector, FastLixFilePathWriteConflict,
     execute_exact_lix_directory_root_listing, execute_exact_lix_file_batch_read,

--- a/packages/engine/src/sql2/planning_cache.rs
+++ b/packages/engine/src/sql2/planning_cache.rs
@@ -63,6 +63,16 @@ pub(crate) struct AutoParameterizedUpdate {
     pub(crate) params: Vec<Value>,
 }
 
+#[derive(Default)]
+pub(crate) struct CachedUpdateLiteralShape {
+    shape_address: usize,
+    shape_len: usize,
+    prefix_end: usize,
+    middle_start: usize,
+    middle_end: usize,
+    suffix_start: usize,
+}
+
 /// Bounded, engine-owned cache for snapshot-independent SQL planning templates.
 ///
 /// Parsed statements depend only on the exact SQL text. Bound write plans also
@@ -282,6 +292,53 @@ where
             sql,
             normalized_shape,
             parameter_count,
+            escape_scratch,
+        )
+    }
+
+    pub(crate) fn decode_update_literals_for_cached_shape<'a>(
+        &self,
+        sql: &'a str,
+        normalized_shape: &str,
+        parameter_count: usize,
+        escape_scratch: &mut SmallVec<[String; 4]>,
+        cached_shape: &mut CachedUpdateLiteralShape,
+    ) -> Option<SmallVec<[Cow<'a, str>; 4]>> {
+        if parameter_count != 2 {
+            return self.decode_update_literals_for_shape(
+                sql,
+                normalized_shape,
+                parameter_count,
+                escape_scratch,
+            );
+        }
+        if cached_shape.shape_address != normalized_shape.as_ptr() as usize
+            || cached_shape.shape_len != normalized_shape.len()
+            || normalized_shape.get(cached_shape.prefix_end..cached_shape.middle_start)
+                != Some("$1")
+            || normalized_shape.get(cached_shape.middle_end..cached_shape.suffix_start)
+                != Some("$2")
+        {
+            let (prefix, remainder) = normalized_shape.split_once("$1")?;
+            let (middle, suffix) = remainder.split_once("$2")?;
+            if prefix.contains('$') || middle.contains('$') || suffix.contains('$') {
+                return None;
+            }
+            cached_shape.shape_address = normalized_shape.as_ptr() as usize;
+            cached_shape.shape_len = normalized_shape.len();
+            cached_shape.prefix_end = prefix.len();
+            cached_shape.middle_start = prefix.len() + 2;
+            cached_shape.middle_end = cached_shape.middle_start + middle.len();
+            cached_shape.suffix_start = cached_shape.middle_end + 2;
+        }
+        if escape_scratch.len() < 2 {
+            escape_scratch.resize_with(2, String::new);
+        }
+        decode_two_update_string_literals(
+            sql,
+            &normalized_shape[..cached_shape.prefix_end],
+            &normalized_shape[cached_shape.middle_start..cached_shape.middle_end],
+            &normalized_shape[cached_shape.suffix_start..],
             escape_scratch,
         )
     }

--- a/packages/engine/src/tracked_state/codec.rs
+++ b/packages/engine/src/tracked_state/codec.rs
@@ -1660,6 +1660,14 @@ fn decode_leaf_v3(body: &[u8]) -> Result<DecodedLeafNodeRef, LixError> {
         let suffix = slice(body, &mut offset, suffix_len)?;
         arena.extend_from_slice(suffix);
         let key_end = arena.len();
+        if !entries.is_empty()
+            && arena[previous_key_start..previous_key_end] >= arena[key_start..key_end]
+        {
+            return Err(LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "tracked-state leaf node keys are not strictly ordered",
+            ));
+        }
 
         let change_id = slice(body, &mut offset, VALUE_CHANGE_ID_END)?;
         let commit_ref = usize_from(

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -1302,6 +1302,7 @@ pub(crate) struct CommitDeltaLiveMembershipCursor {
     manifest: Option<Arc<CommitDeltaManifest>>,
     segment_index: Option<usize>,
     segment: Option<Arc<DecodedCommitDeltaSegment>>,
+    next_entry_index: usize,
 }
 
 #[derive(Default)]
@@ -1322,6 +1323,7 @@ impl CommitDeltaPointReadCache {
             manifest: None,
             segment_index: None,
             segment: None,
+            next_entry_index: 0,
         }
     }
 }
@@ -1405,15 +1407,50 @@ impl CommitDeltaLiveMembershipCursor {
                 self.segment = Some(decoded);
             }
             self.segment_index = Some(segment_index);
+            self.next_entry_index = 0;
         }
         let segment = self
             .segment
             .as_ref()
             .expect("membership cursor loaded its current immutable part");
-        Ok(Some(
-            find_commit_delta_value(&segment.leaf, encoded_key, self.commit_id)?
-                .is_some_and(|value| !value.deleted),
-        ))
+        let mut linear_probes = 0_usize;
+        while self.next_entry_index < segment.leaf.len() {
+            let entry = segment.leaf.entry(self.next_entry_index)?.ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state packed commit_delta leaf has a missing entry",
+                )
+            })?;
+            match entry.key.cmp(encoded_key) {
+                std::cmp::Ordering::Less => {
+                    self.next_entry_index += 1;
+                    linear_probes += 1;
+                    if linear_probes == 8 {
+                        self.next_entry_index = commit_delta_entry_lower_bound_from(
+                            &segment.leaf,
+                            encoded_key,
+                            self.next_entry_index,
+                        )?;
+                    }
+                }
+                std::cmp::Ordering::Greater => return Ok(Some(false)),
+                std::cmp::Ordering::Equal => {
+                    self.next_entry_index += 1;
+                    let value = decode_value(entry.value)?;
+                    if value.commit_id != self.commit_id {
+                        return Err(LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            format!(
+                                "tracked_state packed commit_delta for commit '{}' contains an entry for commit '{}'",
+                                self.commit_id, value.commit_id
+                            ),
+                        ));
+                    }
+                    return Ok(Some(!value.deleted));
+                }
+            }
+        }
+        Ok(Some(false))
     }
 }
 
@@ -9125,7 +9162,21 @@ fn find_commit_delta_entry_index(
     leaf: &DecodedLeafNodeRef,
     target_key: &[u8],
 ) -> Result<Option<usize>, LixError> {
-    let mut lower = 0usize;
+    let lower = commit_delta_entry_lower_bound_from(leaf, target_key, 0)?;
+    let Some(entry) = leaf.entry(lower)? else {
+        return Ok(None);
+    };
+    if entry.key != target_key {
+        return Ok(None);
+    }
+    Ok(Some(lower))
+}
+
+fn commit_delta_entry_lower_bound_from(
+    leaf: &DecodedLeafNodeRef,
+    target_key: &[u8],
+    mut lower: usize,
+) -> Result<usize, LixError> {
     let mut upper = leaf.len();
     while lower < upper {
         let middle = lower + (upper - lower) / 2;
@@ -9141,13 +9192,7 @@ fn find_commit_delta_entry_index(
             upper = middle;
         }
     }
-    let Some(entry) = leaf.entry(lower)? else {
-        return Ok(None);
-    };
-    if entry.key != target_key {
-        return Ok(None);
-    }
-    Ok(Some(lower))
+    Ok(lower)
 }
 
 pub(crate) async fn read_chunk(

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -6566,12 +6566,15 @@ where
         if let Some(error) = &self.mutation_journal_terminal_error {
             return Err(error.clone());
         }
-        let Some((_, program)) = self.prepared_mutation_program.as_ref() else {
-            return Ok(None);
+        let (primary_key, replacement_value) = {
+            let Some((_, program)) = self.prepared_mutation_program.as_ref() else {
+                return Ok(None);
+            };
+            (
+                program.primary_key_text(params)?,
+                program.replacement_value_text(params)?,
+            )
         };
-        let program = Arc::clone(program);
-        let primary_key = program.primary_key_text(params)?;
-        let replacement_value = program.replacement_value_text(params)?;
 
         let same_origin = self
             .mutation_journal
@@ -6592,6 +6595,7 @@ where
         }
         if !same_origin || !ordered_append {
             self.lower_provisional_mutations_to_prepared().await?;
+            self.prepared_mutation_membership = PreparedMutationMembership::Unprepared;
             self.prepared_mutation_overlay_empty = false;
         }
 
@@ -6603,9 +6607,15 @@ where
         }
         if !self.prepared_mutation_overlay_empty {
             let entity_pk = EntityPk::single(primary_key.to_owned());
+            let schema_key = &self
+                .prepared_mutation_program
+                .as_ref()
+                .expect("packed literal mutation retains its prepared program")
+                .1
+                .schema_key;
             if self.staged_writes.staged_identity_may_affect(
                 &self.active_branch_id,
-                &program.schema_key,
+                schema_key,
                 None,
                 &entity_pk,
             )? {
@@ -6628,28 +6638,41 @@ where
         }
 
         let origin_key = next_origin_key.map(SharedStr::from);
-        let functions = self.functions.clone();
-        let (journal_slot, timestamp_slot) = (
-            &mut self.mutation_journal,
-            &mut self.prepared_mutation_timestamp,
-        );
-        let journal = journal_slot.get_or_insert_with(|| TransactionMutationJournal {
-            program: Arc::clone(&program),
-            origin_key: origin_key.clone(),
-            identity_arena: Vec::with_capacity(INITIAL_MUTATION_JOURNAL_ARENA_BYTES),
-            identity_offsets: Vec::with_capacity(INITIAL_MUTATION_JOURNAL_ROWS),
-            snapshot_arena: Vec::with_capacity(INITIAL_MUTATION_JOURNAL_ARENA_BYTES),
-            snapshot_offsets: Vec::with_capacity(INITIAL_MUTATION_JOURNAL_ROWS),
-            timestamp: None,
+        let journal_program = self.mutation_journal.is_none().then(|| {
+            Arc::clone(
+                &self
+                    .prepared_mutation_program
+                    .as_ref()
+                    .expect("packed literal mutation retains its prepared program")
+                    .1,
+            )
         });
-        debug_assert!(Arc::ptr_eq(&journal.program, &program));
+        let timestamp = match self.prepared_mutation_timestamp {
+            Some(timestamp) => timestamp,
+            None => {
+                let timestamp = self.functions.call_timestamp();
+                self.prepared_mutation_timestamp = Some(timestamp);
+                timestamp
+            }
+        };
+        let journal = self
+            .mutation_journal
+            .get_or_insert_with(|| TransactionMutationJournal {
+                program: journal_program
+                    .expect("new mutation journal retains its prepared program"),
+                origin_key: origin_key.clone(),
+                identity_arena: Vec::with_capacity(INITIAL_MUTATION_JOURNAL_ARENA_BYTES),
+                identity_offsets: Vec::with_capacity(INITIAL_MUTATION_JOURNAL_ROWS),
+                snapshot_arena: Vec::with_capacity(INITIAL_MUTATION_JOURNAL_ARENA_BYTES),
+                snapshot_offsets: Vec::with_capacity(INITIAL_MUTATION_JOURNAL_ROWS),
+                timestamp: None,
+            });
         debug_assert_eq!(journal.origin_key, origin_key);
         let snapshot_offset = crate::sql2::append_path_value_replacement_snapshot_text(
             primary_key,
             Some(replacement_value),
             &mut journal.snapshot_arena,
         )?;
-        let timestamp = *timestamp_slot.get_or_insert_with(|| functions.call_timestamp());
         journal.append_identity(primary_key);
         journal.snapshot_offsets.push(snapshot_offset);
         let journal_timestamp = journal.timestamp.get_or_insert(timestamp);
@@ -6828,6 +6851,7 @@ where
         }
         if !same_program || !same_origin || !ordered_append {
             self.lower_provisional_mutations_to_prepared().await?;
+            self.prepared_mutation_membership = PreparedMutationMembership::Unprepared;
             self.prepared_mutation_overlay_empty = false;
         }
         if !same_program {


### PR DESCRIPTION
## What changed

- Advance transaction-owned predecessor membership linearly through strictly ordered commit-delta leaves; switch to a suffix lower-bound after eight probes for sparse ranges.
- Make monotonic ordering structural: both literal and parameterized scalar ingress reset membership authority on program, origin, or key-order barriers.
- Reject duplicate or inverted native leaf keys during decode, so ordered cursors never rely on malformed durable input.
- Cache validated `$1`/`$2` literal-shape spans and remove per-row program/function `Arc` clones and duplicate timestamp construction from the hot scalar path.

## Why

One million scalar `transaction.execute` UPDATE calls already append to the typed mutation journal, but predecessor membership still binary-searched each identity and the SQL literal path repeatedly rediscovered stable shape boundaries and cloned immutable execution state. Ordered journal ingress makes those costs unnecessary.

## Performance

Compared with the immediately previous merged baseline used for this cut, `main` at `1e1fb03d0` (#1190), using the same target, compiler, mold linker, fixture, and five-sample medians:

| 1M scalar UPDATE | Previous | This PR | Change | vs raw SQLite (927.523 ms) |
|---|---:|---:|---:|---:|
| RocksDB | 1.059809 s | 882.745 ms | **-16.7%** | **0.952x** |
| SlateDB | 1.114006 s | 924.754 ms | **-17.0%** | **0.997x** |

Final 10K candidate medians are RocksDB 31.921 ms and SlateDB 33.567 ms versus raw SQLite 13.626 ms. The 1M target is cleared; the remaining 10K scalar fixed-cost gap is explicitly outside this cut and is the next bottleneck. Parameterized `executeBatch` already clears the target at 10K.

## Validation

- `cargo clippy -p lix_engine --all-targets --features storage-benches -- -D warnings`
- `RUST_MIN_STACK=8388608 cargo test -p lix_engine --features storage-benches`
  - 1,892 unit tests passed; 8 ignored
  - 442 integration tests passed; 2 ignored
  - 3 doctests passed
- Independent correctness, storage, and performance reviews approved

No changenote.