### PR TITLE
refactor(engine): make commit state physically immutable

### DIFF
--- a/packages/engine/src/changelog/bench_support.rs
+++ b/packages/engine/src/changelog/bench_support.rs
@@ -229,14 +229,10 @@ pub fn append_ordered_commits(
             .checked_add(offset)
             .ok_or_else(|| LixError::unknown("ordered benchmark commit index overflow"))?;
         append.commits.push(CommitRecord {
-            format_version: 1,
+            format_version: 2,
             commit_id: CommitId::new(ordered_bench_uuid(commit_index, 0)),
             generation: 0,
             parent_commit_ids: Vec::new(),
-            tracked_state_rootless: false,
-            tracked_state_rootless_depth: 0,
-            tracked_state_rootless_rows: 0,
-            tracked_state_rootless_bytes: 0,
             change_id: ChangeId::new(ordered_bench_uuid(commit_index, 1)),
             account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             created_at: crate::common::LixTimestamp::expect_parse(
@@ -256,14 +252,10 @@ pub fn append_ordered_linear_commits(commit_count: usize) -> Result<BenchAppend,
     for commit_index in 0..commit_count {
         let commit_id = CommitId::new(ordered_bench_uuid(commit_index, 0));
         append.commits.push(CommitRecord {
-            format_version: 1,
+            format_version: 2,
             commit_id,
             generation: u64::try_from(commit_index).expect("benchmark commit index fits u64"),
             parent_commit_ids: parent_commit_id.into_iter().collect(),
-            tracked_state_rootless: false,
-            tracked_state_rootless_depth: 0,
-            tracked_state_rootless_rows: 0,
-            tracked_state_rootless_bytes: 0,
             change_id: ChangeId::new(ordered_bench_uuid(commit_index, 1)),
             account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             created_at: crate::common::LixTimestamp::expect_parse(
@@ -622,14 +614,10 @@ fn direct_append_with_shape(
             next_change += 1;
         }
         append.commits.push(CommitRecord {
-            format_version: 1,
+            format_version: 2,
             commit_id: typed_commit_id,
             generation: 0,
             parent_commit_ids: Vec::new(),
-            tracked_state_rootless: false,
-            tracked_state_rootless_depth: 0,
-            tracked_state_rootless_rows: 0,
-            tracked_state_rootless_bytes: 0,
             change_id: ChangeId::for_test_label(&commit_change_id),
             account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             created_at: crate::common::LixTimestamp::expect_parse(

--- a/packages/engine/src/changelog/types.rs
+++ b/packages/engine/src/changelog/types.rs
@@ -313,25 +313,13 @@ pub(crate) struct ChangelogAppend {
 #[derive(Clone, Debug, Eq, PartialEq, musli::Encode, musli::Decode)]
 #[musli(packed)]
 pub(crate) struct CommitRecord {
+    /// Version 2 removes physical replay policy from the semantic commit row.
     pub(crate) format_version: u32,
     pub(crate) commit_id: CommitId,
     /// Longest-path distance from a graph root. Every parent has a strictly
     /// smaller generation, enabling bounded priority graph walks.
     pub(crate) generation: u64,
     pub(crate) parent_commit_ids: Vec<CommitId>,
-    /// Normal serial tracked commits carry all required state in the
-    /// changelog/delta index and intentionally omit an immutable root. Root
-    /// fences remain the topology and checkpoint fallback.
-    pub(crate) tracked_state_rootless: bool,
-    /// First-parent distance from the nearest rooted commit. Zero means this
-    /// commit is rooted; rootless intervals use this to schedule bounded
-    /// automatic root fences without graph walks on the write path.
-    pub(crate) tracked_state_rootless_depth: u16,
-    /// Cumulative delta rows since the nearest rooted first-parent ancestor.
-    /// This bounds foreground replay work independently of commit depth.
-    pub(crate) tracked_state_rootless_rows: u64,
-    /// Conservative encoded/payload work estimate for the same interval.
-    pub(crate) tracked_state_rootless_bytes: u64,
     pub(crate) change_id: ChangeId,
     pub(crate) account_id: String,
     pub(crate) created_at: LixTimestamp,

--- a/packages/engine/src/checkpoint.rs
+++ b/packages/engine/src/checkpoint.rs
@@ -427,14 +427,10 @@ mod tests {
 
     fn commit_record(id: CommitId, generation: u64, parent: Option<CommitId>) -> CommitRecord {
         CommitRecord {
-            format_version: 1,
+            format_version: 2,
             commit_id: id,
             generation,
             parent_commit_ids: parent.into_iter().collect(),
-            tracked_state_rootless: false,
-            tracked_state_rootless_depth: 0,
-            tracked_state_rootless_rows: 0,
-            tracked_state_rootless_bytes: 0,
             change_id: ChangeId::for_test_label(&format!("{id}-change")),
             account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             created_at: timestamp(),

--- a/packages/engine/src/commit_graph/context.rs
+++ b/packages/engine/src/commit_graph/context.rs
@@ -400,18 +400,7 @@ fn commit_graph_node_from_authority(
             ),
         ));
     };
-    let manifest_rootless = manifest.replay_debt.depth > 0;
-    if record.commit_id != manifest.commit_id
-        || record.generation != manifest.generation
-        || record.parent_commit_ids != manifest.parent_commit_ids
-        || record.change_id != manifest.commit_change_id
-        || record.account_id != manifest.account_id
-        || record.created_at != manifest.created_at
-        || record.tracked_state_rootless != manifest_rootless
-        || record.tracked_state_rootless_depth != manifest.replay_debt.depth
-        || record.tracked_state_rootless_rows != manifest.replay_debt.rows
-        || record.tracked_state_rootless_bytes != manifest.replay_debt.bytes
-    {
+    if record.commit_id != manifest.commit_id {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
             format!(
@@ -420,12 +409,12 @@ fn commit_graph_node_from_authority(
         ));
     }
     Ok(Some(CommitGraphNode {
-        commit_id: manifest.commit_id,
-        change_id: manifest.commit_change_id,
-        account_id: manifest.account_id,
-        generation: manifest.generation,
-        parent_commit_ids: manifest.parent_commit_ids,
-        created_at: manifest.created_at,
+        commit_id: record.commit_id,
+        change_id: record.change_id,
+        account_id: record.account_id,
+        generation: record.generation,
+        parent_commit_ids: record.parent_commit_ids,
+        created_at: record.created_at,
     }))
 }
 
@@ -660,11 +649,7 @@ mod tests {
             &mut writes,
             &CommitStateManifest {
                 commit_id,
-                generation: 0,
-                parent_commit_ids: Vec::new(),
-                commit_change_id: change_id("retained-payload-authority-change"),
-                account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
-                created_at: ts("2026-01-01T00:00:00Z"),
+                change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 replay_debt: CommitStateReplayDebt {
                     depth: 1,
                     rows: 0,
@@ -673,7 +658,6 @@ mod tests {
                 mutations: CommitStateMutationInventory::default(),
                 touched_scope_filter: Default::default(),
                 current_state_scoped_ranges: None,
-                snapshot_root: None,
             },
         )
         .expect("retained payload authority should stage");
@@ -724,12 +708,6 @@ mod tests {
                 commit_id.as_uuid().as_bytes(),
             )),
         );
-        writes.delete(
-            crate::tracked_state::TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
-            StorageKey(bytes::Bytes::copy_from_slice(
-                commit_id.as_uuid().as_bytes(),
-            )),
-        );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
@@ -745,50 +723,6 @@ mod tests {
             .await
             .expect_err("a changelog projection cannot replace missing authority");
         assert!(error.message.contains("has no commit-state authority"));
-    }
-
-    #[tokio::test]
-    async fn load_node_rejects_changelog_projection_drift() {
-        let storage = StorageAdapter::new(Memory::new());
-        append_changes(
-            &storage,
-            &[commit_change(
-                "drift-authority-change",
-                "drift-authority",
-                &[],
-                &[],
-            )],
-        )
-        .await;
-        let commit_id = commit_id("drift-authority");
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("authority read should open");
-        let mut manifest = crate::tracked_state::load_commit_state_manifest(&read, commit_id)
-            .await
-            .expect("authority should load")
-            .expect("authority should exist");
-        drop(read);
-        manifest.commit_change_id = change_id("different-authority-change");
-        let mut writes = storage.new_write_set();
-        crate::tracked_state::stage_resealed_commit_state_manifest_for_test(&mut writes, &manifest)
-            .expect("drifted but structurally valid authority should stage");
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("drifted authority should commit");
-
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("read should open");
-        let error = CommitGraphContext::new()
-            .reader(read)
-            .load_node(&commit_id)
-            .await
-            .expect_err("projection drift must fail closed");
-        assert!(error.message.contains("projection disagrees"));
     }
 
     #[tokio::test]
@@ -997,14 +931,10 @@ mod tests {
             .stage_append(ChangelogAppend {
                 changes: Vec::new(),
                 commits: vec![CommitRecord {
-                    format_version: 1,
+                    format_version: 2,
                     commit_id,
                     generation: 0,
                     parent_commit_ids: Vec::new(),
-                    tracked_state_rootless: true,
-                    tracked_state_rootless_depth: 1,
-                    tracked_state_rootless_rows: 3,
-                    tracked_state_rootless_bytes: 0,
                     change_id: change_id("selected-tombstone-commit-change"),
                     account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                     created_at,
@@ -1071,11 +1001,7 @@ mod tests {
             &mut writes,
             &CommitStateManifest {
                 commit_id,
-                generation: 0,
-                parent_commit_ids: Vec::new(),
-                commit_change_id: change_id("selected-tombstone-commit-change"),
-                account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
-                created_at,
+                change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 replay_debt: CommitStateReplayDebt {
                     depth: 1,
                     rows: 3,
@@ -1084,7 +1010,6 @@ mod tests {
                 mutations: staged.mutation_inventory().clone(),
                 touched_scope_filter: Default::default(),
                 current_state_scoped_ranges: None,
-                snapshot_root: None,
             },
         )
         .expect("selected tombstone commit-state manifest should stage");
@@ -1504,16 +1429,10 @@ mod tests {
             }
 
             append.commits.push(CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id,
                 generation,
                 parent_commit_ids: change.parent_commit_ids.clone(),
-                tracked_state_rootless: true,
-                tracked_state_rootless_depth: u16::try_from(generation + 1)
-                    .expect("test commit generation should fit replay depth"),
-                tracked_state_rootless_rows: u64::try_from(members.len())
-                    .expect("test member count should fit u64"),
-                tracked_state_rootless_bytes: 0,
                 change_id: change.change.id,
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: change.change.created_at,
@@ -1576,20 +1495,16 @@ mod tests {
             writes,
             &CommitStateManifest {
                 commit_id: record.commit_id,
-                generation: record.generation,
-                parent_commit_ids: record.parent_commit_ids.clone(),
-                commit_change_id: record.change_id,
-                account_id: record.account_id.clone(),
-                created_at: record.created_at,
+                change_account_id: record.account_id.clone(),
                 replay_debt: CommitStateReplayDebt {
-                    depth: record.tracked_state_rootless_depth,
-                    rows: record.tracked_state_rootless_rows,
-                    bytes: record.tracked_state_rootless_bytes,
+                    depth: u16::try_from(record.generation + 1)
+                        .expect("test generation should fit replay depth"),
+                    rows: u64::from(mutations.member_count),
+                    bytes: 0,
                 },
                 mutations,
                 touched_scope_filter: Default::default(),
                 current_state_scoped_ranges: None,
-                snapshot_root: None,
             },
         )
         .expect("test commit-state manifest should stage");
@@ -1598,14 +1513,10 @@ mod tests {
     fn append_empty_commit(append: &mut ChangelogAppend, commit_id: CommitId) {
         let change_id = format!("{commit_id}-change");
         append.commits.push(CommitRecord {
-            format_version: 1,
+            format_version: 2,
             commit_id,
             generation: 0,
             parent_commit_ids: Vec::new(),
-            tracked_state_rootless: true,
-            tracked_state_rootless_depth: 1,
-            tracked_state_rootless_rows: 0,
-            tracked_state_rootless_bytes: 0,
             change_id: ChangeId::for_test_label(&change_id),
             account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             created_at: ts("2026-01-01T00:00:00Z"),

--- a/packages/engine/src/commit_graph/walker.rs
+++ b/packages/engine/src/commit_graph/walker.rs
@@ -355,14 +355,10 @@ mod tests {
             crate::changelog::COMMIT_SPACE,
             StorageKey(Bytes::copy_from_slice(requested.as_uuid().as_bytes())),
             crate::changelog::encode_commit_record(&CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id: embedded,
                 generation: 0,
                 parent_commit_ids: Vec::new(),
-                tracked_state_rootless: false,
-                tracked_state_rootless_depth: 0,
-                tracked_state_rootless_rows: 0,
-                tracked_state_rootless_bytes: 0,
                 change_id: ChangeId::for_test_label("mismatched-key-change"),
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: ts("2026-01-01T00:00:00Z"),
@@ -398,14 +394,10 @@ mod tests {
         for (label, parent) in [("commit-a", "commit-b"), ("commit-b", "commit-a")] {
             let commit_id = commit_id(label);
             let record = CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id,
                 generation: 1,
                 parent_commit_ids: commit_ids([parent]),
-                tracked_state_rootless: true,
-                tracked_state_rootless_depth: 1,
-                tracked_state_rootless_rows: 0,
-                tracked_state_rootless_bytes: 0,
                 change_id: ChangeId::for_test_label(&format!("{label}-change")),
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: ts("2026-01-01T00:00:00Z"),
@@ -692,14 +684,10 @@ mod tests {
         let child = commit_id("commit-child");
         let mut writes = storage.new_write_set();
         let record = CommitRecord {
-            format_version: 1,
+            format_version: 2,
             commit_id: child,
             generation: 0,
             parent_commit_ids: commit_ids(["commit-root"]),
-            tracked_state_rootless: true,
-            tracked_state_rootless_depth: 2,
-            tracked_state_rootless_rows: 0,
-            tracked_state_rootless_bytes: 0,
             change_id: ChangeId::for_test_label("commit-child-change"),
             account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             created_at: ts("2026-01-01T00:00:00Z"),
@@ -1021,15 +1009,10 @@ mod tests {
                 .map_or(0, |parent_generation| parent_generation + 1);
             let typed_commit_id = CommitId::for_test_label(&commit_id);
             append.commits.push(CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id: typed_commit_id,
                 generation,
                 parent_commit_ids,
-                tracked_state_rootless: true,
-                tracked_state_rootless_depth: u16::try_from(generation + 1)
-                    .expect("test generation should fit replay depth"),
-                tracked_state_rootless_rows: 0,
-                tracked_state_rootless_bytes: 0,
                 change_id: change.change.id,
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: change.change.created_at,
@@ -1059,20 +1042,16 @@ mod tests {
             writes,
             &CommitStateManifest {
                 commit_id: record.commit_id,
-                generation: record.generation,
-                parent_commit_ids: record.parent_commit_ids.clone(),
-                commit_change_id: record.change_id,
-                account_id: record.account_id.clone(),
-                created_at: record.created_at,
+                change_account_id: record.account_id.clone(),
                 replay_debt: CommitStateReplayDebt {
-                    depth: record.tracked_state_rootless_depth,
-                    rows: record.tracked_state_rootless_rows,
-                    bytes: record.tracked_state_rootless_bytes,
+                    depth: u16::try_from(record.generation + 1)
+                        .expect("test generation should fit replay depth"),
+                    rows: 0,
+                    bytes: 0,
                 },
                 mutations: CommitStateMutationInventory::default(),
                 touched_scope_filter: Default::default(),
                 current_state_scoped_ranges: None,
-                snapshot_root: None,
             },
         )
     }

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -1017,6 +1017,10 @@ where
         COMMIT_SPACE,
         sweep_commits.iter().map(|commit_id| commit_key(*commit_id)),
     );
+    // Snapshot roots are rebuildable commit-addressed projections. Delete
+    // them with their semantic commit even when a selected-source relationship
+    // keeps the immutable mutation manifest alive for another commit.
+    crate::tracked_state::stage_delete_snapshot_commit_roots(writes, sweep_commits.iter().copied());
     stage_sweep_unreachable_content_nodes(
         store,
         writes,
@@ -2007,6 +2011,7 @@ mod tests {
                     .cloned()
                     .unwrap_or_default(),
             );
+            stage_test_snapshot_root(&mut writes, record.commit_id);
         }
         let sidecar_schema = Arc::new(Schema::new(vec![Field::new(
             "value",
@@ -2135,6 +2140,20 @@ mod tests {
             .expect("post-GC packed inventory should scan");
         assert!(inventory.commits.contains_key(&live_parent));
         assert!(inventory.commits.contains_key(&dead_commit));
+        assert!(
+            crate::tracked_state::load_snapshot_commit_root(&read, &live_parent.to_string())
+                .await
+                .expect("live snapshot-root lookup should succeed")
+                .is_some(),
+            "the live commit keeps its snapshot projection"
+        );
+        assert!(
+            crate::tracked_state::load_snapshot_commit_root(&read, &dead_commit.to_string())
+                .await
+                .expect("dead snapshot-root lookup should succeed")
+                .is_none(),
+            "a swept semantic commit must not remain readable through an orphan snapshot root"
+        );
         assert!(
             crate::columnar_row_group::load_row_group_manifest(
                 &read,
@@ -2401,6 +2420,34 @@ mod tests {
     ) {
         stage_commit_state_manifest(writes, &test_commit_state_manifest(record, mutations))
             .expect("GC fixture commit-state manifest should stage");
+    }
+
+    fn stage_test_snapshot_root(
+        writes: &mut crate::storage_adapter::StorageWriteSet,
+        commit_id: CommitId,
+    ) {
+        let root = crate::tracked_state::TrackedStateCommitRoot {
+            commit_id,
+            root_id: crate::tracked_state::TrackedStateRootId::new(
+                *blake3::hash(commit_id.as_uuid().as_bytes()).as_bytes(),
+            ),
+            parent_roots: Vec::new(),
+            changed_key_count: 1,
+            row_count_estimate: 1,
+            tree_height: 1,
+            primary_chunk_count: 1,
+            primary_chunk_bytes: 64,
+        };
+        writes.put(
+            crate::tracked_state::TRACKED_STATE_SNAPSHOT_ROOT_SPACE,
+            StorageKey(Bytes::copy_from_slice(commit_id.as_uuid().as_bytes())),
+            StorageValue {
+                bytes: Bytes::from(
+                    crate::storage_codec::encode("tracked-state snapshot root", &root)
+                        .expect("GC fixture snapshot root should encode"),
+                ),
+            },
+        );
     }
 
     fn test_commit_state_manifest(

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -593,37 +593,17 @@ where
         pending.extend(commits.parent_commit_ids(commit).iter().copied());
     }
 
-    // GC is destructive, so the hard-cut commit-state manifest must be
-    // present and agree with every live changelog topology projection before
-    // payload reachability or sweep mutations are derived. Missing authority
-    // must not silently turn a live commit into an empty mutation owner.
+    // GC is destructive, so every live semantic commit must have an immutable
+    // physical manifest before payload reachability or sweep mutations are
+    // derived. Missing physical authority must not silently turn a live commit
+    // into an empty mutation owner.
     for commit_id in &live_commits {
-        let commit = commits
-            .get(*commit_id)
-            .expect("live commit existence was checked during graph walk");
-        let authority = packed.commits.get(commit_id).ok_or_else(|| {
+        packed.commits.get(commit_id).ok_or_else(|| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 format!("live commit '{commit_id}' has no commit-state authority"),
             )
         })?;
-        let topology = &authority.authority;
-        let manifest_rootless = topology.replay_debt.depth > 0;
-        if topology.generation != commit.generation
-            || topology.parent_commit_ids != commits.parent_commit_ids(commit)
-            || topology.commit_change_id != commit.change_id
-            || topology.account_id != commit.account_id
-            || topology.created_at != commit.created_at
-            || manifest_rootless != commit.tracked_state_rootless
-            || topology.replay_debt.depth != commit.tracked_state_rootless_depth
-            || topology.replay_debt.rows != commit.tracked_state_rootless_rows
-            || topology.replay_debt.bytes != commit.tracked_state_rootless_bytes
-        {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("live commit '{commit_id}' disagrees with its commit-state authority"),
-            ));
-        }
     }
 
     // Mutation parts are immutable: direct ChangeIds encode their physical
@@ -1116,14 +1096,7 @@ where
 #[derive(Clone, Debug)]
 struct GcCommitInventoryEntry {
     commit_id: CommitId,
-    generation: u64,
-    tracked_state_rootless: bool,
-    tracked_state_rootless_depth: u16,
-    tracked_state_rootless_rows: u64,
-    tracked_state_rootless_bytes: u64,
     change_id: ChangeId,
-    account_id: String,
-    created_at: crate::common::LixTimestamp,
     parent_start: usize,
     parent_len: usize,
 }
@@ -1186,14 +1159,7 @@ where
                 .extend(commit.parent_commit_ids.into_iter());
             commits.entries.push(GcCommitInventoryEntry {
                 commit_id: commit.commit_id,
-                generation: commit.generation,
-                tracked_state_rootless: commit.tracked_state_rootless,
-                tracked_state_rootless_depth: commit.tracked_state_rootless_depth,
-                tracked_state_rootless_rows: commit.tracked_state_rootless_rows,
-                tracked_state_rootless_bytes: commit.tracked_state_rootless_bytes,
                 change_id: commit.change_id,
-                account_id: commit.account_id,
-                created_at: commit.created_at,
                 parent_start,
                 parent_len,
             });
@@ -1711,73 +1677,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn authority_gc_rejects_live_topology_drift_before_staging_deletes() {
-        let storage = StorageAdapter::new(Memory::new());
-        let live = gc_authority_record("gc-live-authority-drift");
-        let mut read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("authority-drift fixture read should open");
-        let mut writes = storage.new_write_set();
-        ChangelogContext::new()
-            .writer(&mut read, &mut writes)
-            .stage_append(ChangelogAppend {
-                commits: vec![live.clone()],
-                changes: Vec::new(),
-            })
-            .await
-            .expect("authority-drift commit should stage");
-        let mut drifted = CommitStateManifest {
-            commit_id: live.commit_id,
-            generation: live.generation,
-            parent_commit_ids: live.parent_commit_ids.clone(),
-            commit_change_id: live.change_id,
-            account_id: live.account_id.clone(),
-            created_at: live.created_at,
-            replay_debt: CommitStateReplayDebt {
-                depth: live.tracked_state_rootless_depth,
-                rows: live.tracked_state_rootless_rows,
-                bytes: live.tracked_state_rootless_bytes,
-            },
-            mutations: CommitStateMutationInventory::default(),
-            touched_scope_filter: Default::default(),
-            current_state_scoped_ranges: None,
-            snapshot_root: None,
-        };
-        drifted.generation += 1;
-        stage_commit_state_manifest(&mut writes, &drifted)
-            .expect("internally valid but projection-drifted authority should stage");
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("authority-drift fixture should commit");
-
-        let read = SharedStorageAdapterRead::new(
-            storage
-                .begin_read(StorageReadOptions::default())
-                .await
-                .expect("authority-drift GC read should open"),
-        );
-        let mut gc_writes = storage.new_write_set();
-        let error = super::plan_and_stage_authority_gc(
-            &read,
-            &mut gc_writes,
-            &[GcRoot::BranchHead(live.commit_id)],
-        )
-        .await
-        .expect_err("GC must reject topology projection drift");
-        assert!(
-            error
-                .message
-                .contains("disagrees with its commit-state authority")
-        );
-        assert!(
-            gc_writes.is_empty(),
-            "authority validation must precede every destructive GC mutation"
-        );
-    }
-
-    #[tokio::test]
     async fn authority_gc_retains_tombstone_only_checkpoint_alias_source() {
         let storage = Memory::new();
         let storage_adapter = StorageAdapter::new(storage);
@@ -1799,53 +1698,37 @@ mod tests {
             LixTimestamp::expect_parse("tombstone alias timestamp", "2026-01-01T00:00:00Z");
         let commits = [
             CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id: source_commit,
                 generation: 0,
                 parent_commit_ids: Vec::new(),
-                tracked_state_rootless: true,
-                tracked_state_rootless_depth: 1,
-                tracked_state_rootless_rows: 1,
-                tracked_state_rootless_bytes: 1,
                 change_id: ChangeId::for_test_label("gc-tombstone-alias-source-header"),
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: timestamp,
             },
             CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id: alias_commit,
                 generation: 0,
                 parent_commit_ids: Vec::new(),
-                tracked_state_rootless: true,
-                tracked_state_rootless_depth: 1,
-                tracked_state_rootless_rows: 1,
-                tracked_state_rootless_bytes: 1,
                 change_id: ChangeId::for_test_label("gc-tombstone-alias-live-header"),
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: timestamp,
             },
             CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id: authority_commit,
                 generation: 0,
                 parent_commit_ids: Vec::new(),
-                tracked_state_rootless: true,
-                tracked_state_rootless_depth: 1,
-                tracked_state_rootless_rows: 1,
-                tracked_state_rootless_bytes: 1,
                 change_id: ChangeId::for_test_label("gc-tombstone-alias-authority-header"),
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: timestamp,
             },
             CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id: live_head,
                 generation: 1,
                 parent_commit_ids: vec![alias_commit, authority_commit],
-                tracked_state_rootless: true,
-                tracked_state_rootless_depth: 2,
-                tracked_state_rootless_rows: 2,
-                tracked_state_rootless_bytes: 2,
                 change_id: ChangeId::for_test_label("gc-tombstone-alias-head-header"),
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: timestamp,
@@ -2058,40 +1941,28 @@ mod tests {
             LixTimestamp::expect_parse("authority GC timestamp", "2026-01-01T00:00:00.000Z");
         let commits = vec![
             CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id: live_parent,
                 generation: 0,
                 parent_commit_ids: Vec::new(),
-                tracked_state_rootless: true,
-                tracked_state_rootless_depth: 1,
-                tracked_state_rootless_rows: 1,
-                tracked_state_rootless_bytes: 1,
                 change_id: ChangeId::for_test_label("authority-gc-live-parent-header"),
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: timestamp,
             },
             CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id: live_head,
                 generation: 1,
                 parent_commit_ids: vec![live_parent],
-                tracked_state_rootless: true,
-                tracked_state_rootless_depth: 2,
-                tracked_state_rootless_rows: 2,
-                tracked_state_rootless_bytes: 2,
                 change_id: ChangeId::for_test_label("authority-gc-live-head-header"),
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: timestamp,
             },
             CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id: dead_commit,
                 generation: 0,
                 parent_commit_ids: Vec::new(),
-                tracked_state_rootless: true,
-                tracked_state_rootless_depth: 1,
-                tracked_state_rootless_rows: 1,
-                tracked_state_rootless_bytes: 1,
                 change_id: ChangeId::for_test_label("authority-gc-dead-header"),
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: timestamp,
@@ -2484,14 +2355,10 @@ mod tests {
 
     fn gc_authority_record(label: &str) -> CommitRecord {
         CommitRecord {
-            format_version: 1,
+            format_version: 2,
             commit_id: CommitId::for_test_label(label),
             generation: 0,
             parent_commit_ids: Vec::new(),
-            tracked_state_rootless: true,
-            tracked_state_rootless_depth: 1,
-            tracked_state_rootless_rows: 0,
-            tracked_state_rootless_bytes: 0,
             change_id: ChangeId::for_test_label(&format!("{label}-header")),
             account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             created_at: LixTimestamp::expect_parse(
@@ -2542,20 +2409,15 @@ mod tests {
     ) -> CommitStateManifest {
         CommitStateManifest {
             commit_id: record.commit_id,
-            generation: record.generation,
-            parent_commit_ids: record.parent_commit_ids.clone(),
-            commit_change_id: record.change_id,
-            account_id: record.account_id.clone(),
-            created_at: record.created_at,
+            change_account_id: record.account_id.clone(),
             replay_debt: CommitStateReplayDebt {
-                depth: record.tracked_state_rootless_depth,
-                rows: record.tracked_state_rootless_rows,
-                bytes: record.tracked_state_rootless_bytes,
+                depth: 1,
+                rows: u64::from(mutations.member_count),
+                bytes: u64::from(mutations.member_count),
             },
             mutations,
             touched_scope_filter: Default::default(),
             current_state_scoped_ranges: None,
-            snapshot_root: None,
         }
     }
 

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -42,14 +42,13 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 
 /// Repository-wide compatibility gate for physical storage protocols.
 ///
-/// V56 separates semantic graph ancestry from physical current-state ancestry.
-/// A serving root authenticates the exact commit/root it structurally reuses,
-/// including merge targets and selected sources. Older repositories must fail
-/// closed rather than reinterpret a first-parent root as this stronger proof.
+/// V57 makes commit-state manifests immutable physical authority. Semantic
+/// commit facts remain owned exclusively by `changelog.commit`, while the
+/// rebuildable snapshot-root projection lives in its own mutable space.
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::mutable(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"authenticated-serving-base-lineage.v56";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"immutable-physical-commit-state.v57";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately
@@ -411,22 +410,23 @@ where
                 &initial_mutations,
             )
             .await?;
-        crate::tracked_state::stage_certified_commit_state_manifest(
+        let initial_state =
+            crate::tracked_state::stage_certified_commit_state_manifest_with_handle(
+                &mut writes,
+                &CommitStateManifest {
+                    commit_id: plan.commit.id,
+                    change_account_id: plan.commit.account_id.clone(),
+                    replay_debt: CommitStateReplayDebt::default(),
+                    mutations: initial_mutations,
+                    touched_scope_filter: physical_publication.touched_scope_filter().clone(),
+                    current_state_scoped_ranges: physical_publication.root(),
+                },
+                &physical_publication,
+            )?;
+        crate::tracked_state::stage_staged_commit_state_snapshot_root(
             &mut writes,
-            &CommitStateManifest {
-                commit_id: plan.commit.id,
-                generation: 0,
-                parent_commit_ids: plan.commit.parent_ids.clone(),
-                commit_change_id: plan.commit.change_id,
-                account_id: plan.commit.account_id.clone(),
-                created_at: plan.commit.created_at,
-                replay_debt: CommitStateReplayDebt::default(),
-                mutations: initial_mutations,
-                touched_scope_filter: physical_publication.touched_scope_filter().clone(),
-                current_state_scoped_ranges: physical_publication.root(),
-                snapshot_root: Some(snapshot_root),
-            },
-            &physical_publication,
+            &initial_state,
+            snapshot_root,
         )?;
 
         // Seed both visible branches with a complete hot current-state generation.
@@ -606,14 +606,10 @@ async fn stage_init_changelog_commit(
     changes: Vec<ChangeRecord>,
 ) -> Result<(), LixError> {
     let commit = CommitRecord {
-        format_version: 1,
+        format_version: 2,
         commit_id: plan.commit.id,
         generation: 0,
         parent_commit_ids: plan.commit.parent_ids.clone(),
-        tracked_state_rootless: false,
-        tracked_state_rootless_depth: 0,
-        tracked_state_rootless_rows: 0,
-        tracked_state_rootless_bytes: 0,
         change_id: plan.commit.change_id,
         account_id: plan.commit.account_id.clone(),
         created_at: plan.commit.created_at,

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -2749,14 +2749,10 @@ mod tests {
             let commit_id_text = CommitId::for_test_label(commit_id).to_string();
             let commit_change_id = format!("{commit_id_text}:commit");
             let record = crate::changelog::CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id: CommitId::for_test_label(&commit_id_text),
                 generation: 0,
                 parent_commit_ids: Vec::new(),
-                tracked_state_rootless: false,
-                tracked_state_rootless_depth: 0,
-                tracked_state_rootless_rows: 0,
-                tracked_state_rootless_bytes: 0,
                 change_id: ChangeId::for_test_label(&commit_change_id),
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: ts("1970-01-01T00:00:00.000Z"),
@@ -2788,23 +2784,24 @@ mod tests {
             let record = records
                 .get(&typed_commit_id)
                 .expect("empty commit record should exist");
-            stage_commit_state_manifest(
+            let staged = crate::tracked_state::stage_commit_state_manifest_with_handle(
                 &mut writes,
                 &CommitStateManifest {
                     commit_id: record.commit_id,
-                    generation: record.generation,
-                    parent_commit_ids: record.parent_commit_ids.clone(),
-                    commit_change_id: record.change_id,
-                    account_id: record.account_id.clone(),
-                    created_at: record.created_at,
+                    change_account_id: record.account_id.clone(),
                     replay_debt: CommitStateReplayDebt::default(),
                     mutations: Default::default(),
                     touched_scope_filter: Default::default(),
                     current_state_scoped_ranges: None,
-                    snapshot_root: Some(snapshot_root),
                 },
             )
             .expect("empty commit-state authority should stage");
+            crate::tracked_state::stage_staged_commit_state_snapshot_root(
+                &mut writes,
+                &staged,
+                snapshot_root,
+            )
+            .expect("empty snapshot root should stage");
         }
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -2990,15 +2987,10 @@ mod tests {
         for (commit_id, generation, parents) in [(parent, 0, Vec::new()), (child, 1, vec![parent])]
         {
             append.commits.push(crate::changelog::CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id,
                 generation,
                 parent_commit_ids: parents,
-                tracked_state_rootless: true,
-                tracked_state_rootless_depth: u16::try_from(generation + 1)
-                    .expect("fixture generation should fit replay depth"),
-                tracked_state_rootless_rows: 0,
-                tracked_state_rootless_bytes: 0,
                 change_id: ChangeId::for_test_label(&format!("{commit_id}:change")),
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: ts("1970-01-01T00:00:00.000Z"),
@@ -3016,20 +3008,16 @@ mod tests {
                 &mut writes,
                 &CommitStateManifest {
                     commit_id: record.commit_id,
-                    generation: record.generation,
-                    parent_commit_ids: record.parent_commit_ids,
-                    commit_change_id: record.change_id,
-                    account_id: record.account_id,
-                    created_at: record.created_at,
+                    change_account_id: record.account_id.clone(),
                     replay_debt: CommitStateReplayDebt {
-                        depth: record.tracked_state_rootless_depth,
-                        rows: record.tracked_state_rootless_rows,
-                        bytes: record.tracked_state_rootless_bytes,
+                        depth: u16::try_from(record.generation + 1)
+                            .expect("fixture generation should fit replay depth"),
+                        rows: 0,
+                        bytes: 0,
                     },
                     mutations: Default::default(),
                     touched_scope_filter: Default::default(),
                     current_state_scoped_ranges: None,
-                    snapshot_root: None,
                 },
             )
             .expect("mixed derived commit authority should stage");
@@ -3176,14 +3164,10 @@ mod tests {
                 .map(|id| CommitId::for_test_label(id))
                 .collect::<Vec<_>>();
             let record = crate::changelog::CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id: CommitId::for_test_label(&commit_id),
                 generation,
                 parent_commit_ids: typed_parent_ids,
-                tracked_state_rootless: false,
-                tracked_state_rootless_depth: 0,
-                tracked_state_rootless_rows: 0,
-                tracked_state_rootless_bytes: 0,
                 change_id: ChangeId::for_test_label(&commit_change_id),
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: commit_created_at,
@@ -3234,21 +3218,21 @@ mod tests {
                 .cloned()
                 .ok_or_else(|| LixError::unknown("test materialization did not stage a root"))?;
             drop(root_writer);
-            stage_commit_state_manifest(
+            let staged = crate::tracked_state::stage_commit_state_manifest_with_handle(
                 writes,
                 &CommitStateManifest {
                     commit_id: record.commit_id,
-                    generation: record.generation,
-                    parent_commit_ids: record.parent_commit_ids,
-                    commit_change_id: record.change_id,
-                    account_id: record.account_id,
-                    created_at: record.created_at,
+                    change_account_id: record.account_id.clone(),
                     replay_debt: CommitStateReplayDebt::default(),
                     mutations: mutation_inventory,
                     touched_scope_filter: Default::default(),
                     current_state_scoped_ranges: None,
-                    snapshot_root: Some(snapshot_root),
                 },
+            )?;
+            crate::tracked_state::stage_staged_commit_state_snapshot_root(
+                writes,
+                &staged,
+                snapshot_root,
             )?;
         }
 

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -4124,6 +4124,7 @@ fn sql_uses_public_filesystem_path_surface(sql: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::changelog::{ChangelogContext, ChangelogReader, CommitLoadRequest};
     use crate::entity_pk::EntityPk;
     use crate::telemetry::{
         CallbackTelemetrySink, CompletedTelemetrySpan, TelemetrySpanKind, TelemetryValue,
@@ -5087,8 +5088,6 @@ mod tests {
 
     #[tokio::test]
     async fn large_certified_insert_publishes_rootless_history_and_reads_packed_head() {
-        use crate::changelog::{ChangelogContext, ChangelogReader, CommitLoadRequest};
-
         const ROW_COUNT: usize = 32 * 1_024;
         let session = open_session().await;
         let schema = serde_json::json!({
@@ -5176,25 +5175,16 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("history read should open");
-        let head_commit_ids = [head.commit_id];
-        let commits = ChangelogContext::new()
-            .reader(&history_read)
-            .load_commits(CommitLoadRequest {
-                commit_ids: &head_commit_ids,
-            })
-            .await
-            .expect("head commit should load");
-        let record = commits
-            .into_iter()
-            .next()
-            .and_then(|(_, record)| record)
-            .expect("head commit should exist");
-        assert!(record.tracked_state_rootless);
-        assert!(record.tracked_state_rootless_depth >= 1);
-        assert!(record.tracked_state_rootless_rows >= ROW_COUNT as u64);
-        assert!(record.tracked_state_rootless_bytes > record.tracked_state_rootless_rows);
+        let commit_state =
+            crate::tracked_state::load_commit_state_manifest(&history_read, head.commit_id)
+                .await
+                .expect("head physical state should load")
+                .expect("head physical state should exist");
+        assert!(commit_state.replay_debt.depth >= 1);
+        assert!(commit_state.replay_debt.rows >= ROW_COUNT as u64);
+        assert!(commit_state.replay_debt.bytes > commit_state.replay_debt.rows);
         assert!(
-            crate::tracked_state::load_authoritative_commit_root(
+            crate::tracked_state::load_snapshot_commit_root(
                 &history_read,
                 &head.commit_id.to_string(),
             )
@@ -5260,36 +5250,28 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("descendant history read should open");
-        let descendant_commit_ids = [descendant.commit_id];
-        let descendant_commits = ChangelogContext::new()
-            .reader(&descendant_history_read)
-            .load_commits(CommitLoadRequest {
-                commit_ids: &descendant_commit_ids,
-            })
-            .await
-            .expect("descendant commit should load");
-        let descendant_record = descendant_commits
-            .into_iter()
-            .next()
-            .and_then(|(_, record)| record)
-            .expect("descendant commit should exist");
+        let descendant_state = crate::tracked_state::load_commit_state_manifest(
+            &descendant_history_read,
+            descendant.commit_id,
+        )
+        .await
+        .expect("descendant physical state should load")
+        .expect("descendant physical state should exist");
         assert!(
-            descendant_record.tracked_state_rootless,
+            descendant_state.replay_debt.depth > 0,
             "a sparse descendant must extend the rootless first-parent interval"
         );
         assert_eq!(
-            descendant_record.tracked_state_rootless_depth,
-            record.tracked_state_rootless_depth + 1
+            descendant_state.replay_debt.depth,
+            commit_state.replay_debt.depth + 1
         );
         assert_eq!(
-            descendant_record.tracked_state_rootless_rows,
-            record.tracked_state_rootless_rows + 1
+            descendant_state.replay_debt.rows,
+            commit_state.replay_debt.rows + 1
         );
+        assert!(descendant_state.replay_debt.bytes > commit_state.replay_debt.bytes);
         assert!(
-            descendant_record.tracked_state_rootless_bytes > record.tracked_state_rootless_bytes
-        );
-        assert!(
-            crate::tracked_state::load_authoritative_commit_root(
+            crate::tracked_state::load_snapshot_commit_root(
                 &descendant_history_read,
                 &descendant.commit_id.to_string(),
             )
@@ -5405,21 +5387,12 @@ mod tests {
             .await
             .expect("reseed head should load")
             .expect("reseed head should exist");
-        let reseed_commit_ids = [reseed_head.commit_id];
-        let reseed_commits = ChangelogContext::new()
-            .reader(&reseed_read)
-            .load_commits(CommitLoadRequest {
-                commit_ids: &reseed_commit_ids,
-            })
-            .await
-            .expect("reseed commit should load");
-        let reseed_record = reseed_commits
-            .into_iter()
-            .next()
-            .and_then(|(_, record)| record)
-            .expect("reseed commit should exist");
-        assert!(reseed_record.tracked_state_rootless);
-        assert!(reseed_record.tracked_state_rootless_depth >= 1);
+        let reseed_state =
+            crate::tracked_state::load_commit_state_manifest(&reseed_read, reseed_head.commit_id)
+                .await
+                .expect("reseed physical state should load")
+                .expect("reseed physical state should exist");
+        assert!(reseed_state.replay_debt.depth >= 1);
 
         let mut rooted_fence = None;
         for generation_offset in 1..=32 {
@@ -5442,25 +5415,15 @@ mod tests {
                 .await
                 .expect("root-fence head should load")
                 .expect("root-fence head should exist");
-            let fence_commit_ids = [head.commit_id];
-            let commits = ChangelogContext::new()
-                .reader(&read)
-                .load_commits(CommitLoadRequest {
-                    commit_ids: &fence_commit_ids,
-                })
+            let state = crate::tracked_state::load_commit_state_manifest(&read, head.commit_id)
                 .await
-                .expect("root-fence commit should load");
-            let record = commits
-                .into_iter()
-                .next()
-                .and_then(|(_, record)| record)
-                .expect("root-fence commit should exist");
-            if !record.tracked_state_rootless {
-                assert_eq!(record.tracked_state_rootless_depth, 0);
-                assert_eq!(record.tracked_state_rootless_rows, 0);
-                assert_eq!(record.tracked_state_rootless_bytes, 0);
+                .expect("root-fence physical state should load")
+                .expect("root-fence physical state should exist");
+            if state.replay_debt.depth == 0 {
+                assert_eq!(state.replay_debt.rows, 0);
+                assert_eq!(state.replay_debt.bytes, 0);
                 assert!(
-                    crate::tracked_state::load_authoritative_commit_root(
+                    crate::tracked_state::load_snapshot_commit_root(
                         &read,
                         &head.commit_id.to_string(),
                     )
@@ -5727,7 +5690,20 @@ mod tests {
             .columnar_parts
             .as_ref()
             .expect("fixture must publish column pages as sole mutation authority");
-        assert_eq!(commit_state.account_id, crate::SYSTEM_ACCOUNT_ID);
+        let semantic_commit_ids = [commit_state.commit_id];
+        let commit_records = ChangelogContext::new()
+            .reader(&read)
+            .load_commits(CommitLoadRequest {
+                commit_ids: &semantic_commit_ids,
+            })
+            .await
+            .expect("typed lifecycle semantic owner should load");
+        let semantic_owner = commit_records
+            .into_iter()
+            .next()
+            .and_then(|(_, record)| record)
+            .expect("typed lifecycle semantic owner should exist");
+        assert_eq!(semantic_owner.account_id, crate::SYSTEM_ACCOUNT_ID);
         assert!(commit_state.mutations.inline_part.is_empty());
         assert!(commit_state.mutations.parts.is_empty());
         assert_eq!(columnar_parts.page_first_keys.len(), 33);

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -1725,12 +1725,11 @@ mod tests {
             .expect("repeat repository gc plan");
 
         assert_eq!(first.swept_commits, 10);
-        // Each unreachable commit removes its changelog projection and the
-        // unified commit-state authority. The hard cut retired the separate
-        // tracked-root record.
-        assert_eq!(first.staged_deletes, 20);
-        assert_eq!(first.key_shared_buffers, 2);
-        assert_eq!(first.key_shared_bytes, 20 * 16);
+        // Each unreachable commit removes its changelog projection, immutable
+        // commit-state authority, and rebuildable snapshot-root projection.
+        assert_eq!(first.staged_deletes, 30);
+        assert_eq!(first.key_shared_buffers, 3);
+        assert_eq!(first.key_shared_bytes, 30 * 16);
         assert_eq!(second.swept_commits, first.swept_commits);
         assert_eq!(second.staged_deletes, first.staged_deletes);
     }

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -24,13 +24,7 @@ fn stage_bench_commit_deltas(
         writes,
         &crate::tracked_state::CommitStateManifest {
             commit_id,
-            generation: 0,
-            parent_commit_ids: Vec::new(),
-            commit_change_id: crate::changelog::ChangeId::for_test_label(&format!(
-                "{commit_id}:bench-commit"
-            )),
-            account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
-            created_at: crate::common::LixTimestamp::from_unix_millis_utc_lossy(0),
+            change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             replay_debt: crate::tracked_state::CommitStateReplayDebt {
                 depth: 1,
                 rows: u64::from(mutations.member_count),
@@ -39,7 +33,6 @@ fn stage_bench_commit_deltas(
             mutations,
             touched_scope_filter: Default::default(),
             current_state_scoped_ranges: None,
-            snapshot_root: None,
         },
     )?;
     Ok(staged.locators)

--- a/packages/engine/src/test_support.rs
+++ b/packages/engine/src/test_support.rs
@@ -538,32 +538,29 @@ fn stage_test_commit_state_manifest(
     mutations: CommitStateMutationInventory,
     snapshot_root: Option<TrackedStateCommitRoot>,
 ) -> Result<(), crate::LixError> {
-    let record = &staged.record;
     let replay_debt = if snapshot_root.is_some() {
         CommitStateReplayDebt::default()
     } else {
-        CommitStateReplayDebt {
-            depth: record.tracked_state_rootless_depth,
-            rows: record.tracked_state_rootless_rows,
-            bytes: record.tracked_state_rootless_bytes,
-        }
+        staged.replay_debt
     };
-    crate::tracked_state::stage_commit_state_manifest(
-        writes,
-        &CommitStateManifest {
-            commit_id: record.commit_id,
-            generation: record.generation,
-            parent_commit_ids: record.parent_commit_ids.clone(),
-            commit_change_id: record.change_id,
-            account_id: record.account_id.clone(),
-            created_at: record.created_at,
-            replay_debt,
-            mutations,
-            touched_scope_filter: Default::default(),
-            current_state_scoped_ranges: None,
+    let manifest = CommitStateManifest {
+        commit_id: staged.record.commit_id,
+        change_account_id: staged.record.account_id.clone(),
+        replay_debt,
+        mutations,
+        touched_scope_filter: Default::default(),
+        current_state_scoped_ranges: None,
+    };
+    let staged_manifest =
+        crate::tracked_state::stage_commit_state_manifest_with_handle(writes, &manifest)?;
+    if let Some(snapshot_root) = snapshot_root {
+        crate::tracked_state::stage_staged_commit_state_snapshot_root(
+            writes,
+            &staged_manifest,
             snapshot_root,
-        },
-    )
+        )?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -673,23 +670,22 @@ async fn stage_test_changelog_commit(
             commit_ids: &typed_parent_ids,
         })
         .await?;
+    let parent_manifests =
+        crate::tracked_state::load_commit_state_manifests(&*read, &typed_parent_ids).await?;
+    let first_parent_debt = parent_manifests
+        .first()
+        .and_then(Option::as_ref)
+        .map_or(CommitStateReplayDebt::default(), |manifest| {
+            manifest.replay_debt
+        });
     let tracked_state_rootless_depth = if tracked_state_rootless {
-        parent_records
-            .iter()
-            .next()
-            .and_then(|(_, record)| record)
-            .map_or(1, |record| {
-                record.tracked_state_rootless_depth.saturating_add(1)
-            })
+        first_parent_debt.depth.saturating_add(1)
     } else {
         0
     };
     let tracked_state_rootless_rows = if tracked_state_rootless {
-        parent_records
-            .iter()
-            .next()
-            .and_then(|(_, record)| record)
-            .map_or(0, |record| record.tracked_state_rootless_rows)
+        first_parent_debt
+            .rows
             .saturating_add(u64::try_from(rows.len()).unwrap_or(u64::MAX))
     } else {
         0
@@ -730,14 +726,10 @@ async fn stage_test_changelog_commit(
         .map(|row| crate::common::LixTimestamp::expect_parse("created_at", &row.created_at))
         .unwrap_or_else(test_timestamp);
     let record = CommitRecord {
-        format_version: 1,
+        format_version: 2,
         commit_id: typed_commit_id,
         generation,
         parent_commit_ids: typed_parent_ids,
-        tracked_state_rootless,
-        tracked_state_rootless_depth,
-        tracked_state_rootless_rows,
-        tracked_state_rootless_bytes,
         change_id: typed_commit_change_id,
         account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
         created_at,
@@ -748,12 +740,18 @@ async fn stage_test_changelog_commit(
     change_commit_ids.sort_by_key(|(row_index, _)| *row_index);
     Ok(TestStagedChangelogCommit {
         record,
+        replay_debt: CommitStateReplayDebt {
+            depth: tracked_state_rootless_depth,
+            rows: tracked_state_rootless_rows,
+            bytes: tracked_state_rootless_bytes,
+        },
         change_commit_ids,
     })
 }
 
 struct TestStagedChangelogCommit {
     record: CommitRecord,
+    replay_debt: CommitStateReplayDebt,
     change_commit_ids: Vec<(usize, CommitId)>,
 }
 

--- a/packages/engine/src/tracked_state/bench_support.rs
+++ b/packages/engine/src/tracked_state/bench_support.rs
@@ -28,11 +28,7 @@ fn stage_bench_commit_deltas(
         writes,
         &CommitStateManifest {
             commit_id,
-            generation: 0,
-            parent_commit_ids: Vec::new(),
-            commit_change_id: ChangeId::for_test_label(&format!("{commit_id}:bench-commit")),
-            account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
-            created_at: crate::common::LixTimestamp::from_unix_millis_utc_lossy(0),
+            change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             replay_debt: CommitStateReplayDebt {
                 depth: 1,
                 rows: u64::from(mutations.member_count),
@@ -41,7 +37,6 @@ fn stage_bench_commit_deltas(
             mutations,
             touched_scope_filter: Default::default(),
             current_state_scoped_ranges: None,
-            snapshot_root: None,
         },
     )?;
     Ok(staged.locators)
@@ -523,11 +518,7 @@ where
         .expect("stage benchmark merge serving root");
         let merged = CommitStateManifest {
             commit_id: merge_id,
-            generation: self.current_manifest.generation.saturating_add(1),
-            parent_commit_ids: vec![self.current_manifest.commit_id, other_id],
-            commit_change_id: ChangeId::for_test_label("scoped-range-empty-merge-change"),
-            account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
-            created_at: crate::common::LixTimestamp::from_unix_millis_utc_lossy(33),
+            change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             replay_debt: CommitStateReplayDebt {
                 depth: self
                     .current_manifest
@@ -541,7 +532,6 @@ where
             mutations,
             touched_scope_filter: publication.touched_scope_filter().clone(),
             current_state_scoped_ranges: publication.root(),
-            snapshot_root: None,
         };
         super::storage::stage_certified_commit_state_manifest(&mut writes, &merged, &publication)
             .expect("stage certified benchmark merge manifest");
@@ -734,7 +724,7 @@ fn bench_addressable_commit_id(label: &str) -> CommitId {
 
 fn bench_current_state_manifest(
     commit_id: CommitId,
-    parent_commit_id: Option<CommitId>,
+    _parent_commit_id: Option<CommitId>,
     replay_depth: u16,
     mutations: super::types::CommitStateMutationInventory,
     touched_scope_filter: super::types::CommitStateTouchedScopeFilter,
@@ -742,11 +732,7 @@ fn bench_current_state_manifest(
 ) -> CommitStateManifest {
     CommitStateManifest {
         commit_id,
-        generation: 0,
-        parent_commit_ids: parent_commit_id.into_iter().collect(),
-        commit_change_id: ChangeId::for_test_label(&format!("{commit_id}:bench-state")),
-        account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
-        created_at: crate::common::LixTimestamp::from_unix_millis_utc_lossy(0),
+        change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
         replay_debt: CommitStateReplayDebt {
             depth: replay_depth,
             rows: u64::from(mutations.member_count),
@@ -755,7 +741,6 @@ fn bench_current_state_manifest(
         mutations,
         touched_scope_filter,
         current_state_scoped_ranges,
-        snapshot_root: None,
     }
 }
 

--- a/packages/engine/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/engine/src/tracked_state/commit_root_rebuild.rs
@@ -149,8 +149,7 @@ where
         if !seen.insert(commit_id.to_string()) {
             return Ok(None);
         }
-        let Some(metadata) = storage::load_authoritative_commit_root(store, commit_id).await?
-        else {
+        let Some(metadata) = storage::load_snapshot_commit_root(store, commit_id).await? else {
             seen.remove(commit_id);
             return Ok(None);
         };

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -969,7 +969,7 @@ pub(crate) struct TrackedStateStoreReader<S> {
     /// in one snapshot, so resolving neighbouring observed revisions never
     /// reloads the same changelog records.
     point_replay_commits: HashMap<CommitId, PointReplayCommit>,
-    /// Shares decoded immutable manifests between rootless topology discovery
+    /// Shares decoded immutable manifests between rootless layout discovery
     /// and the later delta scan in this storage snapshot.
     commit_delta_point_cache: storage::CommitDeltaPointReadCache,
 }
@@ -1636,7 +1636,7 @@ where
             }
 
             let current_metadata =
-                storage::load_authoritative_commit_root(&self.store, &current_commit_id).await?;
+                storage::load_snapshot_commit_root(&self.store, &current_commit_id).await?;
             let (parent_commit_id, parent_value, current_is_rootless) = if let Some(metadata) =
                 current_metadata
             {
@@ -1867,7 +1867,7 @@ where
         if let Some(metadata) = cache.commit_root_metadata.get(commit_id) {
             return Ok(metadata.clone());
         }
-        let metadata = storage::load_authoritative_commit_root(&self.store, commit_id)
+        let metadata = storage::load_snapshot_commit_root(&self.store, commit_id)
             .await?
             .ok_or_else(|| missing_commit_root_error(commit_id))?;
         cache
@@ -1884,11 +1884,9 @@ where
         if let Some(root_id) = cache.commit_roots.get(commit_id) {
             return Ok(root_id.clone());
         }
-        let typed_commit_id = CommitId::parse_lix(
-            commit_id,
-            "tracked-state optional authoritative root lookup",
-        )?;
-        let manifest = storage::load_commit_state_manifest(&self.store, typed_commit_id)
+        let typed_commit_id =
+            CommitId::parse_lix(commit_id, "tracked-state optional snapshot root lookup")?;
+        storage::load_commit_state_manifest(&self.store, typed_commit_id)
             .await?
             .ok_or_else(|| {
                 LixError::new(
@@ -1898,7 +1896,9 @@ where
                     ),
                 )
             })?;
-        let root_id = manifest.snapshot_root.map(|root| root.root_id);
+        let root_id = storage::load_snapshot_commit_root(&self.store, commit_id)
+            .await?
+            .map(|root| root.root_id);
         cache
             .commit_roots
             .insert(commit_id.to_string(), root_id.clone());
@@ -1965,9 +1965,7 @@ where
         change_created_at: crate::common::LixTimestamp,
     ) -> Result<(), LixError> {
         let mut expected_created_at = change_created_at;
-        if let Some(metadata) =
-            storage::load_authoritative_commit_root(&self.store, commit_id).await?
-        {
+        if let Some(metadata) = storage::load_snapshot_commit_root(&self.store, commit_id).await? {
             if let Some(parent) = metadata.parent_roots.first() {
                 let parent_value = self
                     .tree
@@ -2074,7 +2072,7 @@ where
     ) -> Result<Option<crate::common::LixTimestamp>, LixError> {
         let row_commit_id = row.commit_id.to_string();
         let Some(metadata) =
-            storage::load_authoritative_commit_root(&self.store, &row_commit_id).await?
+            storage::load_snapshot_commit_root(&self.store, &row_commit_id).await?
         else {
             return Ok(None);
         };
@@ -3467,36 +3465,10 @@ where
                     ),
                 )
             })?;
-        if manifest.generation != record.generation
-            || manifest.parent_commit_ids != record.parent_commit_ids
-            || manifest.commit_change_id != record.change_id
-            || manifest.account_id != record.account_id
-            || manifest.created_at != record.created_at
-        {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "tracked_state commit_state_manifest disagrees with the topology projection for commit '{commit_id}'"
-                ),
-            ));
-        }
-        let root_id = manifest
-            .snapshot_root
-            .as_ref()
-            .map(|root| root.root_id.clone());
+        let root_id = storage::load_snapshot_commit_root(&self.store, &commit_id.to_string())
+            .await?
+            .map(|root| root.root_id);
         let rootless = manifest.replay_debt.depth > 0;
-        if rootless != record.tracked_state_rootless
-            || manifest.replay_debt.depth != record.tracked_state_rootless_depth
-            || manifest.replay_debt.rows != record.tracked_state_rootless_rows
-            || manifest.replay_debt.bytes != record.tracked_state_rootless_bytes
-        {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "tracked_state commit_state_manifest disagrees with the replay projection for commit '{commit_id}'"
-                ),
-            ));
-        }
         let replacement_generation = if rootless && manifest.mutations.member_count != 0 {
             storage::seed_commit_delta_point_cache_from_replay_manifest(
                 &manifest,
@@ -3507,7 +3479,7 @@ where
             None
         };
         let replay_commit = PointReplayCommit {
-            parent_commit_id: manifest.parent_commit_ids.first().copied(),
+            parent_commit_id: record.parent_commit_ids.first().copied(),
             root_id,
             rootless,
             replacement_generation,
@@ -3766,9 +3738,9 @@ where
                     format!("tracked-state staged root for commit '{commit_id}' is missing"),
                 )
             })?;
-        let mut staged_manifests = Vec::with_capacity(self.staged_roots.len());
+        let mut staged_commit_states = Vec::with_capacity(self.staged_roots.len());
         for metadata in self.staged_roots.values() {
-            let mut manifest = storage::load_commit_state_manifest(self.store, metadata.commit_id)
+            let manifest = storage::load_commit_state_manifest(self.store, metadata.commit_id)
                 .await?
                 .ok_or_else(|| {
                     LixError::new(
@@ -3779,13 +3751,12 @@ where
                         ),
                     )
                 })?;
-            manifest.snapshot_root = Some(metadata.clone());
-            staged_manifests.push(manifest);
+            staged_commit_states.push((manifest, metadata.clone()));
         }
-        let read = storage::TrackedStateStagedRead::with_commit_state_manifests(
+        let read = storage::TrackedStateStagedRead::with_commit_state_roots(
             self.store,
             &self.chunk_overlay,
-            staged_manifests,
+            staged_commit_states,
         )?;
         TrackedStateContext::new()
             .reader(read)
@@ -3834,8 +3805,7 @@ where
                 let metadata = match self.staged_roots.get(parent_commit_id) {
                     Some(metadata) => Some(metadata.clone()),
                     None => {
-                        storage::load_authoritative_commit_root(self.store, parent_commit_id)
-                            .await?
+                        storage::load_snapshot_commit_root(self.store, parent_commit_id).await?
                     }
                 };
                 let Some(metadata) = metadata else {
@@ -4231,7 +4201,7 @@ where
         let parent_metadata = match parent_commit_id {
             Some(parent_commit_id) => Some(match self.staged_roots.get(parent_commit_id) {
                 Some(metadata) => metadata.clone(),
-                None => storage::load_authoritative_commit_root(self.store, parent_commit_id)
+                None => storage::load_snapshot_commit_root(self.store, parent_commit_id)
                     .await?
                     .ok_or_else(|| {
                         LixError::new(
@@ -4963,33 +4933,16 @@ mod tests {
         writes: &mut StorageWriteSet,
         snapshot_root: TrackedStateCommitRoot,
     ) -> Result<(), LixError> {
-        let parent_commit_ids = snapshot_root
-            .parent_roots
-            .iter()
-            .map(|parent| parent.commit_id)
-            .collect::<Vec<_>>();
-        storage::stage_commit_state_manifest(
-            writes,
-            &crate::tracked_state::CommitStateManifest {
-                commit_id: snapshot_root.commit_id,
-                generation: u64::from(!parent_commit_ids.is_empty()),
-                parent_commit_ids,
-                commit_change_id: ChangeId::for_test_label(&format!(
-                    "{}:snapshot-authority",
-                    snapshot_root.commit_id
-                )),
-                account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
-                created_at: crate::common::LixTimestamp::expect_parse(
-                    "snapshot authority created_at",
-                    "1970-01-01T00:00:00.000Z",
-                ),
-                replay_debt: Default::default(),
-                mutations: Default::default(),
-                touched_scope_filter: Default::default(),
-                current_state_scoped_ranges: None,
-                snapshot_root: Some(snapshot_root),
-            },
-        )
+        let manifest = crate::tracked_state::CommitStateManifest {
+            commit_id: snapshot_root.commit_id,
+            change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
+            replay_debt: Default::default(),
+            mutations: Default::default(),
+            touched_scope_filter: Default::default(),
+            current_state_scoped_ranges: None,
+        };
+        let staged = storage::stage_commit_state_manifest_with_handle(writes, &manifest)?;
+        storage::stage_staged_commit_state_snapshot_root(writes, &staged, snapshot_root)
     }
 
     fn change_id(label: &str) -> String {
@@ -5023,6 +4976,10 @@ mod tests {
             let mut writes = storage.new_write_set();
             writes.delete(
                 storage::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+                commit_root_key("missing-parent"),
+            );
+            writes.delete(
+                storage::TRACKED_STATE_SNAPSHOT_ROOT_SPACE,
                 commit_root_key("missing-parent"),
             );
             storage
@@ -5080,7 +5037,7 @@ mod tests {
             .await
             .expect("child root should load")
             .expect("child root should exist");
-        let metadata = storage::load_authoritative_commit_root(&read, "child")
+        let metadata = storage::load_snapshot_commit_root(&read, "child")
             .await
             .expect("metadata should load")
             .expect("metadata should exist");
@@ -6456,7 +6413,7 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
-        let parent_metadata = storage::load_authoritative_commit_root(&read, "parent")
+        let parent_metadata = storage::load_snapshot_commit_root(&read, "parent")
             .await
             .expect("parent metadata should load")
             .expect("parent metadata should exist");
@@ -6487,7 +6444,7 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should reopen");
-        let child_metadata = storage::load_authoritative_commit_root(&read, "empty-child")
+        let child_metadata = storage::load_snapshot_commit_root(&read, "empty-child")
             .await
             .expect("child metadata should load")
             .expect("child metadata should exist");
@@ -6809,10 +6766,6 @@ mod tests {
                     storage::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
                     commit_root_key(commit_id),
                 );
-                writes.delete(
-                    storage::TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
-                    commit_root_key(commit_id),
-                );
             }
             storage
                 .commit_write_set(writes, StorageWriteOptions::default())
@@ -6873,39 +6826,37 @@ mod tests {
             let mut writes = storage.new_write_set();
             let commit_a = CommitId::for_test_label("commit-a");
             let commit_b = CommitId::for_test_label("commit-b");
-            let mut manifest = storage::load_commit_state_manifest(&read, commit_a)
+            let published = storage::load_published_commit_state_manifest(&read, commit_a)
                 .await
                 .expect("commit-a authority should load")
                 .expect("commit-a authority should exist");
-            manifest.generation = 2;
-            manifest.parent_commit_ids = vec![commit_b];
-            manifest
-                .snapshot_root
-                .as_mut()
-                .expect("commit-a should have a snapshot root")
-                .parent_roots = vec![TrackedStateCommitRootParent {
+            let mut snapshot_root = storage::load_snapshot_commit_root(&read, "commit-a")
+                .await
+                .expect("commit-a root should load")
+                .expect("commit-a root should exist");
+            snapshot_root.parent_roots = vec![TrackedStateCommitRootParent {
                 commit_id: commit_b,
                 root_id: storage::load_root(&read, "commit-b")
                     .await
                     .expect("commit-b root should load")
                     .expect("commit-b root should exist"),
             }];
-            storage::stage_resealed_commit_state_manifest_for_test(&mut writes, &manifest)
-                .expect("corrupt cycle authority should stage");
+            storage::stage_commit_state_snapshot_root_update(
+                &mut writes,
+                &published,
+                Some(snapshot_root),
+            )
+            .expect("corrupt cycle root should stage");
             writes.put(
                 crate::changelog::COMMIT_SPACE,
                 crate::storage_adapter::StorageKey(Bytes::copy_from_slice(
                     commit_a.as_uuid().as_bytes(),
                 )),
                 crate::changelog::encode_commit_record(&CommitRecord {
-                    format_version: 1,
+                    format_version: 2,
                     commit_id: commit_a,
-                    generation: manifest.generation,
+                    generation: 2,
                     parent_commit_ids: vec![commit_b],
-                    tracked_state_rootless: false,
-                    tracked_state_rootless_depth: 0,
-                    tracked_state_rootless_rows: 0,
-                    tracked_state_rootless_bytes: 0,
                     change_id: ChangeId::for_test_label("commit-a:commit"),
                     account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                     created_at: crate::common::LixTimestamp::expect_parse(
@@ -7121,11 +7072,11 @@ mod tests {
                 .await
                 .expect("repaired authority should load")
                 .expect("child authority should exist");
-        let repaired_root = storage::load_authoritative_commit_root(&authority_read, "child")
+        let repaired_root = storage::load_snapshot_commit_root(&authority_read, "child")
             .await
             .expect("repaired root should load")
             .expect("repaired root should exist");
-        assert_eq!(repaired_authority.snapshot_root, Some(repaired_root));
+        assert_eq!(repaired_root.commit_id, repaired_authority.commit_id);
         assert_eq!(repaired_authority.replay_debt, Default::default());
         drop(authority_read);
 
@@ -7723,7 +7674,7 @@ mod tests {
             .await
             .expect_err("materialization must reject missing packed authority");
         assert!(
-            error.message.contains("commit_state_manifest is missing"),
+            error.message.contains("missing from owning commit"),
             "unexpected error: {error}"
         );
     }
@@ -9070,11 +9021,12 @@ mod tests {
             .await
             .expect("commit-state authority should load")
             .expect("root fixture should publish commit-state authority");
-        stale_root.parent_roots = published
-            .snapshot_root
-            .as_ref()
-            .map(|root| root.parent_roots.clone())
-            .unwrap_or_default();
+        stale_root.parent_roots =
+            storage::load_snapshot_commit_root(&read, &typed_commit_id.to_string())
+                .await
+                .expect("published root should load")
+                .map(|root| root.parent_roots)
+                .unwrap_or_default();
         storage::stage_commit_state_snapshot_root_update(&mut writes, &published, Some(stale_root))
             .expect("stale authority should encode");
         storage

--- a/packages/engine/src/tracked_state/diff.rs
+++ b/packages/engine/src/tracked_state/diff.rs
@@ -1239,22 +1239,21 @@ mod tests {
         writes: &mut StorageWriteSet,
         snapshot_root: &TrackedStateCommitRoot,
     ) -> Result<(), LixError> {
-        let mut manifest =
-            crate::tracked_state::storage::load_unchecked_commit_state_manifest_for_test(
-                read,
-                snapshot_root.commit_id,
+        let manifest = crate::tracked_state::storage::load_published_commit_state_manifest(
+            read,
+            snapshot_root.commit_id,
+        )
+        .await?
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "corrupt-root fixture has no commit-state manifest",
             )
-            .await?
-            .ok_or_else(|| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "corrupt-root fixture has no commit-state manifest",
-                )
-            })?;
-        manifest.snapshot_root = Some(snapshot_root.clone());
-        manifest.replay_debt = Default::default();
-        crate::tracked_state::storage::stage_unchecked_commit_state_manifest_for_test(
-            writes, &manifest,
+        })?;
+        crate::tracked_state::storage::stage_commit_state_snapshot_root_update(
+            writes,
+            &manifest,
+            Some(snapshot_root.clone()),
         )
     }
 
@@ -3445,6 +3444,8 @@ mod tests {
                 .contains("does not match changelog first-parent winners")
             || error.message.contains("contains non-winner identity")
             || error.message.contains("but changelog first parent is")
+            || error.message.contains("but its first parent is")
+            || error.message.contains("more than one first-parent root")
             || error
                 .message
                 .contains("nearest available first-parent root")

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -70,9 +70,9 @@ pub(crate) use storage::{
     stage_current_state_scoped_ranges_from_published_parent,
     stage_current_state_scoped_ranges_from_staged_parent,
     stage_current_state_scoped_ranges_from_topology, stage_delete_change_locators,
-    stage_delete_commit_delta_inventory_entry, stage_ordered_addressable_commit_deltas,
-    stage_ordered_addressable_replacement_parts, stage_ordered_columnar_mutations,
-    stage_preencoded_ordered_addressable_replacement_parts,
+    stage_delete_commit_delta_inventory_entry, stage_delete_snapshot_commit_roots,
+    stage_ordered_addressable_commit_deltas, stage_ordered_addressable_replacement_parts,
+    stage_ordered_columnar_mutations, stage_preencoded_ordered_addressable_replacement_parts,
     stage_prefixed_ordered_addressable_replacement_parts, stage_staged_commit_state_snapshot_root,
     validate_current_state_scoped_range_serving_base_manifest,
 };
@@ -88,10 +88,12 @@ pub(crate) use storage::{
 };
 #[cfg(test)]
 pub(crate) use storage::{
-    change_id_from_packed_address, load_commit_delta_change_ids,
+    TRACKED_STATE_SNAPSHOT_ROOT_SPACE, change_id_from_packed_address, load_commit_delta_change_ids,
     load_complete_current_state_values_from_scoped_root, load_snapshot_commit_root,
     scan_commit_delta_members, stage_resealed_commit_state_manifest_for_test,
 };
+#[cfg(test)]
+pub(crate) use types::TrackedStateRootId;
 pub(crate) use types::{COMMIT_STATE_MAX_REPLAY_BYTES, COMMIT_STATE_MAX_REPLAY_DEPTH};
 pub(crate) use types::{
     ColumnarMutationPartSet, CommitDeltaLifecycleSummary, CommitStateManifest,

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -64,7 +64,7 @@ pub(crate) use storage::{
     load_owned_commit_delta_entries_one_ordered_ref, load_published_commit_state_manifest,
     scan_change_records_from_commit_deltas, scan_commit_delta_inventory, scan_commit_delta_values,
     selected_change_selection_fingerprint, stage_addressable_commit_deltas,
-    stage_addressable_commit_deltas_with_selected_source, stage_certified_commit_state_manifest,
+    stage_addressable_commit_deltas_with_selected_source,
     stage_certified_commit_state_manifest_with_handle, stage_change_locators,
     stage_commit_deltas_for_commit_state, stage_commit_state_manifest_with_handle,
     stage_current_state_scoped_ranges_from_published_parent,
@@ -73,7 +73,7 @@ pub(crate) use storage::{
     stage_delete_commit_delta_inventory_entry, stage_ordered_addressable_commit_deltas,
     stage_ordered_addressable_replacement_parts, stage_ordered_columnar_mutations,
     stage_preencoded_ordered_addressable_replacement_parts,
-    stage_prefixed_ordered_addressable_replacement_parts,
+    stage_prefixed_ordered_addressable_replacement_parts, stage_staged_commit_state_snapshot_root,
     validate_current_state_scoped_range_serving_base_manifest,
 };
 #[cfg(feature = "storage-benches")]
@@ -88,10 +88,9 @@ pub(crate) use storage::{
 };
 #[cfg(test)]
 pub(crate) use storage::{
-    TRACKED_STATE_COMMIT_STATE_SEAL_SPACE, change_id_from_packed_address,
-    load_authoritative_commit_root, load_commit_delta_change_ids,
-    load_complete_current_state_values_from_scoped_root, scan_commit_delta_members,
-    stage_resealed_commit_state_manifest_for_test,
+    change_id_from_packed_address, load_commit_delta_change_ids,
+    load_complete_current_state_values_from_scoped_root, load_snapshot_commit_root,
+    scan_commit_delta_members, stage_resealed_commit_state_manifest_for_test,
 };
 pub(crate) use types::{COMMIT_STATE_MAX_REPLAY_BYTES, COMMIT_STATE_MAX_REPLAY_DEPTH};
 pub(crate) use types::{

--- a/packages/engine/src/tracked_state/scoped_current_state.rs
+++ b/packages/engine/src/tracked_state/scoped_current_state.rs
@@ -1,7 +1,7 @@
 //! Manifest-specific authority for the payload-opaque scoped-range tree.
 //!
 //! The tree authenticates physical scope/range routing. This layer alone binds
-//! a tree transition to commit graph ancestry and sealed mutation authority.
+//! a tree transition to commit graph ancestry and certified mutation authority.
 
 use crate::changelog::CommitId;
 use crate::storage_adapter::{StorageAdapterRead, StorageWriteSet};
@@ -318,37 +318,13 @@ pub(crate) fn validate_touched_scope_filter(
 }
 
 /// Opaque proof that the physical serving projection was produced in this
-/// write set from the exact graph topology and sealed mutation inventory.
+/// write set from the exact graph topology and certified mutation inventory.
 pub(crate) struct CertifiedCommitStatePhysicalPublication {
     write_set_id: u64,
-    parent_commit_ids: CertifiedGraphParents,
+    commit_id: CommitId,
     selected_source_commit_id: Option<CommitId>,
     root: Option<CurrentStateScopedRangeRoot>,
     touched_scope_filter: CommitStateTouchedScopeFilter,
-}
-
-enum CertifiedGraphParents {
-    None,
-    One(CommitId),
-    Many(Vec<CommitId>),
-}
-
-impl CertifiedGraphParents {
-    fn from_manifests(parents: &[&CommitStateManifest]) -> Self {
-        match parents {
-            [] => Self::None,
-            [parent] => Self::One(parent.commit_id),
-            _ => Self::Many(parents.iter().map(|parent| parent.commit_id).collect()),
-        }
-    }
-
-    fn as_slice(&self) -> &[CommitId] {
-        match self {
-            Self::None => &[],
-            Self::One(parent) => std::slice::from_ref(parent),
-            Self::Many(parents) => parents,
-        }
-    }
 }
 
 impl CertifiedCommitStatePhysicalPublication {
@@ -356,12 +332,12 @@ impl CertifiedCommitStatePhysicalPublication {
         self.root.clone().map(Box::new)
     }
 
-    pub(crate) fn parent_commit_ids(&self) -> &[CommitId] {
-        self.parent_commit_ids.as_slice()
-    }
-
     pub(crate) fn selected_source_commit_id(&self) -> Option<CommitId> {
         self.selected_source_commit_id
+    }
+
+    pub(crate) fn commit_id(&self) -> CommitId {
+        self.commit_id
     }
 
     pub(crate) fn write_set_id(&self) -> u64 {
@@ -404,7 +380,7 @@ pub(super) fn certify_topology_touched_scope_filter_from_manifests(
     };
     Ok(CertifiedCommitStatePhysicalPublication {
         write_set_id: writes.identity(),
-        parent_commit_ids: CertifiedGraphParents::from_manifests(parents),
+        commit_id,
         selected_source_commit_id,
         root: None,
         touched_scope_filter: advance_touched_scope_filter(
@@ -588,7 +564,6 @@ pub(crate) async fn stage_current_state_scoped_ranges(
     account_id: &str,
     inventory: &CommitStateMutationInventory,
 ) -> Result<CertifiedCommitStatePhysicalPublication, LixError> {
-    let parent_commit_ids = CertifiedGraphParents::from_manifests(graph_parents);
     let selected_source_commit_id = selected_source.map(|source| source.commit_id);
     if selected_source_commit_id != inventory.selected_source_commit_id() {
         return Err(scoped_state_error(
@@ -629,7 +604,7 @@ pub(crate) async fn stage_current_state_scoped_ranges(
             extend_touched_scope_filter(inherited_scope_filter, filter_touched.as_deref())?;
         return Ok(CertifiedCommitStatePhysicalPublication {
             write_set_id: writes.identity(),
-            parent_commit_ids,
+            commit_id,
             selected_source_commit_id,
             root,
             touched_scope_filter,
@@ -653,7 +628,7 @@ pub(crate) async fn stage_current_state_scoped_ranges(
         .await?;
         return Ok(CertifiedCommitStatePhysicalPublication {
             write_set_id: writes.identity(),
-            parent_commit_ids,
+            commit_id,
             selected_source_commit_id,
             root,
             touched_scope_filter,
@@ -663,7 +638,7 @@ pub(crate) async fn stage_current_state_scoped_ranges(
     let Some(mut touched) = touched else {
         return Ok(CertifiedCommitStatePhysicalPublication {
             write_set_id: writes.identity(),
-            parent_commit_ids,
+            commit_id,
             selected_source_commit_id,
             root: None,
             touched_scope_filter,
@@ -672,7 +647,7 @@ pub(crate) async fn stage_current_state_scoped_ranges(
     let Some(parent_root) = parent_root else {
         return Ok(CertifiedCommitStatePhysicalPublication {
             write_set_id: writes.identity(),
-            parent_commit_ids,
+            commit_id,
             selected_source_commit_id,
             root: None,
             touched_scope_filter,
@@ -681,7 +656,7 @@ pub(crate) async fn stage_current_state_scoped_ranges(
     if touched.is_empty() {
         return Ok(CertifiedCommitStatePhysicalPublication {
             write_set_id: writes.identity(),
-            parent_commit_ids,
+            commit_id,
             selected_source_commit_id,
             root: Some(attest_scoped_range_root(
                 commit_id,
@@ -738,7 +713,7 @@ pub(crate) async fn stage_current_state_scoped_ranges(
         else {
             return Ok(CertifiedCommitStatePhysicalPublication {
                 write_set_id: writes.identity(),
-                parent_commit_ids,
+                commit_id,
                 selected_source_commit_id,
                 root: None,
                 touched_scope_filter,
@@ -753,7 +728,7 @@ pub(crate) async fn stage_current_state_scoped_ranges(
     }
     Ok(CertifiedCommitStatePhysicalPublication {
         write_set_id: writes.identity(),
-        parent_commit_ids,
+        commit_id,
         selected_source_commit_id,
         root: Some(attest_scoped_range_root(
             commit_id,
@@ -795,10 +770,6 @@ fn scoped_state_error(message: impl std::fmt::Display) -> LixError {
 
 #[cfg(test)]
 mod tests {
-    use std::future::Future;
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
     use bytes::Bytes;
 
     use crate::changelog::{ChangeId, CommitId};
@@ -815,10 +786,9 @@ mod tests {
     };
     use crate::tracked_state::storage::{
         CertifiedCommitStateTopologyParent, CommitDeltaReplacementGeneration,
-        PublishedCommitStateManifest, load_commit_state_manifest,
-        load_complete_current_state_values_from_scoped_root, load_published_commit_state_manifest,
-        sparse_current_state_materialization_count_for_test, stage_certified_commit_state_manifest,
-        stage_certified_commit_state_manifest_with_handle, stage_commit_state_manifest,
+        PublishedCommitStateManifest, load_complete_current_state_values_from_scoped_root,
+        load_published_commit_state_manifest, sparse_current_state_materialization_count_for_test,
+        stage_certified_commit_state_manifest, stage_certified_commit_state_manifest_with_handle,
         stage_current_state_scoped_ranges_from_published_parent,
         stage_current_state_scoped_ranges_from_staged_parent,
         stage_current_state_scoped_ranges_from_topology, stage_ordered_addressable_commit_deltas,
@@ -839,45 +809,6 @@ mod tests {
         validate_scoped_range_attestation, validate_touched_scope_filter,
     };
 
-    struct ManifestCountingRead<R> {
-        inner: R,
-        manifest_calls: Arc<AtomicUsize>,
-    }
-
-    impl<R> crate::storage_adapter::StorageAdapterRead for ManifestCountingRead<R>
-    where
-        R: crate::storage_adapter::StorageAdapterRead,
-    {
-        fn snapshot_cache_key(&self) -> Option<u128> {
-            self.inner.snapshot_cache_key()
-        }
-
-        fn get_many(
-            &self,
-            requests: &[crate::storage::GetManyRequest<'_>],
-        ) -> impl Future<
-            Output = Result<crate::storage::GetManyResult, crate::storage::StorageError>,
-        > + Send {
-            for request in requests {
-                if request.space == crate::tracked_state::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE
-                {
-                    self.manifest_calls.fetch_add(1, Ordering::Relaxed);
-                }
-            }
-            self.inner.get_many(requests)
-        }
-
-        fn scan(
-            &self,
-            space: crate::storage_adapter::StorageSpace,
-            range: crate::storage::KeyRange,
-            opts: crate::storage::ScanOptions,
-        ) -> impl Future<Output = Result<crate::storage::ScanChunk, crate::storage::StorageError>> + Send
-        {
-            self.inner.scan(space, range, opts)
-        }
-    }
-
     fn scope(schema_key: &str) -> CommitDeltaReplacementScope {
         CommitDeltaReplacementScope {
             schema_key: schema_key.to_owned(),
@@ -887,16 +818,12 @@ mod tests {
 
     fn manifest(
         commit_id: CommitId,
-        parent_commit_id: Option<CommitId>,
+        _parent_commit_id: Option<CommitId>,
         mutations: CommitStateMutationInventory,
     ) -> CommitStateManifest {
         CommitStateManifest {
             commit_id,
-            generation: 0,
-            parent_commit_ids: parent_commit_id.into_iter().collect(),
-            commit_change_id: ChangeId::for_test_label(&format!("{commit_id}:commit")),
-            account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
-            created_at: LixTimestamp::from_unix_millis_utc_lossy(1),
+            change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             replay_debt: CommitStateReplayDebt {
                 depth: 4,
                 rows: u64::from(mutations.member_count),
@@ -905,7 +832,6 @@ mod tests {
             mutations,
             touched_scope_filter: Default::default(),
             current_state_scoped_ranges: None,
-            snapshot_root: None,
         }
     }
 
@@ -1567,7 +1493,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn publication_proof_rejects_wrong_parent_write_set_and_forged_transition() {
+    async fn publication_proof_rejects_wrong_commit_write_set_and_forged_transition() {
         let storage = StorageAdapter::new(Memory::new());
         let commit_id = CommitId::for_test_label("scoped-proof");
         let inventory = CommitStateMutationInventory::default();
@@ -1596,11 +1522,11 @@ mod tests {
                 .expect_err("proof must be tied to one write set");
         assert!(error.message.contains("write set"));
 
-        let mut wrong_parent = valid.clone();
-        wrong_parent.parent_commit_ids = vec![CommitId::for_test_label("wrong-parent")];
-        let error = stage_certified_commit_state_manifest(&mut writes, &wrong_parent, &publication)
-            .expect_err("proof must bind the graph parent");
-        assert!(error.message.contains("parent"));
+        let mut wrong_commit = valid.clone();
+        wrong_commit.commit_id = CommitId::for_test_label("other-scoped-proof");
+        let error = stage_certified_commit_state_manifest(&mut writes, &wrong_commit, &publication)
+            .expect_err("proof must be tied to one commit");
+        assert!(error.message.contains("identity"));
 
         let prefix = ScopedRangePrefix::try_from_components([b"forged".as_slice()]).unwrap();
         let tree = stage_scoped_range_tree(
@@ -1682,14 +1608,11 @@ mod tests {
         let parent_id = CommitId::for_test_label("empty-proof-parent");
         let requested = scope("not-authored-here");
 
-        let mut merge = manifest(
+        let merge = manifest(
             parent_id,
             Some(CommitId::for_test_label("first-parent")),
             CommitStateMutationInventory::default(),
         );
-        merge
-            .parent_commit_ids
-            .push(CommitId::for_test_label("second-parent"));
         assert!(!parent_scope_is_proven_empty(Some(&merge), &requested).unwrap());
 
         let mut selected = manifest(parent_id, None, CommitStateMutationInventory::default());
@@ -1810,12 +1733,8 @@ mod tests {
         )
         .unwrap();
         let mut merged = manifest(commit_id, Some(left.commit_id), inventory);
-        merged.parent_commit_ids.push(right.commit_id);
         merged.touched_scope_filter = publication.touched_scope_filter().clone();
         stage_certified_commit_state_manifest(&mut writes, &merged, &publication).unwrap();
-
-        merged.parent_commit_ids.swap(0, 1);
-        assert!(stage_certified_commit_state_manifest(&mut writes, &merged, &publication).is_err());
     }
 
     #[tokio::test]
@@ -1908,215 +1827,6 @@ mod tests {
                 bits: vec![0; TOUCHED_SCOPE_FILTER_BYTES - 1],
             })
             .is_err()
-        );
-    }
-
-    async fn legacy_lineage_scope_absence_proof(
-        store: &(impl crate::storage_adapter::StorageAdapterRead + ?Sized),
-        parent: &CommitStateManifest,
-        scope: &CommitDeltaReplacementScope,
-    ) -> Result<bool, crate::LixError> {
-        let mut next = Some(parent.clone());
-        let mut visited = std::collections::BTreeSet::new();
-        while let Some(manifest) = next {
-            if !visited.insert(manifest.commit_id) {
-                return Err(crate::LixError::new(
-                    crate::LixError::CODE_INTERNAL_ERROR,
-                    "legacy scope proof encountered a commit cycle",
-                ));
-            }
-            if manifest.parent_commit_ids.len() > 1
-                || manifest.mutations.selected_source_commit_id().is_some()
-            {
-                return Ok(false);
-            }
-            if manifest.mutations.member_count != 0 {
-                let Some(touched) =
-                    crate::tracked_state::storage::commit_state_inventory_exact_touched_scopes(
-                        manifest.commit_id,
-                        &manifest.mutations,
-                        false,
-                    )?
-                else {
-                    return Ok(false);
-                };
-                if touched.contains(scope) {
-                    return Ok(false);
-                }
-            }
-            let Some(parent_id) = manifest.parent_commit_ids.first().copied() else {
-                return Ok(true);
-            };
-            next = load_commit_state_manifest(store, parent_id).await?;
-            if next.is_none() {
-                return Ok(false);
-            }
-        }
-        Ok(false)
-    }
-
-    async fn legacy_graph_scope_absence_proof(
-        store: &(impl crate::storage_adapter::StorageAdapterRead + ?Sized),
-        tip: &CommitStateManifest,
-        scope: &CommitDeltaReplacementScope,
-    ) -> Result<bool, crate::LixError> {
-        let mut pending = vec![tip.clone()];
-        let mut scheduled = std::collections::BTreeSet::from([tip.commit_id]);
-        while let Some(manifest) = pending.pop() {
-            if manifest.mutations.selected_source_commit_id().is_some() {
-                return Ok(false);
-            }
-            if manifest.mutations.member_count != 0 {
-                let Some(touched) =
-                    crate::tracked_state::storage::commit_state_inventory_exact_touched_scopes(
-                        manifest.commit_id,
-                        &manifest.mutations,
-                        false,
-                    )?
-                else {
-                    return Ok(false);
-                };
-                if touched.contains(scope) {
-                    return Ok(false);
-                }
-            }
-            for parent_id in manifest.parent_commit_ids {
-                if !scheduled.insert(parent_id) {
-                    continue;
-                }
-                let parent = load_commit_state_manifest(store, parent_id)
-                    .await?
-                    .ok_or_else(|| {
-                        crate::LixError::new(
-                            crate::LixError::CODE_INTERNAL_ERROR,
-                            "legacy graph proof encountered a missing parent",
-                        )
-                    })?;
-                pending.push(parent);
-            }
-        }
-        Ok(true)
-    }
-
-    #[tokio::test]
-    async fn cumulative_filter_removes_lineage_manifest_reads_from_absence_proof() {
-        const DEPTH: usize = 128;
-        let storage = StorageAdapter::new(Memory::new());
-        let mut parent_id = None;
-        let mut tip = None;
-        for index in 0..DEPTH {
-            let commit_id = CommitId::for_test_label(&format!("scope-proof-{index}"));
-            let authority = manifest(
-                commit_id,
-                parent_id,
-                CommitStateMutationInventory::default(),
-            );
-            let mut writes = storage.new_write_set();
-            stage_commit_state_manifest(&mut writes, &authority).unwrap();
-            storage
-                .commit_write_set(writes, StorageWriteOptions::default())
-                .await
-                .unwrap();
-            parent_id = Some(commit_id);
-            tip = Some(authority);
-        }
-        let mut tip = tip.expect("lineage has a tip");
-        tip.touched_scope_filter = advance_touched_scope_filter(&[], None, Some(&[])).unwrap();
-        let requested = scope("first-columnar-publication");
-        let calls = Arc::new(AtomicUsize::new(0));
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .unwrap();
-        let counted = ManifestCountingRead {
-            inner: read,
-            manifest_calls: calls.clone(),
-        };
-        assert!(
-            legacy_lineage_scope_absence_proof(&counted, &tip, &requested)
-                .await
-                .unwrap()
-        );
-        assert_eq!(calls.load(Ordering::Relaxed), DEPTH - 1);
-
-        assert!(parent_scope_is_proven_empty(Some(&tip), &requested).unwrap());
-        assert_eq!(
-            calls.load(Ordering::Relaxed),
-            DEPTH - 1,
-            "the certified proof must not issue another manifest read"
-        );
-    }
-
-    #[tokio::test]
-    async fn merge_filter_matches_exact_graph_proof_without_reads() {
-        const BRANCH_DEPTH: usize = 64;
-        let storage = StorageAdapter::new(Memory::new());
-        let root_id = CommitId::for_test_label("merge-scope-proof-root");
-        let root = manifest(root_id, None, CommitStateMutationInventory::default());
-        let mut writes = storage.new_write_set();
-        stage_commit_state_manifest(&mut writes, &root).unwrap();
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .unwrap();
-
-        let mut branch_tips = Vec::new();
-        for branch in ["left", "right"] {
-            let mut parent_id = root_id;
-            let mut tip = None;
-            for depth in 0..BRANCH_DEPTH {
-                let commit_id =
-                    CommitId::for_test_label(&format!("merge-scope-proof-{branch}-{depth}"));
-                let authority = manifest(
-                    commit_id,
-                    Some(parent_id),
-                    CommitStateMutationInventory::default(),
-                );
-                let mut writes = storage.new_write_set();
-                stage_commit_state_manifest(&mut writes, &authority).unwrap();
-                storage
-                    .commit_write_set(writes, StorageWriteOptions::default())
-                    .await
-                    .unwrap();
-                parent_id = commit_id;
-                tip = Some(authority);
-            }
-            let mut tip = tip.unwrap();
-            tip.touched_scope_filter = advance_touched_scope_filter(&[], None, Some(&[])).unwrap();
-            branch_tips.push(tip);
-        }
-        let mut merge = manifest(
-            CommitId::for_test_label("merge-scope-proof-tip"),
-            Some(branch_tips[0].commit_id),
-            CommitStateMutationInventory::default(),
-        );
-        merge.parent_commit_ids.push(branch_tips[1].commit_id);
-        merge.touched_scope_filter =
-            advance_touched_scope_filter(&[&branch_tips[0], &branch_tips[1]], None, Some(&[]))
-                .unwrap();
-
-        let requested = scope("first-post-merge-publication");
-        let calls = Arc::new(AtomicUsize::new(0));
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .unwrap();
-        let counted = ManifestCountingRead {
-            inner: read,
-            manifest_calls: calls.clone(),
-        };
-        assert!(
-            legacy_graph_scope_absence_proof(&counted, &merge, &requested)
-                .await
-                .unwrap()
-        );
-        assert_eq!(calls.load(Ordering::Relaxed), BRANCH_DEPTH * 2 + 1);
-
-        assert!(parent_scope_is_proven_empty(Some(&merge), &requested).unwrap());
-        assert_eq!(
-            calls.load(Ordering::Relaxed),
-            BRANCH_DEPTH * 2 + 1,
-            "the certified merge proof must not issue another manifest read"
         );
     }
 }

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -48,8 +48,7 @@ pub(crate) const TRACKED_STATE_COMMIT_DELTA_SEGMENT_NAMESPACE: &str =
 pub(crate) const TRACKED_STATE_CHANGE_LOCATOR_NAMESPACE: &str = "tracked_state.change_locator.v2";
 pub(crate) const TRACKED_STATE_COMMIT_STATE_MANIFEST_NAMESPACE: &str =
     "tracked_state.commit_state_manifest.v6";
-pub(crate) const TRACKED_STATE_COMMIT_STATE_SEAL_NAMESPACE: &str =
-    "tracked_state.commit_state_semantic_authority.v3";
+pub(crate) const TRACKED_STATE_SNAPSHOT_ROOT_NAMESPACE: &str = "tracked_state.snapshot_root.v1";
 const MIN_CURRENT_STATE_SCOPED_RANGE_POINT_READS: u16 = 4;
 pub(crate) const TRACKED_STATE_TREE_CHUNK_SPACE: StorageSpace = StorageSpace::mutable(
     StorageSpaceId(0x0004_0001),
@@ -72,13 +71,13 @@ pub(crate) const TRACKED_STATE_CHANGE_LOCATOR_SPACE: StorageSpace = StorageSpace
 /// Current repositories publish this one manifest per commit, including
 /// commits with no tracked mutations. The former topology, delta-directory,
 /// and root authority spaces are not part of the current protocol.
-pub(crate) const TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE: StorageSpace = StorageSpace::mutable(
+pub(crate) const TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE: StorageSpace = StorageSpace::immutable(
     StorageSpaceId(0x0004_002b),
     TRACKED_STATE_COMMIT_STATE_MANIFEST_NAMESPACE,
 );
-pub(crate) const TRACKED_STATE_COMMIT_STATE_SEAL_SPACE: StorageSpace = StorageSpace::immutable(
-    StorageSpaceId(0x0004_002e),
-    TRACKED_STATE_COMMIT_STATE_SEAL_NAMESPACE,
+pub(crate) const TRACKED_STATE_SNAPSHOT_ROOT_SPACE: StorageSpace = StorageSpace::mutable(
+    StorageSpaceId(0x0004_0031),
+    TRACKED_STATE_SNAPSHOT_ROOT_NAMESPACE,
 );
 
 const COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 512;
@@ -89,8 +88,6 @@ const ORDERED_COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 64 * 1024;
 // replacements authoritative through their immutable part manifest. The
 // payload-less certified-reference encoding is intentionally rejected.
 const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD14";
-const COMMIT_STATE_SEMANTIC_AUTHORITY_MAGIC: &[u8] = b"LXSA5";
-const COMMIT_STATE_SEMANTIC_AUTHORITY_HASH_CONTEXT: &str = "lix.commit-state.semantic-authority.v5";
 // Version 4 makes lossless columnar mutation parts a first-class, exclusive
 // commit payload. LXCS3 repositories are intentionally rejected: there is no
 // compatibility decoder beneath the new authority.
@@ -100,10 +97,10 @@ const COMMIT_STATE_SEMANTIC_AUTHORITY_HASH_CONTEXT: &str = "lix.commit-state.sem
 // Version 6 binds the scope-run v3 node protocol and shared runtime scope
 // identities. LXCS5 roots cannot be reinterpreted under its content hashes.
 // Version 7 authenticates the cumulative touched-schema negative certificate.
-// LXCS6 manifests and LXSA3 semantic seals are deliberately incompatible.
+// Pre-cut manifests are deliberately incompatible with this physical-only format.
 // Version 8 binds current-state serving roots to an explicit physical base
 // commit independently from semantic graph ancestry.
-const COMMIT_STATE_MANIFEST_FORMAT_MAGIC: &[u8] = b"LXCS8";
+const COMMIT_STATE_MANIFEST_FORMAT_MAGIC: &[u8] = b"LXCS9";
 const COMMIT_DELTA_PAYLOAD_OFFSET_BYTES: usize = size_of::<u32>();
 #[cfg(not(test))]
 const COMMIT_DELTA_MAX_SIDECAR_BYTES: usize = 64 * 1024 * 1024;
@@ -503,17 +500,6 @@ pub(crate) struct CommitDeltaInventoryEntry {
     pub(crate) segment_count: usize,
     physical_segment_keys: Vec<Vec<u8>>,
     pub(crate) selected_source_commit_id: Option<CommitId>,
-    pub(crate) authority: CommitStateTopologyProjection,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct CommitStateTopologyProjection {
-    pub(crate) generation: u64,
-    pub(crate) parent_commit_ids: Vec<CommitId>,
-    pub(crate) commit_change_id: crate::changelog::ChangeId,
-    pub(crate) account_id: String,
-    pub(crate) created_at: crate::common::LixTimestamp,
-    pub(crate) replay_debt: crate::tracked_state::types::CommitStateReplayDebt,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -523,7 +509,6 @@ pub(crate) struct CommitDeltaInventory {
 
 struct CommitDeltaPlane {
     manifests: BTreeMap<CommitId, CommitDeltaManifest>,
-    authorities: BTreeMap<CommitId, CommitStateTopologyProjection>,
     segments: BTreeMap<CommitId, BTreeMap<usize, Bytes>>,
     segment_keys: BTreeMap<CommitId, BTreeMap<usize, Bytes>>,
 }
@@ -639,11 +624,11 @@ fn commit_state_inventory_from_delta_manifest(
 
 fn commit_delta_manifest_from_commit_state(manifest: &CommitStateManifest) -> CommitDeltaManifest {
     let mut delta = commit_delta_manifest_from_inventory(&manifest.mutations);
-    delta.account_id.clone_from(&manifest.account_id);
+    delta.account_id = manifest.change_account_id.clone();
     delta
 }
 
-/// Returns the exact collection scopes touched by a sealed mutation inventory.
+/// Returns the exact collection scopes touched by a certified mutation inventory.
 /// `None` means bounds or implicit cascades may affect another scope, in which
 /// case an inherited serving catalog must be discarded fail-closed.
 /// At an empty base, descriptor cascades cannot reach inherited rows, so their
@@ -1124,9 +1109,8 @@ pub(crate) async fn load_complete_current_state_values_from_scoped_root(
 }
 
 /// Uses a manifest returned by [`load_commit_state_manifest`] or
-/// [`load_commit_state_manifests`]. The opaque handle proves that the mutable
-/// manifest matched its immutable semantic authority in the caller's coherent
-/// read.
+/// [`load_commit_state_manifests`]. The opaque handle proves that the manifest
+/// came from the immutable physical authority in the caller's coherent read.
 #[cfg(feature = "storage-benches")]
 pub(crate) async fn load_complete_current_state_values_from_published_manifest(
     store: &(impl StorageAdapterRead + ?Sized),
@@ -1152,8 +1136,8 @@ pub(crate) async fn load_complete_current_state_values_from_replay_manifest(
     encoded_keys: &[Bytes],
 ) -> Result<Option<Vec<Option<TrackedStateIndexValue>>>, LixError> {
     // `load_point_replay_commit_state` decoded this exact manifest from the
-    // immutable semantic-authority seal, including its certified scoped root.
-    // Re-reading the mutable manifest would add point I/O without
+    // immutable physical manifest, including its certified scoped root.
+    // Re-reading the immutable manifest would add point I/O without
     // strengthening that authority.
     load_complete_current_state_values_encoded_inner(store, state, encoded_keys, false, true).await
 }
@@ -2118,23 +2102,38 @@ pub(crate) async fn load_root(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: &str,
 ) -> Result<Option<TrackedStateRootId>, LixError> {
-    Ok(load_authoritative_commit_root(store, commit_id)
+    Ok(load_snapshot_commit_root(store, commit_id)
         .await?
         .map(|metadata| metadata.root_id))
 }
 
-/// Resolves snapshot metadata only through the hard-cut commit authority.
+/// Resolves the rebuildable snapshot projection for one commit.
 ///
-/// Tree chunks are content addressed; the commit-state manifest is the only
-/// durable mapping from a commit to a snapshot root.
-pub(crate) async fn load_authoritative_commit_root(
+/// Tree chunks and this root record are derived from immutable commit-state
+/// authority. Deleting either leaves the mutation inventory sufficient for a
+/// deterministic rebuild.
+pub(crate) async fn load_snapshot_commit_root(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: &str,
 ) -> Result<Option<TrackedStateCommitRoot>, LixError> {
-    let commit_id = CommitId::parse_lix(commit_id, "tracked-state authoritative root lookup")?;
-    Ok(load_commit_state_manifest(store, commit_id)
-        .await?
-        .and_then(|manifest| manifest.snapshot_root))
+    let commit_id = CommitId::parse_lix(commit_id, "tracked-state snapshot root lookup")?;
+    let Some(bytes) = get_one(
+        store,
+        TRACKED_STATE_SNAPSHOT_ROOT_SPACE,
+        commit_state_manifest_key(commit_id),
+    )
+    .await?
+    else {
+        return Ok(None);
+    };
+    let root: TrackedStateCommitRoot =
+        storage_codec::decode("tracked-state snapshot root", &bytes)?;
+    if root.commit_id != commit_id {
+        return Err(replacement_payload_error(
+            "snapshot-root key contains metadata for a different commit",
+        ));
+    }
+    Ok(Some(root))
 }
 
 fn commit_delta_manifest_key(commit_id: CommitId) -> Vec<u8> {
@@ -2145,93 +2144,23 @@ fn commit_state_manifest_key(commit_id: CommitId) -> Vec<u8> {
     commit_id.as_uuid().as_bytes().to_vec()
 }
 
-fn commit_state_semantic_seal(manifest: &CommitStateManifest) -> Result<Vec<u8>, LixError> {
-    // Retain the root published with the commit so one-read point replay can
-    // stop at its original baseline. A later rebuilt root may change only the
-    // mutable manifest; semantic comparison intentionally ignores that field.
-    let payload = storage_codec::encode("commit-state semantic authority", manifest)?;
-    let digest = blake3::Hasher::new_derive_key(COMMIT_STATE_SEMANTIC_AUTHORITY_HASH_CONTEXT)
-        .update(&payload)
-        .finalize();
-    let mut encoded = Vec::with_capacity(
-        COMMIT_STATE_SEMANTIC_AUTHORITY_MAGIC.len() + TRACKED_STATE_HASH_BYTES + payload.len(),
-    );
-    encoded.extend_from_slice(COMMIT_STATE_SEMANTIC_AUTHORITY_MAGIC);
-    encoded.extend_from_slice(digest.as_bytes());
-    encoded.extend_from_slice(&payload);
-    Ok(encoded)
-}
-
-fn decode_commit_state_semantic_authority(bytes: &[u8]) -> Result<CommitStateManifest, LixError> {
-    let payload = bytes
-        .strip_prefix(COMMIT_STATE_SEMANTIC_AUTHORITY_MAGIC)
-        .ok_or_else(|| {
-            replacement_payload_error("commit-state semantic authority has an unsupported format")
-        })?;
-    let (expected_digest, payload) = payload
-        .split_at_checked(TRACKED_STATE_HASH_BYTES)
-        .ok_or_else(|| replacement_payload_error("commit-state semantic authority is truncated"))?;
-    let actual_digest =
-        blake3::Hasher::new_derive_key(COMMIT_STATE_SEMANTIC_AUTHORITY_HASH_CONTEXT)
-            .update(payload)
-            .finalize();
-    if expected_digest != actual_digest.as_bytes() {
-        return Err(replacement_payload_error(
-            "commit-state semantic authority digest is invalid",
-        ));
-    }
-    let manifest = storage_codec::decode("commit-state semantic authority", payload)?;
-    // The immutable seal authenticates bytes, while local validation proves
-    // that those bytes describe a structurally valid serving authority. This
-    // is what lets one-read point replay trust a catalog leaf without loading
-    // the historical complete-replacement manifest that first created it.
-    validate_commit_state_manifest(&manifest)?;
-    Ok(manifest)
-}
-
-fn validate_commit_state_semantic_seal(
-    manifest: &CommitStateManifest,
-    seal: &[u8],
-) -> Result<(), LixError> {
-    let authority = decode_commit_state_semantic_authority(seal)?;
-    validate_commit_state_semantic_projection(manifest, &authority)
-}
-
-fn validate_commit_state_semantic_projection(
-    manifest: &CommitStateManifest,
-    authority: &CommitStateManifest,
-) -> Result<(), LixError> {
-    let mut manifest_semantics = manifest.clone();
-    manifest_semantics.snapshot_root = None;
-    let mut authority_semantics = authority.clone();
-    authority_semantics.snapshot_root = None;
-    if authority_semantics != manifest_semantics {
-        return Err(replacement_payload_error(
-            "commit-state manifest disagrees with its immutable semantic authority",
-        ));
-    }
-    Ok(())
-}
-
-/// Commit authority loaded from the mutable manifest plane after its
-/// immutable semantic authority was verified. Only this opaque handle may bypass
-/// publication-time catalog re-derivation.
+/// Commit authority loaded from the immutable manifest plane. Only this
+/// opaque handle may bypass publication-time catalog re-derivation.
 #[derive(Clone, Debug)]
 pub(crate) struct PublishedCommitStateManifest {
     manifest: CommitStateManifest,
 }
 
-/// One-read immutable semantic authority used by point replay. The wrapper
-/// prevents a freely constructed manifest from claiming authoritative catalog
-/// coverage without passing seal and structural validation.
+/// One-read immutable authority used by point replay. The wrapper prevents a
+/// freely constructed manifest from claiming authoritative catalog coverage.
 #[derive(Clone, Debug)]
 pub(crate) struct AuthenticatedReplayCommitStateManifest {
     manifest: CommitStateManifest,
 }
 
-/// Same-write-set authority produced only after semantic publication. This lets a
-/// later commit in one atomic transaction consume its parent catalog without
-/// treating a freely constructible manifest as provenance.
+/// Same-write-set authority produced only after immutable physical publication.
+/// This lets a later commit in one atomic transaction consume its parent catalog
+/// without treating a freely constructible manifest as provenance.
 pub(crate) struct StagedCommitStateManifest {
     manifest: CommitStateManifest,
     write_set_id: u64,
@@ -2365,7 +2294,7 @@ pub(crate) async fn stage_current_state_scoped_ranges_from_staged_parent(
 }
 
 /// Rewrites one exactly scoped current-state partition from its certified
-/// parent post-image and the current commit's sealed mutation parts. Untouched
+/// parent post-image and the current commit's certified mutation parts. Untouched
 /// parent descriptors are reused byte-for-byte; only intersecting bounded
 /// parts and insertion gaps become native current-state data parts.
 /// Rewrites one covered scope in the unified current-state serving tree.
@@ -3232,40 +3161,22 @@ fn commit_delta_segment_key_for_bounds(
     Ok(encoded)
 }
 
-/// Loads the hard-cut semantic authority for one tracked commit.
+/// Loads the immutable physical authority for one tracked commit.
 pub(crate) async fn load_commit_state_manifest(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
 ) -> Result<Option<CommitStateManifest>, LixError> {
     #[cfg(feature = "storage-benches")]
     crate::storage_bench::record_crud_sealed_manifest_load();
-    let key = StorageKey(Bytes::from(commit_state_manifest_key(commit_id)));
-    let requests = [
-        StorageGetManyRequest {
-            space: TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
-            keys: std::slice::from_ref(&key),
-            opts: StorageGetOptions::default(),
-        },
-        StorageGetManyRequest {
-            space: TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
-            keys: std::slice::from_ref(&key),
-            opts: StorageGetOptions::default(),
-        },
-    ];
-    let mut values = exact_get_many(store, &requests).await?.values.into_iter();
-    let manifest_bytes = values.next().flatten().and_then(full_value_bytes);
-    let seal = values.next().flatten().and_then(full_value_bytes);
-    let Some(bytes) = manifest_bytes else {
-        if seal.is_some() {
-            return Err(replacement_payload_error(
-                "commit-state semantic authority has no mutable manifest",
-            ));
-        }
+    let Some(bytes) = get_one(
+        store,
+        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+        commit_state_manifest_key(commit_id),
+    )
+    .await?
+    else {
         return Ok(None);
     };
-    let seal = seal.ok_or_else(|| {
-        replacement_payload_error("commit-state manifest omitted its immutable semantic authority")
-    })?;
     let manifest = decode_commit_state_manifest(&bytes)?;
     if manifest.commit_id != commit_id {
         return Err(LixError::new(
@@ -3276,7 +3187,6 @@ pub(crate) async fn load_commit_state_manifest(
             ),
         ));
     }
-    validate_commit_state_semantic_seal(&manifest, &seal)?;
     Ok(Some(manifest))
 }
 
@@ -3289,7 +3199,7 @@ pub(crate) async fn load_published_commit_state_manifest(
         .map(|manifest| PublishedCommitStateManifest { manifest }))
 }
 
-/// Loads the replay projection after verifying immutable semantic authority.
+/// Loads the replay projection from immutable physical authority.
 pub(crate) async fn load_replay_commit_state_manifest(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
@@ -3307,19 +3217,19 @@ pub(crate) async fn load_point_replay_commit_state(
     crate::storage_bench::record_crud_replay_manifest_load();
     let Some(authority) = get_one(
         store,
-        TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
+        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
         commit_state_manifest_key(commit_id),
     )
     .await?
     else {
         return Ok(None);
     };
-    let state = decode_commit_state_semantic_authority(&authority)?;
+    let state = decode_commit_state_manifest(&authority)?;
     if state.commit_id != commit_id {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
             format!(
-                "tracked_state semantic authority key for commit '{commit_id}' contains authority for commit '{}'",
+                "tracked_state manifest key for commit '{commit_id}' contains authority for commit '{}'",
                 state.commit_id
             ),
         ));
@@ -3338,41 +3248,21 @@ pub(crate) async fn load_commit_state_manifests(
         .iter()
         .map(|commit_id| StorageKey(Bytes::from(commit_state_manifest_key(*commit_id))))
         .collect::<Vec<_>>();
-    let requests = [
-        StorageGetManyRequest {
-            space: TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
-            keys: &keys,
-            opts: StorageGetOptions::default(),
-        },
-        StorageGetManyRequest {
-            space: TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
-            keys: &keys,
-            opts: StorageGetOptions::default(),
-        },
-    ];
-    let mut values = exact_get_many(store, &requests).await?.values.into_iter();
-    let manifests = values.by_ref().take(keys.len()).collect::<Vec<_>>();
-    let seals = values.collect::<Vec<_>>();
+    let request = [StorageGetManyRequest {
+        space: TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+        keys: &keys,
+        opts: StorageGetOptions::default(),
+    }];
+    let manifests = exact_get_many(store, &request).await?.values;
     commit_ids
         .iter()
         .copied()
-        .zip(manifests.into_iter().zip(seals))
-        .map(|(commit_id, (manifest_value, seal_value))| {
+        .zip(manifests)
+        .map(|(commit_id, manifest_value)| {
             let manifest_bytes = manifest_value.and_then(full_value_bytes);
-            let seal = seal_value.and_then(full_value_bytes);
             let Some(bytes) = manifest_bytes else {
-                if seal.is_some() {
-                    return Err(replacement_payload_error(
-                        "commit-state semantic authority has no mutable manifest",
-                    ));
-                }
                 return Ok(None);
             };
-            let seal = seal.ok_or_else(|| {
-                replacement_payload_error(
-                    "commit-state manifest omitted its immutable semantic authority",
-                )
-            })?;
             let manifest = decode_commit_state_manifest(&bytes)?;
             if manifest.commit_id != commit_id {
                 return Err(LixError::new(
@@ -3383,38 +3273,9 @@ pub(crate) async fn load_commit_state_manifests(
                     ),
                 ));
             }
-            validate_commit_state_semantic_seal(&manifest, &seal)?;
             Ok(Some(manifest))
         })
         .collect()
-}
-
-/// Loads deliberately malformed authority without semantic validation so a
-/// corruption test can replace one forged record with another.
-#[cfg(test)]
-pub(crate) async fn load_unchecked_commit_state_manifest_for_test(
-    store: &(impl StorageAdapterRead + ?Sized),
-    commit_id: CommitId,
-) -> Result<Option<CommitStateManifest>, LixError> {
-    let Some(bytes) = get_one(
-        store,
-        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
-        commit_state_manifest_key(commit_id),
-    )
-    .await?
-    else {
-        return Ok(None);
-    };
-    let payload = bytes
-        .strip_prefix(COMMIT_STATE_MANIFEST_FORMAT_MAGIC)
-        .ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                "tracked_state corrupt-test commit_state_manifest has an unsupported format",
-            )
-        })?;
-    let manifest = storage_codec::decode("tracked_state commit_state_manifest", payload)?;
-    Ok(Some(manifest))
 }
 
 async fn load_commit_delta_manifests(
@@ -3434,29 +3295,18 @@ async fn load_commit_delta_manifests(
     Ok(manifests)
 }
 
-/// Stages one complete commit authority record.
-///
-/// Callers must invoke this only after the immutable mutation inventory and
-/// optional snapshot metadata are final. Publishing a partially populated
-/// manifest and patching it later would make an intermediate representation
-/// authoritative to read-your-writes consumers.
+/// Stages one complete immutable physical commit authority record.
 fn stage_commit_state_manifest_bytes(
     writes: &mut StorageWriteSet,
     manifest: &CommitStateManifest,
 ) -> Result<(), LixError> {
     let encoded = encode_commit_state_manifest(manifest)?;
-    let seal = commit_state_semantic_seal(manifest)?;
     #[cfg(feature = "storage-benches")]
     crate::storage_bench::record_crud_commit_state_manifest_bytes(encoded.len());
     writes.put(
         TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
         key(commit_state_manifest_key(manifest.commit_id)),
         value(encoded),
-    );
-    writes.put(
-        TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
-        key(commit_state_manifest_key(manifest.commit_id)),
-        value(seal.to_vec()),
     );
     Ok(())
 }
@@ -3504,9 +3354,9 @@ pub(crate) fn stage_certified_commit_state_manifest(
             "physical publication proof belongs to a different storage write set",
         ));
     }
-    if manifest.parent_commit_ids != publication.parent_commit_ids() {
+    if manifest.commit_id != publication.commit_id() {
         return Err(replacement_payload_error(
-            "commit manifest graph-parent topology disagrees with its physical publication proof",
+            "commit manifest identity disagrees with its physical publication proof",
         ));
     }
     if manifest.mutations.selected_source_commit_id() != publication.selected_source_commit_id() {
@@ -3539,66 +3389,70 @@ pub(crate) fn stage_certified_commit_state_manifest_with_handle(
     })
 }
 
-/// Updates only the rebuildable snapshot accelerator of an already sealed
-/// authority. All semantic fields come from the opaque published handle and
-/// therefore retain the exact same immutable authority.
+/// Updates only the rebuildable snapshot accelerator of immutable authority.
 pub(crate) fn stage_commit_state_snapshot_root_update(
     writes: &mut StorageWriteSet,
     published: &PublishedCommitStateManifest,
     snapshot_root: Option<TrackedStateCommitRoot>,
 ) -> Result<(), LixError> {
-    let mut manifest = published.manifest.clone();
-    manifest.snapshot_root = snapshot_root;
-    let encoded = encode_commit_state_manifest(&manifest)?;
-    writes.put(
-        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
-        key(commit_state_manifest_key(manifest.commit_id)),
-        value(encoded),
-    );
+    match snapshot_root {
+        Some(root) => {
+            if root.commit_id != published.commit_id {
+                return Err(replacement_payload_error(
+                    "snapshot root belongs to a different commit authority",
+                ));
+            }
+            writes.put(
+                TRACKED_STATE_SNAPSHOT_ROOT_SPACE,
+                key(commit_state_manifest_key(root.commit_id)),
+                value(storage_codec::encode("tracked-state snapshot root", &root)?),
+            );
+        }
+        None => writes.delete(
+            TRACKED_STATE_SNAPSHOT_ROOT_SPACE,
+            key(commit_state_manifest_key(published.commit_id)),
+        ),
+    }
     Ok(())
 }
 
-/// Stages deliberately malformed authority for corruption tests. Production
-/// publication must always use [`stage_commit_state_manifest`].
-#[cfg(test)]
-pub(crate) fn stage_unchecked_commit_state_manifest_for_test(
+/// Publishes the initial rebuildable snapshot projection for a manifest staged
+/// in this exact write set.
+pub(crate) fn stage_staged_commit_state_snapshot_root(
     writes: &mut StorageWriteSet,
-    manifest: &CommitStateManifest,
+    staged: &StagedCommitStateManifest,
+    snapshot_root: TrackedStateCommitRoot,
 ) -> Result<(), LixError> {
-    let payload = storage_codec::encode("tracked_state commit_state_manifest", manifest)?;
-    let mut encoded = Vec::with_capacity(COMMIT_STATE_MANIFEST_FORMAT_MAGIC.len() + payload.len());
-    encoded.extend_from_slice(COMMIT_STATE_MANIFEST_FORMAT_MAGIC);
-    encoded.extend_from_slice(&payload);
+    if staged.write_set_id != writes.identity() || snapshot_root.commit_id != staged.commit_id {
+        return Err(replacement_payload_error(
+            "snapshot root does not belong to its staged commit authority",
+        ));
+    }
     writes.put(
-        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
-        key(commit_state_manifest_key(manifest.commit_id)),
-        value(encoded),
+        TRACKED_STATE_SNAPSHOT_ROOT_SPACE,
+        key(commit_state_manifest_key(snapshot_root.commit_id)),
+        value(storage_codec::encode(
+            "tracked-state snapshot root",
+            &snapshot_root,
+        )?),
     );
     Ok(())
 }
 
-/// Replaces both mutable manifest bytes and the normally immutable seal for a
-/// corruption/test-fixture scenario. Production code cannot compile a call to
-/// this bypass.
+/// Replaces immutable manifest bytes through a mutable test-only declaration.
 #[cfg(test)]
 pub(crate) fn stage_resealed_commit_state_manifest_for_test(
     writes: &mut StorageWriteSet,
     manifest: &CommitStateManifest,
 ) -> Result<(), LixError> {
     let encoded = encode_commit_state_manifest(manifest)?;
-    let seal = commit_state_semantic_seal(manifest)?;
-    writes.put(
-        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
-        key(commit_state_manifest_key(manifest.commit_id)),
-        value(encoded),
-    );
     writes.put(
         StorageSpace::mutable(
-            TRACKED_STATE_COMMIT_STATE_SEAL_SPACE.id,
-            TRACKED_STATE_COMMIT_STATE_SEAL_NAMESPACE,
+            TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE.id,
+            TRACKED_STATE_COMMIT_STATE_MANIFEST_NAMESPACE,
         ),
         key(commit_state_manifest_key(manifest.commit_id)),
-        value(seal.to_vec()),
+        value(encoded),
     );
     Ok(())
 }
@@ -5856,10 +5710,8 @@ pub(crate) async fn load_commit_delta_values_encoded_from_replay_manifest(
         .await;
     }
     if point_cache.manifest(state.commit_id)?.is_none() {
-        point_cache.remember_manifest(
-            state.commit_id,
-            Arc::new(commit_delta_manifest_from_commit_state(state)),
-        )?;
+        let manifest = expanded_commit_delta_manifest_from_commit_state(store, state).await?;
+        point_cache.remember_manifest(state.commit_id, Arc::new(manifest))?;
     }
     load_commit_delta_values_encoded_with_cache(
         store,
@@ -6895,7 +6747,7 @@ async fn load_inventory_part_entries_one_ordered(
                 &payloads,
                 &encoded_keys[encoded],
                 commit_id,
-                &state.account_id,
+                &state.change_account_id,
             )?;
         }
     }
@@ -7739,19 +7591,7 @@ pub(crate) async fn visit_change_records_from_commit_deltas(
                 },
             )
             .await?;
-        let seal_keys = page
-            .value
-            .entries
-            .iter()
-            .map(|entry| entry.key.clone())
-            .collect::<Vec<_>>();
-        let seal_request = [StorageGetManyRequest {
-            space: TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
-            keys: &seal_keys,
-            opts: StorageGetOptions::default(),
-        }];
-        let seals = exact_get_many(store, &seal_request).await?.values;
-        for (entry, seal) in page.value.entries.iter().zip(seals) {
+        for entry in &page.value.entries {
             if entry.key.0.len() != 16 {
                 return Err(LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
@@ -7769,12 +7609,6 @@ pub(crate) async fn visit_change_records_from_commit_deltas(
                     "tracked_state commit-state scan key and manifest commit disagree",
                 ));
             }
-            let seal = seal.and_then(full_value_bytes).ok_or_else(|| {
-                replacement_payload_error(
-                    "commit-state scan found a manifest without its immutable semantic authority",
-                )
-            })?;
-            validate_commit_state_semantic_seal(&state, &seal)?;
             let manifest = expanded_commit_delta_manifest_from_commit_state(store, &state).await?;
             if let Some(parts) = manifest.columnar_parts.as_ref() {
                 emitted = emitted.saturating_add(
@@ -7988,7 +7822,6 @@ pub(crate) async fn scan_commit_delta_inventory(
 ) -> Result<CommitDeltaInventory, LixError> {
     let CommitDeltaPlane {
         manifests,
-        mut authorities,
         mut segments,
         mut segment_keys,
     } = scan_commit_delta_plane(store).await?;
@@ -8059,9 +7892,6 @@ pub(crate) async fn scan_commit_delta_inventory(
                     })
                     .collect::<Result<Vec<_>, _>>()?,
                 selected_source_commit_id: manifest.selected_source_commit_id(),
-                authority: authorities
-                    .remove(&commit_id)
-                    .expect("every decoded mutation manifest has topology authority"),
             },
         );
     }
@@ -8133,7 +7963,6 @@ pub(crate) async fn scan_commit_delta_inventory(
     }
     debug_assert!(segments.is_empty());
     debug_assert!(segment_keys.is_empty());
-    debug_assert!(authorities.is_empty());
     Ok(inventory)
 }
 
@@ -8142,23 +7971,10 @@ async fn scan_commit_delta_plane(
 ) -> Result<CommitDeltaPlane, LixError> {
     let commit_state_rows =
         scan_full_space(store, TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE).await?;
-    let commit_state_seals = scan_full_space(store, TRACKED_STATE_COMMIT_STATE_SEAL_SPACE).await?;
     let segment_rows = scan_full_space(store, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE).await?;
 
-    if commit_state_rows.len() != commit_state_seals.len()
-        || commit_state_rows
-            .iter()
-            .zip(&commit_state_seals)
-            .any(|((manifest_key, _), (seal_key, _))| manifest_key != seal_key)
-    {
-        return Err(replacement_payload_error(
-            "commit-state inventory found an orphan manifest or semantic authority",
-        ));
-    }
-
     let mut manifests = BTreeMap::<CommitId, CommitDeltaManifest>::new();
-    let mut authorities = BTreeMap::<CommitId, CommitStateTopologyProjection>::new();
-    for ((key, bytes), (_, seal)) in commit_state_rows.into_iter().zip(commit_state_seals) {
+    for (key, bytes) in commit_state_rows {
         if key.0.len() != 16 {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
@@ -8175,18 +7991,6 @@ async fn scan_commit_delta_plane(
                 ),
             ));
         }
-        validate_commit_state_semantic_seal(&manifest, &seal)?;
-        authorities.insert(
-            commit_id,
-            CommitStateTopologyProjection {
-                generation: manifest.generation,
-                parent_commit_ids: manifest.parent_commit_ids.clone(),
-                commit_change_id: manifest.commit_change_id,
-                account_id: manifest.account_id.clone(),
-                created_at: manifest.created_at,
-                replay_debt: manifest.replay_debt,
-            },
-        );
         manifests.insert(
             commit_id,
             expanded_commit_delta_manifest_from_commit_state(store, &manifest).await?,
@@ -8242,7 +8046,6 @@ async fn scan_commit_delta_plane(
 
     Ok(CommitDeltaPlane {
         manifests,
-        authorities,
         segments,
         segment_keys,
     })
@@ -8297,10 +8100,6 @@ pub(crate) fn stage_delete_commit_delta_inventory_entry(
 ) -> Result<(), LixError> {
     writes.delete(
         TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
-        key(commit_state_manifest_key(commit_id)),
-    );
-    writes.delete(
-        TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
         key(commit_state_manifest_key(commit_id)),
     );
     for segment_key in &entry.physical_segment_keys {
@@ -8565,8 +8364,7 @@ pub(crate) async fn load_commit_delta_replay_metadata_with_cache(
         .map(|manifest| commit_delta_replay_metadata_from_inventory(&manifest.mutations)))
 }
 
-/// Seeds the snapshot-local delta cache from the seal-verified replay manifest
-/// already read by point traversal, avoiding a second authority read.
+/// Returns replay metadata from an already authenticated physical manifest.
 pub(crate) fn seed_commit_delta_point_cache_from_replay_manifest(
     state: &CommitStateManifest,
     point_cache: &CommitDeltaPointReadCache,
@@ -9996,7 +9794,7 @@ pub(crate) struct TrackedStateStagedRead<'a, S: ?Sized> {
     store: &'a S,
     chunks: &'a TrackedStateChunkOverlay,
     commit_states: HashMap<Vec<u8>, Bytes>,
-    commit_state_seals: HashMap<Vec<u8>, Bytes>,
+    snapshot_roots: HashMap<Vec<u8>, Bytes>,
 }
 
 impl<'a, S> TrackedStateStagedRead<'a, S>
@@ -10008,39 +9806,39 @@ where
             store,
             chunks,
             commit_states: HashMap::new(),
-            commit_state_seals: HashMap::new(),
+            snapshot_roots: HashMap::new(),
         }
     }
 
-    pub(crate) fn with_commit_state_manifests(
+    pub(crate) fn with_commit_state_roots(
         store: &'a S,
         chunks: &'a TrackedStateChunkOverlay,
-        manifests: impl IntoIterator<Item = CommitStateManifest>,
+        commit_states: impl IntoIterator<Item = (CommitStateManifest, TrackedStateCommitRoot)>,
     ) -> Result<Self, LixError> {
-        let manifests = manifests.into_iter().collect::<Vec<_>>();
-        let commit_states = manifests
+        let commit_states = commit_states.into_iter().collect::<Vec<_>>();
+        let manifests = commit_states
             .iter()
-            .map(|manifest| {
+            .map(|(manifest, _)| {
                 Ok((
                     commit_state_manifest_key(manifest.commit_id),
                     Bytes::from(encode_commit_state_manifest(manifest)?),
                 ))
             })
             .collect::<Result<HashMap<_, _>, LixError>>()?;
-        let commit_state_seals = manifests
+        let snapshot_roots = commit_states
             .iter()
-            .map(|manifest| {
+            .map(|(_, root)| {
                 Ok((
-                    commit_state_manifest_key(manifest.commit_id),
-                    Bytes::copy_from_slice(&commit_state_semantic_seal(manifest)?),
+                    commit_state_manifest_key(root.commit_id),
+                    Bytes::from(storage_codec::encode("tracked-state snapshot root", root)?),
                 ))
             })
             .collect::<Result<HashMap<_, _>, LixError>>()?;
         Ok(Self {
             store,
             chunks,
-            commit_states,
-            commit_state_seals,
+            commit_states: manifests,
+            snapshot_roots,
         })
     }
 
@@ -10052,8 +9850,8 @@ where
         if space == TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE.id {
             return self.commit_states.get(key.0.as_ref()).cloned();
         }
-        if space == TRACKED_STATE_COMMIT_STATE_SEAL_SPACE.id {
-            return self.commit_state_seals.get(key.0.as_ref()).cloned();
+        if space == TRACKED_STATE_SNAPSHOT_ROOT_SPACE.id {
+            return self.snapshot_roots.get(key.0.as_ref()).cloned();
         }
         None
     }
@@ -10152,45 +9950,6 @@ fn validate_commit_state_manifest_inner(
     manifest: &CommitStateManifest,
     validate_scoped_range_attestation: bool,
 ) -> Result<(), LixError> {
-    let mut parents = BTreeSet::new();
-    for parent in &manifest.parent_commit_ids {
-        if *parent == manifest.commit_id || !parents.insert(*parent) {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                "tracked_state commit_state_manifest has a self or duplicate parent",
-            ));
-        }
-    }
-
-    match &manifest.snapshot_root {
-        Some(root) => {
-            if root.commit_id != manifest.commit_id {
-                return Err(LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "tracked_state commit_state_manifest snapshot belongs to another commit",
-                ));
-            }
-            if root.parent_roots.first().map(|parent| parent.commit_id)
-                != manifest.parent_commit_ids.first().copied()
-                || root
-                    .parent_roots
-                    .iter()
-                    .any(|parent| !parents.contains(&parent.commit_id))
-            {
-                return Err(LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "tracked_state commit_state_manifest snapshot ancestry disagrees with commit topology",
-                ));
-            }
-        }
-        None if manifest.replay_debt.depth == 0 => {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                "tracked_state rootless commit_state_manifest has zero replay depth",
-            ));
-        }
-        None => {}
-    }
     if manifest.replay_debt.depth == 0
         && (manifest.replay_debt.rows != 0 || manifest.replay_debt.bytes != 0)
     {
@@ -10235,13 +9994,8 @@ fn validate_current_state_scoped_ranges(
         ));
     }
     if let Some(root) = manifest.current_state_scoped_ranges.as_ref() {
-        let expected_serving_base = manifest
-            .mutations
-            .selected_source_commit_id()
-            .or_else(|| manifest.parent_commit_ids.first().copied());
-        if root.serving_base_commit_id.is_some()
-            && root.serving_base_commit_id != expected_serving_base
-        {
+        let selected_source = manifest.mutations.selected_source_commit_id();
+        if selected_source.is_some() && root.serving_base_commit_id != selected_source {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 "tracked_state current-state serving base disagrees with commit authority",
@@ -10475,7 +10229,7 @@ mod tests {
     };
     use crate::branch::BRANCH_HEAD_CONTROL_SPACE;
     use crate::changelog::{
-        CHANGE_SPACE, COMMIT_CHANGE_ID_SPACE, COMMIT_SPACE, ChangeId, CommitId,
+        CHANGE_SPACE, COMMIT_CHANGE_ID_SPACE, COMMIT_SPACE, ChangeId, CommitId, CommitRecord,
     };
     use crate::common::LixTimestamp;
     use crate::entity_pk::EntityPk;
@@ -10496,10 +10250,9 @@ mod tests {
     };
     use crate::tracked_state::types::{
         CommitStateManifest, CommitStateMutationInventory, CommitStateReplayDebt,
-        CurrentStatePartDescriptor, TRACKED_STATE_HASH_BYTES, TrackedStateBaseCoordinate,
-        TrackedStateCommitDeltaRef, TrackedStateCommitRoot, TrackedStateDeltaRef,
-        TrackedStateIndexValue, TrackedStateIndexValueRef, TrackedStateKey, TrackedStateKeyRef,
-        TrackedStateRootId,
+        CurrentStatePartDescriptor, TrackedStateBaseCoordinate, TrackedStateCommitDeltaRef,
+        TrackedStateCommitRoot, TrackedStateDeltaRef, TrackedStateIndexValue,
+        TrackedStateIndexValueRef, TrackedStateKey, TrackedStateKeyRef, TrackedStateRootId,
     };
 
     use super::{
@@ -10765,13 +10518,12 @@ mod tests {
         );
     }
 
-    struct SealCountingRead<R> {
+    struct ManifestCountingRead<R> {
         inner: R,
         manifest_requests: std::sync::Arc<AtomicUsize>,
-        seal_requests: std::sync::Arc<AtomicUsize>,
     }
 
-    impl<R> crate::storage_adapter::StorageAdapterRead for SealCountingRead<R>
+    impl<R> crate::storage_adapter::StorageAdapterRead for ManifestCountingRead<R>
     where
         R: crate::storage_adapter::StorageAdapterRead,
     {
@@ -10788,9 +10540,6 @@ mod tests {
             for request in requests {
                 if request.space == super::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE {
                     self.manifest_requests.fetch_add(1, Ordering::Relaxed);
-                }
-                if request.space == super::TRACKED_STATE_COMMIT_STATE_SEAL_SPACE {
-                    self.seal_requests.fetch_add(1, Ordering::Relaxed);
                 }
             }
             self.inner.get_many(requests)
@@ -10813,11 +10562,7 @@ mod tests {
     ) -> CommitStateManifest {
         CommitStateManifest {
             commit_id,
-            generation: 0,
-            parent_commit_ids: Vec::new(),
-            commit_change_id: ChangeId::for_test_label(&format!("{commit_id}:commit")),
-            account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
-            created_at: LixTimestamp::from_unix_millis_utc_lossy(0),
+            change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             replay_debt: CommitStateReplayDebt {
                 depth: 1,
                 rows: u64::from(mutations.member_count),
@@ -10826,7 +10571,6 @@ mod tests {
             mutations,
             touched_scope_filter: Default::default(),
             current_state_scoped_ranges: None,
-            snapshot_root: None,
         }
     }
 
@@ -10835,6 +10579,20 @@ mod tests {
         commit_id: CommitId,
         mutations: &CommitStateMutationInventory,
     ) -> Result<(), LixError> {
+        let record = CommitRecord {
+            format_version: 2,
+            commit_id,
+            generation: 0,
+            parent_commit_ids: Vec::new(),
+            change_id: ChangeId::for_test_label(&format!("{commit_id}:fixture-commit")),
+            account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
+            created_at: LixTimestamp::from_unix_millis_utc_lossy(0),
+        };
+        writes.put(
+            COMMIT_SPACE,
+            key(commit_id.as_uuid().as_bytes().to_vec()),
+            value(crate::changelog::encode_commit_record(&record)?),
+        );
         stage_commit_state_manifest(
             writes,
             &fixture_commit_state_manifest(commit_id, mutations.clone()),
@@ -12370,7 +12128,7 @@ mod tests {
         assert_eq!(
             writes.stats().staged_puts,
             5,
-            "generic history keeps 300 compact rows in three read-friendly segments plus its commit-state authority and immutable seal"
+            "generic history keeps 300 compact rows in three read-friendly segments plus its physical authority and semantic owner"
         );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -12566,7 +12324,7 @@ mod tests {
         assert_eq!(
             writes.stats().staged_puts,
             4,
-            "the oversized four-row candidate should become two segments plus its commit-state authority and immutable seal"
+            "the oversized four-row candidate should become two segments plus its physical authority and semantic owner"
         );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -13361,7 +13119,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn shallow_point_replay_reads_one_immutable_semantic_authority() {
+    async fn shallow_point_replay_reads_one_immutable_physical_authority() {
         let storage = StorageAdapter::new(Memory::new());
         let commit_id = CommitId::for_test_label("one-read-shallow-point-replay");
         let fixture = packed_commit_delta_fixtures()
@@ -13383,14 +13141,12 @@ mod tests {
             .expect("ordinary delta should commit");
 
         let manifest_requests = std::sync::Arc::new(AtomicUsize::new(0));
-        let seal_requests = std::sync::Arc::new(AtomicUsize::new(0));
-        let read = SealCountingRead {
+        let read = ManifestCountingRead {
             inner: storage
                 .begin_read(StorageReadOptions::default())
                 .await
                 .expect("point read should open"),
             manifest_requests: std::sync::Arc::clone(&manifest_requests),
-            seal_requests: std::sync::Arc::clone(&seal_requests),
         };
         let state = super::load_replay_commit_state_manifest(&read, commit_id)
             .await
@@ -13413,8 +13169,7 @@ mod tests {
         .await
         .expect("cached shallow point replay should load");
         assert_eq!(values, vec![Some(fixture.value(commit_id))]);
-        assert_eq!(manifest_requests.load(Ordering::Relaxed), 0);
-        assert_eq!(seal_requests.load(Ordering::Relaxed), 1);
+        assert_eq!(manifest_requests.load(Ordering::Relaxed), 1);
     }
 
     #[tokio::test]
@@ -13437,7 +13192,7 @@ mod tests {
         assert_eq!(
             writes.stats().staged_puts,
             2,
-            "a one-segment commit should remain inline in its commit-state authority plus immutable seal"
+            "a one-segment commit should remain inline in its physical authority plus semantic owner"
         );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -13478,8 +13233,8 @@ mod tests {
         .expect("inline delta should stage for deletion");
         assert_eq!(
             deletes.stats().staged_deletes,
-            2,
-            "GC should delete the inline commit-state authority and immutable seal"
+            1,
+            "physical inventory deletion should remove its single manifest authority"
         );
     }
 
@@ -13620,7 +13375,7 @@ mod tests {
                 .get(&commit_id)
                 .expect("packed commit should be inventoried")
                 .segment_count
-                + 2,
+                + 1,
         )
         .expect("test segment count fits u64");
         assert_eq!(deletes.stats().staged_deletes, expected_deletes);
@@ -13832,11 +13587,7 @@ mod tests {
         };
         CommitStateManifest {
             commit_id,
-            generation: 7,
-            parent_commit_ids: vec![CommitId::for_test_label("manifest-parent")],
-            commit_change_id: ChangeId::for_test_label("manifest-commit-change"),
-            account_id: "account-a".to_string(),
-            created_at: timestamp,
+            change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             replay_debt: CommitStateReplayDebt {
                 depth: 2,
                 rows: 1,
@@ -13861,7 +13612,6 @@ mod tests {
             },
             touched_scope_filter: Default::default(),
             current_state_scoped_ranges: None,
-            snapshot_root: None,
         }
     }
 
@@ -13878,6 +13628,7 @@ mod tests {
     #[test]
     fn commit_state_manifest_codec_authenticates_scoped_range_root() {
         let mut manifest = commit_state_manifest_fixture();
+        let serving_base_commit_id = None;
         let tree = super::super::scoped_range::ScopedRangeRoot {
             root_id: [7; 32],
             root_digest: [8; 32],
@@ -13886,8 +13637,7 @@ mod tests {
             row_count: 17,
             tree_height: 1,
         };
-        let serving_base_commit_id = manifest.parent_commit_ids.first().copied();
-        let serving_base_root_id = Some([9; 32]);
+        let serving_base_root_id = None;
         let transition_digest = super::super::scoped_current_state::scoped_range_transition_digest(
             manifest.commit_id,
             serving_base_commit_id,
@@ -13918,40 +13668,6 @@ mod tests {
     }
 
     #[test]
-    fn commit_state_manifest_codec_rejects_wrong_serving_base() {
-        let mut manifest = commit_state_manifest_fixture();
-        let tree = super::super::scoped_range::ScopedRangeRoot {
-            root_id: [7; 32],
-            root_digest: [8; 32],
-            marker_count: 1,
-            part_count: 2,
-            row_count: 17,
-            tree_height: 1,
-        };
-        let wrong_base = CommitId::for_test_label("wrong-serving-base");
-        let serving_base_root_id = Some([9; 32]);
-        let transition_digest = super::super::scoped_current_state::scoped_range_transition_digest(
-            manifest.commit_id,
-            Some(wrong_base),
-            serving_base_root_id,
-            &manifest.mutations,
-            &tree,
-        )
-        .expect("transition should hash");
-        manifest.current_state_scoped_ranges =
-            Some(Box::new(super::super::types::CurrentStateScopedRangeRoot {
-                tree,
-                serving_base_commit_id: Some(wrong_base),
-                serving_base_root_id,
-                transition_digest,
-            }));
-
-        let error = encode_commit_state_manifest(&manifest)
-            .expect_err("serving base outside commit authority must fail closed");
-        assert!(error.message.contains("serving base"));
-    }
-
-    #[test]
     fn commit_state_manifest_codec_rejects_pre_cut_formats() {
         let manifest = commit_state_manifest_fixture();
         let payload = storage_codec::encode("tracked_state commit_state_manifest", &manifest)
@@ -13968,31 +13684,6 @@ mod tests {
                 .expect_err("the hard cut must reject pre-v7 manifest formats");
             assert!(error.message.contains("unsupported format"));
         }
-
-        for magic in [
-            b"LXSA1".as_slice(),
-            b"LXSA2".as_slice(),
-            b"LXSA3".as_slice(),
-            b"LXSA4".as_slice(),
-        ] {
-            let mut legacy_seal = magic.to_vec();
-            legacy_seal.extend_from_slice(&[0; TRACKED_STATE_HASH_BYTES]);
-            legacy_seal.extend_from_slice(&payload);
-            let error = super::decode_commit_state_semantic_authority(&legacy_seal)
-                .expect_err("the hard cut must reject pre-v4 semantic seals");
-            assert!(error.message.contains("unsupported format"));
-        }
-
-        let legacy_digest =
-            blake3::Hasher::new_derive_key("lix.commit-state.semantic-authority.v4")
-                .update(&payload)
-                .finalize();
-        let mut retagged_v4 = super::COMMIT_STATE_SEMANTIC_AUTHORITY_MAGIC.to_vec();
-        retagged_v4.extend_from_slice(legacy_digest.as_bytes());
-        retagged_v4.extend_from_slice(&payload);
-        let error = super::decode_commit_state_semantic_authority(&retagged_v4)
-            .expect_err("an LXSA4 digest must not become valid under an LXSA5 prefix");
-        assert!(error.message.contains("digest is invalid"));
     }
 
     #[tokio::test]
@@ -14019,134 +13710,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn semantic_authority_is_the_point_source_and_guards_manifest_scans() {
-        let storage = StorageAdapter::new(Memory::new());
-        let manifest = commit_state_manifest_fixture();
-        let mut writes = storage.new_write_set();
-        stage_commit_state_manifest(&mut writes, &manifest).expect("authority should stage");
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("authority should commit");
-
-        let mut forged = manifest.clone();
-        forged.generation += 1;
-        let mut writes = storage.new_write_set();
-        super::stage_unchecked_commit_state_manifest_for_test(&mut writes, &forged)
-            .expect("mutable manifest corruption should stage without replacing authority");
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("mutable manifest corruption should commit");
-
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("corrupt read should open");
-        let point_state = super::load_point_replay_commit_state(&read, manifest.commit_id)
-            .await
-            .expect("point replay should load immutable semantic authority")
-            .expect("semantic authority should exist");
-        assert_eq!(&*point_state, &manifest);
-        let change_error = scan_change_records_from_commit_deltas(&read)
-            .await
-            .expect_err("packed change scans must verify semantic authority");
-        assert!(change_error.message.contains("semantic authority"));
-        let inventory_error = scan_commit_delta_inventory(&read)
-            .await
-            .expect_err("GC inventory must verify semantic authority");
-        assert!(inventory_error.message.contains("semantic authority"));
-
-        let mut corrupted_authority =
-            super::commit_state_semantic_seal(&manifest).expect("semantic authority should encode");
-        *corrupted_authority
-            .last_mut()
-            .expect("semantic authority should not be empty") ^= 0xff;
-        let mut writes = storage.new_write_set();
-        writes.put(
-            StorageSpace::mutable(
-                super::TRACKED_STATE_COMMIT_STATE_SEAL_SPACE.id,
-                super::TRACKED_STATE_COMMIT_STATE_SEAL_NAMESPACE,
-            ),
-            key(super::commit_state_manifest_key(manifest.commit_id)),
-            value(corrupted_authority),
-        );
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("authority corruption should commit through the test-only mutable alias");
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("corrupt authority read should open");
-        let error = super::load_point_replay_commit_state(&read, manifest.commit_id)
-            .await
-            .expect_err("point replay must reject corrupt immutable authority bytes");
-        assert!(error.message.contains("authority digest"));
-    }
-
-    #[tokio::test]
-    async fn gc_inventory_rejects_missing_and_orphan_semantic_authority() {
-        let missing_storage = StorageAdapter::new(Memory::new());
-        let manifest = commit_state_manifest_fixture();
-        let mut writes = missing_storage.new_write_set();
-        stage_commit_state_manifest(&mut writes, &manifest).expect("authority should stage");
-        missing_storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("authority should commit");
-        let mut deletes = missing_storage.new_write_set();
-        deletes.delete(
-            super::TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
-            key(super::commit_state_manifest_key(manifest.commit_id)),
-        );
-        missing_storage
-            .commit_write_set(deletes, StorageWriteOptions::default())
-            .await
-            .expect("seal deletion should commit");
-        let read = missing_storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("missing-seal read should open");
-        let error = scan_commit_delta_inventory(&read)
-            .await
-            .expect_err("GC inventory must reject a missing seal");
-        assert!(
-            error
-                .message
-                .contains("orphan manifest or semantic authority")
-        );
-
-        let orphan_storage = StorageAdapter::new(Memory::new());
-        let mut writes = orphan_storage.new_write_set();
-        writes.put(
-            super::TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
-            key(super::commit_state_manifest_key(manifest.commit_id)),
-            value(
-                super::commit_state_semantic_seal(&manifest)
-                    .unwrap()
-                    .to_vec(),
-            ),
-        );
-        orphan_storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("orphan seal should commit");
-        let read = orphan_storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("orphan-seal read should open");
-        let error = scan_commit_delta_inventory(&read)
-            .await
-            .expect_err("GC inventory must reject an orphan seal");
-        assert!(
-            error
-                .message
-                .contains("orphan manifest or semantic authority")
-        );
-    }
-
-    #[tokio::test]
     async fn authoritative_root_is_visible_only_through_commit_state() {
         let storage = StorageAdapter::new(Memory::new());
         let mut manifest = commit_state_manifest_fixture();
@@ -14155,7 +13718,7 @@ mod tests {
             commit_id: manifest.commit_id,
             root_id: TrackedStateRootId::new([1; 32]),
             parent_roots: vec![crate::tracked_state::types::TrackedStateCommitRootParent {
-                commit_id: manifest.parent_commit_ids[0],
+                commit_id: CommitId::for_test_label("snapshot-parent"),
                 root_id: TrackedStateRootId::new([3; 32]),
             }],
             changed_key_count: 1,
@@ -14164,9 +13727,11 @@ mod tests {
             primary_chunk_count: 1,
             primary_chunk_bytes: 64,
         };
-        manifest.snapshot_root = Some(authoritative.clone());
         let mut writes = storage.new_write_set();
-        stage_commit_state_manifest(&mut writes, &manifest).expect("authority should stage");
+        let staged = super::stage_commit_state_manifest_with_handle(&mut writes, &manifest)
+            .expect("authority should stage");
+        super::stage_staged_commit_state_snapshot_root(&mut writes, &staged, authoritative.clone())
+            .expect("snapshot root should stage");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
@@ -14177,22 +13742,19 @@ mod tests {
             .expect("read should open");
 
         assert_eq!(
-            super::load_authoritative_commit_root(&read, &manifest.commit_id.to_string())
+            super::load_snapshot_commit_root(&read, &manifest.commit_id.to_string())
                 .await
                 .expect("authority should load"),
             Some(authoritative)
         );
+        let published = super::load_published_commit_state_manifest(&read, manifest.commit_id)
+            .await
+            .expect("published manifest should load")
+            .expect("published manifest should exist");
         drop(read);
-
-        manifest.snapshot_root = None;
-        manifest.replay_debt = CommitStateReplayDebt {
-            depth: 1,
-            rows: 1,
-            bytes: 64,
-        };
         let mut writes = storage.new_write_set();
-        super::stage_resealed_commit_state_manifest_for_test(&mut writes, &manifest)
-            .expect("rootless authority should stage");
+        super::stage_commit_state_snapshot_root_update(&mut writes, &published, None)
+            .expect("snapshot root deletion should stage");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
@@ -14202,7 +13764,7 @@ mod tests {
             .await
             .expect("rootless read should open");
         assert!(
-            super::load_authoritative_commit_root(&read, &manifest.commit_id.to_string())
+            super::load_snapshot_commit_root(&read, &manifest.commit_id.to_string())
                 .await
                 .expect("rootless authority should load")
                 .is_none(),
@@ -14214,7 +13776,6 @@ mod tests {
     async fn rootless_rebuild_updates_only_the_mutable_snapshot_accelerator() {
         let storage = StorageAdapter::new(Memory::new());
         let mut original = commit_state_manifest_fixture();
-        original.snapshot_root = None;
         original.replay_debt = CommitStateReplayDebt {
             depth: 1,
             rows: 1,
@@ -14240,7 +13801,7 @@ mod tests {
             commit_id: original.commit_id,
             root_id: TrackedStateRootId::new([9; 32]),
             parent_roots: vec![crate::tracked_state::types::TrackedStateCommitRootParent {
-                commit_id: original.parent_commit_ids[0],
+                commit_id: CommitId::for_test_label("rebuild-parent"),
                 root_id: TrackedStateRootId::new([8; 32]),
             }],
             changed_key_count: 1,
@@ -14270,7 +13831,13 @@ mod tests {
             .await
             .expect("rebuilt manifest should load")
             .expect("rebuilt manifest should exist");
-        assert_eq!(loaded.snapshot_root, Some(rebuilt));
+        assert_eq!(loaded, original);
+        assert_eq!(
+            super::load_snapshot_commit_root(&read, &loaded.commit_id.to_string())
+                .await
+                .expect("rebuilt root should load"),
+            Some(rebuilt)
+        );
         let point = super::load_point_replay_commit_state(&read, original.commit_id)
             .await
             .expect("immutable point authority should load")
@@ -14299,7 +13866,7 @@ mod tests {
     }
 
     #[test]
-    fn commit_state_manifest_allows_accelerators_and_rejects_replay_drift() {
+    fn commit_state_manifest_rejects_replay_drift() {
         let mut mixed = commit_state_manifest_fixture();
         mixed.mutations.parts.push(super::CommitStateMutationPart {
             first_key: vec![1],
@@ -14313,28 +13880,7 @@ mod tests {
                 .contains("mixes inline and external")
         );
 
-        let mut rooted_with_debt = commit_state_manifest_fixture();
-        rooted_with_debt.snapshot_root = Some(TrackedStateCommitRoot {
-            commit_id: rooted_with_debt.commit_id,
-            root_id: TrackedStateRootId::new([4; 32]),
-            parent_roots: vec![crate::tracked_state::types::TrackedStateCommitRootParent {
-                commit_id: rooted_with_debt.parent_commit_ids[0],
-                root_id: TrackedStateRootId::new([5; 32]),
-            }],
-            changed_key_count: 1,
-            row_count_estimate: 1,
-            tree_height: 1,
-            primary_chunk_count: 1,
-            primary_chunk_bytes: 64,
-        });
-        let encoded = encode_commit_state_manifest(&rooted_with_debt)
-            .expect("an immutable snapshot accelerator may coexist with replay debt");
-        assert_eq!(
-            decode_commit_state_manifest(&encoded).expect("accelerated manifest should decode"),
-            rooted_with_debt
-        );
-
-        let mut invalid_debt = rooted_with_debt.clone();
+        let mut invalid_debt = commit_state_manifest_fixture();
         invalid_debt.replay_debt.depth = 0;
         assert!(
             encode_commit_state_manifest(&invalid_debt)
@@ -14348,7 +13894,7 @@ mod tests {
         forged_empty_authority.mutations.replacement_parts =
             Some(super::StoredReplacementPartsAuthority {
                 directory_digest: [7; 32],
-                uniform_updated_at: forged_empty_authority.created_at,
+                uniform_updated_at: LixTimestamp::from_unix_millis_utc_lossy(1234),
             });
         assert!(
             encode_commit_state_manifest(&forged_empty_authority)

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -8111,6 +8111,24 @@ pub(crate) fn stage_delete_commit_delta_inventory_entry(
     Ok(())
 }
 
+/// Removes rebuildable snapshot projections owned by collected semantic commits.
+///
+/// Snapshot roots are mutable accelerators rather than immutable mutation
+/// authority. A selected-source manifest may therefore remain live after its
+/// semantic commit is swept, but its commit-addressed snapshot root must not:
+/// otherwise historical reads can continue to resolve the collected commit.
+pub(crate) fn stage_delete_snapshot_commit_roots(
+    writes: &mut StorageWriteSet,
+    commit_ids: impl IntoIterator<Item = CommitId>,
+) {
+    writes.delete_batch(
+        TRACKED_STATE_SNAPSHOT_ROOT_SPACE,
+        commit_ids
+            .into_iter()
+            .map(|commit_id| key(commit_state_manifest_key(commit_id))),
+    );
+}
+
 async fn scan_full_space(
     store: &(impl StorageAdapterRead + ?Sized),
     space: StorageSpace,

--- a/packages/engine/src/tracked_state/types.rs
+++ b/packages/engine/src/tracked_state/types.rs
@@ -170,8 +170,8 @@ pub(crate) struct TrackedStateCommitRootParent {
 ///
 /// Zero debt means the snapshot root is the canonical serving layout. Nonzero
 /// debt means readers can reconstruct the state from the bounded interval;
-/// [`CommitStateManifest::snapshot_root`] may still contain an equivalent,
-/// rebuildable snapshot accelerator without changing that policy.
+/// The separate snapshot-root projection may still contain an equivalent,
+/// rebuildable accelerator without changing that policy.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, musli::Encode, musli::Decode)]
 #[musli(packed)]
 pub(crate) struct CommitStateReplayDebt {
@@ -313,7 +313,7 @@ pub(crate) struct CurrentStatePartDescriptor {
 /// Manifest-attested root of the unified scope/part serving tree.
 ///
 /// The generic tree owns only authenticated physical routing. These fields
-/// bind one result root to the physical serving base and sealed mutation
+/// bind one result root to the physical serving base and certified mutation
 /// authority that produced it. Graph ancestry remains an independent semantic
 /// relationship and is not exposed to the tree.
 #[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
@@ -406,27 +406,24 @@ impl CommitStateMutationInventory {
     }
 }
 
-/// Single semantic authority for one tracked commit.
+/// Immutable physical authority for one tracked commit.
 ///
 /// Compact topology projections, point locators, current-state HOT rows, and
 /// snapshot tree chunks remain rebuildable serving indexes. None may carry
-/// commit semantics absent from this manifest.
+/// semantic commit facts, which belong exclusively to `changelog.commit`.
 #[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
 #[musli(packed)]
 pub(crate) struct CommitStateManifest {
     pub(crate) commit_id: CommitId,
-    pub(crate) generation: u64,
-    pub(crate) parent_commit_ids: Vec<CommitId>,
-    pub(crate) commit_change_id: ChangeId,
-    pub(crate) account_id: String,
-    pub(crate) created_at: LixTimestamp,
+    /// Physical decode dictionary for authored mutation rows. This is not
+    /// commit-account authority: it remains with retained immutable payloads
+    /// even if GC removes the semantic commit projection.
+    pub(crate) change_account_id: String,
     pub(crate) replay_debt: CommitStateReplayDebt,
     pub(crate) mutations: CommitStateMutationInventory,
     pub(crate) touched_scope_filter: CommitStateTouchedScopeFilter,
     #[musli(with = crate::storage_codec::option)]
     pub(crate) current_state_scoped_ranges: Option<Box<CurrentStateScopedRangeRoot>>,
-    #[musli(with = crate::storage_codec::option)]
-    pub(crate) snapshot_root: Option<TrackedStateCommitRoot>,
 }
 
 /// Materialized tracked-state commit-root row.

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -1022,6 +1022,7 @@ fn index_prepared_rows(rows: &PreparedStateBatch) -> Result<PreparedRowIndex, Li
 #[derive(Clone, Debug)]
 struct StagedChangelogCommit {
     record: CommitRecord,
+    replay_debt: CommitStateReplayDebt,
     change_count: usize,
     selected_change_batches: Vec<StagedCommitChangeBatch>,
 }
@@ -1179,20 +1180,10 @@ async fn stage_changelog_commits(
                     )
                 })?;
         let manifest = &*published;
-        // Replay debt is the durable layout authority. A rootless commit may
-        // later gain an immutable snapshot accelerator without changing its
-        // changelog topology projection.
-        let manifest_rootless = manifest.replay_debt.depth > 0;
-        if manifest.generation != record.generation
-            || manifest.parent_commit_ids != record.parent_commit_ids
-            || manifest.commit_change_id != record.change_id
-            || manifest.account_id != record.account_id
-            || manifest.created_at != record.created_at
-            || manifest_rootless != record.tracked_state_rootless
-            || manifest.replay_debt.depth != record.tracked_state_rootless_depth
-            || manifest.replay_debt.rows != record.tracked_state_rootless_rows
-            || manifest.replay_debt.bytes != record.tracked_state_rootless_bytes
-        {
+        // Replay debt is physical layout policy. A rootless commit may later
+        // gain a rebuildable snapshot accelerator without changing its
+        // immutable physical manifest or semantic changelog record.
+        if manifest.commit_id != record.commit_id {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 format!(
@@ -1200,7 +1191,7 @@ async fn stage_changelog_commits(
                 ),
             ));
         }
-        generations.insert(*commit_id, manifest.generation);
+        generations.insert(*commit_id, record.generation);
         rootless_depths.insert(*commit_id, manifest.replay_debt.depth);
         rootless_rows.insert(*commit_id, manifest.replay_debt.rows);
         rootless_bytes.insert(*commit_id, manifest.replay_debt.bytes);
@@ -1423,14 +1414,10 @@ async fn stage_changelog_commits(
             })?;
         }
         let record = CommitRecord {
-            format_version: 1,
+            format_version: 2,
             commit_id: commit_row.commit_id,
             generation,
             parent_commit_ids: commit_row.parent_commit_ids.clone(),
-            tracked_state_rootless: rootless_commit_ids.contains(&commit_row.commit_id),
-            tracked_state_rootless_depth: rootless_depths[&commit_row.commit_id],
-            tracked_state_rootless_rows: rootless_rows[&commit_row.commit_id],
-            tracked_state_rootless_bytes: rootless_bytes[&commit_row.commit_id],
             change_id: commit_row.change_id,
             account_id: active_account_id.to_string(),
             created_at: commit_row.created_at,
@@ -1448,6 +1435,11 @@ async fn stage_changelog_commits(
             commit_row.commit_id,
             StagedChangelogCommit {
                 record,
+                replay_debt: CommitStateReplayDebt {
+                    depth: rootless_depths[&commit_row.commit_id],
+                    rows: rootless_rows[&commit_row.commit_id],
+                    bytes: rootless_bytes[&commit_row.commit_id],
+                },
                 change_count,
                 selected_change_batches: commit_row.selected_change_batches.clone(),
             },
@@ -2626,7 +2618,19 @@ async fn certify_complete_replacement_generations(
                         ),
                     )
                 })?;
-            if !record.tracked_state_rootless {
+            let manifest = crate::tracked_state::load_published_commit_state_manifest(
+                read, commit_id,
+            )
+            .await?
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "replacement generation parent '{commit_id}' has no physical authority"
+                    ),
+                )
+            })?;
+            if manifest.replay_debt.depth == 0 {
                 break Some(commit_id);
             }
             let Some(metadata) = load_commit_delta_replay_metadata(read, commit_id).await? else {
@@ -2738,7 +2742,17 @@ async fn certify_ordered_journal_replacement_generations(
                         ),
                     )
                 })?;
-            if !record.tracked_state_rootless {
+            let manifest = crate::tracked_state::load_published_commit_state_manifest(
+                read, commit_id,
+            )
+            .await?
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("immutable replacement parent '{commit_id}' has no physical authority"),
+                )
+            })?;
+            if manifest.replay_debt.depth == 0 {
                 break Some(commit_id);
             }
             let Some(metadata) = load_commit_delta_replay_metadata(read, commit_id).await? else {
@@ -5554,24 +5568,15 @@ where
             }
             let manifest = CommitStateManifest {
                 commit_id: record.commit_id,
-                generation: record.generation,
-                parent_commit_ids: record.parent_commit_ids.clone(),
-                commit_change_id: record.change_id,
-                account_id: record.account_id.clone(),
-                created_at: record.created_at,
+                change_account_id: record.account_id.clone(),
                 replay_debt: if rootless {
-                    CommitStateReplayDebt {
-                        depth: record.tracked_state_rootless_depth,
-                        rows: record.tracked_state_rootless_rows,
-                        bytes: record.tracked_state_rootless_bytes,
-                    }
+                    staged.replay_debt
                 } else {
                     CommitStateReplayDebt::default()
                 },
                 mutations,
                 touched_scope_filter,
                 current_state_scoped_ranges,
-                snapshot_root,
             };
             let staged_manifest = if let Some(publication) = catalog_publication.as_ref() {
                 crate::tracked_state::stage_certified_commit_state_manifest_with_handle(
@@ -5582,6 +5587,13 @@ where
             } else {
                 crate::tracked_state::stage_commit_state_manifest_with_handle(writes, &manifest)?
             };
+            if let Some(snapshot_root) = snapshot_root {
+                crate::tracked_state::stage_staged_commit_state_snapshot_root(
+                    writes,
+                    &staged_manifest,
+                    snapshot_root,
+                )?;
+            }
             published_manifests.insert(record.commit_id, staged_manifest);
         }
         Ok(())
@@ -6763,11 +6775,7 @@ mod tests {
             &mut writes,
             &CommitStateManifest {
                 commit_id,
-                generation: 0,
-                parent_commit_ids: Vec::new(),
-                commit_change_id: change_id("mixed-certified-commit"),
-                account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
-                created_at: timestamp,
+                change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 replay_debt: CommitStateReplayDebt {
                     depth: 1,
                     rows: 2,
@@ -6780,7 +6788,6 @@ mod tests {
                     .expect("mixed certified inventory should stage"),
                 touched_scope_filter: Default::default(),
                 current_state_scoped_ranges: None,
-                snapshot_root: None,
             },
         )
         .expect("mixed certified authority should stage");
@@ -6902,11 +6909,16 @@ mod tests {
             panic!("changelog commit should exist");
         };
         assert_eq!(record.change_id, change_id("test-uuid-2"));
-        assert!(!record.tracked_state_rootless);
         let membership_read = storage
             .begin_read(StorageReadOptions::default())
             .await
             .expect("membership read should open");
+        let physical_state =
+            crate::tracked_state::load_commit_state_manifest(&membership_read, record.commit_id)
+                .await
+                .expect("physical state should load")
+                .expect("physical state should exist");
+        assert_eq!(physical_state.replay_debt, CommitStateReplayDebt::default());
         let change_ids =
             crate::tracked_state::load_commit_delta_change_ids(&membership_read, record.commit_id)
                 .await
@@ -8724,23 +8736,30 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(commits[0].generation, 0);
         assert_eq!(commits[1].generation, 1);
-        assert!(
-            commits.iter().all(|record| record.tracked_state_rootless),
-            "a staged child must inherit its first parent's rootless interval"
-        );
+        let authority_read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("physical authority read should open");
+        let states =
+            crate::tracked_state::load_commit_state_manifests(&authority_read, &commit_ids)
+                .await
+                .expect("physical states should load")
+                .into_iter()
+                .map(|state| state.expect("physical state"))
+                .collect::<Vec<_>>();
         assert_eq!(
-            commits
+            states
                 .iter()
-                .map(|record| record.tracked_state_rootless_depth)
+                .map(|state| state.replay_debt.depth)
                 .collect::<Vec<_>>(),
             vec![1, 2]
         );
-        assert!(commits[0].tracked_state_rootless_bytes > 0);
-        assert!(commits[1].tracked_state_rootless_bytes > commits[0].tracked_state_rootless_bytes);
+        assert!(states[0].replay_debt.bytes > 0);
+        assert!(states[1].replay_debt.bytes > states[0].replay_debt.bytes);
         assert_eq!(
-            commits
+            states
                 .iter()
-                .map(|record| record.tracked_state_rootless_rows)
+                .map(|state| state.replay_debt.rows)
                 .collect::<Vec<_>>(),
             vec![1, 2]
         );
@@ -8818,12 +8837,11 @@ mod tests {
         assert!(rootless_commit_ids.is_empty());
         assert!(durable_root_rebuild_parents.is_empty());
         assert_eq!(staged_root_rebuild_commits.len(), commit_count - 1);
-        assert!(staged.values().all(|commit| {
-            !commit.record.tracked_state_rootless
-                && commit.record.tracked_state_rootless_depth == 0
-                && commit.record.tracked_state_rootless_rows == 0
-                && commit.record.tracked_state_rootless_bytes == 0
-        }));
+        assert!(
+            staged
+                .values()
+                .all(|commit| commit.replay_debt == Default::default())
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -29,8 +29,8 @@ use crate::catalog::{
     stage_catalog_revision,
 };
 use crate::changelog::{
-    ChangeId, ChangeRecord, ChangeRecordProjection, CommitId, load_change_records,
-    materialize_known_change_payloads,
+    ChangeId, ChangeRecord, ChangeRecordProjection, ChangelogContext, ChangelogReader, CommitId,
+    CommitLoadRequest, load_change_records, materialize_known_change_payloads,
 };
 use crate::checkpoint::{
     CHECKPOINT_MARKER_SCHEMA_KEY, checkpoint_history_from_head, checkpoint_marker_stage_row,
@@ -154,13 +154,17 @@ where
             .collect::<BTreeSet<_>>()
             .into_iter()
             .collect::<Vec<_>>();
-        let accounts_by_commit = commit_ids
-            .iter()
-            .copied()
-            .zip(crate::tracked_state::load_commit_state_manifests(&self.store, &commit_ids).await?)
-            .map(|(commit_id, manifest)| {
-                manifest
-                    .map(|manifest| (commit_id, manifest.account_id))
+        let records = ChangelogContext::new()
+            .reader(&self.store)
+            .load_commits(CommitLoadRequest {
+                commit_ids: &commit_ids,
+            })
+            .await?;
+        let accounts_by_commit = records
+            .into_iter()
+            .map(|(commit_id, record)| {
+                record
+                    .map(|record| (*commit_id, record.account_id))
                     .ok_or_else(|| {
                         LixError::new(
                             LixError::CODE_INTERNAL_ERROR,


### PR DESCRIPTION
## Summary

- make `changelog.commit` the sole durable owner of semantic commit topology and identity facts
- make `tracked_state.commit_state_manifest` one immutable physical authority per commit and remove the semantic seal plane
- move the rebuildable snapshot root into its own mutable projection space
- remove replay-policy duplication from semantic commit rows and remove the redundant semantic topology copy from GC physical inventory
- bind physical publication proofs to the exact commit ID
- hard-cut the repository protocol to v57, manifest encoding to LXCS9, and semantic commit rows to format v2

## Performance

Paired 10K SQL-session insert-all medians, 5 samples on the same host/build profile:

- RocksDB: 24.754631 ms -> 25.400012 ms (+2.61%)
- SlateDB: 24.208404 ms -> 25.057067 ms (+3.51%)

Both remain below the 5% critical-path regression gate. Write accounting improves from 71 to 70 staged puts, reduces staged value bytes by about 3.4 KB, and reduces the physical manifest by 43 bytes.

## Validation

- `cargo test -p lix_engine --features all-simulations`
  - 1,883 unit tests passed; 8 ignored
  - 810 integration/simulation tests passed; 2 ignored
  - 3 doctests passed
- `cargo test -p lix_rocksdb_storage`
- `cargo test -p lix_sqlite_storage`
- `cargo test -p lix_slatedb_storage`
- `cargo check -p lix_engine --all-features`
- `cargo fmt --all`
- `git diff --check`

This PR intentionally targets the pinned long-lived `one-layout` integration branch.