### PR TITLE
Preserve physical scope proof across merges

### DIFF
--- a/.changenotes/bounded-first-columnar-publication.md
+++ b/.changenotes/bounded-first-columnar-publication.md
@@ -5,5 +5,6 @@ type: patch
 Bounded first publication of columnar current state on long commit histories.
 
 Lix now authenticates cumulative touched schema families in each commit-state
-manifest, eliminating history-length manifest walks while preserving
-fail-closed behavior for broad, selected-source, and merge lineages.
+manifest and carries that bounded absence authority across linear, merged, and
+selected-source lineages. Mutation scopes that cannot be bounded exactly still
+fail closed.

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -47,10 +47,11 @@ pub(crate) use scoped_range::{SCOPED_RANGE_NODE_SPACE, validate_scoped_range_tre
 #[cfg(any(test, feature = "storage-benches"))]
 pub(crate) use storage::stage_commit_state_manifest;
 pub(crate) use storage::{
-    CommitDeltaChangeLocator, CommitDeltaLiveMembershipCursor, CommitDeltaMember,
-    CommitDeltaPointReadCache, CommitDeltaReplacementGeneration, CommitDeltaReplacementScope,
-    OrderedAddressableCommitDeltaStage, commit_delta_contains_schema, direct_change_locator,
-    load_change_record_by_id, load_commit_delta_change_records,
+    CertifiedCommitStateTopologyParent, CommitDeltaChangeLocator, CommitDeltaLiveMembershipCursor,
+    CommitDeltaMember, CommitDeltaPointReadCache, CommitDeltaReplacementGeneration,
+    CommitDeltaReplacementScope, OrderedAddressableCommitDeltaStage, PublishedCommitStateManifest,
+    StagedCommitStateManifest, certify_topology_touched_scope_filter, commit_delta_contains_schema,
+    direct_change_locator, load_change_record_by_id, load_commit_delta_change_records,
     load_commit_delta_members_with_payloads, load_commit_delta_members_with_payloads_for_schemas,
     load_commit_delta_replay_metadata, load_commit_delta_selection_certificate,
     load_commit_state_manifest, load_commit_state_manifests, load_owned_commit_delta_entries,

--- a/packages/engine/src/tracked_state/scoped_current_state.rs
+++ b/packages/engine/src/tracked_state/scoped_current_state.rs
@@ -208,20 +208,41 @@ pub(crate) fn incomplete_touched_scope_filter() -> CommitStateTouchedScopeFilter
 }
 
 fn advance_touched_scope_filter(
-    parent: Option<&CommitStateManifest>,
+    parents: &[&CommitStateManifest],
+    selected_source: Option<&CommitStateManifest>,
     touched: Option<&[CommitDeltaReplacementScope]>,
 ) -> Result<CommitStateTouchedScopeFilter, LixError> {
     let Some(touched) = touched else {
         return Ok(incomplete_touched_scope_filter());
     };
-    let mut filter = match parent {
-        None => empty_complete_touched_scope_filter(),
-        Some(parent) => {
+    let mut filter = if let Some(source) = selected_source {
+        validate_touched_scope_filter(&source.touched_scope_filter)?;
+        if !source.touched_scope_filter.complete {
+            return Ok(incomplete_touched_scope_filter());
+        }
+        source.touched_scope_filter.clone()
+    } else {
+        for parent in parents {
             validate_touched_scope_filter(&parent.touched_scope_filter)?;
             if !parent.touched_scope_filter.complete {
                 return Ok(incomplete_touched_scope_filter());
             }
-            parent.touched_scope_filter.clone()
+        }
+        match parents.split_first() {
+            None => empty_complete_touched_scope_filter(),
+            Some((first, rest)) => {
+                let mut filter = first.touched_scope_filter.clone();
+                for parent in rest {
+                    for (target, inherited) in filter
+                        .bits
+                        .iter_mut()
+                        .zip(&parent.touched_scope_filter.bits)
+                    {
+                        *target |= *inherited;
+                    }
+                }
+                filter
+            }
         }
     };
     for scope in touched {
@@ -279,22 +300,51 @@ pub(crate) fn validate_touched_scope_filter(
     Ok(())
 }
 
-/// Opaque proof that the serving root was produced in this write set from the
-/// exact graph parent and sealed mutation inventory.
-pub(crate) struct CertifiedCurrentStateScopedRangePublication {
+/// Opaque proof that the physical serving projection was produced in this
+/// write set from the exact graph topology and sealed mutation inventory.
+pub(crate) struct CertifiedCommitStatePhysicalPublication {
     write_set_id: u64,
-    parent_commit_id: Option<CommitId>,
+    parent_commit_ids: CertifiedGraphParents,
+    selected_source_commit_id: Option<CommitId>,
     root: Option<CurrentStateScopedRangeRoot>,
     touched_scope_filter: CommitStateTouchedScopeFilter,
 }
 
-impl CertifiedCurrentStateScopedRangePublication {
+enum CertifiedGraphParents {
+    None,
+    One(CommitId),
+    Many(Vec<CommitId>),
+}
+
+impl CertifiedGraphParents {
+    fn from_manifests(parents: &[&CommitStateManifest]) -> Self {
+        match parents {
+            [] => Self::None,
+            [parent] => Self::One(parent.commit_id),
+            _ => Self::Many(parents.iter().map(|parent| parent.commit_id).collect()),
+        }
+    }
+
+    fn as_slice(&self) -> &[CommitId] {
+        match self {
+            Self::None => &[],
+            Self::One(parent) => std::slice::from_ref(parent),
+            Self::Many(parents) => parents,
+        }
+    }
+}
+
+impl CertifiedCommitStatePhysicalPublication {
     pub(crate) fn root(&self) -> Option<Box<CurrentStateScopedRangeRoot>> {
         self.root.clone().map(Box::new)
     }
 
-    pub(crate) fn parent_commit_id(&self) -> Option<CommitId> {
-        self.parent_commit_id
+    pub(crate) fn parent_commit_ids(&self) -> &[CommitId] {
+        self.parent_commit_ids.as_slice()
+    }
+
+    pub(crate) fn selected_source_commit_id(&self) -> Option<CommitId> {
+        self.selected_source_commit_id
     }
 
     pub(crate) fn write_set_id(&self) -> u64 {
@@ -304,6 +354,47 @@ impl CertifiedCurrentStateScopedRangePublication {
     pub(crate) fn touched_scope_filter(&self) -> &CommitStateTouchedScopeFilter {
         &self.touched_scope_filter
     }
+}
+
+/// Certifies cumulative schema-family absence authority when a serving range
+/// root itself cannot cross a merge or selected-source topology edge. Graph
+/// parents are unioned conservatively. A selected source supplies the complete
+/// inherited state, so it supersedes graph parents for this proof.
+pub(super) fn certify_topology_touched_scope_filter_from_manifests(
+    writes: &StorageWriteSet,
+    parents: &[&CommitStateManifest],
+    selected_source: Option<&CommitStateManifest>,
+    commit_id: CommitId,
+    inventory: &CommitStateMutationInventory,
+) -> Result<CertifiedCommitStatePhysicalPublication, LixError> {
+    let selected_source_commit_id = inventory.selected_source_commit_id();
+    if selected_source_commit_id != selected_source.map(|source| source.commit_id) {
+        return Err(scoped_state_error(
+            "selected-source manifest disagrees with mutation authority",
+        ));
+    }
+    let empty_base = parents.is_empty() && selected_source.is_none();
+    let touched = crate::tracked_state::storage::commit_state_inventory_exact_local_touched_scopes(
+        commit_id, inventory, empty_base,
+    )?;
+    let filter_touched = if touched.is_some() || empty_base {
+        touched
+    } else {
+        crate::tracked_state::storage::commit_state_inventory_exact_local_touched_scopes(
+            commit_id, inventory, true,
+        )?
+    };
+    Ok(CertifiedCommitStatePhysicalPublication {
+        write_set_id: writes.identity(),
+        parent_commit_ids: CertifiedGraphParents::from_manifests(parents),
+        selected_source_commit_id,
+        root: None,
+        touched_scope_filter: advance_touched_scope_filter(
+            parents,
+            selected_source,
+            filter_touched.as_deref(),
+        )?,
+    })
 }
 
 pub(crate) fn current_state_mutation_authority_digest(
@@ -460,8 +551,8 @@ pub(crate) async fn stage_current_state_scoped_ranges(
     commit_id: CommitId,
     account_id: &str,
     inventory: &CommitStateMutationInventory,
-) -> Result<CertifiedCurrentStateScopedRangePublication, LixError> {
-    let parent_commit_id = parent.map(|parent| parent.commit_id);
+) -> Result<CertifiedCommitStatePhysicalPublication, LixError> {
+    let parent_commit_ids = CertifiedGraphParents::from_manifests(parent.as_slice());
     let parent_root = parent.and_then(|parent| parent.current_state_scoped_ranges.as_deref());
     let touched = crate::tracked_state::storage::commit_state_inventory_exact_touched_scopes(
         commit_id,
@@ -480,15 +571,17 @@ pub(crate) async fn stage_current_state_scoped_ranges(
             commit_id, inventory, true,
         )?
     };
-    let touched_scope_filter = advance_touched_scope_filter(parent, filter_touched.as_deref())?;
+    let touched_scope_filter =
+        advance_touched_scope_filter(parent.as_slice(), None, filter_touched.as_deref())?;
     if inventory.columnar_parts.is_some() {
         let root = stage_disjoint_columnar_current_state_pages(
             store, writes, parent, commit_id, inventory,
         )
         .await?;
-        return Ok(CertifiedCurrentStateScopedRangePublication {
+        return Ok(CertifiedCommitStatePhysicalPublication {
             write_set_id: writes.identity(),
-            parent_commit_id,
+            parent_commit_ids,
+            selected_source_commit_id: None,
             root,
             touched_scope_filter,
         });
@@ -503,26 +596,29 @@ pub(crate) async fn stage_current_state_scoped_ranges(
             inventory,
         )
         .await?;
-        return Ok(CertifiedCurrentStateScopedRangePublication {
+        return Ok(CertifiedCommitStatePhysicalPublication {
             write_set_id: writes.identity(),
-            parent_commit_id,
+            parent_commit_ids,
+            selected_source_commit_id: None,
             root,
             touched_scope_filter,
         });
     }
 
     let Some(mut touched) = touched else {
-        return Ok(CertifiedCurrentStateScopedRangePublication {
+        return Ok(CertifiedCommitStatePhysicalPublication {
             write_set_id: writes.identity(),
-            parent_commit_id,
+            parent_commit_ids,
+            selected_source_commit_id: None,
             root: None,
             touched_scope_filter,
         });
     };
     let Some(parent_root) = parent_root else {
-        return Ok(CertifiedCurrentStateScopedRangePublication {
+        return Ok(CertifiedCommitStatePhysicalPublication {
             write_set_id: writes.identity(),
-            parent_commit_id,
+            parent_commit_ids,
+            selected_source_commit_id: None,
             root: None,
             touched_scope_filter,
         });
@@ -570,9 +666,10 @@ pub(crate) async fn stage_current_state_scoped_ranges(
             )
             .await?
         else {
-            return Ok(CertifiedCurrentStateScopedRangePublication {
+            return Ok(CertifiedCommitStatePhysicalPublication {
                 write_set_id: writes.identity(),
-                parent_commit_id,
+                parent_commit_ids,
+                selected_source_commit_id: None,
                 root: None,
                 touched_scope_filter,
             });
@@ -584,9 +681,10 @@ pub(crate) async fn stage_current_state_scoped_ranges(
             "exact touched scopes omitted materialized mutation members",
         ));
     }
-    Ok(CertifiedCurrentStateScopedRangePublication {
+    Ok(CertifiedCommitStatePhysicalPublication {
         write_set_id: writes.identity(),
-        parent_commit_id,
+        parent_commit_ids,
+        selected_source_commit_id: None,
         root: Some(attest_scoped_range_root(
             commit_id,
             Some(parent_root),
@@ -658,9 +756,9 @@ mod tests {
 
     use super::{
         TOUCHED_SCOPE_FILTER_BYTES, advance_touched_scope_filter, attest_scoped_range_root,
-        parent_scope_is_proven_empty, stage_current_state_scoped_ranges,
-        touched_scope_filter_proves_absent, validate_scoped_range_attestation,
-        validate_touched_scope_filter,
+        certify_topology_touched_scope_filter_from_manifests, parent_scope_is_proven_empty,
+        stage_current_state_scoped_ranges, touched_scope_filter_proves_absent,
+        validate_scoped_range_attestation, validate_touched_scope_filter,
     };
 
     struct ManifestCountingRead<R> {
@@ -1521,7 +1619,8 @@ mod tests {
         let authored = scope("authored");
         let child_authored = scope("child-authored");
         let absent = scope("never-authored");
-        let root_filter = advance_touched_scope_filter(None, Some(&[authored.clone()])).unwrap();
+        let root_filter =
+            advance_touched_scope_filter(&[], None, Some(&[authored.clone()])).unwrap();
         assert!(root_filter.complete);
         assert!(!touched_scope_filter_proves_absent(&root_filter, &authored).unwrap());
         assert!(touched_scope_filter_proves_absent(&root_filter, &absent).unwrap());
@@ -1542,7 +1641,8 @@ mod tests {
                 .len();
         assert_eq!(complete_manifest_bytes - incomplete_manifest_bytes, 129);
         let child_filter = advance_touched_scope_filter(
-            Some(&parent),
+            &[&parent],
+            None,
             Some(std::slice::from_ref(&child_authored)),
         )
         .unwrap();
@@ -1550,10 +1650,85 @@ mod tests {
         assert!(!touched_scope_filter_proves_absent(&child_filter, &child_authored).unwrap());
         assert!(touched_scope_filter_proves_absent(&child_filter, &absent).unwrap());
 
-        let incomplete = advance_touched_scope_filter(Some(&parent), None).unwrap();
+        let incomplete = advance_touched_scope_filter(&[&parent], None, None).unwrap();
         assert!(!incomplete.complete);
         assert!(incomplete.bits.is_empty());
         assert!(!touched_scope_filter_proves_absent(&incomplete, &absent).unwrap());
+    }
+
+    #[test]
+    fn cumulative_touched_scope_filter_unions_merges_and_follows_selected_state() {
+        let left_scope = scope("left");
+        let right_scope = scope("right");
+        let local_scope = scope("local");
+        let absent = scope("absent");
+
+        let mut left = manifest(
+            CommitId::for_test_label("scope-filter-left"),
+            None,
+            CommitStateMutationInventory::default(),
+        );
+        left.touched_scope_filter =
+            advance_touched_scope_filter(&[], None, Some(std::slice::from_ref(&left_scope)))
+                .unwrap();
+        let mut right = manifest(
+            CommitId::for_test_label("scope-filter-right"),
+            None,
+            CommitStateMutationInventory::default(),
+        );
+        right.touched_scope_filter =
+            advance_touched_scope_filter(&[], None, Some(std::slice::from_ref(&right_scope)))
+                .unwrap();
+
+        let merged = advance_touched_scope_filter(&[&left, &right], None, Some(&[])).unwrap();
+        assert!(!touched_scope_filter_proves_absent(&merged, &left_scope).unwrap());
+        assert!(!touched_scope_filter_proves_absent(&merged, &right_scope).unwrap());
+        assert!(touched_scope_filter_proves_absent(&merged, &absent).unwrap());
+
+        let selected = advance_touched_scope_filter(
+            &[&left],
+            Some(&right),
+            Some(std::slice::from_ref(&local_scope)),
+        )
+        .unwrap();
+        assert!(touched_scope_filter_proves_absent(&selected, &left_scope).unwrap());
+        assert!(!touched_scope_filter_proves_absent(&selected, &right_scope).unwrap());
+        assert!(!touched_scope_filter_proves_absent(&selected, &local_scope).unwrap());
+    }
+
+    #[test]
+    fn certified_topology_filter_binds_all_graph_parents() {
+        let storage = StorageAdapter::new(Memory::new());
+        let mut left = manifest(
+            CommitId::for_test_label("certified-filter-left"),
+            None,
+            CommitStateMutationInventory::default(),
+        );
+        left.touched_scope_filter = advance_touched_scope_filter(&[], None, Some(&[])).unwrap();
+        let mut right = manifest(
+            CommitId::for_test_label("certified-filter-right"),
+            None,
+            CommitStateMutationInventory::default(),
+        );
+        right.touched_scope_filter = advance_touched_scope_filter(&[], None, Some(&[])).unwrap();
+        let commit_id = CommitId::for_test_label("certified-filter-merge");
+        let inventory = CommitStateMutationInventory::default();
+        let mut writes = storage.new_write_set();
+        let publication = certify_topology_touched_scope_filter_from_manifests(
+            &writes,
+            &[&left, &right],
+            None,
+            commit_id,
+            &inventory,
+        )
+        .unwrap();
+        let mut merged = manifest(commit_id, Some(left.commit_id), inventory);
+        merged.parent_commit_ids.push(right.commit_id);
+        merged.touched_scope_filter = publication.touched_scope_filter().clone();
+        stage_certified_commit_state_manifest(&mut writes, &merged, &publication).unwrap();
+
+        merged.parent_commit_ids.swap(0, 1);
+        assert!(stage_certified_commit_state_manifest(&mut writes, &merged, &publication).is_err());
     }
 
     #[test]
@@ -1618,6 +1793,49 @@ mod tests {
         Ok(false)
     }
 
+    async fn legacy_graph_scope_absence_proof(
+        store: &(impl crate::storage_adapter::StorageAdapterRead + ?Sized),
+        tip: &CommitStateManifest,
+        scope: &CommitDeltaReplacementScope,
+    ) -> Result<bool, crate::LixError> {
+        let mut pending = vec![tip.clone()];
+        let mut scheduled = std::collections::BTreeSet::from([tip.commit_id]);
+        while let Some(manifest) = pending.pop() {
+            if manifest.mutations.selected_source_commit_id().is_some() {
+                return Ok(false);
+            }
+            if manifest.mutations.member_count != 0 {
+                let Some(touched) =
+                    crate::tracked_state::storage::commit_state_inventory_exact_touched_scopes(
+                        manifest.commit_id,
+                        &manifest.mutations,
+                        false,
+                    )?
+                else {
+                    return Ok(false);
+                };
+                if touched.contains(scope) {
+                    return Ok(false);
+                }
+            }
+            for parent_id in manifest.parent_commit_ids {
+                if !scheduled.insert(parent_id) {
+                    continue;
+                }
+                let parent = load_commit_state_manifest(store, parent_id)
+                    .await?
+                    .ok_or_else(|| {
+                        crate::LixError::new(
+                            crate::LixError::CODE_INTERNAL_ERROR,
+                            "legacy graph proof encountered a missing parent",
+                        )
+                    })?;
+                pending.push(parent);
+            }
+        }
+        Ok(true)
+    }
+
     #[tokio::test]
     async fn cumulative_filter_removes_lineage_manifest_reads_from_absence_proof() {
         const DEPTH: usize = 128;
@@ -1641,7 +1859,7 @@ mod tests {
             tip = Some(authority);
         }
         let mut tip = tip.expect("lineage has a tip");
-        tip.touched_scope_filter = advance_touched_scope_filter(None, Some(&[])).unwrap();
+        tip.touched_scope_filter = advance_touched_scope_filter(&[], None, Some(&[])).unwrap();
         let requested = scope("first-columnar-publication");
         let calls = Arc::new(AtomicUsize::new(0));
         let read = storage
@@ -1664,6 +1882,79 @@ mod tests {
             calls.load(Ordering::Relaxed),
             DEPTH - 1,
             "the certified proof must not issue another manifest read"
+        );
+    }
+
+    #[tokio::test]
+    async fn merge_filter_matches_exact_graph_proof_without_reads() {
+        const BRANCH_DEPTH: usize = 64;
+        let storage = StorageAdapter::new(Memory::new());
+        let root_id = CommitId::for_test_label("merge-scope-proof-root");
+        let root = manifest(root_id, None, CommitStateMutationInventory::default());
+        let mut writes = storage.new_write_set();
+        stage_commit_state_manifest(&mut writes, &root).unwrap();
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .unwrap();
+
+        let mut branch_tips = Vec::new();
+        for branch in ["left", "right"] {
+            let mut parent_id = root_id;
+            let mut tip = None;
+            for depth in 0..BRANCH_DEPTH {
+                let commit_id =
+                    CommitId::for_test_label(&format!("merge-scope-proof-{branch}-{depth}"));
+                let authority = manifest(
+                    commit_id,
+                    Some(parent_id),
+                    CommitStateMutationInventory::default(),
+                );
+                let mut writes = storage.new_write_set();
+                stage_commit_state_manifest(&mut writes, &authority).unwrap();
+                storage
+                    .commit_write_set(writes, StorageWriteOptions::default())
+                    .await
+                    .unwrap();
+                parent_id = commit_id;
+                tip = Some(authority);
+            }
+            let mut tip = tip.unwrap();
+            tip.touched_scope_filter = advance_touched_scope_filter(&[], None, Some(&[])).unwrap();
+            branch_tips.push(tip);
+        }
+        let mut merge = manifest(
+            CommitId::for_test_label("merge-scope-proof-tip"),
+            Some(branch_tips[0].commit_id),
+            CommitStateMutationInventory::default(),
+        );
+        merge.parent_commit_ids.push(branch_tips[1].commit_id);
+        merge.touched_scope_filter =
+            advance_touched_scope_filter(&[&branch_tips[0], &branch_tips[1]], None, Some(&[]))
+                .unwrap();
+
+        let requested = scope("first-post-merge-publication");
+        let calls = Arc::new(AtomicUsize::new(0));
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .unwrap();
+        let counted = ManifestCountingRead {
+            inner: read,
+            manifest_calls: calls.clone(),
+        };
+        assert!(
+            legacy_graph_scope_absence_proof(&counted, &merge, &requested)
+                .await
+                .unwrap()
+        );
+        assert_eq!(calls.load(Ordering::Relaxed), BRANCH_DEPTH * 2 + 1);
+
+        assert!(parent_scope_is_proven_empty(Some(&merge), &requested).unwrap());
+        assert_eq!(
+            calls.load(Ordering::Relaxed),
+            BRANCH_DEPTH * 2 + 1,
+            "the certified merge proof must not issue another manifest read"
         );
     }
 }

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -654,6 +654,16 @@ pub(crate) fn commit_state_inventory_exact_touched_scopes(
     if inventory.selected_source_commit_id.is_some() {
         return Ok(None);
     }
+    commit_state_inventory_exact_local_touched_scopes(commit_id, inventory, empty_base)
+}
+
+/// Returns only scopes authored by this inventory, excluding the complete
+/// inherited state supplied by an optional selected source.
+pub(crate) fn commit_state_inventory_exact_local_touched_scopes(
+    commit_id: CommitId,
+    inventory: &CommitStateMutationInventory,
+    empty_base: bool,
+) -> Result<Option<Vec<CommitDeltaReplacementScope>>, LixError> {
     if inventory.member_count == 0 {
         return Ok(Some(Vec::new()));
     }
@@ -2222,6 +2232,31 @@ pub(crate) struct StagedCommitStateManifest {
     write_set_id: u64,
 }
 
+/// Authenticated topology input accepted by cumulative physical publication.
+/// The variants prevent freely constructed manifests from minting a complete
+/// touched-scope certificate.
+#[derive(Clone, Copy)]
+pub(crate) enum CertifiedCommitStateTopologyParent<'a> {
+    Published(&'a PublishedCommitStateManifest),
+    Staged(&'a StagedCommitStateManifest),
+}
+
+impl<'a> CertifiedCommitStateTopologyParent<'a> {
+    fn manifest(self, writes: &StorageWriteSet) -> Result<&'a CommitStateManifest, LixError> {
+        match self {
+            Self::Published(parent) => Ok(&parent.manifest),
+            Self::Staged(parent) => {
+                if parent.write_set_id != writes.identity() {
+                    return Err(replacement_payload_error(
+                        "staged topology parent belongs to a different storage write set",
+                    ));
+                }
+                Ok(&parent.manifest)
+            }
+        }
+    }
+}
+
 impl Deref for PublishedCommitStateManifest {
     type Target = CommitStateManifest;
 
@@ -2246,6 +2281,30 @@ impl Deref for StagedCommitStateManifest {
     }
 }
 
+pub(crate) fn certify_topology_touched_scope_filter(
+    writes: &StorageWriteSet,
+    parents: &[CertifiedCommitStateTopologyParent<'_>],
+    selected_source: Option<CertifiedCommitStateTopologyParent<'_>>,
+    commit_id: CommitId,
+    inventory: &CommitStateMutationInventory,
+) -> Result<super::scoped_current_state::CertifiedCommitStatePhysicalPublication, LixError> {
+    let parents = parents
+        .iter()
+        .copied()
+        .map(|parent| parent.manifest(writes))
+        .collect::<Result<Vec<_>, _>>()?;
+    let selected_source = selected_source
+        .map(|source| source.manifest(writes))
+        .transpose()?;
+    super::scoped_current_state::certify_topology_touched_scope_filter_from_manifests(
+        writes,
+        &parents,
+        selected_source,
+        commit_id,
+        inventory,
+    )
+}
+
 pub(crate) async fn stage_current_state_scoped_ranges_from_published_parent(
     store: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
@@ -2253,7 +2312,7 @@ pub(crate) async fn stage_current_state_scoped_ranges_from_published_parent(
     commit_id: CommitId,
     account_id: &str,
     inventory: &CommitStateMutationInventory,
-) -> Result<super::scoped_current_state::CertifiedCurrentStateScopedRangePublication, LixError> {
+) -> Result<super::scoped_current_state::CertifiedCommitStatePhysicalPublication, LixError> {
     super::scoped_current_state::stage_current_state_scoped_ranges(
         store,
         writes,
@@ -2272,7 +2331,7 @@ pub(crate) async fn stage_current_state_scoped_ranges_from_staged_parent(
     commit_id: CommitId,
     account_id: &str,
     inventory: &CommitStateMutationInventory,
-) -> Result<super::scoped_current_state::CertifiedCurrentStateScopedRangePublication, LixError> {
+) -> Result<super::scoped_current_state::CertifiedCommitStatePhysicalPublication, LixError> {
     if parent.write_set_id != writes.identity() {
         return Err(replacement_payload_error(
             "staged scoped-range parent belongs to a different storage write set",
@@ -3417,30 +3476,26 @@ pub(crate) fn stage_commit_state_manifest_with_handle(
     })
 }
 
-/// Publishes a scoped-range root only when the exact opaque proof from its
-/// canonical staging transition accompanies the manifest.
+/// Publishes physical serving authority only when the exact opaque proof from
+/// its canonical topology and range transition accompanies the manifest.
 pub(crate) fn stage_certified_commit_state_manifest(
     writes: &mut StorageWriteSet,
     manifest: &CommitStateManifest,
-    publication: &super::scoped_current_state::CertifiedCurrentStateScopedRangePublication,
+    publication: &super::scoped_current_state::CertifiedCommitStatePhysicalPublication,
 ) -> Result<(), LixError> {
     if writes.identity() != publication.write_set_id() {
         return Err(replacement_payload_error(
-            "scoped-range publication proof belongs to a different storage write set",
+            "physical publication proof belongs to a different storage write set",
         ));
     }
-    let declared_parent_id = match manifest.parent_commit_ids.as_slice() {
-        [] => None,
-        [parent_id] => Some(*parent_id),
-        _ => {
-            return Err(replacement_payload_error(
-                "certified current-state scoped ranges cannot have multiple graph parents",
-            ));
-        }
-    };
-    if declared_parent_id != publication.parent_commit_id() {
+    if manifest.parent_commit_ids != publication.parent_commit_ids() {
         return Err(replacement_payload_error(
-            "commit manifest graph parent disagrees with its scoped-range publication proof",
+            "commit manifest graph-parent topology disagrees with its physical publication proof",
+        ));
+    }
+    if manifest.mutations.selected_source_commit_id() != publication.selected_source_commit_id() {
+        return Err(replacement_payload_error(
+            "commit manifest selected source disagrees with its physical publication proof",
         ));
     }
     if manifest.current_state_scoped_ranges != publication.root() {
@@ -3459,7 +3514,7 @@ pub(crate) fn stage_certified_commit_state_manifest(
 pub(crate) fn stage_certified_commit_state_manifest_with_handle(
     writes: &mut StorageWriteSet,
     manifest: &CommitStateManifest,
-    publication: &super::scoped_current_state::CertifiedCurrentStateScopedRangePublication,
+    publication: &super::scoped_current_state::CertifiedCommitStatePhysicalPublication,
 ) -> Result<StagedCommitStateManifest, LixError> {
     stage_certified_commit_state_manifest(writes, manifest, publication)?;
     Ok(StagedCommitStateManifest {

--- a/packages/engine/src/tracked_state/types.rs
+++ b/packages/engine/src/tracked_state/types.rs
@@ -327,10 +327,11 @@ pub(crate) struct CurrentStateScopedRangeRoot {
 /// Cumulative negative-membership certificate for collection scopes.
 ///
 /// A complete filter may have false positives, but never false negatives: a
-/// missing schema-family bit therefore proves that no commit in the certified
-/// linear lineage authored any scope for that schema. Coarsening file-scoped
-/// collections to their schema avoids cardinality-driven saturation while
-/// remaining conservative. Incomplete filters fail closed and carry no bits.
+/// missing schema-family bit therefore proves that no effective graph-parent
+/// or selected-source lineage authored any scope for that schema. Coarsening
+/// file-scoped collections to their schema avoids cardinality-driven
+/// saturation while remaining conservative. Incomplete filters fail closed
+/// and carry no bits.
 #[derive(Debug, Clone, Default, PartialEq, Eq, musli::Encode, musli::Decode)]
 #[musli(packed)]
 pub(crate) struct CommitStateTouchedScopeFilter {

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -1120,7 +1120,10 @@ async fn stage_changelog_commits(
     certified_packet_root_rows: &BTreeMap<CommitId, Vec<MaterializedLiveStateRow>>,
     mutation_inventories: &BTreeMap<CommitId, CommitStateMutationInventory>,
     ordered_replacements: &BTreeMap<CommitId, Arc<OrderedMutationJournal>>,
-    external_parent_manifests: &mut BTreeMap<CommitId, CommitStateManifest>,
+    external_parent_manifests: &mut BTreeMap<
+        CommitId,
+        crate::tracked_state::PublishedCommitStateManifest,
+    >,
     active_account_id: &str,
 ) -> Result<BTreeMap<CommitId, StagedChangelogCommit>, LixError> {
     let mut commits = Vec::with_capacity(commit_rows.len());
@@ -1158,15 +1161,16 @@ async fn stage_changelog_commits(
                 format!("commit '{commit_id}' has a missing parent"),
             )
         })?;
-        let manifest = crate::tracked_state::load_commit_state_manifest(read, *commit_id)
-            .await?
-            .ok_or_else(|| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!("commit '{commit_id}' has no commit-state authority"),
-                )
-            })?;
-        external_parent_manifests.insert(*commit_id, manifest.clone());
+        let published =
+            crate::tracked_state::load_published_commit_state_manifest(read, *commit_id)
+                .await?
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!("commit '{commit_id}' has no commit-state authority"),
+                    )
+                })?;
+        let manifest = &*published;
         // Replay debt is the durable layout authority. A rootless commit may
         // later gain an immutable snapshot accelerator without changing its
         // changelog topology projection.
@@ -1192,6 +1196,7 @@ async fn stage_changelog_commits(
         rootless_depths.insert(*commit_id, manifest.replay_debt.depth);
         rootless_rows.insert(*commit_id, manifest.replay_debt.rows);
         rootless_bytes.insert(*commit_id, manifest.replay_debt.bytes);
+        external_parent_manifests.insert(*commit_id, published);
     }
     let mut staged_parent_count = BTreeMap::<CommitId, usize>::new();
     let mut children = BTreeMap::<CommitId, Vec<CommitId>>::new();
@@ -5269,13 +5274,17 @@ fn stage_commit_state_manifests<'a, S>(
     rootless_commit_ids: &'a BTreeSet<CommitId>,
     staged_commits: &'a BTreeMap<CommitId, StagedChangelogCommit>,
     snapshot_roots: &'a BTreeMap<CommitId, TrackedStateCommitRoot>,
-    external_parent_manifests: &'a BTreeMap<CommitId, CommitStateManifest>,
+    external_parent_manifests: &'a BTreeMap<
+        CommitId,
+        crate::tracked_state::PublishedCommitStateManifest,
+    >,
 ) -> std::pin::Pin<Box<dyn Future<Output = Result<(), LixError>> + Send + 'a>>
 where
     S: StorageAdapterRead + ?Sized + 'a,
 {
     Box::pin(async move {
-        let mut published_manifests = BTreeMap::new();
+        let mut published_manifests =
+            BTreeMap::<CommitId, crate::tracked_state::StagedCommitStateManifest>::new();
         if staged_commits.len() != commit_rows.len()
             || commit_rows
                 .iter()
@@ -5313,11 +5322,7 @@ where
             let external_parent = if staged_parent.is_none() {
                 match first_parent {
                     Some(parent_id) => {
-                        let published = crate::tracked_state::load_published_commit_state_manifest(
-                            read, parent_id,
-                        )
-                        .await?
-                        .ok_or_else(|| {
+                        Some(external_parent_manifests.get(&parent_id).ok_or_else(|| {
                             LixError::new(
                                 LixError::CODE_INTERNAL_ERROR,
                                 format!(
@@ -5325,14 +5330,7 @@ where
                                     record.commit_id
                                 ),
                             )
-                        })?;
-                        if external_parent_manifests.get(&parent_id) != Some(&*published) {
-                            return Err(LixError::new(
-                                LixError::CODE_INTERNAL_ERROR,
-                                "published parent authority changed during commit staging",
-                            ));
-                        }
-                        Some(published)
+                        })?)
                     }
                     None => None,
                 }
@@ -5356,7 +5354,7 @@ where
                     crate::tracked_state::stage_current_state_scoped_ranges_from_published_parent(
                         read,
                         writes,
-                        external_parent.as_ref(),
+                        external_parent,
                         record.commit_id,
                         &record.account_id,
                         &mutations,
@@ -5364,7 +5362,80 @@ where
                     .await?
                 })
             } else {
-                None
+                let topology_parents = record
+                    .parent_commit_ids
+                    .iter()
+                    .map(|parent_id| {
+                        published_manifests
+                            .get(parent_id)
+                            .map(crate::tracked_state::CertifiedCommitStateTopologyParent::Staged)
+                            .or_else(|| {
+                                external_parent_manifests.get(parent_id).map(
+                                    crate::tracked_state::CertifiedCommitStateTopologyParent::Published,
+                                )
+                            })
+                            .ok_or_else(|| {
+                                LixError::new(
+                                    LixError::CODE_INTERNAL_ERROR,
+                                    format!(
+                                        "commit '{}' has no certified topology parent '{}'",
+                                        record.commit_id, parent_id
+                                    ),
+                                )
+                            })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                let selected_source_id = mutations.selected_source_commit_id();
+                let loaded_selected_source = if let Some(source_id) = selected_source_id
+                    && !published_manifests.contains_key(&source_id)
+                    && !external_parent_manifests.contains_key(&source_id)
+                {
+                    Some(
+                        crate::tracked_state::load_published_commit_state_manifest(read, source_id)
+                            .await?
+                            .ok_or_else(|| {
+                                LixError::new(
+                                    LixError::CODE_INTERNAL_ERROR,
+                                    format!(
+                                        "commit '{}' has no published selected-source authority '{}'",
+                                        record.commit_id, source_id
+                                    ),
+                                )
+                            })?,
+                    )
+                } else {
+                    None
+                };
+                let selected_source = selected_source_id
+                    .map(|source_id| {
+                        published_manifests
+                            .get(&source_id)
+                            .map(crate::tracked_state::CertifiedCommitStateTopologyParent::Staged)
+                            .or_else(|| {
+                                external_parent_manifests.get(&source_id).map(
+                                    crate::tracked_state::CertifiedCommitStateTopologyParent::Published,
+                                )
+                            })
+                            .or_else(|| {
+                                loaded_selected_source.as_ref().map(
+                                    crate::tracked_state::CertifiedCommitStateTopologyParent::Published,
+                                )
+                            })
+                            .ok_or_else(|| {
+                                LixError::new(
+                                    LixError::CODE_INTERNAL_ERROR,
+                                    "selected-source authority disappeared during commit staging",
+                                )
+                            })
+                    })
+                    .transpose()?;
+                Some(crate::tracked_state::certify_topology_touched_scope_filter(
+                    writes,
+                    &topology_parents,
+                    selected_source,
+                    record.commit_id,
+                    &mutations,
+                )?)
             };
             let current_state_scoped_ranges = catalog_publication
                 .as_ref()


### PR DESCRIPTION
## Summary

- carry the authenticated cumulative touched-schema certificate across multi-parent merges by conservatively unioning every graph parent
- treat a certified selected source as the complete inherited state, then add only exact local authored scopes
- keep current-state range roots fail-closed across unsupported merge and selected-source topology while allowing descendants to make bounded first-publication decisions
- harden provenance so only authenticated published parents or same-write-set staged parents can mint a complete physical publication certificate
- reuse the already authenticated external parent through manifest publication instead of loading the same sealed authority twice

No SQL semantics, `TransactionJournal`, `ColumnarMutationPartSet`, mutation sealing, or replacement-generation digest contract changes.

## Measured benefit

Baseline: main `9693d9fcf`. Candidate: `a7af1da4d`.

Public 10K RocksDB SQL UPDATE with `LIX_TRACKED_STATE_CRUD_PROFILE_ROUTE_ACCOUNTING=1`:

- sealed commit-state authority loads: **3 -> 2 (-33.3%)**
- replay manifest loads: 3 -> 3
- ordered-delta fallbacks: 0 -> 0

The removed load was real duplicate backend work: main authenticated the external parent during changelog staging and loaded/authenticated it again during commit-state manifest staging. The candidate carries the opaque published handle forward.

A focused 64+64-commit merge-DAG test also verifies that the manifest-local certificate matches an exact 129-manifest graph proof without issuing runtime ancestry reads. This is newly preserved proof coverage; it is not presented as a main latency comparison because main previously failed closed immediately at merges.

Paired public SQL regression medians:

| workload | backend | main | candidate | delta |
|---|---:|---:|---:|---:|
| 10K UPDATE_ALL | RocksDB | 14.629760 ms | 14.578625 ms | -0.35% |
| 10K UPDATE_ALL | SlateDB | 14.664616 ms | 14.979378 ms | +2.15% |
| 10K READ_ONE | RocksDB | 1.247165 ms | 1.252675 ms | +0.44% |
| 10K READ_ONE | SlateDB | 1.289655 ms | 1.285226 ms | -0.34% |
| 100K READ_ALL | RocksDB | 31.561238 ms | 31.764882 ms | +0.65% |
| 100K READ_ALL | SlateDB | 31.994723 ms | 32.139426 ms | +0.45% |

No durable-format field or payload is added. Linear parents use an inline one-parent proof representation, and inherited completeness is checked before allocating filter bits.

## Correctness

- ordered graph-parent IDs, selected-source ID, root, filter, and write-set identity are all bound at manifest publication
- incomplete parent/source filters and unbounded local mutations fail closed
- selected-source aliases supersede graph parents only because the existing authority contract defines them as the complete inherited state
- no serving root crosses a merge or selected-source edge
- older incomplete filters remain valid and fail closed; no codec/version change is required

## Validation

- `RUST_MIN_STACK=16777216 cargo test -p lix_engine --features all-simulations --quiet`
  - 1,887 unit tests passed, 8 ignored
  - 810 integration/simulation tests passed, 2 ignored
  - 3 doctests passed
- all 34 branching integration tests passed
- 13 focused scoped-current-state tests passed
- `cargo clippy -p lix_engine --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `node scripts/validate-changes.mjs`
- `git diff --check`

Independent correctness, performance, and integration reviewers all approved after the benchmark qualification and hot-path allocation fixes.