### PR TITLE
Serve current state directly from authenticated column pages

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -679,7 +679,7 @@ fn profile_hot_sql_session_operations(
         }
         print_profile_samples(
             &format!(
-                "sql_session/{}/cold_after_{repeats}_updates",
+                "sql_session/{}/warm_after_{repeats}_updates",
                 profile.name()
             ),
             TransactionBenchOp::ReadManyByPk,

--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -667,6 +667,26 @@ fn profile_hot_sql_session_operations(
         repeats,
         elapsed / repeats_u32,
     );
+    if std::env::var_os("LIX_TRACKED_STATE_CRUD_PROFILE_READ_AFTER_HOT_UPDATES").is_some()
+        && matches!(operation, TransactionBenchOp::UpdateOneByPk)
+    {
+        let _ = runtime.block_on(fixture.read_many_by_pk());
+        let mut samples = Vec::with_capacity(profile_sample_count());
+        for _ in 0..profile_sample_count() {
+            let started = Instant::now();
+            black_box(runtime.block_on(fixture.read_many_by_pk()));
+            samples.push(started.elapsed());
+        }
+        print_profile_samples(
+            &format!(
+                "sql_session/{}/cold_after_{repeats}_updates",
+                profile.name()
+            ),
+            TransactionBenchOp::ReadManyByPk,
+            read_many_pk_count,
+            samples,
+        );
+    }
     if matches!(operation, TransactionBenchOp::ReadOneByPk) {
         let cache = lix_engine::storage_bench::take_entity_point_snapshot_cache_accounting();
         println!(

--- a/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
@@ -1785,7 +1785,17 @@ fn select_many_by_pk_sql(
                 .chain(std::iter::once(UNTRACKED_PROBE_PATH)),
         );
     }
-    select_by_pk_sql(&rows[..read_many_by_pk_count])
+    match std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_READ_MANY_DISTRIBUTION").as_deref() {
+        Ok("spread") if read_many_by_pk_count > 1 => select_by_paths_sql(
+            (0..read_many_by_pk_count)
+                .map(|index| index * (rows.len() - 1) / (read_many_by_pk_count - 1))
+                .map(|index| rows[index].path.as_str()),
+        ),
+        Ok("spread") | Ok("prefix") | Err(_) => select_by_pk_sql(&rows[..read_many_by_pk_count]),
+        Ok(other) => panic!(
+            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_READ_MANY_DISTRIBUTION '{other}'; expected prefix or spread"
+        ),
+    }
 }
 
 fn select_by_paths_sql<'a>(paths: impl IntoIterator<Item = &'a str>) -> String {

--- a/packages/engine/src/columnar_row_group.rs
+++ b/packages/engine/src/columnar_row_group.rs
@@ -32,6 +32,9 @@ use crate::storage_adapter::{
 pub(crate) const ROW_GROUP_MAX_ROWS: usize = 64 * 1024;
 /// Independently compressed point-read unit inside a scan-oriented row group.
 pub(crate) const ROW_GROUP_PAGE_ROWS: usize = 2 * 1024;
+/// Backpressure budget expressed in projected physical column pages. Wider
+/// projections therefore use smaller coordinate batches automatically.
+const ROW_GROUP_POINT_READ_MAX_COLUMN_PAGES: usize = 32;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct RowGroupRowLocation {
@@ -647,48 +650,133 @@ pub(crate) async fn load_row_group_page(
     page_index: usize,
     projection: &[usize],
 ) -> Result<RecordBatch, LixError> {
+    load_row_group_pages(
+        store,
+        id,
+        manifest,
+        &[(group_index, page_index)],
+        projection,
+    )
+    .await?
+    .pop()
+    .ok_or_else(|| row_group_error("row-group page read returned no batch"))
+}
+
+/// Loads multiple pages from one immutable set in one backend point-read
+/// batch. Caller order and duplicate coordinates are preserved.
+pub(crate) async fn load_row_group_pages(
+    store: &(impl StorageAdapterRead + ?Sized),
+    id: RowGroupSetId,
+    manifest: &RowGroupManifest,
+    pages: &[(usize, usize)],
+    projection: &[usize],
+) -> Result<Vec<RecordBatch>, LixError> {
+    let mut batches = Vec::with_capacity(pages.len());
+    visit_row_group_pages(store, id, manifest, pages, projection, |_, batch| {
+        batches.push(batch);
+        Ok(())
+    })
+    .await?;
+    Ok(batches)
+}
+
+/// Visits requested pages in caller order while bounding compressed and
+/// decoded working state. A page batch is dropped before the next physical
+/// read unless the caller deliberately retains it. A projection wider than
+/// the budget still reads one indivisible coordinate at a time; the budget
+/// limits physical working state rather than imposing a query-size policy.
+pub(crate) async fn visit_row_group_pages(
+    store: &(impl StorageAdapterRead + ?Sized),
+    id: RowGroupSetId,
+    manifest: &RowGroupManifest,
+    pages: &[(usize, usize)],
+    projection: &[usize],
+    mut visit: impl FnMut((usize, usize), RecordBatch) -> Result<(), LixError>,
+) -> Result<crate::storage_adapter::StorageReadStats, LixError> {
     validate_projection(manifest, projection)?;
-    let group = manifest.groups.get(group_index).ok_or_else(|| {
-        row_group_error(format!(
-            "row-group index {group_index} is outside the manifest"
-        ))
-    })?;
-    let page_count = (group.row_count as usize).div_ceil(ROW_GROUP_PAGE_ROWS);
-    if page_index >= page_count {
-        return Err(row_group_error(format!(
-            "row-group page index {page_index} is outside {page_count} pages"
-        )));
-    }
-    let page_rows = ROW_GROUP_PAGE_ROWS
-        .min(group.row_count as usize - page_index.saturating_mul(ROW_GROUP_PAGE_ROWS));
-    let keys = projection
-        .iter()
-        .map(|&column_index| id.column_key(group_index, page_index, column_index))
-        .collect::<Result<Vec<_>, _>>()?;
-    let loaded = PointReadPlan::from_unique_keys(ROW_GROUP_COLUMN_SPACE, keys)
-        .materialize(store, StorageGetOptions::default())
-        .await?;
-    let mut arrays = Vec::with_capacity(projection.len());
-    for (&column_index, value) in projection.iter().zip(loaded.value) {
-        let bytes = value
-            .and_then(|value| match value {
-                StorageProjectedValue::FullValue(bytes) => Some(bytes),
-                StorageProjectedValue::KeyOnly => None,
-            })
-            .ok_or_else(|| {
+    let mut stats = crate::storage_adapter::StorageReadStats::default();
+    let coordinates_per_batch = if projection.is_empty() {
+        ROW_GROUP_POINT_READ_MAX_COLUMN_PAGES
+    } else {
+        (ROW_GROUP_POINT_READ_MAX_COLUMN_PAGES / projection.len()).max(1)
+    };
+    for coordinate_batch in pages.chunks(coordinates_per_batch) {
+        let mut page_row_counts = Vec::with_capacity(coordinate_batch.len());
+        let mut keys = Vec::with_capacity(coordinate_batch.len().saturating_mul(projection.len()));
+        for &(group_index, page_index) in coordinate_batch {
+            let group = manifest.groups.get(group_index).ok_or_else(|| {
                 row_group_error(format!(
-                    "row-group {group_index} page {page_index} column {column_index} is missing"
+                    "row-group index {group_index} is outside the manifest"
                 ))
             })?;
-        arrays.push(decode_verified_column(
-            &bytes,
-            group.column_page_digests[column_index][page_index],
-            manifest.fields[column_index].data_type,
-            page_rows,
-        )?);
+            let page_count = (group.row_count as usize).div_ceil(ROW_GROUP_PAGE_ROWS);
+            if page_index >= page_count {
+                return Err(row_group_error(format!(
+                    "row-group page index {page_index} is outside {page_count} pages"
+                )));
+            }
+            page_row_counts
+                .push(ROW_GROUP_PAGE_ROWS.min(
+                    group.row_count as usize - page_index.saturating_mul(ROW_GROUP_PAGE_ROWS),
+                ));
+            for &column_index in projection {
+                keys.push(id.column_key(group_index, page_index, column_index)?);
+            }
+        }
+        let loaded = PointReadPlan::new(ROW_GROUP_COLUMN_SPACE, &keys)
+            .materialize(store, StorageGetOptions::default())
+            .await?;
+        stats.add(loaded.stats);
+        let mut values = loaded.value.into_iter();
+        for (&(group_index, page_index), page_rows) in coordinate_batch.iter().zip(page_row_counts)
+        {
+            if projection.is_empty() {
+                visit(
+                    (group_index, page_index),
+                    RecordBatch::try_new_with_options(
+                        projected_schema(manifest, projection),
+                        Vec::new(),
+                        &RecordBatchOptions::new().with_row_count(Some(page_rows)),
+                    )
+                    .map_err(|error| row_group_error(error.to_string()))?,
+                )?;
+                continue;
+            }
+            let group = &manifest.groups[group_index];
+            let mut arrays = Vec::with_capacity(projection.len());
+            for &column_index in projection {
+                let bytes = values
+                    .next()
+                    .flatten()
+                    .and_then(|value| match value {
+                        StorageProjectedValue::FullValue(bytes) => Some(bytes),
+                        StorageProjectedValue::KeyOnly => None,
+                    })
+                    .ok_or_else(|| {
+                        row_group_error(format!(
+                            "row-group {group_index} page {page_index} column {column_index} is missing"
+                        ))
+                    })?;
+                arrays.push(decode_verified_column(
+                    &bytes,
+                    group.column_page_digests[column_index][page_index],
+                    manifest.fields[column_index].data_type,
+                    page_rows,
+                )?);
+            }
+            visit(
+                (group_index, page_index),
+                RecordBatch::try_new(projected_schema(manifest, projection), arrays)
+                    .map_err(|error| row_group_error(error.to_string()))?,
+            )?;
+        }
+        if values.next().is_some() {
+            return Err(row_group_error(
+                "row-group page read returned excess column values",
+            ));
+        }
     }
-    RecordBatch::try_new(projected_schema(manifest, projection), arrays)
-        .map_err(|error| row_group_error(error.to_string()))
+    Ok(stats)
 }
 
 /// Loads one page through ordinary storage plus the current atomic write set.
@@ -1691,6 +1779,76 @@ mod tests {
         assert_eq!(last.num_rows(), 3);
         assert_eq!(last.num_columns(), 1);
         assert_eq!(last.schema().field(0).name(), "name");
+        let pages =
+            load_row_group_pages(&read, id, &loaded.manifest, &[(0, 0), (0, 1), (0, 0)], &[1])
+                .await
+                .expect("load projected pages in one batch");
+        assert_eq!(
+            pages.iter().map(RecordBatch::num_rows).collect::<Vec<_>>(),
+            vec![
+                ROW_GROUP_PAGE_ROWS,
+                ROW_GROUP_PAGE_ROWS,
+                ROW_GROUP_PAGE_ROWS
+            ]
+        );
+        assert_eq!(pages[0], pages[2], "duplicate coordinates preserve order");
+        let all_page_coordinates = (0..loaded.manifest.groups.len())
+            .flat_map(|group_index| {
+                let page_count = (loaded.manifest.groups[group_index].row_count as usize)
+                    .div_ceil(ROW_GROUP_PAGE_ROWS);
+                (0..page_count).map(move |page_index| (group_index, page_index))
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            all_page_coordinates.len() > ROW_GROUP_POINT_READ_MAX_COLUMN_PAGES,
+            "fixture must cross the physical page backpressure boundary"
+        );
+        let mut visited = Vec::new();
+        let visit_stats = visit_row_group_pages(
+            &read,
+            id,
+            &loaded.manifest,
+            &all_page_coordinates,
+            &[0],
+            |coordinate, batch| {
+                visited.push((coordinate, batch.num_rows()));
+                Ok(())
+            },
+        )
+        .await
+        .expect("visit pages across the backpressure boundary");
+        assert_eq!(
+            visited
+                .iter()
+                .map(|(coordinate, _)| *coordinate)
+                .collect::<Vec<_>>(),
+            all_page_coordinates
+        );
+        assert_eq!(
+            visit_stats.storage_calls, 2,
+            "33 projected pages must collapse from 33 calls to two bounded batches"
+        );
+        let full_projection = (0..loaded.manifest.fields.len()).collect::<Vec<_>>();
+        let full_stats = visit_row_group_pages(
+            &read,
+            id,
+            &loaded.manifest,
+            &all_page_coordinates,
+            &full_projection,
+            |_, _| Ok(()),
+        )
+        .await
+        .expect("visit fully projected pages with bounded batching");
+        let coordinates_per_batch =
+            (ROW_GROUP_POINT_READ_MAX_COLUMN_PAGES / full_projection.len()).max(1);
+        assert_eq!(
+            full_stats.storage_calls,
+            all_page_coordinates.len().div_ceil(coordinates_per_batch) as u64
+        );
+        assert!(
+            full_stats.storage_calls < all_page_coordinates.len() as u64,
+            "full-page hydration must issue fewer calls than one request per page"
+        );
         assert!(
             load_row_group_manifest(&read, RowGroupSetId::new([9; 16]))
                 .await

--- a/packages/engine/src/columnar_row_group.rs
+++ b/packages/engine/src/columnar_row_group.rs
@@ -483,6 +483,20 @@ pub(crate) async fn load_row_group_manifest(
     decode_manifest(&bytes).map(Some)
 }
 
+/// Loads an immutable manifest through the transaction-local write overlay.
+/// Row-group publication and current-state publication share one atomic write
+/// set, so a serving descriptor must validate the exact bytes being staged
+/// without requiring an intermediate storage commit.
+pub(crate) fn load_staged_row_group_manifest(
+    writes: &StorageWriteSet,
+    id: RowGroupSetId,
+) -> Result<Option<RowGroupManifest>, LixError> {
+    if let Some(bytes) = writes.staged_value(ROW_GROUP_MANIFEST_SPACE, id.as_bytes().as_slice()) {
+        return decode_manifest(&bytes).map(Some);
+    }
+    Ok(None)
+}
+
 /// Stages deletion of one immutable set and every addressed column. The
 /// owning commit remains the lifecycle authority; repository GC invokes this
 /// only after that commit leaves the reachable history graph.
@@ -666,6 +680,57 @@ pub(crate) async fn load_row_group_page(
                     "row-group {group_index} page {page_index} column {column_index} is missing"
                 ))
             })?;
+        arrays.push(decode_verified_column(
+            &bytes,
+            group.column_page_digests[column_index][page_index],
+            manifest.fields[column_index].data_type,
+            page_rows,
+        )?);
+    }
+    RecordBatch::try_new(projected_schema(manifest, projection), arrays)
+        .map_err(|error| row_group_error(error.to_string()))
+}
+
+/// Loads one page through ordinary storage plus the current atomic write set.
+/// Only columns absent from the overlay are issued as physical point reads.
+pub(crate) fn load_staged_row_group_page(
+    writes: &StorageWriteSet,
+    id: RowGroupSetId,
+    manifest: &RowGroupManifest,
+    group_index: usize,
+    page_index: usize,
+    projection: &[usize],
+) -> Result<RecordBatch, LixError> {
+    validate_projection(manifest, projection)?;
+    let group = manifest.groups.get(group_index).ok_or_else(|| {
+        row_group_error(format!(
+            "row-group index {group_index} is outside the manifest"
+        ))
+    })?;
+    let page_count = (group.row_count as usize).div_ceil(ROW_GROUP_PAGE_ROWS);
+    if page_index >= page_count {
+        return Err(row_group_error(format!(
+            "row-group page index {page_index} is outside {page_count} pages"
+        )));
+    }
+    let page_rows = ROW_GROUP_PAGE_ROWS
+        .min(group.row_count as usize - page_index.saturating_mul(ROW_GROUP_PAGE_ROWS));
+    let keys = projection
+        .iter()
+        .map(|&column_index| id.column_key(group_index, page_index, column_index))
+        .collect::<Result<Vec<_>, _>>()?;
+    let values = keys
+        .iter()
+        .map(|key| writes.staged_value(ROW_GROUP_COLUMN_SPACE, key.0.as_ref()))
+        .collect::<Vec<_>>();
+    let mut arrays = Vec::with_capacity(projection.len());
+    for ((&column_index, bytes), key) in projection.iter().zip(values).zip(keys) {
+        let bytes = bytes.ok_or_else(|| {
+            row_group_error(format!(
+                "row-group {group_index} page {page_index} column {column_index} is missing at {:?}",
+                key.0
+            ))
+        })?;
         arrays.push(decode_verified_column(
             &bytes,
             group.column_page_digests[column_index][page_index],

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -723,6 +723,7 @@ where
     let scoped_roots = scoped_roots.values().cloned().collect::<Vec<_>>();
     let reachable = crate::tracked_state::validate_scoped_range_trees(store, &scoped_roots).await?;
     live_scoped_range_nodes.extend(reachable.node_ids);
+    let mut live_columnar_sources = BTreeSet::<(CommitId, [u8; 16], [u8; 32])>::new();
     for part in reachable.parts {
         let descriptor =
             crate::tracked_state::current_state_descriptor_from_scoped_range_part(&part)?;
@@ -759,29 +760,11 @@ where
                         format!("live scoped range references missing columnar owner '{owner}'"),
                     ));
                 }
-                let authority = crate::tracked_state::load_commit_state_manifest(store, owner)
-                    .await?
-                    .ok_or_else(|| {
-                        LixError::new(
-                            LixError::CODE_INTERNAL_ERROR,
-                            format!("live scoped range columnar owner '{owner}' has no authority"),
-                        )
-                    })?;
-                let Some(parts) = authority.mutations.columnar_parts.as_ref() else {
-                    return Err(LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        "live columnar scoped range owner has no columnar mutation authority",
-                    ));
-                };
-                if parts.owner_commit_id != descriptor.owner_commit_id
-                    || parts.row_group_set_id != descriptor.source_id
-                    || parts.manifest_digest != descriptor.content_digest
-                {
-                    return Err(LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        "live columnar scoped range descriptor disagrees with owner authority",
-                    ));
-                }
+                live_columnar_sources.insert((
+                    owner,
+                    descriptor.source_id,
+                    descriptor.content_digest,
+                ));
                 retained_authority_commits.insert(owner);
             }
             _ => {
@@ -790,6 +773,34 @@ where
                     "live scoped range contains an unknown part source",
                 ));
             }
+        }
+    }
+    for (owner, source_id, content_digest) in live_columnar_sources {
+        let authority = match live_manifests.get(&owner) {
+            Some(authority) => authority.clone(),
+            None => crate::tracked_state::load_commit_state_manifest(store, owner)
+                .await?
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!("live scoped range columnar owner '{owner}' has no authority"),
+                    )
+                })?,
+        };
+        let Some(parts) = authority.mutations.columnar_parts.as_ref() else {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "live columnar scoped range owner has no columnar mutation authority",
+            ));
+        };
+        if parts.owner_commit_id != *owner.as_uuid().as_bytes()
+            || parts.row_group_set_id != source_id
+            || parts.manifest_digest != content_digest
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "live columnar scoped range descriptor disagrees with owner authority",
+            ));
         }
     }
 

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -751,6 +751,39 @@ where
                     ));
                 }
             }
+            2 => {
+                let owner = CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id));
+                if !packed.commits.contains_key(&owner) {
+                    return Err(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!("live scoped range references missing columnar owner '{owner}'"),
+                    ));
+                }
+                let authority = crate::tracked_state::load_commit_state_manifest(store, owner)
+                    .await?
+                    .ok_or_else(|| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            format!("live scoped range columnar owner '{owner}' has no authority"),
+                        )
+                    })?;
+                let Some(parts) = authority.mutations.columnar_parts.as_ref() else {
+                    return Err(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "live columnar scoped range owner has no columnar mutation authority",
+                    ));
+                };
+                if parts.owner_commit_id != descriptor.owner_commit_id
+                    || parts.row_group_set_id != descriptor.source_id
+                    || parts.manifest_digest != descriptor.content_digest
+                {
+                    return Err(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "live columnar scoped range descriptor disagrees with owner authority",
+                    ));
+                }
+                retained_authority_commits.insert(owner);
+            }
             _ => {
                 return Err(LixError::new(
                     LixError::CODE_INTERNAL_ERROR,

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -49,7 +49,7 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::mutable(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"explicit-current-state-fragments.v53";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"columnar-current-state-pages.v54";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately

--- a/packages/engine/src/live_state/entity_columnar.rs
+++ b/packages/engine/src/live_state/entity_columnar.rs
@@ -1,9 +1,26 @@
-//! Storage identities for derived entity columnar row groups.
+//! Entity-specific contract layered over generic immutable columnar row groups.
 
 use std::collections::BTreeMap;
 
 use crate::changelog::CommitId;
 use crate::columnar_row_group::{RowGroupRowLocation, RowGroupSetId};
+
+pub(crate) const ENTITY_COLUMNAR_LOSSLESS_SNAPSHOT_METADATA_KEY: &str =
+    "lix.entity_columnar.lossless_snapshot.v1";
+pub(crate) const ENTITY_COLUMNAR_ENTITY_PK_FIELD: &str = "lixcol_entity_pk";
+
+pub(crate) fn entity_identity_column_index(
+    manifest: &crate::columnar_row_group::RowGroupManifest,
+) -> Option<usize> {
+    (manifest
+        .metadata
+        .get(ENTITY_COLUMNAR_LOSSLESS_SNAPSHOT_METADATA_KEY)
+        .map(String::as_str)
+        == Some("true"))
+    .then(|| manifest.fields.len().checked_sub(1))
+    .flatten()
+    .filter(|&index| manifest.fields[index].name == ENTITY_COLUMNAR_ENTITY_PK_FIELD)
+}
 
 pub(crate) struct EntityColumnarWriteSets {
     sets: BTreeMap<(CommitId, String), crate::columnar_row_group::EncodedRowGroupSet>,

--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -10,7 +10,10 @@ pub(crate) mod visibility;
 
 #[allow(unused_imports)]
 pub(crate) use context::{BranchHeadControlCache, LiveStateContext, LiveStateStoreReader};
-pub(crate) use entity_columnar::{EntityColumnarWriteSets, entity_row_group_set_id};
+pub(crate) use entity_columnar::{
+    ENTITY_COLUMNAR_ENTITY_PK_FIELD, ENTITY_COLUMNAR_LOSSLESS_SNAPSHOT_METADATA_KEY,
+    EntityColumnarWriteSets, entity_identity_column_index, entity_row_group_set_id,
+};
 pub(crate) use entity_columnar_cache::{
     EntityColumnarArrayBudget, EntityColumnarShadowMaskCache, EntityColumnarShadowMaskKey,
 };

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -5726,6 +5726,75 @@ mod tests {
         assert!(commit_state.mutations.inline_part.is_empty());
         assert!(commit_state.mutations.parts.is_empty());
         assert_eq!(columnar_parts.page_first_keys.len(), 33);
+        let serving_root = commit_state
+            .current_state_scoped_ranges
+            .as_deref()
+            .expect("new collection insert must publish canonical column pages");
+        let serving_scope =
+            crate::tracked_state::current_state_envelope::current_state_scope_prefix(
+                &crate::tracked_state::CommitDeltaReplacementScope {
+                    schema_key: "columnar_lifecycle_probe".to_owned(),
+                    file_id: None,
+                },
+            )
+            .expect("test scope should encode");
+        let serving = crate::tracked_state::scoped_range::scan_scoped_range_scope(
+            &read,
+            &serving_root.tree,
+            &serving_scope,
+        )
+        .await
+        .expect("columnar serving scope should scan");
+        assert_eq!(serving.parts.len(), 33);
+        assert_eq!(
+            serving
+                .parts
+                .iter()
+                .map(|part| {
+                    crate::tracked_state::current_state_descriptor_from_scoped_range_part(part)
+                        .expect("columnar locator should decode")
+                        .source_kind
+                })
+                .collect::<Vec<_>>(),
+            vec![2; 33]
+        );
+        let owner =
+            crate::changelog::CommitId::parse_lix(&inserted_head, "typed lifecycle serving owner")
+                .expect("insert head should be canonical");
+        let point_ids = ["02047", "02048", "65535", "65536", "70000"];
+        let point_keys = point_ids
+            .iter()
+            .map(|identity| {
+                let entity_pk = EntityPk::from_json_array_text(&format!("[\"{identity}\"]"))
+                    .expect("test identity should parse");
+                bytes::Bytes::from(crate::tracked_state::encode_key_ref(
+                    crate::tracked_state::TrackedStateKeyRef {
+                        schema_key: "columnar_lifecycle_probe",
+                        file_id: None,
+                        entity_pk: &entity_pk,
+                    },
+                ))
+            })
+            .collect::<Vec<_>>();
+        let point_values =
+            crate::tracked_state::load_complete_current_state_values_from_scoped_root(
+                &read,
+                serving_root,
+                &point_keys,
+            )
+            .await
+            .expect("page-backed points should load")
+            .expect("the new collection scope should be covered");
+        for (index, ordinal) in [2047_u32, 2048, 65_535, 65_536].into_iter().enumerate() {
+            assert_eq!(
+                point_values[index]
+                    .as_ref()
+                    .expect("inserted page identity should resolve")
+                    .change_id,
+                crate::tracked_state::change_id_from_packed_address(owner, ordinal + 1,)
+            );
+        }
+        assert!(point_values[4].is_none());
         drop(read);
 
         assert_columnar_lifecycle_current(&main, ROW_COUNT, "base-0000", "base-1023").await;

--- a/packages/engine/src/sql2/entity_columnar_layout.rs
+++ b/packages/engine/src/sql2/entity_columnar_layout.rs
@@ -28,9 +28,9 @@ pub(crate) const ENTITY_COLUMNAR_LAYOUT_FINGERPRINT_METADATA_KEY: &str =
     "lix.entity_columnar.layout_fingerprint.v1";
 pub(crate) const ENTITY_COLUMNAR_BASE_COORDINATES_METADATA_KEY: &str =
     "lix.entity_columnar.base_coordinates.v1";
-pub(crate) const ENTITY_COLUMNAR_LOSSLESS_SNAPSHOT_METADATA_KEY: &str =
-    "lix.entity_columnar.lossless_snapshot.v1";
-pub(crate) const ENTITY_COLUMNAR_ENTITY_PK_FIELD: &str = "lixcol_entity_pk";
+pub(crate) use crate::live_state::{
+    ENTITY_COLUMNAR_ENTITY_PK_FIELD, ENTITY_COLUMNAR_LOSSLESS_SNAPSHOT_METADATA_KEY,
+};
 pub(crate) const LOW_CARDINALITY_CLUSTER_MAX_VALUES: usize = 64;
 const LOW_CARDINALITY_CLUSTER_MAX_BUCKETS: usize = 8;
 const ENTITY_COLUMNAR_MAX_CLUSTER_PARTITIONS: usize = 64;

--- a/packages/engine/src/tracked_state/current_state_envelope.rs
+++ b/packages/engine/src/tracked_state/current_state_envelope.rs
@@ -7,7 +7,7 @@ use crate::tracked_state::scoped_range::{
 use crate::tracked_state::types::{CommitDeltaReplacementScope, CurrentStatePartDescriptor};
 use crate::{LixError, storage_codec};
 
-const LOCATOR_PAYLOAD_VERSION: u16 = 2;
+const LOCATOR_PAYLOAD_VERSION: u16 = 3;
 
 #[derive(musli::Encode, musli::Decode)]
 #[musli(packed)]
@@ -15,8 +15,10 @@ struct CurrentStatePartLocatorPayload {
     content_digest: [u8; 32],
     payload_refs_digest: [u8; 32],
     source_kind: u8,
+    source_id: [u8; 16],
     owner_commit_id: [u8; 16],
     part_index: u32,
+    source_page_index: u16,
     source_row_offset: u16,
     fragmented: bool,
     uniform_created_at: crate::common::LixTimestamp,
@@ -58,8 +60,10 @@ pub(crate) fn scoped_range_part_from_current_state_descriptor(
                     content_digest: descriptor.content_digest,
                     payload_refs_digest: descriptor.payload_refs_digest,
                     source_kind: descriptor.source_kind,
+                    source_id: descriptor.source_id,
                     owner_commit_id: descriptor.owner_commit_id,
                     part_index: descriptor.part_index,
+                    source_page_index: descriptor.source_page_index,
                     source_row_offset: descriptor.source_row_offset,
                     fragmented: descriptor.fragmented,
                     uniform_created_at: descriptor.uniform_created_at,
@@ -86,8 +90,10 @@ pub(crate) fn current_state_descriptor_from_scoped_range_part(
         content_digest: payload.content_digest,
         payload_refs_digest: payload.payload_refs_digest,
         source_kind: payload.source_kind,
+        source_id: payload.source_id,
         owner_commit_id: payload.owner_commit_id,
         part_index: payload.part_index,
+        source_page_index: payload.source_page_index,
         source_row_offset: payload.source_row_offset,
         row_count: u16::try_from(part.row_count)
             .map_err(|_| envelope_error("part row count exceeds its locator codec"))?,
@@ -110,17 +116,32 @@ fn validate_current_state_descriptor(
         || descriptor.first_key > descriptor.last_key
         || descriptor.row_count == 0
         || slice_end
-            > crate::tracked_state::current_state_data_part::CURRENT_STATE_DATA_PART_MAX_ROWS as u32
+            > match descriptor.source_kind {
+                2 => crate::columnar_row_group::ROW_GROUP_PAGE_ROWS as u32,
+                _ => {
+                    crate::tracked_state::current_state_data_part::CURRENT_STATE_DATA_PART_MAX_ROWS
+                        as u32
+                }
+            }
         || descriptor.content_digest == [0; 32]
-        || descriptor.source_kind > 1
+        || descriptor.source_kind > 2
         || (descriptor.source_kind == 0
-            && (descriptor.owner_commit_id == [0; 16] || descriptor.payload_refs_digest != [0; 32]))
+            && (descriptor.source_id != [0; 16]
+                || descriptor.source_page_index != 0
+                || descriptor.owner_commit_id == [0; 16]
+                || descriptor.payload_refs_digest != [0; 32]))
         || (descriptor.source_kind == 1
-            && (descriptor.owner_commit_id != [0; 16]
+            && (descriptor.source_id != [0; 16]
+                || descriptor.source_page_index != 0
+                || descriptor.owner_commit_id != [0; 16]
                 || descriptor.part_index != 0
                 || descriptor.payload_refs_digest == [0; 32]
                 || descriptor.uniform_created_at.packed() != 0
                 || descriptor.uniform_updated_at.packed() != 0))
+        || (descriptor.source_kind == 2
+            && (descriptor.source_id == [0; 16]
+                || descriptor.owner_commit_id == [0; 16]
+                || descriptor.payload_refs_digest != [0; 32]))
     {
         return Err(envelope_error("part locator invariants are invalid"));
     }

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -76,8 +76,9 @@ pub(crate) use storage::{
 };
 #[cfg(test)]
 pub(crate) use storage::{
-    TRACKED_STATE_COMMIT_STATE_SEAL_SPACE, load_authoritative_commit_root,
-    load_commit_delta_change_ids, scan_commit_delta_members,
+    TRACKED_STATE_COMMIT_STATE_SEAL_SPACE, change_id_from_packed_address,
+    load_authoritative_commit_root, load_commit_delta_change_ids,
+    load_complete_current_state_values_from_scoped_root, scan_commit_delta_members,
     stage_resealed_commit_state_manifest_for_test,
 };
 pub(crate) use types::{COMMIT_STATE_MAX_REPLAY_BYTES, COMMIT_STATE_MAX_REPLAY_DEPTH};

--- a/packages/engine/src/tracked_state/scoped_current_state.rs
+++ b/packages/engine/src/tracked_state/scoped_current_state.rs
@@ -7,7 +7,8 @@ use crate::changelog::CommitId;
 use crate::storage_adapter::{StorageAdapterRead, StorageWriteSet};
 use crate::tracked_state::current_state_envelope::scoped_range_part_from_current_state_descriptor;
 use crate::tracked_state::scoped_range::{
-    ScopedRangeCoverageMarker, ScopedRangeRoot, stage_replace_scoped_range, stage_scoped_range_tree,
+    ScopedRangeCoverageMarker, ScopedRangeRoot, scan_scoped_range_scope,
+    stage_replace_scoped_range, stage_scoped_range_tree,
 };
 use crate::tracked_state::types::{
     CommitDeltaReplacementScope, CommitStateManifest, CommitStateMutationInventory,
@@ -16,6 +17,262 @@ use crate::tracked_state::types::{
 use crate::{LixError, storage_codec};
 
 const TRANSITION_CONTEXT: &str = "lix current-state scoped-range transition v1";
+
+/// Publishes canonical column pages directly when their closed key envelopes
+/// are disjoint from every inherited post-image part. Interleaved parent rows
+/// require an ordinal-preserving range merge and deliberately fail closed for
+/// now; mutation/history authority remains complete either way.
+async fn stage_disjoint_columnar_current_state_pages(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    parent_manifest: Option<&CommitStateManifest>,
+    commit_id: CommitId,
+    inventory: &CommitStateMutationInventory,
+) -> Result<Option<CurrentStateScopedRangeRoot>, LixError> {
+    use datafusion::arrow::array::{Array, StringArray};
+
+    let parent =
+        parent_manifest.and_then(|manifest| manifest.current_state_scoped_ranges.as_deref());
+    let parts = inventory
+        .columnar_parts
+        .as_ref()
+        .ok_or_else(|| scoped_state_error("columnar publication omitted its part authority"))?;
+    if parts.owner_commit_id != *commit_id.as_uuid().as_bytes()
+        || inventory.single_partition.as_ref()
+            != Some(&CommitDeltaReplacementScope {
+                schema_key: parts.schema_key.clone(),
+                file_id: None,
+            })
+    {
+        return Err(scoped_state_error(
+            "columnar publication disagrees with its commit scope",
+        ));
+    }
+    let set_id = crate::columnar_row_group::RowGroupSetId::new(parts.row_group_set_id);
+    let manifest = crate::columnar_row_group::load_staged_row_group_manifest(writes, set_id)?
+        .ok_or_else(|| scoped_state_error("columnar publication manifest is missing"))?;
+    crate::tracked_state::storage::validate_columnar_mutation_manifest(&manifest, parts)?;
+    let identity_column = manifest
+        .fields
+        .len()
+        .checked_sub(1)
+        .ok_or_else(|| scoped_state_error("columnar publication has no identity column"))?;
+    let mut descriptors = Vec::with_capacity(parts.page_first_keys.len());
+    let mut fence_index = 0usize;
+    let mut global_ordinal = 0u64;
+    for (group_index, group) in manifest.groups.iter().enumerate() {
+        let page_count =
+            (group.row_count as usize).div_ceil(crate::columnar_row_group::ROW_GROUP_PAGE_ROWS);
+        for page_index in 0..page_count {
+            let batch = crate::columnar_row_group::load_staged_row_group_page(
+                writes,
+                set_id,
+                &manifest,
+                group_index,
+                page_index,
+                &[identity_column],
+            )?;
+            let identities = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .ok_or_else(|| scoped_state_error("columnar identity page is not UTF-8"))?;
+            if identities.is_empty() || identities.null_count() != 0 {
+                return Err(scoped_state_error(
+                    "columnar identity page is empty or contains nulls",
+                ));
+            }
+            let encoded_keys = (0..identities.len())
+                .map(|row_index| {
+                    let entity_pk = crate::entity_pk::EntityPk::from_json_array_text(
+                        identities.value(row_index),
+                    )
+                    .map_err(|error| scoped_state_error(error.to_string()))?;
+                    Ok(crate::tracked_state::codec::encode_key_ref(
+                        crate::tracked_state::types::TrackedStateKeyRef {
+                            schema_key: &parts.schema_key,
+                            file_id: None,
+                            entity_pk: &entity_pk,
+                        },
+                    ))
+                })
+                .collect::<Result<Vec<_>, LixError>>()?;
+            if encoded_keys.windows(2).any(|pair| pair[0] >= pair[1])
+                || parts.page_first_keys.get(fence_index) != encoded_keys.first()
+                || parts.page_last_keys.get(fence_index) != encoded_keys.last()
+            {
+                return Err(scoped_state_error(
+                    "columnar identity page disagrees with authenticated key fences",
+                ));
+            }
+            let row_count = u16::try_from(identities.len())
+                .map_err(|_| scoped_state_error("columnar page row count exceeds u16"))?;
+            descriptors.push(CurrentStatePartDescriptor {
+                first_key: encoded_keys.first().expect("non-empty page").clone(),
+                last_key: encoded_keys.last().expect("non-empty page").clone(),
+                content_digest: parts.manifest_digest,
+                payload_refs_digest: [0; 32],
+                source_kind: 2,
+                source_id: parts.row_group_set_id,
+                owner_commit_id: parts.owner_commit_id,
+                part_index: u32::try_from(group_index)
+                    .map_err(|_| scoped_state_error("columnar group index exceeds u32"))?,
+                source_page_index: u16::try_from(page_index)
+                    .map_err(|_| scoped_state_error("columnar page index exceeds u16"))?,
+                source_row_offset: 0,
+                row_count,
+                fragmented: false,
+                uniform_created_at: parts.uniform_created_at,
+                uniform_updated_at: parts.uniform_updated_at,
+            });
+            global_ordinal = global_ordinal
+                .checked_add(identities.len() as u64)
+                .ok_or_else(|| scoped_state_error("columnar row count overflows"))?;
+            fence_index += 1;
+        }
+    }
+    if fence_index != parts.page_first_keys.len() || global_ordinal != u64::from(parts.row_count) {
+        return Err(scoped_state_error(
+            "columnar page topology disagrees with mutation authority",
+        ));
+    }
+
+    let scope = CommitDeltaReplacementScope {
+        schema_key: parts.schema_key.clone(),
+        file_id: None,
+    };
+    let prefix = crate::tracked_state::current_state_envelope::current_state_scope_prefix(&scope)?;
+    let mut scoped_parts = descriptors
+        .iter()
+        .map(|descriptor| scoped_range_part_from_current_state_descriptor(&scope, descriptor))
+        .collect::<Result<Vec<_>, LixError>>()?;
+    let tree = match parent {
+        None => {
+            if !parent_scope_is_proven_empty(store, parent_manifest, &scope).await? {
+                return Ok(None);
+            }
+            let marker = ScopedRangeCoverageMarker {
+                scope: prefix,
+                row_count: global_ordinal,
+                part_count: u32::try_from(scoped_parts.len())
+                    .map_err(|_| scoped_state_error("columnar part count exceeds u32"))?,
+            };
+            stage_scoped_range_tree(writes, [(marker, scoped_parts)])?
+        }
+        Some(parent) => {
+            let inherited = scan_scoped_range_scope(store, &parent.tree, &prefix).await?;
+            let coverage = match inherited.coverage {
+                Some(coverage) => coverage,
+                None => {
+                    if !parent_scope_is_proven_empty(store, parent_manifest, &scope).await? {
+                        return Ok(None);
+                    }
+                    let marker = ScopedRangeCoverageMarker {
+                        scope: prefix,
+                        row_count: global_ordinal,
+                        part_count: u32::try_from(scoped_parts.len())
+                            .map_err(|_| scoped_state_error("columnar part count exceeds u32"))?,
+                    };
+                    let tree = stage_replace_scoped_range(
+                        store,
+                        writes,
+                        &parent.tree,
+                        marker,
+                        scoped_parts,
+                    )
+                    .await?
+                    .root;
+                    return Ok(Some(attest_scoped_range_root(
+                        commit_id,
+                        Some(parent),
+                        inventory,
+                        tree,
+                    )?));
+                }
+            };
+            scoped_parts.extend(inherited.parts);
+            scoped_parts.sort_by(|left, right| left.first_key.cmp(&right.first_key));
+            if scoped_parts
+                .windows(2)
+                .any(|pair| pair[0].last_key >= pair[1].first_key)
+            {
+                return Ok(None);
+            }
+            let marker =
+                ScopedRangeCoverageMarker {
+                    scope: prefix,
+                    row_count: coverage
+                        .row_count
+                        .checked_add(global_ordinal)
+                        .ok_or_else(|| scoped_state_error("columnar scope row count overflows"))?,
+                    part_count: coverage
+                        .part_count
+                        .checked_add(u32::try_from(descriptors.len()).map_err(|_| {
+                            scoped_state_error("columnar scope part count exceeds u32")
+                        })?)
+                        .ok_or_else(|| scoped_state_error("columnar scope part count overflows"))?,
+                };
+            stage_replace_scoped_range(store, writes, &parent.tree, marker, scoped_parts)
+                .await?
+                .root
+        }
+    };
+    Ok(Some(attest_scoped_range_root(
+        commit_id, parent, inventory, tree,
+    )?))
+}
+
+/// Proves that no commit in the first-parent state lineage could have authored
+/// the requested collection. Unknown/cascading scope information fails closed.
+async fn parent_scope_is_proven_empty(
+    store: &(impl StorageAdapterRead + ?Sized),
+    parent: Option<&CommitStateManifest>,
+    scope: &CommitDeltaReplacementScope,
+) -> Result<bool, LixError> {
+    let Some(parent) = parent else {
+        return Ok(true);
+    };
+    let mut next = Some(parent.clone());
+    let mut visited = std::collections::BTreeSet::new();
+    while let Some(manifest) = next {
+        if !visited.insert(manifest.commit_id) {
+            return Err(scoped_state_error(
+                "parent scope emptiness proof encountered a commit cycle",
+            ));
+        }
+        if manifest.mutations.member_count != 0 {
+            if manifest
+                .mutations
+                .columnar_parts
+                .as_ref()
+                .is_some_and(|parts| {
+                    parts.schema_key == scope.schema_key && scope.file_id.is_none()
+                })
+            {
+                return Ok(false);
+            }
+            let Some(touched) =
+                crate::tracked_state::storage::commit_state_inventory_exact_touched_scopes(
+                    manifest.commit_id,
+                    &manifest.mutations,
+                )?
+            else {
+                return Ok(false);
+            };
+            if touched.contains(scope) {
+                return Ok(false);
+            }
+        }
+        let Some(parent_id) = manifest.parent_commit_ids.first().copied() else {
+            return Ok(true);
+        };
+        next = crate::tracked_state::storage::load_commit_state_manifest(store, parent_id).await?;
+        if next.is_none() {
+            return Ok(false);
+        }
+    }
+    Ok(false)
+}
 
 /// Opaque proof that the serving root was produced in this write set from the
 /// exact graph parent and sealed mutation inventory.
@@ -133,9 +390,11 @@ pub(crate) async fn stage_complete_replacement_scoped_range_root(
                 content_digest: part.content_digest,
                 payload_refs_digest: [0; 32],
                 source_kind: 0,
+                source_id: [0; 16],
                 owner_commit_id: part.owner_commit_id,
                 part_index: u32::try_from(part_index)
                     .map_err(|_| scoped_state_error("replacement part index overflows"))?,
+                source_page_index: 0,
                 source_row_offset: 0,
                 row_count,
                 fragmented: false,
@@ -194,6 +453,17 @@ pub(crate) async fn stage_current_state_scoped_ranges(
 ) -> Result<CertifiedCurrentStateScopedRangePublication, LixError> {
     let parent_commit_id = parent.map(|parent| parent.commit_id);
     let parent_root = parent.and_then(|parent| parent.current_state_scoped_ranges.as_deref());
+    if inventory.columnar_parts.is_some() {
+        let root = stage_disjoint_columnar_current_state_pages(
+            store, writes, parent, commit_id, inventory,
+        )
+        .await?;
+        return Ok(CertifiedCurrentStateScopedRangePublication {
+            write_set_id: writes.identity(),
+            parent_commit_id,
+            root,
+        });
+    }
     let touched = crate::tracked_state::storage::commit_state_inventory_exact_touched_scopes(
         commit_id, inventory,
     )?;

--- a/packages/engine/src/tracked_state/scoped_current_state.rs
+++ b/packages/engine/src/tracked_state/scoped_current_state.rs
@@ -29,8 +29,6 @@ async fn stage_disjoint_columnar_current_state_pages(
     commit_id: CommitId,
     inventory: &CommitStateMutationInventory,
 ) -> Result<Option<CurrentStateScopedRangeRoot>, LixError> {
-    use datafusion::arrow::array::{Array, StringArray};
-
     let parent =
         parent_manifest.and_then(|manifest| manifest.current_state_scoped_ranges.as_deref());
     let parts = inventory
@@ -52,64 +50,38 @@ async fn stage_disjoint_columnar_current_state_pages(
     let manifest = crate::columnar_row_group::load_staged_row_group_manifest(writes, set_id)?
         .ok_or_else(|| scoped_state_error("columnar publication manifest is missing"))?;
     crate::tracked_state::storage::validate_columnar_mutation_manifest(&manifest, parts)?;
-    let identity_column = manifest
-        .fields
-        .len()
-        .checked_sub(1)
-        .ok_or_else(|| scoped_state_error("columnar publication has no identity column"))?;
-    let mut descriptors = Vec::with_capacity(parts.page_first_keys.len());
+    let mut descriptors =
+        Vec::<CurrentStatePartDescriptor>::with_capacity(parts.page_first_keys.len());
     let mut fence_index = 0usize;
     let mut global_ordinal = 0u64;
     for (group_index, group) in manifest.groups.iter().enumerate() {
         let page_count =
             (group.row_count as usize).div_ceil(crate::columnar_row_group::ROW_GROUP_PAGE_ROWS);
         for page_index in 0..page_count {
-            let batch = crate::columnar_row_group::load_staged_row_group_page(
-                writes,
-                set_id,
-                &manifest,
-                group_index,
-                page_index,
-                &[identity_column],
-            )?;
-            let identities = batch
-                .column(0)
-                .as_any()
-                .downcast_ref::<StringArray>()
-                .ok_or_else(|| scoped_state_error("columnar identity page is not UTF-8"))?;
-            if identities.is_empty() || identities.null_count() != 0 {
-                return Err(scoped_state_error(
-                    "columnar identity page is empty or contains nulls",
-                ));
-            }
-            let encoded_keys = (0..identities.len())
-                .map(|row_index| {
-                    let entity_pk = crate::entity_pk::EntityPk::from_json_array_text(
-                        identities.value(row_index),
-                    )
-                    .map_err(|error| scoped_state_error(error.to_string()))?;
-                    Ok(crate::tracked_state::codec::encode_key_ref(
-                        crate::tracked_state::types::TrackedStateKeyRef {
-                            schema_key: &parts.schema_key,
-                            file_id: None,
-                            entity_pk: &entity_pk,
-                        },
-                    ))
-                })
-                .collect::<Result<Vec<_>, LixError>>()?;
-            if encoded_keys.windows(2).any(|pair| pair[0] >= pair[1])
-                || parts.page_first_keys.get(fence_index) != encoded_keys.first()
-                || parts.page_last_keys.get(fence_index) != encoded_keys.last()
+            let row_count = u16::try_from(
+                (group.row_count as usize
+                    - page_index * crate::columnar_row_group::ROW_GROUP_PAGE_ROWS)
+                    .min(crate::columnar_row_group::ROW_GROUP_PAGE_ROWS),
+            )
+            .map_err(|_| scoped_state_error("columnar page row count exceeds u16"))?;
+            let first_key = parts.page_first_keys.get(fence_index).ok_or_else(|| {
+                scoped_state_error("columnar mutation authority omitted a page first-key fence")
+            })?;
+            let last_key = parts.page_last_keys.get(fence_index).ok_or_else(|| {
+                scoped_state_error("columnar mutation authority omitted a page last-key fence")
+            })?;
+            if first_key > last_key
+                || descriptors
+                    .last()
+                    .is_some_and(|previous| previous.last_key.as_slice() >= first_key.as_slice())
             {
                 return Err(scoped_state_error(
-                    "columnar identity page disagrees with authenticated key fences",
+                    "columnar mutation authority has unordered page key fences",
                 ));
             }
-            let row_count = u16::try_from(identities.len())
-                .map_err(|_| scoped_state_error("columnar page row count exceeds u16"))?;
             descriptors.push(CurrentStatePartDescriptor {
-                first_key: encoded_keys.first().expect("non-empty page").clone(),
-                last_key: encoded_keys.last().expect("non-empty page").clone(),
+                first_key: first_key.clone(),
+                last_key: last_key.clone(),
                 content_digest: parts.manifest_digest,
                 payload_refs_digest: [0; 32],
                 source_kind: 2,
@@ -126,7 +98,7 @@ async fn stage_disjoint_columnar_current_state_pages(
                 uniform_updated_at: parts.uniform_updated_at,
             });
             global_ordinal = global_ordinal
-                .checked_add(identities.len() as u64)
+                .checked_add(u64::from(row_count))
                 .ok_or_else(|| scoped_state_error("columnar row count overflows"))?;
             fence_index += 1;
         }

--- a/packages/engine/src/tracked_state/scoped_current_state.rs
+++ b/packages/engine/src/tracked_state/scoped_current_state.rs
@@ -7,7 +7,7 @@ use crate::changelog::CommitId;
 use crate::storage_adapter::{StorageAdapterRead, StorageWriteSet};
 use crate::tracked_state::current_state_envelope::scoped_range_part_from_current_state_descriptor;
 use crate::tracked_state::scoped_range::{
-    ScopedRangeCoverageMarker, ScopedRangeRoot, scan_scoped_range_scope,
+    ScopedRangeCoverageMarker, ScopedRangeRoot, load_scoped_range_coverage,
     stage_replace_scoped_range, stage_scoped_range_tree,
 };
 use crate::tracked_state::types::{
@@ -114,7 +114,7 @@ async fn stage_disjoint_columnar_current_state_pages(
         file_id: None,
     };
     let prefix = crate::tracked_state::current_state_envelope::current_state_scope_prefix(&scope)?;
-    let mut scoped_parts = descriptors
+    let scoped_parts = descriptors
         .iter()
         .map(|descriptor| scoped_range_part_from_current_state_descriptor(&scope, descriptor))
         .collect::<Result<Vec<_>, LixError>>()?;
@@ -146,76 +146,32 @@ async fn stage_disjoint_columnar_current_state_pages(
             None => stage_scoped_range_tree(writes, [(marker, scoped_parts)])?,
         }
     } else {
+        // A mutation part set is not a complete post-image by itself. It may
+        // seed a scope only when absence is certified; an already covered
+        // scope waits for the bounded sparse range-rewrite path.
+        if let Some(parent) = parent
+            && load_scoped_range_coverage(store, &parent.tree, &prefix)
+                .await?
+                .is_some()
+        {
+            return Ok(None);
+        }
+        if !parent_scope_is_proven_empty(store, parent_manifest, &scope).await? {
+            return Ok(None);
+        }
+        let marker = ScopedRangeCoverageMarker {
+            scope: prefix.clone(),
+            row_count: global_ordinal,
+            part_count: u32::try_from(scoped_parts.len())
+                .map_err(|_| scoped_state_error("columnar part count exceeds u32"))?,
+        };
         match parent {
-            None => {
-                if !parent_scope_is_proven_empty(store, parent_manifest, &scope).await? {
-                    return Ok(None);
-                }
-                let marker = ScopedRangeCoverageMarker {
-                    scope: prefix,
-                    row_count: global_ordinal,
-                    part_count: u32::try_from(scoped_parts.len())
-                        .map_err(|_| scoped_state_error("columnar part count exceeds u32"))?,
-                };
-                stage_scoped_range_tree(writes, [(marker, scoped_parts)])?
-            }
             Some(parent) => {
-                let inherited = scan_scoped_range_scope(store, &parent.tree, &prefix).await?;
-                let coverage = match inherited.coverage {
-                    Some(coverage) => coverage,
-                    None => {
-                        if !parent_scope_is_proven_empty(store, parent_manifest, &scope).await? {
-                            return Ok(None);
-                        }
-                        let marker = ScopedRangeCoverageMarker {
-                            scope: prefix,
-                            row_count: global_ordinal,
-                            part_count: u32::try_from(scoped_parts.len()).map_err(|_| {
-                                scoped_state_error("columnar part count exceeds u32")
-                            })?,
-                        };
-                        let tree = stage_replace_scoped_range(
-                            store,
-                            writes,
-                            &parent.tree,
-                            marker,
-                            scoped_parts,
-                        )
-                        .await?
-                        .root;
-                        return Ok(Some(attest_scoped_range_root(
-                            commit_id,
-                            Some(parent),
-                            inventory,
-                            tree,
-                        )?));
-                    }
-                };
-                scoped_parts.extend(inherited.parts);
-                scoped_parts.sort_by(|left, right| left.first_key.cmp(&right.first_key));
-                if scoped_parts
-                    .windows(2)
-                    .any(|pair| pair[0].last_key >= pair[1].first_key)
-                {
-                    return Ok(None);
-                }
-                let marker = ScopedRangeCoverageMarker {
-                    scope: prefix,
-                    row_count: coverage
-                        .row_count
-                        .checked_add(global_ordinal)
-                        .ok_or_else(|| scoped_state_error("columnar scope row count overflows"))?,
-                    part_count: coverage
-                        .part_count
-                        .checked_add(u32::try_from(descriptors.len()).map_err(|_| {
-                            scoped_state_error("columnar scope part count exceeds u32")
-                        })?)
-                        .ok_or_else(|| scoped_state_error("columnar scope part count overflows"))?,
-                };
                 stage_replace_scoped_range(store, writes, &parent.tree, marker, scoped_parts)
                     .await?
                     .root
             }
+            None => stage_scoped_range_tree(writes, [(marker, scoped_parts)])?,
         }
     };
     Ok(Some(attest_scoped_range_root(
@@ -223,8 +179,10 @@ async fn stage_disjoint_columnar_current_state_pages(
     )?))
 }
 
-/// Proves that no commit in the first-parent state lineage could have authored
-/// the requested collection. Unknown/cascading scope information fails closed.
+/// Proves one collection has never been authored in the linear state lineage.
+/// This is a correctness fallback for first publication; existing covered
+/// scopes never use it. A cumulative scoped-authority summary will replace
+/// this one-time walk in the next manifest hard cut.
 async fn parent_scope_is_proven_empty(
     store: &(impl StorageAdapterRead + ?Sized),
     parent: Option<&CommitStateManifest>,
@@ -240,6 +198,11 @@ async fn parent_scope_is_proven_empty(
             return Err(scoped_state_error(
                 "parent scope emptiness proof encountered a commit cycle",
             ));
+        }
+        if manifest.parent_commit_ids.len() > 1
+            || manifest.mutations.selected_source_commit_id().is_some()
+        {
+            return Ok(false);
         }
         if manifest.mutations.member_count != 0 {
             if manifest
@@ -623,7 +586,7 @@ mod tests {
     };
 
     use super::{
-        attest_scoped_range_root, stage_current_state_scoped_ranges,
+        attest_scoped_range_root, parent_scope_is_proven_empty, stage_current_state_scoped_ranges,
         validate_scoped_range_attestation,
     };
 
@@ -1407,6 +1370,43 @@ mod tests {
         assert!(
             publication.root().is_none(),
             "cross-scope mutation must not inherit serving authority"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_scope_proof_rejects_merge_and_selected_source_ancestry() {
+        let storage = StorageAdapter::new(Memory::new());
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .unwrap();
+        let parent_id = CommitId::for_test_label("empty-proof-parent");
+        let requested = scope("not-authored-here");
+
+        let mut merge = manifest(
+            parent_id,
+            Some(CommitId::for_test_label("first-parent")),
+            CommitStateMutationInventory::default(),
+        );
+        merge
+            .parent_commit_ids
+            .push(CommitId::for_test_label("second-parent"));
+        assert!(
+            !parent_scope_is_proven_empty(&read, Some(&merge), &requested)
+                .await
+                .unwrap()
+        );
+
+        let mut selected = manifest(parent_id, None, CommitStateMutationInventory::default());
+        selected.mutations.selected_source_commit_id = Some(
+            *CommitId::for_test_label("selected-source")
+                .as_uuid()
+                .as_bytes(),
+        );
+        assert!(
+            !parent_scope_is_proven_empty(&read, Some(&selected), &requested)
+                .await
+                .unwrap()
         );
     }
 }

--- a/packages/engine/src/tracked_state/scoped_current_state.rs
+++ b/packages/engine/src/tracked_state/scoped_current_state.rs
@@ -146,60 +146,88 @@ async fn stage_disjoint_columnar_current_state_pages(
         .iter()
         .map(|descriptor| scoped_range_part_from_current_state_descriptor(&scope, descriptor))
         .collect::<Result<Vec<_>, LixError>>()?;
-    let tree = match parent {
-        None => {
-            if !parent_scope_is_proven_empty(store, parent_manifest, &scope).await? {
-                return Ok(None);
-            }
-            let marker = ScopedRangeCoverageMarker {
-                scope: prefix,
-                row_count: global_ordinal,
-                part_count: u32::try_from(scoped_parts.len())
-                    .map_err(|_| scoped_state_error("columnar part count exceeds u32"))?,
-            };
-            stage_scoped_range_tree(writes, [(marker, scoped_parts)])?
-        }
-        Some(parent) => {
-            let inherited = scan_scoped_range_scope(store, &parent.tree, &prefix).await?;
-            let coverage = match inherited.coverage {
-                Some(coverage) => coverage,
-                None => {
-                    if !parent_scope_is_proven_empty(store, parent_manifest, &scope).await? {
-                        return Ok(None);
-                    }
-                    let marker = ScopedRangeCoverageMarker {
-                        scope: prefix,
-                        row_count: global_ordinal,
-                        part_count: u32::try_from(scoped_parts.len())
-                            .map_err(|_| scoped_state_error("columnar part count exceeds u32"))?,
-                    };
-                    let tree = stage_replace_scoped_range(
-                        store,
-                        writes,
-                        &parent.tree,
-                        marker,
-                        scoped_parts,
-                    )
+    let complete_replacement =
+        inventory
+            .replacement_generation
+            .as_ref()
+            .is_some_and(|generation| {
+                generation.scope == scope && generation.owner_commit_id == parts.owner_commit_id
+            });
+    if inventory.replacement_generation.is_some() && !complete_replacement {
+        return Err(scoped_state_error(
+            "columnar replacement generation disagrees with its scope or owner",
+        ));
+    }
+    let tree = if complete_replacement {
+        let marker = ScopedRangeCoverageMarker {
+            scope: prefix,
+            row_count: global_ordinal,
+            part_count: u32::try_from(scoped_parts.len())
+                .map_err(|_| scoped_state_error("columnar part count exceeds u32"))?,
+        };
+        match parent {
+            Some(parent) => {
+                stage_replace_scoped_range(store, writes, &parent.tree, marker, scoped_parts)
                     .await?
-                    .root;
-                    return Ok(Some(attest_scoped_range_root(
-                        commit_id,
-                        Some(parent),
-                        inventory,
-                        tree,
-                    )?));
-                }
-            };
-            scoped_parts.extend(inherited.parts);
-            scoped_parts.sort_by(|left, right| left.first_key.cmp(&right.first_key));
-            if scoped_parts
-                .windows(2)
-                .any(|pair| pair[0].last_key >= pair[1].first_key)
-            {
-                return Ok(None);
+                    .root
             }
-            let marker =
-                ScopedRangeCoverageMarker {
+            None => stage_scoped_range_tree(writes, [(marker, scoped_parts)])?,
+        }
+    } else {
+        match parent {
+            None => {
+                if !parent_scope_is_proven_empty(store, parent_manifest, &scope).await? {
+                    return Ok(None);
+                }
+                let marker = ScopedRangeCoverageMarker {
+                    scope: prefix,
+                    row_count: global_ordinal,
+                    part_count: u32::try_from(scoped_parts.len())
+                        .map_err(|_| scoped_state_error("columnar part count exceeds u32"))?,
+                };
+                stage_scoped_range_tree(writes, [(marker, scoped_parts)])?
+            }
+            Some(parent) => {
+                let inherited = scan_scoped_range_scope(store, &parent.tree, &prefix).await?;
+                let coverage = match inherited.coverage {
+                    Some(coverage) => coverage,
+                    None => {
+                        if !parent_scope_is_proven_empty(store, parent_manifest, &scope).await? {
+                            return Ok(None);
+                        }
+                        let marker = ScopedRangeCoverageMarker {
+                            scope: prefix,
+                            row_count: global_ordinal,
+                            part_count: u32::try_from(scoped_parts.len()).map_err(|_| {
+                                scoped_state_error("columnar part count exceeds u32")
+                            })?,
+                        };
+                        let tree = stage_replace_scoped_range(
+                            store,
+                            writes,
+                            &parent.tree,
+                            marker,
+                            scoped_parts,
+                        )
+                        .await?
+                        .root;
+                        return Ok(Some(attest_scoped_range_root(
+                            commit_id,
+                            Some(parent),
+                            inventory,
+                            tree,
+                        )?));
+                    }
+                };
+                scoped_parts.extend(inherited.parts);
+                scoped_parts.sort_by(|left, right| left.first_key.cmp(&right.first_key));
+                if scoped_parts
+                    .windows(2)
+                    .any(|pair| pair[0].last_key >= pair[1].first_key)
+                {
+                    return Ok(None);
+                }
+                let marker = ScopedRangeCoverageMarker {
                     scope: prefix,
                     row_count: coverage
                         .row_count
@@ -212,9 +240,10 @@ async fn stage_disjoint_columnar_current_state_pages(
                         })?)
                         .ok_or_else(|| scoped_state_error("columnar scope part count overflows"))?,
                 };
-            stage_replace_scoped_range(store, writes, &parent.tree, marker, scoped_parts)
-                .await?
-                .root
+                stage_replace_scoped_range(store, writes, &parent.tree, marker, scoped_parts)
+                    .await?
+                    .root
+            }
         }
     };
     Ok(Some(attest_scoped_range_root(

--- a/packages/engine/src/tracked_state/scoped_range.rs
+++ b/packages/engine/src/tracked_state/scoped_range.rs
@@ -1580,6 +1580,21 @@ pub(crate) async fn scan_scoped_range_interval(
     })
 }
 
+/// Resolves only the authenticated coverage marker for one exact scope.
+pub(crate) async fn load_scoped_range_coverage(
+    store: &(impl StorageAdapterRead + ?Sized),
+    root: &ScopedRangeRoot,
+    scope: &ScopedRangePrefix,
+) -> Result<Option<ScopedRangeCoverageMarker>, LixError> {
+    match find_exact(store, root, &marker_route(scope)).await? {
+        Some(ScopedRangeEntry::Marker(marker)) if marker.scope == *scope => Ok(Some(marker)),
+        Some(ScopedRangeEntry::Marker(_)) | None => Ok(None),
+        Some(ScopedRangeEntry::Part(_)) => {
+            Err(scoped_range_error("scope marker route resolved a part"))
+        }
+    }
+}
+
 /// Returns every part in one exact scope without inventing a sentinel entity
 /// key. The synthetic route kind sorts after all part starts in that scope.
 pub(crate) async fn scan_scoped_range_scope(
@@ -1587,14 +1602,7 @@ pub(crate) async fn scan_scoped_range_scope(
     root: &ScopedRangeRoot,
     scope: &ScopedRangePrefix,
 ) -> Result<ScopedRangeInterval, LixError> {
-    let marker = find_exact(store, root, &marker_route(scope)).await?;
-    let coverage = match marker {
-        Some(ScopedRangeEntry::Marker(marker)) if marker.scope == *scope => Some(marker),
-        Some(ScopedRangeEntry::Marker(_)) | None => None,
-        Some(ScopedRangeEntry::Part(_)) => {
-            return Err(scoped_range_error("scope marker route resolved a part"));
-        }
-    };
+    let coverage = load_scoped_range_coverage(store, root, scope).await?;
     let Some(coverage) = coverage else {
         return Ok(ScopedRangeInterval {
             coverage: None,

--- a/packages/engine/src/tracked_state/scoped_range.rs
+++ b/packages/engine/src/tracked_state/scoped_range.rs
@@ -328,7 +328,6 @@ pub(crate) struct ScopedRangeCoveredPointRoute {
     pub(crate) covered_part: Option<ScopedRangePart>,
 }
 
-#[cfg(any(test, feature = "storage-benches"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ScopedRangeInterval {
     pub(crate) coverage: Option<ScopedRangeCoverageMarker>,
@@ -1583,7 +1582,6 @@ pub(crate) async fn scan_scoped_range_interval(
 
 /// Returns every part in one exact scope without inventing a sentinel entity
 /// key. The synthetic route kind sorts after all part starts in that scope.
-#[cfg(feature = "storage-benches")]
 pub(crate) async fn scan_scoped_range_scope(
     store: &(impl StorageAdapterRead + ?Sized),
     root: &ScopedRangeRoot,
@@ -1989,7 +1987,6 @@ async fn load_routed_leaf(
     }
 }
 
-#[cfg(any(test, feature = "storage-benches"))]
 async fn collect_route_interval(
     store: &(impl StorageAdapterRead + ?Sized),
     root: &ScopedRangeRoot,

--- a/packages/engine/src/tracked_state/scoped_range.rs
+++ b/packages/engine/src/tracked_state/scoped_range.rs
@@ -328,6 +328,7 @@ pub(crate) struct ScopedRangeCoveredPointRoute {
     pub(crate) covered_part: Option<ScopedRangePart>,
 }
 
+#[cfg(any(test, feature = "storage-benches"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ScopedRangeInterval {
     pub(crate) coverage: Option<ScopedRangeCoverageMarker>,
@@ -1597,6 +1598,7 @@ pub(crate) async fn load_scoped_range_coverage(
 
 /// Returns every part in one exact scope without inventing a sentinel entity
 /// key. The synthetic route kind sorts after all part starts in that scope.
+#[cfg(any(test, feature = "storage-benches"))]
 pub(crate) async fn scan_scoped_range_scope(
     store: &(impl StorageAdapterRead + ?Sized),
     root: &ScopedRangeRoot,
@@ -1995,6 +1997,7 @@ async fn load_routed_leaf(
     }
 }
 
+#[cfg(any(test, feature = "storage-benches"))]
 async fn collect_route_interval(
     store: &(impl StorageAdapterRead + ?Sized),
     root: &ScopedRangeRoot,

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -652,10 +652,15 @@ pub(crate) fn commit_state_inventory_exact_touched_scopes(
     if inventory.member_count == 0 {
         return Ok(Some(Vec::new()));
     }
-    if inventory.columnar_parts.is_some() {
-        // The catalog rewrite path does not yet consume typed column pages.
-        // Discard inherited serving state rather than publishing stale misses.
-        return Ok(None);
+    if let Some(parts) = inventory.columnar_parts.as_ref() {
+        let scope = CommitDeltaReplacementScope {
+            schema_key: parts.schema_key.clone(),
+            file_id: None,
+        };
+        if inventory.single_partition.as_ref() != Some(&scope) {
+            return Ok(None);
+        }
+        return Ok(Some(vec![scope]));
     }
     if !inventory.replacement_part_digests.is_empty() {
         return Ok(inventory.single_partition.clone().map(|scope| vec![scope]));
@@ -766,7 +771,7 @@ async fn load_current_state_values_from_descriptors(
         ));
     }
     let mut routed = BTreeMap::<
-        (u8, [u8; 16], u32, [u8; 32], u16),
+        (u8, [u8; 16], [u8; 16], u32, u16, [u8; 32], u16),
         (CurrentStatePartDescriptor, Vec<usize>),
     >::new();
     for (output_index, descriptor) in descriptors.into_iter().enumerate() {
@@ -776,8 +781,10 @@ async fn load_current_state_values_from_descriptors(
         routed
             .entry((
                 descriptor.source_kind,
+                descriptor.source_id,
                 descriptor.owner_commit_id,
                 descriptor.part_index,
+                descriptor.source_page_index,
                 descriptor.content_digest,
                 descriptor.source_row_offset,
             ))
@@ -877,6 +884,136 @@ async fn load_current_state_values_from_descriptors(
             }) {
                 values[*output_index] = Some(rows[index].value.clone());
             }
+        }
+    }
+    let columnar = routed
+        .iter()
+        .filter(|(_, (descriptor, _))| descriptor.source_kind == 2)
+        .collect::<Vec<_>>();
+    for (_, (descriptor, output_indices)) in columnar {
+        use datafusion::arrow::array::{Array, StringArray};
+
+        let id = crate::columnar_row_group::RowGroupSetId::new(descriptor.source_id);
+        let manifest = crate::columnar_row_group::load_row_group_manifest(store, id)
+            .await?
+            .ok_or_else(|| {
+                replacement_payload_error("current-state columnar manifest is missing")
+            })?;
+        let first_key = decode_key(&descriptor.first_key)?;
+        if manifest.content_digest()? != descriptor.content_digest
+            || manifest.namespace != first_key.schema_key
+            || manifest
+                .metadata
+                .get(crate::sql2::ENTITY_COLUMNAR_LOSSLESS_SNAPSHOT_METADATA_KEY)
+                .map(String::as_str)
+                != Some("true")
+            || crate::live_state::entity_row_group_set_id(
+                CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id)),
+                &manifest.namespace,
+            )
+            .as_bytes()
+                != descriptor.source_id
+        {
+            return Err(replacement_payload_error(
+                "current-state columnar descriptor disagrees with its manifest",
+            ));
+        }
+        let identity_column_index = manifest
+            .fields
+            .len()
+            .checked_sub(1)
+            .ok_or_else(|| replacement_payload_error("columnar manifest has no identity"))?;
+        if manifest.fields[identity_column_index].name
+            != crate::sql2::ENTITY_COLUMNAR_ENTITY_PK_FIELD
+        {
+            return Err(replacement_payload_error(
+                "current-state columnar identity field drifted",
+            ));
+        }
+        let group_index = usize::try_from(descriptor.part_index)
+            .map_err(|_| replacement_payload_error("columnar group index exceeds usize"))?;
+        let page_index = usize::from(descriptor.source_page_index);
+        let batch = crate::columnar_row_group::load_row_group_page(
+            store,
+            id,
+            &manifest,
+            group_index,
+            page_index,
+            &[identity_column_index],
+        )
+        .await?;
+        let identities = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| replacement_payload_error("columnar identity page is not UTF-8"))?;
+        let slice_start = usize::from(descriptor.source_row_offset);
+        let slice_end = slice_start + usize::from(descriptor.row_count);
+        let identities = (slice_end <= identities.len())
+            .then(|| identities.slice(slice_start, usize::from(descriptor.row_count)))
+            .ok_or_else(|| replacement_payload_error("columnar page slice is out of bounds"))?;
+        let identities = identities
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("slicing preserves the string array type");
+        let encode_identity = |identity: &str| -> Result<Vec<u8>, LixError> {
+            let entity_pk = EntityPk::from_json_array_text(identity)
+                .map_err(|error| replacement_payload_error(&error.to_string()))?;
+            Ok(encode_key_ref(TrackedStateKeyRef {
+                schema_key: &manifest.namespace,
+                file_id: None,
+                entity_pk: &entity_pk,
+            }))
+        };
+        if identities.is_empty()
+            || encode_identity(identities.value(0))? != descriptor.first_key
+            || encode_identity(identities.value(identities.len() - 1))? != descriptor.last_key
+        {
+            return Err(replacement_payload_error(
+                "columnar page slice disagrees with current-state key fences",
+            ));
+        }
+        for &output_index in output_indices {
+            let key = decode_key(&encoded_keys[output_index])?;
+            if key.schema_key != manifest.namespace || key.file_id.is_some() {
+                continue;
+            }
+            let identity = key.entity_pk.as_json_array_text()?;
+            let ordered_identities = (0..identities.len())
+                .map(|row_index| identities.value(row_index))
+                .collect::<Vec<_>>();
+            let Ok(row_index) =
+                ordered_identities.binary_search_by(|candidate| candidate.cmp(&identity.as_str()))
+            else {
+                continue;
+            };
+            let group_base = manifest.groups[..group_index]
+                .iter()
+                .try_fold(0usize, |sum, group| {
+                    sum.checked_add(group.row_count as usize)
+                })
+                .ok_or_else(|| replacement_payload_error("columnar group base overflows"))?;
+            let ordinal = group_base
+                .checked_add(
+                    page_index
+                        .checked_mul(crate::columnar_row_group::ROW_GROUP_PAGE_ROWS)
+                        .ok_or_else(|| replacement_payload_error("columnar page base overflows"))?,
+                )
+                .and_then(|base| base.checked_add(slice_start))
+                .and_then(|base| base.checked_add(row_index))
+                .ok_or_else(|| replacement_payload_error("columnar row ordinal overflows"))?;
+            let packed = u32::try_from(ordinal)
+                .map_err(|_| replacement_payload_error("columnar row ordinal exceeds u32"))?
+                .checked_add(1)
+                .ok_or_else(|| replacement_payload_error("columnar change address overflows"))?;
+            let owner = CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id));
+            values[output_index] = Some(TrackedStateIndexValue {
+                change_id: change_id_from_packed_address(owner, packed),
+                commit_id: owner,
+                deleted: false,
+                created_at: descriptor.uniform_created_at,
+                updated_at: descriptor.uniform_updated_at,
+            });
         }
     }
     Ok(values)
@@ -2566,8 +2703,10 @@ fn stage_scoped_native_current_state_rows(
             content_digest: part.digest,
             payload_refs_digest: part.refs_digest,
             source_kind: 1,
+            source_id: [0; 16],
             owner_commit_id: [0; 16],
             part_index: 0,
+            source_page_index: 0,
             source_row_offset: 0,
             row_count: part.row_count,
             fragmented,
@@ -2693,6 +2832,137 @@ async fn load_scoped_current_state_descriptor_rows(
                     replacement_payload_error("native current-state slice is out of bounds")
                 })?
                 .to_vec()
+        }
+        2 => {
+            let id = crate::columnar_row_group::RowGroupSetId::new(descriptor.source_id);
+            let staged_manifest =
+                crate::columnar_row_group::load_staged_row_group_manifest(writes, id)?;
+            let manifest = match staged_manifest {
+                Some(manifest) => manifest,
+                None => crate::columnar_row_group::load_row_group_manifest(store, id)
+                    .await?
+                    .ok_or_else(|| {
+                        replacement_payload_error("columnar current-state manifest is missing")
+                    })?,
+            };
+            let schema_key = decode_key(&descriptor.first_key)?.schema_key;
+            if manifest.content_digest()? != descriptor.content_digest
+                || manifest.namespace != schema_key
+                || crate::live_state::entity_row_group_set_id(
+                    CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id)),
+                    &manifest.namespace,
+                )
+                .as_bytes()
+                    != descriptor.source_id
+            {
+                return Err(replacement_payload_error(
+                    "columnar current-state source disagrees with its descriptor",
+                ));
+            }
+            let projection = (0..manifest.fields.len()).collect::<Vec<_>>();
+            let group_index = usize::try_from(descriptor.part_index)
+                .map_err(|_| replacement_payload_error("columnar group index exceeds usize"))?;
+            let page_index = usize::from(descriptor.source_page_index);
+            let batch = if crate::columnar_row_group::load_staged_row_group_manifest(writes, id)?
+                .is_some()
+            {
+                crate::columnar_row_group::load_staged_row_group_page(
+                    writes,
+                    id,
+                    &manifest,
+                    group_index,
+                    page_index,
+                    &projection,
+                )?
+            } else {
+                crate::columnar_row_group::load_row_group_page(
+                    store,
+                    id,
+                    &manifest,
+                    group_index,
+                    page_index,
+                    &projection,
+                )
+                .await?
+            };
+            let group_base = manifest.groups[..group_index]
+                .iter()
+                .try_fold(0usize, |sum, group| {
+                    sum.checked_add(group.row_count as usize)
+                })
+                .ok_or_else(|| replacement_payload_error("columnar group base overflows"))?;
+            let page_base = group_base
+                .checked_add(
+                    page_index
+                        .checked_mul(crate::columnar_row_group::ROW_GROUP_PAGE_ROWS)
+                        .ok_or_else(|| replacement_payload_error("columnar page base overflows"))?,
+                )
+                .ok_or_else(|| replacement_payload_error("columnar page base overflows"))?;
+            let synthetic_parts = crate::tracked_state::types::ColumnarMutationPartSet {
+                owner_commit_id: descriptor.owner_commit_id,
+                row_group_set_id: descriptor.source_id,
+                manifest_digest: descriptor.content_digest,
+                schema_key: manifest.namespace.clone(),
+                row_count: manifest.groups.iter().map(|group| group.row_count).sum(),
+                group_row_counts: manifest
+                    .groups
+                    .iter()
+                    .map(|group| group.row_count)
+                    .collect(),
+                first_key: descriptor.first_key.clone(),
+                last_key: descriptor.last_key.clone(),
+                page_first_keys: vec![descriptor.first_key.clone()],
+                page_last_keys: vec![descriptor.last_key.clone()],
+                uniform_created_at: descriptor.uniform_created_at,
+                uniform_updated_at: descriptor.uniform_updated_at,
+                origin_key: None,
+            };
+            let owner = CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id));
+            let start = usize::from(descriptor.source_row_offset);
+            let end = start + usize::from(descriptor.row_count);
+            if end > batch.num_rows() {
+                return Err(replacement_payload_error(
+                    "columnar current-state page slice is out of bounds",
+                ));
+            }
+            (start..end)
+                .map(|row_index| {
+                    let ordinal = page_base.checked_add(row_index).ok_or_else(|| {
+                        replacement_payload_error("columnar row ordinal overflows")
+                    })?;
+                    let packed = u32::try_from(ordinal)
+                        .map_err(|_| replacement_payload_error("columnar row ordinal exceeds u32"))?
+                        .checked_add(1)
+                        .ok_or_else(|| {
+                            replacement_payload_error("columnar change address overflows")
+                        })?;
+                    let change_id = change_id_from_packed_address(owner, packed);
+                    let record = decode_columnar_change_record(
+                        &manifest,
+                        &batch,
+                        row_index,
+                        &synthetic_parts,
+                        change_id,
+                        "",
+                    )?;
+                    Ok(CurrentStateDataRow {
+                        encoded_key: encode_key_ref(TrackedStateKeyRef {
+                            schema_key: &record.schema_key,
+                            file_id: record.file_id.as_deref(),
+                            entity_pk: &record.entity_pk,
+                        }),
+                        value: TrackedStateIndexValue {
+                            change_id,
+                            commit_id: owner,
+                            deleted: false,
+                            created_at: descriptor.uniform_created_at,
+                            updated_at: descriptor.uniform_updated_at,
+                        },
+                        snapshot: record.snapshot,
+                        metadata: record.metadata,
+                    })
+                })
+                .collect::<Result<Vec<_>, LixError>>()?
         }
         _ => {
             return Err(replacement_payload_error(
@@ -4282,7 +4552,10 @@ fn addressable_change_id(
     Ok(change_id_from_packed_address(commit_id, packed))
 }
 
-fn change_id_from_packed_address(commit_id: CommitId, packed: u32) -> crate::changelog::ChangeId {
+pub(crate) fn change_id_from_packed_address(
+    commit_id: CommitId,
+    packed: u32,
+) -> crate::changelog::ChangeId {
     let mut bytes = *commit_id.as_uuid().as_bytes();
     bytes[12..].copy_from_slice(&packed.to_be_bytes());
     crate::changelog::ChangeId::new(uuid::Uuid::from_bytes(bytes))
@@ -5002,7 +5275,7 @@ async fn load_columnar_change_record_at_locator(
     )
 }
 
-fn validate_columnar_mutation_manifest(
+pub(crate) fn validate_columnar_mutation_manifest(
     manifest: &crate::columnar_row_group::RowGroupManifest,
     parts: &crate::tracked_state::types::ColumnarMutationPartSet,
 ) -> Result<(), LixError> {
@@ -10059,8 +10332,10 @@ mod tests {
             content_digest: [7; 32],
             payload_refs_digest: [8; 32],
             source_kind: 1,
+            source_id: [0; 16],
             owner_commit_id: [0; 16],
             part_index: 0,
+            source_page_index: 0,
             source_row_offset: 4,
             row_count: 2,
             fragmented: false,
@@ -10154,8 +10429,10 @@ mod tests {
             content_digest: [9; 32],
             payload_refs_digest: [10; 32],
             source_kind: 1,
+            source_id: [0; 16],
             owner_commit_id: [0; 16],
             part_index: 0,
+            source_page_index: 0,
             source_row_offset: 0,
             row_count: alternating_rows.len() as u16,
             fragmented: false,
@@ -10205,8 +10482,10 @@ mod tests {
                     content_digest: *blake3::hash(&index.to_be_bytes()).as_bytes(),
                     payload_refs_digest: [8; 32],
                     source_kind: 1,
+                    source_id: [0; 16],
                     owner_commit_id: [0; 16],
                     part_index: 0,
+                    source_page_index: 0,
                     source_row_offset: 0,
                     row_count: 1,
                     fragmented,

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -890,133 +890,176 @@ async fn load_current_state_values_from_descriptors(
         .iter()
         .filter(|(_, (descriptor, _))| descriptor.source_kind == 2)
         .collect::<Vec<_>>();
-    for (_, (descriptor, output_indices)) in columnar {
-        use datafusion::arrow::array::{Array, StringArray};
-
+    let mut columnar_manifests = HashMap::new();
+    for (_, (descriptor, _)) in &columnar {
         let id = crate::columnar_row_group::RowGroupSetId::new(descriptor.source_id);
-        let manifest = crate::columnar_row_group::load_row_group_manifest(store, id)
-            .await?
-            .ok_or_else(|| {
-                replacement_payload_error("current-state columnar manifest is missing")
-            })?;
-        let first_key = decode_key(&descriptor.first_key)?;
-        if manifest.content_digest()? != descriptor.content_digest
-            || manifest.namespace != first_key.schema_key
-            || manifest
-                .metadata
-                .get(crate::sql2::ENTITY_COLUMNAR_LOSSLESS_SNAPSHOT_METADATA_KEY)
-                .map(String::as_str)
-                != Some("true")
-            || crate::live_state::entity_row_group_set_id(
-                CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id)),
-                &manifest.namespace,
-            )
-            .as_bytes()
-                != descriptor.source_id
+        if let std::collections::hash_map::Entry::Vacant(entry) =
+            columnar_manifests.entry(descriptor.source_id)
         {
-            return Err(replacement_payload_error(
-                "current-state columnar descriptor disagrees with its manifest",
-            ));
-        }
-        let identity_column_index = manifest
-            .fields
-            .len()
-            .checked_sub(1)
-            .ok_or_else(|| replacement_payload_error("columnar manifest has no identity"))?;
-        if manifest.fields[identity_column_index].name
-            != crate::sql2::ENTITY_COLUMNAR_ENTITY_PK_FIELD
-        {
-            return Err(replacement_payload_error(
-                "current-state columnar identity field drifted",
-            ));
-        }
-        let group_index = usize::try_from(descriptor.part_index)
-            .map_err(|_| replacement_payload_error("columnar group index exceeds usize"))?;
-        let page_index = usize::from(descriptor.source_page_index);
-        let batch = crate::columnar_row_group::load_row_group_page(
-            store,
-            id,
-            &manifest,
-            group_index,
-            page_index,
-            &[identity_column_index],
-        )
-        .await?;
-        let identities = batch
-            .column(0)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .ok_or_else(|| replacement_payload_error("columnar identity page is not UTF-8"))?;
-        let slice_start = usize::from(descriptor.source_row_offset);
-        let slice_end = slice_start + usize::from(descriptor.row_count);
-        let identities = (slice_end <= identities.len())
-            .then(|| identities.slice(slice_start, usize::from(descriptor.row_count)))
-            .ok_or_else(|| replacement_payload_error("columnar page slice is out of bounds"))?;
-        let identities = identities
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .expect("slicing preserves the string array type");
-        let encode_identity = |identity: &str| -> Result<Vec<u8>, LixError> {
-            let entity_pk = EntityPk::from_json_array_text(identity)
-                .map_err(|error| replacement_payload_error(&error.to_string()))?;
-            Ok(encode_key_ref(TrackedStateKeyRef {
-                schema_key: &manifest.namespace,
-                file_id: None,
-                entity_pk: &entity_pk,
-            }))
-        };
-        if identities.is_empty()
-            || encode_identity(identities.value(0))? != descriptor.first_key
-            || encode_identity(identities.value(identities.len() - 1))? != descriptor.last_key
-        {
-            return Err(replacement_payload_error(
-                "columnar page slice disagrees with current-state key fences",
-            ));
-        }
-        for &output_index in output_indices {
-            let key = decode_key(&encoded_keys[output_index])?;
-            if key.schema_key != manifest.namespace || key.file_id.is_some() {
-                continue;
-            }
-            let identity = key.entity_pk.as_json_array_text()?;
-            let ordered_identities = (0..identities.len())
-                .map(|row_index| identities.value(row_index))
-                .collect::<Vec<_>>();
-            let Ok(row_index) =
-                ordered_identities.binary_search_by(|candidate| candidate.cmp(&identity.as_str()))
-            else {
-                continue;
-            };
-            let group_base = manifest.groups[..group_index]
-                .iter()
-                .try_fold(0usize, |sum, group| {
-                    sum.checked_add(group.row_count as usize)
-                })
-                .ok_or_else(|| replacement_payload_error("columnar group base overflows"))?;
-            let ordinal = group_base
-                .checked_add(
-                    page_index
-                        .checked_mul(crate::columnar_row_group::ROW_GROUP_PAGE_ROWS)
-                        .ok_or_else(|| replacement_payload_error("columnar page base overflows"))?,
-                )
-                .and_then(|base| base.checked_add(slice_start))
-                .and_then(|base| base.checked_add(row_index))
-                .ok_or_else(|| replacement_payload_error("columnar row ordinal overflows"))?;
-            let packed = u32::try_from(ordinal)
-                .map_err(|_| replacement_payload_error("columnar row ordinal exceeds u32"))?
-                .checked_add(1)
-                .ok_or_else(|| replacement_payload_error("columnar change address overflows"))?;
-            let owner = CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id));
-            values[output_index] = Some(TrackedStateIndexValue {
-                change_id: change_id_from_packed_address(owner, packed),
-                commit_id: owner,
-                deleted: false,
-                created_at: descriptor.uniform_created_at,
-                updated_at: descriptor.uniform_updated_at,
-            });
+            let manifest = crate::columnar_row_group::load_row_group_manifest(store, id)
+                .await?
+                .ok_or_else(|| {
+                    replacement_payload_error("current-state columnar manifest is missing")
+                })?;
+            entry.insert(manifest);
         }
     }
+    for (&source_id, manifest) in &columnar_manifests {
+        let identity_column_index = crate::live_state::entity_identity_column_index(manifest)
+            .ok_or_else(|| {
+                replacement_payload_error("current-state columnar identity contract drifted")
+            })?;
+        let mut page_routes = BTreeMap::new();
+        for (_, (descriptor, output_indices)) in &columnar {
+            if descriptor.source_id == source_id {
+                page_routes
+                    .entry((
+                        descriptor.part_index as usize,
+                        usize::from(descriptor.source_page_index),
+                    ))
+                    .or_insert_with(Vec::new)
+                    .push((descriptor, output_indices.as_slice()));
+            }
+        }
+        let coordinates = page_routes.keys().copied().collect::<Vec<_>>();
+        crate::columnar_row_group::visit_row_group_pages(
+            store,
+            crate::columnar_row_group::RowGroupSetId::new(source_id),
+            manifest,
+            &coordinates,
+            &[identity_column_index],
+            |coordinate, batch| {
+                for (descriptor, output_indices) in &page_routes[&coordinate] {
+                    apply_columnar_identity_page(
+                        manifest,
+                        descriptor,
+                        output_indices,
+                        &batch,
+                        encoded_keys,
+                        &mut values,
+                    )?;
+                }
+                Ok(())
+            },
+        )
+        .await?;
+    }
     Ok(values)
+}
+
+fn apply_columnar_identity_page(
+    manifest: &crate::columnar_row_group::RowGroupManifest,
+    descriptor: &CurrentStatePartDescriptor,
+    output_indices: &[usize],
+    batch: &datafusion::arrow::record_batch::RecordBatch,
+    encoded_keys: &[Bytes],
+    values: &mut [Option<TrackedStateIndexValue>],
+) -> Result<(), LixError> {
+    use datafusion::arrow::array::{Array, StringArray};
+
+    let first_key = decode_key(&descriptor.first_key)?;
+    if manifest.content_digest()? != descriptor.content_digest
+        || manifest.namespace != first_key.schema_key
+        || crate::live_state::entity_row_group_set_id(
+            CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id)),
+            &manifest.namespace,
+        )
+        .as_bytes()
+            != descriptor.source_id
+    {
+        return Err(replacement_payload_error(
+            "current-state columnar descriptor disagrees with its manifest",
+        ));
+    }
+    let group_index = usize::try_from(descriptor.part_index)
+        .map_err(|_| replacement_payload_error("columnar group index exceeds usize"))?;
+    let page_index = usize::from(descriptor.source_page_index);
+    let identities = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| replacement_payload_error("columnar identity page is not UTF-8"))?;
+    let slice_start = usize::from(descriptor.source_row_offset);
+    let slice_end = slice_start + usize::from(descriptor.row_count);
+    let identities = (slice_end <= identities.len())
+        .then(|| identities.slice(slice_start, usize::from(descriptor.row_count)))
+        .ok_or_else(|| replacement_payload_error("columnar page slice is out of bounds"))?;
+    let identities = identities
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("slicing preserves the string array type");
+    let encode_identity = |identity: &str| -> Result<Vec<u8>, LixError> {
+        let entity_pk = EntityPk::from_json_array_text(identity)
+            .map_err(|error| replacement_payload_error(&error.to_string()))?;
+        Ok(encode_key_ref(TrackedStateKeyRef {
+            schema_key: &manifest.namespace,
+            file_id: None,
+            entity_pk: &entity_pk,
+        }))
+    };
+    if identities.is_empty()
+        || encode_identity(identities.value(0))? != descriptor.first_key
+        || encode_identity(identities.value(identities.len() - 1))? != descriptor.last_key
+    {
+        return Err(replacement_payload_error(
+            "columnar page slice disagrees with current-state key fences",
+        ));
+    }
+    let identity_rows = (output_indices.len() > 4).then(|| columnar_identity_row_map(identities));
+    let group_base = manifest.groups[..group_index]
+        .iter()
+        .try_fold(0usize, |sum, group| {
+            sum.checked_add(group.row_count as usize)
+        })
+        .ok_or_else(|| replacement_payload_error("columnar group base overflows"))?;
+    let slice_ordinal_base = group_base
+        .checked_add(
+            page_index
+                .checked_mul(crate::columnar_row_group::ROW_GROUP_PAGE_ROWS)
+                .ok_or_else(|| replacement_payload_error("columnar page base overflows"))?,
+        )
+        .and_then(|base| base.checked_add(slice_start))
+        .ok_or_else(|| replacement_payload_error("columnar slice base overflows"))?;
+    for &output_index in output_indices {
+        let key = decode_key(&encoded_keys[output_index])?;
+        if key.schema_key != manifest.namespace || key.file_id.is_some() {
+            continue;
+        }
+        let identity = key.entity_pk.as_json_array_text()?;
+        let row_index = match &identity_rows {
+            Some(rows) => rows.get(identity.as_str()).copied(),
+            None => {
+                (0..identities.len()).find(|&row_index| identities.value(row_index) == identity)
+            }
+        };
+        let Some(row_index) = row_index else {
+            continue;
+        };
+        let ordinal = slice_ordinal_base
+            .checked_add(row_index)
+            .ok_or_else(|| replacement_payload_error("columnar row ordinal overflows"))?;
+        let packed = u32::try_from(ordinal)
+            .map_err(|_| replacement_payload_error("columnar row ordinal exceeds u32"))?
+            .checked_add(1)
+            .ok_or_else(|| replacement_payload_error("columnar change address overflows"))?;
+        let owner = CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id));
+        values[output_index] = Some(TrackedStateIndexValue {
+            change_id: change_id_from_packed_address(owner, packed),
+            commit_id: owner,
+            deleted: false,
+            created_at: descriptor.uniform_created_at,
+            updated_at: descriptor.uniform_updated_at,
+        });
+    }
+    Ok(())
+}
+
+fn columnar_identity_row_map(
+    identities: &datafusion::arrow::array::StringArray,
+) -> HashMap<&str, usize> {
+    (0..datafusion::arrow::array::Array::len(identities))
+        .map(|row_index| (identities.value(row_index), row_index))
+        .collect()
 }
 
 pub(crate) async fn load_complete_current_state_values_from_scoped_root(
@@ -4898,28 +4941,29 @@ async fn load_change_records_at_locators(
                 .or_default()
                 .push((locator_index, row_in_page));
         }
-        for ((group_index, page_index), page_locators) in page_groups {
-            let batch = crate::columnar_row_group::load_row_group_page(
-                store,
-                id,
-                &row_group_manifest,
-                group_index,
-                page_index,
-                &projection,
-            )
-            .await?;
-            for (locator_index, row_in_page) in page_locators {
-                let locator = locators[locator_index];
-                loaded[locator_index] = Some(decode_columnar_change_record(
-                    &row_group_manifest,
-                    &batch,
-                    row_in_page,
-                    parts,
-                    locator.change_id,
-                    &manifests[&commit_id].account_id,
-                )?);
-            }
-        }
+        let page_coordinates = page_groups.keys().copied().collect::<Vec<_>>();
+        crate::columnar_row_group::visit_row_group_pages(
+            store,
+            id,
+            &row_group_manifest,
+            &page_coordinates,
+            &projection,
+            |coordinate, batch| {
+                for &(locator_index, row_in_page) in &page_groups[&coordinate] {
+                    let locator = locators[locator_index];
+                    loaded[locator_index] = Some(decode_columnar_change_record(
+                        &row_group_manifest,
+                        &batch,
+                        row_in_page,
+                        parts,
+                        locator.change_id,
+                        &manifests[&commit_id].account_id,
+                    )?);
+                }
+                Ok(())
+            },
+        )
+        .await?;
     }
 
     let routes = locators
@@ -5284,19 +5328,13 @@ pub(crate) fn validate_columnar_mutation_manifest(
         != parts.row_group_set_id
         || manifest.content_digest()? != parts.manifest_digest
         || manifest.namespace != parts.schema_key
-        || manifest
-            .metadata
-            .get(crate::sql2::ENTITY_COLUMNAR_LOSSLESS_SNAPSHOT_METADATA_KEY)
-            .map(String::as_str)
-            != Some("true")
+        || crate::live_state::entity_identity_column_index(manifest).is_none()
         || manifest
             .groups
             .iter()
             .map(|group| group.row_count)
             .collect::<Vec<_>>()
             != parts.group_row_counts
-        || manifest.fields.last().map(|field| field.name.as_str())
-            != Some(crate::sql2::ENTITY_COLUMNAR_ENTITY_PK_FIELD)
     {
         return Err(replacement_payload_error(
             "columnar mutation manifest disagrees with commit authority",
@@ -10284,7 +10322,7 @@ mod tests {
         CommitDeltaManifest, CommitDeltaPayloadRef, DecodedCommitDeltaBatch,
         DecodedCommitDeltaCache, DecodedCommitDeltaSegment, GENERIC_COMMIT_DELTA_SEGMENT_MAX_ROWS,
         TRACKED_STATE_CHANGE_LOCATOR_SPACE, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
-        TRACKED_STATE_TREE_CHUNK_SPACE, TrackedStateChunkOverlay,
+        TRACKED_STATE_TREE_CHUNK_SPACE, TrackedStateChunkOverlay, columnar_identity_row_map,
         decode_commit_delta_with_payloads, decode_commit_state_manifest,
         direct_change_locator_in_commit_state, encode_commit_delta_segment,
         encode_commit_delta_segment_with_payloads, encode_commit_delta_segment_with_raw_sidecar,
@@ -10297,6 +10335,19 @@ mod tests {
         stage_delete_commit_delta_inventory_entry,
         stage_fragmented_scoped_current_state_descriptor, value,
     };
+
+    #[test]
+    fn columnar_identity_lookup_does_not_assume_json_text_order() {
+        use datafusion::arrow::array::StringArray;
+
+        // Encoded EntityPk order is not JSON serialization order when a
+        // component requires escaping. Equality routing must therefore not
+        // binary-search the JSON text representation.
+        let identities = StringArray::from(vec![r#"["\n"]"#, r#"["!"]"#]);
+        let rows = columnar_identity_row_map(&identities);
+        assert_eq!(rows.get(r#"["\n"]"#), Some(&0));
+        assert_eq!(rows.get(r#"["!"]"#), Some(&1));
+    }
 
     #[test]
     fn fragmented_native_source_preserves_lifecycle_and_batches_adjacent_updates() {

--- a/packages/engine/src/tracked_state/types.rs
+++ b/packages/engine/src/tracked_state/types.rs
@@ -286,10 +286,18 @@ pub(crate) struct CurrentStatePartDescriptor {
     /// complete-replacement sources whose history authority owns reachability.
     pub(crate) payload_refs_digest: [u8; 32],
     /// 0 references an immutable complete-replacement mutation part; 1
-    /// references a native content-addressed current-state data part.
+    /// references a native content-addressed current-state data part; 2
+    /// references one authenticated page in a canonical entity row-group set.
     pub(crate) source_kind: u8,
+    /// Physical immutable source generation. Zero for replacement/native
+    /// sources; the exact row-group-set ID for columnar pages.
+    pub(crate) source_id: [u8; 16],
     pub(crate) owner_commit_id: [u8; 16],
+    /// Replacement segment index or columnar row-group index. Zero for native
+    /// current-state data parts.
     pub(crate) part_index: u32,
+    /// Columnar page index inside `part_index`. Zero for other source kinds.
+    pub(crate) source_page_index: u16,
     /// First physical row selected from the source part. Descriptor slicing
     /// allows sparse deletes and updates to retain untouched source bytes.
     pub(crate) source_row_offset: u16,


### PR DESCRIPTION
## Summary

Hard-cuts the committed current-state serving layout so authenticated entity column pages can be addressed directly from the unified scoped-range root.

- adds protocol-v54 `source_kind=2` current-state descriptors that bind the existing immutable row-group-set ID, manifest digest, group, page, row slice, key fences, owner, and lifecycle
- publishes canonical 64K groups / 2K pages directly for proven first collection generations and for explicitly certified complete replacements
- routes current-state point reads and historical change hydration through the same immutable pages
- batches page reads under a 32 projected-column-page physical backpressure budget and consumes decoded Arrow batches immediately
- validates exact page fences, manifest identity, owner, namespace, and entity identity-column contract
- retains row-group authority through GC with one validation/load per unique source
- keeps entity-columnar vocabulary in the neutral entity storage contract, outside SQL and the generic row-group codec
- removes the inherited whole-scope scan/sort/rewrite path; covered scopes fail closed after one authenticated marker lookup, while only first publication uses the conservative ancestry absence proof

No SQL semantics or query-shape policy are implemented here. DataFusion remains the general SQL execution layer. Mutation inventory remains historical authority; the scoped root is a rebuildable serving accelerator.

## Performance

Exact 65,537-row / 33-page physical read accounting:

| Phase | Before | After | Change |
| --- | ---: | ---: | ---: |
| identity-page routing | 33 adapter calls | 2 | **-93.9%** |
| four-column page hydration | 33 adapter calls | 5 | **-84.8%** |

The budget is based on projected physical column pages, not row count or a benchmark/workload heuristic. A page is decoded and consumed before the next physical batch.

Public SQL, 100K rows, 100 primary keys spread across the table, 11 setup-excluded samples:

| Adapter | main `d67635848` | PR | Change |
| --- | ---: | ---: | ---: |
| RocksDB | 4.286 ms | 4.246 ms | -0.9% |
| SlateDB | 4.721 ms | 4.677 ms | -0.9% |

The public latency is neutral/slightly better while physical backend-call amplification falls by more than 80%. The earlier 100K INSERT comparison for the full serving stack was 77.73 ms on main versus 79.46 ms here (+2.2%), within the 5% non-regression budget.

## Correctness and safety

- encoded-key ordering is never inferred from JSON serialization order; page lookup uses equality and has escaped-string coverage
- merge, selected-source, unknown-scope, missing-manifest, and cyclic ancestry proofs fail closed
- already-covered scopes do not walk ancestry and do not scan all inherited parts
- complete columnar replacement requires exact scope/owner certification; serving code does not invent replacement authority
- point misses, diff, history, branch, merge, checkpoint, rebuild fallback, corruption checks, and GC retain canonical semantics

## Validation

- `cargo clippy -p lix_engine --all-targets --all-features -- -D warnings`
- `RUST_MIN_STACK=16777216 cargo test -p lix_engine`
  - 1,881 unit tests passed; 8 ignored
  - 440 integration tests passed; 2 ignored
  - 3 doctests passed
- 65,537-row public lifecycle test covering current reads, diff, history, update, delete, and page/group boundaries
- independent subagent correctness, performance, and integration reviews: no blockers
- paired RocksDB and SlateDB public point benchmarks against current main and the immediate pre-batching stack
