### PR TITLE
Redesign website and add weekly download stats

### DIFF
--- a/.github/workflows/update-download-stats.yml
+++ b/.github/workflows/update-download-stats.yml
@@ -1,0 +1,37 @@
+name: Update download stats
+
+on:
+  schedule:
+    # Mondays 06:23 UTC, after npm has finalized the previous week's counts.
+    - cron: "23 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Fetch npm download stats
+        run: node website/scripts/update-npm-downloads.mjs
+
+      - name: Commit and push if changed
+        run: |
+          if git diff --quiet website/src/npm-downloads.gen.json; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add website/src/npm-downloads.gen.json
+          git commit -m "chore(website): update npm download stats"
+          git push

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -1,5 +1,5 @@
 ---
-description: The application-oriented SQL surfaces in Lix: typed entities, files, directories, schema discovery, and workspace activity.
+description: "The application-oriented SQL surfaces in Lix: typed entities, files, directories, schema discovery, and workspace activity."
 ---
 
 # SQL Surfaces

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -15,3 +15,5 @@ todos.json
 content/plugins/*.md
 !content/plugins/index.md
 *.gen.*
+# Committed on purpose: refreshed weekly by .github/workflows/update-download-stats.yml
+!src/npm-downloads.gen.json

--- a/website/scripts/update-npm-downloads.mjs
+++ b/website/scripts/update-npm-downloads.mjs
@@ -1,0 +1,88 @@
+/**
+ * Fetches weekly npm download counts for @lix-js/sdk and writes them to
+ * src/npm-downloads.gen.json.
+ *
+ * The website renders the download chart from this static file. A scheduled
+ * GitHub Actions workflow (.github/workflows/update-download-stats.yml) runs
+ * this script weekly and commits the result, which triggers a redeploy.
+ *
+ * Values are intentionally coarse: full Monday-Sunday weeks only, rounded to
+ * the nearest thousand.
+ *
+ * Usage: node website/scripts/update-npm-downloads.mjs
+ */
+import fs from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const PACKAGE = "@lix-js/sdk";
+const WEEKS = 53;
+const OUTPUT_PATH = fileURLToPath(
+  new URL("../src/npm-downloads.gen.json", import.meta.url),
+);
+
+function toIsoDate(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+/** Most recent completed Sunday (UTC), exclusive of today. */
+function lastCompletedSunday(now) {
+  const date = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+  // getUTCDay(): 0 = Sunday. Step back to the previous Sunday, never today.
+  const daysBack = date.getUTCDay() === 0 ? 7 : date.getUTCDay();
+  date.setUTCDate(date.getUTCDate() - daysBack);
+  return date;
+}
+
+const now = new Date();
+const end = lastCompletedSunday(now);
+const start = new Date(end);
+start.setUTCDate(start.getUTCDate() - (WEEKS * 7 - 1));
+
+const url = `https://api.npmjs.org/downloads/range/${toIsoDate(start)}:${toIsoDate(end)}/${PACKAGE}`;
+const res = await fetch(url);
+if (!res.ok) {
+  throw new Error(`npm downloads fetch failed: ${res.status} ${url}`);
+}
+const body = await res.json();
+const byDay = new Map(
+  (body.downloads ?? []).map((entry) => [entry.day, entry.downloads]),
+);
+
+const weeks = [];
+for (let i = 0; i < WEEKS; i++) {
+  const weekStart = new Date(start);
+  weekStart.setUTCDate(weekStart.getUTCDate() + i * 7);
+  let total = 0;
+  let hasData = false;
+  for (let d = 0; d < 7; d++) {
+    const day = new Date(weekStart);
+    day.setUTCDate(day.getUTCDate() + d);
+    const value = byDay.get(toIsoDate(day));
+    if (value !== undefined) hasData = true;
+    total += value ?? 0;
+  }
+  const weekEnding = new Date(weekStart);
+  weekEnding.setUTCDate(weekEnding.getUTCDate() + 6);
+  // Skip leading weeks from before the package existed.
+  if (!hasData && weeks.length === 0) continue;
+  weeks.push({
+    weekEnding: toIsoDate(weekEnding),
+    downloads: Math.round(total / 1000) * 1000,
+  });
+}
+
+const latest = weeks[weeks.length - 1]?.downloads ?? 0;
+
+const payload = {
+  generatedAt: now.toISOString(),
+  package: PACKAGE,
+  latestWeeklyDownloads: latest,
+  weeks,
+};
+
+await fs.writeFile(OUTPUT_PATH, JSON.stringify(payload, null, 2) + "\n");
+console.log(
+  `Wrote ${weeks.length} weeks for ${PACKAGE} (latest full week: ${latest.toLocaleString("en-US")}) to ${OUTPUT_PATH}`,
+);

--- a/website/src/components/docs-layout.tsx
+++ b/website/src/components/docs-layout.tsx
@@ -19,7 +19,7 @@ export type PageTocItem = {
 };
 
 /**
- * VitePress-style documentation shell with header, left sidebar, and main content.
+ * Three-column documentation shell: sidebar, content, and "On this page" TOC.
  *
  * The sidebar is driven from the docs table of contents and highlights the
  * active entry based on the current doc relative path.
@@ -90,49 +90,47 @@ export function DocsLayout({
   const SidebarContent = () => (
     <nav
       aria-label="Documentation sidebar"
-      className="px-6 pt-6 pb-8 space-y-6"
+      className="flex flex-col gap-8 px-7 pb-16 pt-9"
     >
       {sidebarSections.map((section) => (
-        <section key={section.label} className="space-y-3">
-          <h2 className="text-sm font-semibold text-slate-900">
+        <section key={section.label} className="flex flex-col gap-2.5">
+          <span className="font-mono text-[11px] uppercase tracking-[0.09em] text-ink-faint">
             {section.label}
-          </h2>
-          <ul>
+          </span>
+          <div className="flex flex-col gap-[7px]">
             {section.items.map((item) => {
               const isActive = item.relativePath === activeRelativePath;
               return (
-                <li key={item.href}>
-                  <Link
-                    to={item.href}
-                    onClick={() => setIsMobileMenuOpen(false)}
-                    className={[
-                      "block py-1 text-sm leading-6 transition-colors",
-                      isActive
-                        ? "font-medium text-[#0891B2]"
-                        : "text-slate-600 hover:text-slate-900",
-                    ].join(" ")}
-                  >
-                    {item.label}
-                  </Link>
-                </li>
+                <Link
+                  key={item.href}
+                  to={item.href}
+                  onClick={() => setIsMobileMenuOpen(false)}
+                  className={
+                    isActive
+                      ? "text-[13.5px] font-semibold text-cyan-deep"
+                      : "text-[13.5px] text-ink-muted transition-colors hover:text-cyan-deep"
+                  }
+                >
+                  {item.label}
+                </Link>
               );
             })}
-          </ul>
+          </div>
         </section>
       ))}
     </nav>
   );
 
   return (
-    <div className="min-h-screen bg-white text-slate-900">
+    <div className="min-h-screen bg-paper text-ink">
       <div className="sticky top-0 z-50">
         <Header />
         {/* Mobile menu bar - below header, above content */}
-        <div className="border-b border-gray-200 bg-white lg:hidden">
-          <div className="mx-auto flex w-full max-w-[1440px] items-center px-6 py-2">
+        <div className="border-b border-line bg-paper lg:hidden">
+          <div className="mx-auto flex w-full max-w-[1376px] items-center px-8 py-2">
             <button
               onClick={() => setIsMobileMenuOpen(true)}
-              className="flex items-center gap-2 text-sm font-medium text-gray-700"
+              className="flex items-center gap-2 text-sm font-medium text-ink-secondary"
               aria-label="Open menu"
             >
               <MenuIcon className="h-5 w-5" />
@@ -145,15 +143,15 @@ export function DocsLayout({
       {isMobileMenuOpen && (
         <>
           <div
-            className="fixed inset-0 bg-black/50 z-40 lg:hidden"
+            className="fixed inset-0 z-40 bg-black/50 lg:hidden"
             onClick={() => setIsMobileMenuOpen(false)}
             aria-hidden="true"
           />
-          <aside className="fixed inset-y-0 left-0 w-full bg-slate-50 border-r border-slate-200 overflow-y-auto z-50 lg:hidden">
-            <div className="sticky top-0 bg-slate-50 px-6 py-3 flex justify-end items-center">
+          <aside className="fixed inset-y-0 left-0 z-50 w-full overflow-y-auto border-r border-line bg-paper lg:hidden">
+            <div className="sticky top-0 flex items-center justify-end bg-paper px-6 py-3">
               <button
                 onClick={() => setIsMobileMenuOpen(false)}
-                className="text-slate-600 hover:text-slate-900"
+                className="text-ink-muted hover:text-ink"
                 aria-label="Close menu"
               >
                 <svg
@@ -176,59 +174,48 @@ export function DocsLayout({
           </aside>
         </>
       )}
-      <div className="relative">
-        <div className="absolute left-0 top-14 hidden h-[calc(100vh-3.5rem)] w-64 bg-slate-50 -z-10 lg:block" />
-        <div className="mx-auto flex w-full max-w-[1440px]">
-          <aside className="sticky top-14 hidden h-[calc(100vh-3.5rem)] w-64 shrink-0 overflow-y-auto border-r border-slate-200 lg:block">
+      <div className="grid grid-cols-1 items-stretch lg:grid-cols-[264px_minmax(0,1fr)] xl:grid-cols-[264px_minmax(0,1fr)_224px]">
+        <aside className="hidden border-r border-line lg:block">
+          <div className="sticky top-[50px] max-h-[calc(100vh-50px)] overflow-y-auto">
             <SidebarContent />
-          </aside>
+          </div>
+        </aside>
 
-          <main id="VPContent" className="min-w-0 flex-1">
-            <div className="px-6 py-8 lg:px-8">
-              <div className="mx-auto w-full max-w-3xl">{children}</div>
-            </div>
-          </main>
+        <main className="min-w-0 px-6 pb-[88px] pt-12 sm:px-16">
+          <div className="w-full max-w-[720px]">{children}</div>
+        </main>
 
-          {hasPageToc && (
-            <aside className="sticky top-14 hidden h-[calc(100vh-3.5rem)] w-64 shrink-0 xl:block">
-              <nav
-                aria-label="On this page"
-                className="px-6 py-8 text-sm text-slate-600"
-              >
-                <div className="text-sm font-semibold text-slate-900">
+        {hasPageToc && (
+          <aside className="hidden xl:block">
+            <nav
+              aria-label="On this page"
+              className="sticky top-[50px] py-[52px] pl-2 pr-7"
+            >
+              <div className="flex flex-col gap-[9px] border-l border-line pl-4">
+                <span className="mb-[3px] font-mono text-[11px] uppercase tracking-[0.09em] text-ink-faint">
                   On this page
-                </div>
-                <ul className="mt-3 space-y-2 border-l border-slate-200 pl-4">
-                  {pageToc?.map((item) => {
-                    const isActive = item.id === activeTocId;
-                    return (
-                      <li key={item.id} className="relative">
-                        {isActive && (
-                          <span
-                            className="absolute -left-4 top-1/2 h-5 w-0.5 -translate-y-1/2 bg-[#0891B2]"
-                            aria-hidden="true"
-                          />
-                        )}
-                        <a
-                          href={`#${item.id}`}
-                          className={[
-                            "block transition-colors",
-                            item.level > 2 ? "pl-3" : "",
-                            isActive
-                              ? "font-medium text-[#0891B2]"
-                              : "text-slate-600 hover:text-slate-900",
-                          ].join(" ")}
-                        >
-                          {item.label}
-                        </a>
-                      </li>
-                    );
-                  })}
-                </ul>
-              </nav>
-            </aside>
-          )}
-        </div>
+                </span>
+                {pageToc?.map((item) => {
+                  const isActive = item.id === activeTocId;
+                  return (
+                    <a
+                      key={item.id}
+                      href={`#${item.id}`}
+                      className={[
+                        item.level > 2 ? "pl-3" : "",
+                        isActive
+                          ? "text-[13px] font-semibold text-cyan-deep"
+                          : "text-[13px] text-ink-muted transition-colors hover:text-cyan-deep",
+                      ].join(" ")}
+                    >
+                      {item.label}
+                    </a>
+                  );
+                })}
+              </div>
+            </nav>
+          </aside>
+        )}
       </div>
       <Footer />
     </div>

--- a/website/src/components/downloads-chart.tsx
+++ b/website/src/components/downloads-chart.tsx
@@ -1,0 +1,269 @@
+import { useMemo, useRef, useState } from "react";
+import npmDownloads from "../npm-downloads.gen.json";
+
+const VW = 1000;
+const VH = 220;
+const PAD = 6;
+
+const ranges = [
+  { key: "90d", label: "90d", weeks: 13 },
+  { key: "6m", label: "6m", weeks: 26 },
+  { key: "12m", label: "12M", weeks: 52 },
+] as const;
+
+type RangeKey = (typeof ranges)[number]["key"];
+
+type Week = { weekEnding: string; downloads: number };
+
+const allWeeks: Week[] = npmDownloads.weeks;
+
+/** Latest full-week download count, rounded down to the nearest 10k (e.g. ">440k"). */
+export function coarseWeeklyDownloads(): string {
+  const latest = npmDownloads.latestWeeklyDownloads;
+  return `>${Math.floor(latest / 10_000) * 10}k`;
+}
+
+function formatWeekOf(weekEnding: string): string {
+  const end = new Date(`${weekEnding}T00:00:00Z`);
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - 6);
+  return start.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+/**
+ * Weekly npm downloads chart with 90d / 6m / 12M ranges, rendered from the
+ * statically generated npm-downloads.gen.json.
+ *
+ * @example
+ * <DownloadsChart />
+ */
+export function DownloadsChart() {
+  const [range, setRange] = useState<RangeKey>("12m");
+  const [hoverIdx, setHoverIdx] = useState<number | null>(null);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  const data = useMemo(() => {
+    const take = ranges.find((r) => r.key === range)?.weeks ?? 52;
+    return allWeeks.slice(Math.max(0, allWeeks.length - take));
+  }, [range]);
+
+  const { points, ticks } = useMemo(() => {
+    const values = data.map((week) => week.downloads);
+    const max = Math.max(...values);
+    const min = Math.min(...values);
+    const floor = min * 0.4;
+    const span = Math.max(1, max - floor);
+    const toY = (value: number) =>
+      VH - PAD - ((value - floor) / span) * (VH - PAD * 2);
+    const points = data.map((week, i) => {
+      const x = data.length === 1 ? VW : (i / (data.length - 1)) * VW;
+      return [x, toY(week.downloads)] as const;
+    });
+
+    // Pick a "nice" tick step that yields at most ~5 axis labels.
+    const stepCandidates = [1, 2, 2.5, 5]
+      .flatMap((base) =>
+        [1_000, 10_000, 100_000, 1_000_000].map(
+          (magnitude) => base * magnitude,
+        ),
+      )
+      .sort((a, b) => a - b);
+    const step =
+      stepCandidates.find((candidate) => span / candidate <= 5) ??
+      stepCandidates[stepCandidates.length - 1];
+    const ticks: Array<{ value: number; y: number }> = [];
+    for (
+      let value = Math.ceil(floor / step) * step;
+      value <= max;
+      value += step
+    ) {
+      ticks.push({ value, y: toY(value) });
+    }
+
+    return { points, ticks };
+  }, [data]);
+
+  const linePath = points
+    .map(([x, y], i) => `${i ? "L" : "M"}${x.toFixed(1)} ${y.toFixed(1)}`)
+    .join(" ");
+  const areaPath = `${linePath} L${VW} ${VH} L0 ${VH} Z`;
+  const last = points[points.length - 1];
+
+  const startLabel = useMemo(() => {
+    const first = data[0];
+    if (!first) return "";
+    const start = new Date(`${first.weekEnding}T00:00:00Z`);
+    start.setUTCDate(start.getUTCDate() - 6);
+    return start
+      .toLocaleDateString("en-US", {
+        month: "long",
+        year: "numeric",
+        timeZone: "UTC",
+      })
+      .toLowerCase();
+  }, [data]);
+
+  const throughLabel = useMemo(() => {
+    const lastWeek = allWeeks[allWeeks.length - 1];
+    if (!lastWeek) return "";
+    return new Date(`${lastWeek.weekEnding}T00:00:00Z`).toLocaleDateString(
+      "en-US",
+      { month: "short", day: "numeric", year: "numeric", timeZone: "UTC" },
+    );
+  }, []);
+
+  const onMouseMove = (event: React.MouseEvent<HTMLDivElement>) => {
+    const wrap = wrapRef.current;
+    if (!wrap || points.length === 0) return;
+    const rect = wrap.getBoundingClientRect();
+    const frac = Math.min(
+      1,
+      Math.max(0, (event.clientX - rect.left) / rect.width),
+    );
+    setHoverIdx(Math.round(frac * (data.length - 1)));
+  };
+
+  const hovered = hoverIdx !== null ? data[hoverIdx] : null;
+  const hoveredPoint = hoverIdx !== null ? points[hoverIdx] : null;
+
+  return (
+    <section className="pt-14">
+      <div className="mb-7 flex flex-wrap items-end justify-between gap-6">
+        <div className="flex flex-col gap-2">
+          <h2 className="text-[17px] font-semibold tracking-[-0.01em]">
+            Adoption
+          </h2>
+          <p className="text-[14.5px] text-ink-muted">
+            Weekly npm downloads of{" "}
+            <span className="font-mono text-[13.5px] text-ink-secondary">
+              @lix-js/sdk
+            </span>
+          </p>
+        </div>
+        <div className="inline-flex overflow-hidden rounded-lg border border-line-strong bg-white shadow-[0_1px_2px_rgba(20,23,26,0.04)]">
+          {ranges.map((r) => (
+            <button
+              key={r.key}
+              onClick={() => {
+                setRange(r.key);
+                setHoverIdx(null);
+              }}
+              className={`cursor-pointer px-[15px] py-[9px] font-mono text-xs leading-none transition-colors ${
+                range === r.key
+                  ? "bg-ink text-paper"
+                  : "bg-transparent text-ink-faint"
+              }`}
+            >
+              {r.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div
+        ref={wrapRef}
+        className="relative cursor-crosshair"
+        onMouseMove={onMouseMove}
+        onMouseLeave={() => setHoverIdx(null)}
+      >
+        <svg
+          viewBox={`0 0 ${VW} ${VH}`}
+          className="block h-auto w-full overflow-visible"
+          aria-label="Weekly npm downloads of @lix-js/sdk"
+        >
+          {ticks.map((tick) => (
+            <line
+              key={tick.value}
+              x1="0"
+              y1={tick.y.toFixed(1)}
+              x2={VW}
+              y2={tick.y.toFixed(1)}
+              stroke="#E6E4DD"
+              strokeWidth="1"
+              vectorEffect="non-scaling-stroke"
+            />
+          ))}
+          <path d={areaPath} fill="rgba(7,182,213,0.10)" />
+          <path
+            d={linePath}
+            fill="none"
+            stroke="#07B6D5"
+            strokeWidth="2.25"
+            strokeLinejoin="round"
+            strokeLinecap="round"
+            vectorEffect="non-scaling-stroke"
+          />
+          {hoveredPoint && (
+            <line
+              x1={hoveredPoint[0].toFixed(1)}
+              y1="0"
+              x2={hoveredPoint[0].toFixed(1)}
+              y2={VH}
+              stroke="#9AA0A6"
+              strokeWidth="1"
+              strokeDasharray="3 4"
+              vectorEffect="non-scaling-stroke"
+            />
+          )}
+          {hoveredPoint && (
+            <circle
+              cx={hoveredPoint[0].toFixed(1)}
+              cy={hoveredPoint[1].toFixed(1)}
+              r="4.5"
+              fill="#FFFFFF"
+              stroke="#07B6D5"
+              strokeWidth="2"
+            />
+          )}
+          {last && (
+            <circle
+              cx={last[0].toFixed(1)}
+              cy={last[1].toFixed(1)}
+              r="3.5"
+              fill="#07B6D5"
+            />
+          )}
+        </svg>
+        {ticks.map((tick) => (
+          <span
+            key={tick.value}
+            className="pointer-events-none absolute left-0 -translate-y-full pb-[3px] font-mono text-[11px] leading-none text-ink-faint"
+            style={{ top: `${((tick.y / VH) * 100).toFixed(2)}%` }}
+          >
+            {tick.value >= 1000
+              ? `${(tick.value / 1000).toLocaleString("en-US")}k`
+              : tick.value}
+          </span>
+        ))}
+        {hovered && hoveredPoint && (
+          <div
+            className="pointer-events-none absolute z-[5] flex -translate-x-1/2 translate-y-[-128%] flex-col gap-[3px] whitespace-nowrap rounded-lg bg-ink px-[13px] py-[9px] text-paper shadow-[0_6px_18px_rgba(20,23,26,0.22)]"
+            style={{
+              left: `${Math.min(88, Math.max(10, (hoveredPoint[0] / VW) * 100)).toFixed(1)}%`,
+              top: `${((hoveredPoint[1] / VH) * 100).toFixed(1)}%`,
+            }}
+          >
+            <span className="text-[13.5px] font-bold tracking-[-0.01em]">
+              {hovered.downloads.toLocaleString("en-US")} downloads
+            </span>
+            <span className="text-xs text-[#B8BDC4]">
+              Week of {formatWeekOf(hovered.weekEnding)}
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div className="mt-3.5 flex items-baseline justify-between border-t border-line pt-3">
+        <span className="font-mono text-xs text-ink-faint">{startLabel}</span>
+        <span className="font-mono text-xs text-ink-faint">
+          through {throughLabel}
+        </span>
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/footer.tsx
+++ b/website/src/components/footer.tsx
@@ -1,64 +1,52 @@
-import { getGithubStars } from "../github-stars-cache";
+import type { HeaderWidth } from "./header";
+
+const widthClass: Record<HeaderWidth, string> = {
+  narrow: "max-w-[1100px]",
+  wide: "max-w-[1376px]",
+};
 
 const footerLinks = [
-  { href: "/docs", label: "Docs", emoji: "📘" },
-  { href: "/blog", label: "Blog", emoji: "📝" },
-  { href: "/rfc", label: "RFCs", emoji: "📄" },
+  { href: "https://github.com/opral/lix", label: "GitHub" },
+  { href: "https://x.com/lixCCS", label: "X" },
+  { href: "https://discord.gg/gdMPPWy57R", label: "Discord" },
 ];
 
-export function Footer() {
-  const githubStars = getGithubStars("opral/lix");
-
-  const formatStars = (count: number) => {
-    if (count >= 1000) {
-      return `${(count / 1000).toFixed(1).replace(/\.0$/, "")}k`;
-    }
-    return count.toString();
-  };
-
+/**
+ * Site footer with attribution and social links.
+ *
+ * @example
+ * <Footer width="narrow" />
+ */
+export function Footer({ width = "wide" }: { width?: HeaderWidth }) {
   return (
-    <footer className="bg-white">
-      <div className="border-t border-gray-200">
-        <div className="flex flex-col gap-3 px-6 py-10 sm:flex-row sm:justify-center sm:gap-8">
-          {footerLinks.map((link) => (
+    <footer className="border-t border-line">
+      <div
+        className={`mx-auto flex w-full flex-wrap items-center justify-between gap-6 px-8 py-7 ${widthClass[width]}`}
+      >
+        <span className="text-[13.5px] text-ink-faint">
+          Lix is built by{" "}
+          <a
+            href="https://opral.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-ink-muted underline decoration-[#DDDBD3] underline-offset-[3px] transition-colors hover:text-cyan-deep"
+          >
+            Opral
+          </a>
+          .
+        </span>
+        <div className="flex gap-6">
+          {footerLinks.map(({ href, label }) => (
             <a
-              key={link.href}
-              href={link.href}
-              className="inline-flex items-center justify-center gap-2 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900"
+              key={label}
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[13.5px] text-ink-muted transition-colors hover:text-cyan-deep"
             >
-              <span aria-hidden>{link.emoji}</span>
-              {link.label}
+              {label}
             </a>
           ))}
-          <a
-            href="https://discord.gg/gdMPPWy57R"
-            className="inline-flex items-center justify-center gap-2 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900"
-          >
-            <span aria-hidden>💬</span>
-            Discord
-            <img
-              src="https://img.shields.io/discord/897438559458430986?label=%20&color=f3f4f6&style=flat-square"
-              alt="Discord online members"
-              className="h-4"
-            />
-          </a>
-          <a
-            href="https://github.com/opral/lix"
-            className="inline-flex items-center justify-center gap-2 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900"
-            title={
-              githubStars
-                ? `${githubStars.toLocaleString()} GitHub stars`
-                : "Star us on GitHub"
-            }
-          >
-            <span aria-hidden>⭐</span>
-            Star on GitHub
-            {githubStars !== null && (
-              <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-semibold text-gray-600">
-                {formatStars(githubStars)}
-              </span>
-            )}
-          </a>
         </div>
       </div>
     </footer>

--- a/website/src/components/header.tsx
+++ b/website/src/components/header.tsx
@@ -1,99 +1,23 @@
 import { Link, useRouterState } from "@tanstack/react-router";
 import { getGithubStars } from "../github-stars-cache";
 
-/**
- * Lix logo used across the site.
- *
- * @example
- * <LixLogo className="h-6 w-6" />
- */
-export const LixLogo = ({ className = "" }) => (
-  <svg
-    width="30"
-    height="22"
-    viewBox="0 0 26 18"
-    fill="currentColor"
-    xmlns="http://www.w3.org/2000/svg"
-    className={className}
-  >
-    <g id="Group 162">
-      <path
-        id="Vector"
-        d="M14.7618 5.74842L16.9208 9.85984L22.3675 0.358398H25.7133L19.0723 11.6284L22.5712 17.5085H19.2407L16.9208 13.443L14.6393 17.5085H11.2705L14.7618 11.6284L11.393 5.74842H14.7618Z"
-        fill="currentColor"
-      />
-      <path
-        id="Vector_2"
-        d="M6.16211 17.5081V5.74805H9.42368V17.5081H6.16211Z"
-        fill="currentColor"
-      />
-      <path
-        id="Vector_3"
-        d="M3.52112 0.393555V17.6416H0.287109V0.393555H3.52112Z"
-        fill="currentColor"
-      />
-      <path
-        id="Rectangle 391"
-        d="M6.21582 0.393555H14.8399V3.08856H6.21582V0.393555Z"
-        fill="currentColor"
-      />
-    </g>
-  </svg>
-);
+export type HeaderWidth = "narrow" | "wide";
 
-/**
- * GitHub mark icon used in the site header.
- *
- * @example
- * <GitHubIcon className="h-5 w-5" />
- */
-export const GitHubIcon = ({ className = "" }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 24 24"
-    fill="currentColor"
-    className={className}
-    aria-hidden="true"
-  >
-    <path d="M12 2a10 10 0 00-3.16 19.49c.5.09.68-.21.68-.47v-1.69c-2.78.6-3.37-1.34-3.37-1.34a2.64 2.64 0 00-1.1-1.46c-.9-.62.07-.6.07-.6a2.08 2.08 0 011.52 1 2.1 2.1 0 002.87.82 2.11 2.11 0 01.63-1.32c-2.22-.25-4.56-1.11-4.56-4.95a3.88 3.88 0 011-2.7 3.6 3.6 0 01.1-2.67s.84-.27 2.75 1a9.5 9.5 0 015 0c1.91-1.29 2.75-1 2.75-1a3.6 3.6 0 01.1 2.67 3.87 3.87 0 011 2.7c0 3.85-2.34 4.7-4.57 4.95a2.37 2.37 0 01.68 1.84v2.72c0 .27.18.57.69.47A10 10 0 0012 2z" />
-  </svg>
-);
+const widthClass: Record<HeaderWidth, string> = {
+  narrow: "max-w-[1100px]",
+  wide: "max-w-[1376px]",
+};
 
-/**
- * Discord icon used in the site header.
- *
- * @example
- * <DiscordIcon className="h-5 w-5" />
- */
-export const DiscordIcon = ({ className = "" }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 71 55"
-    fill="currentColor"
-    className={className}
-    aria-hidden="true"
-  >
-    <path d="M60.1045 4.8978C55.5792 2.8214 50.7265 1.2916 45.6527 0.41542C45.5603 0.39851 45.468 0.440769 45.4204 0.525289C44.7963 1.6353 44.105 3.0834 43.6209 4.2216C38.1637 3.4046 32.7345 3.4046 27.3892 4.2216C26.905 3.0581 26.1886 1.6353 25.5617 0.525289C25.5141 0.443589 25.4218 0.40133 25.3294 0.41542C20.2584 1.2888 15.4057 2.8186 10.8776 4.8978C10.8384 4.9147 10.8048 4.9429 10.7825 4.9793C1.57795 18.7309 -0.943561 32.1443 0.293408 45.3914C0.299005 45.4562 0.335386 45.5182 0.385761 45.5574C6.45866 50.0174 12.3413 52.7249 18.1147 54.5195C18.2071 54.5477 18.3052 54.5131 18.363 54.4376C19.7295 52.5728 20.9469 50.6063 21.9907 48.5383C22.0527 48.4172 21.9931 48.2735 21.8674 48.2259C19.9366 47.4931 18.0979 46.6 16.3292 45.5858C16.1893 45.5033 16.1789 45.3039 16.3116 45.2082C16.679 44.9293 17.0464 44.6391 17.4034 44.346C17.4654 44.2947 17.5534 44.2843 17.6228 44.3189C29.2558 49.8743 41.8354 49.8743 53.3179 44.3189C53.3873 44.2817 53.4753 44.292 53.5401 44.3433C53.8971 44.6364 54.2645 44.9293 54.6346 45.2082C54.7673 45.3039 54.7594 45.5033 54.6195 45.5858C52.8508 46.6197 51.0121 47.4931 49.0775 48.223C48.9518 48.2706 48.894 48.4172 48.956 48.5383C50.0198 50.6034 51.2372 52.5699 52.5872 54.4347C52.6414 54.5131 52.7423 54.5477 52.8347 54.5195C58.6464 52.7249 64.529 50.0174 70.6019 45.5574C70.6559 45.5182 70.6894 45.459 70.695 45.3942C72.1747 30.0791 68.2147 16.7757 60.1968 4.9821C60.1772 4.9429 60.1436 4.9147 60.1045 4.8978ZM23.7259 37.3253C20.2276 37.3253 17.3451 34.1136 17.3451 30.1693C17.3451 26.225 20.1717 23.0133 23.7259 23.0133C27.308 23.0133 30.1626 26.2532 30.1066 30.1693C30.1066 34.1136 27.28 37.3253 23.7259 37.3253ZM47.2012 37.3253C43.7029 37.3253 40.8203 34.1136 40.8203 30.1693C40.8203 26.225 43.6469 23.0133 47.2012 23.0133C50.7833 23.0133 53.6379 26.2532 53.5819 30.1693C53.5819 34.1136 50.7833 37.3253 47.2012 37.3253Z" />
-  </svg>
-);
+const navLinks = [
+  { href: "/docs/what-is-lix", label: "Docs", activePrefix: "/docs" },
+  { href: "/plugins", label: "Plugins", activePrefix: "/plugins" },
+  { href: "/blog", label: "Blog", activePrefix: "/blog" },
+];
 
-/**
- * X (formerly Twitter) icon used in the site header.
- *
- * @example
- * <XIcon className="h-5 w-5" />
- */
-export const XIcon = ({ className = "" }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 1200 1227"
-    fill="currentColor"
-    className={className}
-    aria-hidden="true"
-  >
-    <path d="M714.163 519.284 1160.89 0h-105.86L667.137 450.887 357.328 0H0l468.492 681.821L0 1226.37h105.866l409.625-476.152 327.181 476.152H1200L714.137 519.284h.026ZM569.165 687.828l-47.468-67.894-377.686-540.24h162.604l304.797 435.991 47.468 67.894 396.2 566.721H892.476L569.165 687.854v-.026Z" />
-  </svg>
-);
+const socialLinks = [
+  { href: "https://discord.gg/gdMPPWy57R", label: "Discord" },
+  { href: "https://x.com/lixCCS", label: "X" },
+];
 
 /**
  * Hamburger menu icon for mobile navigation.
@@ -119,45 +43,24 @@ export const MenuIcon = ({ className = "" }) => (
   </svg>
 );
 
-const navLinks = [
-  { href: "/docs/what-is-lix", label: "Docs", activePrefix: "/docs" },
-  { href: "/plugins", label: "Plugins", activePrefix: "/plugins" },
-  { href: "/blog", label: "Blog", activePrefix: "/blog" },
-];
-
-const socialLinks = [
-  {
-    href: "https://discord.gg/gdMPPWy57R",
-    label: "Discord",
-    Icon: DiscordIcon,
-    sizeClass: "h-5 w-5",
-  },
-  {
-    href: "https://x.com/lixCCS",
-    label: "X",
-    Icon: XIcon,
-    sizeClass: "h-4 w-4",
-  },
-];
+function formatStars(count: number) {
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+  }
+  return count.toString();
+}
 
 /**
- * Site header with logo, navigation, and social links.
+ * Site header with wordmark, navigation, and social links.
  *
  * @example
- * <Header />
+ * <Header width="narrow" />
  */
-export function Header() {
+export function Header({ width = "wide" }: { width?: HeaderWidth }) {
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
   });
   const githubStars = getGithubStars("opral/lix");
-
-  const formatStars = (count: number) => {
-    if (count >= 1000) {
-      return `${(count / 1000).toFixed(1).replace(/\.0$/, "")}k`;
-    }
-    return count.toString();
-  };
 
   const isActive = (href: string, activePrefix?: string) => {
     const candidate = activePrefix ?? href;
@@ -167,93 +70,73 @@ export function Header() {
   };
 
   return (
-    <header className="sticky top-0 z-50 border-b border-gray-200 bg-white/80 backdrop-blur">
-      <div className="mx-auto flex w-full max-w-[1440px] items-center justify-between pl-6 pr-6 py-3">
+    <header className="sticky top-0 z-50 border-b border-line bg-[rgba(251,250,247,0.92)] backdrop-blur-[8px]">
+      <div
+        className={`mx-auto flex h-[50px] w-full items-center justify-between gap-5 px-8 ${widthClass[width]}`}
+      >
         <Link
           to="/"
-          className="flex items-center text-[#0891B2]"
+          className="text-[21px] font-bold leading-none tracking-[-0.03em] text-cyan-bright"
           aria-label="lix home"
         >
-          <LixLogo className="h-7 w-7" />
-          <span className="sr-only">lix</span>
+          lix
         </Link>
-        <div className="flex items-center gap-6">
-          <nav className="hidden items-center gap-4 text-sm font-medium text-gray-700 sm:flex">
-            {navLinks.map(({ href, label, activePrefix }) => (
-              <Link
-                key={href + label}
-                to={href}
-                className={
-                  isActive(href, activePrefix)
-                    ? href.startsWith("/plugins")
-                      ? "px-2 py-1 text-[#0891B2] hover:text-[#0692B6]"
-                      : "px-2 py-1 text-[#0891B2]"
-                    : "px-2 py-1 transition-colors hover:text-[#0692B6]"
-                }
-                aria-current={isActive(href, activePrefix) ? "page" : undefined}
-              >
-                {label}
-              </Link>
-            ))}
-          </nav>
-          <div
-            className="hidden h-4 w-px bg-gray-200 sm:block"
+        <nav className="flex items-center gap-[22px]">
+          {navLinks.map(({ href, label, activePrefix }) => (
+            <Link
+              key={href}
+              to={href}
+              className={
+                isActive(href, activePrefix)
+                  ? "hidden text-[13.5px] font-semibold text-cyan-deep sm:block"
+                  : "hidden text-[13.5px] font-medium text-ink-secondary transition-colors hover:text-cyan-deep sm:block"
+              }
+              aria-current={isActive(href, activePrefix) ? "page" : undefined}
+            >
+              {label}
+            </Link>
+          ))}
+          <span
+            className="hidden h-4 w-px bg-line-strong sm:block"
             aria-hidden="true"
           />
-          <div className="flex items-center gap-3">
-            {socialLinks.map(({ href, label, Icon, sizeClass }) => (
-              <a
-                key={label}
-                href={href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-gray-900 transition-colors hover:text-gray-900"
-                aria-label={label}
-              >
-                <Icon className={sizeClass ?? "h-5 w-5"} />
-              </a>
-            ))}
-            <div className="h-4 w-px bg-gray-200" aria-hidden="true" />
+          {socialLinks.map(({ href, label }) => (
             <a
-              href="https://github.com/opral/lix"
+              key={label}
+              href={href}
               target="_blank"
               rel="noopener noreferrer"
-              className="group inline-flex items-center gap-1.5 text-sm font-medium text-gray-700 transition-colors hover:text-gray-700"
+              className="hidden text-[13.5px] font-medium text-ink-muted transition-colors hover:text-cyan-deep sm:block"
             >
-              <GitHubIcon className="h-5 w-5" />
-              GitHub
-              {githubStars !== null && (
-                <span
-                  className="inline-flex items-center gap-1 text-gray-500 transition-colors group-hover:text-gray-500"
-                  title={`${githubStars.toLocaleString()} GitHub stars`}
-                  aria-label={`${githubStars.toLocaleString()} GitHub stars`}
-                >
-                  <span className="relative h-3.5 w-3.5" aria-hidden="true">
-                    <svg
-                      className="absolute inset-0 h-3.5 w-3.5 text-gray-400 group-hover:opacity-0 transition-opacity"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    >
-                      <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
-                    </svg>
-                    <svg
-                      className="absolute inset-0 h-3.5 w-3.5 text-yellow-500 opacity-0 group-hover:opacity-100 transition-opacity"
-                      viewBox="0 0 16 16"
-                      fill="currentColor"
-                    >
-                      <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25z" />
-                    </svg>
-                  </span>
-                  <span>{formatStars(githubStars)}</span>
-                </span>
-              )}
+              {label}
             </a>
-          </div>
-        </div>
+          ))}
+          <a
+            href="https://github.com/opral/lix"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-[7px] text-[13.5px] font-medium text-ink-secondary transition-colors hover:text-cyan-deep"
+          >
+            GitHub
+            {githubStars !== null && (
+              <span
+                className="flex items-center gap-1 rounded border border-line-strong px-1.5 py-0.5 font-mono text-xs font-normal leading-none text-ink-muted"
+                title={`${githubStars.toLocaleString()} GitHub stars`}
+                aria-label={`${githubStars.toLocaleString()} GitHub stars`}
+              >
+                <svg
+                  viewBox="0 0 16 16"
+                  fill="currentColor"
+                  className="h-3 w-3"
+                  aria-hidden="true"
+                >
+                  <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25z" />
+                </svg>
+                {formatStars(githubStars)}
+              </span>
+            )}
+          </a>
+        </nav>
       </div>
     </header>
   );

--- a/website/src/components/landing-page.tsx
+++ b/website/src/components/landing-page.tsx
@@ -1,780 +1,531 @@
-import { useRouterState } from "@tanstack/react-router";
+import { useState } from "react";
 import { getGithubStars } from "../github-stars-cache";
+import { DownloadsChart, coarseWeeklyDownloads } from "./downloads-chart";
 import { Footer } from "./footer";
+import { Header } from "./header";
+
+const INSTALL_COMMAND = "npm install @lix-js/sdk";
+
 /**
- * Lix logo used across the landing page.
+ * Copyable `npm install` command button.
  *
  * @example
- * <LixLogo className="h-6 w-6" />
+ * <CopyInstallButton background="white" />
  */
-const LixLogo = ({ className = "" }) => (
-  <svg
-    width="30"
-    height="22"
-    viewBox="0 0 26 18"
-    fill="currentColor"
-    xmlns="http://www.w3.org/2000/svg"
-    className={className}
-  >
-    <g id="Group 162">
-      <path
-        id="Vector"
-        d="M14.7618 5.74842L16.9208 9.85984L22.3675 0.358398H25.7133L19.0723 11.6284L22.5712 17.5085H19.2407L16.9208 13.443L14.6393 17.5085H11.2705L14.7618 11.6284L11.393 5.74842H14.7618Z"
-        fill="currentColor"
-      />
-      <path
-        id="Vector_2"
-        d="M6.16211 17.5081V5.74805H9.42368V17.5081H6.16211Z"
-        fill="currentColor"
-      />
-      <path
-        id="Vector_3"
-        d="M3.52112 0.393555V17.6416H0.287109V0.393555H3.52112Z"
-        fill="currentColor"
-      />
-      <path
-        id="Rectangle 391"
-        d="M6.21582 0.393555H14.8399V3.08856H6.21582V0.393555Z"
-        fill="currentColor"
-      />
-    </g>
-  </svg>
-);
-
-/**
- * GitHub mark icon used in the site header.
- *
- * @example
- * <GitHubIcon className="h-5 w-5" />
- */
-const GitHubIcon = ({ className = "" }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 24 24"
-    fill="currentColor"
-    className={className}
-    aria-hidden="true"
-  >
-    <path d="M12 2a10 10 0 00-3.16 19.49c.5.09.68-.21.68-.47v-1.69c-2.78.6-3.37-1.34-3.37-1.34a2.64 2.64 0 00-1.1-1.46c-.9-.62.07-.6.07-.6a2.08 2.08 0 011.52 1 2.1 2.1 0 002.87.82 2.11 2.11 0 01.63-1.32c-2.22-.25-4.56-1.11-4.56-4.95a3.88 3.88 0 011-2.7 3.6 3.6 0 01.1-2.67s.84-.27 2.75 1a9.5 9.5 0 015 0c1.91-1.29 2.75-1 2.75-1a3.6 3.6 0 01.1 2.67 3.87 3.87 0 011 2.7c0 3.85-2.34 4.7-4.57 4.95a2.37 2.37 0 01.68 1.84v2.72c0 .27.18.57.69.47A10 10 0 0012 2z" />
-  </svg>
-);
-
-/**
- * Discord icon used in the site header.
- *
- * @example
- * <DiscordIcon className="h-5 w-5" />
- */
-const DiscordIcon = ({ className = "" }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 71 55"
-    fill="currentColor"
-    className={className}
-    aria-hidden="true"
-  >
-    <path d="M60.1045 4.8978C55.5792 2.8214 50.7265 1.2916 45.6527 0.41542C45.5603 0.39851 45.468 0.440769 45.4204 0.525289C44.7963 1.6353 44.105 3.0834 43.6209 4.2216C38.1637 3.4046 32.7345 3.4046 27.3892 4.2216C26.905 3.0581 26.1886 1.6353 25.5617 0.525289C25.5141 0.443589 25.4218 0.40133 25.3294 0.41542C20.2584 1.2888 15.4057 2.8186 10.8776 4.8978C10.8384 4.9147 10.8048 4.9429 10.7825 4.9793C1.57795 18.7309 -0.943561 32.1443 0.293408 45.3914C0.299005 45.4562 0.335386 45.5182 0.385761 45.5574C6.45866 50.0174 12.3413 52.7249 18.1147 54.5195C18.2071 54.5477 18.3052 54.5131 18.363 54.4376C19.7295 52.5728 20.9469 50.6063 21.9907 48.5383C22.0527 48.4172 21.9931 48.2735 21.8674 48.2259C19.9366 47.4931 18.0979 46.6 16.3292 45.5858C16.1893 45.5033 16.1789 45.3039 16.3116 45.2082C16.679 44.9293 17.0464 44.6391 17.4034 44.346C17.4654 44.2947 17.5534 44.2843 17.6228 44.3189C29.2558 49.8743 41.8354 49.8743 53.3179 44.3189C53.3873 44.2817 53.4753 44.292 53.5401 44.3433C53.8971 44.6364 54.2645 44.9293 54.6346 45.2082C54.7673 45.3039 54.7594 45.5033 54.6195 45.5858C52.8508 46.6197 51.0121 47.4931 49.0775 48.223C48.9518 48.2706 48.894 48.4172 48.956 48.5383C50.0198 50.6034 51.2372 52.5699 52.5872 54.4347C52.6414 54.5131 52.7423 54.5477 52.8347 54.5195C58.6464 52.7249 64.529 50.0174 70.6019 45.5574C70.6559 45.5182 70.6894 45.459 70.695 45.3942C72.1747 30.0791 68.2147 16.7757 60.1968 4.9821C60.1772 4.9429 60.1436 4.9147 60.1045 4.8978ZM23.7259 37.3253C20.2276 37.3253 17.3451 34.1136 17.3451 30.1693C17.3451 26.225 20.1717 23.0133 23.7259 23.0133C27.308 23.0133 30.1626 26.2532 30.1066 30.1693C30.1066 34.1136 27.28 37.3253 23.7259 37.3253ZM47.2012 37.3253C43.7029 37.3253 40.8203 34.1136 40.8203 30.1693C40.8203 26.225 43.6469 23.0133 47.2012 23.0133C50.7833 23.0133 53.6379 26.2532 53.5819 30.1693C53.5819 34.1136 50.7833 37.3253 47.2012 37.3253Z" />
-  </svg>
-);
-
-/**
- * X (formerly Twitter) icon used in the site header.
- *
- * @example
- * <XIcon className="h-5 w-5" />
- */
-const XIcon = ({ className = "" }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 1200 1227"
-    fill="currentColor"
-    className={className}
-    aria-hidden="true"
-  >
-    <path d="M714.163 519.284 1160.89 0h-105.86L667.137 450.887 357.328 0H0l468.492 681.821L0 1226.37h105.866l409.625-476.152 327.181 476.152H1200L714.137 519.284h.026ZM569.165 687.828l-47.468-67.894-377.686-540.24h162.604l304.797 435.991 47.468 67.894 396.2 566.721H892.476L569.165 687.854v-.026Z" />
-  </svg>
-);
-
-/**
- * JavaScript icon for code tabs.
- */
-const JsIcon = ({ className = "" }) => (
-  <svg
-    viewBox="0 0 24 24"
-    className={className}
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <rect width="24" height="24" fill="#F7DF1E" rx="2" />
-    <path
-      d="M6 18l2-12h4l2 12h-2l-1-4h-4l-1 4H6z" // Placeholder path if text doesn't work well, but let's try text
-      fill="none"
-    />
-    <text
-      x="12"
-      y="17"
-      textAnchor="middle"
-      fontSize="11"
-      fontWeight="bold"
-      fill="black"
-      fontFamily="sans-serif"
-    >
-      JS
-    </text>
-  </svg>
-);
-
-/**
- * Python icon for code tabs.
- */
-const PythonIcon = ({ className = "" }) => (
-  <svg
-    viewBox="16 16 32 32"
-    className={className}
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      fill="url(#python__a)"
-      d="M31.885 16c-8.124 0-7.617 3.523-7.617 3.523l.01 3.65h7.752v1.095H21.197S16 23.678 16 31.876c0 8.196 4.537 7.906 4.537 7.906h2.708v-3.804s-.146-4.537 4.465-4.537h7.688s4.32.07 4.32-4.175v-7.019S40.374 16 31.885 16zm-4.275 2.454a1.394 1.394 0 1 1 0 2.79 1.393 1.393 0 0 1-1.395-1.395c0-.771.624-1.395 1.395-1.395z"
-    />
-    <path
-      fill="url(#python__b)"
-      d="M32.115 47.833c8.124 0 7.617-3.523 7.617-3.523l-.01-3.65H31.97v-1.095h10.832S48 40.155 48 31.958c0-8.197-4.537-7.906-4.537-7.906h-2.708v3.803s.146 4.537-4.465 4.537h-7.688s-4.32-.07-4.32 4.175v7.019s-.656 4.247 7.833 4.247zm4.275-2.454a1.393 1.393 0 0 1-1.395-1.395 1.394 1.394 0 1 1 1.395 1.395z"
-    />
-    <defs>
-      <linearGradient
-        id="python__a"
-        x1="19.075"
-        x2="34.898"
-        y1="18.782"
-        y2="34.658"
-        gradientUnits="userSpaceOnUse"
-      >
-        <stop stopColor="#387EB8" />
-        <stop offset="1" stopColor="#366994" />
-      </linearGradient>
-      <linearGradient
-        id="python__b"
-        x1="28.809"
-        x2="45.803"
-        y1="28.882"
-        y2="45.163"
-        gradientUnits="userSpaceOnUse"
-      >
-        <stop stopColor="#FFE052" />
-        <stop offset="1" stopColor="#FFC331" />
-      </linearGradient>
-    </defs>
-  </svg>
-);
-
-/**
- * Rust icon for code tabs.
- */
-const RustIcon = ({ className = "" }) => (
-  <svg
-    viewBox="0 0 224 224"
-    className={className}
-    fill="currentColor"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      fill="#000"
-      d="M218.46 109.358l-9.062-5.614c-.076-.882-.162-1.762-.258-2.642l7.803-7.265a3.107 3.107 0 00.933-2.89 3.093 3.093 0 00-1.967-2.312l-9.97-3.715c-.25-.863-.512-1.72-.781-2.58l6.214-8.628a3.114 3.114 0 00-.592-4.263 3.134 3.134 0 00-1.431-.637l-10.507-1.709a80.869 80.869 0 00-1.263-2.353l4.417-9.7a3.12 3.12 0 00-.243-3.035 3.106 3.106 0 00-2.705-1.385l-10.671.372a85.152 85.152 0 00-1.685-2.044l2.456-10.381a3.125 3.125 0 00-3.762-3.763l-10.384 2.456a88.996 88.996 0 00-2.047-1.684l.373-10.671a3.11 3.11 0 00-1.385-2.704 3.127 3.127 0 00-3.034-.246l-9.681 4.417c-.782-.429-1.567-.854-2.353-1.265l-1.713-10.506a3.098 3.098 0 00-1.887-2.373 3.108 3.108 0 00-3.014.35l-8.628 6.213c-.85-.27-1.703-.53-2.56-.778l-3.716-9.97a3.111 3.111 0 00-2.311-1.97 3.134 3.134 0 00-2.89.933l-7.266 7.802a93.746 93.746 0 00-2.643-.258l-5.614-9.082A3.125 3.125 0 00111.97 4c-1.09 0-2.085.56-2.642 1.478l-5.615 9.081a93.32 93.32 0 00-2.642.259l-7.266-7.802a3.13 3.13 0 00-2.89-.933 3.106 3.106 0 00-2.312 1.97l-3.715 9.97c-.857.247-1.71.506-2.56.778L73.7 12.588a3.101 3.101 0 00-3.014-.35A3.127 3.127 0 0068.8 14.61l-1.713 10.506c-.79.41-1.575.832-2.353 1.265l-9.681-4.417a3.125 3.125 0 00-4.42 2.95l.372 10.67c-.69.553-1.373 1.115-2.048 1.685l-10.383-2.456a3.143 3.143 0 00-2.93.832 3.124 3.124 0 00-.833 2.93l2.436 10.383a93.897 93.897 0 00-1.68 2.043l-10.672-.372a3.138 3.138 0 00-2.704 1.385 3.126 3.126 0 00-.246 3.035l4.418 9.7c-.43.779-.855 1.563-1.266 2.353l-10.507 1.71a3.097 3.097 0 00-2.373 1.886 3.117 3.117 0 00.35 3.013l6.214 8.628a89.12 89.12 0 00-.78 2.58l-9.97 3.715a3.117 3.117 0 00-1.035 5.202l7.803 7.265c-.098.879-.184 1.76-.258 2.642l-9.062 5.614A3.122 3.122 0 004 112.021c0 1.092.56 2.084 1.478 2.642l9.062 5.614c.074.882.16 1.762.258 2.642l-7.803 7.265a3.117 3.117 0 001.034 5.201l9.97 3.716a110 110 0 00.78 2.58l-6.212 8.627a3.112 3.112 0 00.6 4.27c.419.33.916.547 1.443.63l10.507 1.709c.407.792.83 1.576 1.265 2.353l-4.417 9.68a3.126 3.126 0 002.95 4.42l10.65-.374c.553.69 1.115 1.372 1.685 2.047l-2.435 10.383a3.09 3.09 0 00.831 2.91 3.117 3.117 0 002.931.83l10.384-2.436a82.268 82.268 0 002.047 1.68l-.371 10.671a3.11 3.11 0 001.385 2.704 3.125 3.125 0 003.034.241l9.681-4.416c.779.432 1.563.854 2.353 1.265l1.713 10.505a3.147 3.147 0 001.887 2.395 3.111 3.111 0 003.014-.349l8.628-6.213c.853.271 1.71.535 2.58.783l3.716 9.969a3.112 3.112 0 002.312 1.967 3.112 3.112 0 002.89-.933l7.266-7.802c.877.101 1.761.186 2.642.264l5.615 9.061a3.12 3.12 0 002.642 1.478 3.165 3.165 0 002.663-1.478l5.614-9.061c.884-.078 1.765-.163 2.643-.264l7.265 7.802a3.106 3.106 0 002.89.933 3.105 3.105 0 002.312-1.967l3.716-9.969c.863-.248 1.719-.512 2.58-.783l8.629 6.213a3.12 3.12 0 004.9-2.045l1.713-10.506c.793-.411 1.577-.838 2.353-1.265l9.681 4.416a3.13 3.13 0 003.035-.241 3.126 3.126 0 001.385-2.704l-.372-10.671a81.794 81.794 0 002.046-1.68l10.383 2.436a3.123 3.123 0 003.763-3.74l-2.436-10.382a84.588 84.588 0 001.68-2.048l10.672.374a3.104 3.104 0 002.704-1.385 3.118 3.118 0 00.244-3.035l-4.417-9.68c.43-.779.852-1.563 1.263-2.353l10.507-1.709a3.08 3.08 0 002.373-1.886 3.11 3.11 0 00-.35-3.014l-6.214-8.627c.272-.857.532-1.717.781-2.58l9.97-3.716a3.109 3.109 0 001.967-2.311 3.107 3.107 0 00-.933-2.89l-7.803-7.265c.096-.88.182-1.761.258-2.642l9.062-5.614a3.11 3.11 0 001.478-2.642 3.157 3.157 0 00-1.476-2.663h-.064zm-60.687 75.337c-3.468-.747-5.656-4.169-4.913-7.637a6.412 6.412 0 017.617-4.933c3.468.741 5.676 4.169 4.933 7.637a6.414 6.414 0 01-7.617 4.933h-.02zm-3.076-20.847c-3.158-.677-6.275 1.334-6.936 4.5l-3.22 15.026c-9.929 4.5-21.055 7.018-32.614 7.018-11.89 0-23.12-2.622-33.234-7.328l-3.22-15.026c-.677-3.158-3.778-5.18-6.936-4.499l-13.273 2.848a80.222 80.222 0 01-6.853-8.091h64.61c.731 0 1.218-.132 1.218-.797v-22.91c0-.665-.487-.797-1.218-.797H94.133v-14.469h20.415c1.864 0 9.97.533 12.551 10.898.811 3.179 2.601 13.54 3.818 16.863 1.214 3.715 6.152 11.146 11.415 11.146h32.202c.365 0 .755-.041 1.166-.116a80.56 80.56 0 01-7.307 8.587l-13.583-2.911-.113.058zm-89.38 20.537a6.407 6.407 0 01-7.617-4.933c-.74-3.467 1.462-6.894 4.934-7.637a6.417 6.417 0 017.617 4.933c.74 3.468-1.464 6.894-4.934 7.637zm-24.564-99.28a6.438 6.438 0 01-3.261 8.484c-3.241 1.438-7.019-.025-8.464-3.261-1.445-3.237.025-7.039 3.262-8.483a6.416 6.416 0 018.463 3.26zM33.22 102.94l13.83-6.15c2.952-1.311 4.294-4.769 2.972-7.72l-2.848-6.44H58.36v50.362h-22.5a79.158 79.158 0 01-3.014-21.672c0-2.869.155-5.697.452-8.483l-.08.103zm60.687-4.892v-14.86h26.629c1.376 0 9.722 1.59 9.722 7.822 0 5.18-6.399 7.038-11.663 7.038h-24.77.082zm96.811 13.375c0 1.973-.072 3.922-.216 5.862h-8.113c-.811 0-1.137.532-1.137 1.327v3.715c0 8.752-4.934 10.671-9.268 11.146-4.129.464-8.691-1.726-9.248-4.252-2.436-13.684-6.482-16.595-12.881-21.672 7.948-5.036 16.204-12.487 16.204-22.498 0-10.753-7.369-17.523-12.385-20.847-7.059-4.644-14.862-5.572-16.968-5.572H52.899c11.374-12.673 26.835-21.673 44.174-24.975l9.887 10.361a5.849 5.849 0 008.278.19l11.064-10.568c23.119 4.314 42.729 18.721 54.082 38.598l-7.576 17.09c-1.306 2.951.027 6.419 2.973 7.72l14.573 6.48c.255 2.607.383 5.224.384 7.843l-.021.052zM106.912 24.94a6.398 6.398 0 019.062.209 6.437 6.437 0 01-.213 9.082 6.396 6.396 0 01-9.062-.21 6.436 6.436 0 01.213-9.083v.002zm75.137 60.476a6.402 6.402 0 018.463-3.26 6.425 6.425 0 013.261 8.482 6.402 6.402 0 01-8.463 3.261 6.425 6.425 0 01-3.261-8.483z"
-    />
-  </svg>
-);
-
-/**
- * Go icon for code tabs.
- */
-const GoIcon = ({ className = "" }) => (
-  <svg
-    viewBox="0 0 207 180"
-    className={className}
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <g fill="#00ADD8" fillRule="evenodd" transform="translate(0, 51)">
-      <path d="m16.2 24.1c-.4 0-.5-.2-.3-.5l2.1-2.7c.2-.3.7-.5 1.1-.5h35.7c.4 0 .5.3.3.6l-1.7 2.6c-.2.3-.7.6-1 .6z" />
-      <path d="m1.1 33.3c-.4 0-.5-.2-.3-.5l2.1-2.7c.2-.3.7-.5 1.1-.5h45.6c.4 0 .6.3.5.6l-.8 2.4c-.1.4-.5.6-.9.6z" />
-      <path d="m25.3 42.5c-.4 0-.5-.3-.3-.6l1.4-2.5c.2-.3.6-.6 1-.6h20c.4 0 .6.3.6.7l-.2 2.4c0 .4-.4.7-.7.7z" />
-      <g transform="translate(55)">
-        <path d="m74.1 22.3c-6.3 1.6-10.6 2.8-16.8 4.4-1.5.4-1.6.5-2.9-1-1.5-1.7-2.6-2.8-4.7-3.8-6.3-3.1-12.4-2.2-18.1 1.5-6.8 4.4-10.3 10.9-10.2 19 .1 8 5.6 14.6 13.5 15.7 6.8.9 12.5-1.5 17-6.6.9-1.1 1.7-2.3 2.7-3.7-3.6 0-8.1 0-19.3 0-2.1 0-2.6-1.3-1.9-3 1.3-3.1 3.7-8.3 5.1-10.9.3-.6 1-1.6 2.5-1.6h36.4c-.2 2.7-.2 5.4-.6 8.1-1.1 7.2-3.8 13.8-8.2 19.6-7.2 9.5-16.6 15.4-28.5 17-9.8 1.3-18.9-.6-26.9-6.6-7.4-5.6-11.6-13-12.7-22.2-1.3-10.9 1.9-20.7 8.5-29.3 7.1-9.3 16.5-15.2 28-17.3 9.4-1.7 18.4-.6 26.5 4.9 5.3 3.5 9.1 8.3 11.6 14.1.6.9.2 1.4-1 1.7z" />
-        <path
-          d="m107.2 77.6c-9.1-.2-17.4-2.8-24.4-8.8-5.9-5.1-9.6-11.6-10.8-19.3-1.8-11.3 1.3-21.3 8.1-30.2 7.3-9.6 16.1-14.6 28-16.7 10.2-1.8 19.8-.8 28.5 5.1 7.9 5.4 12.8 12.7 14.1 22.3 1.7 13.5-2.2 24.5-11.5 33.9-6.6 6.7-14.7 10.9-24 12.8-2.7.5-5.4.6-8 .9zm23.8-40.4c-.1-1.3-.1-2.3-.3-3.3-1.8-9.9-10.9-15.5-20.4-13.3-9.3 2.1-15.3 8-17.5 17.4-1.8 7.8 2 15.7 9.2 18.9 5.5 2.4 11 2.1 16.3-.6 7.9-4.1 12.2-10.5 12.7-19.1z"
-          fillRule="nonzero"
-        />
-      </g>
-    </g>
-  </svg>
-);
-
-/**
- * Landing page for the Lix documentation site.
- *
- * @example
- * <LandingPage />
- */
-function LandingPage({
-  readmeHtml,
-  showHeader = true,
+function CopyInstallButton({
+  background = "white",
 }: {
-  readmeHtml?: string;
-  showHeader?: boolean;
+  background?: "white" | "paper";
 }) {
-  const docsPath = "/docs/what-is-lix";
-  const pathname = useRouterState({
-    select: (state) => state.location.pathname,
-  });
-  const githubStars = getGithubStars("opral/lix");
+  const [copied, setCopied] = useState(false);
 
-  const formatStars = (count: number) => {
-    if (count >= 1000) {
-      return `${(count / 1000).toFixed(1).replace(/\.0$/, "")}k`;
-    }
-    return count.toString();
+  const copy = () => {
+    if (navigator.clipboard) navigator.clipboard.writeText(INSTALL_COMMAND);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1600);
   };
-
-  const navLinks = [
-    { href: docsPath, label: "Docs", activePrefix: "/docs" },
-    { href: "/plugins", label: "Plugins", activePrefix: "/plugins" },
-    { href: "/blog", label: "Blog", activePrefix: "/blog" },
-  ];
-
-  const isActive = (href: string, activePrefix?: string) => {
-    const candidate = activePrefix ?? href;
-    const normalized = candidate === "/" ? "/" : candidate.replace(/\/$/, "");
-    if (normalized === "/") return pathname === "/";
-    return pathname === normalized || pathname.startsWith(`${normalized}/`);
-  };
-
-  const socialLinks = [
-    {
-      href: "https://discord.gg/gdMPPWy57R",
-      label: "Discord",
-      Icon: DiscordIcon,
-      sizeClass: "h-5 w-5",
-    },
-    {
-      href: "https://x.com/lixCCS",
-      label: "X",
-      Icon: XIcon,
-      sizeClass: "h-4 w-4",
-    },
-  ];
 
   return (
-    <div className="font-sans text-gray-900 bg-white">
-      {showHeader && (
-        <header className="sticky top-0 z-50 border-b border-gray-200 bg-white/80 backdrop-blur">
-          <div className="mx-auto flex w-full max-w-[1440px] items-center justify-between pl-6 pr-6 py-3">
+    <button
+      onClick={copy}
+      className={`flex h-12 cursor-pointer items-center gap-3.5 rounded-lg border border-[#DDDBD3] px-4 font-mono text-[14.5px] text-ink transition-colors hover:border-cyan-bright ${
+        background === "white"
+          ? "bg-white shadow-[0_1px_2px_rgba(20,23,26,0.04)]"
+          : "bg-paper"
+      }`}
+    >
+      <span className="text-[#A8ACB2]">$</span>
+      <span>{INSTALL_COMMAND}</span>
+      <span className="ml-1.5 font-sans text-xs font-semibold uppercase tracking-[0.04em] text-cyan-deep">
+        {copied ? "copied" : "copy"}
+      </span>
+    </button>
+  );
+}
+
+const whatYouGet = [
+  {
+    title: "Keep normal files",
+    description:
+      "Existing tools and agents can keep reading and writing files on disk.",
+    icon: (
+      <svg viewBox="0 0 80 56" className="block h-14 w-20" aria-hidden="true">
+        <rect
+          x="28"
+          y="6"
+          width="30"
+          height="38"
+          rx="3"
+          fill="#FBFAF7"
+          stroke="#C9C7BF"
+          strokeWidth="1.5"
+        />
+        <rect
+          x="24"
+          y="10"
+          width="30"
+          height="38"
+          rx="3"
+          fill="#FBFAF7"
+          stroke="#C9C7BF"
+          strokeWidth="1.5"
+        />
+        <rect
+          x="20"
+          y="14"
+          width="30"
+          height="38"
+          rx="3"
+          fill="#FFFFFF"
+          stroke="#8A8F96"
+          strokeWidth="1.5"
+        />
+        <line
+          x1="26"
+          y1="24"
+          x2="44"
+          y2="24"
+          stroke="#C9C7BF"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
+        <line
+          x1="26"
+          y1="31"
+          x2="44"
+          y2="31"
+          stroke="#C9C7BF"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
+        <line
+          x1="26"
+          y1="38"
+          x2="36"
+          y2="38"
+          stroke="#07B6D5"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
+      </svg>
+    ),
+  },
+  {
+    title: "Query everything with SQL",
+    description:
+      "Query file content, app data, and change history without rereading whole files.",
+    icon: (
+      <svg viewBox="0 0 80 56" className="block h-14 w-20" aria-hidden="true">
+        <rect
+          x="16"
+          y="10"
+          width="14"
+          height="10"
+          rx="2"
+          fill="none"
+          stroke="#C9C7BF"
+          strokeWidth="1.5"
+        />
+        <rect
+          x="33"
+          y="10"
+          width="14"
+          height="10"
+          rx="2"
+          fill="none"
+          stroke="#C9C7BF"
+          strokeWidth="1.5"
+        />
+        <rect
+          x="50"
+          y="10"
+          width="14"
+          height="10"
+          rx="2"
+          fill="none"
+          stroke="#C9C7BF"
+          strokeWidth="1.5"
+        />
+        <rect
+          x="16"
+          y="23"
+          width="14"
+          height="10"
+          rx="2"
+          fill="none"
+          stroke="#C9C7BF"
+          strokeWidth="1.5"
+        />
+        <rect
+          x="33"
+          y="23"
+          width="14"
+          height="10"
+          rx="2"
+          fill="rgba(7,182,213,0.14)"
+          stroke="#07B6D5"
+          strokeWidth="1.5"
+        />
+        <rect
+          x="50"
+          y="23"
+          width="14"
+          height="10"
+          rx="2"
+          fill="none"
+          stroke="#C9C7BF"
+          strokeWidth="1.5"
+        />
+        <rect
+          x="16"
+          y="36"
+          width="14"
+          height="10"
+          rx="2"
+          fill="none"
+          stroke="#C9C7BF"
+          strokeWidth="1.5"
+        />
+        <rect
+          x="33"
+          y="36"
+          width="14"
+          height="10"
+          rx="2"
+          fill="none"
+          stroke="#C9C7BF"
+          strokeWidth="1.5"
+        />
+        <rect
+          x="50"
+          y="36"
+          width="14"
+          height="10"
+          rx="2"
+          fill="none"
+          stroke="#C9C7BF"
+          strokeWidth="1.5"
+        />
+      </svg>
+    ),
+  },
+  {
+    title: "Track semantic changes",
+    description:
+      "Review the paragraph, CSV record, property, or app row that changed.",
+    icon: (
+      <svg viewBox="0 0 80 56" className="block h-14 w-20" aria-hidden="true">
+        <line
+          x1="16"
+          y1="14"
+          x2="64"
+          y2="14"
+          stroke="#C9C7BF"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+        <line
+          x1="16"
+          y1="24"
+          x2="52"
+          y2="24"
+          stroke="#C9C7BF"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+        <line
+          x1="16"
+          y1="34"
+          x2="30"
+          y2="34"
+          stroke="#C9C7BF"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+        <line
+          x1="35"
+          y1="34"
+          x2="52"
+          y2="34"
+          stroke="#07B6D5"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+        <line
+          x1="57"
+          y1="34"
+          x2="64"
+          y2="34"
+          stroke="#C9C7BF"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+        <line
+          x1="16"
+          y1="44"
+          x2="58"
+          y2="44"
+          stroke="#C9C7BF"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+      </svg>
+    ),
+  },
+  {
+    title: "Branch and merge safely",
+    description:
+      "Give every user or agent an isolated repository, then review and merge its work.",
+    icon: (
+      <svg viewBox="0 0 80 56" className="block h-14 w-20" aria-hidden="true">
+        <path
+          d="M14 40 H66"
+          fill="none"
+          stroke="#C9C7BF"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+        <path
+          d="M26 40 C32 40 32 18 40 18 H46 C56 18 54 40 60 40"
+          fill="none"
+          stroke="#07B6D5"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+        <circle cx="14" cy="40" r="3.5" fill="#8A8F96" />
+        <circle cx="43" cy="18" r="3.5" fill="#07B6D5" />
+        <circle cx="66" cy="40" r="3.5" fill="#8A8F96" />
+      </svg>
+    ),
+  },
+  {
+    title: "Use ACID transactions",
+    description:
+      "Update files and rows together while Lix records their history.",
+    icon: (
+      <svg viewBox="0 0 80 56" className="block h-14 w-20" aria-hidden="true">
+        <rect
+          x="12"
+          y="10"
+          width="56"
+          height="36"
+          rx="6"
+          fill="none"
+          stroke="#C9C7BF"
+          strokeWidth="1.5"
+          strokeDasharray="4 4"
+        />
+        <rect
+          x="20"
+          y="19"
+          width="18"
+          height="18"
+          rx="3"
+          fill="#FFFFFF"
+          stroke="#8A8F96"
+          strokeWidth="1.5"
+        />
+        <rect
+          x="44"
+          y="19"
+          width="18"
+          height="18"
+          rx="3"
+          fill="#FFFFFF"
+          stroke="#8A8F96"
+          strokeWidth="1.5"
+        />
+        <line
+          x1="38"
+          y1="28"
+          x2="44"
+          y2="28"
+          stroke="#07B6D5"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+      </svg>
+    ),
+  },
+  {
+    title: "Run locally or remotely",
+    description:
+      "Embed Lix in an app or connect to a shared repository through the server protocol.",
+    icon: (
+      <svg viewBox="0 0 80 56" className="block h-14 w-20" aria-hidden="true">
+        <rect
+          x="12"
+          y="20"
+          width="16"
+          height="16"
+          rx="3"
+          fill="#FFFFFF"
+          stroke="#8A8F96"
+          strokeWidth="1.5"
+        />
+        <rect
+          x="52"
+          y="20"
+          width="16"
+          height="16"
+          rx="3"
+          fill="#FFFFFF"
+          stroke="#8A8F96"
+          strokeWidth="1.5"
+        />
+        <line
+          x1="28"
+          y1="28"
+          x2="52"
+          y2="28"
+          stroke="#C9C7BF"
+          strokeWidth="1.5"
+          strokeDasharray="3 4"
+          strokeLinecap="round"
+        />
+        <circle cx="40" cy="28" r="3" fill="#07B6D5" />
+      </svg>
+    ),
+  },
+];
+
+/**
+ * Landing page for lix.dev.
+ *
+ * @example
+ * <LandingPage readmeHtml={html} />
+ */
+function LandingPage({ readmeHtml }: { readmeHtml?: string }) {
+  const githubStars = getGithubStars("opral/lix");
+
+  return (
+    <div className="min-h-screen bg-paper text-ink">
+      <Header width="narrow" />
+      <main className="mx-auto w-full max-w-[1100px] px-8">
+        {/* Hero */}
+        <section className="max-w-[820px] pt-[104px]">
+          <p className="mb-[26px] font-mono text-[12.5px] uppercase tracking-[0.08em] text-ink-faint">
+            Open source · MIT
+          </p>
+          <h1 className="text-balance text-[40px] font-bold leading-[1.04] tracking-[-0.035em] sm:text-[60px]">
+            Database, filesystem and version control in one system
+          </h1>
+          <div className="mt-[30px] flex max-w-[660px] flex-col gap-[18px]">
+            <p className="text-xl leading-[1.55] text-ink-secondary">
+              Agents and tools work with files. Applications need a database.
+              Teams need version control.
+            </p>
+            <p className="text-xl leading-[1.55] text-ink-secondary">
+              Lix combines all three: normal files for tools, SQL rows for apps,
+              and version control for every change.
+            </p>
+          </div>
+          <div className="mt-10 flex flex-wrap items-center gap-3.5">
+            <CopyInstallButton background="white" />
             <a
-              href="/"
-              className="flex items-center text-[#0891B2]"
-              aria-label="lix home"
+              href="/docs/what-is-lix"
+              className="flex h-12 items-center rounded-lg bg-ink px-5 text-[14.5px] font-semibold text-paper transition-colors hover:text-paper"
             >
-              <LixLogo className="h-7 w-7" />
-              <span className="sr-only">lix</span>
+              Read the docs
             </a>
-            <div className="flex items-center gap-6">
-              <nav className="hidden items-center gap-4 text-sm font-medium text-gray-700 sm:flex">
-                {navLinks.map(({ href, label, activePrefix }) => (
-                  <a
-                    key={href}
-                    href={href}
-                    className={
-                      isActive(href, activePrefix)
-                        ? href.startsWith("/plugins")
-                          ? "px-2 py-1 text-[#0891B2] hover:text-[#0692B6]"
-                          : "px-2 py-1 text-[#0891B2]"
-                        : "px-2 py-1 transition-colors hover:text-[#0692B6]"
-                    }
-                    aria-current={
-                      isActive(href, activePrefix) ? "page" : undefined
-                    }
-                  >
-                    {label}
-                  </a>
-                ))}
-              </nav>
+          </div>
+        </section>
+
+        {/* Stats */}
+        <section className="mt-[84px] flex flex-wrap gap-14 border-y border-line py-7">
+          <div className="flex flex-col gap-1.5">
+            <span className="text-3xl font-bold leading-none tracking-[-0.02em]">
+              {coarseWeeklyDownloads()}
+            </span>
+            <span className="text-sm text-ink-muted">weekly downloads</span>
+          </div>
+          {githubStars !== null && (
+            <a
+              href="https://github.com/opral/lix"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group flex flex-col gap-1.5"
+            >
+              <span className="text-3xl font-bold leading-none tracking-[-0.02em] transition-colors group-hover:text-cyan-deep">
+                {githubStars.toLocaleString("en-US")}
+              </span>
+              <span className="text-sm text-ink-muted">GitHub stars</span>
+            </a>
+          )}
+        </section>
+
+        {/* Adoption chart */}
+        <DownloadsChart />
+
+        {/* What you get */}
+        <section className="pt-24">
+          <h2 className="mb-1 text-[34px] font-bold tracking-[-0.028em]">
+            What you get
+          </h2>
+          <div className="mt-9">
+            {whatYouGet.map((item, index) => (
               <div
-                className="hidden h-4 w-px bg-gray-200 sm:block"
-                aria-hidden="true"
-              />
-              <div className="flex items-center gap-3">
-                {socialLinks.map(({ href, label, Icon, sizeClass }) => (
-                  <a
-                    key={label}
-                    href={href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-gray-900 transition-colors hover:text-gray-900"
-                    aria-label={label}
-                  >
-                    <Icon className={sizeClass ?? "h-5 w-5"} />
-                  </a>
-                ))}
-                <div className="h-4 w-px bg-gray-200" aria-hidden="true" />
+                key={item.title}
+                className={`grid grid-cols-1 items-center gap-4 border-t border-line py-5 sm:grid-cols-[104px_224px_1fr] sm:gap-8 ${
+                  index === whatYouGet.length - 1 ? "border-b" : ""
+                }`}
+              >
+                {item.icon}
+                <span className="text-[17px] font-semibold tracking-[-0.01em]">
+                  {item.title}
+                </span>
+                <span className="text-[17px] leading-[1.6] text-ink-secondary">
+                  {item.description}
+                </span>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* README */}
+        {readmeHtml && (
+          <section className="pt-[88px]">
+            <div className="overflow-hidden rounded-xl border border-line bg-white">
+              <div className="flex flex-wrap items-center justify-between gap-5 border-b border-line-soft bg-[#FDFCFA] px-7 py-3.5">
+                <span className="font-mono text-[12.5px] text-ink-faint">
+                  README.md · opral/lix
+                </span>
                 <a
                   href="https://github.com/opral/lix"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="group inline-flex items-center gap-1.5 text-sm font-medium text-gray-700 transition-colors hover:text-gray-700"
+                  className="font-mono text-[12.5px] text-ink-muted transition-colors hover:text-cyan-deep"
                 >
-                  <GitHubIcon className="h-5 w-5" />
-                  GitHub
-                  {githubStars !== null && (
-                    <span
-                      className="inline-flex items-center gap-1 text-gray-500 transition-colors group-hover:text-gray-500"
-                      title={`${githubStars.toLocaleString()} GitHub stars`}
-                      aria-label={`${githubStars.toLocaleString()} GitHub stars`}
-                    >
-                      <span className="relative h-3.5 w-3.5" aria-hidden="true">
-                        <svg
-                          className="absolute inset-0 h-3.5 w-3.5 text-gray-400 group-hover:opacity-0 transition-opacity"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                        >
-                          <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
-                        </svg>
-                        <svg
-                          className="absolute inset-0 h-3.5 w-3.5 text-yellow-500 opacity-0 group-hover:opacity-100 transition-opacity"
-                          viewBox="0 0 16 16"
-                          fill="currentColor"
-                        >
-                          <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25z" />
-                        </svg>
-                      </span>
-                      <span>{formatStars(githubStars)}</span>
-                    </span>
-                  )}
+                  view on GitHub →
                 </a>
               </div>
-            </div>
-          </div>
-        </header>
-      )}
-      {/* Main content */}
-      <main className="relative px-4 sm:px-6">
-        {/* Hero Section - Simplified */}
-        <section className="relative pt-20 pb-12 px-4 sm:px-6">
-          <div className="relative max-w-4xl mx-auto text-center">
-            {/* Beta Chip */}
-            <a
-              href="https://github.com/opral/lix/issues/374"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 mb-6 px-3 py-1.5 rounded-full bg-amber-50 border border-amber-200 text-sm text-amber-800 hover:bg-amber-100 transition-colors"
-            >
-              <span className="inline-block w-2 h-2 rounded-full bg-amber-400" />
-              <span>
-                <span className="font-medium">Lix is in alpha</span> · Follow
-                progress to v1.0
-              </span>
-              <svg
-                className="w-3.5 h-3.5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M9 5l7 7-7 7"
+              <div className="px-6 pb-12 pt-10 sm:px-12">
+                <article
+                  className="markdown-wc-body"
+                  dangerouslySetInnerHTML={{ __html: readmeHtml }}
                 />
-              </svg>
-            </a>
-            <h1 className="text-gray-900 font-bold leading-[1.1] text-4xl sm:text-5xl md:text-6xl tracking-tight">
-              Database + filesystem + version control in one system
-            </h1>
-
-            <p className="text-gray-500 text-lg sm:text-xl max-w-4xl mx-auto mt-8">
-              Normal files for tools and agents. SQL rows for apps. Version
-              control for every change.
-            </p>
-
-            {/* Trust signals */}
-            <div className="flex items-center justify-center gap-8 sm:gap-12 mt-12">
-              <div className="flex flex-col items-center">
-                <svg
-                  className="w-5 h-5 text-gray-400 mb-1.5"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={1.5}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
-                  />
-                </svg>
-                <div className="text-2xl font-bold text-gray-900">90k+</div>
-                <div className="text-sm text-gray-500 mt-1">
-                  Weekly downloads
-                </div>
-              </div>
-              <div className="w-px h-14 bg-gray-200" />
-              <div className="flex flex-col items-center">
-                <svg
-                  className="w-5 h-5 text-gray-400 mb-1.5"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={1.5}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3"
-                  />
-                </svg>
-                <div className="text-2xl font-bold text-gray-900">MIT</div>
-                <div className="text-sm text-gray-500 mt-1">Open Source</div>
               </div>
             </div>
+          </section>
+        )}
 
-            <div className="flex flex-col sm:flex-row items-center justify-center gap-3 mt-10">
-              <a
-                href={docsPath}
-                className="inline-flex items-center justify-center h-11 px-6 rounded-lg text-sm font-medium bg-[#0891b2] text-white hover:bg-[#0e7490] transition-colors"
-              >
-                Read the docs
-                <svg
-                  className="h-4 w-4 ml-2"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M14 5l7 7m0 0l-7 7m7-7H3"
-                  />
-                </svg>
-              </a>
-              <a
-                href="https://github.com/opral/lix"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex h-11 items-center justify-center gap-2 px-5 rounded-lg border border-gray-300 bg-white text-sm text-gray-800 transition-colors duration-200 hover:bg-gray-50"
-                title={
-                  githubStars
-                    ? `${githubStars.toLocaleString()} GitHub stars`
-                    : "Star us on GitHub"
-                }
-              >
-                <svg
-                  className="w-5 h-5"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                >
-                  <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.166 6.839 9.489.5.092.682-.217.682-.48 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.645.35-1.087.636-1.337-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.161 22 16.416 22 12c0-5.523-4.477-10-10-10z" />
-                </svg>
-                Star on GitHub
-                {githubStars !== null && (
-                  <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-semibold text-gray-600">
-                    {githubStars >= 1000
-                      ? `${(githubStars / 1000).toFixed(1)}k`
-                      : githubStars}
-                  </span>
-                )}
-              </a>
+        {/* CTA */}
+        <section className="pb-[104px] pt-24">
+          <div className="flex flex-wrap items-center justify-between gap-10 rounded-xl border border-line bg-white px-6 py-11 sm:px-12">
+            <div className="flex flex-col gap-2.5">
+              <h2 className="text-[26px] font-bold tracking-[-0.025em]">
+                Start with the SDK
+              </h2>
+              <p className="text-base text-ink-muted">
+                MIT licensed. Runs in the browser and on the server.
+              </p>
             </div>
-
-            {/* Hero code snippet with language tabs */}
-            <div className="mt-12 w-full max-w-2xl mx-auto">
-              <div className="rounded-xl border border-gray-200 bg-white overflow-hidden">
-                <div className="flex items-center px-4 border-b border-gray-200 bg-gray-50">
-                  <div className="flex gap-6 text-sm">
-                    <button className="flex items-center gap-2 text-gray-900 font-medium border-b-2 border-gray-900 py-3 px-1 cursor-pointer">
-                      <JsIcon className="h-4 w-4" />
-                      JavaScript
-                    </button>
-                    <a
-                      href="https://github.com/opral/lix/issues/370"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center gap-2 text-gray-400 py-3 px-1 hover:text-gray-600 transition-colors cursor-pointer"
-                    >
-                      <PythonIcon className="h-4 w-4" />
-                      Python
-                    </a>
-                    <a
-                      href="https://github.com/opral/lix/issues/371"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center gap-2 text-gray-400 py-3 px-1 hover:text-gray-600 transition-colors cursor-pointer"
-                    >
-                      <RustIcon className="h-4 w-4" />
-                      Rust
-                    </a>
-                    <a
-                      href="https://github.com/opral/lix/issues/373"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center gap-2 text-gray-400 py-3 px-1 hover:text-gray-600 transition-colors cursor-pointer"
-                    >
-                      <GoIcon className="h-4 w-4" />
-                      Go
-                    </a>
-                  </div>
-                </div>
-                <div className="p-5 text-sm leading-relaxed font-mono text-left overflow-x-auto whitespace-pre-wrap">
-                  <span className="text-indigo-600">import</span>{" "}
-                  <span className="text-gray-900">{"{ openLix }"}</span>{" "}
-                  <span className="text-indigo-600">from</span>{" "}
-                  <span className="text-amber-600">"@lix-js/sdk"</span>
-                  <span className="text-gray-900">;</span>
-                  <br />
-                  <span className="text-indigo-600">const</span>{" "}
-                  <span className="text-gray-900">lix</span>{" "}
-                  <span className="text-gray-900">= </span>
-                  <span className="text-indigo-600">await</span>{" "}
-                  <span className="text-gray-900">openLix</span>
-                  <span className="text-gray-900">{"()"}</span>
-                  <span className="text-gray-900">;</span>
-                  <br />
-                  <span className="text-indigo-600">await</span>{" "}
-                  <span className="text-gray-900">lix.fs.writeFile</span>
-                  <span className="text-gray-900">{"("}</span>
-                  <span className="text-amber-600">"/hello.md"</span>
-                  <span className="text-gray-900">{", bytes)"}</span>
-                </div>
-              </div>
-            </div>
+            <CopyInstallButton background="paper" />
           </div>
         </section>
-
-        {/* Value Props - Lightweight */}
-        <section className="py-12 px-6 sm:px-12 md:px-16 bg-white">
-          <div className="max-w-6xl mx-auto">
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-8 sm:gap-12">
-              <div className="flex flex-col items-center sm:items-start gap-4">
-                {/* Library/dependency illustration */}
-                <div className="w-full max-w-[220px] h-32 rounded-lg border border-gray-200 bg-white p-4">
-                  <div className="text-xs text-gray-400 mb-3">dependencies</div>
-                  <div className="space-y-2 font-mono text-xs">
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-2">
-                        <div className="w-2.5 h-2.5 rounded bg-gray-200"></div>
-                        <span className="text-gray-400">http</span>
-                      </div>
-                      <span className="text-gray-300">2.1</span>
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-2">
-                        <div className="w-2.5 h-2.5 rounded bg-gray-200"></div>
-                        <span className="text-gray-400">db</span>
-                      </div>
-                      <span className="text-gray-300">3.0</span>
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-2">
-                        <div className="w-2.5 h-2.5 rounded bg-cyan-200 border border-cyan-400"></div>
-                        <span className="text-gray-700 font-medium">lix</span>
-                      </div>
-                      <span className="text-gray-400">1.0</span>
-                    </div>
-                  </div>
-                </div>
-                <div className="text-center sm:text-left">
-                  <h3 className="text-lg font-semibold text-gray-900">
-                    Works with normal files
-                  </h3>
-                  <p className="text-gray-600 text-base mt-2">
-                    Tools and agents keep reading and writing workspace files.
-                    Lix tracks the changes.
-                  </p>
-                </div>
-              </div>
-              <div className="flex flex-col items-center sm:items-start gap-4">
-                {/* Diff illustration - semantic/field-level */}
-                <div className="w-full max-w-[220px] h-32 rounded-lg border border-gray-200 bg-white p-4">
-                  <div className="text-xs text-gray-400 mb-3">pricing.csv</div>
-                  <div className="space-y-3 text-sm">
-                    <div className="flex items-center justify-between">
-                      <span className="text-gray-600">title</span>
-                      <div className="flex items-center gap-1.5">
-                        <span className="bg-red-50 text-red-700 px-1 rounded line-through">
-                          Draft
-                        </span>
-                        <span className="text-gray-300">→</span>
-                        <span className="bg-green-50 text-green-700 px-1 rounded">
-                          Final
-                        </span>
-                      </div>
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <span className="text-gray-600">price</span>
-                      <div className="flex items-center gap-1.5">
-                        <span className="bg-red-50 text-red-700 px-1 rounded line-through">
-                          10
-                        </span>
-                        <span className="text-gray-300">→</span>
-                        <span className="bg-green-50 text-green-700 px-1 rounded">
-                          12
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div className="text-center sm:text-left">
-                  <h3 className="text-lg font-semibold text-gray-900">
-                    Query file content with SQL
-                  </h3>
-                  <p className="text-gray-600 text-base mt-2">
-                    Plugins map file content to rows. Apps query current data
-                    and history with SQL.
-                  </p>
-                </div>
-              </div>
-              <div className="flex flex-col items-center sm:items-start gap-4">
-                {/* Trace illustration */}
-                <div className="w-full max-w-[220px] h-32 rounded-lg border border-gray-200 bg-white p-4 font-mono text-xs">
-                  <div className="flex items-center gap-2 text-gray-400">
-                    <span>12:03</span>
-                    <svg
-                      className="w-3 h-3"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                    >
-                      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-                      <polyline points="14 2 14 8 20 8" />
-                      <line x1="16" y1="13" x2="8" y2="13" />
-                      <line x1="16" y1="17" x2="8" y2="17" />
-                    </svg>
-                    <span className="text-gray-600">edit brief.md</span>
-                  </div>
-                  <div className="flex items-center gap-2 text-gray-400 mt-1.5">
-                    <span>12:04</span>
-                    <svg
-                      className="w-3 h-3"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                    >
-                      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-                      <polyline points="14 2 14 8 20 8" />
-                      <line x1="16" y1="13" x2="8" y2="13" />
-                      <line x1="16" y1="17" x2="8" y2="17" />
-                    </svg>
-                    <span className="text-gray-600">update pricing.csv</span>
-                  </div>
-                  <div className="flex items-center gap-2 mt-1.5">
-                    <span className="text-gray-400">12:05</span>
-                    <div className="w-3 h-3 rounded-full bg-green-500 flex items-center justify-center">
-                      <svg
-                        className="w-2 h-2 text-white"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="3"
-                      >
-                        <polyline points="20 6 9 17 4 12" />
-                      </svg>
-                    </div>
-                    <span className="text-gray-900 font-medium">approved</span>
-                  </div>
-                  <div className="flex items-center gap-2 text-gray-400 mt-1.5">
-                    <span>12:06</span>
-                    <svg
-                      className="w-3 h-3"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                    >
-                      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-                      <polyline points="14 2 14 8 20 8" />
-                      <line x1="16" y1="13" x2="8" y2="13" />
-                      <line x1="16" y1="17" x2="8" y2="17" />
-                    </svg>
-                    <span className="text-gray-600">edit report.md</span>
-                  </div>
-                </div>
-                <div className="text-center sm:text-left">
-                  <h3 className="text-lg font-semibold text-gray-900">
-                    Safe branches for agents
-                  </h3>
-                  <p className="text-gray-600 text-base mt-2">
-                    Agents work on isolated branches. Humans review, approve,
-                    and merge.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <LandingReadme readmeHtml={readmeHtml} />
-
-        <Footer />
       </main>
+      <Footer width="narrow" />
     </div>
-  );
-}
-
-export function LandingReadme({ readmeHtml }: { readmeHtml?: string }) {
-  if (!readmeHtml) return null;
-
-  return (
-    <section className="py-16 px-6 sm:px-12 md:px-16 bg-[#fafaf7] border-t border-[#e7e6e1]">
-      <div className="max-w-4xl mx-auto">
-        <a
-          href="https://github.com/opral/lix"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center justify-between mb-10 px-4 py-3 rounded-lg border border-[#e7e6e1] bg-[#f5f4ee] hover:bg-[#efeee8] transition-colors group"
-        >
-          <div className="flex items-center gap-3">
-            <svg
-              className="w-5 h-5 text-gray-700"
-              viewBox="0 0 24 24"
-              fill="currentColor"
-            >
-              <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.166 6.839 9.489.5.092.682-.217.682-.48 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.645.35-1.087.636-1.337-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.161 22 16.416 22 12c0-5.523-4.477-10-10-10z" />
-            </svg>
-            <div>
-              <span className="text-sm font-medium text-gray-900">
-                README.md
-              </span>
-              <span className="text-sm text-gray-500 ml-2">from opral/lix</span>
-            </div>
-          </div>
-          <div className="flex items-center gap-1.5 text-sm text-gray-600 group-hover:text-gray-900">
-            View on GitHub
-            <svg
-              className="w-4 h-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M14 5l7 7m0 0l-7 7m7-7H3"
-              />
-            </svg>
-          </div>
-        </a>
-        <article
-          className="markdown-wc-body"
-          dangerouslySetInnerHTML={{ __html: readmeHtml }}
-        />
-      </div>
-    </section>
   );
 }
 

--- a/website/src/components/markdown-page.style.css
+++ b/website/src/components/markdown-page.style.css
@@ -3,20 +3,20 @@
  * Based on VitePress's vp-doc styling
  */
 
-/* CSS Custom Properties matching VitePress */
+/* CSS Custom Properties matching the Lix design tokens */
 :root {
-  --vp-c-brand-1: #3451b2;
-  --vp-c-brand-2: #3a5ccc;
-  --vp-c-brand-soft: rgba(100, 108, 255, 0.14);
-  --vp-c-text-1: rgba(60, 60, 67);
-  --vp-c-text-2: rgba(60, 60, 67, 0.78);
-  --vp-c-text-3: rgba(60, 60, 67, 0.56);
-  --vp-c-divider: rgba(60, 60, 67, 0.12);
+  --vp-c-brand-1: #0891ac;
+  --vp-c-brand-2: #07b6d5;
+  --vp-c-brand-soft: rgba(7, 182, 213, 0.14);
+  --vp-c-text-1: #3d4046;
+  --vp-c-text-2: #6b7076;
+  --vp-c-text-3: #8a8f96;
+  --vp-c-divider: #e6e4dd;
   --vp-c-bg: #ffffff;
-  --vp-c-bg-soft: #f6f6f7;
-  --vp-c-bg-alt: #f6f6f7;
-  --vp-c-border: rgba(60, 60, 67, 0.12);
-  --vp-c-gutter: rgba(60, 60, 67, 0.05);
+  --vp-c-bg-soft: #f7f6f1;
+  --vp-c-bg-alt: #f7f6f1;
+  --vp-c-border: #e0ded6;
+  --vp-c-gutter: #edebe4;
 
   /* Tip colors - Green */
   --vp-c-tip-1: #059669;
@@ -67,15 +67,15 @@
 .markdown-wc-body h5,
 .markdown-wc-body h6 {
   position: relative;
-  font-weight: 600;
+  font-weight: 700;
   outline: none;
-  color: var(--vp-c-text-1);
+  color: #15171b;
 }
 
 .markdown-wc-body h1 {
-  letter-spacing: -0.02em;
-  line-height: 40px;
-  font-size: 28px;
+  letter-spacing: -0.03em;
+  line-height: 1.2;
+  font-size: 36px;
   margin: 0 0 16px 0;
 }
 
@@ -186,7 +186,8 @@
   font-weight: 500;
   color: var(--vp-c-brand-1);
   text-decoration: underline;
-  text-underline-offset: 2px;
+  text-decoration-color: #b9e5ef;
+  text-underline-offset: 3px;
   transition:
     color 0.25s,
     opacity 0.25s;
@@ -288,9 +289,9 @@
 .markdown-wc-body :not(pre) > code {
   font-size: var(--vp-code-font-size);
   color: var(--vp-c-text-1);
-  background-color: var(--vp-c-bg-soft);
+  background-color: #f0eee7;
   border-radius: 4px;
-  padding: 2px 6px;
+  padding: 1px 5px;
   font-weight: 500;
   transition:
     color 0.25s,
@@ -382,8 +383,9 @@
 /* Code blocks */
 .markdown-wc-body pre {
   margin: 16px 0;
-  padding: 8px 12px;
+  padding: 14px 18px;
   background-color: var(--vp-c-bg-soft);
+  border: 1px solid #edebe4;
   border-radius: 8px;
   overflow-x: auto;
   position: relative;
@@ -628,25 +630,22 @@
 
 .markdown-wc-body tr {
   background-color: var(--vp-c-bg);
-  border-top: 1px solid var(--vp-c-divider);
+  border-top: 1px solid #edebe4;
   transition: background-color 0.5s;
-}
-
-.markdown-wc-body tr:nth-child(2n) {
-  background-color: var(--vp-c-bg-soft);
 }
 
 .markdown-wc-body th,
 .markdown-wc-body td {
-  border: 1px solid var(--vp-c-divider);
-  padding: 8px 16px;
+  border: 1px solid #edebe4;
+  padding: 11px 14px;
+  text-align: left;
 }
 
 .markdown-wc-body th {
   font-size: 14px;
   font-weight: 600;
-  color: var(--vp-c-text-1);
-  background-color: var(--vp-c-bg-soft);
+  color: #15171b;
+  background-color: #fdfcfa;
 }
 
 .markdown-wc-body td {

--- a/website/src/components/prev-next-nav.tsx
+++ b/website/src/components/prev-next-nav.tsx
@@ -41,63 +41,40 @@ export function PrevNextNav({
 
   return (
     <nav
-      className={`grid grid-cols-1 gap-4 border-t border-slate-200 pt-8 sm:grid-cols-2 ${className}`}
+      className={`flex justify-between gap-4 border-t border-line pt-5 ${className}`}
     >
-      <div className="min-w-0">
-        {prev && (
-          <Link
-            to={`${basePath}/$${paramName}` as string}
-            params={{ [paramName]: prev.slug } as Record<string, string>}
-            className="group block w-full rounded-xl border border-slate-200 p-4 transition-colors hover:border-slate-300"
-          >
-            <span className="flex items-center gap-1.5 text-sm text-slate-400">
-              <svg
-                className="h-3 w-3"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M19 12H5M12 19l-7-7 7-7" />
-              </svg>
-              {prevLabel}
-            </span>
-            <span className="mt-1 block font-medium text-[#3451b2] group-hover:text-[#3a5ccc]">
-              {prev.title}
-            </span>
-          </Link>
-        )}
-      </div>
-
-      <div className="min-w-0">
-        {next && (
-          <Link
-            to={`${basePath}/$${paramName}` as string}
-            params={{ [paramName]: next.slug } as Record<string, string>}
-            className="group block w-full rounded-xl border border-slate-200 p-4 transition-colors hover:border-slate-300"
-          >
-            <span className="flex items-center justify-end gap-1.5 text-sm text-slate-400">
-              {nextLabel}
-              <svg
-                className="h-3 w-3"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M5 12h14M12 5l7 7-7 7" />
-              </svg>
-            </span>
-            <span className="mt-1 block font-medium text-right text-[#3451b2] group-hover:text-[#3a5ccc]">
-              {next.title}
-            </span>
-          </Link>
-        )}
-      </div>
+      {prev ? (
+        <Link
+          to={`${basePath}/$${paramName}` as string}
+          params={{ [paramName]: prev.slug } as Record<string, string>}
+          className="flex min-w-0 flex-col gap-1"
+        >
+          <span className="font-mono text-[11px] uppercase tracking-[0.08em] text-ink-faint">
+            {prevLabel}
+          </span>
+          <span className="text-[15px] font-semibold text-cyan-deep">
+            ← {prev.title}
+          </span>
+        </Link>
+      ) : (
+        <span />
+      )}
+      {next ? (
+        <Link
+          to={`${basePath}/$${paramName}` as string}
+          params={{ [paramName]: next.slug } as Record<string, string>}
+          className="flex min-w-0 flex-col items-end gap-1 text-right"
+        >
+          <span className="font-mono text-[11px] uppercase tracking-[0.08em] text-ink-faint">
+            {nextLabel}
+          </span>
+          <span className="text-[15px] font-semibold text-cyan-deep">
+            {next.title} →
+          </span>
+        </Link>
+      ) : (
+        <span />
+      )}
     </nav>
   );
 }

--- a/website/src/npm-downloads.gen.json
+++ b/website/src/npm-downloads.gen.json
@@ -1,0 +1,219 @@
+{
+  "generatedAt": "2026-08-04T06:08:32.654Z",
+  "package": "@lix-js/sdk",
+  "latestWeeklyDownloads": 445000,
+  "weeks": [
+    {
+      "weekEnding": "2025-08-03",
+      "downloads": 33000
+    },
+    {
+      "weekEnding": "2025-08-10",
+      "downloads": 33000
+    },
+    {
+      "weekEnding": "2025-08-17",
+      "downloads": 36000
+    },
+    {
+      "weekEnding": "2025-08-24",
+      "downloads": 37000
+    },
+    {
+      "weekEnding": "2025-08-31",
+      "downloads": 39000
+    },
+    {
+      "weekEnding": "2025-09-07",
+      "downloads": 40000
+    },
+    {
+      "weekEnding": "2025-09-14",
+      "downloads": 48000
+    },
+    {
+      "weekEnding": "2025-09-21",
+      "downloads": 44000
+    },
+    {
+      "weekEnding": "2025-09-28",
+      "downloads": 52000
+    },
+    {
+      "weekEnding": "2025-10-05",
+      "downloads": 55000
+    },
+    {
+      "weekEnding": "2025-10-12",
+      "downloads": 51000
+    },
+    {
+      "weekEnding": "2025-10-19",
+      "downloads": 58000
+    },
+    {
+      "weekEnding": "2025-10-26",
+      "downloads": 63000
+    },
+    {
+      "weekEnding": "2025-11-02",
+      "downloads": 59000
+    },
+    {
+      "weekEnding": "2025-11-09",
+      "downloads": 62000
+    },
+    {
+      "weekEnding": "2025-11-16",
+      "downloads": 62000
+    },
+    {
+      "weekEnding": "2025-11-23",
+      "downloads": 66000
+    },
+    {
+      "weekEnding": "2025-11-30",
+      "downloads": 59000
+    },
+    {
+      "weekEnding": "2025-12-07",
+      "downloads": 70000
+    },
+    {
+      "weekEnding": "2025-12-14",
+      "downloads": 70000
+    },
+    {
+      "weekEnding": "2025-12-21",
+      "downloads": 69000
+    },
+    {
+      "weekEnding": "2025-12-28",
+      "downloads": 40000
+    },
+    {
+      "weekEnding": "2026-01-04",
+      "downloads": 40000
+    },
+    {
+      "weekEnding": "2026-01-11",
+      "downloads": 83000
+    },
+    {
+      "weekEnding": "2026-01-18",
+      "downloads": 91000
+    },
+    {
+      "weekEnding": "2026-01-25",
+      "downloads": 111000
+    },
+    {
+      "weekEnding": "2026-02-01",
+      "downloads": 113000
+    },
+    {
+      "weekEnding": "2026-02-08",
+      "downloads": 98000
+    },
+    {
+      "weekEnding": "2026-02-15",
+      "downloads": 110000
+    },
+    {
+      "weekEnding": "2026-02-22",
+      "downloads": 105000
+    },
+    {
+      "weekEnding": "2026-03-01",
+      "downloads": 139000
+    },
+    {
+      "weekEnding": "2026-03-08",
+      "downloads": 136000
+    },
+    {
+      "weekEnding": "2026-03-15",
+      "downloads": 150000
+    },
+    {
+      "weekEnding": "2026-03-22",
+      "downloads": 145000
+    },
+    {
+      "weekEnding": "2026-03-29",
+      "downloads": 174000
+    },
+    {
+      "weekEnding": "2026-04-05",
+      "downloads": 157000
+    },
+    {
+      "weekEnding": "2026-04-12",
+      "downloads": 158000
+    },
+    {
+      "weekEnding": "2026-04-19",
+      "downloads": 172000
+    },
+    {
+      "weekEnding": "2026-04-26",
+      "downloads": 192000
+    },
+    {
+      "weekEnding": "2026-05-03",
+      "downloads": 177000
+    },
+    {
+      "weekEnding": "2026-05-10",
+      "downloads": 216000
+    },
+    {
+      "weekEnding": "2026-05-17",
+      "downloads": 240000
+    },
+    {
+      "weekEnding": "2026-05-24",
+      "downloads": 254000
+    },
+    {
+      "weekEnding": "2026-05-31",
+      "downloads": 255000
+    },
+    {
+      "weekEnding": "2026-06-07",
+      "downloads": 251000
+    },
+    {
+      "weekEnding": "2026-06-14",
+      "downloads": 307000
+    },
+    {
+      "weekEnding": "2026-06-21",
+      "downloads": 318000
+    },
+    {
+      "weekEnding": "2026-06-28",
+      "downloads": 323000
+    },
+    {
+      "weekEnding": "2026-07-05",
+      "downloads": 333000
+    },
+    {
+      "weekEnding": "2026-07-12",
+      "downloads": 349000
+    },
+    {
+      "weekEnding": "2026-07-19",
+      "downloads": 410000
+    },
+    {
+      "weekEnding": "2026-07-26",
+      "downloads": 428000
+    },
+    {
+      "weekEnding": "2026-08-02",
+      "downloads": 445000
+    }
+  ]
+}

--- a/website/src/routes/blog/$slug.tsx
+++ b/website/src/routes/blog/$slug.tsx
@@ -1,11 +1,10 @@
 import { createFileRoute, Link, redirect } from "@tanstack/react-router";
 import { parse } from "@opral/markdown-wc";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import markdownPageCss from "../../components/markdown-page.style.css?url";
 import { getBlogDescription, getBlogTitle } from "../../blog/blogMetadata.js";
 import { Footer } from "../../components/footer.js";
 import { Header } from "../../components/header.js";
-import { PrevNextNav } from "../../components/prev-next-nav.js";
 import { resolveOgImageUrl } from "../../blog/og-image.js";
 import {
   buildCanonicalUrl,
@@ -14,13 +13,10 @@ import {
 } from "../../lib/seo.js";
 import { normalizeMarkdownHtml } from "../../lib/markdown-html.js";
 
-const blogMarkdownFiles = import.meta.glob<string>(
-  "../../../../blog/**/*.md",
-  {
-    query: "?raw",
-    import: "default",
-  },
-);
+const blogMarkdownFiles = import.meta.glob<string>("../../../../blog/**/*.md", {
+  query: "?raw",
+  import: "default",
+});
 const blogJsonFiles = import.meta.glob<string>("../../../../blog/*.json", {
   query: "?raw",
   import: "default",
@@ -159,6 +155,16 @@ async function loadBlogPost(slug: string) {
   const readingTime = calculateReadingTime(rawMarkdown);
   const imports = parsed.frontmatter?.imports as string[] | undefined;
 
+  // The cover is rendered above the article; drop a leading standalone image
+  // from the body so it does not appear twice.
+  let body = rendered.body;
+  if (ogImageOverride) {
+    body = body.replace(
+      /^\s*<p[^>]*>\s*(?:<a[^>]*>)?\s*<img[^>]*>\s*(?:<\/a>)?\s*<\/p>/,
+      "",
+    );
+  }
+
   return {
     post: {
       slug: entry.slug,
@@ -172,7 +178,7 @@ async function loadBlogPost(slug: string) {
       ogImageAlt,
       imports,
     },
-    html: rendered.body,
+    html: body,
     rawMarkdown,
     prevPost,
     nextPost,
@@ -328,7 +334,6 @@ export const Route = createFileRoute("/blog/$slug")({
 
 function BlogPostPage() {
   const { post, html, prevPost, nextPost } = Route.useLoaderData();
-  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     if (!post.imports || post.imports.length === 0) return;
@@ -344,190 +349,108 @@ function BlogPostPage() {
     import("../../components/markdown-page.interactive.js");
   }, [html]);
 
-  const copyUrl = async () => {
-    try {
-      await navigator.clipboard.writeText(window.location.href);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error("Failed to copy URL:", err);
-    }
-  };
-
   return (
-    <div className="flex min-h-screen flex-col bg-white text-slate-900">
+    <div className="flex min-h-screen flex-col bg-paper text-ink">
       <Header />
-      <main className="flex-1">
-        <header className="bg-white">
-          <div className="mx-auto max-w-4xl px-6 pt-12 pb-8">
-            <nav className="mb-8 flex justify-center">
-              <Link
-                to="/blog"
-                className="inline-flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-700 transition-colors"
-              >
-                <svg
-                  className="h-4 w-4"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <path d="M19 12H5M12 19l-7-7 7-7" />
-                </svg>
-                Blog
-              </Link>
-            </nav>
+      <main className="mx-auto w-full max-w-[784px] flex-1 px-8 pb-[104px] pt-16">
+        <Link
+          to="/blog"
+          className="font-mono text-[12.5px] text-ink-muted transition-colors hover:text-cyan-deep"
+        >
+          ← Blog
+        </Link>
+        {post.date && (
+          <p className="mt-9 font-mono text-[12.5px] text-ink-faint">
+            {formatDate(post.date)}
+          </p>
+        )}
+        <h1 className="mt-3.5 text-balance text-[32px] font-bold leading-[1.12] tracking-[-0.03em] sm:text-[40px]">
+          {post.title}
+        </h1>
 
-            <h1 className="text-2xl md:text-3xl lg:text-4xl font-bold text-slate-900 text-center mb-8">
-              {post.title}
-            </h1>
-
-            {post.authors && post.authors.length > 0 && (
-              <div className="flex justify-center gap-6 mb-8">
-                {post.authors.map((author, index) => (
-                  <div key={index} className="flex items-center gap-3">
-                    {author.avatar ? (
-                      <img
-                        src={author.avatar}
-                        alt={author.name}
-                        className="w-10 h-10 rounded-full object-cover"
-                      />
-                    ) : (
-                      <div className="w-10 h-10 rounded-full bg-slate-300 flex items-center justify-center text-slate-600 font-medium">
-                        {author.name.charAt(0)}
-                      </div>
-                    )}
-                    <span className="font-medium text-slate-900">
-                      {author.name}
-                    </span>
-                    {author.twitter && (
-                      <a
-                        href={author.twitter}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-slate-400 hover:text-slate-600 transition-colors"
-                        aria-label={`${author.name} on X`}
-                      >
-                        <svg
-                          className="w-4 h-4"
-                          viewBox="0 0 24 24"
-                          fill="currentColor"
-                        >
-                          <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-                        </svg>
-                      </a>
-                    )}
-                    {author.github && (
-                      <a
-                        href={author.github}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-slate-400 hover:text-slate-600 transition-colors"
-                        aria-label={`${author.name} on GitHub`}
-                      >
-                        <svg
-                          className="w-4 h-4"
-                          viewBox="0 0 24 24"
-                          fill="currentColor"
-                        >
-                          <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-                        </svg>
-                      </a>
-                    )}
-                  </div>
-                ))}
-              </div>
-            )}
-
-            <div className="flex items-center justify-between text-sm text-slate-500 pt-6 border-t border-slate-200">
-              <div className="flex items-center gap-4">
-                <span className="flex items-center gap-1.5">
-                  <svg
-                    className="h-4 w-4"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
+        {post.authors && post.authors.length > 0 && (
+          <div className="mt-[22px] flex flex-wrap items-center gap-5">
+            {post.authors.map((author, index) => (
+              <div key={index} className="flex items-center gap-2.5">
+                {author.avatar ? (
+                  <img
+                    src={author.avatar}
+                    alt={author.name}
+                    className="block h-7 w-7 rounded-full object-cover"
+                  />
+                ) : (
+                  <span className="flex h-7 w-7 items-center justify-center rounded-full bg-line text-xs font-medium text-ink-muted">
+                    {author.name.charAt(0)}
+                  </span>
+                )}
+                {author.github ? (
+                  <a
+                    href={author.github}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm font-semibold text-ink-secondary transition-colors hover:text-cyan-deep"
                   >
-                    <circle cx="12" cy="12" r="10" />
-                    <polyline points="12 6 12 12 16 14" />
-                  </svg>
-                  {post.readingTime} min read
-                </span>
-                <button
-                  onClick={copyUrl}
-                  className="flex items-center gap-1.5 text-cyan-600 hover:text-cyan-700 transition-colors"
-                >
-                  <svg
-                    className="h-4 w-4"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-                    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-                  </svg>
-                  {copied ? "Copied!" : "Copy URL"}
-                </button>
+                    {author.name}
+                  </a>
+                ) : (
+                  <span className="text-sm font-semibold text-ink-secondary">
+                    {author.name}
+                  </span>
+                )}
               </div>
-              {post.date && (
-                <time className="text-slate-500">{formatDate(post.date)}</time>
-              )}
-            </div>
+            ))}
           </div>
-        </header>
+        )}
 
-        <div className="mx-auto max-w-4xl px-6 py-12">
-          <article
-            className="markdown-wc-body"
-            dangerouslySetInnerHTML={{ __html: html }}
+        {post.ogImage && (
+          <img
+            src={post.ogImage}
+            alt={post.ogImageAlt ?? `${post.title} cover`}
+            className="mt-9 block h-auto w-full rounded-[10px] border border-line bg-white"
           />
+        )}
 
-          <form
-            action="https://buttondown.com/api/emails/embed-subscribe/lix-blog"
-            method="post"
-            target="_blank"
-            className="embeddable-buttondown-form mt-16 border-t border-slate-200 pt-8"
-          >
-            <p className="mb-3 text-sm text-slate-500">
-              Get notified about new blog posts
-            </p>
-            <div className="flex gap-2">
-              <label htmlFor="bd-email" className="sr-only">
-                Enter your email
-              </label>
-              <input
-                type="email"
-                name="email"
-                id="bd-email"
-                placeholder="your@email.com"
-                required
-                className="flex-1 rounded-md border border-slate-300 px-4 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-slate-900"
-              />
-              <input
-                type="submit"
-                value="Subscribe"
-                className="rounded-md border border-slate-300 px-4 py-2 text-sm font-medium text-slate-900 transition-colors hover:bg-slate-50"
-              />
-            </div>
-          </form>
+        <article
+          className="markdown-wc-body mt-9"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
 
-          <PrevNextNav
-            prev={prevPost}
-            next={nextPost}
-            basePath="/blog"
-            prevLabel="Previous post"
-            nextLabel="Next post"
-            className="mt-8"
-          />
-        </div>
+        {(prevPost || nextPost) && (
+          <div className="mt-16 flex justify-between gap-4 border-t border-line pt-5">
+            {nextPost ? (
+              <Link
+                to="/blog/$slug"
+                params={{ slug: nextPost.slug }}
+                className="flex flex-col gap-1"
+              >
+                <span className="font-mono text-[11px] uppercase tracking-[0.08em] text-ink-faint">
+                  Older
+                </span>
+                <span className="text-[15px] font-semibold text-cyan-deep">
+                  ← {nextPost.title}
+                </span>
+              </Link>
+            ) : (
+              <span />
+            )}
+            {prevPost ? (
+              <Link
+                to="/blog/$slug"
+                params={{ slug: prevPost.slug }}
+                className="flex flex-col items-end gap-1 text-right"
+              >
+                <span className="font-mono text-[11px] uppercase tracking-[0.08em] text-ink-faint">
+                  Newer
+                </span>
+                <span className="text-[15px] font-semibold text-cyan-deep">
+                  {prevPost.title} →
+                </span>
+              </Link>
+            ) : (
+              <span />
+            )}
+          </div>
+        )}
       </main>
       <Footer />
     </div>
@@ -556,8 +479,9 @@ function formatDate(dateString: string): string {
     const date = new Date(dateString);
     return date.toLocaleDateString("en-US", {
       year: "numeric",
-      month: "long",
+      month: "short",
       day: "numeric",
+      timeZone: "UTC",
     });
   } catch {
     return dateString;

--- a/website/src/routes/blog/index.tsx
+++ b/website/src/routes/blog/index.tsx
@@ -11,13 +11,10 @@ type Author = {
   avatar?: string | null;
 };
 
-const blogMarkdownFiles = import.meta.glob<string>(
-  "../../../../blog/**/*.md",
-  {
-    query: "?raw",
-    import: "default",
-  },
-);
+const blogMarkdownFiles = import.meta.glob<string>("../../../../blog/**/*.md", {
+  query: "?raw",
+  import: "default",
+});
 const blogJsonFiles = import.meta.glob<string>("../../../../blog/*.json", {
   query: "?raw",
   import: "default",
@@ -153,107 +150,60 @@ function BlogIndexPage() {
   const { posts } = Route.useLoaderData();
 
   return (
-    <div className="flex min-h-screen flex-col bg-white text-slate-900">
+    <div className="flex min-h-screen flex-col bg-paper text-ink">
       <Header />
-      <main className="flex-1">
-        <div className="mx-auto max-w-4xl px-6 py-16">
-          <h1 className="mb-6 text-4xl font-bold tracking-tight text-slate-900">
-            Blog
-          </h1>
+      <main className="mx-auto w-full max-w-[880px] flex-1 px-8 pb-[104px] pt-[72px]">
+        <h1 className="text-[44px] font-bold tracking-[-0.032em]">Blog</h1>
+        <p className="mt-4 text-[17px] leading-[1.6] text-ink-muted">
+          Release notes and engineering updates from the Lix team.
+        </p>
 
-          <form
-            action="https://buttondown.com/api/emails/embed-subscribe/lix-blog"
-            method="post"
-            target="_blank"
-            className="embeddable-buttondown-form mb-12"
-          >
-            <p className="mb-3 text-sm text-slate-500">
-              Get notified about new blog posts
-            </p>
-            <div className="flex gap-2">
-              <label htmlFor="bd-email" className="sr-only">
-                Enter your email
-              </label>
-              <input
-                type="email"
-                name="email"
-                id="bd-email"
-                placeholder="your@email.com"
-                required
-                className="flex-1 rounded-md border border-slate-300 px-4 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-slate-900"
-              />
-              <input
-                type="submit"
-                value="Subscribe"
-                className="rounded-md border border-slate-300 px-4 py-2 text-sm font-medium text-slate-900 transition-colors hover:bg-slate-50"
-              />
-            </div>
-          </form>
-
-          <div className="flex flex-col gap-6">
-            {posts.map((post) => (
-              <Link
-                key={post.slug}
-                to="/blog/$slug"
-                params={{ slug: post.slug }}
-                className="group -mx-6 block rounded-xl p-6 transition-colors hover:bg-slate-50"
-              >
-                <article className="flex gap-6">
-                  {post.ogImage && (
-                    <div className="h-24 w-40 flex-shrink-0 overflow-hidden rounded-lg bg-slate-100">
-                      <img
-                        src={post.ogImage}
-                        alt={
-                          post.ogImageAlt ??
-                          `${post.title ?? post.slug} cover image`
-                        }
-                        className="h-full w-full object-cover"
-                      />
-                    </div>
-                  )}
-                  <div className="min-w-0 flex-1">
-                    <h2 className="text-xl font-semibold text-slate-900 transition-colors group-hover:text-slate-700">
-                      {post.title ?? post.slug}
-                    </h2>
-                    {post.description && (
-                      <p className="mt-2 line-clamp-2 text-sm text-slate-600">
-                        {post.description}
-                      </p>
-                    )}
-                    <div className="mt-3 flex items-center gap-2 text-sm text-slate-500">
-                      {post.authors && post.authors.length > 0 && (
-                        <>
-                          {post.authors.map((author, index) => (
-                            <div
-                              key={index}
-                              className="flex items-center gap-2"
-                            >
-                              {author.avatar ? (
-                                <img
-                                  src={author.avatar}
-                                  alt={author.name}
-                                  className="h-5 w-5 rounded-full object-cover"
-                                />
-                              ) : (
-                                <div className="flex h-5 w-5 items-center justify-center rounded-full bg-slate-300 text-xs font-medium text-slate-600">
-                                  {author.name.charAt(0)}
-                                </div>
-                              )}
-                              <span>{author.name}</span>
-                            </div>
-                          ))}
-                          {post.date && (
-                            <span className="text-slate-300">·</span>
-                          )}
-                        </>
-                      )}
-                      {post.date && <time>{formatDate(post.date)}</time>}
-                    </div>
-                  </div>
-                </article>
-              </Link>
-            ))}
-          </div>
+        <div className="mt-12 flex flex-col">
+          {posts.map((post, index) => (
+            <Link
+              key={post.slug}
+              to="/blog/$slug"
+              params={{ slug: post.slug }}
+              className={`group grid grid-cols-1 items-center gap-4 border-t border-line py-[30px] sm:grid-cols-[120px_236px_1fr] sm:gap-8 ${
+                index === posts.length - 1 ? "border-b" : ""
+              }`}
+            >
+              <span className="font-mono text-[12.5px] text-ink-faint">
+                {post.date ? formatDate(post.date) : ""}
+              </span>
+              {post.ogImage ? (
+                <img
+                  src={post.ogImage}
+                  alt={
+                    post.ogImageAlt ?? `${post.title ?? post.slug} cover image`
+                  }
+                  className="block aspect-[1.91/1] w-full max-w-[236px] rounded-lg border border-line bg-white object-cover"
+                />
+              ) : (
+                <span
+                  className="flex aspect-[1.91/1] w-full max-w-[236px] items-center justify-center rounded-lg border border-line"
+                  style={{
+                    backgroundImage:
+                      "repeating-linear-gradient(135deg, #F4F2EC 0px, #F4F2EC 8px, #FBFAF7 8px, #FBFAF7 16px)",
+                  }}
+                >
+                  <span className="rounded-[5px] border border-line bg-paper px-[9px] py-[5px] font-mono text-[11px] text-ink-faint">
+                    no og image
+                  </span>
+                </span>
+              )}
+              <span className="flex flex-col gap-2">
+                <span className="text-xl font-bold tracking-[-0.015em] text-ink transition-colors group-hover:text-cyan-deep">
+                  {post.title ?? post.slug}
+                </span>
+                {post.description && (
+                  <span className="text-[15px] leading-[1.6] text-ink-muted">
+                    {post.description}
+                  </span>
+                )}
+              </span>
+            </Link>
+          ))}
         </div>
       </main>
       <Footer />
@@ -266,8 +216,9 @@ function formatDate(dateString: string): string {
     const date = new Date(dateString);
     return date.toLocaleDateString("en-US", {
       year: "numeric",
-      month: "long",
+      month: "short",
       day: "numeric",
+      timeZone: "UTC",
     });
   } catch {
     return dateString;

--- a/website/src/routes/index.tsx
+++ b/website/src/routes/index.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { Header } from "../components/header";
-import { LandingReadme } from "../components/landing-page";
+import LandingPage from "../components/landing-page";
 import markdownPageCss from "../components/markdown-page.style.css?url";
 import { loadReadmeContent } from "../lib/readme-content";
 import {
@@ -81,10 +80,5 @@ export const Route = createFileRoute("/")({
 function HomeRoute() {
   const { html } = Route.useLoaderData();
 
-  return (
-    <>
-      <Header />
-      <LandingReadme readmeHtml={html} />
-    </>
-  );
+  return <LandingPage readmeHtml={html} />;
 }

--- a/website/src/routes/plugins/$pluginKey.tsx
+++ b/website/src/routes/plugins/$pluginKey.tsx
@@ -55,7 +55,7 @@ export const Route = createFileRoute("/plugins/$pluginKey")({
 
 function PluginsComingSoonPage() {
   return (
-    <div className="min-h-screen bg-white text-slate-900">
+    <div className="min-h-screen bg-paper text-ink">
       <Header />
       <main className="mx-auto flex min-h-[60vh] w-full max-w-3xl flex-col justify-center px-6 py-24 text-center">
         <p className="text-sm font-medium uppercase tracking-wide text-[#0891B2]">

--- a/website/src/routes/plugins/index.tsx
+++ b/website/src/routes/plugins/index.tsx
@@ -55,7 +55,7 @@ export const Route = createFileRoute("/plugins/")({
 
 function PluginsComingSoonPage() {
   return (
-    <div className="min-h-screen bg-white text-slate-900">
+    <div className="min-h-screen bg-paper text-ink">
       <Header />
       <main className="mx-auto flex min-h-[60vh] w-full max-w-3xl flex-col justify-center px-6 py-24 text-center">
         <p className="text-sm font-medium uppercase tracking-wide text-[#0891B2]">

--- a/website/src/routes/readme.tsx
+++ b/website/src/routes/readme.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { Footer } from "../components/footer";
 import { Header } from "../components/header";
-import { LandingReadme } from "../components/landing-page";
 import markdownPageCss from "../components/markdown-page.style.css?url";
 import { loadReadmeContent } from "../lib/readme-content";
 import {
@@ -62,9 +62,32 @@ function ReadmeRoute() {
   const { html } = Route.useLoaderData();
 
   return (
-    <>
+    <div className="flex min-h-screen flex-col bg-paper text-ink">
       <Header />
-      <LandingReadme readmeHtml={html} />
-    </>
+      <main className="mx-auto w-full max-w-[880px] flex-1 px-8 pb-[104px] pt-[72px]">
+        <div className="overflow-hidden rounded-xl border border-line bg-white">
+          <div className="flex flex-wrap items-center justify-between gap-5 border-b border-line-soft bg-[#FDFCFA] px-7 py-3.5">
+            <span className="font-mono text-[12.5px] text-ink-faint">
+              README.md · opral/lix
+            </span>
+            <a
+              href="https://github.com/opral/lix"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-mono text-[12.5px] text-ink-muted transition-colors hover:text-cyan-deep"
+            >
+              view on GitHub →
+            </a>
+          </div>
+          <div className="max-w-[800px] px-6 pb-12 pt-10 sm:px-12">
+            <article
+              className="markdown-wc-body"
+              dangerouslySetInnerHTML={{ __html: html }}
+            />
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
   );
 }

--- a/website/src/routes/rfc/$slug.tsx
+++ b/website/src/routes/rfc/$slug.tsx
@@ -255,7 +255,7 @@ function RfcPage() {
   }, [html]);
 
   return (
-    <div className="flex min-h-screen flex-col bg-white text-slate-900">
+    <div className="flex min-h-screen flex-col bg-paper text-ink">
       <Header />
       <main className="flex-1">
         <div className="mx-auto max-w-4xl px-6 py-12">

--- a/website/src/routes/rfc/index.tsx
+++ b/website/src/routes/rfc/index.tsx
@@ -125,7 +125,7 @@ function RfcIndexPage() {
   const { rfcs } = Route.useLoaderData();
 
   return (
-    <div className="flex min-h-screen flex-col bg-white text-slate-900">
+    <div className="flex min-h-screen flex-col bg-paper text-ink">
       <Header />
       <main className="flex-1">
         <div className="mx-auto max-w-4xl px-6 py-16">

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -1,24 +1,36 @@
-@import url("https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap");
 @import "tailwindcss";
+
+@theme {
+  --font-sans:
+    "Public Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica,
+    sans-serif;
+  --font-mono:
+    "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    monospace;
+
+  /* Lix design tokens */
+  --color-paper: #fbfaf7;
+  --color-ink: #15171b;
+  --color-ink-secondary: #3d4046;
+  --color-ink-muted: #6b7076;
+  --color-ink-faint: #8a8f96;
+  --color-line: #e6e4dd;
+  --color-line-strong: #e0ded6;
+  --color-line-soft: #edebe4;
+  --color-cyan-bright: #07b6d5;
+  --color-cyan-deep: #0891ac;
+}
 
 body {
   @apply m-0;
-  font-family:
-    Inter,
-    ui-sans-serif,
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    sans-serif;
+  font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  color: #213547;
-  background: #ffffff;
+  color: #15171b;
+  background: #fbfaf7;
 }
 
 code {
-  font-family:
-    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
-    "Courier New", monospace;
+  font-family: var(--font-mono);
 }


### PR DESCRIPTION
## What changed

- Rebuilt the website to the new design: Public Sans + JetBrains Mono, paper background (`#FBFAF7`), new header (wordmark, nav, GitHub star chip) and footer, homepage with hero, stats row, adoption chart, "What you get" section, README card, and CTA. Blog index/post pages and the docs layout (sidebar / content / "On this page") match the new designs.
- Download stats are statically pulled: `website/scripts/update-npm-downloads.mjs` writes coarse weekly buckets (rounded to 1k) to `website/src/npm-downloads.gen.json`, committed on purpose via a gitignore exception. A new scheduled workflow (`update-download-stats.yml`, Mondays 06:23 UTC) refreshes and commits it, triggering a redeploy.
- The chart offers only 90d / 6m / 12M ranges with a left value axis; the headline stat rounds down to the nearest 10k (currently >440k weekly downloads).
- Quoted the YAML frontmatter description in `docs/surfaces.md` that crashed `/docs/surfaces` (unquoted `: ` parsed as a nested mapping).

## Notes for review

- The buttondown newsletter subscribe forms on blog pages are not part of the new designs and were removed.
- Blog covers are rendered above the article; a leading standalone image is stripped from the post body to avoid showing the cover twice.
- Website tests (29) pass, `tsc` is clean, and the production build prerenders all pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)