### PR TITLE
Reuse certified columnar authority for current-base publication

### DIFF
--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -5473,6 +5473,49 @@ where
         .await
     }
 
+    /// Publishes an already authenticated lossless columnar mutation set as
+    /// the immutable current-state base. The mutation inventory has already
+    /// walked the strictly ordered identities and sealed their digest, so
+    /// repeating that O(rows) work here would create a second physical-layout
+    /// authority and a large transient pointer index.
+    pub(crate) async fn stage_certified_columnar_insert_current_base(
+        &mut self,
+        branch_id: &str,
+        generation: CommitId,
+        new_head: CommitId,
+        parts: &crate::tracked_state::ColumnarMutationPartSet,
+        lifecycle: &crate::tracked_state::CommitDeltaLifecycleSummary,
+        working_diff_capture_checkpoint_commit_id: Option<CommitId>,
+        coverage: &mut WorkingDiffIndexCoverage,
+    ) -> Result<CommitId, LixError> {
+        if parts.owner_commit_id != *new_head.as_uuid().as_bytes()
+            || parts.row_count == 0
+            || lifecycle.scope.schema_key != parts.schema_key
+            || lifecycle.scope.file_id.is_some()
+            || lifecycle.uniform_created_at != parts.uniform_created_at
+        {
+            return Err(head_value_error(
+                "certified columnar current base disagrees with mutation authority",
+            ));
+        }
+        let schema_increments = BTreeMap::from([(
+            parts.schema_key.as_str(),
+            PackedCollectionIncrement {
+                live_count: u64::from(parts.row_count),
+                ordered_identity_digest: Some(lifecycle.ordered_identity_digest),
+            },
+        )]);
+        self.stage_packed_insert_current_base_manifest(
+            branch_id,
+            generation,
+            new_head,
+            schema_increments,
+            working_diff_capture_checkpoint_commit_id,
+            coverage,
+        )
+        .await
+    }
+
     /// Publishes a commit whose ordered deltas replace every live member of
     /// one tracked, unfiled collection as a new packed base segment.
     ///

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -5069,7 +5069,6 @@ mod tests {
             1,
             "the certified ordered batch must publish its commit delta directly as current state"
         );
-
         let rows = session
             .execute(
                 "SELECT id, value FROM ordered_packed_insert_probe WHERE id IN ('0000', '1023') ORDER BY id",
@@ -5654,6 +5653,7 @@ mod tests {
             .expect("pre-insert head should exist");
 
         crate::transaction::take_ordered_packed_current_base_publications();
+        crate::transaction::take_certified_columnar_current_base_publications();
         let insert_sql = "INSERT INTO columnar_lifecycle_probe (id, value) VALUES ($1, $2)";
         let inserts = (0..ROW_COUNT)
             .map(|row_index| ExecuteBatchStatement {
@@ -5676,6 +5676,11 @@ mod tests {
             crate::transaction::take_ordered_packed_current_base_publications(),
             1,
             "fixture must activate packed current-state publication"
+        );
+        assert_eq!(
+            crate::transaction::take_certified_columnar_current_base_publications(),
+            1,
+            "lossless columnar INSERT must bypass the row-wise current-base publisher"
         );
         let inserted_head = engine
             .load_branch_head_commit_id(&main_branch_id)

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -95,11 +95,11 @@ pub(crate) use storage::{
 };
 pub(crate) use types::{COMMIT_STATE_MAX_REPLAY_BYTES, COMMIT_STATE_MAX_REPLAY_DEPTH};
 pub(crate) use types::{
-    ColumnarMutationPartSet, CommitStateManifest, CommitStateMutationInventory,
-    CommitStateReplayDebt, MaterializedTrackedStateRow, TrackedStateBaseCoordinate,
-    TrackedStateCommitDeltaRef, TrackedStateCommitRoot, TrackedStateDeltaRef, TrackedStateFilter,
-    TrackedStateIndexValue, TrackedStateReadColumns, TrackedStateRootMutationRef,
-    TrackedStateScanRequest, TrackedStateSingleStringReplacementRef,
+    ColumnarMutationPartSet, CommitDeltaLifecycleSummary, CommitStateManifest,
+    CommitStateMutationInventory, CommitStateReplayDebt, MaterializedTrackedStateRow,
+    TrackedStateBaseCoordinate, TrackedStateCommitDeltaRef, TrackedStateCommitRoot,
+    TrackedStateDeltaRef, TrackedStateFilter, TrackedStateIndexValue, TrackedStateReadColumns,
+    TrackedStateRootMutationRef, TrackedStateScanRequest, TrackedStateSingleStringReplacementRef,
 };
 pub(crate) use types::{TrackedStateKey, TrackedStateKeyRef};
 #[cfg(feature = "storage-benches")]

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -85,6 +85,8 @@ fn compare_certified_predecessors(
 std::thread_local! {
     static ORDERED_PACKED_CURRENT_BASE_PUBLICATIONS: std::cell::Cell<usize> =
         const { std::cell::Cell::new(0) };
+    static CERTIFIED_COLUMNAR_CURRENT_BASE_PUBLICATIONS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
     static COMPLETE_REPLACEMENT_PACKED_CURRENT_BASE_PUBLICATIONS: std::cell::Cell<usize> =
         const { std::cell::Cell::new(0) };
     static COMPLETE_REPLACEMENT_PACKED_CURRENT_BASE_RETIREMENTS: std::cell::Cell<usize> =
@@ -101,6 +103,11 @@ static DIRECT_JOURNAL_REPLACEMENT_PUBLICATIONS: std::sync::LazyLock<
 #[cfg(test)]
 pub(crate) fn take_ordered_packed_current_base_publications() -> usize {
     ORDERED_PACKED_CURRENT_BASE_PUBLICATIONS.with(|publications| publications.replace(0))
+}
+
+#[cfg(test)]
+pub(crate) fn take_certified_columnar_current_base_publications() -> usize {
+    CERTIFIED_COLUMNAR_CURRENT_BASE_PUBLICATIONS.with(|publications| publications.replace(0))
 }
 
 #[cfg(test)]
@@ -719,6 +726,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &explicit_branch_targets,
         &branch_control_observations,
         &checkpoint_epochs,
+        &staged_delta_index.inventories,
         &staged_delta_index.ordered_addressable_commits,
         &replacement_generation_commits,
         &ordered_replacements,
@@ -3318,6 +3326,7 @@ async fn stage_tracked_head(
     explicit_branch_targets: &BTreeMap<String, ExplicitBranchHeadTarget>,
     observations: &BTreeMap<String, BranchHeadControlObservation>,
     checkpoint_epochs: &BTreeMap<String, CommitId>,
+    mutation_inventories: &BTreeMap<CommitId, CommitStateMutationInventory>,
     ordered_addressable_commits: &BTreeSet<CommitId>,
     replacement_generation_commits: &BTreeSet<CommitId>,
     ordered_replacements: &BTreeMap<CommitId, Arc<OrderedMutationJournal>>,
@@ -3351,6 +3360,7 @@ async fn stage_tracked_head(
     let tracked_head = TrackedHeadContext::new();
     let mut controls = BTreeMap::new();
     let mut deferred_fresh_hot_plans = Vec::new();
+    let mut exclusive_certified_columnar_publication = false;
 
     for root in tracked_roots_parent_first(tracked_roots)?
         .into_iter()
@@ -3381,6 +3391,9 @@ async fn stage_tracked_head(
             .get(&root.commit_id)
             .map(Vec::as_slice)
             .unwrap_or_default();
+        let certified_columnar_parts = mutation_inventories
+            .get(&root.commit_id)
+            .and_then(|inventory| inventory.columnar_parts.as_ref());
         let selected_materialization = if !staged.selected_change_batches.is_empty()
             && !tracked_snapshots.contains_key(&root.commit_id)
         {
@@ -3417,15 +3430,19 @@ async fn stage_tracked_head(
         } else {
             None
         };
-        let mut untracked_deltas = state_rows
-            .iter()
-            .filter(|row| {
-                row.untracked
-                    && row.branch_id.as_str() == root.branch_id
-                    && row.schema_key != BRANCH_REF_SCHEMA_KEY
-            })
-            .map(current_state_delta_from_state_row)
-            .collect::<Result<Vec<_>, _>>()?;
+        let mut untracked_deltas = if certified_columnar_parts.is_some() {
+            Vec::new()
+        } else {
+            state_rows
+                .iter()
+                .filter(|row| {
+                    row.untracked
+                        && row.branch_id.as_str() == root.branch_id
+                        && row.schema_key != BRANCH_REF_SCHEMA_KEY
+                })
+                .map(current_state_delta_from_state_row)
+                .collect::<Result<Vec<_>, _>>()?
+        };
         untracked_deltas.extend(
             engine_rows
                 .iter()
@@ -3447,21 +3464,22 @@ async fn stage_tracked_head(
             && explicit_branch_targets.is_empty()
             && state_row_indices.len() == state_rows.len()
             && insert_selection.len() == state_rows.len()
-            && state_row_indices.iter().all(|&row_index| {
-                let row = state_rows.row(row_index);
-                insert_selection.contains(row_index)
-                    && row.branch_id.as_str() == root.branch_id
-                    && !row.untracked
-                    && row.snapshot.is_some()
-                    && row.file_id.is_none()
-                    && row.schema_key != BRANCH_REF_SCHEMA_KEY
-                    && row.schema_key
-                        != crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY
-                    && row.commit_id == Some(root.commit_id)
-                    && row
-                        .change_id
-                        .is_some_and(|change_id| change_id != ChangeId::default())
-            });
+            && (certified_columnar_parts.is_some()
+                || state_row_indices.iter().all(|&row_index| {
+                    let row = state_rows.row(row_index);
+                    insert_selection.contains(row_index)
+                        && row.branch_id.as_str() == root.branch_id
+                        && !row.untracked
+                        && row.snapshot.is_some()
+                        && row.file_id.is_none()
+                        && row.schema_key != BRANCH_REF_SCHEMA_KEY
+                        && row.schema_key
+                            != crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY
+                        && row.commit_id == Some(root.commit_id)
+                        && row
+                            .change_id
+                            .is_some_and(|change_id| change_id != ChangeId::default())
+                }));
         let complete_replacement_schema =
             (state_rows.complete_collection_replacement_proof().is_some()
                 && replacement_generation_commits.contains(&root.commit_id)
@@ -3672,25 +3690,56 @@ async fn stage_tracked_head(
             ORDERED_PACKED_CURRENT_BASE_PUBLICATIONS.with(|publications| {
                 publications.set(publications.get().saturating_add(1));
             });
-            let generation = tracked_head
-                .writer(read, writes)
-                .stage_ordered_insert_current_base(
-                    &root.branch_id,
-                    parent_generation,
-                    root.commit_id,
-                    state_row_indices
-                        .iter()
-                        .map(|&row_index| state_rows.row(row_index))
-                        .map(|row| (row.schema_key.as_str(), row.entity_pk)),
-                    entity_columnar_write_sets,
-                    working_diff_capture_checkpoint_commit_id,
-                    &mut coverage,
+            let inventory = mutation_inventories.get(&root.commit_id).ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "ordered current-base publication omitted its mutation inventory",
                 )
-                .instrument(tracing::debug_span!(
-                    target: "lix_perf",
-                    "lix.perf.materialization.tracked_head.stage_ordered_packed_current_base"
-                ))
-                .await?;
+            })?;
+            let mut writer = tracked_head.writer(read, writes);
+            let generation = if let (Some(parts), Some(lifecycle)) = (
+                certified_columnar_parts,
+                inventory.lifecycle_summary.as_ref(),
+            ) {
+                #[cfg(test)]
+                CERTIFIED_COLUMNAR_CURRENT_BASE_PUBLICATIONS.with(|publications| {
+                    publications.set(publications.get().saturating_add(1));
+                });
+                writer
+                    .stage_certified_columnar_insert_current_base(
+                        &root.branch_id,
+                        parent_generation,
+                        root.commit_id,
+                        parts,
+                        lifecycle,
+                        working_diff_capture_checkpoint_commit_id,
+                        &mut coverage,
+                    )
+                    .instrument(tracing::debug_span!(
+                        target: "lix_perf",
+                        "lix.perf.materialization.tracked_head.stage_certified_columnar_current_base"
+                    ))
+                    .await?
+            } else {
+                writer
+                    .stage_ordered_insert_current_base(
+                        &root.branch_id,
+                        parent_generation,
+                        root.commit_id,
+                        state_row_indices
+                            .iter()
+                            .map(|&row_index| state_rows.row(row_index))
+                            .map(|row| (row.schema_key.as_str(), row.entity_pk)),
+                        entity_columnar_write_sets,
+                        working_diff_capture_checkpoint_commit_id,
+                        &mut coverage,
+                    )
+                    .instrument(tracing::debug_span!(
+                        target: "lix_perf",
+                        "lix.perf.materialization.tracked_head.stage_ordered_packed_current_base"
+                    ))
+                    .await?
+            };
             if let Some(epoch) = working_diff_epoch {
                 let next_epoch = TrackedWorkingDiffEpoch {
                     checkpoint_commit_id: epoch.checkpoint_commit_id,
@@ -3707,11 +3756,25 @@ async fn stage_tracked_head(
                 generation,
                 working_diff_checkpoint_commit_id,
             )?;
-            control.note_schemas(
-                state_row_indices
-                    .iter()
-                    .map(|&row_index| state_rows.row(row_index).schema_key.as_str()),
-            );
+            if let Some(parts) = certified_columnar_parts {
+                control.note_schemas(std::iter::once(parts.schema_key.as_str()));
+                debug_assert!(
+                    state_row_indices.len() == state_rows.len()
+                        && insert_selection.len() == state_rows.len()
+                        && untracked_deltas.is_empty()
+                        && engine_rows.is_empty(),
+                    "exclusive columnar publication must cover the whole prepared state batch"
+                );
+                // The same exclusivity proof makes the later global scan for
+                // untracked-only branches redundant.
+                exclusive_certified_columnar_publication = true;
+            } else {
+                control.note_schemas(
+                    state_row_indices
+                        .iter()
+                        .map(|&row_index| state_rows.row(row_index).schema_key.as_str()),
+                );
+            }
             insert_direct_branch_control(&mut controls, &root.branch_id, control)?;
             continue;
         }
@@ -4073,15 +4136,19 @@ async fn stage_tracked_head(
         .iter()
         .map(|root| root.branch_id.as_str())
         .collect::<BTreeSet<_>>();
-    let current_only_branches = state_rows
-        .iter()
-        .filter(|row| row.untracked && row.schema_key != BRANCH_REF_SCHEMA_KEY)
-        .map(|row| row.branch_id.as_str())
-        .chain(engine_rows.iter().map(|row| row.branch_id.as_str()))
-        .filter(|branch_id| {
-            !rooted_branches.contains(branch_id) && !explicit_branches.contains(*branch_id)
-        })
-        .collect::<BTreeSet<_>>();
+    let current_only_branches = if exclusive_certified_columnar_publication {
+        BTreeSet::new()
+    } else {
+        state_rows
+            .iter()
+            .filter(|row| row.untracked && row.schema_key != BRANCH_REF_SCHEMA_KEY)
+            .map(|row| row.branch_id.as_str())
+            .chain(engine_rows.iter().map(|row| row.branch_id.as_str()))
+            .filter(|branch_id| {
+                !rooted_branches.contains(branch_id) && !explicit_branches.contains(*branch_id)
+            })
+            .collect::<BTreeSet<_>>()
+    };
     for branch_id in current_only_branches {
         let control = observations
             .get(branch_id)

--- a/packages/engine/src/transaction/mod.rs
+++ b/packages/engine/src/transaction/mod.rs
@@ -17,6 +17,8 @@ pub mod bench {
 }
 
 #[cfg(test)]
+pub(crate) use commit::take_certified_columnar_current_base_publications;
+#[cfg(test)]
 pub(crate) use commit::take_complete_replacement_packed_current_base_publications;
 #[cfg(test)]
 pub(crate) use commit::take_complete_replacement_packed_current_base_retirements;


### PR DESCRIPTION
## What changed

- Publish packed current-base controls directly from the exclusive authenticated `ColumnarMutationPartSet` and lifecycle certificate.
- Reuse the sealed schema, row count, ordered-identity digest, owner, and lifecycle timestamp instead of reconstructing them from every prepared row.
- Skip five redundant row-linear passes for exclusive lossless columnar INSERTs: untracked discovery, publication eligibility revalidation, identity regrouping/digesting, schema-presence derivation, and the final untracked-only branch scan.
- Preserve the row-wise publisher unchanged for every non-columnar ordered commit.
- Add an explicit test assertion proving the lossless columnar lifecycle fixture takes the certified O(1) publication lane.

This changes no durable codec or descriptor. Mutation inventory, canonical row-group bytes/IDs, current-state scoped ranges, packed-base metadata, snapshot roots, history addresses, and GC reachability are unchanged.

## Why

`try_stage_lossless_columnar_mutations` already proves strict identity order and exclusive dense coverage, computes the ordered-identity digest, and seals the canonical row-group generation as mutation/history authority. HOT publication repeated the same proof over 1 million prepared rows and built an approximately 8 MB transient pointer vector. Treating the sealed certificate as authority removes that drift and makes publication O(1) in row count.

## Performance

Baseline: `d3cfa889e573d108b6d32ae215abc9754de0ddb8` (#1202). Candidate: `7202d9b3b`.

Paired in the same release binary, mold linker, five independently seeded samples per route. The temporary benchmark-only legacy selector used for pairing is not present in this PR.

| Public SQL INSERT | Legacy median (min–max) | Certified median (min–max) | Change |
| --- | ---: | ---: | ---: |
| 1M RocksDB | 719.318 ms (715.943–722.011) | 611.089 ms (607.599–624.375) | **-15.05%** |
| 1M SlateDB | 718.930 ms (712.112–721.777) | 610.682 ms (607.215–705.711) | **-15.06%** |
| 10K RocksDB | 25.418 ms (25.327–27.324) | 25.265 ms (25.154–26.990) | -0.60% |

Median allocation bytes fall by 8.39 MB on RocksDB and 8.34 MB on SlateDB, matching removal of the million-entry pointer vector. Physical row-group writes were already single-copy; the gain is from removing duplicate identity/control publication work.

Representative command:

```bash
LIX_TRACKED_STATE_CRUD_PROFILE=1 \
LIX_TRACKED_STATE_CRUD_PROFILE_ROW_COUNT=1000000 \
LIX_TRACKED_STATE_CRUD_PROFILE_OP=insert_all \
LIX_TRACKED_STATE_CRUD_PROFILE_LAYER=sql_session \
LIX_TRACKED_STATE_CRUD_PROFILE_STORAGE=rocksdb \
LIX_TRACKED_STATE_CRUD_PROFILE_SAMPLES=5 \
LIX_TRACKED_STATE_CRUD_PROFILE_ALLOCATION_BYTES=1 \
cargo bench -p lix_engine_benchmarks --bench tracked_state_crud --features storage-benches
```

SlateDB used `--features storage-benches,slatedb` and `LIX_TRACKED_STATE_CRUD_PROFILE_STORAGE=slatedb`.

## Validation

- `RUST_MIN_STACK=8388608 cargo test --workspace --all-features`
  - engine: 1904 passed, 8 ignored
  - integration simulations: 812 passed, 2 ignored
  - all workspace packages and doctests green
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- Three independent sub-agent reviews: correctness, performance methodology, and physical-layout integration; all approved with no blocking findings.

No changenote is included, per project direction.
