### PR TITLE
Authenticate current-state serving base lineage

### DIFF
--- a/packages/engine-benchmarks/benches/current_state_scope_sharing.rs
+++ b/packages/engine-benchmarks/benches/current_state_scope_sharing.rs
@@ -87,7 +87,7 @@ async fn run_backend<S>(
     S: lix_engine::storage::Storage,
 {
     let setup = Instant::now();
-    let fixture = seed_current_state_point_fixture(
+    let mut fixture = seed_current_state_point_fixture(
         storage,
         rows,
         sparse_commits,
@@ -96,6 +96,12 @@ async fn run_backend<S>(
         point_target,
     )
     .await;
+    let topology = std::env::var("LIX_CURRENT_STATE_TOPOLOGY").unwrap_or_default();
+    if topology == "merge" {
+        fixture = fixture.append_empty_merge().await;
+    } else if !topology.is_empty() && topology != "linear" {
+        panic!("unknown LIX_CURRENT_STATE_TOPOLOGY '{topology}'; expected linear or merge");
+    }
     let setup = setup.elapsed();
     let mode = std::env::var("LIX_CURRENT_STATE_MODE").unwrap_or_default();
     if mode == "scope-scan" {
@@ -118,7 +124,7 @@ async fn run_backend<S>(
         };
         let measured = measure(&fixture, selected, warmups, samples).await;
         println!(
-            "current_state_scope_sharing,backend={backend},mode={mode},shape={sparse_shape:?},target={point_target:?},rows={rows},scopes={},sparse_commits={sparse_commits},final_parts={},setup_ms={:.3},scoped_range_staged_puts={},scoped_range_staged_bytes={},sparse_scoped_range_staged_puts={},sparse_scoped_range_staged_bytes={},sparse_staged_puts={},sparse_written_bytes={},sparse_publication_p50_us={:.3},sparse_publication_p95_us={:.3},first_sparse_ms={:.3},first_sparse_staged_puts={},first_sparse_written_bytes={},scoped_manifest_bytes={},replay_manifest_bytes={},p50_us={:.3},p95_us={:.3}",
+            "current_state_scope_sharing,backend={backend},mode={mode},topology={topology},shape={sparse_shape:?},target={point_target:?},rows={rows},scopes={},sparse_commits={sparse_commits},final_parts={},setup_ms={:.3},scoped_range_staged_puts={},scoped_range_staged_bytes={},sparse_scoped_range_staged_puts={},sparse_scoped_range_staged_bytes={},sparse_staged_puts={},sparse_written_bytes={},sparse_publication_p50_us={:.3},sparse_publication_p95_us={:.3},first_sparse_ms={:.3},first_sparse_staged_puts={},first_sparse_written_bytes={},scoped_manifest_bytes={},replay_manifest_bytes={},p50_us={:.3},p95_us={:.3}",
             fixture.scope_count(),
             fixture.current_state_part_count(),
             millis(setup),
@@ -155,7 +161,7 @@ async fn run_backend<S>(
     )
     .await;
     println!(
-        "current_state_scope_sharing,backend={backend},shape={sparse_shape:?},target={point_target:?},rows={rows},scopes={},sparse_commits={sparse_commits},final_parts={},setup_ms={:.3},scoped_range_staged_puts={},scoped_range_staged_bytes={},sparse_scoped_range_staged_puts={},sparse_scoped_range_staged_bytes={},sparse_staged_puts={},sparse_written_bytes={},sparse_publication_p50_us={:.3},sparse_publication_p95_us={:.3},first_sparse_ms={:.3},first_sparse_staged_puts={},first_sparse_written_bytes={},scoped_manifest_bytes={},replay_manifest_bytes={},serving_p50_us={:.3},serving_p95_us={:.3},replay_p50_us={:.3},replay_p95_us={:.3},p50_reduction_pct={:.2},p95_reduction_pct={:.2}",
+        "current_state_scope_sharing,backend={backend},topology={topology},shape={sparse_shape:?},target={point_target:?},rows={rows},scopes={},sparse_commits={sparse_commits},final_parts={},setup_ms={:.3},scoped_range_staged_puts={},scoped_range_staged_bytes={},sparse_scoped_range_staged_puts={},sparse_scoped_range_staged_bytes={},sparse_staged_puts={},sparse_written_bytes={},sparse_publication_p50_us={:.3},sparse_publication_p95_us={:.3},first_sparse_ms={:.3},first_sparse_staged_puts={},first_sparse_written_bytes={},scoped_manifest_bytes={},replay_manifest_bytes={},serving_p50_us={:.3},serving_p95_us={:.3},replay_p50_us={:.3},replay_p95_us={:.3},p50_reduction_pct={:.2},p95_reduction_pct={:.2}",
         fixture.scope_count(),
         fixture.current_state_part_count(),
         millis(setup),

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -671,11 +671,14 @@ where
         if !retained_authority_commits.insert(commit_id) {
             continue;
         }
-        if !packed.commits.contains_key(&commit_id) {
-            return Err(LixError::new(
+        let authority = packed.commits.get(&commit_id).ok_or_else(|| {
+            LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 format!("canonical mutation authority '{commit_id}' is missing"),
-            ));
+            )
+        })?;
+        if let Some(source_commit_id) = authority.selected_source_commit_id {
+            authority_roots.push(source_commit_id);
         }
     }
     let mut live_scoped_range_nodes = BTreeSet::<[u8; 32]>::new();
@@ -683,7 +686,7 @@ where
     let mut live_current_state_ref_summaries = BTreeMap::<[u8; 32], [u8; 32]>::new();
     let mut live_current_state_payload_hashes = BTreeSet::<[u8; 32]>::new();
     let mut scoped_roots = BTreeMap::new();
-    let mut live_manifests = BTreeMap::new();
+    let mut authority_manifests = BTreeMap::new();
     let live_commit_ids = live_commits.iter().copied().collect::<Vec<_>>();
     let loaded_live_manifests =
         crate::tracked_state::load_commit_state_manifests(store, &live_commit_ids).await?;
@@ -694,7 +697,7 @@ where
                 format!("live commit '{commit_id}' has no commit-state authority"),
             )
         })?;
-        live_manifests.insert(commit_id, manifest.clone());
+        authority_manifests.insert(commit_id, manifest.clone());
         let Some(root) = manifest.current_state_scoped_ranges.as_ref() else {
             continue;
         };
@@ -710,13 +713,50 @@ where
             }
         }
     }
-    for manifest in live_manifests.values() {
-        let parent = manifest
-            .parent_commit_ids
-            .first()
-            .and_then(|parent_id| live_manifests.get(parent_id));
-        crate::tracked_state::validate_current_state_scoped_range_parent_manifest(
-            manifest, parent,
+    let serving_base_ids = authority_manifests
+        .values()
+        .filter_map(|manifest| {
+            manifest
+                .current_state_scoped_ranges
+                .as_ref()
+                .and_then(|root| root.serving_base_commit_id)
+        })
+        .filter(|base_id| !authority_manifests.contains_key(base_id))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    if let Some(base_id) = serving_base_ids
+        .iter()
+        .find(|base_id| !retained_authority_commits.contains(base_id))
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("current-state serving base '{base_id}' is not retained authority"),
+        ));
+    }
+    let loaded_serving_bases =
+        crate::tracked_state::load_commit_state_manifests(store, &serving_base_ids).await?;
+    for (base_id, manifest) in serving_base_ids.into_iter().zip(loaded_serving_bases) {
+        let manifest = manifest.ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("current-state serving base '{base_id}' has no commit-state authority"),
+            )
+        })?;
+        authority_manifests.insert(base_id, manifest);
+    }
+    for commit_id in &live_commits {
+        let manifest = authority_manifests
+            .get(commit_id)
+            .expect("live commit authority was loaded");
+        let serving_base = manifest
+            .current_state_scoped_ranges
+            .as_ref()
+            .and_then(|root| root.serving_base_commit_id)
+            .and_then(|base_id| authority_manifests.get(&base_id));
+        crate::tracked_state::validate_current_state_scoped_range_serving_base_manifest(
+            manifest,
+            serving_base,
         )?;
     }
 
@@ -776,7 +816,7 @@ where
         }
     }
     for (owner, source_id, content_digest) in live_columnar_sources {
-        let authority = match live_manifests.get(&owner) {
+        let authority = match authority_manifests.get(&owner) {
             Some(authority) => authority.clone(),
             None => crate::tracked_state::load_commit_state_manifest(store, owner)
                 .await?
@@ -1856,15 +1896,67 @@ mod tests {
             ),
             (alias_commit, alias_stage.mutation_inventory().clone()),
         ]);
-        for record in &commits {
-            stage_test_commit_state_manifest(
-                &mut writes,
+        let scope = crate::tracked_state::scoped_range::ScopedRangePrefix::try_from_components([
+            b"gc-selected-source-empty".as_slice(),
+        ])
+        .expect("GC selected-source scope should encode");
+        let tree = crate::tracked_state::scoped_range::stage_scoped_range_tree(
+            &mut writes,
+            [(
+                crate::tracked_state::scoped_range::ScopedRangeCoverageMarker {
+                    scope,
+                    row_count: 0,
+                    part_count: 0,
+                },
+                Vec::new(),
+            )],
+        )
+        .expect("GC selected-source empty serving tree should stage");
+        let source_inventory = inventories[&source_commit].clone();
+        let source_root = crate::tracked_state::attest_scoped_range_root(
+            source_commit,
+            None,
+            &source_inventory,
+            tree.clone(),
+        )
+        .expect("source serving root should attest");
+        let mut source_manifest = test_commit_state_manifest(&commits[0], source_inventory);
+        source_manifest.current_state_scoped_ranges = Some(Box::new(source_root.clone()));
+        crate::tracked_state::stage_resealed_commit_state_manifest_for_test(
+            &mut writes,
+            &source_manifest,
+        )
+        .expect("source serving authority should stage");
+
+        let alias_inventory = inventories[&alias_commit].clone();
+        let alias_root = crate::tracked_state::attest_scoped_range_root(
+            alias_commit,
+            Some((source_commit, &source_root)),
+            &alias_inventory,
+            tree,
+        )
+        .expect("selected-source serving root should attest");
+        let mut alias_manifest = test_commit_state_manifest(&commits[1], alias_inventory);
+        alias_manifest.current_state_scoped_ranges = Some(Box::new(alias_root));
+        crate::tracked_state::stage_resealed_commit_state_manifest_for_test(
+            &mut writes,
+            &alias_manifest,
+        )
+        .expect("selected-source serving authority should stage");
+
+        for record in &commits[2..] {
+            let manifest = test_commit_state_manifest(
                 record,
                 inventories
                     .get(&record.commit_id)
                     .cloned()
                     .unwrap_or_default(),
             );
+            crate::tracked_state::stage_resealed_commit_state_manifest_for_test(
+                &mut writes,
+                &manifest,
+            )
+            .expect("GC retained-authority fixture manifest should stage");
         }
         storage_adapter
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -2440,27 +2532,31 @@ mod tests {
         record: &CommitRecord,
         mutations: CommitStateMutationInventory,
     ) {
-        stage_commit_state_manifest(
-            writes,
-            &CommitStateManifest {
-                commit_id: record.commit_id,
-                generation: record.generation,
-                parent_commit_ids: record.parent_commit_ids.clone(),
-                commit_change_id: record.change_id,
-                account_id: record.account_id.clone(),
-                created_at: record.created_at,
-                replay_debt: CommitStateReplayDebt {
-                    depth: record.tracked_state_rootless_depth,
-                    rows: record.tracked_state_rootless_rows,
-                    bytes: record.tracked_state_rootless_bytes,
-                },
-                mutations,
-                touched_scope_filter: Default::default(),
-                current_state_scoped_ranges: None,
-                snapshot_root: None,
+        stage_commit_state_manifest(writes, &test_commit_state_manifest(record, mutations))
+            .expect("GC fixture commit-state manifest should stage");
+    }
+
+    fn test_commit_state_manifest(
+        record: &CommitRecord,
+        mutations: CommitStateMutationInventory,
+    ) -> CommitStateManifest {
+        CommitStateManifest {
+            commit_id: record.commit_id,
+            generation: record.generation,
+            parent_commit_ids: record.parent_commit_ids.clone(),
+            commit_change_id: record.change_id,
+            account_id: record.account_id.clone(),
+            created_at: record.created_at,
+            replay_debt: CommitStateReplayDebt {
+                depth: record.tracked_state_rootless_depth,
+                rows: record.tracked_state_rootless_rows,
+                bytes: record.tracked_state_rootless_bytes,
             },
-        )
-        .expect("GC fixture commit-state manifest should stage");
+            mutations,
+            touched_scope_filter: Default::default(),
+            current_state_scoped_ranges: None,
+            snapshot_root: None,
+        }
     }
 
     async fn json_ref_exists(storage: &Memory, space: StorageSpace, json_ref: JsonRef) -> bool {

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -42,14 +42,14 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 
 /// Repository-wide compatibility gate for physical storage protocols.
 ///
-/// V53 makes structural fragmentation explicit in current-state range
-/// locators. Sparse rewrites may retain immutable source slices, while
-/// compaction clears the fragment bit on canonical output. Older repositories
-/// must fail closed rather than infer this serving invariant from row density.
+/// V56 separates semantic graph ancestry from physical current-state ancestry.
+/// A serving root authenticates the exact commit/root it structurally reuses,
+/// including merge targets and selected sources. Older repositories must fail
+/// closed rather than reinterpret a first-parent root as this stronger proof.
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::mutable(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"certified-touched-scope-filter.v55";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"authenticated-serving-base-lineage.v56";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately
@@ -1001,7 +1001,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn repository_protocol_rejects_pre_columnar_policy_cut_marker() {
+    async fn repository_protocol_rejects_pre_serving_base_lineage_marker() {
         let storage = StorageAdapter::new(Memory::new());
         let mut writes = StorageWriteSet::new();
         writes.put(

--- a/packages/engine/src/tracked_state/bench_support.rs
+++ b/packages/engine/src/tracked_state/bench_support.rs
@@ -466,6 +466,100 @@ impl<StorageImpl> BenchCurrentStatePointFixture<StorageImpl>
 where
     StorageImpl: Storage,
 {
+    /// Appends one production-shaped empty graph merge whose first parent is
+    /// the fixture's current state. Before serving-base lineage this topology
+    /// edge discarded the physical root and forced replay; the v56 path
+    /// re-attests the unchanged tree against the merge authority.
+    pub async fn append_empty_merge(mut self) -> Self {
+        let other_id = bench_addressable_commit_id("scoped-range-merge-other");
+        let other = bench_current_state_manifest(
+            other_id,
+            None,
+            1,
+            super::types::CommitStateMutationInventory::default(),
+            Default::default(),
+            None,
+        );
+        let mut other_writes = self.storage.new_write_set();
+        super::storage::stage_commit_state_manifest(&mut other_writes, &other)
+            .expect("stage benchmark merge parent authority");
+        self.storage
+            .commit_write_set(other_writes, StorageWriteOptions::default())
+            .await
+            .expect("commit benchmark merge parent authority");
+
+        let read = self
+            .storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open benchmark merge publication read");
+        let current = super::storage::load_published_commit_state_manifest(
+            &read,
+            self.current_manifest.commit_id,
+        )
+        .await
+        .expect("load benchmark merge target")
+        .expect("benchmark merge target exists");
+        let other = super::storage::load_published_commit_state_manifest(&read, other_id)
+            .await
+            .expect("load benchmark second merge parent")
+            .expect("benchmark second merge parent exists");
+        let merge_id = bench_addressable_commit_id("scoped-range-empty-merge");
+        let mutations = super::types::CommitStateMutationInventory::default();
+        let mut writes = self.storage.new_write_set();
+        let publication = super::storage::stage_current_state_scoped_ranges_from_topology(
+            &read,
+            &mut writes,
+            &[
+                super::storage::CertifiedCommitStateTopologyParent::Published(&current),
+                super::storage::CertifiedCommitStateTopologyParent::Published(&other),
+            ],
+            None,
+            merge_id,
+            crate::ANONYMOUS_ACCOUNT_ID,
+            &mutations,
+        )
+        .await
+        .expect("stage benchmark merge serving root");
+        let merged = CommitStateManifest {
+            commit_id: merge_id,
+            generation: self.current_manifest.generation.saturating_add(1),
+            parent_commit_ids: vec![self.current_manifest.commit_id, other_id],
+            commit_change_id: ChangeId::for_test_label("scoped-range-empty-merge-change"),
+            account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
+            created_at: crate::common::LixTimestamp::from_unix_millis_utc_lossy(33),
+            replay_debt: CommitStateReplayDebt {
+                depth: self
+                    .current_manifest
+                    .replay_debt
+                    .depth
+                    .saturating_add(1)
+                    .min(super::COMMIT_STATE_MAX_REPLAY_DEPTH),
+                rows: self.current_manifest.replay_debt.rows,
+                bytes: self.current_manifest.replay_debt.bytes,
+            },
+            mutations,
+            touched_scope_filter: publication.touched_scope_filter().clone(),
+            current_state_scoped_ranges: publication.root(),
+            snapshot_root: None,
+        };
+        super::storage::stage_certified_commit_state_manifest(&mut writes, &merged, &publication)
+            .expect("stage certified benchmark merge manifest");
+        drop(read);
+        self.storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit benchmark merge serving root");
+        self.current_manifest = merged;
+        self.commits.push(merge_id);
+        self.current_state_part_count = self
+            .current_manifest
+            .current_state_scoped_ranges
+            .as_ref()
+            .map_or(0, |root| u64::from(root.tree.part_count));
+        self
+    }
+
     pub fn scope_count(&self) -> usize {
         self.scope_count
     }

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -46,6 +46,8 @@ pub(crate) use row_materialization::{
     MaterializedTrackedStateRowRef, materialize_batch_from_index_entries,
     materialize_batch_from_index_entry_refs,
 };
+#[cfg(test)]
+pub(crate) use scoped_current_state::attest_scoped_range_root;
 pub(crate) use scoped_current_state::incomplete_touched_scope_filter;
 pub(crate) use scoped_range::{SCOPED_RANGE_NODE_SPACE, validate_scoped_range_trees};
 #[cfg(any(test, feature = "storage-benches"))]
@@ -54,8 +56,8 @@ pub(crate) use storage::{
     CertifiedCommitStateTopologyParent, CommitDeltaChangeLocator, CommitDeltaLiveMembershipCursor,
     CommitDeltaMember, CommitDeltaPointReadCache, CommitDeltaReplacementGeneration,
     CommitDeltaReplacementScope, OrderedAddressableCommitDeltaStage, PublishedCommitStateManifest,
-    StagedCommitStateManifest, certify_topology_touched_scope_filter, commit_delta_contains_schema,
-    direct_change_locator, load_change_record_by_id, load_commit_delta_change_records,
+    StagedCommitStateManifest, commit_delta_contains_schema, direct_change_locator,
+    load_change_record_by_id, load_commit_delta_change_records,
     load_commit_delta_members_with_payloads, load_commit_delta_members_with_payloads_for_schemas,
     load_commit_delta_replay_metadata, load_commit_delta_selection_certificate,
     load_commit_state_manifest, load_commit_state_manifests, load_owned_commit_delta_entries,
@@ -66,12 +68,13 @@ pub(crate) use storage::{
     stage_certified_commit_state_manifest_with_handle, stage_change_locators,
     stage_commit_deltas_for_commit_state, stage_commit_state_manifest_with_handle,
     stage_current_state_scoped_ranges_from_published_parent,
-    stage_current_state_scoped_ranges_from_staged_parent, stage_delete_change_locators,
+    stage_current_state_scoped_ranges_from_staged_parent,
+    stage_current_state_scoped_ranges_from_topology, stage_delete_change_locators,
     stage_delete_commit_delta_inventory_entry, stage_ordered_addressable_commit_deltas,
     stage_ordered_addressable_replacement_parts, stage_ordered_columnar_mutations,
     stage_preencoded_ordered_addressable_replacement_parts,
     stage_prefixed_ordered_addressable_replacement_parts,
-    validate_current_state_scoped_range_parent_manifest,
+    validate_current_state_scoped_range_serving_base_manifest,
 };
 #[cfg(feature = "storage-benches")]
 pub(crate) use storage::{

--- a/packages/engine/src/tracked_state/scoped_current_state.rs
+++ b/packages/engine/src/tracked_state/scoped_current_state.rs
@@ -16,7 +16,7 @@ use crate::tracked_state::types::{
 };
 use crate::{LixError, storage_codec};
 
-const TRANSITION_CONTEXT: &str = "lix current-state scoped-range transition v1";
+const TRANSITION_CONTEXT: &str = "lix current-state scoped-range transition v2";
 const TOUCHED_SCOPE_FILTER_BYTES: usize = 128;
 const TOUCHED_SCOPE_FILTER_HASHES: usize = 4;
 const TOUCHED_SCOPE_FILTER_CONTEXT: &str = "lix cumulative touched collection scope v1";
@@ -29,6 +29,7 @@ async fn stage_disjoint_columnar_current_state_pages(
     store: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
     parent_manifest: Option<&CommitStateManifest>,
+    inherited_scope_filter: &CommitStateTouchedScopeFilter,
     commit_id: CommitId,
     inventory: &CommitStateMutationInventory,
 ) -> Result<Option<CurrentStateScopedRangeRoot>, LixError> {
@@ -159,7 +160,7 @@ async fn stage_disjoint_columnar_current_state_pages(
         {
             return Ok(None);
         }
-        if !parent_scope_is_proven_empty(parent_manifest, &scope)? {
+        if !touched_scope_filter_proves_absent(inherited_scope_filter, &scope)? {
             return Ok(None);
         }
         let marker = ScopedRangeCoverageMarker {
@@ -178,7 +179,12 @@ async fn stage_disjoint_columnar_current_state_pages(
         }
     };
     Ok(Some(attest_scoped_range_root(
-        commit_id, parent, inventory, tree,
+        commit_id,
+        parent_manifest
+            .zip(parent)
+            .map(|(manifest, root)| (manifest.commit_id, root)),
+        inventory,
+        tree,
     )?))
 }
 
@@ -186,6 +192,7 @@ async fn stage_disjoint_columnar_current_state_pages(
 /// lineage. Bloom false positives only disable publication; a negative is an
 /// exact absence proof because every exactly bounded mutation contributes its
 /// scope and unknown/broad mutations make the certificate incomplete.
+#[cfg(test)]
 fn parent_scope_is_proven_empty(
     parent: Option<&CommitStateManifest>,
     scope: &CommitDeltaReplacementScope,
@@ -212,10 +219,7 @@ fn advance_touched_scope_filter(
     selected_source: Option<&CommitStateManifest>,
     touched: Option<&[CommitDeltaReplacementScope]>,
 ) -> Result<CommitStateTouchedScopeFilter, LixError> {
-    let Some(touched) = touched else {
-        return Ok(incomplete_touched_scope_filter());
-    };
-    let mut filter = if let Some(source) = selected_source {
+    let filter = if let Some(source) = selected_source {
         validate_touched_scope_filter(&source.touched_scope_filter)?;
         if !source.touched_scope_filter.complete {
             return Ok(incomplete_touched_scope_filter());
@@ -245,6 +249,19 @@ fn advance_touched_scope_filter(
             }
         }
     };
+    extend_touched_scope_filter(filter, touched)
+}
+
+fn extend_touched_scope_filter(
+    mut filter: CommitStateTouchedScopeFilter,
+    touched: Option<&[CommitDeltaReplacementScope]>,
+) -> Result<CommitStateTouchedScopeFilter, LixError> {
+    let Some(touched) = touched else {
+        return Ok(incomplete_touched_scope_filter());
+    };
+    if !filter.complete {
+        return Ok(filter);
+    }
     for scope in touched {
         for bit in touched_scope_filter_bits(scope.schema_key.as_bytes()) {
             filter.bits[bit / 8] |= 1 << (bit % 8);
@@ -360,6 +377,7 @@ impl CertifiedCommitStatePhysicalPublication {
 /// root itself cannot cross a merge or selected-source topology edge. Graph
 /// parents are unioned conservatively. A selected source supplies the complete
 /// inherited state, so it supersedes graph parents for this proof.
+#[cfg(test)]
 pub(super) fn certify_topology_touched_scope_filter_from_manifests(
     writes: &StorageWriteSet,
     parents: &[&CommitStateManifest],
@@ -418,16 +436,21 @@ pub(crate) fn current_state_mutation_authority_digest(
 
 pub(crate) fn scoped_range_transition_digest(
     commit_id: CommitId,
-    parent_root_id: Option<[u8; 32]>,
+    serving_base_commit_id: Option<CommitId>,
+    serving_base_root_id: Option<[u8; 32]>,
     inventory: &CommitStateMutationInventory,
     tree: &ScopedRangeRoot,
 ) -> Result<[u8; 32], LixError> {
     let authority = current_state_mutation_authority_digest(inventory)?;
     let mut digest = blake3::Hasher::new_derive_key(TRANSITION_CONTEXT);
     digest.update(commit_id.as_uuid().as_bytes());
-    digest.update(&[u8::from(parent_root_id.is_some())]);
-    if let Some(parent_root_id) = parent_root_id {
-        digest.update(&parent_root_id);
+    digest.update(&[u8::from(serving_base_commit_id.is_some())]);
+    if let Some(serving_base_commit_id) = serving_base_commit_id {
+        digest.update(serving_base_commit_id.as_uuid().as_bytes());
+    }
+    digest.update(&[u8::from(serving_base_root_id.is_some())]);
+    if let Some(serving_base_root_id) = serving_base_root_id {
+        digest.update(&serving_base_root_id);
     }
     digest.update(&authority);
     digest.update(&tree.root_id);
@@ -441,16 +464,23 @@ pub(crate) fn scoped_range_transition_digest(
 
 pub(crate) fn attest_scoped_range_root(
     commit_id: CommitId,
-    parent: Option<&CurrentStateScopedRangeRoot>,
+    serving_base: Option<(CommitId, &CurrentStateScopedRangeRoot)>,
     inventory: &CommitStateMutationInventory,
     tree: ScopedRangeRoot,
 ) -> Result<CurrentStateScopedRangeRoot, LixError> {
-    let parent_root_id = parent.map(|parent| parent.tree.root_id);
-    let transition_digest =
-        scoped_range_transition_digest(commit_id, parent_root_id, inventory, &tree)?;
+    let serving_base_commit_id = serving_base.map(|(commit_id, _)| commit_id);
+    let serving_base_root_id = serving_base.map(|(_, root)| root.tree.root_id);
+    let transition_digest = scoped_range_transition_digest(
+        commit_id,
+        serving_base_commit_id,
+        serving_base_root_id,
+        inventory,
+        &tree,
+    )?;
     Ok(CurrentStateScopedRangeRoot {
         tree,
-        parent_root_id,
+        serving_base_commit_id,
+        serving_base_root_id,
         transition_digest,
     })
 }
@@ -458,6 +488,7 @@ pub(crate) fn attest_scoped_range_root(
 pub(crate) async fn stage_complete_replacement_scoped_range_root(
     store: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
+    serving_base_commit_id: Option<CommitId>,
     parent: Option<&CurrentStateScopedRangeRoot>,
     commit_id: CommitId,
     inventory: &CommitStateMutationInventory,
@@ -537,7 +568,10 @@ pub(crate) async fn stage_complete_replacement_scoped_range_root(
         None => stage_scoped_range_tree(writes, [(marker, parts)])?,
     };
     Ok(Some(attest_scoped_range_root(
-        commit_id, parent, inventory, tree,
+        commit_id,
+        serving_base_commit_id.zip(parent),
+        inventory,
+        tree,
     )?))
 }
 
@@ -547,50 +581,71 @@ pub(crate) async fn stage_complete_replacement_scoped_range_root(
 pub(crate) async fn stage_current_state_scoped_ranges(
     store: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
-    parent: Option<&CommitStateManifest>,
+    graph_parents: &[&CommitStateManifest],
+    selected_source: Option<&CommitStateManifest>,
+    serving_base: Option<&CommitStateManifest>,
     commit_id: CommitId,
     account_id: &str,
     inventory: &CommitStateMutationInventory,
 ) -> Result<CertifiedCommitStatePhysicalPublication, LixError> {
-    let parent_commit_ids = CertifiedGraphParents::from_manifests(parent.as_slice());
-    let parent_root = parent.and_then(|parent| parent.current_state_scoped_ranges.as_deref());
-    let touched = crate::tracked_state::storage::commit_state_inventory_exact_touched_scopes(
+    let parent_commit_ids = CertifiedGraphParents::from_manifests(graph_parents);
+    let selected_source_commit_id = selected_source.map(|source| source.commit_id);
+    if selected_source_commit_id != inventory.selected_source_commit_id() {
+        return Err(scoped_state_error(
+            "selected-source manifest disagrees with mutation authority",
+        ));
+    }
+    let parent_root = serving_base.and_then(|parent| parent.current_state_scoped_ranges.as_deref());
+    let touched = crate::tracked_state::storage::commit_state_inventory_exact_local_touched_scopes(
         commit_id,
         inventory,
-        parent.is_none(),
+        serving_base.is_none(),
     )?;
     // Descriptor cascades make exact per-file serving scopes unknown, but
     // they cannot introduce a schema family that was absent from the parent:
     // every cascaded row had to be authored earlier. Preserve the cumulative
     // negative certificate by adding only the current commit's authored schema
     // families, using empty-base scope extraction to ignore that cascade.
-    let filter_touched = if touched.is_some() || parent.is_none() {
+    let filter_touched = if touched.is_some() || serving_base.is_none() {
         touched.clone()
     } else {
-        crate::tracked_state::storage::commit_state_inventory_exact_touched_scopes(
+        crate::tracked_state::storage::commit_state_inventory_exact_local_touched_scopes(
             commit_id, inventory, true,
         )?
     };
-    let touched_scope_filter =
-        advance_touched_scope_filter(parent.as_slice(), None, filter_touched.as_deref())?;
+    let inherited_scope_filter =
+        advance_touched_scope_filter(graph_parents, selected_source, Some(&[]))?;
     if inventory.columnar_parts.is_some() {
         let root = stage_disjoint_columnar_current_state_pages(
-            store, writes, parent, commit_id, inventory,
+            store,
+            writes,
+            serving_base,
+            &inherited_scope_filter,
+            commit_id,
+            inventory,
         )
         .await?;
+        let touched_scope_filter =
+            extend_touched_scope_filter(inherited_scope_filter, filter_touched.as_deref())?;
         return Ok(CertifiedCommitStatePhysicalPublication {
             write_set_id: writes.identity(),
             parent_commit_ids,
-            selected_source_commit_id: None,
+            selected_source_commit_id,
             root,
             touched_scope_filter,
         });
     }
+    let touched_scope_filter =
+        extend_touched_scope_filter(inherited_scope_filter, filter_touched.as_deref())?;
 
     if inventory.replacement_generation.is_some() {
         let root = stage_complete_replacement_scoped_range_root(
             store,
             writes,
+            touched
+                .as_ref()
+                .and(parent_root)
+                .and(serving_base.map(|parent| parent.commit_id)),
             touched.as_ref().and(parent_root),
             commit_id,
             inventory,
@@ -599,7 +654,7 @@ pub(crate) async fn stage_current_state_scoped_ranges(
         return Ok(CertifiedCommitStatePhysicalPublication {
             write_set_id: writes.identity(),
             parent_commit_ids,
-            selected_source_commit_id: None,
+            selected_source_commit_id,
             root,
             touched_scope_filter,
         });
@@ -609,7 +664,7 @@ pub(crate) async fn stage_current_state_scoped_ranges(
         return Ok(CertifiedCommitStatePhysicalPublication {
             write_set_id: writes.identity(),
             parent_commit_ids,
-            selected_source_commit_id: None,
+            selected_source_commit_id,
             root: None,
             touched_scope_filter,
         });
@@ -618,11 +673,25 @@ pub(crate) async fn stage_current_state_scoped_ranges(
         return Ok(CertifiedCommitStatePhysicalPublication {
             write_set_id: writes.identity(),
             parent_commit_ids,
-            selected_source_commit_id: None,
+            selected_source_commit_id,
             root: None,
             touched_scope_filter,
         });
     };
+    if touched.is_empty() {
+        return Ok(CertifiedCommitStatePhysicalPublication {
+            write_set_id: writes.identity(),
+            parent_commit_ids,
+            selected_source_commit_id,
+            root: Some(attest_scoped_range_root(
+                commit_id,
+                serving_base.map(|parent| (parent.commit_id, parent_root)),
+                inventory,
+                parent_root.tree.clone(),
+            )?),
+            touched_scope_filter,
+        });
+    }
     touched.sort();
     touched.dedup();
     let staged_segments = crate::tracked_state::storage::staged_commit_delta_segment_bytes(
@@ -653,7 +722,8 @@ pub(crate) async fn stage_current_state_scoped_ranges(
     for scope in touched {
         let transient = CurrentStateScopedRangeRoot {
             tree,
-            parent_root_id: parent_root.parent_root_id,
+            serving_base_commit_id: parent_root.serving_base_commit_id,
+            serving_base_root_id: parent_root.serving_base_root_id,
             transition_digest: parent_root.transition_digest,
         };
         let Some(rewritten) =
@@ -669,7 +739,7 @@ pub(crate) async fn stage_current_state_scoped_ranges(
             return Ok(CertifiedCommitStatePhysicalPublication {
                 write_set_id: writes.identity(),
                 parent_commit_ids,
-                selected_source_commit_id: None,
+                selected_source_commit_id,
                 root: None,
                 touched_scope_filter,
             });
@@ -684,10 +754,10 @@ pub(crate) async fn stage_current_state_scoped_ranges(
     Ok(CertifiedCommitStatePhysicalPublication {
         write_set_id: writes.identity(),
         parent_commit_ids,
-        selected_source_commit_id: None,
+        selected_source_commit_id,
         root: Some(attest_scoped_range_root(
             commit_id,
-            Some(parent_root),
+            serving_base.map(|parent| (parent.commit_id, parent_root)),
             inventory,
             tree,
         )?),
@@ -701,7 +771,13 @@ pub(crate) fn validate_scoped_range_attestation(
     root: &CurrentStateScopedRangeRoot,
 ) -> Result<(), LixError> {
     if root.transition_digest
-        != scoped_range_transition_digest(commit_id, root.parent_root_id, inventory, &root.tree)?
+        != scoped_range_transition_digest(
+            commit_id,
+            root.serving_base_commit_id,
+            root.serving_base_root_id,
+            inventory,
+            &root.tree,
+        )?
     {
         return Err(scoped_state_error(
             "root transition is not bound to commit mutation authority",
@@ -738,14 +814,16 @@ mod tests {
         stage_scoped_range_tree, validate_scoped_range_tree,
     };
     use crate::tracked_state::storage::{
-        CommitDeltaReplacementGeneration, PublishedCommitStateManifest, load_commit_state_manifest,
+        CertifiedCommitStateTopologyParent, CommitDeltaReplacementGeneration,
+        PublishedCommitStateManifest, load_commit_state_manifest,
         load_complete_current_state_values_from_scoped_root, load_published_commit_state_manifest,
         sparse_current_state_materialization_count_for_test, stage_certified_commit_state_manifest,
         stage_certified_commit_state_manifest_with_handle, stage_commit_state_manifest,
         stage_current_state_scoped_ranges_from_published_parent,
         stage_current_state_scoped_ranges_from_staged_parent,
-        stage_ordered_addressable_commit_deltas, stage_ordered_addressable_replacement_parts,
-        validate_current_state_scoped_range_parent_manifest,
+        stage_current_state_scoped_ranges_from_topology, stage_ordered_addressable_commit_deltas,
+        stage_ordered_addressable_replacement_parts,
+        validate_current_state_scoped_range_serving_base_manifest,
     };
     use crate::tracked_state::types::{
         CommitDeltaLifecycleSummary, CommitDeltaReplacementScope, CommitStateManifest,
@@ -963,6 +1041,8 @@ mod tests {
         let parent_publication = stage_current_state_scoped_ranges(
             &empty_read,
             &mut parent_writes,
+            &[],
+            None,
             None,
             parent_id,
             crate::ANONYMOUS_ACCOUNT_ID,
@@ -1095,7 +1175,7 @@ mod tests {
             .await
             .expect("child authority should load")
             .expect("child authority should exist");
-        validate_current_state_scoped_range_parent_manifest(&child, Some(&parent))
+        validate_current_state_scoped_range_serving_base_manifest(&child, Some(&parent))
             .expect("child must bind the exact parent root");
         let values = load_complete_current_state_values_from_scoped_root(
             &child_read,
@@ -1499,6 +1579,8 @@ mod tests {
         let publication = stage_current_state_scoped_ranges(
             &read,
             &mut writes,
+            &[],
+            None,
             None,
             commit_id,
             crate::ANONYMOUS_ACCOUNT_ID,
@@ -1549,13 +1631,16 @@ mod tests {
 
         let mut unknown = CommitStateMutationInventory::default();
         unknown.member_count = 1;
-        unknown.selected_source_commit_id =
-            Some(*CommitId::for_test_label("selected").as_uuid().as_bytes());
+        let selected_id = CommitId::for_test_label("selected");
+        unknown.selected_source_commit_id = Some(*selected_id.as_uuid().as_bytes());
+        let selected = manifest(selected_id, None, CommitStateMutationInventory::default());
         let mut writes = storage.new_write_set();
         let publication = stage_current_state_scoped_ranges(
             &read,
             &mut writes,
-            None,
+            &[],
+            Some(&selected),
+            Some(&selected),
             commit_id,
             crate::ANONYMOUS_ACCOUNT_ID,
             &unknown,
@@ -1577,6 +1662,8 @@ mod tests {
         let publication = stage_current_state_scoped_ranges(
             &read,
             &mut writes,
+            &[],
+            None,
             None,
             commit_id,
             crate::ANONYMOUS_ACCOUNT_ID,
@@ -1729,6 +1816,81 @@ mod tests {
 
         merged.parent_commit_ids.swap(0, 1);
         assert!(stage_certified_commit_state_manifest(&mut writes, &merged, &publication).is_err());
+    }
+
+    #[tokio::test]
+    async fn topology_publication_binds_merge_and_selected_source_serving_bases() {
+        let storage = StorageAdapter::new(Memory::new());
+        let left_id = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x0199_3300_0000_7000_8000_0001_0000_0000,
+        ));
+        let left = publish_replacement_scope(&storage, None, left_id, "left_schema").await;
+        let right_id = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x0199_3300_0000_7000_8000_0002_0000_0000,
+        ));
+        let right = publish_replacement_scope(&storage, None, right_id, "right_schema").await;
+        let left_root = left
+            .current_state_scoped_ranges
+            .as_deref()
+            .expect("left parent has a serving root");
+        let right_root = right
+            .current_state_scoped_ranges
+            .as_deref()
+            .expect("right parent has a serving root");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .unwrap();
+
+        let merge_commit = CommitId::for_test_label("serving-base-merge");
+        let merge_inventory = CommitStateMutationInventory::default();
+        let mut merge_writes = storage.new_write_set();
+        let merge_publication = stage_current_state_scoped_ranges_from_topology(
+            &read,
+            &mut merge_writes,
+            &[
+                CertifiedCommitStateTopologyParent::Published(&left),
+                CertifiedCommitStateTopologyParent::Published(&right),
+            ],
+            None,
+            merge_commit,
+            crate::ANONYMOUS_ACCOUNT_ID,
+            &merge_inventory,
+        )
+        .await
+        .unwrap();
+        let merge_root = merge_publication.root().expect("merge reuses target root");
+        assert_eq!(merge_root.serving_base_commit_id, Some(left.commit_id));
+        assert_eq!(
+            merge_root.serving_base_root_id,
+            Some(left_root.tree.root_id)
+        );
+        assert_eq!(merge_root.tree, left_root.tree);
+
+        let alias_commit = CommitId::for_test_label("serving-base-selected-source");
+        let mut alias_inventory = CommitStateMutationInventory::default();
+        alias_inventory.selected_source_commit_id = Some(*right.commit_id.as_uuid().as_bytes());
+        let mut alias_writes = storage.new_write_set();
+        let alias_publication = stage_current_state_scoped_ranges_from_topology(
+            &read,
+            &mut alias_writes,
+            &[CertifiedCommitStateTopologyParent::Published(&left)],
+            Some(CertifiedCommitStateTopologyParent::Published(&right)),
+            alias_commit,
+            crate::ANONYMOUS_ACCOUNT_ID,
+            &alias_inventory,
+        )
+        .await
+        .unwrap();
+        let alias_root = alias_publication
+            .root()
+            .expect("selected source supplies serving root");
+        assert_eq!(alias_root.serving_base_commit_id, Some(right.commit_id));
+        assert_eq!(
+            alias_root.serving_base_root_id,
+            Some(right_root.tree.root_id)
+        );
+        assert_eq!(alias_root.tree, right_root.tree);
     }
 
     #[test]

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -89,8 +89,8 @@ const ORDERED_COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 64 * 1024;
 // replacements authoritative through their immutable part manifest. The
 // payload-less certified-reference encoding is intentionally rejected.
 const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD14";
-const COMMIT_STATE_SEMANTIC_AUTHORITY_MAGIC: &[u8] = b"LXSA4";
-const COMMIT_STATE_SEMANTIC_AUTHORITY_HASH_CONTEXT: &str = "lix.commit-state.semantic-authority.v4";
+const COMMIT_STATE_SEMANTIC_AUTHORITY_MAGIC: &[u8] = b"LXSA5";
+const COMMIT_STATE_SEMANTIC_AUTHORITY_HASH_CONTEXT: &str = "lix.commit-state.semantic-authority.v5";
 // Version 4 makes lossless columnar mutation parts a first-class, exclusive
 // commit payload. LXCS3 repositories are intentionally rejected: there is no
 // compatibility decoder beneath the new authority.
@@ -101,7 +101,9 @@ const COMMIT_STATE_SEMANTIC_AUTHORITY_HASH_CONTEXT: &str = "lix.commit-state.sem
 // identities. LXCS5 roots cannot be reinterpreted under its content hashes.
 // Version 7 authenticates the cumulative touched-schema negative certificate.
 // LXCS6 manifests and LXSA3 semantic seals are deliberately incompatible.
-const COMMIT_STATE_MANIFEST_FORMAT_MAGIC: &[u8] = b"LXCS7";
+// Version 8 binds current-state serving roots to an explicit physical base
+// commit independently from semantic graph ancestry.
+const COMMIT_STATE_MANIFEST_FORMAT_MAGIC: &[u8] = b"LXCS8";
 const COMMIT_DELTA_PAYLOAD_OFFSET_BYTES: usize = size_of::<u32>();
 #[cfg(not(test))]
 const COMMIT_DELTA_MAX_SIDECAR_BYTES: usize = 64 * 1024 * 1024;
@@ -1183,19 +1185,22 @@ fn current_inventory_may_contain_any_key(
     }))
 }
 
-pub(crate) fn validate_current_state_scoped_range_parent_manifest(
+pub(crate) fn validate_current_state_scoped_range_serving_base_manifest(
     state: &CommitStateManifest,
-    parent: Option<&CommitStateManifest>,
+    serving_base: Option<&CommitStateManifest>,
 ) -> Result<(), LixError> {
     let Some(root) = state.current_state_scoped_ranges.as_ref() else {
         return Ok(());
     };
-    let expected_parent_root = parent
-        .and_then(|parent| parent.current_state_scoped_ranges.as_ref())
-        .map(|parent| parent.tree.root_id);
-    if root.parent_root_id != expected_parent_root {
+    let expected_base_commit_id = serving_base.map(|base| base.commit_id);
+    let expected_base_root = serving_base
+        .and_then(|base| base.current_state_scoped_ranges.as_ref())
+        .map(|base| base.tree.root_id);
+    if root.serving_base_commit_id != expected_base_commit_id
+        || root.serving_base_root_id != expected_base_root
+    {
         return Err(replacement_payload_error(
-            "current-state scoped-range transition disagrees with its graph parent",
+            "current-state scoped-range transition disagrees with its serving base",
         ));
     }
     Ok(())
@@ -2281,11 +2286,13 @@ impl Deref for StagedCommitStateManifest {
     }
 }
 
-pub(crate) fn certify_topology_touched_scope_filter(
-    writes: &StorageWriteSet,
+pub(crate) async fn stage_current_state_scoped_ranges_from_topology(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
     parents: &[CertifiedCommitStateTopologyParent<'_>],
     selected_source: Option<CertifiedCommitStateTopologyParent<'_>>,
     commit_id: CommitId,
+    account_id: &str,
     inventory: &CommitStateMutationInventory,
 ) -> Result<super::scoped_current_state::CertifiedCommitStatePhysicalPublication, LixError> {
     let parents = parents
@@ -2296,13 +2303,18 @@ pub(crate) fn certify_topology_touched_scope_filter(
     let selected_source = selected_source
         .map(|source| source.manifest(writes))
         .transpose()?;
-    super::scoped_current_state::certify_topology_touched_scope_filter_from_manifests(
+    let serving_base = selected_source.or_else(|| parents.first().copied());
+    super::scoped_current_state::stage_current_state_scoped_ranges(
+        store,
         writes,
         &parents,
         selected_source,
+        serving_base,
         commit_id,
+        account_id,
         inventory,
     )
+    .await
 }
 
 pub(crate) async fn stage_current_state_scoped_ranges_from_published_parent(
@@ -2316,6 +2328,8 @@ pub(crate) async fn stage_current_state_scoped_ranges_from_published_parent(
     super::scoped_current_state::stage_current_state_scoped_ranges(
         store,
         writes,
+        parent.map(|parent| &parent.manifest).as_slice(),
+        None,
         parent.map(|parent| &parent.manifest),
         commit_id,
         account_id,
@@ -2340,6 +2354,8 @@ pub(crate) async fn stage_current_state_scoped_ranges_from_staged_parent(
     super::scoped_current_state::stage_current_state_scoped_ranges(
         store,
         writes,
+        &[&parent.manifest],
+        None,
         Some(&parent.manifest),
         commit_id,
         account_id,
@@ -10210,8 +10226,7 @@ fn validate_current_state_scoped_ranges(
                 || root.tree.tree_height == 0
                 || root.tree.marker_count == 0
                 || root.transition_digest == [0; 32]
-                || manifest.parent_commit_ids.len() > 1
-                || manifest.mutations.selected_source_commit_id.is_some()
+                || root.serving_base_commit_id.is_some() != root.serving_base_root_id.is_some()
         })
     {
         return Err(LixError::new(
@@ -10220,10 +10235,16 @@ fn validate_current_state_scoped_ranges(
         ));
     }
     if let Some(root) = manifest.current_state_scoped_ranges.as_ref() {
-        if manifest.parent_commit_ids.is_empty() && root.parent_root_id.is_some() {
+        let expected_serving_base = manifest
+            .mutations
+            .selected_source_commit_id()
+            .or_else(|| manifest.parent_commit_ids.first().copied());
+        if root.serving_base_commit_id.is_some()
+            && root.serving_base_commit_id != expected_serving_base
+        {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
-                "tracked_state current-state scoped-range ancestry disagrees with commit topology",
+                "tracked_state current-state serving base disagrees with commit authority",
             ));
         }
         if validate_attestation {
@@ -13865,10 +13886,12 @@ mod tests {
             row_count: 17,
             tree_height: 1,
         };
-        let parent_root_id = Some([9; 32]);
+        let serving_base_commit_id = manifest.parent_commit_ids.first().copied();
+        let serving_base_root_id = Some([9; 32]);
         let transition_digest = super::super::scoped_current_state::scoped_range_transition_digest(
             manifest.commit_id,
-            parent_root_id,
+            serving_base_commit_id,
+            serving_base_root_id,
             &manifest.mutations,
             &tree,
         )
@@ -13876,7 +13899,8 @@ mod tests {
         manifest.current_state_scoped_ranges =
             Some(Box::new(super::super::types::CurrentStateScopedRangeRoot {
                 tree,
-                parent_root_id,
+                serving_base_commit_id,
+                serving_base_root_id,
                 transition_digest,
             }));
 
@@ -13894,6 +13918,40 @@ mod tests {
     }
 
     #[test]
+    fn commit_state_manifest_codec_rejects_wrong_serving_base() {
+        let mut manifest = commit_state_manifest_fixture();
+        let tree = super::super::scoped_range::ScopedRangeRoot {
+            root_id: [7; 32],
+            root_digest: [8; 32],
+            marker_count: 1,
+            part_count: 2,
+            row_count: 17,
+            tree_height: 1,
+        };
+        let wrong_base = CommitId::for_test_label("wrong-serving-base");
+        let serving_base_root_id = Some([9; 32]);
+        let transition_digest = super::super::scoped_current_state::scoped_range_transition_digest(
+            manifest.commit_id,
+            Some(wrong_base),
+            serving_base_root_id,
+            &manifest.mutations,
+            &tree,
+        )
+        .expect("transition should hash");
+        manifest.current_state_scoped_ranges =
+            Some(Box::new(super::super::types::CurrentStateScopedRangeRoot {
+                tree,
+                serving_base_commit_id: Some(wrong_base),
+                serving_base_root_id,
+                transition_digest,
+            }));
+
+        let error = encode_commit_state_manifest(&manifest)
+            .expect_err("serving base outside commit authority must fail closed");
+        assert!(error.message.contains("serving base"));
+    }
+
+    #[test]
     fn commit_state_manifest_codec_rejects_pre_cut_formats() {
         let manifest = commit_state_manifest_fixture();
         let payload = storage_codec::encode("tracked_state commit_state_manifest", &manifest)
@@ -13902,6 +13960,7 @@ mod tests {
             b"LXCS3".as_slice(),
             b"LXCS5".as_slice(),
             b"LXCS6".as_slice(),
+            b"LXCS7".as_slice(),
         ] {
             let mut legacy = magic.to_vec();
             legacy.extend_from_slice(&payload);
@@ -13914,6 +13973,7 @@ mod tests {
             b"LXSA1".as_slice(),
             b"LXSA2".as_slice(),
             b"LXSA3".as_slice(),
+            b"LXSA4".as_slice(),
         ] {
             let mut legacy_seal = magic.to_vec();
             legacy_seal.extend_from_slice(&[0; TRACKED_STATE_HASH_BYTES]);
@@ -13924,14 +13984,14 @@ mod tests {
         }
 
         let legacy_digest =
-            blake3::Hasher::new_derive_key("lix.commit-state.semantic-authority.v3")
+            blake3::Hasher::new_derive_key("lix.commit-state.semantic-authority.v4")
                 .update(&payload)
                 .finalize();
-        let mut retagged_v3 = super::COMMIT_STATE_SEMANTIC_AUTHORITY_MAGIC.to_vec();
-        retagged_v3.extend_from_slice(legacy_digest.as_bytes());
-        retagged_v3.extend_from_slice(&payload);
-        let error = super::decode_commit_state_semantic_authority(&retagged_v3)
-            .expect_err("an LXSA3 digest must not become valid under an LXSA4 prefix");
+        let mut retagged_v4 = super::COMMIT_STATE_SEMANTIC_AUTHORITY_MAGIC.to_vec();
+        retagged_v4.extend_from_slice(legacy_digest.as_bytes());
+        retagged_v4.extend_from_slice(&payload);
+        let error = super::decode_commit_state_semantic_authority(&retagged_v4)
+            .expect_err("an LXSA4 digest must not become valid under an LXSA5 prefix");
         assert!(error.message.contains("digest is invalid"));
     }
 

--- a/packages/engine/src/tracked_state/types.rs
+++ b/packages/engine/src/tracked_state/types.rs
@@ -313,14 +313,17 @@ pub(crate) struct CurrentStatePartDescriptor {
 /// Manifest-attested root of the unified scope/part serving tree.
 ///
 /// The generic tree owns only authenticated physical routing. These fields
-/// bind one result root to the graph parent and sealed mutation authority that
-/// produced it, without exposing mutation payload semantics to the tree.
+/// bind one result root to the physical serving base and sealed mutation
+/// authority that produced it. Graph ancestry remains an independent semantic
+/// relationship and is not exposed to the tree.
 #[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
 #[musli(packed)]
 pub(crate) struct CurrentStateScopedRangeRoot {
     pub(crate) tree: super::scoped_range::ScopedRangeRoot,
     #[musli(with = crate::storage_codec::option)]
-    pub(crate) parent_root_id: Option<[u8; 32]>,
+    pub(crate) serving_base_commit_id: Option<CommitId>,
+    #[musli(with = crate::storage_codec::option)]
+    pub(crate) serving_base_root_id: Option<[u8; 32]>,
     pub(crate) transition_digest: [u8; 32],
 }
 

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -5462,13 +5462,18 @@ where
                             })
                     })
                     .transpose()?;
-                Some(crate::tracked_state::certify_topology_touched_scope_filter(
-                    writes,
-                    &topology_parents,
-                    selected_source,
-                    record.commit_id,
-                    &mutations,
-                )?)
+                Some(
+                    crate::tracked_state::stage_current_state_scoped_ranges_from_topology(
+                        read,
+                        writes,
+                        &topology_parents,
+                        selected_source,
+                        record.commit_id,
+                        &record.account_id,
+                        &mutations,
+                    )
+                    .await?,
+                )
             };
             let current_state_scoped_ranges = catalog_publication
                 .as_ref()


### PR DESCRIPTION
## What changed

- split physical current-state ancestry from semantic commit graph ancestry
- authenticate `serving_base_commit_id` and `serving_base_root_id` in each scoped-range transition
- let two-parent merges reuse the target/first-parent root and selected-source commits reuse the selected root
- apply sealed local mutations as bounded copy-on-write range rewrites; empty merges re-attest the fixed root without staging tree nodes
- hard-cut the repository protocol to v56, commit-state manifests to LXCS8, and semantic seals to LXSA5
- teach GC to retain selected-source authority chains while loading only graph-live manifests plus the unique non-live serving bases they reference
- add a production-shaped two-parent merge benchmark and an outside-graph selected-source GC regression

Graph parents remain semantic history. The serving base is only a physical structural-sharing edge. Mutation inventory remains historical authority, and the directory continues to treat mutation payloads as opaque.

## Why

Topology commits previously discarded an otherwise complete current-state range root because physical reuse was implicitly restricted to a single graph parent. Post-merge point reads therefore fell back to commit replay even when the target tree was already the exact structural base for the merge post-image.

## Performance

Production physical point-read fixture, 1M-row base, 32 sparse commits, real two-parent merge, 101 measured samples:

| Backend | former replay p50 | serving-root p50 | change |
| --- | ---: | ---: | ---: |
| RocksDB | 180.650 us | 65.173 us | -63.9% |
| SlateDB | 278.413 us | 75.792 us | -72.8% |

This is physical post-merge serving latency, not end-to-end public merge/query latency.

Paired unchanged linear 1M-row qualification against exact main showed no regression:

- RocksDB serving p50 68.319 -> 67.406 us; publication p50 237.466 -> 229.651 us
- SlateDB serving p50 79.640 -> 77.897 us; publication p50 310.764 -> 297.509 us
- authenticated base IDs add about 1.1 KB across 32 manifests; range-tree bytes and part counts are unchanged

## Validation

- `RUST_MIN_STACK=8388608 cargo test -p lix_engine --all-features --lib -- --test-threads=4` (1904 passed, 8 ignored)
- `RUST_MIN_STACK=8388608 cargo test -p lix_engine --all-features --test integration -- --test-threads=4` (812 passed, 2 ignored)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- focused serving-base codec, topology, selected-source GC, and 34 branch/merge tests
- `cargo fmt --all -- --check`
- `git diff --check`

Three independent reviews covered correctness/GC, protocol/ownership, and performance. The selected-source GC and retained-manifest read-amplification findings were fixed before final approval.
