### PR TITLE
Structurally share sparse current-state parts

### DIFF
--- a/packages/engine-benchmarks/benches/current_state_scope_sharing.rs
+++ b/packages/engine-benchmarks/benches/current_state_scope_sharing.rs
@@ -19,8 +19,9 @@ fn main() {
     let sparse_shape = match std::env::var("LIX_CURRENT_STATE_SPARSE_SHAPE").as_deref() {
         Ok("unrelated") => BenchCurrentStateSparseShape::UnrelatedScopes,
         Ok("touched") | Err(_) => BenchCurrentStateSparseShape::TouchedScope,
+        Ok("distinct") => BenchCurrentStateSparseShape::TouchedScopeDistinct,
         Ok(other) => panic!(
-            "unknown LIX_CURRENT_STATE_SPARSE_SHAPE '{other}'; expected touched or unrelated"
+            "unknown LIX_CURRENT_STATE_SPARSE_SHAPE '{other}'; expected touched, distinct, or unrelated"
         ),
     };
     let point_target = match std::env::var("LIX_CURRENT_STATE_TARGET").as_deref() {
@@ -117,8 +118,9 @@ async fn run_backend<S>(
         };
         let measured = measure(&fixture, selected, warmups, samples).await;
         println!(
-            "current_state_scope_sharing,backend={backend},mode={mode},shape={sparse_shape:?},target={point_target:?},rows={rows},scopes={},sparse_commits={sparse_commits},setup_ms={:.3},scoped_range_staged_puts={},scoped_range_staged_bytes={},sparse_scoped_range_staged_puts={},sparse_scoped_range_staged_bytes={},sparse_staged_puts={},sparse_written_bytes={},sparse_publication_p50_us={:.3},sparse_publication_p95_us={:.3},first_sparse_ms={:.3},first_sparse_staged_puts={},first_sparse_written_bytes={},scoped_manifest_bytes={},replay_manifest_bytes={},p50_us={:.3},p95_us={:.3}",
+            "current_state_scope_sharing,backend={backend},mode={mode},shape={sparse_shape:?},target={point_target:?},rows={rows},scopes={},sparse_commits={sparse_commits},final_parts={},setup_ms={:.3},scoped_range_staged_puts={},scoped_range_staged_bytes={},sparse_scoped_range_staged_puts={},sparse_scoped_range_staged_bytes={},sparse_staged_puts={},sparse_written_bytes={},sparse_publication_p50_us={:.3},sparse_publication_p95_us={:.3},first_sparse_ms={:.3},first_sparse_staged_puts={},first_sparse_written_bytes={},scoped_manifest_bytes={},replay_manifest_bytes={},p50_us={:.3},p95_us={:.3}",
             fixture.scope_count(),
+            fixture.current_state_part_count(),
             millis(setup),
             fixture.scoped_range_staged_puts(),
             fixture.scoped_range_staged_bytes(),
@@ -153,8 +155,9 @@ async fn run_backend<S>(
     )
     .await;
     println!(
-        "current_state_scope_sharing,backend={backend},shape={sparse_shape:?},target={point_target:?},rows={rows},scopes={},sparse_commits={sparse_commits},setup_ms={:.3},scoped_range_staged_puts={},scoped_range_staged_bytes={},sparse_scoped_range_staged_puts={},sparse_scoped_range_staged_bytes={},sparse_staged_puts={},sparse_written_bytes={},sparse_publication_p50_us={:.3},sparse_publication_p95_us={:.3},first_sparse_ms={:.3},first_sparse_staged_puts={},first_sparse_written_bytes={},scoped_manifest_bytes={},replay_manifest_bytes={},serving_p50_us={:.3},serving_p95_us={:.3},replay_p50_us={:.3},replay_p95_us={:.3},p50_reduction_pct={:.2},p95_reduction_pct={:.2}",
+        "current_state_scope_sharing,backend={backend},shape={sparse_shape:?},target={point_target:?},rows={rows},scopes={},sparse_commits={sparse_commits},final_parts={},setup_ms={:.3},scoped_range_staged_puts={},scoped_range_staged_bytes={},sparse_scoped_range_staged_puts={},sparse_scoped_range_staged_bytes={},sparse_staged_puts={},sparse_written_bytes={},sparse_publication_p50_us={:.3},sparse_publication_p95_us={:.3},first_sparse_ms={:.3},first_sparse_staged_puts={},first_sparse_written_bytes={},scoped_manifest_bytes={},replay_manifest_bytes={},serving_p50_us={:.3},serving_p95_us={:.3},replay_p50_us={:.3},replay_p95_us={:.3},p50_reduction_pct={:.2},p95_reduction_pct={:.2}",
         fixture.scope_count(),
+        fixture.current_state_part_count(),
         millis(setup),
         fixture.scoped_range_staged_puts(),
         fixture.scoped_range_staged_bytes(),

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -42,16 +42,14 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 
 /// Repository-wide compatibility gate for physical storage protocols.
 ///
-/// V46 makes immutable columnar bases a schema-independent physical detail,
-/// routes broad scans and collection aggregates through DataFusion, binds
-/// authenticated row groups to registered SQL schemas, and stores canonical
-/// entity identities for transactional overlay reconciliation. Older
-/// repositories must fail closed rather than interpret earlier workload-policy
-/// sidecars as schema-authenticated physical layouts.
+/// V53 makes structural fragmentation explicit in current-state range
+/// locators. Sparse rewrites may retain immutable source slices, while
+/// compaction clears the fragment bit on canonical output. Older repositories
+/// must fail closed rather than infer this serving invariant from row density.
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::mutable(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"account-attributed-current-state-range-splice.v52";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"explicit-current-state-fragments.v53";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately

--- a/packages/engine/src/tracked_state/bench_support.rs
+++ b/packages/engine/src/tracked_state/bench_support.rs
@@ -74,6 +74,7 @@ pub enum BenchCurrentStatePointMode {
 pub enum BenchCurrentStateSparseShape {
     UnrelatedScopes,
     TouchedScope,
+    TouchedScopeDistinct,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -103,6 +104,7 @@ pub struct BenchCurrentStatePointFixture<StorageImpl: Storage> {
     first_sparse_elapsed_nanos: u64,
     first_sparse_staged_puts: u64,
     first_sparse_written_bytes: u64,
+    current_state_part_count: u64,
 }
 
 pub async fn seed_current_state_point_fixture<StorageImpl>(
@@ -252,7 +254,11 @@ where
     for index in 0..unrelated_sparse_commits {
         let sparse_started = Instant::now();
         let commit_id = bench_addressable_commit_id(&format!("scoped-range-child-{index}"));
-        let touches_alpha = sparse_shape == BenchCurrentStateSparseShape::TouchedScope;
+        let touches_alpha = matches!(
+            sparse_shape,
+            BenchCurrentStateSparseShape::TouchedScope
+                | BenchCurrentStateSparseShape::TouchedScopeDistinct
+        );
         let present_scope = !touches_alpha && scope_count > 1 && index % 4 == 0;
         let schema_key = if touches_alpha {
             "bench_current_state_alpha".to_string()
@@ -263,7 +269,9 @@ where
         };
         let file_id =
             present_scope.then(|| format!("file-{:05}", (1 + index % (scope_count - 1)) % 10_000));
-        let sparse_pk = if touches_alpha {
+        let sparse_pk = if sparse_shape == BenchCurrentStateSparseShape::TouchedScopeDistinct {
+            &entity_pks[(replacement_rows / 4 + index) % replacement_rows]
+        } else if touches_alpha {
             &entity_pks[replacement_rows / 4]
         } else {
             &beta_pk
@@ -348,7 +356,11 @@ where
         .copied()
         .unwrap_or_default();
 
-    let target_index = if sparse_shape == BenchCurrentStateSparseShape::TouchedScope
+    let target_index = if sparse_shape == BenchCurrentStateSparseShape::TouchedScopeDistinct
+        && point_target == BenchCurrentStatePointTarget::HotMutated
+    {
+        (replacement_rows / 4 + unrelated_sparse_commits.saturating_sub(1)) % replacement_rows
+    } else if sparse_shape == BenchCurrentStateSparseShape::TouchedScope
         && point_target == BenchCurrentStatePointTarget::HotMutated
     {
         replacement_rows / 4
@@ -362,6 +374,10 @@ where
             entity_pk: &entity_pks[target_index],
         },
     ));
+    let current_state_part_count = current_manifest
+        .current_state_scoped_ranges
+        .as_ref()
+        .map_or(0, |root| u64::from(root.tree.part_count));
     BenchCurrentStatePointFixture {
         storage,
         commits,
@@ -382,6 +398,7 @@ where
         first_sparse_elapsed_nanos,
         first_sparse_staged_puts,
         first_sparse_written_bytes,
+        current_state_part_count,
     }
 }
 
@@ -501,6 +518,10 @@ where
 
     pub fn first_sparse_written_bytes(&self) -> u64 {
         self.first_sparse_written_bytes
+    }
+
+    pub fn current_state_part_count(&self) -> u64 {
+        self.current_state_part_count
     }
 
     pub async fn read_point(&self, mode: BenchCurrentStatePointMode) -> usize {

--- a/packages/engine/src/tracked_state/current_state_envelope.rs
+++ b/packages/engine/src/tracked_state/current_state_envelope.rs
@@ -7,7 +7,7 @@ use crate::tracked_state::scoped_range::{
 use crate::tracked_state::types::{CommitDeltaReplacementScope, CurrentStatePartDescriptor};
 use crate::{LixError, storage_codec};
 
-const LOCATOR_PAYLOAD_VERSION: u16 = 1;
+const LOCATOR_PAYLOAD_VERSION: u16 = 2;
 
 #[derive(musli::Encode, musli::Decode)]
 #[musli(packed)]
@@ -18,6 +18,7 @@ struct CurrentStatePartLocatorPayload {
     owner_commit_id: [u8; 16],
     part_index: u32,
     source_row_offset: u16,
+    fragmented: bool,
     uniform_created_at: crate::common::LixTimestamp,
     uniform_updated_at: crate::common::LixTimestamp,
 }
@@ -60,6 +61,7 @@ pub(crate) fn scoped_range_part_from_current_state_descriptor(
                     owner_commit_id: descriptor.owner_commit_id,
                     part_index: descriptor.part_index,
                     source_row_offset: descriptor.source_row_offset,
+                    fragmented: descriptor.fragmented,
                     uniform_created_at: descriptor.uniform_created_at,
                     uniform_updated_at: descriptor.uniform_updated_at,
                 },
@@ -89,6 +91,7 @@ pub(crate) fn current_state_descriptor_from_scoped_range_part(
         source_row_offset: payload.source_row_offset,
         row_count: u16::try_from(part.row_count)
             .map_err(|_| envelope_error("part row count exceeds its locator codec"))?,
+        fragmented: payload.fragmented,
         uniform_created_at: payload.uniform_created_at,
         uniform_updated_at: payload.uniform_updated_at,
     };

--- a/packages/engine/src/tracked_state/scoped_current_state.rs
+++ b/packages/engine/src/tracked_state/scoped_current_state.rs
@@ -138,6 +138,7 @@ pub(crate) async fn stage_complete_replacement_scoped_range_root(
                     .map_err(|_| scoped_state_error("replacement part index overflows"))?,
                 source_row_offset: 0,
                 row_count,
+                fragmented: false,
                 uniform_created_at: part.uniform_created_at,
                 uniform_updated_at: part.uniform_updated_at,
             })
@@ -329,7 +330,7 @@ mod tests {
     use crate::tracked_state::codec::encode_key_ref;
     use crate::tracked_state::scoped_range::{
         ScopedRangeCoverageMarker, ScopedRangePart, ScopedRangePartPayload, ScopedRangePrefix,
-        plan_scoped_range_part_splice, route_scoped_range_point,
+        plan_scoped_range_part_splice, route_scoped_range_point, scan_scoped_range_interval,
         snapshot_staged_scoped_range_nodes, stage_scoped_range_part_splice,
         stage_scoped_range_tree, validate_scoped_range_tree,
     };
@@ -405,7 +406,7 @@ mod tests {
             scope: replacement_scope.clone(),
             fallback_commit_id: None,
             lifecycle_summary: CommitDeltaLifecycleSummary {
-                scope: replacement_scope,
+                scope: replacement_scope.clone(),
                 ordered_identity_digest: [7; 32],
                 uniform_created_at: created_at,
             },
@@ -480,7 +481,7 @@ mod tests {
             scope: replacement_scope.clone(),
             fallback_commit_id: None,
             lifecycle_summary: CommitDeltaLifecycleSummary {
-                scope: replacement_scope,
+                scope: replacement_scope.clone(),
                 ordered_identity_digest: [7; 32],
                 uniform_created_at: created_at,
             },
@@ -668,6 +669,43 @@ mod tests {
             Some(child_id)
         );
         assert!(values[3].is_none(), "covered exact miss must not replay");
+
+        let first = encoded_key("scoped-publication", &existing);
+        let last = encoded_key("scoped-publication", &inserted);
+        let interval = scan_scoped_range_interval(
+            &child_read,
+            &child.current_state_scoped_ranges.as_deref().unwrap().tree,
+            &crate::tracked_state::current_state_envelope::current_state_scope_prefix(
+                &replacement_scope,
+            )
+            .unwrap(),
+            &first,
+            &last,
+        )
+        .await
+        .expect("sparse post-image parts should scan");
+        let descriptors = interval
+            .parts
+            .iter()
+            .map(|part| {
+                crate::tracked_state::current_state_envelope::current_state_descriptor_from_scoped_range_part(part)
+                    .expect("current-state locator should decode")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(descriptors.len(), 3);
+        assert_eq!(
+            descriptors
+                .iter()
+                .map(|descriptor| (
+                    descriptor.source_kind,
+                    descriptor.source_row_offset,
+                    descriptor.row_count,
+                    descriptor.fragmented,
+                ))
+                .collect::<Vec<_>>(),
+            vec![(0, 0, 1, true), (0, 2, 1, true), (1, 0, 1, true)],
+            "sparse delete/insert must retain two immutable source slices and write only the insert",
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -2159,23 +2159,88 @@ pub(crate) async fn stage_sparse_current_state_scoped_range(
     let mut replacements = Vec::with_capacity(splice.leaf_count());
     for leaf_index in 0..splice.leaf_count() {
         let leaf_key_indices = splice.leaf_key_indices(leaf_index);
-        let leaf_parts = splice.leaf_parts(leaf_index);
+        let leaf_parts = splice.leaf_parts(leaf_index).collect::<Vec<_>>();
         old_part_count = old_part_count
             .checked_add(leaf_parts.len() as u64)
             .ok_or_else(|| replacement_payload_error("scoped-range part count overflows"))?;
 
-        let mut pending = leaf_key_indices
+        let leaf_mutations = leaf_key_indices
             .iter()
             .map(|&key_index| {
                 mutation_rows[key_index]
                     .take()
                     .expect("each sparse mutation is assigned to one leaf")
             })
-            .collect::<Vec<_>>()
-            .into_iter()
-            .peekable();
+            .collect::<Vec<_>>();
         let mut output = Vec::with_capacity(leaf_parts.len() + leaf_key_indices.len());
-        for part in leaf_parts {
+        let compaction_ranges = sparse_current_state_fragment_compaction_ranges(&leaf_parts)?;
+        let mut compaction_index = 0usize;
+        let mut part_index = 0usize;
+        let mut pending = leaf_mutations.into_iter().peekable();
+        while part_index < leaf_parts.len() {
+            if compaction_ranges
+                .get(compaction_index)
+                .is_some_and(|&(start, _)| start == part_index)
+            {
+                let (start, end) = compaction_ranges[compaction_index];
+                let first = leaf_parts[start];
+                let last = leaf_parts[end - 1];
+                let mut gap = Vec::new();
+                while pending
+                    .peek()
+                    .is_some_and(|(key, _)| key.as_slice() < first.first_key.as_slice())
+                {
+                    let (_, row) = pending.next().expect("peeked sparse mutation");
+                    if let Some(row) = row {
+                        gap.push(row);
+                    }
+                }
+                stage_scoped_native_current_state_rows(writes, &gap, true, &mut output)?;
+                let mut rows = BTreeMap::new();
+                for &part in &leaf_parts[start..end] {
+                    old_row_count = old_row_count.checked_add(part.row_count).ok_or_else(|| {
+                        replacement_payload_error("scoped-range row count overflows")
+                    })?;
+                    let descriptor = current_state_descriptor_from_scoped_range_part(part)?;
+                    for row in load_scoped_current_state_descriptor_rows(store, writes, &descriptor)
+                        .await?
+                    {
+                        if rows.insert(row.encoded_key.clone(), row).is_some() {
+                            return Err(replacement_payload_error(
+                                "fragmented current-state run contains duplicate identities",
+                            ));
+                        }
+                    }
+                }
+                while pending
+                    .peek()
+                    .is_some_and(|(key, _)| key.as_slice() <= last.last_key.as_slice())
+                {
+                    let (key, row) = pending.next().expect("peeked compacted mutation");
+                    match row {
+                        Some(mut row) => {
+                            if let Some(previous) = rows.get(&key) {
+                                row.value.created_at = previous.value.created_at;
+                            }
+                            rows.insert(key, row);
+                        }
+                        None => {
+                            rows.remove(&key);
+                        }
+                    }
+                }
+                stage_scoped_native_current_state_rows(
+                    writes,
+                    &rows.into_values().collect::<Vec<_>>(),
+                    false,
+                    &mut output,
+                )?;
+                part_index = end;
+                compaction_index += 1;
+                continue;
+            }
+
+            let part = leaf_parts[part_index];
             old_row_count = old_row_count
                 .checked_add(part.row_count)
                 .ok_or_else(|| replacement_payload_error("scoped-range row count overflows"))?;
@@ -2190,47 +2255,38 @@ pub(crate) async fn stage_sparse_current_state_scoped_range(
                     gap.push(row);
                 }
             }
-            stage_scoped_native_current_state_rows(writes, &gap, &mut output)?;
+            stage_scoped_native_current_state_rows(writes, &gap, true, &mut output)?;
 
             let touches_descriptor = pending
                 .peek()
                 .is_some_and(|(key, _)| key.as_slice() <= descriptor.last_key.as_slice());
             if !touches_descriptor {
                 output.push(descriptor);
+                part_index += 1;
                 continue;
             }
-            let mut rows = load_scoped_current_state_descriptor_rows(store, writes, &descriptor)
-                .await?
-                .into_iter()
-                .map(|row| (row.encoded_key.clone(), row))
-                .collect::<BTreeMap<_, _>>();
+            let rows =
+                load_scoped_current_state_descriptor_rows(store, writes, &descriptor).await?;
+            let mut descriptor_mutations = Vec::new();
             while pending
                 .peek()
                 .is_some_and(|(key, _)| key.as_slice() <= descriptor.last_key.as_slice())
             {
-                let (key, row) = pending.next().expect("peeked sparse mutation");
-                match row {
-                    Some(mut row) => {
-                        if let Some(previous) = rows.get(&key) {
-                            row.value.created_at = previous.value.created_at;
-                        }
-                        rows.insert(key, row);
-                    }
-                    None => {
-                        rows.remove(&key);
-                    }
-                }
+                descriptor_mutations.push(pending.next().expect("peeked sparse mutation"));
             }
-            stage_scoped_native_current_state_rows(
+            stage_fragmented_scoped_current_state_descriptor(
                 writes,
-                &rows.into_values().collect::<Vec<_>>(),
+                &descriptor,
+                &rows,
+                descriptor_mutations,
                 &mut output,
             )?;
+            part_index += 1;
         }
         let tail = pending
             .filter_map(|(_, row)| row)
             .collect::<Vec<CurrentStateDataRow>>();
-        stage_scoped_native_current_state_rows(writes, &tail, &mut output)?;
+        stage_scoped_native_current_state_rows(writes, &tail, true, &mut output)?;
 
         new_part_count = new_part_count
             .checked_add(output.len() as u64)
@@ -2274,9 +2330,175 @@ pub(crate) async fn stage_sparse_current_state_scoped_range(
     ))
 }
 
+const SPARSE_CURRENT_STATE_COMPACTION_MIN_PARTS: usize = 32;
+const SPARSE_CURRENT_STATE_MAX_PROJECTED_SOURCE_PARTS: usize = 16;
+
+fn sparse_current_state_fragment_compaction_ranges(
+    parts: &[&crate::tracked_state::scoped_range::ScopedRangePart],
+) -> Result<Vec<(usize, usize)>, LixError> {
+    let mut ranges = Vec::new();
+    let mut start = 0usize;
+    while start < parts.len() {
+        if !crate::tracked_state::current_state_envelope::current_state_descriptor_from_scoped_range_part(parts[start])?.fragmented {
+            start += 1;
+            continue;
+        }
+        let mut end = start + 1;
+        while end < parts.len()
+            && crate::tracked_state::current_state_envelope::current_state_descriptor_from_scoped_range_part(parts[end])?.fragmented
+        {
+            end += 1;
+        }
+        if end - start >= SPARSE_CURRENT_STATE_COMPACTION_MIN_PARTS {
+            ranges.push((start, end));
+        }
+        start = end;
+    }
+    Ok(ranges)
+}
+
+/// Applies sparse mutations without copying an immutable source part's
+/// untouched rows. Descriptor slices retain the original payload and only
+/// authored post-images become new native parts.
+fn stage_fragmented_scoped_current_state_descriptor(
+    writes: &mut StorageWriteSet,
+    descriptor: &CurrentStatePartDescriptor,
+    rows: &[crate::tracked_state::current_state_data_part::CurrentStateDataRow],
+    mutations: Vec<(
+        Vec<u8>,
+        Option<crate::tracked_state::current_state_data_part::CurrentStateDataRow>,
+    )>,
+    output: &mut Vec<CurrentStatePartDescriptor>,
+) -> Result<(), LixError> {
+    let mutations = mutations
+        .into_iter()
+        .filter(|(key, mutation)| {
+            mutation.is_some()
+                || rows
+                    .binary_search_by(|row| row.encoded_key.as_slice().cmp(key.as_slice()))
+                    .is_ok()
+        })
+        .collect::<Vec<_>>();
+    if mutations.is_empty() {
+        output.push(descriptor.clone());
+        return Ok(());
+    }
+    if sparse_current_state_projected_source_parts(rows, &mutations)
+        > SPARSE_CURRENT_STATE_MAX_PROJECTED_SOURCE_PARTS
+    {
+        let mut post_image = rows
+            .iter()
+            .cloned()
+            .map(|row| (row.encoded_key.clone(), row))
+            .collect::<BTreeMap<_, _>>();
+        for (key, row) in mutations {
+            match row {
+                Some(mut row) => {
+                    if let Some(previous) = post_image.get(&key) {
+                        row.value.created_at = previous.value.created_at;
+                    }
+                    post_image.insert(key, row);
+                }
+                None => {
+                    post_image.remove(&key);
+                }
+            }
+        }
+        return stage_scoped_native_current_state_rows(
+            writes,
+            &post_image.into_values().collect::<Vec<_>>(),
+            false,
+            output,
+        );
+    }
+    let mut retained_start = 0usize;
+    let mut native_run = Vec::new();
+    for (key, mut mutation) in mutations {
+        let insertion = rows.binary_search_by(|row| row.encoded_key.as_slice().cmp(key.as_slice()));
+        if insertion.is_err() && mutation.is_none() {
+            // Deleting an already absent identity is a physical no-op.
+            continue;
+        }
+        let split = insertion.unwrap_or_else(|index| index);
+        if retained_start < split {
+            stage_scoped_native_current_state_rows(writes, &native_run, true, output)?;
+            native_run.clear();
+        }
+        stage_retained_current_state_slice(descriptor, rows, retained_start, split, output)?;
+        if let Ok(index) = insertion {
+            if let Some(row) = mutation.as_mut() {
+                row.value.created_at = rows[index].value.created_at;
+            }
+            retained_start = index + 1;
+        } else {
+            retained_start = split;
+        }
+        if let Some(row) = mutation {
+            native_run.push(row);
+        }
+    }
+    stage_scoped_native_current_state_rows(writes, &native_run, true, output)?;
+    stage_retained_current_state_slice(descriptor, rows, retained_start, rows.len(), output)
+}
+
+fn sparse_current_state_projected_source_parts(
+    rows: &[crate::tracked_state::current_state_data_part::CurrentStateDataRow],
+    mutations: &[(
+        Vec<u8>,
+        Option<crate::tracked_state::current_state_data_part::CurrentStateDataRow>,
+    )],
+) -> usize {
+    let mut retained_start = 0usize;
+    let mut native_open = false;
+    let mut part_count = 0usize;
+    for (key, mutation) in mutations {
+        let insertion = rows.binary_search_by(|row| row.encoded_key.as_slice().cmp(key.as_slice()));
+        if insertion.is_err() && mutation.is_none() {
+            continue;
+        }
+        let split = insertion.unwrap_or_else(|index| index);
+        if retained_start < split {
+            part_count += usize::from(native_open) + 1;
+            native_open = false;
+        }
+        retained_start = insertion.map_or(split, |index| index + 1);
+        native_open |= mutation.is_some();
+    }
+    part_count += usize::from(native_open);
+    part_count + usize::from(retained_start < rows.len())
+}
+
+fn stage_retained_current_state_slice(
+    descriptor: &CurrentStatePartDescriptor,
+    rows: &[crate::tracked_state::current_state_data_part::CurrentStateDataRow],
+    start: usize,
+    end: usize,
+    output: &mut Vec<CurrentStatePartDescriptor>,
+) -> Result<(), LixError> {
+    if start >= end {
+        return Ok(());
+    }
+    let mut retained = descriptor.clone();
+    retained.first_key = rows[start].encoded_key.clone();
+    retained.last_key = rows[end - 1].encoded_key.clone();
+    retained.source_row_offset = retained
+        .source_row_offset
+        .checked_add(
+            u16::try_from(start)
+                .map_err(|_| replacement_payload_error("current-state slice offset overflows"))?,
+        )
+        .ok_or_else(|| replacement_payload_error("current-state slice offset overflows"))?;
+    retained.row_count = u16::try_from(end - start)
+        .map_err(|_| replacement_payload_error("current-state slice row count overflows"))?;
+    retained.fragmented = true;
+    output.push(retained);
+    Ok(())
+}
+
 fn stage_scoped_native_current_state_rows(
     writes: &mut StorageWriteSet,
     rows: &[crate::tracked_state::current_state_data_part::CurrentStateDataRow],
+    fragmented: bool,
     output: &mut Vec<CurrentStatePartDescriptor>,
 ) -> Result<(), LixError> {
     use crate::tracked_state::current_state_data_part::{
@@ -2311,6 +2533,7 @@ fn stage_scoped_native_current_state_rows(
             part_index: 0,
             source_row_offset: 0,
             row_count: part.row_count,
+            fragmented,
             uniform_created_at: timestamp,
             uniform_updated_at: timestamp,
         });
@@ -9732,9 +9955,10 @@ mod tests {
     };
     use crate::tracked_state::types::{
         CommitStateManifest, CommitStateMutationInventory, CommitStateReplayDebt,
-        TRACKED_STATE_HASH_BYTES, TrackedStateBaseCoordinate, TrackedStateCommitDeltaRef,
-        TrackedStateCommitRoot, TrackedStateDeltaRef, TrackedStateIndexValue,
-        TrackedStateIndexValueRef, TrackedStateKey, TrackedStateKeyRef, TrackedStateRootId,
+        CurrentStatePartDescriptor, TRACKED_STATE_HASH_BYTES, TrackedStateBaseCoordinate,
+        TrackedStateCommitDeltaRef, TrackedStateCommitRoot, TrackedStateDeltaRef,
+        TrackedStateIndexValue, TrackedStateIndexValueRef, TrackedStateKey, TrackedStateKeyRef,
+        TrackedStateRootId,
     };
 
     use super::{
@@ -9752,8 +9976,234 @@ mod tests {
         load_owned_commit_delta_entries, scan_change_records_from_commit_deltas,
         scan_commit_delta_inventory, scan_commit_delta_members, scan_commit_delta_values,
         stage_change_locators, stage_commit_state_manifest,
-        stage_delete_commit_delta_inventory_entry, value,
+        stage_delete_commit_delta_inventory_entry,
+        stage_fragmented_scoped_current_state_descriptor, value,
     };
+
+    #[test]
+    fn fragmented_native_source_preserves_lifecycle_and_batches_adjacent_updates() {
+        use crate::json_store::JsonSlot;
+        use crate::tracked_state::current_state_data_part::{
+            CURRENT_STATE_DATA_PART_SPACE, CurrentStateDataRow, decode_current_state_data_part,
+        };
+
+        let storage = StorageAdapter::new(Memory::new());
+        let created_at = LixTimestamp::from_unix_millis_utc_lossy(10);
+        let updated_at = LixTimestamp::from_unix_millis_utc_lossy(20);
+        let replacement_updated_at = LixTimestamp::from_unix_millis_utc_lossy(30);
+        let owner = CommitId::for_test_label("fragmented-native-owner");
+        let rows = [b"a".to_vec(), b"b".to_vec()]
+            .into_iter()
+            .enumerate()
+            .map(|(index, encoded_key)| CurrentStateDataRow {
+                encoded_key,
+                value: TrackedStateIndexValue {
+                    change_id: ChangeId::for_test_label(&format!("fragmented-source-{index}")),
+                    commit_id: owner,
+                    deleted: false,
+                    created_at,
+                    updated_at,
+                },
+                snapshot: JsonSlot::Inline(format!("{{\"version\":{index}}}").into()),
+                metadata: JsonSlot::None,
+            })
+            .collect::<Vec<_>>();
+        let descriptor = CurrentStatePartDescriptor {
+            first_key: rows[0].encoded_key.clone(),
+            last_key: rows[1].encoded_key.clone(),
+            content_digest: [7; 32],
+            payload_refs_digest: [8; 32],
+            source_kind: 1,
+            owner_commit_id: [0; 16],
+            part_index: 0,
+            source_row_offset: 4,
+            row_count: 2,
+            fragmented: false,
+            uniform_created_at: LixTimestamp::from_unix_millis_utc_lossy(0),
+            uniform_updated_at: LixTimestamp::from_unix_millis_utc_lossy(0),
+        };
+        let mutations = rows
+            .iter()
+            .enumerate()
+            .map(|(index, source)| {
+                let mut row = source.clone();
+                row.value.change_id =
+                    ChangeId::for_test_label(&format!("fragmented-update-{index}"));
+                row.value.commit_id = CommitId::for_test_label("fragmented-native-child");
+                row.value.created_at = replacement_updated_at;
+                row.value.updated_at = replacement_updated_at;
+                (row.encoded_key.clone(), Some(row))
+            })
+            .collect::<Vec<_>>();
+        let mut writes = storage.new_write_set();
+        let mut output = Vec::new();
+        stage_fragmented_scoped_current_state_descriptor(
+            &mut writes,
+            &descriptor,
+            &rows,
+            mutations,
+            &mut output,
+        )
+        .expect("adjacent native updates should fragment");
+        assert_eq!(
+            output.len(),
+            1,
+            "adjacent updates must remain one native run"
+        );
+        assert_eq!(output[0].source_kind, 1);
+        assert_eq!(output[0].row_count, 2);
+        let bytes = writes
+            .staged_value(CURRENT_STATE_DATA_PART_SPACE, &output[0].content_digest)
+            .expect("updated native run should be staged");
+        let decoded = decode_current_state_data_part(&output[0].content_digest, &bytes)
+            .expect("updated native run should decode");
+        assert!(decoded.iter().all(|row| row.value.created_at == created_at));
+
+        let mut writes = storage.new_write_set();
+        let mut output = Vec::new();
+        let mut first_update = decoded[0].clone();
+        first_update.value.created_at = replacement_updated_at;
+        stage_fragmented_scoped_current_state_descriptor(
+            &mut writes,
+            &descriptor,
+            &rows,
+            vec![(first_update.encoded_key.clone(), Some(first_update))],
+            &mut output,
+        )
+        .expect("one native update should retain a source slice");
+        assert_eq!(output.len(), 2);
+        assert_eq!(output[1].source_kind, 1);
+        assert_eq!(output[1].source_row_offset, 5);
+        assert_eq!(output[1].row_count, 1);
+
+        let mut writes = storage.new_write_set();
+        let mut output = Vec::new();
+        stage_fragmented_scoped_current_state_descriptor(
+            &mut writes,
+            &descriptor,
+            &rows,
+            vec![(b"absent".to_vec(), None)],
+            &mut output,
+        )
+        .expect("absent delete should be a physical no-op");
+        assert_eq!(output, vec![descriptor.clone()]);
+        assert!(!output[0].fragmented);
+
+        let alternating_rows = (0..64_u16)
+            .map(|index| CurrentStateDataRow {
+                encoded_key: index.to_be_bytes().to_vec(),
+                value: TrackedStateIndexValue {
+                    change_id: ChangeId::for_test_label(&format!("alternating-source-{index}")),
+                    commit_id: owner,
+                    deleted: false,
+                    created_at,
+                    updated_at,
+                },
+                snapshot: JsonSlot::Inline("{}".into()),
+                metadata: JsonSlot::None,
+            })
+            .collect::<Vec<_>>();
+        let alternating_descriptor = CurrentStatePartDescriptor {
+            first_key: alternating_rows[0].encoded_key.clone(),
+            last_key: alternating_rows.last().unwrap().encoded_key.clone(),
+            content_digest: [9; 32],
+            payload_refs_digest: [10; 32],
+            source_kind: 1,
+            owner_commit_id: [0; 16],
+            part_index: 0,
+            source_row_offset: 0,
+            row_count: alternating_rows.len() as u16,
+            fragmented: false,
+            uniform_created_at: LixTimestamp::from_unix_millis_utc_lossy(0),
+            uniform_updated_at: LixTimestamp::from_unix_millis_utc_lossy(0),
+        };
+        let alternating_mutations = alternating_rows
+            .iter()
+            .step_by(2)
+            .map(|source| {
+                let mut row = source.clone();
+                row.value.updated_at = replacement_updated_at;
+                (row.encoded_key.clone(), Some(row))
+            })
+            .collect::<Vec<_>>();
+        let mut writes = storage.new_write_set();
+        let mut output = Vec::new();
+        stage_fragmented_scoped_current_state_descriptor(
+            &mut writes,
+            &alternating_descriptor,
+            &alternating_rows,
+            alternating_mutations,
+            &mut output,
+        )
+        .expect("alternating updates should use the bounded rewrite fallback");
+        assert_eq!(
+            output.len(),
+            1,
+            "alternating updates must not publish one descriptor per authored run"
+        );
+        assert_eq!(output[0].row_count, 64);
+    }
+
+    #[test]
+    fn sparse_leaf_compaction_budget_bounds_low_density_fragment_growth() {
+        let scope = crate::tracked_state::types::CommitDeltaReplacementScope {
+            schema_key: "fragmented".to_string(),
+            file_id: None,
+        };
+        let part = |index: u32, fragmented: bool| {
+            let key = index.to_be_bytes().to_vec();
+            crate::tracked_state::current_state_envelope::scoped_range_part_from_current_state_descriptor(
+                &scope,
+                &CurrentStatePartDescriptor {
+                    first_key: key.clone(),
+                    last_key: key,
+                    content_digest: *blake3::hash(&index.to_be_bytes()).as_bytes(),
+                    payload_refs_digest: [8; 32],
+                    source_kind: 1,
+                    owner_commit_id: [0; 16],
+                    part_index: 0,
+                    source_row_offset: 0,
+                    row_count: 1,
+                    fragmented,
+                    uniform_created_at: LixTimestamp::from_unix_millis_utc_lossy(0),
+                    uniform_updated_at: LixTimestamp::from_unix_millis_utc_lossy(0),
+                },
+            )
+            .unwrap()
+        };
+        let mut parts = (0..20_u32)
+            .map(|index| part(index, false))
+            .chain((20..51_u32).map(|index| part(index, true)))
+            .chain((52..116_u32).map(|index| part(index, false)))
+            .collect::<Vec<_>>();
+        assert!(
+            super::sparse_current_state_fragment_compaction_ranges(
+                &parts.iter().collect::<Vec<_>>()
+            )
+            .unwrap()
+            .is_empty()
+        );
+        parts.insert(51, part(51, true));
+        assert_eq!(
+            super::sparse_current_state_fragment_compaction_ranges(
+                &parts.iter().collect::<Vec<_>>()
+            )
+            .unwrap(),
+            vec![(20, 52)],
+            "only the contiguous fragment run should compact; 84 healthy neighbors remain untouched"
+        );
+        let naturally_small = (0..64_u32)
+            .map(|index| part(index, false))
+            .collect::<Vec<_>>();
+        assert!(
+            super::sparse_current_state_fragment_compaction_ranges(
+                &naturally_small.iter().collect::<Vec<_>>()
+            )
+            .unwrap()
+            .is_empty(),
+            "canonical byte-limited parts must never be mistaken for structural fragments"
+        );
+    }
 
     struct SealCountingRead<R> {
         inner: R,

--- a/packages/engine/src/tracked_state/types.rs
+++ b/packages/engine/src/tracked_state/types.rs
@@ -294,6 +294,10 @@ pub(crate) struct CurrentStatePartDescriptor {
     /// allows sparse deletes and updates to retain untouched source bytes.
     pub(crate) source_row_offset: u16,
     pub(crate) row_count: u16,
+    /// True only for structural slices and authored islands introduced by a
+    /// sparse rewrite. Canonical encodes clear this bit, making compaction
+    /// self-stabilizing without guessing from physical row density.
+    pub(crate) fragmented: bool,
     pub(crate) uniform_created_at: LixTimestamp,
     pub(crate) uniform_updated_at: LixTimestamp,
 }


### PR DESCRIPTION
## What changed

- hard-cut the repository protocol to v53 and the current-state locator payload to v2
- authenticate an explicit structural-fragment bit in each current-state part descriptor
- retain untouched immutable source slices for sparse update/delete operations
- batch adjacent authored post-images into bounded native parts
- project adversarial alternating mutations before writing and fall back to one bounded post-image when fragmentation would exceed 16 parts
- compact only contiguous runs of at least 32 explicit fragments, then clear the fragment bit on canonical output
- add a distinct-key benchmark shape and final serving-part accounting

Mutation inventory remains historical authority. The CurrentStatePartSet remains a serving accelerator. This does not change TransactionJournal, scalar ingress, read-your-writes, mutation sealing, DataFusion SQL semantics, diff, merge, checkpoint, or history contracts.

## Why

A one-row sparse mutation previously decoded and re-encoded every row in its bounded source part. That copied untouched JSON/value rows, recompressed them, and wrote a replacement payload. Structural slices reuse those bytes directly. Explicit fragment metadata avoids workload/density heuristics: naturally byte-limited small parts stay canonical, while accumulated sparse fragments compact through a self-clearing physical invariant.

The hot-path profile benefit is removal of the per-row BTreeMap rebuild, payload cloning, serialization, and zstd work for untouched rows. Point reads keep the same bounded source lookup and authenticated slice check.

## Exact paired performance

Identical 1M-row, 32-commit touched-scope fixture on commit 0eab78c97 versus this branch, 101 samples, RocksDB and SlateDB:

| Metric | main | candidate | change |
| --- | ---: | ---: | ---: |
| Rocks sparse publication p50 | 435.088 us | 246.644 us | -43.3% |
| Rocks sparse publication p95 | 454.534 us | 260.270 us | -42.7% |
| Slate sparse publication p50 | 477.768 us | 301.697 us | -36.9% |
| Slate sparse publication p95 | 560.995 us | 313.390 us | -44.1% |
| sparse written bytes, 32 commits | 438,855 | 386,164 | -12.0% |
| Rocks cold point p50 | 73.057 us | 71.856 us | -1.6% |
| Slate cold point p50 | 82.896 us | 82.275 us | -0.7% |

The 1M-row, 64-distinct-key RocksDB stress fixture finishes at 2,212 serving parts, only four above the approximately 2,208-part base, with 659,143 total sparse written bytes and 299.743/331.554 us publication p50/p95. A 64-row alternating-update regression produces one canonical 64-row descriptor rather than 32 authored islands plus retained slices.

## Correctness and maintenance bounds

- absent deletes retain the original canonical descriptor
- updates preserve original created_at
- source offsets compose when slicing an already-sliced native part
- projected high-fragmentation writes compact before staging, so no orphan fragment payloads are written
- compaction touches only the contiguous explicit-fragment run; healthy neighbors are reused
- naturally small canonical parts never trigger compaction
- locator v2 authenticates the fragment bit and repository protocol v53 rejects older layouts before tracked-state access
- GC continues to retain native content/ref digests and replacement owners independently of the fragment marker

## Validation

- cargo test -p lix_engine --lib: 1,878 passed, 8 ignored
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- focused fragmentation, alternating-update, mixed-run, naturally-small, scoped publication, staged-parent, and protocol tests
- two independent sub-agent correctness/performance reviews: no blockers
- git diff --check
