### PR TITLE
Seal transaction journal replacement parts eagerly

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
@@ -1008,6 +1008,10 @@ where
 
     #[expect(clippy::cast_possible_truncation)]
     async fn update_all(&self) -> usize {
+        let expected_rows = match &self.update_all_workload {
+            UpdateWorkload::Transaction(statements) => statements.len(),
+            UpdateWorkload::ExecuteBatch(_) => self.row_count,
+        };
         let affected = match &self.update_all_workload {
             UpdateWorkload::Transaction(statements) => {
                 Box::pin(execute_many_in_transaction(&self.session, statements)).await
@@ -1021,7 +1025,7 @@ where
                 .map(|result| result.rows_affected())
                 .sum(),
         };
-        assert_eq!(affected as usize, self.row_count);
+        assert_eq!(affected as usize, expected_rows);
         affected as usize
     }
 
@@ -1566,7 +1570,25 @@ fn update_workload(shape: FixtureShape, rows: &[WorkloadRow]) -> UpdateWorkload 
         Ok(other) => panic!(
             "unknown LIX_TRACKED_STATE_CRUD_PROFILE_UPDATE_API '{other}'; expected execute_batch or execute_batch_parameterized"
         ),
-        Err(_) => UpdateWorkload::Transaction(rows.iter().map(update_row_sql).collect()),
+        Err(_) => {
+            let scalar_rows = std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_SCALAR_UPDATE_ROW_COUNT")
+                .ok()
+                .map(|value| {
+                    value.parse::<usize>().unwrap_or_else(|_| {
+                        panic!(
+                            "LIX_TRACKED_STATE_CRUD_PROFILE_SCALAR_UPDATE_ROW_COUNT must be an integer between 1 and {}, got '{value}'",
+                            rows.len()
+                        )
+                    })
+                })
+                .unwrap_or(rows.len());
+            assert!(
+                (1..=rows.len()).contains(&scalar_rows),
+                "LIX_TRACKED_STATE_CRUD_PROFILE_SCALAR_UPDATE_ROW_COUNT must be between 1 and {}, got {scalar_rows}",
+                rows.len()
+            );
+            UpdateWorkload::Transaction(rows[..scalar_rows].iter().map(update_row_sql).collect())
+        }
     }
 }
 

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -37,6 +37,10 @@ pub(crate) use merge::{
     TrackedStateMergeConflict, TrackedStateMergePick, TrackedStateMergePlan,
     merge_payload_fallback_ids, plan_merge,
 };
+pub(crate) use replacement_part::{
+    EncodedReplacementPart, REPLACEMENT_PART_MAX_ROWS, REPLACEMENT_PART_TARGET_BYTES,
+    ReplacementPartRowRef, encode_replacement_part_with_compressor,
+};
 pub(crate) use row_materialization::{
     MaterializedTrackedStateBatch, MaterializedTrackedStateExactBatch,
     MaterializedTrackedStateRowRef, materialize_batch_from_index_entries,
@@ -65,6 +69,8 @@ pub(crate) use storage::{
     stage_current_state_scoped_ranges_from_staged_parent, stage_delete_change_locators,
     stage_delete_commit_delta_inventory_entry, stage_ordered_addressable_commit_deltas,
     stage_ordered_addressable_replacement_parts, stage_ordered_columnar_mutations,
+    stage_preencoded_ordered_addressable_replacement_parts,
+    stage_prefixed_ordered_addressable_replacement_parts,
     validate_current_state_scoped_range_parent_manifest,
 };
 #[cfg(feature = "storage-benches")]

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -3971,13 +3971,61 @@ where
     I: ExactSizeIterator<Item = Result<R, LixError>>,
     R: ReplacementPartInputRef<'a>,
 {
+    stage_ordered_addressable_replacement_parts_inner(writes, deltas, generation, None)
+}
+
+pub(crate) fn stage_prefixed_ordered_addressable_replacement_parts<'a, I, R>(
+    writes: &mut StorageWriteSet,
+    commit_id: CommitId,
+    uniform_updated_at: crate::common::LixTimestamp,
+    prefix_row_count: usize,
+    prefix_parts: Vec<crate::tracked_state::replacement_part::EncodedReplacementPart>,
+    deltas: I,
+    generation: &CommitDeltaReplacementGeneration,
+) -> Result<OrderedAddressableCommitDeltaStage, LixError>
+where
+    I: ExactSizeIterator<Item = Result<R, LixError>>,
+    R: ReplacementPartInputRef<'a>,
+{
+    stage_ordered_addressable_replacement_parts_inner(
+        writes,
+        deltas,
+        generation,
+        Some((
+            commit_id,
+            uniform_updated_at,
+            prefix_row_count,
+            prefix_parts,
+        )),
+    )
+}
+
+fn stage_ordered_addressable_replacement_parts_inner<'a, I, R>(
+    writes: &mut StorageWriteSet,
+    deltas: I,
+    generation: &CommitDeltaReplacementGeneration,
+    prefix: Option<(
+        CommitId,
+        crate::common::LixTimestamp,
+        usize,
+        Vec<crate::tracked_state::replacement_part::EncodedReplacementPart>,
+    )>,
+) -> Result<OrderedAddressableCommitDeltaStage, LixError>
+where
+    I: ExactSizeIterator<Item = Result<R, LixError>>,
+    R: ReplacementPartInputRef<'a>,
+{
     struct BorrowedRow<'a> {
         key: Vec<u8>,
         snapshot: crate::json_store::JsonSlotRef<'a>,
         metadata: crate::json_store::JsonSlotRef<'a>,
     }
 
-    let row_count = deltas.len();
+    let suffix_row_count = deltas.len();
+    let prefix_row_count = prefix.as_ref().map_or(0, |prefix| prefix.2);
+    let row_count = prefix_row_count
+        .checked_add(suffix_row_count)
+        .ok_or_else(|| LixError::unknown("tracked_state replacement row count overflowed"))?;
     if row_count == 0 {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
@@ -3990,11 +4038,15 @@ where
         row_count
     )
     .entered();
-    let mut commit_id = None;
-    let mut uniform_updated_at = None;
-    let mut previous_key = Vec::new();
+    let mut commit_id = prefix.as_ref().map(|prefix| prefix.0);
+    let mut uniform_updated_at = prefix.as_ref().map(|prefix| prefix.1);
+    let mut previous_key = prefix
+        .as_ref()
+        .and_then(|prefix| prefix.3.last())
+        .map_or_else(Vec::new, |part| part.last_key().to_vec());
     let mut pending = Vec::with_capacity(COMMIT_DELTA_SEGMENT_MAX_ROWS);
-    let mut parts = Vec::with_capacity(row_count.div_ceil(COMMIT_DELTA_SEGMENT_MAX_ROWS));
+    let mut parts = prefix.map_or_else(Vec::new, |prefix| prefix.3);
+    parts.reserve(row_count.div_ceil(COMMIT_DELTA_SEGMENT_MAX_ROWS));
     let mut compressor = None;
     for delta in deltas {
         let delta = delta?.into_replacement_part_input()?;
@@ -4085,6 +4137,45 @@ where
         Ok(())
     }
 
+    stage_preencoded_ordered_addressable_replacement_parts(
+        writes,
+        commit_id,
+        uniform_updated_at,
+        row_count,
+        parts,
+        generation,
+    )
+}
+
+pub(crate) fn stage_preencoded_ordered_addressable_replacement_parts(
+    writes: &mut StorageWriteSet,
+    commit_id: CommitId,
+    uniform_updated_at: crate::common::LixTimestamp,
+    row_count: usize,
+    parts: Vec<crate::tracked_state::replacement_part::EncodedReplacementPart>,
+    generation: &CommitDeltaReplacementGeneration,
+) -> Result<OrderedAddressableCommitDeltaStage, LixError> {
+    if row_count == 0 || parts.is_empty() {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state preencoded replacement generation cannot be empty",
+        ));
+    }
+    if parts
+        .iter()
+        .map(|part| usize::from(part.row_count()))
+        .sum::<usize>()
+        != row_count
+        || parts
+            .windows(2)
+            .any(|pair| pair[0].last_key() >= pair[1].first_key())
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state preencoded replacement parts are not a complete ordered row set",
+        ));
+    }
+    addressable_change_id(commit_id, 0, 0)?;
     let mut first_ordinal = 0u32;
     let directory_entries = parts
         .iter()
@@ -4145,7 +4236,9 @@ where
         writes.put(
             TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
             key(physical_key),
-            value(part.bytes().to_vec()),
+            StorageValue {
+                bytes: part.bytes().clone(),
+            },
         );
         first_address = u32::try_from(segment_index + 1)
             .expect("replacement segment count fits u32")

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -2058,23 +2058,56 @@ async fn stage_tracked_commit_delta_index(
                         "immutable replacement journal has no lifecycle generation",
                     )
                 })?;
+            let (sealed_rows, parts) = journal.sealed_replacement_prefix();
             let created_at = generation.lifecycle_summary.uniform_created_at;
-            let stage = crate::tracked_state::stage_ordered_addressable_replacement_parts(
-                writes,
-                journal.iter().map(|row| {
-                    Ok(TrackedStateSingleStringReplacementRef {
-                        schema_key: journal.schema_key(),
-                        file_id: None,
-                        entity_pk: row.identity(),
-                        commit_id: root.commit_id,
-                        created_at,
-                        updated_at: journal.timestamp(),
-                        snapshot: row.snapshot_slot(),
-                        metadata: crate::json_store::JsonSlotRef::None,
-                    })
-                }),
-                generation,
-            )?;
+            let stage = if sealed_rows == journal.row_count() {
+                crate::tracked_state::stage_preencoded_ordered_addressable_replacement_parts(
+                    writes,
+                    root.commit_id,
+                    journal.timestamp(),
+                    journal.row_count(),
+                    parts,
+                    generation,
+                )?
+            } else if sealed_rows > 0 {
+                crate::tracked_state::stage_prefixed_ordered_addressable_replacement_parts(
+                    writes,
+                    root.commit_id,
+                    journal.timestamp(),
+                    sealed_rows,
+                    parts,
+                    journal.iter().skip(sealed_rows).map(|row| {
+                        Ok(TrackedStateSingleStringReplacementRef {
+                            schema_key: journal.schema_key(),
+                            file_id: None,
+                            entity_pk: row.identity(),
+                            commit_id: root.commit_id,
+                            created_at,
+                            updated_at: journal.timestamp(),
+                            snapshot: row.snapshot_slot(),
+                            metadata: crate::json_store::JsonSlotRef::None,
+                        })
+                    }),
+                    generation,
+                )?
+            } else {
+                crate::tracked_state::stage_ordered_addressable_replacement_parts(
+                    writes,
+                    journal.iter().map(|row| {
+                        Ok(TrackedStateSingleStringReplacementRef {
+                            schema_key: journal.schema_key(),
+                            file_id: None,
+                            entity_pk: row.identity(),
+                            commit_id: root.commit_id,
+                            created_at,
+                            updated_at: journal.timestamp(),
+                            snapshot: row.snapshot_slot(),
+                            metadata: crate::json_store::JsonSlotRef::None,
+                        })
+                    }),
+                    generation,
+                )?
+            };
             inventories.insert(root.commit_id, stage.mutation_inventory().clone());
             ordered_addressable_commits.insert(root.commit_id);
             continue;

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -536,6 +536,12 @@ pub(crate) struct Transaction<StorageImpl: Storage + 'static = Memory> {
     /// same lifecycle boundary, so sealing must not preserve per-call clocks.
     prepared_mutation_timestamp: Option<LixTimestamp>,
     mutation_journal: Option<TransactionMutationJournal>,
+    mutation_journal_compressor: Option<crate::compression::ZstdLevel1Compressor>,
+    mutation_journal_sealed_rows: usize,
+    /// Eagerly sealed parts must remain one canonical prefix. Once a flush
+    /// leaves an unsealed tail or exceeds the bounded prefix, later chunks
+    /// must stay unsealed so commit can encode one contiguous suffix.
+    mutation_journal_seal_prefix_open: bool,
     /// Sealing consumes the journal's owned column buffers. If any fallible
     /// validation or staging step rejects those buffers, this transaction can
     /// no longer provide statement atomicity and must remain rollback-only.
@@ -587,6 +593,7 @@ struct TransactionMutationJournal {
 
 const INITIAL_MUTATION_JOURNAL_ROWS: usize = 16;
 const INITIAL_MUTATION_JOURNAL_ARENA_BYTES: usize = 1_024;
+const MUTATION_JOURNAL_EAGER_SEAL_MAX_ROWS: usize = 16 * 1_024;
 
 enum PreparedMutationMembership {
     Unprepared,
@@ -1454,6 +1461,9 @@ where
                 prepared_mutation_overlay_empty: false,
                 prepared_mutation_timestamp: None,
                 mutation_journal: None,
+                mutation_journal_compressor: None,
+                mutation_journal_sealed_rows: 0,
+                mutation_journal_seal_prefix_open: true,
                 mutation_journal_terminal_error: None,
                 staged_writes,
                 filesystem_path_index_cache: Arc::new(FilesystemPathIndexCache::default()),
@@ -6736,7 +6746,14 @@ where
                 complete_generation = None;
             }
         }
-        self.flush_mutation_journal().await?;
+        if complete_generation.is_some() {
+            self.flush_mutation_journal_final().await?;
+        } else {
+            // Without a certifiable base generation this journal cannot
+            // become complete-set authority. Leave its final tail unsealed
+            // for generic lowering.
+            self.flush_mutation_journal().await?;
+        }
         let replacement_certified =
             if let Some((schema_key, branch_id, (live_count, ordered_identity_digest))) =
                 complete_generation
@@ -6864,17 +6881,28 @@ where
     }
 
     async fn flush_mutation_journal(&mut self) -> Result<(), LixError> {
+        self.flush_mutation_journal_with_tail(false).await
+    }
+
+    async fn flush_mutation_journal_final(&mut self) -> Result<(), LixError> {
+        self.flush_mutation_journal_with_tail(true).await
+    }
+
+    async fn flush_mutation_journal_with_tail(
+        &mut self,
+        finalize_tail: bool,
+    ) -> Result<(), LixError> {
         if let Some(error) = &self.mutation_journal_terminal_error {
             return Err(error.clone());
         }
-        let result = self.flush_mutation_journal_inner().await;
+        let result = self.flush_mutation_journal_inner(finalize_tail).await;
         if let Err(error) = &result {
             self.mutation_journal_terminal_error = Some(error.clone());
         }
         result
     }
 
-    async fn flush_mutation_journal_inner(&mut self) -> Result<(), LixError> {
+    async fn flush_mutation_journal_inner(&mut self, finalize_tail: bool) -> Result<(), LixError> {
         let Some(journal) = self.mutation_journal.take() else {
             return Ok(());
         };
@@ -6894,7 +6922,7 @@ where
                 "non-empty transaction mutation journal has no lifecycle timestamp",
             )
         })?;
-        let chunk = ImmutableMutationJournalChunk::try_new_single_string_identities(
+        let mut chunk = ImmutableMutationJournalChunk::try_new_single_string_identities(
             journal.program.schema_plan_id,
             journal.program.schema_key.as_str().into(),
             self.active_branch_id.clone().into(),
@@ -6906,6 +6934,35 @@ where
             None,
             timestamp,
         )?;
+        let eager_collection_is_bounded = match &self.prepared_mutation_membership {
+            PreparedMutationMembership::Packed(membership) => {
+                usize::try_from(membership.complete_generation().0)
+                    .is_ok_and(|rows| rows <= MUTATION_JOURNAL_EAGER_SEAL_MAX_ROWS)
+            }
+            PreparedMutationMembership::Unprepared | PreparedMutationMembership::Unavailable => {
+                false
+            }
+        };
+        if !eager_collection_is_bounded {
+            self.mutation_journal_seal_prefix_open = false;
+        }
+        if self.mutation_journal_seal_prefix_open {
+            let eager_row_count = self
+                .mutation_journal_sealed_rows
+                .checked_add(chunk.len())
+                .filter(|&rows| rows <= MUTATION_JOURNAL_EAGER_SEAL_MAX_ROWS);
+            if let Some(eager_row_count) = eager_row_count {
+                chunk
+                    .seal_replacement_parts(finalize_tail, &mut self.mutation_journal_compressor)?;
+                if chunk.sealed_replacement_parts().is_some() {
+                    self.mutation_journal_sealed_rows = eager_row_count;
+                } else {
+                    self.mutation_journal_seal_prefix_open = false;
+                }
+            } else {
+                self.mutation_journal_seal_prefix_open = false;
+            }
+        }
         match self.staged_writes.stage_immutable_mutation_chunk(chunk)? {
             ImmutableMutationChunkStage::Staged => {}
             ImmutableMutationChunkStage::RequiresGeneric(chunk) => {

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -96,6 +96,7 @@ pub(crate) struct ImmutableMutationJournalChunk {
     snapshot_arena: Bytes,
     snapshot_offsets: Arc<[(u32, u32)]>,
     large_snapshot_refs: Arc<[(u32, crate::json_store::JsonRef)]>,
+    sealed_replacement_parts: Option<Arc<[crate::tracked_state::EncodedReplacementPart]>>,
     durable_predecessors: Option<Arc<[CertifiedCurrentStatePredecessor]>>,
     timestamp: LixTimestamp,
 }
@@ -111,6 +112,7 @@ impl PartialEq for ImmutableMutationJournalChunk {
             && self.snapshot_arena == other.snapshot_arena
             && self.snapshot_offsets == other.snapshot_offsets
             && self.large_snapshot_refs == other.large_snapshot_refs
+            && self.sealed_replacement_parts == other.sealed_replacement_parts
             && self.timestamp == other.timestamp
             && self.durable_predecessors.as_ref().map(|values| {
                 values
@@ -307,6 +309,7 @@ impl ImmutableMutationJournalChunk {
             snapshot_arena: Bytes::from(snapshot_arena),
             snapshot_offsets: offsets.into(),
             large_snapshot_refs: large_snapshot_refs.into(),
+            sealed_replacement_parts: None,
             durable_predecessors: durable_predecessors.map(Into::into),
             timestamp,
         })
@@ -367,6 +370,91 @@ impl ImmutableMutationJournalChunk {
             .binary_search_by_key(&index, |(ordinal, _)| *ordinal)
             .expect("large immutable mutation snapshot has a content ref");
         crate::json_store::JsonSlotRef::Ref(&self.large_snapshot_refs[position].1)
+    }
+
+    pub(crate) fn seal_replacement_parts(
+        &mut self,
+        finalize_tail: bool,
+        compressor: &mut Option<crate::compression::ZstdLevel1Compressor>,
+    ) -> Result<(), LixError> {
+        if self.sealed_replacement_parts.is_some() {
+            return Ok(());
+        }
+        if !finalize_tail
+            && !self
+                .len()
+                .is_multiple_of(crate::tracked_state::REPLACEMENT_PART_MAX_ROWS)
+        {
+            return Ok(());
+        }
+        let mut parts = Vec::with_capacity(
+            self.len()
+                .div_ceil(crate::tracked_state::REPLACEMENT_PART_MAX_ROWS),
+        );
+        let mut first = 0usize;
+        while first < self.len() {
+            let max_candidate_len =
+                (self.len() - first).min(crate::tracked_state::REPLACEMENT_PART_MAX_ROWS);
+            let mut keys = Vec::with_capacity(max_candidate_len);
+            for index in first..first + max_candidate_len {
+                let mut key = Vec::new();
+                crate::tracked_state::encode_single_string_key_ref_into(
+                    &mut key,
+                    self.schema_key(),
+                    None,
+                    self.identity(index),
+                );
+                keys.push(key);
+            }
+            let mut candidate_len = max_candidate_len;
+            let encoded = loop {
+                let rows = keys[..candidate_len]
+                    .iter()
+                    .enumerate()
+                    .map(
+                        |(offset, key)| crate::tracked_state::ReplacementPartRowRef {
+                            encoded_key: key,
+                            snapshot: self.snapshot_slot(first + offset),
+                            metadata: crate::json_store::JsonSlotRef::None,
+                        },
+                    )
+                    .collect::<Vec<_>>();
+                match crate::tracked_state::encode_replacement_part_with_compressor(
+                    &rows, compressor,
+                ) {
+                    Ok(encoded)
+                        if encoded.bytes().len()
+                            <= crate::tracked_state::REPLACEMENT_PART_TARGET_BYTES
+                            || candidate_len == 1 =>
+                    {
+                        break encoded;
+                    }
+                    Ok(_) | Err(_) if candidate_len > 1 => {
+                        // The canonical commit encoder retains the rejected
+                        // suffix and admits following rows into it. A
+                        // non-final journal chunk cannot reproduce that
+                        // state across its boundary, so leave this chunk and
+                        // every later chunk for the one-pass commit encoder.
+                        if !finalize_tail {
+                            return Ok(());
+                        }
+                        candidate_len = candidate_len.div_ceil(2);
+                    }
+                    Err(error) => return Err(error),
+                    Ok(_) => unreachable!("single-row replacement part satisfies the size guard"),
+                }
+            };
+            first += candidate_len;
+            parts.push(encoded);
+        }
+        self.sealed_replacement_parts = Some(parts.into());
+        Ok(())
+    }
+
+    pub(crate) fn sealed_replacement_parts(
+        &self,
+    ) -> Option<&[crate::tracked_state::EncodedReplacementPart]> {
+        self.sealed_replacement_parts.as_deref()
     }
 
     pub(crate) fn schema_key(&self) -> &str {
@@ -544,6 +632,21 @@ impl OrderedMutationJournal {
 
     pub(crate) fn row_count(&self) -> usize {
         self.row_count
+    }
+
+    pub(crate) fn sealed_replacement_prefix(
+        &self,
+    ) -> (usize, Vec<crate::tracked_state::EncodedReplacementPart>) {
+        let mut parts = Vec::new();
+        let mut row_count = 0usize;
+        for chunk in self.chunks.iter() {
+            let Some(sealed) = chunk.sealed_replacement_parts() else {
+                break;
+            };
+            parts.extend_from_slice(sealed);
+            row_count += chunk.len();
+        }
+        (row_count, parts)
     }
 
     pub(crate) fn commit_id(&self) -> CommitId {
@@ -4403,6 +4506,64 @@ mod tests {
             chunk.snapshot_slot(ROW_COUNT - 1),
             crate::json_store::JsonSlotRef::Ref(_)
         ));
+    }
+
+    #[test]
+    fn immutable_journal_does_not_seal_adaptive_residual_at_chunk_boundary() {
+        const ROW_COUNT: usize = 8 * crate::tracked_state::REPLACEMENT_PART_MAX_ROWS;
+        let mut identity_values = Vec::with_capacity(ROW_COUNT);
+        let mut random = 0x9e37_79b9_7f4a_7c15_u64;
+        for _ in 0..ROW_COUNT {
+            let mut identity = String::with_capacity(640);
+            for _ in 0..40 {
+                random ^= random << 13;
+                random ^= random >> 7;
+                random ^= random << 17;
+                use std::fmt::Write as _;
+                write!(&mut identity, "{random:016x}").expect("write identity");
+            }
+            identity_values.push(identity);
+        }
+        identity_values.sort_unstable();
+
+        let mut identities = Vec::with_capacity(ROW_COUNT * 640);
+        let mut identity_offsets = Vec::with_capacity(ROW_COUNT);
+        let mut snapshots = Vec::with_capacity(ROW_COUNT * 2);
+        let mut snapshot_offsets = Vec::with_capacity(ROW_COUNT);
+        for identity in identity_values {
+            let start = identities.len();
+            identities.extend_from_slice(identity.as_bytes());
+            identity_offsets.push((start, identities.len()));
+
+            let start = snapshots.len();
+            snapshots.extend_from_slice(b"{}");
+            snapshot_offsets.push((start, snapshots.len()));
+        }
+
+        let mut chunk = ImmutableMutationJournalChunk::try_new_single_string_identities(
+            SchemaPlanId::for_test(0),
+            "schema".into(),
+            "branch".into(),
+            None,
+            identities,
+            identity_offsets,
+            snapshots,
+            snapshot_offsets,
+            None,
+            LixTimestamp::expect_parse("timestamp", "2026-01-01T00:00:00Z"),
+        )
+        .expect("large-key journal chunk");
+        let mut compressor = None;
+
+        chunk
+            .seal_replacement_parts(false, &mut compressor)
+            .expect("non-final sealing probe");
+        assert!(chunk.sealed_replacement_parts().is_none());
+
+        chunk
+            .seal_replacement_parts(true, &mut compressor)
+            .expect("final canonical sealing");
+        assert!(chunk.sealed_replacement_parts().is_some());
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- eagerly seal bounded (≤16,384-row) typed transaction-journal chunks into unowned, immutable replacement-part bytes while their arenas are hot
- retain commit as the sole authority boundary: commit ID, lifecycle, replacement generation, directory, manifest, current state, and storage writes are still bound and published atomically
- consume a sealed canonical prefix directly and encode one contiguous suffix when a read barrier leaves an unsealed tail
- fail closed on adaptive >64 KiB part splits so residual rows cannot be finalized at a journal-chunk boundary
- hand compressed payloads into the storage write set through shared `Bytes` instead of copying them
- add a reproducible scalar-subset UPDATE profiling control

There is no storage-format compatibility path or changenote in this cut. Diff/history/merge/checkpoint/branch continue to consume the unchanged committed replacement-part and CommitStateManifest contracts.

## Why

The scalar SQL UPDATE path built the correct typed journal, but waited until commit to reconstruct keys and compress all replacement parts after the journal arenas had gone cold. For representative 10K complete replacements, sealing the existing journal buffers eagerly removes that commit spike without moving durable authority before commit.

Eager sealing is limited to collections whose complete generation is at most 16,384 rows. Large collections retain the canonical one-pass commit path.

## Performance

Exact immediate parent: merged #1198 (`60dcacb95`). Same checkout, release binary, feature set, fixture, and commands; medians of 21 samples.

| 10K scalar UPDATE | #1198 | this PR | change |
| --- | ---: | ---: | ---: |
| RocksDB | 32.552 ms | 25.813 ms | **-20.7%** |
| SlateDB | 32.044 ms | 25.290 ms | **-21.1%** |

Supplementary paired measurements taken immediately before the non-overlapping #1198 rebase, against merged #1197:

- 10K executeBatch: RocksDB -2.2%, SlateDB -1.0%
- 10K allocated bytes: +1.05%
- 1M peak RSS: +0.024%
- 1M scalar UPDATE: RocksDB +4.5%, SlateDB +6.6%, while remaining within the governing raw-SQLite target at 1.123× and 1.175×
- partial 4,096-of-10K scalar UPDATE: RocksDB +8.1%, SlateDB +2.0%

The primary UPDATE win clears the per-PR threshold. The 1M and partial-update regressions are explicitly accepted as an UPDATE-priority tradeoff and tracked in a follow-up issue.

## Correctness

- non-final adaptive-split regression test proves an oversized part cannot seal a non-canonical chunk boundary
- hybrid 8,193-row journal test covers sealed prefix + unsealed read tail, read-your-writes, atomic commit, and fresh commit ownership
- independent correctness and performance reviews approved the final cut
- `RUST_MIN_STACK=8388608 cargo test -p lix_engine --lib`: 1,885 passed, 8 ignored
- `cargo test -p lix_engine --test integration`: 440 passed, 2 ignored
- `cargo clippy -p lix_engine --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The default-stack library suite currently aborts in an unrelated whole-collection DELETE test on both this branch and exact main; tracked in #1199.