### PR TITLE
bench(engine): qualify untracked CRUD end to end

### DIFF
--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -116,7 +116,7 @@ required-features = ["storage-benches"]
 name = "untracked_state_crud"
 path = "benches/untracked_state_crud/main.rs"
 harness = false
-required-features = ["storage-benches"]
+required-features = ["storage-benches", "slatedb"]
 
 [[bench]]
 name = "tracked_state_crud"

--- a/packages/engine-benchmarks/benches/untracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/untracked_state_crud/main.rs
@@ -1138,7 +1138,6 @@ where
     assert_eq!(affected, 1);
 }
 
-#[expect(clippy::cast_possible_truncation)]
 async fn insert_untracked_json_pointer_rows<StorageImpl>(
     session: &SessionContext<StorageImpl>,
     rows: &[PointerRow],

--- a/packages/engine-benchmarks/benches/untracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/untracked_state_crud/main.rs
@@ -23,7 +23,7 @@ use lix_engine::storage_adapter::{
     StoragePrefix, StorageReadOptions, StorageScanOptions, StorageSpace, StorageValue,
     StorageWriteOptions,
 };
-use lix_engine::{Engine, SessionContext, Storage};
+use lix_engine::{Engine, SessionContext, Storage, Value};
 use lix_rocksdb_storage::RocksDB;
 #[cfg(feature = "slatedb")]
 use lix_slatedb_storage::SlateDB;
@@ -1149,14 +1149,20 @@ async fn insert_untracked_json_pointer_rows<StorageImpl>(
         .begin_transaction()
         .await
         .expect("begin untracked insert transaction");
-    for chunk in rows.chunks(SESSION_INSERT_CHUNK_SIZE) {
-        let sql = insert_untracked_json_pointer_sql(chunk);
+    for row in rows {
         let affected = transaction
-            .execute(&sql, &[])
+            .execute(
+                "INSERT INTO json_pointer (path, value, lixcol_untracked) \
+                 VALUES ($1, lix_json($2), true)",
+                &[
+                    Value::Text(row.path.clone()),
+                    Value::Text(row.value_json.clone()),
+                ],
+            )
             .await
             .expect("insert untracked json_pointer rows")
             .rows_affected();
-        assert_eq!(affected as usize, chunk.len());
+        assert_eq!(affected, 1);
     }
     transaction
         .commit()
@@ -1258,14 +1264,20 @@ async fn update_untracked_json_pointer_rows<StorageImpl>(
         .begin_transaction()
         .await
         .expect("begin untracked update transaction");
-    for chunk in rows.chunks(SESSION_INSERT_CHUNK_SIZE) {
-        let sql = update_untracked_json_pointer_sql(chunk);
+    for row in rows {
         let affected = transaction
-            .execute(&sql, &[])
+            .execute(
+                "UPDATE json_pointer SET value = lix_json($1) \
+                 WHERE path = $2 AND lixcol_untracked = true",
+                &[
+                    Value::Text(row.updated_value_json.clone()),
+                    Value::Text(row.path.clone()),
+                ],
+            )
             .await
             .expect("update untracked json_pointer rows")
             .rows_affected();
-        assert_eq!(affected as usize, chunk.len());
+        assert_eq!(affected, 1);
     }
     transaction
         .commit()
@@ -1460,43 +1472,6 @@ fn raw_rows(rows: &[PointerRow]) -> Vec<RawUntrackedRow> {
             global: false,
         })
         .collect()
-}
-
-fn insert_untracked_json_pointer_sql(rows: &[PointerRow]) -> String {
-    let mut sql = String::from("INSERT INTO json_pointer (path, value, lixcol_untracked) VALUES ");
-    for (index, row) in rows.iter().enumerate() {
-        if index > 0 {
-            sql.push(',');
-        }
-        let _ = write!(
-            sql,
-            "('{}', lix_json('{}'), true)",
-            sql_string(row.path.as_str()),
-            sql_string(row.value_json.as_str())
-        );
-    }
-    sql
-}
-
-fn update_untracked_json_pointer_sql(rows: &[PointerRow]) -> String {
-    let mut sql = String::from("UPDATE json_pointer SET value = CASE path ");
-    for row in rows {
-        let _ = write!(
-            sql,
-            "WHEN '{}' THEN lix_json('{}') ",
-            sql_string(&row.path),
-            sql_string(&row.updated_value_json)
-        );
-    }
-    sql.push_str("ELSE value END WHERE lixcol_untracked = true AND path IN (");
-    for (index, row) in rows.iter().enumerate() {
-        if index > 0 {
-            sql.push(',');
-        }
-        let _ = write!(sql, "'{}'", sql_string(&row.path));
-    }
-    sql.push(')');
-    sql
 }
 
 fn entity_pk(row: &PointerRow) -> String {

--- a/packages/engine-benchmarks/benches/untracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/untracked_state_crud/main.rs
@@ -1,3 +1,11 @@
+//! End-to-end untracked CRUD scorecard against raw rusqlite, with separately
+//! named storage-adapter diagnostic lanes. Criterion substring filters select
+//! an individual lane for CPU/I/O profiling; `LIX_UNTRACKED_STATE_CRUD_IO`
+//! prints logical Storage traffic for `smoke`, `real_workload`, or `all`.
+//!
+//! The scorecard intentionally requires `--features storage-benches,slatedb`:
+//! a run without both production adapters is incomplete and Cargo skips it.
+
 use std::fmt::Write as _;
 use std::ops::Bound;
 use std::sync::{Arc, Mutex};
@@ -17,6 +25,8 @@ use lix_engine::storage_adapter::{
 };
 use lix_engine::{Engine, SessionContext, Storage};
 use lix_rocksdb_storage::RocksDB;
+#[cfg(feature = "slatedb")]
+use lix_slatedb_storage::SlateDB;
 use lix_sqlite_storage::SQLite;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde_json::Value as JsonValue;
@@ -65,6 +75,10 @@ struct RawSQLiteFixture {
 
 #[derive(Debug, Clone, Default)]
 struct IoStats {
+    begin_reads: usize,
+    begin_writes: usize,
+    commits: usize,
+    rollbacks: usize,
     get_calls: usize,
     get_keys: usize,
     get_key_bytes: usize,
@@ -106,7 +120,12 @@ impl IoStats {
     }
 
     fn io_ops(&self) -> usize {
-        self.read_ops() + self.write_batches
+        self.begin_reads
+            + self.begin_writes
+            + self.read_ops()
+            + self.write_batches
+            + self.commits
+            + self.rollbacks
     }
 
     fn io_bytes(&self) -> usize {
@@ -195,6 +214,7 @@ where
     where
         Self: 'a;
     async fn begin_read(&self, opts: ReadOptions) -> Result<Self::Read<'_>, StorageError> {
+        self.stats.lock().expect("io stats mutex").begin_reads += 1;
         Ok(CountingRead {
             inner: self.inner.begin_read(opts).await?,
             stats: Arc::clone(&self.stats),
@@ -202,6 +222,7 @@ where
     }
 
     async fn begin_write(&self, opts: WriteOptions) -> Result<Self::Write<'_>, StorageError> {
+        self.stats.lock().expect("io stats mutex").begin_writes += 1;
         Ok(CountingWrite {
             inner: self.inner.begin_write(opts).await?,
             stats: Arc::clone(&self.stats),
@@ -320,6 +341,7 @@ where
     where
         Self: Sized,
     {
+        self.stats.lock().expect("io stats mutex").commits += 1;
         self.inner.commit().await
     }
 
@@ -327,6 +349,7 @@ where
     where
         Self: Sized,
     {
+        self.stats.lock().expect("io stats mutex").rollbacks += 1;
         self.inner.rollback().await
     }
 }
@@ -335,17 +358,73 @@ where
 enum LixStorageProfile {
     SQLite,
     RocksDB,
+    #[cfg(feature = "slatedb")]
+    SlateDB,
 }
 
-const LIX_STORAGE_PROFILES: [LixStorageProfile; 2] =
-    [LixStorageProfile::SQLite, LixStorageProfile::RocksDB];
+const DIRECT_ADAPTER_PROFILES: &[LixStorageProfile] = &[
+    LixStorageProfile::SQLite,
+    LixStorageProfile::RocksDB,
+    #[cfg(feature = "slatedb")]
+    LixStorageProfile::SlateDB,
+];
+
+const SESSION_PROFILES: &[LixStorageProfile] = &[
+    LixStorageProfile::RocksDB,
+    #[cfg(feature = "slatedb")]
+    LixStorageProfile::SlateDB,
+];
 
 impl LixStorageProfile {
     fn name(self) -> &'static str {
         match self {
             Self::SQLite => "lix_sqlite",
             Self::RocksDB => "lix_rocksdb",
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB => "lix_slatedb",
         }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum SessionCrudOperation {
+    InsertAll,
+    InsertOne,
+    SelectAll,
+    SelectOne,
+    UpdateAll,
+    UpdateOne,
+    DeleteAll,
+    DeleteOne,
+}
+
+impl SessionCrudOperation {
+    const ALL: [Self; 8] = [
+        Self::InsertAll,
+        Self::InsertOne,
+        Self::SelectAll,
+        Self::SelectOne,
+        Self::UpdateAll,
+        Self::UpdateOne,
+        Self::DeleteAll,
+        Self::DeleteOne,
+    ];
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::InsertAll => "insert_all_rows",
+            Self::InsertOne => "insert_one_by_pk",
+            Self::SelectAll => "select_all_rows",
+            Self::SelectOne => "select_one_by_pk",
+            Self::UpdateAll => "update_all_rows",
+            Self::UpdateOne => "update_one_by_pk",
+            Self::DeleteAll => "delete_all_rows",
+            Self::DeleteOne => "delete_one_by_pk",
+        }
+    }
+
+    fn needs_seed(self) -> bool {
+        !matches!(self, Self::InsertAll | Self::InsertOne)
     }
 }
 
@@ -359,10 +438,10 @@ fn untracked_state_crud_benches(c: &mut Criterion) {
 
     bench_raw_sqlite(c, &rows, SMOKE_ROWS, "smoke");
     bench_lix(c, &runtime, &rows, SMOKE_ROWS, "smoke");
-    bench_session_execute_untracked_insert(c, &runtime, &rows, SMOKE_ROWS, "smoke");
+    bench_session_crud(c, &runtime, &rows, SMOKE_ROWS, "smoke");
     bench_raw_sqlite(c, &rows, REAL_WORKLOAD_ROWS, "real_workload");
     bench_lix(c, &runtime, &rows, REAL_WORKLOAD_ROWS, "real_workload");
-    bench_session_execute_untracked_insert(c, &runtime, &rows, REAL_WORKLOAD_ROWS, "real_workload");
+    bench_session_crud(c, &runtime, &rows, REAL_WORKLOAD_ROWS, "real_workload");
 }
 
 fn maybe_print_io_report(runtime: &Runtime, all_rows: &[PointerRow]) {
@@ -380,10 +459,10 @@ fn maybe_print_io_report(runtime: &Runtime, all_rows: &[PointerRow]) {
 
     println!("\nuntracked_state_crud/io");
     println!(
-        "logical storage_v2 storage request/result accounting; not physical disk, WAL, or compaction I/O"
+        "logical Storage request/result accounting for non-production storage-adapter diagnostics and end-to-end sessions; not physical disk, WAL, or compaction I/O"
     );
     println!(
-        "| workload | storage | operation | logical rows | io ops | io ops/row | io bytes | io bytes/row | read calls | get calls | get keys | scan calls | read rows | read bytes | read bytes/row | write batches | puts | deletes | delete ranges | write bytes | write bytes/row |"
+        "| workload | storage | operation | logical rows | storage calls | storage calls/row | io bytes | io bytes/row | read calls | get calls | get keys | scan calls | read rows | read bytes | read bytes/row | write batches | puts | deletes | delete ranges | write bytes | write bytes/row |"
     );
     println!(
         "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
@@ -391,7 +470,7 @@ fn maybe_print_io_report(runtime: &Runtime, all_rows: &[PointerRow]) {
 
     for (label, row_count) in workloads {
         let rows = bench_rows(&all_rows[..row_count]);
-        for profile in LIX_STORAGE_PROFILES {
+        for &profile in DIRECT_ADAPTER_PROFILES {
             for operation in [
                 "insert_all_rows",
                 "select_all_rows",
@@ -406,9 +485,50 @@ fn maybe_print_io_report(runtime: &Runtime, all_rows: &[PointerRow]) {
                 let stats = runtime.block_on(measure_lix_io(profile, operation, &rows));
                 let logical_rows = operation_logical_rows(operation, row_count);
                 println!(
-                    "| {label}/{} | {} | `{operation}` | {logical_rows} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |",
+                    "| {label}/{} | adapter_diagnostic/{} | `{operation}` | {logical_rows} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |",
                     row_label(row_count),
                     profile.name(),
+                    stats.io_ops(),
+                    ratio(stats.io_ops(), logical_rows),
+                    stats.io_bytes(),
+                    ratio(stats.io_bytes(), logical_rows),
+                    stats.read_ops(),
+                    stats.get_calls,
+                    stats.get_keys,
+                    stats.scan_calls(),
+                    stats.read_rows(),
+                    stats.read_bytes(),
+                    ratio(stats.read_bytes(), logical_rows),
+                    stats.write_batches,
+                    stats.write_puts,
+                    stats.write_deletes,
+                    stats.write_delete_ranges,
+                    stats.write_bytes,
+                    ratio(stats.write_bytes, logical_rows),
+                );
+            }
+        }
+
+        let session_rows = &all_rows[..row_count];
+        for &profile in SESSION_PROFILES {
+            for operation in SessionCrudOperation::ALL {
+                let stats = runtime.block_on(measure_session_io(profile, operation, session_rows));
+                let logical_rows = if matches!(
+                    operation,
+                    SessionCrudOperation::InsertOne
+                        | SessionCrudOperation::SelectOne
+                        | SessionCrudOperation::UpdateOne
+                        | SessionCrudOperation::DeleteOne
+                ) {
+                    1
+                } else {
+                    row_count
+                };
+                println!(
+                    "| {label}/{} | session/{} | `{}` | {logical_rows} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |",
+                    row_label(row_count),
+                    profile.name(),
+                    operation.name(),
                     stats.io_ops(),
                     ratio(stats.io_ops(), logical_rows),
                     stats.io_bytes(),
@@ -441,7 +561,18 @@ fn bench_raw_sqlite(c: &mut Criterion, all_rows: &[PointerRow], row_count: usize
     group.bench_function(format!("insert_all_rows/{}", row_label(row_count)), |b| {
         b.iter_batched(
             prepare_raw_sqlite_empty,
-            |fixture| black_box(raw_sqlite_insert_all(fixture, &rows)),
+            |fixture| retain_fixture(fixture, |fixture| raw_sqlite_insert_all(fixture, &rows)),
+            BatchSize::LargeInput,
+        );
+    });
+    group.bench_function(format!("insert_one_by_pk/{}", row_label(row_count)), |b| {
+        b.iter_batched(
+            prepare_raw_sqlite_empty,
+            |fixture| {
+                retain_fixture(fixture, |fixture| {
+                    raw_sqlite_insert_one(fixture, pick_pk_row(&rows))
+                })
+            },
             BatchSize::LargeInput,
         );
     });
@@ -453,7 +584,11 @@ fn bench_raw_sqlite(c: &mut Criterion, all_rows: &[PointerRow], row_count: usize
         |b| {
             b.iter_batched(
                 prepare_raw_sqlite_empty,
-                |fixture| black_box(raw_sqlite_insert_all_unprepared_per_row(fixture, &rows)),
+                |fixture| {
+                    retain_fixture(fixture, |fixture| {
+                        raw_sqlite_insert_all_unprepared_per_row(fixture, &rows)
+                    })
+                },
                 BatchSize::LargeInput,
             );
         },
@@ -466,7 +601,11 @@ fn bench_raw_sqlite(c: &mut Criterion, all_rows: &[PointerRow], row_count: usize
         |b| {
             b.iter_batched(
                 prepare_raw_sqlite_empty,
-                |fixture| black_box(raw_sqlite_insert_all_unprepared_chunked(fixture, &rows)),
+                |fixture| {
+                    retain_fixture(fixture, |fixture| {
+                        raw_sqlite_insert_all_unprepared_chunked(fixture, &rows)
+                    })
+                },
                 BatchSize::LargeInput,
             );
         },
@@ -474,42 +613,54 @@ fn bench_raw_sqlite(c: &mut Criterion, all_rows: &[PointerRow], row_count: usize
     group.bench_function(format!("select_all_rows/{}", row_label(row_count)), |b| {
         b.iter_batched(
             || prepare_raw_sqlite_seeded(&rows),
-            |fixture| black_box(raw_sqlite_select_all(fixture, row_count)),
+            |fixture| retain_fixture(fixture, |fixture| raw_sqlite_select_all(fixture, row_count)),
             BatchSize::LargeInput,
         );
     });
     group.bench_function(format!("select_one_by_pk/{}", row_label(row_count)), |b| {
         b.iter_batched(
             || prepare_raw_sqlite_seeded(&rows),
-            |fixture| black_box(raw_sqlite_select_one_by_pk(fixture, pick_pk_row(&rows))),
+            |fixture| {
+                retain_fixture(fixture, |fixture| {
+                    raw_sqlite_select_one_by_pk(fixture, pick_pk_row(&rows))
+                })
+            },
             BatchSize::LargeInput,
         );
     });
     group.bench_function(format!("update_all_rows/{}", row_label(row_count)), |b| {
         b.iter_batched(
             || prepare_raw_sqlite_seeded(&rows),
-            |fixture| black_box(raw_sqlite_update_all(fixture, &rows)),
+            |fixture| retain_fixture(fixture, |fixture| raw_sqlite_update_all(fixture, &rows)),
             BatchSize::LargeInput,
         );
     });
     group.bench_function(format!("update_one_by_pk/{}", row_label(row_count)), |b| {
         b.iter_batched(
             || prepare_raw_sqlite_seeded(&rows),
-            |fixture| black_box(raw_sqlite_update_one_by_pk(fixture, pick_pk_row(&rows))),
+            |fixture| {
+                retain_fixture(fixture, |fixture| {
+                    raw_sqlite_update_one_by_pk(fixture, pick_pk_row(&rows))
+                })
+            },
             BatchSize::LargeInput,
         );
     });
     group.bench_function(format!("delete_all_rows/{}", row_label(row_count)), |b| {
         b.iter_batched(
             || prepare_raw_sqlite_seeded(&rows),
-            |fixture| black_box(raw_sqlite_delete_all(fixture, row_count)),
+            |fixture| retain_fixture(fixture, |fixture| raw_sqlite_delete_all(fixture, row_count)),
             BatchSize::LargeInput,
         );
     });
     group.bench_function(format!("delete_one_by_pk/{}", row_label(row_count)), |b| {
         b.iter_batched(
             || prepare_raw_sqlite_seeded(&rows),
-            |fixture| black_box(raw_sqlite_delete_one_by_pk(fixture, pick_pk_row(&rows))),
+            |fixture| {
+                retain_fixture(fixture, |fixture| {
+                    raw_sqlite_delete_one_by_pk(fixture, pick_pk_row(&rows))
+                })
+            },
             BatchSize::LargeInput,
         );
     });
@@ -524,9 +675,11 @@ fn bench_lix(
     label: &str,
 ) {
     let rows = bench_rows(&all_rows[..row_count]);
-    for profile in LIX_STORAGE_PROFILES {
-        let mut group =
-            c.benchmark_group(format!("untracked_state_crud/{}/{label}", profile.name()));
+    for &profile in DIRECT_ADAPTER_PROFILES {
+        let mut group = c.benchmark_group(format!(
+            "untracked_state_crud/storage_adapter_diagnostic/{}/{label}",
+            profile.name()
+        ));
         configure_group(&mut group, row_count);
 
         bench_lix_profile(&mut group, runtime, profile, &rows);
@@ -640,7 +793,7 @@ fn bench_lix_profile(
     });
 }
 
-fn bench_session_execute_untracked_insert(
+fn bench_session_crud(
     c: &mut Criterion,
     runtime: &Runtime,
     all_rows: &[PointerRow],
@@ -648,25 +801,29 @@ fn bench_session_execute_untracked_insert(
     label: &str,
 ) {
     let rows = all_rows[..row_count].to_vec();
-    for profile in LIX_STORAGE_PROFILES {
+    for &profile in SESSION_PROFILES {
         let mut group = c.benchmark_group(format!(
-            "untracked_state_crud/session_execute_untracked/{}/{label}",
+            "untracked_state_crud/session/{}/{label}",
             profile.name()
         ));
         configure_group(&mut group, row_count);
 
-        group.bench_function(format!("insert_all_rows/{}", row_label(row_count)), |b| {
-            b.iter_batched(
-                || runtime.block_on(prepare_profile_session_empty(profile)),
-                |session| {
-                    retain_fixture(session, |session| {
-                        runtime.block_on(session.insert_untracked_json_pointer_rows(&rows));
-                        rows.len()
-                    })
+        for operation in SessionCrudOperation::ALL {
+            group.bench_function(
+                format!("{}/{}", operation.name(), row_label(row_count)),
+                |b| {
+                    b.iter_batched(
+                        || runtime.block_on(prepare_profile_session(profile, operation, &rows)),
+                        |session| {
+                            retain_fixture(session, |session| {
+                                runtime.block_on(session.run(operation, &rows))
+                            })
+                        },
+                        BatchSize::LargeInput,
+                    );
                 },
-                BatchSize::LargeInput,
             );
-        });
+        }
 
         group.finish();
     }
@@ -674,8 +831,8 @@ fn bench_session_execute_untracked_insert(
 
 /// Keeps fixture destruction (including recursive TempDir cleanup) outside
 /// Criterion's measured routine interval.
-fn retain_fixture<I, O>(fixture: I, routine: impl FnOnce(&I) -> O) -> (O, I) {
-    let output = routine(&fixture);
+fn retain_fixture<I, O>(mut fixture: I, routine: impl FnOnce(&mut I) -> O) -> (O, I) {
+    let output = routine(&mut fixture);
     (output, fixture)
 }
 
@@ -683,7 +840,46 @@ async fn measure_lix_io(profile: LixStorageProfile, operation: &str, rows: &[Ben
     match profile {
         LixStorageProfile::SQLite => measure_lix_io_for_storage(sqlite(), operation, rows).await,
         LixStorageProfile::RocksDB => measure_lix_io_for_storage(rocksdb(), operation, rows).await,
+        #[cfg(feature = "slatedb")]
+        LixStorageProfile::SlateDB => measure_lix_io_for_storage(slatedb(), operation, rows).await,
     }
+}
+
+async fn measure_session_io(
+    profile: LixStorageProfile,
+    operation: SessionCrudOperation,
+    rows: &[PointerRow],
+) -> IoStats {
+    match profile {
+        LixStorageProfile::SQLite => {
+            panic!("raw SQLite is not a Lix session I/O profile")
+        }
+        LixStorageProfile::RocksDB => {
+            measure_session_io_for_storage(rocksdb(), operation, rows).await
+        }
+        #[cfg(feature = "slatedb")]
+        LixStorageProfile::SlateDB => {
+            measure_session_io_for_storage(slatedb(), operation, rows).await
+        }
+    }
+}
+
+async fn measure_session_io_for_storage<StorageImpl>(
+    storage: StorageImpl,
+    operation: SessionCrudOperation,
+    rows: &[PointerRow],
+) -> IoStats
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let (storage, stats) = CountingStorage::new(storage);
+    let session = prepare_session_empty(storage).await;
+    if operation.needs_seed() {
+        insert_untracked_json_pointer_rows(&session, rows).await;
+    }
+    stats.lock().expect("io stats mutex").reset();
+    run_session_operation(&session, operation, rows).await;
+    stats.lock().expect("io stats mutex").clone()
 }
 
 async fn measure_lix_io_for_storage<StorageImpl>(
@@ -706,11 +902,9 @@ where
         }
         "select_all_rows" => {
             lix_select_all(&storage, rows.len(), StorageCoreProjection::FullValue).await;
-            record_scan_result(&stats, rows, true);
         }
         "select_keys_only" => {
             lix_select_all(&storage, rows.len(), StorageCoreProjection::KeyOnly).await;
-            record_scan_result(&stats, rows, false);
         }
         "select_one_by_pk" => {
             lix_select_points(&storage, std::slice::from_ref(&rows[rows.len() / 2])).await;
@@ -734,15 +928,6 @@ where
     }
 
     stats.lock().expect("io stats mutex").clone()
-}
-
-fn record_scan_result(stats: &Arc<Mutex<IoStats>>, rows: &[BenchRow], include_values: bool) {
-    let mut stats = stats.lock().expect("io stats mutex");
-    stats.scan_entries += rows.len();
-    stats.scan_entry_key_bytes += rows.iter().map(|row| row.key.0.len()).sum::<usize>();
-    if include_values {
-        stats.scan_entry_value_bytes += rows.iter().map(|row| row.value.bytes.len()).sum::<usize>();
-    }
 }
 
 async fn lix_insert_all<StorageImpl>(
@@ -872,24 +1057,47 @@ fn profile_storage(profile: LixStorageProfile) -> ProfileStorage {
     match profile {
         LixStorageProfile::SQLite => ProfileStorage::SQLite(StorageAdapter::new(sqlite())),
         LixStorageProfile::RocksDB => ProfileStorage::RocksDB(StorageAdapter::new(rocksdb())),
+        #[cfg(feature = "slatedb")]
+        LixStorageProfile::SlateDB => ProfileStorage::SlateDB(StorageAdapter::new(slatedb())),
     }
 }
 
 enum ProfileStorage {
     SQLite(StorageAdapter<TempStorage<SQLite>>),
     RocksDB(StorageAdapter<TempStorage<RocksDB>>),
+    #[cfg(feature = "slatedb")]
+    SlateDB(StorageAdapter<TempStorage<SlateDB>>),
 }
 
 enum ProfileSession {
-    SQLite(SessionContext<TempStorage<SQLite>>),
     RocksDB(SessionContext<TempStorage<RocksDB>>),
+    #[cfg(feature = "slatedb")]
+    SlateDB(SessionContext<TempStorage<SlateDB>>),
+}
+
+async fn prepare_profile_session(
+    profile: LixStorageProfile,
+    operation: SessionCrudOperation,
+    rows: &[PointerRow],
+) -> ProfileSession {
+    let session = prepare_profile_session_empty(profile).await;
+    if operation.needs_seed() {
+        session.insert_untracked_json_pointer_rows(rows).await;
+    }
+    session
 }
 
 async fn prepare_profile_session_empty(profile: LixStorageProfile) -> ProfileSession {
     match profile {
-        LixStorageProfile::SQLite => ProfileSession::SQLite(prepare_session_empty(sqlite()).await),
+        LixStorageProfile::SQLite => {
+            panic!("raw SQLite is the session scorecard reference, not a Lix session profile")
+        }
         LixStorageProfile::RocksDB => {
             ProfileSession::RocksDB(prepare_session_empty(rocksdb()).await)
+        }
+        #[cfg(feature = "slatedb")]
+        LixStorageProfile::SlateDB => {
+            ProfileSession::SlateDB(prepare_session_empty(slatedb()).await)
         }
     }
 }
@@ -937,15 +1145,132 @@ async fn insert_untracked_json_pointer_rows<StorageImpl>(
 ) where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
+    let mut transaction = session
+        .begin_transaction()
+        .await
+        .expect("begin untracked insert transaction");
     for chunk in rows.chunks(SESSION_INSERT_CHUNK_SIZE) {
         let sql = insert_untracked_json_pointer_sql(chunk);
-        let affected = session
+        let affected = transaction
             .execute(&sql, &[])
             .await
             .expect("insert untracked json_pointer rows")
             .rows_affected();
         assert_eq!(affected as usize, chunk.len());
     }
+    transaction
+        .commit()
+        .await
+        .expect("commit untracked insert transaction");
+}
+
+async fn run_session_operation<StorageImpl>(
+    session: &SessionContext<StorageImpl>,
+    operation: SessionCrudOperation,
+    rows: &[PointerRow],
+) -> usize
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let point = &rows[rows.len() / 2];
+    match operation {
+        SessionCrudOperation::InsertAll => {
+            insert_untracked_json_pointer_rows(session, rows).await;
+            rows.len()
+        }
+        SessionCrudOperation::InsertOne => {
+            insert_untracked_json_pointer_rows(session, std::slice::from_ref(point)).await;
+            1
+        }
+        SessionCrudOperation::SelectAll => {
+            let result = session
+                .execute(
+                    "SELECT path, value, lixcol_entity_pk, lixcol_schema_key, lixcol_file_id, \
+                            lixcol_created_at, lixcol_updated_at, lixcol_global, lixcol_untracked \
+                     FROM json_pointer \
+                     WHERE lixcol_untracked = true ORDER BY path",
+                    &[],
+                )
+                .await
+                .expect("select all untracked json_pointer rows");
+            assert_eq!(result.rows().len(), rows.len());
+            black_box(result.rows()).len()
+        }
+        SessionCrudOperation::SelectOne => {
+            let sql = format!(
+                "SELECT path, value, lixcol_entity_pk, lixcol_schema_key, lixcol_file_id, \
+                        lixcol_created_at, lixcol_updated_at, lixcol_global, lixcol_untracked \
+                 FROM json_pointer \
+                 WHERE path = '{}' AND lixcol_untracked = true",
+                sql_string(&point.path)
+            );
+            let result = session
+                .execute(&sql, &[])
+                .await
+                .expect("select one untracked json_pointer row");
+            assert_eq!(result.rows().len(), 1);
+            black_box(result.rows()).len()
+        }
+        SessionCrudOperation::UpdateAll => {
+            update_untracked_json_pointer_rows(session, rows).await;
+            rows.len()
+        }
+        SessionCrudOperation::UpdateOne => {
+            update_untracked_json_pointer_rows(session, std::slice::from_ref(point)).await;
+            1
+        }
+        SessionCrudOperation::DeleteAll => {
+            let affected = session
+                .execute(
+                    "DELETE FROM json_pointer WHERE lixcol_untracked = true",
+                    &[],
+                )
+                .await
+                .expect("delete all untracked json_pointer rows")
+                .rows_affected();
+            assert_eq!(affected as usize, rows.len());
+            affected as usize
+        }
+        SessionCrudOperation::DeleteOne => {
+            let sql = format!(
+                "DELETE FROM json_pointer \
+                 WHERE path = '{}' AND lixcol_untracked = true",
+                sql_string(&point.path)
+            );
+            let affected = session
+                .execute(&sql, &[])
+                .await
+                .expect("delete one untracked json_pointer row")
+                .rows_affected();
+            assert_eq!(affected, 1);
+            1
+        }
+    }
+}
+
+async fn update_untracked_json_pointer_rows<StorageImpl>(
+    session: &SessionContext<StorageImpl>,
+    rows: &[PointerRow],
+) where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let mut transaction = session
+        .begin_transaction()
+        .await
+        .expect("begin untracked update transaction");
+    for chunk in rows.chunks(SESSION_INSERT_CHUNK_SIZE) {
+        let sql = update_untracked_json_pointer_sql(chunk);
+        let affected = transaction
+            .execute(&sql, &[])
+            .await
+            .expect("update untracked json_pointer rows")
+            .rows_affected();
+        assert_eq!(affected as usize, chunk.len());
+    }
+    transaction
+        .commit()
+        .await
+        .expect("commit untracked update transaction");
 }
 
 impl ProfileStorage {
@@ -953,6 +1278,8 @@ impl ProfileStorage {
         match self {
             Self::SQLite(storage) => lix_insert_all(storage, rows).await,
             Self::RocksDB(storage) => lix_insert_all(storage, rows).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(storage) => lix_insert_all(storage, rows).await,
         }
     }
 
@@ -960,6 +1287,8 @@ impl ProfileStorage {
         match self {
             Self::SQLite(storage) => lix_update_all(storage, rows).await,
             Self::RocksDB(storage) => lix_update_all(storage, rows).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(storage) => lix_update_all(storage, rows).await,
         }
     }
 
@@ -967,6 +1296,8 @@ impl ProfileStorage {
         match self {
             Self::SQLite(storage) => lix_delete_one(storage, row).await,
             Self::RocksDB(storage) => lix_delete_one(storage, row).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(storage) => lix_delete_one(storage, row).await,
         }
     }
 
@@ -974,6 +1305,8 @@ impl ProfileStorage {
         match self {
             Self::SQLite(storage) => lix_delete_all(storage).await,
             Self::RocksDB(storage) => lix_delete_all(storage).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(storage) => lix_delete_all(storage).await,
         }
     }
 
@@ -981,6 +1314,8 @@ impl ProfileStorage {
         match self {
             Self::SQLite(storage) => lix_select_all(storage, expected_rows, projection).await,
             Self::RocksDB(storage) => lix_select_all(storage, expected_rows, projection).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(storage) => lix_select_all(storage, expected_rows, projection).await,
         }
     }
 
@@ -988,6 +1323,8 @@ impl ProfileStorage {
         match self {
             Self::SQLite(storage) => lix_select_points(storage, rows).await,
             Self::RocksDB(storage) => lix_select_points(storage, rows).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(storage) => lix_select_points(storage, rows).await,
         }
     }
 }
@@ -995,8 +1332,17 @@ impl ProfileStorage {
 impl ProfileSession {
     async fn insert_untracked_json_pointer_rows(&self, rows: &[PointerRow]) {
         match self {
-            Self::SQLite(session) => insert_untracked_json_pointer_rows(session, rows).await,
             Self::RocksDB(session) => insert_untracked_json_pointer_rows(session, rows).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(session) => insert_untracked_json_pointer_rows(session, rows).await,
+        }
+    }
+
+    async fn run(&self, operation: SessionCrudOperation, rows: &[PointerRow]) -> usize {
+        match self {
+            Self::RocksDB(session) => run_session_operation(session, operation, rows).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(session) => run_session_operation(session, operation, rows).await,
         }
     }
 }
@@ -1011,6 +1357,13 @@ fn rocksdb() -> TempStorage<RocksDB> {
     let dir = TempDir::new().expect("create rocksdb storage tempdir");
     let path = dir.path().join("bench.rocksdb");
     TempStorage::new(RocksDB::open(path).expect("open rocksdb storage"), dir)
+}
+
+#[cfg(feature = "slatedb")]
+fn slatedb() -> TempStorage<SlateDB> {
+    let dir = TempDir::new().expect("create slatedb storage tempdir");
+    let path = dir.path().join("bench.slatedb");
+    TempStorage::new(SlateDB::open(path).expect("open slatedb storage"), dir)
 }
 
 fn configure_group(
@@ -1125,6 +1478,27 @@ fn insert_untracked_json_pointer_sql(rows: &[PointerRow]) -> String {
     sql
 }
 
+fn update_untracked_json_pointer_sql(rows: &[PointerRow]) -> String {
+    let mut sql = String::from("UPDATE json_pointer SET value = CASE path ");
+    for row in rows {
+        let _ = write!(
+            sql,
+            "WHEN '{}' THEN lix_json('{}') ",
+            sql_string(&row.path),
+            sql_string(&row.updated_value_json)
+        );
+    }
+    sql.push_str("ELSE value END WHERE lixcol_untracked = true AND path IN (");
+    for (index, row) in rows.iter().enumerate() {
+        if index > 0 {
+            sql.push(',');
+        }
+        let _ = write!(sql, "'{}'", sql_string(&row.path));
+    }
+    sql.push(')');
+    sql
+}
+
 fn entity_pk(row: &PointerRow) -> String {
     row.path.clone()
 }
@@ -1192,13 +1566,12 @@ fn prepare_raw_sqlite_empty() -> RawSQLiteFixture {
 }
 
 fn prepare_raw_sqlite_seeded(rows: &[RawUntrackedRow]) -> RawSQLiteFixture {
-    raw_sqlite_insert_all(prepare_raw_sqlite_empty(), rows)
+    let mut fixture = prepare_raw_sqlite_empty();
+    raw_sqlite_insert_all(&mut fixture, rows);
+    fixture
 }
 
-fn raw_sqlite_insert_all(
-    mut fixture: RawSQLiteFixture,
-    rows: &[RawUntrackedRow],
-) -> RawSQLiteFixture {
+fn raw_sqlite_insert_all(fixture: &mut RawSQLiteFixture, rows: &[RawUntrackedRow]) -> usize {
     let tx = fixture.conn.transaction().expect("begin raw sqlite insert");
     {
         let mut statement = tx
@@ -1229,13 +1602,38 @@ fn raw_sqlite_insert_all(
         }
     }
     tx.commit().expect("commit raw sqlite insert");
-    fixture
+    rows.len()
+}
+
+fn raw_sqlite_insert_one(fixture: &mut RawSQLiteFixture, row: &RawUntrackedRow) -> usize {
+    let affected = fixture
+        .conn
+        .execute(
+            "INSERT INTO untracked_state (
+                branch_id, schema_key, entity_pk, file_id, snapshot_content,
+                metadata, created_at, updated_at, global
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![
+                row.branch_id,
+                row.schema_key,
+                row.entity_pk,
+                row.file_id,
+                row.snapshot_content,
+                row.metadata,
+                row.created_at,
+                row.updated_at,
+                i64::from(row.global),
+            ],
+        )
+        .expect("execute raw sqlite insert one");
+    assert_eq!(affected, 1);
+    affected
 }
 
 fn raw_sqlite_insert_all_unprepared_per_row(
-    mut fixture: RawSQLiteFixture,
+    fixture: &mut RawSQLiteFixture,
     rows: &[RawUntrackedRow],
-) -> RawSQLiteFixture {
+) -> usize {
     let tx = fixture
         .conn
         .transaction()
@@ -1257,13 +1655,13 @@ fn raw_sqlite_insert_all_unprepared_per_row(
     }
     assert_eq!(affected, rows.len());
     tx.commit().expect("commit raw sqlite unprepared insert");
-    fixture
+    affected
 }
 
 fn raw_sqlite_insert_all_unprepared_chunked(
-    mut fixture: RawSQLiteFixture,
+    fixture: &mut RawSQLiteFixture,
     rows: &[RawUntrackedRow],
-) -> RawSQLiteFixture {
+) -> usize {
     let tx = fixture
         .conn
         .transaction()
@@ -1291,7 +1689,7 @@ fn raw_sqlite_insert_all_unprepared_chunked(
     assert_eq!(affected, rows.len());
     tx.commit()
         .expect("commit raw sqlite chunked unprepared insert");
-    fixture
+    affected
 }
 
 fn append_raw_sqlite_insert_values_tuple(sql: &mut String, row: &RawUntrackedRow) {
@@ -1311,7 +1709,7 @@ fn append_raw_sqlite_insert_values_tuple(sql: &mut String, row: &RawUntrackedRow
     .expect("write raw sqlite insert tuple SQL");
 }
 
-fn raw_sqlite_select_all(fixture: RawSQLiteFixture, expected_rows: usize) -> usize {
+fn raw_sqlite_select_all(fixture: &RawSQLiteFixture, expected_rows: usize) -> usize {
     let mut statement = fixture
         .conn
         .prepare_cached(
@@ -1352,26 +1750,47 @@ fn raw_sqlite_select_all(fixture: RawSQLiteFixture, expected_rows: usize) -> usi
     count
 }
 
-fn raw_sqlite_select_one_by_pk(fixture: RawSQLiteFixture, row: &RawUntrackedRow) -> usize {
-    let found = fixture
+fn raw_sqlite_select_one_by_pk(fixture: &RawSQLiteFixture, row: &RawUntrackedRow) -> usize {
+    let materialized_bytes = fixture
         .conn
         .query_row(
             "
-            SELECT snapshot_content
+            SELECT branch_id, schema_key, entity_pk, file_id, snapshot_content, metadata,
+                   created_at, updated_at, global
             FROM untracked_state
             WHERE branch_id = ?1 AND schema_key = ?2 AND entity_pk = ?3 AND file_id = ?4
             ",
             params![row.branch_id, row.schema_key, row.entity_pk, row.file_id],
-            |row| row.get::<_, Option<String>>(0),
+            |row| {
+                let branch_id: String = row.get(0)?;
+                let schema_key: String = row.get(1)?;
+                let entity_pk: String = row.get(2)?;
+                let file_id: String = row.get(3)?;
+                let snapshot_content: String = row.get(4)?;
+                let metadata: Option<String> = row.get(5)?;
+                let created_at: String = row.get(6)?;
+                let updated_at: String = row.get(7)?;
+                let global: i64 = row.get(8)?;
+                Ok(branch_id.len()
+                    + schema_key.len()
+                    + entity_pk.len()
+                    + file_id.len()
+                    + snapshot_content.len()
+                    + metadata.as_ref().map_or(0, String::len)
+                    + created_at.len()
+                    + updated_at.len()
+                    + usize::from(global != 0))
+            },
         )
         .optional()
         .expect("execute raw sqlite select one")
-        .is_some();
-    assert!(found);
-    usize::from(found)
+        .expect("raw sqlite point row exists");
+    assert!(materialized_bytes > 0);
+    black_box(materialized_bytes);
+    1
 }
 
-fn raw_sqlite_update_all(mut fixture: RawSQLiteFixture, rows: &[RawUntrackedRow]) -> usize {
+fn raw_sqlite_update_all(fixture: &mut RawSQLiteFixture, rows: &[RawUntrackedRow]) -> usize {
     let tx = fixture
         .conn
         .transaction()
@@ -1405,7 +1824,7 @@ fn raw_sqlite_update_all(mut fixture: RawSQLiteFixture, rows: &[RawUntrackedRow]
     affected
 }
 
-fn raw_sqlite_update_one_by_pk(fixture: RawSQLiteFixture, row: &RawUntrackedRow) -> usize {
+fn raw_sqlite_update_one_by_pk(fixture: &RawSQLiteFixture, row: &RawUntrackedRow) -> usize {
     let affected = fixture
         .conn
         .execute(
@@ -1428,7 +1847,7 @@ fn raw_sqlite_update_one_by_pk(fixture: RawSQLiteFixture, row: &RawUntrackedRow)
     affected
 }
 
-fn raw_sqlite_delete_all(fixture: RawSQLiteFixture, expected_rows: usize) -> usize {
+fn raw_sqlite_delete_all(fixture: &RawSQLiteFixture, expected_rows: usize) -> usize {
     let affected = fixture
         .conn
         .execute("DELETE FROM untracked_state", [])
@@ -1437,7 +1856,7 @@ fn raw_sqlite_delete_all(fixture: RawSQLiteFixture, expected_rows: usize) -> usi
     affected
 }
 
-fn raw_sqlite_delete_one_by_pk(fixture: RawSQLiteFixture, row: &RawUntrackedRow) -> usize {
+fn raw_sqlite_delete_one_by_pk(fixture: &RawSQLiteFixture, row: &RawUntrackedRow) -> usize {
     let affected = fixture
         .conn
         .execute(


### PR DESCRIPTION
## Summary
- compare raw rusqlite with end-to-end `SessionContext` CRUD on RocksDB and SlateDB
- cover bulk and point insert, read, update, and delete while keeping fixture teardown outside timed intervals
- report logical storage traffic and retain explicitly non-production adapter diagnostic lanes
- require SlateDB for this target so an incomplete scorecard is skipped rather than misreported

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/root/projects/lixray/vendor/lix/target CARGO_BUILD_JOBS=2 cargo check -p lix_engine_benchmarks --features "storage-benches slatedb" --bench untracked_state_crud`

## Stack
- depends on #1207
- benchmark-only; no engine behavior change
